### PR TITLE
A failed send leaves nothing pending, and a benchmark for what a crossing costs

### DIFF
--- a/packages/data-model/bench/codec-realm-ipc.bench.ts
+++ b/packages/data-model/bench/codec-realm-ipc.bench.ts
@@ -79,6 +79,25 @@ class FarSide {
         );
       }
     };
+
+    // A worker that fails to start, or throws where nothing catches, sends no
+    // ack at all -- and a benchmark waiting on one that will never arrive
+    // hangs rather than failing, which is the worst way for a measurement to
+    // end. `messageerror` covers the far side receiving something it cannot
+    // deserialize, which no `error` event reports.
+    this.#worker.onerror = (ev: ErrorEvent) => {
+      const pending = this.#pending;
+
+      this.#pending = undefined;
+      pending?.reject(new Error(`Far side failed: ${ev.message}`));
+    };
+
+    this.#worker.onmessageerror = () => {
+      const pending = this.#pending;
+
+      this.#pending = undefined;
+      pending?.reject(new Error("Far side could not deserialize the message"));
+    };
   }
 
   /**

--- a/packages/data-model/bench/fixtures/realm-ipc-worker.ts
+++ b/packages/data-model/bench/fixtures/realm-ipc-worker.ts
@@ -1,6 +1,6 @@
 /**
- * The far side of a `postMessage()` benchmark: it receives a realm-encoded
- * tree, does what the message asks, and acks.
+ * The far side of a `postMessage()` benchmark: it receives what was sent, does
+ * what the message asks, and acks.
  *
  * Lives under `fixtures/` rather than beside the benchmarks because a file
  * here is neither a `*.bench.ts` nor a test, and the coverage tooling counts
@@ -19,12 +19,18 @@ import { fabricFromRealmValue } from "@/codecs.ts";
 export type IpcRequest = {
   /**
    * `decode` reconstructs the value; `clone` leaves it alone, so that the
-   * difference between the two is the decode and nothing else.
+   * difference between the two is the decode and nothing else. `status-quo`
+   * is neither: the payload arrived unencoded, as a connection relying on
+   * structured cloning alone sends it, and there is nothing for this side to
+   * do -- which is the point, that being the whole of the old far side's work.
    */
-  readonly kind: "decode" | "clone";
+  readonly kind: "decode" | "clone" | "status-quo";
 
-  /** The realm-encoded tree. */
-  readonly payload: RealmEncodedValue;
+  /**
+   * What was sent: a realm-encoded tree for `decode` and `clone`, and the
+   * bare value for `status-quo`.
+   */
+  readonly payload: RealmEncodedValue | unknown;
 };
 
 /** What the far side reports. One boolean, so the return leg costs nothing. */
@@ -40,8 +46,11 @@ self.onmessage = (ev: MessageEvent<IpcRequest>) => {
     if (kind === "decode") {
       // The result is dropped, but the walk has run in full: `decode()` is
       // eager, so there is no lazy remainder for dropping it to skip.
-      fabricFromRealmValue(payload);
+      fabricFromRealmValue(payload as RealmEncodedValue);
     }
+    // `clone` and `status-quo` both do nothing here, for different reasons:
+    // the first to isolate the decode, the second because the old far side
+    // genuinely had no work to do.
 
     self.postMessage({ ok: true } satisfies IpcAck);
   } catch (e) {

--- a/packages/data-model/bench/fixtures/realm-ipc-worker.ts
+++ b/packages/data-model/bench/fixtures/realm-ipc-worker.ts
@@ -15,23 +15,37 @@
 import type { RealmEncodedValue } from "@/codec-realm/interface.ts";
 import { fabricFromRealmValue } from "@/codecs.ts";
 
-/** What a benchmark asks the far side to do with what it sent. */
-export type IpcRequest = {
-  /**
-   * `decode` reconstructs the value; `clone` leaves it alone, so that the
-   * difference between the two is the decode and nothing else. `status-quo`
-   * is neither: the payload arrived unencoded, as a connection relying on
-   * structured cloning alone sends it, and there is nothing for this side to
-   * do -- which is the point, that being the whole of the old far side's work.
-   */
-  readonly kind: "decode" | "clone" | "status-quo";
+/**
+ * What a benchmark asks the far side to do with what it sent.
+ *
+ * Discriminated on `kind` rather than widened to cover both payload shapes:
+ * `RealmEncodedValue | unknown` is just `unknown`, the top type absorbing
+ * every other member, which would let a `decode` request carry anything at all
+ * without a compile error and leave the far side casting on faith.
+ */
+export type IpcRequest =
+  | {
+    /**
+     * `decode` reconstructs the value; `clone` leaves it alone, so that the
+     * difference between the two is the decode and nothing else.
+     */
+    readonly kind: "decode" | "clone";
 
-  /**
-   * What was sent: a realm-encoded tree for `decode` and `clone`, and the
-   * bare value for `status-quo`.
-   */
-  readonly payload: RealmEncodedValue | unknown;
-};
+    /** The realm-encoded tree. */
+    readonly payload: RealmEncodedValue;
+  }
+  | {
+    /**
+     * Neither: the payload arrived unencoded, as a connection relying on
+     * structured cloning alone sends it, and there is nothing for this side
+     * to do -- which is the point, that being the whole of that far side's
+     * work.
+     */
+    readonly kind: "status-quo";
+
+    /** The bare value, as it was handed to `postMessage()`. */
+    readonly payload: unknown;
+  };
 
 /** What the far side reports. One boolean, so the return leg costs nothing. */
 export type IpcAck = {
@@ -40,13 +54,14 @@ export type IpcAck = {
 };
 
 self.onmessage = (ev: MessageEvent<IpcRequest>) => {
-  const { kind, payload } = ev.data;
+  const request = ev.data;
 
   try {
-    if (kind === "decode") {
+    if (request.kind === "decode") {
       // The result is dropped, but the walk has run in full: `decode()` is
-      // eager, so there is no lazy remainder for dropping it to skip.
-      fabricFromRealmValue(payload as RealmEncodedValue);
+      // eager, so there is no lazy remainder for dropping it to skip. No cast:
+      // the discriminant is what says this payload is an encoding.
+      fabricFromRealmValue(request.payload);
     }
     // `clone` and `status-quo` both do nothing here, for different reasons:
     // the first to isolate the decode, the second because the old far side

--- a/packages/data-model/bench/ipc-status-quo.bench.ts
+++ b/packages/data-model/bench/ipc-status-quo.bench.ts
@@ -1,0 +1,152 @@
+/**
+ * What the envelope encoding costs a crossing, end to end, against the
+ * connection as it was.
+ *
+ * The other IPC benchmark isolates the far-side decode by holding everything
+ * else equal. This one answers the question a reviewer actually asks: what
+ * does a message cost now, against what it cost before, with `postMessage()`
+ * and the receipt on the far side inside the measurement.
+ *
+ * Two arms, both a full round trip through a real `Worker`:
+ *
+ * - `status quo` posts the bare value, as a connection relying on structured
+ *   cloning alone does. The far side has nothing to do; structured cloning
+ *   already did all of it.
+ * - `envelope` encodes, posts the encoding, and the far side decodes it.
+ *
+ * **The encode is inside the timed region**, unlike the other file's, because
+ * it is part of what the change costs a sender. So is the decode.
+ *
+ * Every subject is like-for-like: both arms carry the same data, so the ratio
+ * between them is a cost rather than an artifact. Where the two arms need
+ * different values to manage that they get them -- bytes cross as a
+ * `Uint8Array` under the status quo, which structured cloning carries
+ * natively, and as a `FabricBytes` under the envelope.
+ *
+ * A payload the status quo cannot carry at all has no place here. Timing a
+ * crossing that arrives damaged against one that arrives whole produces a
+ * ratio that reads as a regression and means nothing, so the instance-bearing
+ * shapes are measured by the in-realm benchmarks instead.
+ *
+ * Run with:
+ *
+ *     deno bench --allow-read --no-check bench/ipc-status-quo.bench.ts
+ */
+
+import { realmFromFabricValue } from "@/codecs.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import type { FabricValue } from "@/interface.ts";
+import {
+  makeJsonPassThroughOmnibus,
+  makeObject,
+  OBJECTS,
+} from "./fixtures/codec-fixtures.ts";
+import type { IpcAck, IpcRequest } from "./fixtures/realm-ipc-worker.ts";
+
+type PendingRequest = {
+  readonly resolve: () => void;
+  readonly reject: (reason: Error) => void;
+};
+
+/** One worker for the whole run, one message outstanding at a time. */
+class FarSide {
+  readonly #worker: Worker;
+  #pending: PendingRequest | undefined;
+
+  constructor() {
+    this.#worker = new Worker(
+      import.meta.resolve("./fixtures/realm-ipc-worker.ts"),
+      { type: "module" },
+    );
+
+    this.#worker.onmessage = (ev: MessageEvent<IpcAck>) => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      if (ev.data.ok) pending?.resolve();
+      else pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
+    };
+  }
+
+  /**
+   * Sends one request and settles when the far side acks.
+   *
+   * @throws If the far side reports failure. An unexamined ack is what makes a
+   *   benchmark measure the wrong thing silently.
+   */
+  send(request: IpcRequest): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.#pending = { resolve, reject };
+      this.#worker.postMessage(request);
+    });
+  }
+
+  close(): void {
+    this.#worker.terminate();
+  }
+}
+
+const farSide = new FarSide();
+
+/**
+ * A spread of payload shapes rather than sizes of one shape: what a crossing
+ * costs turns on how many containers a walk visits and whether anything needs
+ * encoding at all, and these differ in both.
+ *
+ * What is absent is as deliberate as what is here. A subject belongs only if
+ * both arms carry the same data, so that the ratio between them is a cost
+ * rather than an artifact; a payload the status quo drops is not measured
+ * here at all, rather than measured and qualified.
+ */
+const MEGABYTE = 1024 * 1024;
+
+/**
+ * What each arm sends. `statusQuo` defaults to the same value the envelope
+ * arm carries, and differs only where carrying the same data takes a different
+ * shape on the old path.
+ */
+type Subject = {
+  readonly name: string;
+  readonly value: FabricValue;
+  readonly statusQuo?: unknown;
+};
+
+const SUBJECTS: readonly Subject[] = [
+  // A small cell value: one container, a handful of members.
+  { name: "small record", value: makeObject(10) },
+  // A flat object of 100 numbers: one container, many members.
+  { name: "flat 100 members", value: OBJECTS[3]![1] },
+  // ~400 containers of plain data. The shape a VDOM batch or a cell update has.
+  { name: "nested 100 records", value: makeJsonPassThroughOmnibus(100) },
+  // Ten times that, for the scaling.
+  { name: "nested 1000 records", value: makeJsonPassThroughOmnibus(1000) },
+  // A megabyte of bytes, carried both ways: a bare `Uint8Array` is how the
+  // status quo moves bytes at all, structured cloning carrying one natively,
+  // and a `FabricBytes` is how they cross now. Same bytes, both arriving.
+  {
+    name: "1MB of bytes",
+    value: new FabricBytes(new Uint8Array(MEGABYTE)),
+    statusQuo: new Uint8Array(MEGABYTE),
+  },
+];
+
+for (const { name, value, statusQuo } of SUBJECTS) {
+  const before = statusQuo ?? value;
+
+  Deno.bench({
+    name: `status quo — ${name}`,
+    group: name,
+    baseline: true,
+  }, async () => {
+    await farSide.send({ kind: "status-quo", payload: before });
+  });
+
+  Deno.bench({ name: `envelope — ${name}`, group: name }, async () => {
+    // Encoded here, inside the measurement: the send pays for it.
+    await farSide.send({
+      kind: "decode",
+      payload: realmFromFabricValue(value),
+    });
+  });
+}
+
+globalThis.addEventListener("unload", () => farSide.close());

--- a/packages/data-model/bench/ipc-status-quo.bench.ts
+++ b/packages/data-model/bench/ipc-status-quo.bench.ts
@@ -65,6 +65,23 @@ class FarSide {
       if (ev.data.ok) pending?.resolve();
       else pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
     };
+
+    // A worker that fails to start, or throws where nothing catches, sends no
+    // ack -- and a benchmark waiting on one that will never arrive hangs
+    // rather than failing, which is the worst way for a measurement to end.
+    // `messageerror` covers the far side receiving something it cannot
+    // deserialize, which no `error` event reports.
+    this.#worker.onerror = (ev: ErrorEvent) => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      pending?.reject(new Error(`Far side failed: ${ev.message}`));
+    };
+
+    this.#worker.onmessageerror = () => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      pending?.reject(new Error("Far side could not deserialize the message"));
+    };
   }
 
   /**

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -338,7 +338,38 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
         message.data,
       );
     }
-    this.#transport.send(message);
+    // The bookkeeping above -- the timeout, the abort hook, the pending entry
+    // -- is registered on the promise below being returned to someone who will
+    // hold it until a reply settles it. A synchronous throw from `send()`
+    // means no reply is coming and the promise is never returned, so that
+    // bookkeeping would outlive its only holder and reject it into nobody:
+    // sixty seconds later at the timeout, or sooner at disposal, as an
+    // unhandled rejection. `postMessage()` throws for a value structured
+    // cloning refuses, and `T` is unconstrained, so an ordinary bad value
+    // reaches it.
+    //
+    // `#settle()` clears the three, and deliberately does not settle the
+    // deferred: an unsettled promise nobody holds is collected, where a
+    // rejected one is reported. The caller learns of the failure by the throw
+    // rather than through the promise it never received.
+    try {
+      this.#transport.send(message);
+    } catch (error) {
+      this.#settle(msgId);
+      // The timeline reads a missing `doneAtMs` as still in flight, which is
+      // what a reader mid-diagnosis would take from it -- and this request is
+      // as finished as one gets. It never left, so it is marked done at the
+      // moment it failed, and as an error.
+      const timelineEntry = this.#timelineByMsgId.get(msgId);
+      if (timelineEntry) {
+        timelineEntry.doneAtMs = Math.round(
+          performance.now() - this.#constructedAt,
+        );
+        timelineEntry.error = true;
+        this.#timelineByMsgId.delete(msgId);
+      }
+      throw error;
+    }
 
     return deferred.promise;
   }

--- a/packages/runtime-client/test/client/connection.test.ts
+++ b/packages/runtime-client/test/client/connection.test.ts
@@ -64,6 +64,32 @@ async function initializedConnection(
   return connection;
 }
 
+/**
+ * Transport whose `send()` throws, as `postMessage()` does when handed a value
+ * structured cloning refuses.
+ */
+class ThrowingTransport extends EventEmitter<RuntimeTransportEvents>
+  implements RuntimeTransport {
+  constructor(private readonly failOn: RequestType) {
+    super();
+  }
+
+  send(message: IPCClientMessage | IPCClientNotification): void {
+    if (!("msgId" in message)) return;
+    if (message.data.type === this.failOn) {
+      throw new Error("could not be cloned");
+    }
+    // Everything else is acknowledged, so the connection can initialize.
+    queueMicrotask(() => {
+      this.emit("message", { msgId: message.msgId, data: undefined });
+    });
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 describe("connection", () => {
   describe("RuntimeConnection disposal", () => {
     it("settles in-flight requests as cancellation on dispose", async () => {
@@ -192,6 +218,39 @@ describe("connection", () => {
       }
 
       expect(warnings.length).toBe(0);
+    });
+
+    it("leaves nothing pending when the send itself throws", async () => {
+      // The throw reaches the caller, and the promise `request()` would have
+      // returned is never returned at all -- so the timeout and abort hook
+      // registered before the send must not be left holding it. Were they,
+      // disposal would reject a promise nobody holds, which is an unhandled
+      // rejection rather than a caught one.
+      const connection = new RuntimeConnection(
+        new ThrowingTransport(RequestType.CellSet),
+      );
+      await connection.initialize({} as InitializationData);
+
+      expect(() =>
+        connection.request({
+          type: RequestType.CellSet,
+          cell: { id: "of:c", space: "did:key:t", scope: "space", path: [] },
+          value: 1,
+        } as never)
+      ).toThrow("could not be cloned");
+
+      expect(connection.getPendingRequestDiagnostics()).toHaveLength(0);
+
+      // And the timeline says so too: a missing `doneAtMs` reads as still in
+      // flight, which is the one thing this request is not.
+      const entry = connection.getRequestTimelineDiagnostics().find((e) =>
+        e.type === RequestType.CellSet
+      );
+      expect(entry?.doneAtMs).toEqual(expect.any(Number));
+      expect(entry?.error).toBe(true);
+
+      // Would reject the orphan, if the bookkeeping still held one.
+      await connection.dispose();
     });
 
     it("throws when a notification is sent after disposal", async () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Prep for the IPC envelope work (#6323), on the pattern #6330, #6339, #6369 and
#6375 set. A live bug, and the measurement that justifies that change. Neither
depends on it landing.

## A failed send left its bookkeeping behind

`RuntimeConnection.request()` arms a timeout, registers an abort hook and
records a pending entry, then sends, then returns the promise those three will
settle. `send()` can throw — it is `postMessage()`, which refuses a value
structured cloning cannot carry, and `T` is unconstrained on `CellHandle`, so
an ordinary bad value reaches it.

When it throws, `return deferred.promise` never runs. The caller gets the
exception, correctly. But the timeout and the abort listener are still live and
still hold that promise, which now has no other holder — so sixty seconds later
the timeout rejects it, or `dispose()` rejects it sooner, into nobody.
`defer()` attaches no suppression, so that is an unhandled rejection, which a
Deno host treats as fatal.

The send is guarded, and `#settle()` clears all three. It deliberately does not
settle the deferred: an unsettled promise nobody holds is collected, where a
rejected one is reported. The caller still learns of the failure by the throw.

The request's timeline entry is finished too. A missing `doneAtMs` reads as
still in flight, so `getRequestTimelineDiagnostics()` would show a terminally
failed request as hung — the one thing it is not.

**The test is ablated against `main` exactly.** With the guard removed the file
is byte-identical to what it replaced (`git diff` reports no change), and the
test fails. So this is a live defect rather than a hardening.

## And the benchmark that measures a crossing

`bench/ipc-status-quo.bench.ts` times a full round trip through a real `Worker`
— `postMessage()`, receipt and ack — for a connection relying on structured
cloning against one that encodes with `codec-realm` and decodes on arrival. The
encode is inside the timed region, because a sender pays for it.

It lands here rather than with #6323 so the numbers are reproducible without
that branch, and so that PR carries the change rather than the apparatus. On
this branch it measures what an envelope *would* cost; the arms are the same
either way.

| payload | structured clone | envelope | |
| --- | --- | --- | --- |
| small record | 11.9 us | 11.6 us | unchanged |
| flat object, 100 members | 14.2 us | 18.7 us | 1.32x |
| 100 nested records (~400 containers) | 101.0 us | 169.3 us | 1.68x |
| 1000 nested records | 809.0 us | 1417.5 us | 1.75x |
| 1 MB of bytes | 45.5 us | 75.8 us | 1.66x |

Every subject carries the same data in both arms, which is what makes the
ratios mean anything. Where that takes a different shape on each side it gets
one: bytes cross as a `Uint8Array` under structured cloning, which carries one
natively, and as a `FabricBytes` under the envelope. A payload one arm cannot
carry is deliberately absent — timing a crossing that arrives damaged against
one that arrives whole yields a ratio that reads as a regression and says
nothing.

## Verification

- `deno fmt --check`, `deno lint`, `deno task check`: green, repo-wide.
- `runtime-client` (14/328) and `data-model` (48/2534): green.
- The benchmark runs on this branch and reports the same figures it does with
  #6323 applied, which is the point of it standing alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ukZJG1bVUK194EAJhtLNu


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

