### PR TITLE
ci: the shell inside the toolshed binary gets a presence endpoint

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -541,9 +541,44 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      # The co-presence endpoint the shell EMBEDDED IN THIS BINARY offers to
+      # collaborative editors. `SHELL_PRESENCE_URL` is the repository variable
+      # holding the value; `PRESENCE_URL` is the process variable
+      # packages/shell/felt.config.ts reads and bakes in as the
+      # `$PRESENCE_URL` define — the same mapping deploy-shell-staging makes
+      # for the bucket shell, from its own variable. This binary is the one
+      # both estuary and rapids deploy, so both carry whatever is baked here,
+      # and changing the variable takes a rebuild before it reaches either.
+      # Unset omits the define and co-presence stays disabled, which is why
+      # this does not fail the way an unset API URL does: a shell with no
+      # presence endpoint is a working shell.
+      - name: 🔎 Validate the embedded shell's presence endpoint
+        timeout-minutes: *work-timeout
+        env:
+          PRESENCE_URL: ${{ vars.SHELL_PRESENCE_URL }}
+        run: |
+          if [ -n "$PRESENCE_URL" ]; then
+            PRESENCE_URL="$(deno eval '
+              import { optionalPresenceUrl } from "./packages/shell/src/lib/presence-url.ts";
+              console.log(optionalPresenceUrl(Deno.env.get("PRESENCE_URL"))?.href ?? "");
+            ')"
+            echo "PRESENCE_URL=$PRESENCE_URL" >> "$GITHUB_ENV"
+          fi
+
       - name: 🏗️ Build toolshed binary
         timeout-minutes: *work-timeout
-        run: deno task build-binaries toolshed
+        run: |
+          deno task build-binaries toolshed
+
+          # shell-frontend is what the binary serves in production. An endpoint
+          # that was configured but did not reach the bundle would deploy a
+          # shell whose co-presence is silently off, and nothing downstream
+          # looks, so confirm the define landed before the binary is uploaded.
+          if [ -n "$PRESENCE_URL" ] && \
+            ! grep -rqF -e "$PRESENCE_URL" packages/toolshed/shell-frontend/scripts; then
+            echo "::error::The embedded shell does not reference $PRESENCE_URL."
+            exit 1
+          fi
         env:
           COMMIT_SHA: ${{ github.sha }}
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -551,7 +551,9 @@ jobs:
       # and changing the variable takes a rebuild before it reaches either.
       # Unset omits the define and co-presence stays disabled, which is why
       # this does not fail the way an unset API URL does: a shell with no
-      # presence endpoint is a working shell.
+      # presence endpoint is a working shell. The job then succeeds either way,
+      # so which of the two shells a binary carries would leave no trace in it;
+      # the step says which, and the log is where that answer is.
       - name: 🔎 Validate the embedded shell's presence endpoint
         timeout-minutes: *work-timeout
         env:
@@ -568,6 +570,9 @@ jobs:
               console.log(optionalPresenceUrl(Deno.env.get("PRESENCE_URL"))?.href ?? "");
             ')"
             echo "PRESENCE_URL=$PRESENCE_URL" >> "$GITHUB_ENV"
+            echo "The embedded shell gets presence service $PRESENCE_URL."
+          else
+            echo "SHELL_PRESENCE_URL is unset: the embedded shell gets no presence endpoint, so editor co-presence is off in every deployment of this binary."
           fi
 
       - name: 🏗️ Build toolshed binary

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -558,6 +558,11 @@ jobs:
           PRESENCE_URL: ${{ vars.SHELL_PRESENCE_URL }}
         run: |
           if [ -n "$PRESENCE_URL" ]; then
+            # `deno eval` holds every permission implicitly, so the module read
+            # and the environment lookup need no flags; the subcommand takes no
+            # `--allow-read` or `--allow-env` and fails on either as an unknown
+            # argument. What reaches GITHUB_ENV is `URL.href`, so it is the
+            # normalized spelling the bundle carries and the grep below matches.
             PRESENCE_URL="$(deno eval '
               import { optionalPresenceUrl } from "./packages/shell/src/lib/presence-url.ts";
               console.log(optionalPresenceUrl(Deno.env.get("PRESENCE_URL"))?.href ?? "");

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -279,7 +279,7 @@ Most shell config is **build-time**: esbuild injects defines in
 |---|---|---|---|
 | `PRODUCTION` | `$ENVIRONMENT` (`"production"` if set, else `"development"`) | _(unset = dev)_ | Triggers minified bundle and disables sourcemaps. |
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
-| `PRESENCE_URL` | `$PRESENCE_URL` | _(unset)_ | WebSocket endpoint provided to collaborative editors for ephemeral co-presence. When unset, editor co-presence stays disabled unless a component supplies its own endpoint. |
+| `PRESENCE_URL` | `$PRESENCE_URL` | _(unset)_ | WebSocket endpoint provided to collaborative editors for ephemeral co-presence. Must be a credential-free `ws:`/`wss:` URL; `packages/shell/src/lib/presence-url.ts` rejects anything else and fails the build. When unset, editor co-presence stays disabled unless a component supplies its own endpoint. Both deployed shells take it from a repository variable — see [Deploying a commit](./deploying.md). |
 | `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for diagnostics and used by deployed shells to select the immutable `/builds/<sha>` worker asset graph. In development the explicit worker URL remains `/scripts/worker-runtime.js`. It does not authorize system-pattern updates. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
 | `SHELL_PORT` | _(server-only)_ | `5173` (from `ports.json`) | Dev server port. |

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -74,15 +74,23 @@ therefore something the `build-toolshed` job does, and a deploy carries
 whatever that build baked in. It needs no API host: it is served from the same
 origin as the API it calls, which is what the shell falls back to.
 
-`SHELL_PRESENCE_URL` optionally names the WebSocket service used for ephemeral
-collaborative-editor presence. The job passes it to the build under the name
-the build reads, `PRESENCE_URL`, and esbuild bakes it into the bundle as a
-define. A value that is not a credential-free WebSocket URL is rejected by
+`SHELL_PRESENCE_URL`, a repository variable of this repository, optionally
+names the WebSocket service used for ephemeral collaborative-editor presence.
+Setting it is the whole of turning co-presence on for these two environments;
+it is configuration rather than code, so it is set once and every later build
+reads it. The job passes it to the build under the name the build reads,
+`PRESENCE_URL`, and esbuild bakes it into the bundle as a define. A value that
+is not a credential-free WebSocket URL is rejected by
 `packages/shell/src/lib/presence-url.ts` and fails the build rather than
 shipping, and the job confirms the URL reached the bundle before the binary is
 uploaded. An unset variable omits the define, and a shell with no presence
 endpoint is a working shell — unlike an absent API host, an absent presence
 endpoint is not a misconfiguration, so nothing fails.
+
+Because nothing fails either way, a green job does not by itself say which of
+the two shells a binary carries. The build log does: the step names the
+endpoint it passed to the build, or says the variable is unset and that
+co-presence will be off wherever the binary runs.
 
 Two consequences follow from the value being baked rather than read at start-up.
 Changing the variable reaches a deployment only through a rebuild and a

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -4,8 +4,13 @@ A commit reaches a server host by way of the bastion. The deploy jobs in CI
 open an SSH connection to the bastion and run one command there,
 `/opt/cf/deploy.sh`, passing the environment to deploy and the commit to deploy
 to it. That script does the rest: it deploys the binaries that CI already built
-and uploaded for that commit. The shell is a static site rather than a server,
-and reaches its bucket another way; "The staging shell" below covers it.
+and uploaded for that commit.
+
+Two browser shells reach users, and they are configured in different places.
+The toolshed binary carries one and serves it from its own origin, so it is
+configured when that binary is built; "The shell inside the binary" below
+covers it. The other is a static site published to its own bucket, and "The
+staging shell" covers that one.
 
 Two jobs do this:
 
@@ -57,6 +62,38 @@ a mismatch fails on the pull request instead.
 Changing the argument list therefore takes a change in each repository, in
 order: land the infra change, apply the bastion playbook so the host has the
 new script, then change the call sites here.
+
+## The shell inside the binary
+
+`toolshed` serves a browser shell from the `shell-frontend` directory beside
+it, so <https://estuary.saga-castor.ts.net/> and
+<https://rapids.saga-castor.ts.net/> each serve the shell that the binary they
+run was built with. `tasks/build-binaries.ts` builds `packages/shell` as part
+of the toolshed build and moves the output there. Configuring this shell is
+therefore something the `build-toolshed` job does, and a deploy carries
+whatever that build baked in. It needs no API host: it is served from the same
+origin as the API it calls, which is what the shell falls back to.
+
+`SHELL_PRESENCE_URL` optionally names the WebSocket service used for ephemeral
+collaborative-editor presence. The job passes it to the build under the name
+the build reads, `PRESENCE_URL`, and esbuild bakes it into the bundle as a
+define. A value that is not a credential-free WebSocket URL is rejected by
+`packages/shell/src/lib/presence-url.ts` and fails the build rather than
+shipping, and the job confirms the URL reached the bundle before the binary is
+uploaded. An unset variable omits the define, and a shell with no presence
+endpoint is a working shell — unlike an absent API host, an absent presence
+endpoint is not a misconfiguration, so nothing fails.
+
+Two consequences follow from the value being baked rather than read at start-up.
+Changing the variable reaches a deployment only through a rebuild and a
+redeploy, so a redeploy of an existing commit cannot change it. And one binary
+serves both environments, so both carry the same endpoint — though not at the
+same moment, because `deploy-rapids` ships every push to `main` on its own
+while `deploy-estuary` waits to be dispatched. A variable change therefore
+reaches rapids first and estuary when someone deploys it there.
+
+What a running deployment actually carries is visible from outside it: the URL
+is in the `/scripts/index.js` that deployment serves, or it is not.
 
 ## The staging shell
 

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -615,6 +615,81 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
   }
 });
 
+// Both shells CI builds take their co-presence endpoint from a repository
+// variable, and an unset variable is a supported state that builds a working
+// shell. Every check the wiring performs therefore sits inside an
+// `if [ -n "$PRESENCE_URL" ]` that a repository without the variable never
+// enters, so those checks cannot report on the wiring itself: remove the
+// wiring and the same runs stay green. The properties a configured value
+// depends on are checked here instead, against the workflow text, where
+// repository configuration does not get to decide whether the check runs.
+Deno.test("a configured presence URL reaches every shell bundle CI builds", async () => {
+  const deno = await workflow("deno.yml");
+
+  // Each job that builds a shell, and the directory its build leaves the
+  // bundle in. Both are named so the shell embedded in the toolshed binary and
+  // the one published to the bucket are held to a single shape.
+  const bundles = new Map([
+    ["build-toolshed", "packages/toolshed/shell-frontend/scripts"],
+    ["deploy-shell-staging", "dist/scripts"],
+  ]);
+
+  // Membership is checked both ways. A job that starts carrying a presence URL
+  // without being named above would go unchecked, and a job that stops
+  // carrying one is a shell that quietly lost co-presence.
+  const carriers = jobIds(deno).filter((id) =>
+    jobBlock(deno, id).includes('PRESENCE_URL=$PRESENCE_URL" >> "$GITHUB_ENV"')
+  );
+  assertEquals(carriers.sort(), [...bundles.keys()].sort());
+
+  for (const [id, bundle] of bundles) {
+    const steps = stepBlocks(jobBlock(deno, id));
+
+    const exporter = steps.findIndex((step) =>
+      step.body.includes('PRESENCE_URL=$PRESENCE_URL" >> "$GITHUB_ENV"')
+    );
+    assert(exporter >= 0, `${id}: no step exports PRESENCE_URL`);
+
+    // Read from `vars`, never `secrets`: the value ships inside a bundle any
+    // reader can open, so hiding it would cost review and buy nothing.
+    assertStringIncludes(steps[exporter].body, "PRESENCE_URL: ${{ vars.");
+
+    // What the bundle carries is `URL.href`, which is not always the spelling
+    // the variable holds — a host written without a path gains a trailing
+    // slash. Exporting the normalized form is what makes the check below an
+    // equality on the value that shipped rather than a prefix match.
+    assertStringIncludes(
+      steps[exporter].body,
+      "packages/shell/src/lib/presence-url.ts",
+    );
+    assertStringIncludes(steps[exporter].body, "?.href");
+
+    // A configured endpoint that did not reach the bundle is a deployment
+    // whose co-presence is off with nothing downstream to notice, so the build
+    // is not allowed to pass until the URL is found in what it produced.
+    const verifier = steps.findIndex((step) =>
+      step.body.includes(`grep -rqF -e "$PRESENCE_URL" ${bundle}`)
+    );
+    assert(
+      verifier >= 0,
+      `${id}: nothing greps ${bundle} for the presence URL`,
+    );
+    assertStringIncludes(
+      steps[verifier].body,
+      'does not reference $PRESENCE_URL."\n            exit 1\n',
+    );
+
+    // GITHUB_ENV reaches the steps after the one that writes it, and not that
+    // step itself. An exporter placed after the build it configures would
+    // export a value no later step reads, and the guarded check above would
+    // then skip on an empty variable instead of failing.
+    assert(
+      exporter < verifier,
+      `${id}: PRESENCE_URL is exported after the build that has to read it`,
+    );
+  }
+});
+
 Deno.test("every test-records artifact name is store-safe and unique", async () => {
   // The relay derives each store object's name from the artifact's name
   // through objectNameSlug, which collapses characters unsafe in object


### PR DESCRIPTION
## Why

Berni's `<cf-code-editor>` co-presence is proven and Alex wants it on by
default. One of the three shells already has it; two do not, and they are the
two that cannot get it without this change.

Measured on `main` today:

| Shell | Presence URL in `/scripts/index.js` |
| --- | --- |
| staging.commontools.dev | **yes** — `STAGING_SHELL_PRESENCE_URL` was set at 16:58Z and three pushes have shipped since |
| rapids.saga-castor.ts.net | no — 200, 4.85 MB, zero matches |
| estuary.saga-castor.ts.net | no — 200, 2.57 MB, zero matches |

Those last two serve a different shell from the bucket one: the shell
`tasks/build-binaries.ts` builds into `packages/toolshed/shell-frontend` and
embeds in the toolshed binary. It is configured when that binary is built, and
`build-toolshed` passes only `COMMIT_SHA` — so no deploy to either environment
can turn co-presence on. That is why redeploying toolshed alone does nothing
here.

## What Changed

`build-toolshed` maps the repository variable `SHELL_PRESENCE_URL` to
`PRESENCE_URL`, the process variable `packages/shell/felt.config.ts` reads and
bakes in as the `$PRESENCE_URL` define. This is the same mapping
`deploy-shell-staging` already makes for the bucket shell, from its own
variable. `buildShell` spawns the shell build without `clearEnv`, so the value
reaches it.

The value is normalized through the repo's own `optionalPresenceUrl` before the
build, and the build then greps `shell-frontend/scripts` for it. Normalizing
first is load-bearing: the variable holds
`wss://…workers.dev` and the bundle contains `wss://…workers.dev/`, so a naive
grep of the raw variable would not match. A malformed value fails
`optionalPresenceUrl` inside `felt.config.ts` and takes the binary build with
it. An unset variable omits the define and co-presence stays disabled, which is
a working shell — so unlike an unset API host, this does not fail the job.

Docs: `deploying.md` described only the bucket shell and never mentioned that
the binary carries one, which is the gap that makes this hard to scope. It now
has a section for the embedded shell covering where it is configured, that a
redeploy of an existing commit cannot change a baked value, and that one binary
serves both environments on two different cadences. `CONFIGURATION.md`'s
`PRESENCE_URL` row now names the validation rule and points at `deploying.md`.

## Test plan

- `deno fmt --check` (5226 files), `deno lint` (5115 files), `check-docs` (567
  blocks), `check-skill-facts`, `check-docs-history-index`,
  `check-conflict-markers` — all pass.
- `tasks/ci-workflow.test.ts` — 17 pass, including the new case below. It
  caught a missing step `timeout-minutes` on the first attempt;
  `build-toolshed` is a bounded job, unlike `deploy-shell-staging`, whose
  equivalent step carries none.
- **`a configured presence URL reaches every shell bundle CI builds`** — a new
  case pinning this wiring. Every runtime check it performs sits inside
  `if [ -n "$PRESENCE_URL" ]`, which a repository without the variable never
  enters, so those checks cannot report on the wiring itself: delete it and the
  runs stay green. This case reads the workflow text instead, where repository
  configuration does not decide whether the check runs, and holds both
  shell-building jobs to one shape. Mutation-tested six ways — validate step
  deleted, bundle grep removed, `?.href` dropped, `vars.` swapped for
  `secrets.`, the exporter moved after the build, and the
  `vars.SHELL_PRESENCE_URL` env line deleted outright. All six red it.
- Ran the shell production build with `PRESENCE_URL` set to the un-normalized
  variable value and confirmed the bundle contains the normalized href — the
  exact grep this job will run.

**This does not make CI talk to the relay.** Presence needs `participantName`
as well as an endpoint. The only browser suite that renders a collaborative
editor is `cf-code-editor-collaboration.test.ts`, whose fixture sets
`collaborative` alone, and whose `enablePresence` helper always sets
`participantName` and an explicit `presenceUrl` together, pointing at a local
relay. `collaborative-note` is not in any browser suite. Worth knowing that
this safety rests on that pairing holding for future fixtures.

## Before this does anything

`SHELL_PRESENCE_URL` does not exist yet — I was not able to create it:

```
gh api -X POST repos/commontoolsinc/labs/actions/variables \
  -f name=SHELL_PRESENCE_URL \
  -f value='wss://spectral-wombat-c7e91d.commontools.workers.dev'
```

Merging without it is inert rather than broken.

## Rollout, and one open question

Landing this puts co-presence on rapids automatically — `deploy-rapids` ships
every push to `main` — and on estuary only when someone dispatches the
production deploy. Rapids-first is free.

Open question, deliberately not done here: `STAGING_SHELL_PRESENCE_URL` and
`SHELL_PRESENCE_URL` will hold the same value, which is a footgun. Consolidating
to one variable is the cleaner end state but silently drops presence from
staging if the variable is not created before the job switches to it, so it
belongs in its own change rather than riding along with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShJUqgrit1AKPCGUs3WvyA


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


