### PR TITLE
Rapid-note step: robust to the sanctioned optimistic navigation; ON-skip reason narrowed to the a04 residue

### DIFF
--- a/docs/specs/server-side-execution/protocol.md
+++ b/docs/specs/server-side-execution/protocol.md
@@ -761,7 +761,12 @@ Session-scoped, server-computed, client-enacted effects (README §3.7).
   (below) covers abandoned instances.
 - Exactly-once enactment per nonce is the CLIENT's duty (it may enact
   optimistically from speculation, then reconcile by nonce — navigation
-  is reversible). Reload between intent and ack: on resubscribe the
+  is reversible). Nonce reconciliation covers only the intent-ARRIVES
+  case: when the authoritative run computes no intent for an
+  optimistically enacted navigation (branch divergence on a speculative
+  read), the enactment STANDS un-reconciled — ruled PUNT (owner,
+  2026-08-27; register OW45) — and consumers must be robust to it.
+  Reload between intent and ack: on resubscribe the
   client sees unacked intents and enacts them; nonces make re-enactment
   detectable. The reload × optimistic-enactment window MAY re-enact
   a nonce — the enacted-nonce record lives in the reload-wiped

--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -53,7 +53,14 @@ half of Phase 3. Assumes [README.md](README.md) §3.2 and
   identity — a session-blind recomputation would misread "inputs
   changed" for every such node.
 - `navigate-to`: may enact optimistically (protocol.md §5) — navigation
-  is reversible. The overlay records the nonce it acted on.
+  is reversible. The overlay records the nonce it acted on. When the
+  AUTHORITATIVE run's branch computes NO navigation (a speculative read
+  diverged — the 2026-08-27 r06/r09 root cause, register OW45), the
+  optimistic enactment STANDS: ruled PUNT (owner, 2026-08-27) — the
+  client navigates, so be it. Nonce reconciliation covers only the
+  intent-arrives case; no withdrawal mechanism exists, and consumers
+  (tests included) must be robust to the view resting where the
+  speculative branch left it.
 - Child-piece instantiation (builtins.md §3): result-as-pattern
   children MAY instantiate speculatively, overlay-local (owner,
   2026-08-02 — reversing the earlier no-children rule). Child ids

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -708,8 +708,23 @@ describe("default-app flow test", () => {
         await clickButtonWithExactText(page, "Notes ▾");
         await awaitViewSettled(page);
         await clickButtonWithText(page, "New Notebook");
+        // The wait hands back the NOTEBOOK's piece id at the instant it
+        // approved `isNotebook` — the step's stable read target from here
+        // on. Every later wait and assertion reads the notebook BY THIS ID,
+        // never through `view.pieceId` again: under server execution the
+        // final "Create" click's speculative run may read a stale
+        // `usedCreateAnotherNote` and optimistically navigate into the new
+        // note while the authoritative run computes no navigation — a
+        // sanctioned outcome (the L2 optimistic-enactment question, ruled
+        // PUNT 2026-08-27: the client navigates, so be it). A view-following
+        // read then polls a healthy NOTE through notebook accessors until
+        // the step's net (the 2026-08-27 r06/r09 root cause,
+        // docs/history/plans/server-execution-v2/optimize/
+        // keyless-diagnosis-2026-08-27.md); an id-bound read is indifferent
+        // to where the view wandered.
+        let notebookEntityId: string | undefined;
         try {
-          await waitForCondition(page, async () => {
+          notebookEntityId = await waitForCondition(page, async () => {
             const commonfabric = globalThis.commonfabric as
               | { readCell?: (options: { id: string }) => Promise<unknown> }
               | undefined;
@@ -728,7 +743,9 @@ describe("default-app flow test", () => {
               console.log = originalLog;
             }
             return (current as { isNotebook?: unknown } | undefined)
-              ?.isNotebook === true;
+                ?.isNotebook === true
+              ? pieceId
+              : false;
           });
         } catch (error) {
           console.log(
@@ -737,6 +754,10 @@ describe("default-app flow test", () => {
           );
           throw error;
         }
+        assert(
+          notebookEntityId,
+          "Expected the notebook wait to hand back the notebook piece id",
+        );
 
         // Wait until the notebook toolbar is mounted and interactive before
         // clicking. viewSettled resolves once the worker is idle and the
@@ -800,11 +821,11 @@ describe("default-app flow test", () => {
         let waitFailure: unknown;
         try {
           await waitForCondition(page, notebookSourceStateMatches, {
-            args: [noteCreates],
+            args: [noteCreates, notebookEntityId],
           });
           await waitForRuntimeSynced(page);
           summary = await waitForCondition(page, notebookSourceStateMatches, {
-            args: [noteCreates],
+            args: [noteCreates, notebookEntityId],
           });
         } catch (error) {
           // A wait or the sync barrier failed at its net: the state never
@@ -824,7 +845,11 @@ describe("default-app flow test", () => {
           // failing), then re-throw the authority's own error.
           console.log(
             "Notebook rapid create source diagnostics:",
-            JSON.stringify(await collectNotebookSourceState(page), null, 2),
+            JSON.stringify(
+              await collectNotebookSourceState(page, notebookEntityId),
+              null,
+              2,
+            ),
           );
           console.log(
             "Notebook rapid create render diagnostics:",
@@ -1637,14 +1662,24 @@ async function waitForHomePageReady(
   await waitForRuntimeIdle(page);
 }
 
-async function collectNotebookSourceState(page: Page): Promise<{
+// Reads the notebook by `knownNotebookId` when the caller captured one (the
+// sanctioned optimistic navigation can leave the view on a NOTE — see
+// notebookSourceStateMatches), else by the current view's piece id. Reports
+// `viewPieceId` separately either way, so a failure dump distinguishes
+// "wrong state" from "wrong piece under the reader" — the confusion the
+// 2026-08-27 r06/r09 diagnosis found in this step's recorded reds.
+async function collectNotebookSourceState(
+  page: Page,
+  knownNotebookId?: string,
+): Promise<{
   notebookEntityId?: string;
+  viewPieceId?: string;
   argumentNotesLength?: number;
   noteCount?: number;
   showNewNotePrompt?: boolean;
   usedCreateAnotherNote?: boolean;
 }> {
-  return await page.evaluate(async () => {
+  return await page.evaluate(async (knownId?: string) => {
     const api = globalThis.commonfabric as {
       readCell?: (options: {
         id: string;
@@ -1655,12 +1690,13 @@ async function collectNotebookSourceState(page: Page): Promise<{
 
     const appState = globalThis.app?.serialize?.();
     const view = appState?.view;
-    const notebookEntityId = view && typeof view === "object" &&
+    const viewPieceId = view && typeof view === "object" &&
         "pieceId" in view && typeof view.pieceId === "string"
       ? view.pieceId
       : undefined;
+    const notebookEntityId = knownId ?? viewPieceId;
     if (!notebookEntityId || !api?.readCell) {
-      return { notebookEntityId };
+      return { notebookEntityId, viewPieceId };
     }
 
     const resolveInternalManifest = async (
@@ -1715,6 +1751,7 @@ async function collectNotebookSourceState(page: Page): Promise<{
 
     return {
       notebookEntityId,
+      viewPieceId,
       // `notes` is a first-class Cell in the notebook argument schema. Newer
       // argument links preserve that wrapper, so debug reads return a handle;
       // older pieces may still materialize the array inline.
@@ -1739,7 +1776,7 @@ async function collectNotebookSourceState(page: Page): Promise<{
           .usedCreateAnotherNote
         : undefined,
     };
-  });
+  }, { args: [knownNotebookId] });
 }
 
 // The state notebookSourceStateMatches approves and hands back. Every field
@@ -1763,9 +1800,19 @@ type NotebookSourceSummary = {
 // was when the condition held — a fresh read after the wait can instead land
 // in the ruled interim of a served re-derivation (`noteCount` cleanly
 // `undefined`, then re-triggered and healed) and fail a healthy run.
+//
+// Reads the notebook by the CALLER-CAPTURED id, never through the current
+// view: the final "Create" click's speculative run may enact an optimistic
+// navigation into the new note that the authoritative run computed no intent
+// for — sanctioned (L2 ruled PUNT 2026-08-27), so `view.pieceId` is allowed
+// to be a NOTE here, and a view-following read would poll that healthy note
+// through notebook accessors until the step's net (the 2026-08-27 r06/r09
+// root cause). The id-bound read asserts the same product facts wherever the
+// view wandered.
 const notebookSourceStateMatches = async (
   _probe: ProbeApi,
   expectedCount: number,
+  notebookEntityId: string,
 ): Promise<NotebookSourceSummary | false> => {
   const api = globalThis.commonfabric as {
     readCell?: (options: {
@@ -1775,11 +1822,6 @@ const notebookSourceStateMatches = async (
     }) => Promise<unknown>;
   } | undefined;
 
-  const view = globalThis.app?.serialize?.()?.view;
-  const notebookEntityId = view && typeof view === "object" &&
-      "pieceId" in view && typeof view.pieceId === "string"
-    ? view.pieceId
-    : undefined;
   if (!notebookEntityId || !api?.readCell) return false;
 
   const resolveInternalManifest = async (

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -235,6 +235,22 @@ Deno.test("main: the patterns list carries the two current phase-7 entries and k
   assertMatch(entry.reason, /zero pattern-swap-setup-error/);
   assertMatch(entry.reason, /distinct from the split-source/);
   assertMatch(entry.reason, /10\/10 quiet-and-loaded/);
+  // The 2026-08-27 root cause narrowed the charge: the navigation half
+  // (wrong-branch optimistic navigateTo — L2, ruled PUNT: sanctioned) is
+  // absorbed by the step's id-bound reads, so the residue that KEEPS the
+  // entry is the a04 write-side member — consequenced marks whose derived
+  // commits carry none of the effects. Pin the narrowed discriminators so
+  // a stale cause-unassigned reason (or the closed navigation charge)
+  // cannot return silently.
+  assertMatch(entry.reason, /a04/);
+  assertMatch(entry.reason, /mark-without-effects/);
+  assertMatch(entry.reason, /ruled PUNT/);
+  assertMatch(entry.reason, /keyless-diagnosis-2026-08-27\.md/);
+  assert(
+    !/cause is not yet assigned/.test(entry.reason),
+    "the reason must not claim the cause is unassigned — it was root-caused " +
+      "2026-08-27 (register OW45; keyless-diagnosis-2026-08-27.md)",
+  );
   // The shard filter drops exactly the FILE entry's file (the shard
   // lanes feed explicit file lists) and passes every other candidate
   // through untouched — remove the lunch-poll-vote entry and this

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -192,16 +192,18 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
   // verification-coverage.md OW60, not as a flaky test.
   patterns: [
     {
-      // The current charge is a direct CI ON failure, not the invalid
-      // split-source launcher topology root-caused in the OW45 RCA. The
-      // unskip probe at 66a969ca0 ran this exact step in ON shard 5 and
-      // failed at its unchanged 300 s condition bound. Its final client
-      // diagnostics reported all seven invocation traces but no bound
-      // notebook action state, with stored note chips present and none
-      // rendered. The run had no pattern-swap-setup-error, recursive-schema
-      // error, or pattern-load-error, so that older signature is not the
-      // reason for this skip. verification-coverage.md OW45 carries the
-      // full run and job evidence. The entry lifts on the established 10/10
+      // The charge was root-caused 2026-08-27 (register OW45;
+      // docs/history/plans/server-execution-v2/optimize/
+      // keyless-diagnosis-2026-08-27.md) and split in two. The
+      // NAVIGATION half — the client's speculative final-"Create" run
+      // reading a stale usedCreateAnotherNote and optimistically
+      // navigating into the new note while the authoritative run computed
+      // no intent — is SANCTIONED (L2 ruled PUNT) and absorbed: the
+      // step's waits and assertions now read the notebook by its captured
+      // id, indifferent to where the view wandered. What KEEPS this entry
+      // is the residue member the same campaign classified in a04: the
+      // WRITE-side mark-without-effects family, which no test-side
+      // robustness can absorb. The entry lifts on the established 10/10
       // quiet-and-loaded gate under the current source-authority posture;
       // the flip PR needs this list empty.
       file: "integration/default-app.test.ts",
@@ -217,9 +219,17 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "zero pattern-swap-setup-error, recursive-schema errors, and " +
         "pattern-load-error, so this is distinct from the split-source " +
         "off-repository launcher failure root-caused by the OW45 RCA. " +
-        "The current CI failure's cause is not yet assigned. Lifts on " +
-        "10/10 quiet-and-loaded ON under the current source-authority " +
-        "posture.",
+        "ROOT-CAUSED 2026-08-27 (keyless-diagnosis-2026-08-27.md; " +
+        "register OW45): that fingerprint is the wrong-branch optimistic " +
+        "navigation — sanctioned under the L2 ruled PUNT and absorbed by " +
+        "the step's id-bound reads — so the residue keeping this entry " +
+        "is the a04 member: the WRITE-side mark-without-effects family " +
+        "(all create events durably appended and marked consequenced, " +
+        "but the final consequences are 1-op derived commits carrying " +
+        "none of the effects — user actions permanently lost, no basis " +
+        "rows to re-run; the section 3d mark-vs-effects atomicity " +
+        "question is the owner's). Lifts on 10/10 quiet-and-loaded ON " +
+        "under the current source-authority posture.",
     },
     {
       // Re-listed by the lunch-poll identity PR (#5744). This file was


### PR DESCRIPTION
## Why

The default-app rapid-note step ("should persist and reload every rapidly
created notebook note") carries the patterns lane's remaining direct-CI
ON-skip. The 2026-08-27 root cause
(`docs/history/plans/server-execution-v2/optimize/keyless-diagnosis-2026-08-27.md`,
register OW45) proved its r06/r09 reds were never a stranded piece: the
client's speculative run of the final "Create" reads a stale
`usedCreateAnotherNote` and **optimistically navigates into the new note**
while the authoritative run computes no intent. The owner ruled that
navigation **PUNT** (L2, 2026-08-27): the optimistic enactment stands — the
client navigates, so be it — and the test step must be robust to it.

The step was not robust to it: every wait and every diagnostic read
`view.pieceId`, so the sanctioned navigation turned a healthy run into a
300 s timeout polling a healthy NOTE through notebook accessors
(`isNotebook:false, noteCount:-1, notesLength:0` — the diagnosis's "reads
of the wrong piece"). This PR makes the step's reads id-bound and narrows
the ON-skip entry's charge to the residue the same campaign actually
classified — without lifting the entry (that is Phase 3's campaign under
the CI-probe bar). Companion to the keyless close-out guard PR on
`claude/server-exec-v2-keyless-guard`.

## What changed

- **Id-bound reads**: the isNotebook wait now hands back the notebook's
  piece id at the instant it approved it; both
  `notebookSourceStateMatches` waits and the step's assertions read the
  notebook BY THAT ID, indifferent to where the view wandered. Product
  assertions are untouched: all seven notes durable
  (`argumentNotesLength`), derived `noteCount` converged, prompt closed,
  flag cleared, surviving the sync barrier.
- **Honest failure diagnostics**: `collectNotebookSourceState` reports
  `viewPieceId` separately from the id it read, so a future failure dump
  distinguishes "wrong state" from "wrong piece under the reader" — the
  exact confusion the register carried for r06/r09 since 2026-08-24.
- **ON-skip reason narrowed** (`tasks/server-execution-on-skips.ts`): the
  entry keeps its full CI provenance (head 66a969ca0, run 33008274232,
  shard 5, the recorded fingerprint) and now states the root cause: the
  navigation half is sanctioned (L2 ruled PUNT) and absorbed by this PR's
  id-bound reads; what KEEPS the entry is the **a04 write-side
  mark-without-effects family** — create events durably appended and
  marked `consequenced` while the final consequences are 1-op derived
  commits carrying none of the effects (user actions permanently lost, no
  basis rows to re-run; the §3d mark-vs-effects atomicity question is the
  owner's). The entry is NOT lifted; its lift bar (10/10
  quiet-and-loaded) is unchanged.
- **Pin test** (`tasks/server-execution-on-skips.test.ts`): new regexes
  bind the narrowed discriminators (a04, mark-without-effects, ruled PUNT,
  the diagnosis file) and forbid the stale "cause is not yet assigned"
  wording — added red-first (watched fail against the old reason).

- **Live specs carry the ruling** (added on Codex's P1, which was right by
  the repo's live-docs rule): `speculation.md`'s navigate-to entry and
  `protocol.md` §5 now state that nonce reconciliation covers only the
  intent-arrives case and that on authoritative-branch divergence the
  optimistic enactment stands (ruled PUNT, owner 2026-08-27) — the
  contract this step is now robust to lives in the live specification,
  not only in the archived diagnosis.

## Test plan

- `deno test tasks/server-execution-on-skips.test.ts`: 17/17, with the new
  regexes watched red against the pre-narrowing reason first.
- `deno check` on the modified integration test file: clean.
- The step itself remains ON-skipped by the entry (unchanged bar); the OFF
  lane runs it in CI as before — the change is read-target plumbing with
  identical assertions, verified by type-check and review; the ON evidence
  bar belongs to Phase 3's lift campaign, not this PR.
