### PR TITLE
fix(topics): the pivot reads a mid-sync source without throwing

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -122,6 +122,46 @@ export interface TopicIndexRow {
 }
 
 /**
+ * Each source's mention list, read once per source.
+ *
+ * A source whose value has not materialized yet — a topic appended a moment
+ * ago, still mid-sync — reads back as `undefined`, and taking `.mentions` of
+ * that throws. Thrown here it kills the whole pivot, and with it the append
+ * that caused it: the board goes on serving every topic it already had and
+ * silently accepts no new one.
+ *
+ * `mentionedBy` below already declares this element as `| undefined` and
+ * already guards it with `mentions[from]?.some(...)`. So the tolerance is not
+ * being added here; the producer is being made to honor the contract its own
+ * consumer states.
+ *
+ * A read taken straight off the cell gets no help from the compiler. `get()` on
+ * `ReadonlyCell<TopicMentionSource>` is declared to return a value rather than
+ * `T | undefined` — `IReadable` in `packages/api/index.ts` — so omitting the
+ * second `?.` there type-checks exactly as well as including it, and every gate
+ * stays green over a board that silently accepts no new topic. Only a read
+ * against a board with an in-flight append tells the two apart.
+ *
+ * Declaring the source structurally is what changes that. The parameter type
+ * says `get(): { mentions: M } | undefined`, so omitting the second `?.` HERE
+ * is a compile error: `deno task cfcheck` fails with "Object is possibly
+ * 'undefined'". `deno task check` passes either way — it walks the
+ * hand-maintained path list in `tasks/typecheck.ts`, which this package is not
+ * on, and patterns are checked by `cfcheck`. So the structural declaration buys
+ * two things rather than one: the read becomes testable, and the optionality
+ * moves somewhere the pattern typechecker can see it.
+ *
+ * Whether a cell's `get()` may return undefined against its declared type is a
+ * question about the cell contract rather than about this pattern, and it is
+ * not answered here.
+ */
+export function mentionListsOf<M>(
+  sources: readonly ({ get(): { mentions: M } | undefined } | undefined)[],
+): (M | undefined)[] {
+  return Array.from(sources, (source) => source?.get()?.mentions);
+}
+
+/**
  * The topics that mention `topic`, out of `list` — the pivot's whole join,
  * lifted out so it can be handed a list a board cannot produce.
  *
@@ -196,7 +236,7 @@ const crossrefTable = lift(
     // reading it there costs a link resolution per topic per topic.
     const list = Array.from(sources);
     // Each topic's mention list, read once, for the same reason.
-    const mentions = list.map((topic) => topic?.get().mentions);
+    const mentions = mentionListsOf(list);
     list.forEach((topic) => {
       // An entry with nothing behind it yet (mid-sync) has no identity to
       // address a row by, and `Writable.for(undefined)` is not a cause. It gets

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -23,6 +23,7 @@ import {
 import { pattern } from "commonfabric";
 import Topics, {
   mentionedBy,
+  mentionListsOf,
   submitProfileTopic,
   type TopicCrossrefRow,
   type TopicPiece,
@@ -620,6 +621,24 @@ export default pattern(() => {
         .length === 2
   );
 
+  // A source mid-sync reads back as undefined, and taking `.mentions` of that
+  // throws — which killed the pivot and, with it, the append that produced the
+  // half-written source. The first two entries are what a settled board looks
+  // like; the third is the one that used to throw. Reading its list as
+  // undefined is exactly what `mentionedBy` above declares and guards.
+  const assert_mention_lists_tolerate_a_mid_sync_source = assert(() => {
+    const settled = (m: unknown[]) => ({ get: () => ({ mentions: m }) });
+    const midSync = { get: () => undefined };
+    const lists = mentionListsOf([settled([twinA]), settled([]), midSync]);
+    return lists.length === 3 &&
+      (lists[0] as unknown[]).length === 1 &&
+      (lists[1] as unknown[]).length === 0 &&
+      lists[2] === undefined &&
+      // And the consumer stays usable on that output rather than merely not
+      // throwing: the mid-sync row contributes no inbound edge.
+      mentionedBy(twinB, [twinA, twinB], [[twinB], undefined]).length === 1;
+  });
+
   const assert_pure_helpers = assert(() =>
     snippet("a b  c", 3) === "a b…" &&
     snippet("hi", 10) === "hi" &&
@@ -1037,6 +1056,7 @@ export default pattern(() => {
       { assertion: assert_non_topic_mention_lands },
       { action: action_source_retracts_mention },
       { assertion: assert_reference_retracted },
+      { assertion: assert_mention_lists_tolerate_a_mid_sync_source },
       { action: action_ui_mentions_two },
       { action: action_drop_one_from_ui },
       { assertion: assert_ui_dropped_only_that_one },


### PR DESCRIPTION
## Why

**A board deployed from `main` cannot accept a new topic.** Found during the
Topics migration rehearsal: `addTopic` against a live board fails every time,
and the board goes on serving all 125 topics it already had, which is what
makes it quiet.

    [ERROR][scheduler] Action failed: …:crossrefTable
      TypeError: Cannot read properties of undefined (reading 'mentions')
      at packages/patterns/topics/main.tsx

Three calls, three failures. The append does not land, and the caller is told
it settled — `cf call` returns a receipt and exits 0.

Confirmed against the store rather than against anything the pattern computes,
because the obvious instrument (`topicCount`) is produced by the very recompute
that crashes:

| read | result |
| --- | --- |
| board's stored `topics`, offline from the store | 125 |
| board's stored `topics` via the server, `--input` path | 125 |
| write log on the board's argument entity | last write predates the calls |
| `cf piece search` for each of the three titles | nothing, all three |

No new piece entity is created in the window at all. Whether the handling's
transaction aborts when `crossrefTable` throws, or the append never happens, is
a question about the callable path rather than about this pattern, and is being
followed up separately.

The line:

    const mentions = list.map((topic) => topic?.get().mentions);

`topic?.get()` guards the ELEMENT being undefined. It does not guard `get()`
RETURNING undefined, which is what a source mid-sync does — and a topic
appended a moment ago is exactly that. The read throws, `crossrefTable` dies,
and the append that produced the half-written source dies with it.

This is not the migration's doing and not a regression from #6143. The line is
on `main` unchanged, so every board deployed from it has this.

## What Changed

`topic?.get()?.mentions`, moved into an exported `mentionListsOf`.

**It restores an invariant rather than adding a guard.** `mentionedBy`, the
only consumer, already declares the element as
`readonly (readonly (object | undefined)[] | undefined)[]` and already guards
it with `mentions[from]?.some(...)`. The consumer was written expecting
undefined entries; only the producer failed to produce them safely.

**No gate could have caught it.** `get()` is declared in
`packages/api/index.ts` as returning `Readonly<StripDefaultBrand<T>>`, not
`| undefined`, so the read without the second `?.` type-checks exactly as well
as the read with it — `deno task check` and `deno task cfcheck` pass either
way. That is how the line came to sit three lines above a comment describing
the very case it misses ("An entry with nothing behind it yet (mid-sync)…"):
the author guarded where the type told them to, and the type was not telling
them the truth.

The read is extracted for the same reason `mentionedBy` already is — a lift's
internals are otherwise reachable only through a live board, and this failure
only appears while an append is in flight, which a single-runtime pattern test
cannot stage.

## Test plan

- `deno task check`, `deno task cfcheck`, `deno lint`, `deno fmt --check` — all green.
- Topics suites on this base: `topics.test.tsx` 47, `topics-rejections` 14,
  `multi-user` 7.
- **Verified failing on revert, not merely passing on green:** restoring
  `source?.get().mentions` gives `0 passed, 1 failed`; the fix gives 47 passed.
- The original repro was a real migrated board with 125 topics served from a
  clone of the production Topics space, not a synthetic case.

## Not addressed here

Whether a cell's `get()` may return undefined against its declared return type
is a question about the cell contract, not about this pattern. The same shape
is latent at every other `get()` in this file — `newTitle.get().trim()`,
`topics.get().length`, `myName.get().trim()` — and across the tree. This PR
restores the one instance that is provably breaking boards now; the contract
question is being routed separately.

Separately: `cf call` exited **0** on all three failing calls — the action
failed, the error printed, nothing was written, and the exit code said success.
That is being handled elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
