### PR TITLE
fix(html): a `bigint` in an event value no longer costs the whole value

### DIFF
--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -7,6 +7,7 @@
 
 import {
   fabricFromNativeValue,
+  FabricInstance,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import {
@@ -236,16 +237,14 @@ export function serializeEvent(event: Event): SerializedEvent {
  * refuses a circular reference in turn, which is what keeps one from reaching a
  * crossing that has no representation for it.
  *
- * The order is what bounds the conversion to values the far side accepts. The
- * fabric conversion mints a `FabricError` from an `Error`, and the worker's
- * event ingress refuses a `FabricInstance` (`stripSigilCfcLabelViews()` in
- * `@commonfabric/runner/cfc`); an `Error` reaching a detail is ordinary --
- * `cf-file-input` dispatches one -- and the round trip renders it as `{}` and
- * gets there first.
+ * What the far side accepts is narrower than what the fabric conversion
+ * produces, and {@link holdsFabricInstance} is where that is enforced: a value
+ * carrying an instance is described instead, which is what a value reaching
+ * here has always been rendered as when nothing else could render it.
  *
- * TODO(danfuzz): once that ingress descends an instance rather than refusing
- * one, the fabric conversion can go first, and a `FabricBytes` in a detail
- * stops arriving as `{}`.
+ * TODO(danfuzz): once the ingress descends an instance rather than refusing
+ * one, that guard goes, the fabric conversion can go first, and a `FabricBytes`
+ * in a detail stops arriving as `{}`.
  */
 function toSerializableValue(value: unknown): FabricValue {
   try {
@@ -257,12 +256,38 @@ function toSerializableValue(value: unknown): FabricValue {
   }
 
   try {
-    return fabricFromNativeValue(value);
+    const fabric = fabricFromNativeValue(value);
+    if (!holdsFabricInstance(fabric)) return fabric;
   } catch {
     // Described below, as a value with neither rendering is.
   }
 
   return describeUnconvertible(value);
+}
+
+/**
+ * Whether a value holds a `FabricInstance` anywhere within it.
+ *
+ * The worker's event ingress refuses one -- `stripSigilCfcLabelViews()` in
+ * `@commonfabric/runner/cfc`, whose refusal is the tripwire naming the
+ * codec-mediated traversal it owes -- so an event carrying one is dropped
+ * rather than delivered. The conversion above mints a `FabricError` from an
+ * `Error`, and an `Error` in a detail is ordinary: `cf-file-input` dispatches
+ * `cf-error` with one. The round trip renders such a value first and gets
+ * there for its own reasons, which covers the plain case; this covers the rest,
+ * where the round trip refused the value for something else it held.
+ *
+ * No cycle tracking, the conversion having refused a circular reference before
+ * this is reached. Shared structure is walked once per position rather than
+ * once, which an event payload is small enough not to notice.
+ */
+function holdsFabricInstance(value: unknown): boolean {
+  if (value instanceof FabricInstance) return true;
+  if (value === null || typeof value !== "object") return false;
+
+  // A `FabricPrimitive` has no enumerable own properties, so it reports `false`
+  // from here without an arm of its own.
+  return Object.values(value).some(holdsFabricInstance);
 }
 
 /**

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -5,7 +5,10 @@
  * sent to the worker thread for dispatch to the appropriate handler.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  fabricFromNativeValue,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import {
   type EventProvenance,
   getEventProvenance,
@@ -176,6 +179,8 @@ export function serializeEvent(event: Event): SerializedEvent {
         // A `cf-input`, a `cf-tabs` and a `cf-calendar` each declare theirs as
         // `CellHandle<string> | string`, and a `CellHandle` reaches the pattern
         // as the sigil link its `toJSON()` produces, which the worker resolves.
+        // The outbound half of this seam is closed the same way: `SetPropOp`'s
+        // `value` in `../vdom-ops.ts` is a `FabricValue` the envelope carries.
         (serializedTarget as unknown as Record<string, unknown>)[prop] =
           toSerializableValue(value);
         hasTargetProps = true;
@@ -206,18 +211,6 @@ export function serializeEvent(event: Event): SerializedEvent {
     }
   }
 
-  // TODO(danfuzz): a `detail` is a whole value a component chose to hand the
-  // pattern, and the pattern's handler receives it as a `FabricValue`. The
-  // conversion below narrows it to the JSON-compatible subset on the way in: a
-  // `bigint` throws out of `JSON.stringify()` and lands in the `catch`, which
-  // replaces the entire detail with `String(detail)`, and a `FabricBytes`
-  // stringifies to `{}`. The crossing is `postMessage`, not JSON text, so
-  // `codec-realm` carries the whole domain here; what has to stay is the
-  // separate job the conversion does of turning an unencodable detail into
-  // something rather than failing the event. The same holds of a target's
-  // `value` and `checked` above. The outbound half of this seam is closed:
-  // `SetPropOp.value` in `../vdom-ops.ts` is a `FabricValue` the envelope's
-  // encoding carries whole.
   if ("detail" in event && (event as CustomEvent).detail !== undefined) {
     serialized.detail = toSerializableValue((event as CustomEvent).detail);
   }
@@ -226,22 +219,47 @@ export function serializeEvent(event: Event): SerializedEvent {
 }
 
 /**
- * Converts one value a component exposed to the event into a form the VDOM
- * event notification can carry, substituting a description for anything with
- * no conversion at all. Handing the pattern something is the point: an event
- * whose value cannot cross is still an event the handler should see.
+ * Converts one value a component exposed to the event into the form the VDOM
+ * event notification carries, substituting a description for anything with no
+ * conversion at all. Handing the pattern something is the point: an event whose
+ * value cannot cross is still an event the handler should see.
+ *
+ * Two conversions, in this order. The round trip goes first and answers for
+ * everything it can: it resolves whatever `toJSON()` a value defines -- a
+ * `CellHandle` becoming the sigil link the worker resolves -- and it is what
+ * a value reaching a handler has always been rendered by.
+ *
+ * The fabric conversion answers for what the round trip refuses, which is where
+ * the crossing being `postMessage` rather than JSON text starts to matter: a
+ * `bigint` anywhere inside a value throws out of `JSON.stringify()`, and
+ * without a second answer the whole value becomes a description of itself. It
+ * refuses a circular reference in turn, which is what keeps one from reaching a
+ * crossing that has no representation for it.
+ *
+ * The order is what bounds the conversion to values the far side accepts. The
+ * fabric conversion mints a `FabricError` from an `Error`, and the worker's
+ * event ingress refuses a `FabricInstance` (`stripSigilCfcLabelViews()` in
+ * `@commonfabric/runner/cfc`); an `Error` reaching a detail is ordinary --
+ * `cf-file-input` dispatches one -- and the round trip renders it as `{}` and
+ * gets there first.
+ *
+ * TODO(danfuzz): once that ingress descends an instance rather than refusing
+ * one, the fabric conversion can go first, and a `FabricBytes` in a detail
+ * stops arriving as `{}`.
  */
 function toSerializableValue(value: unknown): FabricValue {
   try {
-    // The round trip resolves whatever `toJSON()` a value defines -- a
-    // `CellHandle` becomes its sigil link -- and drops what JSON has no
-    // representation for. `undefined` comes back from `JSON.stringify()` for a
-    // function or a symbol, and a circular reference or a throwing `toJSON()`
-    // throws out of it.
     const jsonString = JSON.stringify(value);
     if (jsonString !== undefined) return JSON.parse(jsonString);
   } catch {
-    // Described below, as a value with no JSON form at all is.
+    // Answered below, first by the fabric conversion and then as a value with
+    // no rendering at all.
+  }
+
+  try {
+    return fabricFromNativeValue(value);
+  } catch {
+    // Described below, as a value with neither rendering is.
   }
 
   return describeUnconvertible(value);

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -412,6 +412,36 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.detail, { error: {}, message: "upload failed" });
   });
 
+  await t.step(
+    "describes an `Error` alongside a `bigint` rather than dropping the event",
+    () => {
+      // The round trip refuses the value for the `bigint`, and the fabric
+      // conversion mints a `FabricError` from the `Error` -- which the worker's
+      // event ingress refuses, so an event carrying one never reaches its
+      // handler. Described instead, which is what such a value has always been.
+      const event = new MockCustomEvent("cf-error", {
+        detail: { error: new Error("boom"), count: 42n },
+      }) as unknown as Event;
+
+      const serialized = serializeEvent(event);
+
+      assertEquals(serialized.detail, "[object Object]");
+    },
+  );
+
+  await t.step("describes an `Error` carrying a `bigint` of its own", () => {
+    // The same shape reached the other way: what makes the round trip refuse
+    // the value is inside the `Error` rather than beside it.
+    const error = Object.assign(new Error("boom"), { count: 42n });
+    const event = new MockCustomEvent("cf-error", {
+      detail: { error, message: "upload failed" },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.detail, "[object Object]");
+  });
+
   await t.step("describes a circular detail rather than passing one on", () => {
     // A circular value has no representation at the crossing, so it must not
     // reach one. Both conversions refuse it, for their own reasons.

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -381,6 +381,61 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals((serialized.detail as { count: number }).count, 42);
   });
 
+  await t.step(
+    "carries a `bigint` in a detail rather than losing the detail",
+    () => {
+      // The whole detail used to go: a `bigint` throws out of `JSON.stringify()`,
+      // and the `catch` answered for the value it was handed rather than for the
+      // member that could not be rendered.
+      const event = new MockCustomEvent("custom", {
+        detail: { message: "hello", count: 42n },
+      }) as unknown as Event;
+
+      const serialized = serializeEvent(event);
+
+      assertEquals(serialized.detail, { message: "hello", count: 42n });
+    },
+  );
+
+  await t.step("renders an `Error` in a detail as a bare record", () => {
+    // What bounds the conversion to values the far side accepts. The fabric
+    // conversion mints a `FabricError` from an `Error`, and the worker's event
+    // ingress refuses a `FabricInstance`; an `Error` in a detail is ordinary,
+    // `cf-file-input` dispatching one on `cf-error`. So the round trip answers
+    // for it first, and what crosses is a record the ingress walks.
+    const event = new MockCustomEvent("cf-error", {
+      detail: { error: new Error("boom"), message: "upload failed" },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.detail, { error: {}, message: "upload failed" });
+  });
+
+  await t.step("describes a circular detail rather than passing one on", () => {
+    // A circular value has no representation at the crossing, so it must not
+    // reach one. Both conversions refuse it, for their own reasons.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const event = new MockCustomEvent("custom", {
+      detail: circular,
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.detail, "[object Object]");
+  });
+
+  await t.step("carries a `bigint` exposed as a target's value", () => {
+    const event = new MockEvent("input", {
+      target: { value: 42n },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.target?.value, 42n);
+  });
+
   await t.step("omits undefined properties", () => {
     const event = new MockEvent("click") as unknown as Event;
     const serialized = serializeEvent(event);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Every value a component exposes to a DOM event — a `detail`, and a target's
`value`, `checked`, `name`, `selected`, `selectedIndex` — went through
`JSON.parse(JSON.stringify(...))`, and a failure was answered by describing the
value as a whole. A `bigint` anywhere inside throws out of `JSON.stringify()`,
so one member with no JSON form took everything with it:

```js
{ message: "hello", count: 42n }   // reached the handler as "[object Object]"
```

The crossing is `postMessage` rather than JSON text, so it carries the whole
`FabricValue` domain. `fabricFromNativeValue()` now answers for what the round
trip refuses — and refuses a circular reference in its own turn, which is what
keeps one from reaching a crossing that has no representation for it.

## Why the round trip stays, and stays first

Two reasons, and the second is the one worth a reviewer's attention.

It resolves a `toJSON()`. That is how a `CellHandle` reaches a pattern as the
sigil link the worker resolves — `cf-input`, `cf-tabs` and `cf-calendar` each
declare `value` as `CellHandle<string> | string` — and no fabric conversion
does it, `CellHandle` being `runtime-client`'s class rather than a fabric type.

And the order is what bounds the conversion to values the far side accepts.
`fabricFromNativeValue()` mints a `FabricError` from an `Error`, and every DOM
event detail passes the worker's `stripSigilCfcLabelViews()`, which refuses a
`FabricInstance`. An `Error` in a detail is ordinary rather than exotic:
`cf-file-input` documents `cf-error` with `detail: { error: Error, message }`.

Measured on the fabric-first ordering before settling on this one:

```
converted.error ctor: FabricError
ingress: THREW -> Cannot yet handle `FabricError` (a `FabricInstance`)...
today's value: {"error":{},"message":"upload failed"}
today's ingress: OK
```

So fabric-first turns a harmless `{error: {}}` into a throw at the event
ingress, ungated and reachable. Round-trip-first gets there first and renders
it as the bare record the ingress walks.

## What this deliberately does not fix

The other half of the original `TODO` stands: a `FabricBytes` in a detail still
arrives as `{}`, and a `Date` as an ISO string, because the round trip succeeds
on both and the fabric conversion never runs. Flipping the order fixes both and
is exactly what the measurement above rules out for now.

A `TODO` at the function records the unblocking work, which is the refusal's own
recorded next step — `descend by codec-mediated traversal into instance state,
at which point this becomes a walk rather than a refusal`, carried by both
`stripSigilCfcLabelViews()` and `mapCellRefsToSigilLinks()`. Once an instance
can be walked, the order flips and both cases come with it.

Forcing it sooner would mean detecting a nested `FabricInstance` at this seam,
which is another container walk; the repository already carries more copies of
that machinery than it should.

## The tests

Three, each pinning one direction, and each checked by ablation rather than
assumed:

- **on the old code**, the two `bigint` tests fail and nothing else does.
- **with the order flipped**, the `Error` test fails and nothing else does.

The `Error` test is the one that matters going forward: it is what stops the
ordering from being rediscovered the hard way.

The pre-existing tests for the `toJSON()`-bearing value, the circular value and
the coercion-refusing value pass unchanged on both sides — this adds an answer
where there was a description, and takes none away.

## Gates

`deno task check` green. `deno fmt` and `deno lint` clean. Full suites green
for `html` and for `runtime-client` (the other end of the crossing).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

