### PR TITLE
Section markers in CSS

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -239,9 +239,15 @@ we were not looking."
 
 ## Section markers
 
-Mark a section of a file or a class with a `//` comment block that opens and
-closes with a line holding nothing but `//`. It carries a noun-phrase title, and
-optionally a fully grammatical description after a blank line:
+Section markers separate major portions of a file or class. They are not
+headers for individual functions and their helpers — doc comments already
+carry that structure, and a reader navigating by rendered documentation never
+sees the marker at all.
+
+Where `//` comments can be used, mark a section of a file or a class with a
+`//` comment block that opens and closes with a line holding nothing but `//`.
+It carries a noun-phrase title, and optionally a fully grammatical description
+after a blank line:
 
 ```ts
 // Shown at module scope.
@@ -256,10 +262,22 @@ optionally a fully grammatical description after a blank line:
 export function fry(): void {}
 ```
 
-Section markers separate major portions of a file or class. They are not
-headers for individual functions and their helpers — doc comments already
-carry that structure, and a reader navigating by rendered documentation never
-sees the marker at all.
+**CSS takes a block comment.** CSS has no line comments, so a section marker in
+a `.css` file, a `css` template literal, or a `<style>` block is a `/* */`
+block, with each delimiter on its own line and every line at the same
+indentation. Each line between the delimiters opens with `**`, which tells a
+marker apart from an ordinary comment:
+
+```css
+/*
+** Frosting variants
+**
+** One per glaze the fryer supports, in the order the menu lists them.
+*/
+```
+
+That flush indentation is what `deno fmt` settles a continuation line on inside
+a `css` template literal, so the single form holds wherever the CSS lives.
 
 **No horizontal rules.** Do not put long runs of dashes, equals signs, or other
 repeated characters into a comment, whether or not as part of a section marker.
@@ -400,8 +418,8 @@ A doc comment with no declaration under it at all is the same defect from the
 other direction, with one exception: the file header documents the file rather
 than any declaration in it, and is written as a doc comment for that reason;
 see [File headers](#file-headers) below. Everything else in that shape is the
-defect. To title a region of a file or a class, use a section marker, which is
-a `//` block; see [Section markers](#section-markers) above.
+defect. To title a region of a file or a class, use a section marker; see
+[Section markers](#section-markers) above.
 
 ### The blank line above
 

--- a/packages/ui/src/v2/components/cf-button/styles.ts
+++ b/packages/ui/src/v2/components/cf-button/styles.ts
@@ -160,7 +160,9 @@ export const styles = css`
     padding: 0;
   }
 
-  /* ── Solid variant ─────────────────────────────────────────────────── */
+  /*
+  ** Solid variant
+  */
 
   .button.solid {
     border-color: transparent;
@@ -208,7 +210,9 @@ export const styles = css`
     border-color: var(--cf-theme-color-danger-pressed);
   }
 
-  /* ── Outline variant ────────────────────────────────────────────────── */
+  /*
+  ** Outline variant
+  */
 
   .button.outline {
     background-color: transparent;
@@ -250,7 +254,9 @@ export const styles = css`
     background-color: var(--cf-theme-color-danger-subtle);
   }
 
-  /* ── Ghost variant ──────────────────────────────────────────────────── */
+  /*
+  ** Ghost variant
+  */
 
   .button.ghost {
     background-color: transparent;

--- a/packages/ui/src/v2/components/cf-map/styles.ts
+++ b/packages/ui/src/v2/components/cf-map/styles.ts
@@ -6,10 +6,11 @@
 import { css } from "lit";
 
 export const styles = css`
-  /* ================================================
-  * Leaflet Core CSS (v1.9.4)
-  * Required for proper map rendering in Shadow DOM
-  * ================================================ */
+  /*
+  ** Leaflet Core CSS (v1.9.4)
+  **
+  ** Required for proper map rendering in Shadow DOM
+  */
 
   /* required styles */
 
@@ -690,10 +691,11 @@ export const styles = css`
     }
   }
 
-  /* ================================================
-  * cf-map Component Styles
-  * Theme-integrated styles for the map container
-  * ================================================ */
+  /*
+  ** cf-map Component Styles
+  **
+  ** Theme-integrated styles for the map container
+  */
 
   :host {
     display: block;
@@ -728,10 +730,11 @@ export const styles = css`
     font-family: var(--cf-font-family, inherit);
   }
 
-  /* ================================================
-  * Popup Theme Integration
-  * Override Leaflet popup styles with cf-* theme
-  * ================================================ */
+  /*
+  ** Popup Theme Integration
+  **
+  ** Override Leaflet popup styles with cf-* theme
+  */
 
   .leaflet-popup-content-wrapper,
   .leaflet-popup-tip {
@@ -851,10 +854,11 @@ export const styles = css`
     outline-offset: 2px;
   }
 
-  /* ================================================
-  * Custom Marker Icon Styles
-  * Styles for divIcon-based markers (emoji and default)
-  * ================================================ */
+  /*
+  ** Custom Marker Icon Styles
+  **
+  ** Styles for divIcon-based markers (emoji and default)
+  */
 
   /* Default marker icon (SVG pin) */
   .cf-map-default-marker {

--- a/packages/ui/src/v2/components/cf-modal/styles.ts
+++ b/packages/ui/src/v2/components/cf-modal/styles.ts
@@ -66,14 +66,18 @@ export const modalStyles = css`
     display: contents;
   }
 
-  /* ===== Hidden State ===== */
+  /*
+  ** Hidden State
+  */
   :host(:not([open])) .backdrop,
   :host(:not([open])) .container {
     visibility: hidden;
     pointer-events: none;
   }
 
-  /* ===== Backdrop ===== */
+  /*
+  ** Backdrop
+  */
   .backdrop {
     position: fixed;
     inset: 0;
@@ -89,7 +93,9 @@ export const modalStyles = css`
     opacity: 1;
   }
 
-  /* ===== Container (centering) ===== */
+  /*
+  ** Container (centering)
+  */
   .container {
     position: fixed;
     inset: 0;
@@ -99,7 +105,9 @@ export const modalStyles = css`
     padding: var(--cf-spacing-4, 16px);
   }
 
-  /* ===== Dialog ===== */
+  /*
+  ** Dialog
+  */
   .dialog {
     position: relative;
     box-sizing: border-box;
@@ -129,7 +137,9 @@ export const modalStyles = css`
     transform: scale(1);
   }
 
-  /* ===== Size Variants ===== */
+  /*
+  ** Size Variants
+  */
   :host([size="sm"]) .dialog {
     width: var(--_width-sm);
   }
@@ -146,7 +156,9 @@ export const modalStyles = css`
     max-height: min(calc(100vh - 32px), 100%);
   }
 
-  /* ===== Header ===== */
+  /*
+  ** Header
+  */
   .header {
     display: flex;
     justify-content: space-between;
@@ -169,7 +181,9 @@ export const modalStyles = css`
     min-width: 0;
   }
 
-  /* ===== Close Button ===== */
+  /*
+  ** Close Button
+  */
   .close-button {
     background: transparent;
     border: none;
@@ -201,14 +215,18 @@ export const modalStyles = css`
     display: none;
   }
 
-  /* ===== Content ===== */
+  /*
+  ** Content
+  */
   .content {
     padding: var(--cf-modal-padding);
     overflow: auto;
     flex: 1;
   }
 
-  /* ===== Footer ===== */
+  /*
+  ** Footer
+  */
   .footer {
     display: flex;
     justify-content: flex-end;
@@ -228,7 +246,9 @@ export const modalStyles = css`
     width: 100%;
   }
 
-  /* ===== Sheet Presentation Mode ===== */
+  /*
+  ** Sheet Presentation Mode
+  */
 
   /* Grabber: hidden by default */
   .grabber {
@@ -299,7 +319,9 @@ export const modalStyles = css`
     width: 100%;
   }
 
-  /* ===== Reduced Motion ===== */
+  /*
+  ** Reduced Motion
+  */
   @media (prefers-reduced-motion: reduce) {
     .backdrop,
     .dialog {

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -373,7 +373,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         }
       }
 
-      /* ---- Variants (CT-1761) -------------------------------------------- */
+      /*
+      ** Variants
+      */
 
       /* chip: compact name-first pill. No avatar — a small DID-hued "seal dot"
         carries the identity treatment, so an inline name still reads as a

--- a/packages/ui/src/v2/components/cf-radio-group/styles.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/styles.ts
@@ -59,9 +59,9 @@ export const radioGroupStyles = `
     cursor: not-allowed;
   }
 
-  /* ========================================
-     Styles for items-based rendering
-     ======================================== */
+  /*
+  ** Styles for items-based rendering
+  */
 
   .radio-item {
     display: flex;

--- a/packages/ui/src/v2/components/cf-tab/cf-tab.ts
+++ b/packages/ui/src/v2/components/cf-tab/cf-tab.ts
@@ -92,7 +92,9 @@ export class CFTab extends BaseElement {
         height: auto;
       }
 
-      /* ===== Chip variant styles ===== */
+      /*
+      ** Chip variant styles
+      */
 
       /* Suppress underline indicator in chip mode */
       :host([data-variant="chip"]) .tab[data-selected="true"]::after {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

CSS has no line comments, so the `//`-delimited section marker this repo uses
cannot be written in a `.css` file, a `css` template literal, or a `<style>`
block. This adds the CSS form to `docs/development/code-comment-style.md` and
conforms every existing CSS section marker to it.

## The form

A `/* */` block with each delimiter on its own line, every line at the same
indentation, and each line between the delimiters opening with `**`:

```css
/*
** Frosting variants
**
** One per glaze the fryer supports, in the order the menu lists them.
*/
```

Flush indentation and `**` are not cosmetic. `deno fmt` formats the CSS inside
a `css` template literal, and it settles a continuation line at the comment's
own indentation. Measured against the alternatives:

| | ` * ` one space in | `**` flush |
| --- | --- | --- |
| stable inside a `css` template literal | no, the `*` is pulled left | yes |
| stable in an untagged template, `<style>`, `.css` | yes | yes |
| one form in every context | no, two alignments | yes |
| a mis-indented marker | stays wrong | the formatter pulls it into the form |
| distinct from an ordinary CSS comment | no | yes |

So the rule needs no formatter caveat: `deno fmt` enforces it.

Two smaller edits keep the surrounding prose true. The section's opening
statement is caveated with "where `//` comments can be used", and a later
clause calling a section marker "a `//` block" is dropped, since the linked
section now states both forms.

## The markers

21 markers across 6 files, all in `packages/ui`: `cf-modal/styles.ts` (11),
`cf-map/styles.ts` (4), `cf-button/styles.ts` (3), and one each in
`cf-radio-group/styles.ts`, `cf-profile-badge.ts`, and `cf-tab.ts`. They were
written five different ways, including `===== Title =====`, `-- Title ------`,
and a `===`-sandwiched block.

Titles carry over verbatim. The single exception is a tracker ID dropped from a
title in `cf-profile-badge.ts`, per the rule against internal designations in
code; it is the only word this change adds or removes anywhere under
`packages/`, which the whole-diff word multiset confirms. No wording is
corrected, so a description that reads as a fragment stays one.

Scope is markers that already exist. Nothing gains a marker it did not have.

## Verification

`deno fmt --check`, `deno lint`, `deno task check-docs`, and `deno task check`
all pass, as does `packages/ui`'s own `deno task test` (167 passed / 1128
steps, plus 52 passed, 0 failed). `deno fmt` leaves what the conversion writes
byte-identical.

Two files that look in scope are deliberately untouched. The four markers in
`toolshed/routes/health/health.handlers.ts` sit at lines 353-521, inside that
file's `<script>` block (163-554) rather than its `<style>` block (74-137), so
they are JavaScript markers. `cf-select.ts` has ten block-comment markers in
its class body, not in CSS. Both belong to the TypeScript sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

