### PR TITLE
Give the test-group headings their delimiters

### DIFF
--- a/packages/api/index.test.ts
+++ b/packages/api/index.test.ts
@@ -7,10 +7,13 @@ import {
   isFabricPrimitiveSchemaType,
 } from "@commonfabric/api";
 
+//
 // The api package is the public type surface for `commonfabric`. Most of it is
 // ambient type and `declare const` material with no runtime footprint, but the
 // module itself still evaluates its concrete re-exports when imported. Loading
 // it here exercises that evaluation and pins the new fetch result surface.
+//
+
 Deno.test("api module loads and re-exports the CFC canonical alias names", () => {
   expect(Array.isArray(CFC_CANONICAL_ALIAS_NAMES)).toBe(true);
   expect(CFC_CANONICAL_ALIAS_NAMES.length).toBeGreaterThan(0);

--- a/packages/api/test/cfc-atom-mints.test.ts
+++ b/packages/api/test/cfc-atom-mints.test.ts
@@ -1,11 +1,13 @@
 import { assertEquals, assertFalse } from "@std/assert";
 import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 
+//
 // Epic B1: mint helpers for the exchange-rule atom families (spec §15).
 // Every helper is exercised with optionals absent AND present: minted atoms
 // compare by structural equality over canonical JSON, so an absent optional
 // must be truly absent (never an explicit-undefined key), and a supplied one
 // must land verbatim.
+//
 
 Deno.test("cfcAtom mints confidentiality principals and Expires", () => {
   assertEquals(cfcAtom.user("did:key:alice"), {

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -181,8 +181,11 @@ Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime alias
   assertEquals(description.cfc.image, "sandbox:deno2");
 });
 
+//
 // The description is persisted into the CFC policy snapshot that the ops
 // dashboard reads, so the wording of these two tags is part of that output.
+//
+
 Deno.test("DockerRunscSandboxRuntime describe names the sandbox kind and the sidecar transport", () => {
   const description = new DockerRunscSandboxRuntime(
     resolveDockerRunscSandboxConfig({

--- a/packages/cf-harness/test/http-fetch.test.ts
+++ b/packages/cf-harness/test/http-fetch.test.ts
@@ -4,9 +4,12 @@ import {
   OpenAICompatibleGatewayClient,
 } from "../src/index.ts";
 
+//
 // Importing through the package barrel keeps `defaultHarnessFetch` reachable
 // from the public entry point that consumers use, alongside the gateway client
 // that falls back to it.
+//
+
 Deno.test("barrel re-exports the harness fetch default", () => {
   assertEquals(typeof defaultHarnessFetch, "function");
   assertEquals(typeof OpenAICompatibleGatewayClient, "function");

--- a/packages/cli/test/view-diff-cov.test.ts
+++ b/packages/cli/test/view-diff-cov.test.ts
@@ -1,10 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { parseDiff } from "../lib/view/diff.ts";
 
+//
 // Coverage-focused tests for lib/view/diff.ts, exercising body-loop branches
 // the canonical suite does not reach: a `\ No newline` marker *inside* a hunk
 // body, a malformed body line that stops the hunk, the empty trailing-context
 // fallback, and a quoted file path in the `---`/`+++` headers.
+//
 
 Deno.test("diff: a `\\ No newline` marker mid-body is metadata, the body continues", () => {
   // git emits the no-newline marker for the OLD side between the removal and

--- a/packages/cli/test/view-diff-gate.test.ts
+++ b/packages/cli/test/view-diff-gate.test.ts
@@ -1,12 +1,14 @@
 import { assertEquals } from "@std/assert";
 import { parseDiff } from "../lib/view/diff.ts";
 
+//
 // Coverage-gate tests for the C-style quoted-path decoder in lib/view/diff.ts.
 // They drive the decoder's malformed-input fallbacks, which the canonical suite
 // only reaches with well-formed quoted paths: a backslash as the final byte
 // before the string ends (no closing quote), an unrecognized escape character,
 // and a quoted path that never closes its quote at all. Each fall-through hands
 // the path to the surrounding-quote strip so the name is never dropped.
+//
 
 Deno.test("diff: a quoted path whose final byte is a lone backslash falls back", () => {
   // The path opens its quote, then ends on a backslash with nothing after it:

--- a/packages/cli/test/view-render-gate.test.ts
+++ b/packages/cli/test/view-render-gate.test.ts
@@ -58,9 +58,11 @@ function mkNode(over: Partial<StructureNode> = {}): StructureNode {
   };
 }
 
+//
 // The guide column (`guideChar`) is only drawn when a node is selected. With no
 // gutter, the glyph sits at visible column 0 of each row. These tests drive
 // every reachable branch of `guideChar`.
+//
 
 Deno.test("guide: a multi-line node draws top corner, body, and bottom corner", () => {
   // Node covers lines 1..3 of a five-line document. Lines 0 and 4 are outside

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -252,9 +252,12 @@ Deno.test("lazyProgram: caches a success and latches a failed build", () => {
   assertEquals(nullCalls, 1, "a program-less build latches and is not retried");
 });
 
+//
 // makeHost's readReal memoizes real-file reads. Under the pager's module
 // resolution TypeScript reads each file once, so the cache hit never fires
 // there; reading the same path twice through the host exercises it directly.
+//
+
 Deno.test("makeHost: a repeated read of the same file is served from the cache", () => {
   const dir = Deno.makeTempDirSync();
   try {

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -351,8 +351,10 @@ Deno.test("filepickercov2: paging the picker up to the top keeps the scroll non-
 // Behavioral anchors for the reachable structure-tree edges near 288/377/380.
 //
 
+//
 // These do not force the unreachable defensive returns, but assert the
 // surrounding navigation/card behavior stays correct from a real session.
+//
 
 Deno.test("session: card down then up across a multi-target card stays consistent", () => {
   const doc = parseDocument(SAMPLE);

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -335,11 +335,14 @@ Deno.test("shell: the page watches its own stream and reopens one that stops del
   assertStringIncludes(html, `addEventListener('online', paint);`);
 });
 
+//
 // The functions the page runs are authored as TypeScript here and reach the
 // browser as the text of `Function.prototype.toString()`. That text has to be
 // JavaScript the browser accepts, and it has to stand alone: a reference to
 // anything outside the function is a name the page does not have. Neither
 // property is visible to a test that only looks for substrings.
+//
+
 Deno.test("shell: the injected script is JavaScript, and each injected function stands alone", () => {
   const scripts = [...shell("", "", 0, 45_000, TEST_VERSION, "good")
     .matchAll(/<script>([\s\S]*?)<\/script>/g)].map((match) => match[1]);

--- a/packages/dashboard/test-records-history.test.ts
+++ b/packages/dashboard/test-records-history.test.ts
@@ -96,8 +96,11 @@ Deno.test("collectDay separates variant records from default history", async () 
   }]);
 });
 
+//
 // A body holding two reports, the second fork-authored: its records must
 // not reach the decision-feeding aggregates.
+//
+
 Deno.test("collectDay excludes fork-authored reports", async () => {
   const forkContext = JSON.stringify({
     schema: 1,

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -289,8 +289,11 @@ Deno.test("discord snapshot: absent Team aliases do not produce a valid snapshot
   assertEquals(missing, null);
 });
 
+//
 // This is the first test that reaches the history, so it is the one that sees the
 // file being loaded. The load happens once per process, on first use.
+//
+
 Deno.test("discord online: a snapshot -> good; the reloaded history draws the chart, stale samples age out", async () => {
   clock = T0;
   const persisted = [

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -47,10 +47,13 @@ Deno.test("smoke test", async function () {
   );
 });
 
+//
 // A harness run can fail for a reason no assertion in this suite anticipates:
 // the browser refuses to boot, a bundle fails, the process is killed. Each of
 // those says what happened on one of the run's two streams, and an assertion
 // that reported only its own words left the reason nowhere.
+//
+
 Deno.test("a failed assertion carries the whole run", function () {
   const run = runWith();
   const error = assertThrows(
@@ -69,8 +72,11 @@ Deno.test("an assertion that holds says nothing", function () {
   runWith().assert(true, "test successful");
 });
 
+//
 // No real run in this suite is killed by a signal, so this states one. The
 // transcript names the signal rather than only the exit code it comes with.
+//
+
 Deno.test("a run the kernel killed names the signal", function () {
   const transcript = runWith({ code: 137, signal: "SIGKILL" }).transcript();
 

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -42,12 +42,15 @@ Deno.test("a stuck test fails by name and the run continues", async function () 
   );
 });
 
+//
 // The detector is only worth having while it fires before astral does. Astral
 // gives each `page.evaluate` five retried 10-second deadlines and throws a
 // `RetryError` once they run out, measured at 53 to 57 seconds; past that the
 // run dies without naming the test. Raising the default above that would put
 // the diagnostic back out of reach, so the relationship is pinned here rather
 // than left in a comment.
+//
+
 Deno.test("the default fires before astral's retries run out", function () {
   assert(
     DEFAULT_TEST_TIMEOUT_MS < 50_000,

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -3597,12 +3597,15 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", asyn
   assertEquals(tree.lookup(state.piecesIno, "My-Note-2") !== undefined, true);
 });
 
+//
 // Regression: on a cold runtime the piece list doesn't load the linked piece
 // docs, so a synchronous piece.name() read returns undefined until the NAME
 // doc is synced. addPieceToSpace must await that sync before choosing the
 // directory name — otherwise the piece mounts under the opaque id-derived
 // fallback name, permanently if no later change event fires (CI fuse-exec
 // "Timed out waiting for path: pieces/Fuse-Exec-Fixture").
+//
+
 Deno.test("CellBridge.addPieceToSpace syncs a late-loading name before naming the directory", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");

--- a/packages/identity/test/key-store.test.ts
+++ b/packages/identity/test/key-store.test.ts
@@ -16,10 +16,13 @@ Deno.test("KeyStore can store and recover keys", async () => {
   assert(recovered && did === recovered.verifier.did());
 });
 
+//
 // The two arms are stored differently -- bytes for one, `CryptoKey` handles
 // for the other -- and each names its own implementation, so a recovered key
 // that arrived through the wrong arm would sign as a different implementation
 // than it was stored as.
+//
+
 Deno.test("KeyStore recovers a key pair holding material as one", async () => {
   const store = await KeyStore.open("test-key-store-material");
   await store.clear();

--- a/packages/integration/pattern-coverage.test.ts
+++ b/packages/integration/pattern-coverage.test.ts
@@ -13,12 +13,15 @@ const span = (fileName: string): PatternCoverageSpan => ({
   endColumn: 2,
 });
 
+//
 // A worker reports two shapes of file name, depending on how the pattern reached
 // it, and the gate only credits a line if its `SF:` path matches the file the
 // source walk found. So resolve each shape the way the LCOV writer will and
 // check it lands on a file that actually exists — a mapping that is merely
 // plausible produces a path nothing matches, and the coverage silently
 // evaporates rather than failing anything.
+//
+
 Deno.test("worker span file names resolve onto real pattern files", async () => {
   const cases = [
     {

--- a/packages/memory/test/v2-commit-class.test.ts
+++ b/packages/memory/test/v2-commit-class.test.ts
@@ -175,6 +175,7 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
   ]);
 });
 
+//
 // commitClassOfSeq (the arrival-witness predicate's server-side read,
 // speculation.md §4): the unknown-seq arm answers undefined, and the memo
 // declines to record inside ANY transaction — `applyCommit` brackets its
@@ -183,6 +184,7 @@ Deno.test("commit class: a pre-class store migrates, backfilling 'authored'", as
 // (`database.inTransaction`), not a caller marker. A rolled-back seq is
 // re-minted by the retry, possibly under another class; a memo entry written
 // mid-transaction would serve that phantom class forever.
+//
 
 Deno.test("commitClassOfSeq: seq 0, negative, and unknown seqs answer undefined (fail-closed substrate of the at-floor witness)", async () => {
   const { engine } = await createEngine();

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1276,6 +1276,7 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
   }
 });
 
+//
 // CT-1824 contract: a stale-read ConflictError must name the conflicted
 // entity BOTH structurally (of/seq/conflictSeq — read in-process by
 // editWithRetry's pull) AND in the message with this exact shape — server
@@ -1283,6 +1284,8 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
 // client re-derives `of` by parsing the message (runner storage/v2.ts
 // toRejectedError). Changing either surface breaks conflict recovery for
 // blind writes.
+//
+
 Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted entity structurally and in the message", async () => {
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";

--- a/packages/memory/test/v2-execution-lease.test.ts
+++ b/packages/memory/test/v2-execution-lease.test.ts
@@ -427,11 +427,13 @@ Deno.test("admission: a holder smuggled into the client payload is inert", async
   }
 });
 
+//
 // The C7 pair, against the real engine. The model's `sealProbe` /
 // `deliverProbe` steps become: capture the cycle's tenure when work seals,
 // and gate the commit on `isCurrentTenure` at delivery time — the in-process
 // discipline a SpaceServer's commit step will implement (serving-loop.md §2's
 // stop-committing MUST, enforced before any reacquire).
+//
 
 Deno.test("discipline (C7a): a probe sealed before an expiry never commits — renewal failure ends the tenure before the reacquire", async () => {
   const { engine } = await createEngine();
@@ -533,6 +535,7 @@ Deno.test("discipline (C7b): without the in-process check the same-process stale
   }
 });
 
+//
 // Idempotent replay vs. the lease (owner review on #5349, 2026-08-12): a
 // byte-identical retry of an ALREADY-ACCEPTED derived commit — same
 // session, same localSeq, same class + holder envelope — answers from the
@@ -546,6 +549,7 @@ Deno.test("discipline (C7b): without the in-process check the same-process stale
 // `sessionId === holder` (no principal): stage F's envelope-session rule
 // (protocol.md §2, RULED 2026-08-05) admits a fresh derived commit only
 // from the lease holder's own service session.
+//
 
 Deno.test("replay: a byte-identical retry answers from the store after the lease is RELEASED — fresh commits stay rejected", async () => {
   const { engine } = await createEngine();

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -1298,11 +1298,13 @@ Deno.test("watch.add with a changed entityScopeKey on an existing watch id is a 
   }
 });
 
+//
 // Delivery-failure rollback for explicit foreign instances (thread
 // r3731191415): the wire frame carries scope NAMES, so rollback cannot
 // recover the instance from the frame alone — the server must retain the
 // frame's true instance keys. A lost foreign-instance frame must be
 // REDELIVERED once sends succeed again.
+//
 
 Deno.test("a failed delivery of an explicit foreign-instance frame is redelivered (rollback keys the exact instance)", async () => {
   const server = newServer("memory://explicit-read-rollback");

--- a/packages/memory/test/v2-server-acl.test.ts
+++ b/packages/memory/test/v2-server-acl.test.ts
@@ -1738,6 +1738,7 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
   }
 });
 
+//
 // OW31 (WRITE ruled 2026-08-18, READ ruled 2026-08-19): the delegated READ
 // binding. A session opened `actingAs: "space-owner"` by a DELEGATING-class
 // principal has its READ-class decisions resolved as the space's ACL OWNER
@@ -1745,6 +1746,7 @@ Deno.test("acl default: absent acl option behaves like off", async () => {
 // WRITE/OWNER requirements keep resolving against the ENVELOPE, so the
 // binding grants no write path; a delegating principal is NOT a service
 // principal and cannot initialize a genesis.
+//
 
 Deno.test("OW31 acl enforce: a delegating principal acting as space-owner READS an owner-only space; its writes and ACL-doc writes stay refused", async () => {
   const server = createAclServer("memory://acl-ow31-binding", {

--- a/packages/memory/test/v2-sqlite-column-origin.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin.test.ts
@@ -74,10 +74,13 @@ Deno.test("pinned libsqlite3 release matches the resolved @db/sqlite", () => {
   );
 });
 
+//
 // Provenance has to be read from the same libsqlite3 image that runs the query,
 // so the only acceptable file is the one `@db/sqlite` picks. These cover the
 // picking rule and the refusal to substitute a different file for one that
 // cannot be opened.
+//
+
 Deno.test("library source follows @db/sqlite's own precedence", () => {
   const env = (vars: Record<string, string>) => (k: string) => vars[k];
   // @db/sqlite reads DENO_SQLITE_LOCAL first, so it wins even with a path set.

--- a/packages/memory/test/v2-sqlite-guard.test.ts
+++ b/packages/memory/test/v2-sqlite-guard.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../v2/sqlite/guard.ts";
 import { open } from "../v2/engine.ts";
 
+//
 // S4: the guard's core-table denylist is hand-maintained, but unqualified
 // pattern-SQL names resolve to the attached cell-db ONLY because `main` (the
 // core store) has no table of that name. If the engine ever adds a `main` table
@@ -24,6 +25,8 @@ import { open } from "../v2/engine.ts";
 // pattern write could silently hit core storage. This asserts the denylist
 // covers every real `main` table, so adding an engine table without updating the
 // guard fails CI.
+//
+
 describe("CORE_TABLE_NAMES vs the engine schema", () => {
   it("covers every table the engine creates in `main`", async () => {
     const path = await Deno.makeTempFile({ suffix: ".sqlite" });

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -250,8 +250,11 @@ describe("asCell scope cap", () => {
   });
 });
 
+//
 // Shapes the first round of this change missed, each found by adversarial
 // review rather than by the tests above.
+//
+
 describe("asCell scope cap, harder shapes", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -20,10 +20,12 @@ await ensureCompilerStack();
 
 const signer = await Identity.fromPassphrase("build-from-compiled");
 
+//
 // The warm load path builds records directly from cached compiled bodies — no
 // TS source, no resolve, no recompile. The export NAMES are recovered from the
 // compiled JS (export * unioned transitively). These tests prove that the
 // resolve-free build produces records equivalent to the source-derived ones.
+//
 
 describe("extractCompiledExports", () => {
   it("recovers exports.X assignments and Object.defineProperty re-exports", () => {

--- a/packages/runner/test/cell-arrays.test.ts
+++ b/packages/runner/test/cell-arrays.test.ts
@@ -635,12 +635,15 @@ describe("plain-schema array traversal", () => {
   });
 });
 
+//
 // CT-1895 (borderline site): the covering schema for a tuple element is
 // index-determined — prefixItems[index] within the slots, `items` past them
 // — so elementSchemaFor takes the index when the caller knows it. Without
 // one (elementById is id-keyed), a tuple schema yields undefined: there is
 // no principled per-element schema to pick, and the schema/$defs loss is
 // the documented cost.
+//
+
 describe("elementSchemaFor tuple (prefixItems) schemas", () => {
   const tupleArraySchema = {
     type: "array",

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -86,6 +86,7 @@ const templateEntry = (
   observes: "labelMetadata",
 });
 
+//
 // Stage B of docs/specs/cfc-template-population.md (§5/§6; spec §4.6.4.1-.2):
 // the §4.6.4.2 field-precise label-metadata population profile, carried as
 // multi-`*` templates under /cfc/labels/<target-envelope-path>/... — minted at
@@ -94,6 +95,7 @@ const templateEntry = (
 // them at concrete clause/alternative paths through the wildcard machinery,
 // falling back to the computed-in-hand interim rule for pre-Stage-B
 // envelopes).
+//
 
 describe("CFC template metadata population (Stage B): persist-seam mints", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -229,10 +229,13 @@ Deno.test("writeDetailValueForTarget: composition preserves large off-spine subt
   }
 });
 
+//
 // A `FabricInstance` holds its state privately, so an overlay path addresses
 // nothing in one. Both arms are covered: the base itself, and an instance
 // nested deeper -- reached only through a descendant's parent path, which the
 // base check does not see.
+//
+
 Deno.test("writeDetailValueForTarget: refuses an overlay onto a `FabricInstance` base", () => {
   const err = FabricError.fromNativeError(new Error("boom"));
   const tx = txWith([

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -76,6 +76,7 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
   }
 });
 
+//
 // Server-execution v2 Phase 2's compile gate (the builtin's flag-ON
 // posture, stated truthfully): compilation is an EFFECTFUL step whose
 // launch is a floating promise the overlay destination cannot
@@ -87,6 +88,8 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
 // memo'd results still read through, `pending` renders the ordinary
 // loading state. A WAVE-STAMPED run passes the gate (the seam the
 // serving port will drive), and the OFF arm is untouched.
+//
+
 Deno.test("compileAndRun's Phase-2 gate: flag-ON non-wave runs launch NO fresh compile (pending stands), a wave-stamped run passes, and the OFF arm is unaffected", async () => {
   const identity = await Identity.fromPassphrase("compile and run gate");
   const space = identity.did();

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -957,8 +957,10 @@ Deno.test("toolAllowsObservedConfidentiality permits tools within maxConfidentia
   assertEquals(allowed, true);
 });
 
+//
 // Tests for simplifySchemaForContext
 // Note: We cast schemas to `any` to avoid strict type checking on `type` field literals
+//
 
 Deno.test("simplifySchemaForContext preserves asCell stream marker", () => {
   const schema: any = {
@@ -1232,7 +1234,9 @@ Deno.test("simplifySchemaForContext handles primitive and composed schemas", () 
   assertEquals(result.allOf?.[0]?.properties?.id?.type, "string");
 });
 
+//
 // Tests for resolveRefsForLLM
+//
 
 Deno.test("resolveRefsForLLM converts boolean true schema to empty object", () => {
   const result = resolveRefsForLLM(true as any);
@@ -1397,7 +1401,9 @@ Deno.test("resolveRefsForLLM handles mutually recursive types", () => {
   );
 });
 
+//
 // Tests for prepareSchemaForLLM
+//
 
 Deno.test("prepareSchemaForLLM returns primitive schemas unchanged", () => {
   assertEquals(prepareSchemaForLLM("plain" as any), "plain" as any);

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -444,12 +444,15 @@ Deno.test("storage ACL bootstrap leaves populated named spaces public", async ()
   }
 });
 
+//
 // OW31 (RULED 2026-08-18; verification-coverage.md): a PROVISIONED
 // space's genesis is signed by the space's own keys and names the ACTING
 // USER as OWNER in that same first commit — the serving identity appears
 // nowhere in the ACL. The client shape (no owner supplied → the signer,
 // i.e. the active user) is pinned byte-for-byte by the named-space tests
 // above.
+//
+
 Deno.test("storage ACL bootstrap names the supplied genesis owner, not the signer (OW31)", async () => {
   const service = await Identity.fromPassphrase("acl bootstrap ow31 service");
   const alice = await Identity.fromPassphrase("acl bootstrap ow31 alice");

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -4936,6 +4936,7 @@ Deno.test("memory v2 stacked commits: a dependant stranded by a dropped optimist
     await harness.close();
   }
 });
+//
 // CT-1872 Class 1a pins (ported from #4608, expectations rewritten for the
 // ops-replay contract): a pending patch layer renders by REPLAYING ITS OPS
 // over the current base — never by copying values out of its optimistic
@@ -4945,6 +4946,7 @@ Deno.test("memory v2 stacked commits: a dependant stranded by a dropped optimist
 // SKIPPED: transiently honest, converging when a frame delivers server
 // truth. Under strict semantics (CT-1875) such commits become terminal
 // rejections at admission instead.
+//
 
 Deno.test("memory v2 stacked commits: a surviving child whose ops cannot apply to the repaired base renders skipped, not crashed", async () => {
   const harness = await createHarness();

--- a/packages/runner/test/memory-v2-watch-id.test.ts
+++ b/packages/runner/test/memory-v2-watch-id.test.ts
@@ -116,11 +116,13 @@ Deno.test("memory v2 selector normalization ignores inherited definition names",
   assertEquals(normalized.schema, { $ref: "#/$defs/toString" });
 });
 
+//
 // The registry of reads a provider replays onto a replacement replica keys its
 // entries by the normalized selector's identity. These two tests pin what that
 // key relies on: normalization hands back one shared instance per distinct
 // registration, so identity separates registrations exactly and the registry
 // needs no content hash per `sync()` call to tell them apart.
+//
 
 Deno.test("memory v2 selector normalization collapses schemaless reads", () => {
   const first = normalizeSyncSelector({

--- a/packages/runner/test/module-export-write-once.test.ts
+++ b/packages/runner/test/module-export-write-once.test.ts
@@ -10,12 +10,14 @@ const noRequire = (s: string): Record<string, unknown> => {
   throw new Error(`unexpected require(${s})`);
 };
 
+//
 // The ESM loader hands the module body a write-once exports object so a write
 // smuggled into the evaluation of an otherwise-accepted expression (e.g. a
 // comma side effect inside a `__cf_data(...)` argument) cannot overwrite an
 // already-assigned export with attacker-controlled state before the loader
 // snapshots it into the (SES-immutable) namespace. These tests pin that
 // behavior, plus the legitimate compiler shapes that must still work.
+//
 
 describe("createWriteOnceExports", () => {
   it("locks a property after a real assignment (blocks the overwrite smuggle)", () => {

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -61,10 +61,13 @@ const programOf = (contents: string): RuntimeProgram => ({
   files: [{ name: "/main.tsx", contents }],
 });
 
+//
 // The repair keys on ONE variant of the handler-stream failure — the
 // setup-missing "marker was never written" case. Its two siblings are NOT
 // setup-missing (re-running setup would not fix them), so they must not trigger
 // a repair. These messages mirror `describeHandlerStreamFailure`'s three shapes.
+//
+
 describe("isMissingStreamMarkerFailure discriminates the setup-missing variant", () => {
   it("matches the marker-never-written variant", () => {
     expect(

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -99,8 +99,11 @@ Deno.test("transformInjectHelperModule injects JS-syntax helpers into .js source
   assertNotMatch(helper.contents, /any\[\]/);
 });
 
+//
 // Coverage remapping assumes this pretransform only adds the one-line helper
 // prelude. Mixed import splitting must preserve the original line count.
+//
+
 Deno.test("mixed import rewrite must not drift coverage line numbers", () => {
   const transformedContents = (contents: string): string =>
     transformInjectHelperModule({
@@ -164,6 +167,7 @@ Deno.test("preserveLineCount rejects expanding rewrites", () => {
   );
 });
 
+//
 // The coverage span mapper subtracts `helperInjectionLineOffset` from every span
 // line to recover the authored line, so it has to predict exactly how far
 // `transformInjectHelperModule` moved that file's content. The two live in
@@ -171,6 +175,8 @@ Deno.test("preserveLineCount rejects expanding rewrites", () => {
 // branches, so pin them against each other rather than against a hand-written
 // number: only the leading helper import shifts lines, and the trailing `h` shim
 // the injector also appends must not count.
+//
+
 Deno.test("helperInjectionLineOffset matches what the injector actually shifts", async () => {
   await ensureCompilerStack();
   const MARKER = "const marker = 1;";

--- a/packages/runner/test/schema-format.test.ts
+++ b/packages/runner/test/schema-format.test.ts
@@ -1,7 +1,9 @@
 import { assert, assertEquals } from "@std/assert";
 import { schemaToTypeString } from "../src/schema-format.ts";
 
+//
 // Tests for schemaToTypeString - TypeScript-like schema representation
+//
 
 Deno.test("schemaToTypeString converts basic types", () => {
   assertEquals(schemaToTypeString({ type: "string" } as any), "string");
@@ -570,9 +572,11 @@ Deno.test("schemaToTypeString formats fixture-style PatternToolResult without le
   );
 });
 
+//
 // A conjunction states its fields across its members. These pin that the
 // rendering merges them the way the CLI's reader does, so a help page's type
 // block and its flag list cannot disagree about the same schema.
+//
 
 Deno.test("schemaToTypeString renders a conjunction's fields alongside its own", () => {
   assertEquals(

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -250,6 +250,7 @@ describe("wish profile-create sidecar duplicate launch", () => {
   });
 });
 
+//
 // The discrimination itself, exhaustively — this is the shared decision both
 // the commit-error arm AND the thrown-error arm of runSidecarInOwnTx consume
 // (a thrown conflict carries the same object shape as a commit-refused one).
@@ -258,6 +259,8 @@ describe("wish profile-create sidecar duplicate launch", () => {
 // its own reads), so the semantics are pinned here and each arm reduces to a
 // mechanical consume of this function; the flow-level pin above covers the
 // commit arm end to end.
+//
+
 describe("sidecarRunFailureDisposition", () => {
   const conflict = { name: "ConflictError" };
   const inconsistent = { name: "StorageTransactionInconsistent" };

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -244,10 +244,13 @@ function normalizeArrayOrdering(obj: unknown): unknown {
   return obj;
 }
 
+//
 // The golden format exists to hold values plain JSON cannot. Guard that
 // directly: a fixture cannot reach these values on its own yet, and a golden
 // that silently flattens them would agree with buggy output instead of
 // catching it.
+//
+
 Deno.test("golden encoding preserves values JSON cannot represent", () => {
   const schema = {
     type: "object",

--- a/packages/shell/test/entity-id-scheme-parsing.test.ts
+++ b/packages/shell/test/entity-id-scheme-parsing.test.ts
@@ -2,11 +2,13 @@ import { assertEquals } from "@std/assert";
 import { normalizeEntityId } from "../src/lib/debug-utils.ts";
 import { XSchedulerGraph } from "../src/views/SchedulerGraphView.ts";
 
+//
 // The debug command surface and the scheduler graph both bridge between
 // human/bare ids and the full schemed URIs that programmatic surfaces
 // (diagnostics pieceId, error strings) emit. Full schemed ids pass through
 // untouched — the scheme is part of the identity — while adding `of:` to a
 // bare id is a human-input convenience only.
+//
 
 Deno.test("normalizeEntityId prefixes bare ids and passes schemed ids through", () => {
   // Bare id (typed or copied from a URL path): of: is the convenience.

--- a/packages/static/scripts/strip-withheld-globals.test.ts
+++ b/packages/static/scripts/strip-withheld-globals.test.ts
@@ -156,9 +156,12 @@ Deno.test("throws when a declaration closes more braces than it opens", () => {
   );
 });
 
+//
 // The checked-in type libraries are kept stripped, so the CLI run over them is
 // the up-to-date path: --check reports clean and returns 0, and a plain run
 // finds nothing to remove and rewrites nothing.
+//
+
 Deno.test("runCli --check passes on the stripped libraries", async () => {
   assertEquals(await runCli(["--check"]), 0);
 });
@@ -182,8 +185,11 @@ Deno.test("cliMain exits with the CLI status when it is the entry point", async 
   assertEquals(code, 0);
 });
 
+//
 // The error and write paths are driven with injected files rather than the
 // checked-in libraries, which are kept clean.
+//
+
 Deno.test("runCli --check fails when a library still declares a withheld global", async () => {
   const status = await runCli(["--check"], {
     files: ["injected.d.ts"],
@@ -442,9 +448,12 @@ Deno.test("drops a namespace value member's trailing blank line", () => {
   );
 });
 
+//
 // `stillDeclared` is the post-strip safety net. `runCli` only ever hands it
 // already-stripped text, where a withheld namespace has no value members left,
 // so its namespace branch is exercised directly here.
+//
+
 Deno.test("stillDeclared flags a withheld namespace that still declares a value", () => {
   const text = [
     "declare namespace Withheld {",

--- a/packages/test-support/src/isolated-deno.test.ts
+++ b/packages/test-support/src/isolated-deno.test.ts
@@ -12,6 +12,7 @@ function decode(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes);
 }
 
+//
 // Three test tasks build their own run allowlist with
 // `--allow-run=$(deno eval "console.log(Deno.execPath())")`, which names the
 // binary the tests start only while a task's `deno` is the Deno running the
@@ -19,6 +20,8 @@ function decode(bytes: Uint8Array): string {
 // the shell's Deno is not the pinned one, which is the case those tasks exist
 // to handle. The decoy below is the only `deno` on the child's `PATH`, so it
 // runs if the resolution ever goes through `PATH`.
+//
+
 Deno.test({
   name: "a task's `deno` is the Deno running the task, not one on PATH",
   ignore: Deno.build.os === "windows",

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -21,8 +21,11 @@ Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () =
   assertEquals(otel(undefined), false);
 });
 
+//
 // The sibling boolean flags shared the same z.coerce.boolean() trap and now use
 // the strict boolFlag() parse. Guard them so they can't silently regress.
+//
+
 Deno.test("DISABLE_LOG_REQ_RES / PLAID_SYNC_ALL_TRANSACTIONS parse strictly", () => {
   const flag = (key: string, v: string | undefined) =>
     (EnvSchema.parse(v === undefined ? {} : { [key]: v }) as Record<

--- a/packages/toolshed/lib/ai-telemetry.test.ts
+++ b/packages/toolshed/lib/ai-telemetry.test.ts
@@ -206,8 +206,11 @@ Deno.test("metadataAttributeValue drops values that have no attribute form", () 
   assertEquals(metadataAttributeValue(() => {}), undefined);
 });
 
+//
 // A request may carry non-string metadata, and every value it can carry has to
 // reach the spans, not just the string ones.
+//
+
 Deno.test("runtimeContextFromMetadata carries every value that has an attribute form", () => {
   const { runtimeContext, includeRuntimeContext } = runtimeContextFromMetadata({
     requestId: "req-abc",

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -37,12 +37,15 @@ Deno.test("spans carry both the service attributes and the SDK defaults", () => 
   );
 });
 
+//
 // `OpenInferenceBatchSpanProcessor` subclasses `BatchSpanProcessor`, but
 // @arizeai/openinference-vercel imports @opentelemetry/sdk-trace-base without
 // declaring it as a dependency, and the range it names in its development
 // dependencies stops below the major this workspace resolves. Which copy it
 // subclasses is therefore decided by the workspace import map rather than by
 // anything the package states, and the span export above depends on the answer.
+//
+
 Deno.test("the OpenInference processor extends the tracer SDK in use", () => {
   assert(
     OpenInferenceBatchSpanProcessor.prototype instanceof BatchSpanProcessor,
@@ -72,9 +75,12 @@ Deno.test("spans pass through the OpenInference processor to the exporter", asyn
   }
 });
 
+//
 // The `ai` package collects no spans until a telemetry integration is
 // registered, and it reports nothing when none is: the LLM spans simply stop
 // being produced. Importing this module is what registers ours.
+//
+
 Deno.test("importing the module registers an AI SDK telemetry integration", () => {
   assert(
     (globalThis.AI_SDK_TELEMETRY_INTEGRATIONS?.length ?? 0) > 0,

--- a/packages/toolshed/lib/rate-limit.test.ts
+++ b/packages/toolshed/lib/rate-limit.test.ts
@@ -3,10 +3,12 @@ import { expect } from "@std/expect";
 import { createRateLimiter } from "@/lib/rate-limit.ts";
 import { clientKey } from "@/middlewares/rate-limit.ts";
 
+//
 // Toolshed had no rate limiting before self-serve minting, so this is the whole
 // of it. The properties worth pinning are the ones an abuse bound depends on:
 // that a burst is actually capped, that keys do not share a bucket, and that
 // eviction cannot be used as a reset primitive.
+//
 
 describe("token bucket", () => {
   it("allows a burst up to capacity, then refuses", () => {

--- a/packages/toolshed/routes/ai/llm/errors.test.ts
+++ b/packages/toolshed/routes/ai/llm/errors.test.ts
@@ -21,10 +21,13 @@ function providerFailure(statusCode: number): APICallError {
   });
 }
 
+//
 // The routes ask the AI SDK for a single attempt, so these two shapes do not
 // reach the classifier from them. They are what the classifier sees if a call
 // site ever asks for retries again, and the status has to survive the wrapping
 // either way.
+//
+
 Deno.test("a status survives a retry wrapper", () => {
   const wrapped = new RetryError({
     message: "Failed after 3 attempts",
@@ -47,9 +50,12 @@ Deno.test("a cycle among causes does not trap the search", () => {
   assertEquals(httpStatusForError(outer), 500);
 });
 
+//
 // The AI SDK raises these over what the caller sent, before any provider is
 // asked. Reporting them against the provider would send the caller looking in
 // the wrong place.
+//
+
 Deno.test("a request the SDK would not send is the caller's mistake", () => {
   assertEquals(
     httpStatusForError(

--- a/packages/toolshed/routes/ai/llm/llm.status.test.ts
+++ b/packages/toolshed/routes/ai/llm/llm.status.test.ts
@@ -183,9 +183,12 @@ Deno.test("a tool the model cannot serve is the caller's mistake", async () => {
   assertStringIncludes(error, "is not supported by model");
 });
 
+//
 // A body sent as JSON is parsed by the route's own validator, which answers
 // its own 400 before the handler runs. A body sent as anything else reaches
 // the handler unparsed.
+//
+
 Deno.test("a body that is not JSON is the caller's mistake", async () => {
   const response = await app.request("/api/ai/llm", {
     method: "POST",

--- a/packages/toolshed/routes/shell/shell.test.ts
+++ b/packages/toolshed/routes/shell/shell.test.ts
@@ -152,9 +152,12 @@ describe("Shell route CORS", () => {
   });
 });
 
+//
 // With no compiled frontend and no SHELL_URL proxy target — the unit-test
 // environment — the shell router answers with a 404 that tells an operator how
 // to bring the shell up. This guards that operator hint and its port.
+//
+
 describe("Shell dev fallback without a compiled build or proxy", () => {
   it("returns 404 with a hint naming SHELL_URL and the shell port", async () => {
     const response = await app.request("/anything");

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -421,9 +421,11 @@ Deno.test("assert records a body that returns early", async () => {
   assertEquals(assertCaptureLabels(root), ["a.get()", "b.get()"]);
 });
 
+//
 // The stage sees the AST before type-checking has rejected anything, so it has
 // to survive a callback it cannot read and leave the call alone rather than
 // emit a broken body. These sources are deliberately not well-typed.
+//
 
 Deno.test("assert leaves a callback it was not given inline alone", async () => {
   const root = await transformed(patternSource(`

--- a/packages/ts-transformers/test/ast/type-building.test.ts
+++ b/packages/ts-transformers/test/ast/type-building.test.ts
@@ -13,6 +13,7 @@ import {
   createCaptureTreeNode,
 } from "../../src/utils/capture-tree.ts";
 
+//
 // The printer extracts literal text by source position from the file it is
 // printing. A declaration member's type node reused in ANOTHER file therefore
 // emits garbage tokens for literal types (e.g. the `"n/a"` in
@@ -20,6 +21,8 @@ import {
 // emit file). cloneTypeNodeDeepForEmission strips positions throughout so
 // literals print from their own `.text`. (Same guarantee as the helper of
 // this name on the #4078 branch.)
+//
+
 Deno.test("cloneTypeNodeDeepForEmission prints cross-file literal types from their own text", () => {
   const declarationFile = ts.createSourceFile(
     "declaration.ts",

--- a/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
+++ b/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
@@ -59,6 +59,7 @@ Deno.test("transformer coverage: projection paths lower as canonical pointers", 
   });
 });
 
+//
 // The canonical OpaqueInput helper was removed (the runner rejects ifc.opaque
 // fail-closed), but a non-canonical local alias with EXPLICIT type arguments
 // still resolves through the Cfc carrier — the generic payload passthrough.
@@ -66,6 +67,8 @@ Deno.test("transformer coverage: projection paths lower as canonical pointers", 
 // lowering mechanism, not an advertised capability. Defaulted type arguments
 // are NOT recovered on non-canonical aliases (only the canonical name
 // registry hardcoded defaults), so `OpaqueInput<string>` would emit no ifc.
+//
+
 Deno.test("transformer coverage: non-canonical Cfc payloads lower structurally", async () => {
   const source = `/// <cts-enable />
     import { toSchema } from "commonfabric";

--- a/packages/ts-transformers/test/fetch-json-injection.test.ts
+++ b/packages/ts-transformers/test/fetch-json-injection.test.ts
@@ -27,10 +27,12 @@ interface Repo {
 }
 `;
 
+//
 // fetchJson<T> lowers T into an injected `schema` property. The object-literal
 // argument form is covered by the schema-injection fixture; these cases reach
 // the other two emission branches: a non-object-literal argument (spread) and
 // no argument at all.
+//
 
 Deno.test("fetchJson injects a schema by spreading a non-literal argument", async () => {
   const source = `

--- a/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
+++ b/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
@@ -3,9 +3,11 @@ import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { emittedSchemas, parseModule } from "./transformed-ast.ts";
 
+//
 // Targeted coverage for schema-injection branches that ran in CI only through
 // patterns: the per-session scope on a `new` cell constructor, and the schema-
 // argument detection that skips injection when two schemas are already present.
+//
 
 Deno.test("schema injection reads the session scope from a `new X.perSession(...)` constructor", async () => {
   const source = [

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -3,12 +3,14 @@ import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import { CFInput, INPUT_PATTERNS } from "./index.ts";
 
+//
 // NOTE: Full DOM interaction tests (input events, Cell two-way binding,
 // timing strategy integration, validation UI) require Lit's rendering
 // pipeline and shadow DOM, which aren't available in Deno's headless
 // test runner. The tests below cover property defaults, validation
 // patterns, Cell property acceptance, and basic configuration.
 // For full integration tests, use a browser-based test harness.
+//
 
 describe("CFInput", () => {
   it("should be defined", () => {

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -117,8 +117,11 @@ Deno.test("namesResolverInCode reads past a comment marker inside a string", () 
   );
 });
 
+//
 // Likewise for a block-comment opener: taken literally it would swallow the
 // rest of the file.
+//
+
 Deno.test("namesResolverInCode reads past a block-comment marker inside a string", () => {
   assert(
     namesResolverInCode(

--- a/tasks/check-single-copy-deps.test.ts
+++ b/tasks/check-single-copy-deps.test.ts
@@ -83,8 +83,11 @@ Deno.test("findProblems reports a package resolved twice", () => {
   assertStringIncludes(problems[0], "ai@7.0.30_zod@3.25.76");
 });
 
+//
 // A package that disappears from the lockfile would otherwise pass silently,
 // which would make this check quietly stop covering it.
+//
+
 Deno.test("findProblems reports a package missing from the lockfile", () => {
   const problems = findProblems({ npm: {} }, { ai: "the AI SDK" });
   assertEquals(problems.length, 1);
@@ -124,10 +127,13 @@ Deno.test("main reports the duplicate and returns 1", async () => {
   }
 });
 
+//
 // Runs the script the way `deno task check-single-copy-deps` does, which the
 // calls to main() above do not: they would still pass if the entry point never
 // ran it, or if the task's declared permissions were too narrow to read the
 // lockfile.
+//
+
 Deno.test("running the script as a command reports single copies", async () => {
   const output = await runDenoCommandWithTemporaryLock({
     root: REPO_ROOT,

--- a/tasks/check-skill-facts.test.ts
+++ b/tasks/check-skill-facts.test.ts
@@ -330,8 +330,10 @@ Deno.test("collectDrift reports a package that declares no exports", () => {
   assert(drift[0].message.includes("has no root export"));
 });
 
+//
 // The tests below drive the command entry point over temp git fixtures, so they
 // cover the clean and drift paths without depending on the real tree.
+//
 
 Deno.test("main reports success and returns 0 on a clean repo", async () => {
   const root = await fixtureRepo(fixtureFiles(
@@ -520,9 +522,12 @@ Deno.test("every cited path and specifier resolves", async () => {
   );
 });
 
+//
 // The three kinds of document this covers are named by different conventions,
 // so each is pinned: a rename that drops one from the scan would otherwise be
 // invisible.
+//
+
 Deno.test("the scan covers skills, AGENTS.md guides, and rules", async () => {
   const root = fromFileUrl(new URL("..", import.meta.url));
   const tree = await readTree(root);

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -4,9 +4,12 @@ import { checkTripwire, main, TRIPWIRES } from "./check-tripwires.ts";
 
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
+//
 // The check is only as good as its manifest: a typo'd path would make it pass
 // vacuously while reporting "intact", which is the failure mode that matters
 // most for a guard nobody looks at until the day it fires.
+//
+
 Deno.test("every tripwire's test file exists and carries its sentinel", async () => {
   assert(
     TRIPWIRES.length > 0,
@@ -32,9 +35,12 @@ Deno.test("every tripwire's weakness is currently present", async () => {
   }
 });
 
+//
 // The obligation text IS the deliverable — it is the only thing the person who
 // trips this will read. A tripwire whose instructions have gone stale is a
 // reminder that fires and then wastes the moment it bought.
+//
+
 Deno.test("every obligation names concrete, runnable next steps", () => {
   for (const tripwire of TRIPWIRES) {
     const text = tripwire.obligation.join("\n");

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -36,9 +36,11 @@ Deno.test("importsAlias matches a dynamic import", () => {
   assert(importsAlias('await import("dagre");', "dagre"));
 });
 
+//
 // These next few pin the specifier shapes that the matcher must keep handling:
 // dropping the `\s*` or an alternative from the lead would reintroduce a false
 // positive on ordinary code, yet leave the happy-path tests above green.
+//
 
 Deno.test("importsAlias matches an import broken across lines", () => {
   const source = [
@@ -89,9 +91,11 @@ Deno.test("importsAlias matches a @deno-types companion comment", () => {
   assert(importsAlias(source, "@types/d3-scale"));
 });
 
+//
 // `@ts-types` is Deno's current spelling of the companion-type comment; the
 // older `@deno-types` above still works and both must be recognized, or an
 // `@types/*` alias reached through the current form would be reported unused.
+//
 
 Deno.test("importsAlias matches a @ts-types companion comment", () => {
   const source = [

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -160,6 +160,7 @@ function workflowTriggers(contents: string): string {
   return contents.slice(0, concurrencyStart);
 }
 
+//
 // Every other check in this file reads the workflow files as TEXT (regex over
 // job and step blocks), so none of them can notice that a file has stopped
 // being valid YAML — and a workflow that does not parse produces ZERO jobs on
@@ -167,6 +168,8 @@ function workflowTriggers(contents: string): string {
 // unquoted `default: ` inside two step names turned deno.yml into a nested
 // mapping the runner refused, and CI silently ran nothing for a whole stack of
 // pushes. This is the one check that would have caught it.
+//
+
 Deno.test("every workflow and composite action is valid YAML", async () => {
   const broken: string[] = [];
   for await (const path of githubYamlPaths()) {
@@ -615,6 +618,7 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
   }
 });
 
+//
 // Both shells CI builds take their co-presence endpoint from a repository
 // variable, and an unset variable is a supported state that builds a working
 // shell. Every check the wiring performs therefore sits inside an
@@ -623,6 +627,8 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
 // wiring and the same runs stay green. The properties a configured value
 // depends on are checked here instead, against the workflow text, where
 // repository configuration does not get to decide whether the check runs.
+//
+
 Deno.test("a configured presence URL reaches every shell bundle CI builds", async () => {
   const deno = await workflow("deno.yml");
 

--- a/tasks/compile-cache-state.test.ts
+++ b/tasks/compile-cache-state.test.ts
@@ -109,10 +109,13 @@ Deno.test("classifyRunAgainstPredecessor fails open to unknown", async () => {
   );
 });
 
+//
 // The drift guard: COMPILE_CACHE_KEY_GLOBS mirrors the FIRST hashFiles(...)
 // argument list of every cc-* compile-cache key in the workflow. If this
 // fails, update the constant and the workflow together (and matcherForGlob
 // if a new glob shape appeared).
+//
+
 Deno.test("COMPILE_CACHE_KEY_GLOBS matches the cc-* cache keys in deno.yml", async () => {
   const workflow = await Deno.readTextFile(
     new URL("../.github/workflows/deno.yml", import.meta.url),

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -370,12 +370,15 @@ function generatedPortOffsets(): number[] {
   return [...offsets].sort((a, b) => a - b);
 }
 
+//
 // A port offset shifts every dev server together, and the servers bind whatever
 // port arithmetic lands on. Browsers and Deno's `fetch` both refuse to open a
 // connection to a port on the WHATWG bad-port list, so an offset that lands a
 // server on one produces a server that starts, passes a curl health check, and
 // that nothing in a test can reach: every browser navigation gets an error page
 // and every server-to-server proxy hop fails.
+//
+
 Deno.test("no generated port offset lands a server on a blocked port", () => {
   const blocked = new Set(ports.blockedPorts);
   const offenders: string[] = [];

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -458,9 +458,12 @@ Deno.test("runTests reports a failure when every member is disabled", async () =
   }
 });
 
+//
 // The runner reads each member's manifest to decide whether an appended
 // --junit-path reaches its `deno test` whole, so an ordinary new package is
 // covered without being named anywhere.
+//
+
 Deno.test("acceptsJUnitPath reads an ordinary test task", () => {
   assertEquals(acceptsJUnitPath("./packages/x", "deno test"), true);
   assertEquals(


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

80 comments across 65 files head a *group* of tests rather than describing one.
That makes each a section marker, so each takes the `//` delimiters and the
blank line the form calls for.

    +//
     // Tests for resolveRefsForLLM
    +//
    +
     Deno.test("resolveRefsForLLM converts boolean true schemas", () => {

These are what is left after #6450, #6452 and #6455 moved the per-test comments
into their tests. A comment above a test is doing one of two jobs; those PRs
handled one, this handles the other. `Tests for resolveRefsForLLM` heads ten
tests, `Coverage-focused tests for lib/view/diff.ts` heads five, `The api
package is the public type surface for commonfabric` heads three.

## Six held

All 86 candidates were read rather than pattern-matched, and six do not belong:
the comment describes only the *first* test and the tests after it are
unrelated.

    schema-basic.test.ts:15   getSchemaScopeCap precedence …
                              then "Schema - Basic Types and References"
    env.test.ts:60            INGEST_SELF_SERVE_ENABLED …
                              then MEMORY_WS_IDLE_TIMEOUT_SECONDS
    check-deno-pins.test.ts   ×3, held on the same grounds in #6452

Neither treatment fits those without rewording, so they stand.

## Verification

Pure addition — 211 lines, every one `//` or blank. Nothing removed, no word
changed, no non-comment line touched.

`deno fmt --check`, `deno lint`, `deno task check` and the `tasks` suite pass,
as do `api`, `cf-harness`, `cli`, `deno-web-test`, `fuse`, `identity`,
`js-compiler`, `memory`, `schema-generator`, `shell`, `static`, `toolshed` and
`ui`. `runner`, `ts-transformers`, `integration`, `dashboard` and `test-support`
are comment-only here and covered by CI.

## Coverage

The ratchet reports three more uncovered lines in `packages/runner`, with the
other five gated groups at `+0`. It is not this change, which adds only `//` and
blank lines and removes nothing. Deno's LCOV emits no `DA:` entry for a comment
line, so a comment-only diff shifts line numbers without altering the uncovered
count — checked on a fixture: an uncovered function with a three-line comment
inside it reports five uncovered lines, and the same function with the comment
deleted reports the same five.

ACCEPT_COVERAGE_DEBT: packages/runner +3 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKEDWw5KuppkpMXRUznTqa


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


