### PR TITLE
Put each test's comment where it belongs

### DIFF
--- a/packages/cli/test/view-keys-cov.test.ts
+++ b/packages/cli/test/view-keys-cov.test.ts
@@ -12,9 +12,9 @@ function names(input: Uint8Array): string[] {
   return decodeKeys(input).keys.map((k) => k.name);
 }
 
-// SS3 split across reads: `ESC O` with the final byte not yet arrived breaks
-// out of the loop and leaves the whole sequence as leftover (line 50).
 Deno.test("decode: SS3 truncated (ESC O) is buffered as leftover", () => {
+  // SS3 split across reads: `ESC O` with the final byte not yet arrived breaks
+  // out of the loop and leaves the whole sequence as leftover (line 50).
   const r = decodeKeys(raw(0x1b, 0x4f));
   assertEquals(r.keys.length, 0);
   assertEquals(Array.from(r.rest), [0x1b, 0x4f]);
@@ -23,8 +23,8 @@ Deno.test("decode: SS3 truncated (ESC O) is buffered as leftover", () => {
   assertEquals(r2.keys.map((k) => k.name), ["up"]);
 });
 
-// ESC followed by a control byte (n < 0x20): Alt+Ctrl combo (lines 81-89).
 Deno.test("decode: ESC + control byte is ctrl+alt combo", () => {
+  // ESC followed by a control byte (n < 0x20): Alt+Ctrl combo (lines 81-89).
   // ESC then 0x01 (ctrl-a): name ctrl-a, ctrl + alt.
   const k = only(raw(0x1b, 0x01));
   assertEquals(k.name, "ctrl-a");
@@ -37,16 +37,17 @@ Deno.test("decode: ESC + control byte is ctrl+alt combo", () => {
   assertEquals(k2.alt, true);
 });
 
-// ESC + printable byte (n < 0x80) is Alt+letter (lines 90-94, sibling branch).
 Deno.test("decode: ESC + printable byte is alt+letter", () => {
+  // ESC + printable byte (n < 0x80) is Alt+letter (lines 90-94, sibling
+  // branch).
   const k = only(raw(0x1b, 0x62)); // ESC 'b'
   assertEquals(k.name, "b");
   assertEquals(k.alt, true);
   assertEquals(k.char, undefined);
 });
 
-// ESC + DEL / ESC + BS → alt-backspace (lines 76-79, sibling branch).
 Deno.test("decode: ESC + backspace is alt-backspace", () => {
+  // ESC + DEL / ESC + BS → alt-backspace (lines 76-79, sibling branch).
   const k = only(raw(0x1b, 0x7f));
   assertEquals(k.name, "backspace");
   assertEquals(k.alt, true);
@@ -55,9 +56,9 @@ Deno.test("decode: ESC + backspace is alt-backspace", () => {
   assertEquals(k2.alt, true);
 });
 
-// ESC followed by a high byte (n >= 0x80) we do not model: emit Escape and
-// only consume the ESC, leaving the high byte to be decoded next (97-100).
 Deno.test("decode: ESC + high byte emits Escape and keeps the high byte", () => {
+  // ESC followed by a high byte (n >= 0x80) we do not model: emit Escape and
+  // only consume the ESC, leaving the high byte to be decoded next (97-100).
   // ESC then 0xc3 0xa9 ('é' in UTF-8): ESC alone, then the char.
   const { keys } = decodeKeys(raw(0x1b, 0xc3, 0xa9));
   assertEquals(keys.length, 2);
@@ -66,13 +67,16 @@ Deno.test("decode: ESC + high byte emits Escape and keeps the high byte", () => 
   assertEquals(keys[1].char, "é");
 });
 
-// ESC ESC → Escape, consuming a single ESC (lines 68-71, sibling branch).
 Deno.test("decode: ESC ESC emits Escape", () => {
+  // ESC ESC → Escape, consuming a single ESC (lines 68-71, sibling branch).
   const { keys } = decodeKeys(raw(0x1b, 0x1b));
   assertEquals(keys[0].name, "escape");
 });
 
+//
 // CSI modifier param: shift bit (line 147) and ctrl bit (line 149).
+//
+
 Deno.test("decode: CSI shift modifier on arrow", () => {
   // ESC [ 1 ; 2 A → shift+up. bits = 2-1 = 1 → shift.
   const k = only(raw(0x1b, 0x5b, 0x31, 0x3b, 0x32, 0x41));
@@ -100,7 +104,10 @@ Deno.test("decode: CSI shift+alt+ctrl combined modifier", () => {
   assertEquals(k.ctrl, true);
 });
 
+//
 // CSI finals beyond the arrows (lines 168-181).
+//
+
 Deno.test("decode: CSI shift-tab (Z)", () => {
   assertEquals(only(raw(0x1b, 0x5b, 0x5a)).name, "shift-tab");
 });
@@ -117,7 +124,10 @@ Deno.test("decode: CSI unknown final is 'unknown'", () => {
   assertEquals(only(raw(0x1b, 0x5b, 0x58)).name, "unknown");
 });
 
+//
 // Tilde sequences (lines 179, 195-226).
+//
+
 Deno.test("decode: tilde delete (3~)", () => {
   const k = only(raw(0x1b, 0x5b, 0x33, 0x7e));
   assertEquals(k.name, "delete");
@@ -166,7 +176,10 @@ Deno.test("decode: tilde unknown code is 'unknown'", () => {
   assertEquals(k.name, "unknown");
 });
 
+//
 // SS3 sequences (lines 234-253).
+//
+
 Deno.test("decode: SS3 down/right/left", () => {
   assertEquals(only(raw(0x1b, 0x4f, 0x42)).name, "down");
   assertEquals(only(raw(0x1b, 0x4f, 0x43)).name, "right");
@@ -190,8 +203,8 @@ Deno.test("decode: SS3 unknown final is 'unknown'", () => {
   assertEquals(only(raw(0x1b, 0x4f, 0x58)).name, "unknown");
 });
 
-// Sanity: a longer batch threading several of the above branches together.
 Deno.test("decode: mixed batch crosses SS3, CSI-mod and tilde branches", () => {
+  // Sanity: a longer batch threading several of the above branches together.
   const input = new Uint8Array([
     0x1b,
     0x4f,

--- a/packages/cli/test/view-session-gate.test.ts
+++ b/packages/cli/test/view-session-gate.test.ts
@@ -51,13 +51,12 @@ function focusLastTarget(s: Session): number {
 // findTargetIndex start-offset-only fallback (436, 437, 439).
 //
 
-// The pattern's card lists a dependency on `__cfLift_1` whose target carries a
-// definition start offset but no end offset (the dependency is found
-// syntactically, with no semantic service to pin the exact range). Following it
-// skips the exact (start + end) lookup and matches the lift node by its start
-// offset alone, landing the selection on that node.
-
 Deno.test("gate: following the last card reference (a dependency, no end offset) matches by start offset", () => {
+  // The pattern's card lists a dependency on `__cfLift_1` whose target carries
+  // a definition start offset but no end offset (the dependency is found
+  // syntactically, with no semantic service to pin the exact range). Following
+  // it skips the exact (start + end) lookup and matches the lift node by its
+  // start offset alone, landing the selection on that node.
   const doc = parseDocument(SAMPLE);
   const s = new Session(
     doc,
@@ -96,10 +95,10 @@ Deno.test("gate: following the last card reference (a dependency, no end offset)
   );
 });
 
-// A second, independent route to the same fallback: opening (Enter) the focused
-// dependency reference resolves its node through `resolveTargetNode`, which
-// shares `findTargetIndex`, and opens that node's card in place.
 Deno.test("gate: Enter on the dependency reference opens the start-matched node's card", () => {
+  // A second, independent route to the same fallback: opening (Enter) the
+  // focused dependency reference resolves its node through `resolveTargetNode`,
+  // which shares `findTargetIndex`, and opens that node's card in place.
   const doc = parseDocument(SAMPLE);
   const s = new Session(
     doc,
@@ -125,12 +124,11 @@ Deno.test("gate: Enter on the dependency reference opens the start-matched node'
 // jumpToTarget nodeAtLine fallback (446).
 //
 
-// The lift's card ends with a plain "use" reference that carries a destination
-// line but no definition offset at all. `findTargetIndex` returns -1 for it, so
-// `jumpToTarget` falls back to `nodeAtLine` on the destination line to pick the
-// node to select.
-
 Deno.test("gate: revealing the last lift reference (a use, no offset) resolves via nodeAtLine", () => {
+  // The lift's card ends with a plain "use" reference that carries a
+  // destination line but no definition offset at all. `findTargetIndex` returns
+  // -1 for it, so `jumpToTarget` falls back to `nodeAtLine` on the destination
+  // line to pick the node to select.
   const doc = parseDocument(SAMPLE);
   const s = new Session(
     doc,
@@ -155,9 +153,10 @@ Deno.test("gate: revealing the last lift reference (a use, no offset) resolves v
   );
 });
 
-// Opening (Enter) the offset-less use reference resolves a node through
-// `resolveTargetNode`/`nodeAtLine` and opens its card, the complementary route.
 Deno.test("gate: Enter on the offset-less use reference resolves a node via nodeAtLine", () => {
+  // Opening (Enter) the offset-less use reference resolves a node through
+  // `resolveTargetNode`/`nodeAtLine` and opens its card, the complementary
+  // route.
   const doc = parseDocument(SAMPLE);
   const s = new Session(
     doc,

--- a/packages/memory/test/v2-patch.test.ts
+++ b/packages/memory/test/v2-patch.test.ts
@@ -360,10 +360,13 @@ Deno.test("memory v2 patch reuses unchanged branches across sibling updates", ()
   });
 });
 
+//
 // An `append` op is tail-relative: it inserts `values` at the array's live tail,
 // creating the array (and the path to it) when absent. This is what lets a client
 // whose base is stale or empty still land its elements after whatever durably
 // precedes them.
+//
+
 Deno.test("memory v2 append lands at the live tail", () => {
   const out = applyPatch({ value: ["a", "b"] }, [
     { op: "append", path: "/value", values: ["c"] },
@@ -403,8 +406,11 @@ Deno.test("memory v2 append rejects a non-array target", () => {
   assert(threw, "append onto a non-array must throw");
 });
 
+//
 // `add-unique` appends each value only if no existing element equals it, and
 // creates the array if absent. It is idempotent against durable state.
+//
+
 Deno.test("memory v2 add-unique adds only absent elements", () => {
   const out = applyPatch({ value: ["a", "b"] }, [
     { op: "add-unique", path: "/value", values: ["b", "c", "c"] },
@@ -433,9 +439,10 @@ Deno.test("memory v2 add-unique compares by stored value (objects)", () => {
   assertEquals(out.value, [{ id: 1 }, { id: 2 }]);
 });
 
-// A `FabricSpecialObject` keeps its state in private `#fields`, so its content
-// is what distinguishes two instances, not its (empty) own-property set.
 Deno.test("memory v2 add-unique compares special objects by content", () => {
+  // A `FabricSpecialObject` keeps its state in private `#fields`, so its
+  // content is what distinguishes two instances, not its (empty) own-property
+  // set.
   const out = applyPatch({ value: [new FabricBytes(new Uint8Array([1, 2]))] }, [
     {
       op: "add-unique",
@@ -454,8 +461,8 @@ Deno.test("memory v2 add-unique compares special objects by content", () => {
   ]);
 });
 
-// `NaN` is the same value as `NaN`; `-0` and `+0` are different values.
 Deno.test("memory v2 add-unique on the weird numbers", () => {
+  // `NaN` is the same value as `NaN`; `-0` and `+0` are different values.
   const nan = applyPatch({ value: [NaN] }, [
     { op: "add-unique", path: "/value", values: [NaN] },
   ]) as { value: number[] };
@@ -469,8 +476,11 @@ Deno.test("memory v2 add-unique on the weird numbers", () => {
   assert(Object.is(zero.value[1], +0), "the added +0 must be distinct");
 });
 
+//
 // `increment` adds `by` to the number at the path, treats an absent value as 0,
 // creates the path if absent, and sums when composed.
+//
+
 Deno.test("memory v2 increment adds to an existing number", () => {
   const out = applyPatch({ value: { count: 5 } }, [
     { op: "increment", path: "/value/count", by: 3 },
@@ -522,10 +532,11 @@ Deno.test("memory v2 increment rejects a zero amount", () => {
   assert(threw, "a zero increment must throw");
 });
 
-// A non-finite `by` is meaningless for a concurrent-sum counter and would set
-// the counter to an absorbing `NaN`/`±Infinity`, so it is rejected alongside a
-// zero amount. (`-0 === 0`, so negative zero is already caught by the zero gate.)
 Deno.test("memory v2 increment rejects a non-finite amount", () => {
+  // A non-finite `by` is meaningless for a concurrent-sum counter and would set
+  // the counter to an absorbing `NaN`/`±Infinity`, so it is rejected alongside
+  // a zero amount. (`-0 === 0`, so negative zero is already caught by the zero
+  // gate.)
   for (const by of [NaN, Infinity, -Infinity]) {
     let threw = false;
     try {
@@ -539,8 +550,11 @@ Deno.test("memory v2 increment rejects a non-finite amount", () => {
   }
 });
 
+//
 // `remove-by-value` removes every element equal to the given value (by stored
 // value), idempotently, and is a no-op on a missing/non-array target.
+//
+
 Deno.test("memory v2 remove-by-value removes matching elements", () => {
   const out = applyPatch({ value: ["a", "b", "a", "c"] }, [
     { op: "remove-by-value", path: "/value", value: "a" },
@@ -603,10 +617,13 @@ Deno.test("memory v2 remove-by-value is a no-op when absent", () => {
   assertEquals(missing, {});
 });
 
+//
 // A non-array target is rejected once the path resolves to a traversable
 // container (an object) rather than to a scalar. A scalar target is caught
 // earlier by the spine thaw with a "not traversable" message; an object target
 // reaches the op's own array-shape check.
+//
+
 Deno.test("memory v2 append rejects a non-array object target", () => {
   let threw = false;
   try {
@@ -643,19 +660,20 @@ Deno.test("memory v2 increment rejects the root path", () => {
   assert(threw, "increment at the root must throw");
 });
 
-// Both `increment` and `remove-by-value` read the current value by walking the
-// path through array indices as well as object keys. Incrementing a numeric
-// array element addresses it positionally and writes back into the array.
 Deno.test("memory v2 increment updates a numeric array element by index", () => {
+  // Both `increment` and `remove-by-value` read the current value by walking
+  // the path through array indices as well as object keys. Incrementing a
+  // numeric array element addresses it positionally and writes back into the
+  // array.
   const out = applyPatch({ scores: [10, 20, 30] }, [
     { op: "increment", path: "/scores/1", by: 5 },
   ]) as { scores: number[] };
   assertEquals(out.scores, [10, 25, 30]);
 });
 
-// A path segment that names an out-of-range array index resolves to absent, so
-// remove-by-value finds no array there and leaves the document untouched.
 Deno.test("memory v2 remove-by-value is a no-op through a missing array index", () => {
+  // A path segment that names an out-of-range array index resolves to absent,
+  // so remove-by-value finds no array there and leaves the document untouched.
   const original = { items: [["a"]] };
   const out = applyPatch(original, [
     { op: "remove-by-value", path: "/items/5/inner", value: "a" },
@@ -663,12 +681,14 @@ Deno.test("memory v2 remove-by-value is a no-op through a missing array index", 
   assertEquals(out, { items: [["a"]] });
 });
 
+//
 // `applyPatchToDocument` is the shared "replay these ops over whatever this
 // document currently is" entry point (server-side reconstruction and the
 // client's pending replay). It normalizes an absent base to the empty
 // envelope and guarantees the result IS an entity envelope — a root-level
 // op can produce any FabricValue, and type-laundering a scalar root into
 // EntityDocument would let an invalid shape reach envelope-assuming code.
+//
 
 Deno.test("memory v2 applyPatchToDocument replays over an absent base as the empty envelope", () => {
   const patched = applyPatchToDocument(undefined, [

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -39,22 +39,20 @@ type StoredEntry = {
   observes?: string;
 };
 
-// Stage A of docs/specs/cfc-template-population.md: runtime-minted `*`-path
-// per-class `structure` entries (the membership/slot templates) close the two
-// SC-4/SC-8 residual under-taints:
-//   §1.1 a per-child existence probe ("is /items/3 present?" — a nonRecursive
-//        shape read AT the child) never consumed the membership J, because
-//        the runner's membership stamp is container-anchored and structure
-//        entries applied only at exactly their own path;
-//   §1.2 a slot-pointer observation (followRef probe at a computed slot)
-//        consumed only the per-slot link entry (the target's transport
-//        label), never the assignment J that decided WHICH element sits
-//        there.
-// The fix mints three `*`-child entries beside the container-anchored
-// enumerate stamp — {path:[...container,"*"], origin:"structure", observes}
-// for observes ∈ {shape, value, followRef} — all carrying the same per-tx J,
-// under the same replace-from-criteria discipline.
 describe("CFC template population (Stage A): the two under-taints", () => {
+  // Stage A of docs/specs/cfc-template-population.md: runtime-minted `*`-path
+  // per-class `structure` entries (the membership/slot templates) close the two
+  // SC-4/SC-8 residual under-taints: §1.1 a per-child existence probe ("is
+  // /items/3 present?" — a nonRecursive shape read AT the child) never consumed
+  // the membership J, because the runner's membership stamp is
+  // container-anchored and structure entries applied only at exactly their own
+  // path; §1.2 a slot-pointer observation (followRef probe at a computed slot)
+  // consumed only the per-slot link entry (the target's transport label), never
+  // the assignment J that decided WHICH element sits there. The fix mints three
+  // `*`-child entries beside the container-anchored enumerate stamp —
+  // {path:[...container,"*"], origin:"structure", observes} for observes ∈
+  // {shape, value, followRef} — all carrying the same per-tx J, under the same
+  // replace-from-criteria discipline.
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -530,19 +528,19 @@ describe("CFC template population (Stage A): the two under-taints", () => {
   });
 });
 
-// The SC-8 remainder (template-population §6, closed here): the generic
-// pure-link value-write route mints the same `*`-child class templates the
-// declared coordinator route does, so HAND-BUILT pure-link containers — no
-// coordinator, no `recordCfcStructureContainer` — carry consumable
-// membership/assignment taint. What makes the route safe to enable is the
-// machinery-read boundary: the op-instantiation/wiring machinery's reads of
-// plumbing containers (slot scalars, `length`, alias shells) carry the
-// `machineryRead` marker and skip template consumption in the flow join, so
-// the runtime's own scaffolding traffic no longer smears one reconcile's J
-// into the next op's action chain (the measured phase-B pointwise re-smear
-// that kept the route off in Stage A). The end-to-end smear pin is the
-// cfc-flow-pointwise map test, which runs with the generic route on.
 describe("CFC template population (SC-8 remainder): generic pure-link containers", () => {
+  // The SC-8 remainder (template-population §6, closed here): the generic
+  // pure-link value-write route mints the same `*`-child class templates the
+  // declared coordinator route does, so HAND-BUILT pure-link containers — no
+  // coordinator, no `recordCfcStructureContainer` — carry consumable
+  // membership/assignment taint. What makes the route safe to enable is the
+  // machinery-read boundary: the op-instantiation/wiring machinery's reads of
+  // plumbing containers (slot scalars, `length`, alias shells) carry the
+  // `machineryRead` marker and skip template consumption in the flow join, so
+  // the runtime's own scaffolding traffic no longer smears one reconcile's J
+  // into the next op's action chain (the measured phase-B pointwise re-smear
+  // that kept the route off in Stage A). The end-to-end smear pin is the
+  // cfc-flow-pointwise map test, which runs with the generic route on.
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -757,10 +755,10 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
   });
 });
 
-// Resolution semantics over hand-seeded template entries with DISTINCT
-// per-class atoms — the runtime mints identical labels per class, so the
-// class split is only observable with seeded metadata.
 describe("CFC template population (Stage A): class-split resolution", () => {
+  // Resolution semantics over hand-seeded template entries with DISTINCT
+  // per-class atoms — the runtime mints identical labels per class, so the
+  // class split is only observable with seeded metadata.
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -1028,11 +1026,11 @@ describe("CFC template population (Stage A): class-split resolution", () => {
   });
 });
 
-// The §4 schema-walk extension: record-only `additionalProperties` descends
-// as a `*` segment; mixed properties+additionalProperties schemas mint NO
-// `*` entry (pinned — the restriction is load-bearing, `*` matches any
-// segment and would over-taint the named fields).
 describe("CFC template population (Stage A): record-only additionalProperties walk", () => {
+  // The §4 schema-walk extension: record-only `additionalProperties` descends
+  // as a `*` segment; mixed properties+additionalProperties schemas mint NO `*`
+  // entry (pinned — the restriction is load-bearing, `*` matches any segment
+  // and would over-taint the named fields).
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -1157,11 +1155,11 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
   });
 });
 
-// Inv-12 Stage 1 rides along (design §3.3): template entries opt into the
-// cross-space representation transform at mint exactly like the container
-// stamps they accompany — a membership J fed by a foreign labeled read
-// persists in commitment form under `enforce`.
 describe("CFC template population (Stage A): cross-space label protection", () => {
+  // Inv-12 Stage 1 rides along (design §3.3): template entries opt into the
+  // cross-space representation transform at mint exactly like the container
+  // stamps they accompany — a membership J fed by a foreign labeled read
+  // persists in commitment form under `enforce`.
   const userAtom = { type: CFC_ATOM_TYPE.User, subject: "did:key:alice" };
 
   it("templates with cross-space J persist commitment forms under enforce", async () => {
@@ -1252,9 +1250,9 @@ describe("CFC template population (Stage A): cross-space label protection", () =
   });
 });
 
-// Canonicalization and coalescing over multi-`*` paths (design §3.3 "no
-// changes required" — verified, not assumed).
 describe("CFC template population (Stage A): canonical form with `*` paths", () => {
+  // Canonicalization and coalescing over multi-`*` paths (design §3.3 "no
+  // changes required" — verified, not assumed).
   const entry = (
     path: string[],
     atom: string,

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -21,10 +21,10 @@ import {
 
 const IMPORT = `const cf = require("commonfabric");`;
 
-// The verifier reports whether a module has a VALID approved `__cfReg` call. The
-// loader uses this to grant the real registrar only to approved modules (and a
-// throwing one to the rest) — so this signal is load-bearing.
 describe("verifyCompiledModuleBody reports hoist-registration approval", () => {
+  // The verifier reports whether a module has a VALID approved `__cfReg` call.
+  // The loader uses this to grant the real registrar only to approved modules
+  // (and a throwing one to the rest) — so this signal is load-bearing.
   it("is true for a module with an approved __cfReg call", () => {
     const body =
       `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ __cfPattern_1 });`;
@@ -39,10 +39,10 @@ describe("verifyCompiledModuleBody reports hoist-registration approval", () => {
   });
 });
 
-// A module the verifier did NOT approve gets the rejecting registrar, so a
-// `__cfReg` call the static check missed (e.g. smuggled inside an accepted
-// expression) fails closed at runtime instead of registering attacker values.
 describe("createRejectingRegistrar", () => {
+  // A module the verifier did NOT approve gets the rejecting registrar, so a
+  // `__cfReg` call the static check missed (e.g. smuggled inside an accepted
+  // expression) fails closed at runtime instead of registering attacker values.
   it("throws on any registration attempt", () => {
     const { register } = createRejectingRegistrar();
     expect(() => register({ __cfPattern_1: {} })).toThrow(
@@ -56,11 +56,12 @@ describe("createRejectingRegistrar", () => {
   });
 });
 
-// The load-bearing trust gate: only a genuine branded builder artifact may
-// acquire a content-addressed ref. The verifier intentionally does NOT check the
-// registered value's kind, so `indexArtifact`'s `isTrustedBuilderArtifact` is the
-// single boundary that stops forgery — pin it hard.
 describe("isTrustedBuilderArtifact rejects forged values", () => {
+  // The load-bearing trust gate: only a genuine branded builder artifact may
+  // acquire a content-addressed ref. The verifier intentionally does NOT check
+  // the registered value's kind, so `indexArtifact`'s
+  // `isTrustedBuilderArtifact` is the single boundary that stops forgery — pin
+  // it hard.
   it("rejects plain objects, functions, and frozen data", () => {
     expect(isTrustedBuilderArtifact({})).toBe(false);
     expect(isTrustedBuilderArtifact(() => {})).toBe(false);
@@ -103,11 +104,11 @@ describe("isTrustedBuilderArtifact rejects forged values", () => {
   });
 });
 
-// Defense-in-depth on the real registrar (run-once / closed-window /
-// transactional) lives in cfreg-builder-identity.test.ts; here we only assert the
-// rejecting variant, the trust gate, and the approval signal — the pieces the
-// verifier-gating relies on.
 describe("HoistRegistrationSink stays untouched on a rejected registration", () => {
+  // Defense-in-depth on the real registrar (run-once / closed-window /
+  // transactional) lives in cfreg-builder-identity.test.ts; here we only assert
+  // the rejecting variant, the trust gate, and the approval signal — the pieces
+  // the verifier-gating relies on.
   it("an approved registrar still stages+commits normally", () => {
     const sink: HoistRegistrationSink = new Map();
     const { register, commit } = createHoistRegistrar("id", sink);
@@ -117,15 +118,16 @@ describe("HoistRegistrationSink stays untouched on a rejected registration", () 
   });
 });
 
-// CT-1623 follow-up: lock the CONTRACT between the transformer's emitted
-// `__cfReg({ … })` shape and the verifier's static approval check. The transformer
-// and the verifier hold two independent definitions of "a valid registration
-// call"; if they drift, a real registration silently routes to the rejecting
-// registrar (fail-closed, but a confusing breakage). These pin the exact shapes
-// the transformer emits (builder-call-hoisting.ts: a trailing call whose argument
-// is a multiline shorthand object of previously-declared top-level bindings) as
-// APPROVED, and assert the tamper shapes the verifier is meant to refuse are not.
 describe("transformer __cfReg emit round-trips through the verifier", () => {
+  // CT-1623 follow-up: lock the CONTRACT between the transformer's emitted
+  // `__cfReg({ … })` shape and the verifier's static approval check. The
+  // transformer and the verifier hold two independent definitions of "a valid
+  // registration call"; if they drift, a real registration silently routes to
+  // the rejecting registrar (fail-closed, but a confusing breakage). These pin
+  // the exact shapes the transformer emits (builder-call-hoisting.ts: a
+  // trailing call whose argument is a multiline shorthand object of
+  // previously-declared top-level bindings) as APPROVED, and assert the tamper
+  // shapes the verifier is meant to refuse are not.
   it("approves the exact multiline shorthand shape the transformer emits", () => {
     // Mirrors builder-call-hoisting.ts: `factory.createObjectLiteralExpression(
     // …, /* multiline */ true)` over shorthand assignments — one entry per line.
@@ -175,13 +177,13 @@ __cfReg({ __cfLift_1 });`;
   });
 });
 
-// CT-1623 follow-up: pin the outdated-overwrite contract at the public sink
-// layer. `indexArtifact` overwrites the reverse mapping on re-eval so by-identity
-// LOOKUP is always fresh; the same freshness must hold one layer down, where a
-// module that re-evaluates (same identity, fresh artifact instance) re-stages and
-// commits. A second commit under the same identity must REPLACE the prior staged
-// map, not merge a stale instance into it.
 describe("re-registration under the same identity commits the fresh staged set", () => {
+  // CT-1623 follow-up: pin the outdated-overwrite contract at the public sink
+  // layer. `indexArtifact` overwrites the reverse mapping on re-eval so
+  // by-identity LOOKUP is always fresh; the same freshness must hold one layer
+  // down, where a module that re-evaluates (same identity, fresh artifact
+  // instance) re-stages and commits. A second commit under the same identity
+  // must REPLACE the prior staged map, not merge a stale instance into it.
   it("a later commit replaces the sink entry for that identity", () => {
     const sink: HoistRegistrationSink = new Map();
 

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -13,18 +13,18 @@ import { newSharedServer } from "./memory-v2-test-utils.ts";
 const signer = await Identity.fromPassphrase("writeback conflict test");
 const space = signer.did();
 
-// CT-1824 regression: a runtime-version bump sends loads through the
-// cold-load recovery path (recompile + write-back). The write-back re-writes
-// version-independent source docs whose cell-layer-derived documents (link/
-// import-edge cells) already exist from the original compile — documents a
-// cold replica has never read. The commit then carries stale seq-0 reads and
-// fails with a ConflictError; before the fix, editWithRetry re-ran
-// immediately against the same stale replica, so every retry failed
-// identically, the compiled cache never healed, and EVERY subsequent cold
-// boot recompiled. The conflict's `readyToRetry` catch-up gate is the
-// designed remedy; editWithRetry must await it like the scheduler does
-// (scheduler/action-run.ts).
 describe("compile-cache write-back after a runtime-version bump", () => {
+  // CT-1824 regression: a runtime-version bump sends loads through the
+  // cold-load recovery path (recompile + write-back). The write-back re-writes
+  // version-independent source docs whose cell-layer-derived documents (link/
+  // import-edge cells) already exist from the original compile — documents a
+  // cold replica has never read. The commit then carries stale seq-0 reads and
+  // fails with a ConflictError; before the fix, editWithRetry re-ran
+  // immediately against the same stale replica, so every retry failed
+  // identically, the compiled cache never healed, and EVERY subsequent cold
+  // boot recompiled. The conflict's `readyToRetry` catch-up gate is the
+  // designed remedy; editWithRetry must await it like the scheduler does
+  // (scheduler/action-run.ts).
   it("recovery write-back persists despite pre-existing docs on a cold replica", async () => {
     const server = newSharedServer();
     const program = {
@@ -124,20 +124,20 @@ describe("compile-cache write-back after a runtime-version bump", () => {
   });
 });
 
-// CT-1848: the write-target pre-sync carries the one-hop edge selector, so
-// the per-edge element docs (the derived docs the cell layer hoists each
-// `imports[i]` into) are client-known BEFORE the re-write. A schema-less
-// pre-sync normalizes to the rejecting selector and delivers only the root
-// doc; in the browser the re-write then touches the element docs blind and
-// the engine reveals the conflicts one per attempt (the CT-1824 loop,
-// converged only by the retry budget). NOTE: the blind-conflict itself does
-// not reproduce in-process (this fixture's flows warm the element docs some
-// other way — same limitation as the healing test above); the conflict-free
-// attempt-1 property is verified live on the browser rig. What IS pinned
-// here, differentially, is the selector semantics the fix rides on: the
-// edge-schema sync materializes the element docs into a cold replica, the
-// schema-less sync does not.
 describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
+  // CT-1848: the write-target pre-sync carries the one-hop edge selector, so
+  // the per-edge element docs (the derived docs the cell layer hoists each
+  // `imports[i]` into) are client-known BEFORE the re-write. A schema-less
+  // pre-sync normalizes to the rejecting selector and delivers only the root
+  // doc; in the browser the re-write then touches the element docs blind and
+  // the engine reveals the conflicts one per attempt (the CT-1824 loop,
+  // converged only by the retry budget). NOTE: the blind-conflict itself does
+  // not reproduce in-process (this fixture's flows warm the element docs some
+  // other way — same limitation as the healing test above); the conflict-free
+  // attempt-1 property is verified live on the browser rig. What IS pinned
+  // here, differentially, is the selector semantics the fix rides on: the
+  // edge-schema sync materializes the element docs into a cold replica, the
+  // schema-less sync does not.
   it("edge-schema sync delivers element docs to a cold replica; schema-less does not", async () => {
     const server = newSharedServer();
     const program = {
@@ -248,9 +248,9 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
   });
 });
 
-// Direct contract test for the fix: a conflict's `readyToRetry` catch-up gate
-// must be awaited BEFORE the retry re-runs, and the retry then succeeds.
 describe("editWithRetry conflict catch-up", () => {
+  // Direct contract test for the fix: a conflict's `readyToRetry` catch-up gate
+  // must be awaited BEFORE the retry re-runs, and the retry then succeeds.
   it("awaits readyToRetry between attempts and then succeeds", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });
@@ -300,16 +300,16 @@ describe("editWithRetry conflict catch-up", () => {
   });
 });
 
-// The browser cold-boot shape of CT-1824 (live-traced on the rig): the
-// write-back's derived docs are discovered ONE per attempt — the engine
-// rejects on the first stale read, the retry pulls exactly that doc, and only
-// then does the next attempt's diff reach the following one. editWithRetry
-// must (a) pull the doc each conflict names so each round makes progress, and
-// (b) survive a pull or catch-up failure without giving up the round (the
-// retry's commit is the definitive outcome). Convergence takes one round per
-// pre-existing derived doc, which is why writeBackCompileCache passes a
-// budget sized to its write set instead of DEFAULT_MAX_RETRIES.
 describe("editWithRetry sequential conflict discovery", () => {
+  // The browser cold-boot shape of CT-1824 (live-traced on the rig): the
+  // write-back's derived docs are discovered ONE per attempt — the engine
+  // rejects on the first stale read, the retry pulls exactly that doc, and only
+  // then does the next attempt's diff reach the following one. editWithRetry
+  // must (a) pull the doc each conflict names so each round makes progress, and
+  // (b) survive a pull or catch-up failure without giving up the round (the
+  // retry's commit is the definitive outcome). Convergence takes one round per
+  // pre-existing derived doc, which is why writeBackCompileCache passes a
+  // budget sized to its write set instead of DEFAULT_MAX_RETRIES.
   it("pulls each named doc and converges one doc per round", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });

--- a/packages/runner/test/mergeable-op-registry.test.ts
+++ b/packages/runner/test/mergeable-op-registry.test.ts
@@ -40,11 +40,11 @@ describe("mergeable op registry consistency", () => {
   });
 });
 
-// A create-from-absent mergeable op adds a key to its parent container; the
-// build stamps `createsKey` so the conflict matcher invalidates a shape reader
-// of the parent (see docs/specs/memory-v2/08-conflict-granularity.md and the
-// engine-side conflict test in packages/memory).
 describe("mergeable op createsKey stamping", () => {
+  // A create-from-absent mergeable op adds a key to its parent container; the
+  // build stamps `createsKey` so the conflict matcher invalidates a shape
+  // reader of the parent (see docs/specs/memory-v2/08-conflict-granularity.md
+  // and the engine-side conflict test in packages/memory).
   it("stamps createsKey when a tail op materializes an absent array", () => {
     expect(
       buildMergeableIntent(
@@ -91,11 +91,11 @@ describe("mergeable op createsKey stamping", () => {
   });
 });
 
-// The tail op builder (append / add-unique) bails in several guarded cases,
-// abandoning the intent so the commit carries the plain diff instead. Some are
-// reachable only through sequences the poison fallback short-circuits before
-// build, so they are covered directly here.
 describe("mergeable tail-op build guards", () => {
+  // The tail op builder (append / add-unique) bails in several guarded cases,
+  // abandoning the intent so the commit carries the plain diff instead. Some
+  // are reachable only through sequences the poison fallback short-circuits
+  // before build, so they are covered directly here.
   // The op path holds no array at commit — the value is absent, or was
   // overwritten with a non-array — so there is nothing to slice a tail from.
   it("a tail op with no working array abandons the intent", () => {
@@ -212,12 +212,13 @@ describe("mergeable tail-op build guards", () => {
   });
 });
 
-// A remove-by-value suppresses the array path AND its whole subtree, so unlike a
-// tail op it leaves the commit no other carrier for that array. It may therefore
-// be emitted only when it fully explains the local value: the working array must
-// be exactly the base with the removed values taken out. Anything else the
-// transaction changed on that array would otherwise be silently discarded.
 describe("mergeable remove-by-value build guards", () => {
+  // A remove-by-value suppresses the array path AND its whole subtree, so
+  // unlike a tail op it leaves the commit no other carrier for that array. It
+  // may therefore be emitted only when it fully explains the local value: the
+  // working array must be exactly the base with the removed values taken out.
+  // Anything else the transaction changed on that array would otherwise be
+  // silently discarded.
   const removeIntent = (...values: string[]) =>
     ({ op: "remove-by-value", path: ["value"], values }) as const;
 
@@ -299,12 +300,12 @@ describe("mergeable remove-by-value build guards", () => {
   });
 });
 
-// Which paths an op's PAYLOAD already carries. Two intents on one document are
-// mutually exclusive when one contains the other: the contained one has already
-// had its change applied by the containing op, whose payload is read from the
-// working array at commit. `buildMergeableOps` abandons the contained intent;
-// this pins the per-op answers it asks for.
 describe("mergeable op payload containment", () => {
+  // Which paths an op's PAYLOAD already carries. Two intents on one document
+  // are mutually exclusive when one contains the other: the contained one has
+  // already had its change applied by the containing op, whose payload is read
+  // from the working array at commit. `buildMergeableOps` abandons the
+  // contained intent; this pins the per-op answers it asks for.
   // A tail op sends `array.slice(tailStart)` — live values out of the working
   // document — so it carries every path at or past that index, at any depth.
   it("a tail op contains the paths at or past its tail start", () => {

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -202,9 +202,12 @@ Deno.test("findProblems flags a Dockerfile without deno images", () => {
   assertEquals(findProblems(files).length, 1);
 });
 
+//
 // check.sh reads the bounds with shell arithmetic, which aborts on a bound
 // carrying anything beyond MAJOR.MINOR.PATCH. Comparing such a bound loosely
 // would report "aligned" for a range that makes check.sh fail for everyone.
+//
+
 Deno.test("findProblems flags a range bound that is not exact", () => {
   for (const bad of ["2.8.0.1", "2.8", "abc"]) {
     const withMin = findProblems({
@@ -418,16 +421,17 @@ Deno.test("main reports each problem and returns 1 when misaligned", async () =>
   }
 });
 
-// The repository's actual files must be aligned; this is the same check CI
-// runs via `deno task check-deno-pins`.
 Deno.test("the repository's pins are aligned", async () => {
+  // The repository's actual files must be aligned; this is the same check CI
+  // runs via `deno task check-deno-pins`.
   assertEquals(await main(), 0);
 });
 
-// Runs the script the way `deno task check-deno-pins` does, which the calls to
-// main() above do not: they would still pass if the entry point never ran it,
-// or if the task's declared permissions were too narrow to read the files.
 Deno.test("running the script as a command reports the aligned pin", async () => {
+  // Runs the script the way `deno task check-deno-pins` does, which the calls
+  // to main() above do not: they would still pass if the entry point never ran
+  // it, or if the task's declared permissions were too narrow to read the
+  // files.
   const output = await runDenoCommandWithTemporaryLock({
     root: REPO_ROOT,
     args: (lockPath) => [

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -69,8 +69,10 @@ Deno.test("importsPollingWaitFor detects an aliased import", () => {
   );
 });
 
+//
 // A type-only import binds the type of `waitFor` and is erased before the test
 // runs, so it cannot poll. The value forms below it still have to be caught.
+//
 
 Deno.test("importsPollingWaitFor ignores a type-only import statement", () => {
   assertEquals(
@@ -164,8 +166,10 @@ Deno.test("importsPollingWaitFor ignores a commented-out member", () => {
   assertEquals(importsPollingWaitFor(source), false);
 });
 
+//
 // Commenting the import out is the first step of migrating a test off the
 // polling waitFor, so none of these shapes may be flagged.
+//
 
 Deno.test("importsPollingWaitFor ignores an import in a line comment", () => {
   assertEquals(
@@ -210,7 +214,9 @@ Deno.test("importsPollingWaitFor ignores an import inside a template literal", (
   assertEquals(importsPollingWaitFor(source), false);
 });
 
+//
 // The blanking of comments and strings must not swallow the code around them.
+//
 
 Deno.test("importsPollingWaitFor detects an import after a comment holding an apostrophe and a brace", () => {
   const source = [
@@ -228,9 +234,9 @@ Deno.test("importsPollingWaitFor detects an import after a template literal", ()
   assert(importsPollingWaitFor(source));
 });
 
-// A template literal ends at its own closing backtick even when it holds a
-// nested one, so what follows is read as code again.
 Deno.test("importsPollingWaitFor detects an import after a nested template literal", () => {
+  // A template literal ends at its own closing backtick even when it holds a
+  // nested one, so what follows is read as code again.
   const source = [
     "const label = `a ${`b ${c}`} d`;",
     'import { waitFor } from "@commonfabric/integration";',
@@ -238,16 +244,18 @@ Deno.test("importsPollingWaitFor detects an import after a nested template liter
   assert(importsPollingWaitFor(source));
 });
 
-// A string may carry a newline through a trailing backslash, so the scan cannot
-// simply stop looking at the end of the line.
 Deno.test("importsPollingWaitFor ignores an import in a line-continued string", () => {
+  // A string may carry a newline through a trailing backslash, so the scan
+  // cannot simply stop looking at the end of the line.
   const source = 'const sample = "\\\n' +
     "import { waitFor } from '@commonfabric/integration';\\\n" +
     '";';
   assertEquals(importsPollingWaitFor(source), false);
 });
 
+//
 // A relative path reaches the same waitFor without naming the package.
+//
 
 Deno.test("importsPollingWaitFor detects a relative import of the package's utils.ts", () => {
   assert(
@@ -324,9 +332,11 @@ Deno.test("isIntegrationTestFile excludes non-integration and non-ts files", () 
   );
 });
 
+//
 // The following two tests run against the real repository tree. Together they
 // assert that the set of in-scope files importing the polling `waitFor` equals
 // the ALLOWLIST exactly.
+//
 
 Deno.test("no un-allowlisted polling waitFor in integration tests", async () => {
   const { violations } = await scan();

--- a/tasks/write-coverage-lcov.test.ts
+++ b/tasks/write-coverage-lcov.test.ts
@@ -27,8 +27,11 @@ Deno.test("normalizeLcovInstancePaths leaves a plain path and non-SF lines uncha
   assertEquals(normalizeLcovInstancePaths(input), input);
 });
 
+//
 // Two cache-busting imports of one file arrive as two records; collapsing the
 // suffix is what lets a downstream consumer accumulate them as one file.
+//
+
 Deno.test("normalizeLcovInstancePaths maps two instances of one file to the same path", () => {
   const out = normalizeLcovInstancePaths(
     [
@@ -99,9 +102,9 @@ Deno.test("write-coverage-lcov writes an empty report when the profile dir is ab
   }
 });
 
-// An empty profile file is dropped, and with nothing left the script writes an
-// empty report rather than invoking `deno coverage` on it.
 Deno.test("write-coverage-lcov drops empty profiles and reports none remain", async () => {
+  // An empty profile file is dropped, and with nothing left the script writes
+  // an empty report rather than invoking `deno coverage` on it.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   try {
     const profileDir = join(root, "raw");
@@ -177,9 +180,10 @@ async function writeProfileForSource(
   );
 }
 
-// The happy path: a real V8 coverage profile is generated from a standalone
-// test, then converted to an LCOV report with the instance-path suffix stripped.
 Deno.test("write-coverage-lcov converts real profiles to a normalized LCOV report", async () => {
+  // The happy path: a real V8 coverage profile is generated from a standalone
+  // test, then converted to an LCOV report with the instance-path suffix
+  // stripped.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   try {
     const rawDir = await generateSampleProfiles(root);
@@ -219,10 +223,10 @@ async function writeUncompiledTrackedFile(): Promise<string> {
   return filePath;
 }
 
-// The dangerous case, because `deno coverage` exits zero and writes a report
-// that simply lacks the file: the report looks healthy, and every line of the
-// dropped file reads as uncovered downstream.
 Deno.test("write-coverage-lcov fails when a tracked file is left out", async () => {
+  // The dangerous case, because `deno coverage` exits zero and writes a report
+  // that simply lacks the file: the report looks healthy, and every line of the
+  // dropped file reads as uncovered downstream.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   const dropped = await writeUncompiledTrackedFile();
   try {
@@ -255,10 +259,10 @@ Deno.test("write-coverage-lcov fails when a tracked file is left out", async () 
   }
 });
 
-// Same loss, but with nothing left to report, so `deno coverage` calls it an
-// error too. The exit status must still say the conversion broke rather than
-// let the empty report stand as a measurement.
 Deno.test("write-coverage-lcov fails when every file left out is a tracked file", async () => {
+  // Same loss, but with nothing left to report, so `deno coverage` calls it an
+  // error too. The exit status must still say the conversion broke rather than
+  // let the empty report stand as a measurement.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   const dropped = await writeUncompiledTrackedFile();
   try {
@@ -281,11 +285,11 @@ Deno.test("write-coverage-lcov fails when every file left out is a tracked file"
   }
 });
 
-// `deno coverage` leaves test files out of a report by design, so a profile set
-// covering nothing else converts to nothing and it calls that an error. No file
-// was lost and nothing downstream tracks a test file, so the empty report is
-// honest and the conversion succeeds.
 Deno.test("write-coverage-lcov succeeds when the profiles cover only test files", async () => {
+  // `deno coverage` leaves test files out of a report by design, so a profile
+  // set covering nothing else converts to nothing and it calls that an error.
+  // No file was lost and nothing downstream tracks a test file, so the empty
+  // report is honest and the conversion succeeds.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   try {
     await Deno.writeTextFile(
@@ -320,10 +324,10 @@ Deno.test("write-coverage-lcov succeeds when the profiles cover only test files"
   }
 });
 
-// A source that is genuinely gone is a different message from a source that is
-// present with no transpiled form, and it is not a failure: no report could name
-// the file and nothing downstream tracks it.
 Deno.test("write-coverage-lcov warns without failing when a dropped source is gone", async () => {
+  // A source that is genuinely gone is a different message from a source that
+  // is present with no transpiled form, and it is not a failure: no report
+  // could name the file and nothing downstream tracks it.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   try {
     const rawDir = await generateSampleProfiles(root);
@@ -342,12 +346,12 @@ Deno.test("write-coverage-lcov warns without failing when a dropped source is go
   }
 });
 
-// A test that copies a fixture project into a temporary directory and runs Deno
-// there gets its modules compiled under a different Deno configuration than the
-// conversion runs under, so `deno coverage` cannot find their transpiled form.
-// Nothing downstream tracks a file outside the repository, so that is a warning
-// and the conversion succeeds.
 Deno.test("write-coverage-lcov succeeds when the file left out is outside the repository", async () => {
+  // A test that copies a fixture project into a temporary directory and runs
+  // Deno there gets its modules compiled under a different Deno configuration
+  // than the conversion runs under, so `deno coverage` cannot find their
+  // transpiled form. Nothing downstream tracks a file outside the repository,
+  // so that is a warning and the conversion succeeds.
   const root = await Deno.makeTempDir({ prefix: "write-lcov-" });
   try {
     const project = join(root, "project");
@@ -386,10 +390,13 @@ Deno.test("write-coverage-lcov succeeds when the file left out is outside the re
   }
 });
 
+//
 // The conversion answers "does the metric charge for this file?" itself, so its
 // own module graph stays small enough for the permissions the CI step grants.
 // That leaves two answers to the same question, and this is what stops them
 // drifting: every path below goes to both, and they must agree.
+//
+
 Deno.test("isTrackedFile gives the same answer as the coverage metric", () => {
   const paths = [
     "packages/a/mod.ts",
@@ -474,12 +481,15 @@ function dirEntry(name: string, isDirectory: boolean): Deno.DirEntry {
   return { name, isDirectory, isFile: !isDirectory, isSymlink: false };
 }
 
+//
 // A full coverage run can leave far more profile files in one directory than
 // the number of arguments V8 lets a single call take (a ceiling near 130,000).
 // Present the collector a directory that large through an injected reader — no
 // real files — and confirm it gathers every profile. A collector that merged a
 // subdirectory's list into its parent with a spread would overflow here; a
 // walk that appends into one shared array does not, whatever the stack size.
+//
+
 Deno.test("collectCoverageProfileFiles gathers a directory larger than the argument limit", async () => {
   const COUNT = 200_000;
   const root = "/coverage-root";


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A comment sitting above a test is doing one of two jobs, and its shape does not
say which. Ten files carry 69 of them — the heaviest concentrations in the tree
— and this sorts them by what *follows* each comment rather than by how it
reads.

The rationale is propagation rather than tidiness: a wrong pattern in the tree
is a template, and the next reader copies what is already there. Clearing the
densest files removes the model.

## 47 describe exactly one test

Another comment follows the test, so the block introduces that one test and
nothing else. Each moves inside the body, where it needs no delimiters:

    -// SS3 split across reads: `ESC O` with the final byte not yet arrived.
    -
     Deno.test("decode: SS3 truncated (ESC O) is buffered", () => {
    +  // SS3 split across reads: `ESC O` with the final byte not yet arrived.

## 19 head a group, and are section markers

`Tilde sequences` heads five tilde tests; `SS3 sequences` heads five SS3 tests;
`` `add-unique` appends each value only if no existing element equals it ``
heads six add-unique tests; `The following two tests run against the real
repository tree` heads exactly two. These take the `//` delimiters, as bare
markers heading a region did in #6432 and #6434.

## 3 are left alone

In `check-deno-pins.test.ts` the comment describes only the first test while the
siblings after it are unrelated — a note about `compareVersions` followed by
`isExactVersion`, `versionInRange` and `findProblems`. Neither treatment fits
without rewording, so they stand.

## Guards

Every move is structural, never a reading of the prose:

- the block sits directly above a one-line `Deno.test/describe/it(...) => {`;
- exactly one such opener follows before the next comment, which is what
  separates "describes this test" from "heads a group";
- re-wrapping to the body's indentation preserves the word multiset, asserted
  per site before the edit is written.

## Verification

No word is lost or gained across the diff, no non-comment line is touched, and
no line exceeds 80 columns.

`deno fmt --check`, `deno lint`, and `deno task check` pass, as do the three
`tasks` suites, `cli` (`ok | 1733 passed`), and `memory`. The `runner` suite was
still running at push time; its four files here are comment-only.

## Coverage

The ratchet reports two more uncovered lines in `packages/memory`. It is not
this change. Deno's LCOV emits no `DA:` entry for a comment line, so a
comment-only diff shifts line numbers without altering the uncovered count —
checked on a fixture: an uncovered function with a three-line comment inside it
reports five uncovered lines, and the same function with the comment deleted
reports the same five. `packages/runner`, which this change touches in four
files, is `+0`.

ACCEPT_COVERAGE_DEBT: packages/memory +2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


