### PR TITLE
Conform the section markers whose rules were too short to detect

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2723,7 +2723,9 @@ export type CompileAndRunFunction = <T = any, S = any>(
  */
 export type DataFileFunction = (path: string) => string;
 
-// --- SQLite builtins (docs/specs/sqlite-builtin) ---
+//
+// SQLite builtins (docs/specs/sqlite-builtin)
+//
 
 declare const __sqliteDb: unique symbol;
 

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -1516,7 +1516,7 @@ function registerDefinition(
 function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
   const { sf } = ctx;
 
-  // --- declarations (also statements) ---
+  // declarations (also statements)
   if (ts.isImportDeclaration(node)) {
     return {
       kind: "import",
@@ -1620,7 +1620,7 @@ function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
     };
   }
 
-  // --- variable statements & declarations ---
+  // variable statements & declarations
   // A single binding is represented by the whole statement (so the `variable`
   // node covers `export const … ;`); a multi-declarator statement stays generic
   // and each declaration becomes its own binding node. The single declaration
@@ -1638,7 +1638,7 @@ function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
     return bindingDesc(node, ctx);
   }
 
-  // --- other statements ---
+  // other statements
   if (ts.isExpressionStatement(node)) {
     return expressionStatementDesc(node.expression, ctx);
   }
@@ -1691,7 +1691,7 @@ function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
     };
   }
 
-  // --- significant expressions (in argument / body / return position) ---
+  // significant expressions (in argument / body / return position)
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
     return {
       kind: "closure",

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -1620,11 +1620,11 @@ function classify(node: ts.Node, ctx: BuildCtx): Desc | null {
     };
   }
 
-  // variable statements & declarations
-  // A single binding is represented by the whole statement (so the `variable`
-  // node covers `export const … ;`); a multi-declarator statement stays generic
-  // and each declaration becomes its own binding node. The single declaration
-  // itself stays generic to avoid labeling one binding at two nesting levels.
+  // variable statements & declarations: A single binding is represented by the
+  // whole statement (so the `variable` node covers `export const … ;`); a
+  // multi-declarator statement stays generic and each declaration becomes its
+  // own binding node. The single declaration itself stays generic to avoid
+  // labeling one binding at two nesting levels.
   if (ts.isVariableStatement(node)) {
     const decls = node.declarationList.declarations;
     if (decls.length === 1) return bindingDesc(decls[0], ctx);

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -329,7 +329,9 @@ export class Session {
   /** How much context each hunk can reveal, cached against the document. */
   private roomCache?: { doc: Document; room: ReadonlyMap<number, HunkRoom> };
 
-  // --- editing ---
+  //
+  // editing
+  //
   private source?: EditableSource;
   private buffer?: EditBuffer;
 
@@ -359,14 +361,18 @@ export class Session {
    * listed above it. */
   private editedFiles: string[] = [];
 
-  // --- file picker (C-x C-f) ---
+  //
+  // file picker (C-x C-f)
+  //
   private readonly files?: FileGateway;
   private pickerDir = "";
   private pickerFilter = "";
   private pickerEntries: DirEntry[] = [];
   private pickerSel = 0;
 
-  // --- jump list (i) ---
+  //
+  // jump list (i)
+  //
 
   /** Every file and commit in the diff, in document order; the filter narrows
    * this into the shown {@link jumpEntries}. */

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -332,6 +332,7 @@ export class Session {
   //
   // editing
   //
+
   private source?: EditableSource;
   private buffer?: EditBuffer;
 
@@ -364,6 +365,7 @@ export class Session {
   //
   // file picker (C-x C-f)
   //
+
   private readonly files?: FileGateway;
   private pickerDir = "";
   private pickerFilter = "";

--- a/packages/cli/test/view-diffdoc-cov.test.ts
+++ b/packages/cli/test/view-diffdoc-cov.test.ts
@@ -475,7 +475,9 @@ Deno.test("buildDiffDocument: a Markdown hunk with no workspace file builds head
   );
 });
 
-// --- fileLineText: a hunk claiming a new-side line past EOF stays unverified -
+//
+// fileLineText: a hunk claiming a new-side line past EOF stays unverified -
+//
 
 Deno.test("buildDiffDocument: a hunk naming new-side lines past the workspace EOF cannot verify", () => {
   const root = Deno.makeTempDirSync();

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -1727,7 +1727,9 @@ Deno.test("diffedit: an edit after expanding context saves without duplicating l
   }
 });
 
-// --- regression: review findings (expand overlap, repeated-path revert, etc.) -
+//
+// regression: review findings (expand overlap, repeated-path revert, etc.) -
+//
 
 const MULTI_DIFF = `diff --git a/m.ts b/m.ts
 index 0000000..1111111 100644

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -477,7 +477,9 @@ Deno.test("parse: an anonymous namespace (string-literal module name) has no nam
   assertEquals(ns!.name, undefined, "a string-named module exposes no name");
 });
 
-// --- classify: multi-declarator variable statement & declaration (1400-1408) -
+//
+// classify: multi-declarator variable statement & declaration (1400-1408) -
+//
 
 Deno.test("parse: a multi-declarator var statement yields a binding node per declaration", () => {
   const doc = parseDocument("const a = 1, b = 2, c = 3;\n", "m.ts");
@@ -589,7 +591,9 @@ Deno.test("parse: a bare arrow-function expression statement is a closure node",
   assert(node!.label.startsWith("λ"), `label was ${node!.label}`);
 });
 
-// --- primaryChildren: arrow + reactive call in return position (1620-1626) ---
+//
+// primaryChildren: arrow + reactive call in return position (1620-1626)
+//
 
 Deno.test("parse: a return of an arrow recurses into its body", () => {
   const src = [

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -240,6 +240,7 @@ Deno.test("parse: null, true and false are colored as boolean literals", () => {
 
 //
 // classifyIdentifier: declaration-name and access branches
+//
 // Covers lines 844-846 (function/method/method-signature names), 848-852
 // (interface/class/class-expression names), 854 (enum name), 869-870
 // (property declaration / enum member), 877 (synthetic helper member access).
@@ -389,12 +390,10 @@ Deno.test("parse: an element-access expression gets a […] generic label", () =
   );
 });
 
-//
-// registerDefinition no-name guard (line 1260)
-// Covered indirectly: registerDefinition is only called when desc.name is set,
-// but the early `if (!desc.name) return` is reached when called for a name.
-// A named binding exercises the body; the guard line itself runs every call.
-//
+// registerDefinition no-name guard (line 1260): Covered indirectly:
+// registerDefinition is only called when desc.name is set, but the early `if
+// (!desc.name) return` is reached when called for a name. A named binding
+// exercises the body; the guard line itself runs every call.
 
 Deno.test("parse: a named binding registers a definition", () => {
   const doc = parseDocument("const namedThing = 1;\n", "m.ts");
@@ -735,6 +734,7 @@ Deno.test("parse: interface metadata describes property, method and index member
 
 //
 // parseSchemaObject + fieldType: array / object / anyOf branches
+//
 // Covers 1819-1820 (non-property-assignment skip), 1847-1857 (fieldType array,
 // object, anyOf/oneOf fallthrough), 1871, 1894-1899 (readSchemaProps/hasProp).
 //

--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -41,7 +41,9 @@ function labelsOf(doc: Document): string[] {
   return doc.flatStructure.map((n) => n.label);
 }
 
-// --- isTypePosition: qualified names in type position (neighbor of 913) ---
+//
+// isTypePosition: qualified names in type position (neighbor of 913)
+//
 
 Deno.test("qualified name in a type annotation resolves as a type name", () => {
   // `a.b.c.D` in type position climbs the qualified-name chain in
@@ -55,7 +57,9 @@ Deno.test("qualified name in a type annotation resolves as a type name", () => {
   );
 });
 
-// --- isTypePosition: typeof type (neighbor of 916) ---
+//
+// isTypePosition: typeof type (neighbor of 916)
+//
 
 Deno.test("typeof in a type annotation resolves the operand as a type name", () => {
   // `typeof foo` as a type produces a TypeQueryNode parent for `foo`. Because a
@@ -71,7 +75,9 @@ Deno.test("typeof in a type annotation resolves the operand as a type name", () 
   );
 });
 
-// --- isTypePosition: heritage clause (neighbor of 917, 919, 920) ---
+//
+// isTypePosition: heritage clause (neighbor of 917, 919, 920)
+//
 
 Deno.test("class heritage type resolves as a type name", () => {
   // `extends Base<number>` produces an ExpressionWithTypeArguments whose
@@ -94,7 +100,9 @@ Deno.test("interface heritage type resolves as a type name", () => {
   );
 });
 
-// --- classifyIdentifier neighbors of 836: the full reachable classification ---
+//
+// classifyIdentifier neighbors of 836: the full reachable classification
+//
 
 Deno.test("identifier classifications across declaration and use sites", () => {
   const src = [
@@ -121,7 +129,9 @@ Deno.test("identifier classifications across declaration and use sites", () => {
   assert(sideClasses.has("propertyName") || sideClasses.has("binding"));
 });
 
-// --- mergeByStart neighbor of 1215: non-empty comment batches merge in ---
+//
+// mergeByStart neighbor of 1215: non-empty comment batches merge in
+//
 
 Deno.test("comments are threaded into the structure tree", () => {
   const src = [
@@ -146,7 +156,9 @@ Deno.test("comments are threaded into the structure tree", () => {
   );
 });
 
-// --- registerDefinition neighbor of 1260: named declarations register ---
+//
+// registerDefinition neighbor of 1260: named declarations register
+//
 
 Deno.test("named declarations are registered as definitions", () => {
   const src = [
@@ -168,7 +180,9 @@ Deno.test("named declarations are registered as definitions", () => {
   assertEquals(alpha[0].name, "alpha");
 });
 
-// --- controlLabel neighbors of 1674: all eight control-statement labels ---
+//
+// controlLabel neighbors of 1674: all eight control-statement labels
+//
 
 Deno.test("every control statement gets its dedicated label", () => {
   const src = [
@@ -194,7 +208,9 @@ Deno.test("every control statement gets its dedicated label", () => {
   assert(has(/^try$/), "missing try label");
 });
 
-// --- safe() neighbors of 1725-1727: extractors never throw on parseable input ---
+//
+// safe() neighbors of 1725-1727: extractors never throw on parseable input
+//
 
 Deno.test("metadata extraction survives malformed but parseable input", () => {
   // These all parse (via TypeScript error recovery) into nodes with valid
@@ -225,7 +241,9 @@ Deno.test("import metadata is extracted without error", () => {
   assertEquals(imp!.meta!.kind, "import");
 });
 
-// --- describeInitializer neighbors of 2051-2053 ---
+//
+// describeInitializer neighbors of 2051-2053
+//
 
 Deno.test("a raw arrow initializer becomes a closure node, not a variable", () => {
   // bindingDesc routes the arrow to a closure before variableMeta /
@@ -271,7 +289,9 @@ Deno.test("describeInitializer reports non-closure initializers", () => {
   );
 });
 
-// --- incremental highlighter still re-highlights an edited closure line ---
+//
+// incremental highlighter still re-highlights an edited closure line
+//
 
 Deno.test("incremental highlighter updates a line that adds a closure", () => {
   const h = createHighlighter("const a = 1;\nconst b = 2;\n");

--- a/packages/cli/test/view-parse-gate.test.ts
+++ b/packages/cli/test/view-parse-gate.test.ts
@@ -120,7 +120,9 @@ Deno.test("gate 913: a qualified name in a type annotation resolves as a type", 
   );
 });
 
-// --- 916: typeof type resolves via ts.isTypeNode before the TypeQuery branch -
+//
+// 916: typeof type resolves via ts.isTypeNode before the TypeQuery branch -
+//
 
 Deno.test("gate 916: a `typeof` type colors its operand as a type name", () => {
   // `typeof base` as a type makes `base`'s parent a TypeQueryNode. Because a
@@ -219,7 +221,9 @@ Deno.test("gate 1270: named declarations are registered; an anonymous one is not
   );
 });
 
-// --- 1668: controlLabel's eight handled kinds (the fall-through never runs) --
+//
+// 1668: controlLabel's eight handled kinds (the fall-through never runs)
+//
 
 Deno.test("gate 1668: every control statement gets its dedicated label", () => {
   // controlLabel runs only for the eight isControlStatement kinds, each with an
@@ -248,7 +252,9 @@ Deno.test("gate 1668: every control statement gets its dedicated label", () => {
   assert(has(/^try$/), "try label");
 });
 
-// --- 1719-1721: safe()'s wrapped extractors never throw on parseable input --
+//
+// 1719-1721: safe()'s wrapped extractors never throw on parseable input
+//
 
 Deno.test("gate 1719-1721: metadata extraction never throws on malformed input", () => {
   // Each input parses (via TypeScript error recovery) into nodes with valid

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2925,6 +2925,7 @@ Deno.test("session: escaping a search with no query typed clears the match set",
 
 //
 // diff edit guards on a non-editable (removed) line
+//
 // Land the cursor on the removed line (index 8 in the DIFF fixture) and run
 // each delete-/kill-style edit. The policy's editStart returns null there, so
 // every gate reports NOT_EDITABLE and refuses the edit.

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2707,7 +2707,9 @@ Deno.test("filepickercov: escape cancels the picker", () => {
 // off-screen scroll, or a non-editable diff line under a policy gate).
 //
 
-// --- card reference up-scroll lands a higher target above the scroll (392) --
+//
+// card reference up-scroll lands a higher target above the scroll (392)
+//
 
 /** A node in the SAMPLE blob whose card carries several reference targets, used
  * to step the card selection and force the overlay to scroll. */
@@ -2776,11 +2778,13 @@ Deno.test("session: a card with many references scrolls down then up across the 
   }
 });
 
-// --- jumpToTarget via a use reference with no def offset (428, 446, 464-477) -
+//
+// jumpToTarget via a use reference with no def offset (428, 446, 464-477) -
 // The lift node's card lists both a definition reference (carrying a node
 // offset) and a plain "use" reference (no offset). Revealing the use one takes
 // the offset-less path: findTargetIndex returns -1, jumpToTarget falls back to
 // nodeAtLine, and the off-screen destination column pans the view.
+//
 
 Deno.test("session: revealing a use reference (no def offset) jumps via nodeAtLine and pans", () => {
   const doc = parseDocument(SAMPLE);
@@ -3045,7 +3049,9 @@ Deno.test("diffcov: a same-line region past the marker is killed (guardRegionEdi
   }
 });
 
-// --- the mark rides onto the added line when a context edit splits (1109-1111)
+//
+// the mark rides onto the added line when a context edit splits (1109-1111)
+//
 
 Deno.test("diffcov: a mark on a context line rides onto the added line when split", () => {
   const { ws, done } = diffWorkspace();
@@ -3064,7 +3070,9 @@ Deno.test("diffcov: a mark on a context line rides onto the added line when spli
   }
 });
 
-// --- ensureCursorVisible scrolls the cursor into view (1371-1372, 1375-1376) -
+//
+// ensureCursorVisible scrolls the cursor into view (1371-1372, 1375-1376) -
+//
 
 Deno.test("session: moving the edit cursor off-screen scrolls it back into view", () => {
   // A tall, wide file so cursor moves cross the viewport edges in both axes.

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -745,7 +745,7 @@ export async function main(argv: string[] = Deno.args) {
     Deno.exit(1);
   }
 
-  // --- Callbacks ---
+  // Callbacks
   // Keep references so GC doesn't collect them.
   // deno-lint-ignore no-explicit-any
   const callbacks: Deno.UnsafeCallback<any>[] = [];
@@ -3432,7 +3432,7 @@ export async function main(argv: string[] = Deno.args) {
   );
   callbacks.push(symlinkCb);
 
-  // --- Build ops struct ---
+  // Build ops struct
   const opsBuf = new ArrayBuffer(OPS_SIZE);
   const opsView = new DataView(opsBuf);
 
@@ -3473,7 +3473,7 @@ export async function main(argv: string[] = Deno.args) {
   }
   setOp(OPS_OFFSETS.create, createCb);
 
-  // --- Mount ---
+  // Mount
   const fuseArgs = buildMountFuseArgs({
     os: Deno.build.os,
     provider: platform.provider(),

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -745,8 +745,7 @@ export async function main(argv: string[] = Deno.args) {
     Deno.exit(1);
   }
 
-  // Callbacks
-  // Keep references so GC doesn't collect them.
+  // Callbacks: Keep references so GC doesn't collect them.
   // deno-lint-ignore no-explicit-any
   const callbacks: Deno.UnsafeCallback<any>[] = [];
 

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -16,7 +16,9 @@ import {
   type StatOpts,
 } from "./platform.ts";
 
-// --- Library paths ---
+//
+// Library paths
+//
 
 /**
  * Candidate libfuse locations, in preference order. FUSE-T's installer
@@ -37,7 +39,9 @@ export function libfusePaths(
   return paths;
 }
 
-// --- Darwin-specific FFI symbols (FUSE v2) ---
+//
+// Darwin-specific FFI symbols (FUSE v2)
+//
 
 const DARWIN_SYMBOLS = {
   ...COMMON_SYMBOLS,
@@ -65,7 +69,8 @@ const DARWIN_SYMBOLS = {
 
 type DarwinLib = Deno.DynamicLibrary<typeof DARWIN_SYMBOLS>;
 
-// --- struct stat (macOS arm64, 144 bytes) ---
+//
+// struct stat (macOS arm64, 144 bytes)
 //   dev_t st_dev      @ 0   (i32)
 //   mode_t st_mode    @ 4   (u16)
 //   nlink_t st_nlink  @ 6   (u16)
@@ -74,6 +79,7 @@ type DarwinLib = Deno.DynamicLibrary<typeof DARWIN_SYMBOLS>;
 //   gid_t st_gid      @ 20  (u32)
 //   ...
 //   off_t st_size     @ 96  (i64)
+//
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 96;
@@ -103,7 +109,9 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   view.setBigInt64(96, BigInt(opts.size), true); // st_size
 }
 
-// --- fuse_entry_param (176 bytes) ---
+//
+// fuse_entry_param (176 bytes)
+//
 
 const ENTRY_PARAM_SIZE = 176;
 const writeEntryParam = makeWriteEntryParam(
@@ -112,13 +120,15 @@ const writeEntryParam = makeWriteEntryParam(
   ENTRY_PARAM_SIZE,
 );
 
-// --- fuse_file_info (macOS 64-bit, 40 bytes) ---
+//
+// fuse_file_info (macOS 64-bit, 40 bytes)
 //   int flags            @  0  (i32)
 //   unsigned long fh_old @  8  (u64, deprecated)
 //   int writepage        @ 16  (i32)
 //   bitfield             @ 20  (u32)
 //   uint64_t fh          @ 24  (u64)
 //   uint64_t lock_owner  @ 32  (u64)
+//
 
 const FUSE_FILE_INFO_SIZE = 40;
 const FH_OFFSET = 24;
@@ -140,20 +150,26 @@ function writeFileInfo(ptr: Deno.PointerValue, fh: bigint): void {
   fiArr[FH_OFFSET / 8] = fh; // offset 24 = index 3
 }
 
-// --- O_* flags (macOS) ---
+//
+// O_* flags (macOS)
+//
 
 const O_CREAT = 0x0200;
 const O_TRUNC = 0x0400;
 const O_APPEND = 0x0008;
 
-// --- Errno constants (macOS) ---
+//
+// Errno constants (macOS)
+//
 
 const ENOTEMPTY = 66;
 const ENOSYS = 78;
 const ENODATA = 93; // macOS ENOATTR
 const ENOTSUP = 45;
 
-// --- fuse_lowlevel_ops offsets (v2) ---
+//
+// fuse_lowlevel_ops offsets (v2)
+//
 
 const OPS_SIZE = 320;
 const OPS_OFFSETS = {
@@ -192,12 +208,16 @@ const OPS_OFFSETS = {
 
 const FUSE_ARGS_STRUCT_SIZE = 24;
 
-// --- Module state ---
+//
+// Module state
+//
 
 let fullLib: DarwinLib | null = null;
 let loadedProvider: FuseProvider = "unknown";
 
-// --- Platform implementation ---
+//
+// Platform implementation
+//
 
 const darwinPlatform: FusePlatform = {
   provider() {

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -69,8 +69,7 @@ const DARWIN_SYMBOLS = {
 
 type DarwinLib = Deno.DynamicLibrary<typeof DARWIN_SYMBOLS>;
 
-//
-// struct stat (macOS arm64, 144 bytes)
+// struct stat (macOS arm64, 144 bytes):
 //   dev_t st_dev      @ 0   (i32)
 //   mode_t st_mode    @ 4   (u16)
 //   nlink_t st_nlink  @ 6   (u16)
@@ -79,7 +78,6 @@ type DarwinLib = Deno.DynamicLibrary<typeof DARWIN_SYMBOLS>;
 //   gid_t st_gid      @ 20  (u32)
 //   ...
 //   off_t st_size     @ 96  (i64)
-//
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 96;
@@ -120,15 +118,13 @@ const writeEntryParam = makeWriteEntryParam(
   ENTRY_PARAM_SIZE,
 );
 
-//
-// fuse_file_info (macOS 64-bit, 40 bytes)
+// fuse_file_info (macOS 64-bit, 40 bytes):
 //   int flags            @  0  (i32)
 //   unsigned long fh_old @  8  (u64, deprecated)
 //   int writepage        @ 16  (i32)
 //   bitfield             @ 20  (u32)
 //   uint64_t fh          @ 24  (u64)
 //   uint64_t lock_owner  @ 32  (u64)
-//
 
 const FUSE_FILE_INFO_SIZE = 40;
 const FH_OFFSET = 24;

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -28,7 +28,6 @@ const LIBFUSE_PATHS = [
   "/usr/lib64/libfuse3.so.4", // Fedora
 ];
 
-//
 // Linux-specific FFI symbols (FUSE v3)
 //
 // Key differences from v2:
@@ -36,7 +35,6 @@ const LIBFUSE_PATHS = [
 //   - fuse_session_mount(session, mountpoint) replaces fuse_mount(mountpoint, args)
 //   - fuse_session_unmount(session) replaces fuse_unmount(mountpoint, chan)
 //   - No channel concept — session manages mount directly
-//
 
 const LINUX_SYMBOLS = {
   ...COMMON_SYMBOLS,
@@ -56,8 +54,7 @@ const LINUX_SYMBOLS = {
 
 type LinuxLib = Deno.DynamicLibrary<typeof LINUX_SYMBOLS>;
 
-//
-// struct stat (Linux x86_64, 144 bytes)
+// struct stat (Linux x86_64, 144 bytes):
 //   dev_t st_dev       @ 0   (u64)
 //   ino_t st_ino       @ 8   (u64)
 //   nlink_t st_nlink   @ 16  (u64)  — note: u64 on Linux, u16 on macOS
@@ -70,7 +67,6 @@ type LinuxLib = Deno.DynamicLibrary<typeof LINUX_SYMBOLS>;
 //
 // NOTE: These offsets are initial best-guesses for x86_64.
 // Run verify-structs.c to confirm exact values.
-//
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 48;
@@ -96,11 +92,9 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   }
 }
 
-//
 // fuse_entry_param
 // Layout: ino(u64) + generation(u64) + stat(144) + attr_timeout(f64) + entry_timeout(f64)
 // = 8 + 8 + 144 + 8 + 8 = 176 bytes (same total as macOS)
-//
 
 const ENTRY_PARAM_SIZE = 176;
 const writeEntryParam = makeWriteEntryParam(
@@ -109,7 +103,6 @@ const writeEntryParam = makeWriteEntryParam(
   ENTRY_PARAM_SIZE,
 );
 
-//
 // fuse_file_info (FUSE v3)
 // v3 removed the deprecated fh_old field.
 //   int flags             @  0  (i32)
@@ -122,7 +115,6 @@ const writeEntryParam = makeWriteEntryParam(
 //   Total: 40 bytes (with trailing padding)
 //
 // NOTE: fh offset is a best-guess. Verify with verify-structs.c.
-//
 
 const FUSE_FILE_INFO_SIZE = 40;
 const FH_OFFSET = 16;
@@ -161,12 +153,10 @@ const ENOSYS = 38;
 const ENODATA = 61; // Linux equivalent of macOS ENOATTR
 const ENOTSUP = 95;
 
-//
 // fuse_lowlevel_ops offsets
 // v3 keeps the same order for existing ops and adds new ones at the end.
 // The offsets below should match v2 for all ops we use.
 // Verify with verify-structs.c.
-//
 
 const OPS_SIZE = 352; // v3 has more ops than v2 (verified by verify-structs.c)
 const OPS_OFFSETS = {

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -92,9 +92,12 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   }
 }
 
+//
 // fuse_entry_param
+//
 // Layout: ino(u64) + generation(u64) + stat(144) + attr_timeout(f64) + entry_timeout(f64)
 // = 8 + 8 + 144 + 8 + 8 = 176 bytes (same total as macOS)
+//
 
 const ENTRY_PARAM_SIZE = 176;
 const writeEntryParam = makeWriteEntryParam(

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -15,7 +15,9 @@ import {
   type StatOpts,
 } from "./platform.ts";
 
-// --- Library paths ---
+//
+// Library paths
+//
 
 const LIBFUSE_PATHS = [
   "/usr/lib/x86_64-linux-gnu/libfuse3.so", // Debian/Ubuntu x86_64
@@ -26,13 +28,15 @@ const LIBFUSE_PATHS = [
   "/usr/lib64/libfuse3.so.4", // Fedora
 ];
 
-// --- Linux-specific FFI symbols (FUSE v3) ---
+//
+// Linux-specific FFI symbols (FUSE v3)
 //
 // Key differences from v2:
 //   - fuse_session_new replaces fuse_lowlevel_new (same signature)
 //   - fuse_session_mount(session, mountpoint) replaces fuse_mount(mountpoint, args)
 //   - fuse_session_unmount(session) replaces fuse_unmount(mountpoint, chan)
 //   - No channel concept — session manages mount directly
+//
 
 const LINUX_SYMBOLS = {
   ...COMMON_SYMBOLS,
@@ -52,7 +56,8 @@ const LINUX_SYMBOLS = {
 
 type LinuxLib = Deno.DynamicLibrary<typeof LINUX_SYMBOLS>;
 
-// --- struct stat (Linux x86_64, 144 bytes) ---
+//
+// struct stat (Linux x86_64, 144 bytes)
 //   dev_t st_dev       @ 0   (u64)
 //   ino_t st_ino       @ 8   (u64)
 //   nlink_t st_nlink   @ 16  (u64)  — note: u64 on Linux, u16 on macOS
@@ -65,6 +70,7 @@ type LinuxLib = Deno.DynamicLibrary<typeof LINUX_SYMBOLS>;
 //
 // NOTE: These offsets are initial best-guesses for x86_64.
 // Run verify-structs.c to confirm exact values.
+//
 
 const STAT_SIZE = 144;
 const STAT_ST_SIZE_OFFSET = 48;
@@ -90,9 +96,11 @@ function writeStat(buf: ArrayBuffer, opts: StatOpts): void {
   }
 }
 
-// --- fuse_entry_param ---
+//
+// fuse_entry_param
 // Layout: ino(u64) + generation(u64) + stat(144) + attr_timeout(f64) + entry_timeout(f64)
 // = 8 + 8 + 144 + 8 + 8 = 176 bytes (same total as macOS)
+//
 
 const ENTRY_PARAM_SIZE = 176;
 const writeEntryParam = makeWriteEntryParam(
@@ -101,7 +109,8 @@ const writeEntryParam = makeWriteEntryParam(
   ENTRY_PARAM_SIZE,
 );
 
-// --- fuse_file_info (FUSE v3) ---
+//
+// fuse_file_info (FUSE v3)
 // v3 removed the deprecated fh_old field.
 //   int flags             @  0  (i32)
 //   bitfield (32 bits)    @  4  (u32)
@@ -113,6 +122,7 @@ const writeEntryParam = makeWriteEntryParam(
 //   Total: 40 bytes (with trailing padding)
 //
 // NOTE: fh offset is a best-guess. Verify with verify-structs.c.
+//
 
 const FUSE_FILE_INFO_SIZE = 40;
 const FH_OFFSET = 16;
@@ -134,23 +144,29 @@ function writeFileInfo(ptr: Deno.PointerValue, fh: bigint): void {
   fiArr[FH_OFFSET / 8] = fh; // offset 16 = index 2
 }
 
-// --- O_* flags (Linux) ---
+//
+// O_* flags (Linux)
+//
 
 const O_CREAT = 0x40;
 const O_TRUNC = 0x200;
 const O_APPEND = 0x400;
 
-// --- Errno constants (Linux) ---
+//
+// Errno constants (Linux)
+//
 
 const ENOTEMPTY = 39;
 const ENOSYS = 38;
 const ENODATA = 61; // Linux equivalent of macOS ENOATTR
 const ENOTSUP = 95;
 
-// --- fuse_lowlevel_ops offsets ---
+//
+// fuse_lowlevel_ops offsets
 // v3 keeps the same order for existing ops and adds new ones at the end.
 // The offsets below should match v2 for all ops we use.
 // Verify with verify-structs.c.
+//
 
 const OPS_SIZE = 352; // v3 has more ops than v2 (verified by verify-structs.c)
 const OPS_OFFSETS = {
@@ -189,11 +205,15 @@ const OPS_OFFSETS = {
 
 const FUSE_ARGS_STRUCT_SIZE = 24;
 
-// --- Module state ---
+//
+// Module state
+//
 
 let fullLib: LinuxLib | null = null;
 
-// --- Platform implementation ---
+//
+// Platform implementation
+//
 
 const linuxPlatform: FusePlatform = {
   provider() {

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -4,7 +4,9 @@
 // platform-linux.ts (FUSE v3). This module provides the shared interface,
 // constants that are identical across platforms, and a runtime dispatcher.
 
-// --- Shared types ---
+//
+// Shared types
+//
 
 export interface StatOpts {
   ino: bigint;
@@ -51,7 +53,9 @@ export function msToTimespec(ms?: number): { sec: bigint; nsec: bigint } {
   };
 }
 
-// --- Common FFI symbols (identical between FUSE v2 and v3) ---
+//
+// Common FFI symbols (identical between FUSE v2 and v3)
+//
 
 export const COMMON_SYMBOLS = {
   // Session lifecycle
@@ -145,7 +149,9 @@ export const COMMON_SYMBOLS = {
 
 export type FuseLib = Deno.DynamicLibrary<typeof COMMON_SYMBOLS>;
 
-// --- Platform interface ---
+//
+// Platform interface
+//
 
 // deno-lint-ignore no-explicit-any
 type AnyCallback = Deno.UnsafeCallback<any>;
@@ -256,7 +262,9 @@ export interface FusePlatform {
   ): void;
 }
 
-// --- Shared constants (identical on macOS and Linux) ---
+//
+// Shared constants (identical on macOS and Linux)
+//
 
 // Errno constants (POSIX-standard values)
 export const ENOENT = 2;
@@ -346,7 +354,9 @@ export const FILE_MODE_RWX = S_IFREG | 0o777;
 export const FILE_MODE_WO = S_IFREG | 0o222;
 export const SYMLINK_MODE = S_IFLNK | 0o777;
 
-// --- Shared utility ---
+//
+// Shared utility
+//
 
 export function readCString(ptr: Deno.PointerValue): string {
   if (!ptr) return "";
@@ -354,7 +364,9 @@ export function readCString(ptr: Deno.PointerValue): string {
   return view.getCString();
 }
 
-// --- Shared struct helpers ---
+//
+// Shared struct helpers
+//
 
 /**
  * Build a writeEntryParam function using the given platform's writeStat and STAT_SIZE.
@@ -436,7 +448,9 @@ export function createFuseArgs(
   return { argsBuf, argv, argvBuf, encodedArgs };
 }
 
-// --- Platform dispatcher ---
+//
+// Platform dispatcher
+//
 
 let _platform: FusePlatform | null = null;
 

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -589,7 +589,9 @@ Deno.test("FsTree - addSymlink", () => {
   }
 });
 
-// --- Sigil link tests ---
+//
+// Sigil link tests
+//
 
 Deno.test("isSigilLink - detects valid sigil links", () => {
   assertEquals(
@@ -763,7 +765,9 @@ Deno.test("buildJsonTree - unresolvable sigil link falls through to object", () 
   assertEquals(refNode?.kind, "dir");
 });
 
-// --- Stream / handler tests ---
+//
+// Stream / handler tests
+//
 
 Deno.test("isStreamValue - detects stream markers", () => {
   assertEquals(isStreamValue({ $stream: true }), true);
@@ -1527,7 +1531,9 @@ Deno.test("CellBridge.loadPieceTree keeps schema-backed callables beside populat
   assertEquals(resultJson.search, { "/tool": "search" });
 });
 
-// --- parseSymlinkTarget tests ---
+//
+// parseSymlinkTarget tests
+//
 
 /** Helper: build a minimal tree mimicking a space with pieces. */
 function buildTestTree(): {

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -207,7 +207,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       rootCell: MockCell,
     ): () => void => reconciler.mount(rootCell as any);
 
-    // --- Test cases ---
+    // Test cases
 
     await t.step("Cell<Props> renders primitive props", async () => {
       const collector = createOpsCollector();

--- a/packages/memory/test/session-open-auth.test.ts
+++ b/packages/memory/test/session-open-auth.test.ts
@@ -123,7 +123,7 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // --- expiry ---
+  // expiry
 
   it("accepts an unexpired open", async () => {
     const msg = await buildOpen(signedFields({ iat: now, exp: now + 300 }));
@@ -196,7 +196,7 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // --- challenge binding ---
+  // challenge binding
 
   it("accepts a challenged open with the matching challenge", async () => {
     const msg = await buildOpen(signedFields());
@@ -243,7 +243,7 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // --- audience binding ---
+  // audience binding
 
   it("accepts an audience-bound open at the matching host", async () => {
     assertEquals(

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1317,7 +1317,9 @@ export type EntityIdLookupRequest = {
   id: EntityId;
 };
 
-// --- SQLite builtins (docs/specs/sqlite-builtin) ---
+//
+// SQLite builtins (docs/specs/sqlite-builtin)
+//
 
 /** Wire form of SQLite bind parameters. */
 export type SqliteParamsWire =

--- a/packages/piece/test/legacy-envelope-default-pattern.test.ts
+++ b/packages/piece/test/legacy-envelope-default-pattern.test.ts
@@ -154,7 +154,7 @@ describe("piece layer over a legacy-envelope default pattern (CT-1838)", () => {
   it("T7: getPieceRegistry returns the registry and add succeeds after a pin bump", async () => {
     const spaceName = "legacy-envelope-default-" + crypto.randomUUID();
 
-    // --- Session 1: build the poisoned space. ---
+    // Session 1: build the poisoned space.
     const runtime1 = newRuntime();
     const session1 = await createSession({ identity: signer, spaceName });
     const pieces1 = new PiecesController(session1, runtime1);
@@ -214,9 +214,9 @@ describe("piece layer over a legacy-envelope default pattern (CT-1838)", () => {
     const persistedId = pieceId(persisted)!;
     expect(persistedId).toBeDefined();
 
-    // --- Session 2: fresh runtime under a BUMPED runtimeVersion (the pin
+    // Session 2: fresh runtime under a BUMPED runtimeVersion (the pin
     // bump): the compiled set written by session 1's heal is a miss, so the
-    // default pattern must COLD-load from the legacy source docs. ---
+    // default pattern must COLD-load from the legacy source docs.
     const restore = setCompileCacheRuntimeVersionForTesting(
       "cf-test-bumped-runtime-version-t7",
     );

--- a/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
+++ b/packages/runner/integration/sqlite-cfc-commit-eval.test.ts
@@ -108,7 +108,7 @@ async function runTest(base: URL) {
       }[];
 
     try {
-      // --- Seed: one valid guarded row; staging = 1 valid + 1 violating. ---
+      // Seed: one valid guarded row; staging = 1 valid + 1 violating.
       await send("seed");
       await waitFor(
         "seed",
@@ -119,10 +119,10 @@ async function runTest(base: URL) {
               ?.length === 2,
       );
 
-      // --- THE POINT (rollback): copy EVERY staging row into the guarded
+      // THE POINT (rollback): copy EVERY staging row into the guarded
       // table. The runner gate admits the INSERT…SELECT (the server
       // advertised 3.c); the server evaluates the two committed rows, the
-      // violating one refuses, and the WHOLE statement rolls back. ---
+      // violating one refuses, and the WHOLE statement rolls back.
       await send("copyBad");
       // The failed commit rolls back the db-handle rev bump too, so `q` does
       // not re-run for it; the next SUCCESSFUL write re-queries server truth.
@@ -144,12 +144,12 @@ async function runTest(base: URL) {
         );
       }
 
-      // --- Upsert, violating post-image: row 2's sender flips to junk ->
-      // the server re-derives the post-image, refuses, rolls back. ---
+      // Upsert, violating post-image: row 2's sender flips to junk ->
+      // the server re-derives the post-image, refuses, rolls back.
       await send("upsertBad");
-      // --- Upsert, valid post-image: row 1's sender flips to carol2. Its
+      // Upsert, valid post-image: row 1's sender flips to carol2. Its
       // successful commit bumps the handle rev, forcing a FRESH query cycle
-      // against server truth (no dependency on rolled-back speculation). ---
+      // against server truth (no dependency on rolled-back speculation).
       await send("upsertGood");
       await waitFor(
         "upserts settled",
@@ -167,7 +167,7 @@ async function runTest(base: URL) {
         );
       }
 
-      // --- The read side re-derives row 1's label from the POST-IMAGE. ---
+      // The read side re-derives row 1's label from the POST-IMAGE.
       const rowLabel = async (i: number) => {
         const dtx = runtime.edit();
         const leaf = result.key("q").key("result").key(i).key("body")

--- a/packages/runner/integration/sqlite-cfc-row-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-row-label.test.ts
@@ -111,7 +111,7 @@ async function runTest(base: URL) {
         );
       }
 
-      // --- THE POINT: distinct per-row labels, re-derived from row data. ---
+      // THE POINT: distinct per-row labels, re-derived from row data.
       // Reading row[i] traverses pattern result -> query result -> the row's
       // own entity doc; the labels the consumer observes accumulate across
       // those dereferences (per-row ROOT label + per-column field labels).
@@ -203,7 +203,7 @@ async function runTest(base: URL) {
         "row 1 integrity",
       );
 
-      // --- Aggregate on a rule-bearing table fails closed. ---
+      // Aggregate on a rule-bearing table fails closed.
       const countError = result.key("qCount").key("error").get() as unknown;
       if (
         typeof countError !== "string" || !countError.includes("aggregate")
@@ -217,7 +217,7 @@ async function runTest(base: URL) {
         );
       }
 
-      // --- Declared ceiling + onExceed:"skip": exactly row 1 survives. ---
+      // Declared ceiling + onExceed:"skip": exactly row 1 survives.
       const skim = result.key("qSkim").key("result").get() as
         | { id: number }[]
         | undefined;
@@ -229,9 +229,9 @@ async function runTest(base: URL) {
         );
       }
 
-      // --- Read-time clearance (Phase 3.b): the owner satisfies no row's
+      // Read-time clearance (Phase 3.b): the owner satisfies no row's
       // conjunctive rule (the did:mailto participants are required too), so a
-      // cleared query returns zero rows and reports withheld: 2. ---
+      // cleared query returns zero rows and reports withheld: 2.
       const clearErr = result.key("qClear").key("error").getRaw();
       const cleared = result.key("qClear").key("result").get() as
         | unknown[]

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -125,6 +125,7 @@ class WishError extends Error {
 // range. Both serve as defense-in-depth against timing side-channel attacks once
 // SES sandboxing removes patterns' direct access to Date.now/performance.now.
 //
+
 const MIN_INTERVAL_SECONDS = 1;
 const MAX_INTERVAL_SECONDS = 24 * 60 * 60;
 const ONE_SHOT_RESOLUTION_MS = 1000;

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -116,12 +116,14 @@ class WishError extends Error {
   }
 }
 
-// -- Interval #now constants and helpers --
+//
+// Interval #now constants and helpers
 // Bounds for #now/N intervals, specified in whole seconds. Values outside this
 // range are rejected, not clamped. The 1-second minimum caps the sampling rate
 // at 1Hz; the 24-hour maximum keeps the scheduled delay within the setTimeout
 // range. Both serve as defense-in-depth against timing side-channel attacks once
 // SES sandboxing removes patterns' direct access to Date.now/performance.now.
+//
 const MIN_INTERVAL_SECONDS = 1;
 const MAX_INTERVAL_SECONDS = 24 * 60 * 60;
 const ONE_SHOT_RESOLUTION_MS = 1000;

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -118,6 +118,7 @@ class WishError extends Error {
 
 //
 // Interval #now constants and helpers
+//
 // Bounds for #now/N intervals, specified in whole seconds. Values outside this
 // range are rejected, not clamped. The 1-second minimum caps the sampling rate
 // at 1Hz; the 24-hour maximum keeps the scheduled delay within the setTimeout

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -2410,7 +2410,7 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
   });
 
   it("runtime B warms from A's cache write and B's cold-compile writeback commits without error", async () => {
-    // --- Session A: cold compile + write-back ---
+    // Session A: cold compile + write-back
     const pmA = rtA.patternManager;
     const txA = rtA.edit();
     await pmA.compilePattern(E2E_PROGRAM, { space: sharedSpace, tx: txA });
@@ -2425,7 +2425,7 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
       byIdentityHits: 0,
     });
 
-    // --- Session B: should warm-hit A's committed cache ---
+    // Session B: should warm-hit A's committed cache
     // smB has its own per-space client replicas, so it must fetch from the
     // shared server. compilePattern drives the storage read-through internally.
     const pmB = rtB.patternManager;

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -19,7 +19,9 @@ interface Attack {
 }
 
 const ATTACKS: Attack[] = [
-  // --- ASI / statement-merge desync (splitter only `}`-terminates block keywords) ---
+  //
+  // ASI / statement-merge desync (splitter only `}`-terminates block keywords)
+  //
   {
     name: "ASI: const builder call then side-effect require, no semicolons",
     body:
@@ -40,7 +42,9 @@ const ATTACKS: Attack[] = [
     body: `${IMPORT}\nconst a = (0, cf.pattern)(() => 1) globalThis.pwned = 1`,
   },
 
-  // --- tokenizer confusion ---
+  //
+  // tokenizer confusion
+  //
   {
     name: "regex-vs-divide: division parsed as regex to swallow a semicolon",
     body:
@@ -57,7 +61,9 @@ const ATTACKS: Attack[] = [
     accept: true, // legitimate: a direct callback whose body is a template
   },
 
-  // --- shadowing trusted names ---
+  //
+  // shadowing trusted names
+  //
   {
     name: "shadow `require` then call it as an arbitrary function",
     body:
@@ -93,7 +99,9 @@ const ATTACKS: Attack[] = [
       `const a = 1, __importStar = (m) => globalThis;\nconst ns = __importStar(require("commonfabric"));`,
   },
 
-  // --- __cf_data / schema opaque-argument boundary ---
+  //
+  // __cf_data / schema opaque-argument boundary
+  //
   {
     name: "legit __cf_data-wrapped plain object (negative control)",
     body: `${IMPORT}\nexports.config = cf.__cf_data({ a: 1, b: 2 });`,
@@ -121,14 +129,18 @@ const ATTACKS: Attack[] = [
     accept: true,
   },
 
-  // --- reexport getter abuse ---
+  //
+  // reexport getter abuse
+  //
   {
     name: "reexport getter returning a call expression",
     body:
       `Object.defineProperty(exports, "x", { enumerable: true, get: function () { return globalThis.fetch("//x"); } });`,
   },
 
-  // --- default export laundering ---
+  //
+  // default export laundering
+  //
   {
     name: "default export of comma-sequence with a side effect",
     body:
@@ -139,7 +151,9 @@ const ATTACKS: Attack[] = [
     body: `${IMPORT}\nexports.default = exports.v = cf.require;`,
   },
 
-  // --- trusted-builder callback indirection ---
+  //
+  // trusted-builder callback indirection
+  //
   {
     name: "builder callback is a member of an import (indirect)",
     body:
@@ -177,7 +191,9 @@ const ATTACKS: Attack[] = [
       `${IMPORT}\nconst cb = () => 1;\nexports.h = cf.handler(cb, () => globalThis.fetch("//x"), 0);`,
   },
 
-  // --- top-level executable / mutable forms ---
+  //
+  // top-level executable / mutable forms
+  //
   {
     name: "IIFE disguised as a parenthesized arrow",
     body: `exports.x = (() => { globalThis.fetch("//x"); return 1; })();`,
@@ -226,7 +242,9 @@ const ATTACKS: Attack[] = [
     accept: true,
   },
 
-  // --- export form abuse ---
+  //
+  // export form abuse
+  //
   { name: "module.exports = runtime", body: `${IMPORT}\nmodule.exports = cf;` },
   {
     name: "computed-key export assignment",
@@ -242,7 +260,9 @@ const ATTACKS: Attack[] = [
     body: `${IMPORT}\nexports.x = cf.\\u0070attern(() => 1);`,
   },
 
-  // --- import fast-path / require boundary abuse ---
+  //
+  // import fast-path / require boundary abuse
+  //
   {
     name: "side-effect require with quote-escape break-out attempt",
     body: `require("./a.ts\\");globalThis.pwned=(\\"");`,
@@ -269,12 +289,14 @@ const ATTACKS: Attack[] = [
     body: `const x = require("commonfabric"), y = globalThis;`,
   },
 
-  // --- `__cfReg` hoist-registration call (CT-1623) ---
+  //
+  // `__cfReg` hoist-registration call (CT-1623)
   // `__cfReg` is supplied to the module wrapper as a parameter (the registrar);
   // it is deliberately NOT a referenceable binding, and only a single top-level
   // `__cfReg({ <shorthand top-level bindings> })` statement is approved. Every
   // other shape must be rejected so an attacker can neither register an arbitrary
   // symbol nor smuggle a second/aliased registrar call.
+  //
   {
     name: "__cfReg: legitimate single shorthand registration (control)",
     accept: true,

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -22,6 +22,7 @@ const ATTACKS: Attack[] = [
   //
   // ASI / statement-merge desync (splitter only `}`-terminates block keywords)
   //
+
   {
     name: "ASI: const builder call then side-effect require, no semicolons",
     body:
@@ -45,6 +46,7 @@ const ATTACKS: Attack[] = [
   //
   // tokenizer confusion
   //
+
   {
     name: "regex-vs-divide: division parsed as regex to swallow a semicolon",
     body:
@@ -64,6 +66,7 @@ const ATTACKS: Attack[] = [
   //
   // shadowing trusted names
   //
+
   {
     name: "shadow `require` then call it as an arbitrary function",
     body:
@@ -102,6 +105,7 @@ const ATTACKS: Attack[] = [
   //
   // __cf_data / schema opaque-argument boundary
   //
+
   {
     name: "legit __cf_data-wrapped plain object (negative control)",
     body: `${IMPORT}\nexports.config = cf.__cf_data({ a: 1, b: 2 });`,
@@ -132,6 +136,7 @@ const ATTACKS: Attack[] = [
   //
   // reexport getter abuse
   //
+
   {
     name: "reexport getter returning a call expression",
     body:
@@ -141,6 +146,7 @@ const ATTACKS: Attack[] = [
   //
   // default export laundering
   //
+
   {
     name: "default export of comma-sequence with a side effect",
     body:
@@ -154,6 +160,7 @@ const ATTACKS: Attack[] = [
   //
   // trusted-builder callback indirection
   //
+
   {
     name: "builder callback is a member of an import (indirect)",
     body:
@@ -194,6 +201,7 @@ const ATTACKS: Attack[] = [
   //
   // top-level executable / mutable forms
   //
+
   {
     name: "IIFE disguised as a parenthesized arrow",
     body: `exports.x = (() => { globalThis.fetch("//x"); return 1; })();`,
@@ -245,6 +253,7 @@ const ATTACKS: Attack[] = [
   //
   // export form abuse
   //
+
   { name: "module.exports = runtime", body: `${IMPORT}\nmodule.exports = cf;` },
   {
     name: "computed-key export assignment",
@@ -263,6 +272,7 @@ const ATTACKS: Attack[] = [
   //
   // import fast-path / require boundary abuse
   //
+
   {
     name: "side-effect require with quote-escape break-out attempt",
     body: `require("./a.ts\\");globalThis.pwned=(\\"");`,
@@ -297,6 +307,7 @@ const ATTACKS: Attack[] = [
   // other shape must be rejected so an attacker can neither register an arbitrary
   // symbol nor smuggle a second/aliased registrar call.
   //
+
   {
     name: "__cfReg: legitimate single shorthand registration (control)",
     accept: true,

--- a/packages/runner/test/linked-stale-read-conflict.test.ts
+++ b/packages/runner/test/linked-stale-read-conflict.test.ts
@@ -64,7 +64,7 @@ describe("stale linked read across two clients", () => {
     const B = "cellB";
     const C = "cellC";
 
-    // --- Client 1 seeds cellB = { isAdmin: true } and links cellA.isAdmin to it.
+    // Client 1 seeds cellB = { isAdmin: true } and links cellA.isAdmin to it.
     const cellB1 = rtA.getCell<{ isAdmin: boolean }>(space, B, undefined);
     const cellA1 = rtA.getCell<{ isAdmin: boolean }>(space, A, undefined);
     {
@@ -85,7 +85,7 @@ describe("stale linked read across two clients", () => {
     // Client 1 reads the linked value -> { isAdmin: true }
     expect(cellA1.get()).toEqual({ isAdmin: true });
 
-    // --- Client 2 converges, then flips cellB.isAdmin = false and publishes it.
+    // Client 2 converges, then flips cellB.isAdmin = false and publishes it.
     const cellB2 = rtB.getCell<{ isAdmin: boolean }>(space, B, undefined);
     await cellB2.sync();
     await cellB2.pull();
@@ -98,7 +98,7 @@ describe("stale linked read across two clients", () => {
       expect(res.error, `flip: ${JSON.stringify(res.error)}`).toBeUndefined();
     }
 
-    // --- Client 1, NOT synced, opens ONE transaction that both READS isAdmin
+    // Client 1, NOT synced, opens ONE transaction that both READS isAdmin
     // through the link in cellA and, on the strength of that read, writes the
     // grant to cellC. Because the read happens via `withTx(tx)`, the stale
     // `isAdmin` (the link target cellB) enters this tx's read-set.

--- a/packages/runner/test/twin-lineage-provenance.test.ts
+++ b/packages/runner/test/twin-lineage-provenance.test.ts
@@ -38,7 +38,9 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("twin-lineage-provenance");
 const space = signer.did();
 
-// ── The twin topology, inlined (mirrors the investigation's twin3e probe) ──
+//
+// The twin topology, inlined (mirrors the investigation's twin3e probe)
+//
 
 const ENTRY_BODY = `
 import {

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -660,6 +660,7 @@ $("#copy-space").onclick=()=>{ navigator.clipboard?.writeText(B.space); flash("c
 //
 // identities (users of this space)
 //
+
 function renderIdentities(){
   const host=$("#idlist"); const ps=B.participants||[];
   $("#idpanel>summary").textContent="Identities ("+ps.length+")";
@@ -681,6 +682,7 @@ function renderIdentities(){
 //
 // conflicts (contested cells)
 //
+
 function renderConflicts(){
   const host=$("#cflist"); const cs=B.conflicts||[];
   const mu=cs.filter(c=>c.multiUser).length;

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -657,7 +657,9 @@ liveInput.onchange=()=>{ LIVE=liveInput.value.trim(); localStorage.setItem("si-l
   if(cur) renderDetail(cur); flash(LIVE?"live links on":"live links off"); };
 $("#copy-space").onclick=()=>{ navigator.clipboard?.writeText(B.space); flash("copied space DID"); };
 
-// --- identities (users of this space) ---
+//
+// identities (users of this space)
+//
 function renderIdentities(){
   const host=$("#idlist"); const ps=B.participants||[];
   $("#idpanel>summary").textContent="Identities ("+ps.length+")";
@@ -676,7 +678,9 @@ function renderIdentities(){
   }
   host.append(el("div",{class:"muted",style:"margin-top:6px",text:"cross-space (home + profiles): cf inspect identity <DID>"}));
 }
-// --- conflicts (contested cells) ---
+//
+// conflicts (contested cells)
+//
 function renderConflicts(){
   const host=$("#cflist"); const cs=B.conflicts||[];
   const mu=cs.filter(c=>c.multiUser).length;

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -3145,7 +3145,9 @@ export type CompileAndRunFunction = <T = any, S = any>(
  */
 export type DataFileFunction = (path: string) => string;
 
-// --- SQLite builtins (docs/specs/sqlite-builtin) ---
+//
+// SQLite builtins (docs/specs/sqlite-builtin)
+//
 
 declare const __sqliteDb: unique symbol;
 

--- a/packages/toolshed/routes/ingest/ingest.utils.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.test.ts
@@ -233,7 +233,7 @@ describe("ingest journal sink", () => {
     expect(cell.getAsNormalizedFullLink().id).toBe(GOLDEN_ID);
   });
 
-  // --- processIngest: the full auth + validation contract ---
+  // processIngest: the full auth + validation contract
   const savedReg = async (
     overrides: Partial<IngestRegistration> = {},
   ): Promise<{ r: IngestRegistration; secret: string }> => {

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -157,7 +157,7 @@ export function createDataFlowAnalyzer(
       isArrayMethodElementBindingReference(current);
   };
 
-  // === Synthetic node helpers ===
+  // Synthetic node helpers
   // These enable unified handling of both synthetic (transformer-created) and
   // non-synthetic (original source) nodes by gracefully handling cases where
   // the TypeChecker can't resolve symbols or types.
@@ -632,7 +632,7 @@ export function createDataFlowAnalyzer(
       setParentPointers(expression);
     }
 
-    // === Helper functions (available for both synthetic and non-synthetic paths) ===
+    // Helper functions (available for both synthetic and non-synthetic paths)
 
     const recordDataFlow = (
       expr: ts.Expression,
@@ -708,7 +708,7 @@ export function createDataFlowAnalyzer(
       return false;
     };
 
-    // === Expression type handlers ===
+    // Expression type handlers
 
     if (ts.isIdentifier(expression)) {
       // Skip property names in property access expressions - they're not data flows.
@@ -1248,7 +1248,7 @@ export function createDataFlowAnalyzer(
       return mergeAnalyses(...analyses);
     }
 
-    // === JSX Expression Handling ===
+    // JSX Expression Handling
     // The analyzer provides complete data flow analysis for JSX elements,
     // including both attributes (like `value={expr}`) and children.
     // This makes the analyzer self-contained - callers get correct results

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -157,10 +157,10 @@ export function createDataFlowAnalyzer(
       isArrayMethodElementBindingReference(current);
   };
 
-  // Synthetic node helpers
-  // These enable unified handling of both synthetic (transformer-created) and
-  // non-synthetic (original source) nodes by gracefully handling cases where
-  // the TypeChecker can't resolve symbols or types.
+  // Synthetic node helpers: These enable unified handling of both synthetic
+  // (transformer-created) and non-synthetic (original source) nodes by
+  // gracefully handling cases where the TypeChecker can't resolve symbols or
+  // types.
 
   const isSynthetic = (node: ts.Node): boolean => !node.getSourceFile();
 
@@ -1248,11 +1248,10 @@ export function createDataFlowAnalyzer(
       return mergeAnalyses(...analyses);
     }
 
-    // JSX Expression Handling
-    // The analyzer provides complete data flow analysis for JSX elements,
-    // including both attributes (like `value={expr}`) and children.
-    // This makes the analyzer self-contained - callers get correct results
-    // regardless of how they traverse the AST.
+    // JSX Expression Handling: The analyzer provides complete data flow
+    // analysis for JSX elements, including both attributes (like
+    // `value={expr}`) and children. This makes the analyzer self-contained -
+    // callers get correct results regardless of how they traverse the AST.
 
     // Helper: analyze JSX attributes (JsxAttribute and JsxSpreadAttribute)
     const analyzeJsxAttributes = (

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -152,7 +152,9 @@ export class CrossStageState {
     return links;
   }
 
-  // --- mapCallbackRegistry ---
+  //
+  // mapCallbackRegistry
+  //
 
   markArrayMethodCallback(node: ts.Node): void {
     this.mapCallbackRegistry.add(node);
@@ -162,7 +164,9 @@ export class CrossStageState {
     return this.#hasWithOriginal(this.mapCallbackRegistry, node);
   }
 
-  // --- syntheticComputeCallbackRegistry ---
+  //
+  // syntheticComputeCallbackRegistry
+  //
 
   markSyntheticComputeCallback(node: ts.Node): void {
     this.syntheticComputeCallbackRegistry.add(node);
@@ -172,7 +176,9 @@ export class CrossStageState {
     return this.#hasWithOriginal(this.syntheticComputeCallbackRegistry, node);
   }
 
-  // --- syntheticComputeOwnedNodeRegistry ---
+  //
+  // syntheticComputeOwnedNodeRegistry
+  //
 
   markSyntheticComputeOwnedSubtree(node: ts.Node): void {
     const registry = this.syntheticComputeOwnedNodeRegistry;
@@ -187,7 +193,9 @@ export class CrossStageState {
     return this.#hasWithOriginal(this.syntheticComputeOwnedNodeRegistry, node);
   }
 
-  // --- syntheticReactiveCollectionRegistry (keyed by ts.Symbol) ---
+  //
+  // syntheticReactiveCollectionRegistry (keyed by ts.Symbol)
+  //
 
   markSyntheticReactiveCollection(symbol: ts.Symbol): void {
     this.syntheticReactiveCollectionRegistry.add(symbol);
@@ -197,7 +205,9 @@ export class CrossStageState {
     return this.syntheticReactiveCollectionRegistry.has(symbol);
   }
 
-  // --- schemaHints ---
+  //
+  // schemaHints
+  //
 
   recordSchemaHint(node: ts.Node, hint: SchemaHint): void {
     this.schemaHints.set(node, hint);
@@ -212,7 +222,9 @@ export class CrossStageState {
       this.schemaHints.get(ts.getOriginalNode(node));
   }
 
-  // --- capabilitySummary (nodeLinks-backed) ---
+  //
+  // capabilitySummary (nodeLinks-backed)
+  //
 
   recordCapabilitySummary(
     fn: ts.Node,
@@ -225,7 +237,9 @@ export class CrossStageState {
     return this.nodeLinks.get(fn)?.capabilitySummary;
   }
 
-  // --- patternResultAnchor (nodeLinks-backed) ---
+  //
+  // patternResultAnchor (nodeLinks-backed)
+  //
 
   recordPatternResultSchemaCall(schemaCall: ts.Node, anchor: ts.Node): void {
     this.#linksFor(schemaCall).patternResultAnchor = anchor;
@@ -238,7 +252,8 @@ export class CrossStageState {
     return this.nodeLinks.get(schemaCall)?.patternResultAnchor;
   }
 
-  // --- schemaInjected (nodeLinks-backed) ---
+  //
+  // schemaInjected (nodeLinks-backed)
   //
   // Marks builder call/new nodes that SchemaInjection has already finalized,
   // so a later re-traversal of the transformer's own output skips re-injection
@@ -250,6 +265,7 @@ export class CrossStageState {
   // user call. Falling back to the original would wrongly report a
   // not-yet-injected user node as injected. (This is why it is a `nodeLinks`
   // field rather than a member of the getOriginalNode-fallback marker family.)
+  //
 
   markSchemaInjected(node: ts.Node): void {
     this.#linksFor(node).schemaInjected = true;
@@ -260,7 +276,9 @@ export class CrossStageState {
     return this.nodeLinks.get(node)?.schemaInjected === true;
   }
 
-  // --- diagnostic dedup ---
+  //
+  // diagnostic dedup
+  //
 
   /**
    * Records that a diagnostic with `key` is being emitted. Returns true the
@@ -275,7 +293,9 @@ export class CrossStageState {
     return true;
   }
 
-  // --- shared helper: membership check with getOriginalNode fallback ---
+  //
+  // shared helper: membership check with getOriginalNode fallback
+  //
 
   #hasWithOriginal(set: WeakSet<ts.Node>, node: ts.Node): boolean {
     if (set.has(node)) return true;

--- a/packages/ts-transformers/test/ast/dataflow-coverage.test.ts
+++ b/packages/ts-transformers/test/ast/dataflow-coverage.test.ts
@@ -203,7 +203,9 @@ function analyzeTsx(source: string, name: string) {
   return createDataFlowAnalyzer(checker)(findInitializer(sourceFile, name));
 }
 
-// === Structural wrappers around a reactive read (1084-1098) ===
+//
+// Structural wrappers around a reactive read (1084-1098)
+//
 
 Deno.test("parenthesized reactive read stays reactive", () => {
   const analysis = analyze(`const value = (state.count);`, "value");
@@ -233,7 +235,9 @@ Deno.test("non-null assertion around a reactive read stays reactive", () => {
   assert(analysis.containsReactive);
 });
 
-// === Common Fabric Default types (790-797, 924-935) ===
+//
+// Common Fabric Default types (790-797, 924-935)
+//
 
 Deno.test("identifier typed as a Common Fabric Default is a reactive dataflow", () => {
   // The identifier's symbol declares Default<>, so it records as an explicit
@@ -266,14 +270,16 @@ Deno.test("property access whose member is a Common Fabric Default requires rewr
   assertEquals(analysis.requiresRewrite, true);
 });
 
-// === Const-binding aliases resolved through a static access path
-//     (224-304) ===
+//
+// Const-binding aliases resolved through a static access path
+// (224-304)
 //
 // These destructure a field off an implicit reactive parameter (`p`), giving
 // the alias a PLAIN field type (e.g. `number`). A plain type skips the
 // branded-cell short-circuit in the identifier handler and forces resolution
 // through getStableConstAliasInitializer -> getBindingElementStaticAccessPath,
 // which rebuilds the read as `p.<field>` and re-analyzes it as reactive.
+//
 
 function analyzePatternArrow(callbackSource: string) {
   const { sourceFile, checker } = createProgram(
@@ -337,7 +343,9 @@ Deno.test("nested destructuring resolves reactive through the whole path", () =>
   assert(analysis.containsReactive, "nested binding alias is reactive");
 });
 
-// === Element access (1044-1082) ===
+//
+// Element access (1044-1082)
+//
 
 Deno.test("static string-index element access on a reactive cell is reactive", () => {
   // Static literal index merges target+argument (lines 1052-1057) and stays
@@ -371,14 +379,18 @@ Deno.test("dynamic element access on an ignored branded parameter is inert", () 
   assertEquals(analysis.dataFlows.length, 0);
 });
 
-// === Array-literal reactive elements (1258-1265) ===
+//
+// Array-literal reactive elements (1258-1265)
+//
 
 Deno.test("array literal with a reactive element carries reactive dataflow", () => {
   const analysis = analyze(`const value = [state.count];`, "value");
   assert(analysis.containsReactive, "reactive array element flows");
 });
 
-// === Synthetic property access whose root is not an identifier (696-697) ===
+//
+// Synthetic property access whose root is not an identifier (696-697)
+//
 
 Deno.test("synthetic property access rooted in an object literal is inert", () => {
   // `({}).bar` built synthetically: findRootIdentifier bottoms out on a
@@ -394,13 +406,15 @@ Deno.test("synthetic property access rooted in an object literal is inert", () =
   assertEquals(analysis.dataFlows.length, 0);
 });
 
-// === Reads whose root originates from an ignored (aggregated) scope
-//     parameter (876-878, 973-975) ===
+//
+// Reads whose root originates from an ignored (aggregated) scope
+// parameter (876-878, 973-975)
 //
 // A parameter of a plain (non-builder, non-array-method) callback is an
 // aggregated scope symbol that is NOT a reactive value, so `isSymbolIgnored`
 // treats reads through it as inert. When the read still looks reactive by
 // type/shape, the `originatesFromIgnored` guard short-circuits it to empty.
+//
 
 function analyzeArrow(source: string) {
   const { sourceFile, checker } = createProgram(
@@ -460,7 +474,9 @@ Deno.test("structurally-opaque read off an ignored Default parameter is inert", 
   );
 });
 
-// === JSX attributes, spreads, children (1263-1264, 1292-1295) ===
+//
+// JSX attributes, spreads, children (1263-1264, 1292-1295)
+//
 
 Deno.test("JSX attribute expression carries reactive dataflow", () => {
   const analysis = analyzeTsx(
@@ -483,7 +499,9 @@ Deno.test("JSX element children with a nested element carry reactive dataflow", 
   assert(analysis.containsReactive, "nested child dataflow is reactive");
 });
 
-// === Function-argument callback with a block body (1180-1189, 1231-1240) ===
+//
+// Function-argument callback with a block body (1180-1189, 1231-1240)
+//
 
 Deno.test("call-argument callback block return propagates reactive dataflow", () => {
   // A callback argument with a block body has its return-statement expressions
@@ -507,8 +525,10 @@ Deno.test("standalone arrow with a block body propagates reactive dataflow", () 
   assert(analysis.containsReactive, "arrow block-return dataflow is reactive");
 });
 
-// === Synthetic (transformer-created) node handling (683-697, 749-751,
-//     1004-1032) ===
+//
+// Synthetic (transformer-created) node handling (683-697, 749-751,
+// 1004-1032)
+//
 
 Deno.test("synthetic bare identifier is treated as an opaque reactive parameter", () => {
   // A fully-synthetic identifier with no resolvable symbol is recorded as an

--- a/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-coverage.test.ts
@@ -1133,7 +1133,9 @@ Deno.test(
   },
 );
 
-// --- Batch 4: aliased identity-writer args, nested patterns, dynamic calls --
+//
+// Batch 4: aliased identity-writer args, nested patterns, dynamic calls
+//
 
 Deno.test(
   "aliased local pushed into a cell writer is read at its aliased path",
@@ -1321,7 +1323,9 @@ Deno.test(
   },
 );
 
-// --- Batch 6: whole-root identity, array-item identity, param array binding --
+//
+// Batch 6: whole-root identity, array-item identity, param array binding
+//
 
 Deno.test(
   "equals() over the whole tracked root records a root comparable passthrough",

--- a/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-interprocedural.test.ts
@@ -348,7 +348,9 @@ Deno.test(
   },
 );
 
-// --- hasUnverifiedCellUse propagation through callee summaries ---
+//
+// hasUnverifiedCellUse propagation through callee summaries
+//
 
 import { COMMONFABRIC_TYPES } from "../commonfabric-test-types.ts";
 

--- a/packages/ui/src/v2/components/cf-chart/cf-chart.ts
+++ b/packages/ui/src/v2/components/cf-chart/cf-chart.ts
@@ -220,7 +220,9 @@ export class CFChart extends BaseElement {
     `;
   }
 
-  // === Chart content rendering ===
+  //
+  // Chart content rendering
+  //
 
   private _renderChartContent(
     allMarks: CollectedMarkData[],
@@ -257,7 +259,9 @@ export class CFChart extends BaseElement {
     return svg`<g transform="translate(${tx}, ${ty})">${marks}${xAxisSvg}${yAxisSvg}${crosshairSvg}<rect class="interaction-overlay" width="${plotWidth}" height="${plotHeight}" @mousemove=${onMove} @click=${onClick} @mouseleave=${this._handleMouseLeave} /></g>`;
   }
 
-  // === Mark rendering ===
+  //
+  // Mark rendering
+  //
 
   private _renderAllMarks(
     allMarks: CollectedMarkData[],
@@ -289,7 +293,9 @@ export class CFChart extends BaseElement {
     return svg`${groups}`;
   }
 
-  // === Tooltip rendering ===
+  //
+  // Tooltip rendering
+  //
 
   private _renderTooltip(padding: ChartPadding) {
     if (!this._tooltipInfo) return html``;
@@ -310,7 +316,9 @@ export class CFChart extends BaseElement {
     `;
   }
 
-  // === Event handlers ===
+  //
+  // Event handlers
+  //
 
   private _handleMouseMove(
     e: MouseEvent,
@@ -362,7 +370,9 @@ export class CFChart extends BaseElement {
     this.emit("cf-leave", {});
   };
 
-  // === Slot management ===
+  //
+  // Slot management
+  //
 
   private _onSlotChange = (): void => {
     this._discoverChildMarks();
@@ -386,13 +396,17 @@ export class CFChart extends BaseElement {
     );
   }
 
-  // === Config marks ===
+  //
+  // Config marks
+  //
 
   private _getConfigMarks(): readonly MarkConfig[] {
     return this._marksController.getValue() || [];
   }
 
-  // === Padding computation ===
+  //
+  // Padding computation
+  //
 
   private _computePadding(): ChartPadding {
     if (this.padding !== undefined) {
@@ -419,7 +433,9 @@ export class CFChart extends BaseElement {
     };
   }
 
-  // === Cleanup ===
+  //
+  // Cleanup
+  //
 
   private _cleanup(): void {
     if (this._resizeTimeoutId !== null) {

--- a/packages/ui/src/v2/components/cf-code-editor/features/prose-markdown.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/prose-markdown.ts
@@ -212,7 +212,7 @@ export function buildProseDecorations(
 
   syntaxTree(state).iterate({
     enter(node) {
-      // ── Headings ──
+      // Headings
       if (HEADING_NODES.has(node.name)) {
         const headingLine = doc.lineAt(node.from).number;
         const isActiveLine = hasFocus && headingLine === cursorLine;
@@ -245,7 +245,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Bullet list markers ──
+      // Bullet list markers
       if (
         node.name === "ListMark" &&
         node.node.parent?.parent?.name === "BulletList"
@@ -268,7 +268,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Ordered list markers ──
+      // Ordered list markers
       if (
         node.name === "ListMark" &&
         node.node.parent?.parent?.name === "OrderedList"
@@ -290,7 +290,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Blockquote markers ──
+      // Blockquote markers
       if (node.name === "QuoteMark") {
         const markLine = doc.lineAt(node.from).number;
         const isActiveLine = hasFocus && markLine === cursorLine;
@@ -313,7 +313,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Tables (GFM) ──
+      // Tables (GFM)
       if (node.name === "Table") {
         const startLine = doc.lineAt(node.from).number;
         const endLine = doc.lineAt(node.to).number;
@@ -381,7 +381,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Indented code blocks ──
+      // Indented code blocks
       if (node.name === "CodeBlock") {
         const startLine = doc.lineAt(node.from).number;
         const endLine = doc.lineAt(node.to).number;
@@ -396,7 +396,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Fenced code blocks ──
+      // Fenced code blocks
       if (node.name === "FencedCode") {
         const startLine = doc.lineAt(node.from).number;
         const endLine = doc.lineAt(node.to).number;
@@ -451,7 +451,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Horizontal rules ──
+      // Horizontal rules
       if (
         node.name === "HorizontalRule" || node.name === "ThematicBreak"
       ) {
@@ -469,7 +469,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Task markers (GFM) ──
+      // Task markers (GFM)
       if (node.name === "TaskMarker") {
         const markerText = doc.sliceString(node.from, node.to);
         const isChecked = /^\[[xX]\]$/.test(markerText);
@@ -502,7 +502,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Links ──
+      // Links
       if (node.name === "Link") {
         const isActive = hasFocus &&
           cursorPos >= node.from && cursorPos <= node.to;
@@ -575,7 +575,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Inline code ──
+      // Inline code
       if (node.name === "InlineCode") {
         const isActive = hasFocus &&
           cursorPos >= node.from && cursorPos <= node.to;
@@ -608,7 +608,7 @@ export function buildProseDecorations(
         return;
       }
 
-      // ── Inline syntax (bold, italic, strikethrough) ──
+      // Inline syntax (bold, italic, strikethrough)
       const inline = INLINE_SYNTAX[node.name];
       if (!inline) return;
 

--- a/packages/ui/src/v2/components/cf-map/cf-map.test.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.test.ts
@@ -24,8 +24,10 @@ import type {
   MapValue,
 } from "./types.ts";
 
-// === Type Structure Tests ===
+//
+// Type Structure Tests
 // These tests verify that the type definitions are correctly structured
+//
 
 describe("CFMap Types - LatLng", () => {
   it("should define lat and lng as numbers", () => {
@@ -271,7 +273,9 @@ describe("CFMap Types - MapValue", () => {
   });
 });
 
-// === Event Detail Type Tests ===
+//
+// Event Detail Type Tests
+//
 
 describe("CFMap Types - CfClickDetail", () => {
   it("should contain lat and lng", () => {
@@ -340,7 +344,9 @@ describe("CFMap Types - CfCircleClickDetail", () => {
   });
 });
 
-// === Coordinate Validation Tests ===
+//
+// Coordinate Validation Tests
+//
 
 describe("CFMap coordinate validation scenarios", () => {
   it("should handle edge case latitudes", () => {
@@ -382,7 +388,9 @@ describe("CFMap coordinate validation scenarios", () => {
   });
 });
 
-// === Data Structure Tests ===
+//
+// Data Structure Tests
+//
 
 describe("CFMap data structure scenarios", () => {
   it("should handle large marker collections", () => {
@@ -440,7 +448,9 @@ describe("CFMap data structure scenarios", () => {
   });
 });
 
-// === Schema Binding Data Shape Tests ===
+//
+// Schema Binding Data Shape Tests
+//
 
 describe("CFMap schema binding data shapes", () => {
   it("should define marker structure compatible with JSON schema", () => {
@@ -503,7 +513,9 @@ describe("CFMap schema binding data shapes", () => {
   });
 });
 
-// === Edge Cases ===
+//
+// Edge Cases
+//
 
 describe("CFMap edge cases", () => {
   it("should handle zero radius circles", () => {

--- a/packages/ui/src/v2/components/cf-map/cf-map.test.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.test.ts
@@ -26,6 +26,7 @@ import type {
 
 //
 // Type Structure Tests
+//
 // These tests verify that the type definitions are correctly structured
 //
 

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -354,7 +354,9 @@ export class CFMap extends BaseElement {
     `;
   }
 
-  // === Keyboard Navigation ===
+  //
+  // Keyboard Navigation
+  //
 
   private _handleKeydown(event: KeyboardEvent): void {
     // Only handle when interactive and map exists and is stable
@@ -397,7 +399,9 @@ export class CFMap extends BaseElement {
     }
   }
 
-  // === Map State Helpers ===
+  //
+  // Map State Helpers
+  //
 
   /**
    * Check if the map is in a stable state for operations.
@@ -425,7 +429,9 @@ export class CFMap extends BaseElement {
     return true;
   }
 
-  // === Map Initialization ===
+  //
+  // Map Initialization
+  //
 
   private _initializeMap(): void {
     const container = this.shadowRoot?.querySelector(
@@ -581,7 +587,9 @@ export class CFMap extends BaseElement {
     this.emit("cf-click", detail);
   }
 
-  // === Value Getters (using CellControllers) ===
+  //
+  // Value Getters (using CellControllers)
+  //
 
   private _getValue(): MapValue {
     return this._valueController.getValue() || {};
@@ -601,7 +609,9 @@ export class CFMap extends BaseElement {
     return this._boundsController.getValue() || null;
   }
 
-  // === Cell Updates (bidirectional, using CellControllers) ===
+  //
+  // Cell Updates (bidirectional, using CellControllers)
+  //
 
   private _updateCenterCell(center: LatLng): void {
     if (!this._centerController.hasCell()) return;
@@ -636,7 +646,9 @@ export class CFMap extends BaseElement {
     }
   }
 
-  // === Map Updates ===
+  //
+  // Map Updates
+  //
 
   private _updateMapCenter(): void {
     if (!this._map) return;
@@ -771,7 +783,9 @@ export class CFMap extends BaseElement {
     }
   }
 
-  // === Feature Rendering ===
+  //
+  // Feature Rendering
+  //
 
   private _clearLayers(): void {
     // Remove event listeners from tracked markers before clearing to prevent memory leaks
@@ -1109,7 +1123,9 @@ export class CFMap extends BaseElement {
     }
   }
 
-  // === Popup Rendering ===
+  //
+  // Popup Rendering
+  //
 
   private _createPopupContent(
     feature: MapMarker | MapCircle,
@@ -1153,7 +1169,9 @@ export class CFMap extends BaseElement {
     return container;
   }
 
-  // === Fit to Bounds ===
+  //
+  // Fit to Bounds
+  //
 
   private _fitMapToBounds(): void {
     if (!this._map) return;
@@ -1262,7 +1280,9 @@ export class CFMap extends BaseElement {
     }
   }
 
-  // === Utilities ===
+  //
+  // Utilities
+  //
 
   private _isEmoji(str: string): boolean {
     // Simple emoji detection - checks for emoji unicode ranges
@@ -1270,7 +1290,9 @@ export class CFMap extends BaseElement {
     return EMOJI_REGEX.test(str);
   }
 
-  // === Coordinate Validation ===
+  //
+  // Coordinate Validation
+  //
 
   /**
    * Clamp zoom level to valid range, handling NaN/Infinity
@@ -1357,7 +1379,9 @@ export class CFMap extends BaseElement {
     return bounds;
   }
 
-  // === Cleanup ===
+  //
+  // Cleanup
+  //
 
   private _cleanup(): void {
     // Cancel pending RAF to prevent race condition if component disconnects before it fires
@@ -1403,7 +1427,9 @@ export class CFMap extends BaseElement {
     // the host element disconnects.
   }
 
-  // === Public API ===
+  //
+  // Public API
+  //
 
   /**
    * Get the underlying Leaflet map instance for advanced usage

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.ts
@@ -378,7 +378,9 @@ export class CFPicker extends BaseElement {
     `;
   }
 
-  // --- Selection methods ---
+  //
+  // Selection methods
+  //
 
   private _selectPrevious = (): void => {
     const items = this._getItems();
@@ -408,7 +410,9 @@ export class CFPicker extends BaseElement {
     this.requestUpdate();
   }
 
-  // --- Keyboard navigation ---
+  //
+  // Keyboard navigation
+  //
 
   private _handleKeyDown = (event: KeyboardEvent): void => {
     const items = this._getItems();
@@ -443,7 +447,9 @@ export class CFPicker extends BaseElement {
     }
   };
 
-  // --- Touch/swipe handling ---
+  //
+  // Touch/swipe handling
+  //
 
   private _handleTouchStart = (event: TouchEvent): void => {
     if (this.disabled) return;
@@ -464,7 +470,9 @@ export class CFPicker extends BaseElement {
     this._isTouching = false;
   };
 
-  // --- Focus handling ---
+  //
+  // Focus handling
+  //
 
   private _handleFocus = (): void => {
     this.emit("cf-focus");
@@ -474,7 +482,9 @@ export class CFPicker extends BaseElement {
     this.emit("cf-blur");
   };
 
-  // --- ARIA ---
+  //
+  // ARIA
+  //
 
   private _updateAriaAttributes(): void {
     this.setAttribute(
@@ -484,13 +494,17 @@ export class CFPicker extends BaseElement {
     this.setAttribute("aria-disabled", String(this.disabled));
   }
 
-  // --- Styling helpers ---
+  //
+  // Styling helpers
+  //
 
   private _updateMinHeight(): void {
     this.style.setProperty("--cf-picker-min-height", this.minHeight);
   }
 
-  // --- Public API ---
+  //
+  // Public API
+  //
 
   getSelectedIndex(): number {
     return this._currentIndex;

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -11,7 +11,9 @@ import {
   scan,
 } from "./check-unused-deps.ts";
 
-// --- importsAlias: the specifier shapes that count as an import ---
+//
+// importsAlias: the specifier shapes that count as an import
+//
 
 Deno.test("importsAlias matches a static import", () => {
   assert(importsAlias('import { x } from "zod";', "zod"));
@@ -150,7 +152,9 @@ Deno.test("importsAlias counts a commented-out import as used", () => {
   assert(importsAlias('// import { x } from "zod";', "zod"));
 });
 
-// --- owningMember: longest-prefix attribution, including nesting ---
+//
+// owningMember: longest-prefix attribution, including nesting
+//
 
 Deno.test("owningMember attributes a file to its member", () => {
   const members = ["packages/memory", "packages/runner"];
@@ -184,7 +188,9 @@ Deno.test("owningMember does not match a member that is only a path-segment pref
   );
 });
 
-// --- parsing ---
+//
+// parsing
+//
 
 Deno.test("parseImportMap returns the imports block", () => {
   const text = `{
@@ -237,7 +243,9 @@ Deno.test("gitTrackedFiles returns null when git is not available", async () => 
   );
 });
 
-// --- scan over the real repository tree ---
+//
+// scan over the real repository tree
+//
 
 Deno.test("no unused import map entries in the repository", async () => {
   const { unused } = await scan();
@@ -265,7 +273,9 @@ Deno.test("the unused-import-map ALLOWLIST has no stale entries", async () => {
   );
 });
 
-// --- main over a temp fixture tree ---
+//
+// main over a temp fixture tree
+//
 
 // Builds a minimal workspace under a fresh temp dir: a root deno.jsonc naming
 // one member, that member's deno.jsonc with the given imports, and one source


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Every sweep in this program defined a horizontal rule as **four or more**
repeats of one character. A marker written `// --- Title ---`, with three, was
never seen — which is why packages this program reported as fully conformant
still held some. Cubic spotted one in `cli` and read it as a dropped title; the
title was intact, and the marker had simply never been converted.

195 lines match the short-run shape. 177 are markers; 18 are not.

## The 177

| | count | treatment |
| --- | --- | --- |
| bracketed, declaration position | 129 | take the delimiters |
| bracketed, inside a function body | 36 | keep their words, lose the rules |
| lead-only, declaration position | 4 | take the delimiters |
| lead-only, inside a function body | 8 | keep their words, lose the rules |

Position comes from the TypeScript parser, walking function, method, arrow,
constructor, and accessor bodies — the same instrument the earlier PRs settled
on, because indentation cannot tell a method body from an object literal.

Four of them wrap, with the closing run on the second line, so the rules are
stripped across the whole comment block rather than off one line:

    // === Const-binding aliases resolved through a static access path
    //     (224-304) ===

## The 18, and why lowering a threshold is not enough

A short run also spells ordinary punctuation and ordinary code. 16 of these
continue the comment line directly above them:

    // === previousCallHash, which completion never clears) and a
    // == { piece: Cell<any> }
    // -- but `decode()` is callable in the realm that built its argument

The first is a fragment of an expression, the second a type, the third a dash
in prose. The tell is the preceding line: a rule brackets a title, whereas a
run that continues a comment is punctuation. The remaining two are type
annotations in `patterns-misc.test.ts`.

One excluded site is
`ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.input.tsx`,
which has an `.expected.jsx` golden. Editing it would have broken the
comparison — an argument for reading this class rather than pattern-matching it.

## Verification

Comments only: across the whole diff the word multiset is unchanged and no
non-comment line is touched.

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do
`check-commonfabric-types`, `check-cfc-types`, and `check-withheld-globals` —
the first of those failed until `commonfabric.d.ts` was regenerated, since
three markers are in `packages/api`, which it inlines.

Twelve package suites pass: `api`, `fuse`, `html`, `memory`, `piece`,
`state-inspector`, `toolshed`, `ts-transformers`, `ui`, `static`, plus
`cli` (`ok | 1733 passed`) and `runner` (`ok | 1303 passed (7587 steps)`).

## Coverage

The ratchet reports two more uncovered lines in `packages/runner`. It is not
this change. Deno's LCOV emits no `DA:` entry for a comment line, so a
comment-only diff shifts line numbers without altering the uncovered count —
checked on a fixture: an uncovered function with a three-line marker inside it
reports five uncovered lines, and the same function with the marker deleted
reports the same five. The other twelve gated groups are all `+0`, `cli` among
them, where this change rewrites 29 markers.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


