### PR TITLE
docs(rehearsal): give the baseline churn command a --since

### DIFF
--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -76,7 +76,8 @@ not see it, you are pointed at something else — stop and check before writing.
 ```bash
 # 3. Baseline, before touching anything.
 deno task cf space verify $CLONE
-deno task cf inspect churn $DB --bucket 60 --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
+deno task cf inspect churn $DB --bucket 60 \
+  --since '<an hour before now>' --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 
 # 4. Run every authored test locally. Then update against the CLONE's api-url
 #    once, with one --test flag per entry and one --datafile flag per attached
@@ -238,6 +239,13 @@ it, the trailing quiet minutes are reported, and the footer prints `last commit`
 against `observed through`: the gap between them is the evidence. A mistyped
 bound is refused rather than silently matching no commits, which would otherwise
 report the window as quiet.
+
+Pass `--since` as well, including for the baseline. Without one the window opens
+at the store's earliest commit, and a clone of a space that has been live for a
+while carries months of them: every bucket between that commit and `--until` is
+materialized, and past 20,000 of them the run is refused rather than reported.
+At `--bucket 60` that ceiling is about fourteen days. An hour of quiet before
+you start is baseline enough to recognize a plateau against.
 
 ## Driving the migration
 


### PR DESCRIPTION
## Why

Step 3 of the space-clone rehearsal — the baseline, the first command an
operator runs — could not run on a real clone.

`cf inspect churn` with `--until` and no `--since` opens the window at the
store's earliest commit and materializes every bucket from there. A clone of a
space that has been live for a while carries months of them, and past 20,000
the run is refused:

```
window spans 69365 buckets at 60s (limit 20000); widen --bucket or narrow --since/--until.
```

At `--bucket 60` that ceiling is about fourteen days of history. The Topics
clone is well past it, which is how this was found.

## What Changed

- Step 3's churn command gains `--since '<an hour before now>'`, matching the
  shape step 5 already used.
- A paragraph beside the existing `--until` guidance says why `--since` is not
  optional in practice, and what an hour of baseline buys you.

Deliberately outside the `# 4.` comment block, which #6143 rewrites.

## Test plan

`docs/` is excluded from `deno fmt`, so prose is wrapped to 80 by hand and
checked. The change touches a bash block and prose only — no TypeScript block,
so `check-docs` is unaffected. The refusal above is quoted from a real run
against the Topics clone.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

