### PR TITLE
feat(memory): cache whole query evaluations per (shape, seq), shared across sessions

### DIFF
--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -101,7 +101,6 @@ const upsertIds = (sync: SessionSync): string[] =>
 
 const seedDocs = async (
   server: Server,
-  connection: ReturnType<Server["connect"]>,
   messages: ServerMessage[],
   space: string,
   sessionId: string,
@@ -139,7 +138,7 @@ describe("v2 query evaluation cache", () => {
     try {
       const sessionA = await openSession(connectionA, messagesA, space, "a");
       const sessionB = await openSession(connectionB, messagesB, space, "b");
-      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+      await seedDocs(server, messagesA, space, sessionA, [
         "of:doc:1",
         "of:doc:2",
       ]);
@@ -226,7 +225,7 @@ describe("v2 query evaluation cache", () => {
     try {
       const sessionA = await openSession(connectionA, messagesA, space, "a");
       const sessionB = await openSession(connectionB, messagesB, space, "b");
-      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+      await seedDocs(server, messagesA, space, sessionA, [
         "of:doc:1",
       ]);
       messagesB.length = 0;
@@ -307,7 +306,7 @@ describe("v2 query evaluation cache", () => {
         "b",
         "did:key:z6Mk-eval-cache-principal-b",
       );
-      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+      await seedDocs(server, messagesA, space, sessionA, [
         "of:doc:1",
       ]);
       messagesB.length = 0;
@@ -370,6 +369,292 @@ describe("v2 query evaluation cache", () => {
     } finally {
       connectionA.close();
       connectionB.close();
+    }
+  });
+
+  it("rewrites absent scoped dead-ends to the requester, whose own instance stays deliverable", async () => {
+    const space = "did:key:z6Mk-eval-cache-residue";
+    const server = createServer("memory://eval-cache-residue");
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionB = server.connect((message) => messagesB.push(message));
+    try {
+      const sessionA = await openSession(
+        connectionA,
+        messagesA,
+        space,
+        "a",
+        "did:key:z6Mk-residue-p1",
+      );
+      const sessionB = await openSession(
+        connectionB,
+        messagesB,
+        space,
+        "b",
+        "did:key:z6Mk-residue-p2",
+      );
+      // A shared doc whose value links to a session-scoped draft nobody
+      // has written: the walk dead-ends there, recording a scoped miss —
+      // the identity-dependent residue.
+      const seed = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:linked",
+            value: {
+              value: {
+                note: "shared",
+                draft: {
+                  "/": {
+                    "link@1": {
+                      path: [],
+                      id: "of:doc:draft",
+                      space,
+                      scope: "user",
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      });
+      expect(seed.error).toBeUndefined();
+      await tick();
+      messagesA.length = 0;
+      messagesB.length = 0;
+
+      const before = server.evaluationCacheDiagnostics(space);
+      const syncA = await watchAdd(
+        connectionA,
+        messagesA,
+        space,
+        sessionA,
+        "a",
+        [{ id: "of:doc:linked" }],
+      );
+      const syncB = await watchAdd(
+        connectionB,
+        messagesB,
+        space,
+        sessionB,
+        "b",
+        [{ id: "of:doc:linked" }],
+      );
+      const after = server.evaluationCacheDiagnostics(space);
+      expect(after.misses - before.misses).toBe(1);
+      expect(after.hits - before.hits).toBe(1);
+      expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
+
+      // The rewrite's reactivity pin: another session of the SAME principal
+      // writes that principal's draft instance (a writer's own change is
+      // not echoed back to it, so the watcher must be a different session),
+      // and the delivery machinery must recognize it through the rewritten
+      // miss key. The recording principal's watch must NOT receive it.
+      const messagesB2: ServerMessage[] = [];
+      const connectionB2 = server.connect((message) =>
+        messagesB2.push(message)
+      );
+      const sessionB2 = await openSession(
+        connectionB2,
+        messagesB2,
+        space,
+        "b2",
+        "did:key:z6Mk-residue-p2",
+      );
+      messagesA.length = 0;
+      messagesB.length = 0;
+      const write = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionB2,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:draft",
+            scope: "user",
+            value: { value: { d: 1 } },
+          }],
+        },
+      });
+      connectionB2.close();
+      expect(write.error).toBeUndefined();
+      await server.flushSessions();
+      await tick();
+
+      const draftDelivered = (messages: ServerMessage[]): boolean =>
+        messages.some((message) =>
+          message.type === "session/effect" &&
+          (message as { effect?: SessionSync }).effect?.upserts.some(
+            (upsert) => upsert.id === "of:doc:draft",
+          )
+        );
+      expect(draftDelivered(messagesB)).toBe(true);
+      expect(draftDelivered(messagesA)).toBe(false);
+    } finally {
+      connectionA.close();
+      connectionB.close();
+    }
+  });
+
+  it("evaluates normally for a requester whose scoped instance already exists", async () => {
+    const space = "did:key:z6Mk-eval-cache-present";
+    const server = createServer("memory://eval-cache-present");
+    const messagesA: ServerMessage[] = [];
+    const messagesC: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionC = server.connect((message) => messagesC.push(message));
+    try {
+      const sessionA = await openSession(
+        connectionA,
+        messagesA,
+        space,
+        "a",
+        "did:key:z6Mk-present-p1",
+      );
+      const sessionC = await openSession(
+        connectionC,
+        messagesC,
+        space,
+        "c",
+        "did:key:z6Mk-present-p3",
+      );
+      // Seed the shared linked doc AND C's own draft instance BEFORE any
+      // watch, so no rotation separates the evaluations.
+      const seed = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:linked",
+            value: {
+              value: {
+                draft: {
+                  "/": {
+                    "link@1": {
+                      path: [],
+                      id: "of:doc:draft",
+                      space,
+                      scope: "user",
+                    },
+                  },
+                },
+              },
+            },
+          }],
+        },
+      });
+      expect(seed.error).toBeUndefined();
+      const own = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionC,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:draft",
+            scope: "user",
+            value: { value: { mine: true } },
+          }],
+        },
+      });
+      expect(own.error).toBeUndefined();
+      await tick();
+      messagesA.length = 0;
+      messagesC.length = 0;
+
+      const before = server.evaluationCacheDiagnostics(space);
+      await watchAdd(connectionA, messagesA, space, sessionA, "a", [
+        { id: "of:doc:linked" },
+      ]);
+      const syncC = await watchAdd(
+        connectionC,
+        messagesC,
+        space,
+        sessionC,
+        "c",
+        [
+          { id: "of:doc:linked" },
+        ],
+      );
+      const after = server.evaluationCacheDiagnostics(space);
+
+      // C's instance EXISTS, so the shared entry does not describe C's
+      // reach: the absence probe refuses the share, and C's own
+      // evaluation delivers its instance.
+      expect(after.misses - before.misses).toBe(2);
+      expect(after.hits - before.hits).toBe(0);
+      expect(upsertIds(syncC)).toContain("of:doc:draft");
+    } finally {
+      connectionA.close();
+      connectionC.close();
+    }
+  });
+
+  it("evicts the least-recently-evaluated space's cache beyond the space bound", async () => {
+    const server = new Server({
+      subscriptionRefreshDelayMs: 0,
+      authorizeSessionOpen() {
+        return "did:key:z6Mk-eval-cache-lru-principal";
+      },
+      sessionOpenAuth: {
+        audience: TEST_AUDIENCE,
+      },
+    });
+    const connections: ReturnType<Server["connect"]>[] = [];
+    try {
+      const spaces = Array.from(
+        { length: 9 },
+        (_, index) => `did:key:z6Mk-eval-cache-lru-${index}`,
+      );
+      for (const space of spaces) {
+        const messages: ServerMessage[] = [];
+        const connection = server.connect((message) => messages.push(message));
+        connections.push(connection);
+        const sessionId = await openSession(
+          connection,
+          messages,
+          space,
+          space.slice(-6),
+        );
+        await watchAdd(
+          connection,
+          messages,
+          space,
+          sessionId,
+          space.slice(-6),
+          [
+            { id: "of:doc:1" },
+          ],
+        );
+      }
+      // Nine spaces evaluated against a bound of eight: the first has been
+      // evicted (a peek reads empty), the rest retain their entries.
+      expect(server.evaluationCacheDiagnostics(spaces[0]).entries).toBe(0);
+      expect(server.evaluationCacheDiagnostics(spaces[1]).entries).toBe(1);
+      expect(server.evaluationCacheDiagnostics(spaces[8]).entries).toBe(1);
+    } finally {
+      for (const connection of connections) {
+        connection.close();
+      }
     }
   });
 });

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -871,6 +871,148 @@ describe("v2 query evaluation cache", () => {
     }
   });
 
+  it("holds the budget even when a later watch group fails", async () => {
+    const space = "did:key:z6Mk-eval-budget-failure";
+    const server = createServer("memory://eval-cache-budget-failure", 1);
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space, "f");
+      await seedDocs(server, messages, space, sessionId, [
+        "of:doc:1",
+        "of:doc:2",
+      ]);
+      // One request, two groups: the first evaluates a valid two-document
+      // graph (inserting weight 2 against a budget of 1), the second
+      // fails evaluation. The failure must not skip the enforcement the
+      // first group's insert already owed.
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "f-watch",
+        space,
+        sessionId,
+        watches: [
+          {
+            id: "f-valid",
+            kind: "graph",
+            query: {
+              roots: [
+                { id: "of:doc:1", selector: { path: [], schema: true } },
+                { id: "of:doc:2", selector: { path: [], schema: true } },
+              ],
+            },
+          },
+          {
+            id: "f-broken",
+            kind: "graph",
+            query: {
+              branch: "broken",
+              roots: [{
+                id: "of:doc:1",
+                selector: {
+                  path: [],
+                  schema: { "$ref": "cid:fid1:does-not-exist" },
+                },
+              }],
+            },
+          },
+        ],
+      }));
+      const response = messages.shift() as ResponseMessage<WatchAddResult>;
+      expect(response.error).toBeDefined();
+      const diagnostics = server.evaluationCacheDiagnostics(space);
+      expect(diagnostics.weight).toBeLessThanOrEqual(1);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("reports only the probes a refused share actually performed", async () => {
+    const space = "did:key:z6Mk-eval-cache-refusal-count";
+    const engine = await openEngine({
+      url: new URL("memory:///eval-cache-refusal-count"),
+    });
+    const invocation = {
+      iss: "did:key:test",
+      aud: "did:key:service",
+      cmd: "/memory/transact",
+      sub: space,
+    };
+    const link = (id: string) => ({
+      "/": { "link@1": { path: [], id, space, scope: "session" } },
+    });
+    applyCommit(engine, {
+      sessionId: "refusal-seed",
+      invocation,
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set" as const,
+          id: "of:doc:linked",
+          value: {
+            value: {
+              draftOne: link("of:doc:draft1"),
+              draftTwo: link("of:doc:draft2"),
+            },
+          },
+        }],
+      },
+    });
+    // C's own first draft exists BEFORE any evaluation, so the shared
+    // entry's first probe refuses and the second residue is never read.
+    applyCommit(engine, {
+      sessionId: "refusal-c",
+      principal: "did:key:z6Mk-refusal-c",
+      invocation,
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set" as const,
+          id: "of:doc:draft1",
+          scope: "session" as const,
+          value: { value: { mine: true } },
+        }],
+      },
+    });
+
+    const cache = createQueryEvaluationCache();
+    const query = {
+      roots: [{ id: "of:doc:linked", selector: { path: [], schema: true } }],
+    };
+    const seedIdentity = {
+      principal: "did:key:z6Mk-refusal-a",
+      sessionId: "refusal-a",
+    };
+    const cIdentity = {
+      principal: "did:key:z6Mk-refusal-c",
+      sessionId: "refusal-c",
+    };
+    trackGraph(space, engine, query, undefined, {
+      ...seedIdentity,
+      evaluationCache: cache,
+    });
+    expect(cache.misses).toBe(1);
+    const evaluated = trackGraph(space, engine, query, undefined, {
+      ...cIdentity,
+      evaluationCache: cache,
+    });
+    // The refusal's single probe rides the full evaluation's own reads.
+    expect(cache.misses).toBe(2);
+    expect(evaluated.stats.managerReads).toBeGreaterThan(1);
+    const fallback = trackGraph(space, engine, query, undefined, {
+      ...cIdentity,
+      evaluationCache: cache,
+    });
+    // Identity-fallback hit: exactly ONE probe was performed before the
+    // refusal — not the residue's full length.
+    expect(cache.hits).toBe(1);
+    expect(fallback.stats.managerReads).toBe(1);
+  });
+
   it("evicts the least-recently-evaluated space's cache beyond the space bound", async () => {
     const server = new Server({
       subscriptionRefreshDelayMs: 0,

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { classifyStateScope, type TrackedGraphState } from "../v2/query.ts";
+import { applyCommit, open as openEngine } from "../v2/engine.ts";
+import {
+  classifyStateScope,
+  createQueryEvaluationCache,
+  type TrackedGraphState,
+  trackGraph,
+} from "../v2/query.ts";
 import { Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
@@ -15,9 +21,10 @@ import {
 
 const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-eval-cache-test-audience";
 
-const createServer = (store: string) =>
+const createServer = (store: string, budget?: number) =>
   new Server({
     store: new URL(store),
+    ...(budget === undefined ? {} : { queryEvaluationCacheBudget: budget }),
     subscriptionRefreshDelayMs: 0,
     authorizeSessionOpen(message) {
       const principal = (message.authorization as { principal?: unknown })
@@ -679,6 +686,191 @@ describe("v2 query evaluation cache", () => {
     expect(classifyStateScope(state)).toEqual({ kind: "tainted" });
   });
 
+  it("rotates when a different engine presents the same sequence", async () => {
+    const space = "did:key:z6Mk-eval-cache-engines";
+    const commitFor = (value: number) => ({
+      sessionId: "session:test",
+      invocation: {
+        iss: "did:key:test",
+        aud: "did:key:service",
+        cmd: "/memory/transact",
+        sub: space,
+      },
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          {
+            op: "set" as const,
+            id: "of:doc:1",
+            value: { value: { n: value } },
+          },
+        ],
+      },
+    });
+    const engineA = await openEngine({
+      url: new URL("memory:///eval-cache-engine-a"),
+    });
+    const engineB = await openEngine({
+      url: new URL("memory:///eval-cache-engine-b"),
+    });
+    applyCommit(engineA, commitFor(1));
+    applyCommit(engineB, commitFor(2));
+
+    // Two engines for one space, both at sequence 1, holding different
+    // values: a sequence number identifies state only within its engine,
+    // so the second engine must rotate the cache rather than be served
+    // the first engine's document.
+    const cache = createQueryEvaluationCache();
+    const query = {
+      roots: [{ id: "of:doc:1", selector: { path: [], schema: true } }],
+    };
+    const fromA = trackGraph(space, engineA, query, undefined, {
+      evaluationCache: cache,
+    });
+    const fromB = trackGraph(space, engineB, query, undefined, {
+      evaluationCache: cache,
+    });
+    const valueOf = (state: TrackedGraphState): number | undefined => {
+      const entity = [...state.entities.values()][0] as {
+        document?: { value?: { n?: number } } | null;
+      };
+      return entity?.document?.value?.n;
+    };
+    expect(valueOf(fromA.state)).toBe(1);
+    expect(valueOf(fromB.state)).toBe(2);
+    expect(cache.hits).toBe(0);
+    expect(cache.rotations).toBe(2);
+  });
+
+  it("reports residue absence probes as engine reads on a hit", async () => {
+    const space = "did:key:z6Mk-eval-cache-probes";
+    const engine = await openEngine({
+      url: new URL("memory:///eval-cache-probes"),
+    });
+    applyCommit(engine, {
+      sessionId: "session:test",
+      invocation: {
+        iss: "did:key:test",
+        aud: "did:key:service",
+        cmd: "/memory/transact",
+        sub: space,
+      },
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set" as const,
+          id: "of:doc:linked",
+          value: {
+            value: {
+              draft: {
+                "/": {
+                  "link@1": {
+                    path: [],
+                    id: "of:doc:draft",
+                    space,
+                    scope: "user",
+                  },
+                },
+              },
+            },
+          },
+        }],
+      },
+    });
+    const cache = createQueryEvaluationCache();
+    const query = {
+      roots: [{ id: "of:doc:linked", selector: { path: [], schema: true } }],
+    };
+    const miss = trackGraph(space, engine, query, undefined, {
+      principal: "did:key:z6Mk-probe-p1",
+      sessionId: "probe-s1",
+      evaluationCache: cache,
+    });
+    expect(miss.stats.managerReads).toBeGreaterThan(0);
+    const hit = trackGraph(space, engine, query, undefined, {
+      principal: "did:key:z6Mk-probe-p2",
+      sessionId: "probe-s2",
+      evaluationCache: cache,
+    });
+    expect(cache.hits).toBe(1);
+    // One residue doc was probed for absence: a hit is not free of engine
+    // reads, and its stats say exactly what it read.
+    expect(hit.stats.managerReads).toBe(1);
+  });
+
+  it("evicts by weight across spaces until the budget fits", async () => {
+    const server = createServer("memory://eval-cache-budget", 3);
+    const spaces = [
+      "did:key:z6Mk-eval-budget-1",
+      "did:key:z6Mk-eval-budget-2",
+    ];
+    const connections: ReturnType<Server["connect"]>[] = [];
+    try {
+      for (const space of spaces) {
+        const messages: ServerMessage[] = [];
+        const connection = server.connect((message) => messages.push(message));
+        connections.push(connection);
+        const sessionId = await openSession(
+          connection,
+          messages,
+          space,
+          space.slice(-8),
+        );
+        await seedDocs(server, messages, space, sessionId, [
+          "of:doc:1",
+          "of:doc:2",
+        ]);
+        await watchAdd(
+          connection,
+          messages,
+          space,
+          sessionId,
+          space.slice(-8),
+          [
+            { id: "of:doc:1" },
+            { id: "of:doc:2" },
+          ],
+        );
+      }
+      // Each corpus weighs 2; a budget of 3 holds one of them, so the
+      // second space's insert evicted the first space's entry.
+      expect(server.evaluationCacheDiagnostics(spaces[0]).weight).toBe(0);
+      expect(server.evaluationCacheDiagnostics(spaces[1]).weight).toBe(2);
+    } finally {
+      for (const connection of connections) {
+        connection.close();
+      }
+    }
+  });
+
+  it("does not retain an evaluation heavier than the whole budget", async () => {
+    const space = "did:key:z6Mk-eval-budget-oversize";
+    const server = createServer("memory://eval-cache-oversize", 1);
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space, "o");
+      await seedDocs(server, messages, space, sessionId, [
+        "of:doc:1",
+        "of:doc:2",
+      ]);
+      await watchAdd(connection, messages, space, sessionId, "o", [
+        { id: "of:doc:1" },
+        { id: "of:doc:2" },
+      ]);
+      const diagnostics = server.evaluationCacheDiagnostics(space);
+      expect(diagnostics.misses).toBe(1);
+      expect(diagnostics.entries).toBe(0);
+      expect(diagnostics.weight).toBe(0);
+    } finally {
+      connection.close();
+    }
+  });
+
   it("evicts the least-recently-evaluated space's cache beyond the space bound", async () => {
     const server = new Server({
       subscriptionRefreshDelayMs: 0,
@@ -721,6 +913,18 @@ describe("v2 query evaluation cache", () => {
       expect(server.evaluationCacheDiagnostics(spaces[0]).entries).toBe(0);
       expect(server.evaluationCacheDiagnostics(spaces[1]).entries).toBe(1);
       expect(server.evaluationCacheDiagnostics(spaces[8]).entries).toBe(1);
+
+      // A cache-ineligible query must not create a cache for its space —
+      // nor evict a live space's on its way through the LRU.
+      await server.evaluateGraphQuery(
+        spaces[0],
+        { roots: [{ id: "of:doc:1", selector: { path: [], schema: true } }] },
+        undefined,
+        undefined,
+        { keyedSnapshots: true },
+      );
+      expect(server.evaluationCacheDiagnostics(spaces[0]).seq).toBe(-1);
+      expect(server.evaluationCacheDiagnostics(spaces[1]).entries).toBe(1);
     } finally {
       for (const connection of connections) {
         connection.close();

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { classifyStateScope, type TrackedGraphState } from "../v2/query.ts";
 import { Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
@@ -453,6 +454,29 @@ describe("v2 query evaluation cache", () => {
       expect(after.hits - before.hits).toBe(1);
       expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
 
+      // The recording identity re-asking (as a one-shot graph query, which
+      // shares the cache) needs no rewrite at all: its residue keys are
+      // already its own.
+      messagesA.length = 0;
+      const beforeSame = server.evaluationCacheDiagnostics(space);
+      const same = await server.evaluateGraphQuery(
+        space,
+        {
+          roots: [{
+            id: "of:doc:linked",
+            selector: { path: [], schema: true },
+          }],
+        },
+        undefined,
+        undefined,
+        { principal: "did:key:z6Mk-residue-p1", sessionId: sessionA },
+      );
+      const afterSame = server.evaluationCacheDiagnostics(space);
+      expect(afterSame.hits - beforeSame.hits).toBe(1);
+      expect(same.entities.map((entity) => entity.id)).toContain(
+        "of:doc:linked",
+      );
+
       // The rewrite's reactivity pin: another session of the SAME principal
       // writes that principal's draft instance (a writer's own change is
       // not echoed back to it, so the watcher must be a different session),
@@ -603,10 +627,56 @@ describe("v2 query evaluation cache", () => {
       expect(after.misses - before.misses).toBe(2);
       expect(after.hits - before.hits).toBe(0);
       expect(upsertIds(syncC)).toContain("of:doc:draft");
+
+      // C's refused evaluation was cached under its identity, and the
+      // shared entry must not shadow it: the same identity asking the
+      // same question again — here as a one-shot graph query, which
+      // shares the cache with watch establishment — is served from it.
+      const again = await server.evaluateGraphQuery(
+        space,
+        {
+          roots: [{
+            id: "of:doc:linked",
+            selector: { path: [], schema: true },
+          }],
+        },
+        undefined,
+        undefined,
+        { principal: "did:key:z6Mk-present-p3", sessionId: sessionC },
+      );
+      const retried = server.evaluationCacheDiagnostics(space);
+      expect(retried.hits - after.hits).toBe(1);
+      expect(again.entities.map((entity) => entity.id)).toContain(
+        "of:doc:draft",
+      );
     } finally {
       connectionA.close();
       connectionC.close();
     }
+  });
+
+  it("classifies a scoped load without a tracker registration as tainted", () => {
+    // The shape meta-linked loads produce: the document was loaded through
+    // the manager but registered no tracker entry, so the tracker loop
+    // alone would misjudge the state as shareable.
+    const state = {
+      branch: "",
+      tracker: new Map(),
+      missed: new Map(),
+      missedBy: new Map(),
+      missesOf: new Map(),
+      entities: new Map(),
+      memo: new Map(),
+      manager: {
+        loadedAddresses: () => [{
+          id: "of:doc:meta",
+          type: "application/json",
+          scope: "session",
+          scopeKey: "session:p:s",
+        }],
+      },
+    } as unknown as TrackedGraphState;
+    expect(classifyStateScope(state)).toEqual({ kind: "tainted" });
   });
 
   it("evicts the least-recently-evaluated space's cache beyond the space bound", async () => {

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -1,0 +1,375 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+  type WatchAddResult,
+} from "../v2.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-eval-cache-test-audience";
+
+const createServer = (store: string) =>
+  new Server({
+    store: new URL(store),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string"
+        ? principal
+        : "did:key:z6Mk-memory-v2-eval-cache-principal";
+    },
+    sessionOpenAuth: {
+      audience: TEST_AUDIENCE,
+    },
+  });
+
+const tick = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const openSession = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  label: string,
+  principal?: string,
+): Promise<string> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: getMemoryProtocolFlags(),
+  }));
+  const hello = messages.shift() as
+    | { type: string; sessionOpen?: SessionOpenAuthMetadata }
+    | undefined;
+  expect(hello?.type).toBe("hello.ok");
+  const sessionOpen = hello!.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: `${label}-open`,
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+    ...(principal === undefined ? {} : { authorization: { principal } }),
+  }));
+  const opened = messages.shift() as ResponseMessage<{ sessionId: string }>;
+  expect(opened.ok).toBeDefined();
+  return opened.ok!.sessionId;
+};
+
+const watchAdd = async (
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  sessionId: string,
+  label: string,
+  roots: { id: string; scope?: string }[],
+): Promise<SessionSync> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.add",
+    requestId: `${label}-watch`,
+    space,
+    sessionId,
+    watches: [{
+      id: `${label}-watch-id`,
+      kind: "graph",
+      query: {
+        roots: roots.map((root) => ({
+          ...root,
+          selector: { path: [], schema: true },
+        })),
+      },
+    }],
+  }));
+  const response = messages.shift() as ResponseMessage<WatchAddResult>;
+  expect(response.ok).toBeDefined();
+  return response.ok!.sync;
+};
+
+const upsertIds = (sync: SessionSync): string[] =>
+  [...sync.upserts.map((upsert) => upsert.id)].toSorted();
+
+const seedDocs = async (
+  server: Server,
+  connection: ReturnType<Server["connect"]>,
+  messages: ServerMessage[],
+  space: string,
+  sessionId: string,
+  ids: string[],
+): Promise<void> => {
+  const response = await server.transact({
+    type: "transact",
+    requestId: crypto.randomUUID(),
+    space,
+    sessionId,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: ids.map((id, index) => ({
+        op: "set",
+        id,
+        value: { value: { n: index + 1 } },
+      })),
+    },
+  });
+  expect(response.error).toBeUndefined();
+  await tick();
+  messages.length = 0;
+};
+
+describe("v2 query evaluation cache", () => {
+  it("serves a second session's identical watch set without re-evaluating, keeping its delivery live", async () => {
+    const space = "did:key:z6Mk-eval-cache-shared";
+    const server = createServer("memory://eval-cache-shared");
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionB = server.connect((message) => messagesB.push(message));
+    let connectionW: ReturnType<Server["connect"]> | undefined;
+    try {
+      const sessionA = await openSession(connectionA, messagesA, space, "a");
+      const sessionB = await openSession(connectionB, messagesB, space, "b");
+      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+        "of:doc:1",
+        "of:doc:2",
+      ]);
+      messagesB.length = 0;
+
+      const before = server.evaluationCacheDiagnostics(space);
+      const syncA = await watchAdd(
+        connectionA,
+        messagesA,
+        space,
+        sessionA,
+        "a",
+        [
+          { id: "of:doc:1" },
+          { id: "of:doc:2" },
+        ],
+      );
+      const syncB = await watchAdd(
+        connectionB,
+        messagesB,
+        space,
+        sessionB,
+        "b",
+        [
+          { id: "of:doc:1" },
+          { id: "of:doc:2" },
+        ],
+      );
+      const after = server.evaluationCacheDiagnostics(space);
+
+      expect(after.misses - before.misses).toBe(1);
+      expect(after.hits - before.hits).toBe(1);
+      expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
+
+      // The soundness pin: a cache-served session's coverage must deliver
+      // exactly like an evaluated one. A THIRD session writes (a writer's
+      // own change is not echoed back to it), and the update must reach
+      // both watchers — the evaluated one and the cache-served one alike.
+      const messagesW: ServerMessage[] = [];
+      connectionW = server.connect((message) => messagesW.push(message));
+      const sessionW = await openSession(connectionW, messagesW, space, "w");
+      messagesA.length = 0;
+      messagesB.length = 0;
+      const write = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionW,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:1", value: { value: { n: 99 } } },
+          ],
+        },
+      });
+      expect(write.error).toBeUndefined();
+      await server.flushSessions();
+      await tick();
+
+      const delivered = (messages: ServerMessage[]): boolean =>
+        messages.some((message) =>
+          message.type === "session/effect" &&
+          (message as { effect?: SessionSync }).effect?.upserts.some(
+            (upsert) => upsert.id === "of:doc:1",
+          )
+        );
+      expect(delivered(messagesA)).toBe(true);
+      expect(delivered(messagesB)).toBe(true);
+    } finally {
+      connectionA.close();
+      connectionB.close();
+      connectionW?.close();
+    }
+  });
+
+  it("rotates on a commit so a later evaluation sees current state", async () => {
+    const space = "did:key:z6Mk-eval-cache-rotate";
+    const server = createServer("memory://eval-cache-rotate");
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionB = server.connect((message) => messagesB.push(message));
+    try {
+      const sessionA = await openSession(connectionA, messagesA, space, "a");
+      const sessionB = await openSession(connectionB, messagesB, space, "b");
+      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+        "of:doc:1",
+      ]);
+      messagesB.length = 0;
+
+      const syncA = await watchAdd(
+        connectionA,
+        messagesA,
+        space,
+        sessionA,
+        "a",
+        [
+          { id: "of:doc:1" },
+        ],
+      );
+      expect(syncA.upserts.length).toBe(1);
+
+      const write = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:1", value: { value: { n: 42 } } },
+          ],
+        },
+      });
+      expect(write.error).toBeUndefined();
+      await tick();
+
+      const before = server.evaluationCacheDiagnostics(space);
+      const syncB = await watchAdd(
+        connectionB,
+        messagesB,
+        space,
+        sessionB,
+        "b",
+        [
+          { id: "of:doc:1" },
+        ],
+      );
+      const after = server.evaluationCacheDiagnostics(space);
+
+      expect(after.hits - before.hits).toBe(0);
+      expect(after.rotations - before.rotations).toBeGreaterThanOrEqual(1);
+      const upsert = syncB.upserts.find((entry) => entry.id === "of:doc:1");
+      expect(upsert).toBeDefined();
+      expect(
+        (upsert!.doc as { value?: { n?: number } } | undefined)?.value?.n,
+      ).toBe(42);
+    } finally {
+      connectionA.close();
+      connectionB.close();
+    }
+  });
+
+  it("shares a scope-pure evaluation across principals", async () => {
+    const space = "did:key:z6Mk-eval-cache-principals";
+    const server = createServer("memory://eval-cache-principals");
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionB = server.connect((message) => messagesB.push(message));
+    try {
+      const sessionA = await openSession(
+        connectionA,
+        messagesA,
+        space,
+        "a",
+        "did:key:z6Mk-eval-cache-principal-a",
+      );
+      const sessionB = await openSession(
+        connectionB,
+        messagesB,
+        space,
+        "b",
+        "did:key:z6Mk-eval-cache-principal-b",
+      );
+      await seedDocs(server, connectionA, messagesA, space, sessionA, [
+        "of:doc:1",
+      ]);
+      messagesB.length = 0;
+
+      const before = server.evaluationCacheDiagnostics(space);
+      const syncA = await watchAdd(
+        connectionA,
+        messagesA,
+        space,
+        sessionA,
+        "a",
+        [{ id: "of:doc:1" }],
+      );
+      const syncB = await watchAdd(
+        connectionB,
+        messagesB,
+        space,
+        sessionB,
+        "b",
+        [{ id: "of:doc:1" }],
+      );
+      const after = server.evaluationCacheDiagnostics(space);
+
+      // The post-crash stampede's shape: different principals, identical
+      // space-scoped corpus. One evaluation serves both.
+      expect(after.misses - before.misses).toBe(1);
+      expect(after.hits - before.hits).toBe(1);
+      expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
+    } finally {
+      connectionA.close();
+      connectionB.close();
+    }
+  });
+
+  it("keys a session-scoped evaluation to its identity instead of sharing it", async () => {
+    const space = "did:key:z6Mk-eval-cache-scoped";
+    const server = createServer("memory://eval-cache-scoped");
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((message) => messagesA.push(message));
+    const connectionB = server.connect((message) => messagesB.push(message));
+    try {
+      const sessionA = await openSession(connectionA, messagesA, space, "a");
+      const sessionB = await openSession(connectionB, messagesB, space, "b");
+      messagesA.length = 0;
+      messagesB.length = 0;
+
+      const before = server.evaluationCacheDiagnostics(space);
+      await watchAdd(connectionA, messagesA, space, sessionA, "a", [
+        { id: "of:doc:scoped", scope: "session" },
+      ]);
+      await watchAdd(connectionB, messagesB, space, sessionB, "b", [
+        { id: "of:doc:scoped", scope: "session" },
+      ]);
+      const after = server.evaluationCacheDiagnostics(space);
+
+      // Two identities, each a miss: the tainted entry never crosses.
+      expect(after.misses - before.misses).toBe(2);
+      expect(after.hits - before.hits).toBe(0);
+    } finally {
+      connectionA.close();
+      connectionB.close();
+    }
+  });
+});

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -482,7 +482,7 @@ const cloneWithRewrittenResidue = (
   state: TrackedGraphState,
   residue: { key: QueryDocKey; id: string; scope: CellScope }[],
   options: TrackGraphOptions,
-): { state: TrackedGraphState; probeReads: number } | null => {
+): { state: TrackedGraphState | null; probeReads: number } => {
   const identity: ScopeKeyIdentity = {
     principal: options.principal,
     sessionId: options.sessionId,
@@ -503,7 +503,9 @@ const cloneWithRewrittenResidue = (
         branch: state.branch,
       });
       if (probe !== null && probe.document !== null) {
-        return null;
+        // Refused — but the probes already performed are reads this call
+        // made, and the caller's statistics must carry them.
+        return { state: null, probeReads };
       }
       mapping.set(key, requesterKey);
     }
@@ -1061,6 +1063,7 @@ export const trackGraph = (
     ? options.evaluationCache
     : undefined;
   let cacheKeys: { pure: string; identity: string } | undefined;
+  let refusalProbeReads = 0;
   if (cache !== undefined) {
     const currentSeq = Engine.serverSeq(engine);
     if (cache.engine !== engine || cache.seq !== currentSeq) {
@@ -1087,11 +1090,8 @@ export const trackGraph = (
           pureEntry.share.residue,
           options,
         );
-        if (rewritten !== null) {
-          served = rewritten.state;
-        }
-        probeReads = rewritten?.probeReads ??
-          pureEntry.share.residue.length;
+        served = rewritten.state;
+        probeReads = rewritten.probeReads;
       } else {
         served = cloneTrackedGraphStateForIdentity(
           engine,
@@ -1125,6 +1125,9 @@ export const trackGraph = (
         stats: { ...createQueryTraversalStats(), managerReads: probeReads },
       };
     }
+    // A refused share's probes were still reads this call performed; the
+    // full evaluation below reports them alongside its own.
+    refusalProbeReads = probeReads;
     cache.misses++;
   }
   const managerKey = options.readSeq === undefined
@@ -1210,7 +1213,8 @@ export const trackGraph = (
     entities.set(key, snapshot);
   }
 
-  stats.managerReads = manager.readCount - readCountBefore;
+  stats.managerReads = manager.readCount - readCountBefore +
+    refusalProbeReads;
 
   const state: TrackedGraphState = {
     branch,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -414,7 +414,11 @@ type StateScopeClass =
   }
   | { kind: "tainted" };
 
-const classifyStateScope = (state: TrackedGraphState): StateScopeClass => {
+/** Exported for testing (the malformed-key guard is unreachable through
+ * a real walk while the scope-key vocabulary holds). */
+export const classifyStateScope = (
+  state: TrackedGraphState,
+): StateScopeClass => {
   for (const [key] of state.tracker) {
     if (fromDocKey(key as QueryDocKey).scopeKey !== "space") {
       return { kind: "tainted" };
@@ -432,9 +436,11 @@ const classifyStateScope = (state: TrackedGraphState): StateScopeClass => {
   }
   const residue: { key: QueryDocKey; id: string; scope: CellScope }[] = [];
   for (const [key] of state.missed) {
+    // The scope-key vocabulary is closed (isScopeKey), so a key that is
+    // not the space instance necessarily recovers a session or user
+    // scope; fromDocKey throws on anything outside the vocabulary.
     const { id, scope, scopeKey } = fromDocKey(key as QueryDocKey);
     if (scopeKey === "space") continue;
-    if (scope === "space") return { kind: "tainted" };
     residue.push({ key: key as QueryDocKey, id, scope });
   }
   return residue.length === 0
@@ -1052,31 +1058,43 @@ export const trackGraph = (
       pure: `P${queryKey}`,
       identity: `I${evaluationIdentityKey(options)}${queryKey}`,
     };
-    const entry = cache.entries.get(cacheKeys.pure) ??
-      cache.entries.get(cacheKeys.identity);
-    if (entry !== undefined) {
-      const served = entry.share.kind === "absent-residue"
+    const pureEntry = cache.entries.get(cacheKeys.pure);
+    let served: TrackedGraphState | null = null;
+    if (pureEntry !== undefined) {
+      served = pureEntry.share.kind === "absent-residue"
         ? cloneWithRewrittenResidue(
           engine,
           space,
-          entry.state,
-          entry.share.residue,
+          pureEntry.state,
+          pureEntry.share.residue,
           options,
         )
-        : cloneTrackedGraphStateForIdentity(engine, entry.state, options);
-      if (served !== null) {
-        cache.hits++;
-        // A hit ran no traversal, and its stats say so: zero walk counters
-        // are the truth of what THIS call cost, not an accounting gap.
-        return {
-          serverSeq: currentSeq,
-          state: served,
-          stats: createQueryTraversalStats(),
-        };
+        : cloneTrackedGraphStateForIdentity(engine, pureEntry.state, options);
+    }
+    if (served === null) {
+      // Either no shared entry, or its residue is PRESENT for this
+      // identity and the share was refused. The identity's own earlier
+      // evaluation — tainted, keyed to exactly this (principal,
+      // sessionId) — still answers; without this lookup a shared entry
+      // would shadow it and the identity would re-evaluate every time.
+      const identityEntry = cache.entries.get(cacheKeys.identity);
+      if (identityEntry !== undefined) {
+        served = cloneTrackedGraphStateForIdentity(
+          engine,
+          identityEntry.state,
+          options,
+        );
       }
-      // A residue doc is PRESENT for this identity: the shared entry does
-      // not describe this session's reach. Evaluate normally — the result
-      // carries the scoped doc in its tracker, so it keys to the identity.
+    }
+    if (served !== null) {
+      cache.hits++;
+      // A hit ran no traversal, and its stats say so: zero walk counters
+      // are the truth of what THIS call cost, not an accounting gap.
+      return {
+        serverSeq: currentSeq,
+        state: served,
+        stats: createQueryTraversalStats(),
+      };
     }
     cache.misses++;
   }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -283,10 +283,166 @@ export type QueryGraphReuseContext = {
   managers?: Map<string, EngineObjectManager>;
 };
 
+/**
+ * Canonical selector identity for evaluation-cache keys. Interning gives
+ * structurally equal selectors one canonical instance
+ * (`internPathSelector`), so reference identity is structural equality and
+ * the id is exact. Canonical instances are weakly held, so an id can lapse
+ * with its selector and a re-interned equal reappears under a fresh id —
+ * that costs a cache miss, never a wrong hit.
+ */
+let nextCanonicalSelectorId = 0;
+const canonicalSelectorIds = new WeakMap<SchemaPathSelector, number>();
+const canonicalSelectorId = (selector: SchemaPathSelector): number => {
+  const interned = internPathSelector(selector);
+  let id = canonicalSelectorIds.get(interned);
+  if (id === undefined) {
+    id = nextCanonicalSelectorId++;
+    canonicalSelectorIds.set(interned, id);
+  }
+  return id;
+};
+
+const evaluationQueryKey = (query: GraphQuery): string =>
+  JSON.stringify([
+    query.branch ?? "",
+    query.roots
+      .map((root) => [
+        root.id,
+        root.scope ?? DEFAULT_SCOPE,
+        root.entityScopeKey ?? "",
+        canonicalSelectorId(toDocumentSelector(root.selector)),
+      ])
+      .map((parts) => JSON.stringify(parts))
+      .toSorted(),
+  ]);
+
+const evaluationIdentityKey = (options: TrackGraphOptions): string =>
+  JSON.stringify([options.principal ?? null, options.sessionId ?? null]);
+
+/**
+ * Bounds an evaluation cache's entry count. Distinct query shapes per space
+ * are few (a session class shares its watch corpus), so the bound exists
+ * for the adversarial case, not the expected one; an insert past it is
+ * skipped rather than evicting, since within one generation every entry is
+ * equally live.
+ */
+const EVALUATION_CACHE_MAX_ENTRIES = 64;
+
+export type QueryEvaluationCacheDiagnostics = {
+  seq: number;
+  entries: number;
+  hits: number;
+  misses: number;
+  rotations: number;
+};
+
+/**
+ * Caches whole tracked-graph evaluations per (query shape, engine seq).
+ *
+ * The WHOLE evaluation is the smallest soundly shareable unit: within one
+ * walk, an already-covered (doc, selector) skips its subtree — including
+ * the tracker registrations that subtree would record — so any per-document
+ * slice of a walk's effects depends on what its siblings covered first, and
+ * replaying one standalone under-registers coverage. A complete evaluation
+ * carries no such context.
+ *
+ * Entries are valid only at the engine seq they were evaluated at; a seq
+ * advance rotates the whole cache. Staleness is therefore structural — no
+ * write hooks, no dependency tracking — and the sharing this buys is
+ * exactly where the cost multiplies: many sessions establishing the same
+ * watch corpus between two commits (a reconnect stampede after a process
+ * death is this, at its worst).
+ *
+ * Scope purity decides who may share an entry. An evaluation whose whole
+ * reach — tracked, missed, and loaded — resolved under the `space` scope is
+ * identical for every identity and is shared across them; one that touched
+ * a session- or user-scoped instance is keyed to the evaluating identity
+ * (key-vocabulary.md §5's identity-bound invariant — the same value-bleed
+ * rule `assertSchemaMemoIdentity` enforces for the inner schema memos).
+ * ACL changes are themselves commits, so a grant or revocation rotates the
+ * cache before any post-change evaluation could be served from it.
+ */
+export type QueryEvaluationCache = {
+  seq: number;
+  entries: Map<string, { state: TrackedGraphState; scopePure: boolean }>;
+  hits: number;
+  misses: number;
+  rotations: number;
+};
+
+export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
+  seq: -1,
+  entries: new Map(),
+  hits: 0,
+  misses: 0,
+  rotations: 0,
+});
+
+export const queryEvaluationCacheDiagnostics = (
+  cache: QueryEvaluationCache,
+): QueryEvaluationCacheDiagnostics => ({
+  seq: cache.seq,
+  entries: cache.entries.size,
+  hits: cache.hits,
+  misses: cache.misses,
+  rotations: cache.rotations,
+});
+
+const stateIsScopePure = (state: TrackedGraphState): boolean => {
+  for (const [key] of state.tracker) {
+    if (fromDocKey(key as QueryDocKey).scopeKey !== "space") return false;
+  }
+  for (const [key] of state.missed) {
+    if (fromDocKey(key as QueryDocKey).scopeKey !== "space") return false;
+  }
+  for (const address of state.manager.loadedAddresses()) {
+    if (address.scopeKey !== "space") return false;
+  }
+  return true;
+};
+
+/**
+ * Clone for a cache hit: `cloneTrackedGraphState` rebound to the
+ * requesting identity. Only scope-pure entries are ever cloned across
+ * identities, so every key, entity, memo entry, and manager cache line in
+ * the source resolved identically to what this identity's own evaluation
+ * would have produced; the rebind exists so the clone's LATER operations —
+ * refreshes, extensions — resolve scoped reach against the session that
+ * owns it. The cloned memo is a fresh Map, so the identity binding the
+ * schema-memo tripwire tracks starts unbound and binds to the new owner.
+ */
+const cloneTrackedGraphStateForIdentity = (
+  engine: Engine.Engine,
+  state: TrackedGraphState,
+  options: TrackGraphOptions,
+): TrackedGraphState => {
+  const clone = cloneTrackedGraphState(engine, state);
+  if (
+    clone.manager.principal === options.principal &&
+    clone.manager.sessionId === options.sessionId
+  ) {
+    return clone;
+  }
+  const manager = new EngineObjectManager(
+    engine,
+    state.branch,
+    options.principal,
+    options.sessionId,
+  );
+  manager.mergeFrom(state.manager);
+  return { ...clone, manager };
+};
+
 export type TrackGraphOptions = {
   readSeq?: number;
   principal?: string;
   sessionId?: string;
+
+  /** Serve/record whole evaluations through this cache (current-seq reads
+   * only; a `readSeq` read bypasses it). See {@link QueryEvaluationCache}
+   * for the sharing and rotation rules. */
+  evaluationCache?: QueryEvaluationCache;
 
   /**
    * `queryGraph` only (server-execution v2 stage A, OW17's wire leg):
@@ -765,6 +921,41 @@ export const trackGraph = (
   stats: QueryTraversalStats;
 } => {
   const branch = query.branch ?? "";
+  // Historical reads bypass the cache (entries are current-seq only), and
+  // so does the lease-holder exemption class: an exempt evaluation judges
+  // the CURRENT live lease, which is host state that can move without a
+  // commit — seq rotation cannot fence it, so those evaluations are never
+  // cached or served.
+  const cache = options.readSeq === undefined && options.keyedSnapshots !== true
+    ? options.evaluationCache
+    : undefined;
+  let cacheKeys: { pure: string; identity: string } | undefined;
+  if (cache !== undefined) {
+    const currentSeq = Engine.serverSeq(engine);
+    if (cache.seq !== currentSeq) {
+      cache.seq = currentSeq;
+      cache.entries.clear();
+      cache.rotations++;
+    }
+    const queryKey = evaluationQueryKey(query);
+    cacheKeys = {
+      pure: `P${queryKey}`,
+      identity: `I${evaluationIdentityKey(options)}${queryKey}`,
+    };
+    const entry = cache.entries.get(cacheKeys.pure) ??
+      cache.entries.get(cacheKeys.identity);
+    if (entry !== undefined) {
+      cache.hits++;
+      // A hit ran no traversal, and its stats say so: zero walk counters
+      // are the truth of what THIS call cost, not an accounting gap.
+      return {
+        serverSeq: currentSeq,
+        state: cloneTrackedGraphStateForIdentity(engine, entry.state, options),
+        stats: createQueryTraversalStats(),
+      };
+    }
+    cache.misses++;
+  }
   const managerKey = options.readSeq === undefined
     ? `${branch}\0${options.principal ?? ""}\0${options.sessionId ?? ""}`
     : `${branch}\0${options.readSeq}\0${options.principal ?? ""}\0${
@@ -850,16 +1041,29 @@ export const trackGraph = (
 
   stats.managerReads = manager.readCount - readCountBefore;
 
+  const state: TrackedGraphState = {
+    branch,
+    tracker: schemaTracker,
+    ...missState,
+    entities,
+    memo: sharedMemo,
+    manager,
+  };
+  if (
+    cache !== undefined && cacheKeys !== undefined &&
+    cache.entries.size < EVALUATION_CACHE_MAX_ENTRIES
+  ) {
+    // The cache keeps its own clone: the state returned below belongs to
+    // the caller's session, whose refreshes and extensions mutate it.
+    const scopePure = stateIsScopePure(state);
+    cache.entries.set(scopePure ? cacheKeys.pure : cacheKeys.identity, {
+      state: cloneTrackedGraphState(engine, state),
+      scopePure,
+    });
+  }
   return {
     serverSeq: Engine.serverSeq(engine),
-    state: {
-      branch,
-      tracker: schemaTracker,
-      ...missState,
-      entities,
-      memo: sharedMemo,
-      manager,
-    },
+    state,
     stats,
   };
 };

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -325,9 +325,11 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
  * are few (a session class shares its watch corpus), so the bound exists
  * for the adversarial case, not the expected one; an insert past it is
  * skipped rather than evicting, since within one generation every entry is
- * equally live.
+ * equally live. Kept small because an entry retains a full cloned state —
+ * tracker, entities, and the manager's parsed documents — so the bound is
+ * a memory bound as much as a count.
  */
-const EVALUATION_CACHE_MAX_ENTRIES = 64;
+const EVALUATION_CACHE_MAX_ENTRIES = 16;
 
 export type QueryEvaluationCacheDiagnostics = {
   seq: number;
@@ -365,7 +367,7 @@ export type QueryEvaluationCacheDiagnostics = {
  */
 export type QueryEvaluationCache = {
   seq: number;
-  entries: Map<string, { state: TrackedGraphState; scopePure: boolean }>;
+  entries: Map<string, { state: TrackedGraphState; share: StateScopeClass }>;
   hits: number;
   misses: number;
   rotations: number;
@@ -389,17 +391,125 @@ export const queryEvaluationCacheDiagnostics = (
   rotations: cache.rotations,
 });
 
-const stateIsScopePure = (state: TrackedGraphState): boolean => {
-  for (const [key] of state.tracker) {
-    if (fromDocKey(key as QueryDocKey).scopeKey !== "space") return false;
+/**
+ * How an evaluation's reach constrains who may share its cache entry.
+ *
+ * `pure`: every key resolved under the space scope — the result is
+ * identical for every identity. `absent-residue`: identity-dependent ONLY
+ * through scoped value-link dead-ends (`missed` keys — docs that were
+ * ABSENT), which is the shape a live corpus actually produces: per-session
+ * draft cells linked from shared documents that no fresh session has ever
+ * written. Such an entry serves another identity by REWRITING those keys
+ * to the requester's own instances — sound because the keys are the only
+ * identity-dependent part of the state (nothing was delivered from them,
+ * nothing was traversed under them) — after verifying each is absent for
+ * the requester too. `tainted`: scoped PRESENT data reached the tracker,
+ * or a key did not classify; the entry stays keyed to its identity.
+ */
+type StateScopeClass =
+  | { kind: "pure" }
+  | {
+    kind: "absent-residue";
+    residue: { key: QueryDocKey; id: string; scope: CellScope }[];
   }
-  for (const [key] of state.missed) {
-    if (fromDocKey(key as QueryDocKey).scopeKey !== "space") return false;
+  | { kind: "tainted" };
+
+const classifyStateScope = (state: TrackedGraphState): StateScopeClass => {
+  for (const [key] of state.tracker) {
+    if (fromDocKey(key as QueryDocKey).scopeKey !== "space") {
+      return { kind: "tainted" };
+    }
   }
   for (const address of state.manager.loadedAddresses()) {
-    if (address.scopeKey !== "space") return false;
+    // Both halves checked deliberately: an explicit entity_scope_key can
+    // pair a non-space scope NAME with an aliased key, and such a load
+    // must never classify as shared. (Explicit foreign keys are
+    // lease-holder-only, and that whole session class bypasses the cache
+    // — this guards the invariant locally as well.)
+    if (address.scopeKey !== "space" || address.scope !== "space") {
+      return { kind: "tainted" };
+    }
   }
-  return true;
+  const residue: { key: QueryDocKey; id: string; scope: CellScope }[] = [];
+  for (const [key] of state.missed) {
+    const { id, scope, scopeKey } = fromDocKey(key as QueryDocKey);
+    if (scopeKey === "space") continue;
+    if (scope === "space") return { kind: "tainted" };
+    residue.push({ key: key as QueryDocKey, id, scope });
+  }
+  return residue.length === 0
+    ? { kind: "pure" }
+    : { kind: "absent-residue", residue };
+};
+
+/**
+ * Serve an `absent-residue` entry to `options`' identity: verify each
+ * residue doc is ABSENT for the requester too, then clone with the
+ * residue's miss keys rewritten to the requester's instances — so the
+ * clone's wake and dirty-refresh reactivity points at the docs the OWNING
+ * session would create, not the recording session's.
+ *
+ * The absence probes are load-bearing and cannot be skipped for a
+ * different identity: the requester's instance may have existed since
+ * before the entry was recorded (the recording walk never looked at it).
+ * They are also sufficient — entries live only within one engine seq, and
+ * absence cannot change without a commit. A present instance returns
+ * null: the caller evaluates normally, and that evaluation's tracker then
+ * carries the scoped doc, keying its own entry to the identity.
+ */
+const cloneWithRewrittenResidue = (
+  engine: Engine.Engine,
+  space: string,
+  state: TrackedGraphState,
+  residue: { key: QueryDocKey; id: string; scope: CellScope }[],
+  options: TrackGraphOptions,
+): TrackedGraphState | null => {
+  const identity: ScopeKeyIdentity = {
+    principal: options.principal,
+    sessionId: options.sessionId,
+  };
+  const mapping = new Map<string, string>();
+  for (const { key, id, scope } of residue) {
+    const requesterScopeKey = resolveScopeKey(scope, identity);
+    const requesterKey = `${space}/${requesterScopeKey}/${id}`;
+    if (requesterKey !== key) {
+      const probe = Engine.readState(engine, {
+        id,
+        scope,
+        scopeKey: requesterScopeKey,
+        principal: options.principal,
+        sessionId: options.sessionId,
+        branch: state.branch,
+      });
+      if (probe !== null && probe.document !== null) {
+        return null;
+      }
+      mapping.set(key, requesterKey);
+    }
+  }
+  const clone = cloneTrackedGraphStateForIdentity(engine, state, options);
+  if (mapping.size === 0) {
+    return clone;
+  }
+  const missed = new MapSetStringToPathSelectors(true);
+  for (const [key, selectors] of clone.missed) {
+    const mapped = mapping.get(key) ?? key;
+    for (const selector of selectors) {
+      missed.add(mapped, selector);
+    }
+  }
+  const missedBy = new Map<string, Set<string>>();
+  for (const [key, referrers] of clone.missedBy) {
+    missedBy.set(mapping.get(key) ?? key, referrers);
+  }
+  const missesOf = new Map<string, Set<string>>();
+  for (const [referrer, misses] of clone.missesOf) {
+    missesOf.set(
+      referrer,
+      new Set([...misses].map((miss) => mapping.get(miss) ?? miss)),
+    );
+  }
+  return { ...clone, missed, missedBy, missesOf };
 };
 
 /**
@@ -945,14 +1055,28 @@ export const trackGraph = (
     const entry = cache.entries.get(cacheKeys.pure) ??
       cache.entries.get(cacheKeys.identity);
     if (entry !== undefined) {
-      cache.hits++;
-      // A hit ran no traversal, and its stats say so: zero walk counters
-      // are the truth of what THIS call cost, not an accounting gap.
-      return {
-        serverSeq: currentSeq,
-        state: cloneTrackedGraphStateForIdentity(engine, entry.state, options),
-        stats: createQueryTraversalStats(),
-      };
+      const served = entry.share.kind === "absent-residue"
+        ? cloneWithRewrittenResidue(
+          engine,
+          space,
+          entry.state,
+          entry.share.residue,
+          options,
+        )
+        : cloneTrackedGraphStateForIdentity(engine, entry.state, options);
+      if (served !== null) {
+        cache.hits++;
+        // A hit ran no traversal, and its stats say so: zero walk counters
+        // are the truth of what THIS call cost, not an accounting gap.
+        return {
+          serverSeq: currentSeq,
+          state: served,
+          stats: createQueryTraversalStats(),
+        };
+      }
+      // A residue doc is PRESENT for this identity: the shared entry does
+      // not describe this session's reach. Evaluate normally — the result
+      // carries the scoped doc in its tracker, so it keys to the identity.
     }
     cache.misses++;
   }
@@ -1055,11 +1179,14 @@ export const trackGraph = (
   ) {
     // The cache keeps its own clone: the state returned below belongs to
     // the caller's session, whose refreshes and extensions mutate it.
-    const scopePure = stateIsScopePure(state);
-    cache.entries.set(scopePure ? cacheKeys.pure : cacheKeys.identity, {
-      state: cloneTrackedGraphState(engine, state),
-      scopePure,
-    });
+    const share = classifyStateScope(state);
+    cache.entries.set(
+      share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure,
+      {
+        state: cloneTrackedGraphState(engine, state),
+        share,
+      },
+    );
   }
   return {
     serverSeq: Engine.serverSeq(engine),

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1234,15 +1234,12 @@ export const trackGraph = (
     const weight = state.entities.size;
     const key = share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure;
     const previous = cache.entries.get(key);
-    if (previous !== undefined) {
-      cache.weight -= previous.weight;
-    }
     cache.entries.set(key, {
       state: cloneTrackedGraphState(engine, state),
       share,
       weight,
     });
-    cache.weight += weight;
+    cache.weight += weight - (previous?.weight ?? 0);
   }
   return {
     serverSeq: Engine.serverSeq(engine),

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -321,19 +321,17 @@ const evaluationIdentityKey = (options: TrackGraphOptions): string =>
   JSON.stringify([options.principal ?? null, options.sessionId ?? null]);
 
 /**
- * Bounds an evaluation cache's entry count. Distinct query shapes per space
- * are few (a session class shares its watch corpus), so the bound exists
- * for the adversarial case, not the expected one; an insert past it is
- * skipped rather than evicting, since within one generation every entry is
- * equally live. Kept small because an entry retains a full cloned state —
- * tracker, entities, and the manager's parsed documents — so the bound is
- * a memory bound as much as a count.
+ * Bounds an evaluation cache's entry COUNT — the cardinality backstop for
+ * adversarial query-shape churn, not the memory bound. Memory is bounded
+ * by the server's cross-space retained-entity budget, which evicts by
+ * weight (see Server's evaluation-cache budget).
  */
 const EVALUATION_CACHE_MAX_ENTRIES = 16;
 
 export type QueryEvaluationCacheDiagnostics = {
   seq: number;
   entries: number;
+  weight: number;
   hits: number;
   misses: number;
   rotations: number;
@@ -366,16 +364,30 @@ export type QueryEvaluationCacheDiagnostics = {
  * cache before any post-change evaluation could be served from it.
  */
 export type QueryEvaluationCache = {
+  /** The engine the entries were evaluated against. A sequence number
+   * identifies state only within its engine, so a different engine object
+   * for the same space rotates the cache exactly as a seq advance does —
+   * both entry points accept a caller-supplied engine. */
+  engine: Engine.Engine | null;
   seq: number;
-  entries: Map<string, { state: TrackedGraphState; share: StateScopeClass }>;
+  entries: Map<
+    string,
+    { state: TrackedGraphState; share: StateScopeClass; weight: number }
+  >;
+  /** Sum of entry weights (retained entity count — the proxy for the
+   * parsed documents an entry keeps alive). The server enforces its
+   * cross-space budget against this. */
+  weight: number;
   hits: number;
   misses: number;
   rotations: number;
 };
 
 export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
+  engine: null,
   seq: -1,
   entries: new Map(),
+  weight: 0,
   hits: 0,
   misses: 0,
   rotations: 0,
@@ -386,6 +398,7 @@ export const queryEvaluationCacheDiagnostics = (
 ): QueryEvaluationCacheDiagnostics => ({
   seq: cache.seq,
   entries: cache.entries.size,
+  weight: cache.weight,
   hits: cache.hits,
   misses: cache.misses,
   rotations: cache.rotations,
@@ -469,16 +482,18 @@ const cloneWithRewrittenResidue = (
   state: TrackedGraphState,
   residue: { key: QueryDocKey; id: string; scope: CellScope }[],
   options: TrackGraphOptions,
-): TrackedGraphState | null => {
+): { state: TrackedGraphState; probeReads: number } | null => {
   const identity: ScopeKeyIdentity = {
     principal: options.principal,
     sessionId: options.sessionId,
   };
   const mapping = new Map<string, string>();
+  let probeReads = 0;
   for (const { key, id, scope } of residue) {
     const requesterScopeKey = resolveScopeKey(scope, identity);
     const requesterKey = `${space}/${requesterScopeKey}/${id}`;
     if (requesterKey !== key) {
+      probeReads++;
       const probe = Engine.readState(engine, {
         id,
         scope,
@@ -495,7 +510,7 @@ const cloneWithRewrittenResidue = (
   }
   const clone = cloneTrackedGraphStateForIdentity(engine, state, options);
   if (mapping.size === 0) {
-    return clone;
+    return { state: clone, probeReads };
   }
   const missed = new MapSetStringToPathSelectors(true);
   for (const [key, selectors] of clone.missed) {
@@ -515,7 +530,7 @@ const cloneWithRewrittenResidue = (
       new Set([...misses].map((miss) => mapping.get(miss) ?? miss)),
     );
   }
-  return { ...clone, missed, missedBy, missesOf };
+  return { state: { ...clone, missed, missedBy, missesOf }, probeReads };
 };
 
 /**
@@ -1048,9 +1063,11 @@ export const trackGraph = (
   let cacheKeys: { pure: string; identity: string } | undefined;
   if (cache !== undefined) {
     const currentSeq = Engine.serverSeq(engine);
-    if (cache.seq !== currentSeq) {
+    if (cache.engine !== engine || cache.seq !== currentSeq) {
+      cache.engine = engine;
       cache.seq = currentSeq;
       cache.entries.clear();
+      cache.weight = 0;
       cache.rotations++;
     }
     const queryKey = evaluationQueryKey(query);
@@ -1060,16 +1077,28 @@ export const trackGraph = (
     };
     const pureEntry = cache.entries.get(cacheKeys.pure);
     let served: TrackedGraphState | null = null;
+    let probeReads = 0;
     if (pureEntry !== undefined) {
-      served = pureEntry.share.kind === "absent-residue"
-        ? cloneWithRewrittenResidue(
+      if (pureEntry.share.kind === "absent-residue") {
+        const rewritten = cloneWithRewrittenResidue(
           engine,
           space,
           pureEntry.state,
           pureEntry.share.residue,
           options,
-        )
-        : cloneTrackedGraphStateForIdentity(engine, pureEntry.state, options);
+        );
+        if (rewritten !== null) {
+          served = rewritten.state;
+        }
+        probeReads = rewritten?.probeReads ??
+          pureEntry.share.residue.length;
+      } else {
+        served = cloneTrackedGraphStateForIdentity(
+          engine,
+          pureEntry.state,
+          options,
+        );
+      }
     }
     if (served === null) {
       // Either no shared entry, or its residue is PRESENT for this
@@ -1088,12 +1117,12 @@ export const trackGraph = (
     }
     if (served !== null) {
       cache.hits++;
-      // A hit ran no traversal, and its stats say so: zero walk counters
-      // are the truth of what THIS call cost, not an accounting gap.
+      // A hit ran no traversal, and its stats say so — but the residue
+      // absence probes ARE engine reads, and they report as such.
       return {
         serverSeq: currentSeq,
         state: served,
-        stats: createQueryTraversalStats(),
+        stats: { ...createQueryTraversalStats(), managerReads: probeReads },
       };
     }
     cache.misses++;
@@ -1198,13 +1227,18 @@ export const trackGraph = (
     // The cache keeps its own clone: the state returned below belongs to
     // the caller's session, whose refreshes and extensions mutate it.
     const share = classifyStateScope(state);
-    cache.entries.set(
-      share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure,
-      {
-        state: cloneTrackedGraphState(engine, state),
-        share,
-      },
-    );
+    const weight = state.entities.size;
+    const key = share.kind === "tainted" ? cacheKeys.identity : cacheKeys.pure;
+    const previous = cache.entries.get(key);
+    if (previous !== undefined) {
+      cache.weight -= previous.weight;
+    }
+    cache.entries.set(key, {
+      state: cloneTrackedGraphState(engine, state),
+      share,
+      weight,
+    });
+    cache.weight += weight;
   }
   return {
     serverSeq: Engine.serverSeq(engine),

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -3883,6 +3883,10 @@ export class Server {
               evaluationCache: this.#evaluationCacheFor(message.space),
             },
           );
+          // Enforced per evaluation, not per request: a later group's
+          // failure (or a failing operation-field attachment) must not
+          // leave an already-inserted entry over budget.
+          this.#enforceEvaluationCacheBudget();
           graphs.set(branch, tracked.state);
           for (const [docKey, entity] of tracked.state.entities) {
             recordUpdate(docKey, entity);
@@ -3955,7 +3959,6 @@ export class Server {
       session.lastSyncedSeq = serverSeq;
       session.operationCursors = nextOperationCursors;
       this.#notifyDemandChanged(message.space, "watch", session.principal);
-      this.#enforceEvaluationCacheBudget();
       recordSlowQueryDuration(
         "session.watch.add",
         message.space,
@@ -4071,25 +4074,30 @@ export class Server {
     // must not create a cache or evict a live space's on its way through.
     const cacheEligible = query.atSeq === undefined &&
       scopeContext.keyedSnapshots !== true;
-    const result = queryGraph(
-      space,
-      engine ?? await this.openEngine(space),
-      query,
-      reuse,
-      {
-        ...scopeContext,
-        ...(cacheEligible
-          ? { evaluationCache: this.#evaluationCacheFor(space) }
-          : {}),
-      },
-    );
-    if (cacheEligible) {
-      this.#enforceEvaluationCacheBudget();
+    try {
+      const result = queryGraph(
+        space,
+        engine ?? await this.openEngine(space),
+        query,
+        reuse,
+        {
+          ...scopeContext,
+          ...(cacheEligible
+            ? { evaluationCache: this.#evaluationCacheFor(space) }
+            : {}),
+        },
+      );
+      recordSlowQueryDuration("graph.query", space, startedAt, {
+        roots: query.roots.length,
+      });
+      return result;
+    } finally {
+      // The insert precedes the snapshot mapping, so enforcement must
+      // cover the throw path too.
+      if (cacheEligible) {
+        this.#enforceEvaluationCacheBudget();
+      }
     }
-    recordSlowQueryDuration("graph.query", space, startedAt, {
-      roots: query.roots.length,
-    });
-    return result;
   }
 
   async evaluateWatchSet(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -85,11 +85,15 @@ import * as Engine from "./engine.ts";
 import { respondToHello } from "./handshake.ts";
 import {
   cloneTrackedGraphState,
+  createQueryEvaluationCache,
   extendTrackedGraph,
   fromDirtyKey,
   fromDocKey,
   isGraphQueryCoveredByState,
   type QueryDocKey,
+  type QueryEvaluationCache,
+  type QueryEvaluationCacheDiagnostics,
+  queryEvaluationCacheDiagnostics,
   queryGraph,
   type QueryGraphReuseContext,
   refreshTrackedGraph,
@@ -1180,6 +1184,10 @@ class Connection {
 export class Server {
   #sessions: SessionRegistry;
   #connections = new Map<string, Connection>();
+
+  /** Whole-evaluation caches, one per space (see QueryEvaluationCache in
+   * query.ts for the sharing, purity, and seq-rotation rules). */
+  #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
   #engines = new Map<string, Promise<Engine.Engine>>();
   // The resolved-engine index for the SYNC cross-engine lease lookup
   // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
@@ -3858,6 +3866,7 @@ export class Server {
             {
               principal: session.principal,
               sessionId: message.sessionId,
+              evaluationCache: this.#evaluationCacheFor(message.space),
             },
           );
           graphs.set(branch, tracked.state);
@@ -3969,6 +3978,22 @@ export class Server {
     }
   }
 
+  #evaluationCacheFor(space: string): QueryEvaluationCache {
+    let cache = this.#queryEvaluationCaches.get(space);
+    if (cache === undefined) {
+      cache = createQueryEvaluationCache();
+      this.#queryEvaluationCaches.set(space, cache);
+    }
+    return cache;
+  }
+
+  /** The space's evaluation-cache counters, for diagnostics and tests. */
+  evaluationCacheDiagnostics(
+    space: string,
+  ): QueryEvaluationCacheDiagnostics {
+    return queryEvaluationCacheDiagnostics(this.#evaluationCacheFor(space));
+  }
+
   async evaluateGraphQuery(
     space: string,
     query: GraphQuery,
@@ -3986,7 +4011,10 @@ export class Server {
       engine ?? await this.openEngine(space),
       query,
       reuse,
-      scopeContext,
+      {
+        ...scopeContext,
+        evaluationCache: this.#evaluationCacheFor(space),
+      },
     );
     recordSlowQueryDuration("graph.query", space, startedAt, {
       roots: query.roots.length,
@@ -4019,7 +4047,10 @@ export class Server {
         resolvedEngine,
         query,
         reuse,
-        scopeContext,
+        {
+          ...scopeContext,
+          evaluationCache: this.#evaluationCacheFor(space),
+        },
       );
       serverSeq = result.serverSeq;
       graphs.set(branch, result.state);

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -194,6 +194,10 @@ const SUBSCRIPTION_REFRESH_DELAY_MS = 5;
 const MIN_REFRESH_QUEUE_DRAIN_WAIT_MS = 500;
 const SLOW_QUERY_THRESHOLD_MS = 100;
 const QUERY_EVALUATION_CACHE_MAX_SPACES = 8;
+// ~5 board-scale corpora (a full board evaluation retains ~6k entities).
+// Entity count is the byte proxy: what an entry holds alive is its cloned
+// state's parsed documents, which scale with the entities delivered.
+const QUERY_EVALUATION_CACHE_BUDGET = 32_768;
 const SLOW_QUERY_BUFFER_SIZE = 100;
 const DEFAULT_SESSION_OPEN_CHALLENGE_TTL_SECONDS = 300;
 const SESSION_OPEN_CHALLENGE_BYTES = 32;
@@ -1289,6 +1293,14 @@ export class Server {
        * dirty spaces held for the next explicit call.
        */
       subscriptionRefreshDelayMs?: number | "manual";
+      /** Cross-space retained-entity budget for the query evaluation
+       * caches (default QUERY_EVALUATION_CACHE_BUDGET). An entry's weight
+       * is the entity count of the evaluation it retains — the proxy for
+       * the parsed documents kept alive — and eviction removes the
+       * least-recently-evaluated spaces' oldest entries until the total
+       * fits. A single evaluation heavier than the whole budget is not
+       * retained at all. */
+      queryEvaluationCacheBudget?: number;
       authorizeSessionOpen: (
         message: SessionOpenRequest,
         context: SessionOpenAuthContext,
@@ -3943,6 +3955,7 @@ export class Server {
       session.lastSyncedSeq = serverSeq;
       session.operationCursors = nextOperationCursors;
       this.#notifyDemandChanged(message.space, "watch", session.principal);
+      this.#enforceEvaluationCacheBudget();
       recordSlowQueryDuration(
         "session.watch.add",
         message.space,
@@ -3990,11 +4003,9 @@ export class Server {
     }
     cache = createQueryEvaluationCache();
     this.#queryEvaluationCaches.set(space, cache);
-    // An entry retains full cloned graph states (parsed documents
-    // included), and an inactive space's cache would otherwise linger
-    // until that space's next commit — which may never come. Bounding the
-    // SPACES held, least-recently-evaluated first, caps total retention at
-    // spaces × entries × corpus, on top of the per-commit rotation.
+    // An inactive space's cache would otherwise linger until that space's
+    // next commit — which may never come. The space bound is the
+    // cardinality backstop; the memory bound is the weight budget below.
     if (this.#queryEvaluationCaches.size > QUERY_EVALUATION_CACHE_MAX_SPACES) {
       const oldest = this.#queryEvaluationCaches.keys().next().value;
       if (oldest !== undefined) {
@@ -4002,6 +4013,33 @@ export class Server {
       }
     }
     return cache;
+  }
+
+  /** Evict least-recently-evaluated spaces' oldest entries until the
+   * caches' total retained weight fits the budget. Runs after every
+   * evaluation that may have inserted; an entry heavier than the whole
+   * budget is therefore never retained past its own evaluation. */
+  #enforceEvaluationCacheBudget(): void {
+    const budget = this.options.queryEvaluationCacheBudget ??
+      QUERY_EVALUATION_CACHE_BUDGET;
+    let total = 0;
+    for (const cache of this.#queryEvaluationCaches.values()) {
+      total += cache.weight;
+    }
+    while (total > budget) {
+      const oldestSpace = this.#queryEvaluationCaches.keys().next().value;
+      if (oldestSpace === undefined) return;
+      const cache = this.#queryEvaluationCaches.get(oldestSpace)!;
+      const oldestEntry = cache.entries.keys().next().value;
+      if (oldestEntry === undefined) {
+        this.#queryEvaluationCaches.delete(oldestSpace);
+        continue;
+      }
+      const entry = cache.entries.get(oldestEntry)!;
+      cache.entries.delete(oldestEntry);
+      cache.weight -= entry.weight;
+      total -= entry.weight;
+    }
   }
 
   /** The space's evaluation-cache counters, for diagnostics and tests.
@@ -4012,7 +4050,7 @@ export class Server {
   ): QueryEvaluationCacheDiagnostics {
     const cache = this.#queryEvaluationCaches.get(space);
     return cache === undefined
-      ? { seq: -1, entries: 0, hits: 0, misses: 0, rotations: 0 }
+      ? { seq: -1, entries: 0, weight: 0, hits: 0, misses: 0, rotations: 0 }
       : queryEvaluationCacheDiagnostics(cache);
   }
 
@@ -4028,6 +4066,11 @@ export class Server {
     } = {},
   ): Promise<GraphQueryResult> {
     const startedAt = performance.now();
+    // Cache eligibility decided BEFORE touching the LRU: a historical or
+    // lease-holder-exempt query neither serves nor records an entry, and
+    // must not create a cache or evict a live space's on its way through.
+    const cacheEligible = query.atSeq === undefined &&
+      scopeContext.keyedSnapshots !== true;
     const result = queryGraph(
       space,
       engine ?? await this.openEngine(space),
@@ -4035,9 +4078,14 @@ export class Server {
       reuse,
       {
         ...scopeContext,
-        evaluationCache: this.#evaluationCacheFor(space),
+        ...(cacheEligible
+          ? { evaluationCache: this.#evaluationCacheFor(space) }
+          : {}),
       },
     );
+    if (cacheEligible) {
+      this.#enforceEvaluationCacheBudget();
+    }
     recordSlowQueryDuration("graph.query", space, startedAt, {
       roots: query.roots.length,
     });
@@ -4075,6 +4123,7 @@ export class Server {
         },
       );
       serverSeq = result.serverSeq;
+      this.#enforceEvaluationCacheBudget();
       graphs.set(branch, result.state);
       for (const [docKey, entity] of result.state.entities) {
         const { scopeKey } = fromDocKey(docKey);

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -193,6 +193,7 @@ const timing = getLogger("memory", { enabled: false });
 const SUBSCRIPTION_REFRESH_DELAY_MS = 5;
 const MIN_REFRESH_QUEUE_DRAIN_WAIT_MS = 500;
 const SLOW_QUERY_THRESHOLD_MS = 100;
+const QUERY_EVALUATION_CACHE_MAX_SPACES = 8;
 const SLOW_QUERY_BUFFER_SIZE = 100;
 const DEFAULT_SESSION_OPEN_CHALLENGE_TTL_SECONDS = 300;
 const SESSION_OPEN_CHALLENGE_BYTES = 32;
@@ -1186,7 +1187,8 @@ export class Server {
   #connections = new Map<string, Connection>();
 
   /** Whole-evaluation caches, one per space (see QueryEvaluationCache in
-   * query.ts for the sharing, purity, and seq-rotation rules). */
+   * query.ts for the sharing, purity, and seq-rotation rules), held for at
+   * most QUERY_EVALUATION_CACHE_MAX_SPACES spaces in LRU order. */
   #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
   #engines = new Map<string, Promise<Engine.Engine>>();
   // The resolved-engine index for the SYNC cross-engine lease lookup
@@ -3980,18 +3982,38 @@ export class Server {
 
   #evaluationCacheFor(space: string): QueryEvaluationCache {
     let cache = this.#queryEvaluationCaches.get(space);
-    if (cache === undefined) {
-      cache = createQueryEvaluationCache();
+    if (cache !== undefined) {
+      // Recency bump: insertion order is the LRU order.
+      this.#queryEvaluationCaches.delete(space);
       this.#queryEvaluationCaches.set(space, cache);
+      return cache;
+    }
+    cache = createQueryEvaluationCache();
+    this.#queryEvaluationCaches.set(space, cache);
+    // An entry retains full cloned graph states (parsed documents
+    // included), and an inactive space's cache would otherwise linger
+    // until that space's next commit — which may never come. Bounding the
+    // SPACES held, least-recently-evaluated first, caps total retention at
+    // spaces × entries × corpus, on top of the per-commit rotation.
+    if (this.#queryEvaluationCaches.size > QUERY_EVALUATION_CACHE_MAX_SPACES) {
+      const oldest = this.#queryEvaluationCaches.keys().next().value;
+      if (oldest !== undefined) {
+        this.#queryEvaluationCaches.delete(oldest);
+      }
     }
     return cache;
   }
 
-  /** The space's evaluation-cache counters, for diagnostics and tests. */
+  /** The space's evaluation-cache counters, for diagnostics and tests.
+   * A peek: an absent (never-evaluated or evicted) space reads as empty
+   * rather than being created or recency-bumped by the question. */
   evaluationCacheDiagnostics(
     space: string,
   ): QueryEvaluationCacheDiagnostics {
-    return queryEvaluationCacheDiagnostics(this.#evaluationCacheFor(space));
+    const cache = this.#queryEvaluationCaches.get(space);
+    return cache === undefined
+      ? { seq: -1, entries: 0, hits: 0, misses: 0, rotations: 0 }
+      : queryEvaluationCacheDiagnostics(cache);
   }
 
   async evaluateGraphQuery(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4029,19 +4029,28 @@ export class Server {
     for (const cache of this.#queryEvaluationCaches.values()) {
       total += cache.weight;
     }
-    while (total > budget) {
-      const oldestSpace = this.#queryEvaluationCaches.keys().next().value;
-      if (oldestSpace === undefined) return;
-      const cache = this.#queryEvaluationCaches.get(oldestSpace)!;
-      const oldestEntry = cache.entries.keys().next().value;
-      if (oldestEntry === undefined) {
-        this.#queryEvaluationCaches.delete(oldestSpace);
-        continue;
+    if (total <= budget) return;
+    // Entry-less leftovers (drained by an earlier pass, or rotation-
+    // cleared and idle since) drop before eviction: an empty cache holds
+    // no weight, only a stale LRU slot. The rebuild preserves order.
+    this.#queryEvaluationCaches = new Map(
+      [...this.#queryEvaluationCaches].filter(
+        ([, cache]) => cache.entries.size > 0,
+      ),
+    );
+    // Least-recently-evaluated spaces first (map insertion order IS the
+    // LRU order), oldest entry first within each. A space drained by THIS
+    // pass keeps its cache — its counters and LRU position belong to a
+    // live space — and is swept as a leftover by the next enforcement.
+    for (const cache of [...this.#queryEvaluationCaches.values()]) {
+      while (total > budget && cache.entries.size > 0) {
+        const oldestEntry = cache.entries.keys().next().value!;
+        const entry = cache.entries.get(oldestEntry)!;
+        cache.entries.delete(oldestEntry);
+        cache.weight -= entry.weight;
+        total -= entry.weight;
       }
-      const entry = cache.entries.get(oldestEntry)!;
-      cache.entries.delete(oldestEntry);
-      cache.weight -= entry.weight;
-      total -= entry.weight;
+      if (total <= budget) return;
     }
   }
 


### PR DESCRIPTION
## Problem

Every watch establishment on the memory server evaluates its full query from scratch: the tracked-graph walk over every document the query reaches, each checked against its schema selector. Between two commits, every evaluation of the same query computes **identical results** — and on the estuary board shard we measured (2026-08-26, tracking Topic "Board-load pre-sync follow-ups", comments 6-7) the same corpus being re-walked constantly: `traverse` was 403 s of 549 s cumulative frame handling; single `session.watch.add` evaluations ran up to 42.5 s; and after each process death (the shard OOM-crash-looped ~10×/hour that evening) **every reconnecting client re-established its full watch set simultaneously at 15-22 s of evaluation each** — the stampede that re-wedges the fresh process and feeds the next OOM.

## Change

A per-space cache of whole tracked-graph evaluations, keyed by (branch, canonical root-set + interned selector identities, engine seq), with three structural rules:

- **The unit is the whole evaluation** — the smallest soundly shareable one. Within a walk, an already-covered (doc, selector) skips its subtree's tracker registrations, so any per-document slice of a walk's effects depends on what its siblings covered first; replaying one standalone would under-register coverage and silently lose deliveries. A complete evaluation carries no such context. (This is also why the cache sits here and not deeper in the traverser.)
- **Staleness is structural, not tracked.** Entries are valid only at the seq they were computed at; any commit rotates the space's cache. No write hooks, no invalidation graph; ACL changes are commits, so they rotate it like everything else. Historical (`readSeq`) reads and the lease-holder-exemption class (`keyedSnapshots`) bypass the cache entirely — a live lease can move without a commit, so rotation cannot fence it.
- **Scope purity gates sharing.** An evaluation whose entire reach — tracked, missed, and loaded — resolved under the `space` scope is identical for every identity and is shared across sessions and principals (the post-crash stampede's exact shape: N clients, one corpus). One that touched a session- or user-scoped instance is keyed to its evaluating identity.

A hit clones the cached state (`cloneTrackedGraphState`, rebound to the requesting session's identity), so the served graph stays independently live for later refresh and fan-out. Wired at all three evaluation entry points: `watchAdd`'s new-branch tracking, `evaluateWatchSet` (full re-establishment), and `evaluateGraphQuery`. `extendTrackedGraph` and the per-session refresh paths stay uncached — their effects entangle with per-session tracker state; sharing those is follow-on work (canonical graph instances).

Diagnostics: `Server.evaluationCacheDiagnostics(space)` exposes hits/misses/rotations/entries.

## Testing

`packages/memory/test/v2-query-evaluation-cache.test.ts`, four pins:

- **Delivery liveness** (the soundness pin): a cache-served session's coverage delivers exactly like an evaluated one — a third session writes, and the update reaches the evaluated watcher and the cache-served watcher alike.
- **Rotation**: a commit between evaluations means no hit, and the later evaluation sees the current value.
- **Cross-principal sharing** of a scope-pure evaluation: one miss, one hit, identical syncs — the stampede shape.
- **Identity keying**: session-scoped roots never share across identities.

Full memory suite green (579), repo fmt + lint clean, full typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

