### PR TITLE
Clad the bare section markers that are unambiguously markers

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1857,7 +1857,10 @@ export type BuiltInLLMMessage = {
   content: BuiltInLLMContent;
 };
 
+//
 // Image types from UI components
+//
+
 export interface ImageData {
   id: string;
   name: string;
@@ -1915,7 +1918,10 @@ export interface BuiltInLLMGroundingSource {
   snippet?: string;
 }
 
+//
 // Built-in types
+//
+
 export interface BuiltInLLMParams {
   messages?: BuiltInLLMMessage[];
   model?: string;
@@ -3234,7 +3240,10 @@ export type ToSchemaFunction = <T>(options?: Partial<JSONSchema>) => JSONSchema;
 /** Internal compiler-emitted helper for top-level data materialization. */
 export type CfDataFunction = <T>(value: T) => T;
 
+//
 // Pattern environment types
+//
+
 export interface PatternEnvironment {
   readonly apiUrl: URL;
 }

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -174,7 +174,10 @@ export interface FusePlatform {
   /** Byte offset of st_mtim(espec) within struct stat. */
   STAT_ST_MTIM_OFFSET: number;
 
+  //
   // Struct helpers
+  //
+
   writeStat(buf: ArrayBuffer, opts: StatOpts): void;
   writeEntryParam(buf: ArrayBuffer, opts: EntryParamOpts): void;
   readFileInfo(ptr: Deno.PointerValue): FileInfo;
@@ -322,7 +325,10 @@ export const FUSE_SET_ATTR_METADATA_KNOWN_MASK = FUSE_SET_ATTR_MODE |
   FUSE_SET_ATTR_BKUPTIME |
   FUSE_SET_ATTR_FLAGS;
 
+//
 // File mode constants
+//
+
 export const S_IFDIR = 0o40000;
 export const S_IFREG = 0o100000;
 export const S_IFLNK = 0o120000;

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -312,7 +312,10 @@ export class XLoginView extends BaseView {
     }
   };
 
+  //
   // Auth event handlers
+  //
+
   private async handlePasskeyRegister() {
     this.isProcessing = true;
     this.error = null;

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -2279,7 +2279,10 @@ export type BuiltInLLMMessage = {
   content: BuiltInLLMContent;
 };
 
+//
 // Image types from UI components
+//
+
 export interface ImageData {
   id: string;
   name: string;
@@ -2337,7 +2340,10 @@ export interface BuiltInLLMGroundingSource {
   snippet?: string;
 }
 
+//
 // Built-in types
+//
+
 export interface BuiltInLLMParams {
   messages?: BuiltInLLMMessage[];
   model?: string;
@@ -3656,7 +3662,10 @@ export type ToSchemaFunction = <T>(options?: Partial<JSONSchema>) => JSONSchema;
 /** Internal compiler-emitted helper for top-level data materialization. */
 export type CfDataFunction = <T>(value: T) => T;
 
+//
 // Pattern environment types
+//
+
 export interface PatternEnvironment {
   readonly apiUrl: URL;
 }

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -209,7 +209,10 @@ export type GetModelsRouteQueryParams = z.infer<
   typeof GetModelsRouteQueryParams
 >;
 
+//
 // Route definitions
+//
+
 export const getModels = createRoute({
   path: "/api/ai/llm/models",
   method: "get",

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -28,7 +28,10 @@ export type Capabilities = {
   nativeModelToolIds?: LLMNativeModelToolId[];
 };
 
+//
 // Gateway /v1/models response types
+//
+
 type GatewayModelCapabilities = {
   type?: string;
   contextWindow?: number;

--- a/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
+++ b/packages/toolshed/routes/integrations/plaid-oauth/plaid-oauth.utils.ts
@@ -77,7 +77,10 @@ export const PlaidAuthSchema = {
   required: ["items"],
 } as const satisfies JSONSchema;
 
+//
 // Types
+//
+
 export type PlaidAuthData = Mutable<Schema<typeof PlaidAuthSchema>>;
 
 export interface PlaidItem {

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -982,7 +982,10 @@ export class CFAutocomplete extends BaseElement {
     }
   };
 
+  //
   // Selection methods
+  //
+
   private _selectItem(item: AutocompleteItem) {
     // Always emit cf-select for side effects
     // Include data field if present (allows passing arbitrary objects through selection)
@@ -1158,7 +1161,10 @@ export class CFAutocomplete extends BaseElement {
     this._dropdownStyle = `top: ${top}px; left: ${left}px; width: ${width}px`;
   }
 
+  //
   // Public API
+  //
+
   override focus(): void {
     this._input?.focus();
   }

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
@@ -101,7 +101,10 @@ export class CFCellLink extends BaseElement {
   private _subscribedCellKey: string | undefined = undefined;
   private _resolveCellGeneration = 0;
 
+  //
   // Drag state
+  //
+
   private _isDragging = false;
   private _isTracking = false;
   private _dragStartX = 0;

--- a/packages/ui/src/v2/components/cf-chart/cf-chart.ts
+++ b/packages/ui/src/v2/components/cf-chart/cf-chart.ts
@@ -87,7 +87,10 @@ export class CFChart extends BaseElement {
   declare padding: number | [number, number, number, number] | undefined;
   declare crosshair: boolean;
 
+  //
   // Internal state
+  //
+
   private _width = 0;
   private _childMarks: MarkElement[] = [];
   private _resizeObserver: ResizeObserver | null = null;

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -306,7 +306,10 @@ export class CFRender extends BaseElement {
   private accessor _hasRendered = false;
   private _startPromise?: Promise<boolean>;
 
+  //
   // Debug helpers
+  //
+
   private _instanceId = DEBUG_LOGGING
     ? Math.random().toString(36).substring(7)
     : "";

--- a/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
+++ b/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
@@ -358,7 +358,10 @@ export class CFScrollArea extends BaseElement {
     }, 1000);
   }
 
+  //
   // Vertical scrollbar handlers
+  //
+
   private handleVerticalThumbMouseDown = (event: MouseEvent): void => {
     event.preventDefault();
     event.stopPropagation();
@@ -427,7 +430,10 @@ export class CFScrollArea extends BaseElement {
     );
   };
 
+  //
   // Horizontal scrollbar handlers
+  //
+
   private handleHorizontalThumbMouseDown = (event: MouseEvent): void => {
     event.preventDefault();
     event.stopPropagation();

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -333,7 +333,10 @@ export class CFTextarea extends BaseElement {
   #internals: ElementInternals;
   private _generatedAriaLabel: string | null = null;
 
+  //
   // Cache + initial setup
+  //
+
   private _textarea: HTMLTextAreaElement | null = null;
   private _cellController = createStringCellController(this, {
     timing: {

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -34,7 +34,10 @@ export interface DragState {
  */
 export type DragListener = (state: DragState | null) => void;
 
+//
 // Module-level singleton state
+//
+
 let currentDrag: DragState | null = null;
 const listeners: Set<DragListener> = new Set();
 

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -344,7 +344,10 @@ describe("FormFieldController registration behavior", () => {
       isDirty: () => buffer !== undefined && buffer !== "original",
     };
 
+    //
     // Initial state
+    //
+
     expect(registration.getValue()).toBe("original");
     expect(registration.isDirty()).toBe(false);
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A section marker written as a lone `// Title` line has none of the form's
delimiters, so it cannot be found by looking for the form. This finds the ones
that are not in doubt, and gives them the delimiters.

## Sniffing out the subset

Looking for the *shape* — a comment sitting directly on a declaration, short,
capitalized, no trailing period — turns up **526** candidates. Sorting and
reading them, three things separated the markers from the noise, and only the
third was the vocabulary:

| filter | what it removes |
| --- | --- |
| declaration position, not inside a function body | `// New constructors` labelling a `const` inside a function; `// Also handle direct CFTheme properties` on an `if` |
| a noun phrase, not an imperative | `Check for uncommitted changes`, `Get current branch`, `10 minute timeout`, `Copy target properties` |
| heads two or more declarations | a comment that documents the single thing beneath it, which is a doc comment |

Together those give **19 markers across 14 files**: `Built-in types`,
`Pattern environment types`, `Struct helpers`, `File mode constants`,
`Auth event handlers`, `Route definitions`, `Public API`, `Selection methods`,
`Drag state`, `Internal state`, `Debug helpers`, `Vertical scrollbar handlers`,
`Horizontal scrollbar handlers`, `Module-level singleton state`, and the rest.

Two findings from the sort that are worth recording:

- **The canonical class-layout vocabulary is not used in this form at all.**
  `Instance members`, `Static members`, `Subclass contract`, and `Constructor`
  appear as a bare title **zero** times across the swept packages. The names the
  development guide gives are not what these files actually say.
- **79 of the 526 candidates are in generated or vendored trees** — 49 of them
  are the identical `Module-scope lift definitions` in
  `packages/generated-patterns/`. None is hand-edited.

## Not included

`packages/html/src/jsx.d.ts` holds nine more that pass every filter
(`Chart components`, `Toast components`, `Form components`, …). It is left out
because it is the target of a symlink from `packages/static/assets/types/`, and
the note I have says it is re-derived from upstream and should stay out of style
sweeps — while its contents read as authored here, importing `@commonfabric`
types. Those two claims disagree, and I would rather ask than guess. If it is in
fact authored, that is nine more sites.

The remaining ~430 candidates need a reader per site. Nothing in the
punctuation separates a section title from a terse imperative.

## Verification

Pure addition — 66 lines, every one `//` or blank. No line removed, no word
changed, no non-comment line touched. `commonfabric.d.ts` is regenerated rather
than edited, since three markers are in `packages/api/index.ts`, which it
inlines.

`deno fmt --check`, `deno lint`, `deno task check`, `check-commonfabric-types`,
`check-cfc-types`, and `check-withheld-globals` all pass, as do the `api`,
`fuse`, `toolshed`, `ui`, and `static` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

