### PR TITLE
ci: keep one commit to one set of release artifacts

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -8,8 +8,17 @@ on:
     branches:
       - main
 
+# Runs of a pull request are grouped by the pull request, and a new push to the
+# branch cancels the run already going. Runs of a push to main are grouped by
+# the commit that was pushed, and a push run is never cancelled: it may be
+# part-way through deploying that commit to staging. Main can receive the same
+# head commit twice, which starts two runs of one commit, and the commit as the
+# group makes the second of them wait for the first. Each run publishes a
+# release artifact named after the commit, and two runs publishing at once
+# leave one run's tarball beside the other run's checksum. See "One commit, one
+# set of artifacts" in docs/development/deploying.md.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # The bounds the jobs below are built from. They are YAML anchors, used as
@@ -2114,12 +2123,31 @@ jobs:
       - name: ⚙️ Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
+      # A release artifact is named after the commit it was built from, and a
+      # host keeps whatever it has already downloaded under that name. So the
+      # first build of a commit publishes the artifact and a later build of the
+      # same commit leaves it alone. Two builds of one commit do not produce the
+      # same bytes: the binaries are compiled again, and `tar` records
+      # modification times.
+      #
+      # The tarball and its checksum are published as a pair. A commit that has
+      # one of them and not the other was published by a build that stopped
+      # between the two copies, and this publishes both of them again. See "One
+      # commit, one set of artifacts" in docs/development/deploying.md.
       - name: 📤 Upload artifacts to Google Cloud Storage
         run: |
-          gsutil cp release/labs-${{ github.sha }}.tar.gz gs://commontools-build-artifacts/workspace-artifacts/
-          gsutil cp release/labs-${{ github.sha }}.hash.txt gs://commontools-build-artifacts/workspace-artifacts/
+          BUCKET=gs://commontools-build-artifacts/workspace-artifacts
+          TARBALL=labs-${{ github.sha }}.tar.gz
+          CHECKSUM=labs-${{ github.sha }}.hash.txt
 
-          # Print clickable links to the uploaded files
+          if gsutil -q stat "$BUCKET/$TARBALL" && gsutil -q stat "$BUCKET/$CHECKSUM"; then
+            echo "An earlier build of ${{ github.sha }} published its artifacts; leaving them as they are."
+          else
+            gsutil cp "release/$TARBALL" "$BUCKET/"
+            gsutil cp "release/$CHECKSUM" "$BUCKET/"
+          fi
+
+          # Print clickable links to the published files
           echo "::group::📦 Artifact Links"
           echo "Tarball URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.tar.gz"
           echo "Hash URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.hash.txt"
@@ -2128,7 +2156,7 @@ jobs:
           # combine step produced it. To download it for a given commit:
           #   gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-<commit-sha>.lcov .
           if [ -f release/labs-${{ github.sha }}.lcov ]; then
-            gsutil cp release/labs-${{ github.sha }}.lcov gs://commontools-build-artifacts/workspace-artifacts/
+            gsutil cp "release/labs-${{ github.sha }}.lcov" "$BUCKET/"
             echo "Coverage LCOV URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.lcov"
           fi
           echo "::endgroup::"

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -36,6 +36,47 @@ deploy. The `deploy-rapids` job still declares GitHub's `toolshed` environment,
 which is where its bastion credentials live; renaming that environment is a
 repository-settings change, and the job has to be updated in the same change.
 
+## One commit, one set of artifacts
+
+The `attest-binaries` job in `.github/workflows/deno.yml` builds the binaries,
+signs them, packs them into `labs-<commit>.tar.gz`, writes that tarball's
+SHA-256 into `labs-<commit>.hash.txt`, and copies both objects into the
+`commontools-build-artifacts` bucket. A deploy is given a commit rather than a
+build, so those two objects are the whole of what a commit means to a host. The
+host downloads them, checks the tarball against the checksum, and unpacks it.
+
+Building one commit twice does not produce the same tarball. The binaries are
+compiled again, and `tar` records the modification time of every file it packs.
+The two objects therefore have to be published together, and what they were
+published as has to stay put. A host holding one build's tarball beside another
+build's checksum fails `sha256sum -c`, and its deploy stops there.
+
+Two things keep a commit to one pair. The workflow's concurrency group keys a
+push by the commit that was pushed, so a second run of a commit waits for the
+first to finish instead of building alongside it. Main does receive the same
+head commit twice from time to time, which is what starts two runs of one
+commit. The second guard is in the publish step: a commit that already has both
+objects in the bucket keeps them, so a later build of that commit leaves alone
+what an earlier build published and a host may already be holding. That covers
+the ways a second build starts without a second run, a re-run of the job among
+them. Removing either object from the bucket by hand lets the next build of
+that commit publish both of them again.
+
+## A host keeps what it has already downloaded
+
+The deploy playbook downloads the tarball and the checksum only when the
+release directory for the commit is missing a binary, and Ansible's `get_url`
+leaves a destination file that is already there as it is. So a release
+directory that failed verification stays as it is across later deploys of that
+commit. The download tasks report no change, the same mismatched pair is
+checked again, and the deploy fails the same way. A re-run cannot recover on
+its own; someone has to remove the directory on the host.
+
+That playbook is `ansible/playbooks/toolshed_binary_deploy.yml` in the
+[infra repository](https://github.com/commontoolsinc/infra), behind the
+`/opt/cf/deploy.sh` wrapper described above. Making the download replace what
+it finds, rather than skip it, is a change in that repository.
+
 ## The wrapper is owned by another repository
 
 `/opt/cf/deploy.sh` is not in this repository. The

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -561,6 +561,66 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
   );
 });
 
+Deno.test("One commit publishes one set of release artifacts", async () => {
+  // A release artifact is named after the commit it was built from, and the
+  // deploy hands the bastion a commit rather than a build. So a commit has one
+  // tarball and one checksum for that tarball, and they stay as they were
+  // published. Two builds of one commit do not produce the same tarball: the
+  // binaries are compiled again, and `tar` records modification times. Publish
+  // a second build over a first and a reader can come away holding one build's
+  // tarball beside the other build's checksum, which is what the deploy's
+  // `sha256sum -c` reports as a failure. docs/development/deploying.md covers
+  // the invariant.
+  const contents = await workflow("deno.yml");
+
+  // Main can receive the same head commit twice, which starts two runs of that
+  // commit. Grouping a push by the commit makes the second run wait for the
+  // first, so the two builds never publish at once. Grouping it by anything
+  // that differs between runs of one commit, `github.run_id` among them, puts
+  // them in separate groups and lets them overlap.
+  assertStringIncludes(
+    contents,
+    "\nconcurrency:\n" +
+      "  group: ${{ github.workflow }}-" +
+      "${{ github.event.pull_request.number || github.sha }}\n" +
+      "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}\n",
+  );
+
+  // Waiting alone leaves the second run free to publish over the first once the
+  // first has finished, so the publish itself is what holds the bytes still: a
+  // commit that already has both objects keeps them. The pair is published
+  // together, in the one branch, because publishing just one of them is how a
+  // commit ends up with two builds' halves.
+  const upload = stepBlock(
+    jobBlock(contents, "attest-binaries"),
+    "📤 Upload artifacts to Google Cloud Storage",
+  );
+  const guard =
+    'if gsutil -q stat "$BUCKET/$TARBALL" && gsutil -q stat "$BUCKET/$CHECKSUM"; then';
+  const guardStart = upload.indexOf(guard);
+  assert(
+    guardStart >= 0,
+    "the published pair is not looked for before it is published",
+  );
+  const branchStart = upload.indexOf("\n          else\n", guardStart);
+  const branchEnd = upload.indexOf("\n          fi\n", branchStart);
+  assert(
+    branchStart >= 0 && branchEnd > branchStart,
+    "publishing branch not found",
+  );
+  const branch = upload.slice(branchStart, branchEnd);
+
+  for (const object of ["$TARBALL", "$CHECKSUM"]) {
+    const copy = `gsutil cp "release/${object}" "$BUCKET/"`;
+    assertStringIncludes(branch, copy);
+    assertEquals(
+      upload.split(copy).length - 1,
+      1,
+      `${copy} runs somewhere other than the branch that publishes the pair`,
+    );
+  }
+});
+
 Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () => {
   // The bastion's /opt/cf/deploy.sh takes an environment name and a
   // 40-character commit SHA, and nothing else. Hand it a third argument, an


### PR DESCRIPTION
Two CI runs on main for the same head commit both failed their staging deploy at the ansible task that verifies the tarball hash. Main received two push events for that commit, so two complete runs started. Each run's attest-binaries job compiled the binaries again, packed them into a tarball named after the commit, wrote that tarball's SHA-256 into a checksum file named after the same commit, and copied both objects into the build-artifact bucket.

Two builds of one commit do not produce the same tarball. The binaries are compiled afresh, and tar records the modification time of every file it packs. The two uploads overlapped, so the second run replaced the first run's tarball while the first run's deploy was reading. That deploy came away holding the second build's tarball beside the first build's checksum, and sha256sum -c failed on the pair. The second run's deploy then found both files already on the host, left them alone, and checked the same mismatched pair again.

The concurrency group keyed a push by github.run_id, which differs for every run, so two runs of one commit were never in the same group and nothing kept them apart. Key a push by the commit that was pushed instead. The second run of a commit then waits for the first to finish rather than building alongside it. A push run is still never cancelled by a later one, because it may be part-way through deploying that commit to staging.

Waiting is not the whole of it, because a second build can start without a second push run: re-running the job on a finished run is the ordinary way. So the publish step also leaves a commit's objects alone when both are already in the bucket, and publishes the tarball and its checksum together whenever either is missing. A commit's artifact is written once and stays as it was written, which is what a host that keeps its downloads assumes. That leaves CI with no way to replace a published artifact, so the documentation says what does: removing either object from the bucket by hand lets the next build of that commit publish both again.

The host side is not fixed here. The deploy playbook downloads the pair only when the release directory for the commit is missing a binary, and ansible's get_url leaves a destination file that is already there as it is. A release directory that failed verification therefore stays that way for every later deploy of that commit, and a re-run cannot recover on its own. That playbook lives in the infra repository. docs/development/deploying.md now describes both halves, and tasks/ci-workflow.test.ts holds the workflow to the grouping and the paired publish.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

