### PR TITLE
fix(cli): a run that writes cannot end without saying what it did

### DIFF
--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -329,6 +329,20 @@ those rows standing. Neither is any piece's fault, so both are reported as the
 run's `stopReason` and never thrown away — the rows a partial migration
 produced are exactly what its operator needs.
 
+**A run that ends without reporting.** Every stop above is a report the engine
+returns. An await inside the run that never settles is not: a process whose
+main promise is pending with nothing left on its event loop does not hang, it
+drains and exits at code 0, having written part of a migration and said
+nothing about it. So the report is not the only thing that decides how `cf`
+ends. Each of `retarget`, `rollback`, and `repair` arms a guard over its whole
+run and stands it down the moment it has reported; a process that ends first
+names the verb, says how many rows had settled and under which verdicts, and
+exits nonzero. The guard runs off the process ending rather than a clock, so
+it costs a run that finishes nothing and can never cut one short. Its summary
+claims only what the run streamed: whether anything past the settled rows was
+written is a question for a survey, which is the answer to every other
+half-finished run too.
+
 ## The fixer contract
 
 A fixer is a TypeScript module the run imports, whose default export is a pure
@@ -531,6 +545,12 @@ Under [`packages/piece/src/ops/`](../../packages/piece/src/ops/):
   diff
 - [`piece-restore.ts`](../../packages/piece/src/ops/piece-restore.ts) —
   reading a piece's restorable revisions and resolving a reference to one
+
+Under [`packages/cli/`](../../packages/cli/):
+
+- [`lib/unreported-run.ts`](../../packages/cli/lib/unreported-run.ts) — the
+  process-end guard a run that writes arms over itself, and the summary it
+  reports when the process ends first
 
 ## Where to read further
 

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -336,12 +336,27 @@ drains and exits at code 0, having written part of a migration and said
 nothing about it. So the report is not the only thing that decides how `cf`
 ends. Each of `retarget`, `rollback`, and `repair` arms a guard over its whole
 run and stands it down the moment it has reported; a process that ends first
-names the verb, says how many rows had settled and under which verdicts, and
-exits nonzero. The guard runs off the process ending rather than a clock, so
-it costs a run that finishes nothing and can never cut one short. Its summary
-claims only what the run streamed: whether anything past the settled rows was
-written is a question for a survey, which is the answer to every other
-half-finished run too.
+names the verb, says what had settled, and exits nonzero. The guard runs off
+the process ending rather than a clock, so it costs a run that finishes
+nothing and can never cut one short.
+
+That summary is the operator's only account of such a run, so no reading of it
+may be false. The retarget and the rollback watch their rows in every output
+mode — `--json` and `--out` hand the engine a reporter that observes and never
+prints, since what a document mode cannot do is stream to stdout, and those
+are the modes with the most to lose: the document is built from the returned
+report, so a run that never returns writes no file at all. Their line therefore
+counts rows and names their verdicts, and a count of zero is a fact about a run
+that was being watched. The repair's engine reports its rows only in the report
+it returns, so its line says the number is not known rather than saying zero —
+its rows really do settle, and a number an operator can act on must never be
+one this process is in no position to give. Neither line claims that rows it
+does not name were left alone: whether anything past the settled rows was
+written is a question for a fresh read, and the line sends the operator to the
+same command without `--apply` — every verb that arms a guard has a dry mode
+that classifies each piece where it now stands, while a survey reads
+references and would say nothing about a repair, whose work is in the
+documents.
 
 ## The fixer contract
 

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -340,6 +340,15 @@ names the verb, says what had settled, and exits nonzero. The guard runs off
 the process ending rather than a clock, so it costs a run that finishes
 nothing and can never cut one short.
 
+The guard spans the writing of the report as well as the run, because that
+stretch can end the process too — a `--out` write that fails, a stdout that
+will not take the document. Releasing the guard the moment the engine returned
+would leave it unguarded, and the silence would simply move one step later. So
+the guard stays and its CLAIM moves instead: a run whose engine never returned
+is reported as one still in flight, and a run whose report never finished is
+reported as exactly that. The second is the more useful of the two, because the
+tally it carries is the very thing the failed report did not print.
+
 That summary is the operator's only account of such a run, so no reading of it
 may be false. The retarget and the rollback watch their rows in every output
 mode — `--json` and `--out` hand the engine a reporter that observes and never
@@ -350,7 +359,9 @@ counts rows and names their verdicts, and a count of zero is a fact about a run
 that was being watched. The repair's engine reports its rows only in the report
 it returns, so its line says the number is not known rather than saying zero —
 its rows really do settle, and a number an operator can act on must never be
-one this process is in no position to give. Neither line claims that rows it
+one this process is in no position to give. That reason names the missing row
+reporter rather than the missing return, so it stays true of a repair whose
+report was the part that failed. Neither line claims that rows it
 does not name were left alone: whether anything past the settled rows was
 written is a question for a fresh read, and the line sends the operator to the
 same command without `--apply` — every verb that arms a guard has a dry mode

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -11,8 +11,10 @@ import {
   type PatternRef,
   type PieceDiffStatus,
   type PiecePatternRef,
+  type PiecePlan,
   type PieceSelector,
   type PlanDiff,
+  type RepairReport,
   type RestorableRevision,
 } from "@commonfabric/piece/ops";
 import ports from "@commonfabric/ports" with { type: "json" };
@@ -103,6 +105,13 @@ import type {
 import { render, safeStringify } from "../lib/render.ts";
 import { newSessionId } from "../lib/session.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
+import {
+  type ApplyRunProgress,
+  describeUnreportedApplyRun,
+  guardRunReport,
+  type RunReportGuard,
+  type UnreportedRunDeps,
+} from "../lib/unreported-run.ts";
 import { absPath } from "../lib/utils.ts";
 
 // Hint system: print helpful next-step suggestions after operations
@@ -3701,6 +3710,9 @@ export interface RepairCommandDependencies {
   printError?: (message: string) => void;
   printHint?: (message: string) => void;
   exit?: (code: number) => never;
+
+  /** The process-end guard's effects; see {@link ApplyCommandDependencies}. */
+  guard?: UnreportedRunDeps;
 }
 
 export async function repairFromCommand(
@@ -3716,7 +3728,22 @@ export async function repairFromCommand(
     ...(options.plan === undefined ? {} : { planPath: absPath(options.plan) }),
     ...(options.apply === true ? { apply: true } : {}),
   };
-  const report = await (deps.runRepair ?? runRepair)(spaceConfig, request);
+  // The repair runs one session rather than the retarget's grouped ones, but
+  // it ends the same way: an await that stops settling drains the process at
+  // code 0 with the fixer's writes half-made and nothing said about them.
+  // The repair streams no rows, so the guard reports the ending alone.
+  const progress = newApplyRunProgress();
+  const guard = guardRunReport(
+    () => describeUnreportedApplyRun("Repair", progress),
+    deps.guard ?? {},
+  );
+  let report: RepairReport;
+  try {
+    report = await (deps.runRepair ?? runRepair)(spaceConfig, request);
+  } catch (error) {
+    guard.reported();
+    throw error;
+  }
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
   if (options.json) {
@@ -3741,6 +3768,9 @@ export async function repairFromCommand(
     [...tally.entries()].map(([verdict, count]) => `${verdict}: ${count}`)
       .join(" · "),
   );
+  // Reported; the guard stands down before the exit below, which never
+  // returns. See {@link reportApplyRun} for the same placement.
+  guard.reported();
   if (options.apply !== true) {
     // The dry run's product is the exact per-piece diff, so every changed
     // position renders — through the data-model's own debug stringifier,
@@ -3812,6 +3842,14 @@ export interface ApplyCommandDependencies {
   printError?: (message: string) => void;
   printHint?: (message: string) => void;
   exit?: (code: number) => never;
+
+  /**
+   * The process-end guard's effects. A run that writes arms one for its
+   * whole life, so a process that ends before the run reports says so and
+   * exits nonzero instead of draining silently at code 0
+   * ([../lib/unreported-run.ts](../lib/unreported-run.ts)).
+   */
+  guard?: UnreportedRunDeps;
 }
 
 export interface RetargetCommandDependencies extends ApplyCommandDependencies {
@@ -3890,19 +3928,40 @@ export async function retargetFromCommand(
   const spaceConfig = { ...parseSpaceOptions(options), jsonOutput: true };
   const print = deps.render ?? render;
   const streaming = options.json !== true && options.out === undefined;
-  const report = await (deps.runRetarget ?? runRetarget)(spaceConfig, {
-    planPath: absPath(options.plan),
-    ...(options.acceptUnretained === undefined
-      ? {}
-      : { accept: options.acceptUnretained }),
-    ...(options.apply === true ? { apply: true } : {}),
-    ...(options.groupSize === undefined
-      ? {}
-      : { groupSize: options.groupSize }),
-    ...(streaming
-      ? { onRow: (row: ApplyRow) => print(formatApplyRow(row)) }
-      : {}),
-  });
+  // Armed before the first session opens and stood down by the report: a run
+  // that stops settling anywhere in between ends the process, and without
+  // this that ending is indistinguishable from a clean finish.
+  const progress = newApplyRunProgress();
+  const guard = guardRunReport(
+    () => describeUnreportedApplyRun("Retarget", progress),
+    deps.guard ?? {},
+  );
+  let report: ApplyReport;
+  try {
+    report = await (deps.runRetarget ?? runRetarget)(spaceConfig, {
+      planPath: absPath(options.plan),
+      ...(options.acceptUnretained === undefined
+        ? {}
+        : { accept: options.acceptUnretained }),
+      ...(options.apply === true ? { apply: true } : {}),
+      ...(options.groupSize === undefined
+        ? {}
+        : { groupSize: options.groupSize }),
+      ...(streaming
+        ? {
+          onRow: (row: ApplyRow) => {
+            countApplyRow(progress, row);
+            print(formatApplyRow(row));
+          },
+        }
+        : {}),
+    });
+  } catch (error) {
+    // A run that ended by throwing reports through the error it threw, which
+    // the CLI prints on its way to a nonzero exit.
+    guard.reported();
+    throw error;
+  }
   // Every accepted piece by name, through the note so `--quiet` cannot
   // silence it: a piece this move could not be reversed for is the fact the
   // operator most needs in front of them, and it is being recorded at the
@@ -3915,12 +3974,30 @@ export async function retargetFromCommand(
       `accepted as unrollbackable: ${piece} (moving it leaves no reversal)`,
     );
   }
-  await reportApplyRun(report, {
-    verb: "Retarget",
-    ...(options.apply === true ? { apply: true } : {}),
-    ...(options.out === undefined ? {} : { out: options.out }),
-    ...(options.json === true ? { json: true } : {}),
-  }, deps);
+  await reportApplyRun(
+    report,
+    {
+      verb: "Retarget",
+      ...(options.apply === true ? { apply: true } : {}),
+      ...(options.out === undefined ? {} : { out: options.out }),
+      ...(options.json === true ? { json: true } : {}),
+    },
+    deps,
+    guard,
+  );
+}
+
+/** A guarded apply run's row counts, empty before its first row settles. */
+function newApplyRunProgress(): ApplyRunProgress {
+  return { verdicts: new Map<string, number>() };
+}
+
+/** Count one settled row toward what a process-end report would say. */
+function countApplyRow(progress: ApplyRunProgress, row: ApplyRow): void {
+  progress.verdicts.set(
+    row.verdict,
+    (progress.verdicts.get(row.verdict) ?? 0) + 1,
+  );
 }
 
 /**
@@ -3934,6 +4011,7 @@ async function reportApplyRun(
   report: ApplyReport,
   run: { verb: string; apply?: boolean; out?: string; json?: boolean },
   deps: ApplyCommandDependencies,
+  guard?: RunReportGuard,
 ): Promise<void> {
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
@@ -3959,6 +4037,10 @@ async function reportApplyRun(
       `written: ${report.applied}`,
     ].join(" · "),
   );
+  // The run has reported, so the process-end guard stands down here rather
+  // than at the end of this function: the exit below never returns, and a
+  // guard released after it would still be armed when the process ends.
+  guard?.reported();
   // A row that landed and was warned about is a success the operator still
   // has to read. It rides the report itself, so `--json` and `--out` carry
   // it whatever the hint does; this is the human copy.
@@ -4085,22 +4167,41 @@ export async function rollbackFromCommand(
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
   const streaming = options.json !== true && options.out === undefined;
-  const { report, plan } = await (deps.runRollback ?? runRollback)(
-    spaceConfig,
-    {
-      planPath: absPath(options.plan),
-      ...(options.acceptUnretained === undefined
-        ? {}
-        : { accept: options.acceptUnretained }),
-      ...(options.apply === true ? { apply: true } : {}),
-      ...(options.groupSize === undefined
-        ? {}
-        : { groupSize: options.groupSize }),
-      ...(streaming
-        ? { onRow: (row: ApplyRow) => print(formatApplyRow(row)) }
-        : {}),
-    },
+  // The same process-end guard the retarget arms, for the same reason: this
+  // runs on the same engine, over the same grouped sessions.
+  const progress = newApplyRunProgress();
+  const guard = guardRunReport(
+    () => describeUnreportedApplyRun("Rollback", progress),
+    deps.guard ?? {},
   );
+  let report: ApplyReport;
+  let plan: PiecePlan;
+  try {
+    ({ report, plan } = await (deps.runRollback ?? runRollback)(
+      spaceConfig,
+      {
+        planPath: absPath(options.plan),
+        ...(options.acceptUnretained === undefined
+          ? {}
+          : { accept: options.acceptUnretained }),
+        ...(options.apply === true ? { apply: true } : {}),
+        ...(options.groupSize === undefined
+          ? {}
+          : { groupSize: options.groupSize }),
+        ...(streaming
+          ? {
+            onRow: (row: ApplyRow) => {
+              countApplyRow(progress, row);
+              print(formatApplyRow(row));
+            },
+          }
+          : {}),
+      },
+    ));
+  } catch (error) {
+    guard.reported();
+    throw error;
+  }
   printHint(`Derived ${plan.rows.length} rollback rows from ${options.plan}`);
   // Every accepted piece by name, on every run that carried one — through
   // the note rather than a hint, so `--quiet` does not silence it. A piece
@@ -4112,12 +4213,17 @@ export async function rollbackFromCommand(
       `accepted as unrollbackable: ${piece} (left out of this reversal)`,
     );
   }
-  await reportApplyRun(report, {
-    verb: "Rollback",
-    ...(options.apply === true ? { apply: true } : {}),
-    ...(options.out === undefined ? {} : { out: options.out }),
-    ...(options.json === true ? { json: true } : {}),
-  }, deps);
+  await reportApplyRun(
+    report,
+    {
+      verb: "Rollback",
+      ...(options.apply === true ? { apply: true } : {}),
+      ...(options.out === undefined ? {} : { out: options.out }),
+      ...(options.json === true ? { json: true } : {}),
+    },
+    deps,
+    guard,
+  );
 }
 
 export interface RestoreCLIOptions extends PieceCLIOptions {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3748,6 +3748,9 @@ export async function repairFromCommand(
     guard.reported();
     throw error;
   }
+  // As the retarget does: the guard stays armed over the writing of what the
+  // engine returned, and says that is where the process ended.
+  progress.phase = "reporting";
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
   if (options.json) {
@@ -3967,6 +3970,12 @@ export async function retargetFromCommand(
     guard.reported();
     throw error;
   }
+  // The engine returned; everything below is the writing of what it returned,
+  // and that can end the process too — a throw here reaches the operator as
+  // an error, but the tally it was about to print does not. The guard stays
+  // armed over it and changes what it claims, rather than standing down and
+  // leaving this stretch unguarded.
+  progress.phase = "reporting";
   // Every accepted piece by name, through the note so `--quiet` cannot
   // silence it: a piece this move could not be reversed for is the fact the
   // operator most needs in front of them, and it is being recorded at the
@@ -3999,7 +4008,7 @@ export async function retargetFromCommand(
  * say the count is unknown rather than say zero.
  */
 function newApplyRunProgress(observed: boolean): ApplyRunProgress {
-  return { observed, verdicts: new Map<string, number>() };
+  return { observed, verdicts: new Map<string, number>(), phase: "running" };
 }
 
 /** Count one settled row toward what a process-end report would say. */
@@ -4209,6 +4218,9 @@ export async function rollbackFromCommand(
     guard.reported();
     throw error;
   }
+  // As the retarget does, and for the same reason: the writing of what the
+  // engine returned is guarded too, under a claim that fits it.
+  progress.phase = "reporting";
   printHint(`Derived ${plan.rows.length} rollback rows from ${options.plan}`);
   // Every accepted piece by name, on every run that carried one — through
   // the note rather than a hint, so `--quiet` does not silence it. A piece

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3731,8 +3731,12 @@ export async function repairFromCommand(
   // The repair runs one session rather than the retarget's grouped ones, but
   // it ends the same way: an await that stops settling drains the process at
   // code 0 with the fixer's writes half-made and nothing said about them.
-  // The repair streams no rows, so the guard reports the ending alone.
-  const progress = newApplyRunProgress();
+  //
+  // Unwatched, because `repairPieces` reports its rows only in the report it
+  // returns — there is no row callback to hand it. So the guard says the
+  // count is unknown rather than zero: this run's rows really do settle, and
+  // a process that never saw them must not report their absence.
+  const progress = newApplyRunProgress(false);
   const guard = guardRunReport(
     () => describeUnreportedApplyRun("Repair", progress),
     deps.guard ?? {},
@@ -3931,7 +3935,7 @@ export async function retargetFromCommand(
   // Armed before the first session opens and stood down by the report: a run
   // that stops settling anywhere in between ends the process, and without
   // this that ending is indistinguishable from a clean finish.
-  const progress = newApplyRunProgress();
+  const progress = newApplyRunProgress(true);
   const guard = guardRunReport(
     () => describeUnreportedApplyRun("Retarget", progress),
     deps.guard ?? {},
@@ -3947,14 +3951,15 @@ export async function retargetFromCommand(
       ...(options.groupSize === undefined
         ? {}
         : { groupSize: options.groupSize }),
-      ...(streaming
-        ? {
-          onRow: (row: ApplyRow) => {
-            countApplyRow(progress, row);
-            print(formatApplyRow(row));
-          },
-        }
-        : {}),
+      // Every mode watches the rows; only a streaming one prints them. What
+      // the document modes cannot do is stream to stdout, and observing is
+      // not streaming — they are the modes with the most to lose from a run
+      // that never returns, since the document they emit is written from
+      // the report and a run that never reports writes nothing at all.
+      onRow: (row: ApplyRow) => {
+        countApplyRow(progress, row);
+        if (streaming) print(formatApplyRow(row));
+      },
     });
   } catch (error) {
     // A run that ended by throwing reports through the error it threw, which
@@ -3987,9 +3992,14 @@ export async function retargetFromCommand(
   );
 }
 
-/** A guarded apply run's row counts, empty before its first row settles. */
-function newApplyRunProgress(): ApplyRunProgress {
-  return { verdicts: new Map<string, number>() };
+/**
+ * A guarded apply run's row counts, empty before its first row settles.
+ * `observed` is whether this run's engine is being handed a row reporter at
+ * all: without one its rows settle unseen, and the process-end report must
+ * say the count is unknown rather than say zero.
+ */
+function newApplyRunProgress(observed: boolean): ApplyRunProgress {
+  return { observed, verdicts: new Map<string, number>() };
 }
 
 /** Count one settled row toward what a process-end report would say. */
@@ -4168,8 +4178,9 @@ export async function rollbackFromCommand(
   const printHint = deps.printHint ?? hint;
   const streaming = options.json !== true && options.out === undefined;
   // The same process-end guard the retarget arms, for the same reason: this
-  // runs on the same engine, over the same grouped sessions.
-  const progress = newApplyRunProgress();
+  // runs on the same engine, over the same grouped sessions — and watches
+  // its rows in every mode, as the retarget does and for the same reason.
+  const progress = newApplyRunProgress(true);
   const guard = guardRunReport(
     () => describeUnreportedApplyRun("Rollback", progress),
     deps.guard ?? {},
@@ -4188,14 +4199,10 @@ export async function rollbackFromCommand(
         ...(options.groupSize === undefined
           ? {}
           : { groupSize: options.groupSize }),
-        ...(streaming
-          ? {
-            onRow: (row: ApplyRow) => {
-              countApplyRow(progress, row);
-              print(formatApplyRow(row));
-            },
-          }
-          : {}),
+        onRow: (row: ApplyRow) => {
+          countApplyRow(progress, row);
+          if (streaming) print(formatApplyRow(row));
+        },
       },
     ));
   } catch (error) {

--- a/packages/cli/lib/unreported-run.ts
+++ b/packages/cli/lib/unreported-run.ts
@@ -117,6 +117,19 @@ export function guardRunReport(
   };
 }
 
+/**
+ * How far a guarded run had got. `running` is before its engine returned;
+ * `reporting` is after — the report is in hand and is being written out.
+ *
+ * The guard stays armed across both, because both can end the process
+ * without the operator being told anything: the engine can stop settling,
+ * and so can the writing of what it returned. What the two cannot share is
+ * the CLAIM. "It did not return" is false of a run that returned, and a
+ * guard that said it would be lying in the opposite direction from the one
+ * it exists to prevent.
+ */
+export type ApplyRunPhase = "running" | "reporting";
+
 /** What one guarded apply run has settled by the time it is asked. */
 export interface ApplyRunProgress {
   /**
@@ -130,6 +143,13 @@ export interface ApplyRunProgress {
 
   /** Rows the run reported, by verdict, in the order first seen. */
   verdicts: Map<string, number>;
+
+  /**
+   * Where the run stands. Moved to `reporting` by the command the moment its
+   * engine returns, so the line the guard composes describes what actually
+   * happened rather than what was true when the guard was armed.
+   */
+  phase: ApplyRunPhase;
 }
 
 /**
@@ -138,17 +158,23 @@ export interface ApplyRunProgress {
  * the missing summary would have carried, minus the claims only a returned
  * report can support.
  *
- * Three readings, and the distinction between the last two is the whole
- * point of {@link ApplyRunProgress.observed}. A watched run that settled
- * rows names them and their verdicts. A watched run that settled none says
- * so, which is a fact about the run. An UNWATCHED run says the number is not
- * known here — never zero, because zero would be a claim this process is in
- * no position to make, and a wrong number is worse than no number: an
- * operator can act on it.
+ * The opening clause is the run's {@link ApplyRunPhase}: a run whose engine
+ * never returned, or one whose report never finished being written. Both end
+ * the process with the operator uninformed; only the first is the engine's
+ * doing, and saying so of the second would be false.
+ *
+ * The row count has three readings, and the distinction between the last two
+ * is the whole point of {@link ApplyRunProgress.observed}. A watched run that
+ * settled rows names them and their verdicts. A watched run that settled none
+ * says so, which is a fact about the run. An UNWATCHED run says the number is
+ * not known here — never zero, because zero would be a claim this process is
+ * in no position to make, and a wrong number is worse than no number: an
+ * operator can act on it. That reason is about the missing callback rather
+ * than about returning, so it holds in either phase.
  *
  * Nothing here asserts that rows it does not name were left alone either. A
- * run that stopped settling stopped somewhere this process cannot see, so
- * the closing line sends the reader to the one thing that can see it.
+ * run that stopped stopped somewhere this process cannot see, so the closing
+ * line sends the reader to the one thing that can see it.
  */
 export function describeUnreportedApplyRun(
   verb: string,
@@ -161,21 +187,33 @@ export function describeUnreportedApplyRun(
   const tally = [...progress.verdicts.entries()]
     .map(([verdict, count]) => `${verdict}: ${count}`)
     .join(" · ");
+  const reporting = progress.phase === "reporting";
   return [
-    `${verb} ended before it reported: the process exited while the run was ` +
-    `still in flight.`,
+    reporting
+      ? `${verb} ran to a report, but the process exited before that report ` +
+        `finished.`
+      : `${verb} ended before it reported: the process exited while the run ` +
+        `was still in flight.`,
     !progress.observed
-      ? `  How many rows it settled is not known here — this run reports ` +
-        `its rows only when it returns, and it did not return.`
+      ? `  How many rows it settled is not known here: this run counts its ` +
+        `rows only in the report itself.`
       : settled === 0
       ? `  No row settled before it ended.`
-      : `  ${settled} ${settled === 1 ? "row" : "rows"} settled — ${tally}. ` +
-        `Whether anything after them was written is not known here.`,
+      : `  ${settled} ${settled === 1 ? "row" : "rows"} settled — ${tally}.` +
+        // Only the running phase has rows beyond the count to be unsure
+        // about. Once the engine has returned, a watched run's count IS its
+        // report's row count, and hedging it would understate what is known.
+        (reporting
+          ? ``
+          : ` Whether anything after them was written is not known here.`),
     // The same command without `--apply`, rather than a named verification:
     // every verb that arms a guard has a dry mode that classifies each piece
     // where it now stands, and a survey — which reads references — would say
     // nothing about a repair, whose work is in the documents.
-    `  Re-running resumes it, and rows that landed are not redone. The same ` +
+    (reporting
+      ? `  What the report would have said beyond this is lost. `
+      : `  `) +
+    `Re-running resumes it, and rows that landed are not redone. The same ` +
     `command without \`--apply\` says where every piece now stands.`,
   ].join("\n");
 }

--- a/packages/cli/lib/unreported-run.ts
+++ b/packages/cli/lib/unreported-run.ts
@@ -119,6 +119,15 @@ export function guardRunReport(
 
 /** What one guarded apply run has settled by the time it is asked. */
 export interface ApplyRunProgress {
+  /**
+   * Whether this run's rows are being watched as they settle. False for a
+   * run whose engine takes no row callback: its rows settle where this
+   * process cannot see them, so a count of zero would be an absence of
+   * observation rather than an absence of work — and "no row settled" would
+   * be false of it rather than merely unhelpful.
+   */
+  observed: boolean;
+
   /** Rows the run reported, by verdict, in the order first seen. */
   verdicts: Map<string, number>;
 }
@@ -129,11 +138,17 @@ export interface ApplyRunProgress {
  * the missing summary would have carried, minus the claims only a returned
  * report can support.
  *
- * The counts come from the rows the run streamed, so a mode that streams
- * none says only that the run ended, which is the honest whole of what such
- * a run knows about itself. Nothing here asserts that the rows it does not
- * name were left alone: a run that stopped settling stopped somewhere this
- * process cannot see, and a survey is what settles that.
+ * Three readings, and the distinction between the last two is the whole
+ * point of {@link ApplyRunProgress.observed}. A watched run that settled
+ * rows names them and their verdicts. A watched run that settled none says
+ * so, which is a fact about the run. An UNWATCHED run says the number is not
+ * known here — never zero, because zero would be a claim this process is in
+ * no position to make, and a wrong number is worse than no number: an
+ * operator can act on it.
+ *
+ * Nothing here asserts that rows it does not name were left alone either. A
+ * run that stopped settling stopped somewhere this process cannot see, so
+ * the closing line sends the reader to the one thing that can see it.
  */
 export function describeUnreportedApplyRun(
   verb: string,
@@ -149,12 +164,18 @@ export function describeUnreportedApplyRun(
   return [
     `${verb} ended before it reported: the process exited while the run was ` +
     `still in flight.`,
-    settled === 0
-      ? `  No row settled, so this run accounts for nothing it may have ` +
-        `written.`
+    !progress.observed
+      ? `  How many rows it settled is not known here — this run reports ` +
+        `its rows only when it returns, and it did not return.`
+      : settled === 0
+      ? `  No row settled before it ended.`
       : `  ${settled} ${settled === 1 ? "row" : "rows"} settled — ${tally}. ` +
         `Whether anything after them was written is not known here.`,
-    `  Re-running resumes from what landed, and a fresh survey says what ` +
-    `that is.`,
+    // The same command without `--apply`, rather than a named verification:
+    // every verb that arms a guard has a dry mode that classifies each piece
+    // where it now stands, and a survey — which reads references — would say
+    // nothing about a repair, whose work is in the documents.
+    `  Re-running resumes it, and rows that landed are not redone. The same ` +
+    `command without \`--apply\` says where every piece now stands.`,
   ].join("\n");
 }

--- a/packages/cli/lib/unreported-run.ts
+++ b/packages/cli/lib/unreported-run.ts
@@ -1,0 +1,160 @@
+/**
+ * The exit discipline for a run that writes: a `cf` invocation that ENDS
+ * while its run has not reported must not look like a success.
+ *
+ * A Deno process whose main promise is still pending, with no work left on
+ * the event loop, does not hang — it drains and exits, silently, with code
+ * 0. Every await in a bulk apply sits under that rule: the engine can stop
+ * settling anywhere between opening a session and returning its report, and
+ * the process then ends having written part of a migration, printed no
+ * summary, and told its caller everything went well. A script cannot see the
+ * difference, and neither can an operator reading a log whose last line is a
+ * row that applied normally.
+ *
+ * So the report is not the only thing that decides how the process ends. A
+ * run arms a guard for the whole of its life and stands it down the moment
+ * it has reported; if the process ends first, the guard says so on stderr
+ * and raises the exit code. It is armed on the real event — the process
+ * ending — rather than on a clock, so it costs a run that finishes nothing
+ * and cannot cut one short.
+ *
+ * Scoped to the runs that write. A command whose whole job is to stay up
+ * until interrupted (`cf piece render --watch`) ends exactly this way on
+ * purpose, so this is never installed process-wide.
+ */
+
+/** Injectable effects, for tests. */
+export interface UnreportedRunDeps {
+  /** Registers the process-end hook the guard reports from. */
+  addUnloadListener?: (handler: () => void) => void;
+
+  /** Where the guard's report goes. */
+  printError?: (message: string) => void;
+
+  /** The code the process is ending with, read inside the hook. */
+  readExitCode?: () => number;
+
+  /** Raise the code the process is ending with. */
+  setExitCode?: (code: number) => void;
+}
+
+/** A run's handle on its own guard. */
+export interface RunReportGuard {
+  /**
+   * This run has reported; the guard stands down. Idempotent, and safe to
+   * call on the failure path too — a run that ended by throwing reports
+   * through the error it threw.
+   */
+  reported(): void;
+}
+
+interface ArmedRun {
+  describe: () => string;
+}
+
+// Module-level rather than per-instance so a process running two guarded
+// runs still installs at most one hook, from at most one registration.
+const armed = new Set<ArmedRun>();
+let unloadHookInstalled = false;
+
+/** Test-only: clears the armed runs and the hook guard between cases. */
+export function resetUnreportedRunGuardsForTest(): void {
+  armed.clear();
+  unloadHookInstalled = false;
+}
+
+/** The production hook registration; a test injects its own. */
+export function addProcessUnloadListener(handler: () => void): void {
+  globalThis.addEventListener("unload", handler);
+}
+
+/** The production reading of the code the process is ending with. */
+export function processExitCode(): number {
+  return Deno.exitCode;
+}
+
+/** The production write of the code the process is ending with. */
+export function setProcessExitCode(code: number): void {
+  Deno.exitCode = code;
+}
+
+/**
+ * Arm a guard over one run. `describe` composes the line the guard reports
+ * if the process ends first — called at that moment, so it can name what the
+ * run had settled by then rather than what it knew when it started.
+ *
+ * The hook is installed once per process, by the first run to arm one, and
+ * every later run joins it. A test that injects effects therefore resets
+ * through {@link resetUnreportedRunGuardsForTest} between cases, the same way
+ * the deferred version-skew note does.
+ */
+export function guardRunReport(
+  describe: () => string,
+  deps: UnreportedRunDeps = {},
+): RunReportGuard {
+  const printError = deps.printError ?? console.error;
+  const readExitCode = deps.readExitCode ?? processExitCode;
+  const setExitCode = deps.setExitCode ?? setProcessExitCode;
+  const addUnloadListener = deps.addUnloadListener ?? addProcessUnloadListener;
+  const run: ArmedRun = { describe };
+  armed.add(run);
+  if (!unloadHookInstalled) {
+    unloadHookInstalled = true;
+    addUnloadListener(() => {
+      if (armed.size === 0) return;
+      for (const pending of armed) printError(pending.describe());
+      // Raise a success into a failure and leave a failure alone: a process
+      // already ending nonzero has a reason of its own, and overwriting it
+      // would replace the report the caller is about to read.
+      if (readExitCode() === 0) setExitCode(1);
+      armed.clear();
+    });
+  }
+  return {
+    reported: () => {
+      armed.delete(run);
+    },
+  };
+}
+
+/** What one guarded apply run has settled by the time it is asked. */
+export interface ApplyRunProgress {
+  /** Rows the run reported, by verdict, in the order first seen. */
+  verdicts: Map<string, number>;
+}
+
+/**
+ * What an apply run reports when the process ends before it does. It names
+ * the verb, what had settled, and what the operator does next — everything
+ * the missing summary would have carried, minus the claims only a returned
+ * report can support.
+ *
+ * The counts come from the rows the run streamed, so a mode that streams
+ * none says only that the run ended, which is the honest whole of what such
+ * a run knows about itself. Nothing here asserts that the rows it does not
+ * name were left alone: a run that stopped settling stopped somewhere this
+ * process cannot see, and a survey is what settles that.
+ */
+export function describeUnreportedApplyRun(
+  verb: string,
+  progress: ApplyRunProgress,
+): string {
+  const settled = [...progress.verdicts.values()].reduce(
+    (total, count) => total + count,
+    0,
+  );
+  const tally = [...progress.verdicts.entries()]
+    .map(([verdict, count]) => `${verdict}: ${count}`)
+    .join(" · ");
+  return [
+    `${verb} ended before it reported: the process exited while the run was ` +
+    `still in flight.`,
+    settled === 0
+      ? `  No row settled, so this run accounts for nothing it may have ` +
+        `written.`
+      : `  ${settled} ${settled === 1 ? "row" : "rows"} settled — ${tally}. ` +
+        `Whether anything after them was written is not known here.`,
+    `  Re-running resumes from what landed, and a fresh survey says what ` +
+    `that is.`,
+  ].join("\n");
+}

--- a/packages/cli/test/fixtures/unreported-run-process.ts
+++ b/packages/cli/test/fixtures/unreported-run-process.ts
@@ -1,0 +1,29 @@
+/**
+ * The defect's own shape in a real process: a run arms the process-end guard
+ * and then stops settling. Deno drains such a process and exits, so what the
+ * ending says — and the code it says it with — is the guard's alone. Run with
+ * `report` to stand the guard down first, which is the ordinary ending this
+ * one is compared against.
+ *
+ * A fixture rather than an in-process case because the thing under test is
+ * the production wiring itself: the `unload` event Deno dispatches as the
+ * loop drains, and `Deno.exitCode` being writable from inside it. Injected
+ * effects cannot observe either.
+ */
+
+import { guardRunReport } from "../../lib/unreported-run.ts";
+
+/**
+ * The run, called and not awaited — which is how `mod.ts` calls `main`, and
+ * why Deno's own "Top-level await promise never resolved" detector never
+ * sees this. That detector also skips the `unload` event, so a `cf` that
+ * awaited its main at the top level would lose both this guard's summary and
+ * the deferred version-skew note.
+ */
+async function run(): Promise<void> {
+  const guard = guardRunReport(() => "the run never reported");
+  if (Deno.args[0] === "report") guard.reported();
+  await new Promise(() => {});
+}
+
+run();

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -263,6 +263,14 @@ describe("piece-repair", () => {
       expect(process.errors.join("\n")).toContain(
         "Repair ended before it reported",
       );
+      // `repairPieces` takes no row callback, so its rows settle where this
+      // process cannot see them. The line must say the count is unknown: a
+      // repair that wrote half its documents and reported "no row settled"
+      // would be telling the operator something false.
+      expect(process.errors.join("\n")).toContain(
+        "How many rows it settled is not known here",
+      );
+      expect(process.errors.join("\n")).not.toContain("No row settled");
       expect(abandoned).toBeInstanceOf(Promise);
     });
 

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -314,6 +314,24 @@ describe("piece-repair", () => {
       expect(process.endProcess()).toBe(0);
       expect(process.errors).toEqual([]);
     });
+
+    it("says nothing at process end when the run threw", async () => {
+      // A plan pinned to another fixer is refused before the module is even
+      // imported. That refusal IS the report, and the CLI prints it on the
+      // way to a nonzero exit; a guard line beside it would be a second
+      // account of a run that already gave one.
+      const process = guardHarness();
+      await expect(
+        repairFromCommand({ ...OPTIONS, path: "topics", apply: true }, {
+          runRepair: () =>
+            Promise.reject(new Error("The plan runs another fixer.")),
+          printHint: () => {},
+          guard: process.deps,
+        }),
+      ).rejects.toThrow("another fixer");
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
+    });
   });
 
   describe("runRepair()", () => {

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -20,6 +20,8 @@ import {
 } from "@commonfabric/piece/ops/bulk-local";
 
 import { type RepairRunRequest, runRepair, zeroRowFixer } from "../lib/bulk.ts";
+import { resetUnreportedRunGuardsForTest } from "../lib/unreported-run.ts";
+import { guardHarness } from "./unreported-run-helpers.ts";
 import { piece, repairFromCommand, setQuietMode } from "../commands/piece.ts";
 
 function captureStdout(fn: () => Promise<void>): Promise<string> {
@@ -83,6 +85,9 @@ const REPORT: RepairReport = {
 describe("piece-repair", () => {
   // The fixtures pass `quiet`, and the action applies it globally.
   afterEach(() => setQuietMode(false));
+  // The process-end hook is installed once per process, by the first run to
+  // arm a guard; a case that injects its own effects starts from none.
+  beforeEach(() => resetUnreportedRunGuardsForTest());
 
   describe("repairFromCommand()", () => {
     it("prints the emitted plan to stdout and the verdict tally as a hint", async () => {
@@ -237,6 +242,41 @@ describe("piece-repair", () => {
         actionHandler?: unknown;
       };
       expect(registered?.actionHandler).toBe(repairFromCommand);
+    });
+
+    it("reports the run and exits nonzero when the process outlives it", async () => {
+      // The repair runs one session rather than the retarget's grouped ones,
+      // and ends the same way if an await stops settling: the fixer's writes
+      // are half-made, the process drains, and code 0 says otherwise.
+      const process = guardHarness();
+      const abandoned = repairFromCommand(
+        { ...OPTIONS, path: "topics", apply: true },
+        {
+          runRepair: () => new Promise<RepairReport>(() => {}),
+          render: () => {},
+          printHint: () => {},
+          guard: process.deps,
+        },
+      );
+      await Promise.resolve();
+      expect(process.endProcess()).toBe(1);
+      expect(process.errors.join("\n")).toContain(
+        "Repair ended before it reported",
+      );
+      expect(abandoned).toBeInstanceOf(Promise);
+    });
+
+    it("says nothing at process end once the run has reported", async () => {
+      const process = guardHarness();
+      await captureStdout(() =>
+        repairFromCommand({ ...OPTIONS, path: "topics" }, {
+          runRepair: () => Promise.resolve(REPORT),
+          printHint: () => {},
+          guard: process.deps,
+        })
+      );
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
     });
   });
 

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -274,6 +274,34 @@ describe("piece-repair", () => {
       expect(abandoned).toBeInstanceOf(Promise);
     });
 
+    it("says the report failed, not that the run never returned, when output throws", async () => {
+      // The repair counts no rows either way, so what its line must get right
+      // here is the other half: the engine DID return, and the reason its
+      // count is unknown is the missing row callback rather than the return.
+      const process = guardHarness();
+      await expect(
+        repairFromCommand(
+          { ...OPTIONS, path: "topics", apply: true, json: true },
+          {
+            runRepair: () => Promise.resolve(REPORT),
+            render: () => {
+              throw new Error("stdout failed");
+            },
+            printHint: () => {},
+            guard: process.deps,
+          },
+        ),
+      ).rejects.toThrow("stdout failed");
+      expect(process.endProcess()).toBe(1);
+      const said = process.errors.join("\n");
+      expect(said).toContain("Repair ran to a report");
+      expect(said).not.toContain("still in flight");
+      expect(said).not.toContain("it did not return");
+      expect(said).toContain(
+        "this run counts its rows only in the report itself",
+      );
+    });
+
     it("says nothing at process end once the run has reported", async () => {
       const process = guardHarness();
       await captureStdout(() =>

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -363,9 +363,14 @@ describe("piece-retarget", () => {
       const out = await captureStdout(() =>
         retargetFromCommand({ ...OPTIONS, json: true }, {
           runRetarget: (_config, request) => {
-            // A single document cannot stream, so no row reporter is handed
-            // to the library at all.
-            expect(Object.keys(request).sort()).toEqual(["planPath"]);
+            // A single document cannot stream, so the reporter this mode
+            // hands the library observes and never prints. The key set, not
+            // each value: an `apply: undefined` riding along is a key the
+            // library still has to reason about, and every matcher that asks
+            // about one property reads a present-but-undefined key as an
+            // absent one.
+            expect(Object.keys(request).sort()).toEqual(["onRow", "planPath"]);
+            for (const row of REPORT.rows) request.onRow?.(row);
             return Promise.resolve(REPORT);
           },
           printHint: () => {},
@@ -373,6 +378,10 @@ describe("piece-retarget", () => {
       );
       expect(out.startsWith("fvj1:")).toBe(true);
       expect(out).toContain('"elapsedMs":412');
+      // What "cannot stream" means, asserted directly rather than inferred
+      // from the absence of a callback: two rows went through the reporter
+      // above and stdout still carries exactly one line, the document.
+      expect(out.trimEnd().split("\n")).toHaveLength(1);
     });
 
     it("writes the report to --out and leaves stdout empty", async () => {
@@ -381,7 +390,10 @@ describe("piece-retarget", () => {
       const out = await captureStdout(() =>
         retargetFromCommand({ ...OPTIONS, out: "report.json" }, {
           runRetarget: (_config, request) => {
-            expect(Object.keys(request).sort()).toEqual(["planPath"]);
+            expect(Object.keys(request).sort()).toEqual(["onRow", "planPath"]);
+            // The reporter observes; the empty stdout asserted below is what
+            // says it printed nothing.
+            for (const row of REPORT.rows) request.onRow?.(row);
             return Promise.resolve(REPORT);
           },
           writeTextFile: (path, text) => {
@@ -614,6 +626,54 @@ describe("piece-retarget", () => {
       // The abandoned promise is the run that never came back; naming it
       // keeps the lint's floating-promise rule honest about that.
       expect(abandoned).toBeInstanceOf(Promise);
+    });
+
+    it("counts the rows a document-mode run settled, which wrote no document", async () => {
+      // The mode with the most to lose: `--json` and `--out` build what they
+      // emit from the returned report, so a run that never returns writes
+      // nothing at all and this line is the operator's whole account of it.
+      // A count of zero here after real writes would be worse than silence —
+      // wrong, and actionable.
+      for (
+        const mode of [{ json: true }, { out: "report.json" }] as const
+      ) {
+        resetUnreportedRunGuardsForTest();
+        const process = guardHarness();
+        let written = false;
+        const out = await captureStdout(() => {
+          retargetFromCommand({ ...OPTIONS, ...mode, apply: true }, {
+            runRetarget: (_config, request) => {
+              request.onRow?.({
+                piece: "fid1:aaa",
+                phase: "topics",
+                verdict: "applied",
+                elapsedMs: 12,
+              });
+              request.onRow?.({
+                piece: "fid1:bbb",
+                phase: "topics",
+                verdict: "applied",
+                elapsedMs: 9,
+              });
+              return new Promise<ApplyReport>(() => {});
+            },
+            writeTextFile: () => {
+              written = true;
+              return Promise.resolve();
+            },
+            printHint: () => {},
+            guard: process.deps,
+          });
+          return Promise.resolve();
+        });
+        expect(process.endProcess()).toBe(1);
+        expect(process.errors.join("\n")).toContain(
+          "2 rows settled — applied: 2.",
+        );
+        // Observing is not streaming, and the document was never written.
+        expect(out).toBe("");
+        expect(written).toBe(false);
+      }
     });
 
     it("says nothing at process end once the run has reported", async () => {

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -6,7 +6,7 @@
  * boundary.
  */
 
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { PiecesController } from "@commonfabric/piece/ops";
 import type {
@@ -17,6 +17,8 @@ import type {
 import { decode } from "@commonfabric/utils/encoding";
 
 import { runRetarget } from "../lib/bulk.ts";
+import { resetUnreportedRunGuardsForTest } from "../lib/unreported-run.ts";
+import { guardHarness } from "./unreported-run-helpers.ts";
 import {
   formatApplyRow,
   piece,
@@ -90,6 +92,9 @@ const REPORT: ApplyReport = {
 describe("piece-retarget", () => {
   // The fixtures pass `quiet`, and the action applies it globally.
   afterEach(() => setQuietMode(false));
+  // The process-end hook is installed once per process, by the first run to
+  // arm a guard; a case that injects its own effects starts from none.
+  beforeEach(() => resetUnreportedRunGuardsForTest());
 
   describe("formatApplyRow()", () => {
     it("puts the verdict, the piece, its phase, and its cost on one line", () => {
@@ -569,6 +574,75 @@ describe("piece-retarget", () => {
         actionHandler?: unknown;
       };
       expect(registered?.actionHandler).toBe(retargetFromCommand);
+    });
+
+    it("reports what settled and exits nonzero when the process outlives the run", async () => {
+      // The defect's own shape: a run whose promise stops settling. Deno
+      // drains such a process and exits 0, so without the guard the apply
+      // ends having written part of a migration, printed no summary, and
+      // told its caller everything went well.
+      const process = guardHarness();
+      const rows: string[] = [];
+      // Deliberately not awaited — the point is that this promise never
+      // settles, exactly as the run that stopped mid-migration did not.
+      const abandoned = retargetFromCommand({ ...OPTIONS, apply: true }, {
+        runRetarget: (_config, request) => {
+          request.onRow?.({
+            piece: "fid1:aaa",
+            phase: "topics",
+            verdict: "applied",
+            elapsedMs: 12,
+          });
+          return new Promise<ApplyReport>(() => {});
+        },
+        render: (value) => {
+          rows.push(String(value));
+        },
+        printHint: () => {},
+        guard: process.deps,
+      });
+      // The row streamed before the run stalled; the process then ends.
+      await Promise.resolve();
+      expect(rows).toEqual(["applied fid1:aaa topics 12ms"]);
+      expect(process.endProcess()).toBe(1);
+      expect(process.errors.join("\n")).toContain(
+        "Retarget ended before it reported",
+      );
+      expect(process.errors.join("\n")).toContain(
+        "1 row settled — applied: 1.",
+      );
+      // The abandoned promise is the run that never came back; naming it
+      // keeps the lint's floating-promise rule honest about that.
+      expect(abandoned).toBeInstanceOf(Promise);
+    });
+
+    it("says nothing at process end once the run has reported", async () => {
+      const process = guardHarness();
+      await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: () => Promise.resolve(REPORT),
+          printHint: () => {},
+          guard: process.deps,
+        })
+      );
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
+    });
+
+    it("says nothing at process end when the run threw", async () => {
+      // The refusal is its own report, and the CLI prints it on the way to
+      // a nonzero exit; a second line about an unreported run would be one
+      // the caller has to rule out.
+      const process = guardHarness();
+      await expect(
+        retargetFromCommand(OPTIONS, {
+          runRetarget: () => Promise.reject(new Error("the plan is stale")),
+          printHint: () => {},
+          guard: process.deps,
+        }),
+      ).rejects.toThrow("the plan is stale");
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
     });
   });
 

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -689,6 +689,60 @@ describe("piece-retarget", () => {
       expect(process.errors).toEqual([]);
     });
 
+    it("says the report failed, not that the run never returned, when output throws", async () => {
+      // The engine came back with every row; what broke was the writing of
+      // it. Claiming the run was "still in flight" would be false, and it
+      // would be printed beside the real error — two statements, one wrong.
+      const process = guardHarness();
+      await expect(
+        retargetFromCommand({ ...OPTIONS, out: "report.json", apply: true }, {
+          runRetarget: (_config, request) => {
+            for (const row of REPORT.rows) request.onRow?.(row);
+            return Promise.resolve(REPORT);
+          },
+          writeTextFile: () => Promise.reject(new Error("the disk is full")),
+          printHint: () => {},
+          guard: process.deps,
+        }),
+      ).rejects.toThrow("the disk is full");
+      // Nonzero anyway, since the throw is what the CLI exits on; the guard
+      // adds the tally that the failed report never got to print.
+      expect(process.endProcess()).toBe(1);
+      const said = process.errors.join("\n");
+      expect(said).toContain(
+        "Retarget ran to a report, but the process exited before that " +
+          "report finished.",
+      );
+      expect(said).not.toContain("still in flight");
+      expect(said).toContain("2 rows settled — applied: 1 · landed: 1.");
+    });
+
+    it("still guards a report that hangs rather than throws", async () => {
+      // The window a `finally` released at the engine's return would have
+      // reopened: the report never finishes, nothing throws, and the process
+      // drains — the original defect, moved one step later. The guard is
+      // still armed, so the run is still accounted for.
+      const process = guardHarness();
+      const abandoned = retargetFromCommand(
+        { ...OPTIONS, out: "report.json", apply: true },
+        {
+          runRetarget: (_config, request) => {
+            for (const row of REPORT.rows) request.onRow?.(row);
+            return Promise.resolve(REPORT);
+          },
+          writeTextFile: () => new Promise<void>(() => {}),
+          printHint: () => {},
+          guard: process.deps,
+        },
+      );
+      await Promise.resolve();
+      expect(process.endProcess()).toBe(1);
+      const said = process.errors.join("\n");
+      expect(said).toContain("Retarget ran to a report");
+      expect(said).toContain("2 rows settled — applied: 1 · landed: 1.");
+      expect(abandoned).toBeInstanceOf(Promise);
+    });
+
     it("says nothing at process end when the run threw", async () => {
       // The refusal is its own report, and the CLI prints it on the way to
       // a nonzero exit; a second line about an unreported run would be one

--- a/packages/cli/test/piece-rollback.test.ts
+++ b/packages/cli/test/piece-rollback.test.ts
@@ -262,12 +262,14 @@ describe("piece-rollback", () => {
       const out = await captureStdout(() =>
         rollbackFromCommand({ ...ROLLBACK_OPTIONS, json: true }, {
           runRollback: (_config, request) => {
-            // A single document cannot stream, so no row reporter is handed
-            // to the library at all. The key set, not each value: an
-            // `apply: undefined` riding along is a key the library still
-            // has to reason about, and every matcher that asks about one
-            // property reads a present-but-undefined key as an absent one.
-            expect(Object.keys(request).sort()).toEqual(["planPath"]);
+            // A single document cannot stream, so the reporter this mode
+            // hands the library observes and never prints. The key set, not
+            // each value: an `apply: undefined` riding along is a key the
+            // library still has to reason about, and every matcher that asks
+            // about one property reads a present-but-undefined key as an
+            // absent one.
+            expect(Object.keys(request).sort()).toEqual(["onRow", "planPath"]);
+            for (const row of REPORT.rows) request.onRow?.(row);
             return Promise.resolve({ report: REPORT, plan: DERIVED });
           },
           printHint: () => {},
@@ -275,6 +277,9 @@ describe("piece-rollback", () => {
       );
       expect(out.startsWith("fvj1:")).toBe(true);
       expect(out).toContain('"elapsedMs":412');
+      // What "cannot stream" means, asserted directly: two rows went through
+      // the reporter above and stdout still carries one line, the document.
+      expect(out.trimEnd().split("\n")).toHaveLength(1);
     });
 
     it("exits nonzero on a stopped run, naming every unattempted piece", async () => {
@@ -374,6 +379,26 @@ describe("piece-rollback", () => {
       );
       expect(process.errors.join("\n")).toContain("1 row settled");
       expect(abandoned).toBeInstanceOf(Promise);
+    });
+
+    it("counts the rows a document-mode run settled, which wrote no document", async () => {
+      // `--json` builds what it emits from the returned report, so a run
+      // that never returns emits nothing and this line is the whole account.
+      const process = guardHarness();
+      const out = await captureStdout(() => {
+        rollbackFromCommand({ ...ROLLBACK_OPTIONS, json: true, apply: true }, {
+          runRollback: (_config, request) => {
+            request.onRow?.(REPORT.rows[0]);
+            return new Promise<never>(() => {});
+          },
+          printHint: () => {},
+          guard: process.deps,
+        });
+        return Promise.resolve();
+      });
+      expect(process.endProcess()).toBe(1);
+      expect(process.errors.join("\n")).toContain("1 row settled — applied: 1");
+      expect(out).toBe("");
     });
 
     it("says nothing at process end once the run has reported", async () => {

--- a/packages/cli/test/piece-rollback.test.ts
+++ b/packages/cli/test/piece-rollback.test.ts
@@ -401,6 +401,31 @@ describe("piece-rollback", () => {
       expect(out).toBe("");
     });
 
+    it("says the report failed, not that the run never returned, when output throws", async () => {
+      // As the retarget: the engine returned, the writing of it did not, and
+      // the guard's line has to say which.
+      const process = guardHarness();
+      await expect(
+        rollbackFromCommand(
+          { ...ROLLBACK_OPTIONS, out: "report.json", apply: true },
+          {
+            runRollback: (_config, request) => {
+              for (const row of REPORT.rows) request.onRow?.(row);
+              return Promise.resolve({ report: REPORT, plan: DERIVED });
+            },
+            writeTextFile: () => Promise.reject(new Error("the disk is full")),
+            printHint: () => {},
+            guard: process.deps,
+          },
+        ),
+      ).rejects.toThrow("the disk is full");
+      expect(process.endProcess()).toBe(1);
+      const said = process.errors.join("\n");
+      expect(said).toContain("Rollback ran to a report");
+      expect(said).not.toContain("still in flight");
+      expect(said).toContain("2 rows settled — applied: 1 · landed: 1.");
+    });
+
     it("says nothing at process end once the run has reported", async () => {
       const process = guardHarness();
       await captureStdout(() =>

--- a/packages/cli/test/piece-rollback.test.ts
+++ b/packages/cli/test/piece-rollback.test.ts
@@ -438,6 +438,26 @@ describe("piece-rollback", () => {
       expect(process.endProcess()).toBe(0);
       expect(process.errors).toEqual([]);
     });
+
+    it("says nothing at process end when the run threw", async () => {
+      // The derivation refuses before any session opens — an unretained row
+      // nobody accepted is the ordinary way. That refusal IS the report, and
+      // the CLI prints it on the way to a nonzero exit; a guard line beside
+      // it would be a second account of a run that already gave one.
+      const process = guardHarness();
+      await expect(
+        rollbackFromCommand(ROLLBACK_OPTIONS, {
+          runRollback: () =>
+            Promise.reject(
+              new Error("The prior source is not retained for fid1:aaa."),
+            ),
+          printHint: () => {},
+          guard: process.deps,
+        }),
+      ).rejects.toThrow("not retained");
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
+    });
   });
 
   describe("runRollback()", () => {

--- a/packages/cli/test/piece-rollback.test.ts
+++ b/packages/cli/test/piece-rollback.test.ts
@@ -6,7 +6,7 @@
  * the listing, the preflight, the write — and the exit discipline of both.
  */
 
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type {
   ApplyReport,
@@ -17,6 +17,8 @@ import type {
 import { decode } from "@commonfabric/utils/encoding";
 
 import { runRestore, runRollback } from "../lib/bulk.ts";
+import { resetUnreportedRunGuardsForTest } from "../lib/unreported-run.ts";
+import { guardHarness } from "./unreported-run-helpers.ts";
 import {
   formatRestorableRevision,
   piece,
@@ -146,6 +148,9 @@ const LISTING: RestoreOutcome = {
 describe("piece-rollback", () => {
   // The fixtures pass `quiet`, and the actions apply it globally.
   afterEach(() => setQuietMode(false));
+  // The process-end hook is installed once per process, by the first run to
+  // arm a guard; a case that injects its own effects starts from none.
+  beforeEach(() => resetUnreportedRunGuardsForTest());
 
   describe("formatRestorableRevision()", () => {
     it("puts the id, the time, the reference, and both standings on one line", () => {
@@ -343,6 +348,45 @@ describe("piece-rollback", () => {
         actionHandler?: unknown;
       };
       expect(registered?.actionHandler).toBe(rollbackFromCommand);
+    });
+
+    it("reports what settled and exits nonzero when the process outlives the run", async () => {
+      // The rollback runs the retarget's engine over the retarget's grouped
+      // sessions, so a run that stops settling ends the process the same
+      // silent way — half a reversal made, exit 0, no summary.
+      const process = guardHarness();
+      const abandoned = rollbackFromCommand(
+        { ...ROLLBACK_OPTIONS, apply: true },
+        {
+          runRollback: (_config, request) => {
+            request.onRow?.(REPORT.rows[0]);
+            return new Promise<never>(() => {});
+          },
+          render: () => {},
+          printHint: () => {},
+          guard: process.deps,
+        },
+      );
+      await Promise.resolve();
+      expect(process.endProcess()).toBe(1);
+      expect(process.errors.join("\n")).toContain(
+        "Rollback ended before it reported",
+      );
+      expect(process.errors.join("\n")).toContain("1 row settled");
+      expect(abandoned).toBeInstanceOf(Promise);
+    });
+
+    it("says nothing at process end once the run has reported", async () => {
+      const process = guardHarness();
+      await captureStdout(() =>
+        rollbackFromCommand(ROLLBACK_OPTIONS, {
+          runRollback: () => Promise.resolve({ report: REPORT, plan: DERIVED }),
+          printHint: () => {},
+          guard: process.deps,
+        })
+      );
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
     });
   });
 

--- a/packages/cli/test/unreported-run-helpers.ts
+++ b/packages/cli/test/unreported-run-helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * One process's worth of the process-end guard's effects, plus the ending
+ * Deno performs when the event loop drains around a promise that never
+ * settles: the unload hook runs, and then the exit code stands.
+ *
+ * Shared by the guard's own tests and by every command that arms one, so all
+ * of them observe the same ending rather than each modelling it a little
+ * differently.
+ */
+
+import type { UnreportedRunDeps } from "../lib/unreported-run.ts";
+
+export interface GuardHarness {
+  /** The effects to hand a command as its `guard` dependency. */
+  deps: UnreportedRunDeps;
+
+  /** What the guard reported, in order. */
+  errors: string[];
+
+  /** End the process; returns the code it ends with. */
+  endProcess: () => number;
+}
+
+/** A harness whose process is ending with `startingExitCode` (0 by default). */
+export function guardHarness(startingExitCode = 0): GuardHarness {
+  const errors: string[] = [];
+  let exitCode = startingExitCode;
+  let hook: (() => void) | undefined;
+  return {
+    errors,
+    deps: {
+      addUnloadListener: (handler) => {
+        hook = handler;
+      },
+      printError: (message) => {
+        errors.push(message);
+      },
+      readExitCode: () => exitCode,
+      setExitCode: (code) => {
+        exitCode = code;
+      },
+    },
+    endProcess: () => {
+      hook?.();
+      return exitCode;
+    },
+  };
+}

--- a/packages/cli/test/unreported-run.test.ts
+++ b/packages/cli/test/unreported-run.test.ts
@@ -19,14 +19,21 @@ import {
 } from "../lib/unreported-run.ts";
 import { guardHarness as harness } from "./unreported-run-helpers.ts";
 
-/** A watched run that has settled `verdicts` so far. */
+/** A watched run, still in its engine, that has settled `verdicts` so far. */
 function progressOf(verdicts: [string, number][]): ApplyRunProgress {
-  return { observed: true, verdicts: new Map(verdicts) };
+  return { observed: true, verdicts: new Map(verdicts), phase: "running" };
 }
 
-/** A run whose engine reports its rows only when it returns. */
-function unwatchedProgress(): ApplyRunProgress {
-  return { observed: false, verdicts: new Map() };
+/** A watched run whose engine returned and whose report is being written. */
+function reportingProgress(verdicts: [string, number][]): ApplyRunProgress {
+  return { observed: true, verdicts: new Map(verdicts), phase: "reporting" };
+}
+
+/** A run whose engine counts its rows only in the report it returns. */
+function unwatchedProgress(
+  phase: ApplyRunProgress["phase"] = "running",
+): ApplyRunProgress {
+  return { observed: false, verdicts: new Map(), phase };
 }
 
 const testDir = dirname(fromFileUrl(import.meta.url));
@@ -162,6 +169,54 @@ describe("unreported-run", () => {
           progressOf([["landed", 25], ["applied", 50]]),
         ),
       ).toContain("75 rows settled — landed: 25 · applied: 50.");
+    });
+
+    it("never says a returned run did not return", () => {
+      // The mirror of the count being wrong: a report that failed to print
+      // is not an engine that failed to come back, and claiming so would be
+      // the same lie pointing the other way.
+      const line = describeUnreportedApplyRun(
+        "Retarget",
+        reportingProgress([["applied", 125]]),
+      );
+      expect(line).toContain(
+        "Retarget ran to a report, but the process exited before that " +
+          "report finished.",
+      );
+      expect(line).not.toContain("still in flight");
+      expect(line).toContain("125 rows settled — applied: 125.");
+      expect(line).toContain("What the report would have said beyond this");
+    });
+
+    it("stops hedging the count once the engine has returned", () => {
+      // While the engine runs, rows may follow the ones counted. Once it has
+      // returned, a watched run's count IS its report's row count, and the
+      // hedge would understate what is known.
+      expect(
+        describeUnreportedApplyRun("Rollback", progressOf([["applied", 3]])),
+      ).toContain("Whether anything after them was written is not known here");
+      expect(
+        describeUnreportedApplyRun(
+          "Rollback",
+          reportingProgress([["applied", 3]]),
+        ),
+      ).not.toContain("Whether anything after them");
+    });
+
+    it("gives an unwatched run a reason that holds in either phase", () => {
+      // "It did not return" was true of one phase only. The missing row
+      // callback is the real reason, and it is the reason in both.
+      for (const phase of ["running", "reporting"] as const) {
+        const line = describeUnreportedApplyRun(
+          "Repair",
+          unwatchedProgress(phase),
+        );
+        expect(line).toContain(
+          "this run counts its rows only in the report itself",
+        );
+        expect(line).not.toContain("it did not return");
+        expect(line).not.toContain("No row settled");
+      }
     });
   });
 

--- a/packages/cli/test/unreported-run.test.ts
+++ b/packages/cli/test/unreported-run.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The process-end guard a run that writes arms over itself: what it reports
+ * when the process ends first, what it leaves alone once the run has
+ * reported, and the exit code each of those ends with.
+ */
+
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { dirname, fromFileUrl, join } from "@std/path";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
+import {
+  type ApplyRunProgress,
+  describeUnreportedApplyRun,
+  guardRunReport,
+  resetUnreportedRunGuardsForTest,
+  type UnreportedRunDeps,
+} from "../lib/unreported-run.ts";
+import { guardHarness as harness } from "./unreported-run-helpers.ts";
+
+function progressOf(verdicts: [string, number][]): ApplyRunProgress {
+  return { verdicts: new Map(verdicts) };
+}
+
+const testDir = dirname(fromFileUrl(import.meta.url));
+const repoRoot = join(testDir, "..", "..", "..");
+const fixture = join(testDir, "fixtures", "unreported-run-process.ts");
+const decoder = new TextDecoder();
+
+/** Run the fixture to completion and report how the process ended. */
+async function endedProcess(
+  ...args: string[]
+): Promise<{ code: number; stderr: string }> {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: repoRoot,
+    args: (lockPath) => ["run", `--lock=${lockPath}`, fixture, ...args],
+  });
+  return { code: output.code, stderr: decoder.decode(output.stderr) };
+}
+
+describe("unreported-run", () => {
+  beforeEach(() => resetUnreportedRunGuardsForTest());
+
+  describe("guardRunReport()", () => {
+    it("reports the run and raises a zero exit code when the process ends first", () => {
+      const process = harness();
+      guardRunReport(() => "the run never reported", process.deps);
+      expect(process.endProcess()).toBe(1);
+      expect(process.errors).toEqual(["the run never reported"]);
+    });
+
+    it("prints nothing and leaves the exit code at zero once the run reported", () => {
+      const process = harness();
+      const guard = guardRunReport(() => "unreachable", process.deps);
+      guard.reported();
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
+    });
+
+    it("leaves a nonzero exit code as the process set it", () => {
+      // The failure already has a reason of its own, and its report is what
+      // the caller is about to read.
+      const process = harness(2);
+      guardRunReport(() => "the run never reported", process.deps);
+      expect(process.endProcess()).toBe(2);
+      expect(process.errors).toEqual(["the run never reported"]);
+    });
+
+    it("composes its line at the moment the process ends", () => {
+      const process = harness();
+      let settled = 0;
+      guardRunReport(() => `settled ${settled}`, process.deps);
+      settled = 7;
+      process.endProcess();
+      expect(process.errors).toEqual(["settled 7"]);
+    });
+
+    it("reports every still-armed run from one process-end hook", () => {
+      const process = harness();
+      let hooks = 0;
+      const deps: UnreportedRunDeps = {
+        ...process.deps,
+        addUnloadListener: (handler) => {
+          hooks += 1;
+          process.deps.addUnloadListener!(handler);
+        },
+      };
+      const first = guardRunReport(() => "first", deps);
+      guardRunReport(() => "second", deps);
+      first.reported();
+      expect(process.endProcess()).toBe(1);
+      expect(hooks).toBe(1);
+      expect(process.errors).toEqual(["second"]);
+    });
+
+    it("treats a second stand-down as the first", () => {
+      const process = harness();
+      const guard = guardRunReport(() => "unreachable", process.deps);
+      guard.reported();
+      guard.reported();
+      expect(process.endProcess()).toBe(0);
+      expect(process.errors).toEqual([]);
+    });
+  });
+
+  describe("describeUnreportedApplyRun()", () => {
+    it("names the verb, the rows that settled, and what resumes the run", () => {
+      const line = describeUnreportedApplyRun(
+        "Retarget",
+        progressOf([["applied", 75]]),
+      );
+      expect(line).toContain(
+        "Retarget ended before it reported: the process exited while the " +
+          "run was still in flight.",
+      );
+      expect(line).toContain("75 rows settled — applied: 75.");
+      expect(line).toContain("Re-running resumes from what landed");
+    });
+
+    it("counts one settled row in the singular", () => {
+      expect(
+        describeUnreportedApplyRun("Rollback", progressOf([["applied", 1]])),
+      ).toContain("1 row settled — applied: 1.");
+    });
+
+    it("says no row settled when the run streamed none", () => {
+      // The repair streams no rows at all, and a stopped retarget can end
+      // before its first row does.
+      expect(
+        describeUnreportedApplyRun("Repair", progressOf([])),
+      ).toContain("No row settled");
+    });
+
+    it("keeps every verdict it was given on the tally", () => {
+      expect(
+        describeUnreportedApplyRun(
+          "Retarget",
+          progressOf([["landed", 25], ["applied", 50]]),
+        ),
+      ).toContain("75 rows settled — landed: 25 · applied: 50.");
+    });
+  });
+
+  describe("the process it guards", () => {
+    it("ends nonzero, saying so, when the run never reported", async () => {
+      // The whole defect in one process: a promise that never settles, an
+      // event loop with nothing left on it, and — without the guard — a
+      // silent exit at code 0. This is the case the injected effects above
+      // cannot reach, because Deno owns both `unload` and `Deno.exitCode`.
+      const ended = await endedProcess();
+      expect(ended.code).toBe(1);
+      expect(ended.stderr).toContain("the run never reported");
+    });
+
+    it("ends at zero, silently, once the run reported", async () => {
+      const ended = await endedProcess("report");
+      expect(ended.code).toBe(0);
+      expect(ended.stderr).not.toContain("the run never reported");
+    });
+  });
+});

--- a/packages/cli/test/unreported-run.test.ts
+++ b/packages/cli/test/unreported-run.test.ts
@@ -19,8 +19,14 @@ import {
 } from "../lib/unreported-run.ts";
 import { guardHarness as harness } from "./unreported-run-helpers.ts";
 
+/** A watched run that has settled `verdicts` so far. */
 function progressOf(verdicts: [string, number][]): ApplyRunProgress {
-  return { verdicts: new Map(verdicts) };
+  return { observed: true, verdicts: new Map(verdicts) };
+}
+
+/** A run whose engine reports its rows only when it returns. */
+function unwatchedProgress(): ApplyRunProgress {
+  return { observed: false, verdicts: new Map() };
 }
 
 const testDir = dirname(fromFileUrl(import.meta.url));
@@ -115,7 +121,12 @@ describe("unreported-run", () => {
           "run was still in flight.",
       );
       expect(line).toContain("75 rows settled — applied: 75.");
-      expect(line).toContain("Re-running resumes from what landed");
+      expect(line).toContain("Re-running resumes it");
+      // The same command minus `--apply`, not a survey: a survey reads
+      // references, which say nothing about the repair's work in documents,
+      // and one line serves all three verbs.
+      expect(line).toContain("without `--apply` says where every piece now");
+      expect(line).not.toContain("survey");
     });
 
     it("counts one settled row in the singular", () => {
@@ -124,12 +135,24 @@ describe("unreported-run", () => {
       ).toContain("1 row settled — applied: 1.");
     });
 
-    it("says no row settled when the run streamed none", () => {
-      // The repair streams no rows at all, and a stopped retarget can end
-      // before its first row does.
+    it("says no row settled when a watched run ended before its first", () => {
+      // Zero is a fact here: the run's rows were being watched, and none
+      // arrived. A retarget can end this way — inside the preflight, or in
+      // the plan decode before a session ever opens.
       expect(
-        describeUnreportedApplyRun("Repair", progressOf([])),
-      ).toContain("No row settled");
+        describeUnreportedApplyRun("Retarget", progressOf([])),
+      ).toContain("No row settled before it ended");
+    });
+
+    it("says the count is unknown for a run whose rows it never watched", () => {
+      // The repair's engine reports its rows only in the report it returns.
+      // Its rows really do settle, so "no row settled" would be false of it
+      // — and a false line is worse than an unhelpful one, because an
+      // operator can act on it.
+      const line = describeUnreportedApplyRun("Repair", unwatchedProgress());
+      expect(line).toContain("How many rows it settled is not known here");
+      expect(line).not.toContain("No row settled");
+      expect(line).not.toContain("0 rows");
     });
 
     it("keeps every verdict it was given on the tally", () => {


### PR DESCRIPTION
## Why

A 125-row `cf piece retarget --apply` against a real Topics clone **wrote 75 rows, printed no summary, and exited 0.** The operator's wrapper checked the exit code, got 0, and would have reported the migration complete. Against production that is a half-migrated board nobody knows is half-migrated. Found by the first person to use this tooling who did not build it.

The mechanism, measured rather than reasoned: `cf` is invoked as a floating `main(Deno.args)` (`packages/cli/mod.ts:65`), so Deno's "Top-level await promise never resolved" detector does not cover it. An await that stops settling mid-run drains the event loop, and Deno ends such a process **silently at code 0**. A six-line probe reproduces it exactly: rows print, summary does not, exit 0.

The summary line and the nonzero-exit-on-incomplete both already existed and were tested — `reportApplyRun`'s tally hint, and `exitWithDataError` behind `if (!report.complete)`. **The defect was unreachability, not wrongness.** Neither ran because the report never came back, and the engine never reached its own report loop either: the 50 remaining rows would have streamed as `unattempted` through `onRow`, and none did.

## What Changed

`guardRunReport()` (`packages/cli/lib/unreported-run.ts`): a run that writes arms a guard over `unload` and stands it down the moment it has reported. If the process ends with a run still armed, the guard names the verb, how many rows settled and their verdicts, and what resumes the run — then raises a zero exit code to 1, leaving a nonzero code alone. Armed on the process ending rather than on a clock, so it costs a finishing run nothing and cannot cut one short. Scoped to the runs that write: `retarget`, `rollback`, `repair` arm it before the first session opens and stand it down after the tally and on the throw path.

Deliberately **not** switching the entry to `await main(...)`, which would let Deno's own detector catch this shape: measured, that path skips the `unload` event entirely, silencing this guard *and* the existing deferred version-skew note that depends on `unload` firing.

**The root cause is not fixed here and the PR does not claim it is.** The guard makes the silence impossible, not the stall. Narrowed brief for whoever owns runtime/storage: between `packages/cli/lib/piece.ts:582` and `bulk-apply.ts:620`, on the 5th sequential `Runtime`+`StorageManager` open in one process, an await stopped settling — and, measured, with no open websocket, no in-flight fetch and no subprocess outstanding, since any of those would have kept the process alive instead of letting it exit.

Sharing: `rollback` has the identical trigger (same sessions, same engine). `repair` opens one session so it has no group boundary, but shares the ending — a stall anywhere leaves the fixer's writes half-made and says nothing.

## Test plan

Six unit cases over injected seams, plus two that spawn a **real subprocess** so the production wiring (`unload` + `Deno.exitCode`) is exercised rather than mocked — the injected seams cannot reach it. Three command-level cases reproduce the defect's shape directly: the injected runner returns a promise that never settles, the command promise is deliberately not awaited, and the harness ends the process.

Revert checks, each measured: deleting `armed.add(run)` fails 4 of 6 unit cases, both subprocess cases and all three command cases; deleting `guard?.reported()` from `reportApplyRun` fails the retarget and rollback quiet-path cases, and from the repair tail fails repair's; deleting the throw-path stand-down fails its case.

`packages/cli` 210 passed / 0 failed; `deno task check`, `fmt`, `lint`, `check-docs`, and the repo's other twelve gates all pass. No existing test weakened.

**Also noted for routing, not fixed:** `runtime.ts:3132-3146`'s `healthCheck` never reads or cancels its response body — one unconsumed body per session, and this arc now opens a runtime per group. Not the cause (an unread body is not an event-loop op, which is exactly why the process could exit), but a leak in a loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

