### PR TITLE
Remove the section-marker horizontal rules that carry no title

### DIFF
--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -122,8 +122,6 @@ const isLinkReference = (atom: unknown): atom is {
   (atom as { type?: unknown }).type ===
     "https://commonfabric.org/cfc/atom/LinkReference";
 
-// ===========================================================================
-
 describe("CFC cross-space integrity", () => {
   // -------------------------------------------------------------------------
   // Primitive: a value gets integrity. Declared `ifc.integrity` with a

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -81,7 +81,6 @@ export const EnvSchema = z.object({
   // See docs/features/active-user-counting.md.
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),
   OTEL_TRACES_SAMPLER_ARG: z.string().default("1.0"),
-  // ===========================================================================
 
   // ===========================================================================
   // (/routes/ai/llm) Environment variables for LLM Providers
@@ -95,7 +94,6 @@ export const EnvSchema = z.object({
   // The gateway is reachable only on Tailscale; toolshed falls back cleanly
   // when the URL is unreachable (see `loadGatewayModels` in routes/ai/llm/models.ts).
   CFTS_AI_GATEWAY_URL: z.string().default("https://llm.stage.commontools.dev"),
-  // ===========================================================================
 
   // ===========================================================================
   // FAL AI API Key
@@ -103,7 +101,6 @@ export const EnvSchema = z.object({
   //   * /routes/ai/voice
   // ===========================================================================
   FAL_API_KEY: z.string().default(""),
-  // ===========================================================================
 
   // ===========================================================================
   // Jina API Key
@@ -111,7 +108,6 @@ export const EnvSchema = z.object({
   //   * /routes/link-preview
   // ===========================================================================
   JINA_API_KEY: z.string().default(""),
-  // ===========================================================================
 
   // ===========================================================================
   // Memory Store
@@ -196,7 +192,6 @@ export const EnvSchema = z.object({
   PLAID_REDIRECT_URI: z.string().optional(),
   // Strict parse (see boolFlag); previously z.coerce.boolean() turned "false" into true.
   PLAID_SYNC_ALL_TRANSACTIONS: boolFlag(),
-  // ===========================================================================
 
   // URL of the toolshed API, for self-referring requests
   API_URL: z.string().default("http://localhost:8000"),

--- a/packages/ts-transformers/test/fixtures/bug-repro/actual-types-repro.ts
+++ b/packages/ts-transformers/test/fixtures/bug-repro/actual-types-repro.ts
@@ -1,6 +1,5 @@
 /**
  * NULL ELIMINATION REPRODUCTION - Using Actual Common Fabric Types
- * ===============================================================
  *
  * This uses the real Reactive from commonfabric to verify the bug.
  *

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -135,8 +135,6 @@ g.customElements = { define: () => {}, get: () => undefined };
 g.requestAnimationFrame = (_cb: () => void) => 0;
 g.cancelAnimationFrame = () => {};
 
-// ---------------------------------------------------------------------------
-
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A census of section markers across the tree turned up eight horizontal rules
that carry no title — none on the rule line, and none on a comment line
touching it. They name nothing, so conforming one to the `//`-delimited form
would mean inventing a title. Each is removed instead.

## What goes

Five in `packages/toolshed/env.ts` (lines 84, 98, 106, 114, 199). Each closes a
section whose *opening* marker is a titled `====` sandwich. Only the titleless
closers go here; the titled openers are nonconforming in a different way and
stay for the sweep that conforms `toolshed`.

One in `packages/runner/test/cfc-cross-space-integrity.test.ts`, dividing the
helper declarations from the suite, and one in
`packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts`, dividing the global
test setup from the imports.

The eighth is a different shape: in
`packages/ts-transformers/test/fixtures/bug-repro/actual-types-repro.ts` a rule
*underlines* the title of the file's doc comment rather than bracketing it.
The rule goes and the title stays.

## Shape of the change

Comments only. The whole diff adds no line at all: of the ten lines it removes,
eight are bare rules and two are blanks that would otherwise have been left
doubled. No wording is changed anywhere.

Each removal was checked against the file before it was made — that the target
line is a bare rule, and that neither neighbouring line is a comment, which is
what makes it titleless rather than part of a titled marker.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` all pass. `toolshed`,
`ui`, and `ts-transformers` each pass their own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

