### PR TITLE
CT-2077: a CFC refusal names the offending input, and an agent can replan against it

### DIFF
--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -764,7 +764,9 @@ bounded window, then surfaces a terminal CommitConvergenceError),
 *terminal* (a deterministic commit-rule refusal — the server's commit-time
 evaluation or the client's CFC boundary refusing the committed data itself —
 never retried, surfaced; a terminal reactive-commit rejection reaches the
-scheduler's error channel carrying the refusal),
+scheduler's error channel carrying the refusal, both its reason texts and the
+structured refusal details their producers recorded, so a consumer can name
+the offending input rather than only the offending label — see §10),
 *non-retryable* (every other non-permanent rejection — deterministic with
 respect to confirmed state, drops on the first attempt), and
 *permanent* (a commit-time precondition failed — drop, never retry).
@@ -1123,6 +1125,22 @@ What remains live here:
   gating (unchanged).
 - The implementation-identity stamping on run transactions
   (`setCfcImplementationIdentity`) is runner-level and unchanged.
+- **Refusal surfacing.** A CFC prepare refusal carries two channels. The
+  *reasons* are prose, one per rule that refused. The *refusal details*
+  (`cfc/refusal-detail.ts`) are the structured form: the boundary that
+  refused, the label atoms outside it, the reads that carried each one, and
+  whether those reads account for every offending atom. A consumer reads the
+  details to state a remedy — dropping the named inputs — which the reasons
+  alone cannot support. Details are recorded by the gates that can describe
+  themselves; a refusal whose producers recorded none carries an empty list
+  and its reasons still stand.
+- **`cfc.prepare-reject` telemetry.** Only a refusal every one of whose
+  reasons is a verdict is terminal, so only that one reaches the error
+  channel; a refusal mixing a verdict with an input prepare could not
+  evaluate is retried, and upstream it looks like a graph that stopped
+  converging. The marker fires on every refusal, terminal or not, carrying
+  the reasons, the details, and which arm the commit boundary took. It
+  reports and decides nothing.
 
 ---
 

--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -198,7 +198,11 @@ storage saw them — and did so on EVERY recorded reason. A refusal is terminal
 only when every reason is a verdict; a reason is a verdict only when its
 producer tags it as one (`cfc/verdict-reason.ts`), so anything untagged — an
 unavailable input, a failed resolution, a prepared state a caller disturbed —
-stays retryable), a
+stays retryable. It carries both channels: `reasons`, the prose one per rule
+that refused, and `refusals`, the structured descriptions
+(`cfc/refusal-detail.ts`) naming the boundary, the offending label atoms, and
+the reads that carried them — which is what lets a consumer state a remedy
+rather than only a verdict), a
 `StoreError`, or the generic `TransactionError`. Those
 are deterministic with respect to the committed data: a re-run recomputes the
 identical refused write, and each doomed attempt costs a server round-trip plus

--- a/packages/cf-harness/src/fabric-observations.ts
+++ b/packages/cf-harness/src/fabric-observations.ts
@@ -20,6 +20,7 @@
 
 import type { Runtime } from "@commonfabric/runner";
 import { RuntimeTelemetryEvent } from "@commonfabric/runner";
+import type { CfcRefusalDetail } from "@commonfabric/runner/cfc";
 import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 
 export interface FabricActionErrorRecord {
@@ -31,6 +32,14 @@ export interface FabricActionErrorRecord {
    * (`CfcCommitRefusalError`) from a thrown computation (`Error`). */
   name: string;
   message: string;
+
+  /**
+   * The structured refusals behind a `CfcCommitRefusalError`, as the commit
+   * boundary minted them: which gate refused, the atoms outside it, and the
+   * reads that carried them. Absent for every other error, and for a refusal
+   * the boundary described only in prose.
+   */
+  refusals?: readonly CfcRefusalDetail[];
 }
 
 export interface FabricDeferredActionRecord {
@@ -114,12 +123,15 @@ export const fabricRuntimeObservations = (
     if (pieceHash === undefined) {
       return;
     }
+    const refusals =
+      (error as { refusals?: readonly CfcRefusalDetail[] }).refusals;
     push(errors, {
       sequence: ++sequence,
       pieceId: pieceHash,
       patternId: typeof error.patternId === "string" ? error.patternId : "",
       name: error.name,
       message: error.message,
+      ...(Array.isArray(refusals) ? { refusals } : {}),
     });
   });
   runtime.telemetry.addEventListener("telemetry", (event) => {

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -7,6 +7,10 @@ import {
   type RuntimeProgram,
 } from "@commonfabric/runner";
 import {
+  type CfcAddress,
+  type CfcRefusalAttribution,
+  type CfcRefusalDetail,
+  type CfcRefusalGate,
   selectReferencedCfcSchemaDefs,
   validateAgainstSchema,
 } from "@commonfabric/runner/cfc";
@@ -116,6 +120,67 @@ export interface RunPatternToolSuccessOutput {
   rawValue?: unknown;
 }
 
+/**
+ * What the commit boundary refused, in terms the caller can act on: the
+ * boundary that refused, the label atoms outside it, and the keys of this
+ * call's own `inputs` that carried those atoms in. When `attribution` is
+ * `complete`, a run without those keys meets the boundary.
+ *
+ * Everything here reaches the model as it stands — the model-facing
+ * rendering strips `rawValue`, `rawCauseMessage`, `pieceId` and
+ * `resultRefSchema` and scrubs the free-text fields, and a structured field
+ * passes through untouched. So nothing here is a document id, a space, or a
+ * path into a document: an offending read that no input key accounts for is
+ * counted rather than named.
+ */
+export interface RunPatternPolicyRefusal {
+  /**
+   * The rules that refused, deduplicated. `sink-ceiling` is an egress whose
+   * confidentiality ceiling the flow exceeded; `writer-fit` is a write whose
+   * target does not admit what the write carries.
+   */
+  gates: readonly CfcRefusalGate[];
+
+  /**
+   * The sinks whose ceilings refused, deduplicated. Empty when what refused
+   * was a write rather than an egress.
+   */
+  sinks: readonly string[];
+
+  /**
+   * The label atoms outside what the boundary admits, rendered as the
+   * boundary renders them.
+   */
+  offendingAtoms: readonly string[];
+
+  /**
+   * Offending atoms left out of `offendingAtoms`. A structured atom can
+   * carry the principal that introduced it, and there is no seam that
+   * redacts a rendered atom, so it is counted rather than named.
+   */
+  withheldAtomCount?: number;
+
+  /**
+   * The keys of this call's own `inputs` whose values carried the offending
+   * atoms in — the inputs to drop and retry without.
+   */
+  inputKeys: readonly string[];
+
+  /**
+   * Offending reads that no key of this call's `inputs` accounts for,
+   * counted by document.
+   */
+  unattributedInputCount?: number;
+
+  /**
+   * Whether `inputKeys` is the whole remedy. `complete` — every offending
+   * atom came in through them, so a run without them proceeds. `partial` —
+   * dropping them narrows the flow without necessarily clearing it. `none` —
+   * nothing was attributed to an input of this call.
+   */
+  attribution: CfcRefusalAttribution;
+}
+
 export interface RunPatternToolErrorOutput {
   outputId: string;
   status: "compile-error" | "error" | "cancelled";
@@ -134,6 +199,12 @@ export interface RunPatternToolErrorOutput {
    * over data the model cannot read may carry that data in its thrown text.
    */
   rawCauseMessage?: string;
+
+  /**
+   * What the commit boundary refused and which of this call's own inputs
+   * carried it, when a policy refusal is what stopped the run.
+   */
+  policyRefusal?: RunPatternPolicyRefusal;
 }
 
 export type RunPatternToolOutput =
@@ -231,6 +302,32 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
         message: { type: "string" },
         pieceId: { type: "string" },
         rawCauseMessage: { type: "string" },
+        policyRefusal: {
+          type: "object",
+          properties: {
+            gates: {
+              type: "array",
+              items: { type: "string", enum: ["sink-ceiling", "writer-fit"] },
+            },
+            sinks: { type: "array", items: { type: "string" } },
+            offendingAtoms: { type: "array", items: { type: "string" } },
+            withheldAtomCount: { type: "integer", minimum: 0 },
+            inputKeys: { type: "array", items: { type: "string" } },
+            unattributedInputCount: { type: "integer", minimum: 0 },
+            attribution: {
+              type: "string",
+              enum: ["complete", "partial", "none"],
+            },
+          },
+          required: [
+            "gates",
+            "sinks",
+            "offendingAtoms",
+            "inputKeys",
+            "attribution",
+          ],
+          additionalProperties: false,
+        },
       },
       required: ["outputId", "status", "message"],
       additionalProperties: false,
@@ -336,6 +433,204 @@ const RUN_PATTERN_SOURCE_MAIN = "/main.tsx";
 /** What a call naming neither a source nor a published pattern is told. */
 const RUN_PATTERN_NO_PROGRAM_MESSAGE =
   "run_pattern requires sourceText or patternId";
+
+/**
+ * What a refusal message says about the raw reason, which stays in the
+ * artifact for the same cause the thrown text does: it names the labels and
+ * the documents the flow touched.
+ */
+const RUN_PATTERN_REFUSAL_ARTIFACT_NOTE =
+  "The refusal reason is retained in the run artifact and withheld here, " +
+  "since it names the labels and documents involved";
+
+/** What a refusal the commit boundary described only in prose is told. */
+const RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE =
+  "the pattern ran but the space's policy refused to commit its result: " +
+  "flow enforcement rejected the write at the commit boundary, so the " +
+  `result never landed. ${RUN_PATTERN_REFUSAL_ARTIFACT_NOTE}`;
+
+/**
+ * Where an agent-supplied input landed. A refusal names the reads that
+ * carried the offending labels; turning one back into something the caller
+ * can act on means finding the key whose value that read belongs to, and the
+ * key is the only part of the answer the caller may be told.
+ */
+interface RunPatternInputAddress {
+  readonly key: string;
+
+  /**
+   * The document the caller's link resolved to, through the canonical entity
+   * seam, so a read spelled differently by another seam still compares.
+   */
+  readonly hash: string;
+
+  readonly path: readonly string[];
+}
+
+const pathStartsWith = (
+  path: readonly string[],
+  prefix: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) => segment === path[index]);
+
+/**
+ * The key of `inputs` a refused read belongs to, or `undefined` when none
+ * does.
+ *
+ * A read reaches an input two ways. It reads the document the caller's link
+ * addressed, which the retained addresses match. Or it reads the piece's
+ * argument document, where every input — link or plain JSON — sits under its
+ * own key, so the first path segment is the key. Both are matched, because
+ * one refusal commonly reports the same input through both.
+ */
+const refusalReadInputKey = (
+  read: CfcAddress,
+  addresses: readonly RunPatternInputAddress[],
+  argumentHash: string | undefined,
+  suppliedKeys: readonly string[],
+): string | undefined => {
+  const readHash = comparableEntityHash(read.id);
+  if (readHash === undefined) {
+    return undefined;
+  }
+  for (const address of addresses) {
+    if (address.hash === readHash && pathStartsWith(read.path, address.path)) {
+      return address.key;
+    }
+  }
+  if (argumentHash !== undefined && readHash === argumentHash) {
+    const first = read.path[0];
+    if (first !== undefined && suppliedKeys.includes(first)) {
+      return first;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Whether a rendered label atom may be named to the model.
+ *
+ * A scalar atom — `"medical"`, `3`, `true` — is the word the data was tagged
+ * with, and naming it is the whole point of the report. A structured atom is
+ * a CFC atom object, and a `Caveat` among them carries the principal that
+ * introduced it; `redactCaveatSourcesForDisplay` strips that principal from a
+ * whole label view, and there is no seam that strips it from an atom already
+ * rendered to a string. So a structured atom is counted rather than named.
+ */
+const namableRefusalAtom = (rendered: string): boolean => {
+  try {
+    const parsed: unknown = JSON.parse(rendered);
+    return parsed === null || typeof parsed !== "object";
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Fold the boundary's refusal details into the one report the caller reads,
+ * resolving each offending read to a key of this call's `inputs`.
+ *
+ * `attribution` is the harness's own question, stricter than the boundary's:
+ * the boundary asks whether every offending atom reached a named READ, and
+ * this asks whether every such read is an input the caller can drop. A read
+ * the caller does not own leaves the answer at `partial` even when the
+ * boundary called its own attribution complete, because dropping inputs
+ * cannot reach it.
+ */
+export const runPatternPolicyRefusal = (
+  refusals: readonly CfcRefusalDetail[],
+  inputKeyFor: (read: CfcAddress) => string | undefined,
+): RunPatternPolicyRefusal | undefined => {
+  if (refusals.length === 0) {
+    return undefined;
+  }
+  const gates: CfcRefusalGate[] = [];
+  const sinks: string[] = [];
+  const offendingAtoms: string[] = [];
+  const inputKeys: string[] = [];
+  const seenAtoms = new Set<string>();
+  const unattributed = new Set<string>();
+  let withheldAtomCount = 0;
+  let everyDetailComplete = true;
+  for (const detail of refusals) {
+    if (!gates.includes(detail.gate)) gates.push(detail.gate);
+    if (detail.sink !== undefined && !sinks.includes(detail.sink)) {
+      sinks.push(detail.sink);
+    }
+    if (detail.attribution !== "complete") everyDetailComplete = false;
+    for (const atom of detail.offendingAtoms) {
+      if (seenAtoms.has(atom)) continue;
+      seenAtoms.add(atom);
+      if (namableRefusalAtom(atom)) offendingAtoms.push(atom);
+      else withheldAtomCount += 1;
+    }
+    for (const input of detail.inputs) {
+      const key = inputKeyFor(input.read);
+      if (key === undefined) {
+        // Counted by document, so one document read at three paths is one
+        // input the caller cannot name rather than three.
+        unattributed.add(comparableEntityHash(input.read.id) ?? "");
+      } else if (!inputKeys.includes(key)) {
+        inputKeys.push(key);
+      }
+    }
+  }
+  const attribution: CfcRefusalAttribution = inputKeys.length === 0
+    ? "none"
+    : everyDetailComplete && unattributed.size === 0
+    ? "complete"
+    : "partial";
+  return {
+    gates,
+    sinks,
+    offendingAtoms,
+    ...(withheldAtomCount > 0 ? { withheldAtomCount } : {}),
+    inputKeys,
+    ...(unattributed.size > 0
+      ? { unattributedInputCount: unattributed.size }
+      : {}),
+    attribution,
+  };
+};
+
+const quoteAll = (values: readonly string[]): string =>
+  values.map((value) => `"${value}"`).join(", ");
+
+/**
+ * The refusal stated as an instruction: what refused, which of the caller's
+ * inputs carried what it refused, and whether dropping those inputs is the
+ * whole remedy or only narrows the flow.
+ */
+export const policyRefusalMessage = (
+  refusal: RunPatternPolicyRefusal,
+): string => {
+  const boundary = refusal.sinks.length > 0
+    ? `the sink${refusal.sinks.length > 1 ? "s" : ""} ${
+      quoteAll(refusal.sinks)
+    }`
+    : "the write it attempted";
+  const atoms = refusal.offendingAtoms.length > 0
+    ? ` (${refusal.offendingAtoms.join(", ")})`
+    : "";
+  const opening =
+    "the pattern ran but the space's policy refused to commit its result: " +
+    `${boundary} does not admit the confidentiality${atoms} this run ` +
+    "carries, so the result never landed";
+  const plural = refusal.inputKeys.length > 1;
+  const keys = `input${plural ? "s" : ""} ${quoteAll(refusal.inputKeys)}`;
+  const remedy = refusal.attribution === "complete"
+    ? `Every label refused here came in through ${keys}, so the same run ` +
+      `without ${plural ? "them" : "it"} proceeds`
+    : refusal.attribution === "partial"
+    ? `Some of what was refused came in through ${keys}; dropping ` +
+      `${plural ? "them" : "it"} narrows the flow without necessarily ` +
+      "clearing it, since reads this call does not own carry refused " +
+      "labels too"
+    : "No input of this call accounts for what was refused, so dropping an " +
+      "input will not clear it";
+  return `${opening}. ${remedy}. ${RUN_PATTERN_REFUSAL_ARTIFACT_NOTE}`;
+};
 
 /**
  * Replaces bare fabric identifiers in model-facing diagnostic text with a
@@ -578,9 +873,15 @@ export const runPatternTool: HarnessToolDefinition<
     let pieceInput: Record<string, unknown> | undefined;
     const liveCellInputs: Array<{ key: string; cell: Cell<unknown> }> = [];
     const plainInputs: Array<{ key: string; value: unknown }> = [];
+    // Where each input landed, kept for the one path that needs it: a policy
+    // refusal names the reads that carried the offending labels, and a read
+    // is only actionable once it is back to the key the caller passed.
+    const suppliedInputKeys: string[] = [];
+    const inputAddresses: RunPatternInputAddress[] = [];
     if (input.inputs !== undefined) {
       const converted: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(input.inputs)) {
+        suppliedInputKeys.push(key);
         const sealedPath = sealedOpaqueLinkPath(value, key);
         if (sealedPath !== undefined) {
           return errorOutput("error", sealedInputRefusal(key, sealedPath));
@@ -601,6 +902,10 @@ export const runPatternTool: HarnessToolDefinition<
                 "error",
                 `run_pattern input "${key}" reference targets another space; only references into the configured session space are allowed`,
               );
+            }
+            const linkHash = comparableEntityHash(link.id);
+            if (linkHash !== undefined) {
+              inputAddresses.push({ key, hash: linkHash, path: link.path });
             }
             const cell = pieces.runtime.getCellFromLink(link);
             liveCellInputs.push({ key, cell });
@@ -1003,13 +1308,40 @@ export const runPatternTool: HarnessToolDefinition<
       );
       if (refusal !== undefined) {
         recordOutcome("run_failed");
+        // The piece's argument document is where every input reaches the
+        // pattern under its own key, so a refused read of it names an input
+        // by its first path segment. Its address is resolved here rather
+        // than kept from creation because only a refusal asks for it, and an
+        // argument cell that will not resolve costs that second route to a
+        // key while the caller's own resolved addresses still answer.
+        let argumentHash: string | undefined;
+        try {
+          argumentHash = comparableEntityHash(
+            (await piece.input.getCell()).getAsNormalizedFullLink().id,
+          );
+        } catch {
+          argumentHash = undefined;
+        }
+        const policyRefusal = runPatternPolicyRefusal(
+          refusal.refusals ?? [],
+          (read) =>
+            refusalReadInputKey(
+              read,
+              inputAddresses,
+              argumentHash,
+              suppliedInputKeys,
+            ),
+        );
         return {
           ...errorOutput(
             "error",
-            `the pattern ran but the space's policy refused to commit its result: flow enforcement rejected the write at the commit boundary, so the result never landed. The refusal reason is retained in the run artifact and withheld here, since it names the labels and documents involved`,
+            policyRefusal === undefined
+              ? RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE
+              : policyRefusalMessage(policyRefusal),
           ),
           pieceId: piece.id,
           rawCauseMessage: refusal.message,
+          ...(policyRefusal !== undefined ? { policyRefusal } : {}),
         };
       }
       if (pieceErrors.length > 0) {

--- a/packages/cf-harness/test/fabric-observations.test.ts
+++ b/packages/cf-harness/test/fabric-observations.test.ts
@@ -7,6 +7,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { type Runtime, RuntimeTelemetry } from "@commonfabric/runner";
+import type { CfcRefusalDetail } from "@commonfabric/runner/cfc";
 import {
   comparableEntityHash,
   fabricRuntimeObservations,
@@ -15,8 +16,34 @@ import {
 type ErrorListener = (error: {
   pieceId?: string;
   patternId?: string;
+  name?: string;
   message: string;
+  refusals?: readonly CfcRefusalDetail[];
 }) => void;
+
+/** One writer-fit refusal, as the commit boundary mints it. */
+const WRITER_FIT_REFUSAL: CfcRefusalDetail = {
+  gate: "writer-fit",
+  target: {
+    space: "did:key:z6MkTest",
+    id: "of:fid1:target",
+    scope: "space",
+    path: [],
+  },
+  offendingAtoms: ['"secret"'],
+  inputs: [{
+    read: {
+      space: "did:key:z6MkTest",
+      id: "of:fid1:source",
+      scope: "space",
+      path: ["secret"],
+    },
+    labelPath: ["secret"],
+    atoms: ['"secret"'],
+  }],
+  attribution: "complete",
+  reason: 'writer-fit confidentiality misfit: "secret"',
+};
 
 // A stand-in carrying exactly the two surfaces the observer subscribes to.
 const stubRuntime = (): {
@@ -54,6 +81,30 @@ describe("fabric-observations", () => {
     expect(observations.errorsSince(start, "fid1:abc").map((e) => e.message))
       .toEqual(["boom"]);
     expect(observations.errorsSince(start, "fid1:other")).toEqual([]);
+  });
+
+  it("carries a commit refusal's structured refusals onto the record", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    emitError({
+      pieceId: "of:fid1:abc",
+      name: "CfcCommitRefusalError",
+      message: "CFC enforcement rejected commit",
+      refusals: [WRITER_FIT_REFUSAL],
+    });
+    expect(observations.errorsSince(start, "fid1:abc")[0]!.refusals)
+      .toEqual([WRITER_FIT_REFUSAL]);
+  });
+
+  it("leaves `refusals` absent on an error that carries none", () => {
+    const { runtime, emitError } = stubRuntime();
+    const observations = fabricRuntimeObservations(runtime);
+    const start = observations.sequence();
+    emitError({ pieceId: "of:fid1:abc", message: "boom" });
+    expect(observations.errorsSince(start, "fid1:abc")[0]!).not.toHaveProperty(
+      "refusals",
+    );
   });
 
   it("drops an error without a piece id rather than throwing in the handler", () => {

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -31,6 +31,7 @@ import {
   type RunPatternToolErrorOutput,
   type RunPatternToolInput,
   type RunPatternToolSuccessOutput,
+  scrubBareFabricIdentifiers,
 } from "../src/tools/run-pattern.ts";
 import type {
   SandboxCommandRequest,
@@ -244,6 +245,65 @@ async function createStrictFabric() {
       await storage.close();
     },
   };
+}
+
+/**
+ * A pattern over one plain input and one optional referenced input, where the
+ * referenced one only widens the answer. Run with the reference it derives
+ * from labelled data; run without it, it still computes a result — which is
+ * what makes dropping a refused input a replan rather than an abandonment.
+ */
+const OPTIONAL_SECRET_PATTERN_SOURCE = [
+  "import { computed, pattern, Reactive } from 'commonfabric';",
+  "interface Source { secret: string; }",
+  "interface Input { amount: number; source?: Reactive<Source>; }",
+  "interface Output { total: number; }",
+  "export default pattern<Input, Output>(({ amount, source }) => ({",
+  "  total: computed(() => {",
+  "    const secret = source?.secret;",
+  "    return amount + (typeof secret === 'string' ? secret.length : 0);",
+  "  }),",
+  "}));",
+  "",
+].join("\n");
+
+const TOTAL_RESULT_SCHEMA = {
+  type: "object",
+  properties: { total: { type: "number" } },
+  required: ["total"],
+} as const;
+
+/**
+ * Seeds a document whose `secret` field carries confidentiality, and answers
+ * the LLM-friendly link an agent would pass as an input naming it.
+ */
+async function seedLabelledSecret(
+  runtime: Runtime,
+  space: ReturnType<PiecesController["getSpace"]>,
+  cause: string,
+): Promise<string> {
+  const seed = runtime.edit();
+  const sourceCell = runtime.getCell(
+    space,
+    cause,
+    { type: "object", properties: { secret: { type: "string" } } },
+    seed,
+  );
+  const sourceId = sourceCell.getAsNormalizedFullLink().id;
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id: sourceId, path: [] }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{ path: ["secret"], label: { confidentiality: ["secret"] } }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+  return createLLMFriendlyLink(sourceCell.getAsNormalizedFullLink(), space);
 }
 
 function createStrictEngine(pieces: PiecesController): CfHarnessEngine {
@@ -851,6 +911,109 @@ describe("run-pattern", () => {
       } finally {
         await strictRuntime.dispose();
         await strictStorage.close();
+      }
+    });
+
+    it("names the input key that carried the refused label, in the message and in `policyRefusal`", async () => {
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "refusal-names-input",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("policy refused to commit");
+        expect(output.message).toContain('input "source"');
+        expect(output.message).toContain("without it proceeds");
+        expect(output.message).not.toContain('"amount"');
+        expect(output.policyRefusal).toEqual({
+          gates: ["writer-fit"],
+          sinks: [],
+          offendingAtoms: ['"secret"'],
+          inputKeys: ["source"],
+          attribution: "complete",
+        });
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("lands a result when the run is repeated without the input its refusal named", async () => {
+      // The replan an actionable refusal is for: the first run is refused
+      // and names one of its own input keys as the whole remedy, and the
+      // second run — the same pattern, that key dropped — commits.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "refusal-replan",
+        );
+        const engine = createStrictEngine(pieces);
+        const inputs: Record<string, unknown> = {
+          amount: 2,
+          source: sourceRef,
+        };
+        const refused = (await engine.invokeBuiltinTool("run_pattern", {
+          sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+          inputs,
+          resultSchema: TOTAL_RESULT_SCHEMA,
+        })).output as RunPatternToolErrorOutput;
+        expect(refused.status).toBe("error");
+        expect(refused.policyRefusal?.attribution).toBe("complete");
+        const named = refused.policyRefusal?.inputKeys ?? [];
+        expect(named).toEqual(["source"]);
+
+        // Drop exactly the keys the refusal named, changing nothing else.
+        const replanned: Record<string, unknown> = { ...inputs };
+        for (const key of named) delete replanned[key];
+        const retried = (await engine.invokeBuiltinTool("run_pattern", {
+          sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+          inputs: replanned,
+          resultSchema: TOTAL_RESULT_SCHEMA,
+        })).output as RunPatternToolSuccessOutput;
+        expect(retried.status).toBe("ok");
+        expect((retried.value as { total: number }).total).toBe(2);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("leaves `policyRefusal` unchanged under the bare-fabric-identifier scrub", async () => {
+      // `policyRefusal` reaches the model as it stands — the prompt loop
+      // scrubs `message` and `valueError` and nothing else — so it must
+      // already hold no document id, space, or path into a document.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "refusal-carries-no-identifier",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        const encoded = JSON.stringify(output.policyRefusal);
+        expect(scrubBareFabricIdentifiers(encoded)).toBe(encoded);
+        expect(encoded).not.toContain(space);
+      } finally {
+        await dispose();
       }
     });
 

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -27,12 +27,19 @@ import { resolveWellKnownGrantRefs } from "../src/well-known-grants.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import {
   asSerializableValue,
+  policyRefusalMessage,
   RUN_PATTERN_MAX_SOURCE_TEXT_BYTES,
+  runPatternPolicyRefusal,
   type RunPatternToolErrorOutput,
   type RunPatternToolInput,
   type RunPatternToolSuccessOutput,
   scrubBareFabricIdentifiers,
 } from "../src/tools/run-pattern.ts";
+import type {
+  CfcAddress,
+  CfcRefusalDetail,
+  CfcRefusalInput,
+} from "@commonfabric/runner/cfc";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -292,6 +299,123 @@ async function seedLabelledSecret(
   const sourceId = sourceCell.getAsNormalizedFullLink().id;
   writeSeedEnvelopeDoc(seed, space);
   seed.writeOrThrow({ space, scope: "space", id: sourceId, path: [] }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{ path: ["secret"], label: { confidentiality: ["secret"] } }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+  return createLLMFriendlyLink(sourceCell.getAsNormalizedFullLink(), space);
+}
+
+/**
+ * The session's pieces with the argument-document route to an input key taken
+ * away: once the piece is running, resolving its argument cell fails. That is
+ * the state a refusal report degrades under when the argument cell of a piece
+ * that ran will not resolve, and the caller's own resolved addresses are all
+ * that is left to answer with.
+ */
+function piecesWithUnresolvableArgument(
+  pieces: PiecesController,
+): PiecesController {
+  let running = false;
+  return new Proxy(pieces, {
+    get(target, property) {
+      if (property === "runPersistent") {
+        return async (
+          ...args: Parameters<PiecesController["runPersistent"]>
+        ) => {
+          const cell = await target.runPersistent(...args);
+          running = true;
+          return cell;
+        };
+      }
+      if (property === "getArgument") {
+        return (...args: Parameters<PiecesController["getArgument"]>) => {
+          if (running) {
+            throw new Error("the piece's argument cell does not resolve");
+          }
+          return target.getArgument(...args);
+        };
+      }
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+/** The space a synthetic refusal detail addresses; never resolved. */
+const REFUSAL_SPACE = "did:key:zRunPatternRefusal" as const;
+
+/**
+ * A read of `id` at `path`, as a refusal detail addresses one. The id is a
+ * plain string rather than an `of:` URI, which the canonical entity-id seam
+ * passes through unchanged, so two details naming one id compare as one
+ * document.
+ */
+function refusalRead(id: string, path: readonly string[] = []): CfcAddress {
+  return { space: REFUSAL_SPACE, id, scope: "space", path: [...path] };
+}
+
+/** One read that carried `"secret"` into a refused operation. */
+function refusalInput(
+  id: string,
+  labelPath: readonly string[] = ["secret"],
+): CfcRefusalInput {
+  return { read: refusalRead(id), labelPath, atoms: ['"secret"'] };
+}
+
+/** A `writer-fit` refusal over one named read, with `overrides` applied. */
+function refusalDetail(
+  overrides: Partial<CfcRefusalDetail> = {},
+): CfcRefusalDetail {
+  return {
+    gate: "writer-fit",
+    offendingAtoms: ['"secret"'],
+    inputs: [],
+    attribution: "complete",
+    reason: "CFC enforcement rejected commit",
+    ...overrides,
+  };
+}
+
+/** Resolves a refused read to an input key by the document it names. */
+function inputKeyByDocument(
+  owned: Readonly<Record<string, string>>,
+): (read: CfcAddress) => string | undefined {
+  return (read) => owned[read.id];
+}
+
+/**
+ * Seeds the same labelled document as {@link seedLabelledSecret} under a
+ * COMPUTED entity id, and answers the link an agent would pass naming it. A
+ * kinded id names a different entity from the `of:` id over the same hash, so
+ * the canonical entity-id seam refuses to reduce it and nothing that compares
+ * documents by hash can place a read of one.
+ */
+async function seedLabelledComputedSecret(
+  runtime: Runtime,
+  space: ReturnType<PiecesController["getSpace"]>,
+  cause: string,
+): Promise<string> {
+  const seed = runtime.edit();
+  const plainId = runtime.getCell(space, cause, undefined, seed)
+    .getAsNormalizedFullLink().id;
+  const computedId: `${string}:${string}` = `computed:${
+    plainId.slice("of:".length)
+  }`;
+  const sourceCell = runtime.getCellFromLink(
+    { id: computedId, path: [], space, scope: "space" },
+    { type: "object", properties: { secret: { type: "string" } } },
+    seed,
+  );
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id: computedId, path: [] }, {
     value: { secret: "s3cr3t" },
     cfc: {
       version: 1,
@@ -1012,6 +1136,64 @@ describe("run-pattern", () => {
         const encoded = JSON.stringify(output.policyRefusal);
         expect(scrubBareFabricIdentifiers(encoded)).toBe(encoded);
         expect(encoded).not.toContain(space);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("counts the reads only the argument document accounted for when the piece's argument cell will not resolve", async () => {
+      // The argument document is the second of the two routes from a refused
+      // read back to an input key. With it gone the report stands on the
+      // addresses the caller's own links resolved to, and states the gap
+      // rather than closing over it: what those addresses do not reach is
+      // counted, and the remedy drops to `partial`.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "refusal-without-argument-route",
+        );
+        const result = await createStrictEngine(
+          piecesWithUnresolvableArgument(pieces),
+        ).invokeBuiltinTool("run_pattern", {
+          sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+          inputs: { amount: 2, source: sourceRef },
+          resultSchema: TOTAL_RESULT_SCHEMA,
+        });
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.policyRefusal?.inputKeys).toEqual(["source"]);
+        expect(output.policyRefusal?.unattributedInputCount).toBe(1);
+        expect(output.policyRefusal?.attribution).toBe("partial");
+        expect(output.message).toContain("narrows the flow");
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("counts a refused read of a computed document, whose kinded id no input address can be compared against", async () => {
+      // A kinded entity id does not reduce to a hash, so neither route from a
+      // refused read to an input key can place it. The report counts it
+      // instead of guessing, and drops to `partial`.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledComputedSecret(
+          runtime,
+          space,
+          "refusal-over-computed-source",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.policyRefusal?.unattributedInputCount).toBe(1);
       } finally {
         await dispose();
       }
@@ -1883,6 +2065,281 @@ describe("run-pattern", () => {
       const output = result.output as RunPatternToolSuccessOutput;
       expect(output.status).toBe("ok");
       expect((output.value as { count: number }).count).toBe(0);
+    });
+  });
+
+  describe("runPatternPolicyRefusal()", () => {
+    it("returns `undefined` for an empty refusal list", () => {
+      expect(runPatternPolicyRefusal([], () => undefined)).toBeUndefined();
+    });
+
+    it("names the sink whose ceiling refused for a `sink-ceiling` detail", () => {
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            gate: "sink-ceiling",
+            sink: "fetchText",
+            inputs: [refusalInput("source-doc")],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["sink-ceiling"],
+        sinks: ["fetchText"],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        attribution: "complete",
+      });
+    });
+
+    it("deduplicates the gates, sinks, offending atoms and input keys of several details", () => {
+      expect(
+        runPatternPolicyRefusal(
+          [
+            refusalDetail({
+              gate: "sink-ceiling",
+              sink: "fetchText",
+              offendingAtoms: ['"secret"', '"medical"'],
+              inputs: [refusalInput("source-doc")],
+            }),
+            refusalDetail({
+              gate: "sink-ceiling",
+              sink: "fetchText",
+              offendingAtoms: ['"medical"'],
+              inputs: [refusalInput("source-doc", ["notes"])],
+            }),
+            refusalDetail({
+              gate: "writer-fit",
+              inputs: [refusalInput("other-doc")],
+            }),
+          ],
+          inputKeyByDocument({
+            "source-doc": "source",
+            "other-doc": "notes",
+          }),
+        ),
+      ).toEqual({
+        gates: ["sink-ceiling", "writer-fit"],
+        sinks: ["fetchText"],
+        offendingAtoms: ['"secret"', '"medical"'],
+        inputKeys: ["source", "notes"],
+        attribution: "complete",
+      });
+    });
+
+    it("counts a structured offending atom into `withheldAtomCount` rather than naming it", () => {
+      // A `Caveat` atom carries the principal that introduced it, and nothing
+      // redacts a principal out of an atom already rendered to a string.
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            offendingAtoms: [
+              '"secret"',
+              '{"caveat":"only-for","source":"did:key:zIntroducer"}',
+            ],
+            inputs: [refusalInput("source-doc")],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        withheldAtomCount: 1,
+        inputKeys: ["source"],
+        attribution: "complete",
+      });
+    });
+
+    it("counts an offending atom whose rendering is not JSON into `withheldAtomCount`", () => {
+      // `renderCfcAtom` is `JSON.stringify`, which produces no JSON text at
+      // all for an atom it cannot carry, so the rendering reaching this fold
+      // need not parse.
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            offendingAtoms: ['"secret"', "undefined"],
+            inputs: [refusalInput("source-doc")],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        withheldAtomCount: 1,
+        inputKeys: ["source"],
+        attribution: "complete",
+      });
+    });
+
+    it("returns `partial` with the unowned read counted when one offending read belongs to no input key", () => {
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            inputs: [refusalInput("source-doc"), refusalInput("hidden-doc")],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        unattributedInputCount: 1,
+        attribution: "partial",
+      });
+    });
+
+    it("counts two paths of one unowned document as a single unattributed input", () => {
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            inputs: [
+              refusalInput("hidden-doc", ["notes"]),
+              refusalInput("hidden-doc", ["archive", "notes"]),
+              refusalInput("source-doc"),
+            ],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        unattributedInputCount: 1,
+        attribution: "partial",
+      });
+    });
+
+    it("returns `none` when no offending read belongs to an input of the call", () => {
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            inputs: [
+              refusalInput("hidden-doc"),
+              refusalInput("other-hidden-doc"),
+            ],
+          }),
+        ], () => undefined),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: [],
+        unattributedInputCount: 2,
+        attribution: "none",
+      });
+    });
+
+    it("returns `partial` for a detail the boundary itself attributed partially, though every named read is an input key", () => {
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({
+            attribution: "partial",
+            inputs: [refusalInput("source-doc")],
+          }),
+        ], inputKeyByDocument({ "source-doc": "source" })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        attribution: "partial",
+      });
+    });
+  });
+
+  describe("policyRefusalMessage()", () => {
+    it("names the single sink whose ceiling refused and the one input to drop", () => {
+      const message = policyRefusalMessage({
+        gates: ["sink-ceiling"],
+        sinks: ["fetchText"],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        attribution: "complete",
+      });
+      expect(message).toContain(
+        'the sink "fetchText" does not admit the confidentiality ("secret")',
+      );
+      expect(message).toContain(
+        'Every label refused here came in through input "source", so the same run without it proceeds',
+      );
+    });
+
+    it("names both sinks when two ceilings refused", () => {
+      expect(policyRefusalMessage({
+        gates: ["sink-ceiling"],
+        sinks: ["fetchText", "postMessage"],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        attribution: "complete",
+      })).toContain('the sinks "fetchText", "postMessage" does not admit');
+    });
+
+    it("names the write it attempted and both inputs to drop when no sink refused", () => {
+      const message = policyRefusalMessage({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"', '"medical"'],
+        inputKeys: ["source", "notes"],
+        attribution: "complete",
+      });
+      expect(message).toContain(
+        'the write it attempted does not admit the confidentiality ("secret", "medical")',
+      );
+      expect(message).toContain(
+        'Every label refused here came in through inputs "source", "notes", so the same run without them proceeds',
+      );
+    });
+
+    it("omits the confidentiality parenthetical when every offending atom was withheld", () => {
+      const message = policyRefusalMessage({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: [],
+        withheldAtomCount: 2,
+        inputKeys: ["source"],
+        attribution: "complete",
+      });
+      expect(message).toContain(
+        "the write it attempted does not admit the confidentiality this run carries",
+      );
+    });
+
+    it("states that dropping the named inputs only narrows the flow for a `partial` attribution", () => {
+      expect(policyRefusalMessage({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source", "notes"],
+        unattributedInputCount: 1,
+        attribution: "partial",
+      })).toContain(
+        'Some of what was refused came in through inputs "source", "notes"; dropping them narrows the flow without necessarily clearing it, since reads this call does not own carry refused labels too',
+      );
+    });
+
+    it("states that dropping the single named input only narrows the flow for a `partial` attribution", () => {
+      expect(policyRefusalMessage({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        unattributedInputCount: 1,
+        attribution: "partial",
+      })).toContain(
+        'came in through input "source"; dropping it narrows the flow',
+      );
+    });
+
+    it("states that no input of the call accounts for the refusal for a `none` attribution", () => {
+      expect(policyRefusalMessage({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: [],
+        unattributedInputCount: 1,
+        attribution: "none",
+      })).toContain(
+        "No input of this call accounts for what was refused, so dropping an input will not clear it",
+      );
     });
   });
 });

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -313,3 +313,14 @@ export {
   validateAndSanitizeStructuredResultValue,
   validateStructuredResultValue,
 } from "./structured-result.ts";
+export {
+  type CfcRefusalAttribution,
+  type CfcRefusalDetail,
+  type CfcRefusalGate,
+  type CfcRefusalInput,
+  type ConsumedAtomSource,
+  consumedAtomSourceKey,
+  refusalAttribution,
+  refusalInputsFor,
+  renderCfcAtom,
+} from "./refusal-detail.ts";

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -319,8 +319,6 @@ export {
   type CfcRefusalGate,
   type CfcRefusalInput,
   type ConsumedAtomSource,
-  consumedAtomSourceKey,
-  refusalAttribution,
-  refusalInputsFor,
+  describeRefusalInputs,
   renderCfcAtom,
 } from "./refusal-detail.ts";

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -101,6 +101,13 @@ import {
 } from "./migration-reason.ts";
 import { verdictReason } from "./verdict-reason.ts";
 import {
+  type ConsumedAtomSource,
+  consumedAtomSourceKey,
+  refusalAttribution,
+  refusalInputsFor,
+  renderCfcAtom,
+} from "./refusal-detail.ts";
+import {
   type ReadClassSelection,
   readConsumesEntry,
   type ReadObservationShape,
@@ -120,6 +127,7 @@ import { createTrustResolver } from "./trust.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
+  type CfcAddress,
   cfcEnforcementStrictness,
   type CfcMetadata,
   type IFCLabel,
@@ -4879,9 +4887,36 @@ const collectConsumedLabel = (
   confidentiality: readonly CfcConfClause[];
   integrity: readonly CfcAtom[];
   modulePolicySpaces: ReadonlyMap<string, ReadonlySet<MemorySpace>>;
+
+  /**
+   * Rendered confidentiality atom -> the reads that carried it in, in
+   * first-seen order and deduplicated by (address, label path). This is the
+   * provenance a refusal needs to name an offending INPUT rather than only an
+   * offending atom (`cfc/refusal-detail.ts`); the gates' fits-decisions
+   * themselves stay transaction-global and read only the unioned label above.
+   */
+  sources: ReadonlyMap<string, readonly ConsumedAtomSource[]>;
 } => {
   const atoms: unknown[] = [];
   const modulePolicySpaces = new Map<string, Set<MemorySpace>>();
+  const sources = new Map<string, ConsumedAtomSource[]>();
+  const noteSource = (
+    atom: unknown,
+    read: CfcAddress,
+    labelPath: readonly string[],
+  ): void => {
+    const key = renderCfcAtom(atom);
+    const existing = sources.get(key);
+    const source: ConsumedAtomSource = { read, labelPath };
+    if (existing === undefined) {
+      sources.set(key, [source]);
+      return;
+    }
+    const sourceKey = consumedAtomSourceKey(source);
+    if (!existing.some((seen) => consumedAtomSourceKey(seen) === sourceKey)) {
+      existing.push(source);
+    }
+  };
   // Integrity evidence riding the same consumed entries: the guard pool the
   // exchange evaluator matches rule preconditions against (Epic B5). Same
   // transaction-global over-approximation as the confidentiality union —
@@ -4934,7 +4969,16 @@ const collectConsumedLabel = (
         : (isPrefix(entryPath, path) ||
           (read.nonRecursive !== true && isPrefix(path, entryPath)));
       if (!overlapsRead) continue;
-      atoms.push(...(entry.label.confidentiality ?? []));
+      const contributed = entry.label.confidentiality ?? [];
+      atoms.push(...contributed);
+      for (const atom of contributed) {
+        noteSource(atom, {
+          space: read.space,
+          id: read.id,
+          scope: normalizeCellScope(read.scope),
+          path,
+        } as CfcAddress, entryPath);
+      }
       for (
         const reference of modulePolicyReferencesIn(
           entry.label.confidentiality,
@@ -4957,12 +5001,16 @@ const collectConsumedLabel = (
   // pool.
   for (const observation of tx.getCfcState().labelMetadataObservations) {
     atoms.push(...observation.confidentiality);
+    for (const atom of observation.confidentiality) {
+      noteSource(atom, observation.target, observation.target.path);
+    }
   }
   // Structural dedup (deep-equal) — the same dedup the rest of CFC uses.
   return {
     confidentiality: uniqueCfcAtoms(atoms),
     integrity: uniqueCfcAtoms(integrityAtoms),
     modulePolicySpaces,
+    sources,
   };
 };
 
@@ -5203,10 +5251,24 @@ const verifySinkRequestCeilings = (
     if (offending.length > 0) {
       // Name the offending atom(s) so an observe-mode diagnostic identifies the
       // exact (sink, atom) pair that needs a ceiling entry (review on #3993).
+      const offendingAtoms = offending.map(renderCfcAtom);
       const reason = `sink-request confidentiality exceeds ceiling for ` +
         `${sink}: ` +
-        offending.map((atom) => JSON.stringify(atom)).join(", ");
+        offendingAtoms.join(", ");
       reasons.push(verdict ? verdictReason(reason) : reason);
+      // The remedy channel (cfc/refusal-detail.ts): which reads carried the
+      // atoms this ceiling refused. Recorded for every mode — an observe-mode
+      // rollout wants the same answer a refusal does, and the commit boundary
+      // keeps only the details whose reason actually refused.
+      const inputs = refusalInputsFor(offendingAtoms, consumed.sources);
+      tx.recordCfcRefusalDetail?.({
+        gate: "sink-ceiling",
+        sink,
+        offendingAtoms,
+        inputs,
+        attribution: refusalAttribution(offendingAtoms, inputs),
+        reason,
+      });
     }
   }
   return reasons;
@@ -5532,6 +5594,21 @@ export const prepareBoundaryCommit = (
         : undefined,
     );
   const flowConfidentiality = flowJoin.confidentiality;
+  // Read provenance for a refusal's remedy channel, computed only if a gate
+  // below actually refuses. `collectConsumedLabel` walks every read against
+  // every label-map entry of the document it resolved to, which is work no
+  // committing transaction should do just in case; a misfit is rare and pays
+  // for it then. The set is transaction-global — wider than the per-write
+  // prefix the writer-fit decision itself runs on — so a named input is a
+  // read that genuinely carried the atom, while `attribution` stays the
+  // honest statement of whether the named ones account for all of them.
+  let memoizedRefusalSources:
+    | ReadonlyMap<string, readonly ConsumedAtomSource[]>
+    | undefined;
+  const refusalSources = (): ReadonlyMap<
+    string,
+    readonly ConsumedAtomSource[]
+  > => memoizedRefusalSources ??= collectConsumedLabel(tx).sources;
   const flowIntegrity = flowJoin.integrity;
   const flowLabeledSpaces = flowJoin.labeledSpaces;
   const flowHasLabels = flowConfidentiality.length > 0 ||
@@ -6642,11 +6719,29 @@ export const prepareBoundaryCommit = (
             // SC-18c error contract: a stable reason naming the rule id and
             // the target path, plus the offending clause(s) so a flag names
             // exactly what the store would need to declare (§8.12.5).
+            const offendingAtoms = offending.map(renderCfcAtom);
             const misfit =
               `writer-fit confidentiality misfit for ${id} at /${
                 path.join("/")
               } (canWrite, §8.12.4): ` +
-              offending.map((atom) => JSON.stringify(atom)).join(", ");
+              offendingAtoms.join(", ");
+            const refusalInputs = refusalInputsFor(
+              offendingAtoms,
+              refusalSources(),
+            );
+            tx.recordCfcRefusalDetail?.({
+              gate: "writer-fit",
+              target: {
+                space: target.space,
+                id,
+                scope: target.scope,
+                path: [...path],
+              } as CfcAddress,
+              offendingAtoms,
+              inputs: refusalInputs,
+              attribution: refusalAttribution(offendingAtoms, refusalInputs),
+              reason: misfit,
+            });
             if (writerFitRejects) {
               reasons.push(verdictReason(misfit));
             } else {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -102,9 +102,7 @@ import {
 import { verdictReason } from "./verdict-reason.ts";
 import {
   type ConsumedAtomSource,
-  consumedAtomSourceKey,
-  refusalAttribution,
-  refusalInputsFor,
+  describeRefusalInputs,
   renderCfcAtom,
 } from "./refusal-detail.ts";
 import {
@@ -4889,33 +4887,38 @@ const collectConsumedLabel = (
   modulePolicySpaces: ReadonlyMap<string, ReadonlySet<MemorySpace>>;
 
   /**
-   * Rendered confidentiality atom -> the reads that carried it in, in
-   * first-seen order and deduplicated by (address, label path). This is the
-   * provenance a refusal needs to name an offending INPUT rather than only an
-   * offending atom (`cfc/refusal-detail.ts`); the gates' fits-decisions
-   * themselves stay transaction-global and read only the unioned label above.
+   * Every (clause, read) pair this transaction consumed, in first-seen order.
+   * This is the provenance a refusal needs to name an offending INPUT rather
+   * than only an offending atom (`cfc/refusal-detail.ts`). A gate matches into
+   * it by `deepEqual`, the same structural identity the union above dedups by;
+   * the gates' fits-decisions themselves stay transaction-global and read only
+   * that union.
    */
-  sources: ReadonlyMap<string, readonly ConsumedAtomSource[]>;
+  sources: readonly ConsumedAtomSource[];
 } => {
   const atoms: unknown[] = [];
   const modulePolicySpaces = new Map<string, Set<MemorySpace>>();
-  const sources = new Map<string, ConsumedAtomSource[]>();
+  const sources: ConsumedAtomSource[] = [];
   const noteSource = (
     atom: unknown,
     read: CfcAddress,
     labelPath: readonly string[],
   ): void => {
-    const key = renderCfcAtom(atom);
-    const existing = sources.get(key);
-    const source: ConsumedAtomSource = { read, labelPath };
-    if (existing === undefined) {
-      sources.set(key, [source]);
+    // Deduplicated on the same terms a consumer matches on: one entry per
+    // (clause, address, label path). Two label-map entries of one document
+    // carrying the same clause to the same read are one source.
+    if (
+      sources.some((seen) =>
+        seen.read.id === read.id && seen.read.space === read.space &&
+        seen.read.scope === read.scope &&
+        pathKey(seen.read.path) === pathKey(read.path) &&
+        pathKey(seen.labelPath) === pathKey(labelPath) &&
+        deepEqual(seen.atom, atom)
+      )
+    ) {
       return;
     }
-    const sourceKey = consumedAtomSourceKey(source);
-    if (!existing.some((seen) => consumedAtomSourceKey(seen) === sourceKey)) {
-      existing.push(source);
-    }
+    sources.push({ atom, read, labelPath });
   };
   // Integrity evidence riding the same consumed entries: the guard pool the
   // exchange evaluator matches rule preconditions against (Epic B5). Same
@@ -5257,16 +5260,14 @@ const verifySinkRequestCeilings = (
         offendingAtoms.join(", ");
       reasons.push(verdict ? verdictReason(reason) : reason);
       // The remedy channel (cfc/refusal-detail.ts): which reads carried the
-      // atoms this ceiling refused. Recorded for every mode — an observe-mode
+      // clauses this ceiling refused. Recorded for every mode — an observe-mode
       // rollout wants the same answer a refusal does, and the commit boundary
       // keeps only the details whose reason actually refused.
-      const inputs = refusalInputsFor(offendingAtoms, consumed.sources);
       tx.recordCfcRefusalDetail?.({
         gate: "sink-ceiling",
         sink,
         offendingAtoms,
-        inputs,
-        attribution: refusalAttribution(offendingAtoms, inputs),
+        ...describeRefusalInputs(offending, consumed.sources),
         reason,
       });
     }
@@ -5602,13 +5603,9 @@ export const prepareBoundaryCommit = (
   // prefix the writer-fit decision itself runs on — so a named input is a
   // read that genuinely carried the atom, while `attribution` stays the
   // honest statement of whether the named ones account for all of them.
-  let memoizedRefusalSources:
-    | ReadonlyMap<string, readonly ConsumedAtomSource[]>
-    | undefined;
-  const refusalSources = (): ReadonlyMap<
-    string,
-    readonly ConsumedAtomSource[]
-  > => memoizedRefusalSources ??= collectConsumedLabel(tx).sources;
+  let memoizedRefusalSources: readonly ConsumedAtomSource[] | undefined;
+  const refusalSources = (): readonly ConsumedAtomSource[] =>
+    memoizedRefusalSources ??= collectConsumedLabel(tx).sources;
   const flowIntegrity = flowJoin.integrity;
   const flowLabeledSpaces = flowJoin.labeledSpaces;
   const flowHasLabels = flowConfidentiality.length > 0 ||
@@ -6725,10 +6722,6 @@ export const prepareBoundaryCommit = (
                 path.join("/")
               } (canWrite, §8.12.4): ` +
               offendingAtoms.join(", ");
-            const refusalInputs = refusalInputsFor(
-              offendingAtoms,
-              refusalSources(),
-            );
             tx.recordCfcRefusalDetail?.({
               gate: "writer-fit",
               target: {
@@ -6738,8 +6731,7 @@ export const prepareBoundaryCommit = (
                 path: [...path],
               } as CfcAddress,
               offendingAtoms,
-              inputs: refusalInputs,
-              attribution: refusalAttribution(offendingAtoms, refusalInputs),
+              ...describeRefusalInputs(offending, refusalSources()),
               reason: misfit,
             });
             if (writerFitRejects) {

--- a/packages/runner/src/cfc/refusal-detail.ts
+++ b/packages/runner/src/cfc/refusal-detail.ts
@@ -1,0 +1,173 @@
+// Why: a refusal that names only what it refused leaves the refused party with
+// nothing to do about it.
+//
+// `sink-request confidentiality exceeds ceiling for fetchText: "medical"` is a
+// complete statement of the verdict and a useless instruction. It says a
+// confidentiality atom reached an egress that does not admit it; it does not
+// say WHICH of the transaction's reads carried that atom in. An agent holding
+// three inputs and one refusal cannot tell which input to drop, so it either
+// drops all of them (losing the run) or retries unchanged (refused again).
+//
+// A refusal detail answers the second question. It names the boundary that
+// refused, the atoms outside it, and the reads that carried each one — and it
+// states, as a checkable property rather than a promise, whether those reads
+// account for every offending atom. When they do, dropping them is a REMEDY:
+// the same operation over the remaining inputs meets the ceiling. When they do
+// not, the detail says so, and the caller learns that taint minimization alone
+// will not clear this one.
+//
+// The detail rides ALONGSIDE the reason string, never inside it. The reason is
+// prose for a person and a matcher; encoding a structure into it would make
+// every consumer a parser and every rewording a breaking change.
+
+import type { CfcAddress } from "./types.ts";
+
+/**
+ * One read that carried a confidentiality atom into a transaction, paired
+ * with the label-map entry path that carried it. The collector in `prepare.ts`
+ * builds these; a gate that refuses turns the ones behind its offending atoms
+ * into {@link CfcRefusalInput}s.
+ */
+export interface ConsumedAtomSource {
+  readonly read: CfcAddress;
+  readonly labelPath: readonly string[];
+}
+
+/**
+ * How an atom is rendered wherever it is named — in a reason string, in a
+ * detail, and as the key a source map is built on. One function, so a
+ * consumer matching a detail's atoms against a reason's prose compares
+ * identical text.
+ */
+export const renderCfcAtom = (atom: unknown): string => JSON.stringify(atom);
+
+/** Dedup key for a source: one entry per (address, label path). */
+export const consumedAtomSourceKey = (source: ConsumedAtomSource): string =>
+  JSON.stringify([
+    source.read.space,
+    source.read.id,
+    source.read.scope,
+    source.read.path,
+    source.labelPath,
+  ]);
+
+/** Which gate refused. Named for the rule, so a consumer can branch on it. */
+export type CfcRefusalGate = "sink-ceiling" | "writer-fit";
+
+/**
+ * One read that carried offending confidentiality into a refused operation.
+ *
+ * `read` is the address the transaction actually read; `labelPath` is the
+ * label-map entry path inside that document which carried the atoms. The two
+ * differ whenever a read of a container picks up a label declared on a field
+ * inside it — which is the common case, and the one where naming only the
+ * document would under-specify the remedy.
+ */
+export interface CfcRefusalInput {
+  readonly read: CfcAddress;
+  readonly labelPath: readonly string[];
+
+  /** The offending atoms this read contributed, JSON-rendered as the reason
+   * strings render them, so detail and prose name atoms identically. */
+  readonly atoms: readonly string[];
+}
+
+/**
+ * How completely {@link CfcRefusalDetail.inputs} accounts for the refusal.
+ *
+ * - `complete` — every offending atom is attributed to a named read. Dropping
+ *   all of them clears this refusal.
+ * - `partial` — some offending atom is attributed to no named read. Dropping
+ *   the named ones narrows the flow without necessarily clearing it.
+ * - `none` — nothing was attributed. The gate still refused; the detail adds
+ *   no remedy beyond the reason.
+ *
+ * An exchange-rule rewrite is the ordinary way to land below `complete`: the
+ * gate decides on a REWRITTEN label whose clauses need not be any clause a
+ * read contributed, so an atom can be genuinely offending and genuinely
+ * unattributable. Reporting that honestly is the point — a confident wrong
+ * remedy costs more than an admitted gap.
+ */
+export type CfcRefusalAttribution = "complete" | "partial" | "none";
+
+/**
+ * A refusal, described in terms a caller can act on.
+ *
+ * Every field is data a consumer reads structurally: the harness turns
+ * `inputs` into the argument names an agent passed, and a console renders the
+ * boundary and the atoms. Nothing here is meant to be parsed out of prose.
+ */
+export interface CfcRefusalDetail {
+  readonly gate: CfcRefusalGate;
+
+  /** The sink whose ceiling refused, for `sink-ceiling`. */
+  readonly sink?: string;
+
+  /** The write the rule refused, for `writer-fit`. */
+  readonly target?: CfcAddress;
+
+  /** Atoms outside what the boundary admits, JSON-rendered. */
+  readonly offendingAtoms: readonly string[];
+
+  /** The reads that carried them, deduplicated by address. */
+  readonly inputs: readonly CfcRefusalInput[];
+
+  readonly attribution: CfcRefusalAttribution;
+
+  /**
+   * The plain reason text this detail describes, verbatim — the pairing key
+   * between the structured detail and the reason list a refusal carries. The
+   * commit boundary keeps only the details whose reason survived into the
+   * refusal, so a detail recorded for a reason that did not refuse (an
+   * observe-mode diagnostic, a rule that later resolved) never rides along.
+   */
+  readonly reason: string;
+}
+
+/**
+ * Turn the sources behind `offendingAtoms` into the refusal's inputs: one
+ * entry per contributing read, carrying every offending atom that read
+ * supplied. An atom no source claims is simply absent, which is what drops
+ * {@link CfcRefusalDetail.attribution} below `complete`.
+ */
+export const refusalInputsFor = (
+  offendingAtoms: readonly string[],
+  sources: ReadonlyMap<string, readonly ConsumedAtomSource[]>,
+): readonly CfcRefusalInput[] => {
+  const byRead = new Map<
+    string,
+    { source: ConsumedAtomSource; atoms: string[] }
+  >();
+  for (const atom of offendingAtoms) {
+    for (const source of sources.get(atom) ?? []) {
+      const key = consumedAtomSourceKey(source);
+      const existing = byRead.get(key);
+      if (existing === undefined) byRead.set(key, { source, atoms: [atom] });
+      else if (!existing.atoms.includes(atom)) existing.atoms.push(atom);
+    }
+  }
+  return [...byRead.values()].map(({ source, atoms }) => ({
+    read: source.read,
+    labelPath: source.labelPath,
+    atoms,
+  }));
+};
+
+/**
+ * Classify how completely {@link CfcRefusalDetail.inputs} accounts for
+ * `offendingAtoms`.
+ *
+ * Compares the rendered atom strings rather than the clause values: the
+ * renderings are what both the reason and the detail publish, so a consumer
+ * matching one against the other sees the same answer this does.
+ */
+export const refusalAttribution = (
+  offendingAtoms: readonly string[],
+  inputs: readonly CfcRefusalInput[],
+): CfcRefusalAttribution => {
+  if (inputs.length === 0) return "none";
+  const attributed = new Set(inputs.flatMap((input) => [...input.atoms]));
+  return offendingAtoms.every((atom) => attributed.has(atom))
+    ? "complete"
+    : "partial";
+};

--- a/packages/runner/src/cfc/refusal-detail.ts
+++ b/packages/runner/src/cfc/refusal-detail.ts
@@ -16,40 +16,53 @@
 // not, the detail says so, and the caller learns that taint minimization alone
 // will not clear this one.
 //
+// A clause is matched by `deepEqual`, the structural identity `uniqueCfcAtoms`
+// and the ceiling-membership test already decide by. It has to be that one and
+// not a rendering: `{a:1,b:2}` and `{b:2,a:1}` are ONE clause to CFC and two
+// strings to `JSON.stringify`, so a rendered key would split a clause two
+// reads carried, name only the first, and call the remedy complete — and
+// dropping that read would leave the other read's identical clause behind,
+// refused again. `-0` and `0` fail the other way: two clauses to CFC, one
+// string, so a rendering would attribute an offending atom to an innocent
+// read. Rendering stays what it is, a display form.
+//
 // The detail rides ALONGSIDE the reason string, never inside it. The reason is
 // prose for a person and a matcher; encoding a structure into it would make
 // every consumer a parser and every rewording a breaking change.
+//
+// Every type here is a `type` alias rather than an `interface` on purpose: a
+// detail travels on the `cfc.prepare-reject` telemetry marker, and a marker
+// crosses the runtime-client IPC boundary as a `FabricValue`. An interface
+// carries no implicit index signature, so it does not satisfy
+// `FabricPlainObject`, and the whole marker union stops being serializable.
+
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 import type { CfcAddress } from "./types.ts";
 
 /**
- * One read that carried a confidentiality atom into a transaction, paired
+ * One read that carried a confidentiality clause into a transaction, paired
  * with the label-map entry path that carried it. The collector in `prepare.ts`
- * builds these; a gate that refuses turns the ones behind its offending atoms
- * into {@link CfcRefusalInput}s.
+ * builds these; a gate that refuses matches the ones behind its offending
+ * clauses into {@link CfcRefusalInput}s.
+ *
+ * `atom` is the clause itself rather than a rendering of it, because matching
+ * is by `deepEqual` — see the module comment for what a rendered key gets
+ * wrong, in both directions.
  */
-export interface ConsumedAtomSource {
+export type ConsumedAtomSource = {
+  readonly atom: unknown;
   readonly read: CfcAddress;
   readonly labelPath: readonly string[];
-}
+};
 
 /**
- * How an atom is rendered wherever it is named — in a reason string, in a
- * detail, and as the key a source map is built on. One function, so a
- * consumer matching a detail's atoms against a reason's prose compares
- * identical text.
+ * How an atom is rendered wherever it is DISPLAYED — in a reason string and in
+ * a detail. One function, so a consumer reading a detail's atoms against a
+ * reason's prose compares identical text. Never an identity: see the module
+ * comment.
  */
 export const renderCfcAtom = (atom: unknown): string => JSON.stringify(atom);
-
-/** Dedup key for a source: one entry per (address, label path). */
-export const consumedAtomSourceKey = (source: ConsumedAtomSource): string =>
-  JSON.stringify([
-    source.read.space,
-    source.read.id,
-    source.read.scope,
-    source.read.path,
-    source.labelPath,
-  ]);
 
 /** Which gate refused. Named for the rule, so a consumer can branch on it. */
 export type CfcRefusalGate = "sink-ceiling" | "writer-fit";
@@ -63,28 +76,27 @@ export type CfcRefusalGate = "sink-ceiling" | "writer-fit";
  * inside it — which is the common case, and the one where naming only the
  * document would under-specify the remedy.
  */
-export interface CfcRefusalInput {
+export type CfcRefusalInput = {
   readonly read: CfcAddress;
   readonly labelPath: readonly string[];
 
-  /** The offending atoms this read contributed, JSON-rendered as the reason
-   * strings render them, so detail and prose name atoms identically. */
+  /** The offending atoms this read contributed, rendered for display. */
   readonly atoms: readonly string[];
-}
+};
 
 /**
  * How completely {@link CfcRefusalDetail.inputs} accounts for the refusal.
  *
- * - `complete` — every offending atom is attributed to a named read. Dropping
- *   all of them clears this refusal.
- * - `partial` — some offending atom is attributed to no named read. Dropping
- *   the named ones narrows the flow without necessarily clearing it.
+ * - `complete` — every offending clause is attributed to a named read.
+ *   Dropping all of them clears this refusal.
+ * - `partial` — some offending clause is attributed to no named read.
+ *   Dropping the named ones narrows the flow without necessarily clearing it.
  * - `none` — nothing was attributed. The gate still refused; the detail adds
  *   no remedy beyond the reason.
  *
  * An exchange-rule rewrite is the ordinary way to land below `complete`: the
  * gate decides on a REWRITTEN label whose clauses need not be any clause a
- * read contributed, so an atom can be genuinely offending and genuinely
+ * read contributed, so a clause can be genuinely offending and genuinely
  * unattributable. Reporting that honestly is the point — a confident wrong
  * remedy costs more than an admitted gap.
  */
@@ -97,7 +109,7 @@ export type CfcRefusalAttribution = "complete" | "partial" | "none";
  * `inputs` into the argument names an agent passed, and a console renders the
  * boundary and the atoms. Nothing here is meant to be parsed out of prose.
  */
-export interface CfcRefusalDetail {
+export type CfcRefusalDetail = {
   readonly gate: CfcRefusalGate;
 
   /** The sink whose ceiling refused, for `sink-ceiling`. */
@@ -106,10 +118,10 @@ export interface CfcRefusalDetail {
   /** The write the rule refused, for `writer-fit`. */
   readonly target?: CfcAddress;
 
-  /** Atoms outside what the boundary admits, JSON-rendered. */
+  /** Clauses outside what the boundary admits, rendered for display. */
   readonly offendingAtoms: readonly string[];
 
-  /** The reads that carried them, deduplicated by address. */
+  /** The reads that carried them, deduplicated by address and label path. */
   readonly inputs: readonly CfcRefusalInput[];
 
   readonly attribution: CfcRefusalAttribution;
@@ -118,56 +130,69 @@ export interface CfcRefusalDetail {
    * The plain reason text this detail describes, verbatim — the pairing key
    * between the structured detail and the reason list a refusal carries. The
    * commit boundary keeps only the details whose reason survived into the
-   * refusal, so a detail recorded for a reason that did not refuse (an
-   * observe-mode diagnostic, a rule that later resolved) never rides along.
+   * refusal, and each prepare pass describes only its own verdict, so a detail
+   * recorded for a reason that did not refuse never rides along.
    */
   readonly reason: string;
-}
-
-/**
- * Turn the sources behind `offendingAtoms` into the refusal's inputs: one
- * entry per contributing read, carrying every offending atom that read
- * supplied. An atom no source claims is simply absent, which is what drops
- * {@link CfcRefusalDetail.attribution} below `complete`.
- */
-export const refusalInputsFor = (
-  offendingAtoms: readonly string[],
-  sources: ReadonlyMap<string, readonly ConsumedAtomSource[]>,
-): readonly CfcRefusalInput[] => {
-  const byRead = new Map<
-    string,
-    { source: ConsumedAtomSource; atoms: string[] }
-  >();
-  for (const atom of offendingAtoms) {
-    for (const source of sources.get(atom) ?? []) {
-      const key = consumedAtomSourceKey(source);
-      const existing = byRead.get(key);
-      if (existing === undefined) byRead.set(key, { source, atoms: [atom] });
-      else if (!existing.atoms.includes(atom)) existing.atoms.push(atom);
-    }
-  }
-  return [...byRead.values()].map(({ source, atoms }) => ({
-    read: source.read,
-    labelPath: source.labelPath,
-    atoms,
-  }));
 };
 
 /**
- * Classify how completely {@link CfcRefusalDetail.inputs} accounts for
- * `offendingAtoms`.
+ * Match `offending` clauses to the reads that carried them, and say how
+ * completely the result accounts for the refusal.
  *
- * Compares the rendered atom strings rather than the clause values: the
- * renderings are what both the reason and the detail publish, so a consumer
- * matching one against the other sees the same answer this does.
+ * One pass produces both, because they are two readings of the same match:
+ * computing them separately would let a caller act on inputs the attribution
+ * does not describe.
  */
-export const refusalAttribution = (
-  offendingAtoms: readonly string[],
-  inputs: readonly CfcRefusalInput[],
-): CfcRefusalAttribution => {
-  if (inputs.length === 0) return "none";
-  const attributed = new Set(inputs.flatMap((input) => [...input.atoms]));
-  return offendingAtoms.every((atom) => attributed.has(atom))
-    ? "complete"
-    : "partial";
+export const describeRefusalInputs = (
+  offending: readonly unknown[],
+  sources: readonly ConsumedAtomSource[],
+): {
+  inputs: readonly CfcRefusalInput[];
+  attribution: CfcRefusalAttribution;
+} => {
+  const byRead = new Map<
+    string,
+    { read: CfcAddress; labelPath: readonly string[]; atoms: string[] }
+  >();
+  let unattributed = 0;
+  for (const clause of offending) {
+    const rendered = renderCfcAtom(clause);
+    let matched = false;
+    for (const source of sources) {
+      if (!deepEqual(source.atom, clause)) continue;
+      matched = true;
+      const key = JSON.stringify([
+        source.read.space,
+        source.read.id,
+        source.read.scope,
+        source.read.path,
+        source.labelPath,
+      ]);
+      const existing = byRead.get(key);
+      if (existing === undefined) {
+        byRead.set(key, {
+          read: source.read,
+          labelPath: source.labelPath,
+          atoms: [rendered],
+        });
+      } else if (!existing.atoms.includes(rendered)) {
+        existing.atoms.push(rendered);
+      }
+    }
+    if (!matched) unattributed += 1;
+  }
+  const inputs = [...byRead.values()].map(({ read, labelPath, atoms }) => ({
+    read,
+    labelPath,
+    atoms,
+  }));
+  return {
+    inputs,
+    attribution: inputs.length === 0
+      ? "none"
+      : unattributed === 0
+      ? "complete"
+      : "partial",
+  };
 };

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -13,6 +13,7 @@ import type {
   LabelObservationClass,
 } from "./label-view-core.ts";
 import type { PolicySnapshot } from "./policy.ts";
+import type { CfcRefusalDetail } from "./refusal-detail.ts";
 import type { SinkMaxConfidentiality } from "./sink-inventory.ts";
 import type { CfcTrustConfig } from "./trust.ts";
 
@@ -802,4 +803,12 @@ export type CfcTxState = {
   // PreparedDigestInput. Only labeled observations are recorded (empty =
   // public = nothing to derive, gate, or bind).
   labelMetadataObservations: CfcLabelMetadataObservation[];
+  // Structured descriptions of the refusals this transaction's gates
+  // recorded (`cfc/refusal-detail.ts`): which boundary refused, which atoms
+  // it refused, and which reads carried them. Recorded in every enforcement
+  // mode; the commit boundary keeps only the ones whose reason survived into
+  // the refusal, so an observe-mode diagnostic never rides out as a verdict.
+  // Never folded into the prepared digest — a description of a decision is
+  // not an input to it.
+  refusalDetails: CfcRefusalDetail[];
 };

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1987,8 +1987,20 @@ export class Runtime {
       onPreparedTx: () => {
         this.cfcStats.cfcPreparedTx += 1;
       },
-      onPrepareReject: () => {
+      onPrepareReject: (refusal) => {
         this.cfcStats.cfcPrepareRejects += 1;
+        // Every refusal is reported here, terminal or not. The scheduler's
+        // error channel carries only the terminal ones (a refusal a fresh
+        // attempt may resolve is retried rather than surfaced), so without
+        // this a mixed-reason refusal — one verdict plus one unevaluable
+        // input — reaches a host as nothing but a graph that stopped
+        // converging.
+        this.telemetry.submit({
+          type: "cfc.prepare-reject",
+          reasons: [...refusal.reasons],
+          refusals: [...refusal.refusals],
+          terminal: refusal.terminal,
+        });
       },
       onDigestInvalidation: () => {
         this.cfcStats.cfcDigestInvalidations += 1;

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import { resolveScopeKey, type ScopeKey } from "@commonfabric/memory/v2";
+import type { CfcRefusalDetail } from "../cfc/refusal-detail.ts";
 import type { Runtime } from "../runtime.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type {
@@ -894,8 +895,9 @@ function normalizeThrownError(error: unknown): Error {
 /**
  * A commit rejection is a plain result object, not an Error, so the error
  * channel gets a constructed one preserving the rejection's name and, for a
- * CFC refusal, its structured `reasons` — the discriminants a consumer needs
- * to tell a policy refusal from a thrown computation. A thrown computation
+ * CFC refusal, its structured `reasons` and `refusals` — the discriminants a
+ * consumer needs to tell a policy refusal from a thrown computation, and the
+ * remedy detail that names the inputs behind it. A thrown computation
  * carries a pattern frame the error decoration reads piece attribution from;
  * a commit rejection has none, so the attribution comes from the action's own
  * observation identity, with the scope prefix stripped back to the result
@@ -906,6 +908,7 @@ function toTerminalRejectionError(error: unknown, action: Action): Error {
     name?: string;
     message?: string;
     reasons?: readonly string[];
+    refusals?: readonly CfcRefusalDetail[];
   };
   const surfaced = new Error(
     typeof rejection?.message === "string" ? rejection.message : String(error),
@@ -913,6 +916,10 @@ function toTerminalRejectionError(error: unknown, action: Action): Error {
   if (typeof rejection?.name === "string") surfaced.name = rejection.name;
   if (rejection?.reasons !== undefined) {
     (surfaced as { reasons?: readonly string[] }).reasons = rejection.reasons;
+  }
+  if (rejection?.refusals !== undefined) {
+    (surfaced as { refusals?: readonly CfcRefusalDetail[] }).refusals =
+      rejection.refusals;
   }
   const identity = (action as Partial<TelemetryAnnotations>)
     .schedulerObservationIdentity;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -70,6 +70,7 @@ import {
   type CfcLabelMetadataProtectionMode,
   type CfcPolicyEvaluationMode,
   type CfcPrefixProvenanceSummary,
+  CfcRefusalDetail,
   type CfcTriggerReadGating,
   type CfcTrustConfig,
   type CfcTxState,
@@ -150,7 +151,19 @@ type CfcInstrumentationHooks = {
    * only. */
   onFlowLabelProbe?(outcome: "computed" | "memo"): void;
   onPreparedTx?(): void;
-  onPrepareReject?(reasons: readonly string[]): void;
+  /**
+   * CFC prepare refused this transaction. `reasons` are the PLAIN reason
+   * texts (the verdict tag is a classification channel and never leaves the
+   * boundary); `refusals` are the structured descriptions their producers
+   * recorded, paired to those texts; `terminal` is what the commit boundary
+   * will decide the refusal is worth — a verdict on the data, or a refusal a
+   * fresh attempt may resolve.
+   */
+  onPrepareReject?(refusal: {
+    reasons: readonly string[];
+    refusals: readonly CfcRefusalDetail[];
+    terminal: boolean;
+  }): void;
   onDigestInvalidation?(reason: string): void;
   onOutboxFlush?(effect: PostCommitSideEffect): void;
   onSinkDedupHit?(key: string): void;
@@ -366,6 +379,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     consultedGrants: [],
     consultedPolicyManifests: [],
     labelMetadataObservations: [],
+    refusalDetails: [],
   };
   private reportedCfcRelevant = false;
   private reportedCfcPrepared = false;
@@ -1350,6 +1364,14 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
+  recordCfcRefusalDetail(detail: CfcRefusalDetail): void {
+    // Deliberately inert: no relevance mark, no digest invalidation, no
+    // prepare-state change. A detail DESCRIBES a decision another line of
+    // this transaction already made; letting it move the enforcement state
+    // would make the description part of the decision.
+    this.#cfcState.refusalDetails.push(deepFreeze(detail));
+  }
+
   writeCfcGrant(input: CfcGrantWriteInput): { space: MemorySpace; id: string } {
     this.assertWritable("writeCfcGrant()");
     // The trusted policy-writer path (§8.12.7 route 2a, design §2.3
@@ -1844,7 +1866,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       reasons = [`CFC commit-prep crashed: ${message}`];
     }
     if (reasons.length > 0) {
-      this.cfcInstrumentation.onPrepareReject?.(reasons);
+      const plainReasons = reasons.map(plainReason);
+      const refusedSet = new Set(plainReasons);
+      this.cfcInstrumentation.onPrepareReject?.({
+        reasons: plainReasons,
+        refusals: this.#cfcState.refusalDetails.filter((detail) =>
+          refusedSet.has(detail.reason)
+        ),
+        terminal: isTerminalRefusal(reasons),
+      });
       // A recorded reason makes the transaction CFC-relevant by definition.
       // Without this mark, a reasoned transaction whose reads/writes never
       // tripped an eager mark (e.g. a schema-less labeled flow feeding a
@@ -2480,11 +2510,21 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
             },
           });
         }
+        const plainReasons = reasons.map(plainReason);
+        // Pair each detail to a reason that actually refused. A gate records
+        // its detail when it decides, which is also how it records an
+        // observe-mode diagnostic and a reason a later resolution cleared —
+        // neither of those refused this commit, and neither may ride out on
+        // an error that says they did.
+        const refusedSet = new Set(plainReasons);
         return this.rejectCommitBeforeStorage({
           error: {
             name: "CfcCommitRefusalError",
             message,
-            reasons: reasons.map(plainReason),
+            reasons: plainReasons,
+            refusals: this.#cfcState.refusalDetails.filter((detail) =>
+              refusedSet.has(detail.reason)
+            ),
           },
         });
       }
@@ -2950,6 +2990,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     observation: CfcLabelMetadataObservation,
   ): void {
     this.wrapped.recordCfcLabelMetadataObservation(observation);
+  }
+
+  recordCfcRefusalDetail(detail: CfcRefusalDetail): void {
+    this.wrapped.recordCfcRefusalDetail(detail);
   }
 
   writeCfcGrant(input: CfcGrantWriteInput): { space: MemorySpace; id: string } {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1815,6 +1815,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // code (audit S18). The runtime's own persistence is the one legitimate
     // writer, so it alone is exempt.
     let reasons: string[];
+    // Each pass describes its own verdict. Diagnostics are append-only
+    // history on purpose — an observe-mode rollout wants every divergence a
+    // transaction ever produced — but a detail is paired to a reason THIS
+    // pass recorded, so carrying one forward from a pass that a later prepare
+    // superseded would render the same refusal twice, or render one the
+    // current verdict no longer holds.
+    this.#cfcState.refusalDetails = [];
     try {
       // The schema-doc materialization is INSIDE the try on purpose: it is
       // part of commit-prep, and a crash in it must take the same modeled

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -63,6 +63,7 @@ import type {
   CfcLabelMetadataObservation,
   CfcLabelMetadataProtectionMode,
   CfcPolicyEvaluationMode,
+  CfcRefusalDetail,
   CfcTriggerReadGating,
   CfcTxState,
   CfcWriteFloorMode,
@@ -1894,6 +1895,18 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   ): void;
 
   /**
+   * Records a structured description of a refusal one of this transaction's
+   * CFC gates just decided (`cfc/refusal-detail.ts`): the boundary, the atoms
+   * outside it, and the reads that carried them.
+   *
+   * The prose reason remains the enforcement channel — a detail never decides
+   * anything, and recording one neither marks the transaction relevant nor
+   * invalidates a preparation. It exists so a refused caller can act: the
+   * detail names the INPUT to drop, which the reason alone cannot.
+   */
+  recordCfcRefusalDetail(detail: CfcRefusalDetail): void;
+
+  /**
    * The trusted policy-writer path for CFC grant documents (§8.12.7 route
    * 2a; cfc/grants.ts module doc). Requires the transaction's CURRENT
    * implementation identity to be a trusted builtin (the arm
@@ -2230,6 +2243,14 @@ export interface IPreconditionFailedError extends Error {
 export interface ICfcCommitRefusalError extends IStorageError {
   readonly name: "CfcCommitRefusalError";
   readonly reasons: readonly string[];
+
+  /**
+   * Structured descriptions of the reasons whose producers could describe
+   * themselves (`cfc/refusal-detail.ts`), paired to `reasons` by their
+   * `reason` text. A refusal every producer left undescribed carries an
+   * empty list — the reasons still stand on their own.
+   */
+  readonly refusals: readonly CfcRefusalDetail[];
 }
 
 /** Commit preparation crashed before any storage attempt. This is typed apart

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -2,6 +2,7 @@
 // to record events that can be subscribed to in other
 // contexts to visualize or log events inside the runtime.
 
+import type { CfcRefusalDetail } from "./cfc/refusal-detail.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { IMemoryChange } from "./storage/interface.ts";
@@ -274,6 +275,23 @@ export type RuntimeTelemetryMarker = {
   busyRatio: number;
   deferredActions?: NonSettlingDeferredAction[];
   deferredActionCount?: number;
+} | {
+  // Emitted every time CFC prepare refuses a transaction, BEFORE the commit
+  // boundary decides what that refusal is worth. That ordering is the point:
+  // a refusal is terminal — and reaches the scheduler's error channel — only
+  // when every reason is a verdict (cfc/verdict-reason.ts), so a refusal
+  // mixing a verdict with an unevaluable input is retried instead, and the
+  // only trace it leaves upstream is a graph that stops converging. This
+  // marker is the trace it leaves either way, so a host can name the cause of
+  // a non-settling episode rather than guess at a reactive cycle.
+  //
+  // It reports; it decides nothing. `terminal` says which arm the commit
+  // boundary will take, so a consumer can tell the refusal that will also
+  // arrive on the error channel from the one that will not.
+  type: "cfc.prepare-reject";
+  reasons: string[];
+  refusals: CfcRefusalDetail[];
+  terminal: boolean;
 };
 
 /**

--- a/packages/runner/test/cfc-refusal-detail.test.ts
+++ b/packages/runner/test/cfc-refusal-detail.test.ts
@@ -39,8 +39,7 @@ import {
   type CfcAddress,
   type CfcRefusalDetail,
   type ConsumedAtomSource,
-  refusalAttribution,
-  refusalInputsFor,
+  describeRefusalInputs,
   renderCfcAtom,
 } from "../src/cfc/mod.ts";
 import { RuntimeTelemetryEvent } from "../src/telemetry.ts";
@@ -69,10 +68,11 @@ const addressOf = (id: string, path: readonly string[]): CfcAddress =>
   ({ space, id, scope: "space", path }) as CfcAddress;
 
 const sourceOf = (
+  atom: unknown,
   id: string,
   readPath: readonly string[],
   labelPath: readonly string[],
-): ConsumedAtomSource => ({ read: addressOf(id, readPath), labelPath });
+): ConsumedAtomSource => ({ atom, read: addressOf(id, readPath), labelPath });
 
 /**
  * Seed a document holding `{ secret: "rosebud" }`. With `confidentiality`, its
@@ -139,16 +139,12 @@ const seedRootLabeledDoc = async (
 };
 
 describe("refusal-detail", () => {
-  describe("refusalInputsFor()", () => {
+  describe("describeRefusalInputs()", () => {
     it("returns one input per contributing read, carrying that read's atoms", () => {
-      const sources = new Map<string, readonly ConsumedAtomSource[]>([
-        [MEDICAL, [sourceOf("of:chart", ["value"], ["secret"])]],
-        [renderCfcAtom("payroll"), [sourceOf("of:ledger", [], ["amount"])]],
+      const { inputs } = describeRefusalInputs(["medical", "payroll"], [
+        sourceOf("medical", "of:chart", ["value"], ["secret"]),
+        sourceOf("payroll", "of:ledger", [], ["amount"]),
       ]);
-      const inputs = refusalInputsFor(
-        [MEDICAL, renderCfcAtom("payroll")],
-        sources,
-      );
       expect(inputs).toEqual([
         {
           read: addressOf("of:chart", ["value"]),
@@ -164,27 +160,19 @@ describe("refusal-detail", () => {
     });
 
     it("groups two offending atoms carried by one read into a single input", () => {
-      const read = sourceOf("of:chart", ["value"], ["secret"]);
-      const sources = new Map<string, readonly ConsumedAtomSource[]>([
-        [MEDICAL, [read]],
-        [renderCfcAtom("payroll"), [read]],
+      const { inputs } = describeRefusalInputs(["medical", "payroll"], [
+        sourceOf("medical", "of:chart", ["value"], ["secret"]),
+        sourceOf("payroll", "of:chart", ["value"], ["secret"]),
       ]);
-      const inputs = refusalInputsFor(
-        [MEDICAL, renderCfcAtom("payroll")],
-        sources,
-      );
       expect(inputs.length).toBe(1);
       expect(inputs[0].atoms).toEqual([MEDICAL, renderCfcAtom("payroll")]);
     });
 
     it("returns separate inputs for two label paths inside one document", () => {
-      const sources = new Map<string, readonly ConsumedAtomSource[]>([
-        [MEDICAL, [
-          sourceOf("of:chart", [], ["secret"]),
-          sourceOf("of:chart", [], ["notes"]),
-        ]],
+      const { inputs } = describeRefusalInputs(["medical"], [
+        sourceOf("medical", "of:chart", [], ["secret"]),
+        sourceOf("medical", "of:chart", [], ["notes"]),
       ]);
-      const inputs = refusalInputsFor([MEDICAL], sources);
       expect(inputs.map((input) => input.labelPath)).toEqual([
         ["secret"],
         ["notes"],
@@ -192,48 +180,60 @@ describe("refusal-detail", () => {
     });
 
     it("returns no input for an offending atom no source claims", () => {
-      const inputs = refusalInputsFor(
-        [MEDICAL],
-        new Map<string, readonly ConsumedAtomSource[]>([[
-          renderCfcAtom("payroll"),
-          [sourceOf("of:ledger", [], ["amount"])],
-        ]]),
-      );
+      const { inputs } = describeRefusalInputs(["medical"], [
+        sourceOf("payroll", "of:ledger", [], ["amount"]),
+      ]);
       expect(inputs).toEqual([]);
     });
-  });
 
-  describe("refusalAttribution()", () => {
-    it("returns `none` for an empty input list", () => {
-      expect(refusalAttribution([MEDICAL], [])).toBe("none");
+    it("names both reads of a clause whose properties two sources ordered differently", () => {
+      // The identity is `deepEqual`, which is what `uniqueCfcAtoms` dedups the
+      // consumed union by — so these are ONE clause, carried by two reads, and
+      // the remedy is to drop both. Keyed on a rendering they would be two
+      // clauses, only the first named, and `complete` would be a lie: dropping
+      // the named read leaves the other read's identical clause behind.
+      const { inputs, attribution } = describeRefusalInputs([{
+        a: 1,
+        b: 2,
+      }], [
+        sourceOf({ a: 1, b: 2 }, "of:chart", [], ["secret"]),
+        sourceOf({ b: 2, a: 1 }, "of:ledger", [], ["amount"]),
+      ]);
+      expect(inputs.map((input) => input.read.id)).toEqual([
+        "of:chart",
+        "of:ledger",
+      ]);
+      expect(attribution).toBe("complete");
     });
 
-    it("returns `complete` when the inputs name every offending atom", () => {
+    it("attributes no read to a signed-zero clause a source carries unsigned", () => {
+      // CFC distinguishes `-0` from `0`; `JSON.stringify` renders both `0`. A
+      // rendered key would name the innocent read as the one to drop.
+      const { inputs, attribution } = describeRefusalInputs([-0], [
+        sourceOf(0, "of:ledger", [], ["amount"]),
+      ]);
+      expect(inputs).toEqual([]);
+      expect(attribution).toBe("none");
+    });
+
+    it("returns `none` when no source claims any offending clause", () => {
+      expect(describeRefusalInputs(["medical"], []).attribution).toBe("none");
+    });
+
+    it("returns `complete` when a source claims every offending clause", () => {
       expect(
-        refusalAttribution([MEDICAL, renderCfcAtom("payroll")], [
-          {
-            read: addressOf("of:chart", []),
-            labelPath: ["secret"],
-            atoms: [MEDICAL],
-          },
-          {
-            read: addressOf("of:ledger", []),
-            labelPath: ["amount"],
-            atoms: [renderCfcAtom("payroll")],
-          },
-        ]),
+        describeRefusalInputs(["medical", "payroll"], [
+          sourceOf("medical", "of:chart", [], ["secret"]),
+          sourceOf("payroll", "of:ledger", [], ["amount"]),
+        ]).attribution,
       ).toBe("complete");
     });
 
-    it("returns `partial` when an offending atom is named by no input", () => {
+    it("returns `partial` when an offending clause is claimed by no source", () => {
       expect(
-        refusalAttribution([MEDICAL, renderCfcAtom("rewritten")], [
-          {
-            read: addressOf("of:chart", []),
-            labelPath: ["secret"],
-            atoms: [MEDICAL],
-          },
-        ]),
+        describeRefusalInputs(["medical", "rewritten"], [
+          sourceOf("medical", "of:chart", [], ["secret"]),
+        ]).attribution,
       ).toBe("partial");
     });
   });
@@ -538,6 +538,42 @@ describe("refusal-detail", () => {
       expect(detail!.sink).toBe("fetchText");
       expect(detail!.offendingAtoms).toContain(MEDICAL);
       expect(detail!.attribution).toBe("complete");
+    });
+
+    it("describes only the pass it ran, when one transaction prepares twice", async () => {
+      // Diagnostics are append-only history on purpose; a detail is paired to
+      // a reason THIS pass recorded. Without the per-pass clear, a second
+      // prepare's refusal would carry the first pass's detail as well as its
+      // own — the same refusal rendered twice, and, once a reason clears, one
+      // the current verdict no longer holds.
+      await seedSecret(runtime, "marker-repeated-secret", ["medical"]);
+      const tx = runtime.edit();
+      const secret = runtime.getCell(
+        space,
+        "marker-repeated-secret",
+        undefined,
+        tx,
+      );
+      expect(secret.key("secret").getRaw() as string).toBe("rosebud");
+      enqueueSinkRequestPostCommitEffect(
+        tx,
+        "fetchText",
+        "fetchText:marker-repeated",
+        createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+        "fetchText-start",
+        () => {},
+      );
+      tx.prepareCfc();
+      tx.prepareCfc();
+      tx.abort();
+
+      expect(markers.length).toBe(2);
+      for (const marker of markers) {
+        expect(
+          marker.refusals.filter((entry) => entry.gate === "sink-ceiling")
+            .length,
+        ).toBe(1);
+      }
     });
 
     it("submits a non-terminal marker carrying the same detail when an untagged reason joins the verdict", async () => {

--- a/packages/runner/test/cfc-refusal-detail.test.ts
+++ b/packages/runner/test/cfc-refusal-detail.test.ts
@@ -1,0 +1,562 @@
+/**
+ * The remedy channel a CFC refusal carries (CT-2077): not only WHAT the gate
+ * refused, but WHICH of the transaction's reads carried the offending
+ * confidentiality in. A refusal naming only its atoms leaves the refused party
+ * with nothing to replan against; a refusal naming its inputs, and stating
+ * whether those inputs account for every offending atom, is one an agent can
+ * act on by dropping an argument and running again.
+ *
+ * Three layers, because the channel breaks at any of them:
+ *
+ * - the pure grouping/classification helpers of `cfc/refusal-detail.ts`;
+ * - the detail riding out on a real pattern's refused egress, all the way to
+ *   the error the scheduler reports — paired with the unlabelled control that
+ *   reaches the network, so the refusal case cannot pass vacuously;
+ * - the `cfc.prepare-reject` telemetry marker, which is the only trace a
+ *   refusal leaves when the commit boundary decides it is retryable rather
+ *   than terminal and so never puts it on the error channel at all.
+ */
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  clearMockResponses,
+  enableMockMode,
+  setMockResponseGate,
+} from "@commonfabric/llm/client";
+import type { URI } from "@commonfabric/memory/interface";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { setPatternEnvironment } from "../src/env.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+import {
+  type CfcAddress,
+  type CfcRefusalDetail,
+  type ConsumedAtomSource,
+  refusalAttribution,
+  refusalInputsFor,
+  renderCfcAtom,
+} from "../src/cfc/mod.ts";
+import { RuntimeTelemetryEvent } from "../src/telemetry.ts";
+import type { RuntimeTelemetryMarker } from "../src/telemetry.ts";
+import type { ErrorWithContext } from "../src/scheduler.ts";
+import type { Cell } from "../src/cell.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-refusal-detail");
+const space = signer.did();
+
+enableMockMode();
+
+/** The one atom every gate in this file refuses, rendered as details name it. */
+const MEDICAL = renderCfcAtom("medical");
+
+type PrepareRejectMarker = Extract<
+  RuntimeTelemetryMarker,
+  { type: "cfc.prepare-reject" }
+>;
+
+/** The structured details a surfaced refusal carries, or none. */
+const refusalsOf = (error: unknown): readonly CfcRefusalDetail[] =>
+  (error as { refusals?: readonly CfcRefusalDetail[] })?.refusals ?? [];
+
+const addressOf = (id: string, path: readonly string[]): CfcAddress =>
+  ({ space, id, scope: "space", path }) as CfcAddress;
+
+const sourceOf = (
+  id: string,
+  readPath: readonly string[],
+  labelPath: readonly string[],
+): ConsumedAtomSource => ({ read: addressOf(id, readPath), labelPath });
+
+/**
+ * Seed a document holding `{ secret: "rosebud" }`. With `confidentiality`, its
+ * `/secret` carries those clauses as persisted store-policy metadata — the
+ * form a read actually picks a label up from. Without, the document is plain,
+ * which is the control every refusal case here is measured against.
+ */
+const seedSecret = async (
+  runtime: Runtime,
+  name: string,
+  confidentiality?: readonly string[],
+): Promise<URI> => {
+  const seed = runtime.edit();
+  const cell = runtime.getCell(space, name, undefined, seed);
+  const id = cell.getAsNormalizedFullLink().id as URI;
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+    value: { secret: "rosebud" },
+    ...(confidentiality === undefined ? {} : {
+      cfc: {
+        version: 1,
+        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["secret"],
+            label: { confidentiality: [...confidentiality] },
+          }],
+        },
+      },
+    }),
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+  return id;
+};
+
+/**
+ * Seed a document whose stored metadata labels its ROOT, so every path on it
+ * is one the schema write-policy requirement quantifies over. A raw write to
+ * such a document records `missing schema write-policy input` — an UNTAGGED
+ * reason, and so the retryable half of a mixed-reason refusal.
+ */
+const seedRootLabeledDoc = async (
+  runtime: Runtime,
+  name: string,
+): Promise<URI> => {
+  const seed = runtime.edit();
+  const id = runtime.getCell(space, name, undefined, seed)
+    .getAsNormalizedFullLink().id as URI;
+  writeSeedEnvelopeDoc(seed, space);
+  seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+    value: { note: "labeled" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{ path: [], label: { confidentiality: ["medical"] } }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+  return id;
+};
+
+describe("refusal-detail", () => {
+  describe("refusalInputsFor()", () => {
+    it("returns one input per contributing read, carrying that read's atoms", () => {
+      const sources = new Map<string, readonly ConsumedAtomSource[]>([
+        [MEDICAL, [sourceOf("of:chart", ["value"], ["secret"])]],
+        [renderCfcAtom("payroll"), [sourceOf("of:ledger", [], ["amount"])]],
+      ]);
+      const inputs = refusalInputsFor(
+        [MEDICAL, renderCfcAtom("payroll")],
+        sources,
+      );
+      expect(inputs).toEqual([
+        {
+          read: addressOf("of:chart", ["value"]),
+          labelPath: ["secret"],
+          atoms: [MEDICAL],
+        },
+        {
+          read: addressOf("of:ledger", []),
+          labelPath: ["amount"],
+          atoms: [renderCfcAtom("payroll")],
+        },
+      ]);
+    });
+
+    it("groups two offending atoms carried by one read into a single input", () => {
+      const read = sourceOf("of:chart", ["value"], ["secret"]);
+      const sources = new Map<string, readonly ConsumedAtomSource[]>([
+        [MEDICAL, [read]],
+        [renderCfcAtom("payroll"), [read]],
+      ]);
+      const inputs = refusalInputsFor(
+        [MEDICAL, renderCfcAtom("payroll")],
+        sources,
+      );
+      expect(inputs.length).toBe(1);
+      expect(inputs[0].atoms).toEqual([MEDICAL, renderCfcAtom("payroll")]);
+    });
+
+    it("returns separate inputs for two label paths inside one document", () => {
+      const sources = new Map<string, readonly ConsumedAtomSource[]>([
+        [MEDICAL, [
+          sourceOf("of:chart", [], ["secret"]),
+          sourceOf("of:chart", [], ["notes"]),
+        ]],
+      ]);
+      const inputs = refusalInputsFor([MEDICAL], sources);
+      expect(inputs.map((input) => input.labelPath)).toEqual([
+        ["secret"],
+        ["notes"],
+      ]);
+    });
+
+    it("returns no input for an offending atom no source claims", () => {
+      const inputs = refusalInputsFor(
+        [MEDICAL],
+        new Map<string, readonly ConsumedAtomSource[]>([[
+          renderCfcAtom("payroll"),
+          [sourceOf("of:ledger", [], ["amount"])],
+        ]]),
+      );
+      expect(inputs).toEqual([]);
+    });
+  });
+
+  describe("refusalAttribution()", () => {
+    it("returns `none` for an empty input list", () => {
+      expect(refusalAttribution([MEDICAL], [])).toBe("none");
+    });
+
+    it("returns `complete` when the inputs name every offending atom", () => {
+      expect(
+        refusalAttribution([MEDICAL, renderCfcAtom("payroll")], [
+          {
+            read: addressOf("of:chart", []),
+            labelPath: ["secret"],
+            atoms: [MEDICAL],
+          },
+          {
+            read: addressOf("of:ledger", []),
+            labelPath: ["amount"],
+            atoms: [renderCfcAtom("payroll")],
+          },
+        ]),
+      ).toBe("complete");
+    });
+
+    it("returns `partial` when an offending atom is named by no input", () => {
+      expect(
+        refusalAttribution([MEDICAL, renderCfcAtom("rewritten")], [
+          {
+            read: addressOf("of:chart", []),
+            labelPath: ["secret"],
+            atoms: [MEDICAL],
+          },
+        ]),
+      ).toBe("partial");
+    });
+  });
+
+  describe("a pattern's refused egress", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let reported: ErrorWithContext[];
+    let originalFetch: typeof globalThis.fetch;
+    let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+    let llmRequests: number;
+
+    beforeEach(() => {
+      clearMockResponses();
+      llmRequests = 0;
+      setMockResponseGate(() => {
+        llmRequests += 1;
+        return Promise.resolve();
+      });
+      storageManager = StorageManager.emulate({ as: signer });
+      reported = [];
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
+        cfcSinkMaxConfidentiality: { fetchText: [], llm: [] },
+        errorHandlers: [(error) => reported.push(error)],
+      });
+      setPatternEnvironment({
+        apiUrl: new URL("http://mock-test-server.local"),
+      });
+      fetchCalls = [];
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = ((
+        input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        fetchCalls.push({ url, init });
+        return Promise.resolve(
+          new Response("hello", {
+            status: 200,
+            headers: { "Content-Type": "text/plain; charset=utf-8" },
+          }),
+        );
+      }) as typeof globalThis.fetch;
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      setMockResponseGate(undefined);
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /** Run `fetchText` over the `secret` field of the named seeded document. */
+    const runFetchTextOver = async (name: string): Promise<void> => {
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern, byRef } = commonfabric;
+      const fetchText = byRef("fetchText");
+      const testPattern = pattern<{ url: string; token: string }>(
+        ({ url, token }) =>
+          fetchText({ url, options: { headers: { "x-token": token } } }),
+      );
+      const tx = runtime.edit();
+      const secret = runtime.getCell(space, name, undefined, tx);
+      const resultCell = runtime.getCell(space, `${name}-out`, undefined, tx);
+      const result = runtime.run(
+        tx,
+        testPattern,
+        {
+          url: "http://mock-test-server.local/text",
+          token: secret.key("secret"),
+        } as unknown as { url: string; token: string },
+        resultCell,
+      );
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+      // The request (if any) fires from a post-commit effect and writes back
+      // through its own transactions. `idle()` deliberately does not span that
+      // async builtin work; `settled()` is the barrier that does.
+      await result.pull();
+      await runtime.settled();
+    };
+
+    /** Run `llm` over the `secret` field of the named seeded document. */
+    const runLlmOver = async (name: string): Promise<void> => {
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern, llm } = commonfabric;
+      const testPattern = pattern<{ token: string }>(({ token }) =>
+        llm({ messages: [{ role: "user", content: token }] })
+      );
+      const tx = runtime.edit();
+      const secret = runtime.getCell(space, name, undefined, tx);
+      const resultCell = runtime.getCell(space, `${name}-out`, undefined, tx);
+      const result = runtime.run(
+        tx,
+        testPattern,
+        { token: secret.key("secret") } as unknown as { token: string },
+        resultCell,
+      ) as Cell<unknown>;
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+      await result.pull();
+      await runtime.settled();
+    };
+
+    const reportedRefusalDetail = (): CfcRefusalDetail => {
+      const refusal = reported.find((error) =>
+        error.name === "CfcCommitRefusalError"
+      );
+      expect(refusal).toBeDefined();
+      expect(refusal!.name).toBe("CfcCommitRefusalError");
+      const details = refusalsOf(refusal);
+      expect(details.length).toBeGreaterThan(0);
+      return details[0];
+    };
+
+    it("names the seeded document as the input behind a refused `fetchText` egress", async () => {
+      const secretId = await seedSecret(runtime, "refusal-fetch-secret", [
+        "medical",
+      ]);
+      await runFetchTextOver("refusal-fetch-secret");
+
+      const detail = reportedRefusalDetail();
+      expect(detail.gate).toBe("sink-ceiling");
+      expect(detail.sink).toBe("fetchText");
+      expect(detail.offendingAtoms).toContain(MEDICAL);
+      // The assertion the whole channel exists for: the refusal names the
+      // INPUT, so dropping that argument is a remedy rather than a guess.
+      const input = detail.inputs.find((entry) => entry.read.id === secretId);
+      expect(input).toBeDefined();
+      expect(input!.atoms).toContain(MEDICAL);
+      expect(detail.attribution).toBe("complete");
+      // Nothing reached the network: the ceiling refused the staging commit,
+      // so the post-commit effect never flushed.
+      expect(fetchCalls).toEqual([]);
+    });
+
+    it("names the seeded document as the input behind a refused `llm` egress", async () => {
+      const secretId = await seedSecret(runtime, "refusal-llm-secret", [
+        "medical",
+      ]);
+      await runLlmOver("refusal-llm-secret");
+
+      const detail = reportedRefusalDetail();
+      expect(detail.gate).toBe("sink-ceiling");
+      expect(detail.sink).toBe("llm");
+      expect(detail.offendingAtoms).toContain(MEDICAL);
+      const input = detail.inputs.find((entry) => entry.read.id === secretId);
+      expect(input).toBeDefined();
+      expect(input!.atoms).toContain(MEDICAL);
+      expect(detail.attribution).toBe("complete");
+      expect(llmRequests).toBe(0);
+    });
+
+    it("settles with no reported error and reaches the network over an unlabelled input", async () => {
+      // The control that makes the two refusals above non-vacuous, and the
+      // property a replan relies on: the same pattern over an input carrying
+      // no confidentiality is not refused, and its request is sent.
+      await seedSecret(runtime, "refusal-clean-secret");
+      await runFetchTextOver("refusal-clean-secret");
+
+      expect(reported.map((error) => error.name)).toEqual([]);
+      expect(fetchCalls.map((call) => call.url)).toEqual([
+        "http://mock-test-server.local/text",
+      ]);
+    });
+  });
+
+  describe("a refused writer-fit misfit", () => {
+    it("names the write target the derived label did not fit", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        await seedSecret(runtime, "refusal-writer-fit-source", ["medical"]);
+
+        const tx = runtime.edit();
+        // Strict is where the misfit REJECTS rather than persists-and-flags,
+        // and a detail only rides out on a refusal.
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          space,
+          "refusal-writer-fit-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("rosebud");
+        // The target declares no store policy, so its ceiling is residency
+        // alone: a `medical`-tainted derived value cannot fit.
+        const derived = runtime.getCell(
+          space,
+          "refusal-writer-fit-derived",
+          undefined,
+          tx,
+        );
+        derived.set({ copied: `${raw.secret}!` });
+        const derivedId = derived.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const result = await tx.commit();
+
+        expect(result.error).toBeDefined();
+        expect(result.error!.name).toBe("CfcCommitRefusalError");
+        const detail = refusalsOf(result.error).find((entry) =>
+          entry.gate === "writer-fit"
+        );
+        expect(detail).toBeDefined();
+        expect(detail!.target?.id).toBe(derivedId);
+        expect(detail!.offendingAtoms.length).toBeGreaterThan(0);
+        expect(detail!.offendingAtoms).toContain(MEDICAL);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
+  describe("the `cfc.prepare-reject` marker", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let markers: PrepareRejectMarker[];
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
+        cfcSinkMaxConfidentiality: { fetchText: [] },
+      });
+      markers = [];
+      runtime.telemetry.addEventListener("telemetry", (event) => {
+        const marker = (event as RuntimeTelemetryEvent).marker;
+        if (marker.type === "cfc.prepare-reject") markers.push(marker);
+      });
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /**
+     * Read the seeded secret and stage a `fetchText` request from it, which
+     * the empty ceiling refuses. `alsoWrite` adds a raw write to a second
+     * labeled document, whose missing schema write-policy input is an
+     * UNTAGGED reason — the refusal then mixes a verdict with a reason a
+     * fresh attempt could resolve.
+     */
+    const refuseWithSink = async (
+      name: string,
+      alsoWrite?: URI,
+    ): Promise<void> => {
+      await seedSecret(runtime, name, ["medical"]);
+      const tx = runtime.edit();
+      const secret = runtime.getCell(space, name, undefined, tx);
+      expect(secret.key("secret").getRaw() as string).toBe("rosebud");
+      if (alsoWrite !== undefined) {
+        tx.writeOrThrow(
+          { space, scope: "space", id: alsoWrite, path: ["value", "slug"] },
+          "late-slug",
+        );
+      }
+      enqueueSinkRequestPostCommitEffect(
+        tx,
+        "fetchText",
+        `fetchText:${name}`,
+        createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+        "fetchText-start",
+        () => {},
+      );
+      tx.prepareCfc();
+      tx.abort();
+    };
+
+    it("submits a terminal marker carrying the refusal detail for a plain ceiling refusal", async () => {
+      await refuseWithSink("marker-terminal-secret");
+
+      expect(markers.length).toBe(1);
+      expect(markers[0].terminal).toBe(true);
+      expect(markers[0].reasons.join("\n")).toContain(
+        "exceeds ceiling for fetchText",
+      );
+      const detail = markers[0].refusals.find((entry) =>
+        entry.gate === "sink-ceiling"
+      );
+      expect(detail).toBeDefined();
+      expect(detail!.sink).toBe("fetchText");
+      expect(detail!.offendingAtoms).toContain(MEDICAL);
+      expect(detail!.attribution).toBe("complete");
+    });
+
+    it("submits a non-terminal marker carrying the same detail when an untagged reason joins the verdict", async () => {
+      // The gap the marker closes: this refusal never reaches the error
+      // channel — the commit boundary downgrades a mixed-reason refusal to a
+      // retryable abort — so the marker is its only trace.
+      const otherId = await seedRootLabeledDoc(runtime, "marker-mixed-other");
+      await refuseWithSink("marker-mixed-secret", otherId);
+
+      expect(markers.length).toBe(1);
+      expect(markers[0].terminal).toBe(false);
+      expect(markers[0].reasons.join("\n")).toContain(
+        "missing schema write-policy input",
+      );
+      const detail = markers[0].refusals.find((entry) =>
+        entry.gate === "sink-ceiling"
+      );
+      expect(detail).toBeDefined();
+      expect(detail!.offendingAtoms).toContain(MEDICAL);
+    });
+  });
+});

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -196,5 +196,36 @@ describe("extended-storage-transaction", () => {
         await tx.commit();
       }
     });
+
+    it("records a refusal detail on the transaction it wraps", async () => {
+      const { tx } = await seeded("wrapped-refusal-detail");
+      const wrapper = createNonReactiveTransaction(tx);
+      try {
+        wrapper.recordCfcRefusalDetail({
+          gate: "sink-ceiling",
+          sink: "fetchText",
+          offendingAtoms: ['"medical"'],
+          inputs: [],
+          attribution: "none",
+          reason: "sink-request confidentiality exceeds ceiling for " +
+            'fetchText: "medical"',
+        });
+
+        // The wrapper shares the inner transaction's CFC state, so a gate
+        // that refuses while running under a wrapper describes itself to the
+        // transaction that will be asked for the refusal.
+        expect(tx.getCfcState().refusalDetails).toEqual([{
+          gate: "sink-ceiling",
+          sink: "fetchText",
+          offendingAtoms: ['"medical"'],
+          inputs: [],
+          attribution: "none",
+          reason: "sink-request confidentiality exceeds ceiling for " +
+            'fetchText: "medical"',
+        }]);
+      } finally {
+        await tx.commit();
+      }
+    });
   });
 });


### PR DESCRIPTION
**Thread C of three parallel cf-harness/runner threads.** Owns `packages/runner/src/cfc/*`, scheduler diagnostics, and `packages/cf-harness/src/tools/run-pattern.ts`.

## The problem

CT-2037 (labs#6114) made a CFC commit refusal terminal and put it on the scheduler's error channel. CT-2077's E4 asked the next question: can an agent *act* on one? It could not. `sink-request confidentiality exceeds ceiling for fetchText: "medical"` is a complete verdict and a useless instruction — it names the atom, never the input that carried it — and `run_pattern` withheld even that from the model.

Ben's framing: a refusal must imply that **removing that input would let the operation succeed**, so the agent bounces off the wall toward taint minimization.

## One correction to E4's verdict

Reproducing E4's method found the runner half is **no longer silent**. Under a ceiling, a pattern driving a labelled value into `byRef("fetchText")` *or* `byRef("llm")` already produces a `CfcCommitRefusalError` on `scheduler.onError`, attributed to the pattern's own result cell — #6114 plus the max-enforcement preset landed that after E4 ran.

But E4 did find a real remaining hole, and this closes it: a refusal is terminal, and therefore surfaced, only when **every** reason is verdict-tagged. A refusal mixing a verdict with an input prepare could not evaluate is downgraded to a retryable abort, retried ten times, and reaches a host as nothing but a graph that stopped converging — with a warning that misdiagnoses it as a reactive cycle. Pinned by test.

## What this lands

**Runner**
- `packages/runner/src/cfc/refusal-detail.ts` — the structured refusal shape (below).
- `collectConsumedLabel` retains the per-clause read provenance it previously discarded into a flat bag. The gates' fits-decisions are untouched.
- Both gates record a detail: the sink-request ceiling and the writer-fit confidentiality misfit. Writer-fit pays for its provenance only on an actual misfit — no committing transaction does that walk speculatively.
- `CfcCommitRefusalError` carries `refusals` next to `reasons`, paired by reason text; each prepare pass describes only its own verdict. The scheduler error channel preserves both.
- New `cfc.prepare-reject` telemetry marker reports **every** refusal with a `terminal` flag (CT-2077 fix 1).

**cf-harness**
- `run_pattern` reports a refusal as a structured, actionable error naming the agent's own input keys, and `FabricActionErrorRecord` carries the details through.

## The refusal shape — for Thread B

Stable; the renderer can build against this.

```ts
type CfcRefusalDetail = {
  gate: "sink-ceiling" | "writer-fit";
  sink?: string;                       // sink-ceiling
  target?: CfcAddress;                 // writer-fit
  offendingAtoms: readonly string[];   // rendered for display, as the reason renders them
  inputs: readonly CfcRefusalInput[];  // the reads that carried them
  attribution: "complete" | "partial" | "none";
  reason: string;                      // pairing key to the reason list
};

type CfcRefusalInput = {
  read: CfcAddress;                    // { space, id, scope, path }
  labelPath: readonly string[];        // label-map entry path inside that doc
  atoms: readonly string[];            // the offending atoms THIS read contributed
};
```

`attribution` is the actionable claim as a checkable property rather than a promise: `complete` means the named inputs account for every offending clause, so dropping them clears the refusal. An exchange-rule rewrite is the ordinary way to land on `partial` — the gate decides on a rewritten label whose clauses need not be any clause a read contributed.

Two shape constraints worth knowing before you extend it. Clause matching is `deepEqual`, CFC's own structural identity — **not** a rendering, since `{a:1,b:2}` and `{b:2,a:1}` are one clause to CFC and two strings to `JSON.stringify`, and `-0`/`0` are the converse. And every type is a `type` alias, not an `interface`: a detail rides the telemetry marker across the runtime-client IPC boundary as a `FabricValue`, and an interface has no implicit index signature.

Reachable from `ICfcCommitRefusalError.refusals`, the scheduler error channel, the `cfc.prepare-reject` marker, and `FabricActionErrorRecord.refusals`.

The harness's model-facing projection is separate and deliberately narrower — `policyRefusal` carries `{gates, sinks, offendingAtoms, withheldAtomCount?, inputKeys, unattributedInputCount?, attribution}` and no document ids, spaces, or paths, because the outbound scrub reaches `message`/`valueError` only.

## Not touched (hand-offs)

- **The pattern-facing surface stays withheld.** `enqueueSinkRequestPostCommitEffect`'s doc argues that handing a refused writer its reason is a strange bargain, and that stands. The harness agent is a different trust position, which is where the actionable projection lands.
- **A bare-atom caveat-source redactor.** `redactCaveatSourcesForDisplay` takes a whole `CfcLabelView`; the bare-atom worker is module-private. So the harness names only atoms that render to a scalar and counts the rest, conservative in the safe direction. Exporting a bare-atom redactor — or minting `offendingAtoms` already redacted — would let structured atoms be named too.
- **Sink *release* rejects are still silent** (`cfc/sink-request.ts` flush path): the tx already committed, so `abandonStagedWork` early-returns, `abandon` never fires, and a pattern that already saw `pending` sits pending forever. Reported only to `cfcStats.sinkReleaseRejects` and tx diagnostics. Separate defect, worth its own issue.
- **Event-path terminal refusals deliberately never call `handleError`** (`scheduler/events.ts` `case "terminal"`). Unchanged.

## Gates

`deno task check` (root, whole path list), `deno fmt --check`, `deno lint`, `deno task check-docs`, `deno test` in `packages/runner` (1310 passed, 0 failed) and `packages/cf-harness` (845 passed).

Four cf-harness failures are environmental, none in files this PR touches: three are the `Deno.makeTempDir` `PermissionDenied` sandbox failures in `prompt-loop.test.ts`, and the fourth is `integration/engine.integration.test.ts` "command timeout returns before child exits", which passes in isolation and fails only under full-suite load — a wall-clock timeout test, the class the repo's own principles name as flaky.

**Coverage: 24 of the ratchet's lines covered, 5 accepted with cause.** The 24 were ordinary untested branches, not unreachable code, and an accepted level becomes the floor later PRs are held to. They are covered instead: the runner's transaction-wrapper delegate, and — on the harness side — every branch that fires when the remedy is *not* clean (`partial`/`none` attribution and their distinct wording, a read no input key owns, a withheld structured atom, the `sink-ceiling` arm). Those are the paths where a wrong message sends an agent to drop an input that was not the problem, which is the failure this feature exists to prevent.

Refs CT-2077, CT-2037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The `+5` that remains is **not this PR's code**, and the gate says so itself: *"Regression not attributable to this PR's added lines: 6 line(s) across 1 unchanged file(s) that the baseline run covered… likely because there are lines that are inconsistently covered on `main`."* The file is `packages/runner/src/builtins/llm.ts` (1013/1014, 1418/1419, 2047/2048) — three copies of the LLM builtin's abandoned-request rejection arm, whose execution depends on whether a staged request gets abandoned during the run. Running the full `packages/runner` suite locally on this branch covers all six. Two consecutive CI runs reproduced the miss, so it is deterministic per-environment rather than random.

Filed as **CT-2112**, same class as CT-2111. Accepting the marker rather than blocking on a pre-existing `main` flake, with the caveat on the record that it raises the `packages/runner` floor by 5 until CT-2112 lands.

ACCEPT_COVERAGE_DEBT: packages/runner +5 lines
