### PR TITLE
Move the rest of the one-test comments into their tests

### DIFF
--- a/packages/background-piece-service/test/env.test.ts
+++ b/packages/background-piece-service/test/env.test.ts
@@ -1,10 +1,11 @@
 import { assertEquals } from "@std/assert";
 import { loadEnv } from "../src/env.ts";
 
-// Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true
-// would silently enable telemetry. loadEnv takes an injectable source so the
-// OTEL_ENABLED transform can be tested without touching the real process env.
 Deno.test("loadEnv: OTEL_ENABLED only enables on 'true'/'1'", () => {
+  // Regression guard for the z.coerce.boolean() footgun: Boolean("false") ===
+  // true would silently enable telemetry. loadEnv takes an injectable source so
+  // the OTEL_ENABLED transform can be tested without touching the real process
+  // env.
   const otel = (v: string | undefined) =>
     loadEnv((key) => (key === "OTEL_ENABLED" ? v : undefined)).OTEL_ENABLED;
 

--- a/packages/cli/test/color-mode.test.ts
+++ b/packages/cli/test/color-mode.test.ts
@@ -142,12 +142,12 @@ Deno.test("resolveColorEnabled honors FORCE_COLOR / CLICOLOR_FORCE when piped", 
   }));
 });
 
-// Guards the invariant behind the "@std/fmt/colors" import-map pin in
-// packages/cli/deno.jsonc: our setColorEnabled() must reach the same module
-// instance Cliffy styles version/error output with. If Cliffy's @std/fmt
-// dependency range drifts away from the pin, this test fails and the pin
-// must be updated.
 Deno.test("setColorEnabled controls Cliffy version output", () => {
+  // Guards the invariant behind the "@std/fmt/colors" import-map pin in
+  // packages/cli/deno.jsonc: our setColorEnabled() must reach the same module
+  // instance Cliffy styles version/error output with. If Cliffy's @std/fmt
+  // dependency range drifts away from the pin, this test fails and the pin must
+  // be updated.
   const previous = getColorEnabled();
   try {
     setColorEnabled(false);
@@ -159,10 +159,10 @@ Deno.test("setColorEnabled controls Cliffy version output", () => {
   }
 });
 
-// Cliffy's HelpGenerator force-sets its own `colors` option while rendering,
-// so help output is controlled through Command.help(), not setColorEnabled —
-// mod.ts mirrors the resolved policy into main.help({ colors }).
 Deno.test("help colors follow the Cliffy help option", () => {
+  // Cliffy's HelpGenerator force-sets its own `colors` option while rendering,
+  // so help output is controlled through Command.help(), not setColorEnabled —
+  // mod.ts mirrors the resolved policy into main.help({ colors }).
   try {
     main.reset().help({ colors: false });
     assertFalse(main.getHelp().includes("\x1b["));

--- a/packages/cli/test/view-card-gate.test.ts
+++ b/packages/cli/test/view-card-gate.test.ts
@@ -9,10 +9,10 @@ function infoText(doc: Document, node: StructureNode): string {
     .join("\n");
 }
 
-// Probe: try every way a `"comment"`-kind node could reach the outline's
-// `glyph(child.kind)` call. The outline hoists through node/comment children
-// rather than listing them, so a comment kind should never reach `glyph`.
 Deno.test("card: a comment child is hoisted through, never listed in the outline", () => {
+  // Probe: try every way a `"comment"`-kind node could reach the outline's
+  // `glyph(child.kind)` call. The outline hoists through node/comment children
+  // rather than listing them, so a comment kind should never reach `glyph`.
   const comment: StructureNode = {
     kind: "comment",
     label: "# a standalone comment",
@@ -99,10 +99,10 @@ Deno.test("card: a comment child is hoisted through, never listed in the outline
   assert(!text.includes("# nested comment"), "nested comment not listed");
 });
 
-// Drive a parsed document with real comments to confirm the same behavior on
-// the production parse path: comments thread in as their own nodes but the
-// outline never lists them with a glyph.
 Deno.test("card: real source comments stay out of the outline glyph list", () => {
+  // Drive a parsed document with real comments to confirm the same behavior on
+  // the production parse path: comments thread in as their own nodes but the
+  // outline never lists them with a glyph.
   const src = `// transformed: /app.ts
 // a leading comment
 function alpha() {

--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -304,11 +304,11 @@ Deno.test("incremental highlighter updates a line that adds a closure", () => {
   assert(/=>/.test(joined), "updated text should contain the arrow");
 });
 
-// safe() wraps the best-effort metadata extractors. The public API never feeds
-// them a node that throws, so the catch is exercised directly through the
-// test-only handle: a throwing extractor degrades to undefined, a succeeding
-// one returns its value.
 Deno.test("safe(): a throwing extractor degrades to undefined", () => {
+  // safe() wraps the best-effort metadata extractors. The public API never
+  // feeds them a node that throws, so the catch is exercised directly through
+  // the test-only handle: a throwing extractor degrades to undefined, a
+  // succeeding one returns its value.
   assertEquals(
     _internal.safe(() => {
       throw new Error("boom");

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -217,11 +217,11 @@ Deno.test("diff semantics: no in-workspace root file means no service (not a fai
   assertEquals(sem, undefined);
 });
 
-// lazyProgram is the shared build/cache/latch both factories use. The
-// configured host never makes it fail, so its failure isolation is exercised
-// directly: a build is cached after the first success, and a throwing or
-// program-less build latches so it is not retried.
 Deno.test("lazyProgram: caches a success and latches a failed build", () => {
+  // lazyProgram is the shared build/cache/latch both factories use. The
+  // configured host never makes it fail, so its failure isolation is exercised
+  // directly: a build is cached after the first success, and a throwing or
+  // program-less build latches so it is not retried.
   const fake = {} as unknown as ts.Program;
 
   let okCalls = 0;

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -55,12 +55,11 @@ function selectByLabel(s: Session, label: string): void {
 // 663 — Enter on an in-blob reference that resolves to no node.
 //
 
-// A "use" reference carries a destination line but no definition offset. When
-// that line falls outside every structure node's range, both findTargetIndex
-// (no offset) and nodeAtLine (no containing node) fail, so resolveTargetNode
-// returns null and Enter reports there is nothing to open.
-
 Deno.test("session: Enter on a reference whose line is in no node reports nothing to open", () => {
+  // A "use" reference carries a destination line but no definition offset. When
+  // that line falls outside every structure node's range, both findTargetIndex
+  // (no offset) and nodeAtLine (no containing node) fail, so resolveTargetNode
+  // returns null and Enter reports there is nothing to open.
   // Real card with real targets, but the structure tree is trimmed to just the
   // subject node — placed so the use site sits below its range, outside every
   // node — so following the use reference resolves to no node.
@@ -108,11 +107,12 @@ const useB = base;`;
 // Behavioral anchor near revealMatch (580).
 //
 
-// revealMatch reads matches[currentMatch] and guards `!m`. Every public caller
-// (runSearch, refreshSearchMatches, stepMatch) checks for an empty match set
-// before reaching it, so the no-match return is unreachable from the public
-// API; this test asserts the surrounding reveal behavior stays correct.
 Deno.test("session: a committed search reveals its single match", () => {
+  // revealMatch reads matches[currentMatch] and guards `!m`. Every public
+  // caller (runSearch, refreshSearchMatches, stepMatch) checks for an empty
+  // match set before reaching it, so the no-match return is unreachable from
+  // the public API; this test asserts the surrounding reveal behavior stays
+  // correct.
   const doc = parseDocument("// transformed: /m.ts\nconst tokenz = 1;");
   const s = new Session(
     doc,

--- a/packages/deno-web-test/test/config.test.ts
+++ b/packages/deno-web-test/test/config.test.ts
@@ -22,11 +22,11 @@ Deno.test("config is applied", async function () {
   );
 });
 
-// The settings a config carries decide how the whole suite runs: which browser
-// flags it gets, how long a test may take, what is served next to it. A run
-// that cannot read them and continues on the defaults instead fails somewhere
-// else entirely, for a reason that says nothing about the config.
 Deno.test("a config that throws on import fails the run", async function () {
+  // The settings a config carries decide how the whole suite runs: which
+  // browser flags it gets, how long a test may take, what is served next to it.
+  // A run that cannot read them and continues on the defaults instead fails
+  // somewhere else entirely, for a reason that says nothing about the config.
   const run = await runDenoWebTest("broken-config-project");
 
   run.assert(!run.success, "the run fails");

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -3,12 +3,12 @@ import { assert, assertEquals, assertThrows } from "@std/assert";
 import { applyDefaults, DEFAULT_TEST_TIMEOUT_MS } from "../config.ts";
 import { runDenoWebTest } from "./utils.ts";
 
-// A test that waits on something which never arrives used to take the whole run
-// down: astral's own deadline on `page.evaluate` eventually threw a `RetryError`
-// that named no test, printed no summary, and skipped every test file after it.
-// The harness now stops waiting on a test of its own accord, so a stuck test is
-// one named failure among otherwise normal results.
 Deno.test("a stuck test fails by name and the run continues", async function () {
+  // A test that waits on something which never arrives used to take the whole
+  // run down: astral's own deadline on `page.evaluate` eventually threw a
+  // `RetryError` that named no test, printed no summary, and skipped every test
+  // file after it. The harness now stops waiting on a test of its own accord,
+  // so a stuck test is one named failure among otherwise normal results.
   const run = await runDenoWebTest("timeout-project");
 
   run.assert(!run.success, "the run fails");

--- a/packages/fuse/platform.test.ts
+++ b/packages/fuse/platform.test.ts
@@ -1,16 +1,17 @@
 import { assertEquals } from "@std/assert";
 import { COMMON_SYMBOLS } from "./platform.ts";
 
-// The FUSE daemon runs fuse_session_loop on an FFI thread and answers every
-// request on the isolate thread. A reverse invalidation (notify_inval_entry /
-// notify_inval_inode) enters the Linux kernel and takes the parent directory's
-// inode lock for write; a concurrent lookup under that directory holds the same
-// lock for read until the daemon answers it. If a notify ran synchronously on
-// the isolate thread it would block there, inside the kernel, behind a lookup
-// only that thread can answer — a deadlock that wedges the mount before it
-// serves anything. The notify symbols must therefore be nonblocking so they run
-// off the isolate thread and leave the request path free.
 Deno.test("reverse-invalidation symbols are nonblocking", () => {
+  // The FUSE daemon runs fuse_session_loop on an FFI thread and answers every
+  // request on the isolate thread. A reverse invalidation (notify_inval_entry /
+  // notify_inval_inode) enters the Linux kernel and takes the parent
+  // directory's inode lock for write; a concurrent lookup under that directory
+  // holds the same lock for read until the daemon answers it. If a notify ran
+  // synchronously on the isolate thread it would block there, inside the
+  // kernel, behind a lookup only that thread can answer — a deadlock that
+  // wedges the mount before it serves anything. The notify symbols must
+  // therefore be nonblocking so they run off the isolate thread and leave the
+  // request path free.
   assertEquals(
     COMMON_SYMBOLS.fuse_lowlevel_notify_inval_entry.nonblocking,
     true,
@@ -23,16 +24,17 @@ Deno.test("reverse-invalidation symbols are nonblocking", () => {
   );
 });
 
-// The session loop owns one FFI thread for the mount's lifetime.
 Deno.test("session loop is nonblocking", () => {
+  // The session loop owns one FFI thread for the mount's lifetime.
   assertEquals(COMMON_SYMBOLS.fuse_session_loop.nonblocking, true);
 });
 
-// Reply functions are called synchronously from inside the op callbacks, which
-// run on the isolate thread. They hand an answer back to an outstanding request
-// rather than waiting on a lock, so they stay blocking; making them nonblocking
-// would return an unawaited promise and break the reply-once contract.
 Deno.test("reply functions stay synchronous", () => {
+  // Reply functions are called synchronously from inside the op callbacks,
+  // which run on the isolate thread. They hand an answer back to an outstanding
+  // request rather than waiting on a lock, so they stay blocking; making them
+  // nonblocking would return an unawaited promise and break the reply-once
+  // contract.
   const replySymbols = [
     "fuse_reply_err",
     "fuse_reply_entry",

--- a/packages/identity/test/did-codec.test.ts
+++ b/packages/identity/test/did-codec.test.ts
@@ -17,11 +17,11 @@ function makeTaggedDid(code: number, keyBytes: Uint8Array): DIDKey {
   return `did:key:${base58btc.encode(bytes)}`;
 }
 
-// The unsupported-multicodec branch is covered in ed25519.test.ts and
-// memory/test/util.test.ts. This covers the adjacent length-check branch,
-// which those tests skip because their non-ed25519 DID throws first: a
-// correct ed25519 tag with one byte too few reaches the length check.
 Deno.test("didToBytes rejects an ed25519 key of the wrong length", () => {
+  // The unsupported-multicodec branch is covered in ed25519.test.ts and
+  // memory/test/util.test.ts. This covers the adjacent length-check branch,
+  // which those tests skip because their non-ed25519 DID throws first: a
+  // correct ed25519 tag with one byte too few reaches the length check.
   const did = makeTaggedDid(
     ED25519_CODE,
     new Uint8Array(ED25519_PUB_KEY_RAW_SIZE - 1),

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -821,11 +821,11 @@ export const tag = "util";
   });
 });
 
-// CT-1819: the boot path defers composition, capturing per-module LINE COUNTS
-// instead of bodies — pin that the count-shaped inputs are byte-equivalent to
-// the body-shaped ones, and that the parser's lazy slot has one-shot,
-// lookup-driven semantics.
 describe("deferred composition inputs and lazy registration (CT-1819)", () => {
+  // CT-1819: the boot path defers composition, capturing per-module LINE COUNTS
+  // instead of bodies — pin that the count-shaped inputs are byte-equivalent to
+  // the body-shaped ones, and that the parser's lazy slot has one-shot,
+  // lookup-driven semantics.
   const raw = (mappings: string, sources: string[] = ["a.ts"]): SourceMap =>
     ({
       version: 3,

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -826,6 +826,7 @@ describe("deferred composition inputs and lazy registration (CT-1819)", () => {
   // instead of bodies — pin that the count-shaped inputs are byte-equivalent to
   // the body-shaped ones, and that the parser's lazy slot has one-shot,
   // lookup-driven semantics.
+
   const raw = (mappings: string, sources: string[] = ["a.ts"]): SourceMap =>
     ({
       version: 3,

--- a/packages/js-compiler/test/typescript.errors.test.ts
+++ b/packages/js-compiler/test/typescript.errors.test.ts
@@ -129,11 +129,11 @@ function programFor(files: Record<string, string>): ts.Program {
   }, host);
 }
 
-// The compile pipeline steps through checkableSources()/collect* one file at a
-// time (compileToModulesSteps); typeCheck()/declarationCheck() remain the
-// whole-program one-call contract with no other production caller, so they are
-// pinned directly here.
 describe("Checker", () => {
+  // The compile pipeline steps through checkableSources()/collect* one file at
+  // a time (compileToModulesSteps); typeCheck()/declarationCheck() remain the
+  // whole-program one-call contract with no other production caller, so they
+  // are pinned directly here.
   it("checkableSources excludes the virtual type libs", () => {
     const checker = new Checker(
       programFor({ "/ok.ts": "export const x: number = 1;" }),

--- a/packages/js-compiler/test/typescript.errors.test.ts
+++ b/packages/js-compiler/test/typescript.errors.test.ts
@@ -134,6 +134,7 @@ describe("Checker", () => {
   // a time (compileToModulesSteps); typeCheck()/declarationCheck() remain the
   // whole-program one-call contract with no other production caller, so they
   // are pinned directly here.
+
   it("checkableSources excludes the virtual type libs", () => {
     const checker = new Checker(
       programFor({ "/ok.ts": "export const x: number = 1;" }),

--- a/packages/memory/test/v2-demand-changed-principal.test.ts
+++ b/packages/memory/test/v2-demand-changed-principal.test.ts
@@ -8,14 +8,14 @@ import {
   testSessionOpenServerOptions,
 } from "./v2-auth-test-helpers.ts";
 
-// W1 (d′) review MINOR-4: the push-growth / watch `demandChanged` notify
-// carries the CHANGED SESSION's principal, so the ExecutorHost can drop
-// the serving runtime's own loopback (service-principal) session — its
-// tracked-set growth is the serving graph's own reads, not client demand,
-// and must neither wake the loop nor count in `pushGrowthWakes`. Mutation
-// (drop `session.principal` from the notify calls) → principal undefined →
-// the host can no longer distinguish the service session → RED here.
 Deno.test("memory v2 demandChanged carries the session principal (watch + push-growth) so the host can drop the service session", async () => {
+  // W1 (d′) review MINOR-4: the push-growth / watch `demandChanged` notify
+  // carries the CHANGED SESSION's principal, so the ExecutorHost can drop the
+  // serving runtime's own loopback (service-principal) session — its
+  // tracked-set growth is the serving graph's own reads, not client demand, and
+  // must neither wake the loop nor count in `pushGrowthWakes`. Mutation (drop
+  // `session.principal` from the notify calls) → principal undefined → the host
+  // can no longer distinguish the service session → RED here.
   const server = new Server({
     ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-demand-principal"),

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -589,15 +589,14 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
 // treat a changed `entityScopeKey` on an existing watch id as a changed
 // spec, never silently the same watch.
 
-// OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease
-// holder may name two instances of one (branch, id, scope) — its frames and
-// query results carry the instance key (`scopeKey`) per entry, so the two
-// stay apart on its wire and in its replica (the serving replica holding
-// BOTH the service instance and a demander's instance of one doc). The
-// wire collapse guard stays for everyone else: a NON-holder's wire carries
-// scope names only, so its ambiguous read set is still refused loudly.
-
 Deno.test("stage A: a lease holder names two instances of one (branch, id, scope) and receives BOTH, keyed — watch.set, watch.add, graph.query, and the push frame; the collapse guard still refuses a non-holder (OW17's wire leg)", async () => {
+  // OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease
+  // holder may name two instances of one (branch, id, scope) — its frames and
+  // query results carry the instance key (`scopeKey`) per entry, so the two
+  // stay apart on its wire and in its replica (the serving replica holding BOTH
+  // the service instance and a demander's instance of one doc). The wire
+  // collapse guard stays for everyone else: a NON-holder's wire carries scope
+  // names only, so its ambiguous read set is still refused loudly.
   const server = newServer("memory://explicit-read-two-instances");
   setServerExecutionConfig(true);
   try {

--- a/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
@@ -11,10 +11,10 @@ import {
   ensureColumnOriginAvailable,
 } from "../v2/sqlite/column-origin.ts";
 
-// Runs first, while nothing has bound the FFI and no reason has been recorded:
-// columnOrigins must refuse rather than read through a null library handle, and
-// the message names the call the caller skipped.
 Deno.test("columnOrigins throws before the FFI is bound", () => {
+  // Runs first, while nothing has bound the FFI and no reason has been
+  // recorded: columnOrigins must refuse rather than read through a null library
+  // handle, and the message names the call the caller skipped.
   assertThrows(
     () => columnOrigins(null, 1),
     Error,

--- a/packages/memory/test/v2-sqlite-guard.test.ts
+++ b/packages/memory/test/v2-sqlite-guard.test.ts
@@ -143,6 +143,7 @@ describe("assertWriteSafe", () => {
 
 describe("guard hardening (review findings)", () => {
   // Regression tests for guard bypasses found in code review.
+
   it("rejects quoted/bracketed core-table identifiers (read + write)", () => {
     expect(() => assertReadOnly('SELECT * FROM "commit"')).toThrow(GuardError);
     expect(() => assertReadOnly("SELECT * FROM [commit]")).toThrow(GuardError);

--- a/packages/memory/test/v2-sqlite-guard.test.ts
+++ b/packages/memory/test/v2-sqlite-guard.test.ts
@@ -141,8 +141,8 @@ describe("assertWriteSafe", () => {
   });
 });
 
-// Regression tests for guard bypasses found in code review.
 describe("guard hardening (review findings)", () => {
+  // Regression tests for guard bypasses found in code review.
   it("rejects quoted/bracketed core-table identifiers (read + write)", () => {
     expect(() => assertReadOnly('SELECT * FROM "commit"')).toThrow(GuardError);
     expect(() => assertReadOnly("SELECT * FROM [commit]")).toThrow(GuardError);

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -753,8 +753,8 @@ Deno.test("an unsupported spec version fails closed", () => {
   );
 });
 
-// endorsedBy variant mints the endorsed claim kind.
 Deno.test("endorsedBy mints claimed-endorsed-by", () => {
+  // endorsedBy variant mints the endorsed claim kind.
   const schema = table(
     { reviewer: "text" },
     (f) => ({
@@ -772,9 +772,9 @@ Deno.test("endorsedBy mints claimed-endorsed-by", () => {
   ]);
 });
 
-// Zero matches in an integrity position mints nothing (the claim simply is not
-// made) — distinct from >1 which is an error.
 Deno.test("zero matches in an integrity position mints no claim", () => {
+  // Zero matches in an integrity position mints nothing (the claim simply is
+  // not made) — distinct from >1 which is an error.
   const schema = table(
     { reviewer: "text" },
     (f) => ({

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -15,6 +15,7 @@ type MockDoc = {
 describe("Piece reference detection", () => {
   // Create a mock environment for testing reference detection
   // Test the core logic of direct reference finding without maybeGetCellLink
+
   it("should find all direct references in an argument structure", () => {
     // Create mock data with multiple references
     const mockData = {

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -12,8 +12,8 @@ type MockDoc = {
   getEntityId: () => unknown;
 };
 
-// Create a mock environment for testing reference detection
 describe("Piece reference detection", () => {
+  // Create a mock environment for testing reference detection
   // Test the core logic of direct reference finding without maybeGetCellLink
   it("should find all direct references in an argument structure", () => {
     // Create mock data with multiple references

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -215,9 +215,9 @@ async function runTest() {
   console.log(`Counter reached ${finalValue} (expected ${expectedValue})`);
 }
 
-// The test runs without a per-test deadline. See
-// docs/development/waiting-in-tests.md.
 Deno.test({
+  // The test runs without a per-test deadline. See
+  // docs/development/waiting-in-tests.md.
   name: "derive array leak test",
   fn: runTest,
   sanitizeResources: false,

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -2162,13 +2162,14 @@ describe("keyed collections via elementById", () => {
   });
 });
 
-// Single-session checks of the mergeable methods' guards and minority branches:
-// the transaction/shape preconditions, the absent-array initialization, the
-// cell-reference (keyed-entity) matching path used by addUnique/removeByValue,
-// the no-op early returns, the element-schema `$defs` carry-through, and the
-// in-transaction accumulation of repeated ops on one path. These do not need
-// concurrency, only the op machinery, so they run against a single runtime.
 describe("mergeable op guards and single-session branches", () => {
+  // Single-session checks of the mergeable methods' guards and minority
+  // branches: the transaction/shape preconditions, the absent-array
+  // initialization, the cell-reference (keyed-entity) matching path used by
+  // addUnique/removeByValue, the no-op early returns, the element-schema
+  // `$defs` carry-through, and the in-transaction accumulation of repeated ops
+  // on one path. These do not need concurrency, only the op machinery, so they
+  // run against a single runtime.
   let server: MemoryV2Server.Server;
   let storage1: EmulatedStorageManager;
   let rt: Runtime;

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -2170,6 +2170,7 @@ describe("mergeable op guards and single-session branches", () => {
   // `$defs` carry-through, and the in-transaction accumulation of repeated ops
   // on one path. These do not need concurrency, only the op machinery, so they
   // run against a single runtime.
+
   let server: MemoryV2Server.Server;
   let storage1: EmulatedStorageManager;
   let rt: Runtime;

--- a/packages/runner/test/blind-write-structural-precondition.test.ts
+++ b/packages/runner/test/blind-write-structural-precondition.test.ts
@@ -21,13 +21,14 @@ const schema = {
   },
 } as const;
 
-// Runner-level coverage for the blind UI-input write path (the runtime-client's
-// handleCellSet / the multi-runtime worker mirror it, but runner's own suite
-// otherwise never marks a tx blind). Drives a blind nested write: mark the tx
-// blind, thread the cell's PARENT as the structural precondition
-// (setBlindStructuralTarget), write, and commit — so buildReads drops the
-// value-equality read and emits the nonRecursive structural read at the parent.
 Deno.test("a blind UI-input write threads a structural precondition at the cell's parent", async () => {
+  // Runner-level coverage for the blind UI-input write path (the
+  // runtime-client's handleCellSet / the multi-runtime worker mirror it, but
+  // runner's own suite otherwise never marks a tx blind). Drives a blind nested
+  // write: mark the tx blind, thread the cell's PARENT as the structural
+  // precondition (setBlindStructuralTarget), write, and commit — so buildReads
+  // drops the value-equality read and emits the nonRecursive structural read at
+  // the parent.
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),

--- a/packages/runner/test/cfc-commitment-matching.test.ts
+++ b/packages/runner/test/cfc-commitment-matching.test.ts
@@ -34,6 +34,7 @@ describe("CFC commitment-form matching (inv-12 Stage 1)", () => {
   // pattern value digest-matches a committed field; a VARIABLE over a committed
   // field does not bind (the rule does not fire — the fail-closed direction: an
   // unevaluable release does not happen).
+
   const reader = "did:key:reader";
   const stranger = "did:key:stranger";
   const committedUser = {

--- a/packages/runner/test/cfc-commitment-matching.test.ts
+++ b/packages/runner/test/cfc-commitment-matching.test.ts
@@ -27,13 +27,13 @@ import {
 } from "../src/cfc/schema-sanitization.ts";
 import { STANDARD_PROMPT_CAVEAT_POLICY } from "../src/cfc/standard-profile.ts";
 
-// Inv-12 Stage 1 same-form matching (SC-25; design §2; spec §4.6.4.1):
-// enforcement keeps working on commitment forms, fail-closed where it
-// cannot. Read gating digests the candidate and compares; a CONCRETE
-// exchange-rule pattern value digest-matches a committed field; a VARIABLE
-// over a committed field does not bind (the rule does not fire — the
-// fail-closed direction: an unevaluable release does not happen).
 describe("CFC commitment-form matching (inv-12 Stage 1)", () => {
+  // Inv-12 Stage 1 same-form matching (SC-25; design §2; spec §4.6.4.1):
+  // enforcement keeps working on commitment forms, fail-closed where it cannot.
+  // Read gating digests the candidate and compares; a CONCRETE exchange-rule
+  // pattern value digest-matches a committed field; a VARIABLE over a committed
+  // field does not bind (the rule does not fire — the fail-closed direction: an
+  // unevaluable release does not happen).
   const reader = "did:key:reader";
   const stranger = "did:key:stranger";
   const committedUser = {

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -21,14 +21,14 @@ type StoredEntry = {
   observes?: string;
 };
 
-// Epic C stage C5 (docs/specs/cfc-observation-classes.md §8): an authored
-// `ifc.observes` classes the declared entry, and the sqlite null-origin
-// merge uses it to declare its conservative whole-schema union as
-// `observes:"value"` — content-channel only. Shape/enumerate consumers of a
-// query's result rows (length, membership — the count consumer) no longer
-// inherit the union; class-unaware readers still treat the entry as
-// covering (the exact pre-C5 behavior — over-taint, fail-safe).
 describe("CFC declared observation classes (C5)", () => {
+  // Epic C stage C5 (docs/specs/cfc-observation-classes.md §8): an authored
+  // `ifc.observes` classes the declared entry, and the sqlite null-origin merge
+  // uses it to declare its conservative whole-schema union as
+  // `observes:"value"` — content-channel only. Shape/enumerate consumers of a
+  // query's result rows (length, membership — the count consumer) no longer
+  // inherit the union; class-unaware readers still treat the entry as covering
+  // (the exact pre-C5 behavior — over-taint, fail-safe).
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-declared-observes.test.ts
+++ b/packages/runner/test/cfc-declared-observes.test.ts
@@ -29,6 +29,7 @@ describe("CFC declared observation classes (C5)", () => {
   // query's result rows (length, membership — the count consumer) no longer
   // inherit the union; class-unaware readers still treat the entry as covering
   // (the exact pre-C5 behavior — over-taint, fail-safe).
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-envelope-schema-staging.test.ts
+++ b/packages/runner/test/cfc-envelope-schema-staging.test.ts
@@ -14,13 +14,13 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 const signer = await Identity.fromPassphrase("runner-cfc-envelope-staging");
 const space = signer.did();
 
-// The CFC envelope store rides the transaction's shared schema-document
-// staging (`stageSchemaDocClosure`) rather than a bespoke write: the
-// envelope document registers in the realm registry, dedupes per
-// transaction, and elides once the space's server has confirmed it —
-// while `loadSchemaDocument`'s read side keeps verifying what the SPACE
-// holds, so a registry hit can never mask a missing document.
 describe("CFC envelope schema documents ride the shared staging path", () => {
+  // The CFC envelope store rides the transaction's shared schema-document
+  // staging (`stageSchemaDocClosure`) rather than a bespoke write: the envelope
+  // document registers in the realm registry, dedupes per transaction, and
+  // elides once the space's server has confirmed it — while
+  // `loadSchemaDocument`'s read side keeps verifying what the SPACE holds, so a
+  // registry hit can never mask a missing document.
   const setup = async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-envelope-schema-staging.test.ts
+++ b/packages/runner/test/cfc-envelope-schema-staging.test.ts
@@ -21,6 +21,7 @@ describe("CFC envelope schema documents ride the shared staging path", () => {
   // elides once the space's server has confirmed it — while
   // `loadSchemaDocument`'s read side keeps verifying what the SPACE holds, so a
   // registry hit can never mask a missing document.
+
   const setup = async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-envelope-version-guard.test.ts
+++ b/packages/runner/test/cfc-envelope-version-guard.test.ts
@@ -27,6 +27,7 @@ describe("CFC envelope version guard", () => {
   // fails closed instead: the metadata reader throws, the applies-to-path probe
   // reports that policy applies, and the commit path classifies the envelope as
   // unreadable and rejects the write.
+
   const seedWithVersion = async (
     runtime: Runtime,
     name: string,

--- a/packages/runner/test/cfc-envelope-version-guard.test.ts
+++ b/packages/runner/test/cfc-envelope-version-guard.test.ts
@@ -21,12 +21,12 @@ import { cfcLabelViewForDereference } from "../src/cfc/label-view-state.ts";
 const signer = await Identity.fromPassphrase("runner-cfc-envelope-version");
 const space = signer.did();
 
-// A stored envelope whose version this build postdates cannot be treated
-// as absent — that would read a labeled document as unlabeled. Every
-// reader fails closed instead: the metadata reader throws, the
-// applies-to-path probe reports that policy applies, and the commit path
-// classifies the envelope as unreadable and rejects the write.
 describe("CFC envelope version guard", () => {
+  // A stored envelope whose version this build postdates cannot be treated as
+  // absent — that would read a labeled document as unlabeled. Every reader
+  // fails closed instead: the metadata reader throws, the applies-to-path probe
+  // reports that policy applies, and the commit path classifies the envelope as
+  // unreadable and rejects the write.
   const seedWithVersion = async (
     runtime: Runtime,
     name: string,

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -26,6 +26,7 @@ describe("CFC external-ingest provenance mint (split-mint)", () => {
   // the tx, that survives the runtime-minted gate while a copy smuggled into
   // the payload is stripped. The toolshed/operator runtime runs CFC *disabled*,
   // so the headline case proves the mark is still minted there.
+
   const makeRuntime = (
     overrides: {
       cfcEnforcementMode?: string;

--- a/packages/runner/test/cfc-external-ingest.test.ts
+++ b/packages/runner/test/cfc-external-ingest.test.ts
@@ -20,12 +20,12 @@ type StoredEntry = {
   origin?: string;
 };
 
-// The Vouched Ingest Channel split-mint: a builtin-authored ExternalIngest
-// provenance mark, derived only from the verified channel metadata stamped on
-// the tx, that survives the runtime-minted gate while a copy smuggled into the
-// payload is stripped. The toolshed/operator runtime runs CFC *disabled*, so
-// the headline case proves the mark is still minted there.
 describe("CFC external-ingest provenance mint (split-mint)", () => {
+  // The Vouched Ingest Channel split-mint: a builtin-authored ExternalIngest
+  // provenance mark, derived only from the verified channel metadata stamped on
+  // the tx, that survives the runtime-minted gate while a copy smuggled into
+  // the payload is stripped. The toolshed/operator runtime runs CFC *disabled*,
+  // so the headline case proves the mark is still minted there.
   const makeRuntime = (
     overrides: {
       cfcEnforcementMode?: string;

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -35,6 +35,7 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
   // class-aware hereditary meet (§8.9.3/§3.1.6.2: an output is certified only
   // when every observed input was) plus runtime-minted TransformedBy derivation
   // provenance.
+
   const makeRuntime = () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -30,11 +30,11 @@ const certified = (policy: string) => ({
   policy,
 });
 
-// S16 phase C: integrity propagation through the default transition —
-// class-aware hereditary meet (§8.9.3/§3.1.6.2: an output is certified only
-// when every observed input was) plus runtime-minted TransformedBy
-// derivation provenance.
 describe("CFC flow labels: integrity propagation (phase C)", () => {
+  // S16 phase C: integrity propagation through the default transition —
+  // class-aware hereditary meet (§8.9.3/§3.1.6.2: an output is certified only
+  // when every observed input was) plus runtime-minted TransformedBy derivation
+  // provenance.
   const makeRuntime = () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-flow-labels.test.ts
+++ b/packages/runner/test/cfc-flow-labels.test.ts
@@ -36,6 +36,7 @@ describe("CFC flow labels (default transition)", () => {
   // read. Without this, "read labeled data, write a derived plain value to an
   // unlabeled cell" launders the label away (audit S16) — the acceptance
   // scenario for the cfcFlowLabels dial.
+
   it("persists derived flow labels on laundered value copies and gates downstream egress", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-flow-labels.test.ts
+++ b/packages/runner/test/cfc-flow-labels.test.ts
@@ -31,11 +31,11 @@ const replicaEntries = (
   return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
 };
 
-// S16 default transition: a transaction's outputs are tainted by what it
-// read. Without this, "read labeled data, write a derived plain value to an
-// unlabeled cell" launders the label away (audit S16) — the acceptance
-// scenario for the cfcFlowLabels dial.
 describe("CFC flow labels (default transition)", () => {
+  // S16 default transition: a transaction's outputs are tainted by what it
+  // read. Without this, "read labeled data, write a derived plain value to an
+  // unlabeled cell" launders the label away (audit S16) — the acceptance
+  // scenario for the cfcFlowLabels dial.
   it("persists derived flow labels on laundered value copies and gates downstream egress", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-label-field-classification.test.ts
+++ b/packages/runner/test/cfc-label-field-classification.test.ts
@@ -11,6 +11,7 @@ describe("CFC label-field classification (inv-12 / SC-25)", () => {
   // The design §2 initial-assignment table
   // (docs/specs/cfc-label-metadata-confidentiality.md, SC-25) as data. Stage 0:
   // table + lookup only; the Stage 1 persist transform consumes it.
+
   it("classifies each design-table row", () => {
     expect(
       classifyLabelField({ type: CFC_ATOM_TYPE.Caveat }, ["source"]),

--- a/packages/runner/test/cfc-label-field-classification.test.ts
+++ b/packages/runner/test/cfc-label-field-classification.test.ts
@@ -7,10 +7,10 @@ import {
   LABEL_FIELD_CLASSIFICATION,
 } from "../src/cfc/label-field-classification.ts";
 
-// The design §2 initial-assignment table
-// (docs/specs/cfc-label-metadata-confidentiality.md, SC-25) as data.
-// Stage 0: table + lookup only; the Stage 1 persist transform consumes it.
 describe("CFC label-field classification (inv-12 / SC-25)", () => {
+  // The design §2 initial-assignment table
+  // (docs/specs/cfc-label-metadata-confidentiality.md, SC-25) as data. Stage 0:
+  // table + lookup only; the Stage 1 persist transform consumes it.
   it("classifies each design-table row", () => {
     expect(
       classifyLabelField({ type: CFC_ATOM_TYPE.Caveat }, ["source"]),

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -15,18 +15,18 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-label-metadata");
 
-// Inv-12 Stage 0 (SC-14/SC-25 prerequisite; docs/specs/
-// cfc-label-metadata-confidentiality.md §3): the carried `cfcLabelView` on a
-// link write round-trips through the main thread (worker →
-// `CellHandle.deserialize` → `mapCellRefsToSigilLinks` → worker) and is
-// main-thread-influenceable. `prepareBoundaryCommit` must therefore treat an
-// inbound view as an untrusted display artifact and persist link-origin
-// labels from the worker-authoritative source — the link source's STORED
-// label map — so a tampered/redacted/incomplete view cannot WEAKEN what the
-// stored metadata provides (the round-trip hazard confirmed on the labs#4622
-// review thread: response-side redaction would otherwise persist redacted,
-// under-labeled views on copy-forward writes).
 describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
+  // Inv-12 Stage 0 (SC-14/SC-25 prerequisite; docs/specs/
+  // cfc-label-metadata-confidentiality.md §3): the carried `cfcLabelView` on a
+  // link write round-trips through the main thread (worker →
+  // `CellHandle.deserialize` → `mapCellRefsToSigilLinks` → worker) and is
+  // main-thread-influenceable. `prepareBoundaryCommit` must therefore treat an
+  // inbound view as an untrusted display artifact and persist link-origin
+  // labels from the worker-authoritative source — the link source's STORED
+  // label map — so a tampered/redacted/incomplete view cannot WEAKEN what the
+  // stored metadata provides (the round-trip hazard confirmed on the labs#4622
+  // review thread: response-side redaction would otherwise persist redacted,
+  // under-labeled views on copy-forward writes).
   type PersistedEntry = {
     path: string[];
     origin?: string;

--- a/packages/runner/test/cfc-label-metadata-persist.test.ts
+++ b/packages/runner/test/cfc-label-metadata-persist.test.ts
@@ -27,6 +27,7 @@ describe("CFC persist-seam link-label re-derivation (inv-12 Stage 0)", () => {
   // stored metadata provides (the round-trip hazard confirmed on the labs#4622
   // review thread: response-side redaction would otherwise persist redacted,
   // under-labeled views on copy-forward writes).
+
   type PersistedEntry = {
     path: string[];
     origin?: string;

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -41,16 +41,16 @@ type PersistedEntry = {
   };
 };
 
-// Inv-12 Stage 1 (SC-25; docs/specs/cfc-label-metadata-confidentiality.md
-// §2/§5; spec §4.6.4.1 "Cross-space derived labels"): at the cross-space
-// persist seam, prepareBoundaryCommit applies the classification table to
-// every source-bearing atom field of entries whose observations originate
-// OUTSIDE the destination space — link-origin entries whose link source
-// lives in another space (including the carried sigil `cfcLabelView`
-// entries, the in-value copy) and flow-derived entries whose join consumed a
-// labeled foreign observation. Same-space-only labels persist verbatim.
-// Behind `cfcLabelMetadataProtection: off | observe | enforce`.
 describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", () => {
+  // Inv-12 Stage 1 (SC-25; docs/specs/cfc-label-metadata-confidentiality.md
+  // §2/§5; spec §4.6.4.1 "Cross-space derived labels"): at the cross-space
+  // persist seam, prepareBoundaryCommit applies the classification table to
+  // every source-bearing atom field of entries whose observations originate
+  // OUTSIDE the destination space — link-origin entries whose link source lives
+  // in another space (including the carried sigil `cfcLabelView` entries, the
+  // in-value copy) and flow-derived entries whose join consumed a labeled
+  // foreign observation. Same-space-only labels persist verbatim. Behind
+  // `cfcLabelMetadataProtection: off | observe | enforce`.
   const fullSource = { space: spaceA, id: "of:remote-origin", path: [] };
   const caveatAtom = {
     type: CFC_ATOM_TYPE.Caveat,

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -51,6 +51,7 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
   // in-value copy) and flow-derived entries whose join consumed a labeled
   // foreign observation. Same-space-only labels persist verbatim. Behind
   // `cfcLabelMetadataProtection: off | observe | enforce`.
+
   const fullSource = { space: spaceA, id: "of:remote-origin", path: [] };
   const caveatAtom = {
     type: CFC_ATOM_TYPE.Caveat,

--- a/packages/runner/test/cfc-label-representation.test.ts
+++ b/packages/runner/test/cfc-label-representation.test.ts
@@ -9,13 +9,13 @@ import {
   transformCfcLabelForCrossSpacePersist,
 } from "../src/cfc/label-representation.ts";
 
-// Inv-12 Stage 1 (SC-25; docs/specs/cfc-label-metadata-confidentiality.md §2;
-// spec §4.6.4.1): the cross-space representation transform. Every
-// commitment-classified source-bearing atom field is replaced by its
-// canonical digest wrapped in the self-describing marker `{digestOf:
-// "<hash>"}`; public-classified and unclassified fields persist verbatim.
-// The transform is deterministic, idempotent, and copy-on-write.
 describe("CFC label representation transform (inv-12 Stage 1)", () => {
+  // Inv-12 Stage 1 (SC-25; docs/specs/cfc-label-metadata-confidentiality.md §2;
+  // spec §4.6.4.1): the cross-space representation transform. Every
+  // commitment-classified source-bearing atom field is replaced by its
+  // canonical digest wrapped in the self-describing marker `{digestOf:
+  // "<hash>"}`; public-classified and unclassified fields persist verbatim. The
+  // transform is deterministic, idempotent, and copy-on-write.
   const alice = "did:key:alice";
   const bob = "did:key:bob";
 

--- a/packages/runner/test/cfc-label-representation.test.ts
+++ b/packages/runner/test/cfc-label-representation.test.ts
@@ -16,6 +16,7 @@ describe("CFC label representation transform (inv-12 Stage 1)", () => {
   // canonical digest wrapped in the self-describing marker `{digestOf:
   // "<hash>"}`; public-classified and unclassified fields persist verbatim. The
   // transform is deterministic, idempotent, and copy-on-write.
+
   const alice = "did:key:alice";
   const bob = "did:key:bob";
 

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1572,6 +1572,7 @@ describe("redactSigilCfcLabelViewsForDisplay", () => {
   // Inv-12 Stage 0: the display redaction that already covers the top-level
   // cfcLabel at the IPC response sites, extended to the cfcLabelView copies
   // riding sigil links inside response values.
+
   const caveat = {
     type: "https://commonfabric.org/cfc/atom/Caveat",
     kind: "derived-from",

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1568,10 +1568,10 @@ describe("CFC label view helpers", () => {
   });
 });
 
-// Inv-12 Stage 0: the display redaction that already covers the top-level
-// cfcLabel at the IPC response sites, extended to the cfcLabelView copies
-// riding sigil links inside response values.
 describe("redactSigilCfcLabelViewsForDisplay", () => {
+  // Inv-12 Stage 0: the display redaction that already covers the top-level
+  // cfcLabel at the IPC response sites, extended to the cfcLabelView copies
+  // riding sigil links inside response values.
   const caveat = {
     type: "https://commonfabric.org/cfc/atom/Caveat",
     kind: "derived-from",

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -33,6 +33,7 @@ describe("CFC labelMap component origins", () => {
   // `declared` (schema store policy, monotone), `link` (reference-carried,
   // replaced when the link is rewritten), `derived` (default-transition flow
   // labels, replaced on overwrite). Effective label = join of components.
+
   it("tags schema-derived entries as declared", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -27,12 +27,12 @@ const replicaEntries = (
   return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
 };
 
-// labelMap v2 components (S16 design): persisted entries carry their
-// provenance component so each can follow its own update discipline —
-// `declared` (schema store policy, monotone), `link` (reference-carried,
-// replaced when the link is rewritten), `derived` (default-transition flow
-// labels, replaced on overwrite). Effective label = join of components.
 describe("CFC labelMap component origins", () => {
+  // labelMap v2 components (S16 design): persisted entries carry their
+  // provenance component so each can follow its own update discipline —
+  // `declared` (schema store policy, monotone), `link` (reference-carried,
+  // replaced when the link is rewritten), `derived` (default-transition flow
+  // labels, replaced on overwrite). Effective label = join of components.
   it("tags schema-derived entries as declared", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-observation-precision.test.ts
+++ b/packages/runner/test/cfc-observation-precision.test.ts
@@ -17,6 +17,7 @@ describe("CFC observation precision (C4)", () => {
   // child under a secret container `shape` no longer inherits the container's
   // shape label (the flat model took the max), and an opaque link handle is a
   // followRef observation consuming the pointer's label only.
+
   const view = (entries: CfcLabelView["entries"]): CfcLabelView => ({
     version: 1,
     entries,

--- a/packages/runner/test/cfc-observation-precision.test.ts
+++ b/packages/runner/test/cfc-observation-precision.test.ts
@@ -11,12 +11,12 @@ import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
 
 const { serializeForLLMObservation } = llmDialogTestHelpers;
 
-// Epic C stage C4 — consumer precision (C0 §7): the observation ceiling and
-// label views consume entries per observation class. A public value read of
-// a child under a secret container `shape` no longer inherits the
-// container's shape label (the flat model took the max), and an opaque link
-// handle is a followRef observation consuming the pointer's label only.
 describe("CFC observation precision (C4)", () => {
+  // Epic C stage C4 — consumer precision (C0 §7): the observation ceiling and
+  // label views consume entries per observation class. A public value read of a
+  // child under a secret container `shape` no longer inherits the container's
+  // shape label (the flat model took the max), and an opaque link handle is a
+  // followRef observation consuming the pointer's label only.
   const view = (entries: CfcLabelView["entries"]): CfcLabelView => ({
     version: 1,
     entries,

--- a/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
+++ b/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
@@ -86,6 +86,7 @@ describe("CFC writeAuthorizedBy policy applies when its value-condition $ref is 
   // `writeAuthorizedBy` entry as not applying and the protected write is
   // accepted unverified — a fail-open direction the nearby comment ("must fail
   // closed on unresolved refs") and the S17 link branch both forbid.
+
   const space = "did:key:policy-schema-refs" as const;
   const target = { space, id: "of:guarded" as const, scope: "space" as const };
   const tx = {

--- a/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
+++ b/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
@@ -79,13 +79,13 @@ describe("CFC policy value matching resolves $refs against the schema root", () 
   });
 });
 
-// A write-authority policy whose value condition is carried by a `$ref` (the
-// generated array-items shape) must still apply when that ref is unresolvable.
-// Otherwise `ifcEntryAppliesToAttemptedWrite` treats the `writeAuthorizedBy`
-// entry as not applying and the protected write is accepted unverified — a
-// fail-open direction the nearby comment ("must fail closed on unresolved
-// refs") and the S17 link branch both forbid.
 describe("CFC writeAuthorizedBy policy applies when its value-condition $ref is unresolvable", () => {
+  // A write-authority policy whose value condition is carried by a `$ref` (the
+  // generated array-items shape) must still apply when that ref is
+  // unresolvable. Otherwise `ifcEntryAppliesToAttemptedWrite` treats the
+  // `writeAuthorizedBy` entry as not applying and the protected write is
+  // accepted unverified — a fail-open direction the nearby comment ("must fail
+  // closed on unresolved refs") and the S17 link branch both forbid.
   const space = "did:key:policy-schema-refs" as const;
   const target = { space, id: "of:guarded" as const, scope: "space" as const };
   const tx = {

--- a/packages/runner/test/cfc-projection.test.ts
+++ b/packages/runner/test/cfc-projection.test.ts
@@ -8,13 +8,13 @@ import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-projection");
 
-// §8.3 projection claims (spec cfc/08-03-projection-semantics.md): a field
-// copied out of a structured source inherits the source's confidentiality in
-// full (§8.3.1) and carries the source's integrity SCOPED to the projected
-// path (§8.3.2) — the projected value can never claim whole-object integrity,
-// and atoms that cannot express the scoping (string atoms, provenance-class
-// evidence) are dropped, fail-closed.
 describe("CFC projection claims", () => {
+  // §8.3 projection claims (spec cfc/08-03-projection-semantics.md): a field
+  // copied out of a structured source inherits the source's confidentiality in
+  // full (§8.3.1) and carries the source's integrity SCOPED to the projected
+  // path (§8.3.2) — the projected value can never claim whole-object integrity,
+  // and atoms that cannot express the scoping (string atoms, provenance-class
+  // evidence) are dropped, fail-closed.
   const createRuntime = () => {
     const storageManager = StorageManager.emulate({
       as: signer,

--- a/packages/runner/test/cfc-projection.test.ts
+++ b/packages/runner/test/cfc-projection.test.ts
@@ -15,6 +15,7 @@ describe("CFC projection claims", () => {
   // path (§8.3.2) — the projected value can never claim whole-object integrity,
   // and atoms that cannot express the scoping (string atoms, provenance-class
   // evidence) are dropped, fail-closed.
+
   const createRuntime = () => {
     const storageManager = StorageManager.emulate({
       as: signer,

--- a/packages/runner/test/cfc-read-scope.test.ts
+++ b/packages/runner/test/cfc-read-scope.test.ts
@@ -84,6 +84,7 @@ describe("CFC flow-join read scope", () => {
   // of a sibling leaf — otherwise a computation that deliberately avoids a
   // confidential field could not prove so by its read set, and strict mode
   // would refuse the untainted aggregate along with the leak.
+
   it("does not taint a sibling-leaf read with a labelled descendant elsewhere", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);

--- a/packages/runner/test/cfc-read-scope.test.ts
+++ b/packages/runner/test/cfc-read-scope.test.ts
@@ -78,12 +78,12 @@ const seedRecord = async (runtime: Runtime, name: string) => {
   expect((await seed.commit()).ok).toBeDefined();
 };
 
-// The flow join quantifies over what a transaction actually read. A labelled
-// leaf taints a read of itself or of any ancestor, and must not taint a read
-// of a sibling leaf — otherwise a computation that deliberately avoids a
-// confidential field could not prove so by its read set, and strict mode
-// would refuse the untainted aggregate along with the leak.
 describe("CFC flow-join read scope", () => {
+  // The flow join quantifies over what a transaction actually read. A labelled
+  // leaf taints a read of itself or of any ancestor, and must not taint a read
+  // of a sibling leaf — otherwise a computation that deliberately avoids a
+  // confidential field could not prove so by its read set, and strict mode
+  // would refuse the untainted aggregate along with the leak.
   it("does not taint a sibling-leaf read with a labelled descendant elsewhere", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1170,6 +1170,7 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
   // CT-1895: the merge-skip decision judged envelopes "covered" via the items
   // branch while their tuple slots differed, dropping the candidate's slot info
   // instead of merging it (fail-open: coverage=true skips the merge).
+
   it("differing tuple slots are not judged covered by matching items", () => {
     const stored = {
       type: "array",
@@ -1344,6 +1345,7 @@ describe("cfcSchemaMergeIssue", () => {
   // rather than attempting the swap and taking a low-level commit rejection.
   // What it must not do is reimplement the rules, so these cases pin that its
   // verdict is the merge's own — including the message, verbatim.
+
   it("reports no issue when the merge succeeds", () => {
     expect(cfcSchemaMergeIssue({
       type: "object",

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1166,10 +1166,10 @@ describe("mergeCfcSchemaEnvelopes", () => {
   });
 });
 
-// CT-1895: the merge-skip decision judged envelopes "covered" via the items
-// branch while their tuple slots differed, dropping the candidate's slot
-// info instead of merging it (fail-open: coverage=true skips the merge).
 describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
+  // CT-1895: the merge-skip decision judged envelopes "covered" via the items
+  // branch while their tuple slots differed, dropping the candidate's slot info
+  // instead of merging it (fail-open: coverage=true skips the merge).
   it("differing tuple slots are not judged covered by matching items", () => {
     const stored = {
       type: "array",
@@ -1338,12 +1338,12 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
   });
 });
 
-// `cfcSchemaMergeIssue` is the dry-run seam over the SAME merge: `cf piece
-// setsrc --check` asks it whether a candidate envelope would be accepted
-// rather than attempting the swap and taking a low-level commit rejection.
-// What it must not do is reimplement the rules, so these cases pin that its
-// verdict is the merge's own — including the message, verbatim.
 describe("cfcSchemaMergeIssue", () => {
+  // `cfcSchemaMergeIssue` is the dry-run seam over the SAME merge: `cf piece
+  // setsrc --check` asks it whether a candidate envelope would be accepted
+  // rather than attempting the swap and taking a low-level commit rejection.
+  // What it must not do is reimplement the rules, so these cases pin that its
+  // verdict is the merge's own — including the message, verbatim.
   it("reports no issue when the merge succeeds", () => {
     expect(cfcSchemaMergeIssue({
       type: "object",

--- a/packages/runner/test/cfc-structure-container.test.ts
+++ b/packages/runner/test/cfc-structure-container.test.ts
@@ -9,11 +9,11 @@ import type { CfcAddress } from "../src/cfc/mod.ts";
 const signer = await Identity.fromPassphrase("runner-cfc-structure-container");
 const space = signer.did();
 
-// Unit coverage for the structure-container declaration seam (S16): list
-// coordinators (filter/flatMap) declare their result container so prepare
-// re-derives its `structure` label from J every reconcile. The end-to-end
-// behavior is in cfc-flow-pointwise.test.ts; this pins the tx plumbing.
 describe("CFC structure-container declaration (tx plumbing)", () => {
+  // Unit coverage for the structure-container declaration seam (S16): list
+  // coordinators (filter/flatMap) declare their result container so prepare
+  // re-derives its `structure` label from J every reconcile. The end-to-end
+  // behavior is in cfc-flow-pointwise.test.ts; this pins the tx plumbing.
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-structure-container.test.ts
+++ b/packages/runner/test/cfc-structure-container.test.ts
@@ -14,6 +14,7 @@ describe("CFC structure-container declaration (tx plumbing)", () => {
   // coordinators (filter/flatMap) declare their result container so prepare
   // re-derives its `structure` label from J every reconcile. The end-to-end
   // behavior is in cfc-flow-pointwise.test.ts; this pins the tx plumbing.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
+++ b/packages/runner/test/cfc-trigger-read-cid-exclusion.test.ts
@@ -31,15 +31,15 @@ const replicaEntries = (
   return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
 };
 
-// §8.9.2 trigger reads name runtime-surface documents only by accident or
-// forgery: `addCfcTriggerReads` drops them at ingest (`flowReadExcluded` on
-// the raw notification path), and `forEachFlowObservation` keeps an id-based
-// `cid:` skip as defense in depth for entries that arrive by other
-// construction paths. That second layer matters because `cid:` schema docs
-// live on an unverified write path any same-space writer can reach (audit
-// S5): a poisoned labelMap on one must not join the flow derivation through
-// a smuggled trigger entry.
 describe("CFC trigger reads: cid: exclusion", () => {
+  // §8.9.2 trigger reads name runtime-surface documents only by accident or
+  // forgery: `addCfcTriggerReads` drops them at ingest (`flowReadExcluded` on
+  // the raw notification path), and `forEachFlowObservation` keeps an id-based
+  // `cid:` skip as defense in depth for entries that arrive by other
+  // construction paths. That second layer matters because `cid:` schema docs
+  // live on an unverified write path any same-space writer can reach (audit
+  // S5): a poisoned labelMap on one must not join the flow derivation through a
+  // smuggled trigger entry.
   it("keeps cid: trigger reads out of the flow derivation even when they bypass ingest filtering", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({

--- a/packages/runner/test/cfc-tx-state-contracts.test.ts
+++ b/packages/runner/test/cfc-tx-state-contracts.test.ts
@@ -8,12 +8,12 @@ import { readOnlyCfcView } from "../src/storage/extended-storage-transaction.ts"
 
 const signer = await Identity.fromPassphrase("runner-cfc-tx-state-contracts");
 
-// Contracts of the transaction's CFC control surface that no other suite
-// pins directly: the flow-labels anti-downgrade pin, the write-once sink
-// ceiling, late-activity invalidation of a prepared transaction, and the
-// diagnostics seams. All are part of the audit-S3 posture the read-only
-// state view (#4517) completes.
 describe("CFC tx state contracts", () => {
+  // Contracts of the transaction's CFC control surface that no other suite pins
+  // directly: the flow-labels anti-downgrade pin, the write-once sink ceiling,
+  // late-activity invalidation of a prepared transaction, and the diagnostics
+  // seams. All are part of the audit-S3 posture the read-only state view
+  // (#4517) completes.
   const withTx = async (
     fn: (runtime: Runtime, tx: ExtendedStorageTransaction) => Promise<void>,
   ) => {

--- a/packages/runner/test/cfc-tx-state-contracts.test.ts
+++ b/packages/runner/test/cfc-tx-state-contracts.test.ts
@@ -14,6 +14,7 @@ describe("CFC tx state contracts", () => {
   // late-activity invalidation of a prepared transaction, and the diagnostics
   // seams. All are part of the audit-S3 posture the read-only state view
   // (#4517) completes.
+
   const withTx = async (
     fn: (runtime: Runtime, tx: ExtendedStorageTransaction) => Promise<void>,
   ) => {

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -134,6 +134,7 @@ describe("CFC policy value-conditions on tuple (prefixItems) schemas", () => {
   // a tuple-shaped (prefixItems) value condition vacuously matched ANY array —
   // the policy entry applied where its condition should have excluded it, or
   // vice versa.
+
   const space = "did:key:tuple-policy" as const;
   const target = { space, id: "of:guarded" as const, scope: "space" as const };
   const tx = {

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -129,11 +129,11 @@ describe("CFC wildcard policy value conditions on `FabricPrimitive` types", () =
   });
 });
 
-// CT-1895: policySchemaMatchesValue validated arrays only against `items`,
-// so a tuple-shaped (prefixItems) value condition vacuously matched ANY
-// array — the policy entry applied where its condition should have excluded
-// it, or vice versa.
 describe("CFC policy value-conditions on tuple (prefixItems) schemas", () => {
+  // CT-1895: policySchemaMatchesValue validated arrays only against `items`, so
+  // a tuple-shaped (prefixItems) value condition vacuously matched ANY array —
+  // the policy entry applied where its condition should have excluded it, or
+  // vice versa.
   const space = "did:key:tuple-policy" as const;
   const target = { space, id: "of:guarded" as const, scope: "space" as const };
   const tx = {

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -134,16 +134,16 @@ const writerFitDiagnostics = (
   tx: { getCfcState(): { diagnostics: string[] } },
 ) => tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit"));
 
-// H4 writer-fit (SC-18b, spec §8.12.4): a write whose derived flow label does
-// not fit the target's write ceiling — its DECLARED store policy joined with
-// the residency clause its own space contributes. Under `enforce-explicit`
-// the derived component is a measurement, not a write ceiling — the write
-// persists and the misfit is flagged as a diagnostic (SC-18a/c). Under
-// `enforce-strict` the same misfit is a fail-closed reject (the strict-only
-// delta of docs/specs/cfc-enforcement-matrix.md §4), leaving the §8.12.5
-// outs: upgrade the store label in the same tx, write to a fitting store, or
-// write to a store whose space the clause already names.
 describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
+  // H4 writer-fit (SC-18b, spec §8.12.4): a write whose derived flow label does
+  // not fit the target's write ceiling — its DECLARED store policy joined with
+  // the residency clause its own space contributes. Under `enforce-explicit`
+  // the derived component is a measurement, not a write ceiling — the write
+  // persists and the misfit is flagged as a diagnostic (SC-18a/c). Under
+  // `enforce-strict` the same misfit is a fail-closed reject (the strict-only
+  // delta of docs/specs/cfc-enforcement-matrix.md §4), leaving the §8.12.5
+  // outs: upgrade the store label in the same tx, write to a fitting store, or
+  // write to a store whose space the clause already names.
   it("rejects a confidentiality misfit under enforce-strict with the SC-18c reason", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -144,6 +144,7 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
   // delta of docs/specs/cfc-enforcement-matrix.md §4), leaving the §8.12.5
   // outs: upgrade the store label in the same tx, write to a fitting store, or
   // write to a store whose space the clause already names.
+
   it("rejects a confidentiality misfit under enforce-strict with the SC-18c reason", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -10,10 +10,10 @@ import {
   type HoistRegistrationSink,
 } from "../src/sandbox/module-record-compiler.ts";
 
-// Unit coverage for the per-module `__cfReg` registrar: run-once, closed-window,
-// and transactional (commit-only-on-success) semantics — the integrity
-// guarantees that let the verifier stay simple.
 describe("createHoistRegistrar", () => {
+  // Unit coverage for the per-module `__cfReg` registrar: run-once,
+  // closed-window, and transactional (commit-only-on-success) semantics — the
+  // integrity guarantees that let the verifier stay simple.
   it("stages entries and commits them to the sink", () => {
     const sink: HoistRegistrationSink = new Map();
     const { register, commit } = createHoistRegistrar("idA", sink);
@@ -57,13 +57,13 @@ describe("createHoistRegistrar", () => {
   });
 });
 
-// End-to-end: under the ESM loader, the hoisted builder artifacts a module
-// produces are registered via `__cfReg` and become addressable by their
-// content-addressed `{ identity, symbol }` reference — with no module exports and
-// no source re-parsing. This source hoists a pattern (the `.map` op) AND a lift
-// (a reactive computation), proving the mechanism generalizes beyond patterns;
-// handlers travel the identical branded node-factory path.
 describe("hoisted builder artifacts are addressable by {identity, symbol}", () => {
+  // End-to-end: under the ESM loader, the hoisted builder artifacts a module
+  // produces are registered via `__cfReg` and become addressable by their
+  // content-addressed `{ identity, symbol }` reference — with no module exports
+  // and no source re-parsing. This source hoists a pattern (the `.map` op) AND
+  // a lift (a reactive computation), proving the mechanism generalizes beyond
+  // patterns; handlers travel the identical branded node-factory path.
   const PROGRAM: RuntimeProgram = {
     main: "/main.tsx",
     files: [{

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -14,6 +14,7 @@ describe("createHoistRegistrar", () => {
   // Unit coverage for the per-module `__cfReg` registrar: run-once,
   // closed-window, and transactional (commit-only-on-success) semantics — the
   // integrity guarantees that let the verifier stay simple.
+
   it("stages entries and commits them to the sink", () => {
     const sink: HoistRegistrationSink = new Map();
     const { register, commit } = createHoistRegistrar("idA", sink);
@@ -64,6 +65,7 @@ describe("hoisted builder artifacts are addressable by {identity, symbol}", () =
   // and no source re-parsing. This source hoists a pattern (the `.map` op) AND
   // a lift (a reactive computation), proving the mechanism generalizes beyond
   // patterns; handlers travel the identical branded node-factory path.
+
   const PROGRAM: RuntimeProgram = {
     main: "/main.tsx",
     files: [{

--- a/packages/runner/test/combine-schema.test.ts
+++ b/packages/runner/test/combine-schema.test.ts
@@ -401,16 +401,15 @@ describe("combineSchema array handling", () => {
   });
 });
 
-// combineSchema builds the pseudo-intersection of the schema a doc was
-// entered with and a schema found on a link inside it. For object schemas,
-// keys defined on only ONE side intersect against the other side's
-// additionalProperties — where JSON Schema's "absent additionalProperties"
-// means UNCONSTRAINED, not `false`. The regression pinned here: absent
-// additionalProperties alongside defined properties used to be coerced to
-// `false`, silently blocking the other side's keys exactly as if the
-// author had written an explicitly closed object.
-
 describe("combineSchema additionalProperties handling", () => {
+  // combineSchema builds the pseudo-intersection of the schema a doc was
+  // entered with and a schema found on a link inside it. For object schemas,
+  // keys defined on only ONE side intersect against the other side's
+  // additionalProperties — where JSON Schema's "absent additionalProperties"
+  // means UNCONSTRAINED, not `false`. The regression pinned here: absent
+  // additionalProperties alongside defined properties used to be coerced to
+  // `false`, silently blocking the other side's keys exactly as if the author
+  // had written an explicitly closed object.
   const schemaWithOneSidedProperty = {
     type: "object",
     properties: {

--- a/packages/runner/test/combine-schema.test.ts
+++ b/packages/runner/test/combine-schema.test.ts
@@ -410,6 +410,7 @@ describe("combineSchema additionalProperties handling", () => {
   // additionalProperties alongside defined properties used to be coerced to
   // `false`, silently blocking the other side's keys exactly as if the author
   // had written an explicitly closed object.
+
   const schemaWithOneSidedProperty = {
     type: "object",
     properties: {

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -325,16 +325,16 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
   });
 });
 
-// System-level degradation pin: the by-identity load's hit test is ENTRY
-// presence (`closure.has(entryIdentity)`), not closure completeness. Chunked
-// interruption cannot create an entry-present/descendant-missing compiled
-// namespace (the entry doc lands last), but the safety argument in
-// planCompileCacheWriteChunks leans on what happens if that state exists
-// anyway: cached-module evaluation fails on the missing module and the load
-// falls back to a clean recompile from the verified source closure — a
-// working pattern, never a corrupt load — and the recovery write-back heals
-// the compiled namespace.
 describe("descendant-missing compiled closure degrades to a clean recompile", () => {
+  // System-level degradation pin: the by-identity load's hit test is ENTRY
+  // presence (`closure.has(entryIdentity)`), not closure completeness. Chunked
+  // interruption cannot create an entry-present/descendant-missing compiled
+  // namespace (the entry doc lands last), but the safety argument in
+  // planCompileCacheWriteChunks leans on what happens if that state exists
+  // anyway: cached-module evaluation fails on the missing module and the load
+  // falls back to a clean recompile from the verified source closure — a
+  // working pattern, never a corrupt load — and the recovery write-back heals
+  // the compiled namespace.
   it("loadPatternByIdentity recompiles from source and heals the compiled set", async () => {
     const RTVER = "test-degrade-1";
     const restoreVersion = setCompileCacheRuntimeVersionForTesting(RTVER);

--- a/packages/runner/test/compile-cache-version.test.ts
+++ b/packages/runner/test/compile-cache-version.test.ts
@@ -11,12 +11,12 @@ type VersionGlobal = typeof globalThis & {
   __cfCompileCacheRuntimeVersion?: unknown;
 };
 
-// The compile-cache runtimeVersion decides when deployed pieces recompile
-// (a version move sends every cold load through the recovery write-back —
-// the CT-1824 arc), so the resolution ladder is load-bearing:
-//   defined global override  >  baked build version  >  live compiler
-//   fingerprint (Deno dev runtime)  >  undefined (no fingerprint source).
 describe("compile-cache runtime-version resolution", () => {
+  // The compile-cache runtimeVersion decides when deployed pieces recompile (a
+  // version move sends every cold load through the recovery write-back — the
+  // CT-1824 arc), so the resolution ladder is load-bearing: defined global
+  // override  >  baked build version  >  live compiler fingerprint (Deno dev
+  // runtime)  >  undefined (no fingerprint source).
   it("a defined global version overrides everything", async () => {
     const g = globalThis as VersionGlobal;
     const previous = g.__cfCompileCacheRuntimeVersion;

--- a/packages/runner/test/compile-cache-version.test.ts
+++ b/packages/runner/test/compile-cache-version.test.ts
@@ -17,6 +17,7 @@ describe("compile-cache runtime-version resolution", () => {
   // CT-1824 arc), so the resolution ladder is load-bearing: defined global
   // override  >  baked build version  >  live compiler fingerprint (Deno dev
   // runtime)  >  undefined (no fingerprint source).
+
   it("a defined global version overrides everything", async () => {
     const g = globalThis as VersionGlobal;
     const previous = g.__cfCompileCacheRuntimeVersion;

--- a/packages/runner/test/compile-interleave.test.ts
+++ b/packages/runner/test/compile-interleave.test.ts
@@ -10,6 +10,7 @@ describe("compile-interleave", () => {
   // predicate default and both arms carry perf contracts the pattern unit
   // suites depend on (Deno batch compiles must add ZERO macrotask turns; the
   // browser worker must get REAL turns), so pin all three here.
+
   it("does not interleave under Deno (batch compiles run straight through)", () => {
     // cf test / toolshed / CLI: the sync compile driver, no yields.
     expect(COMPILE_INTERLEAVES_EVENT_LOOP).toBe(false);

--- a/packages/runner/test/compile-interleave.test.ts
+++ b/packages/runner/test/compile-interleave.test.ts
@@ -5,11 +5,11 @@ import {
   interleaveCompileYield,
 } from "../src/harness/compile-interleave.ts";
 
-// The compile pipeline's yield points run through interleaveCompileYield. The
-// predicate default and both arms carry perf contracts the pattern unit
-// suites depend on (Deno batch compiles must add ZERO macrotask turns; the
-// browser worker must get REAL turns), so pin all three here.
 describe("compile-interleave", () => {
+  // The compile pipeline's yield points run through interleaveCompileYield. The
+  // predicate default and both arms carry perf contracts the pattern unit
+  // suites depend on (Deno batch compiles must add ZERO macrotask turns; the
+  // browser worker must get REAL turns), so pin all three here.
   it("does not interleave under Deno (batch compiles run straight through)", () => {
     // cf test / toolshed / CLI: the sync compile driver, no yields.
     expect(COMPILE_INTERLEAVES_EVENT_LOOP).toBe(false);

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -432,10 +432,9 @@ export default pattern<{ out: string }>(({ out }) => ({
   });
 });
 
-// (The "provenance bundleId fallback" suite retired with the bundleId
-// verification arm — identity E5, data-wipe decision.)
-
 describe("$implRef resolution arm (Runner.resolveJavaScriptFunction)", () => {
+  // (The "provenance bundleId fallback" suite retired with the bundleId
+  // verification arm — identity E5, data-wipe decision.)
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -2181,18 +2181,18 @@ describe("compactChangeSet", () => {
   });
 });
 
-// Scope-isolation write guard (docs/specs/scoped-cell-instances.md;
-// pitfall 6 in docs/development/debugging/gotchas/scoped-cell-pitfalls.md):
-// links do not carry a principal, so a narrower-scoped link stored in a
-// broader-scoped slot resolves to a DIFFERENT instance for every reader —
-// shared data written that way can never propagate (the B2 reader-blackout
-// investigation, #4457). The guard WARNS loudly at the write site unless the
-// slot's schema declares the scope (per-reader semantics opted into by the
-// author). It is a warn, not a throw, because the runtime's own machinery
-// legitimately writes scoped links into scope-silent slots today (.asScope()
-// result links, navigateTo result cells, updateArgument setup wiring); see
-// the enumeration on #4561 for the flip-to-throw checklist.
 describe("scope-isolation write guard", () => {
+  // Scope-isolation write guard (docs/specs/scoped-cell-instances.md; pitfall 6
+  // in docs/development/debugging/gotchas/scoped-cell-pitfalls.md): links do
+  // not carry a principal, so a narrower-scoped link stored in a broader-scoped
+  // slot resolves to a DIFFERENT instance for every reader — shared data
+  // written that way can never propagate (the B2 reader-blackout investigation,
+  // #4457). The guard WARNS loudly at the write site unless the slot's schema
+  // declares the scope (per-reader semantics opted into by the author). It is a
+  // warn, not a throw, because the runtime's own machinery legitimately writes
+  // scoped links into scope-silent slots today (.asScope() result links,
+  // navigateTo result cells, updateArgument setup wiring); see the enumeration
+  // on #4561 for the flip-to-throw checklist.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -2541,10 +2541,10 @@ describe("scope-isolation write guard", () => {
   });
 });
 
-// CT-1895: the overlap predicate deciding whether a schema-policy write
-// input might cover a written path missed ifc labels in tuple slots, so
-// schema-policy inputs for tuple positions were skipped (fail-open).
 describe("schemaIfcOverlapsPath", () => {
+  // CT-1895: the overlap predicate deciding whether a schema-policy write input
+  // might cover a written path missed ifc labels in tuple slots, so
+  // schema-policy inputs for tuple positions were skipped (fail-open).
   const tupleSchema = {
     type: "object",
     properties: {

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -2193,6 +2193,7 @@ describe("scope-isolation write guard", () => {
   // scoped links into scope-silent slots today (.asScope() result links,
   // navigateTo result cells, updateArgument setup wiring); see the enumeration
   // on #4561 for the flip-to-throw checklist.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -2545,6 +2546,7 @@ describe("schemaIfcOverlapsPath", () => {
   // CT-1895: the overlap predicate deciding whether a schema-policy write input
   // might cover a written path missed ifc labels in tuple slots, so
   // schema-policy inputs for tuple positions were skipped (fail-open).
+
   const tupleSchema = {
     type: "object",
     properties: {

--- a/packages/runner/test/engine-verified-functions.test.ts
+++ b/packages/runner/test/engine-verified-functions.test.ts
@@ -11,6 +11,7 @@ describe("Engine verified implementation index", () => {
   // The engine's content-addressed implementation index — the single resolution
   // backing for serialized `$implRef`s (identity E5 deleted the legacy
   // string-keyed `implementationRef` index; this is what remains).
+
   let runtime: Runtime;
   let engine: Engine;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/engine-verified-functions.test.ts
+++ b/packages/runner/test/engine-verified-functions.test.ts
@@ -7,10 +7,10 @@ import { Engine } from "../src/harness/engine.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 
-// The engine's content-addressed implementation index — the single resolution
-// backing for serialized `$implRef`s (identity E5 deleted the legacy
-// string-keyed `implementationRef` index; this is what remains).
 describe("Engine verified implementation index", () => {
+  // The engine's content-addressed implementation index — the single resolution
+  // backing for serialized `$implRef`s (identity E5 deleted the legacy
+  // string-keyed `implementationRef` index; this is what remains).
   let runtime: Runtime;
   let engine: Engine;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -35,6 +35,7 @@ describe("ESM compile via content-addressed cell cache", () => {
   // Step 5: PatternManager drives the content-addressed cell cache on the ESM
   // path — cold compiles write the module set back (CFC-stamped), warm compiles
   // reuse it, and the cache is gated on CFC enforcement.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -656,6 +657,7 @@ describe("ESM compile cache — Pattern.inSpace A → B routing", () => {
   // the per-space routing `PatternFactory.inSpace(B)` relies on: instantiating
   // a child in space B loads it via `loadPattern(id, rootCell.space === B)`,
   // whose core is `compilePattern(source, { space: B })`.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   const spaceA = signer.did();
 

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -31,10 +31,10 @@ if (resolvedRuntimeVersion === undefined) {
 const runtimeVersion = resolvedRuntimeVersion;
 const coverageRuntimeVersion = `${runtimeVersion}/pattern-coverage`;
 
-// Step 5: PatternManager drives the content-addressed cell cache on the ESM
-// path — cold compiles write the module set back (CFC-stamped), warm compiles
-// reuse it, and the cache is gated on CFC enforcement.
 describe("ESM compile via content-addressed cell cache", () => {
+  // Step 5: PatternManager drives the content-addressed cell cache on the ESM
+  // path — cold compiles write the module set back (CFC-stamped), warm compiles
+  // reuse it, and the cache is gated on CFC enforcement.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -649,13 +649,13 @@ describe("ESM compile via content-addressed cell cache", () => {
   });
 });
 
-// Step 4.4 (required): a pattern compiled bound to space B writes its source +
-// compiled docs into B (not the ambient space A), the link closure resolves in
-// B, and the compiled docs carry the required integrity. This is exactly the
-// per-space routing `PatternFactory.inSpace(B)` relies on: instantiating a child
-// in space B loads it via `loadPattern(id, rootCell.space === B)`, whose core is
-// `compilePattern(source, { space: B })`.
 describe("ESM compile cache — Pattern.inSpace A → B routing", () => {
+  // Step 4.4 (required): a pattern compiled bound to space B writes its source
+  // + compiled docs into B (not the ambient space A), the link closure resolves
+  // in B, and the compiled docs carry the required integrity. This is exactly
+  // the per-space routing `PatternFactory.inSpace(B)` relies on: instantiating
+  // a child in space B loads it via `loadPattern(id, rootCell.space === B)`,
+  // whose core is `compilePattern(source, { space: B })`.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   const spaceA = signer.did();
 

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -13,10 +13,10 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 
-// Phase D3.2: the Engine ESM compile path (compileToRecordGraph) runs the real
-// CF transformer pipeline, emits per-module CommonJS, assembles content-
-// addressed records + runtime records, and security-verifies every body.
 describe("Engine.compileToRecordGraph", () => {
+  // Phase D3.2: the Engine ESM compile path (compileToRecordGraph) runs the
+  // real CF transformer pipeline, emits per-module CommonJS, assembles content-
+  // addressed records + runtime records, and security-verifies every body.
   let runtime: Runtime;
   let engine: Engine;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -17,6 +17,7 @@ describe("Engine.compileToRecordGraph", () => {
   // Phase D3.2: the Engine ESM compile path (compileToRecordGraph) runs the
   // real CF transformer pipeline, emits per-module CommonJS, assembles content-
   // addressed records + runtime records, and security-verifies every body.
+
   let runtime: Runtime;
   let engine: Engine;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -15,6 +15,7 @@ describe("Pattern run via the ESM module loader", () => {
   // End-to-end: a real reactive pattern compiles AND runs through the ESM
   // module-record loader path (compileToRecordGraph + evaluateRecordGraph),
   // producing correct reactive output — not just loading.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -11,10 +11,10 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-// End-to-end: a real reactive pattern compiles
-// AND runs through the ESM module-record loader path (compileToRecordGraph +
-// evaluateRecordGraph), producing correct reactive output — not just loading.
 describe("Pattern run via the ESM module loader", () => {
+  // End-to-end: a real reactive pattern compiles AND runs through the ESM
+  // module-record loader path (compileToRecordGraph + evaluateRecordGraph),
+  // producing correct reactive output — not just loading.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -206,14 +206,13 @@ describe("ExperimentalOptions", () => {
   });
 });
 
-// The serverExecution ambient-flag OWNERSHIP family (PR #5439 threads
-// r3731191424, r3731191435, r3731191451): the flag is a process-global
-// admission input, so its lifecycle must be reference-counted across ALL
-// owners (explicit-enabler Runtimes AND the ExecutorHost), survive
-// construction/dispose failures, and never be stomped by a co-hosted
-// non-serving runtime.
-
 describe("serverExecution ambient-flag ownership", () => {
+  // The serverExecution ambient-flag OWNERSHIP family (PR #5439 threads
+  // r3731191424, r3731191435, r3731191451): the flag is a process-global
+  // admission input, so its lifecycle must be reference-counted across ALL
+  // owners (explicit-enabler Runtimes AND the ExecutorHost), survive
+  // construction/dispose failures, and never be stomped by a co-hosted
+  // non-serving runtime.
   afterEach(() => {
     resetModernCellRepConfig();
     resetCommitPreconditionsConfig();

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -213,6 +213,7 @@ describe("serverExecution ambient-flag ownership", () => {
   // owners (explicit-enabler Runtimes AND the ExecutorHost), survive
   // construction/dispose failures, and never be stomped by a co-hosted
   // non-serving runtime.
+
   afterEach(() => {
     resetModernCellRepConfig();
     resetCommitPreconditionsConfig();

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -25,6 +25,7 @@ describe("home favorites handlers", () => {
   // removeFavorite handlers the way the runtime client does: it derives the
   // piece's stable key and the discovery tags as data, and the handlers key the
   // favorite entity by that id.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -20,11 +20,11 @@ type FavoriteEntry = {
   id?: string;
 };
 
-// Compiles and runs the real home pattern, then drives its addFavorite /
-// removeFavorite handlers the way the runtime client does: it derives the
-// piece's stable key and the discovery tags as data, and the handlers key the
-// favorite entity by that id.
 describe("home favorites handlers", () => {
+  // Compiles and runs the real home pattern, then drives its addFavorite /
+  // removeFavorite handlers the way the runtime client does: it derives the
+  // piece's stable key and the discovery tags as data, and the handlers key the
+  // favorite entity by that id.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/linked-stale-read-conflict.test.ts
+++ b/packages/runner/test/linked-stale-read-conflict.test.ts
@@ -27,8 +27,8 @@ import { newSharedServer } from "./memory-v2-test-utils.ts";
 const signer = await Identity.fromPassphrase("linked-stale-read-strand");
 const space = signer.did();
 
-// Two StorageManagers sharing ONE real server, each with its own replicas.
 describe("stale linked read across two clients", () => {
+  // Two StorageManagers sharing ONE real server, each with its own replicas.
   let server: MemoryV2Server.Server;
   let storageA: EmulatedStorageManager;
   let storageB: EmulatedStorageManager;

--- a/packages/runner/test/llm-dialog-reserved-tool-names.test.ts
+++ b/packages/runner/test/llm-dialog-reserved-tool-names.test.ts
@@ -5,12 +5,12 @@ import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 
 const { buildToolCatalog, flattenTools } = llmToolExecutionHelpers;
 
-// A name addresses one tool. A pattern supplying a second under a name the
-// dialog answers to would leave the catalog, the flattened list the UI reads,
-// the CFC gates, and the system prompt each free to describe a different one —
-// and the prompt describes the built-ins in prose that no lookup can redirect.
-// The name is refused where it is registered instead.
 describe("llmDialog reserved tool names", () => {
+  // A name addresses one tool. A pattern supplying a second under a name the
+  // dialog answers to would leave the catalog, the flattened list the UI reads,
+  // the CFC gates, and the system prompt each free to describe a different one
+  // — and the prompt describes the built-ins in prose that no lookup can
+  // redirect. The name is refused where it is registered instead.
   const toolsCellNamed = (name: string) => ({
     get: () => ({
       [name]: {

--- a/packages/runner/test/llm-dialog-reserved-tool-names.test.ts
+++ b/packages/runner/test/llm-dialog-reserved-tool-names.test.ts
@@ -11,6 +11,7 @@ describe("llmDialog reserved tool names", () => {
   // the CFC gates, and the system prompt each free to describe a different one
   // — and the prompt describes the built-ins in prose that no lookup can
   // redirect. The name is refused where it is registered instead.
+
   const toolsCellNamed = (name: string) => ({
     get: () => ({
       [name]: {

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -34,12 +34,12 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("load-by-identity");
 const space = signer.did();
 
-// The load-by-identity warm path: build + evaluate a pattern directly from
-// cached compiled modules (no TS source, no resolve, no recompile), and the
-// cold-recovery path: recreate the pattern from the stored TypeScript alone
-// (content-addressed source set) when the compiled set is unavailable — the
-// runtime-version-bump scenario.
 describe("load by module identity (warm + version-bump recovery)", () => {
+  // The load-by-identity warm path: build + evaluate a pattern directly from
+  // cached compiled modules (no TS source, no resolve, no recompile), and the
+  // cold-recovery path: recreate the pattern from the stored TypeScript alone
+  // (content-addressed source set) when the compiled set is unavailable — the
+  // runtime-version-bump scenario.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let engine: Engine;

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -40,6 +40,7 @@ describe("load by module identity (warm + version-bump recovery)", () => {
   // cold-recovery path: recreate the pattern from the stored TypeScript alone
   // (content-addressed source set) when the compiled set is unavailable — the
   // runtime-version-bump scenario.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let engine: Engine;

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -14,8 +14,9 @@ import {
 const signer = await Identity.fromPassphrase("map-op-by-identity");
 const space = signer.did();
 
-// Unit coverage for the sentinel shape + resolver, independent of the runtime.
 describe("op-pattern-ref helpers", () => {
+  // Unit coverage for the sentinel shape + resolver, independent of the
+  // runtime.
   it("recognizes a well-formed sentinel and rejects others", () => {
     expect(
       isPatternRefSentinel({
@@ -80,12 +81,12 @@ describe("op-pattern-ref helpers", () => {
   });
 });
 
-// End-to-end: the `op` pattern of a `.map` node is
-// passed by its content-addressed `{ identity, symbol }` reference (a
-// `{ $patternRef }` sentinel) and resolved synchronously at runtime via
-// `artifactFromIdentitySync`, instead of being deserialized from an embedded
-// pattern graph.
 describe("map op passed by identity", () => {
+  // End-to-end: the `op` pattern of a `.map` node is passed by its
+  // content-addressed `{ identity, symbol }` reference (a `{ $patternRef }`
+  // sentinel) and resolved synchronously at runtime via
+  // `artifactFromIdentitySync`, instead of being deserialized from an embedded
+  // pattern graph.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -17,6 +17,7 @@ const space = signer.did();
 describe("op-pattern-ref helpers", () => {
   // Unit coverage for the sentinel shape + resolver, independent of the
   // runtime.
+
   it("recognizes a well-formed sentinel and rejects others", () => {
     expect(
       isPatternRefSentinel({
@@ -87,6 +88,7 @@ describe("map op passed by identity", () => {
   // sentinel) and resolved synchronously at runtime via
   // `artifactFromIdentitySync`, instead of being deserialized from an embedded
   // pattern graph.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -235,16 +235,16 @@ describe("materializer envelope collection", () => {
   });
 });
 
-// The branch at the runner's envelope-derivation site: presence of
-// materializerWriteInputPaths switches envelope collection off the
-// opaque-result fallback (collect ALL writable args) onto the path-filtered
-// collector — for a send-only computed with an unwritten writable arg, that
-// flips "collect all" to "collect none". Intended precision: with analyzed
-// write metadata, writable args that were never written would appear in the
-// write paths if written. Pinned here at the only level where the branch
-// selection is observable (the scheduler's materializer index after a real
-// runner-driven run).
 describe("materializer envelope branch selection", () => {
+  // The branch at the runner's envelope-derivation site: presence of
+  // materializerWriteInputPaths switches envelope collection off the
+  // opaque-result fallback (collect ALL writable args) onto the path-filtered
+  // collector — for a send-only computed with an unwritten writable arg, that
+  // flips "collect all" to "collect none". Intended precision: with analyzed
+  // write metadata, writable args that were never written would appear in the
+  // write paths if written. Pinned here at the only level where the branch
+  // selection is observable (the scheduler's materializer index after a real
+  // runner-driven run).
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
 

--- a/packages/runner/test/materializer-envelope-collection.test.ts
+++ b/packages/runner/test/materializer-envelope-collection.test.ts
@@ -245,6 +245,7 @@ describe("materializer envelope branch selection", () => {
   // write paths if written. Pinned here at the only level where the branch
   // selection is observable (the scheduler's materializer index after a real
   // runner-driven run).
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
 

--- a/packages/runner/test/memory-v2-path-helpers.test.ts
+++ b/packages/runner/test/memory-v2-path-helpers.test.ts
@@ -3,11 +3,11 @@ import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/api";
 import { hasValueAtPath, readValueAtPath } from "../src/storage/v2-path.ts";
 
-// `cloneWithValueAtPath` / `cloneWithoutValueAtPath` now live in
-// `@commonfabric/data-model` (`value-clone.ts`); their tests are in
-// `packages/data-model/test/value-clone.test.ts`. This file covers the
-// path-traversal readers that remain in `v2-path.ts`.
 describe("memory v2 path helpers", () => {
+  // `cloneWithValueAtPath` / `cloneWithoutValueAtPath` now live in
+  // `@commonfabric/data-model` (`value-clone.ts`); their tests are in
+  // `packages/data-model/test/value-clone.test.ts`. This file covers the
+  // path-traversal readers that remain in `v2-path.ts`.
   it("ignores inherited object properties during traversal", () => {
     const root = Object.create({
       inherited: 7,

--- a/packages/runner/test/memory-v2-path-helpers.test.ts
+++ b/packages/runner/test/memory-v2-path-helpers.test.ts
@@ -8,6 +8,7 @@ describe("memory v2 path helpers", () => {
   // `@commonfabric/data-model` (`value-clone.ts`); their tests are in
   // `packages/data-model/test/value-clone.test.ts`. This file covers the
   // path-traversal readers that remain in `v2-path.ts`.
+
   it("ignores inherited object properties during traversal", () => {
     const root = Object.create({
       inherited: 7,

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -70,9 +70,10 @@ class FakeByteCache implements ModuleByteCache {
   }
 }
 
-// A shared module-byte cache lets a fresh runtime compiling into a fresh space
-// reuse another runtime's compiled module bytes (cross-runtime, cross-space).
 describe("ModuleByteCache cross-runtime reuse", () => {
+  // A shared module-byte cache lets a fresh runtime compiling into a fresh
+  // space reuse another runtime's compiled module bytes (cross-runtime,
+  // cross-space).
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
   const PROGRAM: RuntimeProgram = {

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -74,6 +74,7 @@ describe("ModuleByteCache cross-runtime reuse", () => {
   // A shared module-byte cache lets a fresh runtime compiling into a fresh
   // space reuse another runtime's compiled module bytes (cross-runtime,
   // cross-space).
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
   const PROGRAM: RuntimeProgram = {

--- a/packages/runner/test/pattern-breakpoint.test.ts
+++ b/packages/runner/test/pattern-breakpoint.test.ts
@@ -2,10 +2,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { patternBreakpoint } from "../src/pattern-breakpoint.ts";
 
-// patternBreakpoint stands in for `fn(argument)` when a debugger breakpoint is
-// set: it logs context, pauses at `debugger` (a no-op with no debugger
-// attached), then calls through only when the argument validated.
 describe("patternBreakpoint", () => {
+  // patternBreakpoint stands in for `fn(argument)` when a debugger breakpoint
+  // is set: it logs context, pauses at `debugger` (a no-op with no debugger
+  // attached), then calls through only when the argument validated.
   it("calls the function with the argument when the argument is valid", () => {
     const logs: unknown[][] = [];
     const originalLog = console.log;

--- a/packages/runner/test/pattern-breakpoint.test.ts
+++ b/packages/runner/test/pattern-breakpoint.test.ts
@@ -6,6 +6,7 @@ describe("patternBreakpoint", () => {
   // patternBreakpoint stands in for `fn(argument)` when a debugger breakpoint
   // is set: it logs context, pauses at `debugger` (a no-op with no debugger
   // attached), then calls through only when the argument validated.
+
   it("calls the function with the argument when the argument is valid", () => {
     const logs: unknown[][] = [];
     const originalLog = console.log;

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -1095,11 +1095,12 @@ Deno.test("pattern coverage records a piece resumed by identity", async () => {
   }
 });
 
-// The integration scenario: a non-coverage realm authored the piece, so the
-// coverage-keyed compiled closure the resuming runtime looks for does not exist.
-// The resume then falls back to cold recovery — a recompile from the stored
-// source closure — which is the only place the instrumentation can come from.
 Deno.test("pattern coverage records a piece authored without coverage and resumed with it", async () => {
+  // The integration scenario: a non-coverage realm authored the piece, so the
+  // coverage-keyed compiled closure the resuming runtime looks for does not
+  // exist. The resume then falls back to cold recovery — a recompile from the
+  // stored source closure — which is the only place the instrumentation can
+  // come from.
   const signer = await Identity.fromPassphrase(
     "cold-recovery pattern coverage",
   );

--- a/packages/runner/test/pattern-provenance.test.ts
+++ b/packages/runner/test/pattern-provenance.test.ts
@@ -15,6 +15,7 @@ describe("pattern provenance brand", () => {
   // provenance brand stamped only by the trusted `pattern()` builder — so a
   // forged pattern-shaped export cannot launder program / verified-load-id
   // metadata.
+
   const patternShape = {
     argumentSchema: {},
     resultSchema: {},

--- a/packages/runner/test/pattern-provenance.test.ts
+++ b/packages/runner/test/pattern-provenance.test.ts
@@ -8,13 +8,13 @@ import {
 } from "../src/builder/pattern-metadata.ts";
 import { freezeVerifiedPlainData } from "../src/sandbox/plain-data.ts";
 
-// `isPattern` is a purely structural check, so an attacker can forge the shape
-// via `__cf_data({...})` (a frozen plain object). Trust-granting sites use
-// `isTrustedPattern`, which additionally requires the value to carry the
-// provenance brand stamped only by the trusted `pattern()` builder — so a forged
-// pattern-shaped export cannot launder program / verified-load-id metadata.
-
 describe("pattern provenance brand", () => {
+  // `isPattern` is a purely structural check, so an attacker can forge the
+  // shape via `__cf_data({...})` (a frozen plain object). Trust-granting sites
+  // use `isTrustedPattern`, which additionally requires the value to carry the
+  // provenance brand stamped only by the trusted `pattern()` builder — so a
+  // forged pattern-shaped export cannot launder program / verified-load-id
+  // metadata.
   const patternShape = {
     argumentSchema: {},
     resultSchema: {},

--- a/packages/runner/test/prototype-named-properties.test.ts
+++ b/packages/runner/test/prototype-named-properties.test.ts
@@ -251,9 +251,9 @@ describe("properties named after Object.prototype members", () => {
   });
 });
 
-// `path-utils` and `piece-helpers` are exported surfaces, so they get direct
-// coverage rather than being exercised only through a cell.
 describe("path helpers and prototype-named segments", () => {
+  // `path-utils` and `piece-helpers` are exported surfaces, so they get direct
+  // coverage rather than being exercised only through a cell.
   it("getValueAtPath does not hand back an inherited member", () => {
     expect(getValueAtPath({}, ["toString"])).toBe(undefined);
     expect(getValueAtPath({}, ["valueOf"])).toBe(undefined);

--- a/packages/runner/test/prototype-named-properties.test.ts
+++ b/packages/runner/test/prototype-named-properties.test.ts
@@ -254,6 +254,7 @@ describe("properties named after Object.prototype members", () => {
 describe("path helpers and prototype-named segments", () => {
   // `path-utils` and `piece-helpers` are exported surfaces, so they get direct
   // coverage rather than being exercised only through a cell.
+
   it("getValueAtPath does not hand back an inherited member", () => {
     expect(getValueAtPath({}, ["toString"])).toBe(undefined);
     expect(getValueAtPath({}, ["valueOf"])).toBe(undefined);

--- a/packages/runner/test/pull-notifications-shaping.test.ts
+++ b/packages/runner/test/pull-notifications-shaping.test.ts
@@ -6,14 +6,14 @@ import { shaperInstanceGroupKey } from "../src/scheduler/wake-shaping.ts";
 // deno-lint-ignore no-explicit-any
 const anyOf = <T>(v: unknown) => v as T;
 
-// The classifier that keys the cell-notification token bucket. Only renderer
-// keystroke input is shaped; server pushes must NOT be, because deferring a
-// push's mark-dirty breaks incremental observation adoption (the writer's
-// observations arrive in the same synchronous turn as the integrate whose dirt
-// they clear). The bucket key is space-qualified so two instances of one pattern
-// in different spaces (which can share a content-addressed pieceId) do not
-// collide.
 describe("shapableWakeGroupKey", () => {
+  // The classifier that keys the cell-notification token bucket. Only renderer
+  // keystroke input is shaped; server pushes must NOT be, because deferring a
+  // push's mark-dirty breaks incremental observation adoption (the writer's
+  // observations arrive in the same synchronous turn as the integrate whose
+  // dirt they clear). The bucket key is space-qualified so two instances of one
+  // pattern in different spaces (which can share a content-addressed pieceId)
+  // do not collide.
   const rendererInputTx = { marker: "renderer-input" };
   const state = anyOf<Parameters<typeof shapableWakeGroupKey>[0]>({
     isRendererInputSource: (source: object | undefined) =>

--- a/packages/runner/test/pull-notifications-shaping.test.ts
+++ b/packages/runner/test/pull-notifications-shaping.test.ts
@@ -14,6 +14,7 @@ describe("shapableWakeGroupKey", () => {
   // dirt they clear). The bucket key is space-qualified so two instances of one
   // pattern in different spaces (which can share a content-addressed pieceId)
   // do not collide.
+
   const rendererInputTx = { marker: "renderer-input" };
   const state = anyOf<Parameters<typeof shapableWakeGroupKey>[0]>({
     isRendererInputSource: (source: object | undefined) =>

--- a/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
@@ -61,6 +61,7 @@ describe("internCellLinkSchema preserves FabricValue schema defaults read throug
   // End-to-end: a schema whose `default` carries a non-JSON FabricValue, read
   // through a query-result proxy, must intern without throwing AND without
   // losing the value to a JSON shadow.
+
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
@@ -57,10 +57,10 @@ describe("query-result proxy: FabricPrimitive leaves are not proxy-wrapped", () 
   });
 });
 
-// End-to-end: a schema whose `default` carries a non-JSON FabricValue, read
-// through a query-result proxy, must intern without throwing AND without losing
-// the value to a JSON shadow.
 describe("internCellLinkSchema preserves FabricValue schema defaults read through a proxy", () => {
+  // End-to-end: a schema whose `default` carries a non-JSON FabricValue, read
+  // through a query-result proxy, must intern without throwing AND without
+  // losing the value to a JSON shadow.
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/replica-eviction-invariants.test.ts
+++ b/packages/runner/test/replica-eviction-invariants.test.ts
@@ -127,10 +127,9 @@ describe("a list projection survives its input emptying", () => {
   });
 });
 
-// Two managers over one in-process server, so a commit on one can conflict with
-// a commit on the other.
-
 describe("a cross-replica conflict settles", () => {
+  // Two managers over one in-process server, so a commit on one can conflict
+  // with a commit on the other.
   let server: MemoryV2Server.Server;
   let storageA: EmulatedStorageManager;
   let storageB: EmulatedStorageManager;

--- a/packages/runner/test/resume-by-identity.test.ts
+++ b/packages/runner/test/resume-by-identity.test.ts
@@ -9,11 +9,11 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 const signer = await Identity.fromPassphrase("resume-by-identity");
 const space = signer.did();
 
-// End-to-end step 3: a result cell records the content-addressed
-// {identity, symbol} pattern reference at setup; a fresh runtime resuming that
-// result cell from storage loads the pattern straight from the compiled cache
-// BY IDENTITY (no TS source pulled, no meta-cell roundtrip), and re-runs it.
 describe("resume a result cell by {identity, symbol}", () => {
+  // End-to-end step 3: a result cell records the content-addressed {identity,
+  // symbol} pattern reference at setup; a fresh runtime resuming that result
+  // cell from storage loads the pattern straight from the compiled cache BY
+  // IDENTITY (no TS source pulled, no meta-cell roundtrip), and re-runs it.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
   const RESULT_CAUSE = "resume-by-identity result cell";

--- a/packages/runner/test/resume-presync-unwrap-failure.test.ts
+++ b/packages/runner/test/resume-presync-unwrap-failure.test.ts
@@ -16,13 +16,13 @@ const presyncWarns = () => {
     ?.total ?? 0;
 };
 
-// The resume pre-sync (syncCellsForRunningPatternInner) unwraps each node's
-// bindings before walking them for write redirects. A node whose bindings
-// cannot be bound — here a partialCause alias with no matching
-// derivedInternalCells descriptor — must be skipped with a warn rather than
-// breaking the pre-sync walk. (Instantiation then rejects the same alias at
-// bind time; that failure is the pattern's problem, not the pre-sync's.)
 describe("resume pre-sync unwrap failure", () => {
+  // The resume pre-sync (syncCellsForRunningPatternInner) unwraps each node's
+  // bindings before walking them for write redirects. A node whose bindings
+  // cannot be bound — here a partialCause alias with no matching
+  // derivedInternalCells descriptor — must be skipped with a warn rather than
+  // breaking the pre-sync walk. (Instantiation then rejects the same alias at
+  // bind time; that failure is the pattern's problem, not the pre-sync's.)
   it("skips a node whose bindings do not unwrap, with a warn", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     try {

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -51,13 +51,14 @@ function makeServer(): MemoryV2Server.Server {
   });
 }
 
-// runtime.dispose() tears down storage as part of shutdown. Storage teardown
-// used to flush in-flight commits — awaiting their confirmation — BEFORE closing
-// the client that would settle them. A commit whose response is withheld past
-// dispose never confirms on its own, so that pre-teardown flush deadlocked, and
-// dispose() hung. Teardown must reject in-flight commits (the way it already
-// rejects in-flight reads) rather than wait on a response that may never come.
 Deno.test("runtime.dispose() resolves while a commit is withheld in flight", async () => {
+  // runtime.dispose() tears down storage as part of shutdown. Storage teardown
+  // used to flush in-flight commits — awaiting their confirmation — BEFORE
+  // closing the client that would settle them. A commit whose response is
+  // withheld past dispose never confirms on its own, so that pre-teardown flush
+  // deadlocked, and dispose() hung. Teardown must reject in-flight commits (the
+  // way it already rejects in-flight reads) rather than wait on a response that
+  // may never come.
   const signer = await Identity.fromPassphrase(
     "runtime-dispose-withheld-commit",
   );

--- a/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
+++ b/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
@@ -27,6 +27,7 @@ describe("Runtime.prepareTxForCommit()", () => {
   // `prepareCfc` reads and writes the derived label map. A settled transaction
   // refuses both, and cannot commit either, so prepare on one returns without
   // touching it and leaves the terminal state to the commit result.
+
   const started: {
     runtime: Runtime;
     storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
+++ b/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
@@ -21,12 +21,12 @@ const LABELED_SCHEMA = {
   required: ["secret"],
 } as const;
 
-// `prepareTxForCommit` reaches storage through the transaction it prepares,
-// by two routes: the flow-labels relevance probe reads stored metadata, and
-// `prepareCfc` reads and writes the derived label map. A settled transaction
-// refuses both, and cannot commit either, so prepare on one returns without
-// touching it and leaves the terminal state to the commit result.
 describe("Runtime.prepareTxForCommit()", () => {
+  // `prepareTxForCommit` reaches storage through the transaction it prepares,
+  // by two routes: the flow-labels relevance probe reads stored metadata, and
+  // `prepareCfc` reads and writes the derived label map. A settled transaction
+  // refuses both, and cannot commit either, so prepare on one returns without
+  // touching it and leaves the terminal state to the commit result.
   const started: {
     runtime: Runtime;
     storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/scheduler-split-clock.test.ts
+++ b/packages/runner/test/scheduler-split-clock.test.ts
@@ -12,13 +12,12 @@ import {
 import type { SchedulerNode } from "../src/scheduler/node-record.ts";
 import type { QueuedEvent } from "../src/scheduler/types.ts";
 
-// F11: a readiness/parked decision must read `performance.now()` once. When the
-// head-event park check is evaluated twice with two different clock reads, an
-// event whose `notBefore` falls between them is classed as neither ready nor
-// parked — so the quiescent continuation resolves idle() with the event still
-// queued and undispatched.
-
 describe("split-clock readiness decisions", () => {
+  // F11: a readiness/parked decision must read `performance.now()` once. When
+  // the head-event park check is evaluated twice with two different clock
+  // reads, an event whose `notBefore` falls between them is classed as neither
+  // ready nor parked — so the quiescent continuation resolves idle() with the
+  // event still queued and undispatched.
   const realNow = performance.now.bind(performance);
 
   afterEach(() => {

--- a/packages/runner/test/scheduler-split-clock.test.ts
+++ b/packages/runner/test/scheduler-split-clock.test.ts
@@ -18,6 +18,7 @@ describe("split-clock readiness decisions", () => {
   // reads, an event whose `notBefore` falls between them is classed as neither
   // ready nor parked — so the quiescent continuation resolves idle() with the
   // event still queued and undispatched.
+
   const realNow = performance.now.bind(performance);
 
   afterEach(() => {

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -32,6 +32,7 @@ describe("schema-doc-sync", () => {
   // Two managers on one shared loopback server model two real sessions: what
   // the writer commits reaches the reader only through an explicit sync, so the
   // reader's registrations come from frame arrival, not from local writes.
+
   let server: MemoryV2Server.Server;
   let writerStorage: EmulatedStorageManager;
   let readerStorage: EmulatedStorageManager;

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -28,10 +28,10 @@ import { resolveSchema } from "../src/schema.ts";
 import { LINK_V1_TAG, type URI } from "../src/sigil-types.ts";
 import { defer } from "@commonfabric/utils/defer";
 
-// Two managers on one shared loopback server model two real sessions: what
-// the writer commits reaches the reader only through an explicit sync, so
-// the reader's registrations come from frame arrival, not from local writes.
 describe("schema-doc-sync", () => {
+  // Two managers on one shared loopback server model two real sessions: what
+  // the writer commits reaches the reader only through an explicit sync, so the
+  // reader's registrations come from frame arrival, not from local writes.
   let server: MemoryV2Server.Server;
   let writerStorage: EmulatedStorageManager;
   let readerStorage: EmulatedStorageManager;

--- a/packages/runner/test/schema-doc-writer.test.ts
+++ b/packages/runner/test/schema-doc-writer.test.ts
@@ -26,10 +26,10 @@ import {
 } from "@commonfabric/memory/v2";
 import type { CellLinkRefPayload, URI } from "../src/sigil-types.ts";
 
-// The Phase 1 writer: with the flag on, a schema-bearing link is stamped
-// with a cid: reference and the commit materializes the schema documents
-// into the destination space (the write-side delivery guarantee).
 describe("schema-doc-writer", () => {
+  // The Phase 1 writer: with the flag on, a schema-bearing link is stamped with
+  // a cid: reference and the commit materializes the schema documents into the
+  // destination space (the write-side delivery guarantee).
   let server: MemoryV2Server.Server;
   let writerStorage: EmulatedStorageManager;
   let readerStorage: EmulatedStorageManager;

--- a/packages/runner/test/schema-doc-writer.test.ts
+++ b/packages/runner/test/schema-doc-writer.test.ts
@@ -30,6 +30,7 @@ describe("schema-doc-writer", () => {
   // The Phase 1 writer: with the flag on, a schema-bearing link is stamped with
   // a cid: reference and the commit materializes the schema documents into the
   // destination space (the write-side delivery guarantee).
+
   let server: MemoryV2Server.Server;
   let writerStorage: EmulatedStorageManager;
   let readerStorage: EmulatedStorageManager;

--- a/packages/runner/test/ses-runtime-source-maps.test.ts
+++ b/packages/runner/test/ses-runtime-source-maps.test.ts
@@ -5,11 +5,12 @@ import { identitySourceMap } from "@commonfabric/js-compiler/source-map";
 
 import { SESRuntime } from "../src/sandbox/ses-runtime.ts";
 
-// The runner-facing source-map surface of the SES runtime: the module-graph boot
-// path registers deferred providers (CT-1819), and both coordinate lookup and
-// stack parsing read what those providers materialize. The provider semantics
-// themselves belong to `SourceMapParser` and are covered by its own tests.
 describe("SESRuntime source-map registration", () => {
+  // The runner-facing source-map surface of the SES runtime: the module-graph
+  // boot path registers deferred providers (CT-1819), and both coordinate
+  // lookup and stack parsing read what those providers materialize. The
+  // provider semantics themselves belong to `SourceMapParser` and are covered
+  // by its own tests.
   it("lazy providers materialize once, on first lookup", () => {
     const runtime = new SESRuntime();
     let providerCalls = 0;

--- a/packages/runner/test/ses-runtime-source-maps.test.ts
+++ b/packages/runner/test/ses-runtime-source-maps.test.ts
@@ -11,6 +11,7 @@ describe("SESRuntime source-map registration", () => {
   // lookup and stack parsing read what those providers materialize. The
   // provider semantics themselves belong to `SourceMapParser` and are covered
   // by its own tests.
+
   it("lazy providers materialize once, on first lookup", () => {
     const runtime = new SESRuntime();
     let providerCalls = 0;

--- a/packages/runner/test/sqlite-write-ceiling.test.ts
+++ b/packages/runner/test/sqlite-write-ceiling.test.ts
@@ -123,10 +123,11 @@ describe("checkSqliteWriteCeiling", () => {
   });
 });
 
-// Regression: every one of these used to FAIL OPEN — a labeled value over the
-// `body` ceiling slipped through because its target column couldn't be resolved
-// and "no ceiling found" was treated as "no ceiling". They must now reject.
 describe("checkSqliteWriteCeiling — fail closed (was fail-open)", () => {
+  // Regression: every one of these used to FAIL OPEN — a labeled value over the
+  // `body` ceiling slipped through because its target column couldn't be
+  // resolved and "no ceiling found" was treated as "no ceiling". They must now
+  // reject.
   it("interleaved literal in VALUES (positional ? mis-maps)", () => {
     // The `?` binds to `body` (capped), but a naive parser maps it to `subject`.
     expect(

--- a/packages/runner/test/sqlite-write-ceiling.test.ts
+++ b/packages/runner/test/sqlite-write-ceiling.test.ts
@@ -128,6 +128,7 @@ describe("checkSqliteWriteCeiling — fail closed (was fail-open)", () => {
   // `body` ceiling slipped through because its target column couldn't be
   // resolved and "no ceiling found" was treated as "no ceiling". They must now
   // reject.
+
   it("interleaved literal in VALUES (positional ? mis-maps)", () => {
     // The `?` binds to `body` (capped), but a naive parser maps it to `subject`.
     expect(

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -877,13 +877,13 @@ describe("stage A: instance keying — unit pins", () => {
   });
 });
 
-// The OFF-arm serialized-form witness the stage-A build report claimed
-// and the independent review found unpinned (finding 9): with the flag OFF
-// and no serving posture — every client today — no storage notification
-// change address, reactivity-log address, replica state, or replica
-// document carries a `scopeKey` own-property. Adopted from the review's
-// probe (`zz-review-off-notification-probe`).
 describe("stage A: OFF-arm serialized forms carry no scopeKey", () => {
+  // The OFF-arm serialized-form witness the stage-A build report claimed and
+  // the independent review found unpinned (finding 9): with the flag OFF and no
+  // serving posture — every client today — no storage notification change
+  // address, reactivity-log address, replica state, or replica document carries
+  // a `scopeKey` own-property. Adopted from the review's probe
+  // (`zz-review-off-notification-probe`).
   let offManager: ReturnType<typeof StorageManager.emulate>;
   let offRuntime: Runtime;
 

--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -10,14 +10,14 @@ import type { CommitError } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
 
-// The `#now/N` grid ticks on a recurring wall-clock-boundary timer. These cases
-// observe the grid value advancing across a boundary, driving the beat with
-// `clock.tick` and reading the coarsened value before and after. They are split
-// out of `wish.test.ts` because the grid's heartbeat and its shared result cell
-// carry state across a suite's cases: run alongside the ~30 other `#now` cases,
-// the beat fires but the observed value stays frozen. In their own file each
-// case starts from a clean grid.
 describe("interval #now wish", () => {
+  // The `#now/N` grid ticks on a recurring wall-clock-boundary timer. These
+  // cases observe the grid value advancing across a boundary, driving the beat
+  // with `clock.tick` and reading the coarsened value before and after. They
+  // are split out of `wish.test.ts` because the grid's heartbeat and its shared
+  // result cell carry state across a suite's cases: run alongside the ~30 other
+  // `#now` cases, the beat fires but the observed value stays frozen. In their
+  // own file each case starts from a clean grid.
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: ReturnType<Runtime["edit"]>;

--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -18,6 +18,7 @@ describe("interval #now wish", () => {
   // result cell carry state across a suite's cases: run alongside the ~30 other
   // `#now` cases, the beat fires but the observed value stays frozen. In their
   // own file each case starts from a clean grid.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: ReturnType<Runtime["edit"]>;

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -323,6 +323,7 @@ describe("sidecarValueIsWinner", () => {
   // The winner predicate itself (Cubic P2, review round): an error ACCOUNT left
   // by commitPatternErrorUI must NOT count as a racing winner — yielding to it
   // would leave the surface permanently red and defeat the heal path.
+
   it("an empty cell is no winner", () => {
     expect(sidecarValueIsWinner(undefined)).toBe(false);
   });

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -319,10 +319,10 @@ describe("sidecarRunFailureDisposition", () => {
   });
 });
 
-// The winner predicate itself (Cubic P2, review round): an error ACCOUNT
-// left by commitPatternErrorUI must NOT count as a racing winner — yielding
-// to it would leave the surface permanently red and defeat the heal path.
 describe("sidecarValueIsWinner", () => {
+  // The winner predicate itself (Cubic P2, review round): an error ACCOUNT left
+  // by commitPatternErrorUI must NOT count as a racing winner — yielding to it
+  // would leave the surface permanently red and defeat the heal path.
   it("an empty cell is no winner", () => {
     expect(sidecarValueIsWinner(undefined)).toBe(false);
   });

--- a/packages/runtime-client/test/page-handle.test.ts
+++ b/packages/runtime-client/test/page-handle.test.ts
@@ -10,6 +10,7 @@ describe("PageHandle start/stop space threading", () => {
   // for a foreign-space page routes to that space's piece context (a home-space
   // handle carries the home space, which resolves to the same context as the
   // no-space form).
+
   const space = "did:key:z6Mk-page-handle-space" as DID;
 
   function makeHandle() {

--- a/packages/runtime-client/test/page-handle.test.ts
+++ b/packages/runtime-client/test/page-handle.test.ts
@@ -5,11 +5,11 @@ import { PageHandle } from "@/page-handle.ts";
 import { $conn, type RuntimeClient } from "@/runtime-client.ts";
 import { type CellRef, RequestType } from "@/protocol/mod.ts";
 
-// Federation PR2: PageHandle.start/stop carry their cell's space so a
-// handle for a foreign-space page routes to that space's piece context
-// (a home-space handle carries the home space, which resolves to the
-// same context as the no-space form).
 describe("PageHandle start/stop space threading", () => {
+  // Federation PR2: PageHandle.start/stop carry their cell's space so a handle
+  // for a foreign-space page routes to that space's piece context (a home-space
+  // handle carries the home space, which resolves to the same context as the
+  // no-space form).
   const space = "did:key:z6Mk-page-handle-space" as DID;
 
   function makeHandle() {

--- a/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
+++ b/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
@@ -10,6 +10,7 @@ describe("SchemaGenerator flap coverage", () => {
   // paths are skipped, so the lines are recorded as covered in some CI runs and
   // uncovered in others. These unit tests drive the same branches directly with
   // hand-built type declarations so they are covered on every run.
+
   it("resolves the element type of an array type alias to the concrete element schema", async () => {
     // type-utils.ts getArrayElementInfo: when a property's TypeNode is a
     // reference to a type alias whose right-hand side is `Element[]`, the

--- a/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
+++ b/packages/schema-generator/test/schema-generator-flap-coverage.test.ts
@@ -4,13 +4,12 @@ import ts from "typescript";
 import { SchemaGenerator } from "../src/schema-generator.ts";
 import { asObjectSchema, createTestProgram, getTypeFromCode } from "./utils.ts";
 
-// The branches exercised here otherwise run only when a pattern compiles
-// "cold" through the transformer. When the compile cache is warm those code
-// paths are skipped, so the lines are recorded as covered in some CI runs and
-// uncovered in others. These unit tests drive the same branches directly with
-// hand-built type declarations so they are covered on every run.
-
 describe("SchemaGenerator flap coverage", () => {
+  // The branches exercised here otherwise run only when a pattern compiles
+  // "cold" through the transformer. When the compile cache is warm those code
+  // paths are skipped, so the lines are recorded as covered in some CI runs and
+  // uncovered in others. These unit tests drive the same branches directly with
+  // hand-built type declarations so they are covered on every run.
   it("resolves the element type of an array type alias to the concrete element schema", async () => {
     // type-utils.ts getArrayElementInfo: when a property's TypeNode is a
     // reference to a type alias whose right-hand side is `Element[]`, the

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -12,6 +12,7 @@ const { FRONTEND_URL } = env;
 describe("shell login tests", () => {
   // Tests the manual logging in via passphrase. Other tests should use the
   // `shell.login(identity)` utility to directly provide an identity.
+
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -9,10 +9,9 @@ import { clickPierce, pierce } from "./shadow-dom.ts";
 
 const { FRONTEND_URL } = env;
 
-// Tests the manual logging in via passphrase.
-// Other tests should use the `shell.login(identity)`
-// utility to directly provide an identity.
 describe("shell login tests", () => {
+  // Tests the manual logging in via passphrase. Other tests should use the
+  // `shell.login(identity)` utility to directly provide an identity.
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 

--- a/packages/shell/test/runtime-lifecycle.test.ts
+++ b/packages/shell/test/runtime-lifecycle.test.ts
@@ -2,11 +2,11 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { shouldRecreateRuntime } from "../src/lib/runtime-lifecycle.ts";
 
-// One runtime per (identity, host). A space/view change must NOT
-// recreate the runtime — that is the load-bearing lifecycle rule behind
-// "space is just part of the address". (apiUrl/identity compare by
-// reference, matching the AppState lifecycle this guards.)
 describe("shouldRecreateRuntime", () => {
+  // One runtime per (identity, host). A space/view change must NOT recreate the
+  // runtime — that is the load-bearing lifecycle rule behind "space is just
+  // part of the address". (apiUrl/identity compare by reference, matching the
+  // AppState lifecycle this guards.)
   const identity = { did: () => "did:key:z6Mk-lifecycle" } as never;
   const otherIdentity = { did: () => "did:key:z6Mk-other" } as never;
   const hostA = new URL("http://host-a.test/");

--- a/packages/shell/test/runtime-lifecycle.test.ts
+++ b/packages/shell/test/runtime-lifecycle.test.ts
@@ -7,6 +7,7 @@ describe("shouldRecreateRuntime", () => {
   // runtime — that is the load-bearing lifecycle rule behind "space is just
   // part of the address". (apiUrl/identity compare by reference, matching the
   // AppState lifecycle this guards.)
+
   const identity = { did: () => "did:key:z6Mk-lifecycle" } as never;
   const otherIdentity = { did: () => "did:key:z6Mk-other" } as never;
   const hostA = new URL("http://host-a.test/");

--- a/packages/static/scripts/compile-type-lib.test.ts
+++ b/packages/static/scripts/compile-type-lib.test.ts
@@ -3,12 +3,13 @@ import { join } from "@std/path";
 
 import { compileMain } from "./compile-type-lib.ts";
 
-// The compiler resolves `/// <reference lib="...">` directives and emits one
-// file, dropping the withheld-global declarations on the way out. This exercises
-// that end to end against a temporary library rather than the real TypeScript
-// tree: a target that references a second file, and a withheld `declare var`
-// that must not survive into the output while its interface does.
 Deno.test("compileMain resolves references and strips withheld globals", async () => {
+  // The compiler resolves `/// <reference lib="...">` directives and emits one
+  // file, dropping the withheld-global declarations on the way out. This
+  // exercises that end to end against a temporary library rather than the real
+  // TypeScript tree: a target that references a second file, and a withheld
+  // `declare var` that must not survive into the output while its interface
+  // does.
   const dir = await Deno.makeTempDir();
   try {
     await Deno.writeTextFile(

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,10 +1,11 @@
 import { assertEquals } from "@std/assert";
 import { EnvSchema } from "@/env.ts";
 
-// Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true,
-// which would silently enable telemetry (and, with the all-span exporter, ship
-// every HTTP request span) when an operator set OTEL_ENABLED=false to disable it.
 Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () => {
+  // Regression guard for the z.coerce.boolean() footgun: Boolean("false") ===
+  // true, which would silently enable telemetry (and, with the all-span
+  // exporter, ship every HTTP request span) when an operator set
+  // OTEL_ENABLED=false to disable it.
   const otel = (v: string | undefined) =>
     EnvSchema.parse(v === undefined ? {} : { OTEL_ENABLED: v }).OTEL_ENABLED;
 
@@ -77,11 +78,11 @@ Deno.test("INGEST_SELF_SERVE_ENABLED is off unless explicitly enabled", () => {
   assertEquals(flag("1"), true);
 });
 
-// The memory websocket pong deadline has to be tunable per deployment: it
-// must exceed the memory server's longest synchronous busy stretch, which an
-// operator observes in production, and 0 must disable the timeout entirely
-// (Deno.upgradeWebSocket's contract for idleTimeout).
 Deno.test("MEMORY_WS_IDLE_TIMEOUT_SECONDS defaults to 300 and accepts overrides", () => {
+  // The memory websocket pong deadline has to be tunable per deployment: it
+  // must exceed the memory server's longest synchronous busy stretch, which an
+  // operator observes in production, and 0 must disable the timeout entirely
+  // (Deno.upgradeWebSocket's contract for idleTimeout).
   const idle = (value: string | undefined) =>
     EnvSchema.parse(
       value === undefined ? {} : { MEMORY_WS_IDLE_TIMEOUT_SECONDS: value },

--- a/packages/toolshed/lib/build-info.test.ts
+++ b/packages/toolshed/lib/build-info.test.ts
@@ -178,12 +178,12 @@ Deno.test("readBuildInfoFrom", async (t) => {
   }
 });
 
-// The shell's baked server-execution posture rides the same COMPILED marker
-// (tasks/build-binaries.ts writes it from the build environment — the value
-// packages/shell/felt.config.ts bakes as the shell's define). CI's
-// server-execution lanes read it back through /api/meta to verify the
-// posture the binary actually carries; a missing/unset value reads null.
 Deno.test("readShellServerExecutionDefineFrom", async (t) => {
+  // The shell's baked server-execution posture rides the same COMPILED marker
+  // (tasks/build-binaries.ts writes it from the build environment — the value
+  // packages/shell/felt.config.ts bakes as the shell's define). CI's
+  // server-execution lanes read it back through /api/meta to verify the posture
+  // the binary actually carries; a missing/unset value reads null.
   const tempDir = await Deno.makeTempDir({ prefix: "build-info-sx-test-" });
   const pathFor = (name: string) => `${tempDir}/${name}`;
   try {

--- a/packages/toolshed/lib/configure-open-api.test.ts
+++ b/packages/toolshed/lib/configure-open-api.test.ts
@@ -11,11 +11,10 @@ if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-// `@/app.ts` is the app the server serves: `configureOpenAPI` plus every
-// router. The document is generated per request from the schemas of the routes
-// mounted on it.
-
 Deno.test("openapi reference", async (t) => {
+  // `@/app.ts` is the app the server serves: `configureOpenAPI` plus every
+  // router. The document is generated per request from the schemas of the
+  // routes mounted on it.
   await t.step("GET /doc serves the OpenAPI document", async () => {
     const response = await app.request("/doc");
     assertEquals(response.status, 200);

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -13,12 +13,12 @@ import {
   shutdownOpenTelemetry,
 } from "@/lib/otel.ts";
 
-// The provider takes the configured resource as given, so the service
-// attributes and the SDK's own defaults have to be merged before it is handed
-// over. Both halves are read off a span the real provider produced, since a
-// span carries the resource the exporter will stamp on it. The span is left
-// unended so nothing is queued for export.
 Deno.test("spans carry both the service attributes and the SDK defaults", () => {
+  // The provider takes the configured resource as given, so the service
+  // attributes and the SDK's own defaults have to be merged before it is handed
+  // over. Both halves are read off a span the real provider produced, since a
+  // span carries the resource the exporter will stamp on it. The span is left
+  // unended so nothing is queued for export.
   const span = provider.getTracer("otel-test").startSpan(
     "resource-probe",
   ) as unknown as ReadableSpan;

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -71,6 +71,7 @@ describe("memoryAclPrincipalsFor", () => {
   // service reads), NEVER an OWNER-class service DID by default — the
   // operator's configured list is verbatim on BOTH arms, retiring the Phase-7
   // implicit-OWNER blanket.
+
   const me = "did:key:z6MkToolshedProcess";
   const operator = "did:key:z6MkOperator";
 

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -65,12 +65,12 @@ describe("serverExecutionEnabledFromEnv", () => {
   });
 });
 
-// OW31 (RULED 2026-08-18/19): the process identity is a DELEGATING
-// principal under the flag (session-level acting-as-owner READ binding;
-// ACL-only service reads), NEVER an OWNER-class service DID by default —
-// the operator's configured list is verbatim on BOTH arms, retiring the
-// Phase-7 implicit-OWNER blanket.
 describe("memoryAclPrincipalsFor", () => {
+  // OW31 (RULED 2026-08-18/19): the process identity is a DELEGATING principal
+  // under the flag (session-level acting-as-owner READ binding; ACL-only
+  // service reads), NEVER an OWNER-class service DID by default — the
+  // operator's configured list is verbatim on BOTH arms, retiring the Phase-7
+  // implicit-OWNER blanket.
   const me = "did:key:z6MkToolshedProcess";
   const operator = "did:key:z6MkOperator";
 

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -223,12 +223,12 @@ describe("startServerExecutionHost OFF witness", () => {
   });
 });
 
-// The RULED test switch's env parsing (OW45 arm-B stage 1, RULED
-// 2026-08-24): unset and "true" are the production posture (ensure ON);
-// only the literal "false" switches the space-root ensure off; garbage
-// FAILS TO PRODUCTION (ON, with a warning) — a typo must never silently
-// strip production spaces of their roots.
 describe("ensureSpaceRootsFromEnv", () => {
+  // The RULED test switch's env parsing (OW45 arm-B stage 1, RULED 2026-08-24):
+  // unset and "true" are the production posture (ensure ON); only the literal
+  // "false" switches the space-root ensure off; garbage FAILS TO PRODUCTION
+  // (ON, with a warning) — a typo must never silently strip production spaces
+  // of their roots.
   const envOf2 =
     (values: Record<string, string | undefined>) => (name: string) =>
       values[name];

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -229,6 +229,7 @@ describe("ensureSpaceRootsFromEnv", () => {
   // "false" switches the space-root ensure off; garbage FAILS TO PRODUCTION
   // (ON, with a warning) — a typo must never silently strip production spaces
   // of their roots.
+
   const envOf2 =
     (values: Record<string, string | undefined>) => (name: string) =>
       values[name];

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.routes.test.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.routes.test.ts
@@ -19,6 +19,7 @@ describe("Ingest channels route (transport + middleware)", () => {
   // (mint/rotate/revoke: capacity 10, refill 0.1/s). Adding many more requests
   // here will silently turn 401 expectations into 429s. Keep it small, or give
   // the new assertions their own verb.
+
   const post = (path: string, init: RequestInit = {}) =>
     app.request(path, {
       method: "POST",

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.routes.test.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.routes.test.ts
@@ -8,17 +8,17 @@ if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-// Smoke tests for the mounted router. The authorization contract itself is
-// tested against a real ACL-enforcing memory server in
-// ingest-channels.utils.test.ts; what can only be checked HERE is the middleware
-// stack — which is the most novel part of this route package and was otherwise
-// asserted by nothing but a comment.
-// NOTE: the rate limiters are module-level in .index.ts, so every request in
-// this file spends real tokens from a bucket shared across the whole test
-// process (mint/rotate/revoke: capacity 10, refill 0.1/s). Adding many more
-// requests here will silently turn 401 expectations into 429s. Keep it small,
-// or give the new assertions their own verb.
 describe("Ingest channels route (transport + middleware)", () => {
+  // Smoke tests for the mounted router. The authorization contract itself is
+  // tested against a real ACL-enforcing memory server in
+  // ingest-channels.utils.test.ts; what can only be checked HERE is the
+  // middleware stack — which is the most novel part of this route package and
+  // was otherwise asserted by nothing but a comment. NOTE: the rate limiters
+  // are module-level in .index.ts, so every request in this file spends real
+  // tokens from a bucket shared across the whole test process
+  // (mint/rotate/revoke: capacity 10, refill 0.1/s). Adding many more requests
+  // here will silently turn 401 expectations into 429s. Keep it small, or give
+  // the new assertions their own verb.
   const post = (path: string, init: RequestInit = {}) =>
     app.request(path, {
       method: "POST",

--- a/packages/toolshed/routes/ingest/ingest.routes.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.routes.test.ts
@@ -7,14 +7,14 @@ if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-// Smoke tests: confirm POST /api/ingest/:id is mounted and its transport-level
-// branches behave. Driven through the real `app` (not a freshly-mounted router)
-// because the handler imports the `runtime` singleton from `@/index.ts`, which
-// is uninitialized under test — so any path that reaches storage yields 502,
-// which is itself the storage-error contract. The full auth + validation
-// contract is unit-tested against a real runtime in ingest.utils.test.ts
-// (processIngest).
 describe("Ingest route (smoke: wired up + transport paths)", () => {
+  // Smoke tests: confirm POST /api/ingest/:id is mounted and its
+  // transport-level branches behave. Driven through the real `app` (not a
+  // freshly-mounted router) because the handler imports the `runtime` singleton
+  // from `@/index.ts`, which is uninitialized under test — so any path that
+  // reaches storage yields 502, which is itself the storage-error contract. The
+  // full auth + validation contract is unit-tested against a real runtime in
+  // ingest.utils.test.ts (processIngest).
   it("POST /api/ingest/:id without a bearer token -> 401", async () => {
     const res = await app.request("/api/ingest/ing_nope", {
       method: "POST",

--- a/packages/toolshed/routes/ingest/ingest.routes.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.routes.test.ts
@@ -15,6 +15,7 @@ describe("Ingest route (smoke: wired up + transport paths)", () => {
   // reaches storage yields 502, which is itself the storage-error contract. The
   // full auth + validation contract is unit-tested against a real runtime in
   // ingest.utils.test.ts (processIngest).
+
   it("POST /api/ingest/:id without a bearer token -> 401", async () => {
     const res = await app.request("/api/ingest/ing_nope", {
       method: "POST",

--- a/packages/toolshed/routes/ingest/ingest.utils.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.test.ts
@@ -30,10 +30,10 @@ const GOLDEN_ID = "of:fid1:d7_RmD4fNpTUheithVm0Q1Vha0Rn32c06qA_hOHE8x8";
 // old token live. A failure = coordinate a change, never just update the literal.
 const GOLDEN_CHANNEL_ID = "ing_jMjaGfRO0Kg0BUegs9mzwImZ-CKcmlVw-wDbmV41_bs";
 
-// The journal sink is the security-critical write path (durable, marked, into a
-// caller-provided space). These exercise it directly against an emulated store
-// (no ACL layer — see the cross-space test's caveat).
 describe("ingest journal sink", () => {
+  // The journal sink is the security-critical write path (durable, marked, into
+  // a caller-provided space). These exercise it directly against an emulated
+  // store (no ACL layer — see the cross-space test's caveat).
   let signer: Identity;
   let space: ReturnType<Identity["did"]>;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/toolshed/routes/ingest/ingest.utils.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.test.ts
@@ -34,6 +34,7 @@ describe("ingest journal sink", () => {
   // The journal sink is the security-critical write path (durable, marked, into
   // a caller-provided space). These exercise it directly against an emulated
   // store (no ACL layer — see the cross-space test's caveat).
+
   let signer: Identity;
   let space: ReturnType<Identity["did"]>;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/toolshed/routes/shell/shell.test.ts
+++ b/packages/toolshed/routes/shell/shell.test.ts
@@ -127,6 +127,7 @@ describe("Shell route CORS", () => {
   // The shell routes serve read-only content to any origin. These pin that
   // permissive CORS keeps working alongside the isolation headers, so a future
   // change to one does not silently disturb the other.
+
   it("allows a cross-origin GET with a wildcard origin", async () => {
     const response = await app.request("/", {
       headers: { Origin: "https://example.com" },

--- a/packages/toolshed/routes/shell/shell.test.ts
+++ b/packages/toolshed/routes/shell/shell.test.ts
@@ -123,10 +123,10 @@ describe("Shell cross-origin isolation posture", () => {
   });
 });
 
-// The shell routes serve read-only content to any origin. These pin that
-// permissive CORS keeps working alongside the isolation headers, so a future
-// change to one does not silently disturb the other.
 describe("Shell route CORS", () => {
+  // The shell routes serve read-only content to any origin. These pin that
+  // permissive CORS keeps working alongside the isolation headers, so a future
+  // change to one does not silently disturb the other.
   it("allows a cross-origin GET with a wildcard origin", async () => {
     const response = await app.request("/", {
       headers: { Origin: "https://example.com" },

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -15,12 +15,12 @@ import {
   toolshedRuntimeOptions,
 } from "@/runtime-options.ts";
 
-// Pins toolshed's runtime wiring decisions (CT-1814): the runtime's storage
-// base is MEMORY_URL while patterns fetch against the public API_URL; the
-// storage manager passes through untouched; EXPERIMENTAL_* flags come from
-// the injected env reader via the canonical mapping; and the shared
-// first-party posture (the CFC pin) rides along from the preset.
 Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env reader", () => {
+  // Pins toolshed's runtime wiring decisions (CT-1814): the runtime's storage
+  // base is MEMORY_URL while patterns fetch against the public API_URL; the
+  // storage manager passes through untouched; EXPERIMENTAL_* flags come from
+  // the injected env reader via the canonical mapping; and the shared
+  // first-party posture (the CFC pin) rides along from the preset.
   const storageManager = {
     sentinel: true,
   } as unknown as RuntimeOptions["storageManager"];
@@ -53,12 +53,12 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
   assertEquals(options.cfcEnforcementMode, "enforce-explicit");
 });
 
-// The runtime→OTel bridge attach rides Runtime construction (CT plan: the
-// bridge is a second consumer of the RuntimeTelemetry bus). Off by default;
-// on OTEL_ENABLED it attaches and flips the preflight-telemetry gate. Without
-// a registered OTel provider the API hands the bridge no-op instruments, so
-// the enabled path is safe to exercise in a test.
 Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", async () => {
+  // The runtime→OTel bridge attach rides Runtime construction (CT plan: the
+  // bridge is a second consumer of the RuntimeTelemetry bus). Off by default;
+  // on OTEL_ENABLED it attaches and flips the preflight-telemetry gate. Without
+  // a registered OTel provider the API hands the bridge no-op instruments, so
+  // the enabled path is safe to exercise in a test.
   const signer = await Identity.fromPassphrase("runtime-options-otel-test");
   const config = {
     MEMORY_URL: "http://memory.test:8000/",
@@ -112,12 +112,12 @@ Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", as
   );
 });
 
-// What `/api/meta` reports, and therefore what a client not built alongside
-// this server adopts (docs/development/EXPERIMENTAL_OPTIONS.md). Taken from
-// the constructed Runtime rather than re-read from the environment, so the
-// published posture includes the defaults and preset resolution the server is
-// actually running under — a second reading could disagree with the first.
 Deno.test("createToolshedRuntime publishes the posture it resolved", async () => {
+  // What `/api/meta` reports, and therefore what a client not built alongside
+  // this server adopts (docs/development/EXPERIMENTAL_OPTIONS.md). Taken from
+  // the constructed Runtime rather than re-read from the environment, so the
+  // published posture includes the defaults and preset resolution the server is
+  // actually running under — a second reading could disagree with the first.
   const signer = await Identity.fromPassphrase("runtime-options-posture-test");
   const storageManager = StorageManager.emulate({ as: signer });
   publishExperimentalPosture(null);

--- a/packages/toolshed/scripts/ingest-channel-scripts.test.ts
+++ b/packages/toolshed/scripts/ingest-channel-scripts.test.ts
@@ -30,12 +30,11 @@ import {
   USAGE,
 } from "./retire-ingest-channels.ts";
 
-// The two operator scripts behind the retirement procedure. They are the only
-// tooling that makes a trust-condition cutover answerable, so the selection
-// logic — what gets retired, what is skipped, what the audit reports — is worth
-// pinning even though the entrypoints themselves are thin.
-
 describe("ingest channel operator scripts", () => {
+  // The two operator scripts behind the retirement procedure. They are the only
+  // tooling that makes a trust-condition cutover answerable, so the selection
+  // logic — what gets retired, what is skipped, what the audit reports — is
+  // worth pinning even though the entrypoints themselves are thin.
   let signer: Identity;
   let serviceSpace: string;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/toolshed/scripts/ingest-channel-scripts.test.ts
+++ b/packages/toolshed/scripts/ingest-channel-scripts.test.ts
@@ -35,6 +35,7 @@ describe("ingest channel operator scripts", () => {
   // tooling that makes a trust-condition cutover answerable, so the selection
   // logic — what gets retired, what is skipped, what the audit reports — is
   // worth pinning even though the entrypoints themselves are thin.
+
   let signer: Identity;
   let serviceSpace: string;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -10,6 +10,7 @@ import { CFMarkdown } from "./index.ts";
 describe("cf-markdown", () => {
   // What the component renders is covered by cf-markdown.browser.test.ts, which
   // runs in a browser and asserts against the DOM the component built.
+
   it("is defined", () => {
     expect(CFMarkdown).toBeDefined();
   });

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -7,9 +7,9 @@ import {
 } from "../../test-utils/mock-cell-handle.ts";
 import { CFMarkdown } from "./index.ts";
 
-// What the component renders is covered by cf-markdown.browser.test.ts, which
-// runs in a browser and asserts against the DOM the component built.
 describe("cf-markdown", () => {
+  // What the component renders is covered by cf-markdown.browser.test.ts, which
+  // runs in a browser and asserts against the DOM the component built.
   it("is defined", () => {
     expect(CFMarkdown).toBeDefined();
   });

--- a/packages/ui/src/v2/core/cfc-label.test.ts
+++ b/packages/ui/src/v2/core/cfc-label.test.ts
@@ -68,6 +68,7 @@ describe("cfcLabelViewIsPublic (egress check)", () => {
   // Host-embedding contract seam 4 (docs/features/host-embedding.md §4): the
   // egress check an embedder uses to fail closed on non-public data. Goes red
   // if the "public iff no non-empty confidentiality clause" contract changes.
+
   it("treats an absent label as public", () => {
     expect(cfcLabelViewIsPublic(undefined)).toBe(true);
   });

--- a/packages/ui/src/v2/core/cfc-label.test.ts
+++ b/packages/ui/src/v2/core/cfc-label.test.ts
@@ -64,10 +64,10 @@ describe("ownerPrincipalFromLabel", () => {
   });
 });
 
-// Host-embedding contract seam 4 (docs/features/host-embedding.md §4): the
-// egress check an embedder uses to fail closed on non-public data. Goes red if
-// the "public iff no non-empty confidentiality clause" contract changes.
 describe("cfcLabelViewIsPublic (egress check)", () => {
+  // Host-embedding contract seam 4 (docs/features/host-embedding.md §4): the
+  // egress check an embedder uses to fail closed on non-public data. Goes red
+  // if the "public iff no non-empty confidentiality clause" contract changes.
   it("treats an absent label as public", () => {
     expect(cfcLabelViewIsPublic(undefined)).toBe(true);
   });

--- a/packages/ui/src/v2/runtime-context.test.ts
+++ b/packages/ui/src/v2/runtime-context.test.ts
@@ -9,15 +9,15 @@ import {
   spaceContext,
 } from "./runtime-context.ts";
 
-// Host-embedding contract seam 2 (docs/features/host-embedding.md §2):
-// `runtimeContext` and `spaceContext` are the only REQUIRED contexts a host
-// provides; `presenceUrlContext` is optional and degrades to disabled. A host
-// and the mounted components must agree on the context *identity* — with
-// `@lit/context`, `createContext(key)` returns the string key itself, so the
-// key string is the wire identity of the seam. A rename, or a merge into a
-// different context, silently breaks every embedder's provide/consume wiring.
-// These assertions go red when that identity changes.
 describe("host embedding contract: runtime/space contexts", () => {
+  // Host-embedding contract seam 2 (docs/features/host-embedding.md §2):
+  // `runtimeContext` and `spaceContext` are the only REQUIRED contexts a host
+  // provides; `presenceUrlContext` is optional and degrades to disabled. A host
+  // and the mounted components must agree on the context *identity* — with
+  // `@lit/context`, `createContext(key)` returns the string key itself, so the
+  // key string is the wire identity of the seam. A rename, or a merge into a
+  // different context, silently breaks every embedder's provide/consume wiring.
+  // These assertions go red when that identity changes.
   it("runtimeContext is keyed 'runtime'", () => {
     expect(runtimeContext).toBe("runtime");
   });

--- a/packages/ui/src/v2/runtime-context.test.ts
+++ b/packages/ui/src/v2/runtime-context.test.ts
@@ -18,6 +18,7 @@ describe("host embedding contract: runtime/space contexts", () => {
   // key string is the wire identity of the seam. A rename, or a merge into a
   // different context, silently breaks every embedder's provide/consume wiring.
   // These assertions go red when that identity changes.
+
   it("runtimeContext is keyed 'runtime'", () => {
     expect(runtimeContext).toBe("runtime");
   });

--- a/packages/ui/src/v2/utils/audio-conversion.test.ts
+++ b/packages/ui/src/v2/utils/audio-conversion.test.ts
@@ -10,11 +10,11 @@ import {
   resample,
 } from "./audio-conversion.ts";
 
-// Note: We're testing the exported helper functions directly
-// The main convertToWav function requires browser AudioContext which isn't available in Deno tests
-// In a real browser environment, we would test the full conversion pipeline
-
 describe("audio-conversion", () => {
+  // Note: We're testing the exported helper functions directly The main
+  // convertToWav function requires browser AudioContext which isn't available
+  // in Deno tests In a real browser environment, we would test the full
+  // conversion pipeline
   describe("WAV file format", () => {
     it("should create valid WAV header structure", () => {
       // Create a simple PCM data array

--- a/packages/ui/src/v2/utils/audio-conversion.test.ts
+++ b/packages/ui/src/v2/utils/audio-conversion.test.ts
@@ -15,6 +15,7 @@ describe("audio-conversion", () => {
   // convertToWav function requires browser AudioContext which isn't available
   // in Deno tests In a real browser environment, we would test the full
   // conversion pipeline
+
   describe("WAV file format", () => {
     it("should create valid WAV header structure", () => {
       // Create a simple PCM data array

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -228,10 +228,10 @@ const referenceFixtures: readonly Fixture[] = [
 // Tests to validate reference encoder
 //
 
-// A small set of explicit byte-level assertions that pin `referenceEncode`
-// against the spec. The rest of the suite trusts it as an oracle, so it
-// matters that these can't both be wrong in the same way.
 describe("`referenceEncode()` (test oracle)", () => {
+  // A small set of explicit byte-level assertions that pin `referenceEncode`
+  // against the spec. The rest of the suite trusts it as an oracle, so it
+  // matters that these can't both be wrong in the same way.
   it("encodes all reference fixtures as expected", () => {
     for (const { value, encoded, label } of referenceFixtures) {
       try {

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -106,9 +106,9 @@ Deno.test("namesResolverInCode ignores a string literal", () => {
   );
 });
 
-// A scan that blanked a line from its first `//` would stop reading here at the
-// URL and never reach the construction that follows it.
 Deno.test("namesResolverInCode reads past a comment marker inside a string", () => {
+  // A scan that blanked a line from its first `//` would stop reading here at
+  // the URL and never reach the construction that follows it.
   assert(
     namesResolverInCode(
       `const docs = "https://example.com/x"; const r = new FileSystemProgramResolver(m);`,
@@ -255,9 +255,9 @@ Deno.test("main reports the offender and the route to take instead", async () =>
   }
 });
 
-// A tracked path that has become a directory is not a deletion, so the read
-// fails for a reason the scan has no answer for and the failure carries.
 Deno.test("scan reports a tracked path it cannot read for another reason", async () => {
+  // A tracked path that has become a directory is not a deletion, so the read
+  // fails for a reason the scan has no answer for and the failure carries.
   const root = await fixtureRepo({
     "packages/foo/build.ts":
       "export const r = new FileSystemProgramResolver(main);\n",
@@ -272,10 +272,10 @@ Deno.test("scan reports a tracked path it cannot read for another reason", async
   }
 });
 
-// Runs the check the way CI does, as a program rather than as an import. The
-// repository passes it, so this doubles as the end-to-end case: the entry
-// point wires the scan to an exit code, and the tree it ships is clean.
 Deno.test("the check runs as a program over this repository", async () => {
+  // Runs the check the way CI does, as a program rather than as an import. The
+  // repository passes it, so this doubles as the end-to-end case: the entry
+  // point wires the scan to an exit code, and the tree it ships is clean.
   const script = fromFileUrl(
     new URL("./check-local-program.ts", import.meta.url),
   );

--- a/tasks/check-single-copy-deps.test.ts
+++ b/tasks/check-single-copy-deps.test.ts
@@ -69,10 +69,10 @@ Deno.test("findProblems reports nothing when each package resolves once", () => 
   assertEquals(findProblems(singleCopyLock()), []);
 });
 
-// The shape of the bug this check exists for: rolling the arizeai packages
-// alone leaves the AI SDK resolved twice, once for toolshed and once for
-// @ai-sdk/otel.
 Deno.test("findProblems reports a package resolved twice", () => {
+  // The shape of the bug this check exists for: rolling the arizeai packages
+  // alone leaves the AI SDK resolved twice, once for toolshed and once for
+  // @ai-sdk/otel.
   const lock = singleCopyLock();
   lock.npm["ai@5.0.27_zod@3.25.76"] = {};
 
@@ -99,10 +99,10 @@ Deno.test("the repository's own lockfile passes", async () => {
   assertEquals(await main(REPO_ROOT), 0);
 });
 
-// main() reads deno.lock from the root it is given, so a temp tree with a
-// duplicated lockfile drives the reporting path the passing repo never does:
-// the message, the per-copy listing, and the non-zero exit.
 Deno.test("main reports the duplicate and returns 1", async () => {
+  // main() reads deno.lock from the root it is given, so a temp tree with a
+  // duplicated lockfile drives the reporting path the passing repo never does:
+  // the message, the per-copy listing, and the non-zero exit.
   const root = await Deno.makeTempDir({ prefix: "check-single-copy-deps-" });
   try {
     const lock = singleCopyLock();

--- a/tasks/check-skill-facts.test.ts
+++ b/tasks/check-skill-facts.test.ts
@@ -503,9 +503,9 @@ Deno.test("the script runs as a command over the real repo", async () => {
   );
 });
 
-// Runs against the real repository: every fact every covered document cites
-// must resolve.
 Deno.test("every cited path and specifier resolves", async () => {
+  // Runs against the real repository: every fact every covered document cites
+  // must resolve.
   const root = fromFileUrl(new URL("..", import.meta.url));
   const tree = await readTree(root);
   const docs = await readSkillDocs(root, tree);

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -145,10 +145,10 @@ Deno.test("importsAlias ignores a substring of a different specifier", () => {
   );
 });
 
-// The loose matching is deliberate: an occurrence inside a comment or string
-// counts as used. That can only ever hide a dead alias, never flag a live one,
-// so the check does not misfire on a real dependency.
 Deno.test("importsAlias counts a commented-out import as used", () => {
+  // The loose matching is deliberate: an occurrence inside a comment or string
+  // counts as used. That can only ever hide a dead alias, never flag a live
+  // one, so the check does not misfire on a real dependency.
   assert(importsAlias('// import { x } from "zod";', "zod"));
 });
 

--- a/tasks/combine-coverage-lcov.test.ts
+++ b/tasks/combine-coverage-lcov.test.ts
@@ -268,10 +268,10 @@ Deno.test("main returns exit code 2 when a required flag is missing", async () =
   assertEquals(await main(["--input-dir=a", "--output=b"]), 2);
 });
 
-// Run the task as its own process so the `import.meta.main` entry point is
-// exercised end to end. Lockfile isolation keeps the real deno.lock untouched,
-// and all inputs and outputs live under temporary directories.
 Deno.test("the CLI entry point runs the task as a process", async () => {
+  // Run the task as its own process so the `import.meta.main` entry point is
+  // exercised end to end. Lockfile isolation keeps the real deno.lock
+  // untouched, and all inputs and outputs live under temporary directories.
   const dir = await Deno.makeTempDir({ prefix: "combine-lcov-cli-" });
   try {
     const inputDir = path.join(dir, "in");

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -395,11 +395,12 @@ Deno.test("generated port offsets span the documented range", () => {
   assertEquals(offsets[offsets.length - 1], GENERATED_PORT_OFFSET_RANGE.last);
 });
 
-// Keeps the recorded list honest against the runtime that enforces it. A
-// blocked port is rejected before any connection is opened, so pointing these
-// probes at a host that cannot resolve reaches no network service: the blocked
-// answer arrives first, and any other port would fail on the name instead.
 Deno.test("every recorded blocked port is one fetch refuses", async () => {
+  // Keeps the recorded list honest against the runtime that enforces it. A
+  // blocked port is rejected before any connection is opened, so pointing these
+  // probes at a host that cannot resolve reaches no network service: the
+  // blocked answer arrives first, and any other port would fail on the name
+  // instead.
   const stillBlocked: number[] = [];
   for (const port of ports.blockedPorts) {
     try {

--- a/tasks/pattern-compat-accepted-breaks.test.ts
+++ b/tasks/pattern-compat-accepted-breaks.test.ts
@@ -18,12 +18,12 @@ const exists = async (path: string): Promise<boolean> => {
   }
 };
 
-// The compatibility run reaches these entries only after compiling every
-// authored pattern, and it reads each one under the shard that examined its
-// pattern. So the shape of an entry — a pattern that exists, a baseline that
-// exists, a pair named once, a path spelled the way the proof spells it — is
-// worth settling here, in milliseconds, against the files on disk.
 describe("pattern-compat-accepted-breaks", () => {
+  // The compatibility run reaches these entries only after compiling every
+  // authored pattern, and it reads each one under the shard that examined its
+  // pattern. So the shape of an entry — a pattern that exists, a baseline that
+  // exists, a pair named once, a path spelled the way the proof spells it — is
+  // worth settling here, in milliseconds, against the files on disk.
   describe("ACCEPTED_CONTRACT_BREAKS", () => {
     it("names a pattern file that exists for every entry", async () => {
       for (const accepted of ACCEPTED_CONTRACT_BREAKS) {

--- a/tasks/pattern-compat-accepted-breaks.test.ts
+++ b/tasks/pattern-compat-accepted-breaks.test.ts
@@ -24,6 +24,7 @@ describe("pattern-compat-accepted-breaks", () => {
   // pattern. So the shape of an entry — a pattern that exists, a baseline that
   // exists, a pair named once, a path spelled the way the proof spells it — is
   // worth settling here, in milliseconds, against the files on disk.
+
   describe("ACCEPTED_CONTRACT_BREAKS", () => {
     it("names a pattern file that exists for every entry", async () => {
       for (const accepted of ACCEPTED_CONTRACT_BREAKS) {

--- a/tasks/test-records-flap-coverage.test.ts
+++ b/tasks/test-records-flap-coverage.test.ts
@@ -3,15 +3,14 @@ import { expect } from "@std/expect";
 
 import { composeLocalContext } from "./test-records.ts";
 
-// The arm of composeLocalContext() that records a branch runs when git named
-// one. Nothing but the ambient checkout drove it before: a working checkout
-// sits on a branch, while the detached merge commit continuous integration
-// builds a pull request from reports an empty branch, so the line ran on some
-// runs and not on others. These cases state the facts the composition is given
-// and assert what it makes of them, so each arm runs on every run and under
-// every configuration.
-
 describe("composeLocalContext() flap coverage", () => {
+  // The arm of composeLocalContext() that records a branch runs when git named
+  // one. Nothing but the ambient checkout drove it before: a working checkout
+  // sits on a branch, while the detached merge commit continuous integration
+  // builds a pull request from reports an empty branch, so the line ran on some
+  // runs and not on others. These cases state the facts the composition is
+  // given and assert what it makes of them, so each arm runs on every run and
+  // under every configuration.
   it("carries the branch when git named one", () => {
     const context = composeLocalContext({
       commit: "a".repeat(40),

--- a/tasks/test-records-flap-coverage.test.ts
+++ b/tasks/test-records-flap-coverage.test.ts
@@ -11,6 +11,7 @@ describe("composeLocalContext() flap coverage", () => {
   // runs and not on others. These cases state the facts the composition is
   // given and assert what it makes of them, so each arm runs on every run and
   // under every configuration.
+
   it("carries the branch when git named one", () => {
     const context = composeLocalContext({
       commit: "a".repeat(40),


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

130 comments across 113 files describe exactly the test beneath them. Each moves
inside that test's body, where it needs no delimiters and sits against the code
it explains — finishing the pattern #6450 and #6452 started, now across the
whole tree rather than the densest files.

## The class was smaller than the count suggested

The earlier survey put 196 sites in this class on a structural test alone.
Applying both guards, the real figure is 130:

| | count |
| --- | --- |
| moved — describes exactly one test | 130 |
| held — heads a group of tests | 84 |
| held — points at its surroundings | 19 |

The 84 head a *group*, which makes them section markers rather than test
descriptions — a different question, left alone here.

## The 19 are why this is not purely mechanical

Each refers to what is around it, so relocating it inside one test would leave
the text asserting something untrue:

    otel.test.ts:123       The setup tests above only prove a provider object exists…
    value-equality.test.ts:60  An executable statement of why the previous comparisons were wrong…
    cf-textarea.test.ts:6      NOTE: Full DOM interaction tests … are covered elsewhere

The guard holds any block mentioning its neighbours — *above*, *below*,
*following*, *previous*, *these tests*. Some of the 19 are surely false
positives of that match; holding is the safe direction, and 19 is a short enough
list to read later if anyone wants them.

## Guards

- the block sits directly above a one-line `Deno.test/describe/it(...) => {`;
- exactly one such opener follows before the next comment;
- the block does not point at its neighbours;
- re-wrapping to the body's indentation preserves the word multiset, asserted
  per site before the edit is written.

## Verification

No word is lost or gained across the diff, no non-comment line is touched, and
no added line exceeds 80 columns.

`deno fmt --check`, `deno lint`, `deno task check`, and the `tasks` suite pass,
as do `background-piece-service`, `cli`, `deno-web-test`, `fuse`, `identity`,
`js-compiler`, `memory`, `piece`, `runtime-client`, `schema-generator`,
`static`, `toolshed`, `ui`, and `utils`. `runner` and `shell` were still running
at push time; their changes here are comment-only.

## Coverage

The ratchet reports two more uncovered lines in `packages/runner`, with the
other sixteen gated groups all at `+0`. It is not this change. Deno's LCOV
emits no `DA:` entry for a comment line, so a comment-only diff shifts line
numbers without altering the uncovered count — checked on a fixture: an
uncovered function with a three-line comment inside it reports five uncovered
lines, and the same function with the comment deleted reports the same five.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


