### PR TITLE
fix(state-inspector): a cell a migration adopts as generated is not removed

### DIFF
--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -151,6 +151,11 @@ is not optional.
   whole-store fingerprint can tell you titles and bodies survived.
 - **`removed` above zero** — durable content was destroyed. Stop and
   investigate before anything else.
+- **`generated N reclassified`** — not a removal, and not an alarm. The
+  baseline hashed cells no pristine manifest listed, and the migrated pieces
+  now call them generated, so they leave the compared set without leaving the
+  store. They are subtracted from `removed` and reported here so the change is
+  visible rather than silent.
 - **`content unchanged`** — nothing moved at all. Correct for a clone that has
   not been migrated yet; suspicious after one that has.
 - **`baseline CORRUPTED`** — the pristine snapshot no longer matches the

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -353,6 +353,10 @@ export const space = new Command()
             diff.changed > 0 ? `  (${kinds(diff.changedByKind)})` : ""
           }\n` +
           `added      ${diff.added}\n` +
+          (diff.reclassifiedGenerated > 0
+            ? `generated  ${diff.reclassifiedGenerated} reclassified — in ` +
+              `both stores, excluded here, not removed\n`
+            : "") +
           `content    ${fingerprint.match ? "unchanged" : "CHANGED"}\n` +
           `commits    ${counts.manifest.commits} → ${counts.working.commits}\n` +
           `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n` +

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -413,12 +413,12 @@ export interface VerifyResult {
     added: number;
 
     /**
-     * Entities the baseline hashed and this store's manifests call generated.
-     * They are present in both stores, so they are not removed; the two sides
-     * derive their exclusions from their own pieces, and a migration that
-     * adopts an unlisted cell into a generated slot moves it from one list to
-     * the other. Reported rather than dropped: a number that silently
-     * disappears is one nobody can check.
+     * Entities the baseline hashed and this store's manifests call generated at
+     * that same (id, scope). They are present in both stores, so they are not
+     * removed; the two sides derive their exclusions from their own pieces, and
+     * a migration that adopts an unlisted cell into a generated slot moves it
+     * from one list to the other. Reported rather than dropped: a number that
+     * silently disappears is one nobody can check.
      */
     reclassifiedGenerated: number;
 
@@ -518,7 +518,7 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
       // is honest here and costs nothing: the reclassification below reads
       // the WORKING store's exclusions, which is the side that can turn a
       // present entity into an absent row.
-      excludedGeneratedIds: [],
+      excludedGeneratedAddresses: [],
       ambiguous: [],
       unhashable: [],
       perEntity: rows,
@@ -534,28 +534,33 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   }
 
   const d = diffFingerprints(before, fingerprint);
+  // Keyed by id AND scope throughout: one id can hold a shared space value plus
+  // per-user/per-session overrides that are genuinely different entities, and a
+  // by-id lookup would let the last scope win — misclassifying the tally, and
+  // clearing a removal below because some OTHER scope of the same id is
+  // generated. `diffFingerprints` reports the address it compared by, so there
+  // is nothing left to guess at here.
+  const addressKey = (at: ScopedEntity) => `${at.id} ${at.scope}`;
   // A removal is an entity gone from the store, never one this store's own
   // manifests reclassified. The two sides compute their exclusions
   // independently — the baseline from the pristine pieces, this from the
   // working ones — so a cell no pristine manifest listed and a migrated piece
   // now calls generated is present in both stores and absent from one list.
   // Subtracting them here is what keeps `removed` meaning destroyed content,
-  // which is the verdict the runbook tells an operator to stop on.
-  const excludedNow = new Set(fingerprint.excludedGeneratedIds);
-  const reclassifiedGenerated = d.removed.filter((at) =>
-    excludedNow.has(at.id)
+  // which is the verdict the runbook tells an operator to stop on. A manifest
+  // link carries no scope, so an adopted id is excluded in every scope that
+  // holds it: only the addresses this store actually enumerated are subtracted,
+  // and a scope whose rows are gone is not among them.
+  const excludedNow = new Set(
+    fingerprint.excludedGeneratedAddresses.map(addressKey),
   );
-  const removed = d.removed.filter((at) => !excludedNow.has(at.id));
-  // Keyed by id AND scope throughout: one id can hold a shared space value plus
-  // per-user/per-session overrides that are genuinely different entities, and a
-  // by-id lookup would let the last scope win and misclassify the tally —
-  // exactly the precision ("74 pieces vs 73 cells") the diff exists to provide.
-  // `diffFingerprints` reports the address it compared by, so there is nothing
-  // left to guess at here.
+  const reclassifiedGenerated = d.removed.filter((at) =>
+    excludedNow.has(addressKey(at))
+  );
+  const removed = d.removed.filter((at) => !excludedNow.has(addressKey(at)));
   const kindIndex = (rows: FingerprintReport["perEntity"]) => {
-    const byAddress = new Map(rows.map((e) => [`${e.id} ${e.scope}`, e.kind]));
-    return (at: ScopedEntity) =>
-      byAddress.get(`${at.id} ${at.scope}`) ?? "unknown";
+    const byAddress = new Map(rows.map((e) => [addressKey(e), e.kind]));
+    return (at: ScopedEntity) => byAddress.get(addressKey(at)) ?? "unknown";
   };
   const kindOf = kindIndex(fingerprint.perEntity);
   const kindWas = kindIndex(before.perEntity);

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -39,6 +39,7 @@ import { openSpace } from "./db.ts";
 import {
   contentFingerprint,
   diffFingerprints,
+  entityAddressKey,
   type FingerprintReport,
   type ScopedEntity,
 } from "./fingerprint.ts";
@@ -534,13 +535,14 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   }
 
   const d = diffFingerprints(before, fingerprint);
-  // Keyed by id AND scope throughout: one id can hold a shared space value plus
-  // per-user/per-session overrides that are genuinely different entities, and a
-  // by-id lookup would let the last scope win — misclassifying the tally, and
-  // clearing a removal below because some OTHER scope of the same id is
-  // generated. `diffFingerprints` reports the address it compared by, so there
-  // is nothing left to guess at here.
-  const addressKey = (at: ScopedEntity) => `${at.id} ${at.scope}`;
+  // Keyed by id AND scope throughout, through the shared `entityAddressKey`:
+  // one id can hold a shared space value plus per-user/per-session overrides
+  // that are genuinely different entities, and a by-id lookup would let the
+  // last scope win — misclassifying the tally, and clearing a removal below
+  // because some OTHER scope of the same id is generated. `diffFingerprints`
+  // reports the address it compared by and keys it the same way, so there is
+  // nothing left to guess at here and no second spelling to drift from.
+  //
   // A removal is an entity gone from the store, never one this store's own
   // manifests reclassified. The two sides compute their exclusions
   // independently — the baseline from the pristine pieces, this from the
@@ -552,15 +554,18 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   // holds it: only the addresses this store actually enumerated are subtracted,
   // and a scope whose rows are gone is not among them.
   const excludedNow = new Set(
-    fingerprint.excludedGeneratedAddresses.map(addressKey),
+    fingerprint.excludedGeneratedAddresses.map(entityAddressKey),
   );
   const reclassifiedGenerated = d.removed.filter((at) =>
-    excludedNow.has(addressKey(at))
+    excludedNow.has(entityAddressKey(at))
   );
-  const removed = d.removed.filter((at) => !excludedNow.has(addressKey(at)));
+  const removed = d.removed.filter((at) =>
+    !excludedNow.has(entityAddressKey(at))
+  );
   const kindIndex = (rows: FingerprintReport["perEntity"]) => {
-    const byAddress = new Map(rows.map((e) => [addressKey(e), e.kind]));
-    return (at: ScopedEntity) => byAddress.get(addressKey(at)) ?? "unknown";
+    const byAddress = new Map(rows.map((e) => [entityAddressKey(e), e.kind]));
+    return (at: ScopedEntity) =>
+      byAddress.get(entityAddressKey(at)) ?? "unknown";
   };
   const kindOf = kindIndex(fingerprint.perEntity);
   const kindWas = kindIndex(before.perEntity);

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -412,6 +412,16 @@ export interface VerifyResult {
     changed: number;
     added: number;
 
+    /**
+     * Entities the baseline hashed and this store's manifests call generated.
+     * They are present in both stores, so they are not removed; the two sides
+     * derive their exclusions from their own pieces, and a migration that
+     * adopts an unlisted cell into a generated slot moves it from one list to
+     * the other. Reported rather than dropped: a number that silently
+     * disappears is one nobody can check.
+     */
+    reclassifiedGenerated: number;
+
     /** Counts per entity kind, so "74 pieces" reads differently from "74 cells". */
     changedByKind: Record<string, number>;
     removedByKind: Record<string, number>;
@@ -504,6 +514,11 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
       hash: manifest.fingerprint.hash,
       entities: rows.length,
       excludedGenerated: manifest.fingerprint.excludedGenerated,
+      // The sidecar records how many the baseline excluded, not which. Empty
+      // is honest here and costs nothing: the reclassification below reads
+      // the WORKING store's exclusions, which is the side that can turn a
+      // present entity into an absent row.
+      excludedGeneratedIds: [],
       ambiguous: [],
       unhashable: [],
       perEntity: rows,
@@ -519,6 +534,18 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   }
 
   const d = diffFingerprints(before, fingerprint);
+  // A removal is an entity gone from the store, never one this store's own
+  // manifests reclassified. The two sides compute their exclusions
+  // independently — the baseline from the pristine pieces, this from the
+  // working ones — so a cell no pristine manifest listed and a migrated piece
+  // now calls generated is present in both stores and absent from one list.
+  // Subtracting them here is what keeps `removed` meaning destroyed content,
+  // which is the verdict the runbook tells an operator to stop on.
+  const excludedNow = new Set(fingerprint.excludedGeneratedIds);
+  const reclassifiedGenerated = d.removed.filter((at) =>
+    excludedNow.has(at.id)
+  );
+  const removed = d.removed.filter((at) => !excludedNow.has(at.id));
   // Keyed by id AND scope throughout: one id can hold a shared space value plus
   // per-user/per-session overrides that are genuinely different entities, and a
   // by-id lookup would let the last scope win and misclassify the tally —
@@ -544,11 +571,12 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
     return out;
   };
   const delta = {
-    removed: d.removed.length,
+    removed: removed.length,
     changed: d.changed.length,
     added: d.added.length,
+    reclassifiedGenerated: reclassifiedGenerated.length,
     changedByKind: tally(d.changed, kindOf),
-    removedByKind: tally(d.removed, kindWas),
+    removedByKind: tally(removed, kindWas),
   };
 
   const match = fingerprint.hash === manifest.fingerprint.hash;

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -102,6 +102,25 @@ function allEntities(
  */
 export type ScopedEntity = EntityAddress & { scope: string };
 
+/**
+ * The composite key an entity address indexes by — one spelling, exported, so
+ * two sides of a comparison cannot key differently and quietly disagree about
+ * which entity is which.
+ *
+ * The separator is NUL because it has to be a byte neither field can hold. A
+ * minted id is `of:fid1:<base64url>`, `computed:fid1:<…>` or a DID, and a scope
+ * key is `space` or `user:`/`session:` over percent-encoded segments, so no
+ * value the runtime writes contains a control byte. A printable separator has
+ * no such floor under it: this tool reads stores it did not write, where both
+ * columns are opaque TEXT, and `("of:a", "b c")` and `("of:a b", "c")` would
+ * then share a key. That is not a cosmetic collision — `verifyClone` subtracts
+ * generated exclusions by this key, so an alias could clear a removal that
+ * really happened, which is the one verdict this module must never soften.
+ */
+export function entityAddressKey(at: ScopedEntity): string {
+  return `${at.id}\x00${at.scope}`;
+}
+
 /** One entity's content hash at head. */
 export interface EntityFingerprint {
   id: string;
@@ -318,9 +337,8 @@ export function diffFingerprints(
   before: FingerprintReport,
   after: FingerprintReport,
 ): FingerprintDiff {
-  const key = (e: EntityFingerprint) => `${e.id}\x00${e.scope}`;
-  const a = new Map(before.perEntity.map((e) => [key(e), e]));
-  const b = new Map(after.perEntity.map((e) => [key(e), e]));
+  const a = new Map(before.perEntity.map((e) => [entityAddressKey(e), e]));
+  const b = new Map(after.perEntity.map((e) => [entityAddressKey(e), e]));
 
   const added: ScopedEntity[] = [];
   const removed: ScopedEntity[] = [];

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -86,6 +86,22 @@ function allEntities(
   return out;
 }
 
+/**
+ * An {@link EntityAddress} whose scope is known — which, for anything this
+ * module reports, it always is.
+ *
+ * An id is NOT unique on its own: one id can hold a shared space value plus
+ * per-user/per-session overrides that are genuinely different entities. So a
+ * report names the pair it computed over. A bare id forces every caller to
+ * re-associate it with a scope by guessing — a lookup that silently lets the
+ * last scope win, misclassifying exactly the per-kind precision ("74 pieces vs
+ * 73 cells") the diff exists to provide.
+ *
+ * Being an `EntityAddress` is the useful part: what a diff entry is FOR is
+ * looking the entity up, and this hands straight to `reconstructDocument`.
+ */
+export type ScopedEntity = EntityAddress & { scope: string };
+
 /** One entity's content hash at head. */
 export interface EntityFingerprint {
   id: string;
@@ -109,14 +125,20 @@ export interface FingerprintReport {
   excludedGenerated: number;
 
   /**
-   * The ids behind {@link excludedGenerated}. A diff against a fingerprint
-   * taken from another store must subtract these before calling anything
-   * removed: the two stores compute their exclusions independently, so a cell
-   * no manifest listed THERE and this manifest calls generated HERE is present
-   * in both and absent from one list. Reporting that as removed content is the
-   * loudest verdict this module has, spent on a filter disagreement.
+   * The entities behind {@link excludedGenerated}, by address. A diff against a
+   * fingerprint taken from another store must subtract these before calling
+   * anything removed: the two stores compute their exclusions independently, so
+   * a cell no manifest listed THERE and this manifest calls generated HERE is
+   * present in both and absent from one list. Reporting that as removed content
+   * is the loudest verdict this module has, spent on a filter disagreement.
+   *
+   * The scope travels with the id because the subtraction is only sound per
+   * (id, scope). A manifest link carries an id and no scope, so calling a cell
+   * generated excludes EVERY scope that holds the id; subtracting by id alone
+   * would then clear the alarm for a scope whose rows are gone, reporting
+   * destroyed per-user state as a filter disagreement.
    */
-  excludedGeneratedIds: string[];
+  excludedGeneratedAddresses: ScopedEntity[];
 
   /**
    * Ids some manifest calls generated and another calls named. Counted as
@@ -230,13 +252,11 @@ export function contentFingerprint(
   );
   const perEntity: EntityFingerprint[] = [];
   const unhashable: { id: string; reason: string }[] = [];
-  let excludedGenerated = 0;
-  const excludedGeneratedIds: string[] = [];
+  const excludedGeneratedAddresses: ScopedEntity[] = [];
 
   for (const model of allEntities(space, branch, options.enumerationCap)) {
     if (generated.has(model.id)) {
-      excludedGenerated++;
-      excludedGeneratedIds.push(model.id);
+      excludedGeneratedAddresses.push({ id: model.id, scope: model.scope });
       continue;
     }
     // The models come from this branch, so the values must too — reading the
@@ -275,29 +295,13 @@ export function contentFingerprint(
       perEntity.map((e) => [e.id, e.scope, e.hash] as const),
     ).toString(),
     entities: perEntity.length,
-    excludedGenerated,
-    excludedGeneratedIds,
+    excludedGenerated: excludedGeneratedAddresses.length,
+    excludedGeneratedAddresses,
     ambiguous,
     unhashable,
     perEntity,
   };
 }
-
-/**
- * An {@link EntityAddress} whose scope is known — which, for a diff, it always
- * is.
- *
- * An id is NOT unique on its own: one id can hold a shared space value plus
- * per-user/per-session overrides that are genuinely different entities. So the
- * diff reports the pair it compared by. Returning a bare id forced every caller
- * to re-associate it with a scope by guessing — a lookup that silently lets the
- * last scope win, misclassifying exactly the per-kind precision ("74 pieces vs
- * 73 cells") the diff exists to provide.
- *
- * Being an `EntityAddress` is the useful part: what a diff entry is FOR is
- * looking the entity up, and this hands straight to `reconstructDocument`.
- */
-export type ScopedEntity = EntityAddress & { scope: string };
 
 export interface FingerprintDiff {
   equal: boolean;

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -109,6 +109,16 @@ export interface FingerprintReport {
   excludedGenerated: number;
 
   /**
+   * The ids behind {@link excludedGenerated}. A diff against a fingerprint
+   * taken from another store must subtract these before calling anything
+   * removed: the two stores compute their exclusions independently, so a cell
+   * no manifest listed THERE and this manifest calls generated HERE is present
+   * in both and absent from one list. Reporting that as removed content is the
+   * loudest verdict this module has, spent on a filter disagreement.
+   */
+  excludedGeneratedIds: string[];
+
+  /**
    * Ids some manifest calls generated and another calls named. Counted as
    * generated (rotation-prone wins, so the fingerprint stays stable) but
    * reported, because that choice can hide a real content change and must never
@@ -221,10 +231,12 @@ export function contentFingerprint(
   const perEntity: EntityFingerprint[] = [];
   const unhashable: { id: string; reason: string }[] = [];
   let excludedGenerated = 0;
+  const excludedGeneratedIds: string[] = [];
 
   for (const model of allEntities(space, branch, options.enumerationCap)) {
     if (generated.has(model.id)) {
       excludedGenerated++;
+      excludedGeneratedIds.push(model.id);
       continue;
     }
     // The models come from this branch, so the values must too — reading the
@@ -264,6 +276,7 @@ export function contentFingerprint(
     ).toString(),
     entities: perEntity.length,
     excludedGenerated,
+    excludedGeneratedIds,
     ambiguous,
     unhashable,
     perEntity,

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -220,6 +220,46 @@ Deno.test("a migration-shaped change is a PASS, not a failure", async () => {
   });
 });
 
+Deno.test("a cell a migration adopts as generated is not a removal", async () => {
+  // Measured on a 5 GB clone of the real Topics store: `verify` reported 114
+  // owned cells REMOVED — "durable content was destroyed", the loudest verdict
+  // it has — while every one of them was present at head in BOTH stores. The
+  // two sides derive their exclusions from their own pieces: the baseline
+  // hashed cells no pristine manifest listed, and after the migration the
+  // pieces call those same cells generated, so they drop out of the second
+  // list. An operator following the runbook aborts a healthy migration on it.
+  await withDirs(async ({ source, clone }) => {
+    // A cell no piece's manifest lists: the baseline hashes it.
+    mutate(source, [["of:orphan", {
+      value: "orphan-v1",
+      result: link("of:piece"),
+    }]]);
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    // What the migration does: the new pattern adopts it into a generated slot.
+    mutate(paths.workingPath, [["of:piece", {
+      value: { $NAME: "Board" },
+      argument: link("of:input"),
+      internal: [
+        { partialCause: "entries", link: link("of:named") },
+        { partialCause: { $generated: 0 }, link: link("of:generated") },
+        { partialCause: { $generated: 1 }, link: link("of:orphan") },
+      ],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }]]);
+
+    const v = await verifyClone(clone);
+    assertEquals(v.diff.removed, 0, "it is in both stores; nothing was lost");
+    assertEquals(
+      v.diff.reclassifiedGenerated,
+      1,
+      "and the reclassification is reported rather than dropped",
+    );
+    assert(v.okAfterMigration, "so the migration verdict passes");
+  });
+});
+
 Deno.test("verify catches a real content change", async () => {
   await withDirs(async ({ source, clone }) => {
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -25,7 +25,26 @@ const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
 const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
 const NOW = () => new Date("2026-07-27T12:00:00.000Z");
 
+/** A per-user scope_key, %-encoded as the runtime stores one. */
+const USER_SCOPE = "user:did%3Akey%3AzAlice";
+
 const link = (id: string) => ({ "/": { "link@1": { id, path: [] } } });
+
+/**
+ * The piece as a pattern update rewrites it: `of:orphan` — a cell no earlier
+ * manifest listed — adopted into a generated slot.
+ */
+const PIECE_ADOPTING_ORPHAN = {
+  value: { $NAME: "Board" },
+  argument: link("of:input"),
+  internal: [
+    { partialCause: "entries", link: link("of:named") },
+    { partialCause: { $generated: 0 }, link: link("of:generated") },
+    { partialCause: { $generated: 1 }, link: link("of:orphan") },
+  ],
+  patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+  schema: { type: "object", properties: {}, $defs: {} },
+};
 
 /** A source store shaped like a real one: a piece with one named and one
  *  generated internal cell, plus its input. */
@@ -63,8 +82,18 @@ CREATE TABLE revision (
   db.close();
 }
 
-/** Append documents to an existing store, continuing its seq sequence. */
-function writeDocs(db: Database, docs: [string, unknown][]): void {
+/**
+ * Append documents to an existing store, continuing its seq sequence.
+ *
+ * `scope` is the stored `scope_key`: `space` for shared state, and
+ * `user:<DID>` / `session:<DID>:<uuid>` for the per-identity rows that can
+ * carry the SAME id as a shared one.
+ */
+function writeDocs(
+  db: Database,
+  docs: [string, unknown][],
+  scope = "space",
+): void {
   const next = db.prepare(`SELECT coalesce(max(seq), 0) s FROM "commit"`)
     .get<{ s: number }>()!.s;
   const commit = db.prepare(
@@ -73,19 +102,36 @@ function writeDocs(db: Database, docs: [string, unknown][]): void {
   );
   const rev = db.prepare(
     `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
-     VALUES (?, 'space', ?, 0, 'set', ?, ?)`,
+     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
   );
   docs.forEach(([id, doc], i) => {
     const seq = next + i + 1;
     commit.run(seq, SESSION, seq);
-    rev.run(id, seq, JSON.stringify(doc), seq);
+    rev.run(id, scope, seq, JSON.stringify(doc), seq);
   });
 }
 
 /** Apply writes to a store on disk (what a rehearsal's migration would do). */
-function mutate(path: string, docs: [string, unknown][]): void {
+function mutate(
+  path: string,
+  docs: [string, unknown][],
+  scope?: string,
+): void {
   const db = new Database(path);
-  writeDocs(db, docs);
+  writeDocs(db, docs, scope);
+  db.close();
+}
+
+/**
+ * Destroy an entity's rows in one scope — content loss at rest, which is what
+ * `removed` names. A `delete` op would not do: a listing keeps tombstones, so
+ * the entity still enumerates and the fingerprint records it with a null hash,
+ * which the diff reads as a change.
+ */
+function dropEntity(path: string, id: string, scope: string): void {
+  const db = new Database(path);
+  db.prepare(`DELETE FROM revision WHERE id = ? AND scope_key = ?`)
+    .run(id, scope);
   db.close();
 }
 
@@ -237,17 +283,7 @@ Deno.test("a cell a migration adopts as generated is not a removal", async () =>
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
     const paths = clonePaths(clone, SPACE);
     // What the migration does: the new pattern adopts it into a generated slot.
-    mutate(paths.workingPath, [["of:piece", {
-      value: { $NAME: "Board" },
-      argument: link("of:input"),
-      internal: [
-        { partialCause: "entries", link: link("of:named") },
-        { partialCause: { $generated: 0 }, link: link("of:generated") },
-        { partialCause: { $generated: 1 }, link: link("of:orphan") },
-      ],
-      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
-      schema: { type: "object", properties: {}, $defs: {} },
-    }]]);
+    mutate(paths.workingPath, [["of:piece", PIECE_ADOPTING_ORPHAN]]);
 
     const v = await verifyClone(clone);
     assertEquals(v.diff.removed, 0, "it is in both stores; nothing was lost");
@@ -257,6 +293,48 @@ Deno.test("a cell a migration adopts as generated is not a removal", async () =>
       "and the reclassification is reported rather than dropped",
     );
     assert(v.okAfterMigration, "so the migration verdict passes");
+  });
+});
+
+Deno.test("an adoption in one scope does not excuse a removal in another", async () => {
+  // The reclassification has to key by (id, scope) for the same reason the
+  // diff does. A manifest link carries an id and no scope, so adopting a cell
+  // excludes EVERY scope holding that id from the working fingerprint —
+  // subtracting by id alone therefore clears the alarm for a scope whose rows
+  // are gone, and reports destroyed per-user state as a filter disagreement.
+  // That inverts the whole point: the reclassification exists to preserve
+  // `removed` as "durable content was destroyed", not to suppress it.
+  await withDirs(async ({ source, clone }) => {
+    // One id in two scopes, listed by no manifest: the baseline hashes both.
+    mutate(source, [["of:orphan", {
+      value: "orphan-v1",
+      result: link("of:piece"),
+    }]]);
+    mutate(source, [["of:orphan", {
+      value: "orphan-per-user",
+      result: link("of:piece"),
+    }]], USER_SCOPE);
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+
+    // The migration adopts the id into a generated slot — and the per-user
+    // rows are destroyed, which no reclassification can account for.
+    mutate(paths.workingPath, [["of:piece", PIECE_ADOPTING_ORPHAN]]);
+    dropEntity(paths.workingPath, "of:orphan", USER_SCOPE);
+
+    const v = await verifyClone(clone);
+    assertEquals(v.diff.removed, 1, "the destroyed per-user row is a removal");
+    assertEquals(
+      v.diff.removedByKind,
+      { "owned-cell": 1 },
+      "classified from the removed entity's own baseline (id, scope)",
+    );
+    assertEquals(
+      v.diff.reclassifiedGenerated,
+      1,
+      "only the space-scope row is present in both stores",
+    );
+    assert(!v.okAfterMigration, "so the alarm still sounds");
   });
 });
 
@@ -520,24 +598,14 @@ Deno.test("the per-kind tally respects scope, not just id", async () => {
   // the tally — the precision ("74 pieces vs 73 cells") the diff exists for.
   await withDirs(async ({ source, clone }) => {
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
-    const db = new Database(clonePaths(clone, SPACE).workingPath);
-    const seq = db.prepare(`SELECT max(seq) s FROM "commit"`)
-      .get<{ s: number }>()!.s + 1;
-    db.prepare(
-      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
-       VALUES (?, ?, ?, '{}', '{}')`,
-    ).run(seq, SESSION, seq);
+    const working = clonePaths(clone, SPACE).workingPath;
     // Same id as an existing space-scope cell, in a per-user scope.
-    db.prepare(
-      `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
-       VALUES ('of:named', 'user:did%3Akey%3AzAlice', ?, 0, 'set', ?, ?)`,
-    ).run(seq, JSON.stringify({ value: "per-user override" }), seq);
-    db.close();
+    mutate(working, [["of:named", { value: "per-user override" }]], USER_SCOPE);
 
     // Also CHANGE the space-scope row of the same id, so the tally has to
     // classify a real entry rather than an empty map. Without this the
     // assertions below pass no matter how the kind lookup behaves.
-    mutate(clonePaths(clone, SPACE).workingPath, [[
+    mutate(working, [[
       "of:named",
       { value: "named-v2", result: link("of:piece") },
     ]]);

--- a/packages/state-inspector/test/fingerprint.test.ts
+++ b/packages/state-inspector/test/fingerprint.test.ts
@@ -15,6 +15,7 @@ import { openSpace, type SpaceDb } from "../db.ts";
 import {
   contentFingerprint,
   diffFingerprints,
+  entityAddressKey,
   generatedInternalCellIds,
   hashEntityValue,
 } from "../fingerprint.ts";
@@ -196,6 +197,27 @@ Deno.test("the same id in two scopes is fingerprinted separately", () => {
     assertEquals(rows.length, 2);
     assert(rows[0].hash !== rows[1].hash, "distinct scopes, distinct content");
   });
+});
+
+Deno.test("an entity address key never aliases a different address", () => {
+  // The key decides which entity is which: `diffFingerprints` pairs rows by it,
+  // and `verifyClone` subtracts generated exclusions by it — where an alias
+  // clears a removal that really happened rather than merely misattributing a
+  // count. Nothing the runtime mints carries a separator byte (ids are
+  // `of:fid1:<base64url>` or DIDs; scope keys percent-encode their segments,
+  // and the admission predicate refuses one that does not), so this pins the
+  // key itself rather than a store shape: the tool reads stores it did not
+  // write, where both columns are opaque TEXT.
+  assert(
+    entityAddressKey({ id: "of:a", scope: "b c" }) !==
+      entityAddressKey({ id: "of:a b", scope: "c" }),
+    "a printable separator would run these two addresses together",
+  );
+  assertEquals(
+    entityAddressKey({ id: "of:a", scope: "space" }),
+    entityAddressKey({ id: "of:a", scope: "space" }),
+    "and one address always keys the same",
+  );
 });
 
 Deno.test("the fingerprint is deterministic and order-independent", () => {


### PR DESCRIPTION
## Why

`cf space verify` reported **114 owned cells REMOVED — "durable content was destroyed"** on a rehearsal of the real Topics migration. All 114 were present at head in **both** stores. Nothing was lost.

`removed` is the loudest verdict this tool has, and `space-clone-rehearsal.md` tells an operator it is "the unambiguous failure; investigate before anything else." Following the runbook exactly, I halted a healthy migration on it — under incident pressure that means rolling back a good change on false evidence, which is worse than the failure the check exists to catch.

The cause is set arithmetic over two differently-filtered views. `verifyClone` diffs a baseline fingerprint (taken from the pristine store, excluding what the *pristine* manifests call generated) against a fresh one (excluding what the *migrated* manifests call generated). A cell that no pristine manifest listed gets hashed into the baseline; the migration adopts it into a generated slot; it drops out of the second list. Present in both stores, absent from one set, reported as destroyed.

Measured on the clone: 114 removals, `generated=0 named=0 unlisted=114` in the pristine store's exclusion pass and `generated=114` in the working store's, and 114/114 present in both `head` tables.

## What Changed

- `fingerprint.ts`: `FingerprintReport` gains `excludedGeneratedIds` — the ids behind the existing `excludedGenerated` count, so a caller comparing across stores can subtract them.
- `clone.ts`: `verifyClone` subtracts those from `removed` and reports them as `diff.reclassifiedGenerated`. `removed` again means gone from the store; the reclassification is counted rather than dropped, because a number that silently disappears is one nobody can check. The baseline sidecar records how many were excluded, not which, so its side stays empty — honest, and the working side is the one that can turn a present entity into an absent row.
- `cf space verify` prints a `generated N reclassified` line only when nonzero.
- `space-clone-rehearsal.md` explains that line where it lists the verdicts.

The `added` count can carry the mirror-image artifact (excluded in the baseline, listed now). It is not an alarm and the sidecar lacks the ids to fix it, so it is deliberately untouched.

## Test plan

`a cell a migration adopts as generated is not a removal` in `test/clone.test.ts` drives `verifyClone` end to end over the real shape: a cell no manifest lists in the source, adopted into a `$generated` slot in the working copy. Asserts `removed 0`, `reclassifiedGenerated 1`, `okAfterMigration`. **Revert check:** restoring the two unsubtracted lines fails that test and only that test (27 passed, 1 failed).

`packages/state-inspector` 102 passed / 0 failed; `packages/cli` 210 passed / 0 failed; repo `deno task check`, `deno fmt --check`, `deno lint`, `check-docs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

