### PR TITLE
refactor(html): one declaration of the DOM-event shapes, not two

### DIFF
--- a/packages/html/deno.jsonc
+++ b/packages/html/deno.jsonc
@@ -14,6 +14,10 @@
     "./in-process": "./src/in-process.ts",
     "./worker": "./src/worker/mod.ts",
     "./vdom-ops": "./src/vdom-ops.ts",
+    // The DOM-event shapes, which the worker protocol re-exports rather than
+    // re-declaring. Narrow on purpose: `main/mod.ts` would bring the applicator
+    // with it, which nothing importing a message shape wants.
+    "./events": "./src/main/events.ts",
     "./debug": "./src/debug.ts"
   },
   "imports": {

--- a/packages/html/src/event-provenance.ts
+++ b/packages/html/src/event-provenance.ts
@@ -1,14 +1,14 @@
-export interface EventProvenance {
+export type EventProvenance = {
   origin: "dom";
   trusted: boolean;
   ui?: EventUiProvenance;
-}
+};
 
-export interface EventUiProvenance {
+export type EventUiProvenance = {
   pattern?: string;
   eventIntegrity?: string[];
   uiContractDataset?: Record<string, string>;
-}
+};
 
 type EventLike = Pick<Event, "isTrusted"> & {
   composedPath?: () => readonly unknown[];

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -16,7 +16,7 @@ import {
  * Serialized DOM event data.
  * Contains a subset of event properties that are safe to serialize.
  */
-export interface SerializedEvent {
+export type SerializedEvent = {
   /** Event type (e.g., "click", "input", "change") */
   type: string;
 
@@ -47,7 +47,7 @@ export interface SerializedEvent {
 
   // Custom event detail
   detail?: FabricValue;
-}
+};
 
 export type { EventProvenance };
 
@@ -55,7 +55,7 @@ export type { EventProvenance };
  * Serialized event target data.
  * Contains common input element properties.
  */
-export interface SerializedEventTarget {
+export type SerializedEventTarget = {
   name?: string;
 
   /**
@@ -76,7 +76,7 @@ export interface SerializedEventTarget {
   selectedIndex?: number;
   selectedOptions?: { value: string }[];
   dataset?: Record<string, string>;
-}
+};
 
 /**
  * Message sent from main thread to worker when a DOM event fires.

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -2184,138 +2184,22 @@ export type VDomEventNotification = BaseClientNotification & {
 };
 
 /**
- * Serialized DOM event data for IPC.
+ * The shape a DOM event crosses in, and the shape of its target within it.
+ *
+ * `serializeEvent()` in `@commonfabric/html` is what produces both, so that is
+ * where they are defined; the protocol re-exports them so a message shape and
+ * the event inside it cannot describe different things. That is the same
+ * arrangement, and for the same reason, as the VDOM op union below.
+ *
+ * The event's name here is `SerializedDomEvent`, which says which of this
+ * file's messages it belongs to; `SerializedEvent` alone would not, among the
+ * other serialized things around it.
  */
-export type SerializedDomEvent = {
-  /**
-   * The DOM event's type, as `click` or `input`.
-   */
-  type: string;
-
-  /**
-   * Where the event came from, so a handler can tell a real user
-   * gesture from a synthesized one.
-   */
-  provenance?: {
-    origin?: string;
-    trusted?: boolean;
-    ui?: {
-      pattern?: string;
-      eventIntegrity?: readonly string[];
-      uiContractDataset?: Record<string, string>;
-    };
-  };
-
-  /**
-   * The key pressed, for a keyboard event.
-   */
-  key?: string;
-
-  /**
-   * The physical key, which `key` does not identify across layouts.
-   */
-  code?: string;
-
-  /**
-   * Whether the key was being held.
-   */
-  repeat?: boolean;
-
-  /**
-   * Whether Alt was held.
-   */
-  altKey?: boolean;
-
-  /**
-   * Whether Control was held.
-   */
-  ctrlKey?: boolean;
-
-  /**
-   * Whether Meta was held.
-   */
-  metaKey?: boolean;
-
-  /**
-   * Whether Shift was held.
-   */
-  shiftKey?: boolean;
-
-  /**
-   * What kind of edit an input event was.
-   */
-  inputType?: string;
-
-  /**
-   * The text an input event inserted, `null` where it inserted none.
-   */
-  data?: string | null;
-
-  /**
-   * Which button a pointer event used.
-   */
-  button?: number;
-
-  /**
-   * Which buttons were held during a pointer event.
-   */
-  buttons?: number;
-
-  /**
-   * What the event fired on, reduced to the fields a handler reads.
-   */
-  target?: SerializedEventTarget;
-
-  /**
-   * A custom event's payload.
-   */
-  detail?: FabricValue;
-};
-
-/**
- * Serialized event target data for IPC.
- */
-export type SerializedEventTarget = {
-  /**
-   * The element's name, or its tag where it has none.
-   */
-  name?: string;
-
-  /**
-   * The element's current value. A `FabricValue` rather than a string: a custom
-   * element chooses what its `value` is, and a `cf-input`, a `cf-tabs` and a
-   * `cf-calendar` each declare theirs as `CellHandle<string> | string`, which
-   * arrives here as the sigil link the main thread resolved it to.
-   */
-  value?: FabricValue;
-
-  /**
-   * Whether a checkbox or radio is checked -- or, where the element chose to
-   * expose something else, what it chose. `cf-checkbox` and `cf-switch` each
-   * declare theirs as `CellHandle<boolean> | boolean`.
-   */
-  checked?: FabricValue;
-
-  /**
-   * Whether an option is selected.
-   */
-  selected?: boolean;
-
-  /**
-   * Which option a select is on.
-   */
-  selectedIndex?: number;
-
-  /**
-   * Every selected option's value, for a multiple select.
-   */
-  selectedOptions?: { value: string }[];
-
-  /**
-   * The element's `data-` attributes.
-   */
-  dataset?: Record<string, string>;
-};
+import type {
+  SerializedEvent as SerializedDomEvent,
+  SerializedEventTarget,
+} from "@commonfabric/html/events";
+export type { SerializedDomEvent, SerializedEventTarget };
 
 /**
  * Request to start VDOM rendering for a cell.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`SerializedEventTarget` was declared in `packages/html/src/main/events.ts` and
again in `packages/runtime-client/src/protocol/types.ts`, down to near-identical
doc comments, with the event around it declared twice as well. Nothing kept the
two in step: the only check was that one is passed where the other is expected,
at a single call site in `connection.ts`.

## Why there were two, which is the part worth knowing

Not carelessness. The protocol's copy has to be assignable to `FabricValue` —
the envelope is encoded whole — and `html` declared these as `interface`, which
can **never** satisfy `FabricPlainObject`, having no implicit index signature.
That is the wall `IMemoryChange` hit in #6323 and was made a type alias for. So
one copy could be envelope-assignable and the other could not, and each end kept
the form it needed.

Converting the four declarations — `SerializedEvent`, `SerializedEventTarget`,
`EventProvenance`, `EventUiProvenance` — to type aliases removes the reason.
`html` then owns the shapes its own `serializeEvent()` produces, and the
protocol re-exports them.

That is the arrangement already in use a few lines further down **in the same
file**, for the VDOM op union, and for the same stated reason:

> The worker reconciler that produces them and the main-thread applicator that
> consumes them both live in `@commonfabric/html`, which defines the union; the
> protocol re-exports it so a message shape and the ops inside it cannot
> describe different things.

The re-export is type-only, and `html` and `runtime-client` already import each
other — one of the two allowlisted package cycles — so nothing joins the runtime
graph and no new cycle appears. `deno task check-package-cycles` is green.

## It is a narrowing, not a byte-for-byte no-op

The unified `provenance` is `html`'s, which is the narrower of the two:

| | protocol (was) | `html` (now) |
| --- | --- | --- |
| `origin` | `origin?: string` | `origin: "dom"` |
| `trusted` | `trusted?: boolean` | `trusted: boolean` |
| `eventIntegrity` | `readonly string[]` | `string[]` |

Nothing read `provenance` through the protocol type — the only occurrence in
`runtime-client` was the declaration itself — which is why the narrowing costs
nothing and why it is the direction to go.

## The control

Reverting one `interface` to its former form reproduces the failure exactly:

```
TS2345: Argument of type 'IPCClientMessage | IPCClientNotification' is not
        assignable to parameter of type 'FabricValue'.
  Type 'VDomEventNotification' is not assignable to type 'FabricValue'.
    Type 'VDomEventNotification' is not assignable to type 'FabricPlainObject'.
```

Restoring it clears every error. So the conversion is load-bearing rather than
cosmetic, and the check that catches a regression here is `deno task check`
itself.

Worth knowing for the reviewer: this scope is deliberate. It came out of typing
the event seam, where a lying `selectedIndex?: number` had to be widened in two
packages — the duplication stating itself. The widening and the rest of that
work stack on top of this; this PR is only the unification, and changes no
behavior.

## Gates

`deno task check`, `deno task check-package-cycles`, `deno fmt`, `deno lint` all
green, and full suites green for `html` and `runtime-client`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

