### PR TITLE
fix(runtime-client): `connect()` no longer leaks its worker

### DIFF
--- a/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
@@ -73,11 +73,28 @@ export class WebWorkerRuntimeTransport
     return this._readyPromise.promise;
   }
 
-  static connect(
+  /**
+   * Constructs a transport, and resolves it once its worker reports ready.
+   *
+   * @throws If readiness fails. The transport is disposed of before the throw,
+   *   so no worker is left running.
+   */
+  static async connect(
     options: WebWorkerRuntimeTransportOptions = {},
   ): Promise<WebWorkerRuntimeTransport> {
     const transport = new WebWorkerRuntimeTransport(options);
-    return transport.ready().then(() => transport);
+
+    try {
+      await transport.ready();
+    } catch (error) {
+      // The caller never receives a transport on this path, so the disposal is
+      // this method's to do. `terminate()` lives only in `dispose()`, and
+      // nothing else is left holding the worker.
+      await transport.dispose();
+      throw error;
+    }
+
+    return transport;
   }
 
   private _handleMessage = (event: MessageEvent): void => {

--- a/packages/runtime-client/test/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/test/client/transport-web-worker.test.ts
@@ -7,8 +7,13 @@ import { WebWorkerRuntimeTransport } from "@/client/transports/web-worker/transp
 // without a real worker: a fake Worker class lets us construct the transport,
 // then we drive its private message handler directly.
 class FakeWorker extends EventTarget {
+  static instances: FakeWorker[] = [];
   posted: unknown[] = [];
   terminated = false;
+  constructor() {
+    super();
+    FakeWorker.instances.push(this);
+  }
   postMessage(message: unknown): void {
     this.posted.push(message);
   }
@@ -24,6 +29,31 @@ function makeTransport(): WebWorkerRuntimeTransport {
     return new WebWorkerRuntimeTransport({
       workerUrl: new URL("http://localhost/worker.js"),
     });
+  } finally {
+    (globalThis as { Worker: unknown }).Worker = OriginalWorker;
+  }
+}
+
+/**
+ * Calls `connect()` with the fake worker in place, handing back both the
+ * pending connection and the fake the call constructed. Unlike the tests that
+ * drive a transport they already hold, one of `connect()` has to reach the
+ * worker through the transport it is not given.
+ */
+function connectWithFakeWorker(): {
+  connection: Promise<WebWorkerRuntimeTransport>;
+  worker: FakeWorker;
+} {
+  const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
+  (globalThis as { Worker: unknown }).Worker = FakeWorker;
+  FakeWorker.instances.length = 0;
+  try {
+    // `connect()` constructs the transport before its first `await`, so the
+    // swap only has to cover the call itself, not the promise it returns.
+    const connection = WebWorkerRuntimeTransport.connect({
+      workerUrl: new URL("http://localhost/worker.js"),
+    });
+    return { connection, worker: FakeWorker.instances[0] };
   } finally {
     (globalThis as { Worker: unknown }).Worker = OriginalWorker;
   }
@@ -63,6 +93,25 @@ describe("WebWorkerRuntimeTransport", () => {
       expect(settled).toBe(true);
 
       await transport.dispose();
+    });
+  });
+
+  describe("connect()", () => {
+    it("terminates the worker when a pre-ready worker error rejects it", async () => {
+      // A failed `connect()` never hands the caller a transport, so there is
+      // nothing left to call `dispose()` on -- and `dispose()` holds the only
+      // `terminate()`. The worker would run for as long as the page did.
+      const { connection, worker } = connectWithFakeWorker();
+
+      worker.dispatchEvent(
+        new ErrorEvent("error", {
+          message: "worker failed to load",
+          cancelable: true,
+        }),
+      );
+
+      await expect(connection).rejects.toThrow("worker failed to load");
+      expect(worker.terminated).toBe(true);
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`WebWorkerRuntimeTransport.connect()` builds a transport and returns
`transport.ready().then(() => transport)`. When readiness rejects, the caller
gets the rejection and never gets the transport — and `terminate()` lives only
in `dispose()`, which there is then nothing left to call. The worker runs for
as long as the page does.

This is reachable by the ordinary failure: `_handleError()` rejects the
readiness promise for a worker error arriving before ready, which is what a
worker that fails to load produces.

## The change

`connect()` disposes of the transport before rethrowing. That is the whole of
it; the rejection the caller sees is unchanged.

The one production caller is `lib-shell`'s `runtime.ts`, which awaits
`connect()` and is unaffected either way — what changes is only what is left
running behind the throw.

## The test, and why there wasn't one

Every existing test in that file constructs a transport directly and drives its
private handlers. The leak is a property of the path that does *not* hand a
transport back, so none of them could see it. The new test goes through
`connect()` and reaches the worker by way of a fake that records the instances
it constructs.

Ablated rather than assumed: with the `dispose()` removed, the test fails on
the terminate assertion specifically, the rejection having been asserted on
both sides.

## Checks

`deno fmt --check`, `deno lint`, and `deno task check` all pass on this branch,
as do the `runtime-client` and `lib-shell` suites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

