### PR TITLE
Tell a section title apart from the paragraph under it

### DIFF
--- a/packages/cf-harness/test/support/responses-fixture.test.ts
+++ b/packages/cf-harness/test/support/responses-fixture.test.ts
@@ -55,12 +55,10 @@ const turn = (
   ...overrides,
 });
 
-//
 // The property that matters: converting a fixture must not change the
 // assistant message the harness derives from it. Both production paths are
 // driven with the same fixture — Chat Completions reads it directly, the
 // Responses path reads the converted form — and the results must agree.
-//
 
 const assertPathsAgree = async (chatFixture: Record<string, unknown>) => {
   // gemini-* stays on Chat Completions and consumes the fixture as written.

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -299,6 +299,7 @@ function fmtSession(s: string): string {
 
 //
 // Remote acquisition (`cf inspect --remote`)
+//
 // The autopsy stays 100% offline; --remote only changes where the SQLite file
 // comes from: instead of the local on-disk store, fetch a read-only snapshot
 // from a toolshed dump endpoint into the local cache, then open it as usual.

--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -25,6 +25,7 @@ export const CALL_NAMES: ReadonlySet<string> = COMMONFABRIC_CALL_EXPORT_NAMES;
 
 //
 // Synthetic identifiers emitted by ts-transformers
+//
 // Mirrors of constants in `packages/ts-transformers/src`. Kept as literals so
 // the pager does not import the transformer's analysis graph. See vocab.test.ts.
 //

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -429,7 +429,7 @@ Deno.test("parse: class methods, constructor and accessors become method nodes",
 });
 
 //
-// --- classify: enum / export assignment / export decl / import equals /
+// classify: enum / export assignment / export decl / import equals /
 // module declaration (lines 1353-1390)
 //
 
@@ -673,6 +673,7 @@ Deno.test("parse: a computed-callee call is labeled by its first source line", (
 
 //
 // safe() catch path (lines 1725-1727)
+//
 // safe() swallows exceptions in metadata extraction. Hard to force a throw from
 // well-formed input; instead, confirm the surrounding metadata still appears
 // for a normal node (the try path), and rely on malformed schema input below to

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -2700,12 +2700,10 @@ Deno.test("filepickercov: escape cancels the picker", () => {
   assertEquals(s.view().message, "Cancelled");
 });
 
-//
 // Additional targeted coverage for the remaining branch bodies. Each test
 // drives a specific guard or conditional that the suite above approaches but
 // does not yet execute (the untaken side of an `if (cond) STMT;` one-liner, an
 // off-screen scroll, or a non-editable diff line under a policy gate).
-//
 
 //
 // card reference up-scroll lands a higher target above the scroll (392)
@@ -2780,6 +2778,7 @@ Deno.test("session: a card with many references scrolls down then up across the 
 
 //
 // jumpToTarget via a use reference with no def offset (428, 446, 464-477) -
+//
 // The lift node's card lists both a definition reference (carrying a node
 // offset) and a plain "use" reference (no offset). Revealing the use one takes
 // the offset-less path: findTargetIndex returns -1, jumpToTarget falls back to
@@ -2827,6 +2826,7 @@ Deno.test("session: opening a use reference (no def offset) resolves a node via 
 
 //
 // findTargetIndex falls back to a start-offset-only match (436-439)
+//
 // The pattern's card lists a dependency reference that carries a definition
 // offset but no end offset (no semantic service to pin the exact range), so
 // following it skips the exact (start+end) lookup and matches on start alone.

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -171,12 +171,10 @@ for (const [size, json] of OBJECTS_JSON) {
   });
 }
 
-//
 // Bulk payloads by magnitude, both reaching base64url text of a byte string
 // of the same length. Sized in bytes so the two columns answer the same
 // question of each; what separates them is the trip a `bigint` takes through
 // `toString(16)` to become bytes in the first place.
-//
 
 const BULK: readonly (readonly [
   string,
@@ -235,12 +233,10 @@ for (const [leaves, json] of OMNIBUSES_JSON) {
   });
 }
 
-//
 // Omnibus trees whose contents need no encoding, and those whose contents need
 // none only under a realm-crossing format. The gap between the two is what
 // this format's tagging and escaping cost over a tree that another format
 // carries directly.
-//
 
 for (const [leaves, value] of JSON_PASS_THROUGH_OMNIBUSES) {
   Deno.bench({

--- a/packages/data-model/bench/codec-realm.bench.ts
+++ b/packages/data-model/bench/codec-realm.bench.ts
@@ -234,10 +234,8 @@ for (const [size, value] of BYTES) {
   });
 }
 
-//
 // Omnibus trees. These hold a `FabricBytes`, so the decode direction builds a
 // fresh tree per iteration and excludes it from the measurement.
-//
 
 for (const [leaves, value] of OMNIBUSES) {
   Deno.bench({

--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -23,10 +23,8 @@
 import { hashOf } from "@/value-hash.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 
-//
 // Doc-shaped test data, mirroring the default-app integration:
 // a note doc (~30 nodes) and a home-list doc holding N note entries.
-//
 
 function makeNoteDoc(i: number): Record<string, unknown> {
   return {

--- a/packages/data-model/src/codec-interface/codec-type-tags.ts
+++ b/packages/data-model/src/codec-interface/codec-type-tags.ts
@@ -5,11 +5,9 @@
  */
 export const CODEC_TYPE_TAGS = Object.freeze(
   {
-    //
     // Tags for JavaScript primitives that aren't representable in JSON. These
     // tags are for wire formats that are layered on top of JSON and so require
     // _some_ way of indicating non-JSON-compatible values.
-    //
 
     /** Constant representing JavaScript type `bigint`. */
     BigInt: "BigInt@1",
@@ -26,11 +24,9 @@ export const CODEC_TYPE_TAGS = Object.freeze(
     /** Constant representing JavaScript type `undefined`. */
     Undefined: "Undefined@1",
 
-    //
     // Tags for the built-in "primitive" `FabricPrimitive` classes. These tags
     // are for wire formats for which instances of (one or more of) these
     // classes do not have protocol-specific forms.
-    //
 
     /** Constant for class `FabricBytes`. */
     Bytes: "Bytes@1",
@@ -50,13 +46,11 @@ export const CODEC_TYPE_TAGS = Object.freeze(
     /** Constant for class `FabricRegExp`. */
     RegExp: "RegExp@1",
 
-    //
     // Tags for the primary versions built-in non-primitive `FabricInstance`
     // classes, specifically the tags used to _encode_ instances from a live
     // system. This is as opposed to the tags used for versions of the (in some
     // sense) "same" classes which are recognized for _decoding_ only (and which
     // get decoded into the corresponding primary versions).
-    //
 
     /** Constant for class `FabricError`. */
     Error: "Error@1",
@@ -73,7 +67,6 @@ export const CODEC_TYPE_TAGS = Object.freeze(
     /** Constant for class `FabricSet`. */
     Set: "Set@1",
 
-    //
     // Tags for non-primary versions of built-in non-primitive classes. These
     // generally correspond to _older_ encoded forms. The property names of
     // these constants encode the versions of the corresponding classes (e.g.,
@@ -82,7 +75,6 @@ export const CODEC_TYPE_TAGS = Object.freeze(
     // As of this writing, there are none of these, so this section is empty
     // except for an example, waiting patiently for a glorious future where this
     // system needs to support data migration.
-    //
 
     /** Example version-2 constant. */
     ExampleV2: "Example@2",

--- a/packages/memory/test/v2-commit-class.test.ts
+++ b/packages/memory/test/v2-commit-class.test.ts
@@ -175,7 +175,6 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
   ]);
 });
 
-//
 // commitClassOfSeq (the arrival-witness predicate's server-side read,
 // speculation.md §4): the unknown-seq arm answers undefined, and the memo
 // declines to record inside ANY transaction — `applyCommit` brackets its
@@ -184,7 +183,6 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
 // (`database.inTransaction`), not a caller marker. A rolled-back seq is
 // re-minted by the retry, possibly under another class; a memo entry written
 // mid-transaction would serve that phantom class forever.
-//
 
 Deno.test("commitClassOfSeq: seq 0, negative, and unknown seqs answer undefined (fail-closed substrate of the at-floor witness)", async () => {
   const { engine } = await createEngine();

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -314,14 +314,12 @@ Deno.test("explicit entity_scope_key reads: lease holder admitted, non-holder an
   }
 });
 
-//
 // The exemption LIFECYCLE (stage-F fix round, thread r3731191378 — P0):
 // `leaseHolderReads` is an authorization exemption tied to holding a LIVE
 // execution lease. The push path's applicable-set filter (protocol.md §3)
 // must key its bypass on CURRENT holdership, lease loss must clear the
 // exemption, and a session resume must revalidate rather than trust the
 // persisted bit. A former holder receives NOTHING foreign.
-//
 
 /** Doc-ids upserted by session/effect frames at or past `from`. */
 const effectUpsertIds = (
@@ -584,16 +582,13 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
   }
 });
 
-//
 // Instance identity across the wire seam (threads r3731191411 and
 // r3731191526): the wire strips scope KEYS (frames carry scope names), so
 // the server must refuse what the wire cannot express — one watch set (or
 // query) resolving TWO instances of one (branch, id, scope) — and must
 // treat a changed `entityScopeKey` on an existing watch id as a changed
 // spec, never silently the same watch.
-//
 
-//
 // OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease
 // holder may name two instances of one (branch, id, scope) — its frames and
 // query results carry the instance key (`scopeKey`) per entry, so the two
@@ -601,7 +596,6 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
 // BOTH the service instance and a demander's instance of one doc). The
 // wire collapse guard stays for everyone else: a NON-holder's wire carries
 // scope names only, so its ambiguous read set is still refused loudly.
-//
 
 Deno.test("stage A: a lease holder names two instances of one (branch, id, scope) and receives BOTH, keyed — watch.set, watch.add, graph.query, and the push frame; the collapse guard still refuses a non-holder (OW17's wire leg)", async () => {
   const server = newServer("memory://explicit-read-two-instances");
@@ -846,7 +840,6 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
   }
 });
 
-//
 // The exemption LIFECYCLE under the keyed wire (fan-out stage A's
 // independent review, finding 1 — 2026-08-17). Two halves of one
 // invariant: (i) a session's wire vocabulary is STICKY once it was
@@ -858,7 +851,6 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
 // RE-ARMS on the first live pass with a full evaluation that re-delivers
 // what the lapse withheld — a renewal blip the SpaceServer survives
 // in-process must not leave its serving replica silently stale.
-//
 
 /** Every session/effect frame's upserts at or past `from`, with keys. */
 const effectUpserts = (
@@ -1307,13 +1299,11 @@ Deno.test("watch.add with a changed entityScopeKey on an existing watch id is a 
   }
 });
 
-//
 // Delivery-failure rollback for explicit foreign instances (thread
 // r3731191415): the wire frame carries scope NAMES, so rollback cannot
 // recover the instance from the frame alone — the server must retain the
 // frame's true instance keys. A lost foreign-instance frame must be
 // REDELIVERED once sends succeed again.
-//
 
 Deno.test("a failed delivery of an explicit foreign-instance frame is redelivered (rollback keys the exact instance)", async () => {
   const server = newServer("memory://explicit-read-rollback");
@@ -1460,7 +1450,6 @@ Deno.test("a non-canonical entity_scope_key (raw '/') is refused at admission �
   }
 });
 
-//
 // Phase 5 — the read row's cross-space widening and its fail-closed twin
 // (protocol.md §2; verification-coverage.md's stage-F read-row entry):
 //
@@ -1475,7 +1464,6 @@ Deno.test("a non-canonical entity_scope_key (raw '/') is refused at admission �
 //   Phase-5 precondition): a co-hosted serving session's UNNAMED scoped
 //   read of a space it does not hold refuses loudly instead of silently
 //   resolving the delegating envelope's (empty) instance.
-//
 
 const HOME_SPACE = "did:key:z6Mk-explicit-read-home";
 

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -1738,7 +1738,6 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
   }
 });
 
-//
 // OW31 (WRITE ruled 2026-08-18, READ ruled 2026-08-19): the delegated READ
 // binding. A session opened `actingAs: "space-owner"` by a DELEGATING-class
 // principal has its READ-class decisions resolved as the space's ACL OWNER
@@ -1746,7 +1745,6 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
 // WRITE/OWNER requirements keep resolving against the ENVELOPE, so the
 // binding grants no write path; a delegating principal is NOT a service
 // principal and cannot initialize a genesis.
-//
 
 Deno.test("OW31 acl enforce: a delegating principal acting as space-owner READS an owner-only space; its writes and ACL-doc writes stay refused", async () => {
   const server = createAclServer("memory://acl-ow31-binding", {

--- a/packages/memory/test/v2-sqlite-commit-eval.test.ts
+++ b/packages/memory/test/v2-sqlite-commit-eval.test.ts
@@ -457,6 +457,7 @@ Deno.test("DELETE and rule-less-table writes stay plain on a rule-bearing db", a
 
 //
 // direct applySqliteCommitWrite: shape rejects + caps
+//
 // (No wrapping transaction here — these assert the THROW; rollback is the
 // applyCommit-level tests' concern.)
 //

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -841,7 +841,6 @@ Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)",
   assert(typeof reason === "string");
 });
 
-//
 // Ambiguous dual-op nodes: a node carrying TWO recognized op keys must refuse
 // everywhere. The validator, the evaluator, and the static common-alternative
 // analysis each dispatch by their own key precedence, so a hand-crafted
@@ -849,7 +848,6 @@ Deno.test("an unbalanced regex in a wire spec returns a reason (no lint crash)",
 // the principal, and STATICALLY count the owner as a common reader — labeling
 // a COUNT(*) [owner] although the owner is not an alternative in any row's
 // label (CFC spec §8.17.4 violation).
-//
 
 const DUAL_PRINCIPAL_OWNER: RowLabelSpec = {
   version: 1,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -371,13 +371,11 @@ export type EventAttentionIndexValue = {
   resolutions?: Record<string, Record<string, ResolvedEventAttention>>;
 };
 
-//
 // Events-down (server-execution v2 Phase 3, D-v2-1;
 // docs/specs/server-side-execution/events.md). The event is an AUTHORED
 // APPEND to a stream document — the client's only computational commit
 // under the flag. Protocol vocabulary, defined once here (protocol.md §7:
 // `eventId`/`firedAt` are commit-metadata additions for event appends).
-//
 
 /**
  * The stream-entries SIDECAR doc id for one stream (events.md §1's "stream
@@ -590,7 +588,6 @@ export type EventAppendDecl = {
   eventId: string;
 };
 
-//
 // The client-effect channel (server-execution v2 Phase 4;
 // docs/specs/server-side-execution/protocol.md §5). Session-scoped,
 // server-computed, client-enacted effects: the SpaceServer writes INTENT
@@ -598,7 +595,6 @@ export type EventAppendDecl = {
 // doc, the session's client enacts and ACKS by nonce (an ordinary authored
 // write into its own instance), and the next wave retires acked entries.
 // Protocol vocabulary, defined once here (the LD3 direction).
-//
 
 /**
  * The well-known client-effects doc, one id per space (protocol.md §5,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -2406,7 +2406,6 @@ export const serverSeq = (engine: Engine): number => {
   return (engine.statements.selectServerSeq.get() as { seq: number }).seq;
 };
 
-//
 // Event-append admission (server-execution v2 Phase 3, D-v2-1;
 // events.md §1, §4; protocol.md §2's event-append rows). ONE stamping
 // site with three identity sources — the authenticated envelope for plain
@@ -2414,7 +2413,6 @@ export const serverSeq = (engine: Engine): number => {
 // (LT1) the already-written inherited actor for derived wave carriage,
 // where producer and admitter are one trust environment and only the
 // entry's stream `seq` needs stamping.
-//
 
 /** Where one declared appended entry sits inside the commit's operations,
  * plus the `firedAt` admission resolved for it. The stamp step clones the

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -160,6 +160,7 @@ async function cleanup(
 
 //
 // write accounting
+//
 // A transaction holds its journal only while it is open: commit() releases it
 // on the way to settling, so tx.journal.novelty(space) is empty afterwards.
 // Each write scenario below therefore takes an `account` callback and hands it

--- a/packages/runner/test/cell-set.bench.ts
+++ b/packages/runner/test/cell-set.bench.ts
@@ -55,6 +55,7 @@ async function cleanup(
 
 //
 // DATA SIZE BENCHMARKS
+//
 // Test how data size affects Cell.set() performance
 //
 
@@ -156,6 +157,7 @@ Deno.bench({
 
 //
 // NESTING DEPTH BENCHMARKS
+//
 // Test how nesting depth affects Cell.set() performance
 //
 
@@ -242,6 +244,7 @@ Deno.bench({
 
 //
 // CHANGE PATTERN BENCHMARKS
+//
 // Test how different change patterns affect Cell.set() performance
 //
 
@@ -420,6 +423,7 @@ Deno.bench({
 
 //
 // CT-1123 REPRODUCTION BENCHMARKS
+//
 // Specifically test scenarios similar to the issue
 //
 
@@ -558,6 +562,7 @@ Deno.bench({
 
 //
 // ARRAY SIZE BENCHMARKS
+//
 // Test how array sizes affect performance (relevant to CT-1123 interests/skills arrays)
 //
 
@@ -616,6 +621,7 @@ Deno.bench({
 
 //
 // ARRAY STRUCTURE BENCHMARKS
+//
 // Test path-level array structural edits that were previously missing coverage
 //
 
@@ -676,6 +682,7 @@ Deno.bench({
 
 //
 // WRITE COUNT BENCHMARKS
+//
 // Test the specific scenario of ~226 writes (like CT-1123)
 //
 
@@ -785,6 +792,7 @@ Deno.bench({
 
 //
 // SCHEMA WITH NESTED CELLS (asCell: ["cell"])
+//
 // Test performance impact of asCell which creates sub-cell references
 //
 
@@ -869,6 +877,7 @@ Deno.bench({
 
 //
 // TRANSACTION OVERHEAD BENCHMARKS
+//
 // Test if transaction management adds overhead
 //
 
@@ -917,6 +926,7 @@ Deno.bench({
 
 //
 // CELL.UPDATE() vs CELL.SET() COMPARISON
+//
 // Test if update() is more efficient than set() for partial changes
 //
 

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -301,6 +301,7 @@ const ATTACKS: Attack[] = [
 
   //
   // `__cfReg` hoist-registration call (CT-1623)
+  //
   // `__cfReg` is supplied to the module wrapper as a parameter (the registrar);
   // it is deliberately NOT a referenceable binding, and only a single top-level
   // `__cfReg({ <shorthand top-level bindings> })` statement is approved. Every

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -123,6 +123,7 @@ Deno.bench({
 
 //
 // 3. Cache-size scaling: K=16, 64, 256.
+//
 // Loop shape is fixed at {write sub0/count; read sub1}. The cache holds K
 // cached sibling reads.
 //
@@ -170,6 +171,7 @@ for (const K of [16, 64, 256]) {
 
 //
 // 4. Deep nested-path write.
+//
 // Writes at depth-7 path `value/a/b/c/d/e/items/0`, with three cached
 // sibling reads at varying depths along the chain. Stresses the per-write
 // walk's depth dependence; a trie walker pays O(D), an O(N) scanner pays

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -162,6 +162,7 @@ const _mixed: MustBeTrue<
 
 //
 // RequireDefaults<T> — Default<T|undefined, V>
+//
 // The implementation strips `| undefined` via Exclude when making the key
 // required, so the value type becomes just T (not T|undefined).
 //
@@ -186,6 +187,7 @@ const _cellDefaultRequired: MustBeTrue<
 
 //
 // RequireDefaults<T> — Default field in a union with a plain type
+//
 // The presence of a Default-branded member in the union makes the field required.
 //
 

--- a/packages/runner/test/traverse-replay/profile-driver.ts
+++ b/packages/runner/test/traverse-replay/profile-driver.ts
@@ -117,6 +117,7 @@ Deno.writeTextFileSync(`${outPrefix}.cpuprofile`, JSON.stringify(profile));
 
 //
 // self-time report
+//
 // Attribute sampled time per node via timeDeltas (more accurate than
 // hitCount * interval), then aggregate by frame and by file.
 //

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -113,6 +113,7 @@ export const EnvSchema = z.object({
 
   //
   // Memory Store
+  //
   //  - MEMORY_DIR is used by toolshed to access sqlite files for common-memory
   //    (directory mode - default, backwards compatible)
   //  - DB_PATH is an optional absolute path to a single SQLite database file
@@ -148,6 +149,7 @@ export const EnvSchema = z.object({
 
   //
   // Airtable Integration
+  //
   //   * /routes/integrations/airtable-oauth
   //
 
@@ -156,6 +158,7 @@ export const EnvSchema = z.object({
 
   //
   // GitHub Integration
+  //
   //   * /routes/integrations/github-oauth
   //
 
@@ -164,6 +167,7 @@ export const EnvSchema = z.object({
 
   //
   // Notion Integration
+  //
   //   * /routes/integrations/notion-oauth
   //
 
@@ -172,6 +176,7 @@ export const EnvSchema = z.object({
 
   //
   // Linear Integration
+  //
   //   * /routes/integrations/linear-oauth
   //
 
@@ -180,6 +185,7 @@ export const EnvSchema = z.object({
 
   //
   // Spotify Integration
+  //
   //   * /routes/integrations/spotify-oauth
   //
 
@@ -188,6 +194,7 @@ export const EnvSchema = z.object({
 
   //
   // Discord OAuth Integration
+  //
   //   * /routes/integrations/discord-oauth
   //
 
@@ -196,6 +203,7 @@ export const EnvSchema = z.object({
 
   //
   // Strava Integration
+  //
   //   * /routes/integrations/strava-oauth
   //
 
@@ -204,6 +212,7 @@ export const EnvSchema = z.object({
 
   //
   // Plaid Integration
+  //
   //   * /routes/integrations/plaid-oauth
   //
 
@@ -263,6 +272,7 @@ export const EnvSchema = z.object({
 
   //
   // State-inspector remote dump endpoint (`cf inspect --remote`).
+  //
   // Exposes raw, read-only space SQLite snapshots over HTTP for offline
   // autopsy. This is a STAGING-ONLY debugging tool: it hard-refuses to mount
   // under ENV=production with no override (a productionized form is a separate,
@@ -299,6 +309,7 @@ export const EnvSchema = z.object({
 
   //
   // Sandbox Service
+  //
   //   * /routes/sandbox/exec
   //
 

--- a/packages/toolshed/lib/space-authority.test.ts
+++ b/packages/toolshed/lib/space-authority.test.ts
@@ -17,10 +17,8 @@ import {
   isValidSpaceDid,
 } from "@/lib/space-authority.ts";
 
-//
 // The narrow entitlement predicate. Cheap, exhaustive, and the place the
 // wildcard attack is pinned — see the "*" cases.
-//
 
 // Shaped like real ed25519 did:keys, and valid base58btc (no 0, O, I or l).
 const ALICE = "did:key:z6MkaaaabbbbccccddddeeeeffffgggghhhhAAAA";

--- a/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
@@ -99,6 +99,7 @@ function extractGroundingChunks(completion: unknown): GroundingChunk[] {
 
 //
 // SSRF guard
+//
 // This route fetches URLs that come from search results (and follows their
 // redirects), so it must never be coaxed into reaching internal hosts. We
 // validate every hop's host (name + resolved IP) against private/reserved

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -870,6 +870,7 @@ export class CFAutocomplete extends BaseElement {
   // Event handlers
   //
   // PERFORMANCE NOTE (Dec 2025):
+  //
   // We use setTimeout(0) here instead of synchronous state updates. This was extensively
   // investigated and verified:
   //

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -16,10 +16,8 @@
  * createMockCellHandle util, exactly like cell-controller.test.ts.
  */
 
-//
 // Minimal DOM shim — installed BEFORE importing the component so that Lit's
 // ReactiveElement base class has an HTMLElement to extend.
-//
 
 interface ShadowStub {
   querySelector(): null;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

101 section markers have no blank line after their first line, so a title and
its description run together. Reading all of them shows two different things
wearing that shape, and a third that cannot be told apart at all.

## 36 take the separator

The first line is a standalone title and the rest describes it, so the blank
`//` the form calls for goes between them. Not a word moves.

    //
    // DATA SIZE BENCHMARKS
   +//
    // Test how data size affects Cell.set() performance
    //

Ten groups in `cell-set.bench.ts`, all eight `env.ts` integration blocks whose
title heads a route list, `Memory Store`, `SSRF guard`, `self-time report`,
`Remote acquisition`, and the rest.

## 24 lose their delimiters

These are a paragraph with no title at all — the first line wraps mid-sentence
into the second — so they are ordinary comments, not markers. The four in
`codec-type-tags.ts`, six in `v2-explicit-read.test.ts`,
`space-authority.test.ts`, and similar.

## 41 are left exactly as they are

Most are in `type-shrinking-coverage.test.ts` and
`schema-injection-coverage.test.ts`, where a block reads

    // length-only access on an Array<T> reference emits unknown[] (array-root on
    // path). Exercises the `allNonItem` array branch in the node-driven path.

That is either a wrapped title or a paragraph, and nothing in the text settles
it. Guessing thirty times in a row would leave the tree worse than not touching
them, so they stand.

## One miss from the short-run sweep

`view-parse-cov.test.ts:432` still read `// --- classify: enum …`. That sweep
skipped any short run whose previous line was a comment, on the reasoning that
such a run continues the line above and is punctuation rather than a rule —
which is right 15 times out of 16. Here the line above is the marker's own
opening `//`. Checked across the tree: this is the only site that exclusion
wrongly caught.

## Verification

Comments only: across the whole diff the word multiset is unchanged and no
non-comment line is touched.

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the
`cf-harness`, `data-model`, `memory`, `toolshed`, `ui`, `cli`
(`ok | 1733 passed`), and `runner` (`ok | 1304 passed (7625 steps)`) suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

