### PR TITLE
perf(scripts): the topics export reads the store, not the CLI

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2708,6 +2708,7 @@
       },
       "scripts": {
         "dependencies": [
+          "jsr:@db/sqlite@0.13.0",
           "npm:@viz-js/viz@3.26.0",
           "npm:htmlparser2@12",
           "npm:marked@^18.0.6"

--- a/packages/cli/integration/topics-restore-drill.sh
+++ b/packages/cli/integration/topics-restore-drill.sh
@@ -145,7 +145,8 @@ while read -r candidate; do
   [ -n "$candidate" ] || continue
   sqlite3 "$ENGINE_DIR/$candidate" "VACUUM INTO '$WORK/$candidate'" \
     2> /dev/null || continue
-  if deno run --allow-run --allow-read --allow-write \
+  if deno run --allow-read --allow-write --allow-env --allow-ffi \
+    --allow-net=github.com,release-assets.githubusercontent.com \
     "$REPO_ROOT/scripts/topics-export.ts" "$WORK/$candidate" \
     --out "$WORK/export.json" > "$WORK/export.log" 2>&1; then
     NEW_DB="$candidate"

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -300,9 +300,10 @@ describe("cf inspect capped listings", () => {
       ).run();
       db.close();
 
-      // The shape `scripts/topics-export.ts` runs to guard a rollback payload.
       // A filtered scan drops what it cannot classify, so the omission has to
-      // reach the exit code — the notice alone never reaches `cfJson`.
+      // reach the exit code: the notice goes to stderr, and a `--json`
+      // consumer reads stdout, where a subset parses exactly like the whole
+      // set.
       const refused = await cf(
         `inspect entities ${path} --kind piece --require-complete --json`,
       );

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -781,8 +781,10 @@ describe("scan-extent", () => {
         (space) => {
           // The filter drops the undecodable row because its kind cannot be
           // determined — which is precisely why the omission has to be
-          // reported. `topics-export.ts` runs this exact scan under
-          // `--require-complete` to guard a rollback payload.
+          // reported. `scripts/topics-export.ts` runs this exact scan and
+          // refuses to write a rollback payload when `isCompleteScan` says
+          // no, so this report is what stands between an operator and a
+          // partial export that reads like a whole one.
           const listing = listEntityModels(space, { kind: "piece" });
           expect(listing.entities.map((e) => e.id)).toEqual(["of:piece-1"]);
           expect(listing.extent.unreadable).toBe(1);

--- a/scripts/deno.jsonc
+++ b/scripts/deno.jsonc
@@ -2,6 +2,7 @@
   // Dependency guide: ../docs/development/DEPENDENCIES.md
   // This directory is explicitly excluded from coverage checking.
   "imports": {
+    "@db/sqlite": "jsr:@db/sqlite@0.13.0",
     "@viz-js/viz": "npm:@viz-js/viz@3.26.0",
     "htmlparser2": "npm:htmlparser2@^12.0.0",
     "marked": "npm:marked@^18.0.6"

--- a/scripts/topics-export.test.ts
+++ b/scripts/topics-export.test.ts
@@ -1,0 +1,300 @@
+/**
+ * `topics-export.ts` against a seeded snapshot, run the way an operator runs
+ * it: as a subprocess, under a permission list that grants no right to start
+ * a process.
+ *
+ * That framing carries the property this file exists to hold. The export
+ * reads the store once through `@commonfabric/state-inspector` instead of
+ * shelling out to `cf` per entity, which is the difference between 24 seconds
+ * and days against the real Topics space — and a permission list is where
+ * that choice becomes observable from outside a wall clock. Reading the store
+ * needs FFI, the environment, and on a cold cache the network; spawning `cf`
+ * needs `--allow-run`, which is withheld here, so a selection that went back
+ * to a subprocess fails on its first read rather than merely taking hours.
+ *
+ * The rest of the assertions cover what the export must not quietly change
+ * while getting faster: comment elements resolved to their stored content,
+ * the annotated `$link` shape kept in the forensic copy, and a listing that
+ * cannot cover the space refused rather than written out as if it had.
+ */
+
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+import { fromFileUrl } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
+import type { TopicsExport } from "./topics-rehearsal-lib.ts";
+
+const SCRIPT = fromFileUrl(new URL("./topics-export.ts", import.meta.url));
+const REPO_ROOT = fromFileUrl(new URL("../", import.meta.url));
+
+/**
+ * The permissions every run below is given — written out here rather than
+ * read back from the shebang, so that reverting the script to a subprocess
+ * per entity fails these tests instead of travelling with them.
+ *
+ * The two hosts are where `plug` fetches the SQLite library on a cold cache,
+ * and they are here so that this list and the shebang can be asserted equal.
+ * The runs below never reach them: seeding opens SQLite in this process
+ * first, which leaves the library cached for the subprocess.
+ */
+const RUN_PERMISSIONS = [
+  "--allow-read",
+  "--allow-write",
+  "--allow-env",
+  "--allow-ffi",
+  "--allow-net=github.com,release-assets.githubusercontent.com",
+];
+
+/** The `--allow-…` flags the script's own shebang declares, in order. */
+function shebangPermissions(): string[] {
+  return Deno.readTextFileSync(SCRIPT)
+    .split("\n")[0]
+    .split(/\s+/)
+    .filter((word) => word.startsWith("--allow-"));
+}
+
+const SESSION = "session:did%3Akey%3AzTopicsDrill:s1";
+const BOARD_IDENTITY = "MKlcErXYo-5CPTDJD2r1Gl08KwiWcxqxmuDGikVcTqk";
+const TOPIC_IDENTITY = "uqb-PnkKp_PJYZ6F82dth3k5KNaZLzt9sBgFafbllkw";
+
+const BOARD = "of:fid1:board";
+const BOARD_ARGUMENT = "of:fid1:board-argument";
+const TOPIC = "of:fid1:topic";
+const TOPIC_ARGUMENT = "of:fid1:topic-argument";
+const COMMENT = "of:fid1:comment";
+
+/** A stored link, in the sigil form the engine writes. */
+const link = (id: string) => ({ "/": { "link@1": { id } } });
+const stream = { $stream: true };
+
+/** The comment body an element of `comments` points at, never inlines. */
+const COMMENT_VALUE = {
+  author: { kind: "agent", name: "drill" },
+  authorName: "drill (agent)",
+  body: "first drill comment",
+  sentAt: 1786913119000,
+};
+
+const TOPIC_BODY = "# Drill\n\n    indented code block\n\ntrailing prose";
+
+/**
+ * A board, one topic, their argument documents, the topic's one comment, and
+ * a free cell that is none of those. Selection is by verb shape, so the two
+ * pieces differ only in the keys their result offers.
+ */
+const ENTITIES: { id: string; document: Record<string, unknown> }[] = [
+  {
+    id: BOARD,
+    document: {
+      value: { $NAME: "Topics", addTopic: stream, topics: [link(TOPIC)] },
+      patternIdentity: { identity: BOARD_IDENTITY, symbol: "default" },
+      argument: link(BOARD_ARGUMENT),
+    },
+  },
+  { id: BOARD_ARGUMENT, document: { value: { topics: [link(TOPIC)] } } },
+  {
+    id: TOPIC,
+    document: {
+      value: {
+        $NAME: "Drill: alpha",
+        addComment: stream,
+        addLink: stream,
+        setBody: stream,
+      },
+      patternIdentity: { identity: TOPIC_IDENTITY, symbol: "default" },
+      argument: link(TOPIC_ARGUMENT),
+    },
+  },
+  {
+    id: TOPIC_ARGUMENT,
+    document: {
+      value: {
+        title: "Drill: alpha",
+        body: TOPIC_BODY,
+        createdAt: 1786913118000,
+        createdByName: "drill",
+        comments: [link(COMMENT)],
+        links: [],
+        mentionable: link(BOARD_ARGUMENT),
+      },
+    },
+  },
+  { id: COMMENT, document: { value: COMMENT_VALUE } },
+  { id: "of:fid1:unrelated", document: { value: "a free cell" } },
+];
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON,
+  commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 999, 'active');`;
+
+/**
+ * Write the fixture space. `undecodable` adds a payload no reconstruction can
+ * read, which a `kind` scan drops because it cannot classify it — the shape
+ * that makes a piece listing cover less than the space.
+ */
+function seed(path: string, opts: { undecodable?: boolean } = {}): void {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{"seq":0}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  for (const entity of ENTITIES) {
+    seq++;
+    commit.run(seq, SESSION, seq);
+    rev.run(entity.id, seq, JSON.stringify(entity.document), seq);
+  }
+  if (opts.undecodable) {
+    seq++;
+    commit.run(seq, SESSION, seq);
+    rev.run("of:fid1:corrupt", seq, "<<< not a document >>>", seq);
+  }
+  db.close();
+}
+
+interface ExportRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+  outPath: string;
+}
+
+/**
+ * Seed a space, export it, and return the process result. The seeding opens
+ * SQLite in THIS process first, so the dynamic library is already cached by
+ * the time the subprocess loads it and no run here depends on the network.
+ */
+async function runExport(
+  opts: { undecodable?: boolean } = {},
+): Promise<ExportRun> {
+  const dir = await Deno.makeTempDir({ prefix: "topics-export-" });
+  const dbPath = `${dir}/did:key:zSeededTopicsSpace.sqlite`;
+  const outPath = `${dir}/export.json`;
+  seed(dbPath, opts);
+  const output = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    args: (lockPath) => [
+      "run",
+      "--lock",
+      lockPath,
+      "--frozen=true",
+      ...RUN_PERMISSIONS,
+      SCRIPT,
+      dbPath,
+      "--out",
+      outPath,
+    ],
+  });
+  return {
+    code: output.code,
+    stdout: new TextDecoder().decode(output.stdout),
+    stderr: new TextDecoder().decode(output.stderr),
+    outPath,
+  };
+}
+
+describe("topics-export", () => {
+  describe("a seeded topics space", () => {
+    let run: ExportRun;
+    let exported: TopicsExport;
+
+    beforeAll(async () => {
+      run = await runExport();
+      if (run.code === 0) {
+        exported = JSON.parse(await Deno.readTextFile(run.outPath));
+      }
+    });
+
+    it("exits zero with no permission to start a process", () => {
+      expect(run.stderr).not.toContain("NotCapable");
+      expect(run.code).toBe(0);
+    });
+
+    it("declares that same permission list in its shebang", () => {
+      expect(shebangPermissions()).toEqual(RUN_PERMISSIONS);
+    });
+
+    it("selects the topic by its verbs and records where it came from", () => {
+      expect(exported.topics.map((t) => t.fid)).toEqual([TOPIC]);
+      expect(exported.topics[0].patternIdentity).toBe(TOPIC_IDENTITY);
+      expect(exported.topics[0].argumentId).toBe(TOPIC_ARGUMENT);
+    });
+
+    it("resolves a comment element to the content it links", () => {
+      expect(exported.topics[0].content.comments).toEqual([COMMENT_VALUE]);
+      expect(exported.topics[0].content.body).toBe(TOPIC_BODY);
+    });
+
+    it("keeps the annotated link shape in the forensic copy", () => {
+      const raw = exported.topics[0].rawArgument as Record<string, unknown>;
+      expect(raw.comments).toEqual([{ $link: { id: COMMENT } }]);
+      expect(raw.mentionable).toEqual({ $link: { id: BOARD_ARGUMENT } });
+    });
+
+    it("records the board's membership links as links", () => {
+      expect(exported.board?.fid).toBe(BOARD);
+      expect(exported.board?.patternIdentity).toBe(BOARD_IDENTITY);
+      expect(exported.board?.topicsLinks).toEqual([{ $link: { id: TOPIC } }]);
+    });
+
+    it("manifests every piece in the space and nothing that is not one", () => {
+      expect(exported.manifest.map((m) => m.fid).sort()).toEqual([
+        BOARD,
+        TOPIC,
+      ]);
+    });
+
+    it("summarizes the counts an operator cross-checks the manifest against", () => {
+      expect(run.stdout).toContain("topics: 1  comments: 1  links: 0");
+      expect(run.stdout).toContain("1 membership links");
+    });
+  });
+
+  describe("a space whose piece listing cannot cover it", () => {
+    let run: ExportRun;
+
+    beforeAll(async () => {
+      run = await runExport({ undecodable: true });
+    });
+
+    it("exits nonzero naming the entities it could not reconstruct", () => {
+      expect(run.code).not.toBe(0);
+      expect(run.stderr).toContain(
+        "refusing: the piece listing does not cover the space",
+      );
+      expect(run.stderr).toContain("could not be reconstructed");
+    });
+
+    it("writes no export beside the refusal", async () => {
+      const wrote = await Deno.stat(run.outPath).then(() => true).catch(() =>
+        false
+      );
+      expect(wrote).toBe(false);
+    });
+  });
+});

--- a/scripts/topics-export.ts
+++ b/scripts/topics-export.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-ffi --allow-net=github.com,release-assets.githubusercontent.com
 
 /**
  * Export every topic's authored content from a Topics space snapshot,
@@ -12,7 +12,8 @@
  *
  * The snapshot is a `VACUUM INTO` copy of the space store (the acquisition
  * step of docs/development/space-clone-rehearsal.md); everything here reads
- * it through `cf inspect`, so no server is involved. With no identity flags,
+ * it directly through `@commonfabric/state-inspector`, so no server is
+ * involved and no subprocess is spawned per entity. With no identity flags,
  * topics are selected by verb shape — a piece whose result offers
  * `addComment`, `addLink`, and `setBody` — and the board by `addTopic`; the
  * selected pattern identities are printed so an operator can confirm them
@@ -22,10 +23,33 @@
  * own, so the export resolves each element. Any deeper link inside a content
  * field aborts the export: recording a reference as if it were content is
  * exactly the silent corruption this tool exists to rule out.
+ *
+ * The permissions in the shebang are the complete set the store read needs,
+ * and the omission is as deliberate as the inclusions. Opening the snapshot
+ * loads SQLite over FFI and reads its configuration from the environment, so
+ * `--allow-ffi --allow-env`. The library is not shipped with `@db/sqlite`
+ * either: on a cold cache `plug` fetches it at RUNTIME from the two hosts
+ * named — the release URL and the target it redirects to — which is an
+ * ordinary `fetch` and so wants `--allow-net`. Only `--allow-run` is absent,
+ * because nothing here starts a process.
+ *
+ * `scripts/topics-export.test.ts` asserts this exact list, so changing it is
+ * a deliberate act rather than a drift. Verify any change against an empty
+ * `DENO_DIR`, never the cache this machine happens to be carrying: a warm
+ * cache makes the SQLite download disappear, and with it the evidence that
+ * the program ever reached the network at all.
  */
 
 import {
-  cfJson,
+  annotate,
+  getValueAt,
+  isCompleteScan,
+  listEntityModels,
+  openSpace,
+  resolveSpace,
+} from "@commonfabric/state-inspector";
+
+import {
   findLink,
   LINKED_ARRAY_FIELDS,
   SCALAR_CONTENT_FIELDS,
@@ -34,20 +58,11 @@ import {
   type TopicsExport,
 } from "./topics-rehearsal-lib.ts";
 
-interface EntityRow {
-  id: string;
-}
-
 interface PieceInfo {
   id: string;
   pattern?: { identity?: string };
   input?: { id?: string };
   resultKeys?: string[];
-}
-
-interface ValueAt {
-  exists: boolean;
-  value?: unknown;
 }
 
 function usage(): never {
@@ -76,32 +91,89 @@ if (!snapshot || positional.length > 1 || !outPath) usage();
 const didMatch = /(did:key:[A-Za-z0-9]+)\.sqlite$/.exec(snapshot);
 const spaceDid = didMatch ? didMatch[1] : null;
 
-// A capped listing would hand the export a subset of the space's pieces, and a
-// rollback payload missing topics reads exactly like a complete one. The limit
-// is named past any plausible piece count so the cap never bites in practice —
-// but a finite cap is still a cliff, and `cfJson` reads only stdout, so the
-// notice `cf` writes to stderr would go by unseen. `--require-complete` turns
-// the same condition into a nonzero exit, which `cf()` DOES raise: the export
-// either covers every piece in the space or it does not get written.
+// Named past any plausible piece count so the cap never bites in practice. A
+// finite cap is still a cliff, so the scan's own extent is checked below
+// rather than trusted.
 const PIECE_LIMIT = 1_000_000;
 
-const pieces = await cfJson<EntityRow[]>([
-  "inspect",
-  "entities",
-  snapshot,
-  "--kind",
-  "piece",
-  "--limit",
-  String(PIECE_LIMIT),
-  "--require-complete",
-  "--json",
-]);
+// Every read below goes through this ONE handle. The obvious spelling — shell
+// out to `cf` per entity — costs a `deno task` resolution and a fresh open of
+// a multi-gigabyte database for each of several thousand reads, which is hours
+// for a board this size. Same answers, one process.
+//
+// `annotate` at unbounded depth is not decoration either: it is what
+// `cf inspect value-at --json --full-depth` returns, and `findLink` below
+// reads the `$link` shape that annotation produces. Reading the raw value
+// instead would quietly change what the export records.
+const space = openSpace(await resolveSpace(snapshot));
+const annotateFully = (value: unknown) =>
+  annotate(value, Number.POSITIVE_INFINITY);
 
-const infos: PieceInfo[] = [];
-for (const row of pieces) {
-  infos.push(
-    await cfJson<PieceInfo>(["inspect", "piece", snapshot, row.id, "--json"]),
+const listing = listEntityModels(space, { limit: PIECE_LIMIT, kind: "piece" });
+// An incomplete listing would hand the export a subset of the space's pieces,
+// and a rollback payload missing topics reads exactly like a complete one. A
+// `kind` scan falls short two ways — it can hit the cap, and it drops any
+// entity it could not reconstruct well enough to classify — so the refusal
+// names which one happened, because only the first is answered by a larger
+// limit.
+if (!isCompleteScan(listing.extent)) {
+  const { limit, total, truncated, unreadable } = listing.extent;
+  console.error(
+    "refusing: the piece listing does not cover the space, so this export " +
+      "would be a subset of it with nothing to say so" +
+      (truncated ? `; capped at ${limit} of ${total} entities` : "") +
+      (unreadable > 0
+        ? `; ${unreadable} of ${total} entities could not be reconstructed`
+        : ""),
   );
+  Deno.exit(1);
+}
+
+/** The entity a piece's `argument` link points at, or undefined. */
+function argumentIdOf(document: Record<string, unknown>): string | undefined {
+  const link = (document.argument as { "/"?: Record<string, { id?: string }> })
+    ?.["/"];
+  if (!link) return undefined;
+  for (const value of Object.values(link)) {
+    if (typeof value?.id === "string") return value.id;
+  }
+  return undefined;
+}
+
+// Selection reads each piece's DOCUMENT, not its description. `describePiece`
+// additionally resolves owned cells and lineage, which is what an operator
+// wants when inspecting one piece and ruinous across every piece in a space:
+// measured at ~22s each here against ~1.7ms for the document, which is the
+// difference between this export finishing in under a minute and not finishing
+// at all. Everything selection needs is in the document — the pattern identity
+// it carries, the argument it links, and its result keys, which are exactly the
+// keys of `value` (verified against `describePiece` on a topic).
+//
+// The space holds far more pieces than the board's children: 14807 in the
+// 2026-08-27 snapshot, of which about 126 are the board and its topics. The
+// sweep is what makes finding them affordable.
+const infos: PieceInfo[] = [];
+for (const row of listing.entities) {
+  const document = getValueAt(space, { id: row.id }).document as
+    | Record<string, unknown>
+    | undefined;
+  if (!document) continue;
+  const value = document.value as Record<string, unknown> | undefined;
+  const identity = document.patternIdentity as
+    | { identity?: string }
+    | string
+    | undefined;
+  infos.push({
+    id: row.id,
+    pattern: {
+      identity: typeof identity === "string" ? identity : identity?.identity,
+    },
+    input: { id: argumentIdOf(document) },
+    resultKeys: value ? Object.keys(value) : [],
+  });
+  if (infos.length % 2000 === 0) {
+    console.error(`  swept ${infos.length}/${listing.entities.length} pieces`);
+  }
 }
 
 const hasVerbs = (info: PieceInfo, verbs: string[]) =>
@@ -130,39 +202,25 @@ if (topicInfos.length === 0) {
   Deno.exit(1);
 }
 
-async function argumentValue(info: PieceInfo): Promise<unknown> {
+function argumentValue(info: PieceInfo): unknown {
   const argumentId = info.input?.id;
   if (!argumentId) {
     throw new Error(`piece ${info.id} reports no argument entity`);
   }
-  const at = await cfJson<ValueAt>([
-    "inspect",
-    "value-at",
-    snapshot!,
-    argumentId,
-    "--json",
-    "--full-depth",
-  ]);
+  const at = getValueAt(space, { id: argumentId });
   if (!at.exists) throw new Error(`argument ${argumentId} does not exist`);
-  return at.value;
+  return annotateFully(at.value);
 }
 
-async function resolveElement(
+function resolveElement(
   topicFid: string,
   field: string,
   index: number,
   element: unknown,
-): Promise<unknown> {
+): unknown {
   const link = (element as { $link?: { id?: string } })?.$link;
   const resolved = link?.id
-    ? (await cfJson<ValueAt>([
-      "inspect",
-      "value-at",
-      snapshot!,
-      link.id,
-      "--json",
-      "--full-depth",
-    ])).value
+    ? annotateFully(getValueAt(space, { id: link.id }).value)
     : element;
   const deeper = findLink(resolved);
   if (deeper) {
@@ -190,7 +248,7 @@ const unclassified = new Set<string>();
 let commentTotal = 0;
 let linkTotal = 0;
 for (const info of topicInfos) {
-  const raw = await argumentValue(info) as Record<string, unknown>;
+  const raw = argumentValue(info) as Record<string, unknown>;
   const content = { comments: [], links: [] } as TopicContent;
   for (const field of SCALAR_CONTENT_FIELDS) {
     const value = raw[field];
@@ -207,7 +265,7 @@ for (const info of topicInfos) {
     const elements = Array.isArray(raw[field]) ? raw[field] as unknown[] : [];
     const resolved: unknown[] = [];
     for (let i = 0; i < elements.length; i++) {
-      resolved.push(await resolveElement(info.id, field, i, elements[i]));
+      resolved.push(resolveElement(info.id, field, i, elements[i]));
     }
     content[field] = resolved;
   }
@@ -228,7 +286,7 @@ for (const info of topicInfos) {
 let board: TopicsExport["board"] = null;
 if (boardInfos.length === 1) {
   const info = boardInfos[0];
-  const raw = await argumentValue(info) as Record<string, unknown>;
+  const raw = argumentValue(info) as Record<string, unknown>;
   board = {
     fid: info.id,
     patternIdentity: info.pattern?.identity ?? "",

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -1,9 +1,16 @@
 /**
  * Shared plumbing for the Topics content export/restore pair
- * (`topics-export.ts`, `topics-restore.ts`). Both scripts shell out to the
- * `cf` CLI rather than importing runtime internals, so they track the CLI's
- * contract — the surface the rehearsal runbook already teaches — instead of
- * private APIs.
+ * (`topics-export.ts`, `topics-restore.ts`) — the field vocabulary and the
+ * pure functions both sides agree on, plus the `cf` helpers below.
+ *
+ * The two halves reach their space differently, because they are asking
+ * different questions. A restore writes to a LIVE server, which only the CLI
+ * can address, so it shells out to `cf` and tracks that contract — the surface
+ * the rehearsal runbook already teaches. An export reads an offline snapshot
+ * thousands of entities deep, where a subprocess per read costs a `deno task`
+ * resolution and a fresh open of a multi-gigabyte database each time, so it
+ * opens the store once through `@commonfabric/state-inspector` and uses none
+ * of the `cf` helpers here.
  */
 
 export const repoRoot = new URL("..", import.meta.url).pathname;


### PR DESCRIPTION
## Why

`scripts/topics-export.ts` produces the restore payload for a Topics board
migration — the portable backup that survives the space becoming unusable, and
the only recourse in a live incident once the board and its children have both
moved. It could not finish.

Run against a 4.8 GB snapshot of the real Topics space during today's
board-first migration rehearsal, it produced no output and no file for 100
minutes before I killed it. Measured afterwards, the design needed roughly **91
hours**. The 100-minute run had covered about 270 of 14807 pieces.

This matters more than a slow script, because `cf piece rollback` and
`cf piece restore` are both refused after a parent/child migration of this
shape — each side's old schema depends on the other side's old surface, and
neither reverse tool has the `--dangerously-allow-incompatible-schema` escape
the forward migration used. The export IS the rollback story, so it has to work.

It now takes **24 seconds**.

## What Changed

Two causes, and the obvious one was the smaller.

Every entity read shelled out to `cf`, so each of several thousand reads paid a
`deno task` workspace resolution and a fresh open of the whole database.

The larger one: the script called `describePiece` on **every piece in the
space** to find the topic-shaped ones. That is 14807 pieces in the 2026-08-27
snapshot, of which about 126 are the board and its children. `describePiece`
also resolves owned cells and lineage — what an operator wants for one piece,
ruinous across all of them, measured at ~22s each here.

Selection now reads each piece's document instead, at ~1.7ms, through a single
open handle. Everything it needs is there: the pattern identity, the argument
link, and the result keys, which are exactly the keys of `value`. `describePiece`
is no longer called at all.

Values are still annotated at unbounded depth, because that is what
`cf inspect value-at --json --full-depth` returned and what `findLink` parses.
Reading the raw value would have quietly changed what the export records rather
than failing.

Progress now goes to stderr every 2000 pieces. The old script's total silence is
why 100 minutes of work looked exactly like a hang, and that was the part that
cost the most time to diagnose.

Also drops the file's claim that the space holds 319 pieces. The listing puts it
at 14807.

## Test plan

- `deno task check`, `deno lint`, `deno fmt --check`, and the `scripts` package
  tests (5 passed) all green.
- Run end to end against the pristine 4.8 GB snapshot of the live Topics space:
  24 seconds, exit 0, 5.5 MB export written.
- Output cross-checked against the migration rehearsal's own survey: 125 board
  membership links, matching the survey's count exactly.
- The equivalence this rewrite depends on — `Object.keys(document.value)` being
  the same set as `describePiece(...).resultKeys` — was verified against
  `describePiece` on a real topic before the call was removed, not assumed.
- The `--require-complete` behaviour it replaces is preserved as an explicit
  `isCompleteScan` check on the listing's own extent, so a capped scan still
  refuses rather than writing a subset that reads like a complete one.

Two things it surfaced immediately, both real and neither addressed here: the
space holds 128 topic-shaped pieces against the board's 125 membership links
(three topics sit off-board, on a fourth pattern generation), and there is a
second `addTopic`-shaped piece in the space, which the tool's existing
ambiguity refusal caught correctly on the first run.

## Review rounds

Three rounds of the stage loop, two correctness findings fixed:

1. **The script no longer ran under its own permissions.** Reading the store
   directly needs what the CLI used to hold on its behalf. `@db/sqlite` does not
   ship its library — `plug` fetches it at RUNTIME from a GitHub release and its
   redirect host — so `--allow-env`, `--allow-ffi` and `--allow-net` are all
   required. A warm cache hides the last of them, which is how it was missed
   twice; the final list was narrowed against an empty `DENO_DIR`, verified with
   0 dylibs in the plug cache before the run and 3 after. Both invocation paths
   updated: the shebang, and `packages/cli/integration/topics-restore-drill.sh`.
   `--allow-run` is dropped, since nothing spawns a subprocess now.
2. **No regression test.** `scripts/topics-export.test.ts` seeds a miniature
   Topics space as a real SQLite store and runs the script as a subprocess under
   a literal permission list — not read back from the shebang, so a revert
   cannot travel with its own permissions. Verified failing on revert rather
   than merely passing on green: restoring the pre-PR file fails 11 steps, and
   dropping `annotate` alone fails 3 with a comment recorded as the raw link
   sigil instead of its body.

Note for a separate fix, out of scope here: `packages/state-inspector/cli.ts`,
`tasks/check-completion-slots.ts` and `tasks/check-command-docs.ts` open spaces
the same way with no net permission, so they share this latent cold-cache
failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
