### PR TITLE
fix(runtime-client): the outbound side is whole, and three stale claims

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1109,10 +1109,10 @@ site has:
   something a flag was deliberately turned on to reach.
 - **De facto**, where the value is shipped and ungated and simply has no
   production caller yet. A `FabricError` is exposed to pattern authors
-  (`builder/factory.ts`) and reaches these throws with every flag off; a
-  `FabricBytes` written from the client reaches `CellHandle.serialize()`'s
-  refusal the same way. Nothing stops such a call being written tomorrow. What
-  makes the tripwire safe today is that none exists.
+  (`builder/factory.ts`) and reaches these throws with every flag off; the same
+  value written from the client reaches `CellHandle.serialize()`'s refusal of a
+  `FabricInstance` the same way. Nothing stops such a call being written
+  tomorrow. What makes the tripwire safe today is that none exists.
 
 The second is the weaker claim, but it does not fail quietly, and that is the
 point. Add a production use of one of these values and the throw fires — at the

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3149,16 +3149,16 @@ export class WorkerReconciler {
   }
 
   /**
-   * Transform a prop value for sending over IPC.
-   * Ensures the value can be cloned via postMessage.
+   * Transforms a prop value into the form the connection carries, a `style`
+   * given as an object becoming a CSS string on the way.
    */
   // deno-lint-ignore no-explicit-any
   private transformPropValue(key: string, value: unknown): any {
-    // TODO(danfuzz): what this returns is not in fact cloneable without loss.
+    // TODO(danfuzz): what this returns does not survive the crossing whole.
     // `convertCellsToLinks()` below preserves a `FabricPrimitive` by identity,
     // and structured clone strips one to `{}` between here and the applicator,
-    // silently. Encoding with `codec-realm` is what makes the doc comment
-    // above true; see the marker on `SetPropOp` in `../vdom-ops.ts`.
+    // silently. Encoding with `codec-realm` is what would carry it; see the
+    // marker on `SetPropOp` in `../vdom-ops.ts`.
     //
     // TODO(danfuzz): the `typeof` gate admits a `FabricSpecialObject`, so a
     // fabric-valued `style` prop is routed into the `Object.entries` walk of

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -344,6 +344,10 @@ export class RuntimeInternals extends EventTarget {
     return this.#favorites;
   }
 
+  /**
+   * Creates a piece in the given space, `options.argument` being the record of
+   * inputs it is created with.
+   */
   async createPiece<T>(
     space: DID,
     source: URL | Program | string,

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1249,7 +1249,7 @@ export class RuntimeProcessor {
             subscription
         ) return;
         queueMicrotask(() =>
-          self.postMessage({
+          postToClient({
             type: NotificationType.OperationUpdate,
             subscriptionId: request.subscriptionId,
             field: operationFieldToWire(field),

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -423,6 +423,13 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     });
   }
 
+  /**
+   * Creates a piece in the given space, from a URL, a program, or the source
+   * of a single-file one.
+   *
+   * `options.argument` is the piece's input, which is a record: a piece is
+   * created with named inputs or with none.
+   */
   async createPage<T = unknown>(
     input: string | URL | Program,
     space: DID,

--- a/packages/runtime-client/test/operation-collaboration.test.ts
+++ b/packages/runtime-client/test/operation-collaboration.test.ts
@@ -440,6 +440,32 @@ describe("RuntimeClient operation collaboration", () => {
           materialized: realmFromFabricValue(field.materialized),
         },
       }]);
+      // The notification goes through `postToClient()`, which is what puts it
+      // under the guard there. It posts from a `queueMicrotask` callback, so
+      // there is no caller's `try` around it: a refused post that threw would
+      // be an uncaught error rather than anything a caller could handle. Made
+      // to throw once, the post is answered with a substitute and nothing
+      // escapes -- where a bare `self.postMessage` here would escape.
+      notifications.length = 0;
+      let thrown = false;
+      (globalThis as { postMessage: (m: unknown) => void }).postMessage = (
+        m,
+      ) => {
+        if (!thrown) {
+          thrown = true;
+          throw new Error("post refused");
+        }
+        notifications.push(m);
+      };
+      subscribed!(field);
+      await Promise.resolve();
+      expect(notifications).toHaveLength(1);
+      expect((notifications[0] as { type?: unknown }).type).toBe(
+        NotificationType.ErrorReport,
+      );
+      expect((notifications[0] as { message?: string }).message).toContain(
+        "Undeliverable message",
+      );
     } finally {
       (globalThis as { postMessage?: unknown }).postMessage = postMessage;
     }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Four findings from reviews of the IPC envelope work (#6323), each true on `main`
today and independent of it. Landing them here keeps them out of a larger
change, and keeps them landed if that change ever has to be reverted.

## The worker's outbound side was not whole

`postToClient()` says of itself:

> This is the whole of the worker's outbound side: every response, error, and
> notification crosses here.

One notification did not. `handleOperationSubscribe()` posted its field updates
through a bare `self.postMessage`, and it was the last such call left outside
`post-to-client.ts` in either `runtime-client/src` or `html/src`.

It is also the site that most wanted the guard there. It posts from a
`queueMicrotask` callback — precisely the case that guard's own comment names:
no caller's `try` stands around it, so a refused post is an uncaught error
rather than something that becomes an error reply.

**Ablated, and the ablation is the argument.** Made to throw, the bare post
escapes and takes the whole test file down — *two* failed tests, not one — where
the routed post is answered with a substitute and nothing escapes:

```
error: Error: post refused
FAILED | 0 passed (4 steps) | 2 failed
```

**Whether it can be refused today is a separate question, and the answer is
no.** `operationFieldToWire()` encodes `materialized` and every operation
payload, and the snapshot's remaining fields are plain data. So this is not a
live crash — it is a sentence that claims what the code does not do. The new
test pins the routing so it stays true.

The existing subscription test needed no change: `postToClient()` posts the
message unaltered on its success path.

## Three stale claims, in prose

**`transformPropValue()` contradicted its own `TODO`.** The doc promised it
"ensures the value can be cloned via postMessage", while a `TODO` three lines
below said what it returns "is not in fact cloneable without loss" and named
what would make the doc true. It now says what the method does under any
transport, and the `TODO` keeps its substance while no longer pointing at a
sentence that has stopped claiming cloneability.

**The experimental-options tripwire roster** named a client-written
`FabricBytes` as reaching `CellHandle.serialize()`'s refusal. That is true, and
the `FabricInstance` arm is the more durable example — it is about a walk that
cannot descend a container, rather than about what a particular wire carries.

**`createPage()` and `createPiece()` had no doc comment at all.** They now say
what `options.argument` is, which their types already constrain.

## Checks

`deno task check`, `deno fmt --check`, `deno lint`, and `deno task check-docs`
all pass, as do the `runtime-client` (16 tests), `html` (25 tests), and
`lib-shell` (5 tests) suites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

