### PR TITLE
A comment about one test belongs inside it

### DIFF
--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -390,12 +390,11 @@ Deno.test("parse: an element-access expression gets a […] generic label", () =
   );
 });
 
-// registerDefinition no-name guard (line 1260): Covered indirectly:
-// registerDefinition is only called when desc.name is set, but the early `if
-// (!desc.name) return` is reached when called for a name. A named binding
-// exercises the body; the guard line itself runs every call.
-
 Deno.test("parse: a named binding registers a definition", () => {
+  // registerDefinition no-name guard (line 1260): Covered indirectly:
+  // registerDefinition is only called when desc.name is set, but the early `if
+  // (!desc.name) return` is reached when called for a name. A named binding
+  // exercises the body; the guard line itself runs every call.
   const doc = parseDocument("const namedThing = 1;\n", "m.ts");
   assert(doc.definitions.has("namedThing"), "named binding is in the index");
   const def = doc.definitions.get("namedThing")![0];

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -934,12 +934,9 @@ Deno.test("cell typed as Scoped<T, union-of-scopes> recovers the first concrete 
   assertEquals(schema.scope, "user");
 });
 
-//
-// lift factory captured in a variable, then applied — recover the result type
-// through the factory's callback
-//
-
 Deno.test("applying a captured lift factory recovers the downstream input schema from the factory callback result", async () => {
+  // lift factory captured in a variable, then applied — recover the result type
+  // through the factory's callback
   const source = [
     "/// <cts-enable />",
     'import { lift } from "commonfabric";',
@@ -991,12 +988,9 @@ Deno.test("pattern result reports an unknown array element with an array path su
   assertStringIncludes(d!.message, "items[]");
 });
 
-//
-// idempotency / author-supplied skips: a builder that already carries its
-// schema is left untouched
-//
-
 Deno.test("new Writable(value, schema) with two arguments is left untouched", async () => {
+  // idempotency / author-supplied skips: a builder that already carries its
+  // schema is left untouched
   const source = [
     'import { Writable } from "commonfabric";',
     "export default function T() {",
@@ -1076,12 +1070,9 @@ Deno.test("new Writable.perSession() with no value derives the value type from t
   assertEquals((ctor!.arguments![0] as ts.Identifier).text, "undefined");
 });
 
-//
-// lift-applied projection recovery: property-access and element-access forms
-// on a downstream callback whose parameter type is recovered from upstream
-//
-
 Deno.test("lift-applied element-access projection recovers the result schema from the indexed field", async () => {
+  // lift-applied projection recovery: property-access and element-access forms
+  // on a downstream callback whose parameter type is recovered from upstream
   const source = [
     "/// <cts-enable />",
     'import { lift } from "commonfabric";',
@@ -1129,13 +1120,10 @@ Deno.test("handler<E, S> marks a read-only Cell state field with asCell readonly
   assertEquals((state.properties as Obj).total.asCell, ["readonly"]);
 });
 
-//
-// lift-applied whose untyped callback calls Cell methods on a Cell input:
-// the input schema is recovered from the cell-like fallback type and marked
-// asCell readonly
-//
-
 Deno.test("lift-applied untyped callback using Cell.get on a Cell input recovers a cell-like input schema", async () => {
+  // lift-applied whose untyped callback calls Cell methods on a Cell input: the
+  // input schema is recovered from the cell-like fallback type and marked
+  // asCell readonly
   const source = [
     "/// <cts-enable />",
     'import { cell, lift } from "commonfabric";',

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -179,13 +179,10 @@ function createContext(sourceFile: ts.SourceFile): {
   return { context, diagnostics };
 }
 
-//
-// Array element node building via type-driven shrinking (Array<T> reference).
-// Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
-// checker, element shrunk, array node rebuilt.
-//
-
 Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed fields", () => {
+  // Array element node building via type-driven shrinking (Array<T> reference).
+  // Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
+  // checker, element shrunk, array node rebuilt.
   const { sourceFile, checker } = createProgram(`
     type Item = { id: string; title: string; unused: number };
     type Input = Array<Item>;
@@ -217,12 +214,10 @@ Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed field
   assertEquals(members.has("id"), false);
 });
 
-//
-// length-only access on an Array<T> reference emits unknown[] (array-root only
-// path). Exercises the `allNonItem` array branch in the node-driven path.
-//
-
 Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]", () => {
+  // length-only access on an Array<T> reference emits unknown[] (array-root
+  // only path). Exercises the `allNonItem` array branch in the node-driven
+  // path.
   const { sourceFile, checker } = createProgram(`
     type Item = { id: string; title: string };
     type Input = Array<Item>;
@@ -245,13 +240,10 @@ Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]"
   assertEquals(printTypeNode(result, sourceFile), "unknown[]");
 });
 
-//
-// Union of object shapes: shrink each non-nullish member; nullish member
-// preserved. Exercises the union branch in buildShrunkTypeNodeFromTypeNode
-// (lines ~1278-1301) via a source-authored union node.
-//
-
 Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", () => {
+  // Union of object shapes: shrink each non-nullish member; nullish member
+  // preserved. Exercises the union branch in buildShrunkTypeNodeFromTypeNode
+  // (lines ~1278-1301) via a source-authored union node.
   const { sourceFile, checker } = createProgram(`
     type Input =
       | { shared: string; onlyA: number }
@@ -278,13 +270,10 @@ Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", (
   assertEquals(members.has("onlyB"), false);
 });
 
-//
-// Union `T | undefined` where only one member holds the accessed property.
-// After shrinking the non-nullish member, a single member remains and the
-// union collapses to that member (line ~1299-1301 `all.length === 1`).
-//
-
 Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish member", () => {
+  // Union `T | undefined` where only one member holds the accessed property.
+  // After shrinking the non-nullish member, a single member remains and the
+  // union collapses to that member (line ~1299-1301 `all.length === 1`).
   const { sourceFile, checker } = createProgram(`
     type Input = { keep: string; drop: number };
   `);
@@ -316,13 +305,10 @@ Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish
   assert(ts.isTypeLiteralNode(node));
 });
 
-//
-// Type-driven union nullish re-wrapping (buildShrunkTypeNodeFromType, ~856-895)
-// and line 888 (`nullishMembers.length === 0` short-circuit not taken).
-// Drive with a synthetic base node to force the type-driven path.
-//
-
 Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a nullable object", () => {
+  // Type-driven union nullish re-wrapping (buildShrunkTypeNodeFromType,
+  // ~856-895) and line 888 (`nullishMembers.length === 0` short-circuit not
+  // taken). Drive with a synthetic base node to force the type-driven path.
   const { sourceFile, checker } = createProgram(`
     type Payload = { keep: string; drop: number };
     type Input = Payload | undefined;
@@ -355,13 +341,10 @@ Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a 
   );
 });
 
-//
-// Nested primitive leaf on a type-driven shrink: `text.length` keeps the
-// string leaf intact instead of shrinking `text` to `{ length }`
-// (lines ~934-962 primitive-scalar branch through the type-driven path).
-//
-
 Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-driven shrinking", () => {
+  // Nested primitive leaf on a type-driven shrink: `text.length` keeps the
+  // string leaf intact instead of shrinking `text` to `{ length }` (lines
+  // ~934-962 primitive-scalar branch through the type-driven path).
   const { sourceFile, checker } = createProgram(`
     type Input = { text: string; other: number };
   `);
@@ -390,13 +373,11 @@ Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-dr
   assertEquals(members.has("other"), false);
 });
 
-//
-// Index-signature access via type-driven shrinking: a numeric/string key that
-// is not a named property resolves through the index signature and the emitted
-// member is optional (lines ~913-936: `isOptional = true`, `984-989`).
-//
-
 Deno.test("applyShrinkAndWrap represents index-signature access as an optional member", () => {
+  // Index-signature access via type-driven shrinking: a numeric/string key that
+  // is not a named property resolves through the index signature and the
+  // emitted member is optional (lines ~913-936: `isOptional = true`,
+  // `984-989`).
   const { sourceFile, checker } = createProgram(`
     type Input = { [key: string]: { name: string; unused: number } };
   `);
@@ -424,13 +405,10 @@ Deno.test("applyShrinkAndWrap represents index-signature access as an optional m
   assertEquals(members.has("unused"), false);
 });
 
-//
-// isUnchangedShrink: a TypeReference whose members are all accessed with no
-// nested change is kept as the original reference to preserve $ref/$defs
-// (lines ~1453-1474 return `node`).
-//
-
 Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccessed members", () => {
+  // isUnchangedShrink: a TypeReference whose members are all accessed with no
+  // nested change is kept as the original reference to preserve $ref/$defs
+  // (lines ~1453-1474 return `node`).
   const { sourceFile, checker } = createProgram(`
     interface Point { x: number; y: number; z: number; }
     type Input = Point;
@@ -458,14 +436,11 @@ Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccess
   assertEquals(members.has("z"), false);
 });
 
-//
-// Interface heritage merge: an interface extending a base contributes inherited
-// members that are merged and de-duplicated (mergeResolvedMembers, ~1416-1442;
-// resolveMembersFromDeclaration heritage branch ~1388-1414). An overriding
-// property in the derived interface wins.
-//
-
 Deno.test("applyShrinkAndWrap merges inherited interface members and honors overrides", () => {
+  // Interface heritage merge: an interface extending a base contributes
+  // inherited members that are merged and de-duplicated (mergeResolvedMembers,
+  // ~1416-1442; resolveMembersFromDeclaration heritage branch ~1388-1414). An
+  // overriding property in the derived interface wins.
   const { sourceFile, checker } = createProgram(`
     interface Base { shared: string; baseOnly: number; }
     interface Derived extends Base { shared: string; derivedOnly: boolean; }
@@ -492,13 +467,10 @@ Deno.test("applyShrinkAndWrap merges inherited interface members and honors over
   assertEquals(members.has("shared"), false);
 });
 
-//
-// Diagnostics: unknown base type with property access reports
-// schema:unknown-type-access (lines ~1876-1893). Driven through
-// applyShrinkAndWrap with a context + fnNode so validateShrinkCoverage runs.
-//
-
 Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with reads", () => {
+  // Diagnostics: unknown base type with property access reports
+  // schema:unknown-type-access (lines ~1876-1893). Driven through
+  // applyShrinkAndWrap with a context + fnNode so validateShrinkCoverage runs.
   const { sourceFile, checker } = createProgram(`
     type Input = unknown;
   `);
@@ -530,12 +502,10 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with 
   assertStringIncludes(diagnostics[0]!.message, "'.missing'");
 });
 
-//
-// Diagnostics: concrete type but an accessed path is absent reports
-// schema:path-not-in-type (lines ~1938-1954, and the missing filter 1939-1941).
-//
-
 Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", () => {
+  // Diagnostics: concrete type but an accessed path is absent reports
+  // schema:path-not-in-type (lines ~1938-1954, and the missing filter
+  // 1939-1941).
   const { sourceFile, checker } = createProgram(`
     type Input = { present: string };
   `);
@@ -566,12 +536,9 @@ Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", 
   assertEquals(diagnostics[0]!.message.includes("'.present'"), false);
 });
 
-//
-// Diagnostics: concrete type with a property typed `unknown` reports
-// schema:unknown-type-access (case 2, lines ~1900-1935).
-//
-
 Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
+  // Diagnostics: concrete type with a property typed `unknown` reports
+  // schema:unknown-type-access (case 2, lines ~1900-1935).
   const { sourceFile, checker } = createProgram(`
     type Input = { amounts: unknown };
   `);
@@ -602,12 +569,10 @@ Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
   assertStringIncludes(diagnostics[0]!.message, "typed as 'unknown'");
 });
 
-//
-// Diagnostics: `never` base type skips validation entirely (lines ~1857-1862).
-// A `never`-typed parameter with reads must produce no diagnostics.
-//
-
 Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
+  // Diagnostics: `never` base type skips validation entirely (lines
+  // ~1857-1862). A `never`-typed parameter with reads must produce no
+  // diagnostics.
   const { sourceFile, checker } = createProgram(`
     type Input = never;
   `);
@@ -634,12 +599,10 @@ Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
   assertEquals(diagnostics.length, 0);
 });
 
-//
-// Diagnostics: wildcard param typed `unknown` passed to an opaque function
-// reports the wildcard-specific unknown-type-access branch (lines ~1733-1750).
-//
-
 Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcard param", () => {
+  // Diagnostics: wildcard param typed `unknown` passed to an opaque function
+  // reports the wildcard-specific unknown-type-access branch (lines
+  // ~1733-1750).
   const { sourceFile, checker } = createProgram(`
     type Input = unknown;
   `);
@@ -669,13 +632,10 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcar
   assertStringIncludes(diagnostics[0]!.message, "logged");
 });
 
-//
-// Validation over an array base: item-level paths validate against the element
-// type. A missing item property reports through the array-element recursion
-// (lines ~1795-1833, getArrayElementTypeNode paths ~1656-1709).
-//
-
 Deno.test("applyShrinkAndWrap validates array item paths against the element type", () => {
+  // Validation over an array base: item-level paths validate against the
+  // element type. A missing item property reports through the array-element
+  // recursion (lines ~1795-1833, getArrayElementTypeNode paths ~1656-1709).
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; }
     type Input = Row[];
@@ -706,14 +666,11 @@ Deno.test("applyShrinkAndWrap validates array item paths against the element typ
   assertStringIncludes(diagnostics[0]!.message, "'.missing'");
 });
 
-//
-// defaults_only mode: a default nested under a path present in the base type
-// gets applied to the fallback shape when the direct node application misses.
-// Also exercises applyCapabilityDefaultsToTypeNode fallback (~2919-2945) and
-// buildDefaultsOnlyFallbackPaths leaf expansion (~2954-2956, 3001-3026).
-//
-
 Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base type shape", () => {
+  // defaults_only mode: a default nested under a path present in the base type
+  // gets applied to the fallback shape when the direct node application misses.
+  // Also exercises applyCapabilityDefaultsToTypeNode fallback (~2919-2945) and
+  // buildDefaultsOnlyFallbackPaths leaf expansion (~2954-2956, 3001-3026).
   const { sourceFile, checker } = createProgram(`
     type Input = { title: string; count: number };
     type TitleDefault = "Untitled";
@@ -744,12 +701,9 @@ Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base typ
   assertEquals(members.get("count")?.type, "number");
 });
 
-//
-// applyCapabilityDefaultsToTypeNode: default applied directly through a tuple
-// index (applySingleDefaultToTypeNode tuple branch ~2825-2850).
-//
-
 Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple index", () => {
+  // applyCapabilityDefaultsToTypeNode: default applied directly through a tuple
+  // index (applySingleDefaultToTypeNode tuple branch ~2825-2850).
   const { sourceFile, checker } = createProgram(`
     type Input = [{ name?: string }, number];
     type NameDefault = "Anon";
@@ -777,12 +731,9 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple i
   );
 });
 
-//
-// applyCapabilityDefaultsToTypeNode: out-of-range tuple index leaves the node
-// unchanged (tuple guard ~2827-2831). No __cfHelpers.Default wrapper appears.
-//
-
 Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index", () => {
+  // applyCapabilityDefaultsToTypeNode: out-of-range tuple index leaves the node
+  // unchanged (tuple guard ~2827-2831). No __cfHelpers.Default wrapper appears.
   const { sourceFile, checker } = createProgram(`
     type Input = [{ name?: string }];
     type NameDefault = "Anon";
@@ -806,13 +757,10 @@ Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index
   assertEquals(hasQualifiedRef(node, "__cfHelpers", "Default"), false);
 });
 
-//
-// Identity-only root on a union base: each union member is replaced with the
-// identity-only shape; nullish members are rebuilt as-is
-// (createIdentityOnlyRootTypeNode union branch ~2367-2400).
-//
-
 Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", () => {
+  // Identity-only root on a union base: each union member is replaced with the
+  // identity-only shape; nullish members are rebuilt as-is
+  // (createIdentityOnlyRootTypeNode union branch ~2367-2400).
   const { sourceFile, checker } = createProgram(`
     type Input = { a: string } | { b: number } | undefined;
   `);
@@ -846,12 +794,9 @@ Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", ()
   assertEquals(members.has("b"), false);
 });
 
-//
-// Identity-only root that is nullish (`undefined`): rebuilt via
-// createIdentityOnlyNullishTypeNode (lines ~2357-2365, 2311-2331).
-//
-
 Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefined", () => {
+  // Identity-only root that is nullish (`undefined`): rebuilt via
+  // createIdentityOnlyNullishTypeNode (lines ~2357-2365, 2311-2331).
   const { sourceFile, checker } = createProgram(`
     type Input = undefined;
   `);
@@ -874,13 +819,10 @@ Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefine
   assertEquals(printTypeNode(result, sourceFile), "undefined");
 });
 
-//
-// Identity paths descending through an array item interface reference resolved
-// via the checker (applyIdentityOnlyPathsToTypeNode Array<T> ref branch
-// ~2557-2583) using an Array<T> reference (not `T[]`).
-//
-
 Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> references", () => {
+  // Identity paths descending through an array item interface reference
+  // resolved via the checker (applyIdentityOnlyPathsToTypeNode Array<T> ref
+  // branch ~2557-2583) using an Array<T> reference (not `T[]`).
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -909,13 +851,10 @@ Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> refe
   assertEquals(members.get("drop")?.type, "number");
 });
 
-//
-// Identity paths through a union base node (applyIdentityOnlyPathsToTypeNode
-// union branch ~2728-2752): each union member is visited and changed members
-// force a rebuilt union.
-//
-
 Deno.test("applyShrinkAndWrap applies identity paths across union members", () => {
+  // Identity paths through a union base node (applyIdentityOnlyPathsToTypeNode
+  // union branch ~2728-2752): each union member is visited and changed members
+  // force a rebuilt union.
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -948,15 +887,12 @@ Deno.test("applyShrinkAndWrap applies identity paths across union members", () =
   assertEquals(members.get("other")?.type, "boolean");
 });
 
-//
-// Identity paths through a named interface reference that resolves to declared
-// members, where a nested member is left unchanged (no matching child path) so
-// the `!changed` early return keeps the reference
-// (applyIdentityOnlyPathsToTypeNode reference branch ~2669-2725, unchanged
-// return ~2721-2723).
-//
-
 Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path matches", () => {
+  // Identity paths through a named interface reference that resolves to
+  // declared members, where a nested member is left unchanged (no matching
+  // child path) so the `!changed` early return keeps the reference
+  // (applyIdentityOnlyPathsToTypeNode reference branch ~2669-2725, unchanged
+  // return ~2721-2723).
   const { sourceFile, checker } = createProgram(`
     interface Outer { inner: { keep: string }; other: string; }
     type Input = Outer;
@@ -982,13 +918,10 @@ Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path
   assertEquals(printTypeNode(result, sourceFile), "Outer");
 });
 
-//
-// applyCellCapabilityPathsToTypeNode through a parenthesized type node
-// (~2181-2193) plus per-property cell capability selection where read+write
-// paths on the same leaf select `writable`.
-//
-
 Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized literals", () => {
+  // applyCellCapabilityPathsToTypeNode through a parenthesized type node
+  // (~2181-2193) plus per-property cell capability selection where read+write
+  // paths on the same leaf select `writable`.
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type Writable<T> = { readonly value?: T };
@@ -1022,9 +955,10 @@ Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized li
 // remaining array-element and default clusters.
 //
 
-// Identity item path on an Array<T> reference that names no member leaves the
-// whole array reference unchanged (Array<T> ref `updated === inner` ~2574-2576).
 Deno.test("applyShrinkAndWrap keeps Array<T> unchanged for an unresolved identity item path", () => {
+  // Identity item path on an Array<T> reference that names no member leaves the
+  // whole array reference unchanged (Array<T> ref `updated === inner`
+  // ~2574-2576).
   const { sourceFile, checker } = createProgram(`
     interface Item { keep: string; }
     type Input = Array<Item>;
@@ -1048,10 +982,10 @@ Deno.test("applyShrinkAndWrap keeps Array<T> unchanged for an unresolved identit
   assertEquals(printTypeNode(result, sourceFile), "Array<Item>");
 });
 
-// Identity item path on a readonly array that names no member leaves the
-// readonly-array node unchanged (readonly-array `updated === elementType`
-// ~2546-2548).
 Deno.test("applyShrinkAndWrap keeps a readonly array unchanged for an unresolved identity item path", () => {
+  // Identity item path on a readonly array that names no member leaves the
+  // readonly-array node unchanged (readonly-array `updated === elementType`
+  // ~2546-2548).
   const { sourceFile, checker } = createProgram(`
     interface Item { keep: string; }
     type Input = readonly Item[];
@@ -1081,10 +1015,10 @@ Deno.test("applyShrinkAndWrap keeps a readonly array unchanged for an unresolved
   assertEquals(node.type.elementType.getText(node.getSourceFile()), "Item");
 });
 
-// Identity path through a parenthesized literal that DOES change a leaf: the
-// parenthesized wrapper is rebuilt around the updated inner
-// (createIdentityOnly paren branch ~2485-2498, change arm).
 Deno.test("applyShrinkAndWrap rebuilds a parenthesized identity root when a leaf changes", () => {
+  // Identity path through a parenthesized literal that DOES change a leaf: the
+  // parenthesized wrapper is rebuilt around the updated inner
+  // (createIdentityOnly paren branch ~2485-2498, change arm).
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -1113,9 +1047,10 @@ Deno.test("applyShrinkAndWrap rebuilds a parenthesized identity root when a leaf
   assertEquals(members.get("drop")?.type, "number");
 });
 
-// Identity path through a Cell-like wrapper reference descends into the inner
-// type argument (applyIdentityOnlyPathsToTypeNode cell-ref branch ~2642-2667).
 Deno.test("applyShrinkAndWrap descends identity paths through a Cell-like wrapper reference", () => {
+  // Identity path through a Cell-like wrapper reference descends into the inner
+  // type argument (applyIdentityOnlyPathsToTypeNode cell-ref branch
+  // ~2642-2667).
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -1147,12 +1082,12 @@ Deno.test("applyShrinkAndWrap descends identity paths through a Cell-like wrappe
   assertEquals(members.get("drop")?.type, "number");
 });
 
-// Node-driven array shrink where the base node is a type alias resolving to an
-// array (not `T[]`/`Array<T>` syntactically) exercises the checker-based array
-// detection (buildShrunkTypeNodeFromTypeNode ~1086-1096, 1185-1202). The alias
-// reference is recognized as array-shaped and preserved as a reference so
-// schema generation keeps its $ref.
 Deno.test("applyShrinkAndWrap recognizes an array type-alias reference as array-shaped", () => {
+  // Node-driven array shrink where the base node is a type alias resolving to
+  // an array (not `T[]`/`Array<T>` syntactically) exercises the checker-based
+  // array detection (buildShrunkTypeNodeFromTypeNode ~1086-1096, 1185-1202).
+  // The alias reference is recognized as array-shaped and preserved as a
+  // reference so schema generation keeps its $ref.
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; title: string; unused: number; }
     type Rows = Row[];
@@ -1177,10 +1112,10 @@ Deno.test("applyShrinkAndWrap recognizes an array type-alias reference as array-
   assertEquals(printTypeNode(result, sourceFile), "Rows");
 });
 
-// Array-like TypeLiteral (numeric index + length) drives the
-// getArrayLikeTypeLiteralElementType path (~557-577) and element shrinking of a
-// literal element node (~565-567). Item field access shrinks the element.
 Deno.test("applyShrinkAndWrap shrinks array-like type literals with numeric index and length", () => {
+  // Array-like TypeLiteral (numeric index + length) drives the
+  // getArrayLikeTypeLiteralElementType path (~557-577) and element shrinking of
+  // a literal element node (~565-567). Item field access shrinks the element.
   const { sourceFile, checker } = createProgram(`
     type Input = {
       length: number;
@@ -1209,10 +1144,10 @@ Deno.test("applyShrinkAndWrap shrinks array-like type literals with numeric inde
   assertEquals(members.has("unused"), false);
 });
 
-// findPropertySymbol resolves a property that lives only on one union
-// constituent (findPropertySymbol union recursion ~684-689) during type-driven
-// shrinking of a union base node.
 Deno.test("applyShrinkAndWrap resolves a union-only property during type-driven shrinking", () => {
+  // findPropertySymbol resolves a property that lives only on one union
+  // constituent (findPropertySymbol union recursion ~684-689) during
+  // type-driven shrinking of a union base node.
   const { sourceFile, checker } = createProgram(`
     type Input = { common: string } & ({ onlyHere: number } | { alt: boolean });
   `);
@@ -1238,11 +1173,12 @@ Deno.test("applyShrinkAndWrap resolves a union-only property during type-driven 
   assertEquals(members.get("common")?.type, "string");
 });
 
-// Type-driven shrink where a deeper path fails to materialize on a nested
-// property: the child is dropped rather than widened (buildShrunkTypeNodeFromType
-// `!shrunkChild && !hasDirectAccess` continue, ~978-989 region). Access a valid
-// head plus an invalid deep path on the same property.
 Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven shrinking", () => {
+  // Type-driven shrink where a deeper path fails to materialize on a nested
+  // property: the child is dropped rather than widened
+  // (buildShrunkTypeNodeFromType `!shrunkChild && !hasDirectAccess` continue,
+  // ~978-989 region). Access a valid head plus an invalid deep path on the same
+  // property.
   const { sourceFile, checker } = createProgram(`
     type Input = { data: { present: string }; other: number };
   `);
@@ -1269,9 +1205,9 @@ Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven 
   assertEquals(members.get("other")?.type, "number");
 });
 
-// applyCapabilityDefaultsToTypeNode applies a default through a union member
-// (applySingleDefaultToTypeNode union branch ~2852-2870).
 Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a union member", () => {
+  // applyCapabilityDefaultsToTypeNode applies a default through a union member
+  // (applySingleDefaultToTypeNode union branch ~2852-2870).
   const { sourceFile, checker } = createProgram(`
     type Input = { a?: string } | { b?: number };
     type ADefault = "x";
@@ -1296,10 +1232,11 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a union m
   assertEquals(members.get("a")?.type, '__cfHelpers.Default<string, "x">');
 });
 
-// defaults-only fallback where a default is nested under a property: the
-// fallback path builder expands the child's leaves so the default lands
-// (buildDefaultsOnlyFallbackPaths nested-head expansion ~2954-2956, 3009-3026).
 Deno.test("applyShrinkAndWrap expands nested defaults-only fallback leaves", () => {
+  // defaults-only fallback where a default is nested under a property: the
+  // fallback path builder expands the child's leaves so the default lands
+  // (buildDefaultsOnlyFallbackPaths nested-head expansion ~2954-2956,
+  // 3009-3026).
   const { sourceFile, checker } = createProgram(`
     type Input = { group: { title: string; note: string }; count: number };
     type TitleDefault = "Untitled";
@@ -1332,10 +1269,10 @@ Deno.test("applyShrinkAndWrap expands nested defaults-only fallback leaves", () 
   assertEquals(members.get("count")?.type, "number");
 });
 
-// Identity-only root whose resolved semantic type is undefined falls back to the
-// replacement type node (createIdentityOnlyRootTypeNode `!resolvedType` branch
-// ~2345-2354) — driven by a synthetic node with no base type.
 Deno.test("applyShrinkAndWrap replaces an identity-only root that has no resolvable type", () => {
+  // Identity-only root whose resolved semantic type is undefined falls back to
+  // the replacement type node (createIdentityOnlyRootTypeNode `!resolvedType`
+  // branch ~2345-2354) — driven by a synthetic node with no base type.
   const { sourceFile, checker } = createProgram(`type Marker = string;`);
   // A synthetic reference to a name that resolves to nothing under noLib.
   const syntheticNode = ts.factory.createTypeReferenceNode("Unresolvable");
@@ -1358,10 +1295,10 @@ Deno.test("applyShrinkAndWrap replaces an identity-only root that has no resolva
   assertEquals(printTypeNode(result, sourceFile), "unknown");
 });
 
-// Cell-capability application over a plain object literal member whose value is
-// a cell wrapper (applyCellCapabilityPathsToTypeNode literal member branch
-// ~2199-2264): a read+write access selects the `writable` capability.
 Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cell leaves", () => {
+  // Cell-capability application over a plain object literal member whose value
+  // is a cell wrapper (applyCellCapabilityPathsToTypeNode literal member branch
+  // ~2199-2264): a read+write access selects the `writable` capability.
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type Writable<T> = { readonly value?: T };
@@ -1394,10 +1331,11 @@ Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cel
 // Batch 3: array-union validation and remaining union collapse / defensive arms.
 //
 
-// Validation over a `Row[] | undefined` base with a valid item field reports no
-// diagnostic, exercising getArrayElementTypeNode's union branch (~1643-1657):
-// the nullish member is skipped and the array member yields the element type.
 Deno.test("applyShrinkAndWrap accepts item paths present on a nullable array union element", () => {
+  // Validation over a `Row[] | undefined` base with a valid item field reports
+  // no diagnostic, exercising getArrayElementTypeNode's union branch
+  // (~1643-1657): the nullish member is skipped and the array member yields the
+  // element type.
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; }
     type Input = Row[] | undefined;
@@ -1427,10 +1365,11 @@ Deno.test("applyShrinkAndWrap accepts item paths present on a nullable array uni
   assertEquals(diagnostics.length, 0);
 });
 
-// A union node whose single non-nullish member shrinks collapses to that member
-// (buildShrunkTypeNodeFromTypeNode union `all.length === 1` ~1298-1301). A
-// one-element union node with one accessed property drives the collapse.
 Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk member", () => {
+  // A union node whose single non-nullish member shrinks collapses to that
+  // member (buildShrunkTypeNodeFromTypeNode union `all.length === 1`
+  // ~1298-1301). A one-element union node with one accessed property drives the
+  // collapse.
   const { sourceFile, checker } = createProgram(`
     type Input = { keep: string; drop: number };
   `);
@@ -1459,9 +1398,9 @@ Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk me
   assert(ts.isTypeLiteralNode(node));
 });
 
-// A union node with only nullish members is returned unchanged
-// (buildShrunkTypeNodeFromTypeNode `nonNullish.length === 0` ~1278).
 Deno.test("applyShrinkAndWrap leaves an all-nullish union node unchanged", () => {
+  // A union node with only nullish members is returned unchanged
+  // (buildShrunkTypeNodeFromTypeNode `nonNullish.length === 0` ~1278).
   const { sourceFile, checker } = createProgram(`type Input = string;`);
   const nullOnly = ts.factory.createUnionTypeNode([
     ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
@@ -1495,10 +1434,10 @@ Deno.test("applyShrinkAndWrap leaves an all-nullish union node unchanged", () =>
   );
 });
 
-// A valid tuple index whose nested default path does not resolve leaves the
-// tuple unchanged (applySingleDefaultToTypeNode tuple `!updatedChild.applied`
-// arm ~2841-2843).
 Deno.test("applyCapabilityDefaultsToTypeNode ignores a tuple default whose nested path is absent", () => {
+  // A valid tuple index whose nested default path does not resolve leaves the
+  // tuple unchanged (applySingleDefaultToTypeNode tuple `!updatedChild.applied`
+  // arm ~2841-2843).
   const { sourceFile, checker } = createProgram(`
     type Input = [{ present?: string }];
     type D = "x";

--- a/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
@@ -164,15 +164,12 @@ function createContext(sourceFile: ts.SourceFile): {
   return { context, diagnostics };
 }
 
-//
-// Type-driven shrink descending into an `unknown`/`any` property drops that
-// property rather than widening it (buildShrunkTypeNodeFromType
-// `!hasDirectAccess && isAnyOrUnknownType(propType)` continue, lines 964-967).
-// A synthetic base node forces the type-driven path; a deep path into an
-// `unknown`-typed member reaches the guard.
-//
-
 Deno.test("applyShrinkAndWrap drops a deep read into an unknown-typed property under type-driven shrinking", () => {
+  // Type-driven shrink descending into an `unknown`/`any` property drops that
+  // property rather than widening it (buildShrunkTypeNodeFromType
+  // `!hasDirectAccess && isAnyOrUnknownType(propType)` continue, lines
+  // 964-967). A synthetic base node forces the type-driven path; a deep path
+  // into an `unknown`-typed member reaches the guard.
   const { sourceFile, checker } = createProgram(`
     type Input = { blob: unknown; kept: string };
   `);
@@ -202,15 +199,13 @@ Deno.test("applyShrinkAndWrap drops a deep read into an unknown-typed property u
   assertEquals(members.get("kept")?.type, "string");
 });
 
-//
-// getArrayElementTypeNode fallback: a base node that is a plain type-alias
-// reference (not `T[]`, `Array<T>`, readonly array, union, or type literal)
-// resolves to an array only through the checker, so the element node is built
-// from the resolved element type (lines 1685-1688, 1694, 1699-1709). Validating
-// an item path on such a base runs the fallback and finds the item field.
-//
-
 Deno.test("validateShrinkCoverage resolves array element node from an array type-alias reference", () => {
+  // getArrayElementTypeNode fallback: a base node that is a plain type-alias
+  // reference (not `T[]`, `Array<T>`, readonly array, union, or type literal)
+  // resolves to an array only through the checker, so the element node is built
+  // from the resolved element type (lines 1685-1688, 1694, 1699-1709).
+  // Validating an item path on such a base runs the fallback and finds the item
+  // field.
   const { sourceFile, checker } = createProgram(`
     interface Array<T> { length: number; [n: number]: T; }
     interface Row { id: string; title: string; }
@@ -247,15 +242,12 @@ Deno.test("validateShrinkCoverage resolves array element node from an array type
   assertEquals(diagnostics[0]!.message.includes("'.id'"), false);
 });
 
-//
-// validateShrinkCoverage over an array base where the shrunk node is NOT
-// array-shaped: array-root paths (`length`) survive and re-drive validation
-// against the array base (line 1832-1833 `paths = arrayRootPaths`), and the
-// array-root head is checked via typeNodeHasHead's array-shape arm (line 1545).
-// A bogus non-array head keeps the top-1763 fast path from firing.
-//
-
 Deno.test("validateShrinkCoverage validates array-root paths against the array base when the shrunk node is not array-shaped", () => {
+  // validateShrinkCoverage over an array base where the shrunk node is NOT
+  // array-shaped: array-root paths (`length`) survive and re-drive validation
+  // against the array base (line 1832-1833 `paths = arrayRootPaths`), and the
+  // array-root head is checked via typeNodeHasHead's array-shape arm (line
+  // 1545). A bogus non-array head keeps the top-1763 fast path from firing.
   const { sourceFile, checker } = createProgram(`
     interface Array<T> { length: number; [n: number]: T; }
     interface Row { id: string; }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

48 comment blocks in the transformer and parser coverage suites describe exactly
the test beneath them — which branch it drives, which source lines it covers.
That is neither a section of the file nor documentation of a declaration, so
each moves inside its own test body, where it needs no delimiters and sits
against the code it explains.

    -//
    -// Array element node building via type-driven shrinking (Array<T> reference).
    -// Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
    -// checker, element shrunk, array node rebuilt.
    -//
    -
     Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed fields", () => {
    +  // Array element node building via type-driven shrinking (Array<T> reference).
    +  // Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
    +  // checker, element shrunk, array node rebuilt.
       const { sourceFile, checker } = createProgram(`

31 of them were `//`-delimited markers that the earlier sweeps left alone as too
ambiguous to call title or prose. Moving them settles that question by removing
it — a comment inside a body is an ordinary comment, and no judgment about
titles is needed. The other 17 were already plain comments above their test, in
the same files and the same idiom.

## What each move has to satisfy

- the block sits directly above a one-line `Deno.test(...) => {` opener;
- it heads exactly that one item, not a region;
- its word multiset survives re-wrapping to the body's indentation, asserted
  per site before the edit is written.

## Not moved

Eight blocks head a **region** rather than a single test — between two and
eleven declarations each, in `dataflow-coverage.test.ts`, `bench-fixtures.ts`,
`require-defaults.test.ts`, `view-parse-cov.test.ts` and `ci-gantt.ts`. Those
are section markers and stay. Two more head a helper function rather than a
test. Several of the eight are simply titles that wrap across two lines, with
their blank separator already in place.

## Verification

Across the whole diff no word is lost or gained, no non-comment line is touched,
and no added line exceeds 80 columns.

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the
`ts-transformers` suite — which compares 380 fixture goldens — and `cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

