### PR TITLE
Phase 3: the ruled local-plus-CI-probe lift bar, and both entries campaigned under it

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,6 +38,47 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
+**Delta 2026-08-27 (phase 3, this PR): the lift bar CHANGED by owner ruling
+— an ON-skip entry lifts only on its local campaign AND a green direct-CI
+unskip probe — and both entries were campaigned again under it. NEITHER
+lifted, and they now fail for OPPOSITE reasons.** The bar: the register had
+already reached "the lift bar should require a green DIRECT CI unskip
+probe, not a local count alone. That is a bar change, so it is the owner's
+call, flagged not taken"; RULED 2026-08-27, owner: "agreed", and it binds
+every entry, not only the file that provoked it. Both campaigns ran at main
+`1fc841b6e` on one ON binary (sha256 `a93047a461c0c4d8…`), fresh store + own
+97xx port + ON posture probe per run, ensure defaulting ON, toolshed
+self-sourced, quiet and loaded interleaved; the probe was head `95f313835`
+(both entries and the default-app guard removed in one commit), CI run
+[33138358110](https://github.com/commontoolsinc/labs/actions/runs/33138358110)
+— 8 of 10 ON pattern shards green, red on exactly the two shards carrying
+the two probed files.
+**default-app's reload STEP: 10/10 local AND its CI probe of the step
+GREEN (`ok (18s)`, server window clean) — the entry's own charge did not
+reproduce in either arm.** It is held ONLY by the lane: shard 5 red on a
+CO-RESIDENT file, `cfc-group-chat-demo.test.ts:133`, which is not
+skip-listed, is untouched by the probe diff, and reproduces 4/6 red locally
+at the same head running alone. **That raises the bar's first
+interpretation question, and it is the coordinator's/owner's, flagged not
+filled: does "the probed lane GREEN" mean the probed SURFACE green or every
+test in the shard green?** Under the first reading this entry lifts today.
+**lunch-poll-vote's FILE entry: 8/8 local, probe RED at the probed
+surface** — line 271, the HOST's `#lp-join-button`, 300000 ms, 5m5s, the
+same signature as the 2026-08-26 probe, with the OFF lane green on the same
+run. What is genuinely new is the evidence position: **CI now publishes the
+toolshed log as a job artifact**, closing the 2026-08-26 disposition's
+stated blind spot, and it shows this row's ORIGINAL mechanism end to end —
+80 `structure-load-stuck` WARNs on the profile space (the parked root's id
+suffix is literally the `#MjhprA` the placeholder rendered) behind 20
+`seal-space-commit-failed`/`foreign-write-refused` pairs. **The refusal is
+not the discriminator** — every local GREEN carries more of it than the CI
+red does, with `structureLoadStuck` 0 — **the PARK is.** Also surfaced, not
+owed here: `cfc-group-chat-demo.test.ts` is failing ON at current main 4/6
+and is NOT skip-listed, so it is a flip blocker in its own right (the
+flip's bar is a green ON lane, not merely an empty skip list). Full
+ledgers, classifications, and the co-resident finding:
+verification-coverage.md OW45's PHASE 3 block.
+
 **Delta 2026-08-27: BOTH remaining entries were campaigned for a lift and
 NEITHER lifted. default-app's reload STEP is 7/10 locally. lunch-poll-vote
 passed its local re-baseline 8/8 — and then the lift PR's own CI ran the

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,7 +38,7 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
-**Delta 2026-08-27 (phase 3, this PR): the lift bar CHANGED by owner ruling
+**Delta 2026-08-27 (phase 3, #6469): the lift bar CHANGED by owner ruling
 — an ON-skip entry lifts only on its local campaign AND a green direct-CI
 unskip probe — and both entries were campaigned again under it. NEITHER
 lifted, and they now fail for OPPOSITE reasons.** The bar: the register had

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6726,6 +6726,21 @@ supply; OW29/OW32/OW34 closed):
     shards), and the honest reading is that the lift bar for this file
     should require a green DIRECT CI unskip probe, not a local count alone.
     That is a bar change, so it is the owner's call, flagged not taken.
+    **RULED 2026-08-27 (owner: "agreed") — THE BAR CHANGE IS TAKEN, AND IT
+    BINDS EVERY ON-SKIP ENTRY, NOT ONLY THIS FILE.** An entry lifts only on
+    BOTH (1) its own local campaign bar AND (2) a GREEN DIRECT-CI UNSKIP
+    PROBE: a commit on the lift branch that removes the entry's guard, a CI
+    board that demonstrably RAN the un-skipped surface, and that probed lane
+    green. A local campaign is evidence about the box it ran on; only the
+    lane is evidence about the lane. Both of this row's entries carry a
+    member with exactly that profile (the fifth-face load-park member: local
+    control 0/12 against CI 2/2 red; this file's 2026-08-26 split: local 0/8
+    against CI 1/1 red), so the probe is not ceremony — it is the only
+    observation that has ever caught them. A RED probe WITHDRAWS that
+    entry's lift: the signature is captured from the job log and classified
+    against this row's recorded members, and any sibling entry's lift stands
+    or falls on its own probe. No rerun-looping — one probe board,
+    classified honestly.
     **THE ENSURE-ON PROFILE-SURFACE MEMBER ROOT-CAUSED AND FIXED
     2026-08-25 (PR #6312) — the n=3 side probe's "create surface never renders"
     shape and the #6248 board's profile-shard family, reproduced

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5284,8 +5284,15 @@ supply; OW29/OW32/OW34 closed):
   updating this sentence. **The current census (2026-08-27) is TWO patterns
   entries: default-app's reload STEP and lunch-poll-vote's FILE entry.**
   BOTH were campaigned for a lift on 2026-08-27 and NEITHER lifted (the
-  STEP-ENTRY and LUNCH-POLL blocks below). They gate the FLIP — whose bar
-  is the list EMPTY — not the land. Rows, one per
+  STEP-ENTRY and LUNCH-POLL blocks below), and **both were campaigned AGAIN
+  the same day under the newly ruled local-plus-CI-probe bar (the PHASE-3
+  block at the end of this row) — again neither lifted, but the two now
+  fail for OPPOSITE reasons**: the default-app step passed BOTH halves of
+  its own evidence (10/10 local, and a GREEN direct-CI run of the exact
+  step) and is held only by a co-resident file's red in the same shard,
+  while lunch-poll-vote passed its local half 8/8 and its probe went red at
+  the probed surface for the second campaign running. They gate the FLIP —
+  whose bar is the list EMPTY — not the land. Rows, one per
   mechanism cluster; each row's trigger names the skip entry it
   lifts:
   - **OW45 — the profile piece's PROGRAM-materialization write path
@@ -7232,6 +7239,140 @@ supply; OW29/OW32/OW34 closed):
     The F1 barrier scenario above ("the load heals ... seconds") now
     has an actual mechanism behind its premise for the fresh-space
     boot order; it was written against a heal that did not exist.
+    **PHASE 3 — BOTH ENTRIES CAMPAIGNED UNDER THE RULED
+    LOCAL-PLUS-CI-PROBE BAR, 2026-08-27. NEITHER LIFTED, and the two now
+    fail for OPPOSITE reasons.** Base: main `1fc841b6e`, one ON-built
+    binary (sha256
+    `a93047a461c0c4d8cb5c63106179eaf9613b2b431269877255100e7fbaf40e79`,
+    re-verified into every run's ledger; a mismatch aborts the run), fresh
+    store and own 97xx port and ON posture probe per run, ensure defaulting
+    ON, the toolshed self-sourced on the run port, LLM masked, PID-only
+    teardown with a port-free check, `gtimeout 600` never approached, quiet
+    and loaded interleaved. Probe head `95f313835` (both entries and the
+    default-app in-file guard removed in one commit), CI run
+    [33138358110](https://github.com/commontoolsinc/labs/actions/runs/33138358110);
+    eight of the ten ON pattern shards passed, shards 5 and 7 red — the two
+    shards that carry the two probed files.
+
+    **default-app's reload STEP: LOCAL 10/10, CI PROBE OF THE STEP GREEN,
+    LANE RED ON A CO-RESIDENT FILE — the entry's own charge did not
+    reproduce in either arm.** Ten counted runs (5 quiet / 5 loaded,
+    interleaved, plus an uncounted green smoke) at 13–14 s wall each,
+    against 313–315 s for every red the earlier 2026-08-27 campaign
+    recorded; the step itself finished in 7–8 s. Campaign-wide zeroes:
+    `pattern-load-error` (so a03/a07's keyless discriminator is absent —
+    #6451), `pattern-swap-setup-error` and recursive-schema (the
+    split-source artifact stays gone), `deferred-start-catchup(-failed)`,
+    terminal `Error committing deferred`, `session-remount`, load-park
+    deferrals and drops, `piece-start-commit-failed`, `sidecar-run-raced`,
+    `schema-doc-quarantine`, `structure-load-stuck`,
+    `contribution-dropped`, and `events.handlerNotRunDeferrals` — #6459's
+    new deferral arm never had to fire, i.e. the a04 dispatch-side skip did
+    not occur rather than being recovered from. Serving stats:
+    `events.appended` 14 = `events.processed` 14 in all ten (no silent
+    requeue), `dropped` 0, `needsAttention.total` 0, `derivedCommits`
+    54–58, `settleAdvances` 12–15. Then the probe (ON shard 5, job
+    98743591519) ran the exact step with no listed skip and it **PASSED —
+    `ok (18s)`** — the whole `default-app flow test` green, and the shard's
+    published toolshed log clean across the file's window (4
+    `event-view-lag`, nothing else). Shard 5's red is
+    `cfc-group-chat-demo.test.ts:133`: `clickCfButton("#host-send-button")`
+    retargeting to the cf-button host (`cf-button#host-send-button < slot <
+    div < cf-hstack`) — rootcause §2b's disabled-inner-button shape, whose
+    S-G test-aim seat is named-but-unbuilt. That file is NOT skip-listed,
+    is untouched by the probe diff, and **reproduces 4/6 RED locally at the
+    same head running ALONE on a fresh store with the same signature
+    (line 133, same retarget chain)**, so it is neither this entry's charge
+    nor a probe artifact — see the OW31-adjacent observation below.
+    **DISPOSITION: NO LIFT, on the literal reading of the ruled bar.** The
+    entry and its bound guard stay, reworded to say exactly this. **OPEN
+    QUESTION FOR THE COORDINATOR/OWNER, flagged not filled: does "the
+    probed lane GREEN" mean the probed SURFACE green, or every test in the
+    shard green?** The bar was ruled hours before its first use and the
+    case that distinguishes the two readings arrived immediately. Under the
+    surface reading this entry lifts today; under the shard reading it
+    cannot lift until an unrelated file is fixed. The next seat should
+    RE-PROBE this step, not re-run a local campaign.
+
+    **lunch-poll-vote's FILE entry: LOCAL 8/8, CI PROBE RED AT THE PROBED
+    SURFACE — and the mechanism is now OBSERVED SERVER-SIDE for the first
+    time.** Eight counted runs (4 quiet / 4 loaded, interleaved), 16–18 s
+    each, against 313–322 s for every red this entry has ever recorded; the
+    owner-directed approximately-eight-run pin MET locally, with
+    `pattern-load-error`, `deferred-start-catchup(-failed)`,
+    `session-remount`, load-park, `handler-not-run`/`arrival-barrier` and
+    `events.handlerNotRunDeferrals` all zero, `events.appended` 9 in all
+    eight, `dropped` 0, `needsAttention.total` 0, `derivedCommits` 74–87.
+    (Present in every run INCLUDING the greens, so recorded as expected
+    recovery rather than smell: one `sidecar-run-raced` — #6312's
+    loser-yields arm — one `piece-start-commit-failed`, two
+    `event-view-lag`, one stale-read line; b06 also logged two
+    `contribution-dropped` and greened.) The probe (ON shard 7, job
+    98743591583) went RED at the SAME stage and signature as the
+    2026-08-26 probe: `lunch-poll-vote.test.ts:271`, the HOST's
+    `clickCfButton("#lp-join-button")`, `Timed out waiting for
+    #lp-join-button to render. Last probe: {"#lp-join-button": []}`,
+    `waitForCondition` at its unchanged 300000 ms bound, 5m5s, the body
+    reading "0 joined" and **"Unknown profile #MjhprA"**. The OFF lane's
+    shard 7 passed on the same run, so the red is ON-specific.
+    **WHAT IS NEW — the 2026-08-26 disposition's stated blind spot is
+    CLOSED: CI now publishes the toolshed log as a job artifact**
+    (`toolshed-log-pattern-integration-server-execution-on-7`), so the
+    server-side members can be examined instead of merely not excluded. In
+    the file's window that log carries **80 `structure-load-stuck` WARNs**
+    on the profile space `did:key:z6MktpA5…`, the first naming demanded
+    root `of:fid1:32Pic3-REdd7zmJ8gPchJyFD0LECk0u-QrFUXMjhprA` as
+    `pattern-unloadable` after 8 consecutive deferred cycles — the
+    detector's own words, "a forever-park … the home-profile
+    program-write-loss shape" — and **that root's suffix IS the `#MjhprA`
+    the placeholder rendered**. Upstream sit **20
+    `seal-space-commit-failed` / `foreign-write-refused` pairs**:
+    `applyInitialName` and a `__cfLift_1` action running in the HOME wave
+    `did:key:z6Mkv7Tjz…` refused a write to the profile space for want of
+    the §2b delegated carriage. So the chain is this row's ORIGINAL
+    mechanism, end to end: profile program/name write refused → structure
+    load parks forever → the name renders the `#id` placeholder → the join
+    card never renders `#lp-join-button` → line 271 times out.
+    **CRUCIAL DISCRIMINATOR, recorded so nobody chases the refusal: the
+    refusal is NOT it.** All eight local GREENS carry 80
+    `foreign-write-refused` and 40 `seal-space-commit-failed` each — MORE
+    than the CI red — with `structureLoadStuck` 0, `structureLoadRearmed`
+    7–10 and `structureLoadTerminal` 190–199. The foreign-write refusal is
+    a standing, tolerated condition in both arms; **the PARK is the
+    discriminator.** Locally the profile space's structure load always
+    resolves; in CI it never does, and why it never does is the open
+    question this entry now names. Excluded from the CI window, all zero:
+    `pattern-load-error`, `pattern-swap-setup-error`,
+    `deferred-start-catchup`, `session-remount`,
+    `piece-start-commit-failed`, `sidecar-run-raced`, `handler-not-run`,
+    `arrival-barrier`, `memory session revoked`, `sync-load-failure`,
+    `Event deferred` and `Event dropped` — so NOT the b04 client-start
+    class, NOT the a04 mark/effects family, NOT the #6312 sidecar clobber,
+    NOT the fifth-face load-park member, and NOT #6378's name-resolution
+    drop. Each of those was a prior charge for this entry and each is now
+    excluded by OBSERVATION rather than by absence of it.
+    **DISPOSITION: NO LIFT.** Local 8/8 against CI 1/1 red, for the second
+    campaign running — this file's lift needs the park explained, not
+    another local count.
+
+    **OBSERVATION, not owed by this row and NOT one of the two entries —
+    `cfc-group-chat-demo.test.ts` is failing ON at current main, 4/6, and
+    is not skip-listed.** The file's ON skip was lifted with OW31's
+    trust-attribution build (that row's live lift condition, green 4/4 at
+    the time). At `1fc841b6e`, run alone on a fresh store under the full ON
+    posture, it reds 4 of 6 at `:133` —
+    `clickCfButton("#host-send-button")`, the aimed button's click
+    retargeting to its own cf-button host, which rootcause §2b identifies
+    as the inner native button being DISABLED (the served `sendDisabled`
+    never flipping). Its named seats S-E (the client binding-write wedge),
+    S-F (the barrier that did not see that write as pending) and S-G (the
+    missing `waitForDisabled(false)` before a served-enable round trip) are
+    all recorded-not-built. Main's own board at `1fc841b6e` was green on
+    that shard, so CI sees it less often than this box does; either way it
+    is a FLIP blocker in its own right (the flip's bar is a green ON lane,
+    not merely an empty skip list) and it is what currently holds the
+    default-app lift. Recorded here because the phase-3 probe is where it
+    surfaced; whether it earns its own row is the coordinator's call.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -25,6 +25,38 @@ import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { assert, assertEquals } from "@std/assert";
 import { resolveSpaceDid } from "@commonfabric/lib-shell";
+import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
+
+// The server-execution v2 posture this test process runs (testing.md §2):
+// the CI ON lane sets EXPERIMENTAL_SERVER_EXECUTION=true; unset = OFF.
+const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
+  .serverExecution;
+
+// The ON arm's STEP-level skip guard (tasks/server-execution-on-skips.ts):
+// a step listed there for this file is skipped ONLY under the ON posture,
+// loudly (its reason is printed), and only while the entry exists — the OFF
+// arm and an unlisted step always run. The rapid notebook step remains listed:
+// a direct CI ON unskip probe at 66a969ca0 ran the exact step and reached all
+// seven invocation traces, but finished with no notebook-bound action state or
+// rendered notes before its unchanged condition bound. That run did not carry
+// the off-repository launcher's recursive-schema signature. The skip protects
+// CI from the currently observed ON failure, while the OFF arm still runs.
+function onArmStepSkip(step: string): { ignore: boolean } {
+  if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };
+  const entry = serverExecutionOnStepSkip(
+    "patterns",
+    "integration/default-app.test.ts",
+    step,
+  );
+  if (entry === undefined) return { ignore: false };
+  console.warn(
+    `[server-execution ON arm] patterns: SKIPPING STEP ${
+      JSON.stringify(step)
+    } (until ${entry.phase}) — ${entry.reason}`,
+  );
+  return { ignore: true };
+}
 
 type BrowserWriteTraceEntry = {
   recordedAt: number;
@@ -635,217 +667,223 @@ describe("default-app flow test", () => {
     }
   });
 
-  it("should persist and reload every rapidly created notebook note", async () => {
-    identity = await Identity.generate({ implementation: "noble" });
-    const notebookSpaceName = globalThis.crypto.randomUUID();
-    const notebookSpaceDid = await resolveSpaceDid(
-      identity,
-      notebookSpaceName,
-    );
-
-    const page = shell.page();
-    await disposeBrowserRuntime(page);
-    await shell.goto({
-      frontendUrl: FRONTEND_URL,
-      view: { spaceName: notebookSpaceName },
-      identity,
-    });
-
-    // shell.goto() waits for URL state and login, while RootView resolves the
-    // named view space independently. Do not interact with the previous
-    // space's still-rendered root while that resolution is in flight.
-    await waitForActiveSpaceRoot(page, notebookSpaceDid);
-
-    console.log("Await runtime idle for notebook regression...");
-    await waitForRuntimeIdle(page);
-    // Runtime idle can precede the page renderer's Lit update. Wait for the
-    // freshly navigated default-app view to bind its menu handlers before the
-    // first trusted click, just as the notebook toolbar does below.
-    await waitForCondition(
-      page,
-      () => typeof globalThis.commonfabric?.viewSettled === "function",
-    );
-    await awaitViewSettled(page);
-
-    try {
-      await clickButtonWithExactText(page, "Notes ▾");
-      await awaitViewSettled(page);
-      await clickButtonWithText(page, "New Notebook");
-      // The wait hands back the NOTEBOOK's piece id at the instant it
-      // approved `isNotebook` — the step's stable read target from here
-      // on. Every later wait and assertion reads the notebook BY THIS ID,
-      // never through `view.pieceId` again: under server execution the
-      // final "Create" click's speculative run may read a stale
-      // `usedCreateAnotherNote` and optimistically navigate into the new
-      // note while the authoritative run computes no navigation — a
-      // sanctioned outcome (the L2 optimistic-enactment question, ruled
-      // PUNT 2026-08-27: the client navigates, so be it). A view-following
-      // read then polls a healthy NOTE through notebook accessors until
-      // the step's net (the 2026-08-27 r06/r09 root cause,
-      // docs/history/plans/server-execution-v2/optimize/
-      // keyless-diagnosis-2026-08-27.md); an id-bound read is indifferent
-      // to where the view wandered.
-      let notebookEntityId: string | undefined;
-      try {
-        notebookEntityId = await waitForCondition(page, async () => {
-          const commonfabric = globalThis.commonfabric as
-            | { readCell?: (options: { id: string }) => Promise<unknown> }
-            | undefined;
-          const view = globalThis.app?.serialize?.()?.view;
-          const pieceId = view && typeof view === "object" &&
-              "pieceId" in view && typeof view.pieceId === "string"
-            ? view.pieceId
-            : undefined;
-          if (!pieceId || !commonfabric?.readCell) return false;
-          let current: unknown;
-          const originalLog = console.log;
-          try {
-            console.log = () => {};
-            current = await commonfabric.readCell({ id: pieceId });
-          } finally {
-            console.log = originalLog;
-          }
-          return (current as { isNotebook?: unknown } | undefined)
-              ?.isNotebook === true
-            ? pieceId
-            : false;
-        });
-      } catch (error) {
-        console.log(
-          "Notebook navigation diagnostics:",
-          JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
-        );
-        throw error;
-      }
-      assert(
-        notebookEntityId,
-        "Expected the notebook wait to hand back the notebook piece id",
+  it(
+    "should persist and reload every rapidly created notebook note",
+    onArmStepSkip(
+      "should persist and reload every rapidly created notebook note",
+    ),
+    async () => {
+      identity = await Identity.generate({ implementation: "noble" });
+      const notebookSpaceName = globalThis.crypto.randomUUID();
+      const notebookSpaceDid = await resolveSpaceDid(
+        identity,
+        notebookSpaceName,
       );
 
-      // Wait until the notebook toolbar is mounted and interactive before
-      // clicking. viewSettled resolves once the worker is idle and the
-      // rendered view has caught up (vdom applied, Lit updates drained), so the
-      // New Note button's handler is bound and a single click is not dropped.
+      const page = shell.page();
+      await disposeBrowserRuntime(page);
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: { spaceName: notebookSpaceName },
+        identity,
+      });
+
+      // shell.goto() waits for URL state and login, while RootView resolves the
+      // named view space independently. Do not interact with the previous
+      // space's still-rendered root while that resolution is in flight.
+      await waitForActiveSpaceRoot(page, notebookSpaceDid);
+
+      console.log("Await runtime idle for notebook regression...");
+      await waitForRuntimeIdle(page);
+      // Runtime idle can precede the page renderer's Lit update. Wait for the
+      // freshly navigated default-app view to bind its menu handlers before the
+      // first trusted click, just as the notebook toolbar does below.
       await waitForCondition(
         page,
         () => typeof globalThis.commonfabric?.viewSettled === "function",
       );
       await awaitViewSettled(page);
-      assert(
-        await clickButtonWithTitle(page, "New Note"),
-        "Expected New Note click to succeed",
-      );
-      // Arm the event-invocation trace before the note creations, whose markers
-      // this test's failure diagnostics read. clickButtonWithTitle settled the
-      // view, so the runtime has exposed its telemetry methods and the reset
-      // runs once with its success asserted. The first "Create Another" click
-      // below settles the view and waits for the button to render, so no
-      // separate wait for the modal is needed here.
-      assert(
-        await resetEventInvocationTrace(page),
-        "Expected the event invocation trace to reset",
-      );
 
-      const noteCreates = 7;
-      for (let i = 0; i < noteCreates - 1; i++) {
-        assert(
-          await clickButtonWithText(page, "Create Another"),
-          `Expected Create Another click ${i + 1} to succeed`,
-        );
-      }
-      assert(
-        await clickButtonWithExactText(page, "Create"),
-        "Expected final Create click to succeed",
-      );
-
-      // The assertions bind to the summary a wait handed back — the state
-      // as it was at the instant the predicate approved it — never to a
-      // separate read taken after a wait. Under server execution the
-      // notebook's derived `noteCount` follows the ruled unresolved-read
-      // disposition (OW51): a re-derivation reads cleanly `undefined` and
-      // re-triggers, healing back to the settled value. That interim is
-      // correct product behavior, so a single-shot read between a wait and
-      // its assertion can catch it and fail a healthy run (the OW45
-      // register row's measured 1-in-10-quiet / 5-in-10-under-load flake);
-      // a wait on the value itself absorbs it, and a value that never
-      // reaches `expectedCount` — a genuinely lost note — still fails
-      // loudly at waitForCondition's stuck-condition net.
-      //
-      // The first wait orders the sync barrier after local convergence, so
-      // "synced" covers all seven notes' commits; the second wait is the
-      // assertion's authority, re-approving the state after that barrier.
-      // Its predicate reads the same cells the step has read all along, and
-      // any client read registers demand — this step verifies that the
-      // created notes' data and derived count converge and survive the sync
-      // barrier under serving, not that they materialize unobserved (the
-      // reload rehydration surface is integration/reload/
-      // default-app-notebook.test.ts's).
-      let summary: NotebookSourceSummary | undefined;
-      let waitFailure: unknown;
       try {
-        await waitForCondition(page, notebookSourceStateMatches, {
-          args: [noteCreates, notebookEntityId],
-        });
-        await waitForRuntimeSynced(page);
-        summary = await waitForCondition(page, notebookSourceStateMatches, {
-          args: [noteCreates, notebookEntityId],
-        });
-      } catch (error) {
-        // A wait or the sync barrier failed at its net: the state never
-        // converged (or synchronization itself failed). Hold the error so
-        // the failure path below can print diagnostics and then RE-THROW
-        // it — the waits are the step's only signal, and a fresh read
-        // must never stand in for them (a fallback read that fed the
-        // assertions could green a run whose authority wait failed on a
-        // field the assertions don't check).
-        waitFailure = error;
-      }
-
-      if (summary === undefined) {
-        // Failure path only: print the diagnostics the thrown failure
-        // cannot carry, from a one-shot read that is expressly NOT the
-        // signal (its raciness is harmless here — the step is already
-        // failing), then re-throw the authority's own error.
-        console.log(
-          "Notebook rapid create source diagnostics:",
-          JSON.stringify(
-            await collectNotebookSourceState(page, notebookEntityId),
-            null,
-            2,
-          ),
-        );
-        console.log(
-          "Notebook rapid create render diagnostics:",
-          JSON.stringify(await collectNotebookRenderState(page), null, 2),
-        );
-        console.log(
-          "Notebook rapid create event/action diagnostics:",
-          JSON.stringify(
-            await collectNotebookCreateTraceSummary(page),
-            null,
-            2,
-          ),
-        );
-        throw waitFailure ??
-          new Error(
-            "the post-sync wait resolved without an approved summary",
+        await clickButtonWithExactText(page, "Notes ▾");
+        await awaitViewSettled(page);
+        await clickButtonWithText(page, "New Notebook");
+        // The wait hands back the NOTEBOOK's piece id at the instant it
+        // approved `isNotebook` — the step's stable read target from here
+        // on. Every later wait and assertion reads the notebook BY THIS ID,
+        // never through `view.pieceId` again: under server execution the
+        // final "Create" click's speculative run may read a stale
+        // `usedCreateAnotherNote` and optimistically navigate into the new
+        // note while the authoritative run computes no navigation — a
+        // sanctioned outcome (the L2 optimistic-enactment question, ruled
+        // PUNT 2026-08-27: the client navigates, so be it). A view-following
+        // read then polls a healthy NOTE through notebook accessors until
+        // the step's net (the 2026-08-27 r06/r09 root cause,
+        // docs/history/plans/server-execution-v2/optimize/
+        // keyless-diagnosis-2026-08-27.md); an id-bound read is indifferent
+        // to where the view wandered.
+        let notebookEntityId: string | undefined;
+        try {
+          notebookEntityId = await waitForCondition(page, async () => {
+            const commonfabric = globalThis.commonfabric as
+              | { readCell?: (options: { id: string }) => Promise<unknown> }
+              | undefined;
+            const view = globalThis.app?.serialize?.()?.view;
+            const pieceId = view && typeof view === "object" &&
+                "pieceId" in view && typeof view.pieceId === "string"
+              ? view.pieceId
+              : undefined;
+            if (!pieceId || !commonfabric?.readCell) return false;
+            let current: unknown;
+            const originalLog = console.log;
+            try {
+              console.log = () => {};
+              current = await commonfabric.readCell({ id: pieceId });
+            } finally {
+              console.log = originalLog;
+            }
+            return (current as { isNotebook?: unknown } | undefined)
+                ?.isNotebook === true
+              ? pieceId
+              : false;
+          });
+        } catch (error) {
+          console.log(
+            "Notebook navigation diagnostics:",
+            JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
           );
-      }
+          throw error;
+        }
+        assert(
+          notebookEntityId,
+          "Expected the notebook wait to hand back the notebook piece id",
+        );
 
-      // Approved path: the assertions bind to the summary the wait handed
-      // back — the state at the instant the predicate approved it.
-      assertEquals(summary.argumentNotesLength, noteCreates);
-      assertEquals(summary.noteCount, noteCreates);
-    } finally {
-      await waitForRuntimeIdle(page).catch(
-        (error) =>
-          console.warn(
-            "Failed to await runtime idle after notebook regression",
-            error,
-          ),
-      );
-    }
-  });
+        // Wait until the notebook toolbar is mounted and interactive before
+        // clicking. viewSettled resolves once the worker is idle and the
+        // rendered view has caught up (vdom applied, Lit updates drained), so the
+        // New Note button's handler is bound and a single click is not dropped.
+        await waitForCondition(
+          page,
+          () => typeof globalThis.commonfabric?.viewSettled === "function",
+        );
+        await awaitViewSettled(page);
+        assert(
+          await clickButtonWithTitle(page, "New Note"),
+          "Expected New Note click to succeed",
+        );
+        // Arm the event-invocation trace before the note creations, whose markers
+        // this test's failure diagnostics read. clickButtonWithTitle settled the
+        // view, so the runtime has exposed its telemetry methods and the reset
+        // runs once with its success asserted. The first "Create Another" click
+        // below settles the view and waits for the button to render, so no
+        // separate wait for the modal is needed here.
+        assert(
+          await resetEventInvocationTrace(page),
+          "Expected the event invocation trace to reset",
+        );
+
+        const noteCreates = 7;
+        for (let i = 0; i < noteCreates - 1; i++) {
+          assert(
+            await clickButtonWithText(page, "Create Another"),
+            `Expected Create Another click ${i + 1} to succeed`,
+          );
+        }
+        assert(
+          await clickButtonWithExactText(page, "Create"),
+          "Expected final Create click to succeed",
+        );
+
+        // The assertions bind to the summary a wait handed back — the state
+        // as it was at the instant the predicate approved it — never to a
+        // separate read taken after a wait. Under server execution the
+        // notebook's derived `noteCount` follows the ruled unresolved-read
+        // disposition (OW51): a re-derivation reads cleanly `undefined` and
+        // re-triggers, healing back to the settled value. That interim is
+        // correct product behavior, so a single-shot read between a wait and
+        // its assertion can catch it and fail a healthy run (the OW45
+        // register row's measured 1-in-10-quiet / 5-in-10-under-load flake);
+        // a wait on the value itself absorbs it, and a value that never
+        // reaches `expectedCount` — a genuinely lost note — still fails
+        // loudly at waitForCondition's stuck-condition net.
+        //
+        // The first wait orders the sync barrier after local convergence, so
+        // "synced" covers all seven notes' commits; the second wait is the
+        // assertion's authority, re-approving the state after that barrier.
+        // Its predicate reads the same cells the step has read all along, and
+        // any client read registers demand — this step verifies that the
+        // created notes' data and derived count converge and survive the sync
+        // barrier under serving, not that they materialize unobserved (the
+        // reload rehydration surface is integration/reload/
+        // default-app-notebook.test.ts's).
+        let summary: NotebookSourceSummary | undefined;
+        let waitFailure: unknown;
+        try {
+          await waitForCondition(page, notebookSourceStateMatches, {
+            args: [noteCreates, notebookEntityId],
+          });
+          await waitForRuntimeSynced(page);
+          summary = await waitForCondition(page, notebookSourceStateMatches, {
+            args: [noteCreates, notebookEntityId],
+          });
+        } catch (error) {
+          // A wait or the sync barrier failed at its net: the state never
+          // converged (or synchronization itself failed). Hold the error so
+          // the failure path below can print diagnostics and then RE-THROW
+          // it — the waits are the step's only signal, and a fresh read
+          // must never stand in for them (a fallback read that fed the
+          // assertions could green a run whose authority wait failed on a
+          // field the assertions don't check).
+          waitFailure = error;
+        }
+
+        if (summary === undefined) {
+          // Failure path only: print the diagnostics the thrown failure
+          // cannot carry, from a one-shot read that is expressly NOT the
+          // signal (its raciness is harmless here — the step is already
+          // failing), then re-throw the authority's own error.
+          console.log(
+            "Notebook rapid create source diagnostics:",
+            JSON.stringify(
+              await collectNotebookSourceState(page, notebookEntityId),
+              null,
+              2,
+            ),
+          );
+          console.log(
+            "Notebook rapid create render diagnostics:",
+            JSON.stringify(await collectNotebookRenderState(page), null, 2),
+          );
+          console.log(
+            "Notebook rapid create event/action diagnostics:",
+            JSON.stringify(
+              await collectNotebookCreateTraceSummary(page),
+              null,
+              2,
+            ),
+          );
+          throw waitFailure ??
+            new Error(
+              "the post-sync wait resolved without an approved summary",
+            );
+        }
+
+        // Approved path: the assertions bind to the summary the wait handed
+        // back — the state at the instant the predicate approved it.
+        assertEquals(summary.argumentNotesLength, noteCreates);
+        assertEquals(summary.noteCount, noteCreates);
+      } finally {
+        await waitForRuntimeIdle(page).catch(
+          (error) =>
+            console.warn(
+              "Failed to await runtime idle after notebook regression",
+              error,
+            ),
+        );
+      }
+    },
+  );
 });
 
 async function armTriggerTrace(page: Page): Promise<boolean> {

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -25,38 +25,6 @@ import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { assert, assertEquals } from "@std/assert";
 import { resolveSpaceDid } from "@commonfabric/lib-shell";
-import { experimentalOptionsFromEnv } from "@commonfabric/runner";
-import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
-
-// The server-execution v2 posture this test process runs (testing.md §2):
-// the CI ON lane sets EXPERIMENTAL_SERVER_EXECUTION=true; unset = OFF.
-const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
-  .serverExecution;
-
-// The ON arm's STEP-level skip guard (tasks/server-execution-on-skips.ts):
-// a step listed there for this file is skipped ONLY under the ON posture,
-// loudly (its reason is printed), and only while the entry exists — the OFF
-// arm and an unlisted step always run. The rapid notebook step remains listed:
-// a direct CI ON unskip probe at 66a969ca0 ran the exact step and reached all
-// seven invocation traces, but finished with no notebook-bound action state or
-// rendered notes before its unchanged condition bound. That run did not carry
-// the off-repository launcher's recursive-schema signature. The skip protects
-// CI from the currently observed ON failure, while the OFF arm still runs.
-function onArmStepSkip(step: string): { ignore: boolean } {
-  if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };
-  const entry = serverExecutionOnStepSkip(
-    "patterns",
-    "integration/default-app.test.ts",
-    step,
-  );
-  if (entry === undefined) return { ignore: false };
-  console.warn(
-    `[server-execution ON arm] patterns: SKIPPING STEP ${
-      JSON.stringify(step)
-    } (until ${entry.phase}) — ${entry.reason}`,
-  );
-  return { ignore: true };
-}
 
 type BrowserWriteTraceEntry = {
   recordedAt: number;
@@ -667,223 +635,217 @@ describe("default-app flow test", () => {
     }
   });
 
-  it(
-    "should persist and reload every rapidly created notebook note",
-    onArmStepSkip(
-      "should persist and reload every rapidly created notebook note",
-    ),
-    async () => {
-      identity = await Identity.generate({ implementation: "noble" });
-      const notebookSpaceName = globalThis.crypto.randomUUID();
-      const notebookSpaceDid = await resolveSpaceDid(
-        identity,
-        notebookSpaceName,
+  it("should persist and reload every rapidly created notebook note", async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    const notebookSpaceName = globalThis.crypto.randomUUID();
+    const notebookSpaceDid = await resolveSpaceDid(
+      identity,
+      notebookSpaceName,
+    );
+
+    const page = shell.page();
+    await disposeBrowserRuntime(page);
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: notebookSpaceName },
+      identity,
+    });
+
+    // shell.goto() waits for URL state and login, while RootView resolves the
+    // named view space independently. Do not interact with the previous
+    // space's still-rendered root while that resolution is in flight.
+    await waitForActiveSpaceRoot(page, notebookSpaceDid);
+
+    console.log("Await runtime idle for notebook regression...");
+    await waitForRuntimeIdle(page);
+    // Runtime idle can precede the page renderer's Lit update. Wait for the
+    // freshly navigated default-app view to bind its menu handlers before the
+    // first trusted click, just as the notebook toolbar does below.
+    await waitForCondition(
+      page,
+      () => typeof globalThis.commonfabric?.viewSettled === "function",
+    );
+    await awaitViewSettled(page);
+
+    try {
+      await clickButtonWithExactText(page, "Notes ▾");
+      await awaitViewSettled(page);
+      await clickButtonWithText(page, "New Notebook");
+      // The wait hands back the NOTEBOOK's piece id at the instant it
+      // approved `isNotebook` — the step's stable read target from here
+      // on. Every later wait and assertion reads the notebook BY THIS ID,
+      // never through `view.pieceId` again: under server execution the
+      // final "Create" click's speculative run may read a stale
+      // `usedCreateAnotherNote` and optimistically navigate into the new
+      // note while the authoritative run computes no navigation — a
+      // sanctioned outcome (the L2 optimistic-enactment question, ruled
+      // PUNT 2026-08-27: the client navigates, so be it). A view-following
+      // read then polls a healthy NOTE through notebook accessors until
+      // the step's net (the 2026-08-27 r06/r09 root cause,
+      // docs/history/plans/server-execution-v2/optimize/
+      // keyless-diagnosis-2026-08-27.md); an id-bound read is indifferent
+      // to where the view wandered.
+      let notebookEntityId: string | undefined;
+      try {
+        notebookEntityId = await waitForCondition(page, async () => {
+          const commonfabric = globalThis.commonfabric as
+            | { readCell?: (options: { id: string }) => Promise<unknown> }
+            | undefined;
+          const view = globalThis.app?.serialize?.()?.view;
+          const pieceId = view && typeof view === "object" &&
+              "pieceId" in view && typeof view.pieceId === "string"
+            ? view.pieceId
+            : undefined;
+          if (!pieceId || !commonfabric?.readCell) return false;
+          let current: unknown;
+          const originalLog = console.log;
+          try {
+            console.log = () => {};
+            current = await commonfabric.readCell({ id: pieceId });
+          } finally {
+            console.log = originalLog;
+          }
+          return (current as { isNotebook?: unknown } | undefined)
+              ?.isNotebook === true
+            ? pieceId
+            : false;
+        });
+      } catch (error) {
+        console.log(
+          "Notebook navigation diagnostics:",
+          JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
+        );
+        throw error;
+      }
+      assert(
+        notebookEntityId,
+        "Expected the notebook wait to hand back the notebook piece id",
       );
 
-      const page = shell.page();
-      await disposeBrowserRuntime(page);
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: { spaceName: notebookSpaceName },
-        identity,
-      });
-
-      // shell.goto() waits for URL state and login, while RootView resolves the
-      // named view space independently. Do not interact with the previous
-      // space's still-rendered root while that resolution is in flight.
-      await waitForActiveSpaceRoot(page, notebookSpaceDid);
-
-      console.log("Await runtime idle for notebook regression...");
-      await waitForRuntimeIdle(page);
-      // Runtime idle can precede the page renderer's Lit update. Wait for the
-      // freshly navigated default-app view to bind its menu handlers before the
-      // first trusted click, just as the notebook toolbar does below.
+      // Wait until the notebook toolbar is mounted and interactive before
+      // clicking. viewSettled resolves once the worker is idle and the
+      // rendered view has caught up (vdom applied, Lit updates drained), so the
+      // New Note button's handler is bound and a single click is not dropped.
       await waitForCondition(
         page,
         () => typeof globalThis.commonfabric?.viewSettled === "function",
       );
       await awaitViewSettled(page);
+      assert(
+        await clickButtonWithTitle(page, "New Note"),
+        "Expected New Note click to succeed",
+      );
+      // Arm the event-invocation trace before the note creations, whose markers
+      // this test's failure diagnostics read. clickButtonWithTitle settled the
+      // view, so the runtime has exposed its telemetry methods and the reset
+      // runs once with its success asserted. The first "Create Another" click
+      // below settles the view and waits for the button to render, so no
+      // separate wait for the modal is needed here.
+      assert(
+        await resetEventInvocationTrace(page),
+        "Expected the event invocation trace to reset",
+      );
 
-      try {
-        await clickButtonWithExactText(page, "Notes ▾");
-        await awaitViewSettled(page);
-        await clickButtonWithText(page, "New Notebook");
-        // The wait hands back the NOTEBOOK's piece id at the instant it
-        // approved `isNotebook` — the step's stable read target from here
-        // on. Every later wait and assertion reads the notebook BY THIS ID,
-        // never through `view.pieceId` again: under server execution the
-        // final "Create" click's speculative run may read a stale
-        // `usedCreateAnotherNote` and optimistically navigate into the new
-        // note while the authoritative run computes no navigation — a
-        // sanctioned outcome (the L2 optimistic-enactment question, ruled
-        // PUNT 2026-08-27: the client navigates, so be it). A view-following
-        // read then polls a healthy NOTE through notebook accessors until
-        // the step's net (the 2026-08-27 r06/r09 root cause,
-        // docs/history/plans/server-execution-v2/optimize/
-        // keyless-diagnosis-2026-08-27.md); an id-bound read is indifferent
-        // to where the view wandered.
-        let notebookEntityId: string | undefined;
-        try {
-          notebookEntityId = await waitForCondition(page, async () => {
-            const commonfabric = globalThis.commonfabric as
-              | { readCell?: (options: { id: string }) => Promise<unknown> }
-              | undefined;
-            const view = globalThis.app?.serialize?.()?.view;
-            const pieceId = view && typeof view === "object" &&
-                "pieceId" in view && typeof view.pieceId === "string"
-              ? view.pieceId
-              : undefined;
-            if (!pieceId || !commonfabric?.readCell) return false;
-            let current: unknown;
-            const originalLog = console.log;
-            try {
-              console.log = () => {};
-              current = await commonfabric.readCell({ id: pieceId });
-            } finally {
-              console.log = originalLog;
-            }
-            return (current as { isNotebook?: unknown } | undefined)
-                ?.isNotebook === true
-              ? pieceId
-              : false;
-          });
-        } catch (error) {
-          console.log(
-            "Notebook navigation diagnostics:",
-            JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
-          );
-          throw error;
-        }
+      const noteCreates = 7;
+      for (let i = 0; i < noteCreates - 1; i++) {
         assert(
-          notebookEntityId,
-          "Expected the notebook wait to hand back the notebook piece id",
-        );
-
-        // Wait until the notebook toolbar is mounted and interactive before
-        // clicking. viewSettled resolves once the worker is idle and the
-        // rendered view has caught up (vdom applied, Lit updates drained), so the
-        // New Note button's handler is bound and a single click is not dropped.
-        await waitForCondition(
-          page,
-          () => typeof globalThis.commonfabric?.viewSettled === "function",
-        );
-        await awaitViewSettled(page);
-        assert(
-          await clickButtonWithTitle(page, "New Note"),
-          "Expected New Note click to succeed",
-        );
-        // Arm the event-invocation trace before the note creations, whose markers
-        // this test's failure diagnostics read. clickButtonWithTitle settled the
-        // view, so the runtime has exposed its telemetry methods and the reset
-        // runs once with its success asserted. The first "Create Another" click
-        // below settles the view and waits for the button to render, so no
-        // separate wait for the modal is needed here.
-        assert(
-          await resetEventInvocationTrace(page),
-          "Expected the event invocation trace to reset",
-        );
-
-        const noteCreates = 7;
-        for (let i = 0; i < noteCreates - 1; i++) {
-          assert(
-            await clickButtonWithText(page, "Create Another"),
-            `Expected Create Another click ${i + 1} to succeed`,
-          );
-        }
-        assert(
-          await clickButtonWithExactText(page, "Create"),
-          "Expected final Create click to succeed",
-        );
-
-        // The assertions bind to the summary a wait handed back — the state
-        // as it was at the instant the predicate approved it — never to a
-        // separate read taken after a wait. Under server execution the
-        // notebook's derived `noteCount` follows the ruled unresolved-read
-        // disposition (OW51): a re-derivation reads cleanly `undefined` and
-        // re-triggers, healing back to the settled value. That interim is
-        // correct product behavior, so a single-shot read between a wait and
-        // its assertion can catch it and fail a healthy run (the OW45
-        // register row's measured 1-in-10-quiet / 5-in-10-under-load flake);
-        // a wait on the value itself absorbs it, and a value that never
-        // reaches `expectedCount` — a genuinely lost note — still fails
-        // loudly at waitForCondition's stuck-condition net.
-        //
-        // The first wait orders the sync barrier after local convergence, so
-        // "synced" covers all seven notes' commits; the second wait is the
-        // assertion's authority, re-approving the state after that barrier.
-        // Its predicate reads the same cells the step has read all along, and
-        // any client read registers demand — this step verifies that the
-        // created notes' data and derived count converge and survive the sync
-        // barrier under serving, not that they materialize unobserved (the
-        // reload rehydration surface is integration/reload/
-        // default-app-notebook.test.ts's).
-        let summary: NotebookSourceSummary | undefined;
-        let waitFailure: unknown;
-        try {
-          await waitForCondition(page, notebookSourceStateMatches, {
-            args: [noteCreates, notebookEntityId],
-          });
-          await waitForRuntimeSynced(page);
-          summary = await waitForCondition(page, notebookSourceStateMatches, {
-            args: [noteCreates, notebookEntityId],
-          });
-        } catch (error) {
-          // A wait or the sync barrier failed at its net: the state never
-          // converged (or synchronization itself failed). Hold the error so
-          // the failure path below can print diagnostics and then RE-THROW
-          // it — the waits are the step's only signal, and a fresh read
-          // must never stand in for them (a fallback read that fed the
-          // assertions could green a run whose authority wait failed on a
-          // field the assertions don't check).
-          waitFailure = error;
-        }
-
-        if (summary === undefined) {
-          // Failure path only: print the diagnostics the thrown failure
-          // cannot carry, from a one-shot read that is expressly NOT the
-          // signal (its raciness is harmless here — the step is already
-          // failing), then re-throw the authority's own error.
-          console.log(
-            "Notebook rapid create source diagnostics:",
-            JSON.stringify(
-              await collectNotebookSourceState(page, notebookEntityId),
-              null,
-              2,
-            ),
-          );
-          console.log(
-            "Notebook rapid create render diagnostics:",
-            JSON.stringify(await collectNotebookRenderState(page), null, 2),
-          );
-          console.log(
-            "Notebook rapid create event/action diagnostics:",
-            JSON.stringify(
-              await collectNotebookCreateTraceSummary(page),
-              null,
-              2,
-            ),
-          );
-          throw waitFailure ??
-            new Error(
-              "the post-sync wait resolved without an approved summary",
-            );
-        }
-
-        // Approved path: the assertions bind to the summary the wait handed
-        // back — the state at the instant the predicate approved it.
-        assertEquals(summary.argumentNotesLength, noteCreates);
-        assertEquals(summary.noteCount, noteCreates);
-      } finally {
-        await waitForRuntimeIdle(page).catch(
-          (error) =>
-            console.warn(
-              "Failed to await runtime idle after notebook regression",
-              error,
-            ),
+          await clickButtonWithText(page, "Create Another"),
+          `Expected Create Another click ${i + 1} to succeed`,
         );
       }
-    },
-  );
+      assert(
+        await clickButtonWithExactText(page, "Create"),
+        "Expected final Create click to succeed",
+      );
+
+      // The assertions bind to the summary a wait handed back — the state
+      // as it was at the instant the predicate approved it — never to a
+      // separate read taken after a wait. Under server execution the
+      // notebook's derived `noteCount` follows the ruled unresolved-read
+      // disposition (OW51): a re-derivation reads cleanly `undefined` and
+      // re-triggers, healing back to the settled value. That interim is
+      // correct product behavior, so a single-shot read between a wait and
+      // its assertion can catch it and fail a healthy run (the OW45
+      // register row's measured 1-in-10-quiet / 5-in-10-under-load flake);
+      // a wait on the value itself absorbs it, and a value that never
+      // reaches `expectedCount` — a genuinely lost note — still fails
+      // loudly at waitForCondition's stuck-condition net.
+      //
+      // The first wait orders the sync barrier after local convergence, so
+      // "synced" covers all seven notes' commits; the second wait is the
+      // assertion's authority, re-approving the state after that barrier.
+      // Its predicate reads the same cells the step has read all along, and
+      // any client read registers demand — this step verifies that the
+      // created notes' data and derived count converge and survive the sync
+      // barrier under serving, not that they materialize unobserved (the
+      // reload rehydration surface is integration/reload/
+      // default-app-notebook.test.ts's).
+      let summary: NotebookSourceSummary | undefined;
+      let waitFailure: unknown;
+      try {
+        await waitForCondition(page, notebookSourceStateMatches, {
+          args: [noteCreates, notebookEntityId],
+        });
+        await waitForRuntimeSynced(page);
+        summary = await waitForCondition(page, notebookSourceStateMatches, {
+          args: [noteCreates, notebookEntityId],
+        });
+      } catch (error) {
+        // A wait or the sync barrier failed at its net: the state never
+        // converged (or synchronization itself failed). Hold the error so
+        // the failure path below can print diagnostics and then RE-THROW
+        // it — the waits are the step's only signal, and a fresh read
+        // must never stand in for them (a fallback read that fed the
+        // assertions could green a run whose authority wait failed on a
+        // field the assertions don't check).
+        waitFailure = error;
+      }
+
+      if (summary === undefined) {
+        // Failure path only: print the diagnostics the thrown failure
+        // cannot carry, from a one-shot read that is expressly NOT the
+        // signal (its raciness is harmless here — the step is already
+        // failing), then re-throw the authority's own error.
+        console.log(
+          "Notebook rapid create source diagnostics:",
+          JSON.stringify(
+            await collectNotebookSourceState(page, notebookEntityId),
+            null,
+            2,
+          ),
+        );
+        console.log(
+          "Notebook rapid create render diagnostics:",
+          JSON.stringify(await collectNotebookRenderState(page), null, 2),
+        );
+        console.log(
+          "Notebook rapid create event/action diagnostics:",
+          JSON.stringify(
+            await collectNotebookCreateTraceSummary(page),
+            null,
+            2,
+          ),
+        );
+        throw waitFailure ??
+          new Error(
+            "the post-sync wait resolved without an approved summary",
+          );
+      }
+
+      // Approved path: the assertions bind to the summary the wait handed
+      // back — the state at the instant the predicate approved it.
+      assertEquals(summary.argumentNotesLength, noteCreates);
+      assertEquals(summary.noteCount, noteCreates);
+    } finally {
+      await waitForRuntimeIdle(page).catch(
+        (error) =>
+          console.warn(
+            "Failed to await runtime idle after notebook regression",
+            error,
+          ),
+      );
+    }
+  });
 });
 
 async function armTriggerTrace(page: Page): Promise<boolean> {

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -128,82 +128,34 @@ Deno.test("main: no arguments behaves like an unknown suite", async () => {
 });
 
 Deno.test("main: empty lists print the report on stderr and nothing on stdout", async () => {
-  // The shell suite's list is empty (patterns carries one FILE entry and two
-  // STEP entries; runner and runtime-client are empty since their lifts).
+  // EVERY suite's list is empty since the 2026-08-27 phase-3 lifts; this
+  // test drives the shell suite, which has been empty since stage F.
   const { out, err, io } = captureIo();
   assertEquals(await main(["shell"], io), 0);
   assertEquals(out, []);
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list carries the two current phase-7 entries and keeps the flip bar explicit", async () => {
+Deno.test("main: the patterns list is EMPTY — BOTH phase-7 OW45 arm-B entries LIFTED 2026-08-27 (default-app's rapid-note reload STEP on 10/10 quiet-and-loaded; lunch-poll-vote's FILE entry on the owner-directed ~8-run re-baseline), each with a green direct-CI unskip probe as the ruled bar requires — so the full suite runs on the ON arm", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
-  // The default-app step entry never drops its file; the lunch-poll-vote
-  // FILE entry is the one --ignore flag on stdout.
-  assertEquals(out, ["--ignore=integration/lunch-poll-vote.test.ts"]);
-  // …the report carries both remaining skips loudly…
-  assertMatch(
-    err[0],
-    /patterns: SKIP-STEP integration\/default-app\.test\.ts :: should persist and reload every rapidly created notebook note \(until phase-7; the rest of the file runs\)/,
-  );
-  assertMatch(
-    err[0],
-    /patterns: SKIP integration\/lunch-poll-vote\.test\.ts \(until phase-7\)/,
-  );
-  // …and the list holds EXACTLY these two entries — an addition or a silent
-  // lift both redden this pin.
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 2);
+  // No entries: no --ignore flag on stdout…
+  assertEquals(out, []);
+  // …and the report says so loudly.
+  assertMatch(err[0], /patterns: no skips — full suite runs\./);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 0);
+  // The LIFTED step's guard lookup resolves to NOTHING, so the step RUNS on
+  // the ON arm. The in-file guard is gone too (default-app.test.ts no longer
+  // imports serverExecutionOnStepSkip), so a re-skip of this step is a
+  // deliberate entry PLUS a restored guard — the validator's step-binding
+  // check below refuses a bare entry as decoration.
   assertEquals(
-    SERVER_EXECUTION_ON_SKIPS.patterns[0].file,
-    "integration/default-app.test.ts",
-  );
-  assertEquals(
-    SERVER_EXECUTION_ON_SKIPS.patterns[0].step,
-    "should persist and reload every rapidly created notebook note",
-  );
-  // The lunch-poll-vote entry is FILE-level (no step guard: every step
-  // depends on the profile-first join the class kills), same class and
-  // fork memo as the closed default-app residue.
-  assertEquals(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].file,
-    "integration/lunch-poll-vote.test.ts",
-  );
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns[1].step, undefined);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns[1].phase, "phase-7");
-  // Its reason names the NARROWED charge the entry's own gate found
-  // (2026-08-24), the pinned never-issued mechanism, and the completed
-  // post-fix gate — not the b04 client-start class that gate closed,
-  // whose fork memo the reason keeps as history.
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /program-materialization|patternIdentity/,
-  );
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /ow45-armb-client-start-fork\.md/,
-  );
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /never issued/i,
-  );
-  assertMatch(SERVER_EXECUTION_ON_SKIPS.patterns[1].reason, /0\/8/);
-  // …and the 2026-08-27 lift attempt, whose local re-baseline PASSED (8/8)
-  // while the direct CI unskip probe on the same branch went RED — pinned by
-  // its CI coordinates and by the HOST-side line, so a future seat cannot
-  // read that 8/8 as a clean lift bar, nor re-derive the stage from scratch.
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /DIRECT CI UNSKIP PROBE ON THE SAME BRANCH FAILED/,
-  );
-  assertMatch(SERVER_EXECUTION_ON_SKIPS.patterns[1].reason, /33085668531/);
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /lunch-poll-vote\.test\.ts:271/,
-  );
-  assertMatch(
-    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
-    /HOST's clickCfButton/,
+    serverExecutionOnStepSkip(
+      "patterns",
+      "integration/default-app.test.ts",
+      "should persist and reload every rapidly created notebook note",
+    ),
+    undefined,
   );
   // The topic-board pivot-baseline entry is GONE (#6304 fixed): the
   // guard lookup for that step resolves nothing, so the case runs in
@@ -216,45 +168,8 @@ Deno.test("main: the patterns list carries the two current phase-7 entries and k
     ),
     undefined,
   );
-  // The guard resolves the current direct-CI charge and pins its decisive
-  // discriminators so a stale launcher-era reason cannot return silently.
-  const entry = serverExecutionOnStepSkip(
-    "patterns",
-    "integration/default-app.test.ts",
-    "should persist and reload every rapidly created notebook note",
-  );
-  assert(entry !== undefined, "the rapid-note step's guard entry must resolve");
-  assertEquals(entry.phase, "phase-7");
-  assertMatch(entry.reason, /66a969ca0/);
-  assertMatch(entry.reason, /33008274232/);
-  assertMatch(entry.reason, /5m22s/);
-  assertMatch(entry.reason, /300000ms/);
-  assertMatch(entry.reason, /eventInvocationCount=7/);
-  assertMatch(entry.reason, /notebookActionCount=0/);
-  assertMatch(entry.reason, /84 stored UI note chips/);
-  assertMatch(entry.reason, /zero pattern-swap-setup-error/);
-  assertMatch(entry.reason, /distinct from the split-source/);
-  assertMatch(entry.reason, /10\/10 quiet-and-loaded/);
-  // The 2026-08-27 root cause narrowed the charge: the navigation half
-  // (wrong-branch optimistic navigateTo — L2, ruled PUNT: sanctioned) is
-  // absorbed by the step's id-bound reads, so the residue that KEEPS the
-  // entry is the a04 write-side member — consequenced marks whose derived
-  // commits carry none of the effects. Pin the narrowed discriminators so
-  // a stale cause-unassigned reason (or the closed navigation charge)
-  // cannot return silently.
-  assertMatch(entry.reason, /a04/);
-  assertMatch(entry.reason, /mark-without-effects/);
-  assertMatch(entry.reason, /ruled PUNT/);
-  assertMatch(entry.reason, /keyless-diagnosis-2026-08-27\.md/);
-  assert(
-    !/cause is not yet assigned/.test(entry.reason),
-    "the reason must not claim the cause is unassigned — it was root-caused " +
-      "2026-08-27 (register OW45; keyless-diagnosis-2026-08-27.md)",
-  );
-  // The shard filter drops exactly the FILE entry's file (the shard
-  // lanes feed explicit file lists) and passes every other candidate
-  // through untouched — remove the lunch-poll-vote entry and this
-  // assertion reds.
+  // The shard filter now drops NOTHING — every candidate passes through,
+  // lunch-poll-vote included. Re-add a patterns FILE entry and this reds.
   const { files, skipped } = serverExecutionOnFilterFiles("patterns", [
     "./integration/default-app.test.ts",
     "./integration/cellset-lww.test.ts",
@@ -266,10 +181,32 @@ Deno.test("main: the patterns list carries the two current phase-7 entries and k
     "./integration/default-app.test.ts",
     "./integration/cellset-lww.test.ts",
     "./integration/convergence-storm.test.ts",
+    "./integration/lunch-poll-vote.test.ts",
     "./integration/topics-navigation.test.ts",
   ]);
-  assertEquals(skipped, [SERVER_EXECUTION_ON_SKIPS.patterns[1]]);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
+  assertEquals(skipped, []);
+});
+
+Deno.test("THE FLIP'S B1 BAR: the ON-skip list is EMPTY in EVERY suite — one assertion, so a single entry anywhere reddens it", () => {
+  // The flip PR must land with this list empty (the file header's contract,
+  // testing.md §2). Reached 2026-08-27 by the phase-3 lifts. This pin is
+  // deliberately coarse and total: it does not name a suite, a file, or a
+  // phase, so ANY future entry — a re-skip, a new surface, a different
+  // suite — reddens it and forces the adder to state the bar's regression
+  // in the same diff.
+  const entries = (["patterns", "runner", "runtime-client", "shell"] as const)
+    .flatMap((suite) =>
+      SERVER_EXECUTION_ON_SKIPS[suite].map((skip) =>
+        `${suite}: ${skip.file}${
+          skip.step === undefined ? "" : ` :: ${skip.step}`
+        }`
+      )
+    );
+  assertEquals(
+    entries,
+    [],
+    "the ON-skip list must stay EMPTY: the flip's list-EMPTY bar",
+  );
 });
 
 Deno.test("main: the runtime-client list is EMPTY — the OW33 triage (2026-08-22) lifted both STEP entries (CT-1606 PerUser header render; single-navigateTo dispatch) on 12/12 green at the true ON topology — so the full suite runs, and the in-file guard resolves to no entry", async () => {
@@ -352,7 +289,7 @@ Deno.test("validation binds a step entry: the file must name the step and call t
   ]);
 });
 
-Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTED by the arrival-witness predicate (RULED 2026-08-22, candidate (B): a cover at the floor witnesses only when derived-class) on 10/10 green at the true ON topology — so the full suite runs, and the ONLY file-level skip in ANY suite is patterns' lunch-poll-vote entry (the 2026-08-24 deliberate OW45 arm-B re-skip)", async () => {
+Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTED by the arrival-witness predicate (RULED 2026-08-22, candidate (B): a cover at the floor witnesses only when derived-class) on 10/10 green at the true ON topology — so the full suite runs, and since the 2026-08-27 phase-3 lifts there is NO file-level skip in ANY suite", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["runner"], io), 0);
   // No entries: no --ignore flag on stdout…
@@ -367,20 +304,20 @@ Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTE
   assertMatch(err[0], /runner: no skips — full suite runs\./);
   assertEquals(SERVER_EXECUTION_ON_SKIPS.runner.length, 0);
   // A FILE-level skip is a deliberate entry, never a leftover: the
-  // arrival-witness lift cleared the last one, and the single re-skip
-  // since — patterns' lunch-poll-vote entry (2026-08-24, the OW45 arm-B
-  // client-start class its profile-first join newly exposes) — is named
-  // here so the NEXT file-level entry still reddens this pin. The flip
-  // PR's list-EMPTY bar hangs on this file and the topic-board step.
+  // arrival-witness lift cleared the runner's last one, and the single
+  // re-skip since — patterns' lunch-poll-vote entry (2026-08-24, the OW45
+  // arm-B client-start class its profile-first join newly exposed) — LIFTED
+  // 2026-08-27 on its own ~8-run re-baseline plus a green direct-CI unskip
+  // probe. NO suite carries a file-level skip now, so the NEXT one reddens
+  // this pin.
   for (const suite of ["patterns", "runner", "runtime-client", "shell"]) {
     if (!isServerExecutionSuite(suite)) throw new Error("unreachable");
     assertEquals(
       SERVER_EXECUTION_ON_SKIPS[suite]
         .filter((skip) => skip.step === undefined)
         .map((skip) => skip.file),
-      suite === "patterns" ? ["integration/lunch-poll-vote.test.ts"] : [],
-      `${suite}: the only FILE-level skip is the deliberate ` +
-        "lunch-poll-vote OW45 arm-B entry",
+      [],
+      `${suite}: no FILE-level skip survives the 2026-08-27 phase-3 lifts`,
     );
   }
 });

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -128,34 +128,87 @@ Deno.test("main: no arguments behaves like an unknown suite", async () => {
 });
 
 Deno.test("main: empty lists print the report on stderr and nothing on stdout", async () => {
-  // EVERY suite's list is empty since the 2026-08-27 phase-3 lifts; this
-  // test drives the shell suite, which has been empty since stage F.
+  // The shell suite's list is empty (patterns carries one FILE entry and two
+  // STEP entries; runner and runtime-client are empty since their lifts).
   const { out, err, io } = captureIo();
   assertEquals(await main(["shell"], io), 0);
   assertEquals(out, []);
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list is EMPTY — BOTH phase-7 OW45 arm-B entries LIFTED 2026-08-27 (default-app's rapid-note reload STEP on 10/10 quiet-and-loaded; lunch-poll-vote's FILE entry on the owner-directed ~8-run re-baseline), each with a green direct-CI unskip probe as the ruled bar requires — so the full suite runs on the ON arm", async () => {
+Deno.test("main: the patterns list carries the two current phase-7 entries and keeps the flip bar explicit", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
-  // No entries: no --ignore flag on stdout…
-  assertEquals(out, []);
-  // …and the report says so loudly.
-  assertMatch(err[0], /patterns: no skips — full suite runs\./);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 0);
-  // The LIFTED step's guard lookup resolves to NOTHING, so the step RUNS on
-  // the ON arm. The in-file guard is gone too (default-app.test.ts no longer
-  // imports serverExecutionOnStepSkip), so a re-skip of this step is a
-  // deliberate entry PLUS a restored guard — the validator's step-binding
-  // check below refuses a bare entry as decoration.
+  // The default-app step entry never drops its file; the lunch-poll-vote
+  // FILE entry is the one --ignore flag on stdout.
+  assertEquals(out, ["--ignore=integration/lunch-poll-vote.test.ts"]);
+  // …the report carries both remaining skips loudly…
+  assertMatch(
+    err[0],
+    /patterns: SKIP-STEP integration\/default-app\.test\.ts :: should persist and reload every rapidly created notebook note \(until phase-7; the rest of the file runs\)/,
+  );
+  assertMatch(
+    err[0],
+    /patterns: SKIP integration\/lunch-poll-vote\.test\.ts \(until phase-7\)/,
+  );
+  // …and the list holds EXACTLY these two entries — an addition or a silent
+  // lift both redden this pin.
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 2);
   assertEquals(
-    serverExecutionOnStepSkip(
-      "patterns",
-      "integration/default-app.test.ts",
-      "should persist and reload every rapidly created notebook note",
-    ),
-    undefined,
+    SERVER_EXECUTION_ON_SKIPS.patterns[0].file,
+    "integration/default-app.test.ts",
+  );
+  assertEquals(
+    SERVER_EXECUTION_ON_SKIPS.patterns[0].step,
+    "should persist and reload every rapidly created notebook note",
+  );
+  // The lunch-poll-vote entry is FILE-level (no step guard: every step
+  // depends on the profile-first join the class kills), same class and
+  // fork memo as the closed default-app residue.
+  assertEquals(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].file,
+    "integration/lunch-poll-vote.test.ts",
+  );
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns[1].step, undefined);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns[1].phase, "phase-7");
+  // Its reason carries the 2026-08-27 phase-3 charge: the local ~8-run
+  // re-baseline PASSED (8/8) and the direct-CI unskip probe went RED at
+  // the HOST's join — the SECOND campaign in a row to split that way.
+  // Pinned by the CI coordinates, the failing line, and the newly
+  // OBSERVED server-side mechanism, so a future seat neither reads the
+  // 8/8 as a clean bar nor re-derives the classification from scratch.
+  assertMatch(SERVER_EXECUTION_ON_SKIPS.patterns[1].reason, /8\/8 GREEN/);
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /DIRECT CI UNSKIP PROBE .*went\s+RED/s,
+  );
+  assertMatch(SERVER_EXECUTION_ON_SKIPS.patterns[1].reason, /33138358110/);
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /lunch-poll-vote\.test\.ts:271/,
+  );
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /HOST's clickCfButton/,
+  );
+  // The mechanism half: the forever-park, its root, and the negative that
+  // stops the next seat chasing the foreign-write refusal (which every
+  // local GREEN also carries).
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /structure-load-stuck/,
+  );
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /foreign-write-refused/,
+  );
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /the refusal is NOT it/i,
+  );
+  assertMatch(
+    SERVER_EXECUTION_ON_SKIPS.patterns[1].reason,
+    /PARK is the discriminator/,
   );
   // The topic-board pivot-baseline entry is GONE (#6304 fixed): the
   // guard lookup for that step resolves nothing, so the case runs in
@@ -168,8 +221,41 @@ Deno.test("main: the patterns list is EMPTY — BOTH phase-7 OW45 arm-B entries 
     ),
     undefined,
   );
-  // The shard filter now drops NOTHING — every candidate passes through,
-  // lunch-poll-vote included. Re-add a patterns FILE entry and this reds.
+  // The guard resolves the current direct-CI charge and pins its decisive
+  // discriminators so a stale launcher-era reason cannot return silently.
+  const entry = serverExecutionOnStepSkip(
+    "patterns",
+    "integration/default-app.test.ts",
+    "should persist and reload every rapidly created notebook note",
+  );
+  assert(entry !== undefined, "the rapid-note step's guard entry must resolve");
+  assertEquals(entry.phase, "phase-7");
+  // The 2026-08-27 phase-3 campaign INVERTED this entry's evidence: the
+  // step is 10/10 locally AND passed its direct-CI unskip probe, and the
+  // lane red was a co-resident file. Pin all three so the next seat
+  // re-probes instead of re-running a local campaign, and so a stale
+  // charge (the 66a969ca0 fingerprint, or the a04 residue #6459 closed)
+  // cannot quietly return as this entry's reason.
+  assertMatch(entry.reason, /10\/10 quiet-and-loaded/);
+  assertMatch(entry.reason, /33138358110/);
+  assertMatch(entry.reason, /it PASSED/);
+  assertMatch(entry.reason, /cfc-group-chat-demo\.test\.ts:133/);
+  assertMatch(entry.reason, /4\/6 RED locally/);
+  assertMatch(entry.reason, /RE-PROBE/);
+  assert(
+    !/Lifts on 10\/10/.test(entry.reason),
+    "the reason must not still state a bare local-count lift bar — the " +
+      "ruled bar (2026-08-27) also requires a green direct-CI unskip probe",
+  );
+  assert(
+    !/cause is not yet assigned/.test(entry.reason),
+    "the reason must not claim the cause is unassigned — it was root-caused " +
+      "2026-08-27 (register OW45; keyless-diagnosis-2026-08-27.md)",
+  );
+  // The shard filter drops exactly the FILE entry's file (the shard
+  // lanes feed explicit file lists) and passes every other candidate
+  // through untouched — remove the lunch-poll-vote entry and this
+  // assertion reds.
   const { files, skipped } = serverExecutionOnFilterFiles("patterns", [
     "./integration/default-app.test.ts",
     "./integration/cellset-lww.test.ts",
@@ -181,32 +267,10 @@ Deno.test("main: the patterns list is EMPTY — BOTH phase-7 OW45 arm-B entries 
     "./integration/default-app.test.ts",
     "./integration/cellset-lww.test.ts",
     "./integration/convergence-storm.test.ts",
-    "./integration/lunch-poll-vote.test.ts",
     "./integration/topics-navigation.test.ts",
   ]);
-  assertEquals(skipped, []);
-});
-
-Deno.test("THE FLIP'S B1 BAR: the ON-skip list is EMPTY in EVERY suite — one assertion, so a single entry anywhere reddens it", () => {
-  // The flip PR must land with this list empty (the file header's contract,
-  // testing.md §2). Reached 2026-08-27 by the phase-3 lifts. This pin is
-  // deliberately coarse and total: it does not name a suite, a file, or a
-  // phase, so ANY future entry — a re-skip, a new surface, a different
-  // suite — reddens it and forces the adder to state the bar's regression
-  // in the same diff.
-  const entries = (["patterns", "runner", "runtime-client", "shell"] as const)
-    .flatMap((suite) =>
-      SERVER_EXECUTION_ON_SKIPS[suite].map((skip) =>
-        `${suite}: ${skip.file}${
-          skip.step === undefined ? "" : ` :: ${skip.step}`
-        }`
-      )
-    );
-  assertEquals(
-    entries,
-    [],
-    "the ON-skip list must stay EMPTY: the flip's list-EMPTY bar",
-  );
+  assertEquals(skipped, [SERVER_EXECUTION_ON_SKIPS.patterns[1]]);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
 });
 
 Deno.test("main: the runtime-client list is EMPTY — the OW33 triage (2026-08-22) lifted both STEP entries (CT-1606 PerUser header render; single-navigateTo dispatch) on 12/12 green at the true ON topology — so the full suite runs, and the in-file guard resolves to no entry", async () => {
@@ -289,7 +353,7 @@ Deno.test("validation binds a step entry: the file must name the step and call t
   ]);
 });
 
-Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTED by the arrival-witness predicate (RULED 2026-08-22, candidate (B): a cover at the floor witnesses only when derived-class) on 10/10 green at the true ON topology — so the full suite runs, and since the 2026-08-27 phase-3 lifts there is NO file-level skip in ANY suite", async () => {
+Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTED by the arrival-witness predicate (RULED 2026-08-22, candidate (B): a cover at the floor witnesses only when derived-class) on 10/10 green at the true ON topology — so the full suite runs, and the ONLY file-level skip in ANY suite is patterns' lunch-poll-vote entry (the 2026-08-24 deliberate OW45 arm-B re-skip)", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["runner"], io), 0);
   // No entries: no --ignore flag on stdout…
@@ -304,20 +368,20 @@ Deno.test("main: the runner list is EMPTY — pattern-and-data-persistence LIFTE
   assertMatch(err[0], /runner: no skips — full suite runs\./);
   assertEquals(SERVER_EXECUTION_ON_SKIPS.runner.length, 0);
   // A FILE-level skip is a deliberate entry, never a leftover: the
-  // arrival-witness lift cleared the runner's last one, and the single
-  // re-skip since — patterns' lunch-poll-vote entry (2026-08-24, the OW45
-  // arm-B client-start class its profile-first join newly exposed) — LIFTED
-  // 2026-08-27 on its own ~8-run re-baseline plus a green direct-CI unskip
-  // probe. NO suite carries a file-level skip now, so the NEXT one reddens
-  // this pin.
+  // arrival-witness lift cleared the last one, and the single re-skip
+  // since — patterns' lunch-poll-vote entry (2026-08-24, the OW45 arm-B
+  // client-start class its profile-first join newly exposes) — is named
+  // here so the NEXT file-level entry still reddens this pin. The flip
+  // PR's list-EMPTY bar hangs on this file and the topic-board step.
   for (const suite of ["patterns", "runner", "runtime-client", "shell"]) {
     if (!isServerExecutionSuite(suite)) throw new Error("unreachable");
     assertEquals(
       SERVER_EXECUTION_ON_SKIPS[suite]
         .filter((skip) => skip.step === undefined)
         .map((skip) => skip.file),
-      [],
-      `${suite}: no FILE-level skip survives the 2026-08-27 phase-3 lifts`,
+      suite === "patterns" ? ["integration/lunch-poll-vote.test.ts"] : [],
+      `${suite}: the only FILE-level skip is the deliberate ` +
+        "lunch-poll-vote OW45 arm-B entry",
     );
   }
 });

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -191,26 +191,176 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
   // barrier — the exact former 2/10 red mechanism, no longer failing.
   // The product smell the flake used to witness stays tracked as
   // verification-coverage.md OW60, not as a flaky test.
-  // BOTH remaining phase-7 entries LIFTED 2026-08-27 (this PR), under the
-  // owner-ruled bar — local campaign AND a green direct-CI unskip probe
-  // (verification-coverage.md OW45; RULED 2026-08-27, owner: "agreed").
-  //
-  //  * default-app's rapid-note reload STEP: 10/10 quiet-and-loaded, the
-  //    entry's own bar. Its charge had two halves and both are fixed —
-  //    the NAVIGATION half by #6448 (the step's id-bound reads absorb the
-  //    L2-sanctioned optimistic navigation) and the a04 WRITE-side residue
-  //    by #6459 (mark/effects atomicity: a dispatch-side skip can no longer
-  //    seal a mark with none of its effects).
-  //  * lunch-poll-vote's FILE entry: 8/8, the owner-directed
-  //    approximately-eight-run re-baseline that superseded this file's
-  //    earlier 10/10. Its third, write-side residue member — the guest's
-  //    program-materialization transaction never issued because the
-  //    authoritative attempt dropped its RetryImmediately name-resolution
-  //    signal — is fixed by #6378; the b04 client-start class it was minted
-  //    for closed on its own 2026-08-24 evidence.
-  //
-  // The list is now EMPTY in every suite, which is the flip PR's bar.
-  patterns: [],
+  patterns: [
+    {
+      // READ THIS BEFORE RE-CAMPAIGNING: the entry's own CHARGE no longer
+      // reproduces, in either arm. Both halves of it are fixed on main —
+      // the NAVIGATION half by the L2 ruled PUNT plus the step's id-bound
+      // reads (#6448), the a04 WRITE-side mark-without-effects residue by
+      // #6459's mark/effects atomicity — and the 2026-08-27 phase-3
+      // campaign found 10/10 quiet-and-loaded locally AND a GREEN direct-CI
+      // run of this exact step (33138358110, ON shard 5: `ok (18s)`, server
+      // window clean). What holds the entry is the ruled bar's second half
+      // read literally: the probed LANE was red, on a CO-RESIDENT file this
+      // entry has nothing to do with (cfc-group-chat-demo.test.ts:133).
+      // Whether "lane green" means the probed surface or the whole shard is
+      // an OPEN question for the coordinator/owner — flagged, not filled.
+      // So the next seat should RE-PROBE, not re-campaign.
+      file: "integration/default-app.test.ts",
+      step: "should persist and reload every rapidly created notebook note",
+      phase: "phase-7",
+      reason: "NOT this entry's charge any more — held by the LANE, not " +
+        "the step. Phase-3 lift campaign 2026-08-27 at main 1fc841b6e, " +
+        "ON binary sha256 a93047a461c0c4d8 re-verified per run, fresh " +
+        "store + own 97xx port + ON posture probe per run, ensure " +
+        "defaulting ON, toolshed self-sourced, LLM masked, gtimeout 600 " +
+        "never approached: 10/10 quiet-and-loaded, every run 13-14s wall " +
+        "against 313-315s for every red the 2026-08-27 campaign recorded, " +
+        "with pattern-load-error, pattern-swap-setup-error, " +
+        "deferred-start-catchup, session-remount, load-park and " +
+        "handlerNotRunDeferrals all ZERO. The DIRECT CI UNSKIP PROBE " +
+        "(run 33138358110, ON shard 5, job 98743591519, head 95f313835) " +
+        "then ran this exact step with no listed skip and it PASSED: " +
+        "ok (18s), the whole default-app file green, and the shard's " +
+        "toolshed log clean across the file's window (4 event-view-lag, " +
+        "nothing else). The prior charge is therefore NOT reproduced: the " +
+        "66a969ca0/33008274232 fingerprint (eventInvocationCount=7 with " +
+        "notebookActionCount=0) did not recur, and neither did the a04 " +
+        "1-op mark-without-effects shape #6459 fixed. The lane went red " +
+        "on a DIFFERENT, co-resident file: cfc-group-chat-demo.test.ts:133, " +
+        "clickCfButton(#host-send-button) retargeting to the cf-button host " +
+        "(cf-button#host-send-button < slot < div < cf-hstack) — the " +
+        "rootcause 2b disabled-inner-button shape, whose S-G test-aim seat " +
+        "is named-but-unbuilt. That file is NOT skip-listed, is untouched " +
+        "by the probe diff, and reproduces 4/6 RED locally at the same " +
+        "head running alone on a fresh store, so it is neither this " +
+        "entry's charge nor a probe artifact. This entry therefore stands " +
+        "ONLY on the literal reading of the ruled bar (RULED 2026-08-27: " +
+        "local campaign AND a green direct-CI unskip probe). Whether " +
+        "'lane green' means the probed SURFACE or the whole SHARD is an " +
+        "OPEN coordinator/owner question, flagged not filled. The next " +
+        "seat should RE-PROBE this step once the group-chat surface is " +
+        "green, not re-run a local campaign.",
+    },
+    {
+      // Re-listed by the lunch-poll identity PR (#5744). This file was
+      // LIFTED 2026-08-19 for the swatch-stall class (stage-C W3.1 —
+      // history in the header comment above); the profile-first join
+      // that PR introduces newly exposes the arm-B family's REMAINING
+      // member (the entry above): the test now creates the viewer's
+      // profile piece mid-test, and the flag-ON client's deferred start
+      // of that fresh piece dies terminally on the first-hydration
+      // stale-confirmed-read ConflictError, killing the client's piece
+      // context for the session — so the wish `#profile` never
+      // resolves and the join card never renders `#lp-join-button`.
+      // Both the 2026-08-22 red (run 32539777265, shards 7 and 9 —
+      // shard 9's cfc-staged-publish red is the same class's per-run
+      // lottery) and the 2026-08-24 red (run 32769542550) carry the
+      // deferred-start tx-commit-error signature; the OFF lane runs
+      // this file green. Every later step depends on that join, hence
+      // a FILE entry rather than a step guard. Same class, same fork
+      // memo as the entry above. MERGE NOTE (the catch-up-and-start
+      // PR): both recorded reds PREDATE the recovery landing — the
+      // "dies terminally" mechanism is exactly the b04 death that
+      // recovery closes (verification-coverage.md OW45's
+      // CATCH-UP-AND-START block), so this entry's lift condition is
+      // now concretely testable; it lifts on its own gate evidence at
+      // the merged head, never by inference from the default-app gate.
+      // THAT GATE RAN 2026-08-24 — 10 runs at merged head f14e44830
+      // (ON binary sha256 ce65782063f4f14a1…, fresh store + posture
+      // probe per run, ensure-off, 5 quiet / 5 loaded interleaved):
+      // 7/10, NO LIFT, and the b04 class above is CLOSED on this
+      // file's own evidence (catchup activations in 10/10 runs,
+      // deferred-start-catchup-failed 0, terminal "Error committing
+      // deferred …" 0, pattern-load-error 0 — the "dies terminally"
+      // mechanism did not reproduce once). The three reds are ONE
+      // shape and a THIRD residue member, on the WRITE side: the
+      // GUEST browser's mid-session profile piece never lands its
+      // ~98-101-op program-materialization commit, so its space holds
+      // exactly 4 commits (byte-identical across all three reds), no
+      // patternIdentity anywhere, and appears in ZERO toolshed log
+      // lines — greens reach 14-21 commits with patternIdentity named
+      // 57-216 times. That campaign deliberately left refused vs
+      // dropped vs never issued undetermined. PR #6378 later pinned the
+      // mechanism: the authoritative server attempt was dropped on its
+      // `RetryImmediately` name-resolution signal before it could issue
+      // the transaction. Flagged there, not here: S-B's barrier
+      // cannot cover a write that is never in flight, and the S-C
+      // skip ruling's premise (waitForRuntimeIdle before any reload)
+      // does not reach a surface with no reload. Recorded so nobody
+      // re-derives them: piece-start-commit-failed is NOT the
+      // discriminator (13 occurrences, green runs included) and
+      // OW46's structure-load-stuck is blind here (fires in both
+      // arms, names only the host's space). Full evidence in
+      // verification-coverage.md OW45's LUNCH-POLL FILE ENTRY'S OWN
+      // GATE block.
+      file: "integration/lunch-poll-vote.test.ts",
+      phase: "phase-7",
+      reason: "OW45 arm B. The charge is now the ROW'S OWN ROOT " +
+        "MECHANISM, observed SERVER-SIDE in CI for the first time. " +
+        "Phase-3 re-baseline 2026-08-27 at main 1fc841b6e (ON binary " +
+        "sha256 a93047a461c0c4d8 re-verified per run, fresh store + own " +
+        "97xx port + ON posture probe per run, ensure defaulting ON, " +
+        "toolshed self-sourced, LLM masked): 8/8 GREEN in 16-18s, the " +
+        "owner-directed approximately-eight-run pin MET locally, with " +
+        "pattern-load-error, deferred-start-catchup, session-remount, " +
+        "piece-start-commit-failed(server), load-park and " +
+        "handlerNotRunDeferrals all ZERO. The DIRECT CI UNSKIP PROBE (run " +
+        "33138358110, ON shard 7, job 98743591583, head 95f313835) went " +
+        "RED at the SAME stage and signature as the 2026-08-26 probe: " +
+        "lunch-poll-vote.test.ts:271, the HOST's " +
+        "clickCfButton(#lp-join-button), " +
+        "'Timed out waiting for #lp-join-button to render. Last probe: " +
+        "{\"#lp-join-button\": []}', waitForCondition's unchanged " +
+        "300000ms bound, 5m5s; the body read '0 joined' and 'Unknown " +
+        "profile #MjhprA'. WHAT IS NEW: CI now publishes the toolshed log " +
+        "as a job artifact, closing the 2026-08-26 disposition's stated " +
+        "blind spot. In the file's window that log carries EIGHTY " +
+        "structure-load-stuck WARNs on the profile space " +
+        "did:key:z6MktpA5, the first naming demanded root " +
+        "of:fid1:32Pic3-REdd7zmJ8gPchJyFD0LECk0u-QrFUXMjhprA as " +
+        "pattern-unloadable after 8 consecutive deferred cycles — 'a " +
+        "forever-park ... the home-profile program-write-loss shape' — " +
+        "and that root's suffix IS the #MjhprA the placeholder rendered. " +
+        "Upstream sit TWENTY seal-space-commit-failed / " +
+        "foreign-write-refused pairs: applyInitialName and a __cfLift_1 " +
+        "action running in the HOME wave did:key:z6Mkv7Tjz refused a " +
+        "write to the profile space for want of the section 2b delegated " +
+        "carriage. CRUCIAL DISCRIMINATOR, so nobody chases the refusal: " +
+        "the refusal is NOT it. All eight local GREENS carry 80 " +
+        "foreign-write-refused and 40 seal-space-commit-failed each, with " +
+        "structureLoadStuck 0, structureLoadRearmed 7-10 and " +
+        "structureLoadTerminal 190-199. The PARK is the discriminator — " +
+        "locally the profile space's structure load always resolves, in " +
+        "CI it never does. Excluded from the CI window, all zero: " +
+        "pattern-load-error, pattern-swap-setup-error, " +
+        "deferred-start-catchup, session-remount, " +
+        "piece-start-commit-failed, sidecar-run-raced, handler-not-run, " +
+        "arrival-barrier, 'memory session revoked', sync-load-failure, " +
+        "Event deferred and Event dropped. So this is NOT the b04 " +
+        "client-start class (closed 2026-08-24), NOT the a04 " +
+        "mark/effects family (#6459), NOT the #6312 sidecar clobber, NOT " +
+        "the fifth-face load-park member, and NOT #6378's " +
+        "name-resolution drop — those were the entry's prior charges and " +
+        "each is now excluded by observation rather than by absence. The " +
+        "OFF lane's shard 7 PASSED on the same run, so the red is " +
+        "ON-specific. Local 8/8 against CI 1/1 red, for the second " +
+        "campaign running: this file's lift needs the PARK explained, " +
+        "not another local count. This FILE entry remains explicit until " +
+        "the phase-7 coordinator lifts it.",
+    },
+    // The sqlite identity pair's two FILE entries were LIFTED (OW53
+    // CLOSED, 2026-08-22): the sqlite builtins consumed the RUNTIME's
+    // ambient identity — the SERVICE, on a serving runtime — where the
+    // ruled model carries the RUN's acting principal (serving-loop.md
+    // §3c; protocol.md §1). The db-owner mint, the cleared-read hash
+    // keying, and the effect flush's reader and writeback identity now
+    // consume the run-carried principal (client/OFF byte-identical), so
+    // `sqlite-db-owner-multi-runtime` and
+    // `sqlite-read-clearance-multi-runtime` both green under the true ON
+    // topology (fresh-store gate 5/5 each; verification-coverage.md OW53
+    // carries the traces and the lift evidence).
+  ],
   // pattern-and-data-persistence LIFTED (the arrival-witness predicate,
   // RULED 2026-08-22 — candidate (B) of the OW33 fork memo, built with
   // red-first pins for both observed arms): the entry's root cause was

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -191,158 +191,26 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
   // barrier — the exact former 2/10 red mechanism, no longer failing.
   // The product smell the flake used to witness stays tracked as
   // verification-coverage.md OW60, not as a flaky test.
-  patterns: [
-    {
-      // The charge was root-caused 2026-08-27 (register OW45;
-      // docs/history/plans/server-execution-v2/optimize/
-      // keyless-diagnosis-2026-08-27.md) and split in two. The
-      // NAVIGATION half — the client's speculative final-"Create" run
-      // reading a stale usedCreateAnotherNote and optimistically
-      // navigating into the new note while the authoritative run computed
-      // no intent — is SANCTIONED (L2 ruled PUNT) and absorbed: the
-      // step's waits and assertions now read the notebook by its captured
-      // id, indifferent to where the view wandered. What KEEPS this entry
-      // is the residue member the same campaign classified in a04: the
-      // WRITE-side mark-without-effects family, which no test-side
-      // robustness can absorb. The entry lifts on the established 10/10
-      // quiet-and-loaded gate under the current source-authority posture;
-      // the flip PR needs this list empty.
-      file: "integration/default-app.test.ts",
-      step: "should persist and reload every rapidly created notebook note",
-      phase: "phase-7",
-      reason: "Direct CI ON unskip probe at head 66a969ca0, run " +
-        "33008274232, shard 5: the log proved this exact step ran with " +
-        "no listed skip, then it failed after 5m22s at waitForCondition's " +
-        "unchanged 300000ms bound. Final client diagnostics reported " +
-        "eventInvocationCount=7 and notebookInvocationCount=7, but " +
-        "isNotebook=false, notesLength=0, notebookActionCount=0, 84 " +
-        "stored UI note chips, and zero rendered note chips. The run had " +
-        "zero pattern-swap-setup-error, recursive-schema errors, and " +
-        "pattern-load-error, so this is distinct from the split-source " +
-        "off-repository launcher failure root-caused by the OW45 RCA. " +
-        "ROOT-CAUSED 2026-08-27 (keyless-diagnosis-2026-08-27.md; " +
-        "register OW45): that fingerprint is the wrong-branch optimistic " +
-        "navigation — sanctioned under the L2 ruled PUNT and absorbed by " +
-        "the step's id-bound reads — so the residue keeping this entry " +
-        "is the a04 member: the WRITE-side mark-without-effects family " +
-        "(all create events durably appended and marked consequenced, " +
-        "but the final consequences are 1-op derived commits carrying " +
-        "none of the effects — user actions permanently lost, no basis " +
-        "rows to re-run; the section 3d mark-vs-effects atomicity " +
-        "question is the owner's). Lifts on 10/10 quiet-and-loaded ON " +
-        "under the current source-authority posture.",
-    },
-    {
-      // Re-listed by the lunch-poll identity PR (#5744). This file was
-      // LIFTED 2026-08-19 for the swatch-stall class (stage-C W3.1 —
-      // history in the header comment above); the profile-first join
-      // that PR introduces newly exposes the arm-B family's REMAINING
-      // member (the entry above): the test now creates the viewer's
-      // profile piece mid-test, and the flag-ON client's deferred start
-      // of that fresh piece dies terminally on the first-hydration
-      // stale-confirmed-read ConflictError, killing the client's piece
-      // context for the session — so the wish `#profile` never
-      // resolves and the join card never renders `#lp-join-button`.
-      // Both the 2026-08-22 red (run 32539777265, shards 7 and 9 —
-      // shard 9's cfc-staged-publish red is the same class's per-run
-      // lottery) and the 2026-08-24 red (run 32769542550) carry the
-      // deferred-start tx-commit-error signature; the OFF lane runs
-      // this file green. Every later step depends on that join, hence
-      // a FILE entry rather than a step guard. Same class, same fork
-      // memo as the entry above. MERGE NOTE (the catch-up-and-start
-      // PR): both recorded reds PREDATE the recovery landing — the
-      // "dies terminally" mechanism is exactly the b04 death that
-      // recovery closes (verification-coverage.md OW45's
-      // CATCH-UP-AND-START block), so this entry's lift condition is
-      // now concretely testable; it lifts on its own gate evidence at
-      // the merged head, never by inference from the default-app gate.
-      // THAT GATE RAN 2026-08-24 — 10 runs at merged head f14e44830
-      // (ON binary sha256 ce65782063f4f14a1…, fresh store + posture
-      // probe per run, ensure-off, 5 quiet / 5 loaded interleaved):
-      // 7/10, NO LIFT, and the b04 class above is CLOSED on this
-      // file's own evidence (catchup activations in 10/10 runs,
-      // deferred-start-catchup-failed 0, terminal "Error committing
-      // deferred …" 0, pattern-load-error 0 — the "dies terminally"
-      // mechanism did not reproduce once). The three reds are ONE
-      // shape and a THIRD residue member, on the WRITE side: the
-      // GUEST browser's mid-session profile piece never lands its
-      // ~98-101-op program-materialization commit, so its space holds
-      // exactly 4 commits (byte-identical across all three reds), no
-      // patternIdentity anywhere, and appears in ZERO toolshed log
-      // lines — greens reach 14-21 commits with patternIdentity named
-      // 57-216 times. That campaign deliberately left refused vs
-      // dropped vs never issued undetermined. PR #6378 later pinned the
-      // mechanism: the authoritative server attempt was dropped on its
-      // `RetryImmediately` name-resolution signal before it could issue
-      // the transaction. Flagged there, not here: S-B's barrier
-      // cannot cover a write that is never in flight, and the S-C
-      // skip ruling's premise (waitForRuntimeIdle before any reload)
-      // does not reach a surface with no reload. Recorded so nobody
-      // re-derives them: piece-start-commit-failed is NOT the
-      // discriminator (13 occurrences, green runs included) and
-      // OW46's structure-load-stuck is blind here (fires in both
-      // arms, names only the host's space). Full evidence in
-      // verification-coverage.md OW45's LUNCH-POLL FILE ENTRY'S OWN
-      // GATE block.
-      file: "integration/lunch-poll-vote.test.ts",
-      phase: "phase-7",
-      reason: "OW45 arm B, charge NARROWED 2026-08-24 by this entry's " +
-        "OWN 10-run gate at merged head f14e44830 — 7/10 green, no " +
-        "lift (verification-coverage.md OW45's LUNCH-POLL FILE " +
-        "ENTRY'S OWN GATE block). The b04 client-start class this " +
-        "entry was minted for (fork memo: " +
-        "optimize/ow45-armb-client-start-fork.md) is CLOSED at that " +
-        "head: catch-up activations in 10/10 runs, zero terminal " +
-        "deferred-start deaths, zero recovery failures, zero " +
-        "pattern-load-error. The entry's THIRD, WRITE-SIDE residue " +
-        "member is RESOLVED by PR #6378: the authoritative server " +
-        "attempt reached ProfileHome.inSpace() before the anonymous " +
-        "target name was cached, then retries: false dropped its " +
-        "RetryImmediately signal. The ~98-101-op " +
-        "program-materialization transaction was therefore never " +
-        "issued; this was neither a refusal nor loss of a required " +
-        "client wire send. The 2026-08-26 owner ruling makes the " +
-        "server transaction authoritative under ON. Current-main " +
-        "evidence moved from 2/8 target-member reds to 0/8 after the " +
-        "scheduler retained the served carriage across the " +
-        "name-resolution requeue. The prior 10/10 lift bar is " +
-        "superseded by that owner-directed approximately eight-run " +
-        "pin. THAT RE-BASELINE RAN 2026-08-27 AND PASSED LOCALLY, AND " +
-        "THE DIRECT CI UNSKIP PROBE ON THE SAME BRANCH FAILED: 8/8 " +
-        "green at main 4b70949ac on the ON binary at the current lane " +
-        "posture (ensure ON, toolshed self-sourced), with the " +
-        "member's own store discriminator negative in every run — but " +
-        "the un-skipped file went RED in ON shard 7 of run " +
-        "33085668531 (job 98564797510, head 0cebb3621), at " +
-        "lunch-poll-vote.test.ts:271 on the HOST's " +
-        "clickCfButton(#lp-join-button), 300000ms, 5m10s. That is an " +
-        "EARLIER stage than every red this entry records: the " +
-        "2026-08-24 gate's three reds were the GUEST's join at line " +
-        "306, and its finding was that the host always joins. The CI " +
-        "window is silent — zero pattern-load-error, " +
-        "pattern-swap-setup-error, sidecar-run-raced, " +
-        "deferred-start-catchup, session-remount and " +
-        "piece-start-commit-failed between the file's start and its " +
-        "failure — and CI does not publish the toolshed log, so the " +
-        "server-side members cannot be excluded from that artifact. " +
-        "The OFF lane's shard 7 PASSED on that same run, so the red " +
-        "is ON-specific rather than a general flake in this file. " +
-        "Local 0/8 against CI 1/1 is itself the observation. This " +
-        "FILE entry remains explicit until the phase-7 coordinator " +
-        "lifts it.",
-    },
-    // The sqlite identity pair's two FILE entries were LIFTED (OW53
-    // CLOSED, 2026-08-22): the sqlite builtins consumed the RUNTIME's
-    // ambient identity — the SERVICE, on a serving runtime — where the
-    // ruled model carries the RUN's acting principal (serving-loop.md
-    // §3c; protocol.md §1). The db-owner mint, the cleared-read hash
-    // keying, and the effect flush's reader and writeback identity now
-    // consume the run-carried principal (client/OFF byte-identical), so
-    // `sqlite-db-owner-multi-runtime` and
-    // `sqlite-read-clearance-multi-runtime` both green under the true ON
-    // topology (fresh-store gate 5/5 each; verification-coverage.md OW53
-    // carries the traces and the lift evidence).
-  ],
+  // BOTH remaining phase-7 entries LIFTED 2026-08-27 (this PR), under the
+  // owner-ruled bar — local campaign AND a green direct-CI unskip probe
+  // (verification-coverage.md OW45; RULED 2026-08-27, owner: "agreed").
+  //
+  //  * default-app's rapid-note reload STEP: 10/10 quiet-and-loaded, the
+  //    entry's own bar. Its charge had two halves and both are fixed —
+  //    the NAVIGATION half by #6448 (the step's id-bound reads absorb the
+  //    L2-sanctioned optimistic navigation) and the a04 WRITE-side residue
+  //    by #6459 (mark/effects atomicity: a dispatch-side skip can no longer
+  //    seal a mark with none of its effects).
+  //  * lunch-poll-vote's FILE entry: 8/8, the owner-directed
+  //    approximately-eight-run re-baseline that superseded this file's
+  //    earlier 10/10. Its third, write-side residue member — the guest's
+  //    program-materialization transaction never issued because the
+  //    authoritative attempt dropped its RetryImmediately name-resolution
+  //    signal — is fixed by #6378; the b04 client-start class it was minted
+  //    for closed on its own 2026-08-24 evidence.
+  //
+  // The list is now EMPTY in every suite, which is the flip PR's bar.
+  patterns: [],
   // pattern-and-data-persistence LIFTED (the arrival-witness predicate,
   // RULED 2026-08-22 — candidate (B) of the OW33 fork memo, built with
   // red-first pins for both observed arms): the entry's root cause was


### PR DESCRIPTION
## Why

Phase 3 of the server-execution v2 endgame: land the owner-ruled lift bar,
then campaign both remaining ON-skip entries under it. **Neither lifted —
and they now fail for opposite reasons, one of which is a question for the
coordinator rather than a defect.**

### The bar (RULED 2026-08-27, owner: "agreed")

The register had already reached this on evidence and correctly left it
open: after the lunch-poll entry went 8/8 locally and then RED on its
direct CI unskip probe, the disposition recorded that "the lift bar for
this file should require a green DIRECT CI unskip probe, not a local count
alone. That is a bar change, so it is the owner's call, flagged not
taken." Ruled, and it binds every entry. The rule is not ceremony: both
entries carry a member only a lane observation has ever caught (local 0/12
vs CI 2/2 red; local 0/8 vs CI 1/1 red).

### What the probe established

Base main `1fc841b6e`, one ON binary (sha256 `a93047a461c0c4d8…`,
re-verified per run), fresh store + own 97xx port + ON posture probe per
run, ensure defaulting ON, toolshed self-sourced, LLM masked, PID-only
teardown, `gtimeout 600` never approached, quiet/loaded interleaved. Probe
head `95f313835`, CI run
[33138358110](https://github.com/commontoolsinc/labs/actions/runs/33138358110):
8 of 10 ON pattern shards green; red on exactly the two shards carrying the
two probed files.

**default-app's reload STEP — 10/10 local, and the CI probe of the step was
GREEN.** `ok (18s)`, the whole `default-app flow test` green, the shard's
published toolshed log clean across the file's window (4 `event-view-lag`,
nothing else). The entry's charge did not reproduce in either arm: no
66a969ca0 fingerprint, no a04 mark-without-effects shape (#6459), no
keyless `pattern-load-error` (#6451). What holds it is the LANE — shard 5
red on a co-resident file, `cfc-group-chat-demo.test.ts:133`, not
skip-listed, untouched by the probe diff, and **4/6 red locally at the same
head running alone** with the identical signature.

> **Open question, for the coordinator/owner — flagged, not filled:** does
> "the probed lane GREEN" mean the probed SURFACE green, or every test in
> the shard green? The bar was ruled hours before its first use and the
> distinguishing case arrived immediately. Under the surface reading this
> entry lifts today. This PR takes the conservative reading and withdraws.

**lunch-poll-vote's FILE entry — 8/8 local, probe RED at the probed
surface.** `lunch-poll-vote.test.ts:271`, the HOST's `#lp-join-button`,
300000 ms, 5m5s — the same stage and signature as the 2026-08-26 probe; the
OFF lane's shard 7 passed on the same run. **What is new: CI now publishes
the toolshed log as a job artifact**, closing the 2026-08-26 disposition's
stated blind spot. It shows the OW45 row's original mechanism end to end —
80 `structure-load-stuck` WARNs on the profile space, the first naming a
`pattern-unloadable` root whose id suffix IS the `#MjhprA` the placeholder
rendered, behind 20 `seal-space-commit-failed`/`foreign-write-refused`
pairs. **The refusal is not the discriminator** — every local GREEN carries
80 refusals and 40 seal failures, more than the CI red, with
`structureLoadStuck` 0. **The park is.** Five prior charges are now
excluded by observation rather than by absence of it.

## What Changed

1. `verification-coverage.md`: the ruled bar text, with the probe defined
   and the red-probe protocol (withdraw, capture, classify, no
   rerun-looping).
2. The probe commit: both entries and the default-app in-file guard
   removed, the validator test rebound, plus a coarse "THE FLIP'S B1 BAR"
   pin. Kept in history as the probe's provenance; reverted by (3).
3. The withdrawal: entries restored byte-identical, both `reason` strings
   rewritten to the charge each now carries (with the negatives that stop
   the next seat re-deriving them), the validator test rebound to the new
   charges, and the register + plan doc updated.

Also recorded, not owed here: `cfc-group-chat-demo.test.ts` fails ON at
current main 4/6 and is not skip-listed — a flip blocker in its own right,
since the flip's bar is a green ON lane and not merely an empty skip list.

## Test plan

- `deno test tasks/server-execution-on-skips.test.ts` — 17/17 green.
- Mutation kill watched on the probe commit's pins: re-adding one entry
  reddens three, the B1 bar among them.
- Ledgers: 10/10 and 8/8, per-run posture probe and binary-sha
  re-verification; probe board 33138358110, classified from the job logs
  and the published toolshed artifacts.
- `packages/patterns/integration/default-app.test.ts` ends this PR
  byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)