### PR TITLE
fix(runtime-client): the worker's outbound side, and readonly payloads

### DIFF
--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -173,7 +173,7 @@ export type VDomBatch = {
   batchId: number;
 
   /** The operations to apply, in order */
-  ops: VDomOp[];
+  ops: readonly VDomOp[];
 
   /**
    * The root node ID for this render tree; `null` while the tree has no root

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -2845,7 +2845,7 @@ async function collectNoteCreateProfile(page: Page): Promise<unknown> {
     };
 
     const settleHistory = await api
-      .getSettleStatsHistory() as SettleHistoryEntry[];
+      .getSettleStatsHistory() as readonly SettleHistoryEntry[];
     const recentHistory = settleHistory.slice(-8);
     const settle = {
       executeCalls: settleHistory.length,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2350,7 +2350,9 @@ export class Runtime {
     return this.writeDebugContext.run(label, fn);
   }
 
-  setWriteStackTraceMatchers(matchers: WriteStackTraceMatcher[]): void {
+  setWriteStackTraceMatchers(
+    matchers: readonly WriteStackTraceMatcher[],
+  ): void {
     setWriteStackTraceMatchers(matchers, { scopeId: this.id });
   }
 

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1576,7 +1576,7 @@ export class Scheduler {
   /**
    * Set action IDs that should trigger a debugger breakpoint before execution.
    */
-  setBreakpoints(actionIds: string[]): void {
+  setBreakpoints(actionIds: readonly string[]): void {
     this.breakpoints.clear();
     for (const id of actionIds) {
       this.breakpoints.add(id);

--- a/packages/runner/src/storage/write-stack-trace.ts
+++ b/packages/runner/src/storage/write-stack-trace.ts
@@ -144,7 +144,7 @@ function captureStack(): string | undefined {
 }
 
 export function setWriteStackTraceMatchers(
-  matchers: WriteStackTraceMatcher[],
+  matchers: readonly WriteStackTraceMatcher[],
   options: { scopeId?: string } = {},
 ): void {
   const normalizedScopeId = getWriteTraceScopeId(options.scopeId);

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -742,7 +742,7 @@ export default pattern((_) => {
       const session = await createTestSession();
       await using rt = await createRuntimeClient(session);
 
-      const consoleEvents: { method: string; args: unknown[] }[] = [];
+      const consoleEvents: { method: string; args: readonly unknown[] }[] = [];
       const gotHello = defer<void>();
       rt.on(
         "console",

--- a/packages/runtime-client/src/backends/post-to-client.ts
+++ b/packages/runtime-client/src/backends/post-to-client.ts
@@ -1,12 +1,65 @@
-import type { IPCRemotePost } from "@/protocol/mod.ts";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
+import { type IPCRemotePost, NotificationType } from "@/protocol/mod.ts";
+import { describeFailure } from "@/shared/utils.ts";
 
 /**
- * Posts one message from the worker to its client. This is the whole of the
- * worker's outbound side: every response, error, and notification crosses
- * here.
+ * How much of an undeliverable message to render. Enough to recognize which
+ * message it was, short enough that a hostile payload cannot flood the
+ * channel it is being reported on.
  */
-export function postToClient(message: IPCRemotePost): void {
-  // Read off `self` at call time rather than captured at module load, so that
-  // a test driving this without a real worker can substitute its own.
-  self.postMessage(message);
+const MAX_UNDELIVERABLE_RENDER = 512;
+
+/**
+ * Posts one message from the worker to its client, reporting whether what was
+ * asked for is what went. This is the whole of the worker's outbound side:
+ * every response, error, and notification crosses here.
+ *
+ * `false` says a substitute went instead, the post having been refused. A
+ * caller that records what it answered needs to know which, so that a failure
+ * is not counted as the reply it replaced.
+ */
+export function postToClient(message: IPCRemotePost): boolean {
+  try {
+    // Read off `self` at call time rather than captured at module load, so
+    // that a test driving this without a real worker can substitute its own.
+    self.postMessage(message);
+    return true;
+  } catch (error) {
+    // Defense in depth. `postMessage` refuses part of the value domain the
+    // protocol types admit -- an interned `symbol` is a `FabricValue` and is
+    // not structured-cloneable, nested or not -- and the notification paths
+    // reach here from a `queueMicrotask` callback, outside any caller's
+    // `try`. A throw there is an uncaught error rather than something that
+    // becomes an error reply, so losing one message loudly beats taking the
+    // worker's dispatch with it.
+    self.postMessage(undeliverableMessageFrom(message, error));
+    return false;
+  }
+}
+
+/**
+ * Builds what stands in for a message that could not be posted.
+ *
+ * A reply is answered as a failure rather than dropped: the client is awaiting
+ * one, and dropping it would hang that request until it times out. A
+ * notification has nobody waiting, so it becomes an error report carrying a
+ * rendering of what could not be sent -- degraded rather than silent, which
+ * matters most for the console, whose whole job is to say what happened.
+ *
+ * What this returns is built from strings and numbers alone, which
+ * `postMessage` cannot refuse, so the caller posts it without a guard.
+ */
+function undeliverableMessageFrom(
+  message: IPCRemotePost,
+  error: unknown,
+): IPCRemotePost {
+  const reason = `Undeliverable message: ${describeFailure(error)}: ${
+    toCompactDebugString(message, MAX_UNDELIVERABLE_RENDER)
+  }`;
+  const msgId = (message as { msgId?: unknown }).msgId;
+
+  return typeof msgId === "number"
+    ? { msgId, error: reason }
+    : { type: NotificationType.ErrorReport, message: reason };
 }

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -159,6 +159,7 @@ import {
   type PageStopRequest,
   type PageSyncedRequest,
   type PatternCoverageResponse,
+  type PatternSourceInfo,
   type PatternSourcesResponse,
   type PieceCloneRequest,
   type PieceGetSourceRequest,
@@ -1919,7 +1920,7 @@ export class RuntimeProcessor {
   ): PatternSourcesResponse {
     const snapshot = this.runtime.scheduler.getGraphSnapshot();
     const seen = new Set<string>();
-    const patterns: PatternSourcesResponse["patterns"] = [];
+    const patterns: PatternSourceInfo[] = [];
 
     for (const node of snapshot.nodes) {
       const ref = node.patternIdentity;

--- a/packages/runtime-client/src/backends/web-worker/index.ts
+++ b/packages/runtime-client/src/backends/web-worker/index.ts
@@ -8,6 +8,7 @@
 import "core-js/proposals/explicit-resource-management";
 import "core-js/proposals/async-explicit-resource-management";
 
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { unrefTimer } from "@commonfabric/utils/sleep";
 import { isObjectNotArray } from "@commonfabric/utils/types";
@@ -144,6 +145,13 @@ function setWorkerConsoleBridge(enabled: boolean): void {
   else uninstallWorkerConsoleBridge();
 }
 
+/**
+ * How much of an unreadable request to render in the report about it. Enough
+ * to recognize which message it was, short enough that a hostile payload
+ * cannot flood the channel it is being reported on.
+ */
+const MAX_INVALID_REQUEST_RENDER = 512;
+
 self.addEventListener("message", async (event: MessageEvent) => {
   // TODO(danfuzz): what arrives here is whatever structured cloning preserved,
   // which is less than the payload type describes; decoding with `codec-realm`
@@ -169,7 +177,14 @@ self.addEventListener("message", async (event: MessageEvent) => {
 
   try {
     if (!isIPCClientMessage(message)) {
-      throw new Error(`Invalid IPC request: ${JSON.stringify(message)}`);
+      // Rendered by `value-debug` rather than `JSON.stringify`, which throws
+      // on a `bigint` -- a value structured cloning delivers here intact --
+      // replacing this report with one that names nothing.
+      throw new Error(
+        `Invalid IPC request: ${
+          toCompactDebugString(message, MAX_INVALID_REQUEST_RENDER)
+        }`,
+      );
     }
     const { msgId, data: request } = message;
     ipcLogger.debug(`received/${request.type}`, () => []);
@@ -239,8 +254,14 @@ self.addEventListener("message", async (event: MessageEvent) => {
     const payload: IPCRemoteResponse = response !== undefined
       ? { msgId, data: response }
       : { msgId };
-    postToClient(payload);
-    ipcLogger.debug(`responded/${request.type}`, () => []);
+    // Counted by what went, not by what was asked for: a refused post
+    // substitutes an error reply, and recording that as a response would say
+    // the request succeeded.
+    const delivered = postToClient(payload);
+    ipcLogger.debug(
+      `${delivered ? "responded" : "responded-error"}/${request.type}`,
+      () => [],
+    );
   } catch (error) {
     console.error("[RuntimeWorker] Error:", error);
     const type = isIPCClientMessage(message) ? message.data.type : "invalid";

--- a/packages/runtime-client/src/backends/web-worker/index.ts
+++ b/packages/runtime-client/src/backends/web-worker/index.ts
@@ -152,6 +152,19 @@ function setWorkerConsoleBridge(enabled: boolean): void {
  */
 const MAX_INVALID_REQUEST_RENDER = 512;
 
+/**
+ * Posts one reply and records it in the ledger by what actually went. A
+ * refused post substitutes an error reply, and counting that as a response
+ * would say the request succeeded.
+ */
+function postReply(payload: IPCRemoteResponse, type: RequestType): void {
+  const delivered = postToClient(payload);
+  ipcLogger.debug(
+    `${delivered ? "responded" : "responded-error"}/${type}`,
+    () => [],
+  );
+}
+
 self.addEventListener("message", async (event: MessageEvent) => {
   // TODO(danfuzz): what arrives here is whatever structured cloning preserved,
   // which is less than the payload type describes; decoding with `codec-realm`
@@ -211,12 +224,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
         request.data,
       );
       worker = await workerInitialization;
-      // Count the reply only once it is actually posted: if postMessage throws
-      // (e.g. a non-cloneable payload) the catch below records a
-      // `responded-error/*` instead, so the ledger never double-counts one
-      // request as both a success and an error.
-      postToClient({ msgId: message.msgId });
-      ipcLogger.debug(`responded/${request.type}`, () => []);
+      postReply({ msgId: message.msgId }, request.type);
       return;
     }
 
@@ -225,8 +233,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
     // of runtime initialization, so it is answered before the init check.
     if (request.type === RequestType.SetForwardWorkerConsole) {
       setWorkerConsoleBridge(request.enabled);
-      postToClient({ msgId });
-      ipcLogger.debug(`responded/${request.type}`, () => []);
+      postReply({ msgId }, request.type);
       return;
     }
 
@@ -237,8 +244,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
       // After disposal, silently ack any late-arriving requests.
       // Components may still be unsubscribing or finishing in-flight
       // operations during teardown — no point erroring on these.
-      postToClient({ msgId });
-      ipcLogger.debug(`responded/${request.type}`, () => []);
+      postReply({ msgId }, request.type);
       return;
     }
 
@@ -254,14 +260,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
     const payload: IPCRemoteResponse = response !== undefined
       ? { msgId, data: response }
       : { msgId };
-    // Counted by what went, not by what was asked for: a refused post
-    // substitutes an error reply, and recording that as a response would say
-    // the request succeeded.
-    const delivered = postToClient(payload);
-    ipcLogger.debug(
-      `${delivered ? "responded" : "responded-error"}/${request.type}`,
-      () => [],
-    );
+    postReply(payload, request.type);
   } catch (error) {
     console.error("[RuntimeWorker] Error:", error);
     const type = isIPCClientMessage(message) ? message.data.type : "invalid";

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -1,6 +1,7 @@
 import type { MetaField } from "@commonfabric/api";
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import type {
+  FabricArray,
   FabricPlainObject,
   FabricValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -970,7 +971,7 @@ export type OperationFieldResponse = {
 
 /** A response naming the operation codecs available for a cell. */
 export type OperationCapabilitiesResponse = {
-  codecs: string[];
+  codecs: readonly string[];
 };
 
 /** A response carrying the authoritative resolution of an operation. */
@@ -1264,7 +1265,7 @@ export type SetWriteStackTraceMatchersRequest = BaseRequest & {
    * The writes whose stack to record. Replaces the current set rather than
    * adding to it.
    */
-  matchers: WriteStackTraceMatcher[];
+  matchers: readonly WriteStackTraceMatcher[];
 };
 
 /**
@@ -1294,7 +1295,7 @@ export type SettleStatsHistoryResponse = {
   /**
    * One entry per recorded pass, oldest first.
    */
-  history: SettleStatsHistoryEntry[];
+  history: readonly SettleStatsHistoryEntry[];
 };
 
 /** The recorded action runs, in the order they ran. */
@@ -1302,7 +1303,7 @@ export type ActionRunTraceResponse = {
   /**
    * The recorded runs, in the order they ran.
    */
-  trace: ActionRunTraceEntry[];
+  trace: readonly ActionRunTraceEntry[];
 };
 
 /** The recorded triggers, in the order they fired. */
@@ -1310,7 +1311,7 @@ export type TriggerTraceResponse = {
   /**
    * The recorded triggers, in the order they fired.
    */
-  trace: TriggerTraceEntry[];
+  trace: readonly TriggerTraceEntry[];
 };
 
 /**
@@ -1321,7 +1322,7 @@ export type WriteStackTraceResponse = {
   /**
    * The recorded writes, in the order they happened.
    */
-  trace: WriteStackTraceEntry[];
+  trace: readonly WriteStackTraceEntry[];
 };
 
 /** What the scheduler's non-idempotency diagnosis found. */
@@ -1363,10 +1364,10 @@ export type PatternSourceInfo = {
   /**
    * Every file of the pattern, code and data alike.
    */
-  files: PatternSourceFile[];
+  files: readonly PatternSourceFile[];
 
   /** Names among `files` that carry data rather than code. */
-  dataFiles?: string[];
+  dataFiles?: readonly string[];
 };
 
 /** One entry per distinct pattern in the graph, not per graph node. */
@@ -1374,7 +1375,7 @@ export type PatternSourcesResponse = {
   /**
    * One entry per distinct pattern.
    */
-  patterns: PatternSourceInfo[];
+  patterns: readonly PatternSourceInfo[];
 };
 
 /**
@@ -1387,7 +1388,7 @@ export type SetBreakpointsRequest = BaseRequest & {
   /**
    * The actions to break on. Replaces the current set.
    */
-  actionIds: string[];
+  actionIds: readonly string[];
 };
 
 /**
@@ -1581,7 +1582,7 @@ export type TimingStats = {
   /**
    * The distribution over every sample since the worker started.
    */
-  cdf: CDFPoint[];
+  cdf: readonly CDFPoint[];
 
   /**
    * The distribution over samples since the last baseline reset, `null`
@@ -1982,15 +1983,15 @@ export type PieceSourceView = {
   /**
    * Every file of the source, code and data alike.
    */
-  files: PatternSourceFile[];
+  files: readonly PatternSourceFile[];
 
   /** Names among `files` that carry data rather than code. */
-  dataFiles?: string[];
+  dataFiles?: readonly string[];
 
   /**
    * Every revision, which is what the current one is chosen from.
    */
-  history: PieceSourceRevisionView[];
+  history: readonly PieceSourceRevisionView[];
 
   /**
    * Which of `history` the piece is on.
@@ -2019,10 +2020,10 @@ export type PieceSourceRevisionSourceView = {
   /**
    * The files as of that revision.
    */
-  files: PatternSourceFile[];
+  files: readonly PatternSourceFile[];
 
   /** Names among `files` that carry data rather than code. */
-  dataFiles?: string[];
+  dataFiles?: readonly string[];
 };
 
 /** One named revision of a piece's source, without the history around it. */
@@ -2216,7 +2217,7 @@ export type SerializedDomEvent = {
     trusted?: boolean;
     ui?: {
       pattern?: string;
-      eventIntegrity?: string[];
+      eventIntegrity?: readonly string[];
       uiContractDataset?: Record<string, string>;
     };
   };
@@ -2679,7 +2680,7 @@ export type ConsoleMessage = Omit<ConsoleNotification, "args"> & {
   /**
    * The arguments, decoded back into the values the pattern logged.
    */
-  args: FabricValue[];
+  args: FabricArray;
 };
 
 /**
@@ -2822,7 +2823,7 @@ export type VDomBatchNotification = {
   batchId: number;
 
   /** The operations to apply, in order */
-  ops: VDomOp[];
+  ops: readonly VDomOp[];
 
   /**
    * The root node ID for this render tree; `null` while the tree has no root

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -807,7 +807,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    * Return recent settle stats history captured from worker execute() calls.
    * Entries are ordered oldest first.
    */
-  async getSettleStatsHistory(): Promise<SettleStatsHistoryEntry[]> {
+  async getSettleStatsHistory(): Promise<readonly SettleStatsHistoryEntry[]> {
     const res = await this.#conn.request<RequestType.GetSettleStatsHistory>({
       type: RequestType.GetSettleStatsHistory,
     });
@@ -818,7 +818,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    * Return recent exact action-run history captured from worker scheduler runs.
    * Entries are ordered oldest first.
    */
-  async getActionRunTrace(): Promise<ActionRunTraceEntry[]> {
+  async getActionRunTrace(): Promise<readonly ActionRunTraceEntry[]> {
     const res = await this.#conn.request<RequestType.GetActionRunTrace>({
       type: RequestType.GetActionRunTrace,
     });
@@ -851,7 +851,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    * Return recent structured trigger-trace entries captured from worker storage changes.
    * Entries are ordered oldest first.
    */
-  async getTriggerTrace(): Promise<TriggerTraceEntry[]> {
+  async getTriggerTrace(): Promise<readonly TriggerTraceEntry[]> {
     const res = await this.#conn.request<RequestType.GetTriggerTrace>({
       type: RequestType.GetTriggerTrace,
     });
@@ -875,7 +875,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    * Return recent transaction-level write stack trace entries from the worker.
    * Entries are ordered oldest first.
    */
-  async getWriteStackTrace(): Promise<WriteStackTraceEntry[]> {
+  async getWriteStackTrace(): Promise<readonly WriteStackTraceEntry[]> {
     const res = await this.#conn.request<RequestType.GetWriteStackTrace>({
       type: RequestType.GetWriteStackTrace,
     });

--- a/packages/runtime-client/test/backends/post-to-client.test.ts
+++ b/packages/runtime-client/test/backends/post-to-client.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { postToClient } from "@/backends/post-to-client.ts";
+import { NotificationType } from "@/protocol/mod.ts";
+
+/**
+ * Captures what the worker posts, standing in for the real `self.postMessage`
+ * — which is read off `self` at call time so that this substitution works.
+ */
+function capturing(): {
+  posted: Record<string, unknown>[];
+  restore: () => void;
+} {
+  const posted: Record<string, unknown>[] = [];
+  const original = (globalThis as { postMessage?: unknown }).postMessage;
+  (globalThis as { postMessage: (m: unknown) => void }).postMessage = (m) => {
+    // Refuse exactly what a real `postMessage` refuses, by asking the same
+    // algorithm rather than by guessing which values those are.
+    structuredClone(m);
+    posted.push(m as Record<string, unknown>);
+  };
+  return {
+    posted,
+    restore: () => {
+      (globalThis as { postMessage?: unknown }).postMessage = original;
+    },
+  };
+}
+
+describe("post-to-client", () => {
+  describe("a message `postMessage` refuses", () => {
+    // An interned `symbol` is a `FabricValue`, so the protocol types admit one
+    // and structured cloning throws on it, nested or not. That is the whole
+    // gap: this is the worker's only outbound call, and the notification paths
+    // reach it from a microtask where a throw is uncaught.
+
+    it("answers a reply as a failure, so the request settles", () => {
+      const { posted, restore } = capturing();
+
+      try {
+        postToClient(
+          {
+            msgId: 7,
+            data: { value: Symbol.for("cf.test.unpostable") },
+          } as never,
+        );
+
+        expect(posted).toHaveLength(1);
+        expect(posted[0].msgId).toBe(7);
+        expect(posted[0].error).toContain("Undeliverable message");
+      } finally {
+        restore();
+      }
+    });
+
+    it("reports a notification, carrying a rendering of what was lost", () => {
+      const { posted, restore } = capturing();
+
+      try {
+        postToClient(
+          {
+            type: NotificationType.CellUpdate,
+            cell: { id: "of:x", space: "did:key:t", scope: "space", path: [] },
+            value: Symbol.for("cf.test.unpostable"),
+          } as never,
+        );
+
+        expect(posted).toHaveLength(1);
+        expect(posted[0].type).toBe(NotificationType.ErrorReport);
+        expect(posted[0].message).toContain("Undeliverable message");
+        // The rendering names the message, so a reader can tell which one went.
+        expect(posted[0].message).toContain("cell:update");
+      } finally {
+        restore();
+      }
+    });
+
+    it("does not throw, which is the whole point", () => {
+      // The notification paths post from a `queueMicrotask` callback, where a
+      // throw is an uncaught error rather than something a caller catches.
+      const { restore } = capturing();
+
+      try {
+        expect(() =>
+          postToClient(
+            {
+              type: NotificationType.ErrorReport,
+              message: Symbol.for("x"),
+            } as never,
+          )
+        ).not.toThrow();
+      } finally {
+        restore();
+      }
+    });
+
+    it("posts an ordinary message unchanged", () => {
+      // Without this the three above pass for an implementation that
+      // substitutes unconditionally.
+      const { posted, restore } = capturing();
+
+      try {
+        postToClient({ msgId: 8, data: { value: 1 } } as never);
+
+        expect(posted).toEqual([{ msgId: 8, data: { value: 1 } }]);
+      } finally {
+        restore();
+      }
+    });
+  });
+});

--- a/packages/runtime-client/test/backends/post-to-client.test.ts
+++ b/packages/runtime-client/test/backends/post-to-client.test.ts
@@ -39,12 +39,18 @@ describe("post-to-client", () => {
       const { posted, restore } = capturing();
 
       try {
-        postToClient(
-          {
-            msgId: 7,
-            data: { value: Symbol.for("cf.test.unpostable") },
-          } as never,
-        );
+        // The return is the contract: `web-worker/index.ts` counts a reply
+        // as `responded` or `responded-error` by it, so an implementation that
+        // substituted while still answering `true` would misreport every
+        // refused reply and pass on the posted message alone.
+        expect(
+          postToClient(
+            {
+              msgId: 7,
+              data: { value: Symbol.for("cf.test.unpostable") },
+            } as never,
+          ),
+        ).toBe(false);
 
         expect(posted).toHaveLength(1);
         expect(posted[0].msgId).toBe(7);
@@ -58,13 +64,20 @@ describe("post-to-client", () => {
       const { posted, restore } = capturing();
 
       try {
-        postToClient(
-          {
-            type: NotificationType.CellUpdate,
-            cell: { id: "of:x", space: "did:key:t", scope: "space", path: [] },
-            value: Symbol.for("cf.test.unpostable"),
-          } as never,
-        );
+        expect(
+          postToClient(
+            {
+              type: NotificationType.CellUpdate,
+              cell: {
+                id: "of:x",
+                space: "did:key:t",
+                scope: "space",
+                path: [],
+              },
+              value: Symbol.for("cf.test.unpostable"),
+            } as never,
+          ),
+        ).toBe(false);
 
         expect(posted).toHaveLength(1);
         expect(posted[0].type).toBe(NotificationType.ErrorReport);
@@ -82,14 +95,16 @@ describe("post-to-client", () => {
       const { restore } = capturing();
 
       try {
-        expect(() =>
-          postToClient(
+        let delivered: boolean | undefined;
+        expect(() => {
+          delivered = postToClient(
             {
               type: NotificationType.ErrorReport,
               message: Symbol.for("x"),
             } as never,
-          )
-        ).not.toThrow();
+          );
+        }).not.toThrow();
+        expect(delivered).toBe(false);
       } finally {
         restore();
       }
@@ -101,7 +116,8 @@ describe("post-to-client", () => {
       const { posted, restore } = capturing();
 
       try {
-        postToClient({ msgId: 8, data: { value: 1 } } as never);
+        expect(postToClient({ msgId: 8, data: { value: 1 } } as never))
+          .toBe(true);
 
         expect(posted).toEqual([{ msgId: 8, data: { value: 1 } }]);
       } finally {

--- a/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
+++ b/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
@@ -367,7 +367,9 @@ describe("web-worker-console-bridge", () => {
         }]);
 
         // A failed response post: the success counter must NOT tick (the reply
-        // never left), the catch posts an error reply and counts that instead.
+        // never left). `postToClient()` substitutes an error reply naming what
+        // could not go, and says so by returning `false`, which is what the
+        // ledger counts instead.
         const respondedIdleBefore = ledgerCount(
           `responded/${RequestType.Idle}`,
         );
@@ -383,7 +385,12 @@ describe("web-worker-console-bridge", () => {
         };
         posted.length = 0;
         await dispatch({ msgId: 106, data: { type: RequestType.Idle } });
-        expect(posted).toEqual([{ msgId: 106, error: "post failed" }]);
+        expect(posted).toHaveLength(1);
+        expect(posted[0].msgId).toBe(106);
+        // Carries the reason and the message that could not go, rather than
+        // the reason alone -- the rendering itself is not pinned here.
+        expect(posted[0].error).toContain("Undeliverable message");
+        expect(posted[0].error).toContain("post failed");
         expect(ledgerCount(`responded/${RequestType.Idle}`)).toBe(
           respondedIdleBefore,
         );

--- a/packages/shell/src/lib/debug-utils.ts
+++ b/packages/shell/src/lib/debug-utils.ts
@@ -321,7 +321,7 @@ export function summarizeDebugValue(value: unknown): DebugValueSummary {
 }
 
 export function summarizeTriggerTraceEntries(
-  trace: TriggerTraceEntry[],
+  trace: readonly TriggerTraceEntry[],
   options: { limit?: number; rootOnly?: boolean } = {},
 ): TriggerTraceExplanation {
   const { limit = 10, rootOnly = false } = options;
@@ -544,7 +544,7 @@ export function createDebugUtils(
   }
 
   async function getWriteStackTrace(): Promise<
-    WriteStackTraceEntry[] | undefined
+    readonly WriteStackTraceEntry[] | undefined
   > {
     const rt = getRt();
     if (!rt) {

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -70,7 +70,7 @@ export class DebuggerController implements ReactiveController {
   private schedulerBaselineVersion = 0;
 
   // Pattern source files for source browser
-  private patternSources: PatternSourceInfo[] = [];
+  private patternSources: readonly PatternSourceInfo[] = [];
   private patternSourcesVersion = 0;
 
   // Debugger breakpoints: action IDs
@@ -476,7 +476,7 @@ export class DebuggerController implements ReactiveController {
   /**
    * Get cached pattern sources
    */
-  getPatternSources(): PatternSourceInfo[] {
+  getPatternSources(): readonly PatternSourceInfo[] {
     return this.patternSources;
   }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Three findings a review of the IPC envelope work (#6323) turned up, each of
which is true on `main` today and independent of that work. Landing them here
keeps them out of a larger change — and keeps them landed if that change ever
has to be reverted.

## `postToClient()` had no guard

It is the whole of the worker's outbound side, and `postMessage` refuses part
of the value domain the protocol types admit. An interned `symbol` is a
`FabricValue`, and structured cloning throws on one, nested or not:

```
clone THROWS:: interned symbol -> DOMException
clone THROWS:: record holding an interned symbol -> DOMException
```

Replies survive that today — the message listener's `catch` turns the throw
into an error reply. The notification paths do not: they post from a
`queueMicrotask` callback, outside any caller's `try`, where the throw is an
uncaught error instead. A refused post now substitutes a strings-only stand-in
naming what could not go, and reports that by returning `false`.

**The return is not decoration, and an existing test proved it.** Guarding
without reporting the outcome counts a substituted reply as `responded` rather
than `responded-error`, silently corrupting the request ledger — which
`web-worker-console-bridge.test.ts` caught immediately. Its claims about the
ledger are unchanged. What changed is the reply's text, which now names the
message as well as the reason, so its assertion asks for that rather than for
an exact rendering.

The new `post-to-client.test.ts` drives the three refusal paths and one
ordinary message. Its fake `postMessage` calls `structuredClone` so it refuses
exactly what a real one refuses, rather than guessing which values those are.
Ablated: with the guard rethrowing, the three refusal tests fail and the
ordinary-message control still passes.

## `JSON.stringify()` destroyed the report that used it

The invalid-request report renders the message it is refusing. Structured
cloning delivers a `bigint` intact, and `JSON.stringify()` throws on one:

```
structured clone carries bigint: bigint 42n
JSON.stringify THROWS: TypeError: Do not know how to serialize a BigInt
```

So the one report whose whole job is to say which message was wrong could
instead say "Do not know how to serialize a BigInt". It renders through
`value-debug` now, bounded, as the other reports here already do.

## Decoded payload arrays say `readonly`

Nineteen protocol payload fields, and the four `RuntimeClient` trace accessors
that return them. Every consumer the type checker then flagged wanted an honest
declaration and never a copy: three `runner` parameters that read their
argument and never write it, a `shell` cached field and its accessor, an `html`
op array, and two test annotations.

The console arguments become a `FabricArray`, that being the data model's own
name for the readonly array of `FabricValue` they are.

Nothing changes at run time. What changes is that the declarations stop
promising more than the values give — and the type checker is what proved that
none of the promises were being used: had any of those functions actually
mutated its argument, the widening would not compile.

## Checks

`deno task check`, `deno fmt --check`, `deno lint`, `deno task check-docs`, and
`deno task cfcheck` (422 pattern files) all pass, as do the `runtime-client`
(16 tests), `html` (25 tests), and full `runner` (1303 tests) suites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

