### PR TITLE
docs(common): a tour of the read/write path, and the demo that runs it

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -89,6 +89,7 @@ on the Common Fabric runtime.
 - [workflows/development.md](workflows/development.md) — `cf` CLI loop: check, deploy, setsrc, inspect, link
 - [workflows/pattern-testing.md](workflows/pattern-testing.md) — writing and running pattern tests
 - [workflows/handlers-cli-testing.md](workflows/handlers-cli-testing.md) — invoking mounted callables from the CLI
+- [workflows/reading-and-writing.md](workflows/reading-and-writing.md) — the tour of reading a piece's cells and writing them: the two cells one piece has and the flag that chooses between them, the shaped read, and why a write recomputes nothing until `cf piece step` observes the piece
 - [workflows/bulk-operations.md](workflows/bulk-operations.md) — the tour of surveying, repairing and retargeting a collection of deployed pieces, walked act by act against the demo that runs it; the contract these operations hold is [features/piece-bulk-operations.md](../features/piece-bulk-operations.md)
 
 ### verbs/ — driving a deployed piece through `cf`

--- a/docs/common/verbs/README.md
+++ b/docs/common/verbs/README.md
@@ -1,7 +1,10 @@
 # Verbs
 
 A **verb** is an operation a pattern declares — a `Stream` property, an event
-type in and a result type out — and the only way a piece's state ever changes.
+type in and a result type out — and the only way a pattern changes its own
+state; an operator can write a piece's cells directly with `cf set`, which runs
+nothing and which a recomputation may overwrite
+([the read and write session](../workflows/reading-and-writing.md)).
 These five documents cover driving one from the command line. They divide by
 the question they answer, so start with the one that matches yours.
 

--- a/docs/common/verbs/the-verb-session.md
+++ b/docs/common/verbs/the-verb-session.md
@@ -28,8 +28,11 @@ vocabulary, and they map cleanly onto ideas you already have.
 | **Space** | The shared durable place pieces live in, named by a cryptographic identifier. | A database, or a tenant. |
 
 The fourth term is the one this work is named for. A **verb** is an operation a
-pattern declares — the only way its state ever changes. In the source it is a
-typed stream: an event type in, a result type out.
+pattern declares — the only way a pattern changes its own state, an operator
+writing a cell directly with `cf set` being a write that runs nothing and that
+the next recomputation may overwrite
+([the read and write session](../workflows/reading-and-writing.md)). In the
+source it is a typed stream: an event type in, a result type out.
 
 Every example from here on comes from one program: a work-item tracker,
 written to be driven and nothing else. Items sit in a tree on a **board**, and

--- a/docs/common/workflows/reading-and-writing.md
+++ b/docs/common/workflows/reading-and-writing.md
@@ -1,0 +1,371 @@
+# The read and write session
+
+*What is this, and why is it shaped this way?* A tour of reading a piece's
+cells and writing them, walked act by act against a thermostat with two
+derived fields. It assumes you can deploy a piece; it assumes nothing about
+what a piece is made of.
+
+## What this is for
+
+A piece answers two questions a caller asks constantly: what does it hold,
+and how do I change it. The reading half is the friendlier one — a read is a
+query, you name the shape you want, and asking twice costs nothing. The
+writing half is where the surprises live, and all of them come from one fact
+about the surface: **a write addresses a cell, and addressing a cell is not
+running a program.**
+
+That sentence has three consequences, and they are what this tour exists to
+demonstrate. The write goes somewhere a caller does not expect. Nothing
+recomputes afterward, so a derived field read straight back looks wrong. And
+the read that looks most like the others — `cf wish` — is the one that is not
+free at all.
+
+### Two cells, one piece
+
+A piece has two cells, and every read and every write picks one of them.
+
+The **result** cell is what the pattern produced: its declared outputs, its
+derived fields, and handles for its verbs. It is where a command goes by
+default. The **arguments** cell is what a caller supplied: exactly the fields
+the pattern declared as input, and nothing else. A command reaches it two
+ways, `--input` as a flag and an `#argument` suffix on the address, and the
+two are one selection rather than two.
+
+The CLI's own help calls that second cell the *input* cell where the flag is
+described and the *arguments* cell where the suffix is. They are one cell.
+This document says arguments cell throughout, except where it quotes.
+
+`cf piece describe` splits its page on the same line — `STATE` is the result
+cell's contents, `INPUTS` is the arguments cell's — so the page a piece prints
+about itself is already telling you which cell a field lives in.
+
+They are two cells rather than two views of one, which is why a field can
+exist in one and not the other. A derived field is the clear case: the pattern
+computes it, so it has a position in the result cell and no position at all in
+the arguments cell. Act 2 asks for one there and is told which keys exist
+instead.
+
+Where a result field is the input passed straight through, the result holds a
+link to the arguments cell rather than a copy, and a write at that position
+follows the link. So for a pass-through field the two spellings land in the
+same place, and for a derived field they do not — which is why the flag is
+worth understanding rather than memorizing.
+
+### The default is the result cell, and the flag says so
+
+`cf set` writes the **result** cell unless told otherwise. That is the piece's
+output — the answer half, not the question half. `--input` is what redirects
+the write to the arguments cell, and the flag's own help is the plainest
+statement of the default there is: *Write to the piece's input cell instead of
+result cell.*
+
+Four commands take `--input` — `cf get`, `cf set`, `cf piece get-label` and
+`cf piece set-label` — and those same four are the ones that accept the
+`#argument` suffix. That is not two lists that happen to agree: a command
+declares it accepts an arguments-cell selection once, and both spellings are
+read out of that one declaration. Any other command is refused by name, `cf
+call` among them, so a call cannot quietly be aimed at a cell no handler
+reads.
+
+The suffix rides the canonical reference form — `/of:fid1:…#argument` — and
+nothing else. On a slug or a bare id it is refused, because there is no
+reference there for it to attach to. On a `--url` it is not refused: a URL
+fragment is not part of the path a URL's piece is read out of, so it is
+dropped without comment and the read goes to the result cell. With a `--url`
+or a bare id, `--input` is the only spelling that reaches the arguments cell.
+
+### Nothing here runs the program
+
+A write commits a value to a cell. It does not start the piece, and it does
+not recompute anything downstream. A pattern's derived fields hold whatever
+they were last computed to, so a computed field read straight after a write
+reports an answer to the state before it.
+
+`cf set` says so itself, on every write:
+
+```text
+TIP: Computed values may be stale. Run 'cf piece step --piece … ' to trigger
+recomputation.
+```
+
+**A verb call is no different.** This is the part that catches people who
+already know the verb surface: calling a verb runs the handler, and the
+handler's own result is computed inside the piece and is correct — but
+settlement is that handler's commit, deliberately and not the recomputation
+the commit sets off. Waiting for the graph to quiesce would hold an
+already-committed write hostage to every recomputation it triggered elsewhere,
+so `executeResolvedCallable` in
+[`packages/cli/lib/callable.ts`](../../../packages/cli/lib/callable.ts) does
+not wait. Act 8 calls a verb and then reads a derived field that has not
+moved.
+
+`cf piece step` is the command whose whole job is to be the observer nothing
+else is: start the piece, let the graph settle, sync what it wrote, stop. It
+is the act this tour exists for, and it is the answer to every "why is this
+number wrong" the rest of the tour produces. A read can carry the same step
+inline with `cf get --step`, which recomputes, commits, and answers in one
+session.
+
+## The session, act by act
+
+Nine acts against a space that starts empty. Every command below is one the
+demo runs; `$SPACE` is a throwaway space and `-s` names it on each command,
+because `cf` has no environment variable for a space. `$ADDRESS` and `$FOUND`
+are addresses the session read out of a run rather than a second, hidden one.
+
+### Acts 1–3 · What a piece holds, and how to ask for less of it
+
+#### Act 1 · A piece to read and write
+
+The fixture is
+[`thermostat.tsx`](../../../packages/cli/integration/pattern/thermostat.tsx),
+and it belongs to this demonstration and nothing else. A target a caller
+writes, three zones with a reading each, and two figures derived from both:
+`targetFahrenheit` from the target alone, and `belowTarget` from the target
+and the zones together. Two derived fields rather than one, because the tour
+needs to show that neither of them moves.
+
+```bash
+cf piece new packages/cli/integration/pattern/thermostat.tsx -s demo --slug thermostat
+```
+
+#### Act 2 · Two cells behind one piece
+
+The piece's own page is split by who writes what. `targetFahrenheit` and
+`belowTarget` appear under `STATE` and not under `INPUTS`, because nothing
+supplied them.
+
+```bash
+cf piece describe -s demo --piece thermostat
+```
+
+The arguments cell holds only what the pattern declared as input, so reading
+it whole is a short answer — `target` and `zones`, each a link.
+
+```bash
+cf get -s demo --piece thermostat --input
+```
+
+And a derived field has no position there at all. The refusal names the keys
+that do exist, which is the fastest way to find out which cell you are
+addressing.
+
+```bash
+cf get -s demo --piece thermostat targetFahrenheit --input
+```
+
+#### Act 3 · A read is a query: name the shape you want
+
+An unshaped read carries everything the result cell holds, including the verb
+handle — a link, and not data anyone asked for. Three flags shape the answer,
+and `--select` and `--schema` are refused together rather than resolved,
+because a command naming both has not said what shape it wants.
+
+```bash
+cf get -s demo --piece thermostat
+cf get -s demo --piece thermostat --select target,targetFahrenheit,belowTarget
+cf get -s demo --piece thermostat zones --filter '.celsius < 20'
+cf get -s demo --piece thermostat zones \
+  --schema '{"type":"array","items":{"type":"object","properties":{"name":true}}}'
+```
+
+`--select` names fields and prunes everything else. `--filter` decides
+membership in an array with a jq-inspired predicate, before any projection
+runs — so a field can decide the answer without appearing in it. `--schema` is
+the same projection written as JSON Schema: the spelling a program generates
+rather than one a person types.
+
+The full account of what a selection can ask for — including `@`, which asks
+for a position's **address** in place of its contents, and which act 7 uses to
+get this piece's own — is in
+[verbs over the CLI](../verbs/over-the-cli.md#asking-a-read-for-an-address).
+
+### Acts 4–6 · The write, and what it does not do
+
+#### Act 4 · A write lands on the result cell unless you say otherwise
+
+`cf set` reads its value from stdin, so the value arrives on the pipe and the
+path is the argument. No flag here means the result cell.
+
+```bash
+echo '25' | cf set -s demo --piece thermostat target
+cf get -s demo --piece thermostat --select target,targetFahrenheit,belowTarget
+```
+
+The target moved to 25. The two figures derived from it did not: 68°F is 20°C,
+and the count is still the count against 20. Both are answers to the target
+that was there before this write, because a write commits a value and runs no
+program.
+
+#### Act 5 · `cf piece step` is the recomputation
+
+A derived value moves when something observes the piece, and a CLI process
+that writes and exits never does.
+
+```bash
+cf piece step -s demo --piece thermostat
+cf get -s demo --piece thermostat --select target,targetFahrenheit,belowTarget
+```
+
+Same read as before the step; now both figures answer to 25. Nothing about the
+piece changed between those two reads except that something ran it.
+
+#### Act 6 · Writing a derived field, and what the next step does to it
+
+Nothing stops a write landing on a derived field. It is a position in the
+result cell like any other, and the write is accepted and reads back exactly
+as written.
+
+```bash
+echo '100' | cf set -s demo --piece thermostat targetFahrenheit
+cf get -s demo --piece thermostat --select targetFahrenheit
+cf piece step -s demo --piece thermostat
+cf get -s demo --piece thermostat --select targetFahrenheit
+```
+
+It survives until something recomputes it. The pattern owns that position, so
+the next step puts the derived answer back and the written one is gone with no
+record that it was ever there. **This is the shape of the whole hazard.** A
+write to a cell a pattern computes is not a change to the program; it is a
+value sitting in the program's way until the program next runs. Change the
+input and step, or call the verb — do not write the output.
+
+### Act 7 · The arguments cell, by flag and by suffix
+
+`--input` sends the same write to the arguments cell.
+
+```bash
+echo '15' | cf set -s demo --piece thermostat target --input
+cf get -s demo --piece thermostat target --input
+```
+
+The other spelling of that choice rides the address. `@` alone answers with
+the address of what is being read, so the piece can hand over its own:
+
+```bash
+cf get -s demo --piece thermostat --select @
+```
+
+A trailing `#argument` on that address selects the same cell `--input` does,
+on the read and on the write alike:
+
+```bash
+cf get -s demo "$ADDRESS#argument" target
+echo '30' | cf set -s demo "$ADDRESS#argument" target
+cf get -s demo --piece thermostat target --input
+```
+
+Two refusals bound it. A slug or a bare id carries no canonical reference, so
+the suffix has nothing to attach to and is refused rather than folded into the
+id — which is the failure it is guarding against, since an id with a fragment
+buried in it fails later as an unknown piece.
+
+```bash
+cf get -s demo --piece 'thermostat#argument' target
+```
+
+And a command that takes no `--input` takes no `#argument` either. The refusal
+names the flag rather than the suffix, because they are one selection with two
+spellings.
+
+```bash
+cf call -s demo "$ADDRESS#argument" setTarget '{"celsius":21}'
+```
+
+### Acts 8–9 · The two things that look like exceptions
+
+#### Act 8 · A verb writes, and leaves the derived fields behind just the same
+
+A verb is how a pattern changes its own state: the handler runs inside the
+piece, with capabilities a caller does not have, and what it returns was
+computed there. The result of this call is right.
+
+```bash
+cf call -s demo --piece thermostat setTarget -- --celsius 10
+cf get -s demo --piece thermostat --select target,targetFahrenheit,belowTarget
+```
+
+Then read the piece, and the target is the verb's while the derived fields
+still answer to the target the last step saw. A call is no more of an observer
+than a set is.
+
+```bash
+cf piece step -s demo --piece thermostat
+cf get -s demo --piece thermostat --select target,targetFahrenheit,belowTarget
+```
+
+One step, and the whole piece agrees with itself again.
+
+#### Act 9 · A query instead of an address, and the read that writes
+
+Every read so far named its target. `cf wish` names a **query** and lets the
+space answer with what matches — resolving through the same runtime builtin a
+pattern's own `wish()` uses, driven headless so no picker UI spins up. Asking
+for the answer as addresses rather than contents makes it a discovery command:
+you arrive with no id and leave with one.
+
+```bash
+cf wish -s demo '#pieceRegistry' --select @
+cf get -s demo "$FOUND" --select target,belowTarget
+```
+
+**Resolving a wish is a write.** It builds a one-node pattern holding the
+query, runs it into a cell in the space, and commits that transaction before
+reading the answer back — so resolving leaves a durable trace, and the command
+is a write against the space however much it reads like a query. This is the
+one command in this tour that breaks the read/call dividing line the verb
+tour's
+[act 6](../verbs/the-verb-session.md#act-6--ask-the-same-question-twice)
+draws: it is shaped like a read, and it is not effect-free.
+
+## How the story is kept honest
+
+Every command above is one
+`packages/cli/integration/read-write-demo.sh` runs. The demo narrates each act
+and then executes it, and each act re-parses its own displayed line and
+compares the words against the argv that ran — so a line a reader retypes is
+the line that executed, checked rather than asserted. The `echo … |` half of a
+write is rendered from the same value the pipe carries, so those cannot
+disagree either.
+
+`deno task check-verb-session-sync` holds this document to that script: a `cf`
+line here either quotes a command the demo runs or carries a
+`# not in the demo` comment saying why it cannot. There are none of the latter
+in this document — every line above ran.
+
+What the demo cannot check is the prose, and two claims here are properties of
+the implementation rather than of a transcript: that `cf set`'s default lands
+on the result cell (`setCellValue` in
+[`packages/cli/lib/piece.ts`](../../../packages/cli/lib/piece.ts) branches on
+`options.input` and reaches `piece.result` without it), and that resolving a
+wish commits (`resolveWish` in
+[`packages/cli/lib/wish.ts`](../../../packages/cli/lib/wish.ts) opens a
+transaction, runs its pattern into a cell, and commits before reading). Both
+are stated from those functions.
+
+## Running it yourself
+
+```bash
+API_URL=http://localhost:8000 packages/cli/integration/read-write-demo.sh
+```
+
+The transcript is the artifact, and every act in it runs. Each one makes a
+claim the demo counts: an unmarked act says the command works, a REFUSED act
+says the surface turns it down, and a displayed line that would not re-parse
+to the argv that ran is counted too. A transcript that reads clean is one
+where every one of those claims held, because a run that got any of them wrong
+cannot exit zero.
+
+## Where to read further
+
+- [The Verb Session](../verbs/the-verb-session.md) — the tour of the other
+  half: what a pattern, piece, space and verb are, and how a caller drives a
+  piece it has never seen
+- [Verbs over the CLI](../verbs/over-the-cli.md) — what a verb hands back, and
+  what a retry does and does not guarantee
+- [An agent's entry](../verbs/agents-over-the-cli.md) — the discovery surfaces
+  `cf wish` sits among, and what an empty answer does not prove
+- [`packages/cli/README.md`](../../../packages/cli/README.md) — the reference
+  for `get`, `set`, `wish`, and the reference forms their targets take
+- [computed()](../concepts/computed/computed.md) — the authoring side of a
+  derived field: what makes one, and why it is the pattern's to write

--- a/packages/cli/integration/pattern/thermostat.tsx
+++ b/packages/cli/integration/pattern/thermostat.tsx
@@ -1,0 +1,121 @@
+/**
+ * Fixture for the CLI read/write tour
+ * (`docs/common/workflows/reading-and-writing.md`).
+ *
+ * It exists so the tour owns its subject: the shipped patterns are used
+ * elsewhere, and a change to one of them should never break a demonstration
+ * of what reading and writing a piece's cells through `cf` looks like.
+ * Nothing else deploys this file.
+ *
+ * A thermostat, chosen because it is the smallest thing with the shape the
+ * tour needs: a target a caller writes, readings a caller shapes a query
+ * over, and two fields derived from both. A derived field is what makes the
+ * difference between writing a cell and running a program visible — write
+ * the target and nothing recomputes, so `targetFahrenheit` and `belowTarget`
+ * keep reporting the old target until something observes the piece.
+ */
+
+import {
+  action,
+  computed,
+  type Default,
+  NAME,
+  pattern,
+  type Stream,
+  type Writable,
+} from "commonfabric";
+
+/** One zone, and the last reading taken in it. */
+export interface Zone {
+  /** Where the reading was taken. */
+  name: string;
+
+  /** The reading, in celsius. */
+  celsius: number;
+}
+
+interface SetTargetEvent {
+  /** The target to hold, in celsius. */
+  celsius: number;
+}
+
+interface SetTargetResult {
+  /** The target as persisted. */
+  target: number;
+
+  /** Zones reading below the new target, counted after the write. */
+  belowTarget: number;
+}
+
+interface ThermostatInput {
+  /** The target to hold, in celsius. */
+  target?: Writable<number | Default<20>>;
+
+  /** The zones this thermostat watches, and the last reading from each. */
+  zones?: Writable<
+    | Zone[]
+    | Default<[
+      { name: "hall"; celsius: 18 },
+      { name: "loft"; celsius: 22 },
+      { name: "shed"; celsius: 11 },
+    ]>
+  >;
+}
+
+/** A thermostat: a target to hold, the zones it watches, and two figures
+ * derived from both. `setTarget` is the verb that moves the target. The
+ * derived fields are the pattern's to compute — they take their next value
+ * whenever the piece runs, and nothing outside the pattern produces one. */
+interface ThermostatOutput {
+  [NAME]: string;
+
+  /** The target to hold, in celsius. */
+  target: number;
+
+  /** The zones this thermostat watches, and the last reading from each. */
+  zones: Zone[];
+
+  /** The target in fahrenheit. Derived from `target`. */
+  targetFahrenheit: number;
+
+  /** How many zones read below the target. Derived from `target` and
+   * `zones`, so it moves when either does. */
+  belowTarget: number;
+
+  /** Move the target, and report what the zones look like against it. */
+  setTarget: Stream<SetTargetEvent, SetTargetResult>;
+}
+
+function belowCount(zones: readonly Zone[], target: number): number {
+  return zones.filter((zone) => zone.celsius < target).length;
+}
+
+export default pattern<ThermostatInput, ThermostatOutput>(
+  ({ target, zones }) => {
+    const targetFahrenheit = computed(() => target.get() * 9 / 5 + 32);
+    const belowTarget = computed(() =>
+      belowCount(zones.get() ?? [], target.get())
+    );
+
+    const setTarget = action<SetTargetEvent, SetTargetResult>((event) => {
+      const celsius = event.celsius;
+      if (!Number.isFinite(celsius)) {
+        throw new Error("setTarget: celsius must be a number");
+      }
+      target.set(celsius);
+      return {
+        target: celsius,
+        belowTarget: belowCount(zones.get() ?? [], celsius),
+      };
+    });
+
+    return {
+      [NAME]: "Thermostat",
+      target,
+      zones,
+      targetFahrenheit,
+      belowTarget,
+      setTarget,
+    };
+  },
+);

--- a/packages/cli/integration/read-write-demo.sh
+++ b/packages/cli/integration/read-write-demo.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# Reading and writing a piece's cells as something to watch — the half of the
+# CLI a caller reaches for before any verb: a shaped read, the two cells one
+# piece has and the flag that chooses between them, the `#argument` suffix
+# that spells the same choice on an address, the write that runs nothing, the
+# step that recomputes, and the wish that answers with an address it had to
+# write a cell to find.
+#
+# This is a demo, not a test. It narrates each command before running it, so
+# the transcript is the artifact.
+#
+# Every command that runs is one array of words, printed and then run. There
+# is no second, prettier spelling of it anywhere in this file: `run` displays
+# `"$@"` and executes `"$@"`, and every act re-parses its own displayed line
+# and compares the words against the argv that ran, so a line a reader
+# retypes is the line that executed — checked, not asserted. `run_stdin`
+# renders the `echo … |` half from the same payload it pipes, so the two
+# cannot disagree either.
+#
+#   API_URL=http://localhost:8000 packages/cli/integration/read-write-demo.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# Run from the repository root so the fixture path a reader sees is the one
+# they would type.
+cd "$REPO_ROOT" || exit 1
+FIXTURE=packages/cli/integration/pattern/thermostat.tsx
+
+# `cf` is this checkout's CLI as a shell function. That is what lets a command
+# be a plain array of words rather than a string assembled twice.
+if [ -n "${CF_BINARY:-}" ]; then
+  cf() { "$CF_BINARY" "$@"; }
+else
+  cf() { deno task --quiet --cwd "$REPO_ROOT" cf "$@"; }
+fi
+
+# The connection lives in the environment cf documents, so it stays off every
+# command line. The space cannot: cf has no environment variable for it, so
+# `-s` is on each command, exactly as a reader would have to type it.
+export CF_API_URL="${CF_API_URL:-${API_URL:-http://localhost:8000}}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  cf id new >"$CF_IDENTITY" 2>/dev/null
+fi
+export CF_IDENTITY
+SPACE="${SPACE:-$(mktemp -u readwriteXXXXXXXX)}"
+
+B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; N=$'\033[0m'
+R=$'\033[31m'
+# Every act makes a claim: an unmarked one says the command works, a REFUSED
+# one says the surface turns this down. Both are counted, so a transcript that
+# got either wrong cannot exit 0 and read as a clean session.
+UNEXPECTED=0
+UNREFUSED=0
+MISRENDERED=0
+# stderr is read back rather than shown as it arrives, so a failure can be
+# printed under the act it belongs to. mktemp rather than a name built from
+# the pid: this runs in a shared directory, and a predictable path is one an
+# unrelated process can have already made a symlink at.
+ERR=$(mktemp)
+trap 'rm -f "$ERR"' EXIT
+act() { printf '\n%s━━ %s %s\n' "$B" "$1" "$N"; }
+say() { printf '%s   %s%s\n' "$D" "$1" "$N"; }
+
+# Render one word the way a person would have typed it: bare when every
+# character is shell-inert, single-quoted otherwise, and an embedded single
+# quote spelled '\'' — close, escaped quote, reopen — the one spelling a
+# POSIX shell reparses to the original word.
+q_word() {
+  case $1 in
+    *\'*) printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")" ;;
+    ''|*[![:alnum:]./=@:,_+-]*) printf "'%s'" "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# Render argv the way a person would have typed it. Display only — the same
+# array is what runs — and `retypable` holds the two to each other.
+shown() {
+  local line="" word
+  for word in "$@"; do
+    line="$line $(q_word "$word")"
+  done
+  printf '%s' "${line# }"
+}
+
+# The transcript's central invariant, checked on every act: the displayed
+# line, re-parsed by the shell, is the argv that ran. The re-parse is an
+# eval into an array — safe here because the line is this script's own
+# rendering of its own argv, and quoting keeps every expansion inert — and
+# a mismatch counts against the transcript like any other broken claim.
+retypable() {
+  local line=$1
+  shift
+  local -a reparsed=()
+  eval "reparsed=($line)" 2>/dev/null
+  if [ "$(printf '%s\037' "${reparsed[@]}")" != "$(printf '%s\037' "$@")" ]; then
+    printf '%s     MISRENDERED — retyping the line above would not run this act%s\n' \
+      "$R" "$N"
+    MISRENDERED=$((MISRENDERED + 1))
+  fi
+}
+
+# The held-back stderr, minus the connection preamble and the interactive
+# tip. What survives is cf's own next-step advice, and for the write acts
+# that advice is part of what this demo exists to show.
+hints() {
+  grep -v \
+    '^invocation:\|^session:\|^(Use --quiet\|^Experimental flag\|^NEXT STEPS:\|^  *→\|^$' \
+    "$ERR" | sed "s/^/     ${D}·${N} /"
+}
+
+report_failure() {
+  printf '%s     UNEXPECTED FAILURE (exit %s)%s\n' "$R" "$1" "$N"
+  sed 's/^/       /' "$ERR"
+  UNEXPECTED=$((UNEXPECTED + 1))
+}
+
+# Print a command and run it. Its output is shown and also kept in $OUT, so an
+# act that needs an address takes it out of the run the reader just watched.
+# stderr is held back rather than dropped: on success it carries only cf's
+# next-step hints, but a failure here is the demo being wrong about the
+# surface and has to be as visible as the transcript it would otherwise sit
+# inside quietly.
+run() {
+  local line
+  line=$(shown "$@")
+  printf '\n%s   $ %s%s\n' "$C" "$line" "$N"
+  retypable "$line" "$@"
+  OUT=$("$@" 2>"$ERR")
+  local rc=$?
+  printf '%s\n' "$OUT" | sed 's/^/     /'
+  [ "$rc" = "0" ] || report_failure "$rc"
+}
+
+# `run`, with the held-back hints shown after the output.
+run_loud() {
+  run "$@"
+  hints
+}
+
+# `run`, for a command that reads its value from stdin. The displayed `echo`
+# half is rendered from the same payload the pipe carries, so the line a
+# reader retypes carries the value that was written. Always loud: every write
+# here answers with cf's own advice about what a write does not do, and that
+# advice is the act.
+run_stdin() {
+  local payload=$1
+  shift
+  local line
+  line=$(shown "$@")
+  printf '\n%s   $ echo %s | %s%s\n' "$C" "$(q_word "$payload")" "$line" "$N"
+  retypable "$line" "$@"
+  OUT=$(printf '%s\n' "$payload" | "$@" 2>"$ERR")
+  local rc=$?
+  printf '%s\n' "$OUT" | sed 's/^/     /'
+  hints
+  [ "$rc" = "0" ] || report_failure "$rc"
+}
+
+# `run`, for a command that is SUPPOSED to fail: a refusal is a capability, so
+# the error is the act's payoff and a nonzero exit is the success condition.
+# The claim is matched against the refusal's own message, not the exit status
+# alone: a parser slip or a server hiccup also exits nonzero, and an act that
+# cannot tell those apart keeps its claim through failures that have nothing
+# to do with it.
+refused() {
+  local why=$1 signature=$2
+  shift 2
+  local line
+  line=$(shown "$@")
+  printf '\n%s   $ %s%s\n' "$C" "$line" "$N"
+  retypable "$line" "$@"
+  printf '%s     REFUSED — %s%s\n' "$D" "$why" "$N"
+  CF_SKIP_VERSION_CHECK=1 "$@" >/dev/null 2>"$ERR"
+  local rc=$?
+  grep -v '^invocation:\|^session:\|^TIP:\|^(Use --quiet\|^NEXT STEPS:\|^  *→\|^Experimental flag' \
+    "$ERR" | grep -v '^$' | sed 's/^/       /'
+  if [ "$rc" = "0" ]; then
+    printf '%s     NOT REFUSED — this act says the surface turns this down,%s\n' \
+      "$R" "$N"
+    printf '%s     and it was accepted%s\n' "$R" "$N"
+    UNREFUSED=$((UNREFUSED + 1))
+  elif ! grep -q "$signature" "$ERR"; then
+    printf '%s     REFUSED FOR ANOTHER REASON — the failure above is not the%s\n' \
+      "$R" "$N"
+    printf '%s     refusal this act claims%s\n' "$R" "$N"
+    UNREFUSED=$((UNREFUSED + 1))
+  fi
+}
+
+printf '%s\n' "${B}Reading and writing a piece, watched end to end${N}"
+say "A piece answers two questions a caller asks constantly: what does it"
+say "hold, and how do I change it. The reads are queries — you name the shape"
+say "you want. The writes are the surprising half: a write addresses a cell,"
+say "and addressing a cell is not running a program."
+say ""
+say "space $SPACE · CF_API_URL=$CF_API_URL · CF_IDENTITY exported;"
+say "everything else you see is the whole command."
+
+act "1 · A piece to read and write"
+say "A thermostat: a target a caller writes, the zones it watches, and two"
+say "figures derived from both. The slug names it, so no fid is ever typed."
+run cf piece new "$FIXTURE" -s "$SPACE" --slug thermostat
+
+act "2 · Two cells behind one piece"
+say "The piece's own page splits what it holds by who writes it. INPUTS are"
+say "what a caller supplied; STATE is what the pattern produced from them —"
+say "and targetFahrenheit and belowTarget appear only under STATE, because"
+say "nothing supplied them."
+run cf piece describe -s "$SPACE" --piece thermostat
+say "Those are two cells, not two views of one. A read goes to the result"
+say "cell; --input sends it to the arguments cell instead, which holds only"
+say "what the pattern declared as input — here, links to target and zones."
+run cf get -s "$SPACE" --piece thermostat --input
+say "So a derived field has no position in the arguments cell at all, and"
+say "asking for one there names the keys that are:"
+refused "a derived field lives on the result cell, not on the arguments cell" \
+  "Available keys: target, zones" \
+  cf get -s "$SPACE" --piece thermostat targetFahrenheit --input
+
+act "3 · A read is a query: name the shape you want"
+say "Unshaped, a read carries everything the result cell holds — including"
+say "the verb handle, which is a link and not data anyone asked for."
+run cf get -s "$SPACE" --piece thermostat
+say "--select names fields and keeps nothing else."
+run cf get -s "$SPACE" --piece thermostat --select target,targetFahrenheit,belowTarget
+say "--filter decides membership in an array, with a jq-inspired predicate."
+run cf get -s "$SPACE" --piece thermostat zones --filter '.celsius < 20'
+say "--schema is the same projection written as JSON Schema — the spelling a"
+say "program generates rather than types."
+run cf get -s "$SPACE" --piece thermostat zones \
+  --schema '{"type":"array","items":{"type":"object","properties":{"name":true}}}'
+
+act "4 · A write lands on the result cell unless you say otherwise"
+say "cf set reads its value from stdin and addresses the RESULT cell by"
+say "default — the pattern's output, not its input. --input is what sends it"
+say "to the arguments cell, which is the flag's own wording: 'instead of"
+say "result cell'."
+run_stdin '25' cf set -s "$SPACE" --piece thermostat target
+say "The target moved. The two figures derived from it did not."
+run cf get -s "$SPACE" --piece thermostat --select target,targetFahrenheit,belowTarget
+say "68F is 20C and 2 is the count against 20 — both answers to the target"
+say "that was there before this write. Nothing recomputed them, because a"
+say "write is a write: it commits a value to a cell and runs no program."
+
+act "5 · cf piece step is the recomputation"
+say "A derived value moves when something observes the piece, and a CLI"
+say "process that writes and exits never does. cf piece step is the command"
+say "whose whole job is to be that observer: start the piece, let the graph"
+say "settle, sync what it wrote, stop."
+run cf piece step -s "$SPACE" --piece thermostat
+say "Same read as before the step, and now both figures answer to 25."
+run cf get -s "$SPACE" --piece thermostat --select target,targetFahrenheit,belowTarget
+
+act "6 · Writing a derived field, and what the next step does to it"
+say "Nothing stops a write landing on a derived field: it is a position in"
+say "the result cell like any other, and the write is accepted."
+run_stdin '100' cf set -s "$SPACE" --piece thermostat targetFahrenheit
+run cf get -s "$SPACE" --piece thermostat --select targetFahrenheit
+say "It reads back exactly as written — and survives only until something"
+say "recomputes it. The pattern owns that position, so the next step puts"
+say "the derived answer back."
+run cf piece step -s "$SPACE" --piece thermostat
+run cf get -s "$SPACE" --piece thermostat --select targetFahrenheit
+
+act "7 · The arguments cell, by flag and by suffix"
+say "--input sends the same write to the arguments cell."
+run_stdin '15' cf set -s "$SPACE" --piece thermostat target --input
+run cf get -s "$SPACE" --piece thermostat target --input
+say "The other spelling of that choice rides the address. Ask the piece for"
+say "its own — @ alone answers with the address of what is being read —"
+run cf get -s "$SPACE" --piece thermostat --select @
+ADDRESS=$(printf '%s' "$OUT" | jq -r '."$link"')
+say "— and a trailing #argument on that address selects the same cell --input"
+say "does, on both the read and the write."
+run cf get -s "$SPACE" "$ADDRESS#argument" target
+run_stdin '30' cf set -s "$SPACE" "$ADDRESS#argument" target
+run cf get -s "$SPACE" --piece thermostat target --input
+say "The suffix rides the canonical reference form and nothing else. On a"
+say "slug or a bare id there is no reference for it to attach to, and it is"
+say "refused rather than folded into the id:"
+refused "the suffix rides the canonical reference, not a slug or bare id" \
+  "rides the canonical reference form" \
+  cf get -s "$SPACE" --piece 'thermostat#argument' target
+say "And a command that takes no --input takes no #argument either, so a"
+say "call cannot quietly be aimed at the arguments cell:"
+refused "a command without --input has no arguments cell to select" \
+  'does not take' \
+  cf call -s "$SPACE" "$ADDRESS#argument" setTarget '{"celsius":21}'
+
+act "8 · A verb writes, and leaves the derived fields behind just the same"
+say "A verb is how a pattern changes its own state: the handler runs inside"
+say "the piece, and what it returns is computed there. Watch what it hands"
+say "back —"
+run cf call -s "$SPACE" --piece thermostat setTarget -- --celsius 10
+say "— and then read the piece. The target is the verb's; the derived fields"
+say "still answer to the target the last step saw. Settlement is the"
+say "handler's commit, not the recomputation that commit sets off, so a call"
+say "is no more of an observer than a set is."
+run cf get -s "$SPACE" --piece thermostat --select target,targetFahrenheit,belowTarget
+say "One step, and the whole piece agrees with itself again."
+run cf piece step -s "$SPACE" --piece thermostat
+run cf get -s "$SPACE" --piece thermostat --select target,targetFahrenheit,belowTarget
+
+act "9 · A query instead of an address, and the read that writes"
+say "Every read so far named its target. cf wish names a query and lets the"
+say "space answer with what matches — here the registry of pieces, projected"
+say "to addresses rather than contents."
+run cf wish -s "$SPACE" '#pieceRegistry' --select @
+FOUND=$(printf '%s' "$OUT" | jq -r '.[0]."$link"')
+say "That address is an ordinary one: it goes into a read unedited."
+run cf get -s "$SPACE" "$FOUND" --select target,belowTarget
+say "Resolving a wish is not free the way a get is. It runs a one-node"
+say "pattern to hold the query and commits it, so the resolution is a WRITE"
+say "against the space — the one command here that reads like a query and"
+say "is not effect-free."
+
+printf '\n%s━━ The shape of it %s\n' "$B" "$N"
+say "A piece has two cells and one flag that chooses between them, spelled"
+say "again as a suffix on an address. A read shapes its own answer and"
+say "changes nothing. A write commits a value and runs nothing — not a set,"
+say "and not a verb call either — so a derived field keeps answering to the"
+say "state it was last computed from until cf piece step observes the piece."
+say "And the one read here that is not free is the one that never named an"
+say "address: a wish resolves by writing."
+say ""
+say "docs/common/workflows/reading-and-writing.md is the tour written from"
+say "this session, and check-verb-session-sync holds it to these commands."
+
+if [ "$UNEXPECTED" != "0" ]; then
+  printf '\n%s━━ %d act(s) failed that this demo says work%s\n' \
+    "$R" "$UNEXPECTED" "$N"
+  say "Every act above that is not marked REFUSED is a claim about the"
+  say "surface. One of them did not hold, so this transcript does not"
+  say "describe cf."
+fi
+
+if [ "$UNREFUSED" != "0" ]; then
+  printf '\n%s━━ %d act(s) marked REFUSED did not get their refusal%s\n' \
+    "$R" "$UNREFUSED" "$N"
+  say "A refusal this demo shows as a capability is no longer being made as"
+  say "claimed: the call was accepted, or it failed for some other reason —"
+  say "either way the act's claim about the surface did not hold."
+fi
+
+if [ "$MISRENDERED" != "0" ]; then
+  printf '\n%s━━ %d displayed line(s) would not run their act if retyped%s\n' \
+    "$R" "$MISRENDERED" "$N"
+  say "The transcript's one invariant is that a shown line re-parses to the"
+  say "argv that ran. One did not, so this transcript is not retypable."
+fi
+
+[ "$UNEXPECTED" = "0" ] && [ "$UNREFUSED" = "0" ] && [ "$MISRENDERED" = "0" ]

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -55,6 +55,16 @@ observed. Against a remote board that is megabytes of upload per survey and tens
 of seconds of wall clock, and it grows the space's database as a side effect.
 Survey through `index` and project with `--select`; expand one Topic at a time.
 
+Every read below names its target with `--url`, and that settles a choice the
+CLI otherwise offers two spellings of. `--input` reads a piece's arguments cell
+rather than its result cell; a canonical reference ending `#argument` selects
+that same cell, on the commands that take `--input`. A `--url` carries no
+canonical reference and its fragment is dropped rather than refused, so
+`--input` is the spelling that reaches the arguments cell in every example here.
+The suffix is what to reach for once an address from `--select @` is the target
+instead. `skills/cf/SKILL.md` says where each is accepted, and
+`docs/common/workflows/reading-and-writing.md` walks the difference.
+
 The current pattern exports `index` — a compact discovery result whose rows ARE
 the Topics, declared through scalar summaries, so one read surveys the whole
 board without expanding any Topic:

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -117,18 +117,34 @@ describe("check-verb-session-sync", () => {
         .toEqual([["cf", "get", "--piece", "a", "x"]]);
     });
 
-    it("leaves a command piping its own output onward with no payload", () => {
-      // Only a leading `echo <value> |` is a stdin payload. A pipe after the
-      // command belongs to the shell around it, and reading one as a payload
-      // would put a phantom token on every substitution the demos capture.
-      expect(demoCommands(`X=$(cf piece get --piece a title | jq -r .)`))
-        .toEqual([["cf", "piece", "get", "--piece", "a", "title"]]);
-    });
-
     it("ignores a helper it does not know", () => {
       // The head list is the whole of what makes a line a command the demo
       // ran; a new helper that executes one has to be added to it.
       expect(demoCommands(`frobnicate cf set --piece a target`)).toEqual([]);
+    });
+  });
+
+  describe("walkthroughCommands", () => {
+    const block = (line: string) => ["```bash", line, "```"].join("\n");
+
+    it("reads a piped value as part of the command it feeds", () => {
+      // The document's spelling of a demo's `run_stdin`, asserted here as
+      // tokens rather than only through the violations it produces.
+      expect(
+        walkthroughCommands(block("echo '25' | cf set --piece a target"))
+          .map((command) => command.tokens),
+      ).toEqual([["echo", "25", "|", "cf", "set", "--piece", "a", "target"]]);
+    });
+
+    it("finds no command in a line piping into anything but cf", () => {
+      // The payload rule's boundary: `echo`, a value, the bar, and then `cf`
+      // — all four, or the line is not a command at all. Dropping the last
+      // of those requirements would make every `echo … | jq` in a document
+      // a command the demo is then asked to have run.
+      expect(walkthroughCommands(block("echo '25' | jq -r .")))
+        .toEqual([]);
+      expect(walkthroughCommands(block("echo '25' | cfx set --piece a x")))
+        .toEqual([]);
     });
   });
 

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -101,6 +101,22 @@ describe("check-verb-session-sync", () => {
         .toEqual([["echo", "25", "|", "cf", "set", "--piece", "a", "target"]]);
     });
 
+    it("does not mistake a payload spelled `cf` for the command", () => {
+      // Searching for the `cf` token found the payload first and read the
+      // rest as the argv, recording `cf cf set …` — a command no demo runs,
+      // against which the honest quote of the write reads as invented. The
+      // helper's shape says where the command starts; nothing is searched.
+      expect(demoCommands(`run_stdin 'cf' cf set --piece a target`))
+        .toEqual([["echo", "cf", "|", "cf", "set", "--piece", "a", "target"]]);
+    });
+
+    it("reads a refusal's own claim and signature past, not through", () => {
+      // The same hazard on the helper carrying two arguments: either can be
+      // spelled `cf`, and only the table knows the command is the third.
+      expect(demoCommands(`refused 'why' 'cf' cf get --piece a x`))
+        .toEqual([["cf", "get", "--piece", "a", "x"]]);
+    });
+
     it("leaves a command piping its own output onward with no payload", () => {
       // Only a leading `echo <value> |` is a stdin payload. A pipe after the
       // command belongs to the shell around it, and reading one as a payload
@@ -347,6 +363,28 @@ describe("check-verb-session-sync", () => {
       const demo = `run_stdin '25' cf set --piece a target\n`;
       const halved = "```bash\ncf set --piece a target\n```";
       expect(findViolations(demo, halved).length).toBe(1);
+    });
+
+    it("keeps a value holding a bar as one value on both sides", () => {
+      // Splitting the raw line at its first bar split INSIDE the quotes, so
+      // a document showing `a|b` matched a demo piping `a`: the separator is
+      // the bar that stands alone as a token, never the first bar character.
+      const pipesA = `run_stdin 'a' cf set --piece a target\n`;
+      const showsAB = "```bash\necho 'a|b' | cf set --piece a target\n```";
+      expect(findViolations(pipesA, showsAB).length).toBe(1);
+      const pipesAB = `run_stdin 'a|b' cf set --piece a target\n`;
+      expect(findViolations(pipesAB, showsAB)).toEqual([]);
+    });
+
+    it("keeps a value holding the word cf out of the command", () => {
+      // The document side reads its command positionally for the same
+      // reason the demo side does: found in the raw text, the first `cf `
+      // a value spells is taken for the start of the command.
+      const demo = `run_stdin 'x cf y' cf set --piece a target\n`;
+      const quoted = "```bash\necho 'x cf y' | cf set --piece a target\n```";
+      expect(findViolations(demo, quoted)).toEqual([]);
+      const drifted = "```bash\necho 'x cf y' | cf set --piece a label\n```";
+      expect(findViolations(demo, drifted).length).toBe(1);
     });
 
     it("keeps every write in the read/write tour matched to its demo", () => {

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -27,6 +27,8 @@ import {
   findViolations,
   joinContinuations,
   main,
+  READ_WRITE_DEMO_PATH,
+  READ_WRITE_TOUR_PATH,
   tokenize,
   TOUR_PATH,
   WALKTHROUGH_PATH,
@@ -77,6 +79,20 @@ describe("check-verb-session-sync", () => {
     it("extracts a command out of an assignment's substitution", () => {
       expect(demoCommands(`X=$(cf piece get --piece a title | jq -r .)`))
         .toEqual([["cf", "piece", "get", "--piece", "a", "title"]]);
+    });
+
+    it("reads past a helper's own leading arguments", () => {
+      // `run_stdin` carries the piped value ahead of the argv, so a rule that
+      // read the second token would take the payload for the command and
+      // report every write in a tour as invented.
+      expect(demoCommands(`run_stdin '25' cf set --piece a target`))
+        .toEqual([["cf", "set", "--piece", "a", "target"]]);
+    });
+
+    it("ignores a helper it does not know", () => {
+      // The head list is the whole of what makes a line a command the demo
+      // ran; a new helper that executes one has to be added to it.
+      expect(demoCommands(`frobnicate cf set --piece a target`)).toEqual([]);
     });
   });
 
@@ -265,6 +281,24 @@ describe("check-verb-session-sync", () => {
       expect(lines.join("\n")).toContain("1 document(s)");
       expect(demoFor(BULK_TOUR_PATH)).toBe(BULK_DEMO_PATH);
       expect(demoFor(TOUR_PATH)).toBe(DEMO_PATH);
+    });
+
+    it("holds the read/write tour to the demo that runs it", async () => {
+      // Every command in the tour is one read-write-demo.sh runs, and none of
+      // them is one the verb demo runs — so the pairing is what makes the
+      // document check at all, and the wrong demo says so loudly.
+      const lines: string[] = [];
+      expect(
+        await main({ mdPath: READ_WRITE_TOUR_PATH, log: (l) => lines.push(l) }),
+      ).toBe(0);
+      expect(demoFor(READ_WRITE_TOUR_PATH)).toBe(READ_WRITE_DEMO_PATH);
+      expect(
+        await main({
+          mdPath: READ_WRITE_TOUR_PATH,
+          shPath: DEMO_PATH,
+          error: () => {},
+        }),
+      ).toBe(1);
     });
 
     it("refuses a document no demo is paired with", async () => {

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -1,10 +1,12 @@
 /**
- * These pin the walkthrough↔demo sync check to the three drift classes it
+ * These pin the walkthrough↔demo sync check to the four drift classes it
  * exists to catch, each of which shipped at least once: a composed command
  * the demo never runs (one was wrong from the day it was written and
  * survived four editing passes), an act reference gone stale under
- * renumbering (twice), and a shape-table row pairing a verb with an act that
- * no longer shows it.
+ * renumbering (twice), a shape-table row pairing a verb with an act that
+ * no longer shows it, and a write quoted with a value other than the one the
+ * demo pipes — invisible for as long as the payload was dropped, and the
+ * substance of every act a tour about writing narrates.
  *
  * The real files are checked too, so the gate's green on this repository is
  * itself a pinned fact — and so is the check's grip: each class is asserted
@@ -41,10 +43,18 @@ describe("check-verb-session-sync", () => {
   let sh = "";
   let md = "";
   let tour = "";
+  let readWriteDemo = "";
+  let readWriteTour = "";
   beforeAll(async () => {
     sh = await Deno.readTextFile(join(REPO_ROOT, DEMO_PATH));
     md = await Deno.readTextFile(join(REPO_ROOT, WALKTHROUGH_PATH));
     tour = await Deno.readTextFile(join(REPO_ROOT, TOUR_PATH));
+    readWriteDemo = await Deno.readTextFile(
+      join(REPO_ROOT, READ_WRITE_DEMO_PATH),
+    );
+    readWriteTour = await Deno.readTextFile(
+      join(REPO_ROOT, READ_WRITE_TOUR_PATH),
+    );
   });
 
   describe("tokenize", () => {
@@ -84,9 +94,19 @@ describe("check-verb-session-sync", () => {
     it("reads past a helper's own leading arguments", () => {
       // `run_stdin` carries the piped value ahead of the argv, so a rule that
       // read the second token would take the payload for the command and
-      // report every write in a tour as invented.
+      // report every write in a tour as invented. The payload comes back in
+      // the document's own spelling for it, which is what holds the two to
+      // each other.
       expect(demoCommands(`run_stdin '25' cf set --piece a target`))
-        .toEqual([["cf", "set", "--piece", "a", "target"]]);
+        .toEqual([["echo", "25", "|", "cf", "set", "--piece", "a", "target"]]);
+    });
+
+    it("leaves a command piping its own output onward with no payload", () => {
+      // Only a leading `echo <value> |` is a stdin payload. A pipe after the
+      // command belongs to the shell around it, and reading one as a payload
+      // would put a phantom token on every substitution the demos capture.
+      expect(demoCommands(`X=$(cf piece get --piece a title | jq -r .)`))
+        .toEqual([["cf", "piece", "get", "--piece", "a", "title"]]);
     });
 
     it("ignores a helper it does not know", () => {
@@ -307,6 +327,41 @@ describe("check-verb-session-sync", () => {
       await expect(main({ mdPath: "docs/nowhere.md" })).rejects.toThrow(
         /No demo is paired with/,
       );
+    });
+
+    it("catches a write the document shows a different value for", () => {
+      // The drift class this pairing exists to catch, and the one a rule
+      // that dropped the payload missed: a tour ABOUT writing can narrate
+      // setting 250 beside the answer the session got for 25, and every
+      // claim around it still reads as verified.
+      const demo = `run_stdin '25' cf set --piece a target\n`;
+      const quoted = "```bash\necho '25' | cf set --piece a target\n```";
+      const drifted = "```bash\necho '250' | cf set --piece a target\n```";
+      expect(findViolations(demo, quoted)).toEqual([]);
+      expect(findViolations(demo, drifted).length).toBe(1);
+    });
+
+    it("catches a write the document quotes without its value", () => {
+      // The other half: a document that quotes only the command half leaves
+      // a reader with a `cf set` that hangs waiting on stdin.
+      const demo = `run_stdin '25' cf set --piece a target\n`;
+      const halved = "```bash\ncf set --piece a target\n```";
+      expect(findViolations(demo, halved).length).toBe(1);
+    });
+
+    it("keeps every write in the read/write tour matched to its demo", () => {
+      // Against the real files: each of the four writes must be quoted with
+      // the value the demo pipes, and changing any one of them is caught.
+      const values = ["25", "100", "15", "30"];
+      for (const value of values) {
+        const drifted = readWriteTour.replace(
+          `echo '${value}' |`,
+          `echo '${value}0' |`,
+        );
+        expect(drifted).not.toBe(readWriteTour);
+        expect(findViolations(readWriteDemo, drifted, READ_WRITE_TOUR_PATH))
+          .toHaveLength(1);
+      }
     });
 
     it("does not let a reasonless marker exempt anything", () => {

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -5,7 +5,8 @@
  *
  * Each document is paired with the demo that runs the session it describes —
  * the tour and the walkthrough with `verb-session-demo.sh`, the bulk tour with
- * `bulk-ops-demo.sh` — and a document may QUOTE its demo's commands but never
+ * `bulk-ops-demo.sh`, the read/write tour with `read-write-demo.sh` — and a
+ * document may QUOTE its demo's commands but never
  * compose them: every `cf` line in one of its command blocks must be a command
  * that demo actually runs, or sit under a `# not in the demo` comment saying
  * why it cannot be. Nothing
@@ -45,18 +46,27 @@ export const BULK_DEMO_PATH = "packages/cli/integration/bulk-ops-demo.sh";
 /** The tour written from that demo, and held to it below. */
 export const BULK_TOUR_PATH = "docs/common/workflows/bulk-operations.md";
 
+/** The demo that reads and writes a piece's cells, act by act. */
+export const READ_WRITE_DEMO_PATH =
+  "packages/cli/integration/read-write-demo.sh";
+
+/** The tour written from that demo, and held to it below. */
+export const READ_WRITE_TOUR_PATH =
+  "docs/common/workflows/reading-and-writing.md";
+
 /**
  * Each document, paired with the demo that runs the session it describes.
  *
  * A document is held to its own demo and no other: the verb tour and its
- * walkthrough describe one session, and the bulk tour describes a different
- * one. Pairing them here is what lets a second story be added without either
- * demo having to grow commands the other document quotes.
+ * walkthrough describe one session, and the bulk and read/write tours each
+ * describe a different one. Pairing them here is what lets another story be
+ * added without any demo having to grow commands another document quotes.
  */
 export const DOC_DEMOS: ReadonlyArray<{ doc: string; demo: string }> = [
   { doc: TOUR_PATH, demo: DEMO_PATH },
   { doc: WALKTHROUGH_PATH, demo: DEMO_PATH },
   { doc: BULK_TOUR_PATH, demo: BULK_DEMO_PATH },
+  { doc: READ_WRITE_TOUR_PATH, demo: READ_WRITE_DEMO_PATH },
 ];
 
 /** Every document held to a demo. Each quotes commands and names acts, and a
@@ -173,9 +183,13 @@ function extractCf(line: string): string | null {
 }
 
 /** Every command a demo runs, as normalized token lists: `run`, `run_loud`,
- * `refused` and `broken` lines execute theirs, and a `pending` line's first
- * argument is the command it promises. `run_loud` differs from `run` only in
- * how much of the output it shows, so both are commands the demo ran. */
+ * `run_stdin`, `refused` and `broken` lines execute theirs, and a `pending`
+ * line's first argument is the command it promises. `run_loud` differs from
+ * `run` only in how much of the output it shows, and `run_stdin` only in the
+ * value it pipes in ahead of the same argv, so all three are commands the
+ * demo ran. Slicing from the `cf` token is what lets a helper carry its own
+ * leading arguments — `run_stdin`'s payload, `refused`'s claim — without a
+ * rule per helper. */
 export function demoCommands(shText: string): string[][] {
   const commands: string[][] = [];
   for (const line of joinContinuations(shText)) {
@@ -184,8 +198,8 @@ export function demoCommands(shText: string): string[][] {
     if (tokens.length === 0) continue;
     const head = tokens[0]!;
     if (
-      head === "run" || head === "run_loud" || head === "refused" ||
-      head === "broken"
+      head === "run" || head === "run_loud" || head === "run_stdin" ||
+      head === "refused" || head === "broken"
     ) {
       const at = tokens.indexOf("cf");
       if (at !== -1) commands.push(dropSpaceFlag(tokens.slice(at)));

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -20,9 +20,11 @@
  * Three checks, run over every document in `DOC_PATHS`:
  * - Every `cf` command matches a demo command, token for token, after
  *   normalization: an `-s <space>` pair is dropped from both sides, quotes
- *   are stripped, and a token holding a `$variable` or a `<placeholder>`
- *   matches anything. An address a transcript shortened for width needs no
- *   rule of its own: the demo holds every address in a variable.
+ *   are stripped, a value read from stdin is folded in ahead of the command
+ *   as `echo <value> |`, and a token holding a `$variable` or a
+ *   `<placeholder>` matches anything. An address a transcript shortened for
+ *   width needs no rule of its own: the demo holds every address in a
+ *   variable.
  * - Every "act N" reference, in any case, names an act the demo has.
  * - Every row of a verb shape table pairs its verbs with acts whose demo
  *   text actually mentions them.
@@ -182,14 +184,47 @@ function extractCf(line: string): string | null {
   return span.trim();
 }
 
+/**
+ * The value a command reads from stdin, folded into its token list.
+ *
+ * A demo spells it `run_stdin '25' cf set …` and a document spells it
+ * `echo '25' | cf set …`; both normalize to the document's form, so
+ * {@link commandMatches} compares the value like any other word and a
+ * `$variable` payload still wildcards. Dropping it instead would leave the
+ * value a write act is ABOUT unchecked — a tour could narrate setting 250
+ * beside the answer a demo got for 25, and every claim around it would still
+ * read as verified.
+ */
+function withStdin(payload: string | undefined, tokens: string[]): string[] {
+  return payload === undefined ? tokens : ["echo", payload, "|", ...tokens];
+}
+
+/**
+ * The payload of a leading `echo <value> |` on a command line, if it has one.
+ *
+ * Only that exact shape counts: everything before the first pipe has to be
+ * `echo` and one word. A command piping its own output onward — `cf … | jq`,
+ * a `$(cf …)` substitution — has something else there and reads as no
+ * payload, which is what keeps this off every line the other demos quote.
+ */
+function extractStdin(line: string): string | undefined {
+  const bar = line.indexOf("|");
+  if (bar === -1) return undefined;
+  const before = tokenize(line.slice(0, bar));
+  if (before.length !== 2 || before[0] !== "echo") return undefined;
+  return before[1];
+}
+
 /** Every command a demo runs, as normalized token lists: `run`, `run_loud`,
  * `run_stdin`, `refused` and `broken` lines execute theirs, and a `pending`
  * line's first argument is the command it promises. `run_loud` differs from
  * `run` only in how much of the output it shows, and `run_stdin` only in the
  * value it pipes in ahead of the same argv, so all three are commands the
  * demo ran. Slicing from the `cf` token is what lets a helper carry its own
- * leading arguments — `run_stdin`'s payload, `refused`'s claim — without a
- * rule per helper. */
+ * leading arguments — `refused`'s claim and grep signature among them —
+ * without a rule per helper. A `run_stdin` payload is the one such argument
+ * that is part of the command rather than part of the act's bookkeeping, so
+ * it rides back in through {@link withStdin} rather than being dropped. */
 export function demoCommands(shText: string): string[][] {
   const commands: string[][] = [];
   for (const line of joinContinuations(shText)) {
@@ -202,7 +237,12 @@ export function demoCommands(shText: string): string[][] {
       head === "refused" || head === "broken"
     ) {
       const at = tokens.indexOf("cf");
-      if (at !== -1) commands.push(dropSpaceFlag(tokens.slice(at)));
+      if (at !== -1) {
+        // The payload is the helper's first argument, and only `run_stdin`
+        // has one that reaches the command line.
+        const payload = head === "run_stdin" && at >= 2 ? tokens[1] : undefined;
+        commands.push(withStdin(payload, dropSpaceFlag(tokens.slice(at))));
+      }
       continue;
     }
     if (head === "pending" && tokens.length > 1) {
@@ -255,7 +295,13 @@ export function walkthroughCommands(
       exempt = false;
       continue;
     }
-    out.push({ tokens: dropSpaceFlag(tokenize(span)), line: i + 1 });
+    out.push({
+      tokens: withStdin(
+        extractStdin(logical),
+        dropSpaceFlag(tokenize(span)),
+      ),
+      line: i + 1,
+    });
   }
   return out;
 }

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -200,31 +200,51 @@ function withStdin(payload: string | undefined, tokens: string[]): string[] {
 }
 
 /**
- * The payload of a leading `echo <value> |` on a command line, if it has one.
+ * A document's `echo <value> | cf …` line, as the tokens to match on — or
+ * null when the line is not one.
  *
- * Only that exact shape counts: everything before the first pipe has to be
- * `echo` and one word. A command piping its own output onward — `cf … | jq`,
- * a `$(cf …)` substitution — has something else there and reads as no
- * payload, which is what keeps this off every line the other demos quote.
+ * The shape is read out of the token stream by position: `echo`, one value,
+ * the bar, then the command. Every part of that has to be positional rather
+ * than found by searching the raw line. A bar inside the value is one
+ * character of a quoted token and not the separator, and the separator is
+ * the bar that stands alone — so `echo 'a|b' | cf …` carries `a|b`, where
+ * splitting the string at its first bar carried `a`. The command likewise
+ * starts where the bar ends rather than at the first `cf ` the line spells,
+ * which a value holding the word can otherwise be.
  */
-function extractStdin(line: string): string | undefined {
-  const bar = line.indexOf("|");
-  if (bar === -1) return undefined;
-  const before = tokenize(line.slice(0, bar));
-  if (before.length !== 2 || before[0] !== "echo") return undefined;
-  return before[1];
+function documentStdinCommand(line: string): string[] | null {
+  const tokens = tokenize(line);
+  if (tokens[0] !== "echo" || tokens[2] !== "|" || tokens[3] !== "cf") {
+    return null;
+  }
+  return ["echo", tokens[1]!, "|", ...dropSpaceFlag(tokens.slice(3))];
 }
+
+/**
+ * How many of its own arguments each demo helper takes before the command.
+ *
+ * The command's position is this table's to say, never the position of the
+ * first `cf` token: a helper argument can be spelled `cf` — a payload, a
+ * refusal's grep signature — and searching for the token finds that one
+ * first, recording everything after it as the argv. A helper the table does
+ * not name runs nothing, so a new one that does has to be added here.
+ */
+const HELPER_LEADING_ARGS: ReadonlyMap<string, number> = new Map([
+  ["run", 0],
+  ["run_loud", 0],
+  ["run_stdin", 1], // the value piped in
+  ["refused", 2], // the claim, and the signature that checks it holds
+  ["broken", 2], // the same
+]);
 
 /** Every command a demo runs, as normalized token lists: `run`, `run_loud`,
  * `run_stdin`, `refused` and `broken` lines execute theirs, and a `pending`
  * line's first argument is the command it promises. `run_loud` differs from
  * `run` only in how much of the output it shows, and `run_stdin` only in the
  * value it pipes in ahead of the same argv, so all three are commands the
- * demo ran. Slicing from the `cf` token is what lets a helper carry its own
- * leading arguments — `refused`'s claim and grep signature among them —
- * without a rule per helper. A `run_stdin` payload is the one such argument
- * that is part of the command rather than part of the act's bookkeeping, so
- * it rides back in through {@link withStdin} rather than being dropped. */
+ * demo ran. A `run_stdin` payload is the one helper argument that is part of
+ * the command rather than part of the act's bookkeeping, so it rides back in
+ * through {@link withStdin} rather than being dropped. */
 export function demoCommands(shText: string): string[][] {
   const commands: string[][] = [];
   for (const line of joinContinuations(shText)) {
@@ -232,15 +252,13 @@ export function demoCommands(shText: string): string[][] {
     const tokens = tokenize(trimmed);
     if (tokens.length === 0) continue;
     const head = tokens[0]!;
-    if (
-      head === "run" || head === "run_loud" || head === "run_stdin" ||
-      head === "refused" || head === "broken"
-    ) {
-      const at = tokens.indexOf("cf");
-      if (at !== -1) {
+    const leading = HELPER_LEADING_ARGS.get(head);
+    if (leading !== undefined) {
+      const at = leading + 1;
+      if (tokens[at] === "cf") {
         // The payload is the helper's first argument, and only `run_stdin`
         // has one that reaches the command line.
-        const payload = head === "run_stdin" && at >= 2 ? tokens[1] : undefined;
+        const payload = head === "run_stdin" ? tokens[1] : undefined;
         commands.push(withStdin(payload, dropSpaceFlag(tokens.slice(at))));
       }
       continue;
@@ -289,19 +307,19 @@ export function walkthroughCommands(
     while (logical.endsWith("\\") && i + 1 < lines.length) {
       logical = logical.slice(0, -1) + " " + lines[++i]!;
     }
-    const span = extractCf(logical);
-    if (!span) continue;
+    // An `echo <value> | cf …` line is read positionally; every other line
+    // finds its command in the raw text, where nothing precedes it.
+    let command = documentStdinCommand(logical);
+    if (command === null) {
+      const span = extractCf(logical);
+      command = span ? dropSpaceFlag(tokenize(span)) : null;
+    }
+    if (command === null) continue;
     if (exempt) {
       exempt = false;
       continue;
     }
-    out.push({
-      tokens: withStdin(
-        extractStdin(logical),
-        dropSpaceFlag(tokenize(span)),
-      ),
-      line: i + 1,
-    });
+    out.push({ tokens: command, line: i + 1 });
   }
   return out;
 }


### PR DESCRIPTION
## Why

Reading and writing a piece is the first thing a caller does and the last thing
we documented. `cf get` had reference prose; `cf set`, the `#argument` suffix,
`cf piece step` and `cf wish` had none of the narrative kind — no document walked
someone through changing a value and looking at the result.

That gap hides a surprise. `cf set` writes the **result** cell by default —
`--input` targets the arguments cell "instead of result cell" — and a write runs
nothing, so a computed field read straight afterwards answers with the state it
was last computed from. A caller who does not know that concludes their write
was lost.

The verb tour could not absorb this: its fixture is deliberately verbs-only
("nothing here is written directly"), so a write act would have argued with the
program it runs against. This is its own session with its own fixture, and the
sync gate holds it to the demo the same way.

## What Changed

- `docs/common/workflows/reading-and-writing.md` — the tour, nine acts, indexed
  in `docs/common/README.md`.
- `packages/cli/integration/read-write-demo.sh` — the demo it quotes: 9 acts, 23
  `cf` invocations, throwaway space, self-verifying counters.
- `packages/cli/integration/pattern/thermostat.tsx` — a fixture built for this: a
  written input driving two computed outputs, so the tour can show that neither
  moves until a step.
- `tasks/check-verb-session-sync.ts` — a fourth document/demo pairing, plus the
  `run_stdin` helper the demo needed. Three tests, including that the wrong demo
  fails the pairing.
- `skills/topics/SKILL.md` — says the suffix exists and why none of its own
  examples can carry it (each rides `--url`, which has no canonical reference for
  it to attach to). No examples changed.
- `docs/common/verbs/the-verb-session.md` and `verbs/README.md` — a verb is the
  only way a **pattern** changes its own state. An operator writing a cell
  directly is the other way, and now has somewhere to be explained.

## The correction worth reading

The brief for this work said `cf set` runs nothing *in contrast to* a verb call.
That is wrong: `cf call` leaves derived fields stale too, deliberately —
`executeResolvedCallable` returns at the commit rather than awaiting
`runtime.idle()`, because doing otherwise "would hold an already-committed write
hostage to every derived recomputation it triggered elsewhere in the graph".
Measured in two clean spaces. The tour is framed around what is actually true:
nothing in an ephemeral CLI session commits a recompute except `cf piece step`.

## Test plan

- `read-write-demo.sh` against a live server: **exit 0, 9 acts, 0 unexpected
  failures, 0 unmet refusals, 0 misrendered lines**. Every refusal act matched
  its own message signature.
- The gate bites: appending a `cf` line the demo does not run makes
  `check-verb-session-sync` fail naming it; restoring returns it to green.
- `deno task test` in `tasks/` — 637 passed / 0 failed.
- `deno fmt --check`, `deno lint`, `check-docs` (567 blocks), `check-skill-facts`
  (46), `check-command-docs` (96), `check-verb-session-sync` (4 documents),
  `check-docs-history-index` — all clean.

Every factual claim in the tour is derived from a code path rather than from the
demos own narration, which is the rule the last tour was written without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

