### PR TITLE
Conform the section markers in `ts-transformers`

### DIFF
--- a/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
@@ -190,7 +190,9 @@ export class PatternCallbackLoweringTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const scopeStack: PatternScopeInfo[] = [];
 
-    // ── Main transform pass ────────────────────────────────────────────
+    //
+    // Main transform pass
+    //
     const visit: ts.Visitor = (node: ts.Node): ts.Node => {
       const callback = ts.isCallExpression(node)
         ? getPatternBuilderCallbackArgument(node, context.checker)

--- a/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
@@ -190,9 +190,7 @@ export class PatternCallbackLoweringTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const scopeStack: PatternScopeInfo[] = [];
 
-    //
     // Main transform pass
-    //
     const visit: ts.Visitor = (node: ts.Node): ts.Node => {
       const callback = ts.isCallExpression(node)
         ? getPatternBuilderCallbackArgument(node, context.checker)

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -24,9 +24,9 @@ import {
 } from "../ast/mod.ts";
 import { getCellKind } from "./cell-type.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Types
-// ---------------------------------------------------------------------------
+//
 
 /**
  * How a capability summary is applied to a parameter's schema. `full` shrinks
@@ -69,9 +69,9 @@ const NON_ITEM_PROPS = new Set([
   "update",
 ]);
 
-// ---------------------------------------------------------------------------
+//
 // Utility helpers
-// ---------------------------------------------------------------------------
+//
 
 function groupPathsByHead(
   paths: readonly (readonly string[])[],
@@ -776,9 +776,9 @@ export function printTypeNode(
   return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Core type-shrinking
-// ---------------------------------------------------------------------------
+//
 
 function buildShrunkTypeNodeFromType(
   type: ts.Type,
@@ -1569,9 +1569,9 @@ function shrinkTypeLiteralMembers(
     : factory.createTypeLiteralNode(result);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Validation
-// ---------------------------------------------------------------------------
+//
 
 /** Node-level check: does this TypeNode have a member named `head`? */
 function typeNodeHasHead(
@@ -1993,13 +1993,13 @@ export function validateShrinkCoverage(
   });
 }
 
-// ---------------------------------------------------------------------------
+//
 // Wrapping and defaults
-// ---------------------------------------------------------------------------
+//
 
-// ---------------------------------------------------------------------------
+//
 // Contract-mode capability overlay
-// ---------------------------------------------------------------------------
+//
 
 /** A serialized path key with numeric segments normalized to `*`, so an
  * element access observed at one index matches the element position. */
@@ -3370,9 +3370,9 @@ function buildDefaultsOnlyFallbackPaths(
   return uniquePaths(fallbackPaths);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Main entry point
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Shared implementation for applying capability summary shrinking and wrapping

--- a/packages/ts-transformers/test/ast/event-handlers.test.ts
+++ b/packages/ts-transformers/test/ast/event-handlers.test.ts
@@ -114,9 +114,9 @@ function findJsxAttribute(
   return found;
 }
 
-// =============================================================================
+//
 // Tests for isEventHandlerType
-// =============================================================================
+//
 
 Deno.test("isEventHandlerType - function with 0-1 params is a handler", () => {
   const { checker, sourceFile } = createJsxTestProgram(
@@ -214,9 +214,9 @@ Deno.test("isEventHandlerType - non-function type is NOT a handler", () => {
   }
 });
 
-// =============================================================================
+//
 // Tests for isEventHandlerJsxAttribute - name-based detection
-// =============================================================================
+//
 
 Deno.test("isEventHandlerJsxAttribute - onClick detected by name (without checker)", () => {
   const { sourceFile } = createJsxTestProgram(
@@ -269,9 +269,9 @@ Deno.test("isEventHandlerJsxAttribute - non-on attribute not detected (without c
   );
 });
 
-// =============================================================================
+//
 // Tests for isEventHandlerJsxAttribute - type-based detection
-// =============================================================================
+//
 
 Deno.test("isEventHandlerJsxAttribute - function prop detected by type (with checker)", () => {
   const { sourceFile, checker } = createJsxTestProgram(

--- a/packages/ts-transformers/test/ast/type-building-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/type-building-coverage.test.ts
@@ -112,7 +112,9 @@ function findPropertyAccess(
   return found;
 }
 
-// -- shouldPreserveBindingDeclaredTypeNode ---------------------------------
+//
+// shouldPreserveBindingDeclaredTypeNode
+//
 
 Deno.test("shouldPreserveBindingDeclaredTypeNode: unwraps parentheses to find a preserved Default alias", () => {
   const factory = ts.factory;
@@ -165,7 +167,9 @@ Deno.test("shouldPreserveBindingDeclaredTypeNode: a union containing a scope wra
   assertEquals(shouldPreserveBindingDeclaredTypeNode(node), true);
 });
 
-// -- reportUnknownReactiveType / describeCapture ---------------------------
+//
+// reportUnknownReactiveType / describeCapture
+//
 
 Deno.test("reportUnknownReactiveType: an unknown-typed capture with no printable text falls back to the label", () => {
   // The capture expression prints to empty text, so describeCapture returns the
@@ -222,7 +226,9 @@ Deno.test("reportUnknownReactiveType: a non-unknown capture is not reported", ()
   });
 });
 
-// -- buildCaptureTypeElements: intermediate nodes --------------------------
+//
+// buildCaptureTypeElements: intermediate nodes
+//
 
 Deno.test("buildCaptureTypeElements: an optional intermediate property is emitted with a question token", () => {
   // `config.nested.value` where `nested?: Nested` on `Config`. The intermediate

--- a/packages/ts-transformers/test/ast/type-inference-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/type-inference-coverage.test.ts
@@ -350,13 +350,15 @@ Deno.test("inferArrayElementType: a Box<Default<string[]>> unwraps the Default a
   assertEquals(elementTypeText("boxedDefaultArray"), "string");
 });
 
-// -- Synthetic composite type registration ---------------------------------
+//
+// Synthetic composite type registration
 //
 // A TypeNode built by the factory has no source position, so
 // `checker.getTypeFromTypeNode` widens it to `any`. When each leaf is
 // pre-registered with a real Type, ensureTypeNodeRegistered rebuilds the
 // composite Type from the registered children through the TypeScript-internal
 // createArrayType / getUnionType / createAnonymousType entry points.
+//
 
 function programForSynthetics(): {
   checker: ts.TypeChecker;

--- a/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
@@ -48,9 +48,9 @@ function printExpr(node: ts.Node, sourceFile: ts.SourceFile): string {
   );
 }
 
-// ---------------------------------------------------------------------------
+//
 // Constructor scanning: getCFHelpersIdentifier
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("CFHelpers detects the __cfHelpers named import from commonfabric", () => {
   const helpers = helpersFor(
@@ -122,9 +122,9 @@ Deno.test("CFHelpers ignores a bare import declaration with no import clause", (
   assertFalse(helpers.sourceHasHelpers());
 });
 
-// ---------------------------------------------------------------------------
+//
 // getHelperExpr / getHelperQualified
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("getHelperExpr throws when the source has no helpers import", () => {
   const helpers = helpersFor(`const x = 1;`);
@@ -196,9 +196,9 @@ Deno.test("getHelperQualified builds a qualified name against the helper identif
   assertEquals((qualified.left as ts.Identifier).text, CF_HELPERS_IDENTIFIER);
 });
 
-// ---------------------------------------------------------------------------
+//
 // transformCfDirective / injectCfHelpers (string passes)
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("transformCfDirective returns an all-blank source unchanged", () => {
   // With no content line, `findFirstContentLineIndex` returns null and the

--- a/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
+++ b/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
@@ -19,9 +19,9 @@ import {
   symbolDeclaresCommonFabricDefault,
 } from "../../src/core/common-fabric-symbols.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Test infrastructure
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Build a minimal TypeScript program from an in-memory file map.
@@ -117,9 +117,9 @@ function findFirstNode<T extends ts.Node>(
   return found;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Tests
-// ---------------------------------------------------------------------------
+//
 
 describe("isCommonFabricModuleName", () => {
   it("matches Common Fabric module names", () => {

--- a/packages/ts-transformers/test/fixtures/bug-repro/actual-types-repro.ts
+++ b/packages/ts-transformers/test/fixtures/bug-repro/actual-types-repro.ts
@@ -8,9 +8,9 @@
 
 import type { Reactive, OpaqueCell } from "commonfabric";
 
-// ============================================================================
+//
 // TEST CASES
-// ============================================================================
+//
 
 // Direct nullable type
 type Direct = Reactive<string | null>;
@@ -33,9 +33,9 @@ type RequiredStateRef = Reactive<Required<State>>;
 type RequiredValueProp = RequiredStateRef["value"];
 type RequiredValueInner = RequiredValueProp extends OpaqueCell<infer T> ? T : never;
 
-// ============================================================================
+//
 // EXPORTS
-// ============================================================================
+//
 export type {
   Direct, DirectInner, DirectGet,
   StateRef, ValueProp, ValueInner, ValueGet,

--- a/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
@@ -120,7 +120,7 @@ function unwrapParens(expression: ts.Expression): ts.Expression {
   return current;
 }
 
-// ===========================================================================
+//
 // closures/strategies/array-method-policy.ts:54-56
 //
 // `isReactiveFallbackLeft` recognizes a `(<reactive> ?? []).map(...)` receiver
@@ -131,7 +131,7 @@ function unwrapParens(expression: ts.Expression): ts.Expression {
 // `isReactiveValueExpression(left)` branch. The array method still does not
 // transform (a compute-context receiver is auto-unwrapped), so the decision is
 // false — but the receiver has been classified as a reactive fallback.
-// ===========================================================================
+//
 
 function fallbackMapDecision(source: string): {
   kind: string;
@@ -181,7 +181,7 @@ export default pattern<Input, Output>(({ tags }) => ({
   assertEquals(result.decision, true);
 });
 
-// ===========================================================================
+//
 // transformers/expression-site-policy.ts:1341-1343
 //
 // `findPreferredNestedLowerableExpressionSite` scans the descendants of an
@@ -190,7 +190,7 @@ export default pattern<Input, Output>(({ tags }) => ({
 // sites inside a nested closure are never chosen. An expression whose only
 // lowerable content sits inside an array-method callback therefore yields no
 // nested site.
-// ===========================================================================
+//
 
 Deno.test("expression-site-policy: the nested-site search does not descend into a nested function, so a site behind a closure boundary is not chosen", () => {
   const { program, sourceFile } = buildProgram(`/// <cts-enable />
@@ -223,14 +223,14 @@ export default pattern<Input, Output>(({ flag, items }) => ({
   assert(ts.isArrowFunction(arrow));
 });
 
-// ===========================================================================
+//
 // ast/type-inference.ts:313
 //
 // `unwrapOpaqueLikeType` guards against cyclic types with a `seen` set: when a
 // type it is already unwrapping reappears (a self-referential branded cell such
 // as `type R = OpaqueCell<R>`), it returns that type unchanged instead of
 // recursing forever.
-// ===========================================================================
+//
 
 Deno.test("type-inference: unwrapping a self-referential branded cell terminates via the seen-set guard", () => {
   const { program, sourceFile } = buildProgram(`
@@ -258,14 +258,14 @@ export const x = r;
   assertEquals(result, recursiveType);
 });
 
-// ===========================================================================
+//
 // core/common-fabric-symbols.ts:159
 //
 // `symbolDeclaresCommonFabricDefault` bails out with `false` when the symbol has
 // no declarations. A synthetic property produced by a mapped type — e.g. the
 // `x` member of `Record<"x", number>` — is exactly such a symbol: it exists on
 // the type but `getDeclarations()` returns undefined.
-// ===========================================================================
+//
 
 Deno.test("common-fabric-symbols: a synthetic mapped-type property with no declarations is not a Common Fabric Default", () => {
   const { program, sourceFile } = buildProgram(`
@@ -292,14 +292,14 @@ export const y = r;
   );
 });
 
-// ===========================================================================
+//
 // transformers/expression-rewrite/emitters/element-access-expression.ts:19
 //
 // `emitElementAccessExpression` declines (returns undefined) when the element
 // access carries no relevant reactive data flows. An index read on a plain,
 // non-reactive local array produces an empty data-flow set, so the emitter emits
 // nothing and leaves the access untouched.
-// ===========================================================================
+//
 
 Deno.test("element-access-expression: an index read with no reactive data flows is left untouched by the emitter", () => {
   const { program, sourceFile } = buildProgram(`/// <cts-enable />

--- a/packages/ts-transformers/test/opaque-roots-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-roots-coverage.test.ts
@@ -103,9 +103,9 @@ function findVariable(
   return found;
 }
 
-// ---------------------------------------------------------------------------
+//
 // classifyOpaquePathTerminalCall
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("classifyOpaquePathTerminalCall recognizes .get() and .key() property-access terminals", () => {
   const { sourceFile } = createProgram(`
@@ -170,9 +170,9 @@ Deno.test("classifyOpaquePathTerminalCall returns undefined for a bare identifie
   assertEquals(classifyOpaquePathTerminalCall(call), undefined);
 });
 
-// ---------------------------------------------------------------------------
+//
 // getOpaqueAccessInfo
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("getOpaqueAccessInfo records the root identifier and property path", () => {
   const { sourceFile, checker } = createProgram(`const a = root.foo.bar;`);
@@ -278,9 +278,9 @@ Deno.test("getOpaqueAccessInfo returns no root when the chain does not bottom ou
   assertEquals(info.path, ["foo"]);
 });
 
-// ---------------------------------------------------------------------------
+//
 // addBindingTargetSymbols
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("addBindingTargetSymbols collects a simple identifier binding symbol", () => {
   const { sourceFile, checker } = createProgram(`const single = 1;`);

--- a/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
@@ -607,7 +607,9 @@ Deno.test(
   },
 );
 
-// --- Batch 2: checker-gated and shape-specific branches ---------------------
+//
+// Batch 2: checker-gated and shape-specific branches
+//
 
 Deno.test(
   "numeric destructure key records a numeric path segment",
@@ -939,7 +941,9 @@ Deno.test(
   },
 );
 
-// --- Batch 3: assignment patterns, opaque roots, method dispatch edges ------
+//
+// Batch 3: assignment patterns, opaque roots, method dispatch edges
+//
 
 Deno.test(
   "parenthesized assignment destructure target treats the source as passthrough",
@@ -1230,7 +1234,9 @@ Deno.test(
   },
 );
 
-// --- Batch 5: shape equality, dynamic markers, identity array items ---------
+//
+// Batch 5: shape equality, dynamic markers, identity array items
+//
 
 Deno.test(
   "?? fallback between differently-shaped aliases keeps both source reads",
@@ -1384,7 +1390,9 @@ Deno.test(
   },
 );
 
-// --- Batch 7: key() wrapper unwrapping, identity-only aliased arguments ------
+//
+// Batch 7: key() wrapper unwrapping, identity-only aliased arguments
+//
 
 Deno.test(
   "key() call wrapped in parentheses then chained still defers to member access",
@@ -1419,7 +1427,9 @@ Deno.test(
   },
 );
 
-// --- Batch 8: get()-chain specific paths restored across a for-of loop ------
+//
+// Batch 8: get()-chain specific paths restored across a for-of loop
+//
 
 Deno.test(
   "get()-chain specific-path aliases survive a for-of scope and stay narrowed",

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -41,9 +41,9 @@ function allEmittedSchemaValues(root: ts.SourceFile): unknown[] {
 // deno-lint-ignore no-explicit-any
 type Obj = Record<string, any>;
 
-// ---------------------------------------------------------------------------
+//
 // pattern<Input, Output> — property type schemas
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("pattern schema encodes primitive property types and a required array", async () => {
   const source = [
@@ -167,9 +167,9 @@ Deno.test("pattern output schema encodes a VNode UI slot as a $ref", async () =>
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // handler — event/state schemas and asCell markers
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("handler<E, S> injects two schemas and marks a written Cell state field with asCell writeonly", async () => {
   const source = [
@@ -200,9 +200,9 @@ Deno.test("handler inline form injects the event schema from the annotated param
   assertEquals((event.properties as Obj).label.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift — many call-site forms
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift<T, R> injects input and result schemas from type arguments", async () => {
   const source = [
@@ -252,9 +252,9 @@ Deno.test("lift(toSchema<T>(), fn) transfers the authored input schema into the 
   assertEquals((input.properties as Obj).label.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // cell(...) factory — value inference, scope, explicit type argument
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("cell(value) infers a widened schema from the seed value and injects it as the second argument", async () => {
   const source = [
@@ -280,9 +280,9 @@ Deno.test("cell<T>() with an explicit type argument injects the T schema", async
   assertEquals((schema.properties as Obj).name.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // wish(...) — schema injected as trailing argument
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("wish<T>() injects a schema argument for the wished type", async () => {
   const source = [
@@ -295,9 +295,9 @@ Deno.test("wish<T>() injects a schema argument for the wished type", async () =>
   assertEquals((schema.properties as Obj).answer.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // generateObject — schema property injected into the options object
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("generateObject<T>({...}) injects a schema property into the existing options literal", async () => {
   const source = [
@@ -313,9 +313,9 @@ Deno.test("generateObject<T>({...}) injects a schema property into the existing 
   assertStringIncludes(output, "schema:");
 });
 
-// ---------------------------------------------------------------------------
+//
 // sqliteQuery — rowSchema injected
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("sqliteQuery<Row>({...}) injects a rowSchema property from the Row type argument", async () => {
   const source = [
@@ -332,9 +332,9 @@ Deno.test("sqliteQuery<Row>({...}) injects a rowSchema property from the Row typ
   assertStringIncludes(output, "rowSchema:");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Reactive conditionals: when / unless / ifElse prepend generated schemas
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("when(condition, value) prepends condition, value and result schemas", async () => {
   const source = [
@@ -386,9 +386,9 @@ Deno.test("ifElse(condition, ifTrue, ifFalse) prepends four schemas for its 3-ar
   assert(numSchemas >= 3, `expected >=3 number schemas, got ${numSchemas}`);
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift-applied (derive) chains: object-literal input, direct projection
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift-applied object-literal input builds a schema from composed reactive cell types", async () => {
   const source = [
@@ -441,9 +441,9 @@ Deno.test("lift-applied empty-object input lowers the no-capture placeholder to 
   assert(inputArg && inputArg.kind === ts.SyntaxKind.FalseKeyword);
 });
 
-// ---------------------------------------------------------------------------
+//
 // pattern — single type argument (result inferred), one schema argument
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("pattern<Input> with a single type argument infers the result schema from the callback", async () => {
   const source = [
@@ -483,9 +483,9 @@ Deno.test("pattern(fn, inputSchema) keeps the author input schema and appends an
   assertStringIncludes(output, '{ type: "object" } as const,');
 });
 
-// ---------------------------------------------------------------------------
+//
 // handler inline single-argument form — event/state inference
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("handler(fn) with no type args infers both event and state schemas from annotations", async () => {
   const source = [
@@ -518,9 +518,9 @@ Deno.test("handler(fn) with an underscore-prefixed unused event param yields a f
   assertEquals(values[0], false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // cell scope: call form cell.perSession(...), and PerSession contextual scope
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("new Writable.perUser(seed) reads the user scope and injects it into the schema", async () => {
   const source = [
@@ -550,9 +550,9 @@ Deno.test("new Writable.perSpace(seed) reads the space scope and injects it into
   assertEquals(schema.type, "boolean");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift result recovery: direct property / element-access projection
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift property projection recovers the result schema from the projected field type", async () => {
   const source = [
@@ -582,9 +582,9 @@ Deno.test("lift element-access projection recovers the result schema from the in
   assertEquals(result.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // pattern result diagnostics
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("pattern with an inferred any/unknown result reports pattern:any-result-schema", async () => {
   const source = [
@@ -603,9 +603,9 @@ Deno.test("pattern with an inferred any/unknown result reports pattern:any-resul
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // handler<E, S> with only one usable type argument bails out
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("handler event schema encodes an optional field as not required", async () => {
   const source = [
@@ -622,9 +622,9 @@ Deno.test("handler event schema encodes an optional field as not required", asyn
   assert(!((event.required as string[] | undefined) ?? []).includes("amount"));
 });
 
-// ---------------------------------------------------------------------------
+//
 // generateObject — options variations
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("generateObject<T>() with no options builds a fresh options object carrying the schema", async () => {
   const source = [
@@ -653,9 +653,9 @@ Deno.test("generateObject<T>(spreadOptions) spreads a non-literal options expres
   assertStringIncludes(output, "...opts");
 });
 
-// ---------------------------------------------------------------------------
+//
 // sqliteQuery — method form and no-options form
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("sqliteQuery<Row>() with no options builds a fresh options object carrying rowSchema", async () => {
   const source = [
@@ -682,9 +682,9 @@ Deno.test("untyped sqliteQuery(options) injects no rowSchema", async () => {
   assertEquals(emittedSchemas(parseModule(output)).length, 0);
 });
 
-// ---------------------------------------------------------------------------
+//
 // contextual cell scope from a Scoped<> / PerX<> annotation
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("cell(value) assigned to a PerSession<T> variable reads the session scope from the annotation", async () => {
   const source = [
@@ -721,9 +721,9 @@ Deno.test("cell(value) assigned to a PerSpace<T> variable reads the space scope 
   assertEquals(schema.scope, "space");
 });
 
-// ---------------------------------------------------------------------------
+//
 // pattern result: inferred unknown output field reports pattern-result:unknown-type
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("pattern with an inferred unknown output field reports pattern-result:unknown-type", async () => {
   const source = [
@@ -748,9 +748,9 @@ Deno.test("pattern with an inferred unknown output field reports pattern-result:
   assertStringIncludes(paths[0]!.message, "out");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift result shape: tuple, enum literal, and nested arrays
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift<T, R> encodes a tuple result as an array schema with a positional item type set", async () => {
   const source = [
@@ -788,9 +788,9 @@ Deno.test("lift<T, R> encodes a nested array-of-objects result schema", async ()
   assertEquals(((result.items as Obj).properties as Obj).id.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // cell-for scope wrapping via .asSchema(...)
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("scoped cell-for value schema carries the scope marker", async () => {
   const source = [
@@ -805,9 +805,9 @@ Deno.test("scoped cell-for value schema carries the scope marker", async () => {
   assertEquals(schema.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // new cell constructor: value inference, explicit type argument
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("new Writable(value) infers a widened schema from the seed and injects it as the second argument", async () => {
   const source = [
@@ -848,9 +848,9 @@ Deno.test("new Writable<T>() with an explicit type argument and no value injects
   assertEquals((schema.properties as Obj).n.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // contextual scope from a raw Scoped<T, scope> brand (no PerX alias)
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("cell(value) typed as raw Scoped<T, scope> reads the scope from the SCOPE_BRAND property", async () => {
   const source = [
@@ -865,9 +865,9 @@ Deno.test("cell(value) typed as raw Scoped<T, scope> reads the scope from the SC
   assertEquals(schema.scope, "session");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift<T, R>(fn)(input): type arguments on the inner lift drive both schemas
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift<T, R>(fn)(input) reads the schemas from the inner lift type arguments", async () => {
   const source = [
@@ -881,9 +881,9 @@ Deno.test("lift<T, R>(fn)(input) reads the schemas from the inner lift type argu
   assertEquals(result.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // chained lift-applied (derive) inputs: recover the upstream result type
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("chained lift-applied recovers the input schema from the upstream lift's inferred result", async () => {
   const source = [
@@ -917,9 +917,9 @@ Deno.test("chained lift-applied whose upstream is a single-field object recovers
   assertEquals(input.type, "object");
 });
 
-// ---------------------------------------------------------------------------
+//
 // scope brand recovery when the scope is a union of literal scope values
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("cell typed as Scoped<T, union-of-scopes> recovers the first concrete scope from the brand union", async () => {
   const source = [
@@ -934,10 +934,10 @@ Deno.test("cell typed as Scoped<T, union-of-scopes> recovers the first concrete 
   assertEquals(schema.scope, "user");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift factory captured in a variable, then applied — recover the result type
 // through the factory's callback
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applying a captured lift factory recovers the downstream input schema from the factory callback result", async () => {
   const source = [
@@ -955,9 +955,9 @@ Deno.test("applying a captured lift factory recovers the downstream input schema
   assertEquals(result.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // pattern result: unknown paths are walked into nested objects and arrays
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("pattern result reports a nested unknown output field with a dotted path", async () => {
   const source = [
@@ -991,10 +991,10 @@ Deno.test("pattern result reports an unknown array element with an array path su
   assertStringIncludes(d!.message, "items[]");
 });
 
-// ---------------------------------------------------------------------------
+//
 // idempotency / author-supplied skips: a builder that already carries its
 // schema is left untouched
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("new Writable(value, schema) with two arguments is left untouched", async () => {
   const source = [
@@ -1050,9 +1050,9 @@ Deno.test("untyped sqliteQuery already carrying a rowSchema is left untouched", 
   assertEquals((output.match(/rowSchema:/g) ?? []).length, 1);
 });
 
-// ---------------------------------------------------------------------------
+//
 // new scoped cell with no value: scope from accessor, value type from context
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("new Writable.perSession() with no value derives the value type from the contextual scope annotation", async () => {
   const source = [
@@ -1076,10 +1076,10 @@ Deno.test("new Writable.perSession() with no value derives the value type from t
   assertEquals((ctor!.arguments![0] as ts.Identifier).text, "undefined");
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift-applied projection recovery: property-access and element-access forms
 // on a downstream callback whose parameter type is recovered from upstream
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift-applied element-access projection recovers the result schema from the indexed field", async () => {
   const source = [
@@ -1110,9 +1110,9 @@ Deno.test("lift-applied property-access projection recovers the result schema fr
   assertEquals(result.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // handler state Cell that is read marks the schema field asCell readonly
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("handler<E, S> marks a read-only Cell state field with asCell readonly", async () => {
   const source = [
@@ -1129,11 +1129,11 @@ Deno.test("handler<E, S> marks a read-only Cell state field with asCell readonly
   assertEquals((state.properties as Obj).total.asCell, ["readonly"]);
 });
 
-// ---------------------------------------------------------------------------
+//
 // lift-applied whose untyped callback calls Cell methods on a Cell input:
 // the input schema is recovered from the cell-like fallback type and marked
 // asCell readonly
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("lift-applied untyped callback using Cell.get on a Cell input recovers a cell-like input schema", async () => {
   const source = [

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -709,9 +709,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
     },
   );
 
-  //
   // Type-arg form vs inline form: schemas must be identical
-  //
 
   await t.step(
     "handler<E, T> generates same schemas as handler((e: E, t: T) => ...)",

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -709,9 +709,9 @@ Deno.test("Schema Shrink Validation", async (t) => {
     },
   );
 
-  // =========================================================================
+  //
   // Type-arg form vs inline form: schemas must be identical
-  // =========================================================================
+  //
 
   await t.step(
     "handler<E, T> generates same schemas as handler((e: E, t: T) => ...)",

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../src/transformers/type-shrinking.ts";
 import { collect, parseModule } from "./transformed-ast.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Structural inspection of printed type nodes.
 //
 // `printTypeNode` renders a `ts.TypeNode` to text. Asserting on that text with
@@ -21,7 +21,7 @@ import { collect, parseModule } from "./transformed-ast.ts";
 // helpers reparse the printed type node and expose its members as real AST
 // nodes so tests can assert on property names, optional flags, exact member
 // types, and the shape of the root node.
-// ---------------------------------------------------------------------------
+//
 
 /** Reparse a printed type node into a `ts.TypeNode`. */
 function parseType(printed: string): ts.TypeNode {
@@ -78,9 +78,9 @@ function hasQualifiedRef(node: ts.Node, left: string, right: string): boolean {
   });
 }
 
-// ---------------------------------------------------------------------------
+//
 // Harness (mirrors test/type-shrinking.test.ts so cases stay comparable).
-// ---------------------------------------------------------------------------
+//
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -179,11 +179,11 @@ function createContext(sourceFile: ts.SourceFile): {
   return { context, diagnostics };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Array element node building via type-driven shrinking (Array<T> reference).
 // Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
 // checker, element shrunk, array node rebuilt.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed fields", () => {
   const { sourceFile, checker } = createProgram(`
@@ -217,10 +217,10 @@ Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed field
   assertEquals(members.has("id"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // length-only access on an Array<T> reference emits unknown[] (array-root only
 // path). Exercises the `allNonItem` array branch in the node-driven path.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]", () => {
   const { sourceFile, checker } = createProgram(`
@@ -245,11 +245,11 @@ Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]"
   assertEquals(printTypeNode(result, sourceFile), "unknown[]");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Union of object shapes: shrink each non-nullish member; nullish member
 // preserved. Exercises the union branch in buildShrunkTypeNodeFromTypeNode
 // (lines ~1278-1301) via a source-authored union node.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", () => {
   const { sourceFile, checker } = createProgram(`
@@ -278,11 +278,11 @@ Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", (
   assertEquals(members.has("onlyB"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Union `T | undefined` where only one member holds the accessed property.
 // After shrinking the non-nullish member, a single member remains and the
 // union collapses to that member (line ~1299-1301 `all.length === 1`).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish member", () => {
   const { sourceFile, checker } = createProgram(`
@@ -316,11 +316,11 @@ Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish
   assert(ts.isTypeLiteralNode(node));
 });
 
-// ---------------------------------------------------------------------------
+//
 // Type-driven union nullish re-wrapping (buildShrunkTypeNodeFromType, ~856-895)
 // and line 888 (`nullishMembers.length === 0` short-circuit not taken).
 // Drive with a synthetic base node to force the type-driven path.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a nullable object", () => {
   const { sourceFile, checker } = createProgram(`
@@ -355,11 +355,11 @@ Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a 
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // Nested primitive leaf on a type-driven shrink: `text.length` keeps the
 // string leaf intact instead of shrinking `text` to `{ length }`
 // (lines ~934-962 primitive-scalar branch through the type-driven path).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-driven shrinking", () => {
   const { sourceFile, checker } = createProgram(`
@@ -390,11 +390,11 @@ Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-dr
   assertEquals(members.has("other"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Index-signature access via type-driven shrinking: a numeric/string key that
 // is not a named property resolves through the index signature and the emitted
 // member is optional (lines ~913-936: `isOptional = true`, `984-989`).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap represents index-signature access as an optional member", () => {
   const { sourceFile, checker } = createProgram(`
@@ -424,11 +424,11 @@ Deno.test("applyShrinkAndWrap represents index-signature access as an optional m
   assertEquals(members.has("unused"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // isUnchangedShrink: a TypeReference whose members are all accessed with no
 // nested change is kept as the original reference to preserve $ref/$defs
 // (lines ~1453-1474 return `node`).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccessed members", () => {
   const { sourceFile, checker } = createProgram(`
@@ -458,12 +458,12 @@ Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccess
   assertEquals(members.has("z"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Interface heritage merge: an interface extending a base contributes inherited
 // members that are merged and de-duplicated (mergeResolvedMembers, ~1416-1442;
 // resolveMembersFromDeclaration heritage branch ~1388-1414). An overriding
 // property in the derived interface wins.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap merges inherited interface members and honors overrides", () => {
   const { sourceFile, checker } = createProgram(`
@@ -492,11 +492,11 @@ Deno.test("applyShrinkAndWrap merges inherited interface members and honors over
   assertEquals(members.has("shared"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Diagnostics: unknown base type with property access reports
 // schema:unknown-type-access (lines ~1876-1893). Driven through
 // applyShrinkAndWrap with a context + fnNode so validateShrinkCoverage runs.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with reads", () => {
   const { sourceFile, checker } = createProgram(`
@@ -530,10 +530,10 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with 
   assertStringIncludes(diagnostics[0]!.message, "'.missing'");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Diagnostics: concrete type but an accessed path is absent reports
 // schema:path-not-in-type (lines ~1938-1954, and the missing filter 1939-1941).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", () => {
   const { sourceFile, checker } = createProgram(`
@@ -566,10 +566,10 @@ Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", 
   assertEquals(diagnostics[0]!.message.includes("'.present'"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Diagnostics: concrete type with a property typed `unknown` reports
 // schema:unknown-type-access (case 2, lines ~1900-1935).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
   const { sourceFile, checker } = createProgram(`
@@ -602,10 +602,10 @@ Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
   assertStringIncludes(diagnostics[0]!.message, "typed as 'unknown'");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Diagnostics: `never` base type skips validation entirely (lines ~1857-1862).
 // A `never`-typed parameter with reads must produce no diagnostics.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
   const { sourceFile, checker } = createProgram(`
@@ -634,10 +634,10 @@ Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
   assertEquals(diagnostics.length, 0);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Diagnostics: wildcard param typed `unknown` passed to an opaque function
 // reports the wildcard-specific unknown-type-access branch (lines ~1733-1750).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcard param", () => {
   const { sourceFile, checker } = createProgram(`
@@ -669,11 +669,11 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcar
   assertStringIncludes(diagnostics[0]!.message, "logged");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Validation over an array base: item-level paths validate against the element
 // type. A missing item property reports through the array-element recursion
 // (lines ~1795-1833, getArrayElementTypeNode paths ~1656-1709).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap validates array item paths against the element type", () => {
   const { sourceFile, checker } = createProgram(`
@@ -706,12 +706,12 @@ Deno.test("applyShrinkAndWrap validates array item paths against the element typ
   assertStringIncludes(diagnostics[0]!.message, "'.missing'");
 });
 
-// ---------------------------------------------------------------------------
+//
 // defaults_only mode: a default nested under a path present in the base type
 // gets applied to the fallback shape when the direct node application misses.
 // Also exercises applyCapabilityDefaultsToTypeNode fallback (~2919-2945) and
 // buildDefaultsOnlyFallbackPaths leaf expansion (~2954-2956, 3001-3026).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base type shape", () => {
   const { sourceFile, checker } = createProgram(`
@@ -744,10 +744,10 @@ Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base typ
   assertEquals(members.get("count")?.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // applyCapabilityDefaultsToTypeNode: default applied directly through a tuple
 // index (applySingleDefaultToTypeNode tuple branch ~2825-2850).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple index", () => {
   const { sourceFile, checker } = createProgram(`
@@ -777,10 +777,10 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple i
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // applyCapabilityDefaultsToTypeNode: out-of-range tuple index leaves the node
 // unchanged (tuple guard ~2827-2831). No __cfHelpers.Default wrapper appears.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index", () => {
   const { sourceFile, checker } = createProgram(`
@@ -806,11 +806,11 @@ Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index
   assertEquals(hasQualifiedRef(node, "__cfHelpers", "Default"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Identity-only root on a union base: each union member is replaced with the
 // identity-only shape; nullish members are rebuilt as-is
 // (createIdentityOnlyRootTypeNode union branch ~2367-2400).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", () => {
   const { sourceFile, checker } = createProgram(`
@@ -846,10 +846,10 @@ Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", ()
   assertEquals(members.has("b"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Identity-only root that is nullish (`undefined`): rebuilt via
 // createIdentityOnlyNullishTypeNode (lines ~2357-2365, 2311-2331).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefined", () => {
   const { sourceFile, checker } = createProgram(`
@@ -874,11 +874,11 @@ Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefine
   assertEquals(printTypeNode(result, sourceFile), "undefined");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Identity paths descending through an array item interface reference resolved
 // via the checker (applyIdentityOnlyPathsToTypeNode Array<T> ref branch
 // ~2557-2583) using an Array<T> reference (not `T[]`).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> references", () => {
   const { sourceFile, checker } = createProgram(`
@@ -909,11 +909,11 @@ Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> refe
   assertEquals(members.get("drop")?.type, "number");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Identity paths through a union base node (applyIdentityOnlyPathsToTypeNode
 // union branch ~2728-2752): each union member is visited and changed members
 // force a rebuilt union.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap applies identity paths across union members", () => {
   const { sourceFile, checker } = createProgram(`
@@ -948,13 +948,13 @@ Deno.test("applyShrinkAndWrap applies identity paths across union members", () =
   assertEquals(members.get("other")?.type, "boolean");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Identity paths through a named interface reference that resolves to declared
 // members, where a nested member is left unchanged (no matching child path) so
 // the `!changed` early return keeps the reference
 // (applyIdentityOnlyPathsToTypeNode reference branch ~2669-2725, unchanged
 // return ~2721-2723).
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path matches", () => {
   const { sourceFile, checker } = createProgram(`
@@ -982,11 +982,11 @@ Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path
   assertEquals(printTypeNode(result, sourceFile), "Outer");
 });
 
-// ---------------------------------------------------------------------------
+//
 // applyCellCapabilityPathsToTypeNode through a parenthesized type node
 // (~2181-2193) plus per-property cell capability selection where read+write
 // paths on the same leaf select `writable`.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized literals", () => {
   const { sourceFile, checker } = createProgram(`
@@ -1017,10 +1017,10 @@ Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized li
   assertEquals(members.get("value")?.type, "__cfHelpers.ReadonlyCell<number>");
 });
 
-// ---------------------------------------------------------------------------
+//
 // Batch 2: "unchanged / no-match" arms of each identity-path node shape, plus
 // remaining array-element and default clusters.
-// ---------------------------------------------------------------------------
+//
 
 // Identity item path on an Array<T> reference that names no member leaves the
 // whole array reference unchanged (Array<T> ref `updated === inner` ~2574-2576).
@@ -1390,9 +1390,9 @@ Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cel
   assertEquals(members.has("untouched"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // Batch 3: array-union validation and remaining union collapse / defensive arms.
-// ---------------------------------------------------------------------------
+//
 
 // Validation over a `Row[] | undefined` base with a valid item field reports no
 // diagnostic, exercising getArrayElementTypeNode's union branch (~1643-1657):

--- a/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
@@ -18,10 +18,10 @@ import { collect, parseModule } from "./transformed-ast.ts";
 // tests below drive them directly through the exported shrinking entry points so
 // they are recorded every run.
 
-// ---------------------------------------------------------------------------
+//
 // Structural inspection of printed type nodes (mirrors
 // type-shrinking-coverage.test.ts).
-// ---------------------------------------------------------------------------
+//
 
 /** Reparse a printed type node into a `ts.TypeNode`. */
 function parseType(printed: string): ts.TypeNode {
@@ -63,9 +63,9 @@ function shrunkProps(result: ts.TypeNode, sourceFile: ts.SourceFile): {
   return { node, props: props(node) };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Harness (mirrors type-shrinking-coverage.test.ts so cases stay comparable).
-// ---------------------------------------------------------------------------
+//
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -164,13 +164,13 @@ function createContext(sourceFile: ts.SourceFile): {
   return { context, diagnostics };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Type-driven shrink descending into an `unknown`/`any` property drops that
 // property rather than widening it (buildShrunkTypeNodeFromType
 // `!hasDirectAccess && isAnyOrUnknownType(propType)` continue, lines 964-967).
 // A synthetic base node forces the type-driven path; a deep path into an
 // `unknown`-typed member reaches the guard.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("applyShrinkAndWrap drops a deep read into an unknown-typed property under type-driven shrinking", () => {
   const { sourceFile, checker } = createProgram(`
@@ -202,13 +202,13 @@ Deno.test("applyShrinkAndWrap drops a deep read into an unknown-typed property u
   assertEquals(members.get("kept")?.type, "string");
 });
 
-// ---------------------------------------------------------------------------
+//
 // getArrayElementTypeNode fallback: a base node that is a plain type-alias
 // reference (not `T[]`, `Array<T>`, readonly array, union, or type literal)
 // resolves to an array only through the checker, so the element node is built
 // from the resolved element type (lines 1685-1688, 1694, 1699-1709). Validating
 // an item path on such a base runs the fallback and finds the item field.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("validateShrinkCoverage resolves array element node from an array type-alias reference", () => {
   const { sourceFile, checker } = createProgram(`
@@ -247,13 +247,13 @@ Deno.test("validateShrinkCoverage resolves array element node from an array type
   assertEquals(diagnostics[0]!.message.includes("'.id'"), false);
 });
 
-// ---------------------------------------------------------------------------
+//
 // validateShrinkCoverage over an array base where the shrunk node is NOT
 // array-shaped: array-root paths (`length`) survive and re-drive validation
 // against the array base (line 1832-1833 `paths = arrayRootPaths`), and the
 // array-root head is checked via typeNodeHasHead's array-shape arm (line 1545).
 // A bogus non-array head keeps the top-1763 fast path from firing.
-// ---------------------------------------------------------------------------
+//
 
 Deno.test("validateShrinkCoverage validates array-root paths against the array base when the shrunk node is not array-shaped", () => {
   const { sourceFile, checker } = createProgram(`

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../src/transformers/type-shrinking.ts";
 import { collect, parseModule } from "./transformed-ast.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Structural inspection of printed type nodes.
 //
 // `printTypeNode` renders a `ts.TypeNode` to text. Asserting on that text with
@@ -24,7 +24,7 @@ import { collect, parseModule } from "./transformed-ast.ts";
 // helpers reparse the printed type node and expose its members as real AST
 // nodes so tests can assert on property names, optional flags, exact member
 // types, and the shape of the root node.
-// ---------------------------------------------------------------------------
+//
 
 /** Reparse a printed type node into a `ts.TypeNode`. */
 function parseType(printed: string): ts.TypeNode {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 103 section markers in `packages/ts-transformers` to the
`//`-delimited form. They were written as a `===` rule above and below the
title, as a dash rule above it, and as `// ===== Title =====`. Nearly all are in
the test suites, titling the phases of a coverage scenario.

## The fixture goldens

This package compares `*.input.tsx` against `*.expected.jsx` — 380 golden files,
and they do carry comments through from their inputs. A comment sweep across
fixtures would therefore be a golden-breaking change, so the question is which
fixtures this touches.

Exactly one: `test/fixtures/bug-repro/actual-types-repro.ts`. It has no
`.expected` pair, and nothing reads it but its sibling `verify-actual.ts`, which
type-checks it through the TypeScript API where comments do not signify. The
package's own suite — 1160 tests, 868 steps, 404 fixture assertions — passes.

Worth stating plainly because I got this wrong earlier in the sweep: I had
reported that this package has no golden machinery. It has 380 goldens. The
check that produced that answer globbed only the top level of `test/fixtures/`,
and the goldens live one directory further down, in `test/fixtures/<suite>/`.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and every long rule run removed had text on one side only — a rule
brackets a title, an operator sits inside one.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/ts-transformers`'s own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

