### PR TITLE
fix(runner): the meta seam is the runtime's to write

### DIFF
--- a/docs/plans/runner_cfc_implementation.md
+++ b/docs/plans/runner_cfc_implementation.md
@@ -325,10 +325,54 @@ Memory-v2 keeps a full entity-document boundary. Low-level `tx.read()` and
 `tx.write()` operate on the whole entity document, including reserved metadata
 siblings such as `source` and `cfc`.
 
-Only the logical `value` surface is exposed to untrusted or user-authored code.
+The read and materialization paths present the logical `value` surface:
 `Cell.get()`, `Cell.sync()`, query materialization, and similar
-validate/transform paths read under `value`, not the full document. Reserved
-siblings remain system metadata, not user JSON content.
+validate/transform paths read under `value`, not the full document, so a
+reserved sibling never arrives as user JSON content.
+
+That is a property of those paths rather than a boundary around untrusted
+code. A pattern's handler holds a runtime cell in the runtime's own realm, so
+the document surface is within its reach: `getMetaRaw` reads a meta field, and
+the storage transaction the cell is bound to addresses any path of the
+document, `value` and its reserved siblings alike. Each seam on that surface
+therefore carries its own guard:
+
+- The meta seam — `patternIdentity`, `argument`, `slug`, and the rest of the
+  `MetaField` union — is the runtime's to write. `setMetaRaw` marks the write
+  it makes, and the write chokepoint refuses a meta write that arrives
+  unmarked, whatever the enforcement mode, because a write there names the
+  program a piece runs rather than editing its data. Three shapes reach a
+  meta field and all three are refused: an address naming the field, a
+  document-root envelope carrying it as a key, and a document-root write that
+  leaves it out, which drops it, since a root write replaces the envelope.
+  The third is decided by reading each meta member of the stored document,
+  never its root: a root read would name a logical path covering every entry
+  in the document's label map, and a guard has no business widening what the
+  transaction around it counts as consumed. Those reads carry no commit
+  precondition, because a precondition would turn a whole-document write into
+  a read-modify-write, and the blind root writes the runtime makes would lose
+  the race against any advance of the document they replace. What that leaves
+  open is an erasure racing the guard, never a forgery: the two shapes that
+  name a field are refused from the write itself, with no read at all. The
+  refusal is also the first of these guards to run, ahead of the ones keyed
+  by target id, so which document a write names cannot decide whether it is
+  asked for an authorization. Meta fields stay readable.
+- A write addressed at a document's `["cfc"]` label map from outside the
+  runtime's privileged persistence scope is recorded, and the commit boundary
+  turns each record into a fail-closed reason (audit S18).
+- A document-root (`path: []`) write whose envelope carries a `cfc` record
+  reaches the label map with no record made: the `["cfc"]` guard keys on the
+  address, and this write's address is the document. The meta guard covers
+  that shape for its own fields, so what stands open here is label-map
+  forgery through the document root.
+- A guard on a seam governs writes to it, not the runtime entry points that
+  write it while doing their own work. The same reach that hands a handler
+  the storage transaction hands it the runtime: `runtime.run` instantiates a
+  pattern of the caller's choosing onto a cell the caller names, and stamps
+  that cell's `patternIdentity` through the authorized entry point on the
+  caller's behalf. What that costs is a question about the object graph a
+  cell hands pattern code, and it is where a boundary around untrusted code
+  would have to be drawn.
 
 Storage rules:
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -261,50 +261,6 @@ export interface IReadable<T> {
   sample(): Readonly<StripDefaultBrand<T>>;
 }
 
-export type MetaLinkField =
-  | "pattern"
-  | "argument"
-  | "result";
-
-/**
- * The `pattern` field links a result cell to its pattern
- * The `argument` field links a result cell to its argument cell
- * The `internal` field contains a manifest with links to derived internal cells.
- * The `schema` field stores the schema for a result cell
- * The `patternSetupIdentity` field records the pattern identity whose complete
- * setup state was installed on a result cell.
- * The `result` field lets a result cell link to its parent result cell,
- * and also lets the argument and derived internal cells link back to the result cell.
- *
- * `cfc` is deliberately NOT a MetaField: the `["cfc"]` document field holds
- * raw label metadata (Caveat.source and other principal identities), which
- * must not ride the raw meta seam (inv-12 Stage 0 / SC-14 / SC-25). The cfc
- * code reads the field directly through its own verifier seams; display
- * consumers get the redacted view via getCfcLabel.
- */
-export type MetaField =
-  | MetaLinkField
-  | "patternIdentity" // content-addressed {identity, symbol} pattern reference
-  | "patternSetupIdentity" // setup-completion {identity, symbol} marker
-  | "patternSource" // active web or `cf:` source origin
-  | "pieceSourceHistory" // append-only source revisions and retention roots
-  | "pieceReconciliation" // what following the active origin last did:
-  // {outcome, at, origin, offered?, reason?, detail?} — a piece that refused
-  // or could not reach its origin looks otherwise exactly like one that is
-  // running what its origin offers
-  | "patternRepository" // optional caller-supplied repository locator
-  | "displacedPattern" // {identity, symbol, displacedAt}: the prior pattern
-  // reference recorded when system-pattern auto-update replaces an unloadable
-  // sourceless root — the recovery pointer for a displaced custom program
-  | "internal"
-  | "schema"
-  | "slug";
-
-export interface IMetaCell {
-  getMetaRaw(metaField: MetaField, options?: unknown): FabricValue;
-  setMetaRaw(metaField: MetaField, value: FabricValue): void;
-}
-
 /**
  * Writable cells can update their value.
  *
@@ -1142,7 +1098,6 @@ export interface ICell<T>
     IEquatable,
     IKeyable<T, AsCell>,
     IDerivable<T>,
-    IMetaCell,
     IResolvable<T, Cell<T>> {}
 
 export interface Cell<T = unknown> extends BrandedCell<T, "cell">, ICell<T> {}

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -10,6 +10,7 @@ import { slugIdForSpace } from "../../runner/src/slugs.ts";
 import { collectLocalProgram } from "../lib/dev.ts";
 import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
 import { cf, stripAnsi } from "./utils.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 const signer = await Identity.fromPassphrase("cli fabric deps test");
 const space = signer.did();
@@ -45,7 +46,7 @@ describe("cli fabric deps", () => {
       pieceWithTx.setMetaRaw("patternIdentity", {
         identity: ENTRY,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     const slugCell = runtime.getCellFromEntityId(
       space,

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -65,6 +65,7 @@ import {
 } from "../lib/piece.ts";
 import { safeStringify } from "../lib/render.ts";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -2924,12 +2925,13 @@ describe("cli piece parsing", () => {
       unregisteredPieceValue.setMetaRaw("patternIdentity", {
         identity: "P".repeat(43),
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
       unregisteredKeylessValue.set({ text: "unregistered keyless match" });
       unregisteredKeylessArgument.set({});
       unregisteredKeylessValue.setMetaRaw(
         "argument",
         unregisteredKeylessArgument.getAsWriteRedirectLink(),
+        rawMetaWriteAuthorization,
       );
       ownerResult.set({});
       ownerInput.set({

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -88,6 +88,7 @@ import {
 import { PieceController } from "./piece-controller.ts";
 import { reconcilePieceSource } from "./piece-origin.ts";
 import { compileProgram } from "./utils.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 export {
   DEFAULT_APP_PATTERN_SOURCE,
   deriveSystemPatternSource,
@@ -2305,9 +2306,13 @@ export class PiecesController<T = unknown> {
           identity: pinnedRef.identity,
           symbol: pinnedRef.symbol,
           displacedAt: sourceTransition.timestamp,
-        });
+        }, rawMetaWriteAuthorization);
       }
-      rootTx.setMetaRaw("patternIdentity", officialRef);
+      rootTx.setMetaRaw(
+        "patternIdentity",
+        officialRef,
+        rawMetaWriteAuthorization,
+      );
       return true;
     });
     if (swapResult.error) {

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -13,6 +13,7 @@ import {
 } from "@commonfabric/runner";
 import { pieceId } from "./piece-id.ts";
 import type { PiecesController } from "./ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 export { SlugResolutionError };
 
@@ -97,9 +98,13 @@ export async function setSlugLink(
       metadataTargetWithTx !== undefined &&
       metadataTargetLink?.path.length === 0
     ) {
-      metadataTargetWithTx.setMetaRaw("slug", validSlug);
+      metadataTargetWithTx.setMetaRaw(
+        "slug",
+        validSlug,
+        rawMetaWriteAuthorization,
+      );
     }
-    slugWithTx.setMetaRaw("slug", validSlug);
+    slugWithTx.setMetaRaw("slug", validSlug, rawMetaWriteAuthorization);
     slugWithTx.setRawUntyped(
       targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
     );

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -25,6 +25,7 @@ import {
   readPieceSourceState,
   reconcilePieceSource,
 } from "../src/ops/piece-origin.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 // The routes those refs resolve to. A system pattern is still SERVED at, and
 // its modules still NAMED by, the route path; the `system:` ref is what a
@@ -375,7 +376,11 @@ describe("opening a space root", () => {
     const piece = await controller.ensureDefaultPattern();
     const identityFetchesBefore = stub.identityFetches();
     const { error } = await runtime.editWithRetry((tx) => {
-      piece.getCell().withTx(tx).setMetaRaw("patternIdentity", "missing");
+      piece.getCell().withTx(tx).setMetaRaw(
+        "patternIdentity",
+        "missing",
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
     const root = (await controller.getDefaultPattern(false))!;
@@ -476,7 +481,11 @@ describe("opening a space root", () => {
     expect(currentPattern.resultSchema).toEqual(root.getMetaRaw("schema"));
 
     const metadataUpdate = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", currentRef);
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        currentRef,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(metadataUpdate.error).toBeUndefined();
     const metadataOnlyRoot = (await controller.getDefaultPattern(false))!;
@@ -531,7 +540,11 @@ describe("opening a space root", () => {
       currentPattern,
     )!;
     const metadataUpdate = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", currentRef);
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        currentRef,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(metadataUpdate.error).toBeUndefined();
     const metadataOnlyRoot = (await controller.getDefaultPattern(false))!;
@@ -733,13 +746,17 @@ describe("opening a space root", () => {
     );
     await controller.stopPiece(root);
     const { error } = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", {
-        identity: staleIdentity,
-        // The obsolete runtime selected an export the current system source no
-        // longer has. Dead-root recovery must select the official entry's
-        // default export, rather than trying to preserve this broken symbol.
-        symbol: "removed-export",
-      });
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        {
+          identity: staleIdentity,
+          // The obsolete runtime selected an export the current system source no
+          // longer has. Dead-root recovery must select the official entry's
+          // default export, rather than trying to preserve this broken symbol.
+          symbol: "removed-export",
+        },
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
     const staleRoot = (await controller.getDefaultPattern(false))!;
@@ -776,8 +793,12 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: orphan,
         symbol: "default",
-      });
-      root.withTx(tx).setMetaRaw("patternSource", undefined);
+      }, rawMetaWriteAuthorization);
+      root.withTx(tx).setMetaRaw(
+        "patternSource",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
 
@@ -845,7 +866,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: staleIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
 
@@ -884,7 +905,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: staleIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
     stub.setSource(SOURCE_V2);
@@ -973,7 +994,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: staleIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
     stub.setSource(SOURCE_V2);
@@ -1298,7 +1319,11 @@ describe("opening a space root", () => {
     const identityFetchesBefore = stub.identityFetches();
     const externalSource = "https://patterns.example/root.tsx";
     const { error } = await runtime.editWithRetry((tx) => {
-      piece.getCell().withTx(tx).setMetaRaw("patternSource", externalSource);
+      piece.getCell().withTx(tx).setMetaRaw(
+        "patternSource",
+        externalSource,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
     const root = (await controller.getDefaultPattern(false))!;
@@ -1724,7 +1749,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: targetId,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
 
@@ -1778,7 +1803,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: oldRef.identity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(pinError).toBeUndefined();
     // The pinned OLD pattern really is loadable — "loadable but unrunnable" is
@@ -1912,7 +1937,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: oldRef.identity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(pinError).toBeUndefined();
 
@@ -2114,7 +2139,7 @@ describe("opening a space root", () => {
             root.withTx(tx).setMetaRaw("patternIdentity", {
               identity: concurrentId,
               symbol: "default",
-            });
+            }, rawMetaWriteAuthorization);
           });
           throw new Error(MIGRATION_REJECTION);
         })();
@@ -2228,7 +2253,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: officialRef.identity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     const restore = patchRunSynced((opts) =>
       opts?.expectedPatternIdentity?.identity === officialRef.identity
@@ -2297,7 +2322,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: legacyRef.identity,
         symbol: "legacyHome",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(pinError).toBeUndefined();
 
@@ -2454,7 +2479,11 @@ describe("opening a space root", () => {
       currentPattern,
     )!;
     const metadataUpdate = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", currentRef);
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        currentRef,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(metadataUpdate.error).toBeUndefined();
 
@@ -2517,7 +2546,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: targetId,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
 
@@ -2568,7 +2597,11 @@ describe("opening a space root", () => {
     const root = (await controller.getDefaultPattern(false))!;
     await controller.stopPiece(root);
     const { error } = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", { malformed: true });
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        { malformed: true },
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
 

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -19,6 +19,7 @@ import {
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
 import { reconcilePieceSource } from "../src/ops/piece-origin.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 // The route that ref expands to — what the toolshed serves, and what the
 // worker names the module by when it compiles the pattern over HTTP.
@@ -367,7 +368,11 @@ describe("default-app golden replay (state survives an in-place roll-forward)", 
       currentPattern,
     )!;
     const { error } = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", currentRef);
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        currentRef,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(error).toBeUndefined();
     const metadataOnlyRoot = (await controller.getDefaultPattern(false))!;
@@ -461,7 +466,11 @@ describe("default-app golden replay (state survives an in-place roll-forward)", 
     // Reproduce the updater that advanced only patternIdentity. The persisted
     // root still carries V1's stored schema and projection.
     const metadataUpdate = await runtime.editWithRetry((tx) => {
-      root.withTx(tx).setMetaRaw("patternIdentity", currentRef);
+      root.withTx(tx).setMetaRaw(
+        "patternIdentity",
+        currentRef,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(metadataUpdate.error).toBeUndefined();
     const metadataOnlyRoot = (await controller.getDefaultPattern(false))!;

--- a/packages/piece/test/fixtures/piece-source-transition-compiler-preload.ts
+++ b/packages/piece/test/fixtures/piece-source-transition-compiler-preload.ts
@@ -9,6 +9,7 @@ import {
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { sourceDocKey } from "../../../runner/src/compilation-cache/cell-cache.ts";
 import { PiecesController } from "../../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 const SOURCE = "export default 1;\n";
 const SOURCE_IDENTITY = "Qxkzi6OeLOLPP3A3-e-8kLe0DyNgoDZMZVIKr4PLz3w";
@@ -53,10 +54,15 @@ try {
   const seedTx = runtime.edit();
   const seededPiece = piece.withTx(seedTx);
   seededPiece.set({});
-  seededPiece.setMetaRaw("patternIdentity", currentPattern);
+  seededPiece.setMetaRaw(
+    "patternIdentity",
+    currentPattern,
+    rawMetaWriteAuthorization,
+  );
   seededPiece.setMetaRaw(
     "patternSource",
     "https://example.test/missing-pattern.tsx",
+    rawMetaWriteAuthorization,
   );
   runtime.getCell(
     pieces.getSpace(),
@@ -98,7 +104,11 @@ try {
       expected,
     },
   );
-  piece.withTx(transitionTx).setMetaRaw("patternIdentity", nextPattern);
+  piece.withTx(transitionTx).setMetaRaw(
+    "patternIdentity",
+    nextPattern,
+    rawMetaWriteAuthorization,
+  );
   runtime.prepareTxForCommit(transitionTx);
   const transitionCommit = await transitionTx.commit();
   if (transitionCommit.error !== undefined) throw transitionCommit.error;

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_APP_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 // The route that ref resolves to.
 const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
@@ -922,7 +923,7 @@ describe("reading a piece's source state", () => {
     value: unknown,
   ): Promise<void> {
     const tx = runtime.edit();
-    cell.withTx(tx).setMetaRaw(key, value as never);
+    cell.withTx(tx).setMetaRaw(key, value as never, rawMetaWriteAuthorization);
     runtime.prepareTxForCommit(tx);
     const result = await tx.commit();
     expect(result.error).toBeUndefined();
@@ -1009,7 +1010,7 @@ describe("reading a piece's source state", () => {
     cell.withTx(tx).setMetaRaw("pieceSourceHistory", [{
       ...revision,
       origin: "not an origin",
-    }] as never);
+    }] as never, rawMetaWriteAuthorization);
     await tx.commit();
 
     const state = await readPieceSourceState(runtime, cell);
@@ -1817,6 +1818,7 @@ describe("reading a piece's source state", () => {
       source.getCell().withTx(tx).setMetaRaw(
         "patternSource",
         "https://example.test/changed.tsx",
+        rawMetaWriteAuthorization,
       );
       runtime.prepareTxForCommit(tx);
       const result = await tx.commit();

--- a/packages/piece/test/piece-source-lifecycle.test.ts
+++ b/packages/piece/test/piece-source-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
   reconcilePieceSource,
 } from "../src/ops/piece-origin.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 const signer = await Identity.fromPassphrase("piece source lifecycle");
 
@@ -658,7 +659,11 @@ describe("piece source lifecycle", () => {
       if (!cleared) {
         cleared = true;
         const tx = runtime.edit();
-        cell.withTx(tx).setMetaRaw("patternIdentity", undefined);
+        cell.withTx(tx).setMetaRaw(
+          "patternIdentity",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
         await tx.commit();
       }
       return pattern;
@@ -689,7 +694,11 @@ describe("piece source lifecycle", () => {
       if (!cleared) {
         cleared = true;
         const tx = runtime.edit();
-        cell.withTx(tx).setMetaRaw("patternIdentity", undefined);
+        cell.withTx(tx).setMetaRaw(
+          "patternIdentity",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
         await tx.commit();
       }
       return pattern;
@@ -756,7 +765,11 @@ describe("piece source lifecycle", () => {
     const editWithRetry = runtime.editWithRetry;
     runtime.editWithRetry = (async () => {
       const tx = runtime.edit();
-      cell.withTx(tx).setMetaRaw("pieceSourceHistory", "invalid");
+      cell.withTx(tx).setMetaRaw(
+        "pieceSourceHistory",
+        "invalid",
+        rawMetaWriteAuthorization,
+      );
       await tx.commit();
       return {
         ok: false,
@@ -865,7 +878,11 @@ describe("piece source lifecycle", () => {
     expect(second.entityId).toEqual(first.entityId);
 
     const tx = runtime.edit();
-    first.withTx(tx).setMetaRaw("patternIdentity", undefined);
+    first.withTx(tx).setMetaRaw(
+      "patternIdentity",
+      undefined,
+      rawMetaWriteAuthorization,
+    );
     await tx.commit();
     await expect(
       pieces.setupPersistent(pattern, {}, cause),
@@ -1557,7 +1574,11 @@ describe("piece source lifecycle", () => {
     const runWithPattern = pieces.runWithPattern.bind(pieces);
     mutablePieces.runWithPattern = async (...args) => {
       const tx = runtime.edit();
-      piece.getCell().withTx(tx).setMetaRaw("argument", undefined);
+      piece.getCell().withTx(tx).setMetaRaw(
+        "argument",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
       await tx.commit();
       return await runWithPattern(...args);
     };

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -54,6 +54,7 @@ import {
 } from "../src/ops/piece-controller.ts";
 import { readPieceSourceState } from "../src/ops/piece-origin.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 const signer = await Identity.fromPassphrase("piece pull materialization");
 
@@ -1345,7 +1346,11 @@ describe("piece pull materialization", () => {
       { start: true },
     );
     await runtime.editWithRetry((tx) => {
-      producer.withTx(tx).setMetaRaw("schema", argumentSchema);
+      producer.withTx(tx).setMetaRaw(
+        "schema",
+        argumentSchema,
+        rawMetaWriteAuthorization,
+      );
     });
 
     const base = runtime.getCell(
@@ -1460,7 +1465,11 @@ describe("piece pull materialization", () => {
         { start: true },
       );
       await runtime.editWithRetry((tx) => {
-        source.withTx(tx).setMetaRaw("schema", schema);
+        source.withTx(tx).setMetaRaw(
+          "schema",
+          schema,
+          rawMetaWriteAuthorization,
+        );
       });
       return source;
     };
@@ -1566,7 +1575,11 @@ describe("piece pull materialization", () => {
       { start: true },
     );
     await runtime.editWithRetry((tx) => {
-      source.withTx(tx).setMetaRaw("schema", scalarAncestorSchema);
+      source.withTx(tx).setMetaRaw(
+        "schema",
+        scalarAncestorSchema,
+        rawMetaWriteAuthorization,
+      );
     });
     const base = runtime.getCell(
       pieces.getSpace(),
@@ -1617,13 +1630,14 @@ describe("piece pull materialization", () => {
           }),
         },
         ...(originalInternal as FabricValue[]),
-      ]);
+      ], rawMetaWriteAuthorization);
       orphan.withTx(tx).setMetaRaw(
         "result",
         piece.withTx(tx).getAsWriteRedirectLink({
           base: orphan.withTx(tx),
           includeSchema: true,
         }),
+        rawMetaWriteAuthorization,
       );
     });
 
@@ -1823,7 +1837,7 @@ describe("piece pull materialization", () => {
       unknownPiece.withTx(tx).setMetaRaw("patternIdentity", {
         identity: "Z".repeat(43),
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
 
     await expect(runtime.setup(undefined, undefined, {}, unknownPiece))
@@ -5972,7 +5986,7 @@ describe("piece pull materialization", () => {
       piece.withTx(tx).setMetaRaw("patternIdentity", {
         identity: "keyless:fid1:legacy-orphan-from-a-pre-guard-session",
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
 

--- a/packages/piece/test/setsrc-cold-argument.test.ts
+++ b/packages/piece/test/setsrc-cold-argument.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 // CT-1917 at the `cf piece setsrc` boundary: a slot the piece cannot READ right
 // now is not a slot holding the wrong value.
@@ -121,6 +122,7 @@ describe("setsrc over a cold argument document", () => {
       piece.getCell().withTx(tx).setMetaRaw(
         "argument",
         cold.getAsWriteRedirectLink({ base: piece.getCell() }),
+        rawMetaWriteAuthorization,
       );
     });
     expect(

--- a/packages/piece/test/setsrc-unloadable-pattern.test.ts
+++ b/packages/piece/test/setsrc-unloadable-pattern.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 // The manual-rescue case for a stranded piece. A piece whose stored
 // `patternIdentity` resolves to nothing — the live population is the board
@@ -106,9 +107,13 @@ describe("setsrc over an unloadable current pattern", () => {
       cell.setMetaRaw("patternIdentity", {
         identity: RETIRED_BUNDLE_IDENTITY,
         symbol: "default",
-      });
-      cell.setMetaRaw("pieceSourceHistory", undefined);
-      cell.setMetaRaw("patternSource", undefined);
+      }, rawMetaWriteAuthorization);
+      cell.setMetaRaw(
+        "pieceSourceHistory",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
+      cell.setMetaRaw("patternSource", undefined, rawMetaWriteAuthorization);
     });
     expect(
       error?.message,
@@ -158,7 +163,7 @@ describe("setsrc over an unloadable current pattern", () => {
       piece.getCell().withTx(tx).setMetaRaw("patternIdentity", {
         identity: RETIRED_BUNDLE_IDENTITY,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error?.message).toBeUndefined();
     await runtime.idle();

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -87,6 +87,7 @@ import {
   companionSpace,
   vintageCompanionDir,
 } from "./vintage-layout.ts";
+import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
 
 class LoopbackSessions implements SessionFactory {
   readonly #server: () => MemoryV2Server.Server;
@@ -1563,7 +1564,7 @@ export async function materializeOnCell(
     root.withTx(tx).setMetaRaw("patternIdentity", {
       identity: ref.identity,
       symbol: ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
   });
   if (stampError !== undefined) {
     throw new Error(

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -29,6 +29,7 @@
     "./entity-kind": "./src/entity-kind.ts",
     "./experimental-posture": "./src/experimental-posture.ts",
     "./fabric-url": "./src/fabric-url.ts",
+    "./meta-seam": "./src/meta-seam.ts",
     "./slugs": "./src/slugs.ts",
     "./schemas": "./src/schemas.ts",
     "./telemetry-otel-bridge": "./src/telemetry-otel-bridge.ts",

--- a/packages/runner/src/builtins/scope-policy.ts
+++ b/packages/runner/src/builtins/scope-policy.ts
@@ -15,6 +15,7 @@ import {
   getMetaLink,
   parseLink,
 } from "../link-utils.ts";
+import { rawMetaWriteAuthorization } from "../meta-seam.ts";
 
 export function resolvedCellScope(
   runtime: Runtime,
@@ -137,6 +138,7 @@ export function exposedResultCell<T>(
         base: exposed,
         includeSchema: true,
       }),
+      rawMetaWriteAuthorization,
     );
   }
   const value = initialCell.get();

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -48,6 +48,7 @@ import {
 } from "../storage/rejection.ts";
 import { onSchemaRegistryClear } from "../schema-registry.ts";
 import { scopedCell } from "./scope-policy.ts";
+import { rawMetaWriteAuthorization } from "../meta-seam.ts";
 
 const wishFlowLogger = getLogger("runner.wish-flow", {
   enabled: true,
@@ -2209,6 +2210,7 @@ export function wish(
             base: scoped,
             includeSchema: true,
           }),
+          rawMetaWriteAuthorization,
         );
       }
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,5 +1,4 @@
 import type { ReadonlyCell } from "@commonfabric/api";
-import { MetaField } from "@commonfabric/api";
 import {
   type EntityRef,
   entityRefFromString,
@@ -134,6 +133,7 @@ import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "./query-result-proxy.ts";
+import { type MetaField, type RawMetaWriteAuthorization } from "./meta-seam.ts";
 import type { Runtime } from "./runtime.ts";
 import {
   type Action,
@@ -485,6 +485,15 @@ declare module "@commonfabric/api" {
       ) => Cancel | undefined | void,
       options?: SinkOptions,
     ): Cancel;
+    getMetaRaw(
+      metaField: MetaField,
+      options?: IReadOptions,
+    ): FabricValue | undefined;
+    setMetaRaw(
+      metaField: MetaField,
+      value: FabricValue,
+      authorization: RawMetaWriteAuthorization,
+    ): void;
     sinkMeta(
       metaField: MetaField,
       callback: (value: FabricValue) => Cancel | undefined | void,
@@ -3225,7 +3234,23 @@ export class CellImpl<T extends FabricValue>
     return this.runtime.readTx(this.tx).readOrThrow(metaAddr, options);
   }
 
-  setMetaRaw(metaField: MetaField, value: FabricValue): void {
+  /**
+   * Writes a meta field on this cell's document.
+   *
+   * A meta field names the program a piece runs, the cells it is wired to,
+   * the shape its result is validated against, and its name in the space, so
+   * a write here redirects a piece rather than editing its data. The seam is
+   * the runtime's: `authorization` travels with the write as its options, and
+   * the storage-write chokepoint refuses a meta write that arrives without
+   * one. {@link rawMetaWriteAuthorization} is the value, and the sandbox
+   * hands pattern code the builder namespace rather than the runner's
+   * modules, so pattern code cannot name it.
+   */
+  setMetaRaw(
+    metaField: MetaField,
+    value: FabricValue,
+    authorization: RawMetaWriteAuthorization,
+  ): void {
     if (!this.tx) throw new Error("Transaction required for setMetaRaw");
     // No await for the sync, just kicking this off, so we have the data to
     // retry on conflict.
@@ -3236,7 +3261,7 @@ export class CellImpl<T extends FabricValue>
       path: [metaField],
       ...(this.#link.scope !== undefined && { scope: this.#link.scope }),
     };
-    this.tx.writeOrThrow(metaAddr, value);
+    this.tx.writeOrThrow(metaAddr, value, authorization);
   }
 
   /**

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -55,6 +55,17 @@ export type {
 export * from "./interface.ts";
 export { raw } from "./module.ts";
 export type { Cell, Stream } from "./cell.ts";
+// The seam's vocabulary, which describes a document's shape and is read by
+// hosts. Its write authorization is deliberately not here: it rides the
+// `@commonfabric/runner/meta-seam` subpath, so an import of it names the seam
+// it opens.
+export {
+  isMetaField,
+  META_FIELDS,
+  META_LINK_FIELDS,
+  type MetaField,
+  type MetaLinkField,
+} from "./meta-seam.ts";
 export type { NormalizedFullLink, NormalizedLink } from "./link-types.ts";
 export { encodeJsonPointer } from "./link-types.ts";
 export type { SigilLink, URI } from "./sigil-types.ts";

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,4 +1,3 @@
-import { MetaLinkField } from "@commonfabric/api";
 import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
@@ -20,6 +19,8 @@ import {
   onSchemaRegistryClear,
   registerSchemaDocument,
 } from "./schema-registry.ts";
+import type { MetaLinkField } from "./meta-seam.ts";
+import type { IReadOptions } from "./storage/interface.ts";
 import { getContentAddressedSchemasConfig } from "./schema-doc-config.ts";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 
@@ -840,7 +841,7 @@ const META_READ_OPTIONS = {
 export function getMetaLink(
   resultCell: Cell<unknown>,
   field: MetaLinkField,
-  options: unknown = META_READ_OPTIONS,
+  options: IReadOptions = META_READ_OPTIONS,
 ): NormalizedFullLink | undefined {
   const linkObj = resultCell.getMetaRaw(field, options);
   if (linkObj === undefined) return undefined;

--- a/packages/runner/src/meta-seam.ts
+++ b/packages/runner/src/meta-seam.ts
@@ -1,0 +1,153 @@
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+export const META_LINK_FIELDS = Object.freeze(
+  [
+    "pattern",
+    "argument",
+    "result",
+  ] as const,
+);
+
+export type MetaLinkField = typeof META_LINK_FIELDS[number];
+
+/**
+ * The meta fields: the document-root siblings of `value` that the raw meta
+ * seam addresses. This list is the authority — {@link MetaField} is derived
+ * from it, and {@link isMetaField} tests membership at runtime.
+ *
+ * The seam is the runtime's, to read as well as to write, so none of this
+ * reaches the cell surface a pattern compiles against. `pattern` links a
+ * result cell to its pattern, and `argument` to its argument cell. `internal`
+ * holds a manifest of links to derived internal cells. `schema` stores the
+ * schema for a result cell. `patternSetupIdentity` records the pattern
+ * identity whose complete setup state was installed on a result cell.
+ * `result` lets a result cell link to its parent result cell, and lets the
+ * argument and derived internal cells link back to the result cell.
+ *
+ * `cfc` is deliberately NOT a meta field: the `["cfc"]` document field holds
+ * raw label metadata (Caveat.source and other principal identities), which
+ * must not ride the raw meta seam. The cfc code reads the field directly
+ * through its own verifier seams; display consumers get the redacted view via
+ * getCfcLabel.
+ */
+export const META_FIELDS = Object.freeze(
+  [
+    ...META_LINK_FIELDS,
+    "patternIdentity", // content-addressed {identity, symbol} pattern reference
+    "patternSetupIdentity", // setup-completion {identity, symbol} marker
+    "patternSource", // active web or `cf:` source origin
+    "pieceSourceHistory", // append-only source revisions and retention roots
+    "pieceReconciliation", // what following the active origin last did:
+    // {outcome, at, origin, offered?, reason?, detail?} — a piece that refused
+    // or could not reach its origin looks otherwise exactly like one that is
+    // running what its origin offers
+    "patternRepository", // optional caller-supplied repository locator
+    "displacedPattern", // {identity, symbol, displacedAt}: the prior pattern
+    // reference recorded when system-pattern auto-update replaces an unloadable
+    // sourceless root — the recovery pointer for a displaced custom program
+    "internal",
+    "schema",
+    "slug",
+  ] as const,
+);
+
+export type MetaField = typeof META_FIELDS[number];
+
+const META_FIELD_SET: ReadonlySet<string> = new Set(META_FIELDS);
+
+/** Whether the given field name addresses the raw meta seam. */
+export function isMetaField(field: string): field is MetaField {
+  return META_FIELD_SET.has(field);
+}
+
+/**
+ * Marks a write as one the runtime makes on the meta seam.
+ *
+ * The write chokepoint refuses a meta write whose options do not carry this
+ * mark. `setMetaRaw` in `cell.ts` is the one holder of
+ * {@link rawMetaWriteAuthorization}, the options value that carries it: a
+ * symbol cannot be named by a module that did not import it, and the sandbox
+ * hands pattern code the builder namespace rather than the runner's modules.
+ */
+export const RAW_META_WRITE: unique symbol = Symbol("raw-meta-write");
+
+/** Write options that authorize the meta fields the write lands. */
+export interface RawMetaWriteAuthorization {
+  readonly [RAW_META_WRITE]: true;
+}
+
+/**
+ * The authorization `setMetaRaw` passes with the write it makes.
+ *
+ * The authorization travels as the write's own options rather than as a scope
+ * open around the call, so it reaches the one write that carries it and no
+ * other — including no write another transaction makes in the meantime.
+ */
+export const rawMetaWriteAuthorization: RawMetaWriteAuthorization = Object
+  .freeze({ [RAW_META_WRITE]: true } as RawMetaWriteAuthorization);
+
+/** Whether write options carry {@link rawMetaWriteAuthorization}. */
+export function rawMetaWriteAuthorized(options: unknown): boolean {
+  return isObjectNotArray(options) &&
+    (options as Partial<RawMetaWriteAuthorization>)[RAW_META_WRITE] === true;
+}
+
+/**
+ * The meta fields a write at `path` carrying `value` lands on a document.
+ *
+ * A meta field is a document-root sibling of `value`, so a write reaches one
+ * two ways: addressed at the field (or at a path inside it), or addressed at
+ * the document root with the field as a key of the written envelope. A write
+ * under `value` reaches none, whatever a user key is named: a user field
+ * named `slug` is addressed at `["value", "slug"]`.
+ */
+export function metaFieldsWritten(
+  path: readonly string[],
+  value: unknown,
+): readonly MetaField[] {
+  if (path.length === 0) return metaFieldsIn(value);
+  return isMetaField(path[0]) ? [path[0]] : NO_META_FIELDS;
+}
+
+/**
+ * The meta fields a stored document carries, asked one member at a time.
+ *
+ * A write at the document root replaces the envelope, so the fields it does
+ * not carry are the fields it drops, and telling which those are means
+ * reading what the document holds. `readField` reads one member surface,
+ * which is the question the guard asked; a read of the document root asks
+ * after the whole document, and a guard has no business widening what the
+ * transaction around it counts as consumed.
+ *
+ * A field is carried when its value is defined. The storage layer can hold a
+ * field that is present and `undefined` — that is what `IWriteOptions.delete`
+ * distinguishes — and this treats such a field as absent, because the seam's
+ * read half does too: `getMetaRaw` returns `undefined` for both, and no
+ * reader addresses a meta path any other way. A root write that drops such a
+ * field redirects no piece, which is what the guard is here to stop.
+ */
+export function storedMetaFields(
+  readField: (field: MetaField) => unknown,
+): readonly MetaField[] {
+  let carried: MetaField[] | undefined;
+  for (const field of META_FIELDS) {
+    if (readField(field) === undefined) continue;
+    (carried ??= []).push(field);
+  }
+  return carried ?? NO_META_FIELDS;
+}
+
+function metaFieldsIn(document: unknown): readonly MetaField[] {
+  return isObjectNotArray(document)
+    ? Object.keys(document).filter(isMetaField)
+    : NO_META_FIELDS;
+}
+
+/**
+ * No meta fields.
+ *
+ * Every write in the runtime asks the two questions above, and almost every
+ * write is addressed under `value`. The shared answer keeps that path
+ * allocation free.
+ */
+export const NO_META_FIELDS: readonly MetaField[] = Object.freeze([]);

--- a/packages/runner/src/result-utils.ts
+++ b/packages/runner/src/result-utils.ts
@@ -1,6 +1,7 @@
 import type { FabricValue } from "@commonfabric/api";
 
 import type { Cell } from "./cell.ts";
+import { rawMetaWriteAuthorization } from "./meta-seam.ts";
 
 /**
  * @param resultCell The cell whose meta pattern will be set
@@ -19,7 +20,11 @@ export function setPatternCell(
     // A `Cell`'s type parameter is always `FabricValue`-compatible, so
     // `getRaw()` yields a `FabricValue`. `Cell<unknown>` just cannot say so;
     // constraining `Cell<T extends FabricValue>` is what would remove this.
-    resultCell.setMetaRaw("pattern", parentPattern as FabricValue);
+    resultCell.setMetaRaw(
+      "pattern",
+      parentPattern as FabricValue,
+      rawMetaWriteAuthorization,
+    );
   }
 }
 
@@ -27,5 +32,6 @@ export function setResultCell(cell: Cell<unknown>, resultCell: Cell<unknown>) {
   cell.setMetaRaw(
     "result",
     resultCell.getAsWriteRedirectLink({ includeSchema: true }),
+    rawMetaWriteAuthorization,
   );
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -174,6 +174,7 @@ import { normalizeSandboxResult } from "./sandbox/result-normalization.ts";
 import { isCellScope, narrowestScope } from "./scope.ts";
 import { SigilLink } from "./sigil-types.ts";
 import { toURI } from "./uri-utils.ts";
+import { rawMetaWriteAuthorization } from "./meta-seam.ts";
 export {
   extractDefaultValues,
   mergeObjects,
@@ -2069,7 +2070,7 @@ export class Runner {
       meta: ignoreReadForScheduling,
     });
     if (!deepEqual(previous, resultSchema)) {
-      cell.setMetaRaw("schema", resultSchema);
+      cell.setMetaRaw("schema", resultSchema, rawMetaWriteAuthorization);
     }
   }
 
@@ -2311,7 +2312,11 @@ export class Runner {
       resultCell,
       previousInternal,
     );
-    resultCell.withTx(tx).setMetaRaw("internal", internalManifest);
+    resultCell.withTx(tx).setMetaRaw(
+      "internal",
+      internalManifest,
+      rawMetaWriteAuthorization,
+    );
 
     let nextArgument: T | undefined = argument;
     let argumentUpdated = false;
@@ -2338,7 +2343,11 @@ export class Runner {
         includeSchema: true,
         keepAsCell: KeepAsCell.All,
       });
-      resultCell.withTx(tx).setMetaRaw("argument", newArgumentSigilLink);
+      resultCell.withTx(tx).setMetaRaw(
+        "argument",
+        newArgumentSigilLink,
+        rawMetaWriteAuthorization,
+      );
 
       argumentLink = newArgumentCell.getAsNormalizedFullLink();
       if (argumentLink === undefined) {
@@ -2362,7 +2371,11 @@ export class Runner {
         includeSchema: true,
         keepAsCell: KeepAsCell.All,
       });
-      resultCell.withTx(tx).setMetaRaw("argument", nextArgumentSigilLink);
+      resultCell.withTx(tx).setMetaRaw(
+        "argument",
+        nextArgumentSigilLink,
+        rawMetaWriteAuthorization,
+      );
       argumentLink = nextArgumentCell.getAsNormalizedFullLink();
 
       if (argument === undefined && previousArgument === undefined) {
@@ -2443,7 +2456,7 @@ export class Runner {
       resultCell.withTx(tx).setMetaRaw("patternIdentity", {
         identity: durableEntryRef.identity,
         symbol: durableEntryRef.symbol,
-      });
+      }, rawMetaWriteAuthorization);
     }
     // The instantiation observer is a session-side reporting channel, not a
     // durable write, so it deliberately does NOT share the durable stamp's
@@ -2481,7 +2494,7 @@ export class Runner {
       resultCell.withTx(tx).setMetaRaw("patternSetupIdentity", {
         identity: durableEntryRef.identity,
         symbol: durableEntryRef.symbol,
-      });
+      }, rawMetaWriteAuthorization);
       // The durable stamps staged above supersede a keyless session pointer
       // — WHEN they commit. They are transaction state, so the pointer
       // removal rides the same commit: dropping it at staging would leave a
@@ -2512,12 +2525,20 @@ export class Runner {
       // (no-pattern-meta), and clearing writes no keyless identity.
       const staleRef = getPatternIdentityRef(resultCell.withTx(tx));
       if (staleRef !== undefined) {
-        resultCell.withTx(tx).setMetaRaw("patternIdentity", undefined);
+        resultCell.withTx(tx).setMetaRaw(
+          "patternIdentity",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
       }
       if (
         getPatternSetupIdentityRef(resultCell.withTx(tx)) !== undefined
       ) {
-        resultCell.withTx(tx).setMetaRaw("patternSetupIdentity", undefined);
+        resultCell.withTx(tx).setMetaRaw(
+          "patternSetupIdentity",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
       }
       // The KEYLESS piece's stand-in for both skipped stamps, session-side:
       // the pattern pointer (start/resume flows) and the setup-completion
@@ -3420,7 +3441,7 @@ export class Runner {
                     resultCell.withTx(tx).setMetaRaw("patternIdentity", {
                       identity: revertRef.identity,
                       symbol: revertRef.symbol,
-                    });
+                    }, rawMetaWriteAuthorization);
                     return true;
                   }).then((result) => {
                     // Only reclaim the observed key while it is STILL the
@@ -6579,7 +6600,9 @@ export class Runner {
         // transaction, which the create-only mark below gates, so the schema
         // and the value it describes commit together or not at all.
         const shape = receiptShapeSchema(receiptValue);
-        if (shape !== undefined) receipt.setMetaRaw("schema", shape);
+        if (shape !== undefined) {
+          receipt.setMetaRaw("schema", shape, rawMetaWriteAuthorization);
+        }
         tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
       }
       return result;
@@ -8704,7 +8727,11 @@ export function setPatternSource(
   tx: IExtendedStorageTransaction,
   url: string,
 ): void {
-  resultCell.withTx(tx).setMetaRaw("patternSource", url);
+  resultCell.withTx(tx).setMetaRaw(
+    "patternSource",
+    url,
+    rawMetaWriteAuthorization,
+  );
 }
 
 /** Read the validated, append-only source revisions carried by a piece. */
@@ -8825,6 +8852,7 @@ export function setPieceReconciliation(
   resultCell.withTx(tx).setMetaRaw(
     "pieceReconciliation",
     reconciliation as unknown as FabricValue,
+    rawMetaWriteAuthorization,
   );
 }
 
@@ -8934,7 +8962,9 @@ function initializePieceSourceHistory(
   ) {
     return;
   }
-  if (origin !== undefined) candidate.setMetaRaw("patternSource", origin);
+  if (origin !== undefined) {
+    candidate.setMetaRaw("patternSource", origin, rawMetaWriteAuthorization);
+  }
   candidate.setMetaRaw("pieceSourceHistory", [{
     revisionId: crypto.randomUUID(),
     timestamp: Date.now(),
@@ -8942,7 +8972,7 @@ function initializePieceSourceHistory(
     source: sourceRetentionLink(runtime, resultCell, tx, pattern),
     ...(origin === undefined ? {} : { origin }),
     operation: "create",
-  }]);
+  }], rawMetaWriteAuthorization);
 }
 
 function samePieceSourceSnapshot(
@@ -9110,7 +9140,7 @@ export function applyPieceSourceTransition(
       identity: current.pattern.identity,
       symbol: current.pattern.symbol,
       displacedAt: transition.timestamp,
-    });
+    }, rawMetaWriteAuthorization);
   }
 
   const history = getPieceSourceRevisions(candidate);
@@ -9161,15 +9191,24 @@ export function applyPieceSourceTransition(
       ? {}
       : { selectedRevisionId: transition.selectedRevisionId }),
   });
-  candidate.setMetaRaw("patternSource", nextOrigin.origin ?? undefined);
+  candidate.setMetaRaw(
+    "patternSource",
+    nextOrigin.origin ?? undefined,
+    rawMetaWriteAuthorization,
+  );
   candidate.setMetaRaw(
     "pieceSourceHistory",
     history as unknown as FabricValue,
+    rawMetaWriteAuthorization,
   );
   // An accepted transition supersedes whatever the last reconciliation
   // concluded: the piece has moved, and the recorded outcome describes a state
   // it has left.
-  candidate.setMetaRaw("pieceReconciliation", undefined);
+  candidate.setMetaRaw(
+    "pieceReconciliation",
+    undefined,
+    rawMetaWriteAuthorization,
+  );
 }
 
 /** Read an explicitly supplied repository locator for a piece's source. */
@@ -9188,7 +9227,11 @@ export function setPatternRepository(
   tx: IExtendedStorageTransaction,
   repository: string,
 ): void {
-  resultCell.withTx(tx).setMetaRaw("patternRepository", repository);
+  resultCell.withTx(tx).setMetaRaw(
+    "patternRepository",
+    repository,
+    rawMetaWriteAuthorization,
+  );
 }
 
 /** Narrow a raw meta value to a `{ identity, symbol }` pattern ref, or undefined. */

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -107,12 +107,19 @@ import {
   type NormalizedFullLink,
   toMemorySpaceAddress,
 } from "../link-types.ts";
+import {
+  metaFieldsWritten,
+  NO_META_FIELDS,
+  rawMetaWriteAuthorized,
+  storedMetaFields,
+} from "../meta-seam.ts";
 import { ignoreReadForScheduling } from "../scheduler.ts";
 import { normalizeCellScope, scopeRank } from "../scope.ts";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
 import { CFC_ENFORCEMENT_REJECTION_PREFIX } from "./rejection.ts";
 import {
   clearSchemaRefusalTx,
+  ignoreReadForCommit,
   isInternalVerifierRead,
   isLazyMaterializationTx,
   isUiInputBlindWriteTx,
@@ -920,12 +927,70 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // disabled window must still be on record when a later escalation evaluates
   // it. A transaction still `disabled` at commit never runs
   // prepareBoundaryCommit, so the record stays inert there.
-  #noteSystemWrite(address: IMemorySpaceAddress): void {
+  #noteSystemWrite(
+    address: IMemorySpaceAddress,
+    value?: FabricValue,
+    options?: IWriteOptions,
+  ): void {
     if (this.#privilegedSystemWriteDepth > 0) return;
     if (address.id.startsWith(CFC_POLICY_MANIFEST_ID_PREFIX)) {
       throw new Error(
         `cfcPolicyManifest: ${address.id} is immutable reserved policy state`,
       );
+    }
+    // The raw meta seam. A meta field is a document-root sibling of `value`:
+    // `patternIdentity` and `pattern` name the program a piece runs,
+    // `argument`, `result` and `internal` name the cells it is wired to,
+    // `schema` names the shape its result is validated against, `slug` names
+    // it in the space, and the source fields record where its program came
+    // from. A write there redirects a piece rather than editing its data, so
+    // the seam is the runtime's: `setMetaRaw` marks the write it makes with
+    // `rawMetaWriteAuthorization`, carried in the write's own options, and a
+    // meta write arriving unmarked is refused here. The refusal is in-process
+    // and holds whatever the CFC enforcement mode, like the space-ACL arm
+    // below and unlike the ["cfc"] arm at the end — this is an authorization
+    // decision about the piece graph rather than a label-derivation signal
+    // whose treatment follows the mode. It is also the first arm that can
+    // refuse: every arm below is keyed by target id, and one that recorded
+    // and returned ahead of this would leave the seam open on the documents
+    // its prefix names.
+    if (!rawMetaWriteAuthorized(options)) {
+      // Three shapes reach a meta field: an address naming the field, a
+      // document-root envelope carrying it as a key, and a document-root
+      // write that leaves it out — the root write replaces the envelope, so
+      // every stored meta field it does not carry is a field it drops. The
+      // first two are settled by the write alone. The third is settled by
+      // reading what the document carries, one meta member at a time,
+      // through the inner transaction and under a read that carries no
+      // weight of its own. Reading through the outer transaction would put
+      // the guard's read in the reactivity log and the flow join. Reading
+      // the document root would name a logical path covering every entry in
+      // the document's label map, widening what the transaction counts as
+      // consumed. And the read takes no commit precondition:
+      // `ignoreReadForCommit` drops it from the conflict set, so the blind
+      // root writes the runtime makes stay blind rather than becoming
+      // read-modify-writes that lose the race against any advance of the
+      // document they replace. What that leaves open is an erasure racing
+      // the guard, never a forgery — the two shapes that name a field are
+      // refused from the write itself, with no read at all.
+      const written = metaFieldsWritten(address.path, value);
+      const dropped = address.path.length === 0
+        ? storedMetaFields((field) =>
+          this.tx.read({ ...address, path: [field] }, {
+            meta: { ...ignoreReadForScheduling, ...ignoreReadForCommit },
+          }).ok?.value
+        ).filter((field) => !written.includes(field))
+        : NO_META_FIELDS;
+      if (written.length > 0 || dropped.length > 0) {
+        const reached = [...written, ...dropped];
+        throw new Error(
+          `${address.id}: refusing an unauthorized write to the meta seam (${
+            reached.join(", ")
+          }). These document-root fields name the program a piece runs and ` +
+            `the cells it is wired to; the runtime writes them through ` +
+            `setMetaRaw.`,
+        );
+      }
     }
     // Reserved grant documents (§8.12.7 route 2a, cfc/grants.ts): the WHOLE
     // document is policy state — a forged grant at the derived address would
@@ -2016,7 +2081,9 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // write. The ["cfc"]-path arm is structurally unreachable here (a
     // NormalizedFullLink always yields a value-rooted storage path), but the
     // reserved `grant:cfc:` documents are keyed by ID, and the mergeable
-    // path must not slip an unprivileged grant mutation past the gate.
+    // path must not slip an unprivileged grant mutation past the gate. The
+    // meta-seam arm is unreachable for the same reason the ["cfc"] arm is,
+    // which is why no value reaches it from here.
     this.#noteSystemWrite(address);
     // Record a mergeable intent only when the underlying transaction can also
     // poison it. Recording an intent that can never be poisoned would let a
@@ -2135,7 +2202,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     options?: IWriteOptions,
   ): Result<IAttestation, WriteError | WriterError> {
     this.#assertWritable("write()");
-    this.#noteSystemWrite(address);
+    this.#noteSystemWrite(address, value, options);
     this.#noteWriteIdentity();
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
@@ -2154,7 +2221,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     options?: IWriteOptions,
   ): void {
     this.#assertWritable("writeOrThrow()");
-    this.#noteSystemWrite(address);
+    this.#noteSystemWrite(address, value, options);
     this.#noteWriteIdentity();
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
@@ -2275,8 +2342,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // throw propagate past the commit, which is what every caller does
       // today). See `writeValuesOrThrow` partial-batch coverage in
       // `packages/runner/test/memory-v2-acl-mutation.test.ts`.
-      const noteSystemWrite = (address: IMemorySpaceAddress) =>
-        this.#noteSystemWrite(address);
+      // The value reaches the chokepoint's meta-seam arm, which reads the
+      // envelope of a document-root write. A batch addresses its writes by
+      // link, and `toMemorySpaceAddress` prefixes "value", so no batch write
+      // is addressed at a document root; the value travels anyway, so the
+      // batch and single-write paths ask the chokepoint the same question.
+      const noteSystemWrite = (
+        address: IMemorySpaceAddress,
+        value: FabricValue,
+      ) => this.#noteSystemWrite(address, value);
       // Capture the identity per yielded write, not once up front: an empty
       // batch authored nothing, so it must not record a write for the
       // transaction's write-identity summary.
@@ -2291,7 +2365,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         (function* () {
           for (const write of writes) {
             const address = toMemorySpaceAddress(write.address);
-            noteSystemWrite(address);
+            noteSystemWrite(address, write.value);
             noteWriteIdentity();
             if (!write.delete && getContentAddressedSchemasConfig()) {
               staged.push({ address, value: write.value });

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -75,6 +75,7 @@ import type {
   WritePolicyInput,
 } from "../cfc/mod.ts";
 import type { NormalizedFullLink } from "../link-types.ts";
+import { RAW_META_WRITE } from "../meta-seam.ts";
 export type { DID, MediaType, MemorySpace, Result, Signer, State, Unit, URI };
 export type ChangeGroup = unknown;
 
@@ -909,6 +910,12 @@ export interface IWriteOptions {
    * from absent. A root-path delete retracts the document.
    */
   delete?: boolean;
+  /**
+   * Marks the write as one the runtime makes on a document's meta seam. See
+   * {@link RAW_META_WRITE}: the write chokepoint accepts a write that reaches
+   * a meta field on this mark and refuses one that arrives without it.
+   */
+  readonly [RAW_META_WRITE]?: true;
 }
 
 export interface ITransactionWriteRequest {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../src/storage/interface.ts";
 import { setResultCell } from "../src/result-utils.ts";
 import { trustPattern } from "./support/trusted-builder.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -533,7 +534,7 @@ describe("Cell", () => {
       tx,
     );
     cell.set({ value: 1 });
-    cell.setMetaRaw("slug", "first");
+    cell.setMetaRaw("slug", "first", rawMetaWriteAuthorization);
     await tx.commit();
     tx = runtime.edit();
 
@@ -547,7 +548,7 @@ describe("Cell", () => {
     expect(seen).toEqual(["first"]);
 
     const metaTx = runtime.edit();
-    cell.withTx(metaTx).setMetaRaw("slug", "second");
+    cell.withTx(metaTx).setMetaRaw("slug", "second", rawMetaWriteAuthorization);
     await metaTx.commit();
     await runtime.idle();
 

--- a/packages/runner/test/cell-meta-sink.test.ts
+++ b/packages/runner/test/cell-meta-sink.test.ts
@@ -6,6 +6,7 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { Cancel } from "../src/cancel.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -44,7 +45,11 @@ describe("Cell meta subscriptions", () => {
     ) as MetaSinkCell;
 
     const initialTx = runtime.edit();
-    resultCell.withTx(initialTx).setMetaRaw("patternIdentity", ref1);
+    resultCell.withTx(initialTx).setMetaRaw(
+      "patternIdentity",
+      ref1,
+      rawMetaWriteAuthorization,
+    );
     await initialTx.commit();
 
     const seenIdentities: Array<string | undefined> = [];
@@ -57,7 +62,11 @@ describe("Cell meta subscriptions", () => {
     expect(seenIdentities).toEqual([ref1.identity]);
 
     const updateTx = runtime.edit();
-    resultCell.withTx(updateTx).setMetaRaw("patternIdentity", ref2);
+    resultCell.withTx(updateTx).setMetaRaw(
+      "patternIdentity",
+      ref2,
+      rawMetaWriteAuthorization,
+    );
     await updateTx.commit();
     await runtime.idle();
 

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -48,6 +48,7 @@ import {
   TEST_MEMORY_SERVER_AUTH,
   testSessionOpenAuthFactory,
 } from "./memory-v2-test-utils.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-boundary-tests");
 
@@ -2906,7 +2907,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         type: "object",
         ifc: { confidentiality: ["card-space"] },
         properties: { title: { type: "string" } },
-      });
+      }, rawMetaWriteAuthorization);
       const linkedTarget = runtime.getCell(
         signer.did(),
         "cfc-link-setup-schema-target",

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -5274,7 +5274,6 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       );
       expect(getMetaLink(plainTarget2, "result", {
         meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
-        frozen: false,
       })).toBeDefined();
       plainTarget2.set({ bar: "updated" });
       tx2.prepareCfc();

--- a/packages/runner/test/cfc-meta-seam-write-policy.test.ts
+++ b/packages/runner/test/cfc-meta-seam-write-policy.test.ts
@@ -10,6 +10,7 @@ import {
   SEED_ENVELOPE_SCHEMA_HASH,
   writeSeedEnvelopeDoc,
 } from "./cfc-seed-envelope.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-meta-seam");
 
@@ -83,11 +84,11 @@ describe("cfc-meta-seam-write-policy", () => {
       const tx = runtime.edit();
       const cell = runtime.getCell(signer.did(), cause, undefined, tx);
       await cell.sync();
-      cell.setMetaRaw("slug", "piece-slug");
+      cell.setMetaRaw("slug", "piece-slug", rawMetaWriteAuthorization);
       cell.setMetaRaw("patternIdentity", {
         identity: "cid:pattern",
         symbol: "main",
-      });
+      }, rawMetaWriteAuthorization);
       tx.prepareCfc();
       // Prepared (not invalidated): the prepare pass recorded no reasons at
       // all for the meta writes.
@@ -190,7 +191,7 @@ describe("cfc-meta-seam-write-policy", () => {
       });
       const sink = runtime.getCell(signer.did(), sinkCause, undefined, tx);
       await sink.sync();
-      sink.setMetaRaw("slug", secret as string);
+      sink.setMetaRaw("slug", secret as string, rawMetaWriteAuthorization);
       tx.prepareCfc();
       expect((await tx.commit()).ok).toBeDefined();
 

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -293,15 +293,16 @@ describe("CFC privileged system write (S18)", () => {
   });
 
   it("does not gate a path-[] full-document write carrying a cfc field", async () => {
-    // Documented deferred residual: the guard keys on path[0] === "cfc", so a
-    // path-[] full-document write whose value embeds a `cfc` record is NOT
-    // gated. This is the shape hydration delivers and the raw-seed idiom other
-    // CFC tests rely on (seedPrivilegedCfc in cfc-boundary.test.ts); per the
-    // sandbox invariant only the logical `value` surface is exposed to
-    // untrusted or user-authored code (docs/plans/runner_cfc_implementation.md
-    // "Document Surface Rules"), so untrusted code cannot reach this vector.
-    // If document-root writes ever become reachable from untrusted code, this
-    // test documents the seam that must then be gated.
+    // Open residual: the guard keys on path[0] === "cfc", so a path-[]
+    // full-document write whose value embeds a `cfc` record is NOT gated.
+    // This is the shape hydration delivers and the raw-seed idiom other CFC
+    // tests rely on (seedPrivilegedCfc in cfc-boundary.test.ts), and it is
+    // reachable from untrusted code: a handler holds a runtime cell and the
+    // transaction it is bound to addresses the whole document
+    // (docs/plans/runner_cfc_implementation.md "Document Surface Rules").
+    // The meta seam is gated across both addressing modes, this one included
+    // (meta-seam-write-authorization.test.ts); label-map forgery through the
+    // document root is what this test still records as ungated.
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -12,6 +12,7 @@ import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-writer-fit");
 
@@ -632,8 +633,16 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         await target.sync();
         // The two paths the piece-update flows land on, and the two the
         // strict measurement used to reject at.
-        target.setMetaRaw("schema", { type: "object" });
-        target.setMetaRaw("internal", { derived: raw.secret });
+        target.setMetaRaw(
+          "schema",
+          { type: "object" },
+          rawMetaWriteAuthorization,
+        );
+        target.setMetaRaw(
+          "internal",
+          { derived: raw.secret },
+          rawMetaWriteAuthorization,
+        );
         tx.prepareCfc();
 
         const result = await tx.commit();
@@ -687,7 +696,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           tx,
         );
         await target.sync();
-        target.setMetaRaw("slug", `${raw.secret}!`);
+        target.setMetaRaw("slug", `${raw.secret}!`, rawMetaWriteAuthorization);
         tx.prepareCfc();
 
         expect((await tx.commit()).ok).toBeDefined();
@@ -795,7 +804,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           tx,
         );
         await target.sync();
-        target.setMetaRaw("slug", `${raw.secret}!`);
+        target.setMetaRaw("slug", `${raw.secret}!`, rawMetaWriteAuthorization);
         tx.prepareCfc();
 
         expect((await tx.commit()).ok).toBeDefined();
@@ -840,7 +849,11 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
           tx,
         );
         await target.sync();
-        target.setMetaRaw("schema", { type: "object" });
+        target.setMetaRaw(
+          "schema",
+          { type: "object" },
+          rawMetaWriteAuthorization,
+        );
         tx.writeOrThrow({
           space: signer.did(),
           scope: "space",

--- a/packages/runner/test/ensure-piece-running.test.ts
+++ b/packages/runner/test/ensure-piece-running.test.ts
@@ -9,6 +9,7 @@ import { ensurePieceRunning } from "../src/ensure-piece-running.ts";
 import { trustPattern } from "./support/trusted-builder.ts";
 import { getDerivedInternalCell, getMetaCell } from "../src/link-utils.ts";
 import { setResultCell } from "../src/result-utils.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -65,7 +66,7 @@ describe("ensurePieceRunning", () => {
     );
 
     resultCell.set({ value: 1 });
-    resultCell.setMetaRaw("argument", { value: 1 });
+    resultCell.setMetaRaw("argument", { value: 1 }, rawMetaWriteAuthorization);
 
     await tx.commit();
     tx = runtime.edit();
@@ -92,8 +93,8 @@ describe("ensurePieceRunning", () => {
     resultCell.setMetaRaw("patternIdentity", {
       identity: "missing-pattern-identity",
       symbol: "default",
-    });
-    resultCell.setMetaRaw("argument", { value: 1 });
+    }, rawMetaWriteAuthorization);
+    resultCell.setMetaRaw("argument", { value: 1 }, rawMetaWriteAuthorization);
 
     await tx.commit();
     tx = runtime.edit();
@@ -168,8 +169,16 @@ describe("ensurePieceRunning", () => {
     resultCell.setRaw({
       doubled: doubledCell.getAsWriteRedirectLink(),
     });
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     setResultCell(doubledCell, resultCell);
     argumentCell.set({ value: 5 });
 
@@ -235,8 +244,16 @@ describe("ensurePieceRunning", () => {
     );
 
     resultCell.set({});
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     argumentCell.set({});
 
     await tx.commit();
@@ -312,8 +329,16 @@ describe("ensurePieceRunning", () => {
     );
 
     resultCell.set({});
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     argumentCell.set({});
 
     await tx.commit();
@@ -472,8 +497,16 @@ describe("queueEvent with auto-start", () => {
       doubled: doubledCell.getAsWriteRedirectLink(),
       events: eventsCell.getAsWriteRedirectLink(),
     });
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     setResultCell(doubledCell, resultCell);
     setResultCell(eventsCell, resultCell);
     argumentCell.set({ value: 5 });
@@ -626,8 +659,16 @@ describe("queueEvent with auto-start", () => {
       events: eventsCell.getAsWriteRedirectLink(),
       eventCount: eventCountCell.getAsWriteRedirectLink(),
     });
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     setResultCell(doubledCell, resultCell);
     setResultCell(eventsCell, resultCell);
     setResultCell(eventCountCell, resultCell);
@@ -769,8 +810,16 @@ describe("queueEvent with auto-start", () => {
       doubled: doubledCell.getAsWriteRedirectLink(),
       events: eventsCell.getAsWriteRedirectLink(),
     });
-    resultCell.setMetaRaw("patternIdentity", patternIdentity);
-    resultCell.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    resultCell.setMetaRaw(
+      "patternIdentity",
+      patternIdentity,
+      rawMetaWriteAuthorization,
+    );
+    resultCell.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
     setResultCell(doubledCell, intermediateCell);
     setResultCell(eventsCell, intermediateCell);
     argumentCell.set({ value: 6 });

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -40,6 +40,7 @@ import type {
   TransactionSealDestination,
 } from "../src/storage/interface.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("p2f run supply");
 const space = signer.did();
@@ -785,7 +786,7 @@ describe("stage P2-F piece-start commit failure surfacing (F1)", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v3Ref.identity,
       symbol: v3Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     return cell;
   };

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -48,6 +48,7 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { getArtifactEntryRef } from "../src/builder/pattern-metadata.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { waitUntil } from "./support/wait-until.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
   // Delegate to the base connectTo (shared-harness extraction, CT-1962):
@@ -989,7 +990,11 @@ describe("stage F serving loop", () => {
     // v1's pre-swap derived commits.
     const preSwapHead = Engine.serverSeq(engine);
     const pointerTx = clientRuntime.edit();
-    clientResult.withTx(pointerTx).setMetaRaw("patternIdentity", v2Ref!);
+    clientResult.withTx(pointerTx).setMetaRaw(
+      "patternIdentity",
+      v2Ref!,
+      rawMetaWriteAuthorization,
+    );
     expect((await pointerTx.commit()).error).toBeUndefined();
 
     // The SpaceServer's watcher swaps to v2 and the wave serves the new

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -12,6 +12,7 @@ import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import type { Cell } from "../src/cell.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("fabric imports engine test");
 const space = signer.did();
@@ -93,7 +94,7 @@ describe("Engine fabric imports", () => {
       cellWithTx.setMetaRaw("patternIdentity", {
         identity: entryIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     return { cell };
   }

--- a/packages/runner/test/fabric-imports-snapshot.test.ts
+++ b/packages/runner/test/fabric-imports-snapshot.test.ts
@@ -11,6 +11,7 @@ import { resolveFabricRefToIdentity } from "../src/fabric-ref-resolution.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import type { Cell } from "../src/cell.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase(
   "fabric imports snapshot semantics test",
@@ -93,7 +94,7 @@ describe("fabric import snapshot semantics", () => {
       cellWithTx.setMetaRaw("patternIdentity", {
         identity: entryIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     return cell;
   }

--- a/packages/runner/test/fabric-ref-resolution.test.ts
+++ b/packages/runner/test/fabric-ref-resolution.test.ts
@@ -8,6 +8,7 @@ import { resolveFabricRefToIdentity } from "../src/fabric-ref-resolution.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import type { Cell } from "../src/cell.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("fabric ref resolution test");
 const space = signer.did();
@@ -98,7 +99,7 @@ describe("fabric ref resolution", () => {
       pieceWithTx.setMetaRaw("patternIdentity", {
         identity: ENTRY_A,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     await writeSlug("dep", piece);
 
@@ -145,7 +146,7 @@ describe("fabric ref resolution", () => {
       pieceWithTx.setMetaRaw("patternIdentity", {
         identity: ENTRY_A,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     const pieceUri = piece.getAsNormalizedFullLink().id; // "of:fid1:<hash>"
     expect(pieceUri.startsWith("of:fid1:")).toBe(true);

--- a/packages/runner/test/fabric-resolver.test.ts
+++ b/packages/runner/test/fabric-resolver.test.ts
@@ -24,6 +24,7 @@ import { entityIdFrom } from "../src/create-ref.ts";
 import type { Cell } from "../src/cell.ts";
 
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -115,7 +116,7 @@ describe("FabricAwareResolver", () => {
       cellWithTx.setMetaRaw("patternIdentity", {
         identity: entryIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     return { cell };
   }

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -8,6 +8,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // A pattern that maps over durable data must accept the rows its PRODUCER
 // actually writes. Nothing checks that agreement: the row's element schema
@@ -227,7 +228,7 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     managerCell.withTx(v2Tx).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await v2Tx.commit();
     await rt.idle();
     await rt.runner.idlePointerMaintenance();

--- a/packages/runner/test/keyless-never-durable.test.ts
+++ b/packages/runner/test/keyless-never-durable.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
@@ -331,7 +332,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
       cell.withTx(repointTx).setMetaRaw("patternIdentity", {
         identity: unloadableIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
       await repointTx.commit();
     }
     await runtime.idle();
@@ -391,7 +392,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
       cell.withTx(repointTx).setMetaRaw("patternIdentity", {
         identity: "keyless:fid1:legacy-orphan-from-a-pre-guard-session",
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
       await repointTx.commit();
     }
     await runtime.idle();
@@ -426,7 +427,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
     cell.withTx(tx).setMetaRaw("patternIdentity", {
       identity: "keyless:fid1:legacy-orphan-from-a-pre-guard-session",
       symbol: "default",
-    });
+    }, rawMetaWriteAuthorization);
     await tx.commit();
     await runtime.idle();
 
@@ -1195,7 +1196,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
         cell.withTx(tx).setMetaRaw("patternIdentity", {
           identity: orphan,
           symbol: "default",
-        });
+        }, rawMetaWriteAuthorization);
         await tx.commit();
         await runtime.idle();
         expect(await runtime.runner.start(cell)).toBe(false);
@@ -1234,7 +1235,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
           cell.withTx(repointTx).setMetaRaw("patternIdentity", {
             identity: orphan,
             symbol: "default",
-          });
+          }, rawMetaWriteAuthorization);
           await repointTx.commit();
         }
         await runtime.idle();
@@ -1267,7 +1268,7 @@ describe("keyless identities never land durably (L3(a), RULED 2026-08-27)", () =
           cell.withTx(repointTx).setMetaRaw("patternIdentity", {
             identity: unloadableIdentity,
             symbol: "default",
-          });
+          }, rawMetaWriteAuthorization);
           await repointTx.commit();
         }
         await runtime.idle();

--- a/packages/runner/test/meta-seam-write-authorization.test.ts
+++ b/packages/runner/test/meta-seam-write-authorization.test.ts
@@ -1,0 +1,372 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { FabricValue } from "@commonfabric/api";
+import { type MetaField, rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { Identity } from "@commonfabric/identity";
+import type { URI } from "@commonfabric/memory/interface";
+
+import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { CfcEnforcementMode } from "../src/cfc/types.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("runner-meta-seam-write");
+
+// A meta field is a document-root sibling of `value`: `patternIdentity` names
+// the program a piece runs, `argument`, `result` and `internal` name the cells
+// it is wired to, `schema` names the shape its result is validated against,
+// and `slug` names it in the space. Writing one redirects a piece rather than
+// editing its data, and the runtime is the only writer with a use for that, so
+// `setMetaRaw` marks the writes the runtime makes and the write chokepoint
+// refuses every unmarked one.
+//
+// Pattern-authored code runs in the runtime's own realm and receives runtime
+// cells, so it reaches both the cell method and the storage transaction the
+// cell is bound to. The casts below stand for that reach: the sandbox erases
+// types, so a type that omits a method, or a signature that requires an
+// authorization, is a compile-time boundary and not a runtime one.
+type RawMetaCellWriter = {
+  setMetaRaw(metaField: MetaField, value: FabricValue): void;
+};
+
+const forgedIdentity = {
+  identity: "of:forged-pattern",
+  symbol: "default",
+};
+
+describe("meta-seam-write-authorization", () => {
+  const withRuntime = async (
+    body: (context: {
+      runtime: Runtime;
+      tx: IExtendedStorageTransaction;
+      cell: Cell<{ note: string }>;
+      id: URI;
+    }) => void,
+    cfcEnforcementMode: CfcEnforcementMode = "enforce-explicit",
+  ): Promise<void> => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    try {
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode,
+      });
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<{ note: string }>(
+          signer.did(),
+          `raw-meta-${crypto.randomUUID()}`,
+          undefined,
+          tx,
+        );
+        body({
+          runtime,
+          tx,
+          cell,
+          id: cell.getAsNormalizedFullLink().id as URI,
+        });
+      } finally {
+        await runtime.dispose();
+      }
+    } finally {
+      await storageManager.close();
+    }
+  };
+
+  const documentAddress = (id: URI, path: string[]) => ({
+    space: signer.did(),
+    id,
+    type: "application/json" as const,
+    path,
+  });
+
+  describe("setMetaRaw()", () => {
+    it("writes the meta field it names", async () => {
+      await withRuntime(({ cell }) => {
+        cell.setMetaRaw(
+          "patternIdentity",
+          forgedIdentity,
+          rawMetaWriteAuthorization,
+        );
+
+        expect(cell.getMetaRaw("patternIdentity")).toEqual(forgedIdentity);
+      });
+    });
+
+    it("authorizes only the write it makes", async () => {
+      await withRuntime(({ cell }) => {
+        cell.setMetaRaw("slug", "named", rawMetaWriteAuthorization);
+
+        expect(() =>
+          (cell as unknown as RawMetaCellWriter).setMetaRaw("slug", "renamed")
+        ).toThrow(/meta seam/);
+        expect(cell.getMetaRaw("slug")).toBe("named");
+      });
+    });
+  });
+
+  describe("the storage-write chokepoint", () => {
+    it("throws on the cell method called without an authorization", async () => {
+      await withRuntime(({ cell }) => {
+        expect(() =>
+          (cell as unknown as RawMetaCellWriter).setMetaRaw(
+            "patternIdentity",
+            forgedIdentity,
+          )
+        ).toThrow(/patternIdentity/);
+        expect(cell.getMetaRaw("patternIdentity")).toBeUndefined();
+      });
+    });
+
+    it("throws on a transaction write addressed at a meta field", async () => {
+      await withRuntime(({ tx, cell, id }) => {
+        expect(() =>
+          tx.writeOrThrow(
+            documentAddress(id, ["patternIdentity"]),
+            forgedIdentity,
+          )
+        ).toThrow(/patternIdentity/);
+        expect(cell.getMetaRaw("patternIdentity")).toBeUndefined();
+      });
+    });
+
+    it("throws on a transaction write addressed inside a meta field", async () => {
+      await withRuntime(({ tx, id }) => {
+        expect(() =>
+          tx.writeOrThrow(
+            documentAddress(id, ["internal", "subject"]),
+            "forged",
+          )
+        ).toThrow(/internal/);
+      });
+    });
+
+    it("throws on a document-root write whose envelope carries a meta field", async () => {
+      await withRuntime(({ tx, cell, id }) => {
+        expect(() =>
+          tx.writeOrThrow(documentAddress(id, []), {
+            value: { note: "kept" },
+            patternIdentity: forgedIdentity,
+          })
+        ).toThrow(/patternIdentity/);
+        expect(cell.getMetaRaw("patternIdentity")).toBeUndefined();
+      });
+    });
+
+    it("throws with CFC enforcement disabled", async () => {
+      await withRuntime(({ cell }) => {
+        expect(() =>
+          (cell as unknown as RawMetaCellWriter).setMetaRaw(
+            "patternIdentity",
+            forgedIdentity,
+          )
+        ).toThrow(/patternIdentity/);
+      }, "disabled");
+    });
+
+    it("accepts a value write at a path named after a meta field", async () => {
+      await withRuntime(({ tx, cell, id }) => {
+        tx.writeOrThrow(documentAddress(id, ["value", "slug"]), "user-data");
+
+        expect(cell.key("slug" as never).get()).toBe("user-data");
+        expect(cell.getMetaRaw("slug")).toBeUndefined();
+      });
+    });
+
+    it("throws on a document-root write that would drop a document's meta fields", async () => {
+      // A document-root write replaces the envelope, so one that names no
+      // meta field erases every meta field the document carries.
+
+      await withRuntime(({ tx, cell, id }) => {
+        cell.setMetaRaw(
+          "patternIdentity",
+          forgedIdentity,
+          rawMetaWriteAuthorization,
+        );
+
+        expect(() =>
+          tx.writeOrThrow(documentAddress(id, []), { value: { note: "kept" } })
+        ).toThrow(/patternIdentity/);
+        expect(cell.getMetaRaw("patternIdentity")).toEqual(forgedIdentity);
+      });
+    });
+
+    it("throws on a document-root delete of a document carrying meta fields", async () => {
+      await withRuntime(({ tx, cell, id }) => {
+        cell.setMetaRaw("slug", "named", rawMetaWriteAuthorization);
+
+        expect(() =>
+          tx.writeOrThrow(documentAddress(id, []), undefined, { delete: true })
+        ).toThrow(/slug/);
+        expect(cell.getMetaRaw("slug")).toBe("named");
+      });
+    });
+
+    it("throws on a meta write to a reserved grant document", async () => {
+      // A reserved `grant:cfc:` document is recorded by an arm of the same
+      // chokepoint, and a recording arm returns. The seam's refusal comes
+      // first, so which document a write names cannot decide whether it is
+      // asked for an authorization. CFC is disabled here, the mode in which
+      // the recording the grant arm makes is never read back.
+
+      await withRuntime(({ tx }) => {
+        expect(() =>
+          tx.writeOrThrow(
+            documentAddress("grant:cfc:meta-seam-probe" as URI, [
+              "patternIdentity",
+            ]),
+            forgedIdentity,
+          )
+        ).toThrow(/patternIdentity/);
+      }, "disabled");
+    });
+
+    it("accepts a document-root write on a document carrying no meta field", async () => {
+      await withRuntime(({ tx, cell, id }) => {
+        tx.writeOrThrow(documentAddress(id, []), { value: { note: "seeded" } });
+
+        expect(cell.get()).toEqual({ note: "seeded" });
+      });
+    });
+  });
+
+  describe("a running pattern", () => {
+    // A handler receives the cells its pattern was given, and a cell reaches
+    // its whole document, meta seam included. The victim here is a separate
+    // running piece, so the `patternIdentity` on its document is the one the
+    // runtime loads its program from: a handler that could write it would
+    // choose the program another piece runs.
+    const withVictimAndAttacker = async (
+      makeHandlerBody: (
+        // deno-lint-ignore no-explicit-any
+        commonfabric: any,
+      ) => (victim: unknown) => void,
+      body: (context: {
+        runtime: Runtime;
+        victimCell: Cell<{ note: string }>;
+        attacker: Cell<{ onAttack: unknown }>;
+      }) => Promise<void>,
+    ): Promise<void> => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      try {
+        const runtime = new Runtime({
+          apiUrl: new URL("https://example.com"),
+          storageManager,
+        });
+        try {
+          const tx = runtime.edit();
+          const { commonfabric } = createTrustedBuilder(runtime);
+          const { handler, pattern } = commonfabric;
+          const handlerBody = makeHandlerBody(commonfabric);
+          const Victim = pattern(() => ({ note: "victim" }));
+          const attack = handler(
+            { type: "object", properties: {} },
+            {
+              type: "object",
+              properties: { victim: { asCell: ["cell"] } },
+              required: ["victim"],
+            },
+            (_event: unknown, { victim }: { victim: unknown }) =>
+              handlerBody(victim),
+          );
+          const Attacker = pattern<{ victim: unknown }>((
+            { victim }: { victim: unknown },
+          ) => ({
+            onAttack: attack({ victim }),
+          }));
+
+          const victimCell = runtime.getCell<{ note: string }>(
+            signer.did(),
+            `raw-meta-victim-${crypto.randomUUID()}`,
+            undefined,
+            tx,
+          );
+          runtime.run(tx, Victim, {}, victimCell);
+          const attackerCell = runtime.getCell<{ onAttack: unknown }>(
+            signer.did(),
+            `raw-meta-attacker-${crypto.randomUUID()}`,
+            undefined,
+            tx,
+          );
+          const attacker = runtime.run(
+            tx,
+            Attacker,
+            { victim: victimCell },
+            attackerCell,
+          );
+          await tx.commit();
+          await attacker.pull();
+          await runtime.scheduler.idleWithPendingCommits();
+
+          await body({ runtime, victimCell, attacker });
+        } finally {
+          await runtime.dispose();
+        }
+      } finally {
+        await storageManager.close();
+      }
+    };
+
+    it("cannot swap the program a piece it holds a cell for runs", async () => {
+      await withVictimAndAttacker(
+        () => (victim) => {
+          (victim as RawMetaCellWriter).setMetaRaw(
+            "patternIdentity",
+            forgedIdentity,
+          );
+        },
+        async ({ runtime, victimCell, attacker }) => {
+          const running = victimCell.getMetaRaw("patternIdentity");
+          const errors: string[] = [];
+          runtime.scheduler.onError((error) =>
+            errors.push(String(error?.message ?? error))
+          );
+
+          attacker.key("onAttack").send({});
+          await runtime.scheduler.idleWithPendingCommits();
+
+          expect(victimCell.getMetaRaw("patternIdentity")).toEqual(running);
+          expect(victimCell.get()).toEqual({ note: "victim" });
+          expect(errors.some((message) => /patternIdentity/.test(message)))
+            .toBe(true);
+        },
+      );
+    });
+
+    // The guard covers writes to the seam, not the runtime's own entry points
+    // that write it as part of their work. A cell carries `runtime` and `tx`,
+    // so a handler can ask the runtime to instantiate a pattern of its
+    // choosing onto a cell it holds, and the runtime wires that cell to the
+    // chosen program on its behalf — the result the victim's own pattern
+    // computed is replaced by the attacker's. What that costs is a question
+    // about the object graph a cell hands pattern code, not about this seam;
+    // this test records the reach so that closing it is visible. It reads
+    // the result rather than the identity meta, which a pattern evaluated
+    // without a content-addressed entry does not carry.
+    it("can still ask the runtime to run its own pattern on that piece", async () => {
+      await withVictimAndAttacker(
+        (commonfabric) => {
+          const Evil = commonfabric.pattern(() => ({ note: "evil" }));
+          return (victim: unknown) => {
+            const reachable = victim as unknown as {
+              runtime: { run: (...args: unknown[]) => unknown };
+              tx: unknown;
+            };
+            reachable.runtime.run(reachable.tx, Evil, {}, reachable);
+          };
+        },
+        async ({ runtime, victimCell, attacker }) => {
+          expect(victimCell.get()).toEqual({ note: "victim" });
+
+          attacker.key("onAttack").send({});
+          await runtime.scheduler.idleWithPendingCommits();
+
+          expect(victimCell.get()).toEqual({ note: "evil" });
+        },
+      );
+    });
+  });
+});

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -7,6 +7,7 @@ import { Runtime } from "../src/runtime.ts";
 import { getMetaLink } from "../src/link-utils.ts";
 import { isMissingStreamMarkerFailure } from "../src/runner.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // A nested/embedded piece — a profile mounted via a `#wish`, say — is
 // instantiated by the runtime's start walk WITHOUT a setup phase and with no
@@ -155,7 +156,7 @@ describe("nested-piece cold-start setup repair", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v3Ref.identity,
       symbol: v3Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     // It is not the space's defaultPattern, so the runner repair (not the
     // controller) is what must heal it.

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -40,6 +40,7 @@ import { Runtime } from "../src/runtime.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -111,6 +112,7 @@ describe("pattern-binding", () => {
       testCell.setMetaRaw(
         "argument",
         argumentCell.getAsWriteRedirectLink({ base: testCell }),
+        rawMetaWriteAuthorization,
       );
 
       sendValueToBinding(tx, testCell, undefined, {

--- a/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
+++ b/packages/runner/test/pattern-pointer-unloadable-swap.test.ts
@@ -6,6 +6,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { getPatternIdentityRef, resolveEntryIdentity } from "../src/index.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // CT-1923 (2026-07-29 estuary): a running piece whose durable patternIdentity
 // names an identity this runtime cannot load sat stranded forever: the
@@ -122,7 +123,7 @@ describe("unloadable patternIdentity pointer vs a running pattern", () => {
     cell.withTx(tx).setMetaRaw("patternIdentity", {
       identity,
       symbol: "default",
-    });
+    }, rawMetaWriteAuthorization);
     await tx.commit();
     await rt.idle();
     // Deterministic: settles the watcher load chain and any roll-forward.

--- a/packages/runner/test/pattern-source.test.ts
+++ b/packages/runner/test/pattern-source.test.ts
@@ -13,6 +13,7 @@ import {
   preparePieceSourceTransitionBaseline,
   setPatternSource,
 } from "../src/runner.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 
@@ -93,7 +94,11 @@ describe("patternSource meta accessors", () => {
     const origin = "https://example.test/pattern.tsx";
     const seed = runtime.edit();
     const seededCell = runtime.getCell(signer.did(), id, undefined, seed);
-    seededCell.setMetaRaw("patternIdentity", pattern);
+    seededCell.setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     setPatternSource(seededCell, seed, origin);
     await seed.commit();
 
@@ -156,7 +161,11 @@ describe("patternSource meta accessors", () => {
     const pattern = { identity: "current-pattern", symbol: "default" };
     const seed = runtime.edit();
     const seededCell = runtime.getCell(signer.did(), id, undefined, seed);
-    seededCell.setMetaRaw("patternIdentity", pattern);
+    seededCell.setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     setPatternSource(seededCell, seed, "https://example.test/first.tsx");
     await seed.commit();
 
@@ -202,11 +211,15 @@ describe("patternSource meta accessors", () => {
     const pattern = { identity: "current-pattern", symbol: "default" };
     const seed = runtime.edit();
     const seededCell = runtime.getCell(signer.did(), id, undefined, seed);
-    seededCell.setMetaRaw("patternIdentity", pattern);
+    seededCell.setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     seededCell.setMetaRaw("pieceSourceHistory", [{
       revisionId: "broken",
       timestamp: 42,
-    }]);
+    }], rawMetaWriteAuthorization);
     await seed.commit();
 
     const cell = runtime.getCell(signer.did(), id);
@@ -259,7 +272,11 @@ describe("patternSource meta accessors", () => {
         `malformed-source-history-${index}`,
       );
       const seed = runtime.edit();
-      cell.withTx(seed).setMetaRaw("pieceSourceHistory", history as never);
+      cell.withTx(seed).setMetaRaw(
+        "pieceSourceHistory",
+        history as never,
+        rawMetaWriteAuthorization,
+      );
       await seed.commit();
 
       expect(() => getPieceSourceRevisions(cell)).toThrow(
@@ -273,7 +290,11 @@ describe("patternSource meta accessors", () => {
     const pattern = { identity: "expected-pattern", symbol: "default" };
     const seed = runtime.edit();
     const seededCell = runtime.getCell(signer.did(), id, undefined, seed);
-    seededCell.setMetaRaw("patternIdentity", pattern);
+    seededCell.setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     seededCell.setMetaRaw("pieceSourceHistory", [{
       revisionId: "wrong-source",
       timestamp: 42,
@@ -285,7 +306,7 @@ describe("patternSource meta accessors", () => {
         seed,
       ).getAsLink(),
       operation: "create",
-    }]);
+    }], rawMetaWriteAuthorization);
     await seed.commit();
 
     expect(() => getPieceSourceRevisions(runtime.getCell(signer.did(), id)))
@@ -304,7 +325,11 @@ describe("patternSource meta accessors", () => {
     const pattern = runtime.patternManager.getArtifactEntryRef(compiled)!;
     const piece = runtime.getCell(signer.did(), "source-verification-race");
     const seed = runtime.edit();
-    piece.withTx(seed).setMetaRaw("patternIdentity", pattern);
+    piece.withTx(seed).setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     await seed.commit();
     const expected = getPieceSourceSnapshot(piece)!;
     const baseline = await preparePieceSourceTransitionBaseline(
@@ -348,7 +373,11 @@ describe("patternSource meta accessors", () => {
     const missing = { identity: "missing-source", symbol: "default" };
     const seed = runtime.edit();
     const seededCell = runtime.getCell(signer.did(), id, undefined, seed);
-    seededCell.setMetaRaw("patternIdentity", missing);
+    seededCell.setMetaRaw(
+      "patternIdentity",
+      missing,
+      rawMetaWriteAuthorization,
+    );
     await seed.commit();
 
     const cell = runtime.getCell(signer.did(), id);
@@ -388,7 +417,11 @@ describe("patternSource meta accessors", () => {
         expected,
       },
     );
-    cell.withTx(transition).setMetaRaw("patternIdentity", replacement);
+    cell.withTx(transition).setMetaRaw(
+      "patternIdentity",
+      replacement,
+      rawMetaWriteAuthorization,
+    );
     await transition.commit();
 
     expect(
@@ -406,7 +439,11 @@ describe("patternSource meta accessors", () => {
     const pattern = { identity: "current-pattern", symbol: "default" };
     const cell = runtime.getCell(signer.did(), "stale-source-baseline");
     const seed = runtime.edit();
-    cell.withTx(seed).setMetaRaw("patternIdentity", pattern);
+    cell.withTx(seed).setMetaRaw(
+      "patternIdentity",
+      pattern,
+      rawMetaWriteAuthorization,
+    );
     setPatternSource(cell, seed, "https://example.test/first.tsx");
     await seed.commit();
     const stale = getPieceSourceSnapshot(cell)!;

--- a/packages/runner/test/pattern-swap-link-argument.test.ts
+++ b/packages/runner/test/pattern-swap-link-argument.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // CT-1917 (2026-07-28 estuary): a hot-swap to a new pattern version re-runs
 // setup, and setup re-validates the STORED argument against the candidate
@@ -100,7 +101,7 @@ describe("pattern swap with a link-valued argument slot", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();
@@ -187,11 +188,12 @@ describe("pattern swap with a link-valued argument slot", () => {
     cell.withTx(tx2).setMetaRaw(
       "argument",
       coldArgument.getAsWriteRedirectLink({ base: cell }),
+      rawMetaWriteAuthorization,
     );
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -14,6 +14,7 @@ import { readStoredLinkChainRaw } from "../src/runner.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { getMetaLink } from "../src/link-utils.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // A pattern update must not leave durable state the new version's argument
 // schema cannot read. `packages/piece/src/schema-compatibility.ts` waives one
@@ -161,7 +162,7 @@ describe("pattern update validates the stored argument", () => {
       cell.withTx(tx).setMetaRaw("patternIdentity", {
         identity: ref.identity,
         symbol: ref.symbol,
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(stampError?.message).toBeUndefined();
     let error: string | undefined;
@@ -334,7 +335,11 @@ describe("pattern update validates the stored argument", () => {
       "markerless-root",
     );
     const { error: stripError } = await rt.editWithRetry((tx) => {
-      cell.withTx(tx).setMetaRaw("patternSetupIdentity", undefined);
+      cell.withTx(tx).setMetaRaw(
+        "patternSetupIdentity",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(stripError?.message).toBeUndefined();
     await rt.idle();
@@ -432,7 +437,7 @@ describe("pattern update validates the stored argument", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();
@@ -524,7 +529,7 @@ describe("pattern update validates the stored argument", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();
@@ -593,6 +598,7 @@ describe("pattern update validates the stored argument", () => {
       cell.withTx(wtx).setMetaRaw(
         "argument",
         coldArgument.getAsWriteRedirectLink({ base: cell }),
+        rawMetaWriteAuthorization,
       );
     });
     expect(retargetError?.message).toBeUndefined();
@@ -637,7 +643,11 @@ describe("pattern update validates the stored argument", () => {
       rt.getCellFromLink(getMetaLink(cell, "argument")!, undefined, wtx)
         .asSchema(undefined as never)
         .set({ count: "seven" } as never);
-      cell.withTx(wtx).setMetaRaw("patternSetupIdentity", undefined);
+      cell.withTx(wtx).setMetaRaw(
+        "patternSetupIdentity",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(prepError?.message).toBeUndefined();
     await rt.idle();
@@ -715,7 +725,7 @@ describe("pattern update validates the stored argument", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();
@@ -724,7 +734,11 @@ describe("pattern update validates the stored argument", () => {
     // Strip the marker AND repair the argument: now the piece is markerless,
     // running V1, under a pointer naming V2, with nothing left to refuse.
     const { error: prepError } = await rt.editWithRetry((wtx) => {
-      cell.withTx(wtx).setMetaRaw("patternSetupIdentity", undefined);
+      cell.withTx(wtx).setMetaRaw(
+        "patternSetupIdentity",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
       rt.getCellFromLink(getMetaLink(cell, "argument")!, undefined, wtx)
         .asSchema(undefined as never)
         .set({ count: 7 } as never);
@@ -790,7 +804,11 @@ describe("pattern update validates the stored argument", () => {
 
     // Strip it, the state a piece written before the meta existed is in.
     const { error: stripError } = await rt.editWithRetry((tx) => {
-      cell.withTx(tx).setMetaRaw("schema", undefined);
+      cell.withTx(tx).setMetaRaw(
+        "schema",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(stripError?.message).toBeUndefined();
     await rt.idle();
@@ -816,7 +834,11 @@ describe("pattern update validates the stored argument", () => {
     // branch returns from a different place — so a fix applied to only one of
     // them leaves half the callers unrepaired.
     const { error: stripAgain } = await rt.editWithRetry((tx) => {
-      cell.withTx(tx).setMetaRaw("schema", undefined);
+      cell.withTx(tx).setMetaRaw(
+        "schema",
+        undefined,
+        rawMetaWriteAuthorization,
+      );
     });
     expect(stripAgain?.message).toBeUndefined();
     await rt.idle();
@@ -1069,7 +1091,11 @@ describe("pattern update validates the stored argument", () => {
       prim.withTx(tx).asSchema(undefined as never).set({ p: true } as never);
       // A doc record a meta-only write leaves behind: present, no value —
       // the stamped-but-unmaterialized state real vintages hold.
-      metaOnly.withTx(tx).setMetaRaw("slug", "walk-meta-only");
+      metaOnly.withTx(tx).setMetaRaw(
+        "slug",
+        "walk-meta-only",
+        rawMetaWriteAuthorization,
+      );
     });
     expect(writeError?.message).toBeUndefined();
     await rt.idle();
@@ -1295,7 +1321,7 @@ describe("pattern update validates the stored argument", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();
@@ -1351,7 +1377,7 @@ describe("pattern update validates the stored argument", () => {
     cell.withTx(tx2).setMetaRaw("patternIdentity", {
       identity: v2Ref.identity,
       symbol: v2Ref.symbol,
-    });
+    }, rawMetaWriteAuthorization);
     await tx2.commit();
     await rt.idle();
     await cell.pull();

--- a/packages/runner/test/piece-helpers.test.ts
+++ b/packages/runner/test/piece-helpers.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/piece-helpers.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test piece helpers");
 const space = signer.did();
@@ -281,7 +282,7 @@ describe("getResultCellWithSourceSchema", () => {
       undefined,
       tx,
     );
-    resultCell.setMetaRaw("schema", resultSchema);
+    resultCell.setMetaRaw("schema", resultSchema, rawMetaWriteAuthorization);
 
     const titleCell = getResultCellWithSourceSchema(
       resultCell.key("title"),
@@ -313,7 +314,7 @@ describe("getResultCellWithSourceSchema", () => {
       undefined,
       tx,
     );
-    resultCell.setMetaRaw("schema", resultSchema);
+    resultCell.setMetaRaw("schema", resultSchema, rawMetaWriteAuthorization);
 
     const explicitCell = resultCell.key("title").asSchema(explicitSchema);
     const annotated = getResultCellWithSourceSchema(explicitCell);

--- a/packages/runner/test/result-utils.test.ts
+++ b/packages/runner/test/result-utils.test.ts
@@ -1,18 +1,80 @@
 import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
 import { setPatternCell } from "../src/result-utils.ts";
-import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
-Deno.test("setPatternCell copies parent pattern metadata when present", () => {
-  const calls: unknown[][] = [];
-  const resultCell = {
-    setMetaRaw: (...args: unknown[]) => calls.push(args),
-  } as unknown as Cell<unknown>;
-  const parentPattern = { "/": "pattern-link" };
-  const patternCell = {
-    getRaw: () => parentPattern,
-  } as unknown as Cell<unknown>;
+const signer = await Identity.fromPassphrase("runner-result-utils");
 
-  setPatternCell(resultCell, patternCell);
+describe("result-utils", () => {
+  const withRuntime = async (
+    body: (runtime: Runtime) => Promise<void>,
+  ): Promise<void> => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    try {
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+      });
+      try {
+        await body(runtime);
+      } finally {
+        await runtime.dispose();
+      }
+    } finally {
+      await storageManager.close();
+    }
+  };
 
-  expect(calls).toEqual([["pattern", parentPattern]]);
+  describe("setPatternCell()", () => {
+    it("copies the parent pattern's value into the result cell's `pattern` meta field", async () => {
+      await withRuntime(async (runtime) => {
+        const tx = runtime.edit();
+        const patternCell = runtime.getCell<{ note: string }>(
+          signer.did(),
+          "result-utils-parent-pattern",
+          undefined,
+          tx,
+        );
+        patternCell.set({ note: "parent" });
+        const resultCell = runtime.getCell(
+          signer.did(),
+          "result-utils-result",
+          undefined,
+          tx,
+        );
+
+        setPatternCell(resultCell, patternCell);
+        await tx.commit();
+
+        expect(resultCell.getMetaRaw("pattern")).toEqual({ note: "parent" });
+      });
+    });
+
+    it("leaves the `pattern` meta field unwritten when the parent pattern has no value", async () => {
+      await withRuntime(async (runtime) => {
+        const tx = runtime.edit();
+        const patternCell = runtime.getCell(
+          signer.did(),
+          "result-utils-empty-parent",
+          undefined,
+          tx,
+        );
+        const resultCell = runtime.getCell(
+          signer.did(),
+          "result-utils-unwritten-result",
+          undefined,
+          tx,
+        );
+
+        setPatternCell(resultCell, patternCell);
+        await tx.commit();
+
+        expect(resultCell.getMetaRaw("pattern")).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -41,6 +41,7 @@ import {
   type URI,
 } from "../src/storage/interface.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -1528,6 +1529,7 @@ describe("setup/start", () => {
     resultCell.withTx(metaTx).setMetaRaw(
       "internal",
       legacyInternalCell.getAsWriteRedirectLink({ base: resultCell }),
+      rawMetaWriteAuthorization,
     );
     await metaTx.commit();
 
@@ -2072,7 +2074,11 @@ describe("setup/start", () => {
       undefined,
       tx,
     );
-    candidate.setMetaRaw("argument", argumentCell.getAsWriteRedirectLink());
+    candidate.setMetaRaw(
+      "argument",
+      argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
+    );
 
     expect(guard(candidate)).toBe(false);
     tx.abort();
@@ -2105,6 +2111,7 @@ describe("setup/start", () => {
     resultCell.setMetaRaw(
       "argument",
       argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
     );
     await setupTx.commit();
     await runtime.idle();
@@ -2135,6 +2142,7 @@ describe("setup/start", () => {
     differentCandidate.setMetaRaw(
       "argument",
       differentArgument.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
     );
     expect(guard(differentCandidate)).toBe(false);
     differentTx.abort();
@@ -2175,6 +2183,7 @@ describe("setup/start", () => {
     resultCell.setMetaRaw(
       "argument",
       argumentCell.getAsWriteRedirectLink(),
+      rawMetaWriteAuthorization,
     );
     await setupTx.commit();
     await runtime.idle();
@@ -2425,7 +2434,7 @@ describe("runner utils", () => {
     resultCell.setMetaRaw("patternSetupIdentity", {
       identity: "pattern-identity",
       symbol: "main",
-    });
+    }, rawMetaWriteAuthorization);
     expect(getPatternSetupIdentityRef(resultCell)).toEqual({
       identity: "pattern-identity",
       symbol: "main",
@@ -2434,7 +2443,7 @@ describe("runner utils", () => {
     resultCell.setMetaRaw("patternSetupIdentity", {
       identity: 42,
       symbol: "main",
-    });
+    }, rawMetaWriteAuthorization);
     expect(getPatternSetupIdentityRef(resultCell)).toBeUndefined();
   });
 

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -24,6 +24,7 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { getDirectTransactionReactivityLog } from "../src/storage/transaction-inspection.ts";
 import { PASS_RUN_BUDGET } from "../src/scheduler/constants.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 // Seed stored CFC metadata via an ungated path-[] full-document write (the
 // shape hydration delivers it), reading the current doc first so the value
@@ -1314,7 +1315,7 @@ describe("scheduler", () => {
       tx,
     );
     testCell.set({ value: 1 });
-    testCell.setMetaRaw("slug", "tracked-slug");
+    testCell.setMetaRaw("slug", "tracked-slug", rawMetaWriteAuthorization);
     tx.commit();
     tx = runtime.edit();
 

--- a/packages/runner/test/source-reconciler.test.ts
+++ b/packages/runner/test/source-reconciler.test.ts
@@ -17,6 +17,7 @@ import {
   setPatternSource,
   systemPatternSource,
 } from "../src/index.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("piece source reconciliation");
 const PARENT_PATH = "/api/patterns/system/reconcile-parent.tsx";
@@ -1235,7 +1236,11 @@ describe("piece source reconciliation", () => {
       // A detach lands while the update is resolving. The transition it was
       // going to write names an origin the piece no longer follows.
       await runtime.editWithRetry((tx) => {
-        piece.withTx(tx).setMetaRaw("patternSource", undefined);
+        piece.withTx(tx).setMetaRaw(
+          "patternSource",
+          undefined,
+          rawMetaWriteAuthorization,
+        );
       });
       identityGate.resolve();
 
@@ -1276,7 +1281,11 @@ describe("piece source reconciliation", () => {
       const moved = await compileMarkerPattern("v3");
       const movedRef = runtime.patternManager.getArtifactEntryRef(moved)!;
       const { error } = await runtime.editWithRetry((tx) => {
-        piece.withTx(tx).setMetaRaw("patternIdentity", movedRef);
+        piece.withTx(tx).setMetaRaw(
+          "patternIdentity",
+          movedRef,
+          rawMetaWriteAuthorization,
+        );
       });
       expect(error).toBeUndefined();
       identityGate.resolve();
@@ -1305,7 +1314,11 @@ describe("piece source reconciliation", () => {
       ) => {
         const unchanged = await sync(...args);
         const { error } = await runtime.editWithRetry((tx) => {
-          piece.withTx(tx).setMetaRaw("patternIdentity", movedRef);
+          piece.withTx(tx).setMetaRaw(
+            "patternIdentity",
+            movedRef,
+            rawMetaWriteAuthorization,
+          );
         });
         expect(error).toBeUndefined();
         return unchanged;

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -19,6 +19,7 @@ import {
   getPatternEnvironment,
   setPatternEnvironment,
 } from "../src/builder/env.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
@@ -410,10 +411,11 @@ describe("wish built-in", () => {
       defaultPatternCell.setMetaRaw("patternIdentity", {
         identity: "stored-default-app",
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
       defaultPatternCell.setMetaRaw(
         "patternSource",
         "/api/patterns/system/default-app.tsx",
+        rawMetaWriteAuthorization,
       );
       (spaceCell as any).key("defaultPattern").set(defaultPatternCell);
 

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -1,4 +1,4 @@
-import type { MetaField } from "@commonfabric/api";
+import type { MetaField } from "@commonfabric/runner";
 import type {
   FabricBytes,
   FabricKeyPair,

--- a/packages/shell/src/lib/debug-utils.ts
+++ b/packages/shell/src/lib/debug-utils.ts
@@ -21,7 +21,7 @@ import type {
 import type { DID } from "@commonfabric/identity";
 import { hasEntityUriScheme } from "@commonfabric/runner/entity-kind";
 import { isObjectOrArray } from "@commonfabric/utils/types";
-import type { MetaField } from "@commonfabric/api";
+import type { MetaField } from "@commonfabric/runner";
 import { createVDomDebugHelpers, viewSettled } from "@commonfabric/html/debug";
 
 /**

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -683,50 +683,6 @@ export interface IReadable<T> {
   sample(): Readonly<StripDefaultBrand<T>>;
 }
 
-export type MetaLinkField =
-  | "pattern"
-  | "argument"
-  | "result";
-
-/**
- * The `pattern` field links a result cell to its pattern
- * The `argument` field links a result cell to its argument cell
- * The `internal` field contains a manifest with links to derived internal cells.
- * The `schema` field stores the schema for a result cell
- * The `patternSetupIdentity` field records the pattern identity whose complete
- * setup state was installed on a result cell.
- * The `result` field lets a result cell link to its parent result cell,
- * and also lets the argument and derived internal cells link back to the result cell.
- *
- * `cfc` is deliberately NOT a MetaField: the `["cfc"]` document field holds
- * raw label metadata (Caveat.source and other principal identities), which
- * must not ride the raw meta seam (inv-12 Stage 0 / SC-14 / SC-25). The cfc
- * code reads the field directly through its own verifier seams; display
- * consumers get the redacted view via getCfcLabel.
- */
-export type MetaField =
-  | MetaLinkField
-  | "patternIdentity" // content-addressed {identity, symbol} pattern reference
-  | "patternSetupIdentity" // setup-completion {identity, symbol} marker
-  | "patternSource" // active web or `cf:` source origin
-  | "pieceSourceHistory" // append-only source revisions and retention roots
-  | "pieceReconciliation" // what following the active origin last did:
-  // {outcome, at, origin, offered?, reason?, detail?} — a piece that refused
-  // or could not reach its origin looks otherwise exactly like one that is
-  // running what its origin offers
-  | "patternRepository" // optional caller-supplied repository locator
-  | "displacedPattern" // {identity, symbol, displacedAt}: the prior pattern
-  // reference recorded when system-pattern auto-update replaces an unloadable
-  // sourceless root — the recovery pointer for a displaced custom program
-  | "internal"
-  | "schema"
-  | "slug";
-
-export interface IMetaCell {
-  getMetaRaw(metaField: MetaField, options?: unknown): FabricValue;
-  setMetaRaw(metaField: MetaField, value: FabricValue): void;
-}
-
 /**
  * Writable cells can update their value.
  *
@@ -1564,7 +1520,6 @@ export interface ICell<T>
     IEquatable,
     IKeyable<T, AsCell>,
     IDerivable<T>,
-    IMetaCell,
     IResolvable<T, Cell<T>> {}
 
 export interface Cell<T = unknown> extends BrandedCell<T, "cell">, ICell<T> {}


### PR DESCRIPTION
A document's meta fields sit at its root, siblings of `value`. `patternIdentity` and `pattern` name the program a piece runs. `argument`, `result` and `internal` name the cells it is wired to. `schema` names the shape its result is validated against, and `slug` names it in the space. `patternSource`, `pieceSourceHistory`, `patternRepository`, `displacedPattern` and `patternSetupIdentity` record where its program came from and what it displaced. A write to any of them redirects a piece rather than editing its data.

That seam had no authorization gate. The cell method performed no check, and pattern-authored code reached it with no cast: `Cell` extends `IMetaCell`, which declared the method, and a pattern imports `Cell` from `commonfabric`. The write chokepoint did not stop it either. `noteSystemWrite` recorded a forgery only when the address named the `["cfc"]` label map, so a write at `["patternIdentity"]` recorded nothing at all. A handler could therefore choose the program another piece runs, and a test here demonstrates it: with the gate removed, a handler holding a cell for a second running piece moves that piece's `patternIdentity` to a pattern of its own.

No meta field has a writer outside the runtime, and none has a use for one, so the gate is uniform over the seam rather than a list of which fields are writable by whom.

The authorization travels with the write. `setMetaRaw` hands the cell method an authorization value, the method passes it to `writeOrThrow` as that write's options, and the chokepoint accepts the write on it. The value is keyed by a symbol the runner's modules hold and pattern code cannot name, since the sandbox hands a pattern the builder namespace rather than the runner's modules. Authorizing one write at a time rather than opening a scope around a call keeps the authority to the write that carries it: no other write, in this transaction or another, can pick it up.

Three shapes reach a meta field, and the chokepoint refuses all three when the write arrives unauthorized. An address can name the field, or a path inside it. A document-root write can carry the field as a key of its envelope. A document-root write can also leave the field out, which drops it, because a root write replaces the envelope rather than merging into it — erasing a piece's `patternIdentity` and `internal` corrupts the piece graph as surely as forging them. The third is decided by reading what the document carries, one meta member at a time, through the inner transaction, and under a read that carries no weight of its own. Reading through the outer transaction would put the guard's read in the reactivity log and the flow join. Reading the document root would make every path in the document a precondition of the commit, so a concurrent write anywhere in its value would conflict a write the guard had let through. And a precondition on a member would turn a whole-document write into a read-modify-write: the runtime makes blind root writes, and one of those would then lose the race against any advance of the document it replaces. Where the guard finds a meta field it refuses the write, so nothing commits and the dropped precondition costs nothing. Where it finds none, this transaction has either loaded the document and seen none, or never read it at all, and a blind write over a document nobody read stays as blind as it was.

The refusal is in-process and holds whatever the CFC enforcement mode, like the space-ACL arm beside it and unlike the `["cfc"]` arm below it. That arm records a reason for the commit boundary to weigh, because forged label metadata is a signal whose treatment follows the mode. This is not a signal. A write on the seam from outside the runtime is unauthorized in every mode, a deployment running with enforcement disabled included, so recording it for a pass that will not run would have gated nothing.

The check sits in two places for two different failure modes. The chokepoint is the enforcement: pattern code runs in the runtime's own realm and holds a runtime cell, so it reaches the storage transaction the cell is bound to whatever the cell surface declares, and a check on the method alone would gate nothing. The type surface is the other half. `IMetaCell` keeps `getMetaRaw` and drops the write half, so the seam's writer is no longer part of the cell type a pattern compiles against (`types/commonfabric.d.ts` is a symlink to `api/index.ts`). Reaching for it is a compile error for an author who did not mean to, and a refused write for one who did.

Every runtime writer moves to the authorized entry point, in the runner, the piece controller, slug assignment, the pattern updater, and the tests that stand in for those flows. The entry point is spelled `setMetaRaw`, matching the `getMetaRaw` it is the counterpart to rather than reordering the same two words.

The chokepoint tests membership through `isMetaField`, which needs the seam enumerated as values rather than as a type. `META_FIELDS` becomes that enumeration, and `MetaField` is derived from it, so the type and the list are one declaration and a member cannot be added to either alone. The link fields are enumerated the same way, for the same reason.

That list is not a second copy of the one `isMetaSeamPath` consults in the CFC prepare pass, because the two answer different questions. The prepare pass asks which of a transaction's logical write paths a schema could speak for, decided per path across every write that reached it, and it counts every raw path outside `value` — the `["cfc"]` label map among them, which no schema describes either. The chokepoint asks whether one write, as it happens, reaches a meta field, and it has to tell a meta field from `["cfc"]`: the label map is guarded by the arm below this one, which records a reason for the commit boundary rather than refusing in place. A path-shape rule cannot make that distinction, so this rule names the fields.

The claim in the CFC implementation plan that only the logical `value` surface is exposed to untrusted or user-authored code was false, and a test leaned on it. Reads and materialization do present the value surface, but that is a property of those paths rather than a boundary: a handler holds a runtime cell, and the transaction it is bound to addresses the whole document. The document surface rules now say so, and describe the guard each seam on that surface carries. Two seams stay open and are recorded there on true grounds. A document-root write whose envelope embeds a `cfc` record reaches the label map with nothing recorded, because the `["cfc"]` guard keys on the address. And a guard on a seam governs writes to it, not the runtime entry points that write it while doing their own work: a cell carries the runtime, so a handler can ask `runtime.run` to instantiate a pattern of its choosing onto a cell it holds, and the runtime stamps that document's `patternIdentity` on its behalf through the authorized entry point. Where to draw a boundary against that is a question about the object graph a cell hands pattern code. A test records the reach, so closing it is visible.

Tests pin the seam from both directions. A cell method call without an authorization, a transaction write addressed at a meta field, a write addressed inside one, a document-root write carrying one, a document-root write that would drop one, and a document-root delete of a document that carries one are each refused, with CFC enforcement disabled as well as enforcing. A value write at `["value", "slug"]` and a document-root write on a document that carries no meta field are each left alone. And a handler in a running pattern that reaches for `patternIdentity` on a cell it holds for another piece fails without moving the identity that piece is running.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

