### PR TITLE
cf-harness kickoff: the Index view inspects the pattern index

### DIFF
--- a/packages/cf-harness/kickoff/README.md
+++ b/packages/cf-harness/kickoff/README.md
@@ -39,7 +39,8 @@ cookie when it loads. Do not put it behind a public address.
 - **A pattern index URL**, optionally. With one set, the session also offers
   `search_patterns` and `record_feedback`, so a run can find an existing pattern
   rather than write one from scratch, and publishes what it worked out back to
-  the index.
+  the index. It is also what the Index view reads; without one that view says so
+  and the server answers its route with a 404.
 
 ## Running it
 
@@ -208,6 +209,47 @@ Handle scope is reconstructed rather than recorded. A run keeps one handle
 table, its last, so the timeline takes a handle to be in scope from the step its
 token first appears in — the order the model met them in, which is the order
 that matters for reading a run back.
+
+## The Index view
+
+The header switches between **Runs** — everything above — and **Index**, which
+reads the pattern index the server was configured with. The view is named in the
+address as `?view=index`, so it is a page to reload into and to link someone at.
+It needs `--pattern-index-url`; without one, the route it reads through answers
+404 saying the server was started without an index, and the view shows that.
+
+The page holds no key and addresses no host but this server. It posts a function
+name to `/api/index/call`, and the server signs the request with the fabric
+identity and sends it — so the index sees the operator's own identity, the same
+principal a run writes with. Four functions are reachable, all of them reads:
+`listPatterns`, `listEvents`, `getPattern` and `searchPatterns`. Anything else —
+a publication, a recorded event — is refused by name before the index is
+touched, and the request the server sends is composed field by field rather than
+forwarded, so nothing extra survives the crossing. `getPattern` is called
+without `includeSource`: this surface shows metadata, schemas, dependencies and
+events, and a pattern's source is read through the CLI.
+
+The route sits under `/api/`, so the `Host`, `Origin` and token gates that cover
+every other route cover it too.
+
+Three panes:
+
+- **Patterns** — everything the index holds, by score. A row carries the pattern
+  id, its description and hashtags, a badge per event type counted against it,
+  the weighted score those counts produce, and when it was created; the weights
+  themselves are printed beside the heading. Opening a row reads that pattern's
+  argument and result schemas, its dependencies, and the events you recorded
+  against it. Every identifier is a button that copies the whole of itself.
+- **Your events** — your own event stream, newest first, with a box that filters
+  on any field. The index answers each signer with their own events and nobody
+  else's; the shared reading of what everyone did is the score in the table
+  above.
+- **Search** — the query the runtime's `search_patterns` would make, run by
+  hand. Tags, free text and a limit compose a request, and the request is shown
+  beside the results, because what the pane is for is how the index answers
+  rather than what it answered once. Each hit reads `matched/asked` on its text
+  terms: matching is disjunctive and ranked, so the ratio is what says how close
+  a hit is.
 
 ## How the configuration reaches the run
 

--- a/packages/cf-harness/kickoff/index-inspector.ts
+++ b/packages/cf-harness/kickoff/index-inspector.ts
@@ -1,0 +1,113 @@
+/**
+ * What the Index view reads out of the index's answers: the orderings, the
+ * filter and the derived labels the three panes render. These are functions of
+ * their arguments alone, so the pane that shows a pattern's standing and the
+ * test that pins it are reading the same rule.
+ */
+
+import type {
+  PatternIndexEvent,
+  PatternIndexListedPattern,
+  PatternIndexSearchResult,
+} from "../src/pattern-index/client.ts";
+
+/** One event type counted against a pattern. */
+export interface PatternEventBadge {
+  eventType: string;
+  count: number;
+}
+
+/**
+ * The patterns in the order the table shows them: by score, highest first, and
+ * by identity within a score so a redraw of the same answer keeps the same
+ * order. The index sorts its own answer; this makes the order the table's
+ * property rather than a claim about what the deployment happened to send.
+ */
+export const patternsByScore = (
+  patterns: readonly PatternIndexListedPattern[],
+): readonly PatternIndexListedPattern[] =>
+  [...patterns].sort((left, right) =>
+    right.score - left.score || left.patternId.localeCompare(right.patternId)
+  );
+
+/**
+ * A pattern's counted events as badges, by type. A type counted zero times is
+ * left out: the badge row says what happened to this pattern, and an index
+ * that grows a new event type should not widen every row with it.
+ */
+export const eventBadges = (
+  events: Readonly<Record<string, number>> | undefined,
+): readonly PatternEventBadge[] =>
+  Object.entries(events ?? {})
+    .filter(([, count]) => count > 0)
+    .map(([eventType, count]) => ({ eventType, count }))
+    .sort((left, right) => left.eventType.localeCompare(right.eventType));
+
+/**
+ * The events a filter box leaves showing. The needle is matched against every
+ * field of an event rather than one chosen column, because the stream is read
+ * to answer "what happened to this pattern" and "what did I do at 11:04" with
+ * the same box. An empty needle filters nothing.
+ */
+export const filterEvents = (
+  events: readonly PatternIndexEvent[],
+  needle: string,
+): readonly PatternIndexEvent[] => {
+  const wanted = needle.trim().toLowerCase();
+  if (wanted === "") {
+    return events;
+  }
+  return events.filter((event) =>
+    [event.patternId, event.did, event.eventType, event.ts ?? "", event.note]
+      .some((field) => (field ?? "").toLowerCase().includes(wanted))
+  );
+};
+
+/**
+ * How much of a text query a hit carries, as `matched/asked`. Text matching is
+ * disjunctive, so a hit is not a claim that everything matched and the ratio is
+ * what says how close; a search with no text query has no ratio to report.
+ */
+export const matchRatio = (
+  result: PatternIndexSearchResult,
+): string | undefined =>
+  result.queryTerms === undefined || result.queryTerms === 0
+    ? undefined
+    : `${result.matchedTerms ?? 0}/${result.queryTerms}`;
+
+/** The head of an identifier, for a column that copies the whole on a click. */
+export const truncateId = (value: string, length = 10): string =>
+  value.length <= length ? value : `${value.slice(0, length)}…`;
+
+/**
+ * A timestamp to the second, as the index wrote it. The instant is not shifted
+ * into the reading machine's zone: the index records UTC, and an operator
+ * comparing a row here against a log line elsewhere is comparing the recorded
+ * instants.
+ */
+export const formatIndexTime = (ts: string | null | undefined): string =>
+  ts === null || ts === undefined || ts === ""
+    ? "—"
+    : ts.slice(0, 19).replace("T", " ");
+
+/**
+ * The search request a tags box, a text box and a limit box compose. Every
+ * empty box is left out rather than sent empty, so the request shown beside the
+ * results is exactly what the index was asked.
+ */
+export const searchRequestOf = (
+  tagText: string,
+  text: string,
+  limitText: string,
+): { tags?: readonly string[]; text?: string; limit?: number } => {
+  const tags = tagText.split(",").map((tag) => tag.trim()).filter((tag) =>
+    tag !== ""
+  );
+  const trimmedText = text.trim();
+  const limit = Number(limitText.trim());
+  return {
+    ...(tags.length > 0 ? { tags } : {}),
+    ...(trimmedText === "" ? {} : { text: trimmedText }),
+    ...(Number.isSafeInteger(limit) && limit > 0 ? { limit } : {}),
+  };
+};

--- a/packages/cf-harness/kickoff/public/styles/kickoff.css
+++ b/packages/cf-harness/kickoff/public/styles/kickoff.css
@@ -635,3 +635,120 @@ button[disabled] {
 .muted {
   color: var(--muted);
 }
+
+/* The Index view: what the pattern index holds, and how it answers a query. */
+
+.index-view .run-list-head {
+  margin-top: 1.75rem;
+}
+
+.index-weights {
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0;
+  margin-left: 0.5rem;
+  text-transform: none;
+}
+
+.index-table {
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  width: 100%;
+}
+
+.index-table th {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.index-table td,
+.index-table th {
+  border-bottom: 1px solid var(--line);
+  padding: 0.3rem 0.6rem 0.3rem 0;
+  vertical-align: top;
+}
+
+.index-row {
+  cursor: pointer;
+}
+
+.index-row:hover td {
+  background: #fff;
+}
+
+.index-row.open td {
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.index-detail-row td {
+  background: #fff;
+}
+
+.index-detail .label {
+  margin-top: 0.6rem;
+}
+
+.index-id {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  padding: 0;
+}
+
+.index-tag {
+  color: #6d3fbe;
+  margin-right: 0.35rem;
+  white-space: nowrap;
+}
+
+.index-toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.index-toolbar label {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.index-toolbar input {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.85rem;
+  margin-left: 0.3rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.index-toolbar button {
+  font-size: 0.85rem;
+  padding: 0.3rem 0.9rem;
+}
+
+.index-search {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) 20rem;
+}
+
+.index-search > * {
+  min-width: 0;
+}
+
+@media (max-width: 56rem) {
+  .index-search {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/packages/cf-harness/kickoff/server.ts
+++ b/packages/cf-harness/kickoff/server.ts
@@ -990,13 +990,20 @@ export class KickoffServer {
       // and anything else reads as this server failing to reach it. The
       // message alone: a `PatternIndexError`'s detail is the index's body,
       // which is not what an operator page renders.
-      const status = error instanceof PatternIndexError &&
-          error.status >= 400 && error.status < 500
-        ? error.status
-        : 502;
-      return Response.json({
-        error: error instanceof Error ? error.message : String(error),
-      }, { status });
+      // Only the typed index error's stable message crosses to the page: a
+      // host-side failure — an unreadable identity keyfile among them — can
+      // name paths this machine's operator configured, which the browser has
+      // no business reading.
+      if (error instanceof PatternIndexError) {
+        const status = error.status >= 400 && error.status < 500
+          ? error.status
+          : 502;
+        return Response.json({ error: error.message }, { status });
+      }
+      return Response.json(
+        { error: "the index request failed on this server; see its log" },
+        { status: 502 },
+      );
     }
   }
 

--- a/packages/cf-harness/kickoff/server.ts
+++ b/packages/cf-harness/kickoff/server.ts
@@ -1000,6 +1000,8 @@ export class KickoffServer {
           : 502;
         return Response.json({ error: error.message }, { status });
       }
+      // The generic answer promises the log carries the detail, so it must.
+      console.error("index proxy failed host-side:", error);
       return Response.json(
         { error: "the index request failed on this server; see its log" },
         { status: 502 },

--- a/packages/cf-harness/kickoff/server.ts
+++ b/packages/cf-harness/kickoff/server.ts
@@ -79,6 +79,13 @@ import {
 } from "../src/interactive-chat-service.ts";
 import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
 import {
+  cacheHarnessPatternIndexClientFactory,
+  createHarnessPatternIndexClientFactory,
+  type HarnessPatternIndexClientFactory,
+  type PatternIndexClient,
+  PatternIndexError,
+} from "../src/pattern-index/client.ts";
+import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
 } from "../src/sandbox/docker-runsc.ts";
@@ -225,6 +232,66 @@ const PATTERN_INDEX_TOOL_IDS = [
   "search_patterns",
   "record_feedback",
 ] as const satisfies readonly BuiltinToolId[];
+
+/**
+ * The index functions the Index view may reach through the proxy. Every one of
+ * them reads: this surface inspects what the index holds and never writes to
+ * it, so a page that asked for `publishPattern` or `recordEvent` is refused by
+ * name rather than by the index. `getPattern` is called without
+ * `includeSource`, which is why a pattern's source cannot arrive at the page
+ * whatever the page sends.
+ */
+const INDEX_FUNCTIONS = [
+  "searchPatterns",
+  "listPatterns",
+  "listEvents",
+  "getPattern",
+] as const;
+
+type IndexFunction = typeof INDEX_FUNCTIONS[number];
+
+const isIndexFunction = (value: unknown): value is IndexFunction =>
+  typeof value === "string" &&
+  (INDEX_FUNCTIONS as readonly string[]).includes(value);
+
+const stringList = (value: unknown): readonly string[] | undefined =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+
+/**
+ * Dispatches one allowlisted read at the typed client. The request is rebuilt
+ * field by field rather than forwarded, so what reaches the index is what this
+ * server composed — a page cannot smuggle `includeSource`, or any other field,
+ * past the allowlist by putting it in the body.
+ */
+const callPatternIndex = (
+  client: PatternIndexClient,
+  fn: IndexFunction,
+  body: Readonly<Record<string, unknown>>,
+): Promise<unknown> => {
+  switch (fn) {
+    case "searchPatterns": {
+      const tags = stringList(body.tags);
+      return client.searchPatterns({
+        ...(tags !== undefined ? { tags } : {}),
+        ...(typeof body.text === "string" ? { text: body.text } : {}),
+        ...(typeof body.limit === "number" ? { limit: body.limit } : {}),
+      });
+    }
+    case "listPatterns":
+      return client.listPatterns();
+    case "listEvents":
+      return client.listEvents({
+        ...(typeof body.patternId === "string"
+          ? { patternId: body.patternId }
+          : {}),
+        ...(typeof body.limit === "number" ? { limit: body.limit } : {}),
+      });
+    case "getPattern":
+      return client.getPattern({ patternId: body.patternId as string });
+  }
+};
 
 /** Everything the server needs before it can serve a single request. */
 interface KickoffConfig {
@@ -566,6 +633,9 @@ export class KickoffServer {
   readonly #config: KickoffConfig;
   readonly #service: HarnessInteractiveChatService;
   readonly #token = crypto.randomUUID();
+  readonly #patternIndexClientFactory:
+    | HarnessPatternIndexClientFactory
+    | undefined;
   #beats = 0;
 
   /**
@@ -574,15 +644,30 @@ export class KickoffServer {
    * become the page's feed, and the two have no order to be constructed in
    * otherwise. This is the seam the NDJSON stdio transport keeps for the same
    * reason.
+   *
+   * The index client is the other way round: it reads the fabric identity from
+   * disk to sign with, so it is built lazily, cached once healthy, and handed
+   * in by a test that has no keyfile to read.
    */
   constructor(
     config: KickoffConfig,
     createService: (
       onEvent: HarnessInteractiveChatEventListener,
     ) => HarnessInteractiveChatService,
+    patternIndexClientFactory?: HarnessPatternIndexClientFactory,
   ) {
     this.#config = config;
     this.#service = createService((envelope) => this.broadcast(envelope));
+    const factory = patternIndexClientFactory ??
+      (config.patternIndex !== undefined
+        ? createHarnessPatternIndexClientFactory(
+          config.patternIndex,
+          config.fabricSession.identityKeyPath,
+        )
+        : undefined);
+    this.#patternIndexClientFactory = factory === undefined
+      ? undefined
+      : cacheHarnessPatternIndexClientFactory(factory);
   }
 
   /** The chat service this server fronts, for startup and shutdown. */
@@ -639,6 +724,9 @@ export class KickoffServer {
     }
     if (request.method === "POST" && url.pathname === "/api/task") {
       return await this.#startTask(request);
+    }
+    if (request.method === "POST" && url.pathname === "/api/index/call") {
+      return await this.#indexCall(request);
     }
     if (request.method === "POST" && url.pathname === "/api/cancel") {
       return await this.#cancel(request);
@@ -853,6 +941,63 @@ export class KickoffServer {
     return response.ok
       ? Response.json(response.result)
       : chatErrorResponse(response);
+  }
+
+  /**
+   * One read of the pattern index, signed with this server's fabric identity.
+   * The page holds no key and reaches no other host: it names a function from
+   * `INDEX_FUNCTIONS` and this composes the request, so what the index sees is
+   * the operator's own identity and nothing the page could have addressed
+   * elsewhere. The route sits under `/api/`, so the `Host`, `Origin` and token
+   * gates have already refused everything that is not this server's own page.
+   */
+  async #indexCall(request: Request): Promise<Response> {
+    const factory = this.#patternIndexClientFactory;
+    if (factory === undefined) {
+      return Response.json({
+        error:
+          "this server was started without a pattern index; restart it with --pattern-index-url or CF_HARNESS_PATTERN_INDEX_URL",
+      }, { status: 404 });
+    }
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return Response.json({ error: "request body is not JSON" }, {
+        status: 400,
+      });
+    }
+    const envelope: { fn?: unknown; body?: unknown } =
+      typeof parsed === "object" && parsed !== null ? parsed : {};
+    if (!isIndexFunction(envelope.fn)) {
+      return Response.json({
+        error: `fn must be one of ${INDEX_FUNCTIONS.join(", ")}`,
+      }, { status: 400 });
+    }
+    const body: Record<string, unknown> =
+      typeof envelope.body === "object" && envelope.body !== null
+        ? envelope.body as Record<string, unknown>
+        : {};
+    if (envelope.fn === "getPattern" && typeof body.patternId !== "string") {
+      return Response.json({ error: "patternId is required" }, { status: 400 });
+    }
+    try {
+      const client = await factory();
+      return Response.json(await callPatternIndex(client, envelope.fn, body));
+    } catch (error) {
+      // The index's own status is passed through when it named a fault in the
+      // request — a pattern that is not there, an identity it will not take —
+      // and anything else reads as this server failing to reach it. The
+      // message alone: a `PatternIndexError`'s detail is the index's body,
+      // which is not what an operator page renders.
+      const status = error instanceof PatternIndexError &&
+          error.status >= 400 && error.status < 500
+        ? error.status
+        : 502;
+      return Response.json({
+        error: error instanceof Error ? error.message : String(error),
+      }, { status });
+    }
   }
 
   /**

--- a/packages/cf-harness/kickoff/src/api.ts
+++ b/packages/cf-harness/kickoff/src/api.ts
@@ -5,6 +5,15 @@
  */
 
 import type { HarnessChatEventEnvelope } from "../../src/contracts/interactive-chat.ts";
+import type {
+  PatternIndexEvent,
+  PatternIndexListEventsRequest,
+  PatternIndexListEventsResponse,
+  PatternIndexListPatternsResponse,
+  PatternIndexPattern,
+  PatternIndexSearchRequest,
+  PatternIndexSearchResponse,
+} from "../../src/pattern-index/client.ts";
 import type { KickoffRunDetail } from "../run-store.ts";
 import type { KickoffRunSummary } from "../runs.ts";
 import type { KickoffSessionSummary } from "../sessions.ts";
@@ -14,6 +23,11 @@ export type {
   KickoffRunDetail,
   KickoffRunSummary,
   KickoffSessionSummary,
+  PatternIndexEvent,
+  PatternIndexListPatternsResponse,
+  PatternIndexPattern,
+  PatternIndexSearchRequest,
+  PatternIndexSearchResponse,
 };
 
 /** A started turn, and the session it runs in. */
@@ -95,6 +109,49 @@ export const readRun = async (runId: string): Promise<KickoffRunDetail> =>
   await json<KickoffRunDetail>(
     await fetch(`/api/runs/${encodeURIComponent(runId)}`),
   );
+
+/**
+ * One read of the pattern index, through the server that signs it. The page
+ * names a function and the server composes the request, so the set of things
+ * askable from here is the server's allowlist rather than this module's.
+ */
+const callIndex = async <Value>(
+  fn: string,
+  body?: Record<string, unknown>,
+): Promise<Value> =>
+  await json<Value>(
+    await fetch("/api/index/call", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body === undefined ? { fn } : { fn, body }),
+    }),
+  );
+
+export const listIndexPatterns = (): Promise<
+  PatternIndexListPatternsResponse
+> => callIndex<PatternIndexListPatternsResponse>("listPatterns");
+
+export const listIndexEvents = async (
+  request: PatternIndexListEventsRequest = {},
+): Promise<readonly PatternIndexEvent[]> =>
+  (await callIndex<PatternIndexListEventsResponse>(
+    "listEvents",
+    { ...request },
+  )).events;
+
+/**
+ * One pattern's metadata, schemas and dependencies. The server never asks the
+ * index for source, so what comes back is what this surface shows.
+ */
+export const readIndexPattern = (
+  patternId: string,
+): Promise<PatternIndexPattern> =>
+  callIndex<PatternIndexPattern>("getPattern", { patternId });
+
+export const searchIndexPatterns = (
+  request: PatternIndexSearchRequest,
+): Promise<PatternIndexSearchResponse> =>
+  callIndex<PatternIndexSearchResponse>("searchPatterns", { ...request });
 
 /**
  * One artifact or tool output as its own text. It is returned unparsed: the

--- a/packages/cf-harness/kickoff/src/app.ts
+++ b/packages/cf-harness/kickoff/src/app.ts
@@ -17,7 +17,11 @@ import {
   listRuns,
   startTask,
 } from "./api.ts";
+import "./index-view.ts";
 import "./run-view.ts";
+
+/** Which surface the shell is showing: the runs, or the pattern index. */
+type View = "kickoff" | "index";
 
 /** The address a run named, raised above the timeline once it exists. */
 interface Piece {
@@ -73,8 +77,10 @@ export class KickoffApp extends LitElement {
     activity: { attribute: false },
     piece: { attribute: false },
     error: { attribute: false },
+    view: { attribute: false },
   };
 
+  declare view: View;
   declare sessionId: string | undefined;
   declare turnId: string | undefined;
   declare runs: readonly KickoffRunSummary[];
@@ -97,6 +103,7 @@ export class KickoffApp extends LitElement {
     this.runs = [];
     this.state = "idle";
     this.running = false;
+    this.view = "kickoff";
   }
 
   protected override createRenderRoot(): HTMLElement {
@@ -106,7 +113,11 @@ export class KickoffApp extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     void this.#loadRuns();
-    const named = new URLSearchParams(location.search).get("sessionId");
+    const params = new URLSearchParams(location.search);
+    if (params.get("view") === "index") {
+      this.view = "index";
+    }
+    const named = params.get("sessionId");
     if (named !== null && named !== "") {
       this.sessionId = named;
       this.#subscribe();
@@ -304,6 +315,28 @@ export class KickoffApp extends LitElement {
     }
   }
 
+  /**
+   * Switches surface, and says so in the address bar: the Index view is one an
+   * operator reloads into, and the session the runs are being watched under is
+   * kept so switching back returns to it rather than to a fresh page.
+   */
+  #showView(view: View): void {
+    this.view = view;
+    const params = new URLSearchParams();
+    if (this.sessionId !== undefined) {
+      params.set("sessionId", this.sessionId);
+    }
+    if (view === "index") {
+      params.set("view", "index");
+    }
+    const query = params.toString();
+    history.replaceState(
+      null,
+      "",
+      query === "" ? location.pathname : `?${query}`,
+    );
+  }
+
   #runRow(node: RunNode, depth: number): TemplateResult {
     const run = node.run;
     return html`
@@ -331,10 +364,24 @@ export class KickoffApp extends LitElement {
   }
 
   protected override render(): TemplateResult {
+    const viewTab = (view: View, label: string) =>
+      html`
+        <button
+          class="tab ${this.view === view ? "on" : ""}"
+          type="button"
+          @click=${() => this.#showView(view)}
+        >
+          ${label}
+        </button>
+      `;
     return html`
       <main>
         <header>
           <h1>cf-harness kickoff</h1>
+          <div class="views">
+            ${viewTab("kickoff", "Runs")}
+            ${viewTab("index", "Index")}
+          </div>
           <span id="state">
             ${this.running && this.activity !== undefined
               ? this.activity
@@ -342,6 +389,17 @@ export class KickoffApp extends LitElement {
           </span>
         </header>
 
+        ${this.view === "index"
+          ? html`<kickoff-index-view></kickoff-index-view>`
+          : this.#kickoffView()}
+      </main>
+    `;
+  }
+
+  /** Type a task, watch it run, read what any run did. */
+  #kickoffView(): TemplateResult {
+    return html`
+      <div>
         <textarea
           id="task"
           placeholder="Describe what you want built. The harness writes the pattern, runs it in your space, and names the piece."
@@ -412,7 +470,7 @@ export class KickoffApp extends LitElement {
               this.openRunId = event.detail}
           ></kickoff-run-view>
         </div>
-      </main>
+      </div>
     `;
   }
 }

--- a/packages/cf-harness/kickoff/src/index-view.ts
+++ b/packages/cf-harness/kickoff/src/index-view.ts
@@ -1,0 +1,483 @@
+/**
+ * The Index view: the pattern index as an operator reads it. What is
+ * published and how it ranks, what this identity did with it, and what a query
+ * would actually return — the last beside the request that produced it, because
+ * the point of the playground is the search's behavior rather than its answer.
+ *
+ * Every read goes through the server, which signs it with the fabric identity
+ * and refuses anything outside its allowlist. Source is not among what this
+ * surface asks for: a pattern's metadata, schemas, dependencies and events are
+ * what it shows, and source is read through the CLI.
+ */
+
+import { html, LitElement, nothing, type TemplateResult } from "lit";
+import {
+  eventBadges,
+  filterEvents,
+  formatIndexTime,
+  matchRatio,
+  patternsByScore,
+  searchRequestOf,
+  truncateId,
+} from "../index-inspector.ts";
+import type {
+  PatternIndexEvent,
+  PatternIndexListedPattern,
+  PatternIndexPattern,
+  PatternIndexSearchResult,
+} from "../../src/pattern-index/client.ts";
+import {
+  listIndexEvents,
+  listIndexPatterns,
+  readIndexPattern,
+  searchIndexPatterns,
+} from "./api.ts";
+
+/** One pattern read open, and that pattern's own events beside it. */
+interface OpenPattern {
+  patternId: string;
+  pattern?: PatternIndexPattern;
+  events?: readonly PatternIndexEvent[];
+  error?: string;
+}
+
+const reason = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const prettyJson = (value: unknown): string => JSON.stringify(value, null, 2);
+
+export class KickoffIndexView extends LitElement {
+  static override properties = {
+    patterns: { attribute: false },
+    eventTypes: { attribute: false },
+    patternsError: { attribute: false },
+    open: { attribute: false },
+    events: { attribute: false },
+    eventsError: { attribute: false },
+    eventFilter: { attribute: false },
+    copied: { attribute: false },
+    searchRequest: { attribute: false },
+    searchResults: { attribute: false },
+    searchError: { attribute: false },
+    searching: { attribute: false },
+    loaded: { attribute: false },
+  };
+
+  declare patterns: readonly PatternIndexListedPattern[];
+  /** The weight the index scores each event type at, as it reported them. */
+  declare eventTypes: Readonly<Record<string, number>>;
+  declare patternsError: string | undefined;
+  declare open: OpenPattern | undefined;
+  declare events: readonly PatternIndexEvent[];
+  declare eventsError: string | undefined;
+  declare eventFilter: string;
+  /** The identifier the last copy button copied, so the page can say so. */
+  declare copied: string | undefined;
+  declare searchRequest: string | undefined;
+  declare searchResults: readonly PatternIndexSearchResult[] | undefined;
+  declare searchError: string | undefined;
+  declare searching: boolean;
+  /** False until the first read of the index answers, however it answered. */
+  declare loaded: boolean;
+
+  /** Which read of a pattern's detail is current; only the newest may show. */
+  #detailReads = 0;
+  /** Which search is current, for the same reason. */
+  #searches = 0;
+
+  constructor() {
+    super();
+    this.patterns = [];
+    this.eventTypes = {};
+    this.events = [];
+    this.eventFilter = "";
+    this.searching = false;
+    this.loaded = false;
+  }
+
+  protected override createRenderRoot(): HTMLElement {
+    return this;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.refresh();
+  }
+
+  /** Re-reads both listings. Neither read's failure hides the other's answer. */
+  async refresh(): Promise<void> {
+    await Promise.all([this.#loadPatterns(), this.#loadEvents()]);
+    this.loaded = true;
+  }
+
+  async #loadPatterns(): Promise<void> {
+    try {
+      const listing = await listIndexPatterns();
+      this.patterns = listing.patterns;
+      this.eventTypes = listing.eventTypes ?? {};
+      this.patternsError = undefined;
+    } catch (error) {
+      this.patternsError = reason(error);
+    }
+  }
+
+  async #loadEvents(): Promise<void> {
+    try {
+      this.events = await listIndexEvents({ limit: 100 });
+      this.eventsError = undefined;
+    } catch (error) {
+      this.eventsError = reason(error);
+    }
+  }
+
+  /**
+   * Opens one pattern, or closes it when it is the one already open. The
+   * pattern and its events are read independently, so one endpoint refusing
+   * still shows what the other returned.
+   */
+  async #openPattern(patternId: string): Promise<void> {
+    if (this.open?.patternId === patternId) {
+      this.open = undefined;
+      return;
+    }
+    const read = ++this.#detailReads;
+    this.open = { patternId };
+    const [pattern, events] = await Promise.all([
+      readIndexPattern(patternId).catch((error: unknown) => reason(error)),
+      listIndexEvents({ patternId }).catch((error: unknown) => reason(error)),
+    ]);
+    if (read !== this.#detailReads) {
+      return;
+    }
+    this.open = {
+      patternId,
+      ...(typeof pattern === "string" ? { error: pattern } : { pattern }),
+      ...(typeof events === "string" ? {} : { events }),
+    };
+  }
+
+  async #runSearch(): Promise<void> {
+    const field = (id: string): string =>
+      (this.querySelector(`#${id}`) as HTMLInputElement | null)?.value ?? "";
+    const request = searchRequestOf(
+      field("index-tags"),
+      field("index-text"),
+      field("index-limit"),
+    );
+    const run = ++this.#searches;
+    this.searchRequest = prettyJson(request);
+    this.searching = true;
+    try {
+      const response = await searchIndexPatterns(request);
+      if (run !== this.#searches) {
+        return;
+      }
+      this.searchResults = response.results;
+      this.searchError = undefined;
+    } catch (error) {
+      if (run !== this.#searches) {
+        return;
+      }
+      this.searchError = reason(error);
+      this.searchResults = undefined;
+    } finally {
+      if (run === this.#searches) {
+        this.searching = false;
+      }
+    }
+  }
+
+  /**
+   * A truncated identifier that hands over the whole of itself. The column is
+   * narrow enough to read a table by and a pattern id is what every other tool
+   * wants in full, so the cell is the button.
+   */
+  #idCell(value: string | undefined, length = 10): TemplateResult {
+    if (value === undefined || value === "") {
+      return html`<span class="muted">—</span>`;
+    }
+    return html`
+      <button
+        class="index-id"
+        title=${value}
+        type="button"
+        @click=${(event: Event) => {
+          event.stopPropagation();
+          this.copied = value;
+          void navigator.clipboard?.writeText(value);
+        }}
+      >
+        ${this.copied === value ? "copied" : truncateId(value, length)}
+      </button>
+    `;
+  }
+
+  #hashtags(hashtags: readonly string[] | undefined): TemplateResult {
+    return html`${
+      (hashtags ?? []).map((tag) =>
+        html`<span class="index-tag">#${tag}</span>`
+      )
+    }`;
+  }
+
+  #eventsTable(events: readonly PatternIndexEvent[]): TemplateResult {
+    return html`
+      <table class="index-table">
+        <thead>
+          <tr>
+            <th>when</th>
+            <th>event</th>
+            <th>pattern</th>
+            <th>identity</th>
+            <th>note</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${events.map((event) =>
+            html`
+              <tr>
+                <td class="muted">${formatIndexTime(event.ts)}</td>
+                <td>${event.eventType}</td>
+                <td>${this.#idCell(event.patternId)}</td>
+                <td>${this.#idCell(event.did, 14)}</td>
+                <td>${event.note ?? ""}</td>
+              </tr>
+            `
+          )}
+        </tbody>
+      </table>
+    `;
+  }
+
+  #detail(open: OpenPattern): TemplateResult {
+    const pattern = open.pattern;
+    return html`
+      <div class="index-detail">
+        ${open.error === undefined
+          ? nothing
+          : html`<p class="empty bad">${open.error}</p>`}
+        ${pattern === undefined
+          ? (open.error === undefined
+            ? html`<p class="empty">Reading…</p>`
+            : nothing)
+          : html`
+            <div class="label">
+              owner ${this.#idCell(pattern.ownerDid, 18)} · created
+              ${formatIndexTime(pattern.createdAt)}
+              ${pattern.priorPatternId === undefined
+                ? nothing
+                : html`· revises ${this.#idCell(pattern.priorPatternId)}`}
+            </div>
+            <div class="label">
+              dependencies
+              <span class="tool">
+                ${pattern.dependencies.length === 0
+                  ? "none"
+                  : pattern.dependencies.join(", ")}
+              </span>
+            </div>
+            ${pattern.argumentSchema === undefined ? nothing : html`
+              <div class="label">argument schema</div>
+              <pre class="raw">${prettyJson(pattern.argumentSchema)}</pre>
+            `}
+            ${pattern.resultSchema === undefined ? nothing : html`
+              <div class="label">result schema</div>
+              <pre class="raw">${prettyJson(pattern.resultSchema)}</pre>
+            `}
+          `}
+        <div class="label">its events</div>
+        ${open.events === undefined
+          ? html`<p class="empty">Reading…</p>`
+          : open.events.length === 0
+          ? html`<p class="empty">You recorded none against this pattern.</p>`
+          : this.#eventsTable(open.events)}
+      </div>
+    `;
+  }
+
+  #patternsPane(): TemplateResult {
+    if (this.patternsError !== undefined) {
+      return html`<p class="empty bad">${this.patternsError}</p>`;
+    }
+    if (this.patterns.length === 0) {
+      return html`
+        <p class="empty">
+          ${this.loaded ? "The index holds no patterns." : "Reading…"}
+        </p>
+      `;
+    }
+    return html`
+      <table class="index-table">
+        <thead>
+          <tr>
+            <th>pattern</th>
+            <th>description</th>
+            <th>hashtags</th>
+            <th>events</th>
+            <th>score</th>
+            <th>created</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${patternsByScore(this.patterns).map((pattern) =>
+            html`
+              <tr
+                class="index-row ${this.open?.patternId === pattern.patternId
+                  ? "open"
+                  : ""}"
+                @click=${() => this.#openPattern(pattern.patternId)}
+              >
+                <td>${this.#idCell(pattern.patternId)}</td>
+                <td>${pattern.description}</td>
+                <td>${this.#hashtags(pattern.hashtags)}</td>
+                <td>
+                  ${eventBadges(pattern.events).map((badge) =>
+                    html`<span class="badge">
+                    ${badge.eventType} ×${badge.count}
+                  </span>`
+                  )}
+                </td>
+                <td>${pattern.score ?? 0}</td>
+                <td class="muted">${formatIndexTime(pattern.createdAt)}</td>
+              </tr>
+              ${this.open?.patternId === pattern.patternId
+                ? html`
+                  <tr class="index-detail-row">
+                    <td colspan="6">${this.#detail(this.open)}</td>
+                  </tr>
+                `
+                : nothing}
+            `
+          )}
+        </tbody>
+      </table>
+    `;
+  }
+
+  #eventsPane(): TemplateResult {
+    if (this.eventsError !== undefined) {
+      return html`<p class="empty bad">${this.eventsError}</p>`;
+    }
+    const showing = filterEvents(this.events, this.eventFilter);
+    return html`
+      <div class="index-toolbar">
+        <label>
+          filter
+          <input
+            .value=${this.eventFilter}
+            placeholder="any field"
+            @input=${(event: Event) =>
+              this.eventFilter = (event.target as HTMLInputElement).value}
+          />
+        </label>
+        <span class="muted">
+          ${showing.length} of ${this.events.length} shown
+        </span>
+      </div>
+      ${this.events.length === 0
+        ? html`
+          <p class="empty">
+            ${this.loaded
+              ? "This identity has recorded nothing in the index."
+              : "Reading…"}
+          </p>
+        `
+        : this.#eventsTable(showing)}
+    `;
+  }
+
+  #searchPane(): TemplateResult {
+    return html`
+      <div class="index-toolbar">
+        <label>tags <input id="index-tags" placeholder="comma,separated" /></label>
+        <label>text <input id="index-text" placeholder="free text" /></label>
+        <label>limit <input id="index-limit" size="4" value="20" /></label>
+        <button
+          type="button"
+          ?disabled=${this.searching}
+          @click=${() => this.#runSearch()}
+        >
+          Search
+        </button>
+      </div>
+      <div class="index-search">
+        <div>
+          ${this.searchError !== undefined
+            ? html`<p class="empty bad">${this.searchError}</p>`
+            : this.searchResults === undefined
+            ? html`<p class="empty">No query has been run yet.</p>`
+            : this.searchResults.length === 0
+            ? html`<p class="empty">No pattern matched.</p>`
+            : html`
+              <table class="index-table">
+                <thead>
+                  <tr>
+                    <th>match</th>
+                    <th>pattern</th>
+                    <th>description</th>
+                    <th>hashtags</th>
+                    <th>uses</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${this.searchResults.map((result) =>
+                    html`
+                      <tr>
+                        <td>
+                          ${matchRatio(result) ??
+                            html`<span class="muted">—</span>`}
+                        </td>
+                        <td>${this.#idCell(result.patternId)}</td>
+                        <td>${result.description}</td>
+                        <td>${this.#hashtags(result.hashtags)}</td>
+                        <td>${result.signals?.uses ?? 0}</td>
+                      </tr>
+                    `
+                  )}
+                </tbody>
+              </table>
+            `}
+        </div>
+        <div>
+          <div class="label">request sent</div>
+          <pre class="raw">${this.searchRequest ?? "—"}</pre>
+        </div>
+      </div>
+    `;
+  }
+
+  protected override render(): TemplateResult {
+    const weights = Object.entries(this.eventTypes)
+      .map(([eventType, weight]) => `${eventType}=${weight}`)
+      .join(" ");
+    return html`
+      <div class="index-view">
+        <div class="run-list-head">
+          <span>
+            Patterns
+            ${weights === ""
+              ? nothing
+              : html`<span class="index-weights">${weights}</span>`}
+          </span>
+          <button class="secondary" type="button" @click=${() =>
+            this.refresh()}>
+            Refresh
+          </button>
+        </div>
+        ${this.#patternsPane()}
+
+        <div class="run-list-head">
+          <span>Your events</span>
+        </div>
+        ${this.#eventsPane()}
+
+        <div class="run-list-head">
+          <span>Search</span>
+        </div>
+        ${this.#searchPane()}
+      </div>
+    `;
+  }
+}
+
+customElements.define("kickoff-index-view", KickoffIndexView);

--- a/packages/cf-harness/kickoff/src/index-view.ts
+++ b/packages/cf-harness/kickoff/src/index-view.ts
@@ -39,6 +39,9 @@ interface OpenPattern {
   pattern?: PatternIndexPattern;
   events?: readonly PatternIndexEvent[];
   error?: string;
+
+  /** Why `events` is absent when its read failed rather than pending. */
+  eventsError?: string;
 }
 
 const reason = (error: unknown): string =>
@@ -82,6 +85,7 @@ export class KickoffIndexView extends LitElement {
 
   /** Which read of a pattern's detail is current; only the newest may show. */
   #detailReads = 0;
+  #refreshes = 0;
   /** Which search is current, for the same reason. */
   #searches = 0;
 
@@ -104,28 +108,43 @@ export class KickoffIndexView extends LitElement {
     void this.refresh();
   }
 
-  /** Re-reads both listings. Neither read's failure hides the other's answer. */
+  /**
+   * Re-reads both listings. Neither read's failure hides the other's answer,
+   * and a refresh superseded by a newer one writes nothing — two clicks in
+   * flight must not let the older answer land last.
+   */
   async refresh(): Promise<void> {
-    await Promise.all([this.#loadPatterns(), this.#loadEvents()]);
-    this.loaded = true;
+    const generation = ++this.#refreshes;
+    await Promise.all([
+      this.#loadPatterns(generation),
+      this.#loadEvents(generation),
+    ]);
+    if (generation === this.#refreshes) {
+      this.loaded = true;
+    }
   }
 
-  async #loadPatterns(): Promise<void> {
+  async #loadPatterns(generation: number): Promise<void> {
     try {
       const listing = await listIndexPatterns();
+      if (generation !== this.#refreshes) return;
       this.patterns = listing.patterns;
       this.eventTypes = listing.eventTypes ?? {};
       this.patternsError = undefined;
     } catch (error) {
+      if (generation !== this.#refreshes) return;
       this.patternsError = reason(error);
     }
   }
 
-  async #loadEvents(): Promise<void> {
+  async #loadEvents(generation: number): Promise<void> {
     try {
-      this.events = await listIndexEvents({ limit: 100 });
+      const events = await listIndexEvents({ limit: 100 });
+      if (generation !== this.#refreshes) return;
+      this.events = events;
       this.eventsError = undefined;
     } catch (error) {
+      if (generation !== this.#refreshes) return;
       this.eventsError = reason(error);
     }
   }
@@ -137,6 +156,9 @@ export class KickoffIndexView extends LitElement {
    */
   async #openPattern(patternId: string): Promise<void> {
     if (this.open?.patternId === patternId) {
+      // Closing also invalidates a read still in flight, so its late answer
+      // cannot reopen the row.
+      ++this.#detailReads;
       this.open = undefined;
       return;
     }
@@ -152,11 +174,13 @@ export class KickoffIndexView extends LitElement {
     this.open = {
       patternId,
       ...(typeof pattern === "string" ? { error: pattern } : { pattern }),
-      ...(typeof events === "string" ? {} : { events }),
+      ...(typeof events === "string" ? { eventsError: events } : { events }),
     };
   }
 
   async #runSearch(): Promise<void> {
+    // The disabled binding lands on the next render, not on the click.
+    if (this.searching) return;
     const field = (id: string): string =>
       (this.querySelector(`#${id}`) as HTMLInputElement | null)?.value ?? "";
     const request = searchRequestOf(
@@ -286,7 +310,9 @@ export class KickoffIndexView extends LitElement {
             `}
           `}
         <div class="label">its events</div>
-        ${open.events === undefined
+        ${open.eventsError !== undefined
+          ? html`<p class="error">${open.eventsError}</p>`
+          : open.events === undefined
           ? html`<p class="empty">Reading…</p>`
           : open.events.length === 0
           ? html`<p class="empty">You recorded none against this pattern.</p>`

--- a/packages/cf-harness/src/pattern-index/client.ts
+++ b/packages/cf-harness/src/pattern-index/client.ts
@@ -93,6 +93,56 @@ export interface PatternIndexGetRequest {
 }
 
 /**
+ * One row of `listPatterns`: a pattern's public metadata, the events recorded
+ * against it counted by type, and the weighted total those counts produce.
+ * Carries no source and none of the private query fields a publication
+ * supplied.
+ */
+export interface PatternIndexListedPattern {
+  patternId: string;
+  description: string;
+  hashtags: readonly string[];
+  keywords: readonly string[];
+  ownerDid: string;
+
+  /** `null` for a pattern the index holds no creation time for. */
+  createdAt: string | null;
+
+  /** Event type to how many times it was recorded against this pattern. */
+  events: Readonly<Record<string, number>>;
+  score: number;
+}
+
+export interface PatternIndexListPatternsResponse {
+  patterns: readonly PatternIndexListedPattern[];
+
+  /** Event type to the weight `score` counts one of them at. */
+  eventTypes: Readonly<Record<string, number>>;
+}
+
+export interface PatternIndexListEventsRequest {
+  patternId?: string;
+
+  /** The index caps this at 500, whatever a caller asks for. */
+  limit?: number;
+}
+
+/** One recorded event of the calling identity's own stream. */
+export interface PatternIndexEvent {
+  patternId: string;
+  did: string;
+  eventType: string;
+
+  /** `null` for an event the index holds no timestamp for. */
+  ts: string | null;
+  note?: string;
+}
+
+export interface PatternIndexListEventsResponse {
+  events: readonly PatternIndexEvent[];
+}
+
+/**
  * What a run reports back about a pattern it took from the index. The index
  * ranks on these, so a run that instantiates a pattern and then fails says
  * both things rather than only the first.
@@ -284,6 +334,31 @@ export class PatternIndexClient {
       ...(request.includeSource !== undefined
         ? { includeSource: request.includeSource }
         : {}),
+    });
+  }
+
+  /**
+   * Every pattern the index holds, scored, for an operator reading the index
+   * as a whole. The aggregate is public — a count and a weight per pattern —
+   * so this says what is indexed and how it ranks without naming who did what.
+   */
+  listPatterns(): Promise<PatternIndexListPatternsResponse> {
+    return this.#call<PatternIndexListPatternsResponse>("listPatterns", {});
+  }
+
+  /**
+   * The calling identity's OWN events, newest first. The index answers each
+   * signer with their own stream and nobody else's, so this is what a run made
+   * of the index rather than what everyone made of it.
+   */
+  listEvents(
+    request: PatternIndexListEventsRequest = {},
+  ): Promise<PatternIndexListEventsResponse> {
+    return this.#call<PatternIndexListEventsResponse>("listEvents", {
+      ...(request.patternId !== undefined
+        ? { patternId: request.patternId }
+        : {}),
+      ...(request.limit !== undefined ? { limit: request.limit } : {}),
     });
   }
 

--- a/packages/cf-harness/test/kickoff/index-inspector.test.ts
+++ b/packages/cf-harness/test/kickoff/index-inspector.test.ts
@@ -1,0 +1,227 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  eventBadges,
+  filterEvents,
+  formatIndexTime,
+  matchRatio,
+  patternsByScore,
+  searchRequestOf,
+  truncateId,
+} from "../../kickoff/index-inspector.ts";
+import type {
+  PatternIndexEvent,
+  PatternIndexListedPattern,
+  PatternIndexSearchResult,
+} from "../../src/pattern-index/client.ts";
+
+const pattern = (
+  patternId: string,
+  score: number,
+  events: Record<string, number> = {},
+): PatternIndexListedPattern => ({
+  patternId,
+  description: `pattern ${patternId}`,
+  hashtags: [],
+  keywords: [],
+  ownerDid: "did:key:zOwner",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  events,
+  score,
+});
+
+const event = (
+  overrides: Partial<PatternIndexEvent> = {},
+): PatternIndexEvent => ({
+  patternId: "pat-1",
+  did: "did:key:zOwner",
+  eventType: "run_succeeded",
+  ts: "2026-08-02T09:04:11.000Z",
+  ...overrides,
+});
+
+describe("kickoff/index-inspector", () => {
+  describe("patternsByScore", () => {
+    it("puts the highest score first", () => {
+      const sorted = patternsByScore([
+        pattern("pat-a", 1),
+        pattern("pat-b", 7),
+        pattern("pat-c", 3),
+      ]);
+
+      expect(sorted.map((entry) => entry.patternId)).toEqual([
+        "pat-b",
+        "pat-c",
+        "pat-a",
+      ]);
+    });
+
+    it("orders patterns of one score by identity", () => {
+      const sorted = patternsByScore([
+        pattern("pat-c", 2),
+        pattern("pat-a", 2),
+        pattern("pat-b", 2),
+      ]);
+
+      expect(sorted.map((entry) => entry.patternId)).toEqual([
+        "pat-a",
+        "pat-b",
+        "pat-c",
+      ]);
+    });
+
+    it("orders a negative score below one of zero", () => {
+      const sorted = patternsByScore([
+        pattern("pat-a", -2),
+        pattern("pat-b", 0),
+      ]);
+
+      expect(sorted.map((entry) => entry.patternId)).toEqual([
+        "pat-b",
+        "pat-a",
+      ]);
+    });
+
+    it("leaves the listing it was given alone", () => {
+      const listing = [pattern("pat-a", 1), pattern("pat-b", 7)];
+
+      patternsByScore(listing);
+
+      expect(listing.map((entry) => entry.patternId)).toEqual([
+        "pat-a",
+        "pat-b",
+      ]);
+    });
+  });
+
+  describe("eventBadges", () => {
+    it("answers one badge per counted event type, by type", () => {
+      expect(eventBadges({ thumbs_up: 2, instantiated: 5 })).toEqual([
+        { eventType: "instantiated", count: 5 },
+        { eventType: "thumbs_up", count: 2 },
+      ]);
+    });
+
+    it("leaves out an event type counted zero times", () => {
+      expect(eventBadges({ run_failed: 0, run_succeeded: 1 })).toEqual([
+        { eventType: "run_succeeded", count: 1 },
+      ]);
+    });
+
+    it("answers no badges for a pattern with no counts", () => {
+      expect(eventBadges(undefined)).toEqual([]);
+      expect(eventBadges({})).toEqual([]);
+    });
+  });
+
+  describe("filterEvents", () => {
+    const events = [
+      event({ eventType: "run_succeeded", note: "ran in the harness" }),
+      event({ patternId: "pat-2", eventType: "thumbs_down" }),
+    ];
+
+    it("keeps every event for an empty filter", () => {
+      expect(filterEvents(events, "   ")).toHaveLength(2);
+    });
+
+    it("keeps the events whose note carries the filter", () => {
+      expect(filterEvents(events, "harness")).toEqual([events[0]]);
+    });
+
+    it("matches a pattern identifier as readily as an event type", () => {
+      expect(filterEvents(events, "pat-2")).toEqual([events[1]]);
+      expect(filterEvents(events, "thumbs")).toEqual([events[1]]);
+    });
+
+    it("matches without regard to case", () => {
+      expect(filterEvents(events, "HARNESS")).toEqual([events[0]]);
+    });
+
+    it("keeps no event a filter matches nothing of", () => {
+      expect(filterEvents(events, "nothing here")).toEqual([]);
+    });
+
+    it("matches an event carrying no note", () => {
+      expect(filterEvents([event({ note: undefined })], "run_succeeded"))
+        .toHaveLength(1);
+    });
+  });
+
+  describe("matchRatio", () => {
+    const result = (
+      overrides: Partial<PatternIndexSearchResult>,
+    ): PatternIndexSearchResult => ({
+      patternId: "pat-1",
+      description: "Totals an expense list",
+      hashtags: [],
+      ownerDid: "did:key:zOwner",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      dependencies: [],
+      ...overrides,
+    });
+
+    it("reads as matched over asked", () => {
+      expect(matchRatio(result({ matchedTerms: 2, queryTerms: 3 })))
+        .toBe("2/3");
+    });
+
+    it("reads a hit that matched no term as zero of the terms asked", () => {
+      expect(matchRatio(result({ queryTerms: 3 }))).toBe("0/3");
+    });
+
+    it("answers nothing for a search that asked no text", () => {
+      expect(matchRatio(result({}))).toBeUndefined();
+      expect(matchRatio(result({ queryTerms: 0 }))).toBeUndefined();
+    });
+  });
+
+  describe("truncateId", () => {
+    it("shortens an identifier longer than the width asked", () => {
+      expect(truncateId("abcdefghijklmno", 10)).toBe("abcdefghij…");
+    });
+
+    it("leaves an identifier the width holds whole", () => {
+      expect(truncateId("abcdefghij", 10)).toBe("abcdefghij");
+    });
+  });
+
+  describe("formatIndexTime", () => {
+    it("reads a recorded instant to the second, as the index wrote it", () => {
+      expect(formatIndexTime("2026-08-02T09:04:11.000Z")).toBe(
+        "2026-08-02 09:04:11",
+      );
+    });
+
+    it("answers a dash for an instant the index does not hold", () => {
+      expect(formatIndexTime(null)).toBe("—");
+      expect(formatIndexTime(undefined)).toBe("—");
+      expect(formatIndexTime("")).toBe("—");
+    });
+  });
+
+  describe("searchRequestOf", () => {
+    it("composes the fields the boxes were filled with", () => {
+      expect(searchRequestOf(" expenses, todo ", " totals ", "5")).toEqual({
+        tags: ["expenses", "todo"],
+        text: "totals",
+        limit: 5,
+      });
+    });
+
+    it("leaves out every box left empty", () => {
+      expect(searchRequestOf("", "  ", "")).toEqual({});
+    });
+
+    it("leaves out a limit that is not a whole count", () => {
+      expect(searchRequestOf("", "totals", "0")).toEqual({ text: "totals" });
+      expect(searchRequestOf("", "totals", "-3")).toEqual({ text: "totals" });
+      expect(searchRequestOf("", "totals", "many")).toEqual({ text: "totals" });
+    });
+
+    it("drops an empty tag left by a trailing comma", () => {
+      expect(searchRequestOf("expenses,,", "", "")).toEqual({
+        tags: ["expenses"],
+      });
+    });
+  });
+});

--- a/packages/cf-harness/test/kickoff/server.test.ts
+++ b/packages/cf-harness/test/kickoff/server.test.ts
@@ -321,6 +321,32 @@ describe("kickoff/server", () => {
         jsonRequest("/api/index/call", body, { cookie: indexed.cookie }),
       );
 
+    it("answers a host-side failure generically, never with its message", async () => {
+      // A factory that cannot build its client throws host-side — an
+      // unreadable keyfile names the path the operator configured, which the
+      // page must not read.
+      const server = new KickoffServer(
+        config(),
+        (onEvent) =>
+          new HarnessInteractiveChatService({
+            createPromptLoop: answeringLoop,
+            now: advancingClock(),
+            onEvent,
+          }),
+        () => Promise.reject(new Error("ENOENT: /Users/operator/.secret.key")),
+      );
+      const page = await server.handle(getRequest("/"));
+      await page.body?.cancel();
+      const cookie = page.headers.get("set-cookie")!.split(";")[0];
+      const response = await server.handle(
+        jsonRequest("/api/index/call", { fn: "listPatterns" }, { cookie }),
+      );
+      expect(response.status).toBe(502);
+      const body = await response.json();
+      expect(body.error).not.toContain(".secret.key");
+      expect(body.error).toContain("see its log");
+    });
+
     it("answers an allowlisted read with what the index returned", async () => {
       const listing = {
         patterns: [{

--- a/packages/cf-harness/test/kickoff/server.test.ts
+++ b/packages/cf-harness/test/kickoff/server.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
 import { KickoffServer, resolveKickoffConfig } from "../../kickoff/server.ts";
 import type { KickoffSessionListing } from "../../kickoff/sessions.ts";
+import type { HarnessFetch } from "../../src/contracts/http-fetch.ts";
+import { PatternIndexClient } from "../../src/pattern-index/client.ts";
 import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
@@ -47,6 +50,9 @@ const advancingClock = () => {
   };
 };
 
+/** The identity the proxied index client signs with in these tests. */
+const signer = await Identity.fromPassphrase("cf-harness kickoff index proxy");
+
 const config = () =>
   resolveKickoffConfig(
     [
@@ -56,6 +62,23 @@ const config = () =>
       "kickoff-test",
       "--session-db",
       "none",
+    ],
+    {},
+    "/kickoff",
+  );
+
+/** The same configuration, with an index for the proxy route to reach. */
+const configWithIndex = () =>
+  resolveKickoffConfig(
+    [
+      "--fabric-identity",
+      "key.pkcs8",
+      "--fabric-space",
+      "kickoff-test",
+      "--session-db",
+      "none",
+      "--pattern-index-url",
+      "https://index.test/api",
     ],
     {},
     "/kickoff",
@@ -116,6 +139,60 @@ describe("kickoff/server", () => {
     );
     expect(response.status).toBe(200);
     return await response.json();
+  };
+
+  /** What the index client was asked for, as it composed the request. */
+  interface IndexRequest {
+    url: string;
+    body: string;
+  }
+
+  /**
+   * A second server, configured with an index, whose client answers from
+   * `responses` rather than from a deployment. The client is handed in because
+   * the real one reads a keyfile off disk to sign with; what the routes are
+   * about is which requests reach it and which are refused before they do.
+   */
+  const indexServer = async (
+    responses: readonly Response[],
+  ): Promise<
+    { server: KickoffServer; cookie: string; requests: IndexRequest[] }
+  > => {
+    const requests: IndexRequest[] = [];
+    let answered = 0;
+    const fetchFn: HarnessFetch = (input, init) => {
+      requests.push({
+        url: String(input),
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+      const response = responses[answered] ?? Response.json({});
+      answered += 1;
+      return Promise.resolve(response);
+    };
+    const indexed = new KickoffServer(
+      configWithIndex(),
+      (onEvent) =>
+        new HarnessInteractiveChatService({
+          createPromptLoop: answeringLoop,
+          now: advancingClock(),
+          onEvent,
+        }),
+      () =>
+        Promise.resolve(
+          new PatternIndexClient({
+            baseUrl: "https://index.test/api",
+            fetchFn,
+            signer,
+          }),
+        ),
+    );
+    const page = await indexed.handle(getRequest("/"));
+    await page.body?.cancel();
+    return {
+      server: indexed,
+      cookie: page.headers.get("set-cookie")!.split(";")[0],
+      requests,
+    };
   };
 
   describe("GET /api/sessions", () => {
@@ -231,6 +308,167 @@ describe("kickoff/server", () => {
       );
 
       expect(response.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/index/call", () => {
+    /** Posts one proxied read at a server that has an index. */
+    const call = async (
+      indexed: { server: KickoffServer; cookie: string },
+      body: unknown,
+    ): Promise<Response> =>
+      await indexed.server.handle(
+        jsonRequest("/api/index/call", body, { cookie: indexed.cookie }),
+      );
+
+    it("answers an allowlisted read with what the index returned", async () => {
+      const listing = {
+        patterns: [{
+          patternId: "pat-1",
+          description: "Totals an expense list",
+          hashtags: ["expenses"],
+          keywords: [],
+          ownerDid: "did:key:zOwner",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          events: { run_succeeded: 2 },
+          score: 2,
+        }],
+        eventTypes: { run_succeeded: 1 },
+      };
+      const indexed = await indexServer([Response.json(listing)]);
+
+      const response = await call(indexed, { fn: "listPatterns" });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(listing);
+      expect(indexed.requests[0].url).toBe(
+        "https://index.test/api/listPatterns",
+      );
+      expect(JSON.parse(indexed.requests[0].body)).toEqual({});
+    });
+
+    it("sends only the search fields the page supplied", async () => {
+      const indexed = await indexServer([Response.json({ results: [] })]);
+
+      await call(indexed, {
+        fn: "searchPatterns",
+        body: { tags: ["expenses"], text: "totals", limit: 5, mystery: true },
+      });
+
+      expect(indexed.requests[0].url).toBe(
+        "https://index.test/api/searchPatterns",
+      );
+      expect(JSON.parse(indexed.requests[0].body)).toEqual({
+        tags: ["expenses"],
+        text: "totals",
+        limit: 5,
+      });
+    });
+
+    it("asks for a pattern without its source, whatever the page sent", async () => {
+      const indexed = await indexServer([
+        Response.json({
+          patternId: "pat-1",
+          ownerDid: "did:key:zOwner",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          description: "Totals an expense list",
+          hashtags: [],
+          dependencies: [],
+        }),
+      ]);
+
+      await call(indexed, {
+        fn: "getPattern",
+        body: { patternId: "pat-1", includeSource: true },
+      });
+
+      expect(JSON.parse(indexed.requests[0].body)).toEqual({
+        patternId: "pat-1",
+      });
+    });
+
+    it("answers 400 for getPattern with no pattern named", async () => {
+      const indexed = await indexServer([]);
+
+      const response = await call(indexed, { fn: "getPattern", body: {} });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toBe("patternId is required");
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 400 for a function outside the allowlist", async () => {
+      const indexed = await indexServer([]);
+
+      for (
+        const fn of ["recordEvent", "publishPattern", "deletePattern", 7]
+      ) {
+        const response = await call(indexed, {
+          fn,
+          body: { patternId: "pat-1", eventType: "thumbs_up" },
+        });
+        expect(response.status).toBe(400);
+        expect((await response.json()).error).toContain("fn must be one of");
+      }
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 400 for a body that is not JSON", async () => {
+      const indexed = await indexServer([]);
+
+      const response = await indexed.server.handle(
+        new Request("http://127.0.0.1:8100/api/index/call", {
+          method: "POST",
+          headers: {
+            cookie: indexed.cookie,
+            "content-type": "application/json",
+          },
+          body: "not json",
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("passes through the status the index gave a request it faulted", async () => {
+      const indexed = await indexServer([
+        Response.json({ error: "unknown pattern" }, { status: 404 }),
+      ]);
+
+      const response = await call(indexed, {
+        fn: "getPattern",
+        body: { patternId: "missing" },
+      });
+
+      expect(response.status).toBe(404);
+      // The message names the function and the status; the index's own body
+      // stays behind, as it does everywhere else a failure is rendered.
+      expect((await response.json()).error).toBe(
+        "pattern index getPattern failed (404)",
+      );
+    });
+
+    it("answers 502 when the index itself failed", async () => {
+      const indexed = await indexServer([
+        Response.json({ error: "datastore unavailable" }, { status: 503 }),
+      ]);
+
+      const response = await call(indexed, { fn: "listPatterns" });
+
+      expect(response.status).toBe(502);
+      expect((await response.json()).error).toContain("listPatterns");
+    });
+
+    it("answers 404 when the server was started without an index", async () => {
+      const response = await server.handle(
+        jsonRequest("/api/index/call", { fn: "listPatterns" }, { cookie }),
+      );
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error).toContain(
+        "started without a pattern index",
+      );
     });
   });
 
@@ -361,6 +599,29 @@ describe("kickoff/server", () => {
       );
 
       expect(response.status).toBe(403);
+    });
+
+    it("answers 403 for an index read made without the cookie", async () => {
+      const indexed = await indexServer([]);
+      const response = await indexed.server.handle(
+        jsonRequest("/api/index/call", { fn: "listPatterns" }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(indexed.requests).toEqual([]);
+    });
+
+    it("answers 403 for an index read from another origin", async () => {
+      const indexed = await indexServer([]);
+      const response = await indexed.server.handle(
+        jsonRequest("/api/index/call", { fn: "listPatterns" }, {
+          cookie: indexed.cookie,
+          origin: "http://evil.test",
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(indexed.requests).toEqual([]);
     });
 
     it("answers 415 for a task posted as a form submission", async () => {

--- a/packages/cf-harness/test/pattern-index/client.test.ts
+++ b/packages/cf-harness/test/pattern-index/client.test.ts
@@ -206,6 +206,85 @@ describe("PatternIndexClient", () => {
     expect(pattern.program).toBeUndefined();
   });
 
+  it("posts listPatterns with no fields and answers with the scored listing", async () => {
+    const { client, requests } = createClient([
+      jsonResponse({
+        patterns: [{
+          patternId: "pat-1",
+          description: "Totals an expense list",
+          hashtags: ["expenses"],
+          keywords: ["total"],
+          ownerDid: "did:key:zOwner",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          events: { run_succeeded: 3, thumbs_up: 1 },
+          score: 5,
+        }],
+        eventTypes: { run_succeeded: 1, thumbs_up: 2 },
+      }),
+    ]);
+    const listing = await client.listPatterns();
+    expect(requests[0].url).toBe("https://index.test/api/listPatterns");
+    expect(JSON.parse(requests[0].body)).toEqual({});
+    expect(listing.patterns[0].events).toEqual({
+      run_succeeded: 3,
+      thumbs_up: 1,
+    });
+    expect(listing.eventTypes.thumbs_up).toBe(2);
+  });
+
+  it("carries a listing's absent creation time through as null", async () => {
+    const { client } = createClient([
+      jsonResponse({
+        patterns: [{
+          patternId: "pat-1",
+          description: "Totals an expense list",
+          hashtags: [],
+          keywords: [],
+          ownerDid: "did:key:zOwner",
+          createdAt: null,
+          events: {},
+          score: 0,
+        }],
+        eventTypes: {},
+      }),
+    ]);
+    expect((await client.listPatterns()).patterns[0].createdAt).toBeNull();
+  });
+
+  it("sends only the listEvents fields the caller supplied", async () => {
+    const { client, requests } = createClient([
+      jsonResponse({ events: [] }),
+      jsonResponse({ events: [] }),
+    ]);
+    await client.listEvents();
+    expect(requests[0].url).toBe("https://index.test/api/listEvents");
+    expect(JSON.parse(requests[0].body)).toEqual({});
+
+    await client.listEvents({ patternId: "pat-1", limit: 20 });
+    expect(JSON.parse(requests[1].body)).toEqual({
+      patternId: "pat-1",
+      limit: 20,
+    });
+  });
+
+  it("answers listEvents with the caller's own recorded events", async () => {
+    const { client } = createClient([
+      jsonResponse({
+        events: [{
+          patternId: "pat-1",
+          did: "did:key:zOwner",
+          eventType: "run_succeeded",
+          ts: "2026-08-02T09:00:00.000Z",
+          note: "ran in the harness",
+        }],
+      }),
+    ]);
+    const response = await client.listEvents({ limit: 1 });
+    expect(response.events).toHaveLength(1);
+    expect(response.events[0].eventType).toBe("run_succeeded");
+    expect(response.events[0].note).toBe("ran in the harness");
+  });
+
   it("posts an event with its type and optional note", async () => {
     const { client, requests } = createClient([jsonResponse({ ok: true })]);
     const response = await client.recordEvent({


### PR DESCRIPTION
Folds the pattern-index operator tooling into the kickoff surface, so one authenticated localhost page serves both halves of the loop: watching harness sessions and inspecting what the index holds.

- **Index view** beside the run reader (`?view=index`): patterns table sorted by weighted score with per-event-type badges (row click: schemas, dependencies, that pattern's events), the caller's own event stream with client-side filtering, and a search playground showing the raw request beside ranked hits with their matchedTerms/queryTerms ratio.
- **`POST /api/index/call`** proxies to the deployed index, signed CF1 with the fabric identity. It sits behind the existing Host/Origin/cookie-token gates, allowlists exactly the four read functions, and rebuilds request bodies field by field — `includeSource` cannot ride through, pinned by test. Without `--pattern-index-url` the route answers 404 naming the flag.
- The typed client gains `listPatterns`/`listEvents` matching the index's documented shapes.
- Verified in a real browser against the production index: 19 patterns render scored, the events pane shows only the signing identity's own stream, and the playground reproduces the ranked-search behavior.

This supersedes the standalone `inspector.ts` script in the pattern-index repo, which can now be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



ACCEPT_COVERAGE_DEBT: packages/cf-harness +510 lines

