### PR TITLE
feat(memory): per-class evaluation-cache diagnostics; record the recipient-blindness invariant

### DIFF
--- a/docs/specs/server-side-execution/key-vocabulary.md
+++ b/docs/specs/server-side-execution/key-vocabulary.md
@@ -340,6 +340,25 @@ per-run identities where run contexts carry them):
   where a shared memo meets a traversal (the SchemaObjectTraverser
   constructor) and throws on any other identity — a future sharing
   change becomes a loud error, never silent value-bleed.
+- the query evaluation cache — `QueryEvaluationCache`
+  (`packages/memory/v2/query.ts`) serves whole tracked-graph
+  evaluations ACROSS identities, and its sharing rests on an
+  assumption wider than key construction: evaluation is
+  recipient-blind. The walk consults the requesting identity only
+  to resolve scope instances, so `classifyStateScope` decides
+  shareability from scope keys alone — a scope-pure entry serves
+  every identity, an absent-residue entry serves after per-requester
+  absence probes, and anything else keys to the evaluating identity.
+  ACL changes hold the invariant from outside: they are commits, and
+  any commit rotates the cache. A per-recipient filter INSIDE
+  evaluation (CFC label enforcement, say — the runtime's flow-label
+  and sink-ceiling dials own it today, and the server's sqlite read
+  labeling annotates rather than filters) would break the sharing
+  invisibly: clearance differs between identities at one seq, so
+  rotation cannot fence it and scope classification cannot see it.
+  Such a filter must key the cache by its filtering context or
+  bypass it — a separate, deliberate change, never a side effect of
+  landing the filter.
 
 **Instance-safe transients** (why each is fine as-is):
 

--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -4,6 +4,7 @@ import { applyCommit, open as openEngine } from "../v2/engine.ts";
 import {
   classifyStateScope,
   createQueryEvaluationCache,
+  queryEvaluationCacheDiagnostics,
   type TrackedGraphState,
   trackGraph,
 } from "../v2/query.ts";
@@ -342,6 +343,8 @@ describe("v2 query evaluation cache", () => {
       // space-scoped corpus. One evaluation serves both.
       expect(after.misses - before.misses).toBe(1);
       expect(after.hits - before.hits).toBe(1);
+      expect(after.hitsPure - before.hitsPure).toBe(1);
+      expect(after.entriesPure - before.entriesPure).toBe(1);
       expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
     } finally {
       connectionA.close();
@@ -374,6 +377,7 @@ describe("v2 query evaluation cache", () => {
       // Two identities, each a miss: the tainted entry never crosses.
       expect(after.misses - before.misses).toBe(2);
       expect(after.hits - before.hits).toBe(0);
+      expect(after.entriesTainted - before.entriesTainted).toBe(2);
     } finally {
       connectionA.close();
       connectionB.close();
@@ -459,6 +463,8 @@ describe("v2 query evaluation cache", () => {
       const after = server.evaluationCacheDiagnostics(space);
       expect(after.misses - before.misses).toBe(1);
       expect(after.hits - before.hits).toBe(1);
+      expect(after.hitsAbsentResidue - before.hitsAbsentResidue).toBe(1);
+      expect(after.entriesAbsentResidue - before.entriesAbsentResidue).toBe(1);
       expect(upsertIds(syncB)).toEqual(upsertIds(syncA));
 
       // The recording identity re-asking (as a one-shot graph query, which
@@ -480,6 +486,8 @@ describe("v2 query evaluation cache", () => {
       );
       const afterSame = server.evaluationCacheDiagnostics(space);
       expect(afterSame.hits - beforeSame.hits).toBe(1);
+      expect(afterSame.hitsAbsentResidue - beforeSame.hitsAbsentResidue)
+        .toBe(1);
       expect(same.entities.map((entity) => entity.id)).toContain(
         "of:doc:linked",
       );
@@ -633,6 +641,7 @@ describe("v2 query evaluation cache", () => {
       // evaluation delivers its instance.
       expect(after.misses - before.misses).toBe(2);
       expect(after.hits - before.hits).toBe(0);
+      expect(after.residueRefusals - before.residueRefusals).toBe(1);
       expect(upsertIds(syncC)).toContain("of:doc:draft");
 
       // C's refused evaluation was cached under its identity, and the
@@ -653,6 +662,7 @@ describe("v2 query evaluation cache", () => {
       );
       const retried = server.evaluationCacheDiagnostics(space);
       expect(retried.hits - after.hits).toBe(1);
+      expect(retried.hitsIdentity - after.hitsIdentity).toBe(1);
       expect(again.entities.map((entity) => entity.id)).toContain(
         "of:doc:draft",
       );
@@ -684,6 +694,28 @@ describe("v2 query evaluation cache", () => {
       },
     } as unknown as TrackedGraphState;
     expect(classifyStateScope(state)).toEqual({ kind: "tainted" });
+  });
+
+  it("reads a never-evaluated space's diagnostics as empty", () => {
+    const server = createServer("memory://eval-cache-absent-diagnostics");
+    const diagnostics = server.evaluationCacheDiagnostics(
+      "did:key:z6Mk-eval-cache-never-evaluated",
+    );
+    expect(diagnostics).toEqual({
+      seq: -1,
+      entries: 0,
+      weight: 0,
+      hits: 0,
+      misses: 0,
+      rotations: 0,
+      hitsPure: 0,
+      hitsAbsentResidue: 0,
+      hitsIdentity: 0,
+      residueRefusals: 0,
+      entriesPure: 0,
+      entriesAbsentResidue: 0,
+      entriesTainted: 0,
+    });
   });
 
   it("rotates when a different engine presents the same sequence", async () => {
@@ -740,7 +772,7 @@ describe("v2 query evaluation cache", () => {
     };
     expect(valueOf(fromA.state)).toBe(1);
     expect(valueOf(fromB.state)).toBe(2);
-    expect(cache.hits).toBe(0);
+    expect(queryEvaluationCacheDiagnostics(cache).hits).toBe(0);
     expect(cache.rotations).toBe(2);
   });
 
@@ -796,7 +828,7 @@ describe("v2 query evaluation cache", () => {
       sessionId: "probe-s2",
       evaluationCache: cache,
     });
-    expect(cache.hits).toBe(1);
+    expect(cache.hitsAbsentResidue).toBe(1);
     // One residue doc was probed for absence: a hit is not free of engine
     // reads, and its stats say exactly what it read.
     expect(hit.stats.managerReads).toBe(1);
@@ -1008,8 +1040,11 @@ describe("v2 query evaluation cache", () => {
       evaluationCache: cache,
     });
     // Identity-fallback hit: exactly ONE probe was performed before the
-    // refusal — not the residue's full length.
-    expect(cache.hits).toBe(1);
+    // refusal — not the residue's full length. The shared entry is
+    // consulted (and refused) on EVERY ask, so both of C's asks count a
+    // refusal.
+    expect(cache.hitsIdentity).toBe(1);
+    expect(cache.residueRefusals).toBe(2);
     expect(fallback.stats.managerReads).toBe(1);
   });
 

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -332,9 +332,29 @@ export type QueryEvaluationCacheDiagnostics = {
   seq: number;
   entries: number;
   weight: number;
+  /** Total serves: the sum of the three per-class hit counters. */
   hits: number;
   misses: number;
   rotations: number;
+  /** Serves of a scope-pure entry (identical for every identity). */
+  hitsPure: number;
+  /** Serves of an absent-residue entry — the recording identity's own
+   * re-ask included (its keys need no rewrite, but the entry is the
+   * same class). */
+  hitsAbsentResidue: number;
+  /** Serves of a tainted entry to the identity it is keyed to. */
+  hitsIdentity: number;
+  /** Absent-residue shares refused because a residue doc is PRESENT
+   * for the requester. A refusal is not a miss by itself: the call
+   * then serves from the identity entry (an identity hit) or
+   * evaluates in full (a miss). */
+  residueRefusals: number;
+  /** Live entries by share class. Together with the hit split, this
+   * is the production measure of how often scoped reach actually
+   * forecloses cross-identity sharing. */
+  entriesPure: number;
+  entriesAbsentResidue: number;
+  entriesTainted: number;
 };
 
 /**
@@ -362,6 +382,18 @@ export type QueryEvaluationCacheDiagnostics = {
  * rule `assertSchemaMemoIdentity` enforces for the inner schema memos).
  * ACL changes are themselves commits, so a grant or revocation rotates the
  * cache before any post-change evaluation could be served from it.
+ *
+ * Cross-identity sharing rests on evaluation being recipient-blind: the
+ * walk consults the requesting identity only to resolve scope instances,
+ * never to shape what a document contributes, so scope classification
+ * alone decides who an entry may serve. CFC enforcement lives outside
+ * this path (the runtime's flow-label and sink-ceiling dials; the
+ * server's sqlite read labeling annotates results rather than filtering
+ * them). A per-recipient filter inside evaluation would invalidate
+ * shared entries invisibly — clearance differs between identities at
+ * one seq, so rotation cannot fence it and scope keys cannot classify
+ * it — and must therefore key this cache by its filtering context or
+ * bypass it (key-vocabulary.md §5, the identity-bound inventory).
  */
 export type QueryEvaluationCache = {
   /** The engine the entries were evaluated against. A sequence number
@@ -378,7 +410,12 @@ export type QueryEvaluationCache = {
    * parsed documents an entry keeps alive). The server enforces its
    * cross-space budget against this. */
   weight: number;
-  hits: number;
+  /** Per-class serve counters ({@link QueryEvaluationCacheDiagnostics}
+   * defines each class); diagnostics report their sum as `hits`. */
+  hitsPure: number;
+  hitsAbsentResidue: number;
+  hitsIdentity: number;
+  residueRefusals: number;
   misses: number;
   rotations: number;
 };
@@ -388,21 +425,37 @@ export const createQueryEvaluationCache = (): QueryEvaluationCache => ({
   seq: -1,
   entries: new Map(),
   weight: 0,
-  hits: 0,
+  hitsPure: 0,
+  hitsAbsentResidue: 0,
+  hitsIdentity: 0,
+  residueRefusals: 0,
   misses: 0,
   rotations: 0,
 });
 
 export const queryEvaluationCacheDiagnostics = (
   cache: QueryEvaluationCache,
-): QueryEvaluationCacheDiagnostics => ({
-  seq: cache.seq,
-  entries: cache.entries.size,
-  weight: cache.weight,
-  hits: cache.hits,
-  misses: cache.misses,
-  rotations: cache.rotations,
-});
+): QueryEvaluationCacheDiagnostics => {
+  const entriesByClass = { "pure": 0, "absent-residue": 0, "tainted": 0 };
+  for (const { share } of cache.entries.values()) {
+    entriesByClass[share.kind]++;
+  }
+  return {
+    seq: cache.seq,
+    entries: cache.entries.size,
+    weight: cache.weight,
+    hits: cache.hitsPure + cache.hitsAbsentResidue + cache.hitsIdentity,
+    misses: cache.misses,
+    rotations: cache.rotations,
+    hitsPure: cache.hitsPure,
+    hitsAbsentResidue: cache.hitsAbsentResidue,
+    hitsIdentity: cache.hitsIdentity,
+    residueRefusals: cache.residueRefusals,
+    entriesPure: entriesByClass["pure"],
+    entriesAbsentResidue: entriesByClass["absent-residue"],
+    entriesTainted: entriesByClass["tainted"],
+  };
+};
 
 /**
  * How an evaluation's reach constrains who may share its cache entry.
@@ -1092,12 +1145,18 @@ export const trackGraph = (
         );
         served = rewritten.state;
         probeReads = rewritten.probeReads;
+        if (served === null) {
+          cache.residueRefusals++;
+        } else {
+          cache.hitsAbsentResidue++;
+        }
       } else {
         served = cloneTrackedGraphStateForIdentity(
           engine,
           pureEntry.state,
           options,
         );
+        cache.hitsPure++;
       }
     }
     if (served === null) {
@@ -1113,10 +1172,10 @@ export const trackGraph = (
           identityEntry.state,
           options,
         );
+        cache.hitsIdentity++;
       }
     }
     if (served !== null) {
-      cache.hits++;
       // A hit ran no traversal, and its stats say so — but the residue
       // absence probes ARE engine reads, and they report as such.
       return {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4444,9 +4444,9 @@ export class Server {
     space: string,
   ): QueryEvaluationCacheDiagnostics {
     const cache = this.#queryEvaluationCaches.get(space);
-    return cache === undefined
-      ? { seq: -1, entries: 0, weight: 0, hits: 0, misses: 0, rotations: 0 }
-      : queryEvaluationCacheDiagnostics(cache);
+    return queryEvaluationCacheDiagnostics(
+      cache ?? createQueryEvaluationCache(),
+    );
   }
 
   async evaluateGraphQuery(


### PR DESCRIPTION
## Problem

#6428's evaluation cache reports only aggregate hits/misses/rotations. The aggregate cannot answer the question the sharing design raises: how often does per-user/per-session reach actually gate cross-identity sharing on a live corpus — how many serves are scope-pure clones vs absent-residue rewrites vs identity-keyed repeats, and how often is an absent-residue share refused because the requester's scoped instance exists? Those are exactly the numbers that decide whether a scoped-frontier split cache (sharing the space-scoped prefix of a walk even when scoped data is present) would add anything over the shipped design.

The cache's cross-identity sharing also rests on an invariant stated nowhere: evaluation is recipient-blind. Scope classification cannot see CFC labels, and a clearance difference between two identities at one seq is not a commit, so seq rotation cannot fence a per-recipient filter the way it fences ACL changes. If enforcement ever moved inside evaluation, sharing would break silently.

## Change

- `QueryEvaluationCacheDiagnostics` gains per-class serve counters — `hitsPure`, `hitsAbsentResidue` (the recording identity's own re-ask included), `hitsIdentity` — plus `residueRefusals` (counted per ask: the shared entry is consulted, probed, and refused on every ask by an identity whose scoped instance exists, before its identity entry answers) and live-entry gauges `entriesPure` / `entriesAbsentResidue` / `entriesTainted`. `hits` is now reported as the sum of the three class counters — one source of truth instead of a parallel counter kept consistent by discipline.
- The server's absent-space diagnostics read serves the same shape through a throwaway `createQueryEvaluationCache()` instead of a duplicated literal (still a peek — nothing is created or recency-bumped).
- The recipient-blindness invariant is recorded where it lives: a paragraph on `QueryEvaluationCache` (CFC enforcement sits outside the serve path — the runtime's flow-label and sink-ceiling dials, the server's sqlite read labeling annotating rather than filtering — and a per-recipient filter inside evaluation must key this cache by its filtering context or bypass it), and a matching entry in key-vocabulary.md §5's identity-bound inventory, beside the schema-memo rule the cache comment already cites.

## Testing

Existing pins extended in `v2-query-evaluation-cache.test.ts`, each class counter asserted in the test that already produces its event: cross-principal share (`hitsPure`, `entriesPure`), identity keying (`entriesTainted`), residue rewrite + same-identity re-ask (`hitsAbsentResidue`, `entriesAbsentResidue`), present-instance refusal (`residueRefusals` per ask, `hitsIdentity` on the fallback), engine rotation (diagnostics `hits` sum). One new test pins the never-evaluated-space diagnostics shape. Full memory suite 584 passed; repo fmt + lint clean; full typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

