### PR TITLE
Tell a section marker from a doc comment in marker clothing

### DIFF
--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -324,11 +324,9 @@ function detailFromDoc(
   const spec = importSpecifier(value);
   const named = ctx.nameOf.get(id);
 
-  //
   // context-aware label + role
   // Label comes from the shared index (it already folds in import/context/legacy
   // refinements); role is computed here.
-  //
   let label = ctx.labelOf.get(id)?.label ?? c.label;
   let role: string = c.kind;
   if (spec) {
@@ -344,9 +342,7 @@ function detailFromDoc(
     role = roleFor(c.kind, c.owned);
   }
 
-  //
   // lineage, resolved to target labels
-  //
   const lineage: EntityDetail["lineage"] = {};
   if (c.lineage.argument) {
     lineage.argument = refTo(c.lineage.argument, ctx);
@@ -382,9 +378,7 @@ function detailFromDoc(
     lineage.pattern = ref;
   }
 
-  //
   // outgoing links, resolved
-  //
   const outLinks: LinkRef[] = linksWithPaths(value).map(({ link, at }) => {
     const external = !!link.space && link.space !== ctx.ownDid &&
       link.space !== `did:key:${ctx.ownDid}`;
@@ -399,15 +393,11 @@ function detailFromDoc(
     };
   });
 
-  //
   // module source
-  //
   let code: string | undefined;
   if (isModuleValue(value)) code = value.code;
 
-  //
   // schema / ifc / cfc
-  //
   let schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
   let schemaKeys = isObjectNotArray(doc.schema)
     ? Object.keys(doc.schema)

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -94,9 +94,7 @@ export function analyzeSpaceSignals(
     )
     .get<{ commits: number; entities: number }>();
 
-  //
   // Session principals (owners who wrote here)
-  //
   const principalCounts = new Map<string, number>();
   for (
     const r of space.db
@@ -118,9 +116,7 @@ export function analyzeSpaceSignals(
     }
   }
 
-  //
   // Home detection + profiles[] edges
-  //
   let isHome = false;
   const profileDids = new Set<string>();
   const homeCandidates = space.db
@@ -155,9 +151,7 @@ export function analyzeSpaceSignals(
     }
   }
 
-  //
   // All cross-space link targets (cheap candidate query)
-  //
   const crossSpaceDids = new Set<string>();
   for (
     const { id } of space.db

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -284,6 +284,7 @@ function kindChip(kind){ return el("span",{class:"kind "+kind,style:"background:
 //
 // live shell link
 //
+
 let LIVE = localStorage.getItem("si-live") || B.liveBase || "";
 function liveUrl(id){ if(!LIVE) return null;
   // The shell navigates by the bare id form (fid1:…); the stored "of:" prefix
@@ -296,6 +297,7 @@ function liveAnchor(id){ const u = liveUrl(id); return u
 //
 // selection + history
 //
+
 let cur = null; const hist = [];
 function select(id, push=true){
   if(!byId.has(id)) return;
@@ -311,6 +313,7 @@ function back(){ const id = hist.pop(); if(id){ cur=null; select(id,false); } }
 //
 // value renderer (links become clickable chips)
 //
+
 function valueDom(v, depth=0){
   if(v===null) return el("span",{class:"muted",text:"null"});
   if(typeof v!=="object") return el("span",{text: typeof v==="string" ? JSON.stringify(v) : String(v)});
@@ -358,6 +361,7 @@ function linkChip(ref){
 //
 // detail pane
 //
+
 function section(title, openByDefault, bodyNodes){
   const d = el("details",{class:"sec"}); if(openByDefault) d.setAttribute("open","");
   d.append(el("summary",{text:title}));
@@ -505,6 +509,7 @@ function fmtSession(s){ try{ s=decodeURIComponent(s);}catch{} const m=s.match(/^
 //
 // tree view
 //
+
 function treeRow(d, childInfo){
   const ov = overlayById.get(d.id);
   const cf = conflictById.get(d.id);
@@ -565,6 +570,7 @@ function renderTree(){
 //
 // graph view
 //
+
 function neighborhood(rootId, depth){
   const adj=new Map();
   for(const e of B.graph.edges){ (adj.get(e.from)??adj.set(e.from,[]).get(e.from)).push(e.to);
@@ -610,6 +616,7 @@ function renderGraph(){
 //
 // timeline
 //
+
 function renderTimeline(){
   const t=B.timeline; const host=$("#tl"); host.innerHTML="";
   if(!t.length){host.append(el("p",{class:"muted",text:"(no commits)"}));return;}
@@ -632,6 +639,7 @@ function renderTimeline(){
 //
 // wiring
 //
+
 for(const b of $$("nav button")) b.onclick=()=>{
   $$("nav button").forEach(x=>x.classList.toggle("active",x===b));
   $$(".tabwrap").forEach(s=>s.classList.toggle("active",s.id===b.dataset.tab));

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -238,10 +238,8 @@ export function classifyDocument(doc: EntityDocument): Classification {
   const lineage: Lineage = {};
   if (owned) lineage.owner = linkId(doc.result);
 
-  //
   // Pieces
   // Modern: the durable piece → pattern pointer is `patternIdentity`.
-  //
   if (isObjectNotArray(doc.patternIdentity)) {
     const pi = doc.patternIdentity as { identity?: unknown; symbol?: unknown };
     lineage.argument = linkId(doc.argument);
@@ -298,9 +296,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
     };
   }
 
-  //
   // Cell sub-kinds by value shape
-  //
   if (isModuleValue(value)) {
     return {
       kind: "module",
@@ -336,9 +332,7 @@ export function classifyDocument(doc: EntityDocument): Classification {
     };
   }
 
-  //
   // Plain cells
-  //
   if (owned) {
     const label = value === undefined ? "(lineage)" : summarize(value);
     return {

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -86,6 +86,7 @@ export const EnvSchema = z.object({
   //
   // (/routes/ai/llm) Environment variables for LLM Providers
   //
+
   CFTS_AI_LLM_ANTHROPIC_API_KEY: z.string().default(""),
   CFTS_AI_LLM_GROQ_API_KEY: z.string().default(""),
   CFTS_AI_LLM_OPENAI_API_KEY: z.string().default(""),
@@ -96,18 +97,18 @@ export const EnvSchema = z.object({
   // when the URL is unreachable (see `loadGatewayModels` in routes/ai/llm/models.ts).
   CFTS_AI_GATEWAY_URL: z.string().default("https://llm.stage.commontools.dev"),
 
-  //
-  // FAL AI API Key
-  //   * /routes/ai/img
-  //   * /routes/ai/voice
-  //
+  /**
+   * FAL AI API Key
+   *   * /routes/ai/img
+   *   * /routes/ai/voice
+   */
   FAL_API_KEY: z.string().default(""),
 
-  //
-  // Jina API Key
-  //   * /routes/agent-tools/web-read
-  //   * /routes/link-preview
-  //
+  /**
+   * Jina API Key
+   *   * /routes/agent-tools/web-read
+   *   * /routes/link-preview
+   */
   JINA_API_KEY: z.string().default(""),
 
   //
@@ -118,6 +119,7 @@ export const EnvSchema = z.object({
   //    holding every space (single-file mode - takes precedence over MEMORY_DIR)
   //  - MEMORY_URL is used by toolshed to connect to memory endpoint
   //
+
   MEMORY_DIR: z.string().default(
     new URL(`./cache/memory/`, Path.toFileUrl(`${Deno.cwd()}/`)).href,
   ),
@@ -134,6 +136,7 @@ export const EnvSchema = z.object({
   // Airtable Integration
   //   * /routes/integrations/airtable-oauth
   //
+
   AIRTABLE_CLIENT_ID: z.string().default(""),
   AIRTABLE_CLIENT_SECRET: z.string().default(""),
 
@@ -141,6 +144,7 @@ export const EnvSchema = z.object({
   // GitHub Integration
   //   * /routes/integrations/github-oauth
   //
+
   GITHUB_CLIENT_ID: z.string().default(""),
   GITHUB_CLIENT_SECRET: z.string().default(""),
 
@@ -148,6 +152,7 @@ export const EnvSchema = z.object({
   // Notion Integration
   //   * /routes/integrations/notion-oauth
   //
+
   NOTION_CLIENT_ID: z.string().default(""),
   NOTION_CLIENT_SECRET: z.string().default(""),
 
@@ -155,6 +160,7 @@ export const EnvSchema = z.object({
   // Linear Integration
   //   * /routes/integrations/linear-oauth
   //
+
   LINEAR_CLIENT_ID: z.string().default(""),
   LINEAR_CLIENT_SECRET: z.string().default(""),
 
@@ -162,6 +168,7 @@ export const EnvSchema = z.object({
   // Spotify Integration
   //   * /routes/integrations/spotify-oauth
   //
+
   SPOTIFY_CLIENT_ID: z.string().default(""),
   SPOTIFY_CLIENT_SECRET: z.string().default(""),
 
@@ -169,6 +176,7 @@ export const EnvSchema = z.object({
   // Discord OAuth Integration
   //   * /routes/integrations/discord-oauth
   //
+
   DISCORD_CLIENT_ID: z.string().default(""),
   DISCORD_CLIENT_SECRET: z.string().default(""),
 
@@ -176,6 +184,7 @@ export const EnvSchema = z.object({
   // Strava Integration
   //   * /routes/integrations/strava-oauth
   //
+
   STRAVA_CLIENT_ID: z.string().default(""),
   STRAVA_CLIENT_SECRET: z.string().default(""),
 
@@ -183,6 +192,7 @@ export const EnvSchema = z.object({
   // Plaid Integration
   //   * /routes/integrations/plaid-oauth
   //
+
   PLAID_CLIENT_ID: z.string().default(""),
   PLAID_SECRET: z.string().default(""),
   PLAID_ENV: z.enum(["sandbox", "development", "production"]).default(
@@ -276,6 +286,7 @@ export const EnvSchema = z.object({
   // Sandbox Service
   //   * /routes/sandbox/exec
   //
+
   SANDBOX_SERVICE_URL: z.string().default(
     "https://sandbox.stage.commontools.dev",
   ),

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
@@ -151,9 +151,6 @@ export function createOAuth2Handlers(
     (OAuth2TokenSchema as unknown as JSONSchema);
   const emptyAuthData = options.emptyAuthData ?? EMPTY_OAUTH2_DATA;
 
-  //
-  // LOGIN
-  //
   async function login(c: Context) {
     try {
       const payload = await c.req.json();
@@ -203,9 +200,6 @@ export function createOAuth2Handlers(
     }
   }
 
-  //
-  // CALLBACK
-  //
   async function callback(c: Context) {
     const query = c.req.query();
     logger.info(`Received ${config.name} OAuth callback`, query);
@@ -366,9 +360,6 @@ export function createOAuth2Handlers(
     }
   }
 
-  //
-  // REFRESH
-  //
   async function refresh(c: Context) {
     try {
       const payload = await c.req.json();
@@ -432,9 +423,6 @@ export function createOAuth2Handlers(
     }
   }
 
-  //
-  // LOGOUT
-  //
   async function logout(c: Context) {
     try {
       const payload = await c.req.json();
@@ -467,6 +455,7 @@ export function createOAuth2Handlers(
   //
   // BACKGROUND INTEGRATION (shared, not provider-specific)
   //
+
   async function backgroundIntegration(c: Context) {
     try {
       const payload = await c.req.json();

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.handlers.ts
@@ -452,10 +452,7 @@ export function createOAuth2Handlers(
     }
   }
 
-  //
-  // BACKGROUND INTEGRATION (shared, not provider-specific)
-  //
-
+  /** BACKGROUND INTEGRATION (shared, not provider-specific) */
   async function backgroundIntegration(c: Context) {
     try {
       const payload = await c.req.json();

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -177,9 +177,7 @@ export class CFChat extends BaseElement {
     `,
   ];
 
-  //
-  // Cell controller for messages binding
-  //
+  /** Cell controller for messages binding */
   private _cellController = createCellController<BuiltInLLMMessage[]>(this, {
     timing: { strategy: "immediate" },
     onChange: () => {

--- a/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
@@ -100,9 +100,7 @@ export type RadioGroupOrientation = "vertical" | "horizontal";
 export class CFRadioGroup extends BaseElement {
   static override styles = unsafeCSS(radioGroupStyles);
 
-  //
-  // Cell controller for value binding
-  //
+  /** Cell controller for value binding */
   private _cellController = createCellController<unknown>(this, {
     timing: { strategy: "immediate" }, // Radio changes should be immediate
     onChange: (newValue, oldValue) => {

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -65,10 +65,7 @@ export interface SelectItem {
 }
 
 export class CFSelect extends BaseElement {
-  //
-  // Styles
-  //
-
+  /** Styles */
   static override styles = [
     BaseElement.baseStyles,
     css`

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -68,6 +68,7 @@ export class CFSelect extends BaseElement {
   //
   // Styles
   //
+
   static override styles = [
     BaseElement.baseStyles,
     css`
@@ -190,9 +191,7 @@ export class CFSelect extends BaseElement {
   /** Mapping from stringified option key -> SelectItem */
   private _keyMap = new Map<string, SelectItem>();
 
-  //
-  // Cell controller for value binding
-  //
+  /** Cell controller for value binding */
   private _cellController = createCellController<unknown | unknown[]>(this, {
     timing: { strategy: "immediate" }, // Select changes should be immediate
     onChange: (newValue, oldValue) => {
@@ -214,9 +213,7 @@ export class CFSelect extends BaseElement {
     },
   });
 
-  //
-  // Form field controller for buffering
-  //
+  /** Form field controller for buffering */
   private _formField = createFormFieldController<unknown | unknown[]>(this, {
     cellController: this._cellController,
     validate: () => ({
@@ -228,6 +225,7 @@ export class CFSelect extends BaseElement {
   //
   // Reactive properties
   //
+
   static override properties = {
     disabled: { type: Boolean, reflect: true },
     multiple: { type: Boolean, reflect: true },
@@ -273,6 +271,7 @@ export class CFSelect extends BaseElement {
   //
   // Lifecycle
   //
+
   override connectedCallback() {
     super.connectedCallback();
     this._updateAccessibilityAttributes();
@@ -339,6 +338,7 @@ export class CFSelect extends BaseElement {
   //
   // Render
   //
+
   override render() {
     return html`
       <!-- The host owns role and tabindex; focus is forwarded to this native
@@ -434,6 +434,7 @@ export class CFSelect extends BaseElement {
   //
   // Events
   //
+
   private _onChange(e: Event) {
     const select = e.target as HTMLSelectElement;
     const _oldValue = this.getCurrentValue();
@@ -456,6 +457,7 @@ export class CFSelect extends BaseElement {
   //
   // Public API
   //
+
   override focus(options?: FocusOptions) {
     if (this.disabled) return;
     this._select?.focus(options);
@@ -483,6 +485,7 @@ export class CFSelect extends BaseElement {
   //
   // Accessibility
   //
+
   private _updateAccessibilityAttributes() {
     // A single select is a combobox; a multi-select is a listbox (ARIA spec).
     const role = this.multiple ? "listbox" : "combobox";
@@ -504,6 +507,7 @@ export class CFSelect extends BaseElement {
   //
   // Internal helpers
   //
+
   private _makeKey(_item: SelectItem, index: number) {
     // Unique deterministic key for each option
     return `${index}`;

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -107,9 +107,7 @@ export class CFTabs extends BaseElement {
   // Track last known value to detect external cell changes
   private _lastKnownValue: string = "";
 
-  //
-  // Cell controller for value binding
-  //
+  /** Cell controller for value binding */
   private _cellController = createStringCellController(this, {
     timing: { strategy: "immediate" }, // Tab changes should be immediate
     onChange: (newValue: string, _oldValue: string) => {

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -104,9 +104,7 @@ const ToolsArraySchema = {
 } as const satisfies JSONSchema;
 
 export class CFToolsChip extends BaseElement {
-  //
-  // Cell controller for tools binding
-  //
+  /** Cell controller for tools binding */
   private _cellController = createCellController<ToolsInput>(this, {
     timing: { strategy: "immediate" },
     onChange: () => {

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -107,31 +107,48 @@ export class CellController<T> implements ReactiveController {
    * delivery supersedes it, or when the binding moves to a different cell.
    */
   private _localEdit: { value: T } | undefined;
-  // Number of in-flight cell writes started by the default setter.
+
+  /** Number of in-flight cell writes started by the default setter. */
   private _inFlightWrites = 0;
-  // Re-entrancy marker: a subscription delivery firing synchronously from our
-  // own optimistic set() (as opposed to a backend push). A local echo must not
-  // release the edit — only durable/bound state catching up may.
+
+  /**
+   * Re-entrancy marker: a subscription delivery firing synchronously from our
+   * own optimistic set() (as opposed to a backend push). A local echo must not
+   * release the edit — only durable/bound state catching up may.
+   */
   private _applyingLocalWrite = false;
-  // All writes settled but bound state never converged (e.g. a rebind swapped
-  // in a pre-write snapshot first): deliveries are FIFO, so the next one
-  // reflects post-write state and is authoritative.
+
+  /**
+   * All writes settled but bound state never converged (e.g. a rebind swapped
+   * in a pre-write snapshot first): deliveries are FIFO, so the next one
+   * reflects post-write state and is authoritative.
+   */
   private _settledAwaitingRelease = false;
-  // Last authoritative user-visible value. Survives same-cell rebinds so a
-  // replacement handle that has not hydrated yet (get() still undefined)
-  // does not repaint emptiness over it.
+
+  /**
+   * Last authoritative user-visible value. Survives same-cell rebinds so a
+   * replacement handle that has not hydrated yet (get() still undefined)
+   * does not repaint emptiness over it.
+   */
   private _lastKnownValue: T | undefined;
-  // Whether the current subscription has received a real (asynchronous)
-  // delivery. subscribe()'s synchronous initial callback merely echoes the
-  // handle's local cache — for a freshly minted rebound handle that is
-  // "no information yet", NOT an authoritative undefined. Once any real
-  // delivery arrives, an undefined value is an authoritative clear and must
-  // repaint (it may not be masked by _lastKnownValue).
+
+  /**
+   * Whether the current subscription has received a real (asynchronous)
+   * delivery. subscribe()'s synchronous initial callback merely echoes the
+   * handle's local cache — for a freshly minted rebound handle that is
+   * "no information yet", NOT an authoritative undefined. Once any real
+   * delivery arrives, an undefined value is an authoritative clear and must
+   * repaint (it may not be masked by _lastKnownValue).
+   */
   private _bindingHydrated = false;
-  // True only while subscribe() runs its synchronous initial callback.
+
+  /** True only while subscribe() runs its synchronous initial callback. */
   private _subscribeEcho = false;
-  // Bumped when binding to a different persistent cell, so settle callbacks
-  // from writes against a previous binding cannot release the new one.
+
+  /**
+   * Bumped when binding to a different persistent cell, so settle callbacks
+   * from writes against a previous binding cannot release the new one.
+   */
   private _bindEpoch = 0;
 
   constructor(

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -98,14 +98,14 @@ export class CellController<T> implements ReactiveController {
   private _cellUnsubscribe: (() => void) | null = null;
   private _inputTiming?: InputTimingController;
 
-  //
-  // Pending-local-edit tracking (early-boot wipe guard)
-  // A locally-edited value that bound state has not yet confirmed. While set,
-  // it wins over stale bound state in getValue(), so a re-render cannot
-  // repaint a pre-write snapshot over what the user just typed. Released when
-  // the echo confirms it (a delivery equal to the edit), when a post-settle
-  // delivery supersedes it, or when the binding moves to a different cell.
-  //
+  /**
+   * Pending-local-edit tracking (early-boot wipe guard)
+   * A locally-edited value that bound state has not yet confirmed. While set,
+   * it wins over stale bound state in getValue(), so a re-render cannot
+   * repaint a pre-write snapshot over what the user just typed. Released when
+   * the echo confirms it (a delivery equal to the edit), when a post-settle
+   * delivery supersedes it, or when the binding moves to a different cell.
+   */
   private _localEdit: { value: T } | undefined;
   // Number of in-flight cell writes started by the default setter.
   private _inFlightWrites = 0;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A section marker separates major portions of a file or a class, and is not a
header for an individual declaration — a doc comment already carries that
structure. The sweeps that conformed markers to the `//`-delimited form
conformed their *shape* without asking which of the two each one was. Some were
doc comments wearing marker clothing, and stayed that way.

This sorts out the 52 markers that sit directly on a declaration with no blank
line between.

## Four treatments, by what the comment is

**10 become doc comments.** They document exactly one declaration and describe
it. `cell-controller.ts` is the clearest — five lines of contract about when a
pending local edit wins over bound state, sitting on `_localEdit`. The same file
already documents its neighbours with `/** … */`, so the marker form was the
odd one out.

**27 keep the marker and gain the blank line** the form calls for. These are
category names over a genuine region: `cf-select.ts`'s `Reactive properties`,
`Lifecycle`, `Render`, `Public API`; `env.ts`'s integration groups; the
embedded-script sections in `state-inspector/html.ts`.

**11 become ordinary comments.** They sit inside a function *body*, which is
neither a file nor a class, so they were never section markers — they are steps
in a procedure, in `detail.ts`, `grouping.ts`, and `model.ts`.

**4 are deleted.** `LOGIN`, `CALLBACK`, `REFRESH`, and `LOGOUT`, each on a
function named `login`, `callback`, `refresh`, and `logout`. The label repeats
the name and a doc comment made of it would say nothing.

`BACKGROUND INTEGRATION (shared, not provider-specific)` is the one CAPS label
that stays, as the tenth doc comment. Its parenthetical carries something the
name `backgroundIntegration` does not — that the handler is shared across
providers rather than provider-specific — which is the difference between a
label and documentation. Its wording is unchanged, capitals included.

## On the tell

"No blank line after" is what surfaced these, and it is worth recording that it
is imperfect in both directions. It finds 52; it also misses 61 markers that
*do* have a blank line yet still cover exactly one declaration. And several of
the 52 it finds are perfectly good markers that merely lack the blank line.

The discriminator that actually holds is whether the text **describes the
declaration below it** or **names a region** — which is a judgment per site, not
a rule a script can apply. So these 52 were classified by reading them, in an
explicit table, and each entry asserts against the file before it edits: that
the named line really is a marker, and that the block is terminated. The 61
remaining suspects are deliberately left for a later pass.

## Verification

No wording changed: across the whole diff the word multiset loses exactly the
four deleted labels and gains nothing but doc-comment closers.

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the
`state-inspector`, `toolshed`, and `ui` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


