### PR TITLE
docs(features): the contract points at the demo, the tour describes it

### DIFF
--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -431,10 +431,8 @@ row whose fixed document the schema refuses — is completed the same way, by
 re-invoking with an amended fixer, and the rows that landed are not rewritten.
 
 [`bulk-ops-demo.sh`](../../packages/cli/integration/bulk-ops-demo.sh) shows the
-same surface live: it narrates each command and then runs it, and each act
-re-parses its own displayed line and compares the words against the argv that
-ran, so a line a reader retypes is the line that executed. Run it against any
-host:
+same surface live, narrating each command and then running it. Run it against
+any host:
 
 ```bash
 API_URL=http://localhost:8000 packages/cli/integration/bulk-ops-demo.sh


### PR DESCRIPTION
## Why

`bulk-ops-demo.sh`'s self-checking — each act re-parsing its displayed line and comparing it against the argv that ran — was described in two live documents: this contract, and the companion tour in #6370. A fact with two homes is the one that silently disagrees when the mechanism changes, which is the failure this arc has now hit three times in a day.

The tour is the document a gate holds to that demo, so the machinery is load-bearing there and incidental here. Under the split agreed with b11 (the contract defines, the tour uses), this document keeps the pointer and drops the description; the tour keeps the description. The same pass leaves the fixer definition and the three verification outcomes here, and #6370 drops its copies of those.

## What Changed

`docs/features/piece-bulk-operations.md`: the demo paragraph is now a pointer and an invocation, without the retypability description.

## Test plan

Prose-only. `check-docs` (568 blocks) and `check-skill-facts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

