### PR TITLE
Conform the section markers in seven small packages

### DIFF
--- a/packages/cf-harness/test/openai-compaction.test.ts
+++ b/packages/cf-harness/test/openai-compaction.test.ts
@@ -69,9 +69,9 @@ const registry = (models: Array<Record<string, unknown>>) => ({
   data: models,
 });
 
-// ---------------------------------------------------------------------------
+//
 // Threshold policy
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("the threshold is 75% of the input budget, not of context window", () => {
   // gpt-5.6 family: 1,050,000 total - 128,000 output = 922,000 input.
@@ -132,9 +132,9 @@ Deno.test("a per-request threshold overrides, and 0 disables", async () => {
   assertEquals(captured[2].body.context_management, undefined);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Retention and pruning
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("a compaction item is retained rather than dropped", async () => {
   const captured: Captured[] = [];
@@ -303,9 +303,9 @@ Deno.test("a compaction from another model is not replayed", async () => {
   assert(JSON.stringify(input).includes("early contents"));
 });
 
-// ---------------------------------------------------------------------------
+//
 // The default must work on the normal run path, with no primed catalog.
-// ---------------------------------------------------------------------------
+//
 
 const toolHeavyTranscript = (): HarnessTranscriptMessage[] => [
   { role: "user", content: "Go." },
@@ -501,9 +501,9 @@ Deno.test("a later turn retries after an unreachable registry", async () => {
   }]);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Unsupported paths must fail loudly rather than ignore the option.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("a positive threshold on a chat-routed model is rejected", async () => {
   const client = clientWith([], [completed([])]);

--- a/packages/cf-harness/test/support/responses-fixture.test.ts
+++ b/packages/cf-harness/test/support/responses-fixture.test.ts
@@ -55,12 +55,12 @@ const turn = (
   ...overrides,
 });
 
-// ---------------------------------------------------------------------------
+//
 // The property that matters: converting a fixture must not change the
 // assistant message the harness derives from it. Both production paths are
 // driven with the same fixture — Chat Completions reads it directly, the
 // Responses path reads the converted form — and the results must agree.
-// ---------------------------------------------------------------------------
+//
 
 const assertPathsAgree = async (chatFixture: Record<string, unknown>) => {
   // gemini-* stays on Chat Completions and consumes the fixture as written.
@@ -129,9 +129,9 @@ Deno.test("converted fixtures preserve text alongside multiple tool calls", asyn
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Conversion details and pass-through rules.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("responsesBodyFromChatFixture leaves non-chat bodies untouched", () => {
   // Model listings and error payloads flow through the same stub boundary.
@@ -214,9 +214,9 @@ Deno.test("responsesBodyFromChatFixture carries id and usage through", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Request projection.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("chatViewOfRequest projects a Responses request to the chat view", () => {
   const view = chatViewOfRequest({

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -414,7 +414,9 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
   assertEquals(context.currentDir, "/workspace/repo");
 });
 
-// --- recoverable vs fatal tool-boundary narrowing (D9 / cf-review) ----------
+//
+// recoverable vs fatal tool-boundary narrowing (D9 / cf-review)
+//
 
 Deno.test("bash tool: a SandboxPathEscapeError on cwd is a recoverable result, not a throw", async () => {
   class PathEscapeSandbox extends FakeSandboxRuntime {

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -79,7 +79,9 @@ function ctx(env: Record<string, string> = {}): Ctx {
   };
 }
 
-// ---------------------------------------------------------------- zip building
+//
+// zip building
+//
 
 function concat(parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
   const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
@@ -165,7 +167,9 @@ async function benchZip(json: string): Promise<Uint8Array<ArrayBuffer>> {
   ]);
 }
 
-// ------------------------------------------------------------- the stub api
+//
+// the stub api
+//
 
 interface GhRun {
   id: number;
@@ -282,7 +286,9 @@ const apiCalls = (calls: string[]) =>
 const runListCalls = (calls: string[]) =>
   calls.filter((call) => call.startsWith(runsPath));
 
-// ------------------------------------------------------------ bench json
+//
+// bench json
+//
 
 interface Timings {
   min?: number;
@@ -373,7 +379,9 @@ async function withTotals(
   }, run);
 }
 
-// ----------------------------------------------------------------- the tests
+//
+// the tests
+//
 
 Deno.test("benchmark: no token -> gray, and nothing is fetched", async () => {
   await withApi({ throws: new Error("no request expected") }, async (calls) => {

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -41,9 +41,9 @@ import {
 } from "./annotations.ts";
 import { encodeFuseComponent } from "./path-codec.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Shared helpers
-// ---------------------------------------------------------------------------
+//
 
 const decoder = new TextDecoder();
 
@@ -1995,9 +1995,9 @@ Deno.test("CellBridge fails closed without paginated identifier listing", async 
   assertEquals(pieceListRequests, 0);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Group 1: loadPieceTree — initial tree structure
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("CellBridge.loadPieceTree creates meta.json with a pattern reference", async () => {
   const tree = new FsTree();
@@ -3556,9 +3556,9 @@ Deno.test("CellBridge.hydratePieceProp labels void handlers as no-arg callables 
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // Group 2: addPieceToSpace — name collision
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", async () => {
   const tree = new FsTree();
@@ -3680,9 +3680,9 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 and -3 suffixes for three colli
   assertEquals(tree.lookup(state.piecesIno, "Standup-3") !== undefined, true);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Group 3: updateIndexJson
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("CellBridge.updateIndexJson writes .index.json mapping names to entity IDs", async () => {
   const tree = new FsTree();
@@ -4338,9 +4338,9 @@ Deno.test("CellBridge decodes encoded space directory names for source write pat
   assertEquals(patternRefReads, 1);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Group 4: syncPieceListOnce — add/remove
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("CellBridge.syncPieceListOnce adds a new piece to the tree", async () => {
   const tree = new FsTree();
@@ -4444,9 +4444,9 @@ Deno.test("CellBridge.syncPieceListOnce removes a deleted piece from the tree", 
   assertEquals(state.pieceMap.size, 0);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Group 5: subscribePiece — rename on cell change
-// ---------------------------------------------------------------------------
+//
 
 Deno.test({
   name: "CellBridge.subscribePiece renames directory when piece name changes",

--- a/packages/fuse/tree.test.ts
+++ b/packages/fuse/tree.test.ts
@@ -262,7 +262,9 @@ Deno.test("getNameForIno returns the registered child name", () => {
   assertEquals(tree.getNameForIno(ino), undefined);
 });
 
-// --- transplantSubtree ---------------------------------------------------
+//
+// transplantSubtree
+//
 
 type BuildSpec =
   | { file: string; jsonType?: JsonType }
@@ -564,7 +566,9 @@ Deno.test("transplant removes a vanished child's CFC directory entry", () => {
   assertEquals(entries?.map((entry) => entry.name), ["keep"]);
 });
 
-// --- mtime tracking ------------------------------------------------------
+//
+// mtime tracking
+//
 
 Deno.test("a node records the clock time it was created at", () => {
   let clock = 1_000;
@@ -692,7 +696,9 @@ Deno.test("clear on a missing inode is a no-op", () => {
   assertEquals(tree.inodes.size, before);
 });
 
-// --- generated files (.status) -------------------------------------------
+//
+// generated files (.status)
+//
 
 Deno.test("addGeneratedFile publishes an initial render", () => {
   const tree = new FsTree();

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -288,7 +288,9 @@ export class DomApplicator {
     };
   }
 
-  // ============== Operation Implementations ==============
+  //
+  // Operation Implementations
+  //
 
   private createElement(nodeId: number, tagName: string, space?: string): void {
     const element = this.document.createElement(tagName);

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -241,7 +241,9 @@ export class VDomRenderer {
     return this.mountId;
   }
 
-  // ============== Private Methods ==============
+  //
+  // Private Methods
+  //
 
   private handleVDomBatch = (notification: VDomBatchNotification): void => {
     if (this.disposed) return;

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -472,7 +472,9 @@ export class WorkerReconciler {
     return this.rootChildId;
   }
 
-  // ============== Private Methods ==============
+  //
+  // Private Methods
+  //
 
   /**
    * Queue operations to be sent to the main thread.

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2666,10 +2666,12 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // --- Default render ceiling (spec §8.10.6, S16 phase D) ---------------
+    //
+    // Default render ceiling (spec §8.10.6, S16 phase D)
     // A host-supplied root ceiling gates labeled cells with NO authored
     // boundary in the tree: atoms render only when listed exactly or when
     // they are Caveat atoms of an allow-listed kind.
+    //
 
     const PROMPT_INFLUENCE_KIND =
       "https://commonfabric.org/cfc/concepts/prompt-influence";

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -5,9 +5,9 @@ import { SourceMap } from "./interface.ts";
 
 export type { MappedPosition };
 
-// ---------------------------------------------------------------------------
+//
 // VLQ-level composition (the fast path of `composeBundleSourceMap`)
-// ---------------------------------------------------------------------------
+//
 
 /**
  * A mappings stream the transcoder cannot compose: malformed VLQs, unsorted

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -80,9 +80,9 @@ export const setLLMUrl = (toolshedUrl: string) => {
   llmApiUrl = new URL("/api/ai/llm", toolshedUrl).toString();
 };
 
-// ============================================================================
+//
 // Mock Mode for Testing
-// ============================================================================
+//
 
 type MockResponseMatcher = (request: LLMRequest) => boolean;
 type MockObjectResponseMatcher = (request: LLMGenerateObjectRequest) => boolean;
@@ -272,9 +272,9 @@ export function addMockObjectResponse(
   mockCatalog.addObjectResponse(matcher, response);
 }
 
-// ============================================================================
+//
 // Conversation Fixtures for Testing
-// ============================================================================
+//
 
 /**
  * Optional assertions to validate the request when a fixture entry is matched.

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -608,9 +608,9 @@ export class DebuggerController implements ReactiveController {
     return this.activeFlags?.["runner"]?.[flagName]?.[id] ?? null;
   }
 
-  // ============================================================
+  //
   // Diagnosis for non-idempotent detection
-  // ============================================================
+  //
 
   /**
    * Run diagnosis and store the result.

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -1356,9 +1356,9 @@ export class XDebuggerView extends LitElement {
     return String(value);
   }
 
-  // ============================================================
+  //
   // Logger stats methods
-  // ============================================================
+  //
 
   private getLoggerRegistry(): Record<string, Logger> {
     const global = globalThis as unknown as {

--- a/packages/shell/test/device-link.test.ts
+++ b/packages/shell/test/device-link.test.ts
@@ -415,7 +415,8 @@ describe("runDeviceLinkLogin", () => {
   });
 });
 
-// ── the confirm gate itself ────────────────────────────────────────────────
+//
+// the confirm gate itself
 //
 // Previously uncovered: every test above injects its own `confirm`, so the
 // production path and the whole view were unexercised. Two mutations passed the
@@ -425,6 +426,7 @@ describe("runDeviceLinkLogin", () => {
 //
 // Follows the repo's view-test idiom (see login-view.test.ts): install fake
 // browser globals, instantiate the element, and inspect what render() produces.
+//
 
 function installBrowserGlobals(): () => void {
   const originals = new Map<string, PropertyDescriptor | undefined>();
@@ -710,7 +712,8 @@ describe("confirmWithUser (the production confirm path)", () => {
   });
 });
 
-// ── the modal activation seam ──────────────────────────────────────────────
+//
+// the modal activation seam
 //
 // firstUpdated's imperative DOM work runs only against a real DOM, so the
 // browser-behavior mutations (Escape rewired to accept, showModal never
@@ -718,6 +721,7 @@ describe("confirmWithUser (the production confirm path)", () => {
 // tests stub document.body.appendChild to a no-op, so the element never
 // connects and firstUpdated never fires. `activateModalDialog` is extracted so
 // exactly those rules can be pinned against a fake dialog, no browser needed.
+//
 
 /** Records what the component does to a dialog. */
 function fakeDialog(
@@ -873,12 +877,14 @@ describe("firstUpdated wiring (component-level, via a stubbed shadow root)", () 
   });
 });
 
-// ── failure reporting + fallback paths ─────────────────────────────────────
+//
+// failure reporting + fallback paths
 //
 // These cover the error/degradation paths the coverage ratchet flagged as
 // uncovered. They are not padding: `reportDeviceLinkFailure` is the whole
 // reason a failed scan isn't silent, and the two `catch` arms are what keep a
 // hostile or exotic environment from turning a failure into a hang.
+//
 
 describe("reportDeviceLinkFailure", () => {
   /** Install a document whose createElement yields drivable fake views. */
@@ -1090,12 +1096,14 @@ describe("the tap-through guard actually releases", () => {
   });
 });
 
-// ── handleDeviceLink: the whole per-scan decision ──────────────────────────
+//
+// handleDeviceLink: the whole per-scan decision
 //
 // This logic used to live in index.ts — an entry module with a top-level await
 // that no unit test can import, so every branch here was uncoverable by
 // construction. Moving it into a real module is what makes these assertions
 // possible at all; the coverage ratchet was pointing at a genuine design smell.
+//
 
 describe("handleDeviceLink", () => {
   it("reports a malformed fragment and never attempts a login", async () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A section marker is a `//` block opening and closing with a line holding
nothing but `//`, and a horizontal rule is not part of one. This converts the
34 markers in `llm`, `js-compiler`, `html`, `dashboard`, `shell`, `cf-harness`,
and `fuse`.

It is the first of the per-package sweeps that follow the CSS rule, and the
smallest, so it doubles as the shakedown for the conversion.

## What the markers looked like

Seven shapes across the seven packages, all reduced to the one form:

| was | now |
| --- | --- |
| `// ===== Title =====` | `//` / `// Title` / `//` |
| a `===` rule above and below the title | same |
| `// --- Title -------------` filled to the margin | same |
| `// ------------- title` right-aligned | same |
| `// ── Title ────────` in box drawing | same |
| a rule above the title only, or below it only | same |
| a title line followed by a description | title, `//`, description, all inside |

Titles carry over verbatim. Nothing gains a marker it did not have, and a
description that reads as a fragment stays one.

## How it is checked

Three properties over the whole diff, not a sample of it:

- the word multiset is unchanged — no word added, none lost;
- no added line retains a run of two or more rule characters;
- no non-comment line is touched.

That second one caught a real bug mid-flight. The stripper matched runs of four
or more, so a *short* leading run survived: `// --- Default render ceiling ...`
and `// ── the confirm gate itself ...` kept their prefixes. Short runs are now
stripped too, but only at an end of the line and only against whitespace, so an
interior token like `--verbose` is never eaten. That case is one of six the
stripper is tested against directly.

The converter also refuses rather than guesses. A rule sitting between two
non-empty comment lines would silently weld a declaration's own comment onto
the section title; those are reported instead of converted, and the one such
case in the tree so far (in `toolshed`, not this PR) turned out to be exactly
that hazard.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass. `llm`,
`js-compiler`, `html`, `cf-harness`, and `fuse` each pass their own
`deno task test`. `dashboard` and `shell` have no non-browser suite to run
here; CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

