### PR TITLE
cf-harness console: sessions scan their skills root into the run

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -78,6 +78,15 @@ Every environment variable has a flag, and the flag wins:
 | `--artifact-root`     | `CF_HARNESS_ARTIFACT_ROOT`           | `.cf-harness-console/runs`            |
 | `--session-db`        | `CF_HARNESS_CONSOLE_SESSION_DB`      | `.cf-harness-console/sessions.sqlite` |
 | `--max-model-turns`   | `CF_HARNESS_CONSOLE_MAX_MODEL_TURNS` | the prompt loop's default             |
+| `--skills-root`       | `CF_HARNESS_CONSOLE_SKILLS_ROOT`     | the repository's `skills/` tree       |
+
+Every turn scans the skills root and records the registry on its run before the
+first model call, so `read_skill_resource` can answer and a delegated
+`pattern-author` child inherits its profile's preloaded skills — the authoring,
+schema, and UI guides. A turn whose run carries no registry authors patterns
+without them. Tools read the tree on the host, so it needs no sandbox mount; the
+registry names host paths, and the run's `skill-registry.json` artifact records
+what the scan found.
 
 Everything the server writes lives under `.cf-harness-console/` in the working
 directory — the sandbox workspace, run artifacts, the session database, and the

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -85,10 +85,8 @@ import {
   type CreateHarnessPromptLoopOptions,
   type HarnessPromptLoopResult,
 } from "./prompt-loop.ts";
-import {
-  discoverHarnessSkills,
-  loadHarnessSkillContext,
-} from "./skills/registry.ts";
+import { loadHarnessSkillContext } from "./skills/registry.ts";
+import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
 import {
   parseAllowedSkillScriptSpec,
   uniqueAllowedSkillScripts,
@@ -3065,11 +3063,12 @@ export const runCfHarnessCli = async (
       if (parsed.skillsRoot === undefined) {
         return [];
       }
-      const registry = await discoverHarnessSkills({
+      const registry = await persistHarnessRunSkillRegistry(engine, {
         skillsRoot: parsed.skillsRoot,
-        sandboxSkillsRoot: parsed.skillsRootSandboxPath,
+        ...(parsed.skillsRootSandboxPath !== undefined
+          ? { sandboxSkillsRoot: parsed.skillsRootSandboxPath }
+          : {}),
       });
-      await engine.persistSkillRegistry(registry);
       if (parsed.skillNames.length === 0) {
         return [];
       }

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -2,11 +2,13 @@ import {
   isObjectNotArray,
   type ReadonlyRecord,
 } from "@commonfabric/utils/types";
+import { CfHarnessEngine } from "./engine.ts";
 import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
   type RunHarnessTranscriptOptions,
 } from "./prompt-loop.ts";
+import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
 import {
   createHarnessChatErrorResponse,
   createHarnessChatEventEnvelope,
@@ -1420,7 +1422,7 @@ export class HarnessInteractiveChatService {
     const startedSubagents = new Map<string, HarnessChatSubagentSummary>();
 
     try {
-      const loop = this.#createPromptLoop(
+      const loop = await this.#startPromptLoop(
         this.#buildPromptLoopOptions(session, policy, browserAccess),
       );
       const result = await loop.runTranscript({
@@ -1501,6 +1503,29 @@ export class HarnessInteractiveChatService {
         error: chatTurnError(error),
       });
     }
+  }
+
+  /**
+   * Starts a turn's loop on a run that already knows its skills. A turn is its
+   * own run, so the scan happens per turn, against the engine this builds and
+   * hands to the loop: the registry has to be on the run state before the
+   * first model turn for `read_skill_resource` to answer and for a delegated
+   * subagent to inherit its profile's preloaded skills.
+   *
+   * Tools reach the tree on the host here, so the scan records host paths and
+   * no sandbox mount is involved.
+   */
+  async #startPromptLoop(
+    options: CreateHarnessPromptLoopOptions,
+  ): Promise<HarnessInteractivePromptLoop> {
+    if (options.engine !== undefined || options.skillsRoot === undefined) {
+      return this.#createPromptLoop(options);
+    }
+    const engine = new CfHarnessEngine(options);
+    await persistHarnessRunSkillRegistry(engine, {
+      skillsRoot: options.skillsRoot,
+    });
+    return this.#createPromptLoop({ ...options, engine });
   }
 
   #buildPromptLoopOptions(

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -1518,13 +1518,18 @@ export class HarnessInteractiveChatService {
   async #startPromptLoop(
     options: CreateHarnessPromptLoopOptions,
   ): Promise<HarnessInteractivePromptLoop> {
-    if (options.engine !== undefined || options.skillsRoot === undefined) {
+    if (options.skillsRoot === undefined) {
       return this.#createPromptLoop(options);
     }
-    const engine = new CfHarnessEngine(options);
-    await persistHarnessRunSkillRegistry(engine, {
-      skillsRoot: options.skillsRoot,
-    });
+    // Scan whichever engine will run — an injected one included, since its
+    // presence is not proof the registry was already recorded. Idempotent:
+    // an engine that already carries a registry is left as it is.
+    const engine = options.engine ?? new CfHarnessEngine(options);
+    if (engine.getRunState().skillRegistry === undefined) {
+      await persistHarnessRunSkillRegistry(engine, {
+        skillsRoot: options.skillsRoot,
+      });
+    }
     return this.#createPromptLoop({ ...options, engine });
   }
 

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -1518,18 +1518,19 @@ export class HarnessInteractiveChatService {
   async #startPromptLoop(
     options: CreateHarnessPromptLoopOptions,
   ): Promise<HarnessInteractivePromptLoop> {
-    if (options.skillsRoot === undefined) {
+    // The skills root reaches this either way: on the options directly, or on
+    // an injected engine's own config (where `options.skillsRoot` is unset).
+    // Read both so neither shape is missed.
+    const skillsRoot = options.engine?.config.skillsRoot ?? options.skillsRoot;
+    if (skillsRoot === undefined) {
       return this.#createPromptLoop(options);
     }
-    // Scan whichever engine will run — an injected one included, since its
-    // presence is not proof the registry was already recorded. Idempotent:
-    // an engine that already carries a registry is left as it is.
+    // A turn is its own run, so the scan happens every turn: it records the
+    // registry the skill tools read before the first model call, and a run
+    // that reuses an engine still refreshes it, so a skill added or removed
+    // mid-session is not stale.
     const engine = options.engine ?? new CfHarnessEngine(options);
-    if (engine.getRunState().skillRegistry === undefined) {
-      await persistHarnessRunSkillRegistry(engine, {
-        skillsRoot: options.skillsRoot,
-      });
-    }
+    await persistHarnessRunSkillRegistry(engine, { skillsRoot });
     return this.#createPromptLoop({ ...options, engine });
   }
 

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -873,10 +873,22 @@ const PATTERN_INDEX_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
   ["search_patterns", "record_feedback"] as const,
 );
 
+/**
+ * The tools that exist only over a skill registry, gated on the same terms.
+ * A run given no skills root scans no registry, so `read_skill_resource`
+ * would answer `skill_registry_missing` on every call and `run_skill_script`
+ * has nothing to run — absent rather than present-but-failing, so a model
+ * does not spend turns discovering a tool it was never backed to use.
+ */
+const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["read_skill_resource", "run_skill_script"] as const,
+);
+
 /** What a run can back the gated tools with. */
 interface HarnessToolBackingAvailability {
   fabricSessionAvailable: boolean;
   patternIndexAvailable: boolean;
+  skillRegistryAvailable: boolean;
 }
 
 /** The gated tools this run cannot back, and so does not offer. */
@@ -886,6 +898,7 @@ const withheldToolIds = (
   new Set([
     ...(availability.fabricSessionAvailable ? [] : FABRIC_SESSION_TOOL_IDS),
     ...(availability.patternIndexAvailable ? [] : PATTERN_INDEX_TOOL_IDS),
+    ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
   ]);
 
 /**
@@ -2353,6 +2366,11 @@ export class CfHarnessPromptLoop {
     return {
       fabricSessionAvailable: this.engine.fabricSessionAvailable,
       patternIndexAvailable: this.engine.patternIndexAvailable,
+      // A configured skills root is what a run scans into the registry the
+      // skill tools read, so its presence is the tools' backing — a run that
+      // has yet to scan still knows it will, and one that never will offers
+      // neither tool.
+      skillRegistryAvailable: this.engine.config.skillsRoot !== undefined,
     };
   }
 

--- a/packages/cf-harness/src/skills/run-registry.ts
+++ b/packages/cf-harness/src/skills/run-registry.ts
@@ -1,0 +1,45 @@
+import type { HarnessSkillRegistry } from "../contracts/skill.ts";
+import { discoverHarnessSkills } from "./registry.ts";
+
+/**
+ * The part of a run a registry scan writes to. Narrow on purpose: a caller
+ * holds a whole engine, and what it hands over is the one method that records
+ * a registry.
+ */
+export interface HarnessSkillRegistryRun {
+  persistSkillRegistry(
+    registry: HarnessSkillRegistry,
+  ): Promise<string | undefined>;
+}
+
+export interface PersistHarnessRunSkillRegistryOptions {
+  skillsRoot: string;
+
+  /**
+   * Where the skills tree appears to a sandboxed tool. Absent when tools read
+   * the tree on the host, which is what the scan then records.
+   */
+  sandboxSkillsRoot?: string;
+}
+
+/**
+ * Scans a configured skills tree and records it on the run before the run's
+ * first model turn. The registry is what `read_skill_resource`,
+ * `run_skill_script`, and subagent profile preloading read, and a subagent
+ * inherits it from its parent's run state — so a run that carries a skills
+ * root and no registry offers none of them, to itself or to its children.
+ * Every path that starts a run with a skills root calls this.
+ */
+export const persistHarnessRunSkillRegistry = async (
+  run: HarnessSkillRegistryRun,
+  options: PersistHarnessRunSkillRegistryOptions,
+): Promise<HarnessSkillRegistry> => {
+  const registry = await discoverHarnessSkills({
+    skillsRoot: options.skillsRoot,
+    ...(options.sandboxSkillsRoot !== undefined
+      ? { sandboxSkillsRoot: options.sandboxSkillsRoot }
+      : {}),
+  });
+  await run.persistSkillRegistry(registry);
+  return registry;
+};

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -24,6 +24,7 @@ import type {
   SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+import { createPatternSkillsFixture } from "./support/pattern-skills-fixture.ts";
 import {
   chatViewOfRequest,
   responsesBodyFromChatFixture,
@@ -405,6 +406,7 @@ Deno.test({
     "CfHarnessPromptLoop persists the transcript when artifactRoot is configured",
   permissions: { read: true, write: true },
   async fn() {
+    await using fixture = await createPatternSkillsFixture();
     const artifactRoot = await Deno.makeTempDir({
       prefix: "cf-harness-transcript-",
     });
@@ -423,6 +425,7 @@ Deno.test({
           ]),
           runId: "run-loop-persisted",
           model: "gpt-5.4",
+          skillsRoot: fixture.skillsRoot,
           now: (() => {
             const timestamps = [
               "2026-04-15T21:10:00.000Z",

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -1,4 +1,10 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import { fromFileUrl } from "@std/path";
 import {
   createHarnessChatEventEnvelope,
   createHarnessChatSessionStatus,
@@ -10,21 +16,27 @@ import {
   type HarnessChatRequestEnvelope,
   type HarnessChatTurnRecord,
 } from "../src/contracts/interactive-chat.ts";
+import { PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES } from "../src/contracts/subagent.ts";
 import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
 } from "../src/interactive-chat-service.ts";
 import { HarnessControlError } from "../src/control-errors.ts";
-import type {
-  CreateHarnessPromptLoopOptions,
-  HarnessPromptLoopResult,
-  RunHarnessTranscriptOptions,
+import {
+  CfHarnessPromptLoop,
+  type CreateHarnessPromptLoopOptions,
+  type HarnessPromptLoopResult,
+  type RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
 import type { HarnessChatSessionStore } from "../src/session-store.ts";
 import {
   type HarnessTranscriptMessage,
   inspectHarnessTranscriptPairing,
 } from "../src/contracts/transcript.ts";
+import {
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
 import {
   FAULT_KINDS,
   FAULT_POINTS,
@@ -1827,4 +1839,157 @@ Deno.test("a normalization whose write fails leaves the record on the stored his
     started.ok === false ? started.error.code : "",
     "incomplete_transcript",
   );
+});
+
+Deno.test("an interactive turn scans its configured skills root into the run and a pattern-author child inherits it", async () => {
+  const skillsRoot = fromFileUrl(new URL("../../../skills", import.meta.url));
+  const loopOptions: CreateHarnessPromptLoopOptions[] = [];
+  const requestBodies: unknown[] = [];
+  const service = new HarnessInteractiveChatService({
+    basePromptLoopOptions: {
+      apiKey: "test-key",
+      skillsRoot,
+      runId: "run-interactive-skills",
+      cfcEnforcementMode: "observe",
+      fetchFn: (_input, init) => {
+        const body = JSON.parse(String(init?.body));
+        requestBodies.push(body);
+        const payload = requestBodies.length === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-delegate-pattern-author",
+                  type: "function",
+                  function: {
+                    name: "delegate_task",
+                    arguments: JSON.stringify({
+                      goal: "Author a counter pattern.",
+                      profile: "pattern-author",
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : requestBodies.length === 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-read-skill-resource",
+                  type: "function",
+                  function: {
+                    name: "read_skill_resource",
+                    arguments: JSON.stringify({
+                      skill: "lit-component",
+                      path: "references/component-patterns.md",
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : requestBodies.length === 3
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Read the component patterns reference.",
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Pattern authored.",
+              },
+            }],
+          };
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              responsesBodyFromChatFixture(payload, init?.body ?? null),
+            ),
+            { status: 200 },
+          ),
+        );
+      },
+    },
+    createPromptLoop: (options) => {
+      loopOptions.push(options);
+      return new CfHarnessPromptLoop(options);
+    },
+    now: nextIsoNow(),
+    randomUUID: () => "generated-id",
+  });
+
+  const startSession = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-1",
+    method: "start_session",
+    params: {
+      sessionId: "session-1",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-test",
+      policy: {
+        type: "cf-harness.chat-policy",
+        toolMode: "workspace-write",
+        allowedToolIds: ["delegate_task"],
+        allowedSubagentProfiles: ["pattern-author"],
+      },
+    },
+  });
+  assertEquals(startSession.ok, true);
+
+  const startTurn = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-2",
+    method: "start_turn",
+    params: {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      input: { text: "Author a counter pattern." },
+    },
+  });
+  assertEquals(startTurn.ok, true);
+  await service.waitForTurn("session-1", "turn-1");
+
+  const registry = loopOptions[0].engine?.getRunState().skillRegistry;
+  assertEquals(registry?.skillsRoot, skillsRoot);
+  for (const name of PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES) {
+    assertEquals(
+      registry?.skills.some((skill) => skill.name === name),
+      true,
+      `run-start registry names ${name}`,
+    );
+  }
+
+  // The child's first request carries the profile's preloaded skills, which
+  // it can only have inherited from the parent run's registry.
+  assertStringIncludes(
+    chatViewOfRequest(requestBodies[1]).messages[1].content,
+    '<skill_context name="pattern-dev"',
+  );
+  const readMessage = chatViewOfRequest(requestBodies[2]).messages.at(-1);
+  assertEquals(readMessage?.role, "tool");
+  const readOutput = JSON.parse(readMessage?.content ?? "") as {
+    status: string;
+    digestMatchesRegistry?: boolean;
+    content?: string;
+  };
+  assertEquals(readOutput.status, "read");
+  assertEquals(readOutput.digestMatchesRegistry, true);
+  assertEquals((readOutput.content ?? "").length > 0, true);
 });

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -4,7 +4,10 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
-import { fromFileUrl } from "@std/path";
+import {
+  createPatternSkillsFixture,
+  PATTERN_SKILL_FIXTURE_RESOURCE_PATH,
+} from "./support/pattern-skills-fixture.ts";
 import {
   createHarnessChatEventEnvelope,
   createHarnessChatSessionStatus,
@@ -1842,7 +1845,8 @@ Deno.test("a normalization whose write fails leaves the record on the stored his
 });
 
 Deno.test("an interactive turn scans its configured skills root into the run and a pattern-author child inherits it", async () => {
-  const skillsRoot = fromFileUrl(new URL("../../../skills", import.meta.url));
+  await using fixture = await createPatternSkillsFixture();
+  const skillsRoot = fixture.skillsRoot;
   const loopOptions: CreateHarnessPromptLoopOptions[] = [];
   const requestBodies: unknown[] = [];
   const service = new HarnessInteractiveChatService({
@@ -1888,8 +1892,8 @@ Deno.test("an interactive turn scans its configured skills root into the run and
                   function: {
                     name: "read_skill_resource",
                     arguments: JSON.stringify({
-                      skill: "lit-component",
-                      path: "references/component-patterns.md",
+                      skill: "pattern-ui",
+                      path: PATTERN_SKILL_FIXTURE_RESOURCE_PATH,
                     }),
                   },
                 }],

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -25,6 +25,12 @@ import {
   type HarnessInteractivePromptLoopFactory,
 } from "../src/interactive-chat-service.ts";
 import { HarnessControlError } from "../src/control-errors.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
+import type {
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+} from "../src/sandbox/types.ts";
 import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
@@ -1996,4 +2002,111 @@ Deno.test("an interactive turn scans its configured skills root into the run and
   assertEquals(readOutput.status, "read");
   assertEquals(readOutput.digestMatchesRegistry, true);
   assertEquals((readOutput.content ?? "").length > 0, true);
+});
+
+/** A sandbox a no-tool turn never drives; enough to build an engine. */
+class StubSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: "/workspace",
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+  resolvePath(path: string): string {
+    return path.startsWith("/") ? path : `/workspace/${path}`;
+  }
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+  run(): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+  runShell(): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+Deno.test("an interactive turn scans a skills root carried on an injected engine's config", async () => {
+  // The console passes the skills root on the options directly; an injected
+  // engine carries it on `engine.config` instead, with no top-level
+  // `skillsRoot`. Both must scan — reading the options alone would miss this.
+  await using fixture = await createPatternSkillsFixture();
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new StubSandboxRuntime(),
+    runId: "run-interactive-injected-engine",
+    model: "gpt-test",
+    skillsRoot: fixture.skillsRoot,
+  });
+  const service = new HarnessInteractiveChatService({
+    basePromptLoopOptions: {
+      apiKey: "test-key",
+      engine,
+      cfcEnforcementMode: "observe",
+      fetchFn: (_input, init) =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify(
+              responsesBodyFromChatFixture(
+                {
+                  choices: [{
+                    index: 0,
+                    message: { role: "assistant", content: "Done." },
+                  }],
+                },
+                init?.body ?? null,
+              ),
+            ),
+            { status: 200 },
+          ),
+        ),
+    },
+    createPromptLoop: (options) => new CfHarnessPromptLoop(options),
+    now: nextIsoNow(),
+    randomUUID: () => "generated-id",
+  });
+
+  const startSession = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-1",
+    method: "start_session",
+    params: {
+      sessionId: "session-1",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-test",
+      policy: {
+        type: "cf-harness.chat-policy",
+        toolMode: "workspace-write",
+        allowedToolIds: ["read_file"],
+        allowedSubagentProfiles: [],
+      },
+    },
+  });
+  assertEquals(startSession.ok, true);
+
+  const startTurn = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-2",
+    method: "start_turn",
+    params: {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      input: { text: "Say hi." },
+    },
+  });
+  assertEquals(startTurn.ok, true);
+  await service.waitForTurn("session-1", "turn-1");
+
+  // The scan ran against the injected engine even though no top-level
+  // skillsRoot was set, so its run state now carries the registry.
+  const registry = engine.getRunState().skillRegistry;
+  assertEquals(registry?.skillsRoot, fixture.skillsRoot);
 });

--- a/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
@@ -25,6 +25,7 @@ import {
   PATTERN_AUTHOR_SUBAGENT_MAX_MODEL_TURNS,
 } from "../src/contracts/subagent.ts";
 import type { HarnessHandleTable } from "../src/contracts/handle-table.ts";
+import { createPatternSkillsFixture } from "./support/pattern-skills-fixture.ts";
 import {
   chatViewOfRequest,
   responsesBodyFromChatFixture,
@@ -588,6 +589,7 @@ describe("prompt-loop cross-agent address handles", () => {
   });
 
   it("keeps `run_pattern` out of the `pattern-author` child tool surface when no fabric session is configured", async () => {
+    await using fixture = await createPatternSkillsFixture();
     const requestBodies: unknown[] = [];
     const loop = new CfHarnessPromptLoop({
       apiKey: "test-key",
@@ -596,6 +598,7 @@ describe("prompt-loop cross-agent address handles", () => {
         runId: "run-subagent-pattern-author-no-session",
         model: "gpt-5.4",
         cfcEnforcementMode: "disabled",
+        skillsRoot: fixture.skillsRoot,
       }),
       allowedSubagentProfiles: ["pattern-author"],
       fetchFn: scriptedFetch([

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -46,6 +46,7 @@ import type {
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 import { discoverHarnessSkills } from "../src/skills/registry.ts";
+import { createPatternSkillsFixture } from "./support/pattern-skills-fixture.ts";
 import {
   chatViewOfRequest,
   responsesBodyFromChatFixture,
@@ -1026,6 +1027,7 @@ const observedCfcResult = (
 });
 
 Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant response", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -1036,6 +1038,7 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       runId: "run-loop",
       model: "gpt-5.4",
       cfcEnforcementMode: "disabled",
+      skillsRoot: fixture.skillsRoot,
       now: (() => {
         const timestamps = [
           "2026-04-15T20:00:00.000Z",
@@ -1965,6 +1968,7 @@ const noToolCallFetch =
   };
 
 Deno.test("CfHarnessPromptLoop advertises run_pattern in the default tool surface when a fabric session is configured", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -1972,6 +1976,7 @@ Deno.test("CfHarnessPromptLoop advertises run_pattern in the default tool surfac
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "run-pattern-default-surface",
       model: "gpt-5.4",
+      skillsRoot: fixture.skillsRoot,
       fabricSessionFactory: () =>
         Promise.reject(new Error("session is never built in this test")),
     }),
@@ -2050,6 +2055,56 @@ Deno.test("CfHarnessPromptLoop drops run_pattern from an explicit allowlist when
   );
 });
 
+Deno.test("CfHarnessPromptLoop withholds the skill tools from an explicit allowlist when no skills root is configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "read_skill_resource", "run_skill_script"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-skill-tools-no-root",
+      model: "gpt-5.4",
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    ["read_file"],
+  );
+});
+
+Deno.test("CfHarnessPromptLoop advertises the skill tools from an explicit allowlist when a skills root is configured", async () => {
+  await using fixture = await createPatternSkillsFixture();
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "read_skill_resource", "run_skill_script"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-skill-tools-with-root",
+      model: "gpt-5.4",
+      skillsRoot: fixture.skillsRoot,
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    ["read_file", "read_skill_resource", "run_skill_script"],
+  );
+});
+
 /**
  * A pattern-index client factory that is never called: what the gate turns on
  * is whether the run HAS one, and no test of the surface reaches the index.
@@ -2058,6 +2113,7 @@ const unusedPatternIndexClientFactory = () =>
   Promise.reject(new Error("the index client is never built in this test"));
 
 Deno.test("CfHarnessPromptLoop advertises the pattern-index tools in the default tool surface when an index is configured", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -2065,6 +2121,7 @@ Deno.test("CfHarnessPromptLoop advertises the pattern-index tools in the default
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "pattern-index-default-surface",
       model: "gpt-5.4",
+      skillsRoot: fixture.skillsRoot,
       fabricSessionFactory: () =>
         Promise.reject(new Error("session is never built in this test")),
       patternIndexClientFactory: unusedPatternIndexClientFactory,
@@ -2146,6 +2203,7 @@ Deno.test("CfHarnessPromptLoop drops the pattern-index tools from an explicit al
 });
 
 Deno.test("CfHarnessPromptLoop withholds the pattern-index tools from the pattern-author profile when no index is configured", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -2154,6 +2212,7 @@ Deno.test("CfHarnessPromptLoop withholds the pattern-index tools from the patter
       sandboxRuntime: new FakeSandboxRuntime(),
       runId: "pattern-index-profile-gate",
       model: "gpt-5.4",
+      skillsRoot: fixture.skillsRoot,
       fabricSessionFactory: () =>
         Promise.reject(new Error("session is never built in this test")),
     }),
@@ -2177,6 +2236,7 @@ Deno.test("CfHarnessPromptLoop withholds the pattern-index tools from the patter
 });
 
 Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summary-only result", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const requestBodies: Array<{
     messages: Array<{ role: string; content: string }>;
     tools: Array<{ function: { name: string } }>;
@@ -2188,6 +2248,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
       runId: "run-delegate",
       model: "gpt-5.4",
       cfcEnforcementMode: "enforce-explicit",
+      skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3074,6 +3135,7 @@ Deno.test("CfHarnessPromptLoop applies the web_search profile model override and
 });
 
 Deno.test("CfHarnessPromptLoop keeps browser unavailable to the parent by default", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({
     apiKey: "test-key",
@@ -3083,6 +3145,7 @@ Deno.test("CfHarnessPromptLoop keeps browser unavailable to the parent by defaul
       runId: "run-parent-host-tool-denied",
       model: "gpt-5.4",
       cfcEnforcementMode: "enforce-explicit",
+      skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});
@@ -3156,6 +3219,7 @@ Deno.test("CfHarnessPromptLoop keeps browser unavailable to the parent by defaul
 });
 
 Deno.test("CfHarnessPromptLoop gives the browser tool only to the authorized browser subagent profile", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const requestBodies: Array<{
     messages: Array<{ role: string; content: string }>;
     tools: Array<{ function: { name: string } }>;
@@ -3170,6 +3234,7 @@ Deno.test("CfHarnessPromptLoop gives the browser tool only to the authorized bro
       runId: "run-delegate-browser-profile",
       model: "gpt-5.4",
       cfcEnforcementMode: "enforce-explicit",
+      skillsRoot: fixture.skillsRoot,
     }),
     fetchFn: (_input, init) => {
       const body = JSON.parse(String(init?.body)) as {
@@ -3784,6 +3849,7 @@ Deno.test("CfHarnessPromptLoop gives web_fetch only to the authorized web_fetch 
 });
 
 Deno.test("CfHarnessPromptLoop keeps browser subagent observations behind structured opaque links", async () => {
+  await using fixture = await createPatternSkillsFixture();
   const baseDir = await Deno.makeTempDir({
     dir: "/tmp",
     prefix: "cf-harness-browser-return-",
@@ -3835,6 +3901,7 @@ Deno.test("CfHarnessPromptLoop keeps browser subagent observations behind struct
         runId: "run-browser-structured-return",
         model: "gpt-5.4",
         cfcEnforcementMode: "enforce-explicit",
+        skillsRoot: fixture.skillsRoot,
       }),
       fetchFn: (_input, init) => {
         const body = JSON.parse(String(init?.body)) as {
@@ -5247,6 +5314,7 @@ Deno.test({
         runId: "run-missing-cfc-script-result",
         model: "gpt-5.4",
         cfcEnforcementMode: "enforce-explicit",
+        skillsRoot: root,
         allowedSkillScripts: [{
           skill: "deno-memory-profiler",
           path: "scripts/memory.ts",
@@ -5391,6 +5459,7 @@ Deno.test({
         runId: "run-mediated-skill-script",
         model: "gpt-5.4",
         cfcEnforcementMode: "enforce-explicit",
+        skillsRoot: root,
         allowedSkillScripts: [{
           skill: "deno-memory-profiler",
           path: "scripts/memory.ts",

--- a/packages/cf-harness/test/support/pattern-skills-fixture.ts
+++ b/packages/cf-harness/test/support/pattern-skills-fixture.ts
@@ -1,0 +1,61 @@
+import { join } from "@std/path";
+
+import { PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES } from "../../src/contracts/subagent.ts";
+
+/**
+ * The one resource every fixture skill indexes. A pattern-author child reads it
+ * back through `read_skill_resource`, so the path is part of the fixture's
+ * contract.
+ */
+export const PATTERN_SKILL_FIXTURE_RESOURCE_PATH = "references/guide.md";
+
+const skillMarkdown = (name: string): string =>
+  [
+    "---",
+    `name: ${name}`,
+    `description: Synthetic ${name} skill for harness tool-surface tests`,
+    "---",
+    "",
+    `# ${name}`,
+    "",
+    "Synthetic skill body. This tree stands in for the live repo skills so a",
+    "test never depends on a real skill file that a rename could move.",
+  ].join("\n");
+
+/**
+ * A disposable synthetic skills tree. Points a run's `skillsRoot` at
+ * {@linkcode skillsRoot} to advertise `read_skill_resource`/`run_skill_script`
+ * and to give a pattern-author child a real resource to read. `await using`
+ * removes the temp tree when the binding leaves scope.
+ */
+export interface PatternSkillsFixture extends AsyncDisposable {
+  readonly skillsRoot: string;
+}
+
+/**
+ * Writes a minimal skills tree holding the pattern-author preload skills
+ * ({@linkcode PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES}) plus one indexed resource
+ * under each, then returns the disposable handle over it.
+ */
+export const createPatternSkillsFixture = async (): Promise<
+  PatternSkillsFixture
+> => {
+  const skillsRoot = await Deno.makeTempDir({
+    prefix: "cf-harness-pattern-skills-",
+  });
+  for (const name of PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES) {
+    const skillDir = join(skillsRoot, name);
+    await Deno.mkdir(join(skillDir, "references"), { recursive: true });
+    await Deno.writeTextFile(join(skillDir, "SKILL.md"), skillMarkdown(name));
+    await Deno.writeTextFile(
+      join(skillDir, PATTERN_SKILL_FIXTURE_RESOURCE_PATH),
+      `# ${name} guide\n\nSynthetic reference resource for harness tests.\n`,
+    );
+  }
+  return {
+    skillsRoot,
+    async [Symbol.asyncDispose]() {
+      await Deno.remove(skillsRoot, { recursive: true });
+    },
+  };
+};


### PR DESCRIPTION
Fixes **CT-2102**.

Found examining a live console run (build-a-counter): every console session, parent and pattern-author child, ran with `skillRegistry` undefined — `read_skill_resource` returned `skill_registry_missing`, and the pattern-author profile's preloaded skills (pattern-dev/schema/ui) were silently absent, so children authored blind and guessed the pattern API.

Root cause: only `src/cli.ts` scanned `--skills-root` into a registry and persisted it. `HarnessInteractiveChatService` (the console path) threaded the skills root into config but never scanned it, so `runState.skillRegistry` stayed undefined and everything downstream was inert.

Fix: extract the scan-and-persist into a shared seam `src/skills/run-registry.ts`, called from both the CLI (identical behavior) and the interactive service (per turn, before the first model call; children inherit via existing prompt-loop threading). CLI sandbox-mount checks unchanged — they're CLI-specific; the console reads the skills tree host-side. README documents the `--skills-root` / `CF_HARNESS_CONSOLE_SKILLS_ROOT` surface. 841/0 tests, including a new case proving a configured session persists the registry and a delegated pattern-author child inherits it and can read a skill resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

