### PR TITLE
fix(runtime-client): a piece's argument is checked, not cast

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -7,7 +7,7 @@ import { NameSchema } from "@commonfabric/runner/schemas";
 import {
   CellHandle,
   FavoritesManager,
-  JSONValue,
+  JSONObject,
   PageHandle,
   type PieceSourceView,
   Program,
@@ -348,7 +348,7 @@ export class RuntimeInternals extends EventTarget {
   async createPiece<T>(
     space: DID,
     source: URL | Program | string,
-    options?: { argument?: JSONValue; run?: boolean },
+    options?: { argument?: JSONObject; run?: boolean },
   ): Promise<PageHandle<T>> {
     this.#check();
     const page = await this.#client.createPage<T>(source, space, options);

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -36,6 +36,7 @@ export {
 export {
   CHIP_UI,
   FRAMEWORK_RESULT_KEYS,
+  type JSONObject,
   type JSONSchema,
   type JSONValue,
   NAME,

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -6,7 +6,11 @@ import {
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { toStructuredDebugValue } from "@commonfabric/data-model/value-debug";
+import {
+  toCompactDebugString,
+  toStructuredDebugValue,
+} from "@commonfabric/data-model/value-debug";
+import { isPlainObject } from "@commonfabric/utils/types";
 import {
   type SiteTable,
   siteTableCause,
@@ -1526,8 +1530,24 @@ export class RuntimeProcessor {
       throw new Error("Invalid source.");
     }
 
+    // Checked rather than cast. A piece's input is a record of named inputs,
+    // which is the question `isPlainObject()` asks; casting a bare string or
+    // an array to `object` would hand the runtime something it cannot use and
+    // say nothing about why.
+    const argument = request.argument;
+    if ((argument !== undefined) && !isPlainObject(argument)) {
+      // The rejected value is named rather than its `typeof`, which calls both
+      // an array and `null` an `object` and so says nothing about either. It
+      // is bounded because the argument is a caller's data.
+      throw new Error(
+        `A piece's argument must be a record, not: ${
+          toCompactDebugString(argument, 120)
+        }`,
+      );
+    }
+
     const piece = await cc.create<NameSchema>(program, {
-      input: request.argument as object | undefined,
+      input: argument,
       origin,
       start: request.run ?? true,
     }, request.cause);

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -5,7 +5,6 @@
 import {
   FabricInstance,
   FabricPrimitive,
-  FabricSpecialObject,
   type FabricValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
@@ -550,7 +549,9 @@ export class CellHandle<T = unknown> {
    * Converts a value the client holds into the one the connection carries,
    * which is the same data with a `CellRef` wherever a `CellHandle` sat.
    *
-   * Refuses a `FabricSpecialObject`, which the connection cannot carry.
+   * Refuses a `FabricPrimitive`, which the connection cannot carry, and a
+   * `FabricInstance`, which is a container this walk cannot descend to find a
+   * handle inside.
    *
    * `CellHandle.deserialize()` is the inverse.
    */
@@ -561,7 +562,7 @@ export class CellHandle<T = unknown> {
       return value.map((element) => CellHandle.serialize(element));
     }
 
-    // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like
+    // A `FabricPrimitive` is a `ClientCellValue` -- a cell holds one like
     // any other value -- but `WireCellValue` has no representation for it, so
     // this refuses rather than converting. It goes _before_ the record test:
     // such a value is also a record, and that branch would otherwise rebuild
@@ -579,11 +580,20 @@ export class CellHandle<T = unknown> {
     // connection, at which point this becomes a conversion rather than a
     // refusal. `codec-realm` is the mechanism, and the gap it closes is the
     // one marked on `WireCellValue` in `protocol/types.ts`.
-    if (value instanceof FabricSpecialObject) {
+    if (value instanceof FabricPrimitive) {
       throw new Error(
         `Cannot yet handle \`${value.constructor.name}\` (a ` +
           "`FabricSpecialObject`) on this connection.",
       );
+    }
+
+    // An instance is refused for a second reason, which outlives the first: it
+    // is a container whose contents this walk cannot reach, so a `CellHandle`
+    // inside one would cross unconverted even on a connection that carried the
+    // class. Refused through the shared helper, as `deserialize()` above
+    // already does, so the two walks say the same thing about the same value.
+    if (value instanceof FabricInstance) {
+      refuseFabricInstance(value, "when sending a value over this connection");
     }
 
     if (isObjectOrArray(value)) {

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -17,6 +17,7 @@ import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type {
   ActionRunTraceEntry,
+  JSONObject,
   JSONSchema,
   JSONValue,
   NormalizedFullLink,
@@ -30,7 +31,7 @@ import type {
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
 import { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";
-export type { JSONSchema, JSONValue, Program };
+export type { JSONObject, JSONSchema, JSONValue, Program };
 
 export type { CfcLabelView };
 

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -53,7 +53,7 @@ import {
   ConsoleMessage,
   ErrorNotification,
   InitializationData,
-  JSONValue,
+  JSONObject,
   type LoggerCountsData,
   type LoggerFlagsData,
   type LoggerMetadata,
@@ -389,7 +389,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   async createPage<T = unknown>(
     input: string | URL | Program,
     space: DID,
-    options?: { argument?: JSONValue; run?: boolean },
+    options?: { argument?: JSONObject; run?: boolean },
   ): Promise<PageHandle<T>> {
     const source = input instanceof URL
       ? { url: input.href }

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -606,6 +606,74 @@ describe("runtime-processor", () => {
     });
   });
 
+  describe("piece creation", () => {
+    const space = "did:key:z6Mk-runtime-processor-create" as const;
+    const source = { program: { main: "/main.tsx", files: [] } };
+
+    const refusalFor = async (argument: unknown) => {
+      try {
+        // deno-lint-ignore no-explicit-any
+        await (RuntimeProcessor.prototype as any).handlePieceCreate.call(
+          { getSpaceCtx: () => ({}) },
+          { type: RequestType.PageCreate, space, source, argument },
+        );
+      } catch (error) {
+        return (error as Error).message;
+      }
+      throw new Error("handlePieceCreate returned instead of refusing");
+    };
+
+    it("names the rejected argument rather than its type", async () => {
+      // A piece's input is a record of named inputs, and the guard turns away
+      // everything else. `typeof` is not what says which: it renders an array
+      // and `null` alike, as `object`, and those are two of the kinds that get
+      // here. The message exists to explain the refusal, so it names the
+      // value.
+      expect(await refusalFor([1, 2]))
+        .toBe("A piece's argument must be a record, not: [1,2]");
+      expect(await refusalFor(null))
+        .toBe("A piece's argument must be a record, not: null");
+      expect(await refusalFor("a bare string"))
+        .toBe('A piece\'s argument must be a record, not: "a bare string"');
+    });
+
+    it("refuses a fabric class instance as the whole argument", async () => {
+      // The arm that separates `isPlainObject()` from the looser
+      // `isObjectNotArray()`, which admits any class instance. A piece's
+      // entire input is not one value, whatever that value is.
+      expect(await refusalFor(new FabricBytes(new Uint8Array([1, 2, 3]))))
+        .toContain("A piece's argument must be a record, not:");
+      expect(await refusalFor(FabricError.fromNativeError(new Error("x"))))
+        .toContain("A piece's argument must be a record, not:");
+    });
+
+    it("admits a record that holds a fabric class instance", async () => {
+      // The other side of the same line, and the case that has to keep
+      // working: the guard asks what the argument *is*, not what it holds.
+      const created: unknown[] = [];
+      const processor = {
+        getSpaceCtx: () => ({
+          create: (_program: unknown, options: { input?: unknown }) => {
+            created.push(options.input);
+            throw new Error("stop after the guard");
+          },
+        }),
+      };
+      const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+      await expect(
+        // deno-lint-ignore no-explicit-any
+        (RuntimeProcessor.prototype as any).handlePieceCreate.call(processor, {
+          type: RequestType.PageCreate,
+          space,
+          source,
+          argument: { image: bytes },
+        }),
+      ).rejects.toThrow("stop after the guard");
+      expect(created).toEqual([{ image: bytes }]);
+    });
+  });
+
   describe("space ACL state", () => {
     it("reports owner controls from the active principal's ACL entry", async () => {
       const space = "did:key:z6Mk-runtime-processor-acl" as const;

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -1,7 +1,10 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+import {
+  FabricError,
+  FabricLink,
+} from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
@@ -901,6 +904,21 @@ describe("cell-handle", () => {
           "Cannot yet handle `FabricBytes` (a `FabricSpecialObject`) on this " +
             "connection.",
         );
+    });
+
+    it("refuses a `FabricInstance` for its own reason, as `deserialize()` does", () => {
+      // The two arms are refused for different reasons -- a primitive because
+      // the wire has no representation for it, an instance because this walk
+      // cannot descend one to find a handle inside -- and only the second
+      // reason outlives a wire that carries the class. The instance arm says
+      // so through the shared helper, which is what every other refusal site
+      // in the tree uses, `deserialize()` below included.
+      expect(() =>
+        CellHandle.serialize(FabricError.fromNativeError(new Error("boom")))
+      ).toThrow(
+        "Cannot yet handle `FabricError` (a `FabricInstance`) when sending a " +
+          "value over this connection.",
+      );
     });
 
     it("serializes an ordinary record unchanged", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two findings from reviews of the IPC envelope work (#6323), both true on `main`
today and independent of it. Landing them here keeps them out of a larger
change, and keeps them landed if that change ever has to be reverted.

## A piece's argument is cast, not checked

`handlePieceCreate()` passes the argument straight through:

```ts
input: request.argument as object | undefined,
```

Both client facades type it `JSONValue`, which admits `null`, a bare string, a
number and an array. So a caller can hand a piece a non-record as its entire
input, the cast launders it into `object`, and whatever fails downstream fails
away from the call that caused it.

It asks `isPlainObject()` now — a piece's input being a record of named inputs
— and names the value it turned away rather than its `typeof`, which renders an
array and `null` alike as `object` and so says nothing about either. Both
facades narrow to `JSONObject` to match.

**`JSONObject` rather than a fabric record type, on purpose.** Widening the
element domain from JSON to `FabricValue` is a separate question; the wire
field still carries the existing `TODO` describing it. Narrowing to a fabric
type *here* would put the declaration ahead of a connection that strips a
`FabricBytes` to `{}` — the inbound case that is not safe to extract.

## `serialize()` conflates two refusals into one

It refused a `FabricSpecialObject` in a single arm, for a single stated reason.
There are two reasons, and only one is about what the connection can carry:

- a `FabricPrimitive` has no representation on the wire;
- a `FabricInstance` is a container this walk cannot descend to find a handle
  inside — which stays true of any wire.

Its own inverse, `deserialize()`, **already splits them exactly this way** and
refuses the instance through the shared `refuseFabricInstance()`. `serialize()`
was the odd one out, and was hand-rolling a near-copy of that helper's message
with a different noun.

Behavior is unchanged — both arms still throw — and the primitive arm's message
is byte-identical, so the three existing tests that pin it are untouched. The
instance arm was reachable and unexercised; it has a test now.

## Ablations

Both, rather than asserted:

- Remove the guard: the two refusal tests fail, while "admits a record that
  holds a fabric class instance" still passes — so the assertions grip the
  refusal and are not merely inverted.
- Remove the instance arm from `serialize()`: only the instance test fails, and
  all three primitive tests still pass. That is the separability the split
  claims, demonstrated rather than described.

## Checks

`deno task check` (workspace), `deno fmt --check`, and `deno lint` pass, as do
the `runtime-client` (16 tests), `lib-shell` (5 tests), and full `runner` (1303
tests) suites. The `runner` change is one line: re-exporting `JSONObject`
alongside the `JSONValue` it already exports.


## Coverage

The ratchet reports `packages/runner +4`, and the four lines are flake, not
this change. Attributed from the run's own LCOV rather than guessed: three are
`executor/space-server.ts:2658-2660`, one `if` block whose own comment
describes the race window that decides whether it runs, and one is
`executor/wave.ts:1923`, a cross-space-failure path.

Both files are byte-identical to `main`, and the only `runner` change here is a
single **type-only** re-export, which emits no runtime code and so cannot add
an instrumented line.

Shown flaky rather than argued. Across three `main` runs of identical source,
`wave.ts:1923` scores 2, 0, 2 — it flips with no code change at all — and the
`runner` uncovered total is itself 5675, 5676, 5675 across those same runs.

Accepted rather than chased, per Dan; the flake is not this change's to fix.

ACCEPT_COVERAGE_DEBT: packages/runner +4 lines

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


