### PR TITLE
Conform the section markers in `spec-model` and `state-inspector`

### DIFF
--- a/packages/spec-model/server-execution/model.ts
+++ b/packages/spec-model/server-execution/model.ts
@@ -17,7 +17,9 @@
  * filtering (protocol §3).
  */
 
-// ---------- identities and keys ----------
+//
+// identities and keys
+//
 
 export type UserId = string;
 export type SessionId = string;
@@ -85,7 +87,9 @@ export const isCanonicalKey = (value: string): boolean => {
 /** The scope kinds a handler write can declare (scopes.md §2). */
 export type ScopeKind = "space" | "user" | "session";
 
-// ---------- the program under test ----------
+//
+// the program under test
+//
 
 /** Handler behavior attached to a stream — the model's "pattern". */
 export interface HandlerSpec {
@@ -105,7 +109,9 @@ export interface DerivationSpec {
   out: DocId;
 }
 
-// ---------- world state ----------
+//
+// world state
+//
 
 export interface StreamEntry {
   seq: number;
@@ -321,7 +327,9 @@ export interface World {
   skippedIdempotent: number;
 }
 
-// ---------- construction ----------
+//
+// construction
+//
 
 export interface SpaceSpec {
   streams: Record<DocId, HandlerSpec>;
@@ -400,7 +408,9 @@ export function makeWorld(opts: {
 
 const clone = <T>(x: T): T => structuredClone(x);
 
-// ---------- admission ----------
+//
+// admission
+//
 
 /** protocol §2 row 2: stamp firedAt from the authenticated envelope. */
 function admitClientAppend(
@@ -478,7 +488,9 @@ export function admitDerived(
     commit.envelope.startsWith("service:");
 }
 
-// ---------- the wave (serving-loop §3, §3d; events §2, §4) ----------
+//
+// the wave (serving-loop §3, §3d; events §2, §4)
+//
 
 /** Stage one event's handler run into a contribution — no world
  * mutation beyond id minting; everything applies at COMMIT. */
@@ -886,7 +898,9 @@ function runWave(w: World, space: SpaceId): void {
   commitWave(w, space);
 }
 
-// ---------- push filtering (protocol §3) ----------
+//
+// push filtering (protocol §3)
+//
 
 export function applicableSet(c: ClientSession): string[] {
   return [SPACE_KEY, userKey(c.user), sessionKey(c.user, c.session)];
@@ -901,7 +915,9 @@ export function pushRowsFor(
   return commit.writes.filter((r) => ok.has(r.scopeKey));
 }
 
-// ---------- transitions ----------
+//
+// transitions
+//
 
 export type Step =
   | { kind: "fire"; session: SessionId; space: SpaceId; stream: DocId }
@@ -1114,7 +1130,9 @@ export function apply(w0: World, step: Step): World {
   return w;
 }
 
-// ---------- schedule exploration ----------
+//
+// schedule exploration
+//
 
 function stableStringify(x: unknown): string {
   return JSON.stringify(x, function (this: unknown, _k, v) {
@@ -1167,7 +1185,8 @@ export function explore(
   return { finals, all, statesSeen: visited.size };
 }
 
-// ---------- narrowing / fan-out sub-model (Phase 2 pre-gate, OW3) ----------
+//
+// narrowing / fan-out sub-model (Phase 2 pre-gate, OW3)
 //
 // The three bound rules ONE extension covers (verification-coverage
 // OW3): instance sets are CLEAN PRODUCTS over principals, never ragged
@@ -1180,6 +1199,7 @@ export function explore(
 // downstream of one shared space-scoped input, exhaustively driven by
 // the property suite's own DFS. Uses the SAME key constructors as the
 // main model (bridge-checked against the wire vocabulary).
+//
 
 export interface FanoutState {
   /** The principals that exist (each may demand its own instance). */

--- a/packages/spec-model/server-execution/properties.test.ts
+++ b/packages/spec-model/server-execution/properties.test.ts
@@ -62,7 +62,9 @@ function assertInheritance(w: World) {
   }
 }
 
-// ---------- C1: same-space cascade (trace T3's shape) ----------
+//
+// C1: same-space cascade (trace T3's shape)
+//
 
 function c1World(splitWaves = false) {
   return makeWorld({
@@ -194,7 +196,9 @@ Deno.test("C1-LT8: a reload between enact and ack can re-enact — bounded, and 
   assert(sawReEnact, "the LT8 window is real: a schedule re-enacts");
 });
 
-// ---------- C2: cross-space chain (trace T4's shape) + FP1 ----------
+//
+// C2: cross-space chain (trace T4's shape) + FP1
+//
 
 function c2World() {
   return makeWorld({
@@ -353,7 +357,9 @@ Deno.test("C2-dedupe: at-least-once redelivery is idempotent at the target (even
   );
 });
 
-// ---------- C3: sessionless chains and uniform inheritance (LT6) ----------
+//
+// C3: sessionless chains and uniform inheritance (LT6)
+//
 
 Deno.test("C3: derivation-emitted events carry the demand identity uniformly (LT6); sessionless writes error", () => {
   const base = makeWorld({
@@ -422,7 +428,9 @@ Deno.test("C3: derivation-emitted events carry the demand identity uniformly (LT
   }
 });
 
-// ---------- C4: push privacy and settledness ----------
+//
+// C4: push privacy and settledness
+//
 
 Deno.test("C4: a subscriber receives only its applicable set (protocol §3); settledness is sound (protocol §4)", () => {
   const w0 = makeWorld({
@@ -455,7 +463,9 @@ Deno.test("C4: a subscriber receives only its applicable set (protocol §3); set
   assert(w.spaces.A.streams.s.entries.every((e) => e.consequenced));
 });
 
-// ---------- C6: admission negatives ----------
+//
+// C6: admission negatives
+//
 
 Deno.test("C6: derived admission is the lease equality check — forgeries and non-holders rejected (protocol §2, serving-loop §2)", () => {
   const w = makeWorld({
@@ -477,7 +487,9 @@ Deno.test("C6: derived admission is the lease equality check — forgeries and n
   assert(!admitDerived(sp, { holder: me, envelope: "service:A" }));
 });
 
-// ---------- C7: the lease fence (DR1, serving-loop §2) ----------
+//
+// C7: the lease fence (DR1, serving-loop §2)
+//
 
 const C7_MENU: Step[] = [
   { kind: "sealProbe", space: "A" },
@@ -535,7 +547,9 @@ Deno.test("C7b: the residue the MUST exists for — discipline OFF makes a same-
   assertEquals(w.servers.A.pendingProbes.length, 0, "probe consumed");
 });
 
-// ---------- C8: mid-wave conflicts, per write class (§3d) ----------
+//
+// C8: mid-wave conflicts, per write class (§3d)
+//
 
 function c8World() {
   return makeWorld({
@@ -634,7 +648,9 @@ Deno.test("C8c: exactly-once under exhaustive racing — no event's consequences
   }
 });
 
-// ---------- C9: DROP vs REQUEUE — the T3 distinction ----------
+//
+// C9: DROP vs REQUEUE — the T3 distinction
+//
 
 Deno.test("C9: an UNRUNNABLE event DROPS (notice + watermark advance, non-wedging); a RACED event never does (events §5; serving-loop §3d)", () => {
   const base = makeWorld({
@@ -673,7 +689,9 @@ Deno.test("C9: an UNRUNNABLE event DROPS (notice + watermark advance, non-wedgin
   assertEquals(w.requeues, 0, "an unrunnable event is never requeued");
 });
 
-// ---------- C10: budget exhaustion — W pinned, continuation ----------
+//
+// C10: budget exhaustion — W pinned, continuation
+//
 
 Deno.test("C10: an exhausted wave commits WITHOUT advancing W; continuation waves finish; W jumps only at true quiescence (serving-loop §3)", () => {
   let w = makeWorld({
@@ -708,7 +726,9 @@ Deno.test("C10: an exhausted wave commits WITHOUT advancing W; continuation wave
   for (const n of counts.values()) assertEquals(n, 1);
 });
 
-// ---------- C8d + C0: rollback closure and the guard rails ----------
+//
+// C8d + C0: rollback closure and the guard rails
+//
 
 Deno.test("C8d: a requeued parent's same-wave cascade NEVER escapes — rollback closes over descendants (events §4; serving-loop §3d)", () => {
   const w0 = makeWorld({
@@ -828,7 +848,9 @@ Deno.test("C0-guards: connection guards; no-actor space writes carry no attribut
   assertEquals("user" in sessionless.firedAt, false, "no user key (OW15)");
 });
 
-// ---------- conformance bridge: model keys === the wire vocabulary ----------
+//
+// conformance bridge: model keys === the wire vocabulary
+//
 
 Deno.test("bridge: model scope-key constructors byte-agree with the real wire vocabulary (LD3, key-vocabulary §3)", () => {
   // The model RESTATES the constructors (model.ts stays import-free);
@@ -919,7 +941,8 @@ Deno.test("bridge: model scope-key constructors byte-agree with the real wire vo
   }
 });
 
-// ---------- C11: narrowing / fan-out (Phase 2 pre-gate, OW3) ----------
+//
+// C11: narrowing / fan-out (Phase 2 pre-gate, OW3)
 //
 // One extension covers the OW3 trio (verification-coverage §3):
 // instance sets stay CLEAN PRODUCTS over principals (scopes §2's
@@ -928,6 +951,7 @@ Deno.test("bridge: model scope-key constructors byte-agree with the real wire vo
 // and W never forks (scopes §9): one integer, waiting on DEMANDED
 // siblings only, undemanded instances never holding it back
 // (scopes §2's watermark × fan-out composition).
+//
 
 const FAN_MENU = (): FanoutStep[] => [
   { kind: "fanInput" },

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -324,9 +324,11 @@ function detailFromDoc(
   const spec = importSpecifier(value);
   const named = ctx.nameOf.get(id);
 
-  // --- context-aware label + role ----------------------------------------
+  //
+  // context-aware label + role
   // Label comes from the shared index (it already folds in import/context/legacy
   // refinements); role is computed here.
+  //
   let label = ctx.labelOf.get(id)?.label ?? c.label;
   let role: string = c.kind;
   if (spec) {
@@ -342,7 +344,9 @@ function detailFromDoc(
     role = roleFor(c.kind, c.owned);
   }
 
-  // --- lineage, resolved to target labels --------------------------------
+  //
+  // lineage, resolved to target labels
+  //
   const lineage: EntityDetail["lineage"] = {};
   if (c.lineage.argument) {
     lineage.argument = refTo(c.lineage.argument, ctx);
@@ -378,7 +382,9 @@ function detailFromDoc(
     lineage.pattern = ref;
   }
 
-  // --- outgoing links, resolved ------------------------------------------
+  //
+  // outgoing links, resolved
+  //
   const outLinks: LinkRef[] = linksWithPaths(value).map(({ link, at }) => {
     const external = !!link.space && link.space !== ctx.ownDid &&
       link.space !== `did:key:${ctx.ownDid}`;
@@ -393,11 +399,15 @@ function detailFromDoc(
     };
   });
 
-  // --- module source -----------------------------------------------------
+  //
+  // module source
+  //
   let code: string | undefined;
   if (isModuleValue(value)) code = value.code;
 
-  // --- schema / ifc / cfc ------------------------------------------------
+  //
+  // schema / ifc / cfc
+  //
   let schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
   let schemaKeys = isObjectNotArray(doc.schema)
     ? Object.keys(doc.schema)

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -94,7 +94,9 @@ export function analyzeSpaceSignals(
     )
     .get<{ commits: number; entities: number }>();
 
-  // --- Session principals (owners who wrote here) ------------------------
+  //
+  // Session principals (owners who wrote here)
+  //
   const principalCounts = new Map<string, number>();
   for (
     const r of space.db
@@ -116,7 +118,9 @@ export function analyzeSpaceSignals(
     }
   }
 
-  // --- Home detection + profiles[] edges ---------------------------------
+  //
+  // Home detection + profiles[] edges
+  //
   let isHome = false;
   const profileDids = new Set<string>();
   const homeCandidates = space.db
@@ -151,7 +155,9 @@ export function analyzeSpaceSignals(
     }
   }
 
-  // --- All cross-space link targets (cheap candidate query) --------------
+  //
+  // All cross-space link targets (cheap candidate query)
+  //
   const crossSpaceDids = new Set<string>();
   for (
     const { id } of space.db

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -281,7 +281,9 @@ function copyBtn(text, label){ return el("button",{class:"copy",title:"copy "+te
   onclick:e=>{e.stopPropagation(); navigator.clipboard?.writeText(text); flash("copied "+(label||"id"));}}, label||"copy"); }
 function kindChip(kind){ return el("span",{class:"kind "+kind,style:"background:"+(KC[kind]||"#999"),text:kind}); }
 
-// ---- live shell link --------------------------------------------------
+//
+// live shell link
+//
 let LIVE = localStorage.getItem("si-live") || B.liveBase || "";
 function liveUrl(id){ if(!LIVE) return null;
   // The shell navigates by the bare id form (fid1:…); the stored "of:" prefix
@@ -291,7 +293,9 @@ function liveAnchor(id){ const u = liveUrl(id); return u
   ? el("a",{href:u,target:"_blank",rel:"noopener",text:"open in app ↗",title:u})
   : el("span",{class:"muted",text:"(set app URL ↗ to enable live links)"}); }
 
-// ---- selection + history ----------------------------------------------
+//
+// selection + history
+//
 let cur = null; const hist = [];
 function select(id, push=true){
   if(!byId.has(id)) return;
@@ -304,7 +308,9 @@ function select(id, push=true){
 }
 function back(){ const id = hist.pop(); if(id){ cur=null; select(id,false); } }
 
-// ---- value renderer (links become clickable chips) --------------------
+//
+// value renderer (links become clickable chips)
+//
 function valueDom(v, depth=0){
   if(v===null) return el("span",{class:"muted",text:"null"});
   if(typeof v!=="object") return el("span",{text: typeof v==="string" ? JSON.stringify(v) : String(v)});
@@ -349,7 +355,9 @@ function linkChip(ref){
   return c;
 }
 
-// ---- detail pane ------------------------------------------------------
+//
+// detail pane
+//
 function section(title, openByDefault, bodyNodes){
   const d = el("details",{class:"sec"}); if(openByDefault) d.setAttribute("open","");
   d.append(el("summary",{text:title}));
@@ -494,7 +502,9 @@ function renderDetail(id){
 function fmtSession(s){ try{ s=decodeURIComponent(s);}catch{} const m=s.match(/^session:(did:key:)?([^:]+):([0-9a-f-]+)/i);
   if(m) return (m[2].length>12?m[2].slice(0,6)+"…"+m[2].slice(-4):m[2])+"/"+m[3].slice(0,6); return s.slice(0,18); }
 
-// ---- tree view --------------------------------------------------------
+//
+// tree view
+//
 function treeRow(d, childInfo){
   const ov = overlayById.get(d.id);
   const cf = conflictById.get(d.id);
@@ -552,7 +562,9 @@ function renderTree(){
   host.append(ul);
 }
 
-// ---- graph view -------------------------------------------------------
+//
+// graph view
+//
 function neighborhood(rootId, depth){
   const adj=new Map();
   for(const e of B.graph.edges){ (adj.get(e.from)??adj.set(e.from,[]).get(e.from)).push(e.to);
@@ -595,7 +607,9 @@ function renderGraph(){
   if(sel.value) layoutGraph(sel.value);
 }
 
-// ---- timeline ---------------------------------------------------------
+//
+// timeline
+//
 function renderTimeline(){
   const t=B.timeline; const host=$("#tl"); host.innerHTML="";
   if(!t.length){host.append(el("p",{class:"muted",text:"(no commits)"}));return;}
@@ -615,7 +629,9 @@ function renderTimeline(){
     el("th",{text:"touched"}),el("th",{text:"total"}),el("th",{text:"who"}),el("th",{text:"when"})])),tb]));
 }
 
-// ---- wiring -----------------------------------------------------------
+//
+// wiring
+//
 for(const b of $$("nav button")) b.onclick=()=>{
   $$("nav button").forEach(x=>x.classList.toggle("active",x===b));
   $$(".tabwrap").forEach(s=>s.classList.toggle("active",s.id===b.dataset.tab));

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -238,8 +238,10 @@ export function classifyDocument(doc: EntityDocument): Classification {
   const lineage: Lineage = {};
   if (owned) lineage.owner = linkId(doc.result);
 
-  // --- Pieces -------------------------------------------------------------
+  //
+  // Pieces
   // Modern: the durable piece → pattern pointer is `patternIdentity`.
+  //
   if (isObjectNotArray(doc.patternIdentity)) {
     const pi = doc.patternIdentity as { identity?: unknown; symbol?: unknown };
     lineage.argument = linkId(doc.argument);
@@ -296,7 +298,9 @@ export function classifyDocument(doc: EntityDocument): Classification {
     };
   }
 
-  // --- Cell sub-kinds by value shape -------------------------------------
+  //
+  // Cell sub-kinds by value shape
+  //
   if (isModuleValue(value)) {
     return {
       kind: "module",
@@ -332,7 +336,9 @@ export function classifyDocument(doc: EntityDocument): Classification {
     };
   }
 
-  // --- Plain cells -------------------------------------------------------
+  //
+  // Plain cells
+  //
   if (owned) {
     const label = value === undefined ? "(lineage)" : summarize(value);
     return {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 41 section markers in these two packages to the `//`-delimited
form — 22 in `spec-model` and 19 in `state-inspector`. They were written as
`// ---- Title ----` and as a dash rule above the title.

Titles carry over verbatim. Nothing gains a marker it did not have.

## A title can contain what looks like a rule

`properties.test.ts` has a marker reading

    // ---------- conformance bridge: model keys === the wire vocabulary ----------

where the `===` is JavaScript strict equality inside the title, not a rule. It
survives the conversion intact.

Guarding that is worth stating, because the obvious check cannot see it: a
word-multiset comparison normalizes rule characters away on both sides, so it
would report "nothing lost" whether or not the `===` had been eaten. The check
that does bite is structural — every long run removed across the diff has text
on one side only. A rule brackets a title; an operator sits inside one. All
removals are of the first kind, and none of the second.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and the structural property above holds for every removal.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the
`spec-model` and `state-inspector` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

