### PR TITLE
ci: upload server-execution toolshed logs on failure

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1567,6 +1567,15 @@ jobs:
             --junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
+      - name: 📋 Upload toolshed log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}
+          path: ${{ runner.temp }}/toolshed.log
+          retention-days: 14
+          if-no-files-found: ignore
+
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v7

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -830,3 +830,22 @@ Deno.test("server-execution ON jobs ship records under their variant", async () 
     assertStringIncludes(ship, "variant: server-execution");
   }
 });
+
+Deno.test("server-execution ON pattern failures upload the toolshed log", async () => {
+  const contents = await workflow("deno.yml");
+  const patternJob = jobBlock(
+    contents,
+    "pattern-integration-test-server-execution-on",
+  );
+  const upload = stepBlock(patternJob, "📋 Upload toolshed log on failure");
+
+  assertStringIncludes(upload, "if: failure()");
+  assertStringIncludes(upload, "uses: actions/upload-artifact@v7");
+  assertStringIncludes(
+    upload,
+    "name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}",
+  );
+  assertStringIncludes(upload, "path: ${{ runner.temp }}/toolshed.log");
+  assertStringIncludes(upload, "retention-days: 14");
+  assertStringIncludes(upload, "if-no-files-found: ignore");
+});


### PR DESCRIPTION
## Why

The latest direct CI unskip probe for `lunch-poll-vote` (#6410) failed in the server-execution ON lane, but the job did not publish its toolshed log. That left the server-side failure class unclassifiable from the retained artifacts.

The ON pattern-integration job already writes `$RUNNER_TEMP/toolshed.log`; it only needs to preserve that file when a shard fails.

## What changed

- upload the failing ON shard's toolshed log as a shard-specific artifact
- retain it for 14 days and tolerate the file being absent
- run the upload only after a failure, avoiding ten extra artifacts on green runs
- pin the workflow contract in `tasks/ci-workflow.test.ts`

## Tests

- `deno test -A tasks/ci-workflow.test.ts`
- `deno fmt --check`
- `deno lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

