### PR TITLE
Conform the section markers in `toolshed`

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -61,9 +61,10 @@ export const EnvSchema = z.object({
   DISABLE_LOG_REQ_RES: boolFlag(),
   CACHE_DIR: z.string().default("./cache"),
 
-  // ===========================================================================
+  //
   // OpenTelemetry Configuration
-  // ===========================================================================
+  //
+
   // Strict parse (see boolFlag): only "true"/"1" enable telemetry; "false"/unset
   // disable it. z.coerce.boolean() would wrongly enable on the string "false".
   OTEL_ENABLED: boolFlag(),
@@ -82,9 +83,9 @@ export const EnvSchema = z.object({
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),
   OTEL_TRACES_SAMPLER_ARG: z.string().default("1.0"),
 
-  // ===========================================================================
+  //
   // (/routes/ai/llm) Environment variables for LLM Providers
-  // ===========================================================================
+  //
   CFTS_AI_LLM_ANTHROPIC_API_KEY: z.string().default(""),
   CFTS_AI_LLM_GROQ_API_KEY: z.string().default(""),
   CFTS_AI_LLM_OPENAI_API_KEY: z.string().default(""),
@@ -95,28 +96,28 @@ export const EnvSchema = z.object({
   // when the URL is unreachable (see `loadGatewayModels` in routes/ai/llm/models.ts).
   CFTS_AI_GATEWAY_URL: z.string().default("https://llm.stage.commontools.dev"),
 
-  // ===========================================================================
+  //
   // FAL AI API Key
   //   * /routes/ai/img
   //   * /routes/ai/voice
-  // ===========================================================================
+  //
   FAL_API_KEY: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Jina API Key
   //   * /routes/agent-tools/web-read
   //   * /routes/link-preview
-  // ===========================================================================
+  //
   JINA_API_KEY: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Memory Store
   //  - MEMORY_DIR is used by toolshed to access sqlite files for common-memory
   //    (directory mode - default, backwards compatible)
   //  - DB_PATH is an optional absolute path to a single SQLite database file
   //    holding every space (single-file mode - takes precedence over MEMORY_DIR)
   //  - MEMORY_URL is used by toolshed to connect to memory endpoint
-  // ===========================================================================
+  //
   MEMORY_DIR: z.string().default(
     new URL(`./cache/memory/`, Path.toFileUrl(`${Deno.cwd()}/`)).href,
   ),
@@ -129,59 +130,59 @@ export const EnvSchema = z.object({
   GOOGLE_CLIENT_ID: z.string().default(""),
   GOOGLE_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Airtable Integration
   //   * /routes/integrations/airtable-oauth
-  // ===========================================================================
+  //
   AIRTABLE_CLIENT_ID: z.string().default(""),
   AIRTABLE_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // GitHub Integration
   //   * /routes/integrations/github-oauth
-  // ===========================================================================
+  //
   GITHUB_CLIENT_ID: z.string().default(""),
   GITHUB_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Notion Integration
   //   * /routes/integrations/notion-oauth
-  // ===========================================================================
+  //
   NOTION_CLIENT_ID: z.string().default(""),
   NOTION_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Linear Integration
   //   * /routes/integrations/linear-oauth
-  // ===========================================================================
+  //
   LINEAR_CLIENT_ID: z.string().default(""),
   LINEAR_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Spotify Integration
   //   * /routes/integrations/spotify-oauth
-  // ===========================================================================
+  //
   SPOTIFY_CLIENT_ID: z.string().default(""),
   SPOTIFY_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Discord OAuth Integration
   //   * /routes/integrations/discord-oauth
-  // ===========================================================================
+  //
   DISCORD_CLIENT_ID: z.string().default(""),
   DISCORD_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Strava Integration
   //   * /routes/integrations/strava-oauth
-  // ===========================================================================
+  //
   STRAVA_CLIENT_ID: z.string().default(""),
   STRAVA_CLIENT_SECRET: z.string().default(""),
 
-  // ===========================================================================
+  //
   // Plaid Integration
   //   * /routes/integrations/plaid-oauth
-  // ===========================================================================
+  //
   PLAID_CLIENT_ID: z.string().default(""),
   PLAID_SECRET: z.string().default(""),
   PLAID_ENV: z.enum(["sandbox", "development", "production"]).default(
@@ -271,10 +272,10 @@ export const EnvSchema = z.object({
   // compiled binary reads from its baked COMPILED file.
   COMMIT_SHA: z.string().optional(),
 
-  // ===========================================================================
+  //
   // Sandbox Service
   //   * /routes/sandbox/exec
-  // ===========================================================================
+  //
   SANDBOX_SERVICE_URL: z.string().default(
     "https://sandbox.stage.commontools.dev",
   ),

--- a/packages/toolshed/lib/space-authority.test.ts
+++ b/packages/toolshed/lib/space-authority.test.ts
@@ -17,10 +17,10 @@ import {
   isValidSpaceDid,
 } from "@/lib/space-authority.ts";
 
-// ---------------------------------------------------------------------------
+//
 // The narrow entitlement predicate. Cheap, exhaustive, and the place the
 // wildcard attack is pinned — see the "*" cases.
-// ---------------------------------------------------------------------------
+//
 
 // Shaped like real ed25519 did:keys, and valid base58btc (no 0, O, I or l).
 const ALICE = "did:key:z6MkaaaabbbbccccddddeeeeffffgggghhhhAAAA";
@@ -103,7 +103,7 @@ describe("isValidSpaceDid", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Against a REAL memory-v2 server with ACL enforcement on.
 //
 // This is the fixture the existing ingest suite lacks: ingest.utils.test.ts uses
@@ -112,7 +112,7 @@ describe("isValidSpaceDid", () => {
 // the harness below, the central security property of this feature — "refused
 // when naming a space you don't control" — is not testable, and a regression
 // would pass CI silently.
-// ---------------------------------------------------------------------------
+//
 
 describe("authorizeSpaceOwner against real ACL enforcement", () => {
   let server: MemoryV2Server.Server;

--- a/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
@@ -97,11 +97,13 @@ function extractGroundingChunks(completion: unknown): GroundingChunk[] {
   return Array.isArray(chunks) ? (chunks as GroundingChunk[]) : [];
 }
 
-// --- SSRF guard ---------------------------------------------------------
+//
+// SSRF guard
 // This route fetches URLs that come from search results (and follows their
 // redirects), so it must never be coaxed into reaching internal hosts. We
 // validate every hop's host (name + resolved IP) against private/reserved
 // ranges before connecting.
+//
 
 function isPrivateIpv4(ip: string): boolean {
   const m = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);

--- a/packages/toolshed/routes/ingest-channels/space-key-derivation-tripwire.test.ts
+++ b/packages/toolshed/routes/ingest-channels/space-key-derivation-tripwire.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { createSession, Identity } from "@commonfabric/identity";
 
-// ============================================================================
+//
 // STOP. THIS IS A TRIPWIRE, NOT A NORMAL TEST.        @tripwire:space-key-derivation
 //
 // IF YOU ARE AN AI AGENT OR A HUMAN WHO JUST SAW THIS FAIL:
@@ -31,7 +31,7 @@ import { createSession, Identity } from "@commonfabric/identity";
 // and retracts nothing already issued.
 //
 // A procedure in a document would be missed. This cannot be.
-// ============================================================================
+//
 
 const SPACE_NAME = "tripwire-shared-space";
 

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
@@ -151,9 +151,9 @@ export function createOAuth2Handlers(
     (OAuth2TokenSchema as unknown as JSONSchema);
   const emptyAuthData = options.emptyAuthData ?? EMPTY_OAUTH2_DATA;
 
-  // -----------------------------------------------------------------------
+  //
   // LOGIN
-  // -----------------------------------------------------------------------
+  //
   async function login(c: Context) {
     try {
       const payload = await c.req.json();
@@ -203,9 +203,9 @@ export function createOAuth2Handlers(
     }
   }
 
-  // -----------------------------------------------------------------------
+  //
   // CALLBACK
-  // -----------------------------------------------------------------------
+  //
   async function callback(c: Context) {
     const query = c.req.query();
     logger.info(`Received ${config.name} OAuth callback`, query);
@@ -366,9 +366,9 @@ export function createOAuth2Handlers(
     }
   }
 
-  // -----------------------------------------------------------------------
+  //
   // REFRESH
-  // -----------------------------------------------------------------------
+  //
   async function refresh(c: Context) {
     try {
       const payload = await c.req.json();
@@ -432,9 +432,9 @@ export function createOAuth2Handlers(
     }
   }
 
-  // -----------------------------------------------------------------------
+  //
   // LOGOUT
-  // -----------------------------------------------------------------------
+  //
   async function logout(c: Context) {
     try {
       const payload = await c.req.json();
@@ -464,9 +464,9 @@ export function createOAuth2Handlers(
     }
   }
 
-  // -----------------------------------------------------------------------
+  //
   // BACKGROUND INTEGRATION (shared, not provider-specific)
-  // -----------------------------------------------------------------------
+  //
   async function backgroundIntegration(c: Context) {
     try {
       const payload = await c.req.json();

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.utils.ts
@@ -17,9 +17,9 @@ import {
 
 const logger = getLogger("oauth2-common");
 
-// ---------------------------------------------------------------------------
+//
 // OAuth2 Client
-// ---------------------------------------------------------------------------
+//
 
 export function createOAuth2Client(
   config: OAuth2ProviderConfig,
@@ -40,9 +40,9 @@ export function createOAuth2Client(
   });
 }
 
-// ---------------------------------------------------------------------------
+//
 // URL helpers
-// ---------------------------------------------------------------------------
+//
 
 export function getBaseUrl(url: string): string {
   try {
@@ -56,9 +56,9 @@ export function getBaseUrl(url: string): string {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Callback HTML
-// ---------------------------------------------------------------------------
+//
 
 function escapeHtml(str: string): string {
   return str
@@ -108,9 +108,9 @@ export function generateCallbackHtml(result: Record<string, unknown>): string {
   `;
 }
 
-// ---------------------------------------------------------------------------
+//
 // User info
-// ---------------------------------------------------------------------------
+//
 
 export async function fetchUserInfo(
   accessToken: string,
@@ -136,9 +136,9 @@ export async function fetchUserInfo(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Auth cell CRUD
-// ---------------------------------------------------------------------------
+//
 
 export async function getAuthCell(docLink: string, schema: JSONSchema) {
   try {
@@ -210,9 +210,9 @@ export async function clearAuthData(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Token mapping (generic: uses accessToken field)
-// ---------------------------------------------------------------------------
+//
 
 export function tokenToGenericAuthData(
   token: Tokens | OAuth2Tokens,
@@ -229,9 +229,9 @@ export function tokenToGenericAuthData(
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Response helpers
-// ---------------------------------------------------------------------------
+//
 
 export function createCallbackResponse(
   result: Record<string, unknown>,
@@ -297,9 +297,9 @@ export function createBackgroundIntegrationErrorResponse(
   return c.json({ success: false, error: errorMessage }, status);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Provider metadata discovery (RFC 8414 / OIDC)
-// ---------------------------------------------------------------------------
+//
 
 // In-memory cache: metadataUrl → discovered endpoints
 const metadataCache = new Map<string, {

--- a/packages/toolshed/routes/integrations/provider-registry.ts
+++ b/packages/toolshed/routes/integrations/provider-registry.ts
@@ -45,9 +45,9 @@ import type { AppRouteHandler } from "@/lib/types.ts";
 
 const logger = getLogger("provider-registry");
 
-// ---------------------------------------------------------------------------
+//
 // Shared CORS configuration for all OAuth2 provider routes
-// ---------------------------------------------------------------------------
+//
 
 const OAUTH_CORS_CONFIG = {
   origin: "*",
@@ -58,9 +58,9 @@ const OAUTH_CORS_CONFIG = {
   credentials: true,
 };
 
-// ---------------------------------------------------------------------------
+//
 // Descriptor catalog — add new OAuth2 providers here
-// ---------------------------------------------------------------------------
+//
 
 const DESCRIPTORS: ProviderDescriptor[] = [
   GoogleDescriptor,
@@ -73,9 +73,9 @@ const DESCRIPTORS: ProviderDescriptor[] = [
   StravaDescriptor,
 ];
 
-// ---------------------------------------------------------------------------
+//
 // Descriptor → OAuth2ProviderConfig
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Resolve a ProviderDescriptor to a fully populated OAuth2ProviderConfig.
@@ -120,9 +120,9 @@ async function resolveProviderConfig(
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Single-provider router factory
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Create a fully wired Hono router for a single OAuth2 provider.
@@ -189,9 +189,9 @@ async function createProviderRouter(
   return router;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Public API
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Build routers for all registered OAuth2 provider descriptors.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 36 section markers in `packages/toolshed` to the `//`-delimited
form. They were written as a `===` rule above and below the title, and as
`// ===== Title =====` on one line.

## One marker needed a split, not a conversion

In `env.ts` the OpenTelemetry marker's closing rule butted straight against the
next declaration's comment, with no blank line between them:

    // ===========================================================================
    // OpenTelemetry Configuration
    // ===========================================================================
    // Strict parse (see boolFlag): only "true"/"1" enable telemetry; ...
    OTEL_ENABLED: boolFlag(),

Dropping the rule lines and closing the block around everything left would have
turned `OTEL_ENABLED`'s own documentation into the section's description. So the
marker closes after its title and a blank line separates it from that comment,
which is left exactly as it was.

This is the only such case in the package, and it was found rather than guessed
at: the converter refuses any rule sitting between two non-empty comment lines
and reports it, instead of welding them together.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and every long rule run removed had text on one side only — a rule
brackets a title, an operator sits inside one.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/toolshed`'s own `deno task test`.

Note for whoever reads `env.ts` next: the five titleless closing rules removed
earlier left its sections opening with a marker and not closing. This PR is
what squares that up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

