### PR TITLE
refactor(patterns): resolve topic link targets in one map

### DIFF
--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -2,6 +2,7 @@ import {
   action,
   cellFromUrl,
   type ComparableCell,
+  computed,
   Default,
   equals,
   handler,
@@ -1582,8 +1583,10 @@ export default pattern<TopicInput, TopicOutput>(
 
     // A link's URL, asked of `cellFromUrl` once per link. Most answer with no
     // cell — they are web pages — and those simply are not mentions.
-    const linkUrls = links.get().map((link) => link.url ?? "");
-    const linkTargets = linkUrls.map((url) => cellFromUrl({ url }));
+    const linksToResolve = computed(() => links.get());
+    const linkTargets = linksToResolve.map((link) =>
+      cellFromUrl({ url: link.url ?? "" })
+    );
     // Outbound: what this topic points at. Only this half depends on the
     // topic's own content, which is what keeps the board's join reading one
     // small list per topic.


### PR DESCRIPTION
## Summary

`linkTargets` was built from two chained maps — one projecting each link's `url` out of `links.get()`, and a second asking `cellFromUrl` about the result. Nothing else reads the intermediate array, so the pair costs a map coordinator and a persistent cell to carry a value no one wants.

Asking `cellFromUrl` directly of each link collapses that to one map over an explicitly reactive receiver.

- same per-element footprint: the element op still declares `{ element: { url } }`, and `cellFromUrl` still answers `{ pending, cell }`, which is what `mentionsOf` reads
- the explicit `computed` receiver earns the scheduler scope-purity certificate the two-step form did not

Split out of #6281, where this was written to satisfy a transformer diagnostic that turned out to be a false positive (fixed there separately). It stands on its own merits rather than as compiler appeasement, which is why it belongs in its own change with its own upgrade note.

**Upgrade note:** the element op's identity changes, so each link's `cellFromUrl` element run re-derives once — idempotent — and the old `linkUrls` cell is orphaned in existing topic pieces.

## Validation

- `deno fmt --check`
- `deno task cfcheck` (422 patterns)
- `deno task pattern-compat` (339 patterns updatable from every recorded contract)
- `deno task cf test packages/patterns/topics/topics.test.tsx` — 38 passed, identical to the pre-change baseline on this commit

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

