### PR TITLE
fix(toolshed): disable the memory websocket idle timeout

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -148,7 +148,6 @@ The toolshed-embedded memory service has two modes:
 | `MEMORY_DIR` | `./cache/memory/` (as a `file://` URL) | **Directory mode** — one SQLite file per space. Default; backwards-compatible. |
 | `DB_PATH` | _(unset)_ | **Single-file mode** — absolute path to one SQLite database holding every space, instead of a file per space. Takes precedence over `MEMORY_DIR`. Validated as an absolute path. |
 | `MEMORY_URL` | `http://localhost:8000` | Where other components reach the memory service. |
-| `MEMORY_WS_IDLE_TIMEOUT_SECONDS` | `300` | Pong deadline for memory WebSockets, in seconds. Set to `0` to disable it. Size it above the longest legitimate synchronous memory-server stretch, not as a network round-trip timeout. |
 | `MEMORY_ACL_MODE` | `enforce` | Space ACL policy: `off`, `observe`, or `enforce`. `observe` logs ordinary access shortfalls, while malformed ACLs and fresh-space genesis violations still fail closed. |
 | `RATE_LIMIT_TRUST_FORWARDED_FOR` | `false` | Set to `true` ONLY when a trusted reverse proxy that overwrites `X-Forwarded-For` sits in front of toolshed. Control-plane rate limiting keys on the real TCP peer by default. Enabling it without such a proxy makes the header client-controlled and the limiter a no-op; leaving it off behind a proxy collapses every caller onto one bucket. |
 | `MEMORY_SERVICE_DIDS` | _(empty)_ | Comma-separated DIDs with implicit OWNER on every space. These identities may initialize ACLs but still cannot make an ordinary first write before genesis. |

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -86,28 +86,3 @@ Deno.test("INGEST_SELF_SERVE_ENABLED is off unless explicitly enabled", () => {
   assertEquals(flag("true"), true);
   assertEquals(flag("1"), true);
 });
-
-Deno.test("MEMORY_WS_IDLE_TIMEOUT_SECONDS defaults to 300 and accepts overrides", () => {
-  // The memory websocket pong deadline has to be tunable per deployment: it
-  // must exceed the memory server's longest synchronous busy stretch, which an
-  // operator observes in production, and 0 must disable the timeout entirely
-  // (Deno.upgradeWebSocket's contract for idleTimeout).
-
-  const idle = (value: string | undefined) =>
-    EnvSchema.parse(
-      value === undefined ? {} : { MEMORY_WS_IDLE_TIMEOUT_SECONDS: value },
-    ).MEMORY_WS_IDLE_TIMEOUT_SECONDS;
-
-  assertEquals(idle(undefined), 300);
-  assertEquals(idle(""), 300);
-  assertEquals(idle("   "), 300);
-  assertEquals(idle("45"), 45);
-  assertEquals(idle("0"), 0);
-
-  // A negative deadline has no meaning for a pong window; reject rather
-  // than hand Deno an invalid option at upgrade time.
-  assertEquals(
-    EnvSchema.safeParse({ MEMORY_WS_IDLE_TIMEOUT_SECONDS: "-5" }).success,
-    false,
-  );
-});

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -129,20 +129,6 @@ export const EnvSchema = z.object({
     { message: "DB_PATH must be an absolute path" },
   ).optional(),
   MEMORY_URL: z.string().default("http://localhost:8000"),
-  // Seconds an unresponsive memory websocket may miss its ping before the
-  // runtime closes it (Deno.upgradeWebSocket's idleTimeout; 0 disables).
-  // The memory server evaluates frames and flush passes synchronously on
-  // its event loop, so during a long evaluation stretch every connection's
-  // pong sits unprocessed — a deadline shorter than the longest legitimate
-  // stretch closes ALL of the process's connections at once when the loop
-  // yields, and the reconnecting clients then re-establish their watch
-  // sets against the same busy process. Size this above the worst
-  // single-loop stretch, not above a round-trip time.
-  MEMORY_WS_IDLE_TIMEOUT_SECONDS: z.preprocess(
-    (value) =>
-      typeof value === "string" && value.trim() === "" ? undefined : value,
-    z.coerce.number().nonnegative().default(300),
-  ),
 
   GOOGLE_CLIENT_ID: z.string().default(""),
   GOOGLE_CLIENT_SECRET: z.string().default(""),

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -16,7 +16,6 @@ import { getLogger } from "@commonfabric/utils/logger";
 
 import type * as Routes from "./memory.routes.ts";
 import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
-import env from "@/env.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
 import { createSpan } from "@/middlewares/opentelemetry.ts";
 import { memoryServer } from "@/routes/storage/memory.ts";
@@ -332,14 +331,12 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
     try {
       span.setAttribute("memory.operation", "subscribe");
 
-      // The pong deadline must exceed the memory server's longest
-      // synchronous busy stretch (frame evaluation, flush passes), not a
-      // round-trip time: Deno's 30-second default closes every connection
-      // on the process at once whenever the event loop is busy longer than
-      // that, and the resulting reconnect stampede re-establishes each
-      // session's full watch set against the same busy process.
+      // Deno's default idle timeout can mistake a legitimate synchronous
+      // memory-server stretch for a dead peer, then close every connection
+      // together when the event loop yields. Disable that transport-level
+      // pong deadline rather than turning server load into a reconnect storm.
       const { socket, response } = Deno.upgradeWebSocket(c.req.raw, {
-        idleTimeout: env.MEMORY_WS_IDLE_TIMEOUT_SECONDS,
+        idleTimeout: 0,
       });
       span.setAttribute("websocket.upgrade", "success");
 


### PR DESCRIPTION
Summary
- pass idleTimeout: 0 explicitly when upgrading memory WebSockets
- remove the now-unused MEMORY_WS_IDLE_TIMEOUT_SECONDS deployment knob
- remove its configuration reference and schema tests

Why
Deno defaults this timeout to 30 seconds. A legitimate synchronous memory-server stretch can delay pong processing and make that transport timeout close every connection together. This follow-up to #6397 removes the timeout entirely instead of asking operators to tune it.

Testing
- deno task test in packages/toolshed: 146 passed, 458 steps
- deno fmt --check
- deno lint
- deno task check-docs
- targeted deno check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

