### PR TITLE
fix(ts-transformers): a `satisfies` receiver keeps its capture shrunk

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1036,8 +1036,9 @@ The rewriter uses normalized data-flow dependencies and ordered emitters:
 
 The container emitter owns a literal that holds other expressions, and a
 transparent wrapper around one: it rewrites the children and leaves the
-container unwrapped. It reads the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes), so a wrapped container is owned on the
-same terms as a bare one.
+container unwrapped. It reads the transparent wrapper set (parentheses, `as`,
+`<T>x`, `satisfies`, `!`, and partially emitted nodes), so a wrapped container
+is owned on the same terms as a bare one.
 
 The data-flow analysis behind these emitters reads that same set twice. An
 expression wrapped in it is analyzed as the expression it wraps, which is what
@@ -1046,6 +1047,15 @@ named there falls to the generic child walk, which merges through
 `mergeAnalyses` and drops the hint. Normalization then groups flows by their
 normalized text, and strips the set before comparing, so flows differing only
 by a wrapper collapse into one dependency instead of splitting.
+
+Capture selection reads it a third time. A lift captures the fields its body
+reads, and the dedup deciding that asks each data flow for its root identifier,
+looking through member access, calls, and the wrapper set. A reference whose
+root goes unrecognized is not merely skipped: the free-identifier pass then adds
+that root as a capture of its own, and a whole-object capture subsumes the
+narrower paths beside it. The lift is then applied to the whole object and
+re-runs for any field of it, where it could have been applied to the one field
+the body reads.
 
 Key rewrite rules:
 

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -326,30 +326,34 @@ function unionWithEnclosingScopeFreeIdentifiers(
   return [...refs, ...added];
 }
 
+/**
+ * The identifier a reference is rooted at, looking through member access, calls,
+ * and the transparent wrapper set.
+ *
+ * This decides which names an existing data flow already covers. A reference
+ * whose root goes unrecognized is not merely skipped: the free-identifier pass
+ * below then adds that root as its own capture, and a whole-object capture
+ * subsumes the narrower paths beside it — so the lift subscribes to the whole
+ * object where it could have subscribed to one field.
+ */
 function getRootIdentifier(expr: ts.Expression): ts.Identifier | undefined {
   let current: ts.Expression = expr;
-  while (
-    ts.isPropertyAccessExpression(current) ||
-    ts.isElementAccessExpression(current) ||
-    ts.isCallExpression(current) ||
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isNonNullExpression(current)
-  ) {
-    if (ts.isCallExpression(current)) {
-      current = current.expression;
-    } else if (ts.isPropertyAccessExpression(current)) {
-      current = current.expression;
-    } else if (ts.isElementAccessExpression(current)) {
-      current = current.expression;
-    } else {
-      current = (current as
-        | ts.ParenthesizedExpression
-        | ts.AsExpression
-        | ts.NonNullExpression).expression;
+  while (true) {
+    const unwrapped = unwrapTransparentWrapperOnce(current);
+    if (unwrapped) {
+      current = unwrapped;
+      continue;
     }
+    if (
+      ts.isPropertyAccessExpression(current) ||
+      ts.isElementAccessExpression(current) ||
+      ts.isCallExpression(current)
+    ) {
+      current = current.expression;
+      continue;
+    }
+    return ts.isIdentifier(current) ? current : undefined;
   }
-  return ts.isIdentifier(current) ? current : undefined;
 }
 
 function isReferenceSite(node: ts.Identifier): boolean {

--- a/packages/ts-transformers/test/transformed-ast.ts
+++ b/packages/ts-transformers/test/transformed-ast.ts
@@ -7,14 +7,20 @@ import ts from "typescript";
 // a structural match only holds when the transformer actually produced the
 // node.
 
-/** Parse printed transformer output into a source file. */
-export function parseModule(source: string): ts.SourceFile {
+/**
+ * Parses printed transformer output into a source file. Defaults to TSX;
+ * callers exercising angle-bracket assertions pass {@link ts.ScriptKind.TS}.
+ */
+export function parseModule(
+  source: string,
+  scriptKind: ts.ScriptKind = ts.ScriptKind.TSX,
+): ts.SourceFile {
   return ts.createSourceFile(
     "/transformed.tsx",
     source,
     ts.ScriptTarget.ESNext,
     /*setParentNodes*/ true,
-    ts.ScriptKind.TSX,
+    scriptKind,
   );
 }
 

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -16,6 +16,11 @@ import { expect } from "@std/expect";
 import ts from "typescript";
 
 import { transformFiles, transformSource, validateSource } from "./utils.ts";
+import {
+  callsMatching,
+  hasKeyPathRead,
+  parseModule,
+} from "./transformed-ast.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import type { TransformationDiagnostic } from "../src/mod.ts";
 import { normalizeDataFlows } from "../src/ast/normalize.ts";
@@ -232,26 +237,48 @@ describe("transparent wrapper consistency", () => {
       }));
     `;
 
-    /** The capture object the second lift is applied to, whitespace-flattened.
-     *  Sliced by width rather than matched to a closing paren, because the
-     *  captures themselves contain parentheses (`obj.key("b")`). */
-    const captureArgumentOf = (output: string): string => {
-      const flattened = output.replace(/\s+/g, " ");
-      const start = flattened.indexOf("__cfLift_2(");
-      expect(start).toBeGreaterThanOrEqual(0);
-      return flattened.slice(start, start + 120);
+    /** The value each emitted lift captures under `obj`, queried from the
+     *  parsed output rather than matched against printed text, per this
+     *  directory's "assert on structure, not printed text" convention. Both
+     *  lifts in the source capture `obj` — the `a` projection for `x`, and
+     *  the value under test for `y` — so two entries come back. */
+    const objCaptureValues = (root: ts.SourceFile): ts.Expression[] => {
+      const values: ts.Expression[] = [];
+      for (const call of callsMatching(root, /^__cfLift_\d+$/)) {
+        const captures = call.arguments[0];
+        if (!captures || !ts.isObjectLiteralExpression(captures)) continue;
+        for (const property of captures.properties) {
+          if (
+            ts.isShorthandPropertyAssignment(property) &&
+            property.name.text === "obj"
+          ) {
+            values.push(property.name);
+          }
+          if (
+            ts.isPropertyAssignment(property) &&
+            ts.isIdentifier(property.name) && property.name.text === "obj"
+          ) {
+            values.push(property.initializer);
+          }
+        }
+      }
+      return values;
     };
 
     for (const [name, receiver] of Object.entries(RECEIVERS)) {
       it(`captures only the field read behind a ${name} receiver`, async () => {
-        const captures = captureArgumentOf(
+        const root = parseModule(
           await transformSource(source(receiver), {
             types: COMMONFABRIC_TYPES,
           }),
         );
+        const values = objCaptureValues(root);
 
-        expect(captures).toContain('obj.key("b")');
-        expect(captures).not.toContain("obj: obj");
+        expect(values.length).toBeGreaterThan(0);
+        // The bug shape: the whole object captured as a bare identifier.
+        expect(values.some((value) => ts.isIdentifier(value))).toBe(false);
+        // The shrunk shape: a capture projects `b` off `obj` with `.key("b")`.
+        expect(hasKeyPathRead(root, "b", "obj")).toBe(true);
       });
     }
   });

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -216,8 +216,8 @@ describe("transparent wrapper consistency", () => {
     // subsumes the narrower paths beside it. The lift then re-runs for any
     // field of the object rather than for the one field it reads.
     //
-    // These spellings parenthesize the whole wrapper and asserts to the
-    // receiver's own type. `(obj) as S` would not do: appending `.b` to it
+    // The assertion spellings parenthesize the whole wrapper and assert it to
+    // the receiver's own type. `(obj) as S` would not do: appending `.b` to it
     // parses as the qualified type name `S.b`, not a read of the cast value.
     const RECEIVERS: Readonly<Record<string, string>> = {
       bare: "obj",
@@ -281,6 +281,18 @@ describe("transparent wrapper consistency", () => {
         expect(hasKeyPathRead(root, "b", "obj")).toBe(true);
       });
     }
+
+    it("captures only the field read behind an angle-bracket assertion", async () => {
+      const output = await transformFiles({
+        "/m.ts": source("(<S>obj)"),
+      }, { types: COMMONFABRIC_TYPES });
+      const root = parseModule(output["/m.ts"]!, ts.ScriptKind.TS);
+      const values = objCaptureValues(root);
+
+      expect(values.length).toBeGreaterThan(0);
+      expect(values.some((value) => ts.isIdentifier(value))).toBe(false);
+      expect(hasKeyPathRead(root, "b", "obj")).toBe(true);
+    });
   });
 
   describe("normalizeDataFlows()", () => {

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -203,6 +203,59 @@ describe("transparent wrapper consistency", () => {
     }
   });
 
+  describe("capture shrinking", () => {
+    // A lift captures the fields its body actually reads. The dedup that
+    // decides this asks each data flow for its root identifier, so a spelling
+    // whose root goes unrecognized is not simply skipped — the free-identifier
+    // pass adds that root as its own capture, and a whole-object capture
+    // subsumes the narrower paths beside it. The lift then re-runs for any
+    // field of the object rather than for the one field it reads.
+    //
+    // These spellings parenthesize the whole wrapper and asserts to the
+    // receiver's own type. `(obj) as S` would not do: appending `.b` to it
+    // parses as the qualified type name `S.b`, not a read of the cast value.
+    const RECEIVERS: Readonly<Record<string, string>> = {
+      bare: "obj",
+      parenthesized: "(obj)",
+      "non-null": "obj!",
+      "as-cast": "(obj as S)",
+      satisfies: "(obj satisfies S)",
+      stacked: "((obj satisfies S) as S)!",
+    };
+
+    const source = (receiver: string) =>
+      `      import { pattern } from "commonfabric";
+      interface S { a: number; b: number; }
+      export default pattern<{ obj: S }, { x: number; y: number }>(({ obj }) => ({
+        x: obj.a * 2,
+        y: ${receiver}.b + 1,
+      }));
+    `;
+
+    /** The capture object the second lift is applied to, whitespace-flattened.
+     *  Sliced by width rather than matched to a closing paren, because the
+     *  captures themselves contain parentheses (`obj.key("b")`). */
+    const captureArgumentOf = (output: string): string => {
+      const flattened = output.replace(/\s+/g, " ");
+      const start = flattened.indexOf("__cfLift_2(");
+      expect(start).toBeGreaterThanOrEqual(0);
+      return flattened.slice(start, start + 120);
+    };
+
+    for (const [name, receiver] of Object.entries(RECEIVERS)) {
+      it(`captures only the field read behind a ${name} receiver`, async () => {
+        const captures = captureArgumentOf(
+          await transformSource(source(receiver), {
+            types: COMMONFABRIC_TYPES,
+          }),
+        );
+
+        expect(captures).toContain('obj.key("b")');
+        expect(captures).not.toContain("obj: obj");
+      });
+    }
+  });
+
   describe("normalizeDataFlows()", () => {
     // Built directly rather than through the pipeline: a partially emitted node
     // is synthetic, so a hand-built graph is the only way to put one in front


### PR DESCRIPTION
The one real finding left open by #6274. It was surfaced there while evaluating review feedback, confirmed pre-existing, and deliberately not fixed in a PR whose every other change was proved inert.

## The symptom

A lift captures the fields its body reads, so it re-runs only when one of them changes. One wrapper spelling lost that:

```js
y: (obj as S).b + 1         __cfLift_2({ obj: { b: obj.key("b") } })   // re-runs for b
y: (obj satisfies S).b + 1  __cfLift_2({ obj: obj })                    // re-runs for any field
```

Correctness is unaffected — the body reads the same value either way — so the cost was subscription breadth, not results. That is why it went unnoticed.

## The cause, traced rather than guessed

I instrumented what `parseCaptureExpression` is actually handed:

```
--- as              --- satisfies
SEEN obj.a          SEEN obj.a
SEEN (obj as S).b   SEEN (obj satisfies S).b
                    SEEN obj          <-- an extra whole-object capture
```

That extra capture comes from `getRootIdentifier` in `rewrite-helpers.ts`, which walked member access, calls, parentheses, `as`, and `!` — but not `satisfies` or `<T>x`. It feeds the dedup deciding which names the existing data flows already cover.

So the miss is not a skipped optimization. An unrecognized root is simply absent from the covered set, and the free-identifier pass that follows then adds it as a capture of its own — where a whole-object capture subsumes the narrower paths beside it. **A lookup that fails quietly turns into an addition that widens the result**, the same shape as the boundary-classification bug in #6274.

Reading the shared set fixes it, and removes the cast the hand-written walk needed to narrow its own union back down.

## Ruled out before fixing

`as S` erases nothing that `satisfies S` preserves — I checked the obvious alternative explanation, that this was a type-level artifact of the brand surviving one spelling and not the other:

```
bare        shrunk        as S        shrunk
parens      shrunk        as never    shrunk
non-null    shrunk        satisfies   NOT shrunk   <-- sole outlier
```

`satisfies` is the only spelling that behaves differently, so it is the wrapper handling and not the type.

## Verification

```
                WITHOUT fix                        WITH fix
bare            { obj: { b: obj.key("b") } }        same
parens          { obj: { b: obj.key("b") } }        same
non-null        { obj: { b: obj.key("b") } }        same
as-cast         { obj: { b: obj.key("b") } }        same
satisfies       { obj: obj }                        { obj: { b: obj.key("b") } }
stacked         { obj: obj }                        { obj: { b: obj.key("b") } }
```

- Full suite **1164 passed, 0 failed**; `UPDATE_GOLDENS=1` moves **no golden** — no fixture used a wrapped receiver in that position.
- `deno task cfcheck` exit 0 across the pattern corpus; repo-wide `deno fmt --check`, `deno lint`, `deno task check`, and every `check-*` gate.
- Regression tests in `transparent-wrapper-consistency.test.ts`; **3 steps fail against the pre-fix walk**.

## A note on the test, since it bit me

The receiver spellings are written out locally rather than reusing the shared table the rest of that file uses, and they parenthesize the whole wrapper. `(obj) as S` will not do: appending `.b` gives `(obj) as S.b`, where `S.b` parses as a qualified **type name**, not a read of the cast value. My first draft reused the shared table and produced malformed sources that failed uniformly — including for spellings that were already correct, which is what gave it away. The reason is recorded in the test so the next person does not repeat it.

Refs #6274.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

