### PR TITLE
Conform the section markers in `cli`

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -273,10 +273,12 @@ function fmtSession(s: string): string {
   return decoded.length > 22 ? `${decoded.slice(0, 21)}…` : decoded;
 }
 
-// ── Remote acquisition (`cf inspect --remote`) ──────────────────────────────
+//
+// Remote acquisition (`cf inspect --remote`)
 // The autopsy stays 100% offline; --remote only changes where the SQLite file
 // comes from: instead of the local on-disk store, fetch a read-only snapshot
 // from a toolshed dump endpoint into the local cache, then open it as usual.
+//
 
 interface RemoteOpts {
   remote?: string | boolean;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -437,9 +437,9 @@ export interface TestRunnerOptions {
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Verbose-mode logger stats helpers
-// ---------------------------------------------------------------------------
+//
 
 type GlobalWithLoggers = {
   commonfabric?: {

--- a/packages/cli/lib/view/actions.ts
+++ b/packages/cli/lib/view/actions.ts
@@ -131,7 +131,8 @@ export function nextMatchIndex(
   return matches.length - 1; // wrap
 }
 
-// --- Structure-tree navigation (over the flattened pre-order list) -----------
+//
+// Structure-tree navigation (over the flattened pre-order list)
 //
 // WASD walk the AST outline by family relationship:
 //   w -> previous sibling   s -> next sibling   a -> parent   d -> first child
@@ -140,6 +141,7 @@ export function nextMatchIndex(
 // so it never gets stuck. At the first sibling, `w` steps up to the parent node
 // itself. Tab/Shift-Tab navigate the same nodes by depth-first (pre-order)
 // traversal instead, descending into children.
+//
 
 /**
  * Next sibling at the same depth; if none, exit the parent and take the

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -85,7 +85,9 @@ export function visibleWidth(text: string): number {
   return cpLen(stripAnsi(text));
 }
 
-// --- Terminal control --------------------------------------------------------
+//
+// Terminal control
+//
 
 export const term = {
   enterAltScreen: `${CSI}?1049h`,

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -195,7 +195,9 @@ function cardTitle(node: StructureNode): string {
   return `${node.kind}  ${node.label}`;
 }
 
-// --- sections ----------------------------------------------------------------
+//
+// sections
+//
 
 function metaLine(node: StructureNode): Line {
   const span = node.endLine - node.startLine + 1;
@@ -808,13 +810,17 @@ function enclosingNode(
   return best;
 }
 
-// --- schema rendering --------------------------------------------------------
+//
+// schema rendering
+//
 
-// --- schema → TypeScript-like type rendering --------------------------------
+//
+// schema → TypeScript-like type rendering
 //
 // Schemas are shown as a type signature (`{ token: string }`, `string[]`,
 // nested objects) rather than the underlying JSON-schema shape. Optional fields
 // (not in `required`) get a `?`. Rendered inline when it fits, else multi-line.
+//
 
 const INLINE_MAX = 56;
 
@@ -907,7 +913,9 @@ function pad(indent: number): string {
   return "  ".repeat(indent);
 }
 
-// --- line/span helpers -------------------------------------------------------
+//
+// line/span helpers
+//
 
 type Part = readonly [string, TokenClass];
 

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -908,7 +908,9 @@ export function buildDiffDocument(
       mappings.set(absPath, mapping);
     }
 
-    // --- file header lines -------------------------------------------------
+    //
+    // file header lines
+    //
     for (let i = file.headerLine; i <= file.endLine; i++) {
       const kind = model.lines[i]?.kind;
       if (kind !== "meta") continue;
@@ -948,7 +950,9 @@ export function buildDiffDocument(
       }));
     }
 
-    // --- the file's section node -------------------------------------------
+    //
+    // the file's section node
+    //
     const label = file.newPath ?? file.oldPath ?? "(unknown file)";
     const start = diffLineStarts[file.headerLine];
     const end = lineEndOffset(diffLineStarts, text, file.endLine);
@@ -1008,7 +1012,9 @@ function buildEdit(
   return { sourceText, lines, fileText, oldFileLines, hunks };
 }
 
-// --- hunk rendering + structure ------------------------------------------------
+//
+// hunk rendering + structure
+//
 
 interface MutableLine {
   text: string;
@@ -1282,13 +1288,15 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     restoreLossyRenderedChanges(hunk, ctx, sourceFallbacks);
   }
 
-  // --- structure ---------------------------------------------------------
+  //
+  // structure
   // Verified hunks remap the workspace file's own nodes (precise ranges, live
   // semantics). Unverified hunks — drifted workspace, missing file — still get
   // navigable structure from the fragment parse of their new side: the nodes
   // come from the diff text itself, so navigation always works; only the
   // semantic extras (types, definitions) stay silent there. Either way the
   // new-side language projects its own structure into the hunk's coordinates.
+  //
   const children: StructureNode[] = [];
   let source:
     | {
@@ -1550,7 +1558,9 @@ function shiftFragmentSpans(
   ]);
 }
 
-// --- offset maps for semantics ----------------------------------------------
+//
+// offset maps for semantics
+//
 
 function buildMaps(
   diffLineStarts: number[],
@@ -1598,7 +1608,9 @@ function buildMaps(
   };
 }
 
-// --- small helpers -----------------------------------------------------------
+//
+// small helpers
+//
 
 function lineEndOffset(
   lineStarts: number[],

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -908,9 +908,7 @@ export function buildDiffDocument(
       mappings.set(absPath, mapping);
     }
 
-    //
     // file header lines
-    //
     for (let i = file.headerLine; i <= file.endLine; i++) {
       const kind = model.lines[i]?.kind;
       if (kind !== "meta") continue;
@@ -950,9 +948,7 @@ export function buildDiffDocument(
       }));
     }
 
-    //
     // the file's section node
-    //
     const label = file.newPath ?? file.oldPath ?? "(unknown file)";
     const start = diffLineStarts[file.headerLine];
     const end = lineEndOffset(diffLineStarts, text, file.endLine);
@@ -1288,7 +1284,6 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
     restoreLossyRenderedChanges(hunk, ctx, sourceFallbacks);
   }
 
-  //
   // structure
   // Verified hunks remap the workspace file's own nodes (precise ranges, live
   // semantics). Unverified hunks — drifted workspace, missing file — still get
@@ -1296,7 +1291,6 @@ function buildHunk(hunk: DiffHunk, ctx: HunkCtx): StructureNode {
   // come from the diff text itself, so navigation always works; only the
   // semantic extras (types, definitions) stay silent there. Either way the
   // new-side language projects its own structure into the hunk's coordinates.
-  //
   const children: StructureNode[] = [];
   let source:
     | {

--- a/packages/cli/lib/view/display.ts
+++ b/packages/cli/lib/view/display.ts
@@ -255,7 +255,9 @@ function displayHidden(src: readonly SourcePoint[]): DisplayCell[] {
   return cells;
 }
 
-// --- non-printable classification & glyphs -----------------------------------
+//
+// non-printable classification & glyphs
+//
 
 /** A control code (C0 or DEL/C1) with no ordinary glyph of its own. */
 function isNonPrintable(cp: string): boolean {
@@ -285,7 +287,9 @@ export function glyphFor(cp: string): string {
   return "␦";
 }
 
-// --- ANSI (CSI) recognition --------------------------------------------------
+//
+// ANSI (CSI) recognition
+//
 
 interface CsiMatch {
   /** Number of source code points the whole sequence spans. */

--- a/packages/cli/lib/view/editbuffer.ts
+++ b/packages/cli/lib/view/editbuffer.ts
@@ -60,7 +60,9 @@ export class EditBuffer {
     this.lineEndings = this.lines.map((_, index) => lineEndings[index]);
   }
 
-  // --- state ----------------------------------------------------------------
+  //
+  // state
+  //
 
   text(): string {
     return this.lines.join("\n");
@@ -196,7 +198,9 @@ export class EditBuffer {
     this.lastYank = null;
   }
 
-  // --- cursor motion --------------------------------------------------------
+  //
+  // cursor motion
+  //
 
   moveLeft(): void {
     this.resetGoal();
@@ -302,7 +306,9 @@ export class EditBuffer {
     this.mark = { row: this.row, col: this.col };
   }
 
-  // --- insertion ------------------------------------------------------------
+  //
+  // insertion
+  //
 
   insert(s: string): void {
     this.resetGoal();
@@ -349,7 +355,9 @@ export class EditBuffer {
     this.col = 0;
   }
 
-  // --- deletion -------------------------------------------------------------
+  //
+  // deletion
+  //
 
   deleteBackward(previousEndColumn?: number): void { // Backspace
     this.resetGoal();
@@ -395,7 +403,9 @@ export class EditBuffer {
     }
   }
 
-  // --- kill / yank ----------------------------------------------------------
+  //
+  // kill / yank
+  //
 
   /** C-k: kill to end of line; at end of line, kill the newline (join next).
    * `endColumn` can keep source-owned transport after the editable text. */
@@ -534,7 +544,9 @@ export class EditBuffer {
     this.lastYank = null;
   }
 
-  // --- case operations (operate over the next word, advancing point) --------
+  //
+  // case operations (operate over the next word, advancing point)
+  //
 
   lowercaseWord(): void { // M-l
     this.transformWord((s) => s.toLowerCase());
@@ -571,7 +583,9 @@ export class EditBuffer {
     this.col = this.col + replaced.length;
   }
 
-  // --- helpers --------------------------------------------------------------
+  //
+  // helpers
+  //
 
   /** Cut text between two ordered points and return it; cursor left at a-side
    * is the caller's responsibility. */

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -129,7 +129,9 @@ function cpCount(s: string): number {
   return n;
 }
 
-// --- the collapsed line list ------------------------------------------------
+//
+// the collapsed line list
+//
 
 /**
  * Maps between the full document's lines and the collapsed display: a collapsed
@@ -211,7 +213,9 @@ function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n));
 }
 
-// --- file-category detection ------------------------------------------------
+//
+// file-category detection
+//
 
 /** Whether a path selects the pager's Markdown language. */
 export function isMarkdownPath(path: string): boolean {

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -308,7 +308,9 @@ export function jsonLinesDocument(text: string): Document {
   };
 }
 
-// --- structure ---------------------------------------------------------------
+//
+// structure
+//
 
 /** The significant tokens (no whitespace, no comments), which the structure
  * pass walks as a recursive-descent value grammar. */

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -374,7 +374,9 @@ export function readOnlyReasonFor(language: Language): string | undefined {
   return language.input.readOnlyReason;
 }
 
-// --- selection ---------------------------------------------------------------
+//
+// selection
+//
 
 /**
  * Every language the pager knows, most specific first, built on first use.

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -799,7 +799,9 @@ function lineEq(a: Line, b: Line): boolean {
   return true;
 }
 
-// --- Tokenisation ------------------------------------------------------------
+//
+// Tokenisation
+//
 
 function collectLeafTokens(sf: ts.SourceFile): RawToken[] {
   const tokens: RawToken[] = [];
@@ -1176,7 +1178,9 @@ function isFunctionLike(node: ts.Node): boolean {
     ts.isSetAccessorDeclaration(node);
 }
 
-// --- Structure tree ----------------------------------------------------------
+//
+// Structure tree
+//
 
 interface BuildCtx {
   sf: ts.SourceFile;
@@ -1918,7 +1922,9 @@ function calleeName(call: ts.CallExpression, sf: ts.SourceFile): string {
   return nodeFirstLine(e, sf, 16);
 }
 
-// --- Metadata extraction (best-effort; never throws) -------------------------
+//
+// Metadata extraction (best-effort; never throws)
+//
 
 type FnLike =
   | ts.ArrowFunction
@@ -2411,7 +2417,9 @@ function nodeFirstLine(node: ts.Node, sf: ts.SourceFile, max: number): string {
   return firstLine(text.slice(start, stop), max);
 }
 
-// --- Sections ----------------------------------------------------------------
+//
+// Sections
+//
 
 interface SectionMark {
   name: string;
@@ -2472,7 +2480,9 @@ function attachSections(
   return sectionNodes;
 }
 
-// --- Lines -------------------------------------------------------------------
+//
+// Lines
+//
 
 function spansToLines(
   text: string,

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -379,7 +379,9 @@ function lineAndPreview(
   };
 }
 
-// --- section splitting -------------------------------------------------------
+//
+// section splitting
+//
 
 const HEADER = /^\/\/\s*transformed:\s*(.*)$/;
 
@@ -429,7 +431,9 @@ function uniqueName(
     : `${name}.${dupesBefore}.ts`;
 }
 
-// --- compiler host -----------------------------------------------------------
+//
+// compiler host
+//
 
 function makeHost(
   sections: SectionFile[],
@@ -558,7 +562,9 @@ function extensionOf(path: string): ts.Extension {
   return ts.Extension.Ts;
 }
 
-// --- import map + libs -------------------------------------------------------
+//
+// import map + libs
+//
 
 /**
  * Map a specifier to a real local file via the import map. Values in `importMap`
@@ -681,7 +687,9 @@ function defaultLibDir(): string {
   return dirname(fromFileUrl(import.meta.resolve("typescript")));
 }
 
-// --- ast helpers -------------------------------------------------------------
+//
+// ast helpers
+//
 
 /** The deepest node whose range contains `pos`. */
 function nodeAt(sf: ts.SourceFile, pos: number): ts.Node | undefined {

--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -23,9 +23,11 @@ export const BUILDER_NAMES: ReadonlySet<string> =
 /** Reactive call helpers, e.g. `ifElse`, `when`, `cell`, `wish`. */
 export const CALL_NAMES: ReadonlySet<string> = COMMONFABRIC_CALL_EXPORT_NAMES;
 
-// --- Synthetic identifiers emitted by ts-transformers ------------------------
+//
+// Synthetic identifiers emitted by ts-transformers
 // Mirrors of constants in `packages/ts-transformers/src`. Kept as literals so
 // the pager does not import the transformer's analysis graph. See vocab.test.ts.
+//
 
 /** `packages/ts-transformers/src/core/cf-helpers.ts` `CF_HELPERS_IDENTIFIER`. */
 export const CF_HELPERS_IDENTIFIER = "__cfHelpers";

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -1218,7 +1218,9 @@ function lineInfo(
   return `${first}-${last}/${total}  ${where}`;
 }
 
-// --- Overlay (info card / definition peek) ----------------------------------
+//
+// Overlay (info card / definition peek)
+//
 
 export interface OverlayBox {
   x: number;
@@ -1351,7 +1353,9 @@ function darkenSpan(
   rows[r] = overlayRow(rows[r], from, paint(chars, ui.overlayShadow));
 }
 
-// --- Modal dialog (save / revert / amend prompt) ----------------------------
+//
+// Modal dialog (save / revert / amend prompt)
+//
 
 /** Blank columns between adjacent buttons in a dialog's button row. */
 const BUTTON_GAP = 3;
@@ -1579,7 +1583,9 @@ function overlayRow(base: string, x: number, insert: string): string {
   return left + RESET + insert + RESET + right;
 }
 
-// --- Cell / style helpers ----------------------------------------------------
+//
+// Cell / style helpers
+//
 
 function cellsToAnsi(cells: Cell[], color: boolean): string {
   if (!color) return cells.map((c) => c.ch).join("");
@@ -1653,7 +1659,9 @@ function kindGlyph(kind: string): string {
   }
 }
 
-// --- Visible-width string ops (ANSI-aware) -----------------------------------
+//
+// Visible-width string ops (ANSI-aware)
+//
 
 // deno-lint-ignore no-control-regex
 const ANSI = /\x1b\[[0-9;?]*[A-Za-z]/g;

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -464,7 +464,9 @@ export class Session {
     }
   }
 
-  // --- file folding ----------------------------------------------------------
+  //
+  // file folding
+  //
 
   /** The diff's files (with collapsed summaries), or [] for a non-diff view.
    * Cached against the current document. */
@@ -1140,7 +1142,9 @@ export class Session {
     this.handleNormalKey(key);
   }
 
-  // --- internals -------------------------------------------------------------
+  //
+  // internals
+  //
 
   private contentRows(): number {
     return Math.max(1, this.height - 1);
@@ -2021,7 +2025,9 @@ export class Session {
     this.message = `Line wrapping: ${this.wrapMode}`;
   }
 
-  // --- file-fold commands ----------------------------------------------------
+  //
+  // file-fold commands
+  //
 
   private ensureDiffForFolding(): boolean {
     if (this.foldFiles().length === 0) {
@@ -2159,7 +2165,9 @@ export class Session {
     }.`;
   }
 
-  // --- editing ---------------------------------------------------------------
+  //
+  // editing
+  //
 
   private scrollOrPan(name: string): void {
     const lastTop = this.lastTop();
@@ -4208,7 +4216,9 @@ export class Session {
     return { blocked: edge.room.atFileBottom ? "bottom" : "hunk" };
   }
 
-  // --- file picker (C-x C-f) -------------------------------------------------
+  //
+  // file picker (C-x C-f)
+  //
 
   private openFilePicker(): void {
     if (!this.files) {
@@ -4425,7 +4435,9 @@ export class Session {
     };
   }
 
-  // --- jump list (i) ---------------------------------------------------------
+  //
+  // jump list (i)
+  //
 
   /** Open the list of the diff's files and commit messages, so Enter jumps the
    * view to the one chosen. Only a diff has this list; a plain source view says

--- a/packages/cli/test/view-card-cov.test.ts
+++ b/packages/cli/test/view-card-cov.test.ts
@@ -20,7 +20,9 @@ function findByLabel(doc: Document, label: string): StructureNode {
   return node!;
 }
 
-// --- card title + "merges" line for merged generic AST nodes -----------------
+//
+// card title + "merges" line for merged generic AST nodes
+//
 
 Deno.test("card: a merged generic node names every AST kind it merges", () => {
   // In `a as B`, the type annotation `B` is a TypeReference whose sole child is
@@ -89,7 +91,9 @@ Deno.test("card: a node with no AST kinds falls back to its structure kind", () 
   assertEquals(card.title, "node  mystery");
 });
 
-// --- detail sections by meta kind --------------------------------------------
+//
+// detail sections by meta kind
+//
 
 Deno.test("card: a schema node renders its labeled type", () => {
   const doc = parseDocument(`// transformed: /app.ts
@@ -201,7 +205,9 @@ const __cfLift_1 = lift({ type: "object" } as const satisfies __cfHelpers.JSONSc
   assert(text.includes("calls") && text.includes("computed"), text);
 });
 
-// --- outline overflow + glyphs -----------------------------------------------
+//
+// outline overflow + glyphs
+//
 
 Deno.test("card: an outline past the cap shows a trailing 'N more' line", () => {
   let src = "// transformed: /app.ts\n";
@@ -351,7 +357,9 @@ Deno.test("card: the outline glyphs cover pattern/builder/closure/schema/type/im
   assert(text.includes("⏎"), "return glyph");
 });
 
-// --- uses overflow -----------------------------------------------------------
+//
+// uses overflow
+//
 
 Deno.test("card: more than ten uses fold into a 'N more' line", () => {
   let src = "// transformed: /app.ts\nconst target = 1;\n";
@@ -365,7 +373,9 @@ Deno.test("card: more than ten uses fold into a 'N more' line", () => {
   assert(text.includes("3 more"), `uses overflow line: ${text}`);
 });
 
-// --- deps overflow -----------------------------------------------------------
+//
+// deps overflow
+//
 
 Deno.test("card: more than ten dependencies fold into a 'N more' line", () => {
   let src = "// transformed: /app.ts\n";
@@ -380,7 +390,9 @@ Deno.test("card: more than ten dependencies fold into a 'N more' line", () => {
   assert(text.includes("2 more"), `deps overflow line: ${text}`);
 });
 
-// --- dependency jump through the semantic service ----------------------------
+//
+// dependency jump through the semantic service
+//
 
 /** A fake semantic service whose `definitionOf` ignores the query offset and
  * returns a fixed result, so a card can be driven down a chosen resolution
@@ -604,7 +616,9 @@ function consumer() {
   assertEquals(dep!.defEndOffset, undefined);
 });
 
-// --- external ("defined elsewhere") section ----------------------------------
+//
+// external ("defined elsewhere") section
+//
 
 Deno.test("card: symbols resolving to a file land in 'defined elsewhere'", () => {
   const doc = parseDocument(`// transformed: /app.ts
@@ -659,7 +673,9 @@ Deno.test("card: more than eight external symbols fold into a 'N more' line", ()
   assert(text.includes("3 more"), `external overflow line: ${text}`);
 });
 
-// --- schema rendering: scalar root + deeply nested multiline -----------------
+//
+// schema rendering: scalar root + deeply nested multiline
+//
 
 /** Build a one-line `Line` of identifier spans for a synthetic document. */
 function identLine(text: string): Line {

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -54,7 +54,9 @@ function runGit(root: string, args: string[]): string {
   return new TextDecoder().decode(output.stdout);
 }
 
-// --- fixtures ---------------------------------------------------------------
+//
+// fixtures
+//
 
 const FILE_TEXT = `export function double(n: number): number {
     return n * 2;
@@ -135,7 +137,9 @@ function tempWorkspace(): {
 
 const NO_WS: DiffWorkspace = { resolve: () => null, read: () => null };
 
-// --- detection ----------------------------------------------------------------
+//
+// detection
+//
 
 Deno.test("diff: detection accepts git and plain unified diffs, rejects code", () => {
   assert(looksLikeDiff(DIFF), "git diff detected");
@@ -194,7 +198,9 @@ rename to new.ts
   assert(looksLikeDiff(rename), "a metadata-only git diff is detected");
 });
 
-// --- parsing -------------------------------------------------------------------
+//
+// parsing
+//
 
 Deno.test("diff: parses files, hunks and per-line old/new numbering", () => {
   const model = parseDiff(DIFF)!;
@@ -269,7 +275,9 @@ new file mode 100644
   assertEquals(model.files[1].hunks.length, 0);
 });
 
-// --- document -------------------------------------------------------------------
+//
+// document
+//
 
 Deno.test("diff doc: verbatim text, tints, markers and syntax color", () => {
   const { ws, done } = tempWorkspace();
@@ -736,7 +744,9 @@ function a() {
   }
 });
 
-// --- semantics ------------------------------------------------------------------
+//
+// semantics
+//
 
 Deno.test("diff semantics: types and definitions answer against the workspace", () => {
   const { root, ws, done } = tempWorkspace();
@@ -803,7 +813,9 @@ Deno.test("diff semantics: a definition outside the diff opens as a file", () =>
   }
 });
 
-// --- rendering ------------------------------------------------------------------
+//
+// rendering
+//
 
 Deno.test("diff render: added lines carry the add tint under the syntax color", () => {
   const { ws, done } = tempWorkspace();
@@ -842,7 +854,9 @@ Deno.test("diff render: added lines carry the add tint under the syntax color", 
   }
 });
 
-// --- review fixes -----------------------------------------------------------
+//
+// review fixes
+//
 
 Deno.test("diff doc: a hunk interior to nested code hoists the inner nodes", () => {
   // Both `outer` and `middle` clamp to the same visible range; the fold must
@@ -1537,7 +1551,9 @@ ${removed}
   assert(!text.includes("remaining uses"), `nothing live is deferred: ${text}`);
 });
 
-// --- object-literal properties are navigable in a diff hunk ------------------
+//
+// object-literal properties are navigable in a diff hunk
+//
 
 Deno.test("diff structure: an object literal's properties are each navigable", () => {
   const root = Deno.makeTempDirSync();

--- a/packages/cli/test/view-diffdoc-cov.test.ts
+++ b/packages/cli/test/view-diffdoc-cov.test.ts
@@ -28,7 +28,9 @@ function stubWs(root: string): DiffWorkspace {
 
 const NO_WS: DiffWorkspace = { resolve: () => null, read: () => null };
 
-// --- realWorkspace: read() error branch -------------------------------------
+//
+// realWorkspace: read() error branch
+//
 
 Deno.test("realWorkspace: read of a bounded directory returns null (catch branch)", () => {
   const root = Deno.makeTempDirSync();
@@ -197,7 +199,9 @@ Deno.test("realWorkspace: resolve of a bounded directory falls through to null",
   }
 });
 
-// --- findRepoRoot: no .git ancestor walks to the filesystem root ------------
+//
+// findRepoRoot: no .git ancestor walks to the filesystem root
+//
 
 Deno.test("realWorkspace: a cwd with no .git ancestor leaves only the cwd base", () => {
   // A temp dir with no `.git` anywhere up to `/` exercises the walk that ends
@@ -216,7 +220,9 @@ Deno.test("realWorkspace: a cwd with no .git ancestor leaves only the cwd base",
   }
 });
 
-// --- loadFile: cache hit short-circuits -------------------------------------
+//
+// loadFile: cache hit short-circuits
+//
 
 Deno.test("buildDiffDocument: a shared cache is reused across builds (cache hit)", () => {
   const root = Deno.makeTempDirSync();
@@ -264,7 +270,9 @@ Deno.test("buildDiffDocument: a shared cache is reused across builds (cache hit)
   }
 });
 
-// --- file header lines: an empty meta header line is skipped ----------------
+//
+// file header lines: an empty meta header line is skipped
+//
 
 Deno.test("buildDiffDocument: an empty header line is left untouched", () => {
   // A blank line sits among the file's header lines (between `index` and `---`).
@@ -294,7 +302,9 @@ index 1111111..2222222 100644
   );
 });
 
-// --- hunk body: meta line inside the hunk gets diffMeta spans ----------------
+//
+// hunk body: meta line inside the hunk gets diffMeta spans
+//
 
 Deno.test("buildDiffDocument: a `\\ No newline` line in the hunk body is diffMeta", () => {
   // The `\ No newline at end of file` marker lands inside the hunk body range,
@@ -325,7 +335,9 @@ Deno.test("buildDiffDocument: a `\\ No newline` line in the hunk body is diffMet
   );
 });
 
-// --- hunk body: an empty trailing line is left without spans -----------------
+//
+// hunk body: an empty trailing line is left without spans
+//
 
 Deno.test("buildDiffDocument: a trailing empty line outside the hunk gets no spans", () => {
   // The text ends with a newline, so the split yields a final empty entry. It
@@ -346,7 +358,9 @@ Deno.test("buildDiffDocument: a trailing empty line outside the hunk gets no spa
   );
 });
 
-// --- Markdown hunk with a workspace file: shown headings drive the tree ------
+//
+// Markdown hunk with a workspace file: shown headings drive the tree
+//
 
 Deno.test("buildDiffDocument: a Markdown hunk shows its heading as a section", () => {
   const root = Deno.makeTempDirSync();
@@ -386,7 +400,9 @@ Deno.test("buildDiffDocument: a Markdown hunk shows its heading as a section", (
   }
 });
 
-// --- Markdown hunk where no heading line is shown -> empty heading tree ------
+//
+// Markdown hunk where no heading line is shown -> empty heading tree
+//
 
 Deno.test("buildDiffDocument: a Markdown hunk showing only body has no sections", () => {
   const root = Deno.makeTempDirSync();
@@ -427,7 +443,9 @@ Deno.test("buildDiffDocument: a Markdown hunk showing only body has no sections"
   }
 });
 
-// --- Markdown hunk with NO workspace file: fragment heading tree -------------
+//
+// Markdown hunk with NO workspace file: fragment heading tree
+//
 
 Deno.test("buildDiffDocument: a Markdown hunk with no workspace file builds heading sections from the fragment", () => {
   // No workspace file: ctx.fileDoc is null, so the heading tree comes from the
@@ -496,7 +514,9 @@ Deno.test("buildDiffDocument: a hunk naming new-side lines past the workspace EO
   }
 });
 
-// --- buildMaps.fromFile: a file offset on a hidden line maps to nothing ------
+//
+// buildMaps.fromFile: a file offset on a hidden line maps to nothing
+//
 
 Deno.test("buildDiffDocument: fromFile returns null for a file line the diff hides", () => {
   const root = Deno.makeTempDirSync();
@@ -535,7 +555,9 @@ Deno.test("buildDiffDocument: fromFile returns null for a file line the diff hid
   }
 });
 
-// --- lineEndOffset: a file section whose last line is the final text line ----
+//
+// lineEndOffset: a file section whose last line is the final text line
+//
 
 Deno.test("buildDiffDocument: the file section end offset reaches the end of the text", () => {
   // The diff has no trailing newline, so the file's endLine IS the last line of
@@ -552,7 +574,9 @@ Deno.test("buildDiffDocument: the file section end offset reaches the end of the
   );
 });
 
-// --- findRepoRoot: the 64-deep walk cap -------------------------------------
+//
+// findRepoRoot: the 64-deep walk cap
+//
 
 Deno.test("realWorkspace: a path nested past the walk depth cap finds no repo root", () => {
   // findRepoRoot walks up at most 64 ancestors. A path nested deeper than that,
@@ -573,7 +597,9 @@ Deno.test("realWorkspace: a path nested past the walk depth cap finds no repo ro
   }
 });
 
-// --- crafted DiffModel: synthetic/defensive body and header branches ---------
+//
+// crafted DiffModel: synthetic/defensive body and header branches
+//
 
 /**
  * Build a one-file, one-hunk {@link DiffModel} from a caller-supplied per-line

--- a/packages/cli/test/view-diffdoc-gate.test.ts
+++ b/packages/cli/test/view-diffdoc-gate.test.ts
@@ -2,7 +2,8 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { realWorkspace } from "../lib/view/diffdoc.ts";
 
-// --- realWorkspace.resolve: the file-vs-directory check ----------------------
+//
+// realWorkspace.resolve: the file-vs-directory check
 //
 // resolve() walks each base and, for a candidate that bounded() accepts, checks
 // Deno.statSync(abs).isFile. bounded() already canonicalized abs through
@@ -10,6 +11,7 @@ import { realWorkspace } from "../lib/view/diffdoc.ts";
 // removed (read() guards the file contents). These tests pin resolve()'s data
 // paths — a bounded regular file, a directory, an out-of-bounds path — the ones
 // a real `cf view` invocation drives.
+//
 
 Deno.test("realWorkspace.resolve: a bounded regular file resolves to its absolute path", () => {
   const root = Deno.makeTempDirSync();

--- a/packages/cli/test/view-diffdoc.test.ts
+++ b/packages/cli/test/view-diffdoc.test.ts
@@ -4,7 +4,9 @@ import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 
 const NO_WS: DiffWorkspace = { resolve: () => null, read: () => null };
 
-// --- a deleted Markdown file keeps Markdown highlighting --------------------
+//
+// a deleted Markdown file keeps Markdown highlighting
+//
 
 Deno.test("buildDiffDocument: a deleted Markdown file (new path /dev/null) highlights as Markdown", () => {
   // A plain `diff -u doc.md /dev/null` has no `diff --git` line, so the new
@@ -54,7 +56,9 @@ Deno.test("buildDiffDocument: a deleted Markdown file (new path /dev/null) highl
   );
 });
 
-// --- a deleted non-Markdown file is unaffected by the fallback --------------
+//
+// a deleted non-Markdown file is unaffected by the fallback
+//
 
 Deno.test("buildDiffDocument: a deleted .ts file (new path /dev/null) stays TypeScript", () => {
   // The old-path fallback must not turn a deleted TypeScript file into

--- a/packages/cli/test/view-diffedit-cov.test.ts
+++ b/packages/cli/test/view-diffedit-cov.test.ts
@@ -158,7 +158,9 @@ index 0000000..1111111 100644
  const z = 3;
 `;
 
-// --- revert error branches ---------------------------------------------------
+//
+// revert error branches
+//
 
 Deno.test("diffedit cov: revert returns null when the edited text no longer parses as a diff", () => {
   const { ws, done } = tempWs({ "m.ts": FILE_TEXT });
@@ -308,7 +310,9 @@ Deno.test("diffedit cov: revert chunk returns null when the original has no matc
   }
 });
 
-// --- expandContext error branches -------------------------------------------
+//
+// expandContext error branches
+//
 
 const EXPAND_FILE = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n";
 const EXPAND_DIFF = `diff --git a/m.ts b/m.ts
@@ -513,7 +517,9 @@ Deno.test("diffedit cov: expandContext reveals context below the hunk and grows 
   }
 });
 
-// --- dirtyLabels branches ----------------------------------------------------
+//
+// dirtyLabels branches
+//
 
 Deno.test("diffedit cov: dirtyLabels returns empty when a side fails to parse", () => {
   const { ws, done } = tempWs({ "m.ts": FILE_TEXT });
@@ -598,7 +604,9 @@ diff --git a/x.ts b/x.ts
   }
 });
 
-// --- createDiffHighlighter: getter, no-op update, markdown line scan ----------
+//
+// createDiffHighlighter: getter, no-op update, markdown line scan
+//
 
 Deno.test("diffedit cov: the highlighter's lines getter returns the seeded lines and a no-op update is a no-op", () => {
   const { ws, done } = tempWs({ "m.ts": FILE_TEXT });
@@ -954,7 +962,9 @@ Deno.test("diffedit cov: the highlighter returns plain (non-Markdown) coloring w
   assertEquals(out[2].spans[0].cls, "diffAdd");
 });
 
-// --- read-only source and save's defensive guards ---------------------------
+//
+// read-only source and save's defensive guards
+//
 
 Deno.test("diffedit cov: a diff matching no file on disk yields a read-only source whose save is a no-op", () => {
   // An empty `lines` map means nothing on disk backs the diff: the source is
@@ -3141,7 +3151,9 @@ index 1111111..2222222 100644
   });
 });
 
-// --- editableStart: position/verified-aware line editability -----------------
+//
+// editableStart: position/verified-aware line editability
+//
 
 Deno.test("editableStart: a null model (buffer is not a diff) refuses every line", () => {
   assertEquals(_de.editableStart(null, [], " some text", 0), null);
@@ -3186,7 +3198,9 @@ Deno.test("editableStart: editable only inside a verified hunk", () => {
   );
 });
 
-// --- commit amend helpers ----------------------------------------------------
+//
+// commit amend helpers
+//
 
 Deno.test("pendingAmend: null when there is no editable message", () => {
   assertEquals(
@@ -3297,7 +3311,9 @@ Deno.test("save: rejects a diff with a different hunk count", () => {
   }
 });
 
-// --- message-scope revert ----------------------------------------------------
+//
+// message-scope revert
+//
 
 const SHOW_DIFF = [
   "commit 0123456789abcdef0123456789abcdef01234567",
@@ -3365,7 +3381,9 @@ Deno.test("diffedit cov: message revert is null when the baseline has no such re
   }
 });
 
-// --- expandRoom and the join helpers ----------------------------------------
+//
+// expandRoom and the join helpers
+//
 
 Deno.test("diffedit cov: expandRoom is empty when the text no longer parses", () => {
   const { ws, done } = tempWs({ "m.ts": EXPAND_FILE });

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -2187,7 +2187,9 @@ Deno.test("diffedit: insert + expand + edit then save writes the file correctly"
   }
 });
 
-// --- regression: git log -p multi-commit diffs must not corrupt files --------
+//
+// regression: git log -p multi-commit diffs must not corrupt files
+//
 
 function stubWs(root: string): DiffWorkspace {
   return {
@@ -2898,7 +2900,9 @@ Deno.test("diffedit: editing a hunk with a blank context line saves without trun
   }
 });
 
-// --- refusing edits that cannot be saved (a commit-message preamble) ---------
+//
+// refusing edits that cannot be saved (a commit-message preamble)
+//
 
 Deno.test("diffedit: refuses editing text before the diff (a commit-message subject)", () => {
   const { ws, done } = tempWorkspace();
@@ -2958,7 +2962,9 @@ Deno.test("diffedit: an edit-mode search skips the preamble to a savable line", 
   }
 });
 
-// --- editing the HEAD commit's message (git show) ----------------------------
+//
+// editing the HEAD commit's message (git show)
+//
 
 Deno.test("diffedit: the HEAD commit's message is editable; save prompts then amends", () => {
   const { root, ws, done } = tempWorkspace();
@@ -4425,7 +4431,9 @@ Deno.test("diffedit: with no git runner the message is not editable", () => {
   }
 });
 
-// --- amend safety (review follow-ups) ----------------------------------------
+//
+// amend safety (review follow-ups)
+//
 
 Deno.test("diffedit: refuses to amend an all-blank commit message", () => {
   const { ws, done } = tempWorkspace();
@@ -4550,7 +4558,9 @@ Deno.test("diffedit: quitting after a message-only edit names the message, not f
   }
 });
 
-// --- context-aware revert prompt ---------------------------------------------
+//
+// context-aware revert prompt
+//
 
 /** Move the text cursor to `line` (up or down), in edit mode. */
 function moveCursorTo(s: Session, line: number): void {

--- a/packages/cli/test/view-display.test.ts
+++ b/packages/cli/test/view-display.test.ts
@@ -46,7 +46,9 @@ Deno.test("displayWidth: matches the rendered cell count", () => {
   }
 });
 
-// --- mode cycle & labels -----------------------------------------------------
+//
+// mode cycle & labels
+//
 
 Deno.test("DISPLAY_MODES: pictures is first, and every mode has a label", () => {
   assertEquals(DISPLAY_MODES[0], "pictures");
@@ -56,7 +58,9 @@ Deno.test("DISPLAY_MODES: pictures is first, and every mode has a label", () => 
   assertEquals(displayModeLabel("hidden"), "hidden");
 });
 
-// --- pictures mode -----------------------------------------------------------
+//
+// pictures mode
+//
 
 Deno.test("pictures: control codes become Control Pictures glyphs, one column each", () => {
   // U+000B (vertical tab) → ␋ (U+240B), tab → ␉, CR → ␍, ESC → ␛.
@@ -78,7 +82,9 @@ Deno.test("pictures: does not interpret ANSI — the escape shows as ␛", () =>
   assertEquals(glyphs("\x1b[31mx", "pictures"), "␛[31mx");
 });
 
-// --- ansi mode ---------------------------------------------------------------
+//
+// ansi mode
+//
 
 Deno.test("ansi: an SGR color sequence is hidden and colors the text after it", () => {
   const cells = displayLine(ln("a\x1b[31mb"), "ansi");
@@ -123,7 +129,9 @@ Deno.test("ansi: 256-color and truecolor foregrounds", () => {
   assertEquals(truecolor.ansi?.fg, [10, 20, 30]);
 });
 
-// --- hidden mode -------------------------------------------------------------
+//
+// hidden mode
+//
 
 Deno.test("hidden: ANSI sequences are dropped whatever their final byte", () => {
   assertEquals(glyphs("a\x1b[31mb", "hidden"), "ab");
@@ -163,7 +171,9 @@ Deno.test("hidden: a cell visitor can stop on a collapsed control run", () => {
   assertEquals(ranges, [[0, 2]]);
 });
 
-// --- source → display column mapping (horizontal scrolling) ------------------
+//
+// source → display column mapping (horizontal scrolling)
+//
 
 Deno.test("displayColumnOf: pictures maps 1:1", () => {
   assertEquals(displayColumnOf(ln("a\x01b"), "pictures", 2), 2);
@@ -205,7 +215,9 @@ Deno.test("sourceColumnOf: maps compact display offsets back to source", () => {
   assertEquals(sourceColumnOf(ln("\x1b[31m"), "ansi", 0), 0);
 });
 
-// --- internals ---------------------------------------------------------------
+//
+// internals
+//
 
 Deno.test("glyphFor: DEL and C1 codes have block glyphs", () => {
   assertEquals(glyphFor("\x7f"), "␡");

--- a/packages/cli/test/view-editbuffer-cov.test.ts
+++ b/packages/cli/test/view-editbuffer-cov.test.ts
@@ -5,7 +5,9 @@ function at(b: EditBuffer): [number, number] {
   return [b.row, b.col];
 }
 
-// --- construction / setText / spliceLines -----------------------------------
+//
+// construction / setText / spliceLines
+//
 
 Deno.test("editbuffer: constructor splits on newlines, single line otherwise", () => {
   const b = new EditBuffer("a\nb\nc");
@@ -63,7 +65,9 @@ Deno.test("editbuffer: spliceLines clamps cursor into the replacement", () => {
   );
 });
 
-// --- vertical motion (moveUp) -----------------------------------------------
+//
+// vertical motion (moveUp)
+//
 
 Deno.test("editbuffer: moveUp keeps a goal column across short lines", () => {
   const b = new EditBuffer("first line\nx\nlast line");
@@ -83,7 +87,9 @@ Deno.test("editbuffer: moveUp at the top row is a no-op", () => {
   assertEquals(at(b), [0, 2], "cannot move above the first line");
 });
 
-// --- buffer-edge motion -----------------------------------------------------
+//
+// buffer-edge motion
+//
 
 Deno.test("editbuffer: moveBufferStart goes to row 0 col 0", () => {
   const b = new EditBuffer("aaa\nbbb\nccc");
@@ -101,7 +107,9 @@ Deno.test("editbuffer: moveBufferEnd goes to the last line's end", () => {
   assertEquals(at(b), [2, 4], "last row, col at its length");
 });
 
-// --- insertion edge ----------------------------------------------------------
+//
+// insertion edge
+//
 
 Deno.test("editbuffer: insert of an empty string is a no-op", () => {
   const b = new EditBuffer("abc");
@@ -119,7 +127,9 @@ Deno.test("editbuffer: insert of a multi-line string splits and inserts", () => 
   assertEquals(at(b), [1, 1]);
 });
 
-// --- deletion (line joins) ---------------------------------------------------
+//
+// deletion (line joins)
+//
 
 Deno.test("editbuffer: deleteForward deletes a character mid-line", () => {
   const b = new EditBuffer("abc");
@@ -143,7 +153,9 @@ Deno.test("editbuffer: deleteForward at line end joins with the next line", () =
   assertEquals(b.text(), "abcd");
 });
 
-// --- killLine / killWholeLine ------------------------------------------------
+//
+// killLine / killWholeLine
+//
 
 Deno.test("editbuffer: killLine mid-line kills to the end of the line", () => {
   const b = new EditBuffer("hello world");
@@ -206,7 +218,9 @@ Deno.test("editbuffer: killWholeLine on the only line empties it in place", () =
   );
 });
 
-// --- killRegion / yank / yankPop early returns ------------------------------
+//
+// killRegion / yank / yankPop early returns
+//
 
 Deno.test("editbuffer: killRegion with no mark is a no-op", () => {
   const b = new EditBuffer("hello");
@@ -246,7 +260,9 @@ Deno.test("editbuffer: yankPop after a yank replaces with the next ring entry", 
   assertEquals(b.text(), "A", "wraps around the ring");
 });
 
-// --- pushKill empty-text guard ----------------------------------------------
+//
+// pushKill empty-text guard
+//
 
 Deno.test("editbuffer: killLine on an empty last line kills nothing", () => {
   // killLine at end of a non-final empty line joins; on the final empty line
@@ -271,7 +287,9 @@ Deno.test("editbuffer: killWordForward with no word ahead pushes nothing", () =>
   assertEquals(b.killRing.length, 0, "empty kill is not pushed");
 });
 
-// --- case operations ---------------------------------------------------------
+//
+// case operations
+//
 
 Deno.test("editbuffer: capitalizeWord with no letter/number leaves the word as-is", () => {
   const b = new EditBuffer("--- rest");
@@ -306,7 +324,9 @@ Deno.test("editbuffer: a word op whose word ends on the next line just moves to 
   assertEquals(at(b), [0, 3], "cursor moves to the end of the current line");
 });
 
-// --- multi-line cut (via killRegion across lines) ----------------------------
+//
+// multi-line cut (via killRegion across lines)
+//
 
 Deno.test("editbuffer: killRegion across multiple lines cuts and rejoins", () => {
   const b = new EditBuffer("one\ntwo\nthree\nfour");
@@ -356,7 +376,9 @@ Deno.test("editbuffer: killWordForward across a line boundary cuts multiple line
   assertEquals(b.text(), "ab \ncd");
 });
 
-// --- word scanning across lines ---------------------------------------------
+//
+// word scanning across lines
+//
 
 Deno.test("editbuffer: moveWordForward crosses blank/short lines to the next word", () => {
   const b = new EditBuffer("ab\n\ncd");

--- a/packages/cli/test/view-editbuffer-gate.test.ts
+++ b/packages/cli/test/view-editbuffer-gate.test.ts
@@ -5,12 +5,14 @@ function at(b: EditBuffer): [number, number] {
   return [b.row, b.col];
 }
 
-// --- constructor / setText: the line-splitting paths -----------------------
+//
+// constructor / setText: the line-splitting paths
 //
 // `String.split("\n")` always yields an array of length >= 1 (even for the
 // empty string it yields `[""]`), so the constructor and setText need no
 // empty-buffer guard after the split. These tests pin that: the split supplies
 // at least one line, and the cursor placement that follows stays in range.
+//
 
 Deno.test("editbuffer: constructor splits every input into at least one line", () => {
   // The empty string still produces a single empty line — the split, not the

--- a/packages/cli/test/view-editbuffer.test.ts
+++ b/packages/cli/test/view-editbuffer.test.ts
@@ -6,7 +6,9 @@ function at(b: EditBuffer): [number, number] {
   return [b.row, b.col];
 }
 
-// --- motion -----------------------------------------------------------------
+//
+// motion
+//
 
 Deno.test("editbuffer: left/right cross line boundaries", () => {
   const b = new EditBuffer("ab\ncd");
@@ -42,7 +44,9 @@ Deno.test("editbuffer: line and word motion", () => {
   assertEquals(b.col, 6, "back to start of `bar`");
 });
 
-// --- insertion / deletion ---------------------------------------------------
+//
+// insertion / deletion
+//
 
 Deno.test("editbuffer: insert characters and a newline", () => {
   const b = new EditBuffer("ac");
@@ -145,7 +149,9 @@ Deno.test("editbuffer: commitSaved makes the current text clean", () => {
   assert(b.dirty(), "a later edit is measured against the saved text");
 });
 
-// --- kill / yank ------------------------------------------------------------
+//
+// kill / yank
+//
 
 Deno.test("editbuffer: kill-line then yank round-trips", () => {
   const b = new EditBuffer("hello world");
@@ -256,7 +262,9 @@ Deno.test("editbuffer: yank-pop cycles through the ring", () => {
   assertEquals(b.text(), "A", "wraps around the ring");
 });
 
-// --- case ops ---------------------------------------------------------------
+//
+// case ops
+//
 
 Deno.test("editbuffer: case operations transform the next word, advancing", () => {
   const b = new EditBuffer("foo BAR baz");
@@ -273,7 +281,9 @@ Deno.test("editbuffer: case operations transform the next word, advancing", () =
   assertEquals(b.text(), "foo BAR Baz");
 });
 
-// --- non-BMP ----------------------------------------------------------------
+//
+// non-BMP
+//
 
 Deno.test("editbuffer: cursor steps whole code points past an emoji", () => {
   const b = new EditBuffer("a😀b");
@@ -290,7 +300,9 @@ Deno.test("editbuffer: cursor steps whole code points past an emoji", () => {
   assertEquals(b.text(), "ab");
 });
 
-// --- key decoding -----------------------------------------------------------
+//
+// key decoding
+//
 
 function decode1(bytes: number[]) {
   const { keys } = decodeKeys(new Uint8Array(bytes));

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -122,7 +122,9 @@ Deno.test("diffFiles: a non-diff yields no files", () => {
   assertEquals(diffFiles("just some text\nnot a diff\n"), []);
 });
 
-// --- fold plan ---------------------------------------------------------------
+//
+// fold plan
+//
 
 const ln = (text: string): Line => ({
   text,
@@ -180,7 +182,9 @@ Deno.test("buildFoldPlan: nothing collapsed is the identity", () => {
   assertEquals(plan.displayLines.length, docLines.length);
 });
 
-// --- test-path detection -----------------------------------------------------
+//
+// test-path detection
+//
 
 Deno.test("isMarkdownPath: matches the pager's filename classification", () => {
   for (
@@ -235,7 +239,9 @@ Deno.test("isTestPath: directories and basenames", () => {
   }
 });
 
-// --- folding through the session ---------------------------------------------
+//
+// folding through the session
+//
 
 function press(s: Session, ...names: string[]): void {
   for (const name of names) {

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -371,7 +371,9 @@ Deno.test("realPagerDeps: the wrappers reach the real primitives", () => {
   } catch { /* no controlling terminal in this environment */ }
 });
 
-// --- Ctrl-L reveal frames ---------------------------------------------------
+//
+// Ctrl-L reveal frames
+//
 
 /** A one-file diff whose hunk has room to reveal ten lines above it. */
 function revealFixture() {

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -61,7 +61,9 @@ function labels(doc: Document): string[] {
   return doc.flatStructure.map((n) => `${n.kind}:${n.label}`);
 }
 
-// --- registry: a .md filename highlights as Markdown ------------------------
+//
+// registry: a .md filename highlights as Markdown
+//
 
 Deno.test("registry: a .md filename is highlighted as Markdown", () => {
   const lines = languageForFile("README.md").highlightLines(
@@ -89,7 +91,9 @@ Deno.test("registry: a .md filename is highlighted as Markdown", () => {
   );
 });
 
-// --- createHighlighter no-op + diffRange identical (lines 297, 403) ----------
+//
+// createHighlighter no-op + diffRange identical (lines 297, 403)
+//
 
 Deno.test("createHighlighter: update with identical text returns the same lines", () => {
   const src = "const a = 1;\nconst b = 2;\n";
@@ -116,7 +120,9 @@ Deno.test("highlightLineEditLocally: editing a called member key refreshes its d
   assertEquals(key.exactDefinitionDisplayName, '"stop"');
 });
 
-// --- safeStartLine walk-back past a multi-line token (lines 459, 460) --------
+//
+// safeStartLine walk-back past a multi-line token (lines 459, 460)
+//
 
 /** Assert that the incremental highlighter's result for `edited` is identical
  * to a full parse, span for span. */
@@ -174,7 +180,9 @@ Deno.test("createHighlighter: editing a statement whose line opens inside an ear
   assertIncrementalMatches(base, base.replace("const b = 2", "const b = 22"));
 });
 
-// --- collectTokensInRange skips JSDoc (line 572) -----------------------------
+//
+// collectTokensInRange skips JSDoc (line 572)
+//
 
 Deno.test("createHighlighter: an edit near a JSDoc comment stays one whole comment", () => {
   // A JSDoc block with @tags attaches as JSDoc nodes to the function below it.
@@ -217,7 +225,9 @@ Deno.test("createHighlighter: an edit near a JSDoc comment stays one whole comme
   }
 });
 
-// --- classifyToken: null is a boolean-class literal (line 803) ---------------
+//
+// classifyToken: null is a boolean-class literal (line 803)
+//
 
 Deno.test("parse: null, true and false are colored as boolean literals", () => {
   const doc = parseDocument(
@@ -228,10 +238,12 @@ Deno.test("parse: null, true and false are colored as boolean literals", () => {
   assert(classesOf(doc, "false").has("boolean"), "false is boolean-classed");
 });
 
-// --- classifyIdentifier: declaration-name and access branches ---------------
+//
+// classifyIdentifier: declaration-name and access branches
 // Covers lines 844-846 (function/method/method-signature names), 848-852
 // (interface/class/class-expression names), 854 (enum name), 869-870
 // (property declaration / enum member), 877 (synthetic helper member access).
+//
 
 Deno.test("parse: function, method and interface declaration names are classified", () => {
   const src = [
@@ -304,7 +316,9 @@ Deno.test("parse: a synthetic identifier used as a type name is a cfHelper", () 
   );
 });
 
-// --- isTypePosition branches (lines 913-920) --------------------------------
+//
+// isTypePosition branches (lines 913-920)
+//
 
 Deno.test("parse: type parameters, typeof queries and heritage clauses are type positions", () => {
   const src = [
@@ -333,7 +347,9 @@ Deno.test("parse: a generic type parameter declaration name is a typeName", () =
   assert(classesOf(doc, "T").has("typeName"), "type parameter declaration");
 });
 
-// --- comments threaded into the structure tree (mergeByStart, 1214/1216) -----
+//
+// comments threaded into the structure tree (mergeByStart, 1214/1216)
+//
 
 Deno.test("parse: comments are merged into the structure tree in source order", () => {
   // Several comments at the same nesting level batch and merge via mergeByStart.
@@ -360,7 +376,9 @@ Deno.test("parse: comments are merged into the structure tree in source order", 
   ]);
 });
 
-// --- genericLabel: ElementAccessExpression (lines 1095-1097) -----------------
+//
+// genericLabel: ElementAccessExpression (lines 1095-1097)
+//
 
 Deno.test("parse: an element-access expression gets a […] generic label", () => {
   const doc = parseDocument("const e = arr[index];\n", "m.ts");
@@ -371,10 +389,12 @@ Deno.test("parse: an element-access expression gets a […] generic label", () =
   );
 });
 
-// --- registerDefinition no-name guard (line 1260) ---------------------------
+//
+// registerDefinition no-name guard (line 1260)
 // Covered indirectly: registerDefinition is only called when desc.name is set,
 // but the early `if (!desc.name) return` is reached when called for a name.
 // A named binding exercises the body; the guard line itself runs every call.
+//
 
 Deno.test("parse: a named binding registers a definition", () => {
   const doc = parseDocument("const namedThing = 1;\n", "m.ts");
@@ -383,7 +403,9 @@ Deno.test("parse: a named binding registers a definition", () => {
   assertEquals(def.kind, "variable");
 });
 
-// --- classify: method / constructor / accessor declarations (1308-1334) ------
+//
+// classify: method / constructor / accessor declarations (1308-1334)
+//
 
 Deno.test("parse: class methods, constructor and accessors become method nodes", () => {
   const src = [
@@ -407,8 +429,10 @@ Deno.test("parse: class methods, constructor and accessors become method nodes",
   assert(doc.definitions.has("doThing"), "method is a definition");
 });
 
+//
 // --- classify: enum / export assignment / export decl / import equals /
-//     module declaration (lines 1353-1390) -----------------------------------
+// module declaration (lines 1353-1390)
+//
 
 Deno.test("parse: enums, exports, import-equals and namespaces classify distinctly", () => {
   const src = [
@@ -467,7 +491,9 @@ Deno.test("parse: a multi-declarator var statement yields a binding node per dec
   assert(ls.includes("variable:b"), "b is a variable node");
 });
 
-// --- classify: labeled / break / continue / empty / debugger (1435-1450) -----
+//
+// classify: labeled / break / continue / empty / debugger (1435-1450)
+//
 
 Deno.test("parse: labeled statements and jump statements are reachable nodes", () => {
   const src = [
@@ -485,7 +511,9 @@ Deno.test("parse: labeled statements and jump statements are reachable nodes", (
   assert(ls.some((l) => l.startsWith("statement:debugger")), "debugger node");
 });
 
-// --- classify: in-statement-list fallback (lines 1455-1460) ------------------
+//
+// classify: in-statement-list fallback (lines 1455-1460)
+//
 
 Deno.test("parse: an unusual statement still becomes a reachable statement node", () => {
   // A `with` statement is not specially handled, so it falls through to the
@@ -501,7 +529,9 @@ Deno.test("parse: an unusual statement still becomes a reachable statement node"
   );
 });
 
-// --- bindingDesc: no initializer (lines 1496-1505) ---------------------------
+//
+// bindingDesc: no initializer (lines 1496-1505)
+//
 
 Deno.test("parse: an uninitialized binding becomes a variable node with no init meta", () => {
   const doc = parseDocument("let pending: number;\n", "m.ts");
@@ -517,7 +547,9 @@ Deno.test("parse: an uninitialized binding becomes a variable node with no init 
   }
 });
 
-// --- bindingDesc: object initializer that is a schema (lines 1534-1543) ------
+//
+// bindingDesc: object initializer that is a schema (lines 1534-1543)
+//
 
 Deno.test("parse: a binding whose initializer is a schema object is a schema node", () => {
   const src = [
@@ -545,7 +577,9 @@ Deno.test("parse: a binding whose initializer is a plain object is an object nod
   assert(node!.label.startsWith("cfg {"), `label was ${node!.label}`);
 });
 
-// --- expressionStatementDesc: arrow / function expression (1572-1579) --------
+//
+// expressionStatementDesc: arrow / function expression (1572-1579)
+//
 
 Deno.test("parse: a bare arrow-function expression statement is a closure node", () => {
   // An expression statement whose expression is an arrow function.
@@ -590,7 +624,9 @@ Deno.test("parse: a return of a reactive call recurses into its arguments", () =
   );
 });
 
-// --- controlLabel: while / do / switch / for / for-in / try (1667-1674) ------
+//
+// controlLabel: while / do / switch / for / for-in / try (1667-1674)
+//
 
 Deno.test("parse: every control-flow shape gets its distinct label", () => {
   const src = [
@@ -615,7 +651,9 @@ Deno.test("parse: every control-flow shape gets its distinct label", () => {
   assert(ls.some((l) => l === "control:try"), "try label");
 });
 
-// --- calleeName: a non-identifier non-property callee (line 1708) ------------
+//
+// calleeName: a non-identifier non-property callee (line 1708)
+//
 
 Deno.test("parse: a computed-callee call is labeled by its first source line", () => {
   // `(obj["m"])(…)` — the callee is neither a plain identifier nor a property
@@ -630,13 +668,17 @@ Deno.test("parse: a computed-callee call is labeled by its first source line", (
   );
 });
 
-// --- safe() catch path (lines 1725-1727) ------------------------------------
+//
+// safe() catch path (lines 1725-1727)
 // safe() swallows exceptions in metadata extraction. Hard to force a throw from
 // well-formed input; instead, confirm the surrounding metadata still appears
 // for a normal node (the try path), and rely on malformed schema input below to
 // drive readSchemaProps over odd shapes without throwing.
+//
 
-// --- importMeta: default name + namespace import (lines 1740, 1743) ----------
+//
+// importMeta: default name + namespace import (lines 1740, 1743)
+//
 
 Deno.test("parse: import metadata captures default, namespace and named bindings", () => {
   const src = [
@@ -664,7 +706,9 @@ Deno.test("parse: import metadata captures default, namespace and named bindings
   assert(module.length > 0, "a module specifier is recorded");
 });
 
-// --- membersOf: method signature + index signature (lines 1792-1804) ---------
+//
+// membersOf: method signature + index signature (lines 1792-1804)
+//
 
 Deno.test("parse: interface metadata describes property, method and index members", () => {
   const src = [
@@ -685,9 +729,11 @@ Deno.test("parse: interface metadata describes property, method and index member
   }
 });
 
-// --- parseSchemaObject + fieldType: array / object / anyOf branches ----------
+//
+// parseSchemaObject + fieldType: array / object / anyOf branches
 // Covers 1819-1820 (non-property-assignment skip), 1847-1857 (fieldType array,
 // object, anyOf/oneOf fallthrough), 1871, 1894-1899 (readSchemaProps/hasProp).
+//
 
 Deno.test("parse: schema metadata describes nested arrays, objects and unions", () => {
   const src = [
@@ -776,7 +822,9 @@ Deno.test("parse: a schema with neither type nor properties roots as any", () =>
   }
 });
 
-// --- contractMeta + builder schemas / config args (lines 1899-1937) ----------
+//
+// contractMeta + builder schemas / config args (lines 1899-1937)
+//
 
 Deno.test("parse: a builder call records input/output schemas, config args and captures", () => {
   const src = [
@@ -813,7 +861,9 @@ Deno.test("parse: a builder call records input/output schemas, config args and c
   assert(fetch, "the fetchJson binding is a node");
 });
 
-// --- inferExprType branches (lines 2007-2053) & describeInitializer ----------
+//
+// inferExprType branches (lines 2007-2053) & describeInitializer
+//
 
 Deno.test("parse: variable type is inferred from satisfies, casts and literals", () => {
   const cases: Array<[string, string, string]> = [
@@ -897,7 +947,9 @@ Deno.test("parse: a non-reactive call binding records describeInitializer text",
   }
 });
 
-// --- A reconstruction sanity check over a varied blob ------------------------
+//
+// A reconstruction sanity check over a varied blob
+//
 
 Deno.test("parse: spans reconstruct every line of a varied blob verbatim", () => {
   const src = [

--- a/packages/cli/test/view-parse-gate.test.ts
+++ b/packages/cli/test/view-parse-gate.test.ts
@@ -45,7 +45,9 @@ function byName(doc: Document, name: string): StructureNode | undefined {
   return doc.flatStructure.find((n) => n.name === name);
 }
 
-// --- 836: classifyIdentifier with a parent (the only reachable case) --------
+//
+// 836: classifyIdentifier with a parent (the only reachable case)
+//
 
 Deno.test("gate 836: leaf identifiers are classified by their parent context", () => {
   // `if (!p) …` is the parentless fall-through. Every identifier in a parsed
@@ -102,7 +104,9 @@ Deno.test("called element keys carry one exact-position lookup marker", () => {
   );
 });
 
-// --- 913: a qualified name in type position always has a parent -------------
+//
+// 913: a qualified name in type position always has a parent
+//
 
 Deno.test("gate 913: a qualified name in a type annotation resolves as a type", () => {
   // isTypePosition climbs the qualified-name chain (`outer.inner.Leaf`) and then
@@ -129,7 +133,9 @@ Deno.test("gate 916: a `typeof` type colors its operand as a type name", () => {
   );
 });
 
-// --- 917, 919, 920: heritage types resolve via ts.isTypeNode first ----------
+//
+// 917, 919, 920: heritage types resolve via ts.isTypeNode first
+//
 
 Deno.test("gate 917-920: a class heritage type colors as a type name", () => {
   // `extends Parent<number>` produces an ExpressionWithTypeArguments whose
@@ -151,7 +157,9 @@ Deno.test("gate 917-920: an interface heritage type colors as a type name", () =
   );
 });
 
-// --- 1225: mergeByStart only ever runs with a non-empty additions batch -----
+//
+// 1225: mergeByStart only ever runs with a non-empty additions batch
+//
 
 Deno.test("gate 1225: comment batches (always non-empty) merge into their host", () => {
   // insertComments pushes a comment node into a batch before merging it, so
@@ -182,7 +190,9 @@ Deno.test("gate 1225: comment batches (always non-empty) merge into their host",
   );
 });
 
-// --- 1270: registerDefinition is only called for named declarations ---------
+//
+// 1270: registerDefinition is only called for named declarations
+//
 
 Deno.test("gate 1270: named declarations are registered; an anonymous one is not", () => {
   // The caller guards `registerDefinition` with `if (desc.name)`, so the
@@ -282,7 +292,9 @@ Deno.test("gate 1719-1721: safe() returns the value when the extractor succeeds"
   }
 });
 
-// --- 2045-2047: describeInitializer never sees a raw arrow initializer -------
+//
+// 2045-2047: describeInitializer never sees a raw arrow initializer
+//
 
 Deno.test("gate 2045-2047: an arrow initializer becomes a closure node", () => {
   // bindingDesc peels the initializer and routes any arrow / function

--- a/packages/cli/test/view-parse.test.ts
+++ b/packages/cli/test/view-parse.test.ts
@@ -362,7 +362,9 @@ Deno.test("parse: handles empty and whitespace-only input without throwing", () 
   }
 });
 
-// --- full-AST navigation ----------------------------------------------------
+//
+// full-AST navigation
+//
 
 Deno.test("parse: the whole AST is navigable — RHS expression, chained calls, args", () => {
   const doc = parseDocument(

--- a/packages/cli/test/view-render-cov.test.ts
+++ b/packages/cli/test/view-render-cov.test.ts
@@ -56,7 +56,9 @@ function node(
   };
 }
 
-// --- cursorScreenPos / layout ------------------------------------------------
+//
+// cursorScreenPos / layout
+//
 
 Deno.test("cursorScreenPos: null when there is no cursor", () => {
   const doc = parseDocument(SAMPLE);
@@ -156,7 +158,9 @@ Deno.test("cursorScreenPos: null when a dialog covers the content", () => {
   assertEquals(cursorScreenPos(doc, view), null);
 });
 
-// --- notice rows -------------------------------------------------------------
+//
+// notice rows
+//
 
 Deno.test("renderFrame: notice overwrites the bottom content rows", () => {
   const doc = parseDocument(SAMPLE);
@@ -196,7 +200,9 @@ Deno.test("renderFrame: an empty notice array leaves content untouched", () => {
   assertEquals(withNotice, without);
 });
 
-// --- selectionSpan: schema / closure / selection backgrounds -----------------
+//
+// selectionSpan: schema / closure / selection backgrounds
+//
 
 Deno.test("renderFrame: a schema node tints its line", () => {
   const doc = parseDocument("const x = 1;\n");
@@ -235,7 +241,9 @@ Deno.test("renderFrame: a plain node uses the selection background", () => {
   assert(/48;2;/.test(rows[0]), "selection region tinted");
 });
 
-// --- search-match column clamping --------------------------------------------
+//
+// search-match column clamping
+//
 
 Deno.test("renderFrame: search matches off the left edge are clipped", () => {
   const doc = parseDocument("hello world\n");
@@ -255,7 +263,9 @@ Deno.test("renderFrame: search matches off the right edge are clipped", () => {
   assert(/48;2;/.test(rows[0]), "in-bounds match columns highlighted");
 });
 
-// --- renderStatus branches ---------------------------------------------------
+//
+// renderStatus branches
+//
 
 Deno.test("renderStatus: the input line replaces the status bar", () => {
   const doc = parseDocument(SAMPLE);
@@ -397,7 +407,9 @@ Deno.test("renderStatus: a narrow bar drops the lowest-priority hints first", ()
   assert(!tight.includes("WASD Tree"), "WASD drops before Q");
 });
 
-// --- kindGlyph: every branch -------------------------------------------------
+//
+// kindGlyph: every branch
+//
 
 Deno.test("renderStatus: kindGlyph maps every node kind to a glyph", () => {
   const doc = parseDocument("x\n");
@@ -430,7 +442,9 @@ Deno.test("renderStatus: kindGlyph maps every node kind to a glyph", () => {
   }
 });
 
-// --- display modes: tabs and control characters ------------------------------
+//
+// display modes: tabs and control characters
+//
 
 Deno.test("renderFrame: a tab renders as its Control Pictures glyph", () => {
   const doc = parseDocument("a\tb\n");
@@ -450,7 +464,9 @@ Deno.test("renderFrame: a control character renders as its Control Pictures glyp
   assert(!text.includes("\x01"), "control char scrubbed");
 });
 
-// --- overlay: span past the inner width / truncCenter truncation -------------
+//
+// overlay: span past the inner width / truncCenter truncation
+//
 
 Deno.test("overlay: a span wider than the box is clipped at the inner edge", () => {
   const doc = parseDocument(SAMPLE);
@@ -799,7 +815,9 @@ Deno.test("renderFrame: the guide rail is blank on lines outside the selected no
   assertEquals(stripAnsi(rows[1])[0], "▶", "single-line node carries a glyph");
 });
 
-// --- SGR encoding helpers (rich modifiers and background merge) ---------------
+//
+// SGR encoding helpers (rich modifiers and background merge)
+//
 
 Deno.test("cellsToAnsi: encodes rich text attributes", () => {
   const cells = [
@@ -840,7 +858,9 @@ Deno.test("darkenSpan: repaints a shadow span and clips out-of-bounds cells", ()
   assertEquals(stripAnsi(rows[0]), "hello world", "the characters are kept");
 });
 
-// --- status-bar fitting (file, and left truncation) --------------------------
+//
+// status-bar fitting (file, and left truncation)
+//
 
 Deno.test("renderStatus: a long current file is tail-truncated with a leading ellipsis", () => {
   const doc = parseDocument(SAMPLE);

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -1142,7 +1142,9 @@ Deno.test("renderFrame: selecting a node draws a guide bar", () => {
   assert(/[╭│╰▶]/.test(joined), "guide glyphs present when a node is selected");
 });
 
-// --- display modes at the frame level ----------------------------------------
+//
+// display modes at the frame level
+//
 
 /** A one-line document whose text is `text` verbatim, in a single plain span. */
 function docOf(text: string) {

--- a/packages/cli/test/view-semantics-cov.test.ts
+++ b/packages/cli/test/view-semantics-cov.test.ts
@@ -30,7 +30,9 @@ function nameOffsetOf(doc: Document, name: string): number {
   return node.nameOffset;
 }
 
-// --- createSemantics: lazy build, prewarm, and degrade-to-null paths --------
+//
+// createSemantics: lazy build, prewarm, and degrade-to-null paths
+//
 
 Deno.test("semantics: createSemantics returns a service for a single-section blob", () => {
   // No section headers: the fallback single section runs, the service builds,
@@ -141,7 +143,9 @@ const out = triple(7);`;
   assert(first === second, "the cache hands back the identical array");
 });
 
-// --- JSONC parsing edge cases (stripJsonc) ----------------------------------
+//
+// JSONC parsing edge cases (stripJsonc)
+//
 
 Deno.test("semantics: JSONC import map survives block comments and escapes", () => {
   // A block comment AND a string value containing an escaped quote and a `//`
@@ -212,7 +216,9 @@ const y = x;`;
   }
 });
 
-// --- typeStringAt branches + lineAndPreview clamp ---------------------------
+//
+// typeStringAt branches + lineAndPreview clamp
+//
 
 Deno.test("semantics: typeStringAt returns null when no node holds the offset", () => {
   // A run of trailing blank space after the only statement, all inside the
@@ -273,7 +279,9 @@ const flag = ext();`;
   }
 });
 
-// --- makeHost: extension classification of resolved modules -----------------
+//
+// makeHost: extension classification of resolved modules
+//
 
 Deno.test("semantics: classifies a resolved .tsx import (extensionOf Tsx)", () => {
   // The import-map value points directly at a `.tsx` file; resolveRelative
@@ -492,7 +500,9 @@ const value = asset;`;
   });
 });
 
-// --- createDiffSemantics: full service over a real workspace ----------------
+//
+// createDiffSemantics: full service over a real workspace
+//
 
 const FILE_TEXT = `export function double(n: number): number {
     return n * 2;
@@ -723,7 +733,9 @@ Deno.test("diff semantics: types the workspace binding from a real subdir cwd", 
   }
 });
 
-// --- diff-mode catch-to-empty branches via a throwing DiffMaps stub ----------
+//
+// diff-mode catch-to-empty branches via a throwing DiffMaps stub
+//
 
 /**
  * Wrap a real DiffMaps but force `toFile`/`fromFile` to throw on demand. The
@@ -840,7 +852,9 @@ Deno.test("diff semantics: fileLines rejects a path outside the workspace", () =
   }
 });
 
-// --- end-to-end against the real repo (resolves commonfabric) ---------------
+//
+// end-to-end against the real repo (resolves commonfabric)
+//
 
 Deno.test("semantics: SAMPLE blob types a pattern binding from a real subdir", () => {
   const doc = parseDocument(SAMPLE);

--- a/packages/cli/test/view-semantics-cov2.test.ts
+++ b/packages/cli/test/view-semantics-cov2.test.ts
@@ -70,7 +70,9 @@ function cwdThatThrows(): string {
   return 12345 as unknown as string;
 }
 
-// --- createSemantics: setup-time guards -------------------------------------
+//
+// createSemantics: setup-time guards
+//
 
 Deno.test("semantics: a text that throws while splitting yields no service", () => {
   // `splitSections` reads `text.length` first; that throw is caught and the
@@ -111,7 +113,9 @@ Deno.test("semantics: a build failure latches and every later query stays silent
   assertEquals(sem.fileLines(join(CWD, "anything.ts")), null);
 });
 
-// --- createSemantics: per-query catch wrappers ------------------------------
+//
+// createSemantics: per-query catch wrappers
+//
 
 Deno.test("semantics: typeAt swallows a throw raised while locating the section", () => {
   // The program builds; then an offset that throws on numeric coercion makes
@@ -141,7 +145,9 @@ Deno.test("semantics: fileLines swallows a throw from the containment check", ()
   assertEquals(sem.fileLines(pathThatThrows()), null);
 });
 
-// --- createDiffSemantics: setup-time fallback -------------------------------
+//
+// createDiffSemantics: setup-time fallback
+//
 
 Deno.test("diff semantics: an un-discoverable config still runs the fallback", () => {
   // With a cwd the path helpers reject, `discoverConfig` throws and the diff

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -32,7 +32,9 @@ function nameOffsetOf(doc: Document, name: string): number {
   return node.nameOffset;
 }
 
-// --- createSemantics: build success path that the !program guard backstops ----
+//
+// createSemantics: build success path that the !program guard backstops
+//
 
 Deno.test("semantics: a healthy build returns a Program (the !program guard is a backstop)", () => {
   // build() runs createLanguageService + getProgram and returns a real Program,
@@ -62,7 +64,9 @@ const y = x;`;
   assertEquals(sem.definitionOf(nameOffsetOf(doc, "y")), []);
 });
 
-// --- createSemantics: the host file cache (populated once, never re-hit) -------
+//
+// createSemantics: the host file cache (populated once, never re-hit)
+//
 
 Deno.test("semantics: the host reads each real file once (cache populated, not re-hit)", () => {
   // Under Bundler resolution the host loads each resolved file a single time;
@@ -98,7 +102,9 @@ const b = ext();`;
   }
 });
 
-// --- within()/realDir: a child resolves => its ancestor root resolves too ------
+//
+// within()/realDir: a child resolves => its ancestor root resolves too
+//
 
 Deno.test("semantics: within() resolves a real child under a real root (realDir succeeds)", () => {
   // realDir(root) is only reached after the child's realPathSync succeeds; the
@@ -136,7 +142,9 @@ const x = 1;`;
   }
 });
 
-// --- createDiffSemantics: build success path the failure guards backstop ------
+//
+// createDiffSemantics: build success path the failure guards backstop
+//
 
 const FILE_TEXT = `export function double(n: number): number {
     return n * 2;

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -20,7 +20,9 @@ import { overlayBox, renderFrame, type ViewState } from "../lib/view/render.ts";
 import type { Document } from "../lib/view/model.ts";
 import { frameTop, maxTop } from "../lib/view/actions.ts";
 
-// --- key helpers -----------------------------------------------------------
+//
+// key helpers
+//
 
 function press(s: Session, ...names: string[]): void {
   for (const name of names) {
@@ -65,7 +67,9 @@ function makeSession(width = 90, height = 24): Session {
   );
 }
 
-// --- save dialog: more than six edited files -------------------------------
+//
+// save dialog: more than six edited files
+//
 
 Deno.test("session: the save prompt lists six files plus an '… and N more' line", () => {
   const path = "/work/main.ts";
@@ -123,7 +127,9 @@ Deno.test("session: a single edited file shows no notice list", () => {
   assert(promptText(s.view()).includes("solo.ts"), promptText(s.view()));
 });
 
-// --- selectNode out-of-range guard (288) ------------------------------------
+//
+// selectNode out-of-range guard (288)
+//
 
 Deno.test("session: navigating past the last node is a no-op (selectNode guard)", () => {
   const s = makeSession();
@@ -142,7 +148,9 @@ Deno.test("session: navigating past the last node is a no-op (selectNode guard)"
   assert(last, "a node stayed selected");
 });
 
-// --- definition lookup (319-348) --------------------------------------------
+//
+// definition lookup (319-348)
+//
 
 Deno.test("session: definition lookup reports a miss", () => {
   const s = makeSession();
@@ -204,7 +212,9 @@ Deno.test("session: definition lookup without a matching structure node falls ba
   assert(ov.footer.includes("scroll"), ov.footer);
 });
 
-// --- card selection movement & external file (377-484, 644-701) ------------
+//
+// card selection movement & external file (377-484, 644-701)
+//
 
 function externalSession(destLine = 1, fileLines = 3): {
   s: Session;
@@ -574,7 +584,9 @@ Deno.test("session: Tab toggles a peek card to source and z reveals the subject 
   assertEquals(s.view().overlay!.scroll, 0);
 });
 
-// --- normal-mode keys: search stepping & paging (546-845) -------------------
+//
+// normal-mode keys: search stepping & paging (546-845)
+//
 
 Deno.test("session: n with no matches reports 'No matches'", () => {
   const s = makeSession();
@@ -802,7 +814,9 @@ Deno.test("session: navigateTree with no structure reports no structure", () => 
   assertEquals(s.view().message, "No structure detected");
 });
 
-// --- plain-file editing key paths (888-1090) --------------------------------
+//
+// plain-file editing key paths (888-1090)
+//
 
 function fileSession(text: string, width = 80, height = 12): {
   s: Session;
@@ -1058,7 +1072,9 @@ Deno.test("session: ctrl-c while editing quits a clean buffer", () => {
   assert(s.quit, "ctrl-c quit the clean buffer");
 });
 
-// --- F3 / save / quit prompts (1391-1474) -----------------------------------
+//
+// F3 / save / quit prompts (1391-1474)
+//
 
 Deno.test("session: F3 saves an editable file and ctrl-x ctrl-s also saves", () => {
   const { s, saved } = fileSession("save me\n");
@@ -1211,7 +1227,9 @@ Deno.test("session: C-x C-c quits", () => {
   assert(s.quit, "C-x C-c quit a clean buffer");
 });
 
-// --- revert prompt (1480-1544) ----------------------------------------------
+//
+// revert prompt (1480-1544)
+//
 
 Deno.test("session: ctrl-r on a clean buffer reports nothing to revert", () => {
   const { s } = fileSession("nothing\n");
@@ -1295,7 +1313,9 @@ Deno.test("session: revert that returns nothing-there is reported", () => {
   assertEquals(s.view().message, "Nothing to revert there.");
 });
 
-// --- expand context errors (1556-1574) --------------------------------------
+//
+// expand context errors (1556-1574)
+//
 
 Deno.test("session: ctrl-l when expanding context is unavailable reports it", () => {
   const { s } = fileSession("plain file\n");
@@ -1354,7 +1374,9 @@ Deno.test("session: ctrl-l when expandContext yields nothing reports no more con
   }
 });
 
-// --- diff edit machinery exercised through a real diff source ---------------
+//
+// diff edit machinery exercised through a real diff source
+//
 
 const EXPAND_FILE = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\neta\ntheta\n";
 const EXPAND_DIFF = `diff --git a/m.ts b/m.ts
@@ -2460,7 +2482,9 @@ Deno.test("diffcov: after a revert the cursor snaps to an editable line", () => 
   }
 });
 
-// --- file picker (1656-1849) ------------------------------------------------
+//
+// file picker (1656-1849)
+//
 
 const TREE: Record<string, DirEntry[]> = {
   "/work": [
@@ -2676,12 +2700,12 @@ Deno.test("filepickercov: escape cancels the picker", () => {
   assertEquals(s.view().message, "Cancelled");
 });
 
-// ===========================================================================
+//
 // Additional targeted coverage for the remaining branch bodies. Each test
 // drives a specific guard or conditional that the suite above approaches but
 // does not yet execute (the untaken side of an `if (cond) STMT;` one-liner, an
 // off-screen scroll, or a non-editable diff line under a policy gate).
-// ===========================================================================
+//
 
 // --- card reference up-scroll lands a higher target above the scroll (392) --
 
@@ -2797,10 +2821,12 @@ Deno.test("session: opening a use reference (no def offset) resolves a node via 
   assert(ov, "a node resolved and its card opened");
 });
 
-// --- findTargetIndex falls back to a start-offset-only match (436-439) -------
+//
+// findTargetIndex falls back to a start-offset-only match (436-439)
 // The pattern's card lists a dependency reference that carries a definition
 // offset but no end offset (no semantic service to pin the exact range), so
 // following it skips the exact (start+end) lookup and matches on start alone.
+//
 
 Deno.test("session: following a dependency with no end offset matches a node by start offset", () => {
   const doc = parseDocument(SAMPLE);
@@ -2820,7 +2846,9 @@ Deno.test("session: following a dependency with no end offset matches a node by 
   assert(s.view().message.startsWith("→"), s.view().message);
 });
 
-// --- overlay enter/z with no reference (484, 665-668) ------------------------
+//
+// overlay enter/z with no reference (484, 665-668)
+//
 
 Deno.test("session: Enter on a card with no reference selected closes the overlay", () => {
   const s = makeSession(100, 24);
@@ -2839,7 +2867,9 @@ Deno.test("session: z on the help overlay (no subject node) does nothing", () =>
   assert(s.view().overlay!.title.toLowerCase().includes("keys"));
 });
 
-// --- edit-mode search with no editable match (546-547, 560) ------------------
+//
+// edit-mode search with no editable match (546-547, 560)
+//
 
 Deno.test("diffcov: an edit-mode search whose only matches are non-editable keeps the cursor", () => {
   const { ws, done } = diffWorkspace();
@@ -2876,7 +2906,9 @@ Deno.test("diffcov: committing an edit-mode search with no matches is a no-op on
   }
 });
 
-// --- escape an empty-query search clears the (empty) match set (599) ---------
+//
+// escape an empty-query search clears the (empty) match set (599)
+//
 
 Deno.test("session: escaping a search with no query typed clears the match set", () => {
   const s = makeSession();
@@ -2887,10 +2919,12 @@ Deno.test("session: escaping a search with no query typed clears the match set",
   assertEquals(s.view().matches, null, "no matches set with an empty query");
 });
 
-// --- diff edit guards on a non-editable (removed) line ----------------------
+//
+// diff edit guards on a non-editable (removed) line
 // Land the cursor on the removed line (index 8 in the DIFF fixture) and run
 // each delete-/kill-style edit. The policy's editStart returns null there, so
 // every gate reports NOT_EDITABLE and refuses the edit.
+//
 
 Deno.test("diffcov: delete-forward on a removed line is refused (guardForwardEdit)", () => {
   const { ws, done } = diffWorkspace();
@@ -3054,7 +3088,9 @@ Deno.test("session: moving the edit cursor off-screen scrolls it back into view"
   assertEquals(s.view().left, 0, "panned back to column 0");
 });
 
-// --- ensurePickerVisible never lets the scroll go negative (1705) ------------
+//
+// ensurePickerVisible never lets the scroll go negative (1705)
+//
 
 Deno.test("filepickercov: scrolling the picker selection up keeps the scroll non-negative", () => {
   const s = pickerSession();
@@ -3067,7 +3103,9 @@ Deno.test("filepickercov: scrolling the picker selection up keeps the scroll non
   assertEquals(s.view().overlay!.selectedLine, 0, "back at the first entry");
 });
 
-// --- adjustHunkCounts: removing the last context line above a hunk (1152) ----
+//
+// adjustHunkCounts: removing the last context line above a hunk (1152)
+//
 
 Deno.test("diffcov: removing an added line shrinks the hunk header counts", () => {
   const { ws, done } = diffWorkspace();
@@ -3096,7 +3134,9 @@ Deno.test("diffcov: removing an added line shrinks the hunk header counts", () =
   }
 });
 
-// --- only visible hunk edges, and what stops them ---------------------------
+//
+// only visible hunk edges, and what stops them
+//
 
 /** A diff whose only hunk sits hard against the top of its file, with a second
  * hunk close enough below that expanding down soon meets it. */
@@ -3726,7 +3766,9 @@ index 0000000..1111111 100644
   }
 });
 
-// --- reveal-frame remapping and room-less hunks -----------------------------
+//
+// reveal-frame remapping and room-less hunks
+//
 
 Deno.test("diffcov: a reveal frame carries a selected node to its shifted place", () => {
   const { s, done } = tallSession(13);

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -22,7 +22,9 @@ import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";
 
-// --- key helpers ------------------------------------------------------------
+//
+// key helpers
+//
 
 function press(s: Session, ...names: string[]): void {
   for (const name of names) {
@@ -49,9 +51,10 @@ function selectByLabel(s: Session, label: string): void {
   throw new Error(`node not reached: ${label}`);
 }
 
-// ===========================================================================
+//
 // 663 — Enter on an in-blob reference that resolves to no node.
-// ===========================================================================
+//
+
 // A "use" reference carries a destination line but no definition offset. When
 // that line falls outside every structure node's range, both findTargetIndex
 // (no offset) and nodeAtLine (no containing node) fail, so resolveTargetNode
@@ -101,9 +104,10 @@ const useB = base;`;
   assert(s.view().overlay, "the card stays open");
 });
 
-// ===========================================================================
+//
 // Behavioral anchor near revealMatch (580).
-// ===========================================================================
+//
+
 // revealMatch reads matches[currentMatch] and guards `!m`. Every public caller
 // (runSearch, refreshSearchMatches, stepMatch) checks for an empty match set
 // before reaching it, so the no-match return is unreachable from the public
@@ -122,9 +126,10 @@ Deno.test("session: a committed search reveals its single match", () => {
   assertEquals(s.view().currentMatch, 0, "the only match is focused");
 });
 
-// ===========================================================================
+//
 // 1152 / 1156 — adjustHunkCounts walks above a hunk it cannot find or parse.
-// ===========================================================================
+//
+
 // adjustHunkCounts climbs from the edited row to the nearest "@@ " header. If
 // it reaches the top of the buffer with no header and no diff/---/+++ marker,
 // `h < 0` returns (1152). If it stops on a line that begins "@@ " but does not
@@ -267,9 +272,10 @@ Deno.test("diffcov2: adjustHunkCounts rejects a malformed explicit hunk header",
   }
 });
 
-// ===========================================================================
+//
 // 1705 — ensurePickerVisible clamps a negative overlay scroll back to zero.
-// ===========================================================================
+//
+
 // When the picker selection moves up to an entry above the current scroll,
 // ensurePickerVisible sets the scroll to the selection's index. A selection of
 // 0 with a stale negative scroll would be clamped by the final guard. We reach
@@ -341,9 +347,10 @@ Deno.test("filepickercov2: paging the picker up to the top keeps the scroll non-
   assertEquals(s.view().overlay!.scroll, 0, "scroll reset to the top");
 });
 
-// ===========================================================================
+//
 // Behavioral anchors for the reachable structure-tree edges near 288/377/380.
-// ===========================================================================
+//
+
 // These do not force the unreachable defensive returns, but assert the
 // surrounding navigation/card behavior stays correct from a real session.
 

--- a/packages/cli/test/view-session-gate.test.ts
+++ b/packages/cli/test/view-session-gate.test.ts
@@ -47,9 +47,10 @@ function focusLastTarget(s: Session): number {
   return steps;
 }
 
-// ---------------------------------------------------------------------------
+//
 // findTargetIndex start-offset-only fallback (436, 437, 439).
-// ---------------------------------------------------------------------------
+//
+
 // The pattern's card lists a dependency on `__cfLift_1` whose target carries a
 // definition start offset but no end offset (the dependency is found
 // syntactically, with no semantic service to pin the exact range). Following it
@@ -120,9 +121,10 @@ Deno.test("gate: Enter on the dependency reference opens the start-matched node'
   );
 });
 
-// ---------------------------------------------------------------------------
+//
 // jumpToTarget nodeAtLine fallback (446).
-// ---------------------------------------------------------------------------
+//
+
 // The lift's card ends with a plain "use" reference that carries a destination
 // line but no definition offset at all. `findTargetIndex` returns -1 for it, so
 // `jumpToTarget` falls back to `nodeAtLine` on the destination line to pick the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 209 section markers in `packages/cli` to the `//`-delimited form.
198 of them were `// --- Title ------------` filled to the margin, which is this
package's house style; the rest were bracketed or a bare rule.

## Two hazards checked, both clear

**Fixture documents.** `cli` is a viewer and an editor, so its tests build
documents and assert on their contents. A marker rewritten from one line to
three inside such a document would corrupt the fixture. Checked with the
TypeScript parser, walking `NoSubstitutionTemplateLiteral` and
`TemplateExpression`: zero rule-bearing `//` lines in this package sit inside a
template literal. (An earlier hand-rolled scan claimed 36 here; every one was an
artifact of mis-pairing a backtick that appeared inside a comment.)

**Line-number citations.** Several coverage tests carry a comment naming the
source line a case exercises — `(line 803)`, `(lines 913-920)` — and this change
shifts lines in the files they cite: `parse.ts` by ten, `session.ts` by twelve.

Those citations were already drifting before this change. Of the fourteen in
`view-parse-cov.test.ts`, five point at a blank line or a bare closing brace on
`main` today. Nothing asserts on them, so nothing breaks either way, and
refreshing or removing them is a different question from conforming a marker —
so their wording is left exactly as it was. Worth doing deliberately at some
point, since a line number in a comment rots by construction.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and every long rule run removed had text on one side only.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as does
`packages/cli`'s own `deno task test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

