### PR TITLE
The last rule-form section marker in `toolshed`

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -247,7 +247,7 @@ export const EnvSchema = z.object({
   // background service operator identity).
   MEMORY_SERVICE_DIDS: z.string().default(""),
 
-  // ===========================================================================
+  //
   // State-inspector remote dump endpoint (`cf inspect --remote`).
   // Exposes raw, read-only space SQLite snapshots over HTTP for offline
   // autopsy. This is a STAGING-ONLY debugging tool: it hard-refuses to mount
@@ -256,7 +256,8 @@ export const EnvSchema = z.object({
   // entire contents of a space, so access is gated by CF1 first-party signature
   // auth + a DID allowlist, and every dump is audit-logged. See
   // routes/storage/memory/memory-dump.index.ts.
-  // ===========================================================================
+  //
+
   // Master switch. Unset/"false" => the endpoint 404s as if it did not exist.
   // Mounting ALSO requires ENV to be a recognized non-production value
   // (development | test | staging) — unknown/alias envs fail closed. See


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

One marker in `packages/toolshed/env.ts` still carried its `====` rules after
the sweep. This converts it, and records why it was missed, because the miss
was silent.

## Why it was skipped

The conversion refuses to touch a table or an ASCII diagram, since a rule of
dashes is part of the layout there rather than a section marker. That guard
tested for a pipe or box-drawing character *anywhere* in the comment block. This
marker's description contains

    // (development | test | staging) — unknown/alias envs fail closed.

so the whole block read as a table and was passed over — not converted, and not
reported either, since the guard returns before the refusal path.

The guard now asks a narrower question: is a *rule* line itself part of the
drawing, or are two or more lines pipe- or plus-delimited? That is what a table
looks like, and what prose containing a pipe does not.

Rechecked across the tree: exactly three blocks were skipped for this reason.
The other two are in `runner` and `ts-transformers`, which are still to be
swept, so this is the only one in already-merged code. The controls still hold —
`iframe-sandbox/src/ipc.ts`'s protocol diagram and the markdown table in
`runner/src/runtime-presets.ts` are still skipped.

## The marker itself

Its region covers `MEMORY_DUMP_ENABLED` and `MEMORY_DUMP_DIDS`, each with its
own comment, so it is a genuine section marker rather than a doc comment for a
single declaration. Its closing rule butted straight against
`MEMORY_DUMP_ENABLED`'s own comment, so the marker closes and a blank line
separates the two, as elsewhere in this file.

With this, every package that has been swept is fully conformant except for
four one-line block comments in `health.handlers.ts`, which are JavaScript
inside a `<script>` block and belong with the TypeScript sweeps.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/toolshed`'s own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

