### PR TITLE
feat(piece,cli): the plan records the origin a retarget detaches

### DIFF
--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -206,8 +206,9 @@ as a completed one; and a group size that is not a positive integer.
 
 A retarget's write detaches the piece from the origin it follows. The source
 it runs afterwards is the one the plan names, chosen by a human and reviewed
-as part of the plan, and a piece that went on taking its origin's next update
-would run something that plan's reviewer never approved.
+as part of the plan; a piece still carrying that origin could be repointed
+afterwards to whatever the origin ships, which is not what the plan's
+reviewer approved.
 
 The detach is recorded rather than gated. The survey reads the origin into the
 row's `expect.origin`, and the apply carries it onto every report row for that
@@ -227,12 +228,22 @@ fired on nearly every row would be a rubber stamp rather than a decision,
 which is the same risk the per-row compatibility override exists to avoid.
 
 Which mechanism moves a piece follows from who chose the source and whether
-there is a set. A piece that records an origin can move on its own, whenever
-its user next opens it, to whatever source that origin then ships: one piece
-at a time, with the choice belonging to whoever ships the origin. Bulk is the
-operator's lane — a set that has to move together in a chosen order, from a
-plan a human reviewed, and the only lane at all for pieces that record no
-origin.
+there is a set. Bulk is the operator's lane: a set that has to move together
+in a chosen order, from a plan a human reviewed. It is also the only lane for
+a piece that records no origin.
+
+The other lane is origin-following — one piece moving to whatever source its
+origin ships, the choice belonging to whoever ships that origin rather than
+to the operator. What a piece does with an origin today is narrower: the
+origin is recorded on the piece, and explicit history actions act on it, one
+clearing it and another repointing the piece to what the recorded origin now
+ships. Following an origin as one mechanism, triggered by a user opening the
+piece, is specified and not built.
+[`piece-source-lifecycle.md`](../specs/piece-source-lifecycle.md) is where
+that status is recorded — its logical-state table gives a repository status
+per state — so a reader checks it there rather than inferring it here. A
+retarget detaches the recorded origin whichever lane would have moved the
+piece next, which is why every row records it.
 
 ## The safety model
 
@@ -511,8 +522,9 @@ Under [`packages/piece/src/ops/`](../../packages/piece/src/ops/):
   measurement
 - [`docs/specs/piece-source-lifecycle.md`](../specs/piece-source-lifecycle.md)
   — the append-only revision log a piece keeps, the restore built on it, and
-  origin-following: the other mechanism a piece's source moves by, one piece
-  at a time and at its user's next open, which a retarget detaches
+  the origin-following lane it specifies: one piece moving at its user's next
+  open, on an origin a retarget detaches. That lane is specified there and
+  not built; the document's logical-state table carries what has landed
 - [`packages/cli/README.md`](../../packages/cli/README.md) — the commands,
   their flags, and the reference forms their selections take
 - [`space-clone-rehearsal.md`](../development/space-clone-rehearsal.md) — the

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -188,7 +188,9 @@ the source was saved and something after it complained — so a warned row is
 still complete, and the warning rides the report rather than a console nobody
 keeps. A row's `origin` is neither: it is a fact about the plan's row rather
 than about this run's outcome, so it rides every verdict, the dry run's
-included — which is the only moment the detach below is still a decision.
+included — which is the only moment the detach below is still a decision. Its
+`detachedOrigin` is the matching fact about the outcome, and rides only a row
+this run wrote.
 
 `complete` is true when every row reached what the run was for and no session
 boundary failed: under an apply, every row landed or applied; on a dry run,
@@ -210,10 +212,24 @@ as part of the plan; a piece still carrying that origin could be repointed
 afterwards to whatever the origin ships, which is not what the plan's
 reviewer approved.
 
-The detach is recorded rather than gated. The survey reads the origin into the
-row's `expect.origin`, and the apply carries it onto every report row for that
-piece, so both the artifact and the report name what the run detaches.
-Re-attaching afterwards is by hand, from that string. Nothing re-attaches on
+The detach is recorded rather than gated, and recorded twice over, because a
+survey's reading of an origin and a write's are not the same fact. The survey
+reads the origin into the row's `expect.origin` and the apply carries that
+onto every report row, labelled as the plan's. A row this run wrote carries a
+second value beside it — `detachedOrigin`, the origin the write actually
+detached, taken from the snapshot its transaction committed against.
+
+The two disagree when the plan went stale before the run reached the row.
+Only the `{identity, symbol}` pair is a retarget's precondition, so a piece
+whose origin alone moved since the survey is still written, and is detached
+off the origin it holds then rather than the one the plan recorded — including
+the case where it holds none by that point and the write detaches nothing.
+Reporting the recorded value there would send an operator re-attaching by hand
+to an origin the run never touched, which is worse than recording nothing: a
+wrong record is confidently actionable. Substituting the live value silently
+would be a smaller lie and still a lie, so both ride the row, the report names
+both when they differ, and re-attaching is from the report rather than from
+the plan. Re-attaching afterwards is by hand. Nothing re-attaches on
 its own: the runtime's `follow` resolves an origin as it currently stands and
 adopts whatever source it now ships, which is not the reference the plan or
 its rollback promises to land, and a restore detaches in its own right by

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -55,8 +55,9 @@ retained in the space, the origin the piece follows when it follows one, the
 current source revision when the piece keeps a log, and the stored document's
 hash when a repair recorded one. The origin is the string the piece stores and
 nothing derived from it: the canonical URL and the kind are both computed from
-it, against the host this deployment routes the space to, and what re-attaching
-by hand takes is what the piece stored. An `op` is a
+it, against the host this deployment routes the space to, so either would read
+differently elsewhere. It records what the plan was built against rather than
+what a run detaches, which the report carries instead. An `op` is a
 retarget (a local source, the identity it produces, the symbol, and a per-row
 compatibility override), a restore (the reference to return to, and the
 revision when one was read), or a repair (the fixer's name and the content

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -51,8 +51,12 @@ A row carries the piece's canonical bare address, an optional `phase` label,
 the `expect` record the operation requires, and — once an operation is chosen
 — the `op` that performs it. `expect` holds the pattern identity the piece is
 on, the export symbol that identity runs, whether that source is verifiably
-retained in the space, the current source revision when the piece keeps a log,
-and the stored document's hash when a repair recorded one. An `op` is a
+retained in the space, the origin the piece follows when it follows one, the
+current source revision when the piece keeps a log, and the stored document's
+hash when a repair recorded one. The origin is the string the piece stores and
+nothing derived from it: the canonical URL and the kind are both computed from
+it, against the host this deployment routes the space to, and what re-attaching
+by hand takes is what the piece stored. An `op` is a
 retarget (a local source, the identity it produces, the symbol, and a per-row
 compatibility override), a restore (the reference to return to, and the
 revision when one was read), or a repair (the fixer's name and the content
@@ -182,7 +186,9 @@ A row's `problem` and its `warning` are different facts. A `problem` belongs
 to a row that did not apply. A `warning` belongs to a row that **did** —
 the source was saved and something after it complained — so a warned row is
 still complete, and the warning rides the report rather than a console nobody
-keeps.
+keeps. A row's `origin` is neither: it is a fact about the plan's row rather
+than about this run's outcome, so it rides every verdict, the dry run's
+included — which is the only moment the detach below is still a decision.
 
 `complete` is true when every row reached what the run was for and no session
 boundary failed: under an apply, every row landed or applied; on a dry run,
@@ -195,6 +201,38 @@ Before any read, a run refuses: a plan whose header names pieces the survey
 did not account for; a plan carrying rows of another operation's kind, one run
 applying one kind; a plan with no rows of this kind, since an empty run reads
 as a completed one; and a group size that is not a positive integer.
+
+## The origin a retarget detaches
+
+A retarget's write detaches the piece from the origin it follows. The source
+it runs afterwards is the one the plan names, chosen by a human and reviewed
+as part of the plan, and a piece that went on taking its origin's next update
+would run something that plan's reviewer never approved.
+
+The detach is recorded rather than gated. The survey reads the origin into the
+row's `expect.origin`, and the apply carries it onto every report row for that
+piece, so both the artifact and the report name what the run detaches.
+Re-attaching afterwards is by hand, from that string. Nothing re-attaches on
+its own: the runtime's `follow` resolves an origin as it currently stands and
+adopts whatever source it now ships, which is not the reference the plan or
+its rollback promises to land, and a restore detaches in its own right by
+design — so that reverting to repair a regression is not undone by the next
+load.
+
+It is recorded rather than gated because a detached origin is not the kind of
+loss an unretained source is. An unretained row names a piece that can never
+be returned; a detached origin is recoverable by hand from the record the run
+leaves. Gate the irreversible, report the recoverable. An acceptance that
+fired on nearly every row would be a rubber stamp rather than a decision,
+which is the same risk the per-row compatibility override exists to avoid.
+
+Which mechanism moves a piece follows from who chose the source and whether
+there is a set. A piece that records an origin can move on its own, whenever
+its user next opens it, to whatever source that origin then ships: one piece
+at a time, with the choice belonging to whoever ships the origin. Bulk is the
+operator's lane — a set that has to move together in a chosen order, from a
+plan a human reviewed, and the only lane at all for pieces that record no
+origin.
 
 ## The safety model
 
@@ -335,10 +373,11 @@ must exist in the piece's log *and* carry the recorded reference; without one,
 the reference selects the most recent revision carrying it. A revision whose
 source is no longer retained is not a restore target, however it was selected.
 
-Restoring severs the origin the piece follows. So a piece is already where a
-restore would leave it only when it runs the revision's reference **and**
-follows no origin; a piece that runs the reference while still following an
-origin is written, and the run names the origin it cuts. A compatibility
+Restoring detaches the piece from the origin it follows, as a retarget does.
+So a piece is already where a restore would leave it only when it runs the
+revision's reference **and** follows no origin; a piece that runs the reference
+while still following an origin is written, and the run names the origin it
+detaches. A compatibility
 verdict against the piece as it now stands is a refusal naming the piece and
 the reason, and an argument the restored source cannot use at all is the
 runtime's hard refusal, which arrives as an operational failure instead. Both
@@ -471,7 +510,9 @@ Under [`packages/piece/src/ops/`](../../packages/piece/src/ops/):
   the design and build sequence, including the stage that is still gated on
   measurement
 - [`docs/specs/piece-source-lifecycle.md`](../specs/piece-source-lifecycle.md)
-  — the append-only revision log a piece keeps and the restore built on it
+  — the append-only revision log a piece keeps, the restore built on it, and
+  origin-following: the other mechanism a piece's source moves by, one piece
+  at a time and at its user's next open, which a retarget detaches
 - [`packages/cli/README.md`](../../packages/cli/README.md) — the commands,
   their flags, and the reference forms their selections take
 - [`space-clone-rehearsal.md`](../development/space-clone-rehearsal.md) — the

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -378,7 +378,8 @@ that would otherwise have no mechanism:
   row's `expect` holds the `{identity, symbol}` reference the piece runs —
   the pair, because two patterns one module exports share an identity and
   differ only in symbol — whether the source behind it is still retained in
-  the space, and, for a piece that already keeps a revision log, the revision
+  the space, the origin the piece follows when it follows one, and, for a
+  piece that already keeps a revision log, the revision
   it is at; its `op` holds the source to apply and the reference that source
   produces, computed from the source without compiling it (a source that
   mounts other patterns over fabric imports is the exception, and a compile

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -159,8 +159,12 @@ Each write detaches its piece from the origin it follows: what it runs
 afterwards is the source the plan names. That is recorded rather than gated —
 the survey reads the origin into the row's `expect.origin` and every report row
 for that piece carries it, on the dry run as much as under `--apply`, so what an
-apply would detach is in hand while it is still a decision. Re-attaching
-afterwards is by hand, from the string the report names.
+apply would detach is in hand while it is still a decision. A row the run wrote
+carries a second value, the origin its write actually detached, which is the one
+to re-attach from: only the pattern reference is a precondition, so a piece
+whose origin alone moved since the survey is still written and detached off what
+it holds at the write. The report names both when they differ, and says so.
+Re-attaching afterwards is by hand.
 
 `--apply` refuses to start over a row whose prior source is not retained
 (`expect.retained: false`), because such a piece cannot be returned once it has

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -119,9 +119,10 @@ the default pattern and starts each registered piece to obtain its name and
 pattern metadata. It does not enumerate every stored piece root.
 
 `cf piece inspect --pattern-identity` prints one piece's source pin — pattern
-identity, export symbol, current source revision when the piece keeps a log, and
-whether the identity's source is retained in the space — without running the
-piece and without pulling its input, result, or link graph.
+identity, export symbol, current source revision when the piece keeps a log, the
+origin it follows when it follows one, and whether the identity's source is
+retained in the space — without running the piece and without pulling its input,
+result, or link graph.
 
 `cf piece survey` reads a holder's own collection — the enumeration `piece ls`
 cannot provide — one cheap identity read per member, the holder last, and emits
@@ -157,8 +158,8 @@ verification is `cf piece survey --diff`, a separate invocation by design.
 Each write detaches its piece from the origin it follows: what it runs
 afterwards is the source the plan names. That is recorded rather than gated —
 the survey reads the origin into the row's `expect.origin` and every report row
-for that piece carries it, on the dry run as much as under `--apply`, so what
-the run detaches is in hand while it is still a decision. Re-attaching
+for that piece carries it, on the dry run as much as under `--apply`, so what an
+apply would detach is in hand while it is still a decision. Re-attaching
 afterwards is by hand, from the string the report names.
 
 `--apply` refuses to start over a row whose prior source is not retained

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,6 +154,13 @@ already on its row's target reads as landed and is not rewritten, which makes
 re-invoking the same command the resume. Applying implies no verdict — the
 verification is `cf piece survey --diff`, a separate invocation by design.
 
+Each write detaches its piece from the origin it follows: what it runs
+afterwards is the source the plan names. That is recorded rather than gated —
+the survey reads the origin into the row's `expect.origin` and every report row
+for that piece carries it, on the dry run as much as under `--apply`, so what
+the run detaches is in hand while it is still a decision. Re-attaching
+afterwards is by hand, from the string the report names.
+
 `--apply` refuses to start over a row whose prior source is not retained
 (`expect.retained: false`), because such a piece cannot be returned once it has
 moved — accepting that after the move is asking past the point of no return.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3943,17 +3943,38 @@ async function reportApplyRun(
       printHint(`${row.verdict}: ${row.piece} warned: ${row.warning}`);
     }
   }
-  // A retarget's write detaches the piece from its origin, and the report
-  // names the origin on each such row. One line rather than one per piece:
-  // an origin-following row is nearly every row on a board that has one, and
-  // a per-row hint would bury the stop lines the operator has to act on.
-  // Nothing re-attaches, so the line says where the work goes.
-  const following = report.rows.filter((row) => row.origin !== undefined);
-  if (following.length > 0) {
+  // A retarget's write detaches the piece from its origin, so the count is
+  // read off the verdict rather than off the recorded origin alone: a row
+  // this run wrote was detached, a row it did not write was not, and a row
+  // already on its target has nothing left for this plan to detach. The two
+  // cannot both fire — a run that writes reports no row as outstanding, and
+  // a run that reports one wrote nothing at all — so each line is the whole
+  // claim the report supports.
+  //
+  // One line rather than one per piece: an origin-following row is nearly
+  // every row on a board that has one, and a per-row hint would bury the
+  // stop lines the operator has to act on. The report itself names each
+  // origin, and nothing re-attaches, so the line says where the work goes.
+  const withOrigin = (verdict: ApplyRow["verdict"]) =>
+    report.rows.filter((row) =>
+      row.origin !== undefined && row.verdict === verdict
+    ).length;
+  const detached = withOrigin("applied");
+  if (detached > 0) {
     printHint(
-      `${following.length} of ${report.rows.length} rows record an origin ` +
-        `the write detaches; the report names each one, and re-attaching ` +
-        `is by hand.`,
+      `detached from a recorded origin: ${detached} of ` +
+        `${report.rows.length} rows; the report names each origin, and ` +
+        `re-attaching is by hand.`,
+    );
+  }
+  // The dry run is where this matters most: it is the moment the detach is
+  // still a decision, and the only one at which nothing has happened yet.
+  const wouldDetach = withOrigin("outstanding");
+  if (wouldDetach > 0) {
+    printHint(
+      `an apply would detach a recorded origin on ${wouldDetach} of ` +
+        `${report.rows.length} rows; the report names each origin, and ` +
+        `re-attaching is by hand.`,
     );
   }
   if (!report.complete) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3820,14 +3820,38 @@ export interface RetargetCommandDependencies extends ApplyCommandDependencies {
 }
 
 /**
+ * The origin words on a row's line, which differ by whether this run wrote
+ * the row. A row this run wrote reports what the write detached, since that
+ * is what re-attaching by hand takes; every other row has no write to report
+ * and carries the plan's recorded origin instead, labelled as such. The two
+ * disagree exactly when the plan went stale before the run reached the row,
+ * and the line then names both rather than picking one.
+ */
+function originWords(row: ApplyRow): string[] {
+  if (row.verdict !== "applied") {
+    return row.origin === undefined ? [] : [`origin ${row.origin}`];
+  }
+  if (row.detachedOrigin === undefined && row.origin === undefined) return [];
+  return [
+    `detached ${row.detachedOrigin ?? "nothing"}`,
+    // Silent on the ordinary row where the plan was right, loud on the one
+    // where it was not: a plan that recorded an origin this write did not
+    // detach is a plan an operator must not re-attach from.
+    ...(row.detachedOrigin === row.origin
+      ? []
+      : [`(plan recorded ${row.origin ?? "none"})`]),
+  ];
+}
+
+/**
  * One report row as a line: the verdict, the piece, its phase, what the row
- * cost, the origin the plan recorded for it, and what it broke. The cost is
- * on the line rather than in a summary because a run whose cost per piece is
- * unknown cannot be improved, and the number has to arrive while there is
- * still a run to reason about. The origin is on the line for the same
- * reason: a retarget's write detaches the piece from it, and this string is
- * what re-attaching by hand takes. The verdict says whether this row's write
- * happened, so the line states the origin rather than a tense.
+ * cost, what became of the origin, and what it broke. The cost is on the line
+ * rather than in a summary because a run whose cost per piece is unknown
+ * cannot be improved, and the number has to arrive while there is still a run
+ * to reason about. The origin is on the line for the same reason: a
+ * retarget's write detaches the piece from it, and the string is what
+ * re-attaching by hand takes. See {@link originWords} for which string that
+ * is on which row.
  */
 export function formatApplyRow(row: ApplyRow): string {
   return [
@@ -3835,7 +3859,7 @@ export function formatApplyRow(row: ApplyRow): string {
     row.piece,
     ...(row.phase === undefined ? [] : [row.phase]),
     ...(row.elapsedMs === undefined ? [] : [`${row.elapsedMs}ms`]),
-    ...(row.origin === undefined ? [] : [`origin ${row.origin}`]),
+    ...originWords(row),
     ...(row.warning === undefined ? [] : [`! ${row.warning}`]),
     ...(row.problem === undefined ? [] : [`- ${row.problem}`]),
   ].join(" ");
@@ -3943,33 +3967,47 @@ async function reportApplyRun(
       printHint(`${row.verdict}: ${row.piece} warned: ${row.warning}`);
     }
   }
-  // A retarget's write detaches the piece from its origin, so the count is
-  // read off the verdict rather than off the recorded origin alone: a row
-  // this run wrote was detached, a row it did not write was not, and a row
-  // already on its target has nothing left for this plan to detach. The two
-  // cannot both fire — a run that writes reports no row as outstanding, and
-  // a run that reports one wrote nothing at all — so each line is the whole
-  // claim the report supports.
+  // What a run detached is counted off what its writes observed, and what an
+  // apply WOULD detach off what the plan recorded — the only value a row
+  // with no write has. The two lines cannot both fire: a run that writes
+  // reports no row as outstanding, and a run that reports one wrote nothing
+  // at all, so each line is the whole claim its report supports. A row that
+  // landed, was refused, or went unattempted supports neither, and gets
+  // neither.
   //
   // One line rather than one per piece: an origin-following row is nearly
   // every row on a board that has one, and a per-row hint would bury the
   // stop lines the operator has to act on. The report itself names each
   // origin, and nothing re-attaches, so the line says where the work goes.
-  const withOrigin = (verdict: ApplyRow["verdict"]) =>
-    report.rows.filter((row) =>
-      row.origin !== undefined && row.verdict === verdict
-    ).length;
-  const detached = withOrigin("applied");
+  const detached =
+    report.rows.filter((row) => row.detachedOrigin !== undefined).length;
   if (detached > 0) {
     printHint(
-      `detached from a recorded origin: ${detached} of ` +
-        `${report.rows.length} rows; the report names each origin, and ` +
-        `re-attaching is by hand.`,
+      `detached from an origin: ${detached} of ${report.rows.length} rows; ` +
+        `the report names each origin, and re-attaching is by hand.`,
+    );
+  }
+  // A row whose write detached something other than what the plan recorded —
+  // including nothing at all. The plan is stale for those rows, so an
+  // operator re-attaching from the plan file rather than from this report
+  // would restore an origin this run never touched.
+  const stale =
+    report.rows.filter((row) =>
+      row.verdict === "applied" && row.detachedOrigin !== row.origin
+    ).length;
+  if (stale > 0) {
+    printHint(
+      `the plan's recorded origin was not what the write detached on ` +
+        `${stale} of ${report.rows.length} rows; re-attach from this ` +
+        `report rather than from the plan.`,
     );
   }
   // The dry run is where this matters most: it is the moment the detach is
   // still a decision, and the only one at which nothing has happened yet.
-  const wouldDetach = withOrigin("outstanding");
+  const wouldDetach =
+    report.rows.filter((row) =>
+      row.origin !== undefined && row.verdict === "outstanding"
+    ).length;
   if (wouldDetach > 0) {
     printHint(
       `an apply would detach a recorded origin on ${wouldDetach} of ` +

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3324,6 +3324,10 @@ export async function inspectPieceFromCommand(
         ...(pin.revisionId === undefined
           ? []
           : [`revision: ${pin.revisionId}`]),
+        // Absent for a detached piece, which is what a retarget leaves
+        // behind: the pin reports the origin the piece follows now, not
+        // one it once did.
+        ...(pin.origin === undefined ? [] : [`origin:   ${pin.origin}`]),
         `retained: ${pin.retained}`,
       ].join("\n"),
     );
@@ -3817,9 +3821,13 @@ export interface RetargetCommandDependencies extends ApplyCommandDependencies {
 
 /**
  * One report row as a line: the verdict, the piece, its phase, what the row
- * cost, and what it broke. The cost is on the line rather than in a summary
- * because a run whose cost per piece is unknown cannot be improved, and the
- * number has to arrive while there is still a run to reason about.
+ * cost, the origin the plan recorded for it, and what it broke. The cost is
+ * on the line rather than in a summary because a run whose cost per piece is
+ * unknown cannot be improved, and the number has to arrive while there is
+ * still a run to reason about. The origin is on the line for the same
+ * reason: a retarget's write detaches the piece from it, and this string is
+ * what re-attaching by hand takes. The verdict says whether this row's write
+ * happened, so the line states the origin rather than a tense.
  */
 export function formatApplyRow(row: ApplyRow): string {
   return [
@@ -3827,6 +3835,7 @@ export function formatApplyRow(row: ApplyRow): string {
     row.piece,
     ...(row.phase === undefined ? [] : [row.phase]),
     ...(row.elapsedMs === undefined ? [] : [`${row.elapsedMs}ms`]),
+    ...(row.origin === undefined ? [] : [`origin ${row.origin}`]),
     ...(row.warning === undefined ? [] : [`! ${row.warning}`]),
     ...(row.problem === undefined ? [] : [`- ${row.problem}`]),
   ].join(" ");
@@ -3933,6 +3942,19 @@ async function reportApplyRun(
     if (row.warning !== undefined) {
       printHint(`${row.verdict}: ${row.piece} warned: ${row.warning}`);
     }
+  }
+  // A retarget's write detaches the piece from its origin, and the report
+  // names the origin on each such row. One line rather than one per piece:
+  // an origin-following row is nearly every row on a board that has one, and
+  // a per-row hint would bury the stop lines the operator has to act on.
+  // Nothing re-attaches, so the line says where the work goes.
+  const following = report.rows.filter((row) => row.origin !== undefined);
+  if (following.length > 0) {
+    printHint(
+      `${following.length} of ${report.rows.length} rows record an origin ` +
+        `the write detaches; the report names each one, and re-attaching ` +
+        `is by hand.`,
+    );
   }
   if (!report.complete) {
     const settled = (row: ApplyRow) =>

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -98,6 +98,24 @@ describe("piece-retarget", () => {
       );
     });
 
+    it("carries the origin the plan recorded, on a dry row as on an applied one", () => {
+      const origin = "https://origins.test/member.tsx";
+      // The dry run is the only moment the detach is still a decision, so
+      // the line states the origin rather than a tense; the verdict says
+      // whether this row's write happened.
+      expect(
+        formatApplyRow({
+          piece: "fid1:aaa",
+          phase: "items",
+          verdict: "outstanding",
+          origin,
+        }),
+      ).toBe(`outstanding fid1:aaa items origin ${origin}`);
+      expect(formatApplyRow({ ...REPORT.rows[0], origin })).toBe(
+        `applied fid1:aaa items 412ms origin ${origin}`,
+      );
+    });
+
     it("carries what a row broke, and omits what a row does not have", () => {
       expect(
         formatApplyRow({
@@ -141,6 +159,58 @@ describe("piece-retarget", () => {
       // what it exists for.
       expect(printedWhenSettled).toEqual([1, 2]);
       expect(hints).toEqual(["applied: 1 · landed: 1 · written: 1"]);
+    });
+
+    it("names each row that landed with a warning", async () => {
+      const hints: string[] = [];
+      const warned: ApplyReport = {
+        rows: [
+          { ...REPORT.rows[0], warning: "the piece ran with a warning" },
+          REPORT.rows[1],
+        ],
+        applied: 1,
+        complete: true,
+      };
+      await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: () => Promise.resolve(warned),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      // A warned row landed, so it is not among the stopped rows the exit
+      // message names; the hint is the only place a human reads it.
+      expect(hints).toContain(
+        "applied: fid1:aaa warned: the piece ran with a warning",
+      );
+    });
+
+    it("names how many rows record an origin the write detaches", async () => {
+      const hints: string[] = [];
+      const following: ApplyReport = {
+        rows: [
+          { ...REPORT.rows[0], origin: "https://origins.test/member.tsx" },
+          REPORT.rows[1],
+        ],
+        applied: 1,
+        complete: true,
+      };
+      await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: () => Promise.resolve(following),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      // One line rather than one per piece: an origin-following row is
+      // nearly every row on a board that has one, and the report itself
+      // names each origin.
+      expect(hints).toContain(
+        "1 of 2 rows record an origin the write detaches; the report names " +
+          "each one, and re-attaching is by hand.",
+      );
     });
 
     it("passes the plan path, the apply flag, and the group size through", async () => {

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -186,30 +186,71 @@ describe("piece-retarget", () => {
       );
     });
 
-    it("names how many rows record an origin the write detaches", async () => {
+    it("names the rows this run detached, counting no row it did not write", async () => {
       const hints: string[] = [];
+      // A landed row carries the origin its plan recorded and was NOT
+      // written by this run — the piece was already on its target. Counting
+      // it would claim a detach that did not happen here.
       const following: ApplyReport = {
         rows: [
           { ...REPORT.rows[0], origin: "https://origins.test/member.tsx" },
-          REPORT.rows[1],
+          { ...REPORT.rows[1], origin: "https://origins.test/other.tsx" },
         ],
         applied: 1,
         complete: true,
       };
       await captureStdout(() =>
-        retargetFromCommand(OPTIONS, {
+        retargetFromCommand({ ...OPTIONS, apply: true }, {
           runRetarget: () => Promise.resolve(following),
           printHint: (message) => {
             hints.push(message);
           },
         })
       );
-      // One line rather than one per piece: an origin-following row is
-      // nearly every row on a board that has one, and the report itself
-      // names each origin.
       expect(hints).toContain(
-        "1 of 2 rows record an origin the write detaches; the report names " +
-          "each one, and re-attaching is by hand.",
+        "detached from a recorded origin: 1 of 2 rows; the report names " +
+          "each origin, and re-attaching is by hand.",
+      );
+      expect(hints.some((hint) => hint.includes("would detach"))).toBe(false);
+    });
+
+    it("names the rows an apply would detach when nothing was written", async () => {
+      const hints: string[] = [];
+      // The dry run: no row was written, so the only true claim is the
+      // conditional one — and the landed row is excluded there too, an
+      // apply of this plan having nothing left to write for it.
+      const dry: ApplyReport = {
+        rows: [
+          {
+            piece: "fid1:aaa",
+            phase: "items",
+            verdict: "outstanding",
+            origin: "https://origins.test/member.tsx",
+          },
+          {
+            piece: "fid1:bbb",
+            phase: "items",
+            verdict: "landed",
+            origin: "https://origins.test/other.tsx",
+          },
+        ],
+        applied: 0,
+        complete: true,
+      };
+      await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: () => Promise.resolve(dry),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(hints).toContain(
+        "an apply would detach a recorded origin on 1 of 2 rows; the report " +
+          "names each origin, and re-attaching is by hand.",
+      );
+      expect(hints.some((hint) => hint.startsWith("detached from"))).toBe(
+        false,
       );
     });
 

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -98,11 +98,11 @@ describe("piece-retarget", () => {
       );
     });
 
-    it("carries the origin the plan recorded, on a dry row as on an applied one", () => {
+    it("labels a row with no write as carrying the plan's recorded origin", () => {
       const origin = "https://origins.test/member.tsx";
-      // The dry run is the only moment the detach is still a decision, so
-      // the line states the origin rather than a tense; the verdict says
-      // whether this row's write happened.
+      // No write happened, so the plan's reading is the only value there is
+      // — and the line says whose reading it is rather than claiming a
+      // detach.
       expect(
         formatApplyRow({
           piece: "fid1:aaa",
@@ -111,8 +111,36 @@ describe("piece-retarget", () => {
           origin,
         }),
       ).toBe(`outstanding fid1:aaa items origin ${origin}`);
-      expect(formatApplyRow({ ...REPORT.rows[0], origin })).toBe(
-        `applied fid1:aaa items 412ms origin ${origin}`,
+    });
+
+    it("states what an applied row detached, and stays quiet when the plan agreed", () => {
+      const origin = "https://origins.test/member.tsx";
+      expect(
+        formatApplyRow({ ...REPORT.rows[0], origin, detachedOrigin: origin }),
+      ).toBe(`applied fid1:aaa items 412ms detached ${origin}`);
+    });
+
+    it("names both origins on an applied row whose plan had gone stale", () => {
+      const recorded = "https://origins.test/recorded.tsx";
+      const live = "https://origins.test/live.tsx";
+      // The operator re-attaches from what was detached; the recorded value
+      // rides along because a plan that disagrees with the run is a plan
+      // they must not re-attach from.
+      expect(
+        formatApplyRow({
+          ...REPORT.rows[0],
+          origin: recorded,
+          detachedOrigin: live,
+        }),
+      ).toBe(
+        `applied fid1:aaa items 412ms detached ${live} ` +
+          `(plan recorded ${recorded})`,
+      );
+      // The write found the piece already detached: nothing was detached,
+      // and saying so is what keeps the recorded value from reading as one.
+      expect(formatApplyRow({ ...REPORT.rows[0], origin: recorded })).toBe(
+        `applied fid1:aaa items 412ms detached nothing ` +
+          `(plan recorded ${recorded})`,
       );
     });
 
@@ -188,12 +216,17 @@ describe("piece-retarget", () => {
 
     it("names the rows this run detached, counting no row it did not write", async () => {
       const hints: string[] = [];
-      // A landed row carries the origin its plan recorded and was NOT
+      // The landed row carries the origin its plan recorded and was NOT
       // written by this run — the piece was already on its target. Counting
-      // it would claim a detach that did not happen here.
+      // it would claim a detach that did not happen here, so the count comes
+      // off what the writes observed rather than off the recorded value.
       const following: ApplyReport = {
         rows: [
-          { ...REPORT.rows[0], origin: "https://origins.test/member.tsx" },
+          {
+            ...REPORT.rows[0],
+            origin: "https://origins.test/member.tsx",
+            detachedOrigin: "https://origins.test/member.tsx",
+          },
           { ...REPORT.rows[1], origin: "https://origins.test/other.tsx" },
         ],
         applied: 1,
@@ -208,10 +241,44 @@ describe("piece-retarget", () => {
         })
       );
       expect(hints).toContain(
-        "detached from a recorded origin: 1 of 2 rows; the report names " +
-          "each origin, and re-attaching is by hand.",
+        "detached from an origin: 1 of 2 rows; the report names each " +
+          "origin, and re-attaching is by hand.",
       );
       expect(hints.some((hint) => hint.includes("would detach"))).toBe(false);
+      // The plan agreed with the write, so there is nothing stale to say.
+      expect(hints.some((hint) => hint.includes("not what the write"))).toBe(
+        false,
+      );
+    });
+
+    it("names the rows whose recorded origin was not what the write detached", async () => {
+      const hints: string[] = [];
+      const stale: ApplyReport = {
+        rows: [
+          {
+            ...REPORT.rows[0],
+            origin: "https://origins.test/recorded.tsx",
+            detachedOrigin: "https://origins.test/live.tsx",
+          },
+          { ...REPORT.rows[1], origin: "https://origins.test/other.tsx" },
+        ],
+        applied: 1,
+        complete: true,
+      };
+      await captureStdout(() =>
+        retargetFromCommand({ ...OPTIONS, apply: true }, {
+          runRetarget: () => Promise.resolve(stale),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      // An operator re-attaching from the plan file would restore an origin
+      // this run never touched, so the run says which file to work from.
+      expect(hints).toContain(
+        "the plan's recorded origin was not what the write detached on 1 " +
+          "of 2 rows; re-attach from this report rather than from the plan.",
+      );
     });
 
     it("names the rows an apply would detach when nothing was written", async () => {

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -960,6 +960,22 @@ describe("piece-survey", () => {
       expect(out).toContain("identity: idA");
       expect(out).toContain("revision: rev-1");
       expect(out).toContain("retained: true");
+      // A detached piece follows nothing, so no origin line is printed for
+      // one — which is where a retarget leaves every piece it writes.
+      expect(out).not.toContain("origin:");
+    });
+
+    it("prints the origin a piece follows under --pattern-identity", async () => {
+      const out = await captureStdout(() =>
+        inspectPieceFromCommand({ ...OPTIONS, patternIdentity: true }, {
+          readSourcePin: () =>
+            Promise.resolve({
+              ...PIN,
+              origin: "https://origins.test/member.tsx",
+            }),
+        })
+      );
+      expect(out).toContain("origin:   https://origins.test/member.tsx");
     });
 
     it("exits 1 under --pattern-identity for a piece with no identity", async () => {

--- a/packages/piece/src/ops/bulk-apply.ts
+++ b/packages/piece/src/ops/bulk-apply.ts
@@ -94,6 +94,21 @@ export interface ApplyRow {
    */
   warning?: string;
   /**
+   * The origin the plan recorded for this piece, absent when the plan
+   * recorded none. A retarget's write detaches the piece from its origin —
+   * the source it runs afterwards is one a human chose, not one the origin
+   * ships — so this names what the run detaches, or on a dry run what it
+   * would; the verdict says which, an `applied` row having detached it and
+   * any other row not.
+   *
+   * A field of its own rather than a `warning`, which is a fact about a
+   * write that landed and so cannot reach the dry run — the one moment the
+   * operator can still decide. Nothing re-attaches: re-attaching is by
+   * hand, from this string. See
+   * [docs/features/piece-bulk-operations.md](../../../../docs/features/piece-bulk-operations.md).
+   */
+  origin?: string;
+  /**
    * The row's wall-clock cost in milliseconds, present on every row an
    * apply session began work on: a row reclassified as landed, moved, or
    * refused cost the reads and resolution that reclassified it, and reports
@@ -145,6 +160,14 @@ export type ReferenceOp = Extract<PieceOp, { patternIdentity: string }>;
 export interface WorkRow<Op extends ReferenceOp> {
   piece: string;
   phase?: string;
+  /**
+   * The origin the plan recorded for this piece; see {@link ApplyRow.origin}.
+   * Beside `expect` rather than inside it: `expect` is the precondition a
+   * write is proved against, and the origin is neither proved nor enforced —
+   * a piece that left its origin since the survey is not thereby a row to
+   * refuse.
+   */
+  origin?: string;
   expect: { patternIdentity: string; symbol: string };
   op: Op;
 }
@@ -252,6 +275,22 @@ function classify<Op extends ReferenceOp>(
 }
 
 /**
+ * The fields a report row takes from its plan row whatever its verdict: the
+ * phase label the plan stamped, and the origin the plan recorded. Both
+ * describe the row rather than its outcome, so every report of a row spreads
+ * these rather than assembling its own — a row reported down one path and
+ * not another is how one of them would go missing from a stop.
+ */
+function carriedFields<Op extends ReferenceOp>(
+  row: WorkRow<Op>,
+): { phase?: string; origin?: string } {
+  return {
+    ...(row.phase === undefined ? {} : { phase: row.phase }),
+    ...(row.origin === undefined ? {} : { origin: row.origin }),
+  };
+}
+
+/**
  * Release a session, handing back what a failure broke instead of throwing
  * it. Once a run holds outcomes worth reporting, a session boundary that
  * fails must not throw them away — the rows a partial migration produced
@@ -315,6 +354,9 @@ export async function applyPlan<Op extends ReferenceOp>(
       ? [{
         piece: row.piece,
         ...(row.phase === undefined ? {} : { phase: row.phase }),
+        ...(row.expect.origin === undefined
+          ? {}
+          : { origin: row.expect.origin }),
         expect: {
           patternIdentity: row.expect.patternIdentity,
           symbol: row.expect.symbol,
@@ -391,7 +433,7 @@ export async function applyPlan<Op extends ReferenceOp>(
       // pays its retained load once, not once per row.
       const retainedByIdentity = new Map<string, boolean>();
       for (const row of work) {
-        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        const carried = carriedFields(row);
         try {
           const pin = await readPiecePin(pieces, row.piece, retainedByIdentity);
           const standing = classify(pin, row);
@@ -399,7 +441,7 @@ export async function applyPlan<Op extends ReferenceOp>(
             preflight.set(row.piece, {
               blocked: {
                 piece: row.piece,
-                ...phase,
+                ...carried,
                 verdict: "moved-elsewhere",
                 problem: pin === undefined
                   ? "The piece carries no pattern identity to compare."
@@ -416,7 +458,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           preflight.set(row.piece, {
             blocked: {
               piece: row.piece,
-              ...phase,
+              ...carried,
               verdict: "failed",
               problem:
                 (error instanceof Error ? error.message : String(error)) +
@@ -441,13 +483,13 @@ export async function applyPlan<Op extends ReferenceOp>(
   }
   if (startBlocked || options.apply !== true) {
     for (const row of work) {
-      const phase = row.phase === undefined ? {} : { phase: row.phase };
+      const carried = carriedFields(row);
       // Every work row was classified above — the loop writes one of the
       // three outcomes for each, and duplicates cannot collapse two rows
       // onto one key, the codec having refused them.
       const standing = preflight.get(row.piece)!;
       if (standing === "landed" || standing === "outstanding") {
-        report({ piece: row.piece, ...phase, verdict: standing });
+        report({ piece: row.piece, ...carried, verdict: standing });
       } else {
         report(standing.blocked);
       }
@@ -477,8 +519,8 @@ export async function applyPlan<Op extends ReferenceOp>(
     const group = work.slice(start, start + groupSize);
     if (stopped) {
       for (const row of group) {
-        const phase = row.phase === undefined ? {} : { phase: row.phase };
-        report({ piece: row.piece, ...phase, verdict: "unattempted" });
+        const carried = carriedFields(row);
+        report({ piece: row.piece, ...carried, verdict: "unattempted" });
       }
       continue;
     }
@@ -495,8 +537,8 @@ export async function applyPlan<Op extends ReferenceOp>(
         "; this group's session could not be opened, so its pieces were " +
         "not attempted.";
       for (const row of group) {
-        const phase = row.phase === undefined ? {} : { phase: row.phase };
-        report({ piece: row.piece, ...phase, verdict: "unattempted" });
+        const carried = carriedFields(row);
+        report({ piece: row.piece, ...carried, verdict: "unattempted" });
       }
       stopped = true;
       continue;
@@ -511,8 +553,8 @@ export async function applyPlan<Op extends ReferenceOp>(
       stopped = true;
       try {
         for (const row of group) {
-          const phase = row.phase === undefined ? {} : { phase: row.phase };
-          report({ piece: row.piece, ...phase, verdict: "unattempted" });
+          const carried = carriedFields(row);
+          report({ piece: row.piece, ...carried, verdict: "unattempted" });
         }
       } finally {
         // This session opened, so it is released like any other — in a
@@ -532,9 +574,9 @@ export async function applyPlan<Op extends ReferenceOp>(
     const retainedByIdentity = new Map<string, boolean>();
     try {
       for (const row of group) {
-        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        const carried = carriedFields(row);
         if (stopped) {
-          report({ piece: row.piece, ...phase, verdict: "unattempted" });
+          report({ piece: row.piece, ...carried, verdict: "unattempted" });
           continue;
         }
         const startedAt = now();
@@ -551,7 +593,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           if (standing === "landed") {
             report({
               piece: row.piece,
-              ...phase,
+              ...carried,
               verdict: "landed",
               elapsedMs: now() - startedAt,
             });
@@ -560,7 +602,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           if (standing === "moved-elsewhere") {
             report({
               piece: row.piece,
-              ...phase,
+              ...carried,
               verdict: "moved-elsewhere",
               problem: "The piece left its recorded reference after " +
                 "preflight; something other than this plan moved it.",
@@ -573,7 +615,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           if (outcome?.refused !== undefined) {
             report({
               piece: row.piece,
-              ...phase,
+              ...carried,
               verdict: "refused",
               problem: outcome.refused,
               elapsedMs: now() - startedAt,
@@ -584,7 +626,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           applied += 1;
           report({
             piece: row.piece,
-            ...phase,
+            ...carried,
             verdict: "applied",
             ...(outcome?.warning === undefined
               ? {}
@@ -623,7 +665,7 @@ export async function applyPlan<Op extends ReferenceOp>(
           }
           report({
             piece: row.piece,
-            ...phase,
+            ...carried,
             verdict: "failed",
             problem: problem + state,
             elapsedMs: now() - startedAt,

--- a/packages/piece/src/ops/bulk-apply.ts
+++ b/packages/piece/src/ops/bulk-apply.ts
@@ -95,19 +95,34 @@ export interface ApplyRow {
   warning?: string;
   /**
    * The origin the plan recorded for this piece, absent when the plan
-   * recorded none. A retarget's write detaches the piece from its origin —
-   * the source it runs afterwards is one a human chose, not one the origin
-   * ships — so this names what the run detaches, or on a dry run what it
-   * would; the verdict says which, an `applied` row having detached it and
-   * any other row not.
+   * recorded none. A survey's reading, carried verbatim: it says what the
+   * piece followed when the plan was made and nothing about this run.
    *
    * A field of its own rather than a `warning`, which is a fact about a
    * write that landed and so cannot reach the dry run — the one moment the
-   * operator can still decide. Nothing re-attaches: re-attaching is by
-   * hand, from this string. See
+   * operator can still decide what to do about a detach. See
    * [docs/features/piece-bulk-operations.md](../../../../docs/features/piece-bulk-operations.md).
    */
   origin?: string;
+  /**
+   * The origin this run's write actually detached, present only on a row
+   * this run wrote and only when that write detached one.
+   *
+   * Separate from {@link ApplyRow.origin} because the two can differ and the
+   * difference is the operator's to see. Only the pattern reference is a
+   * precondition of a retarget, so a piece whose origin alone moved since
+   * the survey is still written — and detached off the origin it holds NOW,
+   * not the one the plan recorded. Reporting the recorded one would send an
+   * operator re-attaching by hand to the wrong origin, which is worse than
+   * recording nothing, a wrong record being confidently actionable.
+   *
+   * Substituting it silently would be a smaller lie and still a lie: a plan
+   * that has gone stale is itself worth knowing, so both values ride the
+   * row and the report names both when they disagree. Absent on a row where
+   * the write detached nothing, which — beside a recorded `origin` — is
+   * exactly the case a substitution would have hidden.
+   */
+  detachedOrigin?: string;
   /**
    * The row's wall-clock cost in milliseconds, present on every row an
    * apply session began work on: a row reclassified as landed, moved, or
@@ -181,6 +196,13 @@ export interface WriteOutcome {
   refused?: string;
   /** What the runtime warned about a write that landed anyway. */
   warning?: string;
+  /**
+   * The origin the write detached, when it detached one. The write step is
+   * the only place this can be observed honestly — the detach happens
+   * there, and a value read anywhere earlier is a value the write may have
+   * moved off. See {@link ApplyRow.detachedOrigin}.
+   */
+  detachedOrigin?: string;
 }
 
 /**
@@ -280,6 +302,11 @@ function classify<Op extends ReferenceOp>(
  * describe the row rather than its outcome, so every report of a row spreads
  * these rather than assembling its own — a row reported down one path and
  * not another is how one of them would go missing from a stop.
+ *
+ * What the run OBSERVED does not belong here and is added by the path that
+ * observed it: `detachedOrigin` exists only where a write happened, and
+ * carrying it from the plan row is what made the plan's stale reading
+ * readable as the run's own.
  */
 function carriedFields<Op extends ReferenceOp>(
   row: WorkRow<Op>,
@@ -628,6 +655,13 @@ export async function applyPlan<Op extends ReferenceOp>(
             piece: row.piece,
             ...carried,
             verdict: "applied",
+            // The write's own observation, beside the plan's record rather
+            // than over it: this row is the only one that has both, and a
+            // disagreement between them is what tells the operator their
+            // plan went stale before the run reached it.
+            ...(outcome?.detachedOrigin === undefined
+              ? {}
+              : { detachedOrigin: outcome.detachedOrigin }),
             ...(outcome?.warning === undefined
               ? {}
               : { warning: outcome.warning }),

--- a/packages/piece/src/ops/bulk-apply.ts
+++ b/packages/piece/src/ops/bulk-apply.ts
@@ -97,6 +97,8 @@ export interface ApplyRow {
    * The origin the plan recorded for this piece, absent when the plan
    * recorded none. A survey's reading, carried verbatim: it says what the
    * piece followed when the plan was made and nothing about this run.
+   * {@link ApplyRow.detachedOrigin} carries what a write actually detached,
+   * and that is the one to re-attach from.
    *
    * A field of its own rather than a `warning`, which is a fact about a
    * write that landed and so cannot reach the dry run — the one moment the

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -75,19 +75,25 @@ export interface PieceExpect {
   retained: boolean;
 
   /**
-   * The origin the piece follows, exactly as the piece records it; absent
-   * when the piece is detached. A retarget writes a source a human chose
-   * and detaches the piece from its origin, so this is the record of what
-   * the run detaches — and the string an operator writes back to re-attach it
-   * by hand afterwards.
+   * The origin the piece followed when the survey read it, exactly as the
+   * piece records it; absent when it was detached then.
+   *
+   * A record of what the plan was built against, and no claim about what any
+   * later run does. A retarget detaches the origin the piece holds when its
+   * write commits, which is this one only while nothing moved it in between
+   * — and only the reference pair is a precondition, so a piece whose origin
+   * alone moved is still written. What a run detached rides its own report
+   * row as `ApplyRow.detachedOrigin`
+   * ([bulk-apply.ts](./bulk-apply.ts)), and that is the value to re-attach
+   * from; this one disagreeing with it is what tells an operator the plan
+   * had gone stale.
    *
    * The recorded spelling alone. `PieceOrigin` carries two more fields, the
    * canonical URL and the kind, and `classifyOrigin` derives both from this
    * string — the URL against the host this deployment routes the space to —
    * so recording either would put a re-derivable fact in the artifact in a
-   * spelling that reads differently elsewhere. Re-attaching takes the string
-   * the piece stored and nothing else, which is also how
-   * `RestoreOutcome.origin` spells the same fact.
+   * spelling that reads differently elsewhere. `RestoreOutcome.origin`
+   * spells the same fact the same way.
    */
   origin?: string;
 

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -75,6 +75,23 @@ export interface PieceExpect {
   retained: boolean;
 
   /**
+   * The origin the piece follows, exactly as the piece records it; absent
+   * when the piece is detached. A retarget writes a source a human chose
+   * and detaches the piece from its origin, so this is the record of what
+   * the run detaches — and the string an operator writes back to re-attach it
+   * by hand afterwards.
+   *
+   * The recorded spelling alone. `PieceOrigin` carries two more fields, the
+   * canonical URL and the kind, and `classifyOrigin` derives both from this
+   * string — the URL against the host this deployment routes the space to —
+   * so recording either would put a re-derivable fact in the artifact in a
+   * spelling that reads differently elsewhere. Re-attaching takes the string
+   * the piece stored and nothing else, which is also how
+   * `RestoreOutcome.origin` spells the same fact.
+   */
+  origin?: string;
+
+  /**
    * The revision the piece is at, when it already keeps a source-revision log.
    * A piece with no log yet — a legacy piece — has none until its first
    * transition appends a baseline revision, so a survey cannot read one for it.
@@ -446,6 +463,14 @@ export function deriveRollbackPlan(
     return [{
       piece: row.piece,
       ...(row.phase === undefined ? {} : { phase: row.phase }),
+      // No `origin`: the retarget this reverses detached the piece, so a
+      // detached piece is the precondition, and carrying the forward row's
+      // origin would claim the reversal detaches something already gone.
+      // Re-attaching is not the restore's to do either — a restore detaches
+      // in its own right (`docs/specs/piece-source-lifecycle.md`), and the
+      // only re-attachment the runtime has, `follow`, resolves the origin
+      // NOW and adopts whatever source it currently ships, which is not the
+      // reference a rollback promises to land.
       expect: {
         patternIdentity: row.op.patternIdentity,
         symbol: row.op.symbol,
@@ -564,6 +589,7 @@ function isPlanRow(value: unknown): value is PiecePlanRow {
     expect.patternIdentity === "" ||
     typeof expect.symbol !== "string" || expect.symbol === "" ||
     typeof expect.retained !== "boolean" ||
+    !isOptionalName(expect.origin) ||
     !isOptionalName(expect.revisionId) ||
     !isOptionalName(expect.documentHash)
   ) return false;

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -13,8 +13,9 @@
  *
  * The write detaches the piece from the origin it follows: the source it
  * runs afterwards is the one this plan names, chosen by a human, and a piece
- * that went on taking its origin's next update would leave that plan's
- * reviewer having approved a reference the piece does not keep. What the run
+ * still carrying that origin could be repointed afterwards to whatever the
+ * origin ships, leaving the plan's reviewer having approved a reference the
+ * piece no longer keeps. What the run
  * detaches is recorded — the plan row's `expect.origin`, carried onto every
  * report row — and re-attached by hand or not at all. Nothing here
  * re-attaches: the runtime's `follow` resolves the origin NOW and adopts

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -11,6 +11,17 @@
  * immediately before the write, and a source that no longer produces the
  * reference its row recorded is refused rather than applied.
  *
+ * The write detaches the piece from the origin it follows: the source it
+ * runs afterwards is the one this plan names, chosen by a human, and a piece
+ * that went on taking its origin's next update would leave that plan's
+ * reviewer having approved a reference the piece does not keep. What the run
+ * detaches is recorded — the plan row's `expect.origin`, carried onto every
+ * report row — and re-attached by hand or not at all. Nothing here
+ * re-attaches: the runtime's `follow` resolves the origin NOW and adopts
+ * whatever source it currently ships, which is not the reference a rollback
+ * promises to land, and the restore a rollback runs detaches in its own
+ * right by design (`docs/specs/piece-source-lifecycle.md`).
+ *
  * The row's own precondition rides into the write rather than stopping at
  * the recheck that proved it. A piece is read once to classify it and again
  * by the write itself, and a writer landing between those two reads is

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -15,9 +15,12 @@
  * runs afterwards is the one this plan names, chosen by a human, and a piece
  * still carrying that origin could be repointed afterwards to whatever the
  * origin ships, leaving the plan's reviewer having approved a reference the
- * piece no longer keeps. What the run
- * detaches is recorded — the plan row's `expect.origin`, carried onto every
- * report row — and re-attached by hand or not at all. Nothing here
+ * piece no longer keeps. What the run detaches is recorded and re-attached
+ * by hand or not at all, and it is recorded from the write rather than from
+ * the plan: the row's `expect.origin` is the survey's reading, while the
+ * origin a write detaches is the one the piece holds when the write commits,
+ * and only the pattern reference stands between the two as a precondition.
+ * Nothing here
  * re-attaches: the runtime's `follow` resolves the origin NOW and adopts
  * whatever source it currently ships, which is not the reference a rollback
  * promises to land, and the restore a rollback runs detaches in its own
@@ -88,6 +91,7 @@ const RETARGET: PlanOperation<RetargetOp> = {
     // this program runs, by construction. A source that lost the export
     // outright fails resolution above, named.
     const controller = await pieces.get(row.piece, false);
+    let written;
     try {
       // The override comes from the row and nowhere else, so the plan shows
       // exactly which rows ran with the gate open. The reference the
@@ -98,7 +102,7 @@ const RETARGET: PlanOperation<RetargetOp> = {
       // read through to the transaction that commits it. It is a
       // precondition and not a confirmation — it opens no gate the row's
       // own override does not.
-      await controller.setPattern(program, {
+      written = await controller.setPattern(program, {
         ...(row.op.allowIncompatible === true
           ? { dangerouslyAllowIncompatibleSchema: true }
           : {}),
@@ -116,7 +120,15 @@ const RETARGET: PlanOperation<RetargetOp> = {
       }
       throw error;
     }
-    return undefined;
+    // What this write detached, from the write itself. The row's recorded
+    // origin is the survey's reading and may be older than the piece: only
+    // the pattern reference is a precondition here, so a piece whose origin
+    // alone moved since the survey is written, and detached off the origin
+    // it holds now. Reporting the recorded one would send an operator
+    // re-attaching by hand to an origin this run never touched.
+    return written.detachedOrigin === null
+      ? undefined
+      : { detachedOrigin: written.detachedOrigin };
   },
 };
 

--- a/packages/piece/src/ops/bulk-survey.ts
+++ b/packages/piece/src/ops/bulk-survey.ts
@@ -278,9 +278,9 @@ export async function surveyPieces(
       patternIdentity: pin.patternIdentity,
       symbol: pin.symbol,
       retained: pin.retained,
-      // The origin rides the row so the artifact records what a retarget
-      // will detach: the write cuts the piece loose, and the operator's way
-      // back is this string, by hand.
+      // The origin rides the row so the artifact records what the plan was
+      // built against. It is this read and nothing later: what a run
+      // detaches is the run's to report, on its own row.
       ...(pin.origin === undefined ? {} : { origin: pin.origin }),
       ...(pin.revisionId === undefined ? {} : { revisionId: pin.revisionId }),
     };
@@ -380,8 +380,8 @@ export interface PiecePin {
    * piece is detached. Read raw rather than classified, as
    * `readRestorableSource` in [piece-restore.ts](./piece-restore.ts) reads it
    * and for the same reason: a classified read reports an origin this runtime
-   * cannot resolve as detached, while a retarget detaches that string all the
-   * same, so reading it classified would leave exactly those pieces
+   * cannot resolve as detached, while a write detaches such an origin like
+   * any other, so reading it classified would leave exactly those pieces
    * unrecorded.
    */
   origin?: string;

--- a/packages/piece/src/ops/bulk-survey.ts
+++ b/packages/piece/src/ops/bulk-survey.ts
@@ -17,6 +17,7 @@ import type { CellScope } from "@commonfabric/api";
 import {
   type Cell,
   getPatternIdentityRef,
+  getPatternSource,
   type JSONSchema,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
@@ -277,6 +278,10 @@ export async function surveyPieces(
       patternIdentity: pin.patternIdentity,
       symbol: pin.symbol,
       retained: pin.retained,
+      // The origin rides the row so the artifact records what a retarget
+      // will detach: the write cuts the piece loose, and the operator's way
+      // back is this string, by hand.
+      ...(pin.origin === undefined ? {} : { origin: pin.origin }),
       ...(pin.revisionId === undefined ? {} : { revisionId: pin.revisionId }),
     };
     // An own-property check: a phase named like an `Object.prototype` member
@@ -370,6 +375,17 @@ export interface PiecePin {
   /** The entry export the identity runs. */
   symbol: string;
 
+  /**
+   * The origin the piece follows, exactly as it records it; absent when the
+   * piece is detached. Read raw rather than classified, as
+   * `readRestorableSource` in [piece-restore.ts](./piece-restore.ts) reads it
+   * and for the same reason: a classified read reports an origin this runtime
+   * cannot resolve as detached, while a retarget detaches that string all the
+   * same, so reading it classified would leave exactly those pieces
+   * unrecorded.
+   */
+  origin?: string;
+
   /** The current source revision, when the piece keeps a log. */
   revisionId?: string;
 
@@ -378,11 +394,12 @@ export interface PiecePin {
 }
 
 /**
- * Read one piece's source pin: identity, symbol, current revision when a log
- * exists, and whether the identity's source is verifiably retained. One
- * synced read of the piece plus one retained-source load cached per identity
- * — the piece is never run, and nothing else is pulled. Returns `undefined`
- * for a piece carrying no pattern identity.
+ * Read one piece's source pin: identity, symbol, the origin it follows,
+ * current revision when a log exists, and whether the identity's source is
+ * verifiably retained. One synced read of the piece plus one
+ * retained-source load cached per identity — the piece is never run, and
+ * nothing else is pulled. Returns `undefined` for a piece carrying no
+ * pattern identity.
  */
 export async function readPiecePin(
   pieces: PiecesController,
@@ -391,12 +408,21 @@ export async function readPiecePin(
   scope?: CellScope,
 ): Promise<PiecePin | undefined> {
   const controller = await pieces.get(piece, false, undefined, scope);
-  const state = readPieceSourceMetadata(pieces.runtime, controller.getCell());
+  const cell = controller.getCell();
+  const state = readPieceSourceMetadata(pieces.runtime, cell);
   if (state.pattern === undefined) return undefined;
+  const recorded = getPatternSource(cell);
+  // An empty recorded origin names no place a source can be resolved from,
+  // and the plan codec refuses one — a survey must not emit a plan its own
+  // codec rejects — so it reads as detached here.
+  const origin = recorded === undefined || recorded === ""
+    ? undefined
+    : recorded;
   return {
     piece: controller.id,
     patternIdentity: state.pattern.identity,
     symbol: state.pattern.symbol,
+    ...(origin === undefined ? {} : { origin }),
     ...(state.currentRevisionId === undefined
       ? {}
       : { revisionId: state.currentRevisionId }),

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -418,6 +418,23 @@ export type PieceSourceAction =
   | { kind: "restore"; revisionId: string }
   | { kind: "follow"; revisionId: string };
 
+/** What one {@link PieceController.setPattern} write did beyond landing. */
+export interface PieceSourceSetResult {
+  /**
+   * The origin the write detached, and null when the piece was already
+   * detached.
+   *
+   * Taken from the snapshot the transition committed against, not from a
+   * read beside the call. `applyPieceSourceTransition` refuses inside the
+   * write transaction unless the piece's live origin still equals that
+   * snapshot's, so a write that committed detached exactly this — while a
+   * value any caller read before the call is a value the write may have
+   * moved off. A caller that records what it detached, so an operator can
+   * re-attach by hand, is right only with this one.
+   */
+  detachedOrigin: string | null;
+}
+
 export interface PreparedPieceSourceChange {
   action: PieceSourceAction;
   expected: PieceSourceSnapshot;
@@ -4081,6 +4098,11 @@ export class PieceController<T = unknown> {
    * execute-time validators remain the whole of enforcement, and
    * `dangerouslyAllowIncompatibleSchema` remains the only thing that opens
    * them.
+   *
+   * Returns the origin this write detached — see {@link PieceSourceSetResult}.
+   * A caller reporting what it detached has no other way to be right about
+   * it: the origin at the caller's own read is not the origin at the write,
+   * and only the snapshot this call commits against is.
    */
   async setPattern(
     program: RuntimeProgram,
@@ -4089,7 +4111,7 @@ export class PieceController<T = unknown> {
       dangerouslyAllowIncompatibleSchema?: boolean;
       expectedPattern?: { identity: string; symbol: string };
     },
-  ): Promise<void> {
+  ): Promise<PieceSourceSetResult> {
     const mutationVersion = ++this.#mutationVersion;
     let transition: PieceSourceTransition | undefined;
     try {
@@ -4193,10 +4215,18 @@ export class PieceController<T = unknown> {
           "Piece source was saved, but refreshing the running piece failed:",
           error,
         );
-        return;
+        // The transition committed, so it detached what its precondition
+        // named, whatever happened to the refresh afterwards.
+        return { detachedOrigin: transition.expected.origin };
       }
       throw pinnedSourceMoved(error, options?.expectedPattern);
     }
+    // Assigned by the mutation above before the write it belongs to; a
+    // mutation that returned without assigning it never reached the write.
+    if (transition === undefined) {
+      throw new Error("the source transition was not prepared");
+    }
+    return { detachedOrigin: transition.expected.origin };
   }
 
   async #runMutation(

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -4148,8 +4148,8 @@ export class PieceController<T = unknown> {
         }
         // The `null` is the origin: this transition detaches. A caller
         // supplying the source has chosen what the piece runs, and a piece
-        // that went on taking its origin's next update would run something
-        // that caller never named.
+        // still carrying its origin could be repointed afterwards to
+        // whatever that origin ships, which is not what this caller named.
         transition = pieceSourceTransition(
           expected,
           "edit",

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -4221,12 +4221,11 @@ export class PieceController<T = unknown> {
       }
       throw pinnedSourceMoved(error, options?.expectedPattern);
     }
-    // Assigned by the mutation above before the write it belongs to; a
-    // mutation that returned without assigning it never reached the write.
-    if (transition === undefined) {
-      throw new Error("the source transition was not prepared");
-    }
-    return { detachedOrigin: transition.expected.origin };
+    // The mutation assigns `transition` before the write it belongs to, and
+    // every earlier exit from it throws — so a mutation that resolved has
+    // one, and a mutation that did not took the catch above. Asserted rather
+    // than guarded because a guard here could never fire.
+    return { detachedOrigin: transition!.expected.origin };
   }
 
   async #runMutation(

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -4061,7 +4061,9 @@ export class PieceController<T = unknown> {
   }
 
   /**
-   * Replace the piece's source with `program`.
+   * Replace the piece's source with `program`, detaching the piece from the
+   * origin it follows: what it runs afterwards is `program` and stays
+   * `program` until something writes it again.
    *
    * `expectedPattern` pins the reference this write may run over, exactly as
    * {@link changeSource}'s does and for the same window. The snapshot read
@@ -4144,6 +4146,10 @@ export class PieceController<T = unknown> {
         if (!options?.dangerouslyAllowIncompatibleSchema) {
           assertPatternSchemasBackwardCompatible(previousPattern, pattern);
         }
+        // The `null` is the origin: this transition detaches. A caller
+        // supplying the source has chosen what the piece runs, and a piece
+        // that went on taking its origin's next update would run something
+        // that caller never named.
         transition = pieceSourceTransition(
           expected,
           "edit",

--- a/packages/piece/test/ops/bulk-plan.test.ts
+++ b/packages/piece/test/ops/bulk-plan.test.ts
@@ -244,6 +244,43 @@ describe("bulk-plan", () => {
       ).toThrow("row 1");
     });
 
+    it("throws for an empty origin on an expectation", () => {
+      const plan = retargetPlan();
+      const emptyOrigin = {
+        ...plan.rows[0],
+        expect: { ...plan.rows[0].expect, origin: "" },
+      };
+      expect(() =>
+        decodePlan(JSON.stringify(header) + "\n" + JSON.stringify(emptyOrigin))
+      ).toThrow("row 1");
+    });
+
+    it("carries the origin a row records, and a row that records none", () => {
+      const plan = retargetPlan();
+      const following: PiecePlan = {
+        header,
+        rows: [
+          {
+            ...plan.rows[0],
+            expect: {
+              ...plan.rows[0].expect,
+              origin: "https://origins.test/topic.tsx",
+            },
+          },
+          plan.rows[1],
+        ],
+      };
+
+      const decoded = decodePlan(encodePlan(following));
+
+      expect(decoded.rows[0].expect.origin).toBe(
+        "https://origins.test/topic.tsx",
+      );
+      // The field is additive: a row that records no origin is a valid row,
+      // so every plan an earlier survey wrote is still a plan.
+      expect(decoded.rows[1].expect.origin).toBeUndefined();
+    });
+
     it("throws for an enumeration count that no selection can produce", () => {
       for (const collection of [-1, 2.5, Number.NaN]) {
         const bad = {
@@ -512,6 +549,26 @@ describe("bulk-plan", () => {
           revisionId: "rev-b",
         },
       ]);
+    });
+
+    it("returns a precondition recording no origin, the retarget having detached the piece", () => {
+      const plan = retargetPlan();
+      const following: PiecePlan = {
+        header,
+        rows: plan.rows.map((row) => ({
+          ...row,
+          expect: { ...row.expect, origin: "https://origins.test/topic.tsx" },
+        })),
+      };
+
+      const rollback = deriveRollbackPlan(following, "later");
+
+      // The forward run detached every piece it wrote, so a detached piece
+      // is what the reversal is proved against. Carrying the forward row's
+      // origin here would claim the reversal detaches something already
+      // gone, and the restore it runs re-attaches nothing.
+      expect(rollback.rows.every((row) => row.expect.origin === undefined))
+        .toBe(true);
     });
 
     it("returns a header stamped with the given time, same space", () => {

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, setPatternSource } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import {
@@ -275,6 +275,43 @@ describe("bulk-retarget", () => {
     expect(pin?.patternIdentity).toBe(
       (plan.rows[0].op as RetargetOp).patternIdentity,
     );
+  });
+
+  it("carries the plan's origin onto every report row, and the write detaches it", async () => {
+    const { plan, ids } = await seed(1);
+    const origin = "https://origins.test/member.tsx";
+    const stamper = await sessions.open();
+    const target = await stamper.get(ids[0], false);
+    const { error } = await stamper.runtime.editWithRetry((tx) => {
+      setPatternSource(target.getCell(), tx, origin);
+    });
+    if (error !== undefined) throw error;
+    await stamper.synced();
+    await sessions.close(stamper);
+    const following: PiecePlan = {
+      header: plan.header,
+      rows: [{
+        ...plan.rows[0],
+        expect: { ...plan.rows[0].expect, origin },
+      }],
+    };
+
+    const dry = await retargetPieces(sessions, { plan: following });
+    const applied = await retargetPieces(sessions, {
+      plan: following,
+      apply: true,
+    });
+
+    // The dry run is the only moment the detach is still a decision, so the
+    // origin rides that row as much as the applied one.
+    expect(dry.rows[0].verdict).toBe("outstanding");
+    expect(dry.rows[0].origin).toBe(origin);
+    expect(applied.rows[0].verdict).toBe("applied");
+    expect(applied.rows[0].origin).toBe(origin);
+    // What the report records is a real detach: the piece follows nothing
+    // afterwards, and re-attaching it is by hand from the string the row
+    // carried.
+    expect((await pinOf(ids[0]))?.origin).toBeUndefined();
   });
 
   it("resumes as a re-invocation: landed rows are not rewritten", async () => {

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -227,6 +227,57 @@ describe("bulk-retarget", () => {
     };
   }
 
+  /**
+   * Sessions in which another writer changes `victim`'s ORIGIN — and only
+   * its origin — between the engine's classifying read and the write step's
+   * own. The pattern reference is untouched, so the row still classifies as
+   * outstanding and the write still commits; what moves is the value the
+   * write detaches, which is the reading the report has to take from the
+   * write rather than from the plan.
+   */
+  function changeOriginBeforeWrite(
+    victim: string,
+    origin: string,
+  ): ApplySessions {
+    let sessionIndex = 0;
+    return {
+      open: async () => {
+        sessionIndex += 1;
+        const applySession = sessionIndex >= 2;
+        let reads = 0;
+        const pieces = await sessions.open();
+        return new Proxy(pieces, {
+          get(target, prop, receiver) {
+            if (prop === "get") {
+              return async (id: string, run?: boolean) => {
+                if (id === victim && applySession) {
+                  reads += 1;
+                  // The engine reads once to classify the row, and the write
+                  // step reads again to write it. Landing on the second is
+                  // landing inside the window the write itself closes.
+                  if (reads === 2) {
+                    const piece = await target.get(id, false);
+                    const { error } = await pieces.runtime.editWithRetry(
+                      (tx) => {
+                        setPatternSource(piece.getCell(), tx, origin);
+                      },
+                    );
+                    if (error !== undefined) throw error;
+                    await pieces.synced();
+                  }
+                }
+                return target.get(id, run);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as PiecesController;
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+  }
+
   it("classifies every row from one preflight read on a dry run", async () => {
     const { plan } = await seed(2);
     const before = { opens, closes };
@@ -302,16 +353,92 @@ describe("bulk-retarget", () => {
       apply: true,
     });
 
-    // The dry run is the only moment the detach is still a decision, so the
-    // origin rides that row as much as the applied one.
+    // The dry run has no write to report, so it carries the plan's record
+    // and nothing about a detach — that being the only moment the detach is
+    // still a decision.
     expect(dry.rows[0].verdict).toBe("outstanding");
     expect(dry.rows[0].origin).toBe(origin);
+    expect(dry.rows[0].detachedOrigin).toBeUndefined();
+    // The applied row carries both, and here they agree: nothing moved the
+    // origin between the survey and the write.
     expect(applied.rows[0].verdict).toBe("applied");
     expect(applied.rows[0].origin).toBe(origin);
+    expect(applied.rows[0].detachedOrigin).toBe(origin);
     // What the report records is a real detach: the piece follows nothing
     // afterwards, and re-attaching it is by hand from the string the row
     // carried.
     expect((await pinOf(ids[0]))?.origin).toBeUndefined();
+  });
+
+  it("reports the origin the write detached, not the one the plan recorded", async () => {
+    const { plan, ids } = await seed(1);
+    const recorded = "https://origins.test/recorded.tsx";
+    const live = "https://origins.test/live.tsx";
+    const stamper = await sessions.open();
+    const target = await stamper.get(ids[0], false);
+    const { error } = await stamper.runtime.editWithRetry((tx) => {
+      setPatternSource(target.getCell(), tx, recorded);
+    });
+    if (error !== undefined) throw error;
+    await stamper.synced();
+    await sessions.close(stamper);
+    const following: PiecePlan = {
+      header: plan.header,
+      rows: [{
+        ...plan.rows[0],
+        expect: { ...plan.rows[0].expect, origin: recorded },
+      }],
+    };
+
+    const report = await retargetPieces(
+      changeOriginBeforeWrite(ids[0], live),
+      { plan: following, apply: true },
+    );
+
+    // Only the reference is a precondition, so moving the origin alone does
+    // not refuse the row — the write lands and detaches what it found.
+    expect(report.rows[0].verdict).toBe("applied");
+    expect(report.rows[0].detachedOrigin).toBe(live);
+    // The plan's reading survives beside it rather than being overwritten:
+    // an operator whose plan said one thing while the run did another is
+    // owed both, the disagreement being what tells them the plan went stale.
+    expect(report.rows[0].origin).toBe(recorded);
+    expect((await pinOf(ids[0]))?.origin).toBeUndefined();
+  });
+
+  it("reports no detached origin when the write found the piece already detached", async () => {
+    const { plan, ids } = await seed(1);
+    const recorded = "https://origins.test/recorded.tsx";
+    const stamper = await sessions.open();
+    const target = await stamper.get(ids[0], false);
+    const { error } = await stamper.runtime.editWithRetry((tx) => {
+      setPatternSource(target.getCell(), tx, recorded);
+    });
+    if (error !== undefined) throw error;
+    await stamper.synced();
+    // Somebody detaches the piece by hand between the survey and the run.
+    await target.changeSource({ kind: "detach" });
+    await stamper.synced();
+    await sessions.close(stamper);
+    const following: PiecePlan = {
+      header: plan.header,
+      rows: [{
+        ...plan.rows[0],
+        expect: { ...plan.rows[0].expect, origin: recorded },
+      }],
+    };
+
+    const report = await retargetPieces(sessions, {
+      plan: following,
+      apply: true,
+    });
+
+    // The row's write detached nothing, and reporting the recorded origin as
+    // detached would send an operator re-attaching an origin this run never
+    // touched. The plan's reading stays, labelled as the plan's.
+    expect(report.rows[0].verdict).toBe("applied");
+    expect(report.rows[0].detachedOrigin).toBeUndefined();
+    expect(report.rows[0].origin).toBe(recorded);
   });
 
   it("resumes as a re-invocation: landed rows are not rewritten", async () => {

--- a/packages/piece/test/ops/bulk-survey.test.ts
+++ b/packages/piece/test/ops/bulk-survey.test.ts
@@ -6,6 +6,7 @@ import {
   getPatternIdentityRef,
   Runtime,
   type RuntimeProgram,
+  setPatternSource,
   sourceDocKey,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -147,6 +148,18 @@ describe("bulk-survey", () => {
     return holder;
   }
 
+  /** Stamp the origin a piece follows, as a create from a URL would. */
+  async function stampOrigin(
+    piece: PieceController,
+    origin: string,
+  ): Promise<void> {
+    const { error } = await runtime.editWithRetry((tx) => {
+      setPatternSource(piece.getCell(), tx, origin);
+    });
+    if (error !== undefined) throw error;
+    await runtime.idle();
+  }
+
   function collectionOf(holder: PieceController) {
     return {
       kind: "collection" as const,
@@ -229,6 +242,47 @@ describe("bulk-survey", () => {
       });
       expect(builderRun.plan.rows).toHaveLength(1);
       expect(builderRun.plan.rows[0].expect.retained).toBe(false);
+    });
+
+    it("records the origin a piece follows, and none for a detached one", async () => {
+      const followed = await pieces.create(generationProgram("a"), {
+        input: {},
+      });
+      const detached = await pieces.create(generationProgram("a"), {
+        input: {},
+      });
+      await stampOrigin(followed, "https://origins.test/member.tsx");
+      const holder = await seedHolder([followed, detached]);
+
+      const survey = await surveyPieces(pieces, {
+        selector: collectionOf(holder),
+      });
+
+      // A retarget detaches the piece it writes, so the row records what
+      // the run would detach and what re-attaching by hand takes.
+      expect(survey.plan.rows[0].expect.origin).toBe(
+        "https://origins.test/member.tsx",
+      );
+      expect(survey.plan.rows[1].expect.origin).toBeUndefined();
+      expect(survey.plan.rows[2].expect.origin).toBeUndefined();
+    });
+
+    it("records an origin this runtime cannot resolve, which a retarget detaches all the same", async () => {
+      const followed = await pieces.create(generationProgram("a"), {
+        input: {},
+      });
+      await stampOrigin(followed, "not-a-url");
+      const holder = await seedHolder([followed]);
+
+      const survey = await surveyPieces(pieces, {
+        selector: collectionOf(holder),
+      });
+
+      // Classifying this string drops it — it names no place a source can
+      // be resolved from — while the write detaches it like any other, so
+      // the row records what the piece stores rather than what
+      // classification made of it.
+      expect(survey.plan.rows[0].expect.origin).toBe("not-a-url");
     });
 
     it("reports retained false when the stored source cannot verify", async () => {

--- a/packages/piece/test/piece-source-lifecycle.test.ts
+++ b/packages/piece/test/piece-source-lifecycle.test.ts
@@ -1339,7 +1339,9 @@ describe("piece source lifecycle", () => {
     const heldSyncEntered = defer<void>();
     const releaseHeldSync = defer<void>();
     let interceptDetach = true;
-    let newerEdit: Promise<void> | undefined;
+    // Only awaited, never read: this test is about what the newer edit does
+    // to the detach beside it, not about what it returns.
+    let newerEdit: Promise<unknown> | undefined;
 
     runtime.editWithRetry = (async (action, maxRetries) => {
       const result = await originalEditWithRetry(action, maxRetries);

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -7246,8 +7246,12 @@ describe("piece pull materialization", () => {
     try {
       const firstUpdate = controller.setPattern(firstProgram);
       await firstRunReturned.promise;
+      // Resolves rather than rejects: the transition committed, so the
+      // injected post-commit failure is not this call's failure. It reports
+      // what that committed transition detached, which for a piece following
+      // no origin is nothing.
       await expect(controller.setPattern(winnerProgram)).resolves
-        .toBeUndefined();
+        .toEqual({ detachedOrigin: null });
       expect(getPatternIdentityRef(piece)).toEqual(
         runtime.patternManager.getArtifactEntryRef(winnerPattern),
       );


### PR DESCRIPTION
## Why

A bulk retarget **detaches every piece it touches** — `setPattern` passes `null` as the source transition's origin (`piece-controller.ts:4153`) — and nothing recorded it. `origin` appeared zero times in `bulk-plan.ts` and `bulk-apply.ts`; the survey read it and dropped it; the feature doc stated the detach for `restore` only. So the artifact whose entire job is recording what a run did was silent about a state change it makes to every row.

This matters more as origin-following becomes the other upgrade mechanism (#6384): one piece, at open, source chosen by whoever ships the origin, versus this lane — a set, ordered, from a reviewed plan, source chosen by a human. They partition cleanly, and an operator moving a set needs to see what the move severs. Raised by b10 at Mike's direction; the defect is currently latent because our population is `cf piece new` local-file pieces, already detached — which is also why the Topics rehearsal could not have caught it, and why it is worth fixing before general origins land rather than after.

## What Changed

- `PieceExpect.origin?: string`, optional and additive — a plan without it decodes unchanged (`isOptionalName`, the idiom `revisionId` and `documentHash` already use).
- The survey records it, read **raw** rather than classified: `url` and `kind` are derived from the stored string against *this deployment's* routing, so recording them would put a re-derivable fact in the artifact in a spelling that reads differently elsewhere — and the classified read reports "detached" for an origin this runtime cannot classify, which a retarget severs all the same. Re-attaching by hand takes the raw string back.
- Every report path carries it — preflight, dry run, apply, stop, unattempted — via one `carriedFields()` helper replacing six copies of the same row-fact construction, because a report path that forgets a field is exactly how this goes missing again.
- Carrier is a new `ApplyRow.origin`, **not** `warning`: a warning is a fact about a write that landed, so a dry run — the one moment the detach is still a decision — would carry none of it.
- CLI: `formatApplyRow` prints `origin <url>`; one summary hint counts the rows an apply will detach; `cf piece inspect --pattern-identity` prints it too.
- Rollback derivation deliberately carries **no** origin: the forward retarget already detached the piece.
- Docs: a new section in the feature doc covering the mechanism split, record-not-gate and why, and that nothing re-attaches; the plan doc's `expect` clause; the CLI README's retarget paragraph.

**Reported, not gated** — gate the irreversible, report the recoverable. `retained` gates because an unretained row can never come back; a detached origin is recoverable by hand, and once general origins are the one mechanism an origin-following row is nearly every row, so an acceptance firing on nearly everything is a rubber stamp. **Nothing re-attaches**: `follow` resolves the origin *now* and adopts its current source, which is not the reference a rollback promises, and `restore` detaches by the lifecycle spec's deliberate rule.

## Test plan

Seven revert-checked tests: an empty origin refused by the codec; the survey recording an origin and recording none for a detached piece; the survey recording an origin this runtime cannot classify (pins the raw-read decision); the engine carrying it onto every report row; the CLI row line and the summary hint; the `inspect` line. Each was verified to fail when its own change alone is reverted. Two further tests are labelled design guards rather than revert checks: one reds if the field ever becomes required, one reds if the rollback derivation ever carries the forward row's origin.

**Found while working, and worth a look on its own:** the existing warned-row hint loop in `reportApplyRun` was briefly deleted and the whole CLI suite stayed green, because nothing asserted it. It is restored and now has a test (`names each row that landed with a warning`).

`packages/piece` 48 passed / 709 steps, `packages/cli` 210 passed / 214 steps, `deno task check`, `fmt`, `lint`, `check-docs` (568 blocks), `check-skill-facts` all pass. The drill was checked by reading rather than run: it counts streamed rows and selects named jq fields, so neither the extra report field nor the extra plan field disturbs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

