### PR TITLE
docs: index the cf-harness console, and record that it opts into max-enforcement

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -525,7 +525,11 @@ raise), and leaves `cfcDecomposedEnvelopes`, `cfcTrustConfig`, and
 flip: cf-harness exposes it for its fabric session as `--fabric-cfc-posture`
 (`CF_HARNESS_FABRIC_CFC_POSTURE`); toolshed publishes whatever CFC posture its
 Runtime resolved on `/api/meta` (`lib/cfc-posture.ts`), so a deployment's
-enforcement is readable rather than indistinguishable from the default.
+enforcement is readable rather than indistinguishable from the default. The
+cf-harness console is the one surface that opts in by default — it exists to
+show CFC working, so its fabric session takes the bundle unless
+`--fabric-cfc-posture none` says otherwise, and it prints the posture it
+resolved at startup.
 The interactive `cf-harness` and the `fuse` mount expose the enforcement mode
 through `CF_CFC_MODE` for testing. Because these dials are keys of
 `RuntimeOptions`, the exhaustive `RUNTIME_OPTION_KEYS` registry in the same file

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -262,6 +262,10 @@ What is not done yet:
 - [src/contracts/](src/contracts/)
   - prompt-slot, run-manifest, observation, policy, run-report, subagent, skill,
     transcript, tool-result, and handle-table contracts
+- [console/](console/)
+  - the console: a localhost page that starts a session, watches it live, and
+    reads any run back as a map of its cells, calls and CFC verdicts. See
+    [console/README.md](console/README.md)
 - [integration/](integration/)
   - environment-gated real `runsc-cfc` integration tests
 - [docs/SKILLS_SUPPORT_SPEC.md](docs/SKILLS_SUPPORT_SPEC.md)
@@ -278,6 +282,9 @@ From [packages/cf-harness](.):
 - `deno task run -- ...`
 - `deno task test`
 - `deno task test:integration`
+- `deno task console` — build the console page and serve it on `127.0.0.1:8100`
+- `deno task console:build`, `deno task console:watch` — the build on its own,
+  and a rebuild on save while changing the page
 
 ## CLI Example
 


### PR DESCRIPTION
Follow-up to #6453.

Two live documents that the console work invalidated.

`packages/cf-harness/README.md` indexes what the package is made of and did not
mention the console at all, nor the three tasks that build and serve it.

`docs/development/EXPERIMENTAL_OPTIONS.md` said the `max-enforcement` bundle is
opt-in per runtime and never a fleet flip. That stayed true and stopped being
the whole truth: the console takes the bundle by default, because showing CFC
working is what that surface is for. A registry reading "off unless asked for"
would have someone mis-predict every run the console makes.

## Checks

`check-docs`, `check-skill-facts`, `check-command-docs`,
`check-docs-history-index`, `check-conflict-markers` pass. Documentation only —
no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

