### PR TITLE
Clad the two bare section markers in `cell-controller.ts`

### DIFF
--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -346,7 +346,10 @@ export class CellController<T> implements ReactiveController {
       : null;
   }
 
+  //
   // ReactiveController implementation
+  //
+
   hostConnected(): void {
     this._setupCellSubscription();
   }
@@ -356,7 +359,10 @@ export class CellController<T> implements ReactiveController {
     this._inputTiming?.cancel();
   }
 
+  //
   // Private methods
+  //
+
   private defaultGetValue(value: CellHandle<T> | T): T {
     if (isCellHandle(value)) {
       const cellValue = (value as CellHandle<T>).get();


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two comments in `cell-controller.ts` are section markers over a region, written
as a bare `//` line with none of the form's delimiters. They get them.

- `ReactiveController implementation` titles `hostConnected()` and
  `hostDisconnected()`.
- `Private methods` titles the six private methods that follow it.

This corrects a note left on the previous PR, which guessed these two were doc
comments for the single declarations beneath them. They are not: each covers a
region, and each is a category name rather than a description of any one
member, so neither would make a doc comment.

Pure addition — six lines, every one of them `//` or blank. No word changes and
no non-comment line touched.

## On the wider class

These were found by reading the file, not by a rule, and that is the honest
position for the undelimited-marker class in general. A mechanical search for
"a short capitalized comment with no trailing period, sitting on a region of
two or more declarations" returns 528 candidates across the swept packages, and
they are mostly ordinary step comments — `Check for uncommitted changes`,
`Get current branch`, `10 minute timeout`. Nothing in the punctuation separates
a section title from a terse imperative, so that class cannot be swept the way
the horizontal-rule forms were; it wants a reader per site.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/ui`'s own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

