### PR TITLE
docs(runner): state editWithRetry's actual result contract

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2386,9 +2386,21 @@ export class Runtime {
    * the FIRST attempt, because re-running cannot change the outcome and each
    * doomed attempt costs a round-trip plus a subscriber revert notification.
    *
+   * A caller that decides inside the transaction whether to write at all — one
+   * re-reading a precondition against the fresh state each retry sees — says so
+   * through the value `fn` returns, which comes back as `ok`. An `ok` of
+   * `false` carrying no `error` is the convention for a write that was declined
+   * rather than one that failed. The bound on that convention is that we commit
+   * whatever `fn` staged, whatever `fn` returned: declining does not abort the
+   * transaction, so it stands for "nothing was written" only where the callback
+   * stages nothing before it declines.
+   *
    * @param fn - Function to execute with the transaction.
    * @param maxRetries - Maximum number of retries.
-   * @returns Promise<boolean> that resolves to true on success, or false after exhausting retries.
+   * @returns `{ ok }` once the transaction commits, carrying whatever `fn`
+   *   returned, or `{ error }` when it does not commit: a rejection that is not
+   *   retryable, a retryable one whose retries are spent, or `fn` itself
+   *   throwing, which aborts the transaction.
    */
   editWithRetry<T = void>(
     fn: (tx: IExtendedStorageTransaction) => T,


### PR DESCRIPTION
## Summary

The `@returns` tag on `Runtime.editWithRetry` documented a contract the method does not have:

> `@returns Promise<boolean> that resolves to true on success, or false after exhausting retries.`

It resolves `{ ok: T } | { error: CommitError }`, and an exhausted retry budget comes back as `{ error }`, never `false`. A caller who reads the documented contract would reasonably conclude there is nothing structured to check — which is a fair explanation for the call sites that `await` the method bare, or destructure a single arm.

This replaces the tag with what the method actually returns, and adds the two properties a caller relying on the `ok === false` supersede convention depends on:

- `ok` carries whatever the callback returned, which is what makes `ok === false` with no `error` readable as "declined, not failed".
- The commit runs regardless of what the callback returned. Declining does not abort the transaction, so it stands for "nothing was written" only where the callback stages nothing before it declines.

That second point is the one with teeth: it is the difference between a supersede convention that holds and one that silently commits a partial write. It came out of review on #6283, where a write path staged its changes across two transactions and could land in a split state.

## Scope

Comment-only — the diff touches no code, and the method's body and signature are unchanged. Verified against the implementation line by line: the `{ ok: result }` return, the non-retryable and exhausted-budget `{ error }` paths, the `tx.abort()` on a throwing callback, and the unconditional `prepareTxForCommit`/`commit()` after the callback returns.

One related subtlety is deliberately **not** claimed here: whether a transaction that ends up holding only reads is conflict-checked. `PieceCellIo.edit` in `packages/piece` documents that it is not, but confirming it means reading the memory protocol rather than this method, and an unverified claim does not belong in a core contract.

## Gates

`deno fmt --check` and `deno lint` repo-wide: clean. `deno check` on the file: clean. No test run — the diff is provably comment-only, so there is no behavior for a suite to distinguish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

