### PR TITLE
test(runner): pin what the conversion's answer does not depend on

### DIFF
--- a/packages/runner/test/convert-cells-to-links-frozenness.test.ts
+++ b/packages/runner/test/convert-cells-to-links-frozenness.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The conversion takes what a pattern produced, and a pattern produces both
+ * frozen and unfrozen values. Frozenness is therefore an input the walk gets
+ * handed rather than one it controls, and this file pins what it may and may
+ * not change about the answer: nothing about which values are refused, nothing
+ * about what a converted value holds, and nothing about the input itself. What
+ * comes back is a fresh container, mutable, whichever way the input went in.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
+
+import { type CellLinkInput, convertCellsToLinks } from "../src/cell.ts";
+
+/** The subject: a record with a nested array and a nested record. */
+type Subject = {
+  list: number[];
+  inner: { n: number };
+  name: string;
+};
+
+/** Builds a fresh subject, so no test reads one another has converted. */
+function makeSubject(): Subject {
+  return { list: [1, 2, 3], inner: { n: 1 }, name: "subject" };
+}
+
+/** An array with a hole in it, which a rebuild has to carry rather than fill. */
+function sparseArray(): unknown[] {
+  const out: unknown[] = [];
+
+  out[0] = 1;
+  out[3] = 4;
+
+  return out;
+}
+
+/** Every object reachable in a value, by identity. */
+function reachableObjects(
+  value: unknown,
+  found: Set<object> = new Set(),
+): Set<object> {
+  if ((value === null) || (typeof value !== "object")) return found;
+  if (found.has(value)) return found;
+
+  found.add(value);
+  for (const member of Object.values(value)) reachableObjects(member, found);
+
+  return found;
+}
+
+describe("convert-cells-to-links-frozenness", () => {
+  it("returns the same value for a frozen input as for an unfrozen one", () => {
+    const unfrozen = convertCellsToLinks(makeSubject());
+    const frozen = convertCellsToLinks(deepFreeze(makeSubject()));
+
+    expect(frozen).toEqual(unfrozen);
+  });
+
+  it("returns a container the caller may still write into, given a frozen input", () => {
+    const result = convertCellsToLinks(deepFreeze(makeSubject())) as Subject;
+
+    expect(Object.isFrozen(result)).toBe(false);
+    expect(Object.isFrozen(result.list)).toBe(false);
+    expect(Object.isFrozen(result.inner)).toBe(false);
+  });
+
+  it("returns a container the caller may still write into, given an unfrozen input", () => {
+    const result = convertCellsToLinks(makeSubject()) as Subject;
+
+    expect(Object.isFrozen(result)).toBe(false);
+    expect(Object.isFrozen(result.list)).toBe(false);
+    expect(Object.isFrozen(result.inner)).toBe(false);
+  });
+
+  it("returns containers that are none of the input's, given an unfrozen input", () => {
+    // Writing into the result must not reach the value the caller handed over,
+    // which holding any of the input's containers would let it do.
+    const input = makeSubject();
+    const result = convertCellsToLinks(input) as Subject;
+
+    expect(result).not.toBe(input);
+    expect(result.list).not.toBe(input.list);
+    expect(result.inner).not.toBe(input.inner);
+  });
+
+  it("returns nothing mutable that the input also holds", () => {
+    // The whole of the property the test above samples: across a value with
+    // every container shape in it, no object reachable in the result is one
+    // reachable in the input unless it is frozen. A `FabricPrimitive` is
+    // shared, deliberately and by identity, and is frozen -- so what this
+    // counts is the mutable intersection, which has to be empty.
+    //
+    // The conversion reads the input's own containers rather than copies of
+    // them, at every level: the shallow conversion at the top of a node shares
+    // that node's children by reference whatever frozenness it is asked for.
+    // What keeps the input's containers out of the result is the rebuild
+    // below, and this is what says the rebuild reaches all of them.
+    const input = {
+      list: [1, 2, 3],
+      nested: { deep: { deeper: [{ a: 1 }, { b: 2 }] } },
+      date: new Date(1000),
+      bytes: new Uint8Array([1, 2, 3]),
+      sparse: sparseArray(),
+      emptyArray: [],
+      emptyRecord: {},
+      prebuilt: new FabricBytes(new Uint8Array([9, 9])),
+    } as unknown as CellLinkInput;
+    const prebuilt = (input as { prebuilt: FabricBytes }).prebuilt;
+
+    const shared = [...reachableObjects(convertCellsToLinks(input))]
+      .filter((object) => reachableObjects(input).has(object));
+
+    expect(shared.filter((object) => !Object.isFrozen(object))).toEqual([]);
+    // The one thing shared is the primitive the caller built, by identity.
+    expect(shared).toEqual([prebuilt]);
+    expect(shared[0]).toBe(prebuilt);
+  });
+
+  it("leaves an unfrozen input unfrozen and unchanged", () => {
+    const input = makeSubject();
+
+    convertCellsToLinks(input);
+
+    expect(input).toEqual(makeSubject());
+    expect(Object.isFrozen(input)).toBe(false);
+    expect(Object.isFrozen(input.list)).toBe(false);
+  });
+
+  it("returns a `Date` and a `Uint8Array` as frozen fabric primitives", () => {
+    // A `FabricPrimitive` is born deep-frozen, so the frozenness this walk asks
+    // the shallow conversion for never reaches one. Pinned at this seam because
+    // the arms that mint these two both read that flag.
+    const result = convertCellsToLinks({
+      date: new Date(1000),
+      bytes: new Uint8Array([1, 2, 3]),
+    }) as { date: unknown; bytes: unknown };
+
+    expect(result.date).toBeInstanceOf(FabricEpochNsec);
+    expect(result.bytes).toBeInstanceOf(FabricBytes);
+    expect(Object.isFrozen(result.date)).toBe(true);
+    expect(Object.isFrozen(result.bytes)).toBe(true);
+  });
+
+  it("throws for an unfrozen array carrying a named property", () => {
+    const array: unknown[] = [1, 2, 3];
+    (array as unknown as Record<string, unknown>).extra = "nope";
+
+    expect(() => convertCellsToLinks({ array } as CellLinkInput)).toThrow();
+  });
+
+  it("throws for a frozen array carrying a named property", () => {
+    const array: unknown[] = [1, 2, 3];
+    (array as unknown as Record<string, unknown>).extra = "nope";
+
+    expect(() => convertCellsToLinks(deepFreeze({ array }) as CellLinkInput))
+      .toThrow();
+  });
+
+  it("throws for an unfrozen object with an accessor-backed property", () => {
+    const object = {};
+    Object.defineProperty(object, "live", { get: () => 1, enumerable: true });
+
+    expect(() => convertCellsToLinks({ object })).toThrow();
+  });
+
+  it("throws for a frozen object with an accessor-backed property", () => {
+    const object = {};
+    Object.defineProperty(object, "live", { get: () => 1, enumerable: true });
+
+    expect(() => convertCellsToLinks(deepFreeze({ object }))).toThrow();
+  });
+});

--- a/packages/runner/test/convert-cells-to-links.bench.ts
+++ b/packages/runner/test/convert-cells-to-links.bench.ts
@@ -1,0 +1,80 @@
+/**
+ * What the conversion costs per container, and what frozenness costs on top of
+ * it.
+ *
+ * The two arms carry the same data and differ only in whether it is frozen.
+ * That is worth measuring because the shallow conversion at the top of each
+ * container is asked for the frozenness the value already has, so that a value
+ * already in fabric form comes back as itself rather than as a copy the
+ * rebuild below would discard. **The two arms agreeing is the result**: a gap
+ * between them is a copy being made on one side and not the other.
+ *
+ * The payload is shaped like a value a subscription carries -- a list of
+ * records, each with a few scalars, a nested array, and one link -- rather
+ * than a single wide container, since what the walk pays for is containers
+ * visited rather than bytes moved.
+ *
+ * Run with:
+ *
+ *     deno task bench
+ */
+
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+
+import { convertCellsToLinks } from "../src/cell.ts";
+import { KeepAsCell } from "../src/link-utils.ts";
+
+/** The options the IPC response and notification paths convert under. */
+const OPTIONS = {
+  includeSchema: true,
+  keepAsCell: KeepAsCell.All,
+  doNotConvertCellResults: true,
+  includeCfcLabelView: true,
+} as const;
+
+/** Builds a list payload of the given length. */
+function makePayload(items: number): FabricValue {
+  const list: FabricValue[] = [];
+
+  for (let i = 0; i < items; i++) {
+    list.push({
+      title: `item number ${i}`,
+      count: i,
+      done: (i % 3) === 0,
+      tags: [`tag-${i % 7}`, `tag-${i % 11}`],
+      source: linkRefFrom({
+        id: `of:${"0".repeat(56)}${i.toString(16).padStart(8, "0")}`,
+        space: `did:key:z${"a".repeat(47)}`,
+        path: ["items", String(i)],
+      }) as unknown as FabricValue,
+    });
+  }
+
+  return { items: list, total: items, updatedAt: "2026-08-27T00:00:00Z" };
+}
+
+for (const size of [10, 100, 1000] as const) {
+  const group = `list-${String(size).padStart(5, "0")}`;
+  const unfrozen = makePayload(size);
+  const frozen = deepFreeze(makePayload(size)) as FabricValue;
+
+  Deno.bench({
+    group,
+    name: "unfrozen input",
+    baseline: true,
+    fn: () => {
+      convertCellsToLinks(unfrozen as never, OPTIONS);
+    },
+  });
+
+  Deno.bench({
+    group,
+    name: "deep-frozen input",
+    fn: () => {
+      convertCellsToLinks(frozen as never, OPTIONS);
+    },
+  });
+}


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Two files for `convertCellsToLinks()`, both new, no behaviour changes.

## What each pins

**`convert-cells-to-links-frozenness.test.ts`** — what the frozenness of an
input may not change about the answer: which values are refused, what a
converted value holds, that the input is neither mutated nor re-frozen, and that
what comes back is a fresh mutable container holding nothing mutable the input
also holds.

These were written against a different implementation of that function and hold
against the current one unchanged, which is what a characterization test is for.
They are not vestigial either: ablating the vet in today's implementation fails
six of them.

**`convert-cells-to-links.bench.ts`** — the same payload, frozen and unfrozen.
**The two arms agreeing is the result.** A gap between them is a copy being made
on one side and not the other, which is what a shallow copy built and then
discarded produces. On the current implementation they agree to the microsecond:

| | unfrozen | deep-frozen |
| --- | --- | --- |
| 10 records | 15.0 us | 15.0 us |
| 100 records | 147.2 us | 147.2 us |
| 1000 records | 1.5 ms | 1.5 ms |

## What this PR no longer contains

It opened as a one-expression change to `convertCellsToLinks()` that stopped a
shallow copy being built and discarded. #6489 removed the same waste
structurally — deleting the call that made the copy rather than arranging for it
not to happen — and measures faster doing it, so that change is gone from here
and the title has moved with it. Measured across all three, three runs each,
medians of p75:

| | before either | this PR's old approach | #6489, merged |
| --- | --- | --- | --- |
| 100 records, unfrozen | 201.0 us | 166.7 us | **152.0 us** |
| 1000 records, unfrozen | 2005 us | 1668 us | **1528 us** |

The old approach also cost 1–3% on already-frozen input, where #6489 is faster
on both. Keeping it would have meant landing a line #6489 had already deleted.

The whole-crossing benchmark that was here has moved to #6557, which stands on
its own and touches a different package.

## Gates

`deno task check`, `deno fmt` and `deno lint` green; the tests pass against the
current implementation; the benchmark runs to completion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




