### PR TITLE
Conform the section markers in `api`, and regenerate what is built from it

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -13,9 +13,9 @@ import type {
 
 import type { Cfc, CurrentPrincipal, WriteAuthorizedBy } from "./cfc.ts";
 
-// ============================================================================
+//
 // Common internal definitions
-// ============================================================================
+//
 
 /**
  * Recursively removes `readonly` from all properties of `T`.
@@ -27,20 +27,20 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
   : T extends object ? ({ -readonly [P in keyof T]: Mutable<T[P]> })
   : T;
 
-// ============================================================================
+//
 // Fabric Value Types
-// ============================================================================
 //
 // Declared by `@commonfabric/data-model`, and re-exported here. The pattern
 // compiler resolves no bare specifier, so `generate-commonfabric-types.ts`
 // inlines this module's text when it builds the type file the sandbox is
 // served.
+//
 
 export * from "@commonfabric/data-model/api";
 
-// ============================================================================
+//
 // Fabric Execution Value Types
-// ============================================================================
+//
 
 /**
  * A value that can appear in an in-memory fabric execution graph.
@@ -65,9 +65,9 @@ export interface FabricExecArray extends ReadonlyArray<FabricExecValue> {}
 export interface FabricExecPlainObject
   extends Readonly<Record<string, FabricExecValue>> {}
 
-// ============================================================================
+//
 // Runtime Constants
-// ============================================================================
+//
 
 // Runtime constants - defined by @commonfabric/runner/src/builder/types.ts
 // These are ambient declarations since the actual values are provided by the runtime environment
@@ -106,9 +106,9 @@ export type UIVariantFunction = (
 export declare const SELF: unique symbol;
 export type SELF = typeof SELF;
 
-// ============================================================================
+//
 // Cell Brand System
-// ============================================================================
+//
 
 /**
  * Brand symbol for identifying different cell types at compile-time.
@@ -201,9 +201,9 @@ export type AnyBrandedCell<T, Kind extends string = string> = {
 
 export type BrandedCell<T, Kind extends CellKind> = AnyBrandedCell<T, Kind>;
 
-// ============================================================================
+//
 // Cell Capability Interfaces
-// ============================================================================
+//
 
 // To constrain methods that only exists on objects
 export type IsThisObject =
@@ -964,9 +964,9 @@ export interface IOpaquable<T> {
   setSchema(schema: JSONSchema): void;
 }
 
-// ============================================================================
+//
 // Cell Constructor Interfaces
-// ============================================================================
+//
 
 /**
  * Generic constructor interface for cell types with static methods.
@@ -1084,9 +1084,9 @@ export interface ScopedCellTypeConstructor<
   for<T>(cause: unknown): ScopedConstructorResult<Scope, Apply<Wrap, T>>;
 }
 
-// ============================================================================
+//
 // Cell Type Definitions
-// ============================================================================
+//
 
 /**
  * Base type for all cell variants that has methods. Internal API augments this
@@ -1272,9 +1272,9 @@ export interface WriteonlyCell<T>
 
 export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
 
-// ============================================================================
+//
 // Reactive - annotation for reactively-tracked values
-// ============================================================================
+//
 
 /**
  * Reactive<T> marks a value as reactively tracked by the pattern runtime.
@@ -1284,9 +1284,9 @@ export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
  */
 export type Reactive<T> = T;
 
-// ============================================================================
+//
 // CellLike and FactoryInput - Utility types for accepting cells
-// ============================================================================
+//
 
 /**
  * CellLike is a cell (AnyCell) whose nested values are valid factory inputs.

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -37,7 +37,9 @@ import type {
   WriteonlyCell,
 } from "commonfabric";
 
-// ===== Helper Types =====
+//
+// Helper Types
+//
 
 /**
  * Helper type to recursively remove `readonly` properties from type `T`.
@@ -51,7 +53,9 @@ export type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
 
 type IsAny<T> = 0 extends (1 & T) ? true : false;
 
-// ===== JSON Pointer Path Resolution Utilities =====
+//
+// JSON Pointer Path Resolution Utilities
+//
 
 /**
  * Split a JSON Pointer reference into path segments.
@@ -385,7 +389,9 @@ export type SchemaWithoutCell<
   Depth extends DepthLevel = 9,
 > = SchemaInner<T, Root, Depth, false>;
 
-// ===== Module Augmentation for Schema-based Overloads =====
+//
+// Module Augmentation for Schema-based Overloads
+//
 
 declare module "commonfabric" {
   // Augment PatternFunction with schema-based overloads

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -18,9 +18,9 @@
 
 import type { Cfc, CurrentPrincipal, WriteAuthorizedBy } from "./cfc.ts";
 
-// ============================================================================
+//
 // Common internal definitions
-// ============================================================================
+//
 
 /**
  * Recursively removes `readonly` from all properties of `T`.
@@ -32,14 +32,14 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
   : T extends object ? ({ -readonly [P in keyof T]: Mutable<T[P]> })
   : T;
 
-// ============================================================================
+//
 // Fabric Value Types
-// ============================================================================
 //
 // Declared by `@commonfabric/data-model`, and re-exported here. The pattern
 // compiler resolves no bare specifier, so `generate-commonfabric-types.ts`
 // inlines this module's text when it builds the type file the sandbox is
 // served.
+//
 
 /**
  * Pattern-visible declarations for the fabric value type system, in the form
@@ -460,9 +460,9 @@ export interface FabricArray extends ReadonlyArray<FabricValue> {}
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}
 
-// ============================================================================
+//
 // Fabric Execution Value Types
-// ============================================================================
+//
 
 /**
  * A value that can appear in an in-memory fabric execution graph.
@@ -487,9 +487,9 @@ export interface FabricExecArray extends ReadonlyArray<FabricExecValue> {}
 export interface FabricExecPlainObject
   extends Readonly<Record<string, FabricExecValue>> {}
 
-// ============================================================================
+//
 // Runtime Constants
-// ============================================================================
+//
 
 // Runtime constants - defined by @commonfabric/runner/src/builder/types.ts
 // These are ambient declarations since the actual values are provided by the runtime environment
@@ -528,9 +528,9 @@ export type UIVariantFunction = (
 export declare const SELF: unique symbol;
 export type SELF = typeof SELF;
 
-// ============================================================================
+//
 // Cell Brand System
-// ============================================================================
+//
 
 /**
  * Brand symbol for identifying different cell types at compile-time.
@@ -623,9 +623,9 @@ export type AnyBrandedCell<T, Kind extends string = string> = {
 
 export type BrandedCell<T, Kind extends CellKind> = AnyBrandedCell<T, Kind>;
 
-// ============================================================================
+//
 // Cell Capability Interfaces
-// ============================================================================
+//
 
 // To constrain methods that only exists on objects
 export type IsThisObject =
@@ -1386,9 +1386,9 @@ export interface IOpaquable<T> {
   setSchema(schema: JSONSchema): void;
 }
 
-// ============================================================================
+//
 // Cell Constructor Interfaces
-// ============================================================================
+//
 
 /**
  * Generic constructor interface for cell types with static methods.
@@ -1506,9 +1506,9 @@ export interface ScopedCellTypeConstructor<
   for<T>(cause: unknown): ScopedConstructorResult<Scope, Apply<Wrap, T>>;
 }
 
-// ============================================================================
+//
 // Cell Type Definitions
-// ============================================================================
+//
 
 /**
  * Base type for all cell variants that has methods. Internal API augments this
@@ -1694,9 +1694,9 @@ export interface WriteonlyCell<T>
 
 export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
 
-// ============================================================================
+//
 // Reactive - annotation for reactively-tracked values
-// ============================================================================
+//
 
 /**
  * Reactive<T> marks a value as reactively tracked by the pattern runtime.
@@ -1706,9 +1706,9 @@ export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
  */
 export type Reactive<T> = T;
 
-// ============================================================================
+//
 // CellLike and FactoryInput - Utility types for accepting cells
-// ============================================================================
+//
 
 /**
  * CellLike is a cell (AnyCell) whose nested values are valid factory inputs.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 13 section markers in `packages/api` to the `//`-delimited form.
They were written two ways: a `===` rule above and below the title, and
`// ===== Title =====` on one line.

## Why `static` is in the diff

`packages/static/assets/types/commonfabric.d.ts` is generated from
`packages/api/index.ts`, with each workspace module it re-exports inlined. The
markers travel with that text, so conforming `api` without regenerating would
leave the generated file stale and fail `check-commonfabric-types`. It is
regenerated with `deno task gen-commonfabric-types`, run from
`packages/static` — the workflow declares that working directory, so a
name-based guess at where to run it fails.

That is also why this is its own PR rather than riding along with the other
small packages: it is the one sweep whose blast radius leaves the package.

## How it is checked

Three properties, over each side of the diff separately:

| | `packages/api` | `packages/static` |
| --- | --- | --- |
| words lost or gained | none | none |
| added lines retaining a rule run | 0 | 0 |
| non-comment lines touched | 0 | 0 |

The generated file holding zero rule runs afterwards is the evidence that the
regeneration carried the change through rather than merely rewriting the file.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do
`check-commonfabric-types` and `check-cfc-types`, and the `api` and `static`
suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

