### PR TITLE
Conform the section markers in `runner`

### DIFF
--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -88,9 +88,9 @@ const inputDataSchema: JSONSchema = {
 type InputData = { values: number[]; label: string };
 type ResultData = { sum: number; result: string };
 
-// ============================================================
+//
 // Helper types and functions
-// ============================================================
+//
 
 interface TestContext {
   runtime: Runtime;
@@ -137,9 +137,9 @@ function getResultCell(
   return runtime.getCell<ResultData>(space, cellId, undefined, tx);
 }
 
-// ============================================================
+//
 // Phase functions
-// ============================================================
+//
 
 /**
  * Phase 1: Save pattern and initial data to storage.
@@ -420,9 +420,9 @@ async function phase4CrossSessionReactivity(
   console.log("Runtime 4 disposed");
 }
 
-// ============================================================
+//
 // Main test
-// ============================================================
+//
 
 async function testPatternAndDataPersistence() {
   console.log("\n=== TEST: Pattern and Data Persistence ===");

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -163,9 +163,9 @@ function stripInjectedResult(
   return copy;
 }
 
-// --------------------
+//
 // Helper types + utils
-// --------------------
+//
 
 type ToolKind = "handler" | "cell" | "pattern";
 type LLMObservationSerializationResult = CfcObservationResult;
@@ -1209,9 +1209,10 @@ type PinnedCell = {
   name: string; // Human-readable name for display
 };
 
-// ============================================================================
+//
 // Path Utility Functions
-// ============================================================================
+//
+
 // These utilities handle the conversion between LLM-facing path format (/of:...)
 // and internal runtime format (of:...). The LLM sees paths with a leading slash
 // to make it clear that strings are links.

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -107,7 +107,7 @@ export function navigateTo(
     // navigation; requiring a current value can block valid piece targets.
     if (!target) return;
 
-    // ---- Server-execution v2 Phase 4 (protocol.md §5, builtins.md §4):
+    // Server-execution v2 Phase 4 (protocol.md §5, builtins.md §4):
     // under the flag, navigateTo is the SPLIT contract. The SERVED half
     // (a wave-stamped run) computes the target and writes the intent into
     // the firing session's effects INSTANCE; the CLIENT half of a flag-ON

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -174,10 +174,8 @@ export const parseConfLabelTargetPath = (
   return canonical;
 };
 
-//
 // The §4.6.4.2 population rule: persisted templates as the carrier, the
 // interim rule computed from the entry in hand as source and fallback.
-//
 
 /**
  * Observation label of one atom field, or `undefined` when the field is

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -174,9 +174,10 @@ export const parseConfLabelTargetPath = (
   return canonical;
 };
 
-// ---------------------------------------------------------------------------
+//
 // The §4.6.4.2 population rule: persisted templates as the carrier, the
 // interim rule computed from the entry in hand as source and fallback.
+//
 
 /**
  * Observation label of one atom field, or `undefined` when the field is
@@ -358,8 +359,9 @@ const atomProjectionLabel = (
   return consumed;
 };
 
-// ---------------------------------------------------------------------------
+//
 // Query evaluation.
+//
 
 /**
  * The atom field each §4.6.4.1 query predicate tests, plus the atom FAMILY

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1573,13 +1573,11 @@ const isMetaSeamPath = (
   path: readonly string[],
 ): boolean => metaOnlyByPath?.get(pathKey(path)) === true;
 
-//
 // S16 flow labels (default transition): one conservative confidentiality join
 // per transaction — everything the transaction observed taints everything it
 // wrote (§8.9.2/§8.9.3 collapsed to tx granularity). Reads of runtime-internal
 // surfaces (verifier reads, `cid:` schema docs, `["cfc"]`/`["source"]` paths)
 // are excluded, mirroring the write-side exclusions.
-//
 
 // Keyed on the RAW storage path: the runtime-internal surfaces are
 // document-root siblings of `value` (raw `["cfc", ...]`/`["source", ...]`),
@@ -3212,7 +3210,6 @@ const ifcEntryAppliesToAttemptedWrite = (
   );
 };
 
-//
 // Epic D4 — per-write read-prefix provenance
 // (docs/specs/cfc-write-prefix-provenance.md). Each protected write is gated
 // on only the reads that could have fed it: those whose activity-clock
@@ -3228,7 +3225,6 @@ const ifcEntryAppliesToAttemptedWrite = (
 // counterexample: write P, read R, re-write P = f(R) would exclude R) and
 // NOT keyed on the exact address (a later write to P.child re-creates the
 // same escape one level down — doc §4).
-//
 
 type WritePrefixBounds = {
   /**
@@ -3324,7 +3320,6 @@ const buildWritePrefixBounds = (
   };
 };
 
-//
 // Stage 0 of the value-level-provenance design
 // (docs/specs/cfc-value-level-provenance.md §6, SC-24): per-prepare
 // precision counters measuring how much the shipped D4 prefix narrows the
@@ -3332,7 +3327,6 @@ const buildWritePrefixBounds = (
 // machinery exists. Measurement only: nothing here feeds an enforcement
 // decision, the summary is collected exclusively when a hook consumes it,
 // and the hook-absent path pays one presence check.
-//
 
 /** How a protected write's activity-clock bound was obtained. */
 export type CfcPrefixBoundSource =

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1573,12 +1573,13 @@ const isMetaSeamPath = (
   path: readonly string[],
 ): boolean => metaOnlyByPath?.get(pathKey(path)) === true;
 
-// ---------------------------------------------------------------------------
+//
 // S16 flow labels (default transition): one conservative confidentiality join
 // per transaction — everything the transaction observed taints everything it
 // wrote (§8.9.2/§8.9.3 collapsed to tx granularity). Reads of runtime-internal
 // surfaces (verifier reads, `cid:` schema docs, `["cfc"]`/`["source"]` paths)
 // are excluded, mirroring the write-side exclusions.
+//
 
 // Keyed on the RAW storage path: the runtime-internal surfaces are
 // document-root siblings of `value` (raw `["cfc", ...]`/`["source", ...]`),
@@ -3211,7 +3212,7 @@ const ifcEntryAppliesToAttemptedWrite = (
   );
 };
 
-// ---------------------------------------------------------------------------
+//
 // Epic D4 — per-write read-prefix provenance
 // (docs/specs/cfc-write-prefix-provenance.md). Each protected write is gated
 // on only the reads that could have fed it: those whose activity-clock
@@ -3227,6 +3228,7 @@ const ifcEntryAppliesToAttemptedWrite = (
 // counterexample: write P, read R, re-write P = f(R) would exclude R) and
 // NOT keyed on the exact address (a later write to P.child re-creates the
 // same escape one level down — doc §4).
+//
 
 type WritePrefixBounds = {
   /**
@@ -3322,7 +3324,7 @@ const buildWritePrefixBounds = (
   };
 };
 
-// ---------------------------------------------------------------------------
+//
 // Stage 0 of the value-level-provenance design
 // (docs/specs/cfc-value-level-provenance.md §6, SC-24): per-prepare
 // precision counters measuring how much the shipped D4 prefix narrows the
@@ -3330,6 +3332,7 @@ const buildWritePrefixBounds = (
 // machinery exists. Measurement only: nothing here feeds an enforcement
 // decision, the summary is collected exclusively when a hook consumes it,
 // and the hook-absent path pays one presence check.
+//
 
 /** How a protected write's activity-clock bound was obtained. */
 export type CfcPrefixBoundSource =

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -678,7 +678,9 @@ export function verifySourceDocs(
   };
 }
 
-// --- Source-set store (4.3.2): write/read `pattern:<identity>` cells ---------
+//
+// Source-set store (4.3.2): write/read `pattern:<identity>` cells
+//
 
 /**
  * Stored shape of a source-set cell. Mirrors {@link SourceDoc} but each import
@@ -1113,7 +1115,9 @@ export async function loadVerifiedSourceClosure(
   );
 }
 
-// --- Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC ------
+//
+// Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC
+//
 
 const compiledDocProperties = {
   kind: { type: "string" },

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -556,7 +556,8 @@ export class SpaceServer implements TransactionSealDestination {
     string,
     { id: string; scopeKey: string }
   >();
-  // ---- (d′) — server-settle instrumentation (design §6 W4's
+  //
+  // (d′) — server-settle instrumentation (design §6 W4's
   // metric; §2.8 (c)). Per authored input: admission (the feed notice's
   // arrival, `enqueueCommit`) → COVERAGE (the wave commit whose
   // derivedThrough ≥ seq = the value-only settle) → and, when a
@@ -564,6 +565,7 @@ export class SpaceServer implements TransactionSealDestination {
   // structural-growth path, §2.3), the NEXT derived commit = the
   // structural-growth landing. Attribution of a growth wake to an input
   // is by adjacency (the most recently covered input), stated as such.
+  //
   #growthWakeCounter = 0;
   // MINOR-2 / obligation (iii): the last-folded demand-root enter/leave
   // counter values, so the space-lived accumulators fold the FULL delta
@@ -1367,7 +1369,9 @@ export class SpaceServer implements TransactionSealDestination {
     }, DEMAND_WAKE_GRACE_MS);
   }
 
-  // ---- TransactionSealDestination ----
+  //
+  // TransactionSealDestination
+  //
 
   seal(tx: IExtendedStorageTransaction): Promise<Result<Unit, CommitError>> {
     // Effect-COMPLETION routing (stage G, serving-loop.md §4): a marked
@@ -2184,7 +2188,9 @@ export class SpaceServer implements TransactionSealDestination {
     }
   }
 
-  // ---- the loop (serving-loop.md §3) ----
+  //
+  // the loop (serving-loop.md §3)
+  //
 
   async #loop(): Promise<void> {
     if (this.#loopRunning) return;

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -556,7 +556,6 @@ export class SpaceServer implements TransactionSealDestination {
     string,
     { id: string; scopeKey: string }
   >();
-  //
   // (d′) — server-settle instrumentation (design §6 W4's
   // metric; §2.8 (c)). Per authored input: admission (the feed notice's
   // arrival, `enqueueCommit`) → COVERAGE (the wave commit whose
@@ -565,7 +564,6 @@ export class SpaceServer implements TransactionSealDestination {
   // structural-growth path, §2.3), the NEXT derived commit = the
   // structural-growth landing. Attribution of a growth wake to an input
   // is by adjacency (the most recently covered input), stated as such.
-  //
   #growthWakeCounter = 0;
   // MINOR-2 / obligation (iii): the last-folded demand-root enter/leave
   // counter values, so the space-lived accumulators fold the FULL delta

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -1571,7 +1571,7 @@ export class WaveAccumulator
       return outcome;
     }
 
-    // ---- per-doc conflict resolution, per write class (§3d) ----
+    // per-doc conflict resolution, per write class (§3d)
 
     const homeWrites = this.#contributions.map((contribution) =>
       this.#homeDocInstances(contribution)
@@ -1932,7 +1932,7 @@ export class WaveAccumulator
 
     await resolveConflicts();
 
-    // ---- foreign provisioning commits FIRST (protocol.md §2b) ----
+    // foreign provisioning commits FIRST (protocol.md §2b)
     //
     // Committed exactly once, before the home commit loop below: a home
     // re-attempt never re-sends them. A contribution that requeues AFTER
@@ -1987,7 +1987,7 @@ export class WaveAccumulator
       });
     }
 
-    // ---- the home commit, re-resolving on sink-reported races ----
+    // the home commit, re-resolving on sink-reported races
     while (true) {
       const batch = this.#buildHomeBatch(
         requeued,
@@ -2137,7 +2137,9 @@ export class WaveAccumulator
     }
   }
 
-  // ---- helpers ----
+  //
+  // helpers
+  //
 
   #homeSealed(
     contribution: WaveContribution,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -146,9 +146,9 @@ import type {
   RuntimeOptions,
 } from "./runtime.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Gate 1: the exhaustive option registry.
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Every key of `RuntimeOptions`, by hand. The `satisfies` clause rejects
@@ -201,9 +201,9 @@ type MissingOptionKeys = Exclude<keyof RuntimeOptions, RuntimeOptionKey>;
 // the missing key(s).
 const _unclassifiedOptions: never[] = [] as MissingOptionKeys[];
 
-// ---------------------------------------------------------------------------
+//
 // Gate 2: the canonical experimental-flag env mapping.
-// ---------------------------------------------------------------------------
+//
 
 /** Reads one environment variable; pass `Deno.env.get` in Deno contexts. */
 export type EnvReader = (name: string) => string | undefined;
@@ -280,9 +280,9 @@ export function experimentalOptionsFromEnv(
   return opts;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Gate 3: which flags a deployed client takes from the server it talks to.
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Where a client resolves one flag when it is not built alongside the server
@@ -519,9 +519,9 @@ export async function experimentalOptionsForDeployedClient(
   );
 }
 
-// ---------------------------------------------------------------------------
+//
 // The max-enforcement CFC posture (CT-2075's named bundle).
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Names of the CFC posture bundles a preset caller can opt into. One posture
@@ -590,9 +590,9 @@ export const MAX_ENFORCEMENT_CFC_OPTIONS = Object.freeze(
   } as const,
 ) satisfies Partial<RuntimeOptions>;
 
-// ---------------------------------------------------------------------------
+//
 // Gate 4: the shared core all presets compose.
-// ---------------------------------------------------------------------------
+//
 
 interface CoreParams {
   /** Base URL of the memory/API service this runtime talks to. */
@@ -673,9 +673,9 @@ function coreOptions(params: CoreParams): RuntimeOptions {
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // The presets.
-// ---------------------------------------------------------------------------
+//
 
 export interface ProductionServerPresetParams extends CoreParams {
   /**

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1053,14 +1053,12 @@ export class Scheduler {
     return rearmed;
   }
 
-  //
   // The (d′) standing `demandedWriters` root kind and the
   // per-(instance, demander) currency check (stage-C design §2.2 / §2.4;
   // serving-loop.md §1). The SpaceServer's demand pass calls these on
   // registry DELTAS; nothing here is reached off the serving posture (the
   // registration hook installs lazily on the first `enterDemandedEntity`,
   // so a plain client runtime's `demandedWriters` set stays empty — T9′).
-  //
 
   /** Refcount per demanded ENTITY (scope-NAME keyed, `entityNameKey` —
    * the writer index's vocabulary: two instances of one doc, `user:alice`

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -441,9 +441,9 @@ export class Scheduler {
   // `servingYieldObserver` seam — the SpaceServer's mid-wave lease renew.
   private readonly cooperativeYield: CooperativeYield | undefined;
 
-  // ============================================================
+  //
   // Public API
-  // ============================================================
+  //
 
   constructor(
     readonly runtime: Runtime,
@@ -1053,14 +1053,14 @@ export class Scheduler {
     return rearmed;
   }
 
-  // ============================================================
+  //
   // The (d′) standing `demandedWriters` root kind and the
   // per-(instance, demander) currency check (stage-C design §2.2 / §2.4;
   // serving-loop.md §1). The SpaceServer's demand pass calls these on
   // registry DELTAS; nothing here is reached off the serving posture (the
   // registration hook installs lazily on the first `enterDemandedEntity`,
   // so a plain client runtime's `demandedWriters` set stays empty — T9′).
-  // ============================================================
+  //
 
   /** Refcount per demanded ENTITY (scope-NAME keyed, `entityNameKey` —
    * the writer index's vocabulary: two instances of one doc, `user:alice`
@@ -1495,9 +1495,9 @@ export class Scheduler {
     return this.eventPreflightTelemetryEnabled;
   }
 
-  // ============================================================
+  //
   // Debounce infrastructure for throttling slow actions
-  // ============================================================
+  //
 
   /**
    * Sets a debounce delay for an action.
@@ -1544,9 +1544,9 @@ export class Scheduler {
     this.gates.setNoDebounce(action, optOut);
   }
 
-  // ============================================================
+  //
   // Throttle infrastructure - "value may be outdated by T ms"
-  // ============================================================
+  //
 
   /**
    * Sets a throttle period for an action.
@@ -1645,9 +1645,9 @@ export class Scheduler {
     return buildSchedulerGraphSnapshot(this.graphSnapshotState);
   }
 
-  // ============================================================
+  //
   // Push-triggered filtering
-  // ============================================================
+  //
 
   /**
    * Returns the action's static write surface.
@@ -1656,9 +1656,9 @@ export class Scheduler {
     return this.writeIndex.getSchedulingWrites(action);
   }
 
-  // ============================================================
+  //
   // Compute time tracking for cycle-aware scheduling
-  // ============================================================
+  //
 
   /**
    * Returns the execution statistics for an action, if available.
@@ -1754,9 +1754,9 @@ export class Scheduler {
     return [...this.triggerTrace];
   }
 
-  // ============================================================
+  //
   // Non-settling detection API
-  // ============================================================
+  //
 
   /**
    * Returns whether the scheduler has detected a non-settling condition.
@@ -1783,7 +1783,9 @@ export class Scheduler {
     return runSchedulerDiagnosis(this.diagnosisControlState, durationMs);
   }
 
-  // ── Inline idempotency check mode ──────────────────────────────────
+  //
+  // Inline idempotency check mode
+  //
 
   enableIdempotencyCheck(): void {
     this.idempotencyCheckMode = true;
@@ -1862,9 +1864,9 @@ export class Scheduler {
     this.diagnosisEnabled = false;
   }
 
-  // ============================================================
+  //
   // Execution orchestration
-  // ============================================================
+  //
 
   private handleError(error: Error, action: any) {
     handleSchedulerError(
@@ -2067,9 +2069,9 @@ export class Scheduler {
     }
   }
 
-  // ============================================================
+  //
   // Idempotency diagnosis API (Phase 2 + 3)
-  // ============================================================
+  //
 
   /**
    * Starts diagnosis mode: captures read/write values and causal edges.
@@ -2105,9 +2107,9 @@ export class Scheduler {
     });
   }
 
-  // ============================================================
+  //
   // State wiring
-  // ============================================================
+  //
 
   // Keep state-bundle wiring explicit without making the field declarations
   // read like one large object graph.
@@ -2659,9 +2661,9 @@ export class Scheduler {
     };
   }
 
-  // ============================================================
+  //
   // Private forwarding helpers
-  // ============================================================
+  //
 
   /**
    * Gets a stable identifier for an action based on its source location.

--- a/packages/runner/src/scheduler/wake-shaping.ts
+++ b/packages/runner/src/scheduler/wake-shaping.ts
@@ -268,9 +268,9 @@ export class WakeShaper {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Event-path adapter (channel 3)
-// ---------------------------------------------------------------------------
+//
 
 export interface DeliverOpts {
   eventId?: string;
@@ -461,9 +461,9 @@ export function holdShapedEvent(
   });
 }
 
-// ---------------------------------------------------------------------------
+//
 // Cell-path adapter (plan B, channels 4 and 5)
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Shape a cell-flip wake (plan B). `groupKey` identifies the observing pattern

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -110,7 +110,7 @@ export function createRuntimeTelemetryOtelBridge(
   const mattrs = (extra?: Attributes): Attributes =>
     extra ? { ...mbase, ...extra } : mbase;
 
-  // --- Instruments (created once; no-ops when no MeterProvider is set) --------
+  // Instruments (created once; no-ops when no MeterProvider is set)
   const runs = meter.createCounter("ct.scheduler.runs", {
     description: "Scheduler action runs",
   });
@@ -187,7 +187,7 @@ export function createRuntimeTelemetryOtelBridge(
     description: "Storage push/pull duration",
   });
 
-  // --- In-flight storage spans, keyed by the marker `id` ---------------------
+  // In-flight storage spans, keyed by the marker `id`
   type OpenOp = { span: Span; startMs: number };
   const openOps = new Map<string, OpenOp>();
 

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -101,9 +101,9 @@ export type SchedulerEventPreflightActionSummary = {
   writeCount: number;
 };
 
-// ============================================================
+//
 // Diagnosis types for non-settling / non-idempotent detection
-// ============================================================
+//
 
 /**
  * Report for a single action detected as non-idempotent.

--- a/packages/runner/test/bench-fixtures.ts
+++ b/packages/runner/test/bench-fixtures.ts
@@ -40,13 +40,11 @@ medianComplexityC.items[4].done = false;
 export const medianComplexityD = JSON.parse(JSON.stringify(medianComplexityA));
 medianComplexityD.items[0].done = true;
 
-//
 // Many small objects fixtures - 20 arrays x 15 objects x 15 properties = 4,500
 // properties. Tests deepEqual performance on wide, shallow object graphs.
 // Note: Originally tried 100 x 25 x 25 = 62,500 properties but that caused OOM
 // when running benchmarks with many iterations. Can tune these numbers to find
 // a sweet spot that stresses the comparison without exhausting memory.
-//
 
 function buildSmallObject(groupIdx: number, objIdx: number) {
   const obj: Record<string, string | number | boolean | null> = {};

--- a/packages/runner/test/bench-fixtures.ts
+++ b/packages/runner/test/bench-fixtures.ts
@@ -9,10 +9,10 @@
  * - manySmallObjects: Wide, shallow graphs (tests traversal overhead)
  */
 
-// ============================================================================
+//
 // Median complexity fixtures - representative of typical Cell values
 // (arrays of objects with string/boolean/number fields)
-// ============================================================================
+//
 
 export const medianComplexityA = {
   items: [
@@ -40,13 +40,13 @@ medianComplexityC.items[4].done = false;
 export const medianComplexityD = JSON.parse(JSON.stringify(medianComplexityA));
 medianComplexityD.items[0].done = true;
 
-// ============================================================================
+//
 // Many small objects fixtures - 20 arrays x 15 objects x 15 properties = 4,500
 // properties. Tests deepEqual performance on wide, shallow object graphs.
 // Note: Originally tried 100 x 25 x 25 = 62,500 properties but that caused OOM
 // when running benchmarks with many iterations. Can tune these numbers to find
 // a sweet spot that stresses the comparison without exhausting memory.
-// ============================================================================
+//
 
 function buildSmallObject(groupIdx: number, objIdx: number) {
   const obj: Record<string, string | number | boolean | null> = {};
@@ -99,10 +99,10 @@ manySmallObjectsC.groups[19][14].prop_14 = "DIFFERENT_VALUE";
 export const manySmallObjectsD = JSON.parse(JSON.stringify(manySmallObjectsA));
 manySmallObjectsD.groups[0][0].prop_0 = -999999;
 
-// ============================================================================
+//
 // Large string fixtures - 100k character strings, difference at last character
 // Tests worst case for deepEqual (no short-circuit, maximum traversal)
-// ============================================================================
+//
 
 const hugeString = "x".repeat(100_000);
 const hugeStringDifferentEnd = hugeString.slice(0, -1) + "y";

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -2340,9 +2340,9 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // End-to-end: two runtimes with DISTINCT user identities over shared storage
-// ---------------------------------------------------------------------------
+//
 
 // Two distinct signers for the two "users" in the e2e describe.
 // Declared at module level so top-level await applies.

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -158,7 +158,8 @@ async function cleanup(
   await storageManager.close();
 }
 
-// --- write accounting -------------------------------------------------------
+//
+// write accounting
 // A transaction holds its journal only while it is open: commit() releases it
 // on the way to settling, so tx.journal.novelty(space) is empty afterwards.
 // Each write scenario below therefore takes an `account` callback and hands it
@@ -167,6 +168,7 @@ async function cleanup(
 // A benchmark cannot afford that call inside its timed window, so it does not
 // pass one. Instead it runs the same scenario once more, untimed and with the
 // callback, and reports what came back. The reports are per bench name, once.
+//
 type Account = (tx: IExtendedStorageTransaction) => void;
 
 const reported = new Set<string>();
@@ -208,9 +210,9 @@ function updateLine({ docs, bytes }: WriteAccount): string {
     `(one raw item≈${jsonBytes(makeItem(0))}B)`;
 }
 
-// =============================================================================
+//
 // 1. WRITE: one flat array in ONE doc, via a single Cell.set()
-// =============================================================================
+//
 async function writeOneDoc(
   N: number,
   b?: Deno.BenchContext,
@@ -235,9 +237,9 @@ async function writeOneDoc(
   }
 }
 
-// =============================================================================
+//
 // 2. WRITE: one doc PER ITEM (parent array holds cell links)
-// =============================================================================
+//
 async function writePerItem(
   N: number,
   b?: Deno.BenchContext,
@@ -304,9 +306,9 @@ for (const N of SIZES) {
   });
 }
 
-// =============================================================================
+//
 // 3. READ: one whole-array get() in a fresh tx, then repeated reads in one tx
-// =============================================================================
+//
 for (const N of SIZES) {
   Deno.bench({
     name: `flat list read - fresh-tx schemaless get() (${N} items)`,
@@ -414,7 +416,7 @@ for (const N of SIZES) {
   });
 }
 
-// =============================================================================
+//
 // 4. UPDATE: three writer profiles for "one item changed", distinguished
 //    because they have wildly different write footprints:
 //      a. REGENERATE from scratch (what a derivation/lift recompute does):
@@ -423,7 +425,7 @@ for (const N of SIZES) {
 //         by get() carry their doc identity → only the changed element and
 //         the parent write.
 //      c. TARGETED key(i).set: bypasses the array diff entirely.
-// =============================================================================
+//
 async function updateRegenerate(
   N: number,
   b?: Deno.BenchContext,

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -416,7 +416,6 @@ for (const N of SIZES) {
   });
 }
 
-//
 // 4. UPDATE: three writer profiles for "one item changed", distinguished
 //    because they have wildly different write footprints:
 //      a. REGENERATE from scratch (what a derivation/lift recompute does):
@@ -425,7 +424,6 @@ for (const N of SIZES) {
 //         by get() carry their doc identity → only the changed element and
 //         the parent write.
 //      c. TARGETED key(i).set: bypasses the array diff entirely.
-//
 async function updateRegenerate(
   N: number,
   b?: Deno.BenchContext,

--- a/packages/runner/test/cell-set.bench.ts
+++ b/packages/runner/test/cell-set.bench.ts
@@ -53,10 +53,10 @@ async function cleanup(
   await runtime.dispose();
 }
 
-// =============================================================================
+//
 // DATA SIZE BENCHMARKS
 // Test how data size affects Cell.set() performance
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - size: small object (5 fields)",
@@ -154,10 +154,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // NESTING DEPTH BENCHMARKS
 // Test how nesting depth affects Cell.set() performance
-// =============================================================================
+//
 
 function createNestedObject(depth: number, i: number): any {
   if (depth === 0) {
@@ -240,10 +240,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // CHANGE PATTERN BENCHMARKS
 // Test how different change patterns affect Cell.set() performance
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - change: full replace (same structure)",
@@ -418,10 +418,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // CT-1123 REPRODUCTION BENCHMARKS
 // Specifically test scenarios similar to the issue
-// =============================================================================
+//
 
 // Schema similar to the Person pattern in CT-1123
 const personSchema = {
@@ -556,10 +556,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // ARRAY SIZE BENCHMARKS
 // Test how array sizes affect performance (relevant to CT-1123 interests/skills arrays)
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - array: small (10 items)",
@@ -614,10 +614,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // ARRAY STRUCTURE BENCHMARKS
 // Test path-level array structural edits that were previously missing coverage
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - array: path replace truncation (100↔50 items)",
@@ -674,10 +674,10 @@ Deno.bench({
 // facts), not in Cell.set() itself (~3.4s for all 100 iterations). The benchmark
 // was measuring SQLite write throughput rather than Cell.set() performance.
 
-// =============================================================================
+//
 // WRITE COUNT BENCHMARKS
 // Test the specific scenario of ~226 writes (like CT-1123)
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - write count: ~50 writes (small complex object)",
@@ -783,10 +783,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // SCHEMA WITH NESTED CELLS (asCell: ["cell"])
 // Test performance impact of asCell which creates sub-cell references
-// =============================================================================
+//
 
 const schemaWithAsCell = {
   type: "object",
@@ -867,10 +867,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // TRANSACTION OVERHEAD BENCHMARKS
 // Test if transaction management adds overhead
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.set() - single transaction, many sets",
@@ -915,10 +915,10 @@ Deno.bench({
   },
 });
 
-// =============================================================================
+//
 // CELL.UPDATE() vs CELL.SET() COMPARISON
 // Test if update() is more efficient than set() for partial changes
-// =============================================================================
+//
 
 Deno.bench({
   name: "Cell.update() vs set() - update() for partial changes",

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1389,9 +1389,9 @@ Deno.bench("Notebook read - 100 notes, 1000 reads", async () => {
   await benchmarkNotebookReads(100, 1000);
 });
 
-// ============================================================================
+//
 // Overhead microbenchmarks for comparison
-// ============================================================================
+//
 
 Deno.bench(
   "Overhead - isObjectNotArray check (10000x)",

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -379,9 +379,9 @@ Deno.bench(
   },
 );
 
-// ---------------------------------------------------------------------------
+//
 // watchIdForEntry — exercises hashStringOf on a fresh, ad-hoc watch key
-// ---------------------------------------------------------------------------
+//
 
 const WATCH_SCHEMA: JSONSchema = internSchema({
   type: "object",

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -22,7 +22,6 @@ import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
-//
 // Cross-space integrity & declassification — expressing the four scenarios and
 // pinning where the gaps are.
 //
@@ -47,7 +46,6 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 //     and FAILS CLOSED (3a). `projection` (§8.3) IS implemented — verified at
 //     commit with scoped-integrity carry (3a′ shows the subset-declaration
 //     sliver; full behavior in cfc-projection.test.ts).
-//
 
 const signer = await Identity.fromPassphrase("cfc-cross-space-integrity");
 const spaceA = signer.did();
@@ -695,7 +693,6 @@ describe("CFC cross-space integrity", () => {
   });
 });
 
-//
 // Scenario 2 — declassify while releasing/copying the value. Declassification
 // is a boundary-time rewrite expressed by EXCHANGE RULES: a rule adds an
 // alternative to (or drops) a CONFIDENTIALITY clause, gated by evidence. The
@@ -705,7 +702,6 @@ describe("CFC cross-space integrity", () => {
 //
 // These use the exchange evaluator directly, which is the label transform the
 // sink/egress boundary applies under `cfcPolicyEvaluation: "enforce"`.
-//
 
 const BOB = "did:key:bob";
 const userBob = cfcAtom.user(BOB);

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -22,7 +22,7 @@ import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
-// ===========================================================================
+//
 // Cross-space integrity & declassification — expressing the four scenarios and
 // pinning where the gaps are.
 //
@@ -47,7 +47,7 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 //     and FAILS CLOSED (3a). `projection` (§8.3) IS implemented — verified at
 //     commit with scoped-integrity carry (3a′ shows the subset-declaration
 //     sliver; full behavior in cfc-projection.test.ts).
-// ===========================================================================
+//
 
 const signer = await Identity.fromPassphrase("cfc-cross-space-integrity");
 const spaceA = signer.did();
@@ -123,13 +123,11 @@ const isLinkReference = (atom: unknown): atom is {
     "https://commonfabric.org/cfc/atom/LinkReference";
 
 describe("CFC cross-space integrity", () => {
-  // -------------------------------------------------------------------------
   // Primitive: a value gets integrity. Declared `ifc.integrity` with a
   // non-reserved atom persists as an `origin: "declared"` entry, exactly like
   // declared confidentiality. (Reserved runtime-minted atoms — LlmDerived,
   // PolicyCertified, … — are gated to builtin identities and would be stripped
   // here; a plain string or custom-URL atom is the author-mintable form.)
-  // -------------------------------------------------------------------------
   it("scenario 1a — a value created in a space gets integrity (declared)", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -167,11 +165,9 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Same-space verbatim copy: `exactCopyOf` is content-address verified and
   // carries the SOURCE integrity onto the copy (§8.4). This is the "verbatim
   // copy retains integrity" primitive — but note the space constraint below.
-  // -------------------------------------------------------------------------
   it("scenario 1b — same-space exactCopyOf carries integrity onto the copy", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -214,14 +210,12 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Scenario 1 proper (reference / no-copy): space B holds a LINK to the
   // labeled value in space A. Traversing the link yields the source integrity
   // PRESERVED plus a runtime-minted `LinkReference` endorsement that records
   // BOTH spaces (§3.7.2: integrity = target ∪ link-endorsement), and the
   // source confidentiality carried across the boundary (§3.7.1). This is the
   // mechanism that genuinely crosses spaces today.
-  // -------------------------------------------------------------------------
   it("scenario 1c — a cross-space link retains the source integrity (+ endorsement)", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -274,7 +268,6 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Verbatim copy across spaces, DONE RIGHT: carry the REFERENCE. `exactCopyOf`
   // compares two paths within one value tree — but a path may HOLD a link into
   // another space, and the label it copies is that path's (link-carried) label.
@@ -282,7 +275,6 @@ describe("CFC cross-space integrity", () => {
   // copy AND (b) carries the source's integrity across the boundary. This is the
   // "verbatim copy retains integrity across spaces" scenario — the reference is
   // the carrier, and exactCopyOf is the verified claim on top of it.
-  // -------------------------------------------------------------------------
   it("scenario 1d — exactCopyOf of a cross-space link carries integrity and verifies the copy", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -365,14 +357,12 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // The boundary of scenario 1d: copying the RESOLVED VALUE (plain bytes)
   // rather than the reference does NOT carry the label. Once a handler
   // materializes bytes, the runtime has no basis to attest they are the same
   // labeled thing, so the copy is a fresh, unendorsed value. This is not a bug —
   // it is why the REFERENCE (link) is load-bearing for cross-space integrity:
   // carry the link (scenario 1c/1d), not the extracted bytes.
-  // -------------------------------------------------------------------------
   it("scenario 1e — a resolved-byte copy across spaces is unendorsed (carry the reference, not the bytes)", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -423,12 +413,10 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // GAP (remaining): the spec's reference annotation (§8.2 `passThrough`) is
   // unimplemented; a write through a schema declaring it FAILS CLOSED rather
   // than being silently ignored. Reference behaviors stay reachable via
   // per-path labels and links (scenarios 1c / 3).
-  // -------------------------------------------------------------------------
   it("scenario 3a [GAP] — the passThrough ifc annotation fails closed (unimplemented)", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -456,7 +444,6 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Scenario 3a′ — the §8.3 `projection` annotation IS implemented: the
   // ergonomic "declare this field is a scoped projection" syntax verifies at
   // commit (the target must equal the claimed source field) and carries the
@@ -464,7 +451,6 @@ describe("CFC cross-space integrity", () => {
   // projected pointer, so the projected field can never claim whole-object
   // integrity. Mismatch/wildcard/malformed fail-closed behavior and the
   // provenance-class drops live in cfc-projection.test.ts.
-  // -------------------------------------------------------------------------
   it("scenario 3a′ — the projection ifc annotation verifies and carries a scoped label", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -513,12 +499,10 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Scenario 3 (reference variant): referencing only a SUBSET. A link to a
   // sub-path of the source carries only that sub-path's label — the sibling
   // field's label stays behind. This is the "solve the subset with references,
   // at least partially" case.
-  // -------------------------------------------------------------------------
   it("scenario 3b — a cross-space link to a sub-path carries only that subset's label", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -571,7 +555,6 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Subset — the SUBTLE part. Source data carries MORE fields than the
   // destination schema declares:
   //   { foo: { bar, secret }, baz, secret }   vs   { foo: { bar }, baz }
@@ -582,7 +565,6 @@ describe("CFC cross-space integrity", () => {
   // a read-time VIEW, not a projection: it does not sanitize the reference. The
   // secret fields stay confined by their OWN confidentiality labels (so this is
   // safe, not a leak), but "only the right fields crossed" is FALSE here.
-  // -------------------------------------------------------------------------
   it("scenario 3d — a whole-object cross-space link carries undeclared sibling labels (no projection)", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -647,12 +629,10 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Subset — DONE RIGHT: link the specific sub-paths. Only the selected fields'
   // labels cross; the undeclared `secret` fields are never referenced, so their
   // labels (and values) stay entirely behind. This is how you copy a genuine
   // subset by reference, integrity-preserving and leak-free.
-  // -------------------------------------------------------------------------
   it("scenario 3e — per-field cross-space links copy exactly the chosen subset", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
@@ -715,7 +695,7 @@ describe("CFC cross-space integrity", () => {
   });
 });
 
-// ===========================================================================
+//
 // Scenario 2 — declassify while releasing/copying the value. Declassification
 // is a boundary-time rewrite expressed by EXCHANGE RULES: a rule adds an
 // alternative to (or drops) a CONFIDENTIALITY clause, gated by evidence. The
@@ -725,7 +705,7 @@ describe("CFC cross-space integrity", () => {
 //
 // These use the exchange evaluator directly, which is the label transform the
 // sink/egress boundary applies under `cfcPolicyEvaluation: "enforce"`.
-// ===========================================================================
+//
 
 const BOB = "did:key:bob";
 const userBob = cfcAtom.user(BOB);
@@ -782,9 +762,7 @@ const publishRule: ExchangeRule = {
 };
 
 describe("CFC declassification while copying (exchange rules)", () => {
-  // -------------------------------------------------------------------------
   // Declassify by WIDENING the audience, integrity retained.
-  // -------------------------------------------------------------------------
   it("scenario 2a — releasing to a reader widens confidentiality, integrity untouched", () => {
     const result = evaluateExchangeRules(
       { confidentiality: [spaceASecret], integrity: [bobReadsA, gpsReading] },
@@ -802,9 +780,7 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContainEqual(bobReadsA);
   });
 
-  // -------------------------------------------------------------------------
   // Declassify FULLY (drop the clause → public), integrity retained.
-  // -------------------------------------------------------------------------
   it("scenario 2b — a publish approval drops the clause; integrity survives", () => {
     const result = evaluateExchangeRules(
       {
@@ -821,10 +797,8 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContainEqual(PUBLISH_APPROVED);
   });
 
-  // -------------------------------------------------------------------------
   // No evidence → no declassification (fail-closed). The confidentiality clause
   // stands; nothing is released.
-  // -------------------------------------------------------------------------
   it("scenario 2c — without the evidence, nothing is declassified", () => {
     const result = evaluateExchangeRules(
       { confidentiality: [spaceASecret], integrity: [gpsReading] },
@@ -835,14 +809,12 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContain(gpsReading);
   });
 
-  // -------------------------------------------------------------------------
   // Scenario 3 (declassify only the SUBSET): clause-locality. A `referenced`
   // policy fires only on the clause that carries its hash-bound ref atom — its
   // "home clause" — leaving sibling clauses confined even when the same
   // evidence would satisfy the guard there. Combined with per-path labels
   // (scenario 3b), this scopes a declassification to exactly one part of the
   // value; integrity is still untouched.
-  // -------------------------------------------------------------------------
   it("scenario 3c — a referenced policy declassifies only its home clause", () => {
     const spaceB2 = cfcAtom.space(spaceB);
     const bobReadsB = cfcAtom.hasRole(BOB, spaceB, "reader");

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -223,10 +223,8 @@ const rewriteStoredEntries = async (
 };
 
 describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
-  // ------------------------------------------------------------------
   // Characterization: what the re-mint does TODAY, with no gate dial.
   // These pin the `off`/`observe` byte-compat contract.
-  // ------------------------------------------------------------------
   describe("current behavior (characterization — the off/observe contract)", () => {
     it("(a) a schema dropping a confidentiality clause is rejected by the schema merge", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
@@ -468,9 +466,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // The dial: cfcDeclaredMonotonicity, mirroring cfcWriteFloor exactly.
-  // ------------------------------------------------------------------
   describe("the cfcDeclaredMonotonicity dial", () => {
     it("the enforce pin cannot be weakened mid-transaction", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
@@ -528,11 +524,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // The exception seam: the per-tx privileged widening exemption
   // (§8.12.7 route 2b; design doc §4). Setter discipline only here —
   // the gate-facing semantics are in the enforce block below.
-  // ------------------------------------------------------------------
   describe("the widening-exemption seam (setter discipline)", () => {
     const EXEMPTION = () => ({
       space: signer.did(),
@@ -694,9 +688,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // Shared scenario builders for the gate-behavior blocks below.
-  // ------------------------------------------------------------------
 
   /**
    * Seeded-drop scenario: commit v1 under `schema`, then rewrite the stored
@@ -763,9 +755,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     }
   };
 
-  // ------------------------------------------------------------------
   // The gate under enforce: §8.12.1 weakenings fail closed.
-  // ------------------------------------------------------------------
   describe("enforce: non-monotone declared re-mints fail closed", () => {
     it("a dropped confidentiality clause rejects, naming doc, path and direction", async () => {
       const result = await seededRemintScenario({
@@ -999,9 +989,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // The gate under enforce: §8.12.1 tightenings pass.
-  // ------------------------------------------------------------------
   describe("enforce: monotone tightenings pass", () => {
     it("an added clause passes and persists", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
@@ -1261,9 +1249,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // §8.12.8 component scoping: only declared↔declared is ever compared.
-  // ------------------------------------------------------------------
   describe("component scoping (§8.12.8)", () => {
     it("legacy (origin-less) stored entries are not gated", async () => {
       // A seeded LEGACY entry whose integrity the fresh declared mint does
@@ -1305,9 +1291,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // off/observe: byte-compat with the characterization block.
-  // ------------------------------------------------------------------
   describe("off/observe byte-compat", () => {
     it("off: the seeded weakening persists exactly as characterized, no diagnostic", async () => {
       const result = await seededRemintScenario({
@@ -1430,9 +1414,7 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // The exemption seam consumed by the gate (§8.12.7 route 2b semantics).
-  // ------------------------------------------------------------------
   describe("enforce: the widening exemption", () => {
     const withExemption = (
       clauseDigest: string,
@@ -1614,11 +1596,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // Reason dedup on degenerate duplicate entries (direct unit call: the
   // walk mints one declared entry per path and dedups atoms, so the
   // duplicate arms are reachable only through the exported function).
-  // ------------------------------------------------------------------
   describe("violation-reason dedup (unit)", () => {
     it("reports each violated clause and added atom once across duplicate entries", () => {
       const violations = collectDeclaredMonotonicityViolations({
@@ -1658,10 +1638,8 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // ------------------------------------------------------------------
   // Non-taint: the gate's stored-entry reads ride the internal-verifier
   // meta and must not enter the consumed set.
-  // ------------------------------------------------------------------
   describe("non-taint", () => {
     it("the observe-mode gate adds nothing to the prepared consumed set", async () => {
       const consumedReadsFor = async (

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -112,9 +112,7 @@ const aliceShareFact = (audience: CfcAtom = userBob) => ({
 });
 
 describe("CFC grant records (§8.12.7 route 2a)", () => {
-  // -------------------------------------------------------------------------
   // Build-order item 1: the `policyState` guard kind.
-  // -------------------------------------------------------------------------
   describe("policyState guard validation (boot, fail closed)", () => {
     const withGuard = (policyState: unknown): CfcPolicyRecordInput[] => [{
       id: "p",
@@ -334,9 +332,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Build-order item 2: grant records + reserved-path storage discipline.
-  // -------------------------------------------------------------------------
   describe("grant document addressing", () => {
     const identity = {
       space: ALICE,
@@ -775,9 +771,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Resolution wired into the egress gate (build-order items 1+3).
-  // -------------------------------------------------------------------------
   describe("grant resolution at the sink egress gate", () => {
     it("a live grant releases the owner clause to the audience (enforce)", async () => {
       await withRuntime({}, async (runtime) => {
@@ -961,9 +955,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Build-order item 3: read non-taint + digest binding.
-  // -------------------------------------------------------------------------
   describe("read non-taint (internalVerifierRead discipline)", () => {
     it("grant lookups never enter the consumed read set", async () => {
       await withRuntime({}, async (runtime) => {
@@ -989,11 +981,9 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     });
   });
 
-  // -------------------------------------------------------------------------
   // Arm-level coverage: every reachable validation / fail-closed branch is
   // pinned directly (the repo standard — defensive arms reachable from the
   // runner side get tests, not just the happy path).
-  // -------------------------------------------------------------------------
   describe("writer validation arms (prepareCfcGrantWrite)", () => {
     const base: CfcGrantWriteInput = {
       kind: "ShareGrant",

--- a/packages/runner/test/cfc-label-sync-strategy.bench.ts
+++ b/packages/runner/test/cfc-label-sync-strategy.bench.ts
@@ -51,7 +51,9 @@ const warmReplica = (): Replica =>
   new Set(Array.from({ length: NODE_COUNT }, (_, index) => index));
 const coldReplica = (): Replica => new Set();
 
-// --- "ensure the whole meta-graph is available" strategies ------------------
+//
+// "ensure the whole meta-graph is available" strategies
+//
 
 const ensureSerial = async (replica: Replica) => {
   for (let node = 0; node < NODE_COUNT; node++) {

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -73,9 +73,7 @@ const baseInput = {
 };
 
 describe("CFC single-use grants (§2.2 single-use releases)", () => {
-  // ---------------------------------------------------------------------------
   // Item 1: the `singleUse` field.
-  // ---------------------------------------------------------------------------
   describe("singleUse field (writer validation)", () => {
     it("accepts singleUse: true and stores it in the value", () => {
       const prepared = prepareCfcGrantWrite(
@@ -163,9 +161,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Item 2: the consumption receipt identity.
-  // ---------------------------------------------------------------------------
   describe("consumption receipt derivation", () => {
     const grantId = cfcGrantDocId(identity);
 
@@ -183,11 +179,9 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Shared harness (cfc-grant-records.test.ts style): a labeled cell, a
   // policyState-guarded sink rule, and a Runtime whose experimental
   // commitPreconditions flag is the receipts dial.
-  // ---------------------------------------------------------------------------
   const SECRET_SCHEMA = internSchema(
     {
       type: "object",
@@ -367,11 +361,9 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       (write) => write.address.id === receiptId,
     );
 
-  // ---------------------------------------------------------------------------
   // Consuming vs observing context (the seam decision): single-use grants
   // resolve ONLY in consuming contexts; everywhere else they are
   // unsatisfiable, fail closed.
-  // ---------------------------------------------------------------------------
   describe("consumption context (resolver + evaluator threading)", () => {
     const singleUseRule: ExchangeRule = {
       id: "single-use-share",
@@ -690,9 +682,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Claim staging arms.
-  // ---------------------------------------------------------------------------
   describe("claim staging (flushCfcGrantConsumptionClaims)", () => {
     it("no claims → no writes, no reasons", async () => {
       await withRuntime({}, (runtime) => {
@@ -828,9 +818,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
   // The core: consumption semantics at the sink egress gate, end to end.
-  // ---------------------------------------------------------------------------
   describe("single-use release at the sink egress gate", () => {
     it("releases once, committing the receipt atomically; the second evaluation fails closed", async () => {
       await withRuntime({}, async (runtime) => {
@@ -1266,10 +1254,8 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Digest binding (item 3): receipt consulted-state rides consultedGrants
   // with the grants' own canonicalization + invalidation discipline.
-  // ---------------------------------------------------------------------------
   describe("digest binding of the receipt state", () => {
     it("a receipt appearing between evaluations invalidates the prepared digest", async () => {
       await withRuntime({}, (runtime) => {

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -325,7 +325,7 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // System-level degradation pin: the by-identity load's hit test is ENTRY
 // presence (`closure.has(entryIdentity)`), not closure completeness. Chunked
 // interruption cannot create an entry-present/descendant-missing compiled
@@ -335,7 +335,7 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
 // falls back to a clean recompile from the verified source closure — a
 // working pattern, never a corrupt load — and the recovery write-back heals
 // the compiled namespace.
-// ---------------------------------------------------------------------------
+//
 describe("descendant-missing compiled closure degrades to a clean recompile", () => {
   it("loadPatternByIdentity recompiles from source and heals the compiled set", async () => {
     const RTVER = "test-degrade-1";

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -325,7 +325,6 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
   });
 });
 
-//
 // System-level degradation pin: the by-identity load's hit test is ENTRY
 // presence (`closure.has(entryIdentity)`), not closure completeness. Chunked
 // interruption cannot create an entry-present/descendant-missing compiled
@@ -335,7 +334,6 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
 // falls back to a clean recompile from the verified source closure — a
 // working pattern, never a corrupt load — and the recovery write-back heals
 // the compiled namespace.
-//
 describe("descendant-missing compiled closure degrades to a clean recompile", () => {
   it("loadPatternByIdentity recompiles from source and heals the compiled set", async () => {
     const RTVER = "test-degrade-1";

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -110,9 +110,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
       )
       .map((n) => n.module as Module);
 
-  // ---------------------------------------------------------------------------
   // Attack 1 — forged function with byte-identical source, built outside eval.
-  // ---------------------------------------------------------------------------
   describe("attack 1: byte-identical forged function", () => {
     it("a forged twin (identical source, no eval registration) has no provenance and resolves unsupported", async () => {
       const pattern = await setup();
@@ -159,9 +157,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 2 — $implRef replay / confusion. State graphs are attacker data.
-  // ---------------------------------------------------------------------------
   describe("attack 2: $implRef replay/confusion", () => {
     it("$implRef at a non-existent or host: identity resolves nothing executable (miss → fallback)", async () => {
       await setup();
@@ -248,9 +244,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 3 — __cf_data-forged factory shapes through the indexing sink.
-  // ---------------------------------------------------------------------------
   describe("attack 3: __cf_data-forged factory shapes", () => {
     it("an unbranded {implementation, __cfVerifiedBindingIdentity} shape is dropped by the trust gate", () => {
       const forgedFactory = {
@@ -284,9 +278,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 4 — bindingIdentity spoofing (highest-value: ownership gate).
-  // ---------------------------------------------------------------------------
   describe("attack 4: bindingIdentity spoofing of writeAuthorizedBy ownership", () => {
     it("an attacker-chosen __cfVerifiedBindingIdentity on an unbranded factory yields no verified binding", () => {
       // The factory carries a binding annotation pointing at a victim's
@@ -516,9 +508,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 5 — claim forgery in stored schemas (hand-built __ctWriterIdentityOf).
-  // ---------------------------------------------------------------------------
   describe("attack 5: forged stored writeAuthorizedBy claims", () => {
     const driveClaim = async (
       claim: Record<string, unknown>,
@@ -668,9 +658,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 6 — fn.src spoofing vs the provenance identity.
-  // ---------------------------------------------------------------------------
   describe("attack 6: fn.src spoofing", () => {
     // These probe resolveProvenanceImplementationIdentity directly: we fabricate
     // a provenance entry (the trusted channel's effect) on a function WE control,
@@ -746,9 +734,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 7 — dynamic (in-action-minted) artifact path.
-  // ---------------------------------------------------------------------------
   describe("attack 7: dynamic in-session artifacts", () => {
     it("a dynamic-provenance fn with consistent src resolves verified but carries no symbol (no cross-session ref)", () => {
       const fn = Object.assign(() => undefined, {
@@ -824,13 +810,11 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ===========================================================================
   // E2 red-team gate. The attacks below target the surfaces PR E2 introduced
   // (provenance-only verified identity, the now-LIVE bundleId verification arm,
   // the strong content-addressed implementation index, and the loadId-less
   // dynamic registrar). They are the negative complement to the happy-path
   // tests in content-addressed-identity.test.ts.
-  // ===========================================================================
 
   // A claim/identity driver matching attack 5's, lifted to the outer scope so
   // the E2 bundleId-arm attacks can reuse it.
@@ -865,14 +849,12 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     return { digest, result };
   };
 
-  // ---------------------------------------------------------------------------
   // Attacks 8 + 9 (historical) — the legacy bundleId verification arm and the
   // dynamic-artifact registrar are GONE (identity E5): a claim without a
   // moduleIdentity fails closed, and minting builder artifacts inside an
   // action throws at creation time (test/dynamic-builder-call-throw.test.ts).
   // What remains to pin is the fail-closed floor for stored bundleId-only
   // claims: they never verify, against ANY identity.
-  // ---------------------------------------------------------------------------
   describe("attacks 8+9 (retired arms): bundleId-only claims always fail closed", () => {
     it("a bundleId-only claim is rejected even when the writer is fully verified", async () => {
       const { digest, result } = await driveE2Claim(
@@ -920,12 +902,10 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 10 — the strong content-addressed implementation index
   // (verifiedImplementationsByEntryRef, surfaced as
   // harness.getVerifiedImplementation). A replayed/forged $implRef must MISS,
   // and a genuine one returns the REAL recorded function — never attacker data.
-  // ---------------------------------------------------------------------------
   describe("attack 10: $implRef replay against the strong implementation index", () => {
     it("a forged identity, or the genuine identity with an unregistered symbol, misses; the genuine pair returns the real fn", async () => {
       const pattern = await setup();
@@ -961,14 +941,12 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 11 — host pseudo-module separation (identity E5). Host-trusted
   // functions register into the SAME content-addressed implementation index
   // as verified modules (under minted `host:<n>` identities), so the residual
   // invariant is: that registration makes them EXECUTABLE by `$implRef`, but
   // never VERIFIED — no provenance is recorded, and the CFC policy-facing
   // resolution fails closed on its absence.
-  // ---------------------------------------------------------------------------
   describe("attack 11: host pseudo-module registration grants execution, never verification", () => {
     it("a host entry resolves by { identity, symbol } but carries no provenance", () => {
       const reg = new ExecutableRegistry();
@@ -996,12 +974,10 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
   });
 
-  // ---------------------------------------------------------------------------
   // Attack 12 — host-artifact escalation. A host-trusted callable EXECUTES but
   // yields NO `kind:"verified"` CFC identity, by two independent defenses: the
   // `unsafe-host:` debugName short-circuit AND the absence of provenance. A
   // genuine canonical `fn.src` on a host fn does NOT manufacture verification.
-  // ---------------------------------------------------------------------------
   describe("attack 12: host artifacts execute but never resolve verified", () => {
     it("a host fn with an EMPTY debugName falls into the provenance arm and resolves undefined (src alone is not proof)", () => {
       const hostFn = Object.assign(() => 42, {

--- a/packages/runner/test/delivery-shaping.test.ts
+++ b/packages/runner/test/delivery-shaping.test.ts
@@ -38,9 +38,9 @@ function link(id: string, path: string[] = []): NormalizedFullLink {
   return { space, id, path } as unknown as NormalizedFullLink;
 }
 
-// ---------------------------------------------------------------------------
+//
 // stripClockFields
-// ---------------------------------------------------------------------------
+//
 
 describe("stripClockFields", () => {
   it("removes a top-level timestamp without mutating the input", () => {
@@ -87,9 +87,9 @@ describe("stripClockFields", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // shouldShapeDelivery
-// ---------------------------------------------------------------------------
+//
 
 describe("shouldShapeDelivery", () => {
   it("is true only for renderer-trusted events", () => {
@@ -101,9 +101,9 @@ describe("shouldShapeDelivery", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Wake shaper, event path (unit, deterministic zero-length window)
-// ---------------------------------------------------------------------------
+//
 
 // The old DeliveryShaper surface, expressed over the unified WakeShaper +
 // holdShapedEvent adapter, so the event-path contract assertions below stay
@@ -356,9 +356,9 @@ describe("wake shaper (event path)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Unified engine (plan C): properties specific to one shaper serving both paths
-// ---------------------------------------------------------------------------
+//
 
 describe("WakeShaper (unified engine)", () => {
   it("keeps event-path and cell-path budgets separate for the same pattern", async () => {
@@ -435,9 +435,9 @@ describe("WakeShaper (unified engine)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Scheduler integration (real Runtime, default shaper)
-// ---------------------------------------------------------------------------
+//
 
 const STREAM_SCHEMA = {
   type: "object",

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -36,13 +36,13 @@ import {
   normalizeExact,
 } from "../src/sandbox/tslib-helpers.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Pre-shadow-detection baseline: the single-pass verifyCompiledModuleBody from
 // Phase D2.1 (commit 4e3f69d05), before the helper-shadow bypass fix landed in
 // 3517a3433 / a0213d532 added a second full statement scan.
 // This is used ONLY in the regression-delta bench group to quantify the cost of
 // the shadow-detection pass. Product code is untouched.
-// ---------------------------------------------------------------------------
+//
 
 const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
 
@@ -94,9 +94,9 @@ function verifyCompiledModuleBodyLegacy(
   });
 }
 
-// ---------------------------------------------------------------------------
+//
 // Setup helpers
-// ---------------------------------------------------------------------------
+//
 
 const signer = await Identity.fromPassphrase("bench esm verifier");
 
@@ -124,9 +124,9 @@ async function compileToGraph(program: RuntimeProgram) {
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Programs
-// ---------------------------------------------------------------------------
+//
 
 /** Small: 2 authored modules, minimal bodies. */
 const smallProgram: RuntimeProgram = {
@@ -175,9 +175,9 @@ async function loadParkingCoordinatorProgram(): Promise<RuntimeProgram> {
   };
 }
 
-// ---------------------------------------------------------------------------
+//
 // Pre-compile everything (outside bench timing)
-// ---------------------------------------------------------------------------
+//
 
 const parkingCoordinatorProgram = await loadParkingCoordinatorProgram();
 
@@ -209,12 +209,12 @@ console.error(
     `total body bytes: ${parkingBodies.reduce((s, [, b]) => s + b.length, 0)}`,
 );
 
-// ---------------------------------------------------------------------------
+//
 // Bench naming: performance tracking keys each benchmark's timeline by the
 // origin file, group, and verbatim name, so groups and names must stay
 // stable across commits — no content hashes, byte counts, or module counts.
 // Volatile sizes go to stderr.
-// ---------------------------------------------------------------------------
+//
 
 /** Basenames too vague to identify a module on their own. */
 const GENERIC_BASENAMES = new Set([
@@ -266,9 +266,9 @@ function labelFor(specifier: string): string {
   return label;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Benchmarks: small program
-// ---------------------------------------------------------------------------
+//
 
 Deno.bench(
   "body verify: small",
@@ -288,9 +288,9 @@ Deno.bench(
   },
 );
 
-// ---------------------------------------------------------------------------
+//
 // Benchmarks: parking-coordinator (large)
-// ---------------------------------------------------------------------------
+//
 
 Deno.bench(
   "body verify: parking",
@@ -310,11 +310,11 @@ Deno.bench(
   },
 );
 
-// ---------------------------------------------------------------------------
+//
 // Per-module body verify: one bench per authored module (parking only, to
 // show per-module cost distribution — body size varies widely in a real
 // pattern, the per-module numbers help pinpoint which module dominates).
-// ---------------------------------------------------------------------------
+//
 
 console.error(
   "parking-coordinator modules: " +
@@ -335,13 +335,13 @@ for (const [specifier, body] of parkingBodies) {
   );
 }
 
-// ---------------------------------------------------------------------------
+//
 // Regression delta: shadow-detection pass overhead
 //
 // Compare current `verifyCompiledModuleBody` (two passes: shadow-scan + classify)
 // against the pre-shadow-detection single-pass version from Phase D2.1.
 // The delta is the overhead introduced by commits 3517a3433 + a0213d532.
-// ---------------------------------------------------------------------------
+//
 
 // Use only the dominant large module (first parking body by size) for the
 // per-module regression delta, so the signal is not diluted by tiny modules.

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -36,13 +36,11 @@ import {
   normalizeExact,
 } from "../src/sandbox/tslib-helpers.ts";
 
-//
 // Pre-shadow-detection baseline: the single-pass verifyCompiledModuleBody from
 // Phase D2.1 (commit 4e3f69d05), before the helper-shadow bypass fix landed in
 // 3517a3433 / a0213d532 added a second full statement scan.
 // This is used ONLY in the regression-delta bench group to quantify the cost of
 // the shadow-detection pass. Product code is untouched.
-//
 
 const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
 
@@ -209,12 +207,10 @@ console.error(
     `total body bytes: ${parkingBodies.reduce((s, [, b]) => s + b.length, 0)}`,
 );
 
-//
 // Bench naming: performance tracking keys each benchmark's timeline by the
 // origin file, group, and verbatim name, so groups and names must stay
 // stable across commits — no content hashes, byte counts, or module counts.
 // Volatile sizes go to stderr.
-//
 
 /** Basenames too vague to identify a module on their own. */
 const GENERIC_BASENAMES = new Set([
@@ -310,11 +306,9 @@ Deno.bench(
   },
 );
 
-//
 // Per-module body verify: one bench per authored module (parking only, to
 // show per-module cost distribution — body size varies widely in a real
 // pattern, the per-module numbers help pinpoint which module dominates).
-//
 
 console.error(
   "parking-coordinator modules: " +

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -2172,7 +2172,6 @@ describe("Phase 3 events-down (serving side)", () => {
     cancelParentDemand();
   });
 
-  // ---------------------------------------------------------------------
   // Stage C build W3 — (α): ONE durable entry, ONE completed run
   // (events.md §4, RULED 2026-08-18; register OW35). The pins below drive
   // RAW handlers on the serving runtime (the production chain from the
@@ -2184,7 +2183,6 @@ describe("Phase 3 events-down (serving side)", () => {
   // async child that is still RUNNING when the deadline closes its wave
   // (the in-flight residue the purge cannot reach), and a DERIVATION
   // emitter whose sidecar append the wave supersedes (the orphan).
-  // ---------------------------------------------------------------------
 
   /** Bare stream + value docs for the (α) pins, created by the CLIENT
    * (client commits land natively; the serving runtime's writes must
@@ -2694,7 +2692,6 @@ describe("Phase 3 events-down (serving side)", () => {
     }
   });
 
-  // ---------------------------------------------------------------------
   // The same-eventId SIBLING shape (independent review of W3, B1 / M1):
   // an event can contribute SEVERAL transactions to one wave — the
   // handler run plus a separate event-handler-stamped tx carrying the
@@ -2706,7 +2703,6 @@ describe("Phase 3 events-down (serving side)", () => {
   // the sibling's survival as the handler's: a seq-less entry is marked
   // consequenced only by the LT1 copy's OWN run (`lt1 === true`), and an
   // orphan-refused copy takes its siblings down with it.
-  // ---------------------------------------------------------------------
 
   /** A sibling contribution of the running handler's event: a separate
    * event-handler-stamped tx carrying `tx.dispatchedEventId`, committed

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -161,7 +161,7 @@ describe("stage G outbox + sqlite discharge", () => {
     await server.close();
   });
 
-  // ---- the effect handoff at the seal destination ----
+  // the effect handoff at the seal destination
 
   it("defers a sealed tx's post-commit effects to the destination; without the hook the inline flush stays (serving-loop.md §3)", async () => {
     const lease = liveLease();
@@ -232,7 +232,7 @@ describe("stage G outbox + sqlite discharge", () => {
     lease.release();
   });
 
-  // ---- the process-local effect half ----
+  // the process-local effect half
 
   it("admits sealed effects post-commit with in-flight dedupe per key; counters and carriage are live (serving-loop.md §4–§5, §7)", async () => {
     const { outbox, stats } = newOutbox();
@@ -380,7 +380,7 @@ describe("stage G outbox + sqlite discharge", () => {
     expect(stats.outbox.completed).toBe(0);
   });
 
-  // ---- the durable half: rows in the wave's own transaction (FP1) ----
+  // the durable half: rows in the wave's own transaction (FP1)
 
   it("lands outbound append rows INSIDE the wave's engine transaction, for surviving contributions only (FP1; the model's committed-only fold)", async () => {
     const lease = liveLease();
@@ -471,7 +471,7 @@ describe("stage G outbox + sqlite discharge", () => {
     lease.release();
   });
 
-  // ---- delivery: admit at the target, then delete (FP1 closure) ----
+  // delivery: admit at the target, then delete (FP1 closure)
 
   it("delivers pending rows: delegated admission at the target stamps firedAt from the CARRIED actor (LT5 envelope), then deletes the row; a re-sent duplicate dedupes at the eventId horizon", async () => {
     const lease = liveLease();
@@ -1110,7 +1110,7 @@ describe("stage G outbox + sqlite discharge", () => {
       .toBe(0);
   });
 
-  // ---- the sqliteQuery memo decision (B1's fix, serving-loop.md §4/§6) ----
+  // the sqliteQuery memo decision (B1's fix, serving-loop.md §4/§6)
 
   it("sqliteQuery memo decision: a settled result is a hit, a bare claim never is; an orphaned claim re-issues ONLY under the serving posture", () => {
     // No stored key: issue (the ordinary miss).
@@ -1168,7 +1168,7 @@ describe("stage G outbox + sqlite discharge", () => {
     })).toBe("issue");
   });
 
-  // ---- the sqlite bound's discharge ----
+  // the sqlite bound's discharge
 
   // Unique per test run: the cell-db FILE for a memory-URL engine lives
   // at a deterministic TMPDIR path keyed by (space, id) — a stable id

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -696,11 +696,9 @@ describe("stage P2-F per-(action × instance) run supply", () => {
   });
 });
 
-//
 // F1 (RULED 2026-08-13, option c): the piece-start setup commit's
 // failure must SURFACE — loudly, counted — never be swallowed by the
 // fire-and-forget start path.
-//
 
 const V1_NO_HANDLER = [
   "import { Writable, pattern } from 'commonfabric';",

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -506,7 +506,6 @@ describe("stage P2-F per-(action × instance) run supply", () => {
     }
   });
 
-  // -------------------------------------------------------------------------
   // Fan-out stage B, independent review F1: `RetryImmediately` inside a
   // fanned-out instance run must be BOUNDED — the OFF arm's shape (one
   // queued retry per attempt, a macrotask apart, MAX_RETRIES_FOR_REACTIVE
@@ -515,7 +514,6 @@ describe("stage P2-F per-(action × instance) run supply", () => {
   // the set kept offering it): 501 invocations of a 500-throw action
   // inside ONE `run()`, and a never-resolving name spun the process's
   // microtask queue forever — no timer fired, `idle()` never resolved.
-  // -------------------------------------------------------------------------
 
   it("F1: a demanded action that keeps throwing RetryImmediately is bounded per pass — the loop DEFERS the instance instead of re-running it, the retry rides the queue (a timer fires between attempts), and the budget is MAX_RETRIES_FOR_REACTIVE", async () => {
     const rootId = "of:p2f-retry-root";
@@ -698,11 +696,11 @@ describe("stage P2-F per-(action × instance) run supply", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // F1 (RULED 2026-08-13, option c): the piece-start setup commit's
 // failure must SURFACE — loudly, counted — never be swallowed by the
 // fire-and-forget start path.
-// ---------------------------------------------------------------------------
+//
 
 const V1_NO_HANDLER = [
   "import { Writable, pattern } from 'commonfabric';",

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -688,7 +688,7 @@ describe("stage G SpaceServer recovery seams", () => {
     expect(notices.length).toBe(1);
   });
 
-  // ---- stage P2-F: late-notice accounting (the sx2 unskip flake) ----
+  // stage P2-F: late-notice accounting (the sx2 unskip flake)
 
   it("counts an authored notice that arrives AFTER a higher-seq echo (the two-producer notice race): late records still count and re-arm, and coverage stays in-order", async () => {
     const stats = emptyServingLoopStats();
@@ -745,7 +745,7 @@ describe("stage G SpaceServer recovery seams", () => {
     expect(created.watermark).toBeGreaterThanOrEqual(second.seq);
   });
 
-  // ---- stage P2-F: the demand-cycle terminal state (OW19) ----
+  // stage P2-F: the demand-cycle terminal state (OW19)
 
   /** A facade whose watch registry names exactly the given demanded
    * roots — the unit-level stand-in for client sessions' watches (the
@@ -1097,7 +1097,7 @@ describe("stage G SpaceServer recovery seams", () => {
     }
   });
 
-  // ---- stage P2-F: the argument-doc demand → owning-piece run supply ----
+  // stage P2-F: the argument-doc demand → owning-piece run supply
 
   it("supplies a scoped ARGUMENT-doc demand's identity to the owning piece's derivation runs: the ensure-resolved root differs from the demanded id, and the derived commit still carries the demanding actor (the #pieceRootByDemandKey arm)", async () => {
     // An ordinary nested-doc watch: the client's scoped subscription

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -206,14 +206,14 @@ describe("ExperimentalOptions", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // The serverExecution ambient-flag OWNERSHIP family (PR #5439 threads
 // r3731191424, r3731191435, r3731191451): the flag is a process-global
 // admission input, so its lifecycle must be reference-counted across ALL
 // owners (explicit-enabler Runtimes AND the ExecutorHost), survive
 // construction/dispose failures, and never be stomped by a co-hosted
 // non-serving runtime.
-// ---------------------------------------------------------------------------
+//
 
 describe("serverExecution ambient-flag ownership", () => {
   afterEach(() => {

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -206,14 +206,12 @@ describe("ExperimentalOptions", () => {
   });
 });
 
-//
 // The serverExecution ambient-flag OWNERSHIP family (PR #5439 threads
 // r3731191424, r3731191435, r3731191451): the flag is a process-global
 // admission input, so its lifecycle must be reference-counted across ALL
 // owners (explicit-enabler Runtimes AND the ExecutorHost), survive
 // construction/dispose failures, and never be stomped by a co-hosted
 // non-serving runtime.
-//
 
 describe("serverExecution ambient-flag ownership", () => {
   afterEach(() => {

--- a/packages/runner/test/focus-types.test.ts
+++ b/packages/runner/test/focus-types.test.ts
@@ -14,9 +14,9 @@ import type {
   Stream,
 } from "../src/builder/types.ts";
 
-// ============================================================================
+//
 // Type-level assertions (compile-time checks)
-// ============================================================================
+//
 
 /**
  * Helper type that asserts two types are equal.
@@ -50,9 +50,10 @@ type User = {
   }>;
 };
 
-// ============================================================================
+//
 // KeyResultType type tests
-// ============================================================================
+//
+
 // Use value assignments to enforce type checks at compile time
 
 // Empty keys should return the original type
@@ -136,9 +137,9 @@ const _test12: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // Nested Cell and Stream type tests
-// ============================================================================
+//
 
 // Type with nested Cell and Stream
 type StateWithNestedCells = {
@@ -182,9 +183,9 @@ const _testNestedStream2: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // Runtime tests (behavior verification)
-// ============================================================================
+//
 
 describe("Cell.key() with multiple keys", () => {
   it("compiles with correct types - this test verifies the type assertions above", () => {

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -67,7 +67,9 @@ const setupPrimedSiblingTransaction = (subtreeCount: number) => {
   return { storage, tx };
 };
 
-// --- 1. Hot sibling-rich pattern at K=16 (the baseline shape). -----------
+//
+// 1. Hot sibling-rich pattern at K=16 (the baseline shape).
+//
 
 Deno.bench({
   name: `frozenReads: ${ITERATIONS}x {write sub0; read other 15 siblings}`,
@@ -96,7 +98,9 @@ Deno.bench({
   },
 });
 
-// --- 2. 1-sibling control at K=16. ---------------------------------------
+//
+// 2. 1-sibling control at K=16.
+//
 
 Deno.bench({
   name: `frozenReads: ${ITERATIONS}x {write sub0; read same sibling once}`,
@@ -117,7 +121,8 @@ Deno.bench({
   },
 });
 
-// --- 3. Cache-size scaling: K=16, 64, 256. -------------------------------
+//
+// 3. Cache-size scaling: K=16, 64, 256.
 // Loop shape is fixed at {write sub0/count; read sub1}. The cache holds K
 // cached sibling reads.
 //
@@ -132,6 +137,7 @@ Deno.bench({
 // remains shaped to flag any future change that re-introduces K-scaling.
 // To isolate just the invalidator's O(K)-vs-O(D) behavior, see
 // `packages/utils/test/path-key-map.bench.ts`.
+//
 
 for (const K of [16, 64, 256]) {
   Deno.bench({
@@ -162,11 +168,13 @@ for (const K of [16, 64, 256]) {
   });
 }
 
-// --- 4. Deep nested-path write. ------------------------------------------
+//
+// 4. Deep nested-path write.
 // Writes at depth-7 path `value/a/b/c/d/e/items/0`, with three cached
 // sibling reads at varying depths along the chain. Stresses the per-write
 // walk's depth dependence; a trie walker pays O(D), an O(N) scanner pays
 // the same as the K=16 case.
+//
 
 const seedDeep = () => ({
   value: {

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -321,14 +321,14 @@ describe("list builtin edge paths", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Resume harness for the owned-cell walk's nested-node branches.
 //
 // The walk (Runner.collectResumeOwnedCells) recurses through nested sub-pattern
 // nodes. A sub-pattern whose result cell carries a non-"space" cell scope makes
 // the walk re-scope the child result cell before recursing, the branch the
 // single-space resume tests do not reach. A cold resume drives the walk.
-// ---------------------------------------------------------------------------
+//
 
 function plainLoopback(
   server: MemoryV2Server.Server,
@@ -468,7 +468,7 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
+//
 // Cross-space link load kick (Runtime.ensureLinkedDocLoaded).
 //
 // A value read that follows a link to a target in ANOTHER space, whose doc is
@@ -477,7 +477,7 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
 // queries cannot follow links across space boundaries, so the client fetches
 // the target itself. A reader session that never created the target drives the
 // kick.
-// ---------------------------------------------------------------------------
+//
 
 const spaceH = signer.did(); // "home" — holds the link
 const spaceP = (await Identity.fromPassphrase("edge paths target P")).did();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2023,7 +2023,8 @@ Deno.test("memory v2 stacked commits: divergent basis overrides survive pending-
   }
 });
 
-// ---- CT-1927 parked-accept promotion ----
+//
+// CT-1927 parked-accept promotion
 //
 // Verdicts return inline (the fan-out stays batched server-side), and the
 // client PARKS each accept's state application until a frame's
@@ -2032,6 +2033,7 @@ Deno.test("memory v2 stacked commits: divergent basis overrides survive pending-
 // novelty the accept was applied on top of. These tests use the base
 // ScriptedModelTransport (which advertises verdictCatchUpMarkers) and push
 // markers explicitly.
+//
 
 const markerHarness = () =>
   createHarness({ transport: (model) => new MarkerContractTransport(model) });
@@ -2231,7 +2233,8 @@ Deno.test("memory v2 stacked commits: whenApplied resolves at the parked accept'
   }
 });
 
-// ---- The settle input barrier (server-execution v2 Phase 2 revisit (a)) ----
+//
+// The settle input barrier (server-execution v2 Phase 2 revisit (a))
 //
 // A foreign frame integrating UNDER a parked own write is SHADOWED: the
 // materialized view (and therefore the change notification) reflects the
@@ -2240,6 +2243,7 @@ Deno.test("memory v2 stacked commits: whenApplied resolves at the parked accept'
 // serving loop's W advance can exclude them, and — flag ON — the
 // promotion fires the shadow-flip notification the moment the foreign
 // value becomes visible.
+//
 
 const shadowFloorOf = (harness: Harness): number | undefined =>
   (harness.provider.replica as unknown as {

--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -202,7 +202,9 @@ function op(binding: FabricExecValue, links: Links = withSchema): void {
   );
 }
 
-// ---- deno bench cases ------------------------------------------------------
+//
+// deno bench cases
+//
 for (const aliases of [10, 30, 100, 300]) {
   const binding = makeUiBinding({ aliases, pathDepth: 2 });
   Deno.bench(
@@ -211,7 +213,9 @@ for (const aliases of [10, 30, 100, 300]) {
   );
 }
 
-// ---- direct-run study harness ---------------------------------------------
+//
+// direct-run study harness
+//
 function time(
   label: string,
   binding: FabricExecValue,

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -532,7 +532,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     expect(runCount - runsBeforeRestore).toBe(2);
   });
 
-  // ── filter builtin tests ──────────────────────────────────────────────
+  // filter builtin tests
 
   it("should filter an array by predicate", async () => {
     const isEven = lift((x: number) => x % 2 === 0);
@@ -916,7 +916,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     expect(result.key("positives").get()).toEqual([1, 3]);
   });
 
-  // ── flatMap builtin tests ─────────────────────────────────────────────
+  // flatMap builtin tests
 
   it("should flatMap an array", async () => {
     const duplicate = lift((x: number) => [x, x * 10]);
@@ -1280,7 +1280,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     expect(runCount - runsBeforeRestore).toBe(2);
   });
 
-  // ── WithPattern variant tests ───────────────────────────────────────
+  // WithPattern variant tests
 
   it("should filter with a pre-defined pattern (filterWithPattern)", async () => {
     // The WithPattern variants receive { element, index, array, params } at

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -17,9 +17,9 @@ import type {
   StripDefaultBrand,
 } from "../src/builder/types.ts";
 
-// ============================================================================
+//
 // Helpers
-// ============================================================================
+//
 
 /**
  * Asserts T and U are mutually assignable (structurally equal).
@@ -44,9 +44,9 @@ type Simplify<T> = { [K in keyof T]: T[K] };
 type AssertNotEqual<T, U> = [T] extends [U] ? [U] extends [T] ? never : true
   : true;
 
-// ============================================================================
+//
 // StripDefaultBrand<T> — non-Default types are unchanged
-// ============================================================================
+//
 
 const _stripPlainString: MustBeTrue<
   AssertEqual<StripDefaultBrand<string>, string>
@@ -60,9 +60,9 @@ const _stripPlainObject: MustBeTrue<
   AssertEqual<StripDefaultBrand<{ a: string }>, { a: string }>
 > = true;
 
-// ============================================================================
+//
 // StripDefaultBrand<T> — Default<T,V> strips to plain T
-// ============================================================================
+//
 
 const _stripDefaultString: MustBeTrue<
   AssertEqual<StripDefaultBrand<Default<string, "hello">>, string>
@@ -92,9 +92,9 @@ const _stripDefaultWithUndefined: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — plain optional fields are unchanged
-// ============================================================================
+//
 
 const _plainOptionalPreserved: MustBeTrue<
   AssertEqual<
@@ -110,9 +110,9 @@ const _plainRequiredPreserved: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Default<> fields become required with brand stripped
-// ============================================================================
+//
 
 const _stringDefaultRequired: MustBeTrue<
   AssertEqual<
@@ -142,9 +142,9 @@ const _objectDefaultRequired: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — mixed: Default fields required, plain fields preserved
-// ============================================================================
+//
 
 type Mixed = {
   title?: Default<string, "Untitled">;
@@ -160,11 +160,11 @@ const _mixed: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Default<T|undefined, V>
 // The implementation strips `| undefined` via Exclude when making the key
 // required, so the value type becomes just T (not T|undefined).
-// ============================================================================
+//
 
 const _undefinableDefault: MustBeTrue<
   AssertEqual<
@@ -173,9 +173,9 @@ const _undefinableDefault: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Cell-wrapped Default fields
-// ============================================================================
+//
 
 const _cellDefaultRequired: MustBeTrue<
   AssertEqual<
@@ -184,10 +184,10 @@ const _cellDefaultRequired: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Default field in a union with a plain type
 // The presence of a Default-branded member in the union makes the field required.
-// ============================================================================
+//
 
 const _unionDefault: MustBeTrue<
   AssertEqual<
@@ -247,9 +247,9 @@ const _deepDefaultUnion: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — plain union (no Default) stays optional
-// ============================================================================
+//
 
 const _plainUnionPreserved: MustBeTrue<
   AssertEqual<
@@ -258,10 +258,10 @@ const _plainUnionPreserved: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — is only one level deep (inner Default fields are not
 // processed, preserving the Default brand on nested types)
-// ============================================================================
+//
 
 type Nested = {
   outer?: Default<string, "">;
@@ -276,9 +276,9 @@ const _shallowOnly: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // StripDefaultBrand<T> — any, never, unknown pass through unchanged
-// ============================================================================
+//
 
 const _stripAny: MustBeTrue<AssertEqual<StripDefaultBrand<any>, any>> = true;
 const _stripNever: MustBeTrue<AssertEqual<StripDefaultBrand<never>, never>> =
@@ -287,9 +287,9 @@ const _stripUnknown: MustBeTrue<
   AssertEqual<StripDefaultBrand<unknown>, unknown>
 > = true;
 
-// ============================================================================
+//
 // StripDefaultBrand<T> — array and tuple types
-// ============================================================================
+//
 
 // Plain array is unchanged
 const _stripPlainArrayType: MustBeTrue<
@@ -341,9 +341,9 @@ const _emptyArrayUnionDefaultRequired: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // StripDefaultBrand<T> — Default<T & U, V> intersection
-// ============================================================================
+//
 
 type IntersectedT = { a: string } & { b: number };
 
@@ -354,9 +354,9 @@ const _stripDefaultIntersection: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — any, never, unknown
-// ============================================================================
+//
 
 // any absorbs all intersections: RequireDefaults<any> = any
 const _requireDefaultsAny: MustBeTrue<
@@ -373,9 +373,9 @@ const _requireDefaultsUnknownHasNoKeys: MustBeTrue<
   AssertEqual<keyof Simplify<RequireDefaults<unknown>>, never>
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — empty object
-// ============================================================================
+//
 
 // RequireDefaults on an empty object produces a type with no keys
 // (uses `Record<never, never>` to avoid the `ban-types` lint rule for literal `{}`)
@@ -384,9 +384,9 @@ const _emptyObjectHasNoKeys: MustBeTrue<
   AssertEqual<keyof Simplify<RequireDefaults<_EmptySchema>>, never>
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — array and tuple types as Default fields
-// ============================================================================
+//
 
 const _arrayDefault: MustBeTrue<
   AssertEqual<
@@ -402,9 +402,9 @@ const _tupleDefault: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — index signatures
-// ============================================================================
+//
 
 // Plain index signature is preserved unchanged
 const _plainIndexSig: MustBeTrue<
@@ -422,9 +422,9 @@ const _defaultIndexSig: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Default<T & U, V> intersection field
-// ============================================================================
+//
 
 const _intersectionDefault: MustBeTrue<
   AssertEqual<
@@ -433,9 +433,9 @@ const _intersectionDefault: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — Default in generic context
-// ============================================================================
+//
 
 // RequireDefaults works correctly when used inside a generic type alias
 type ApplyRequireDefaults<T extends object> = Simplify<RequireDefaults<T>>;
@@ -447,9 +447,9 @@ const _genericContext: MustBeTrue<
   >
 > = true;
 
-// ============================================================================
+//
 // RequireDefaults<T> — `any` fields are not treated as Default-branded
-// ============================================================================
+//
 
 // IsDefaultField<any> = false (IsAny guard), so `any` fields remain unchanged.
 // RequireDefaults must not make an `any`-typed field required.
@@ -460,9 +460,9 @@ const _anyFieldOptional: MustBeTrue<
   AssertEqual<undefined extends _AnyFieldResult["x"] ? true : false, true>
 > = true;
 
-// ============================================================================
+//
 // Negative tests — things that must NOT happen
-// ============================================================================
+//
 
 // Plain optional field must NOT be made required
 const _plainOptionalNotRequired: MustBeTrue<
@@ -490,9 +490,9 @@ const _stripPlainNotNever: MustBeTrue<
   AssertNotEqual<StripDefaultBrand<string>, never>
 > = true;
 
-// ============================================================================
+//
 // Runtime stub — the type assertions above are the real tests
-// ============================================================================
+//
 
 describe("RequireDefaults type-level tests", () => {
   it("all type assertions compile correctly", () => {

--- a/packages/runner/test/scheduler-convergence.test.ts
+++ b/packages/runner/test/scheduler-convergence.test.ts
@@ -638,9 +638,7 @@ describe("bounded convergence", () => {
     expect(cellC.get()).toBeLessThanOrEqual(3);
   });
 
-  // ============================================================
   // Action Stats Edge Cases
-  // ============================================================
 
   it("should return undefined for unknown action stats", () => {
     const unknownAction: Action = () => {};
@@ -711,9 +709,7 @@ describe("bounded convergence", () => {
     expect(stats!.averageTime).toBeCloseTo(stats!.totalTime / 3, 5);
   });
 
-  // ============================================================
   // Cycle Convergence Scenarios
-  // ============================================================
 
   it("should handle larger cycles without hanging", async () => {
     const cellA = runtime.getCell<number>(space, "4cycle-A", undefined, tx);

--- a/packages/runner/test/scheduler.bench.ts
+++ b/packages/runner/test/scheduler.bench.ts
@@ -549,9 +549,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // MICRO-BENCHMARKS: Isolated operations to measure overhead
-// ============================================================================
+//
 
 // Benchmark: Just setup/teardown overhead
 Deno.bench(
@@ -710,9 +710,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // MICRO-BENCHMARKS: Utility functions
-// ============================================================================
+//
 
 // Generate test addresses for micro-benchmarks
 function generateAddresses(
@@ -769,9 +769,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // MICRO-BENCHMARKS: Scheduler operations in isolation
-// ============================================================================
+//
 
 // Benchmark: Just subscribe without any cell operations
 Deno.bench(

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -931,7 +931,6 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     destination.close();
   });
 
-  // -------------------------------------------------------------------------
   // The ARRIVAL-WITNESS predicate (speculation.md §4, RULED 2026-08-22 —
   // candidate (B) of the OW33 fork memo): a confirmed cover witnesses
   // arrival only STRICTLY ABOVE the entry's floor (any commit class), or
@@ -950,7 +949,6 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
   // posture (cover below the floor stands), the legitimate at-floor
   // derived retirement, above-floor retirement regardless of class, and
   // the fail-closed unknown-class posture at the floor.
-  // -------------------------------------------------------------------------
 
   /** A scripted overlay over a fake replica with PER-DOC cover state
    * ({confirmedSeq, coverClass}), the predicate pins' harness — the same
@@ -1150,14 +1148,12 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     scripted.destination.close();
   });
 
-  // -------------------------------------------------------------------------
   // The class THREADING (the predicate's plumbing): the replica records
   // the covering commit's class on its confirmed record — from the
   // frame's `coverClass` on integrate, preserved across a same-seq
   // re-upsert without one, dropped when the seq moves without one, and
   // `authored` for an own commit's promotion — and
   // `speculationRetirementView` surfaces it to the sweep.
-  // -------------------------------------------------------------------------
 
   it("class threading: applySessionSync records the frame's coverClass on the confirmed record, preserves it across a same-seq re-upsert without one, and drops it when the seq moves without one; the retirement view surfaces it", async () => {
     const manager = StorageManager.emulate({ as: aliceSigner });

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -650,7 +650,8 @@ describe("intent listener — scripted notification seam (design (e) pins 1–5,
   });
 });
 
-// ─── W2.1: the cascade-echo retirement (scripted; the MARK path) ────────
+//
+// W2.1: the cascade-echo retirement (scripted; the MARK path)
 //
 // W0 l3's "duplicate join", root-caused by W3 as a CLIENT cascade-echo
 // stranding (speculation.md §4 step 2's jobless-cascade consequence,
@@ -693,6 +694,7 @@ describe("intent listener — scripted notification seam (design (e) pins 1–5,
 //  W2.1-7. F6 telemetry: depth-capped walks and thread evictions are
 //          counted (`cascadeWalkDepthCapCount` /
 //          `cascadeThreadEvictionCount`) — truncation is observable.
+//
 
 const W21_SIDECAR = "of:stream-events:w21-click";
 
@@ -1151,7 +1153,9 @@ describe("intent listener — W2.1 cascade-echo retirement (scripted; the jobles
   });
 });
 
-// ─── e2e: the real replica, the real relay, a real serving side ─────────
+//
+// e2e: the real replica, the real relay, a real serving side
+//
 
 const spaceSigner = await Identity.fromPassphrase("intent listener space");
 const space = spaceSigner.did() as MemorySpace;

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -44,12 +44,12 @@ const space = signer.did();
 // against a caller-owned `newSharedServer()`), so each manager has its own
 // heap/replica while sharing the durable state.
 
-// ---------------------------------------------------------------------------
+//
 // The pattern under test: a rule-bearing db whose rule is a term LIST
 // (`all(sender, recipients)` — the mailbox shape), plus a shared query.
 // Rebuilt per runtime (each has its own trusted builder); the causal ids
 // derive from the shared result cell, so both runtimes address the same docs.
-// ---------------------------------------------------------------------------
+//
 
 const RESULT_CAUSE = "sqlite-handle-multi-runtime";
 

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -44,12 +44,10 @@ const space = signer.did();
 // against a caller-owned `newSharedServer()`), so each manager has its own
 // heap/replica while sharing the durable state.
 
-//
 // The pattern under test: a rule-bearing db whose rule is a term LIST
 // (`all(sender, recipients)` — the mailbox shape), plus a shared query.
 // Rebuilt per runtime (each has its own trusted builder); the causal ids
 // derive from the shared result cell, so both runtimes address the same docs.
-//
 
 const RESULT_CAUSE = "sqlite-handle-multi-runtime";
 

--- a/packages/runner/test/sqlite-served-identity.test.ts
+++ b/packages/runner/test/sqlite-served-identity.test.ts
@@ -181,7 +181,7 @@ describe("sqlite-served-identity", () => {
     }
   });
 
-  // ---- The cleared-read half (CFC Phase 3.b under served execution) ----
+  // The cleared-read half (CFC Phase 3.b under served execution)
 
   const KEY = /z[1-9A-HJ-NP-Za-km-z]+/g;
 

--- a/packages/runner/test/storage.bench.ts
+++ b/packages/runner/test/storage.bench.ts
@@ -75,9 +75,9 @@ const readDocument = (
   });
 };
 
-// ============================================================================
+//
 // Write operations
-// ============================================================================
+//
 
 Deno.bench(
   "Storage - tx.write raw (100x)",
@@ -211,9 +211,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Read operations
-// ============================================================================
+//
 
 Deno.bench(
   "Storage - tx.read after tx.write (100x)",
@@ -347,9 +347,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Entity creation overhead
-// ============================================================================
+//
 
 Deno.bench(
   "Storage - new entity overhead (100x)",
@@ -446,9 +446,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Path depth comparison
-// ============================================================================
+//
 
 Deno.bench(
   "Storage - read shallow path (100x)",
@@ -516,9 +516,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Commit overhead
-// ============================================================================
+//
 
 Deno.bench(
   "Storage - empty commit",
@@ -556,9 +556,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Overhead sources (microbenchmarks)
-// ============================================================================
+//
 
 Deno.bench(
   "Overhead - object creation (1000x)",
@@ -633,9 +633,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Entity creation breakdown - isolate what makes first write slow
-// ============================================================================
+//
 
 Deno.bench(
   "Entity creation breakdown - first write only (100x new entities)",
@@ -753,9 +753,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Microbenchmarks to isolate entity creation overhead sources
-// ============================================================================
+//
 
 Deno.bench(
   "Overhead - Map get/set (1000x)",
@@ -840,9 +840,9 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Isolate write vs commit overhead
-// ============================================================================
+//
 
 Deno.bench(
   "Write vs Commit - 100 new entities, measure writes only",
@@ -946,12 +946,12 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Realistic commit benchmarks - using "median complexity" data
 //
 // These measure commit performance with realistic Cell data, testing the
 // differential change detection (which now uses deepEqual).
-// ============================================================================
+//
 
 Deno.bench(
   "Realistic commit - equal values, no change (100x)",
@@ -1035,13 +1035,13 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Realistic commit benchmarks with large strings (100k chars)
 //
 // This tests the case where deepEqual should clearly win: comparing large
 // strings. JSON.stringify must serialize both 100k strings every comparison,
 // while deepEqual just uses === on strings directly (no construction).
-// ============================================================================
+//
 
 Deno.bench(
   "Large string commit - equal values (50x)",
@@ -1097,13 +1097,13 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Read invariant validation benchmarks (exercises attestation.claim())
 //
 // At commit time, each read invariant is validated via attestation.claim()
 // which compares expected vs actual values using JSON.stringify. This tests
 // the impact of that comparison with large string data.
-// ============================================================================
+//
 
 Deno.bench(
   "Read validation - large string, unchanged (50x)",
@@ -1133,12 +1133,12 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Value comparison: JSON.stringify vs deepEqual
 //
 // These benchmarks compare the two approaches used for equality checking in
 // the storage layer. Uses shared "median complexity" fixtures defined at top.
-// ============================================================================
+//
 
 Deno.bench(
   "Compare - JSON.stringify, equal values (1000x)",
@@ -1203,12 +1203,12 @@ Deno.bench(
   },
 );
 
-// ============================================================================
+//
 // Value comparison: JSON.stringify vs deepEqual (many small objects)
 //
 // Tests comparison performance on wide, shallow object graphs with many
 // properties spread across many small objects (4,500 properties total).
-// ============================================================================
+//
 
 Deno.bench(
   "Compare - JSON.stringify, many small objects equal (100x)",

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -17,11 +17,11 @@ import {
   type RuntimeTelemetryMarkerResult,
 } from "../src/telemetry.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Hand-rolled recording fakes for the OTel API interfaces. The bridge only
 // depends on `@opentelemetry/api` (interfaces), so tests don't need the SDK:
 // we record every instrument call and assert on the translation directly.
-// ---------------------------------------------------------------------------
+//
 
 interface InstrumentCall {
   instrument: string;

--- a/packages/runner/test/telemetry-otel-bridge.test.ts
+++ b/packages/runner/test/telemetry-otel-bridge.test.ts
@@ -17,11 +17,9 @@ import {
   type RuntimeTelemetryMarkerResult,
 } from "../src/telemetry.ts";
 
-//
 // Hand-rolled recording fakes for the OTel API interfaces. The bridge only
 // depends on `@opentelemetry/api` (interfaces), so tests don't need the SDK:
 // we record every instrument call and assert on the translation directly.
-//
 
 interface InstrumentCall {
   instrument: string;

--- a/packages/runner/test/traverse-replay/profile-driver.ts
+++ b/packages/runner/test/traverse-replay/profile-driver.ts
@@ -115,9 +115,11 @@ type CPUProfile = {
 
 Deno.writeTextFileSync(`${outPrefix}.cpuprofile`, JSON.stringify(profile));
 
-// ---- self-time report -------------------------------------------------
+//
+// self-time report
 // Attribute sampled time per node via timeDeltas (more accurate than
 // hitCount * interval), then aggregate by frame and by file.
+//
 const nodeTime = new Map<number, number>();
 if (profile.samples && profile.timeDeltas) {
   for (let i = 0; i < profile.samples.length; i++) {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts the 212 section markers in `packages/runner`. They were written four
ways: a `===` rule above and below the title, a dash rule above it,
`// ---- Title ----`, and box drawing.

## 75 of them are not markers

A section marker separates major portions of a file or a class. A function body
is neither, so a comment inside one is an ordinary comment: it keeps its words
and loses the delimiters.

- **6 are inside ordinary functions** in `src/` — steps within
  `createRuntimeTelemetryOtelBridge()`, `wave.ts`, `navigate-to.ts`.
- **69 are inside a `describe()` or `Deno.test()` callback**, titling the phases
  of a long suite. A callback body is still a body, so these are demoted too.

Position is decided by the TypeScript parser, walking function, method, arrow,
constructor, and accessor bodies — not by indentation, which cannot tell a
method from an object literal. Afterwards no marker in the package sits inside
any such body.

The distinction is worth keeping: markers inside an *object literal* stay
markers. `env.ts`'s `z.object({…})` and `codec-type-tags.ts` section a large
literal, which is a legitimate use, and the parser separates that case from a
function body cleanly.

## How it is checked

Over the whole diff: the word multiset is unchanged, no non-comment line is
touched, and every long rule run removed had text on one side only.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` all pass, and
`packages/runner`'s own `deno task test` reports `ok | 1303 passed (7587 steps)
| 0 failed`.

## Coverage

The ratchet reports one more uncovered line in `packages/runner` than the
baseline. It is not this change. Deno's LCOV emits no `DA:` entry for a comment
line at all, so a comment-only diff shifts line numbers without altering the
uncovered count — checked directly on a fixture: an uncovered function with a
three-line marker inside it reports five uncovered lines, and the same function
with the marker deleted reports the same five.

ACCEPT_COVERAGE_DEBT: packages/runner +1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


