### PR TITLE
feat(memory): record slow transacts with lock wait, commit shape, and outcome

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -348,8 +348,14 @@ process:
   `traverse` and `runner/start/*` appear here meaning the *server's* work.
 - `logCounts` — the same per-logger counts, which is how a warning storm shows
   up as a number rather than as a log to grep.
-- `slowQueries` — the last hundred query or watch operations over 100 ms, with
-  the space and the root and watch counts.
+- `slowQueries` — the last hundred query, watch, or commit operations over
+  100 ms, with the space and the root and watch counts. A `transact` entry
+  also carries the commit's operation and read counts, its outcome (`ok`,
+  the error name, or `threw` — a slow rejected commit records like a slow
+  applied one), and `lockWaitMs`: how long the commit waited for the space
+  publication lock before evaluating. Flush passes hold that same lock, so
+  a `transact` whose `lockWaitMs` dominates its elapsed time was queued
+  behind fan-out, not expensive itself.
 - `servingLoop` — the serving loop's counters
   ([`serving-loop.md` §7](../../specs/server-side-execution/serving-loop.md)),
   present only when this process serves. `settle.series` is a ready-made

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { getSlowQueries, Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  toDocumentPath,
+  type TransactRequest,
+} from "../v2.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-slow-query-test-audience";
+
+const createServer = (store: string) =>
+  new Server({
+    store: new URL(store),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen() {
+      return "did:key:z6Mk-memory-v2-slow-query-principal";
+    },
+    sessionOpenAuth: {
+      audience: TEST_AUDIENCE,
+    },
+  });
+
+const openSession = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+): Promise<string> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: getMemoryProtocolFlags(),
+  }));
+  const hello = messages.shift() as
+    | { type: string; sessionOpen?: SessionOpenAuthMetadata }
+    | undefined;
+  expect(hello?.type).toBe("hello.ok");
+  const sessionOpen = hello!.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const opened = messages.shift() as ResponseMessage<{ sessionId: string }>;
+  expect(opened.ok).toBeDefined();
+  return opened.ok!.sessionId;
+};
+
+describe("v2 server slow queries", () => {
+  // The recording thresholds on real elapsed time, so the tests shift
+  // `performance.now` from inside the measured window (the publishVerdict
+  // callback runs between evaluation and the recording) instead of
+  // sleeping. Restored after each test.
+  const realNow = performance.now.bind(performance);
+  let nowOffsetMs = 0;
+
+  beforeEach(() => {
+    nowOffsetMs = 0;
+    performance.now = () => realNow() + nowOffsetMs;
+  });
+
+  afterEach(() => {
+    performance.now = realNow;
+  });
+
+  const transactMessage = (
+    space: string,
+    sessionId: string,
+    commit: TransactRequest["commit"],
+  ): TransactRequest => ({
+    type: "transact",
+    requestId: crypto.randomUUID(),
+    space,
+    sessionId,
+    commit,
+  });
+
+  it("records a slow applied commit with its lock wait and shape", async () => {
+    const space = "did:key:z6Mk-slow-query-applied";
+    const server = createServer("memory://slow-query-applied");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space);
+
+      const response = await server.transact(
+        transactMessage(space, sessionId, {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:slow", value: { value: { n: 1 } } },
+          ],
+        }),
+        () => {
+          nowOffsetMs += 250;
+        },
+      );
+      expect(response.error).toBeUndefined();
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "transact"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.elapsed).toBeGreaterThanOrEqual(250);
+      expect(entry!.outcome).toBe("ok");
+      expect(entry!.operations).toBe(1);
+      expect(entry!.readsConfirmed).toBe(0);
+      expect(entry!.readsPending).toBe(0);
+      expect(entry!.lockWaitMs).toBeGreaterThanOrEqual(0);
+      expect(entry!.lockWaitMs!).toBeLessThan(entry!.elapsed);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("records a slow rejected commit under the error's name", async () => {
+    const space = "did:key:z6Mk-slow-query-conflict";
+    const server = createServer("memory://slow-query-conflict");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space);
+
+      const seed = await server.transact(
+        transactMessage(space, sessionId, {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:contested", value: { value: { n: 1 } } },
+          ],
+        }),
+      );
+      expect(seed.error).toBeUndefined();
+
+      // A confirmed read at seq 0 of a document the space already holds is
+      // deterministically stale — the production shape a slow rejected
+      // commit records under.
+      const rejected = await server.transact(
+        transactMessage(space, sessionId, {
+          localSeq: 2,
+          reads: {
+            confirmed: [
+              {
+                id: "of:doc:contested",
+                path: toDocumentPath(["value"]),
+                seq: 0,
+              },
+            ],
+            pending: [],
+          },
+          operations: [
+            { op: "set", id: "of:doc:contested", value: { value: { n: 2 } } },
+          ],
+        }),
+        () => {
+          nowOffsetMs += 250;
+        },
+      );
+      expect(rejected.error?.name).toBe("ConflictError");
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "transact"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.outcome).toBe("ConflictError");
+      expect(entry!.operations).toBe(1);
+      expect(entry!.readsConfirmed).toBe(1);
+    } finally {
+      connection.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -123,6 +123,58 @@ describe("v2 server slow queries", () => {
     }
   });
 
+  it("records a commit whose wire shape lacks reads without masking the response", async () => {
+    const space = "did:key:z6Mk-slow-query-malformed";
+    const server = createServer("memory://slow-query-malformed");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space);
+
+      // The wire parser validates only the commit's envelope, so a commit
+      // without `reads` reaches transact. Whatever the evaluation decides,
+      // the recording must not replace that outcome with its own throw.
+      let settled: { error?: { name: string } } | undefined;
+      let threw: unknown;
+      try {
+        settled = await server.transact(
+          transactMessage(
+            space,
+            sessionId,
+            {
+              localSeq: 1,
+              operations: [
+                { op: "set", id: "of:doc:bare", value: { value: { n: 1 } } },
+              ],
+            } as unknown as TransactRequest["commit"],
+          ),
+          () => {
+            nowOffsetMs += 250;
+          },
+        );
+      } catch (error) {
+        threw = error;
+      }
+      expect(threw instanceof TypeError).toBe(false);
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "transact"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.operations).toBe(1);
+      expect(entry!.readsConfirmed).toBeUndefined();
+      expect(entry!.readsPending).toBeUndefined();
+      expect(typeof entry!.outcome).toBe("string");
+      if (settled !== undefined) {
+        expect(entry!.outcome).toBe(settled.error?.name ?? "ok");
+      } else {
+        expect(entry!.outcome).toBe("threw");
+      }
+    } finally {
+      connection.close();
+    }
+  });
+
   it("records a slow rejected commit under the error's name", async () => {
     const space = "did:key:z6Mk-slow-query-conflict";
     const server = createServer("memory://slow-query-conflict");

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -171,6 +171,21 @@ export type SlowQuery = {
   space: string;
   roots?: number;
   watches?: number;
+  /** transact only: milliseconds the commit waited for the space
+   * publication lock before evaluation began. Flush passes hold the same
+   * lock, so a large value is head-of-line blocking behind fan-out rather
+   * than the commit's own cost. */
+  lockWaitMs?: number;
+  /** transact only: the commit's operation count. */
+  operations?: number;
+  /** transact only: the commit's confirmed read count. */
+  readsConfirmed?: number;
+  /** transact only: the commit's pending read count. */
+  readsPending?: number;
+  /** transact only: "ok", the response error's name (a rejected commit
+   * that took this long is at least as interesting as an applied one), or
+   * "threw" when evaluation raised instead of responding. */
+  outcome?: string;
 };
 
 const slowQueries: SlowQuery[] = [];
@@ -202,7 +217,7 @@ const recordSlowQueryDuration = (
   });
 };
 
-/** Returns the last N slow query/watch operations (>100ms). */
+/** Returns the last N slow query, watch, and commit operations (>100ms). */
 export const getSlowQueries = (): readonly SlowQuery[] => slowQueries;
 
 /**
@@ -2760,29 +2775,46 @@ export class Server {
     message: TransactRequest,
     publishVerdict?: PublishTransactVerdict,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
+    const requestedAt = performance.now();
     return await this.withSpacePublicationLock(message.space, async () => {
-      const decision = await this.decideTransaction(message);
-      let verdictError: { value: unknown } | undefined;
+      const lockWaitMs = performance.now() - requestedAt;
+      let outcome = "threw";
       try {
-        publishVerdict?.(decision.response);
-      } catch (error) {
-        verdictError = { value: error };
-      }
-      try {
-        await decision.postCommit?.();
-      } catch (postCommitError) {
-        if (verdictError !== undefined) {
-          throw new AggregateError(
-            [verdictError.value, postCommitError],
-            "Verdict publication and post-commit bookkeeping both failed",
-          );
+        const decision = await this.decideTransaction(message);
+        outcome = decision.response.error?.name ?? "ok";
+        let verdictError: { value: unknown } | undefined;
+        try {
+          publishVerdict?.(decision.response);
+        } catch (error) {
+          verdictError = { value: error };
         }
-        throw postCommitError;
+        try {
+          await decision.postCommit?.();
+        } catch (postCommitError) {
+          if (verdictError !== undefined) {
+            throw new AggregateError(
+              [verdictError.value, postCommitError],
+              "Verdict publication and post-commit bookkeeping both failed",
+            );
+          }
+          throw postCommitError;
+        }
+        if (verdictError !== undefined) {
+          throw verdictError.value;
+        }
+        return decision.response;
+      } finally {
+        // The elapsed span deliberately starts at the REQUEST, not at lock
+        // acquisition: what a client waits for is both halves, and the
+        // lockWaitMs field is what splits them apart on the dashboard.
+        recordSlowQueryDuration("transact", message.space, requestedAt, {
+          lockWaitMs: Math.round(lockWaitMs),
+          operations: message.commit.operations.length,
+          readsConfirmed: message.commit.reads.confirmed.length,
+          readsPending: message.commit.reads.pending.length,
+          outcome,
+        });
       }
-      if (verdictError !== undefined) {
-        throw verdictError.value;
-      }
-      return decision.response;
     });
   }
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2807,11 +2807,18 @@ export class Server {
         // The elapsed span deliberately starts at the REQUEST, not at lock
         // acquisition: what a client waits for is both halves, and the
         // lockWaitMs field is what splits them apart on the dashboard.
+        // The wire parser validates only the commit's envelope, so the
+        // arrays may be absent here; a malformed commit records with its
+        // counts missing rather than masking the transaction's own
+        // response with a throw from this finally.
+        const commit = message.commit as Partial<ClientCommit>;
+        const count = (value: unknown): number | undefined =>
+          Array.isArray(value) ? value.length : undefined;
         recordSlowQueryDuration("transact", message.space, requestedAt, {
           lockWaitMs: Math.round(lockWaitMs),
-          operations: message.commit.operations.length,
-          readsConfirmed: message.commit.reads.confirmed.length,
-          readsPending: message.commit.reads.pending.length,
+          operations: count(commit.operations),
+          readsConfirmed: count(commit.reads?.confirmed),
+          readsPending: count(commit.reads?.pending),
           outcome,
         });
       }


### PR DESCRIPTION
## Problem

`/api/health/stats` `slowQueries` covers queries and watch operations but not `transact` — so commit validation, the largest inbound cost class on a busy space, is invisible on the dashboard. During the 2026-08-26 estuary board-shard capture, individual multi-MB commits waited up to 66 s for their response with nothing recorded server-side (evidence on the tracking Topic "Board-load pre-sync follow-ups", comments 6-7).

## Change

`transact` now records into the same slow-query buffer, whatever its outcome:

- **`lockWaitMs`** — time waiting for the space publication lock before evaluation. Flush fan-out passes hold the same lock, so an entry whose lock wait dominates its elapsed time was queued behind fan-out, not expensive itself. This one field splits the two mechanisms the capture could not separate.
- **`operations` / `readsConfirmed` / `readsPending`** — the commit's shape, which identifies the oversized-commit class directly.
- **`outcome`** — `ok`, the response error's name (a slow `ConflictError` records like a slow applied commit), or `threw`.

`docs/development/debugging/profiling.md`'s `slowQueries` description updated in the same change.

## Testing

- New `packages/memory/test/v2-server-slow-query.test.ts`: a slow applied commit records with shape and bounded `lockWaitMs`; a slow **rejected** commit (seq-0 stale confirmed read — the production conflict shape) records under `ConflictError`. Elapsed time is driven by shifting `performance.now` from the `publishVerdict` callback inside the measured window — no sleeps.
- Full memory package suite green (576 passed); repo-wide fmt + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

