### PR TITLE
Two comments that landed inside a test body are not section markers

### DIFF
--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2666,12 +2666,10 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    //
     // Default render ceiling (spec §8.10.6, S16 phase D)
     // A host-supplied root ceiling gates labeled cells with NO authored
     // boundary in the tree: atoms render only when listed exactly or when
     // they are Caveat atoms of an allow-listed kind.
-    //
 
     const PROMPT_INFLUENCE_KIND =
       "https://commonfabric.org/cfc/concepts/prompt-influence";

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -344,9 +344,7 @@ describe("FormFieldController registration behavior", () => {
       isDirty: () => buffer !== undefined && buffer !== "original",
     };
 
-    //
     // Initial state
-    //
 
     expect(registration.getValue()).toBe("original");
     expect(registration.isDirty()).toBe(false);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The section-marker sweeps gave marker delimiters to every rule-form comment
they found, without asking where it sat. A section marker separates major
portions of a file or a class, so a comment inside a function body should have
kept its words and simply lost its dashes.

Two such comments are in the merged tree, both inside a `Deno.test` callback:
one in `html/test/worker-reconciler-cfc-render-policy.test.ts`, one in
`ui/src/v2/core/form-field-controller.test.ts`. This demotes them.

## Scope, and what deliberately stays

Position comes from the TypeScript parser, walking function, method, arrow,
constructor, and accessor bodies across every non-deferred package — not from
indentation, which cannot tell a method body from an object literal.

That distinction matters, because markers inside an **object literal** stay.
`env.ts`'s `z.object({…})`, `codec-type-tags.ts`, and `js-compiler`'s compiler
options each section a large literal, which is a legitimate use and predates
this work in the last case. The parser separates the two cleanly; a
brace-counting check would not.

After this, no section marker in the merged tree sits inside a function body.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the `html`
and `ui` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

