### PR TITLE
test(runner): pin the prepare guard at the caller that lacked one

### DIFF
--- a/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
+++ b/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
@@ -114,6 +114,31 @@ describe("Runtime.prepareTxForCommit()", () => {
     expect(() => runtime.prepareTxForCommit(tx)).not.toThrow();
   });
 
+  // The guard at a caller rather than at the chokepoint. `editWithRetry`
+  // prepares outside the block that turns a throwing action into a result, so
+  // a throw out of prepare escapes it synchronously and defeats the `Result`
+  // it promises. The abort cases in the `editWithRetry` suite abort without
+  // reading or writing first, which leaves the probe nothing to walk.
+  it("returns the abort as `editWithRetry`'s result when the action read before aborting", async () => {
+    const runtime = makeRuntime("persist");
+    const seed = runtime.edit();
+    const cell = runtime.getCell<{ note: string }>(
+      space,
+      "prepare-edit-with-retry",
+      undefined,
+      seed,
+    );
+    cell.set({ note: "seeded" });
+    expect((await seed.commit()).ok).toBeDefined();
+
+    const { error } = await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).get();
+      tx.abort("done with this one");
+    }, 0);
+
+    expect(error?.name).toBe("StorageTransactionAborted");
+  });
+
   it("prepares a ready transaction whose write is CFC-relevant", async () => {
     const runtime = makeRuntime("persist");
     const tx = runtime.edit();


### PR DESCRIPTION
`prepareTxForCommit` returns early on a transaction that is no longer open, and the suite covering that guard exercises it directly. What it does not cover is the caller the guard was needed for.

`editWithRetry` prepares outside the block that turns a throwing action into a result, so a throw out of prepare escapes it synchronously and defeats the `Result` it promises to return. The scheduler's reactive-commit path catches such a throw and converts it into a failed commit; this caller has nothing equivalent.

The `editWithRetry` suite cannot catch that regression, and would not have caught it before the guard landed. Its three aborting actions abort without reading or writing first, so the flow-labels probe finds no activity to walk and reaches no read, and the runtime those tests build leaves the flow dial at the `Runtime` default of "off". Both halves have to be different for the prepare call to reach storage at all.

Add the case that differs in both: an action that reads a seeded document and then aborts, on a runtime with the dial at "persist", asserting the abort comes back as the method's result rather than escaping it. Removing the guard fails this case alongside the two aborted-transaction cases beside it, and leaves the already-committed case and the ready-transaction case passing, which is the same split those two already have.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

