### PR TITLE
Conform the section markers in `memory`

### DIFF
--- a/packages/memory/test/naive-admission.ts
+++ b/packages/memory/test/naive-admission.ts
@@ -196,7 +196,9 @@ export const naiveRecord = (
   sessionRes.set(commit.localSeq, seq);
 };
 
-// --- Reference value semantics (INV-9's naive fold) ---------------------
+//
+// Reference value semantics (INV-9's naive fold)
+//
 
 const clone = <T>(value: T): T => structuredClone(value);
 

--- a/packages/memory/test/v2-commit-class.test.ts
+++ b/packages/memory/test/v2-commit-class.test.ts
@@ -175,7 +175,7 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
   ]);
 });
 
-// ---------------------------------------------------------------------------
+//
 // commitClassOfSeq (the arrival-witness predicate's server-side read,
 // speculation.md §4): the unknown-seq arm answers undefined, and the memo
 // declines to record inside ANY transaction — `applyCommit` brackets its
@@ -184,7 +184,7 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
 // (`database.inTransaction`), not a caller marker. A rolled-back seq is
 // re-minted by the retry, possibly under another class; a memo entry written
 // mid-transaction would serve that phantom class forever.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("commitClassOfSeq: seq 0, negative, and unknown seqs answer undefined (fail-closed substrate of the at-floor witness)", async () => {
   const { engine } = await createEngine();

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -46,7 +46,9 @@ import {
   toNaiveOps,
 } from "./naive-admission.ts";
 
-// --- Deterministic PRNG (mulberry32) -------------------------------------
+//
+// Deterministic PRNG (mulberry32)
+//
 
 const mulberry32 = (seed: number) => {
   let a = seed >>> 0;
@@ -64,7 +66,9 @@ const pick = <T>(rng: Rng, items: readonly T[]): T =>
   items[Math.floor(rng() * items.length)];
 const chance = (rng: Rng, p: number): boolean => rng() < p;
 
-// --- Schedule vocabulary --------------------------------------------------
+//
+// Schedule vocabulary
+//
 
 const ENTITIES = ["entity:A", "entity:B"] as const;
 const SESSIONS = [
@@ -105,7 +109,9 @@ interface AcceptedRecord {
   commit: ClientCommit;
 }
 
-// --- One schedule ----------------------------------------------------------
+//
+// One schedule
+//
 
 const STEPS = 25;
 

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -314,14 +314,14 @@ Deno.test("explicit entity_scope_key reads: lease holder admitted, non-holder an
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // The exemption LIFECYCLE (stage-F fix round, thread r3731191378 — P0):
 // `leaseHolderReads` is an authorization exemption tied to holding a LIVE
 // execution lease. The push path's applicable-set filter (protocol.md §3)
 // must key its bypass on CURRENT holdership, lease loss must clear the
 // exemption, and a session resume must revalidate rather than trust the
 // persisted bit. A former holder receives NOTHING foreign.
-// ---------------------------------------------------------------------------
+//
 
 /** Doc-ids upserted by session/effect frames at or past `from`. */
 const effectUpsertIds = (
@@ -584,16 +584,16 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // Instance identity across the wire seam (threads r3731191411 and
 // r3731191526): the wire strips scope KEYS (frames carry scope names), so
 // the server must refuse what the wire cannot express — one watch set (or
 // query) resolving TWO instances of one (branch, id, scope) — and must
 // treat a changed `entityScopeKey` on an existing watch id as a changed
 // spec, never silently the same watch.
-// ---------------------------------------------------------------------------
+//
 
-// ---------------------------------------------------------------------------
+//
 // OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease
 // holder may name two instances of one (branch, id, scope) — its frames and
 // query results carry the instance key (`scopeKey`) per entry, so the two
@@ -601,7 +601,7 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
 // BOTH the service instance and a demander's instance of one doc). The
 // wire collapse guard stays for everyone else: a NON-holder's wire carries
 // scope names only, so its ambiguous read set is still refused loudly.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("stage A: a lease holder names two instances of one (branch, id, scope) and receives BOTH, keyed — watch.set, watch.add, graph.query, and the push frame; the collapse guard still refuses a non-holder (OW17's wire leg)", async () => {
   const server = newServer("memory://explicit-read-two-instances");
@@ -846,7 +846,7 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // The exemption LIFECYCLE under the keyed wire (fan-out stage A's
 // independent review, finding 1 — 2026-08-17). Two halves of one
 // invariant: (i) a session's wire vocabulary is STICKY once it was
@@ -858,7 +858,7 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
 // RE-ARMS on the first live pass with a full evaluation that re-delivers
 // what the lapse withheld — a renewal blip the SpaceServer survives
 // in-process must not leave its serving replica silently stale.
-// ---------------------------------------------------------------------------
+//
 
 /** Every session/effect frame's upserts at or past `from`, with keys. */
 const effectUpserts = (
@@ -1307,13 +1307,13 @@ Deno.test("watch.add with a changed entityScopeKey on an existing watch id is a 
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // Delivery-failure rollback for explicit foreign instances (thread
 // r3731191415): the wire frame carries scope NAMES, so rollback cannot
 // recover the instance from the frame alone — the server must retain the
 // frame's true instance keys. A lost foreign-instance frame must be
 // REDELIVERED once sends succeed again.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("a failed delivery of an explicit foreign-instance frame is redelivered (rollback keys the exact instance)", async () => {
   const server = newServer("memory://explicit-read-rollback");
@@ -1460,7 +1460,7 @@ Deno.test("a non-canonical entity_scope_key (raw '/') is refused at admission �
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // Phase 5 — the read row's cross-space widening and its fail-closed twin
 // (protocol.md §2; verification-coverage.md's stage-F read-row entry):
 //
@@ -1475,7 +1475,7 @@ Deno.test("a non-canonical entity_scope_key (raw '/') is refused at admission �
 //   Phase-5 precondition): a co-hosted serving session's UNNAMED scoped
 //   read of a space it does not hold refuses loudly instead of silently
 //   resolving the delegating envelope's (empty) instance.
-// ---------------------------------------------------------------------------
+//
 
 const HOME_SPACE = "did:key:z6Mk-explicit-read-home";
 

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -1738,7 +1738,7 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
   }
 });
 
-// ---------------------------------------------------------------------------
+//
 // OW31 (WRITE ruled 2026-08-18, READ ruled 2026-08-19): the delegated READ
 // binding. A session opened `actingAs: "space-owner"` by a DELEGATING-class
 // principal has its READ-class decisions resolved as the space's ACL OWNER
@@ -1746,6 +1746,7 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
 // WRITE/OWNER requirements keep resolving against the ENVELOPE, so the
 // binding grants no write path; a delegating principal is NOT a service
 // principal and cannot initialize a genesis.
+//
 
 Deno.test("OW31 acl enforce: a delegating principal acting as space-owner READS an owner-only space; its writes and ACL-doc writes stay refused", async () => {
   const server = createAclServer("memory://acl-ow31-binding", {

--- a/packages/memory/test/v2-sqlite-commit-eval.test.ts
+++ b/packages/memory/test/v2-sqlite-commit-eval.test.ts
@@ -92,7 +92,9 @@ const VALID = ["alice@a.example", "bob@b.example", "dmarc=pass", "hi"];
 // fails closed at evaluation.
 const VIOLATING = ["not an address", "bob@b.example", "", "boom"];
 
-// --- applyCommit-level: atomic rollback with the cell ops -------------------
+//
+// applyCommit-level: atomic rollback with the cell ops
+//
 
 async function freshEngine() {
   const path = await Deno.makeTempFile({ suffix: ".sqlite" });
@@ -452,9 +454,11 @@ Deno.test("DELETE and rule-less-table writes stay plain on a rule-bearing db", a
   });
 });
 
-// --- direct applySqliteCommitWrite: shape rejects + caps --------------------
+//
+// direct applySqliteCommitWrite: shape rejects + caps
 // (No wrapping transaction here — these assert the THROW; rollback is the
 // applyCommit-level tests' concern.)
+//
 
 function bareDb(): Database {
   const db = new Database(":memory:");

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -57,9 +57,9 @@ function emailSpec(): RowLabelSpec {
   return schema.rowLabel as RowLabelSpec;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Builder -> AST
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("table(columns, rule) serializes the rule to a plain-JSON rowLabel AST", () => {
   const schema = table(EMAIL_COLUMNS, emailRule);
@@ -130,9 +130,9 @@ Deno.test("match() forces the global flag so split-on-match works", () => {
   assert(node.principal.of.match.flags.includes("g"));
 });
 
-// ---------------------------------------------------------------------------
+//
 // Fail-closed at authoring (table() throws)
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("any() builds and validates an OR-clause (Epic E1)", () => {
   // any() no longer throws at table() time — it produces an authored OR-clause
@@ -445,9 +445,9 @@ Deno.test("validateRowLabelSpec re-validates a wire-supplied spec (fail closed)"
   assert(typeof wrongCols === "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // evaluateRowLabel — happy paths
-// ---------------------------------------------------------------------------
+//
 
 const OWNER = "did:key:zOwner";
 
@@ -583,9 +583,9 @@ Deno.test("constant() injects a literal atom; intersect() meets integrity atom s
   assertEquals(res.integrity, ["b"]);
 });
 
-// ---------------------------------------------------------------------------
+//
 // evaluateRowLabel — fail-closed branches (each returns {error}, never partial)
-// ---------------------------------------------------------------------------
+//
 
 function expectError(
   spec: RowLabelSpec,
@@ -790,9 +790,9 @@ Deno.test("zero matches in an integrity position mints no claim", () => {
   assertEquals(res.integrity, []);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Provenance gate predicates (shared server/runner — v2.ts)
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("dbNeedsColumnProvenance: rowLabel-only tables need origin capture too", () => {
   const ruleOnly = {
@@ -821,9 +821,9 @@ Deno.test("dbNeedsColumnProvenance: rowLabel-only tables need origin capture too
   assert(!dbNeedsColumnProvenance(undefined));
 });
 
-// ---------------------------------------------------------------------------
+//
 // Review-round fixes: validator/evaluator robustness on hostile wire specs
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)", () => {
   const spec: RowLabelSpec = {
@@ -841,7 +841,7 @@ Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)",
   assert(typeof reason === "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Ambiguous dual-op nodes: a node carrying TWO recognized op keys must refuse
 // everywhere. The validator, the evaluator, and the static common-alternative
 // analysis each dispatch by their own key precedence, so a hand-crafted
@@ -849,7 +849,7 @@ Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)",
 // the principal, and STATICALLY count the owner as a common reader — labeling
 // a COUNT(*) [owner] although the owner is not an alternative in any row's
 // label (CFC spec §8.17.4 violation).
-// ---------------------------------------------------------------------------
+//
 
 const DUAL_PRINCIPAL_OWNER: RowLabelSpec = {
   version: 1,

--- a/packages/memory/test/v2.test.ts
+++ b/packages/memory/test/v2.test.ts
@@ -41,9 +41,9 @@ const toEntityDocument = (
   return document;
 };
 
-// ---------------------------------------------------------------------------
+//
 // Flag-independent tests (run once, not per-flag-state)
-// ---------------------------------------------------------------------------
+//
 
 describe("memory v2 protocol constants", () => {
   it("exports the phase-1 protocol constants", () => {
@@ -119,9 +119,9 @@ describe("memory v2 paths", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Flag-mechanism test (explicitly tests both OFF and ON in one test)
-// ---------------------------------------------------------------------------
+//
 
 describe("memory v2 flags", () => {
   it("reflects the active runtime storage flags", () => {
@@ -433,9 +433,9 @@ describe("parseMemoryProtocolFlags", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Boundary encode/decode dispatch test (explicitly tests OFF and ON paths)
-// ---------------------------------------------------------------------------
+//
 
 describe("memory v2 boundary decode", () => {
   it("returns deeply-frozen plain JSON trees", () => {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -321,13 +321,13 @@ export const SERVER_EXECUTION_WATERMARK_DOC_ID =
  * space — not per doc, not per piece, never vectorized. */
 export type WatermarkDocValue = { seq: number };
 
-// ---------------------------------------------------------------------------
+//
 // Events-down (server-execution v2 Phase 3, D-v2-1;
 // docs/specs/server-side-execution/events.md). The event is an AUTHORED
 // APPEND to a stream document — the client's only computational commit
 // under the flag. Protocol vocabulary, defined once here (protocol.md §7:
 // `eventId`/`firedAt` are commit-metadata additions for event appends).
-// ---------------------------------------------------------------------------
+//
 
 /**
  * The stream-entries SIDECAR doc id for one stream (events.md §1's "stream
@@ -478,7 +478,7 @@ export type EventAppendDecl = {
   eventId: string;
 };
 
-// ---------------------------------------------------------------------------
+//
 // The client-effect channel (server-execution v2 Phase 4;
 // docs/specs/server-side-execution/protocol.md §5). Session-scoped,
 // server-computed, client-enacted effects: the SpaceServer writes INTENT
@@ -486,7 +486,7 @@ export type EventAppendDecl = {
 // doc, the session's client enacts and ACKS by nonce (an ordinary authored
 // write into its own instance), and the next wave retires acked entries.
 // Protocol vocabulary, defined once here (the LD3 direction).
-// ---------------------------------------------------------------------------
+//
 
 /**
  * The well-known client-effects doc, one id per space (protocol.md §5,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -2373,7 +2373,7 @@ export const serverSeq = (engine: Engine): number => {
   return (engine.statements.selectServerSeq.get() as { seq: number }).seq;
 };
 
-// ---------------------------------------------------------------------------
+//
 // Event-append admission (server-execution v2 Phase 3, D-v2-1;
 // events.md §1, §4; protocol.md §2's event-append rows). ONE stamping
 // site with three identity sources — the authenticated envelope for plain
@@ -2381,7 +2381,7 @@ export const serverSeq = (engine: Engine): number => {
 // (LT1) the already-written inherited actor for derived wave carriage,
 // where producer and admitter are one trust environment and only the
 // entry's stream `seq` needs stamping.
-// ---------------------------------------------------------------------------
+//
 
 /** Where one declared appended entry sits inside the commit's operations,
  * plus the `firedAt` admission resolved for it. The stamp step clones the

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -55,9 +55,9 @@ const isFieldRef = (x: unknown): x is FieldRef =>
   isObjectNotArray(x) && typeof x.field === "string" &&
   Object.keys(x).length === 1;
 
-// ---------------------------------------------------------------------------
+//
 // Builders — each returns its serialized AST node.
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Run `re` (forced global) over a column's text ⟹ the ordered list of matches
@@ -194,9 +194,9 @@ function assertPrincipal(x: unknown, who: string) {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Validation — fail closed at authoring AND on wire-supplied specs.
-// ---------------------------------------------------------------------------
+//
 
 const MAX_REGEX_SOURCE = 512;
 
@@ -545,9 +545,9 @@ export function buildRowLabelSpec<C extends Record<string, unknown>>(
   return spec;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Evaluation — one pure function, shared by write gate, server, and read.
-// ---------------------------------------------------------------------------
+//
 
 class RowLabelEvalError extends Error {}
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 30 section markers in `packages/memory` to the `//`-delimited
form. They were written two ways: a dash rule above the title, and
`// --- Title ------------` filled to the margin.

Most of them are in the v2 test suites, where they title the phases of a long
scenario; the rest are in `v2.ts`, `v2/engine.ts`, and `v2/sqlite/row-label.ts`.

Titles carry over verbatim. Nothing gains a marker it did not have.

## How it is checked

Three properties over the whole diff, not a sample: the word multiset is
unchanged (no word added, none lost), no added line retains a run of two or
more rule characters, and no non-comment line is touched. All three hold.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/memory`'s own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

