### PR TITLE
feat(runner): a wish sidecar carries its system: provenance

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -297,7 +297,9 @@ server](#clients-that-are-not-built-alongside-their-server).
   system root for the space kind (home.tsx / default-app.tsx), recording the
   displaced ref under `displacedPattern` meta (see pattern-updates.md for the
   full exception semantics). URL-based root creation and recreation stamp
-  provenance; custom `RuntimeProgram` recreation does not. Repository-pinned
+  provenance, and the wish builtin stamps its sidecar pieces (profile
+  create/picker, suggestion) with the `system:` ref of the pattern each run
+  fetches; custom `RuntimeProgram` recreation does not stamp. Repository-pinned
   sourceless patterns, cross-origin sources, default roots reached by the
   generic post-start hook, and starts that intentionally install no pattern
   watcher remain excluded. The check remains best-effort; if identity lookup or

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -1249,7 +1249,11 @@ The implementation evidence for this table is concentrated in:
 - System space roots carry a `system:` `patternSource` ref when created through
   `ensureDefaultPattern`, naming a pattern the toolshed serves relative to its
   patterns route. Roots can check that source and replace `patternIdentity`
-  before starting. Other successfully instantiated patterns are checked in the
+  before starting. Wish sidecar pieces (the profile create/picker and
+  suggestion surfaces) carry the same ref, stamped by the run that mints them
+  (`RunnerRunOptions.patternSource`); a sidecar minted before the stamp
+  existed gains it on its next launch, since the stamp fills only the
+  detached case. Other successfully instantiated patterns are checked in the
   background, and only a `system:` ref is fetched. This is a transitional
   implementation and migration input. Under the design above a `system:` ref
   still selects a policy — its releases are gated where they are made, so its

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -36,6 +36,7 @@ import {
   getMetaLink,
   toMemorySpaceAddress,
 } from "../link-utils.ts";
+import { systemPatternSource } from "../pattern-source-scheme.ts";
 import { setRunnableName } from "../runner-utils.ts";
 import { type Runtime, spaceCellSchema } from "../runtime.ts";
 import { type Action, type ReactivityLog } from "../scheduler.ts";
@@ -1610,6 +1611,11 @@ export function createSidecarPatternCache(options: {
   });
 
   return {
+    // The `system:` provenance ref this cache's pattern is served under.
+    // Every run of the pattern stamps it on the minted piece
+    // (`RunnerRunOptions.patternSource`), so the pattern updater's route
+    // check covers wish sidecars the same way it covers default roots.
+    sourceRef: systemPatternSource(`system/${options.name}`),
     // Pattern from a completed fetch for the current environment's URL.
     cached(): Pattern | undefined {
       return fetchUrl === patternUrl() ? pattern : undefined;
@@ -2362,7 +2368,10 @@ export function wish(
               pattern,
               slot.input,
               slot.resultCell,
-              sidecarRunOptions,
+              {
+                ...sidecarRunOptions,
+                patternSource: suggestionPatternCache.sourceRef,
+              },
             );
           }
         },
@@ -2375,7 +2384,10 @@ export function wish(
           cachedSuggestionPattern,
           slot.input,
           slot.resultCell,
-          sidecarRunOptions,
+          {
+            ...sidecarRunOptions,
+            patternSource: suggestionPatternCache.sourceRef,
+          },
         );
       }
     }
@@ -2438,6 +2450,7 @@ export function wish(
     resultCell: Cell<any>,
     pattern: Pattern,
     inputForTx: (tx: IExtendedStorageTransaction) => unknown,
+    patternSource: string,
   ): Promise<void> {
     wishSidecarDiagnostics.sidecarRunsStarted += 1;
     // A conflict-class failure means SOME other writer advanced a doc this
@@ -2491,7 +2504,7 @@ export function wish(
           pattern,
           inputForTx(runTx),
           resultCell.withTx(runTx),
-          sidecarRunOptions,
+          { ...sidecarRunOptions, patternSource },
         );
         runtime.prepareTxForCommit(runTx);
         const { error } = await runTx.commit();
@@ -2665,6 +2678,7 @@ export function wish(
               slot.resultCell,
               pattern,
               profileCreateInputForTx,
+              profileCreatePatternCache.sourceRef,
             );
           }
           // Fetch/compile failed, or a later fetch for a changed apiUrl
@@ -2691,7 +2705,10 @@ export function wish(
         cachedProfileCreatePattern,
         profileCreateInputForTx(tx),
         slot.resultCell.withTx(tx),
-        sidecarRunOptions,
+        {
+          ...sidecarRunOptions,
+          patternSource: profileCreatePatternCache.sourceRef,
+        },
       );
     }
 
@@ -2800,6 +2817,7 @@ export function wish(
               slot.resultCell,
               pattern,
               pickerInputForTx,
+              profilePickerPatternCache.sourceRef,
             );
           } else {
             // Fetch/compile failed (createSidecarPatternCache swallows the
@@ -2831,7 +2849,10 @@ export function wish(
         cachedProfilePickerPattern,
         pickerInputForTx(tx),
         slot.resultCell.withTx(tx),
-        sidecarRunOptions,
+        {
+          ...sidecarRunOptions,
+          patternSource: profilePickerPatternCache.sourceRef,
+        },
       );
     }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -982,6 +982,12 @@ type RunnerRunOptions = {
   // instance) run supply resolves a nested piece's demanded instances
   // through the OUTER piece a client watches (server-execution v2 Phase 7).
   parentPieceRootId?: string;
+  // Provenance stamped into `patternSource` — in the same transaction as the
+  // run, so a piece minted outside the controller paths (a wish sidecar) is
+  // born carrying the origin the pattern updater's route check follows. A
+  // piece already carrying a source keeps it: this fills the detached case
+  // only, and never repoints one.
+  patternSource?: string;
 };
 
 // Placeholder standing in for an argument slot whose stored value routes
@@ -4307,6 +4313,13 @@ export class Runner {
       argument,
       resultCell,
     );
+
+    if (
+      options.patternSource !== undefined &&
+      getPatternSource(resultCell.withTx(tx)) === undefined
+    ) {
+      setPatternSource(resultCell, tx, options.patternSource);
+    }
 
     let installedCancel: Cancel | undefined;
     let cancelDeferredStart: Cancel | undefined;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2991,21 +2991,21 @@ export class Runtime {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
-    options?: { schedulePatternUpdate?: boolean },
+    options?: { schedulePatternUpdate?: boolean; patternSource?: string },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options?: { schedulePatternUpdate?: boolean },
+    options?: { schedulePatternUpdate?: boolean; patternSource?: string },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options: { schedulePatternUpdate?: boolean } = {},
+    options: { schedulePatternUpdate?: boolean; patternSource?: string } = {},
   ): Cell<R> {
     return this.runner.run<T, R>(
       tx,

--- a/packages/runner/test/wish-sidecar-pattern-source.test.ts
+++ b/packages/runner/test/wish-sidecar-pattern-source.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { getPatternSource, setPatternSource } from "../src/runner.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { NAME, UI } from "../src/builder/types.ts";
+import {
+  getPatternEnvironment,
+  setPatternEnvironment,
+} from "../src/builder/env.ts";
+
+// A wish sidecar (the profile create/picker surface, the suggestion surface)
+// is minted by the wish builtin through `runtime.runner.run`, not through the
+// controller paths that stamp `patternSource` — so without the stamp threaded
+// through `RunnerRunOptions.patternSource`, the minted piece carries only its
+// content-addressed compile identity and the pattern updater has no route to
+// follow: the piece stays pinned to the compile of the day it was minted.
+// Pinned here: the sidecar piece is born carrying the `system:` ref of the
+// route its pattern was fetched from, and a piece that already carries a
+// source keeps it.
+const signer = await Identity.fromPassphrase("wish-sidecar-pattern-source");
+const homeSpace = signer.did();
+
+const read = (name: string) =>
+  Deno.readTextFileSync(
+    fromFileUrl(new URL("../../patterns/system/", import.meta.url)) + name,
+  );
+
+const WISH_SRC = [
+  "import { pattern, wish } from 'commonfabric';",
+  "export default pattern(() => ({",
+  "  profile: wish({ query: '#profile' }),",
+  "}));",
+].join("\n");
+
+const WISH_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: WISH_SRC }],
+};
+
+const PLAIN_SRC = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern(() => ({ ok: true }));",
+].join("\n");
+
+const PLAIN_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: PLAIN_SRC }],
+};
+
+describe("wish sidecar patternSource stamp", () => {
+  let server: MemoryV2Server.Server;
+  let manager: EmulatedStorageManager;
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnvironment: ReturnType<typeof getPatternEnvironment>;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    originalFetch = globalThis.fetch;
+    originalEnvironment = getPatternEnvironment();
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    setPatternEnvironment(originalEnvironment);
+    await manager?.close();
+    await server?.close();
+  });
+
+  it("stamps the minted create-surface piece with the system: ref of the pattern it runs", async () => {
+    // A unique pattern-environment origin keys this test's entry in the
+    // module-global sidecar cache (the cache memoizes per URL).
+    setPatternEnvironment({
+      apiUrl: new URL("https://sidecar-pattern-source.test/"),
+    });
+
+    // Serve the REAL profile-create.tsx (+ its profile-home.tsx import).
+    globalThis.fetch = ((input: Request | URL | string) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes("profile-create.tsx")) {
+        return Promise.resolve(
+          new Response(read("profile-create.tsx"), { status: 200 }),
+        );
+      }
+      if (url.includes("profile-home.tsx")) {
+        return Promise.resolve(
+          new Response(read("profile-home.tsx"), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }) as typeof fetch;
+
+    const rt = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: manager,
+    });
+    try {
+      // Home space with a profile-less default pattern: `#profile` resolves
+      // to the missing-profile state, whose UI is the create surface.
+      const setupTx = rt.edit();
+      const homeSpaceCell = rt.getSpaceCell(homeSpace);
+      const homeDefault = rt.getCell(
+        homeSpace,
+        "pattern-source-home-default",
+        undefined,
+        setupTx,
+      );
+      homeDefault.key("marker").set("home");
+      // deno-lint-ignore no-explicit-any
+      (homeSpaceCell.withTx(setupTx) as any).key("defaultPattern").set(
+        homeDefault,
+      );
+      rt.prepareTxForCommit(setupTx);
+      const setupCommit = await setupTx.commit();
+      expect(setupCommit.error).toBeUndefined();
+
+      const tx = rt.edit();
+      const wishPattern = await rt.patternManager.compilePattern(WISH_PROGRAM, {
+        space: homeSpace,
+        tx,
+      });
+      const result = rt.getCell<Record<string, unknown>>(
+        homeSpace,
+        "wish-sidecar-pattern-source-result",
+        undefined,
+        tx,
+      );
+      // deno-lint-ignore no-explicit-any
+      const run = rt.run(tx, wishPattern as any, {}, result);
+      rt.prepareTxForCommit(tx);
+      const commit = await tx.commit();
+      expect(commit.error).toBeUndefined();
+
+      // Demand drives the wish action, which launches the create sidecar;
+      // the tracked launch is covered by idle().
+      await run.pull();
+      await rt.idle();
+      await run.pull();
+
+      const createCell = run.key("profile").key(UI).key("props").key("$cell")
+        .resolveAsCell();
+      await createCell.sync();
+      await createCell.pull();
+
+      // Vacuity killer: the sidecar actually materialized — the stamp
+      // assertion below is about a piece that exists.
+      const surface = createCell.get() as Record<string | symbol, unknown>;
+      expect(surface?.[NAME]).toBe("Create Profile");
+
+      expect(getPatternSource(createCell)).toBe(
+        "system:system/profile-create.tsx",
+      );
+    } finally {
+      await rt.dispose();
+    }
+  });
+
+  it("keeps a piece's existing patternSource over the run option's ref", async () => {
+    const rt = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: manager,
+    });
+    try {
+      const tx = rt.edit();
+      const plainPattern = await rt.patternManager.compilePattern(
+        PLAIN_PROGRAM,
+        { space: homeSpace, tx },
+      );
+
+      const stamped = rt.getCell<Record<string, unknown>>(
+        homeSpace,
+        "pattern-source-already-stamped",
+        undefined,
+        tx,
+      );
+      setPatternSource(stamped, tx, "cf:existing/ref");
+      // deno-lint-ignore no-explicit-any
+      rt.run(tx, plainPattern as any, {}, stamped, {
+        patternSource: "system:system/profile-create.tsx",
+      });
+
+      const detached = rt.getCell<Record<string, unknown>>(
+        homeSpace,
+        "pattern-source-detached",
+        undefined,
+        tx,
+      );
+      // deno-lint-ignore no-explicit-any
+      rt.run(tx, plainPattern as any, {}, detached, {
+        patternSource: "system:system/profile-create.tsx",
+      });
+
+      rt.prepareTxForCommit(tx);
+      const commit = await tx.commit();
+      expect(commit.error).toBeUndefined();
+
+      expect(getPatternSource(stamped)).toBe("cf:existing/ref");
+      expect(getPatternSource(detached)).toBe(
+        "system:system/profile-create.tsx",
+      );
+    } finally {
+      await rt.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Context

While digging into the CFC refusal noise on the Estuary topics board, @gideon-gpn asked whether the wish `#profile` mechanism is working as intended: it fetches `api/patterns/system/profile-create.tsx` / `profile-picker.tsx`, compiles in-session, and mints a per-viewer sidecar piece — but that piece pins the day's compile identity and never records the `system:` route as its origin. This PR is the forward fix for that gap, plus the evidence that shaped it.

## The mechanism, verified

- The per-viewer minting itself is deliberate design, not an accident: sidecar surfaces key per demanding identity so demander #2 never reuses (and clobbers) demander #1's create surface (`docs/common/conventions/wish.md`, `docs/specs/server-side-execution/builtins.md` §sidecar-keying, the F2 fix in `wish.ts`).
- The provenance gap is an unconsidered hole, not a decision. `patternSource` stamping exists only on the controller paths (`ensure-space-root.ts`, `recreateDefaultPattern` in `pieces-controller.ts`); wish sidecars go through `runtime.runner.run` directly, and `RunnerRunOptions` had no provenance field at all. The exclusion list in `EXPERIMENTAL_OPTIONS.md` never anticipated framework-minted pieces.
- The stranding is subtler than "never checked." `patternUpdater.schedule()` **does** fire for sidecars (the post-instantiation hook defaults on), and the updater even has a sourceless reconstruction path that recovers a `system:` ref from the compiled module name. It fails for a different reason per sidecar:
  - `profile-picker.tsx` compiles with no `cacheCtx`, so no verified source closure is persisted anywhere — reconstruction can never resolve.
  - `profile-create.tsx` / `suggestion.tsx` persist their closure into the *viewer's* space (`compileInUserSpace`), while the lookup asks the *app* space where the sidecar cell lives — a miss whenever they differ, which is the normal cross-space case.

  Either way `getPatternSourceProgramByIdentity` returns `undefined`, the check answers `"current"`, and the piece stays pinned to its birth compile forever — per viewer, with no `setsrc` handle to repair it (its cause is `{wish:{profilePickerPattern, user}}`; nothing user-visible addresses it).

## The change

- `RunnerRunOptions.patternSource`: provenance stamped in the same transaction as the run, **only when the piece carries none** — it fills the detached case and never repoints a piece that already has a source. Mirrors what `ensure-space-root.ts` does for space roots, landing where `patternIdentity` lands.
- The wish sidecar caches expose the `system:` ref of the route they fetch (`system:system/profile-create.tsx` etc.), and all six sidecar run sites (suggestion/create/picker × cold/warm) thread it through.
- With the stamp in place, the existing updater covers sidecars end to end with **no new apply machinery**: normalize the stored ref → resolve the route + `?identity` → pointer-swap, applied live by the runner's `patternIdentity` sink. The picker's missing source closure stops mattering for updates, because the route check never needs the closure.

## What happens to the existing unstamped pieces on Estuary

They self-heal. The stamp guard is "fill when detached", and the sidecar launch re-runs into the same cause-derived cell on every board load — so each existing sidecar piece gains its `system:` ref the next time its surface launches, and auto-update (`systemPatternAutoUpdate`, on by default in shell and forced on for serving runtimes) covers it from then on. No migration sweep needed.

## Testing

- `wish-sidecar-pattern-source.test.ts`: drives a real `#profile` wish with no profiles through the stubbed patterns route (same scaffold as the duplicate-launch pin) and asserts the materialized create surface carries `system:system/profile-create.tsx`; a second case pins that an existing `patternSource` survives a run that offers a different ref while a detached piece gains the offered one.
- Existing wish, duplicate-launch, and pattern-auto-update suites pass.

Docs updated in the same change: `piece-source-lifecycle.md` (who carries a `system:` ref) and `EXPERIMENTAL_OPTIONS.md` (the auto-update coverage passage).

## Not addressed here (deliberately)

- The CFC refusal loop on board load (missing link source metadata / wish error-report writes) — tracked in the topics-board topic "Topics-board load spams CFC refusals".
- The picker's absent compile `cacheCtx` — with the route stamp it no longer blocks updates; whether the closure should persist for verification anyway is its own question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

