### PR TITLE
Conform the section markers in the repo-level directories

### DIFF
--- a/docs/check.ts
+++ b/docs/check.ts
@@ -122,7 +122,9 @@ export function extFor(lang: string, ctx: Context, body = ""): string {
   return "tsx";
 }
 
-// --- vocabulary ------------------------------------------------------------
+//
+// vocabulary
+//
 
 interface Vocabulary {
   frameworkValues: string[];
@@ -154,7 +156,9 @@ function arrayReceivers(body: string): Set<string> {
   return out;
 }
 
-// --- block extraction ------------------------------------------------------
+//
+// block extraction
+//
 
 export interface Block {
   file: string; // absolute path
@@ -192,7 +196,9 @@ export function extractBlocks(file: string, text: string): Block[] {
   return out;
 }
 
-// --- context detection -----------------------------------------------------
+//
+// context detection
+//
 
 export function detectContext(body: string): { ctx: Context; body: string } {
   const lines = body.split("\n");
@@ -209,7 +215,9 @@ export function detectContext(body: string): { ctx: Context; body: string } {
   return { ctx: "standalone", body };
 }
 
-// --- source transform ------------------------------------------------------
+//
+// source transform
+//
 
 const DEFINED =
   /^\s*(?:export\s+)?(?:declare\s+)?(?:const|let|var|function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm;
@@ -415,7 +423,9 @@ export function render(ctx: Context, rawBody: string, docDir: string): string {
   }
 }
 
-// --- runner ----------------------------------------------------------------
+//
+// runner
+//
 
 const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 const PARSE_ABORT =

--- a/scripts/bench-setup.ts
+++ b/scripts/bench-setup.ts
@@ -17,13 +17,17 @@ import {
   type SpaceConfig,
 } from "../packages/cli/lib/piece.ts";
 
-// ===== Path resolution =====
+//
+// Path resolution
+//
 
 const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const NOTE_PATTERN = `${REPO_ROOT}/packages/patterns/notes/note.tsx`;
 const TODO_PATTERN = `${REPO_ROOT}/packages/patterns/todo-list/todo-list.tsx`;
 
-// ===== Content =====
+//
+// Content
+//
 
 const NOTES = [
   { title: "Standup 2026-03-27", content: "No blockers today." },
@@ -132,7 +136,9 @@ const TODO_ITEMS = [
   "Write integration test for concurrent FUSE writes",
 ];
 
-// ===== CLI parsing =====
+//
+// CLI parsing
+//
 
 function parseArgs(args: string[]): {
   apiUrl: string;
@@ -160,7 +166,9 @@ function parseArgs(args: string[]): {
   };
 }
 
-// ===== Timestamp =====
+//
+// Timestamp
+//
 
 function timestamp(): string {
   const now = new Date();
@@ -171,7 +179,9 @@ function timestamp(): string {
   );
 }
 
-// ===== Main =====
+//
+// Main
+//
 
 async function deployNote(
   spaceConfig: SpaceConfig,

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -89,10 +89,10 @@ const DEFAULT_SUCCESS_ONLY = !RUN_IDS.length &&
 // Restrict to pushes to main (post-land), excluding pre-land pull_request runs.
 const MAIN_ONLY = args.includes("--main-only");
 
-// ---------------------------------------------------------------------------
+//
 // Data fetching: without --input, calls the GitHub REST API directly,
 // authenticated with GH_TOKEN or GITHUB_TOKEN. One of those must be set.
-// ---------------------------------------------------------------------------
+//
 
 const TOKEN = INPUT
   ? undefined
@@ -254,7 +254,7 @@ function latestJobsByName(jobs: Job[]): Job[] {
   return [...latest.values()];
 }
 
-// ---------------------------------------------------------------------------
+//
 // Step phases
 //
 // Every step is placed into a phase from the marker emoji its name begins with.
@@ -268,7 +268,7 @@ function latestJobsByName(jobs: Job[]): Job[] {
 // and "Complete job". The phase classifier also recognizes the "runner" pair
 // present in retained records. Those are classified by name in that module,
 // because their wording is not ours to set.
-// ---------------------------------------------------------------------------
+//
 
 // Chart order, left to right (matches the order steps run in). "other" trails so
 // an unmarked step stands out at the end of the bar.
@@ -289,9 +289,9 @@ async function fetchJobs(path: string): Promise<Job[]> {
   return jobs;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Statistics
-// ---------------------------------------------------------------------------
+//
 
 interface Stat {
   min: number;
@@ -335,9 +335,9 @@ function shardKeyOf(name: string): string {
   return suite ? suite[1] : "";
 }
 
-// ---------------------------------------------------------------------------
+//
 // Formatting
-// ---------------------------------------------------------------------------
+//
 
 function clock(sec: number): string {
   sec = Math.round(sec);
@@ -350,9 +350,9 @@ function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-// ---------------------------------------------------------------------------
+//
 // Main
-// ---------------------------------------------------------------------------
+//
 
 let runs: Run[];
 let jobsPerRun: GanttInput["runs"];
@@ -614,9 +614,9 @@ const prFinish = Math.max(
   ...(prJobs.length ? prJobs : aggregates).map((j) => j.end.med),
 );
 
-// ---------------------------------------------------------------------------
+//
 // SVG layout
-// ---------------------------------------------------------------------------
+//
 
 const maxEnd = Math.max(...aggregates.map((j) => j.end.max));
 const PAD = 22;
@@ -1090,9 +1090,9 @@ const svg = [
   `</svg>`,
 ].join("\n");
 
-// ---------------------------------------------------------------------------
+//
 // Write output: the raw SVG when --out ends in .svg, otherwise a rasterized PNG.
-// ---------------------------------------------------------------------------
+//
 
 if (OUT.toLowerCase().endsWith(".svg")) {
   await Deno.writeTextFile(OUT, svg);

--- a/scripts/fuse-bench.ts
+++ b/scripts/fuse-bench.ts
@@ -18,9 +18,9 @@
  *     [--result-path result/content]
  */
 
-// ---------------------------------------------------------------------------
+//
 // Helpers
-// ---------------------------------------------------------------------------
+//
 
 function join(...parts: string[]): string {
   return parts.join("/").replace(/\/+/g, "/");
@@ -62,9 +62,9 @@ async function readFileSafe(path: string): Promise<string | null> {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Help & argument parsing
-// ---------------------------------------------------------------------------
+//
 
 function printHelp(): void {
   console.log(`fuse-bench — FUSE multi-op benchmark harness
@@ -175,9 +175,9 @@ function parseArgs(args: string[]): ParsedArgs | null {
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Piece discovery
-// ---------------------------------------------------------------------------
+//
 
 async function discoverPieces(piecesDir: string): Promise<string[]> {
   const pieces: string[] = [];
@@ -189,9 +189,9 @@ async function discoverPieces(piecesDir: string): Promise<string[]> {
   return pieces.sort();
 }
 
-// ---------------------------------------------------------------------------
+//
 // Benchmark operations
-// ---------------------------------------------------------------------------
+//
 
 interface LatencyResult {
   latency_ms: {
@@ -415,9 +415,9 @@ async function benchConcurrentRead(
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Main
-// ---------------------------------------------------------------------------
+//
 
 const opts = parseArgs(Deno.args);
 if (!opts) {

--- a/skills/deno-memory-profiler/scripts/memory.ts
+++ b/skills/deno-memory-profiler/scripts/memory.ts
@@ -3,9 +3,9 @@
 // Deno Memory Profiler — V8 Inspector CDP client
 // Zero dependencies. Single file. JSON output to stdout, status to stderr.
 
-// ---------------------------------------------------------------------------
+//
 // Arg parsing
-// ---------------------------------------------------------------------------
+//
 
 interface GlobalOpts {
   host: string;
@@ -34,9 +34,9 @@ function parseGlobalOpts(args: string[]): { opts: GlobalOpts; rest: string[] } {
   return { opts: { host, port }, rest };
 }
 
-// ---------------------------------------------------------------------------
+//
 // CDP Client
-// ---------------------------------------------------------------------------
+//
 
 type CDPEventHandler = (params: Record<string, unknown>) => void;
 
@@ -130,9 +130,9 @@ class CDPClient {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Commands
-// ---------------------------------------------------------------------------
+//
 
 async function cmdUsage(client: CDPClient, args: string[]) {
   const doGC = args.includes("--gc");
@@ -281,9 +281,9 @@ async function cmdSample(client: CDPClient, args: string[]) {
   );
 }
 
-// ---------------------------------------------------------------------------
+//
 // Snapshot helpers
-// ---------------------------------------------------------------------------
+//
 
 interface HeapSnapshotData {
   snapshot: {
@@ -446,9 +446,9 @@ async function cmdSnapshot(client: CDPClient, _args: string[]) {
   );
 }
 
-// ---------------------------------------------------------------------------
+//
 // Diff
-// ---------------------------------------------------------------------------
+//
 
 async function cmdDiff(client: CDPClient, args: string[], port: number) {
   const subcommand = args[0];
@@ -590,9 +590,9 @@ async function cmdDiff(client: CDPClient, args: string[], port: number) {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Main
-// ---------------------------------------------------------------------------
+//
 
 async function main() {
   const rawArgs = Deno.args;

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -50,7 +50,8 @@ Deno.test("the real manifest passes end to end", async () => {
   assertEquals(await main(), 0);
 });
 
-// --- the evasion paths -----------------------------------------------------
+//
+// the evasion paths
 //
 // Each of these is a way someone silences the reminder without meaning to.
 // They were originally verified by hand, once; a guard whose failure modes are
@@ -59,6 +60,7 @@ Deno.test("the real manifest passes end to end", async () => {
 // Each case writes its own fixture file rather than pointing at a real one.
 // Self-reference bites here: a literal ".ignore(" anywhere in this file would
 // make the healthy case trip the DISABLED branch.
+//
 
 const SENTINEL = "@tripwire:probe-sentinel";
 

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -6,9 +6,9 @@
  *   - post-coverage-comment.ts (posts the gate's coverage comment)
  */
 
-// ---------------------------------------------------------------------------
+//
 // Config (from environment)
-// ---------------------------------------------------------------------------
+//
 
 export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
 
@@ -101,9 +101,9 @@ export const COVERAGE_LOCAL_CHECK_COMMAND = [
   '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
 ].join("\n");
 
-// ---------------------------------------------------------------------------
+//
 // Types
-// ---------------------------------------------------------------------------
+//
 
 export interface WorkflowRun {
   id: number;
@@ -251,9 +251,9 @@ export interface BaselineOverrides {
   coverageBaselineReset: boolean;
 }
 
-// ---------------------------------------------------------------------------
+//
 // GitHub API helpers
-// ---------------------------------------------------------------------------
+//
 
 function apiHeaders(): Record<string, string> {
   return {
@@ -389,9 +389,9 @@ export async function githubPatch<T>(
   return resp.json();
 }
 
-// ---------------------------------------------------------------------------
+//
 // Fetch artifacts
-// ---------------------------------------------------------------------------
+//
 
 export async function fetchArtifactsForRun(
   runId: number,
@@ -682,9 +682,9 @@ export async function downloadAndParseCoverageBaseline(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Compile cache state
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Parse the JSON contents of cache-state artifact files into records.
@@ -756,9 +756,9 @@ export function aggregateCacheStates(
   return states;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Formatting
-// ---------------------------------------------------------------------------
+//
 
 export function isCoverageDebtMetric(name: string): boolean {
   return name.startsWith(COVERAGE_METRIC_PREFIX);
@@ -1427,9 +1427,9 @@ export function buildCoverageResolvedComment(
   return out.join("\n");
 }
 
-// ---------------------------------------------------------------------------
+//
 // Event helpers
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Reads and parses the GHA event. Returns `undefined` if it can't be done.
@@ -1451,9 +1451,9 @@ export async function readAndParseEvent(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // PR helpers
-// ---------------------------------------------------------------------------
+//
 
 /** Fetch the full body of a PR by number. */
 export async function fetchPRBody(prNumber: number): Promise<string> {
@@ -1524,9 +1524,9 @@ export async function fetchCurrentPRBody(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Coverage override parsing
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Each `ACCEPT_COVERAGE_DEBT:` marker that starts a line, and the rest of that

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1750,9 +1750,9 @@ export async function writeCoverageResolved(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Main
-// ---------------------------------------------------------------------------
+//
 
 export async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -263,12 +263,12 @@ export function checkPattern(
   return findings;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Baseline store
 //
 // Parameterized by directory so these are testable against a temp tree rather
 // than only against the real `packages/patterns` layout.
-// ---------------------------------------------------------------------------
+//
 
 /** Read every recorded contract for a pattern. Absent directory → none. */
 export async function readBaselines(


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 40 section markers that live outside `packages/` to the
`//`-delimited form: 17 in `scripts/`, 12 in `tasks/`, 6 in `skills/`, and 5 in
`docs/check.ts`. They were written three ways — `// --- Title ------------`
filled to the margin, a `====` rule above and below the title, and
`// ==== Title ====`.

`skills/` is the canonical authored source, and both `.agents/skills/` and
`.claude/skills/` reach it through symlinks rather than copies, so the one edit
covers all three trees. Checked rather than assumed: the tree holds exactly one
tracked copy of the file involved.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and every long rule run removed had text on one side only.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass. Because this
touches the gate scripts themselves, the gates that read them were run too:
`check-docs`, `check-skill-facts`, `check-conflict-markers`, and
`check-control-characters`, all passing, plus `tasks/check-tripwires.test.ts`
(10 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

