### PR TITLE
CFC legibility in the console: per-cell labels cross-referenced from the space (CT-2100)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -171,14 +171,23 @@ A turn ends by reading the space it wrote into for the labels it holds on the
 cells the run touched, and records them as the run's `cell-labels.json`. That is
 what a cell chip draws its `space` row from, and what the head of the map states
 the regime of — a space that could not be read is a run whose cells are
-unasked-about rather than unlabelled.
+unasked-about rather than unlabelled. A run and the `delegate_task` children
+beneath it each record their own, and the head states what every cell on the map
+can be taken to mean, so a family whose runs did not all read the space is
+stated as read for none of them: one member's reading cannot speak for another
+member's cells.
 
 The read is one hop wide. A pattern's results are their own cells, linked from
 the piece that names them, and the derived label sits on the cell — so the
-labels of every cell a run's own cells link to are read too, under the key that
-named them. The database is opened read-only, and it is found by the space the
-fabric session names; `--space-db` points at the file instead, for a host whose
-store is not where the search looks.
+labels of the cells a run's own cells link to are read too, under the key that
+named them.
+
+It reaches one space. A reference or a link naming a space other than the one
+opened is recorded as unread rather than resolved, because the id it names may
+also exist here and would answer with the wrong cell's labels; such a cell reads
+as nothing known, which is what it is. The database is opened read-only, and it
+is found by the space the fabric session names; `--space-db` points at the file
+instead, for a host whose store is not where the search looks.
 
 ## Reading a run
 
@@ -186,9 +195,11 @@ Three columns, each scrolling on its own: the runs there are, the run being
 read, and the map of how it went. A turn produces a run, and the run's artifacts
 are the record of it, so the same view serves a run that finished an hour ago
 and one still going. The live event stream drives the status line and the
-re-reads; it is not a second feed. A run writes its artifacts as it goes, so
-every completed tool call re-reads the list, the open run and its map. The step
-the scrubber sits on survives the re-read.
+re-reads; it is not a second feed. The event that closes a turn is published
+once that turn's labels have been recorded, so the re-read it drives reads the
+snapshot rather than racing it. A run writes its artifacts as it goes, so every
+completed tool call re-reads the list, the open run and its map. The step the
+scrubber sits on survives the re-read.
 
 ### The runs
 

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -182,12 +182,17 @@ the piece that names them, and the derived label sits on the cell — so the
 labels of the cells a run's own cells link to are read too, under the key that
 named them.
 
-It reaches one space. A reference or a link naming a space other than the one
-opened is recorded as unread rather than resolved, because the id it names may
-also exist here and would answer with the wrong cell's labels; such a cell reads
-as nothing known, which is what it is. The database is opened read-only, and it
-is found by the space the fabric session names; `--space-db` points at the file
-instead, for a host whose store is not where the search looks.
+It reaches one space. A reference or a link naming a space the opened file
+cannot be shown to be — another space, or any space at all where the file's own
+name proves no DID — is recorded as unread rather than resolved, because the id
+it names may also exist here and would answer with the wrong cell's labels. A
+reference is recorded unread as a whole cell; a link is recorded unread at the
+path it sits at, so the cells beneath it read as nothing known rather than as
+cells the space holds no label for. The database is opened read-only, and it is
+found by the space the fabric session names; `--space-db` points at the file
+instead, for a host whose store is not where the search looks — and a file named
+for anything but its space proves no DID, so every spaced reference and link
+goes unread against one.
 
 ## Reading a run
 

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -181,8 +181,18 @@ The read is one hop wide. A pattern's results are their own cells, linked from
 the piece that names them, and the derived label sits on the cell — so the
 labels of the cells a run's own cells link to are read too, at the path the link
 sits at. The walk descends through the objects and arrays of a value to find
-those links, however deep inside one they sit, and stops at each: a linked
-cell's own links belong to that cell, not to this one.
+those links and stops at each: a linked cell's own links belong to that cell,
+not to this one.
+
+It descends a bounded way, and what it does not reach it records rather than
+passes over. The bounds sit far above the shape of any document a pattern writes
+— sixty-four levels deep, a hundred thousand values wide — and a path below that
+depth is recorded unread at the path itself, so the cells beneath it read as
+nothing known. A value large enough to exhaust the node budget is a walk that
+stopped before enumerating what was left, so it can name no path: it marks the
+whole cell's labels partial and warns as it does, because a value that size is a
+cycle far more often than it is a document. Either way, a cell the reader did
+not finish never reads as a cell with no label.
 
 It reaches one space. A reference or a link naming a space the opened file
 cannot be shown to be — another space, or any space at all where the file's own

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -281,14 +281,21 @@ is colored apart from a merely labelled one, and its card names the
 implementation that produced it under `transformed by`.
 
 A cell whose card says the space holds no label for it is saying what the space
-holds. A cell whose card says no label was read for it is saying the run's
-labels name it nowhere, which is a different thing, and the chip cannot tell on
-its own whether that is because the space was never read. The head of the map
-carries that: `cell labels read` with how many of the cells it read carry one,
-`cell labels unavailable` with why, or `cell labels not read`. Read an empty
-chip against it — under a run whose flow labels are `off`, or one whose space
-could not be read, an empty chip is a record of what the run recorded rather
-than a cell with nothing to hide.
+holds, and only a cell read whole says it. A cell whose card says no label was
+read for it is saying nothing was read there, which is a different thing: either
+the run's labels name the cell nowhere, or the reading covered part of it. Where
+it covered part of it, a **reading** row says which part it missed and what a
+path with no entry means under it — `read but for` the paths it declined to
+follow, each named, with every other path read; or `did not finish`, which names
+no path at all, because what it missed it never reached. The chip cannot tell on
+its own whether a cell went unnamed because the space was never read. The head
+of the map carries that: `cell labels read` with how many of the cells it read
+carry one, `cell labels unavailable` with why, or `cell labels not read`. Where
+a cell of the run was read only in part it heads `cell labels read in part`
+instead, and says how many, because the count beside it is then a floor rather
+than a total. Read an empty chip against that head — under a run whose flow
+labels are `off`, or one whose space could not be read, an empty chip is a
+record of what the run recorded rather than a cell with nothing to hide.
 
 ### The run's own panes
 

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -179,8 +179,10 @@ member's cells.
 
 The read is one hop wide. A pattern's results are their own cells, linked from
 the piece that names them, and the derived label sits on the cell — so the
-labels of the cells a run's own cells link to are read too, under the key that
-named them.
+labels of the cells a run's own cells link to are read too, at the path the link
+sits at. The walk descends through the objects and arrays of a value to find
+those links, however deep inside one they sit, and stops at each: a linked
+cell's own links belong to that cell, not to this one.
 
 It reaches one space. A reference or a link naming a space the opened file
 cannot be shown to be — another space, or any space at all where the file's own

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -77,6 +77,7 @@ Every environment variable has a flag, and the flag wins:
 | `--workspace`         | `CF_HARNESS_CONSOLE_WORKSPACE`       | `.cf-harness-console/workspace`       |
 | `--artifact-root`     | `CF_HARNESS_ARTIFACT_ROOT`           | `.cf-harness-console/runs`            |
 | `--session-db`        | `CF_HARNESS_CONSOLE_SESSION_DB`      | `.cf-harness-console/sessions.sqlite` |
+| `--space-db`          | `CF_HARNESS_SPACE_DB`                | the space's own database, discovered  |
 | `--max-model-turns`   | `CF_HARNESS_CONSOLE_MAX_MODEL_TURNS` | the prompt loop's default             |
 | `--skills-root`       | `CF_HARNESS_CONSOLE_SKILLS_ROOT`     | the repository's `skills/` tree       |
 
@@ -166,6 +167,19 @@ These govern the runtime `run_pattern` deploys patterns into. The harness's own
 `cfcEnforcementMode`, which governs tool policy and the sandbox, is a separate
 dial and reaches every run's `policy-snapshot.json` either way.
 
+A turn ends by reading the space it wrote into for the labels it holds on the
+cells the run touched, and records them as the run's `cell-labels.json`. That is
+what a cell chip draws its `space` row from, and what the head of the map states
+the regime of — a space that could not be read is a run whose cells are
+unasked-about rather than unlabelled.
+
+The read is one hop wide. A pattern's results are their own cells, linked from
+the piece that names them, and the derived label sits on the cell — so the
+labels of every cell a run's own cells link to are read too, under the key that
+named them. The database is opened read-only, and it is found by the space the
+fabric session names; `--space-db` points at the file instead, for a host whose
+store is not where the search looks.
+
 ## Reading a run
 
 Three columns, each scrolling on its own: the runs there are, the run being
@@ -217,11 +231,36 @@ the handles a step holds — because two sightings of one cell have to be
 recognisable as one cell. The chip carries the name it goes by: the slug a
 person gave it, else the handle the model held, else its address. Hovering it
 gives the rest — handle, address, the shape the pattern that made it declared,
-the confidentiality atoms riding on it, and the step whose result minted it.
+the labels below, and the step whose result minted it.
 
-A cell showing no atoms under a run whose flow labels are `off` is saying what
-that run recorded, not hiding something. The regime at the top of the map is
-what makes the difference readable.
+A chip holds two label facts, and the card names them apart because they answer
+different questions:
+
+- **cfc** — the atoms the sandbox's invocation context recorded on the arguments
+  of the call this sighting belongs to. What one call saw crossing into it. The
+  count on the chip is this one.
+- **space** — the confidentiality and integrity atoms the space stores for the
+  cell itself, read from the space the run wrote into, with the labelled paths
+  read path by path and the origin of each beside it.
+
+An atom is not a claim that the value was computed from something confidential.
+A value's label can be the join of the fields of the object it was reached
+through, so a plain input reached through a labelled object carries an atom
+having been derived from nothing. What separates the two is the space's own
+account of where the value came from, and the chip wears it as a second state: a
+**derived** cell — one the space says was computed from what a function read —
+is colored apart from a merely labelled one, and its card names the
+implementation that produced it under `transformed by`.
+
+A cell whose card says the space holds no label for it is saying what the space
+holds. A cell whose card says no label was read for it is saying the run's
+labels name it nowhere, which is a different thing, and the chip cannot tell on
+its own whether that is because the space was never read. The head of the map
+carries that: `cell labels read` with how many of the cells it read carry one,
+`cell labels unavailable` with why, or `cell labels not read`. Read an empty
+chip against it — under a run whose flow labels are `off`, or one whose space
+could not be read, an empty chip is a record of what the run recorded rather
+than a cell with nothing to hide.
 
 ### The run's own panes
 
@@ -263,8 +302,9 @@ what makes the difference readable.
   `record_feedback` reported, and every address `assign_slug` named.
 - **Tool outputs** — each tool result as the model read it, untruncated.
 - **Artifacts** — the run's own records: `run-state.json`, `transcript.json`,
-  `run-report.json`, the policy snapshot and trace, the capability snapshot, and
-  the skill registry and activations, whichever the run wrote.
+  `run-report.json`, the policy snapshot and trace, the capability snapshot, the
+  cell labels read back from the space, and the skill registry and activations,
+  whichever the run wrote.
 
 Handle scope is reconstructed rather than recorded. A run keeps one handle
 table, its last, so the timeline takes a handle to be in scope from the step its

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -69,9 +69,9 @@ export type ConsoleCellLabelsStatus = "read" | "unavailable" | "absent";
 /**
  * The run's labels, indexed by the cell they belong to.
  *
- * `byAddress` is keyed by both the entity id and the canonical reference the
- * run held, because a cell is named one way in a handle table and another in
- * an argument written as a whole link, and both have to find the same labels.
+ * `byAddress` is keyed by entity, because that is what a label is stored per.
+ * A reference names a path inside a document as well as the document, and
+ * `cellLabelsAt` is what turns one into the other.
  */
 export interface ConsoleCellLabelIndex {
   status: ConsoleCellLabelsStatus;
@@ -163,13 +163,13 @@ export const consoleCellLabelIndex = (
   if (snapshot === undefined) {
     return { status: "absent", byAddress: new Map() };
   }
+  // Keyed by entity, and by entity alone: a reference names a path inside a
+  // document as well as the document, and two references into one document
+  // narrow to different cells. Keying a whole document's labels under one of
+  // its references would hand every cell of it the same answer.
   const byAddress = new Map<string, ConsoleCellLabels>();
   for (const record of snapshot.cells) {
-    const labels = consoleCellLabels(record);
-    byAddress.set(record.entityId, labels);
-    if (record.ref !== undefined) {
-      byAddress.set(record.ref, labels);
-    }
+    byAddress.set(record.entityId, consoleCellLabels(record));
   }
   return {
     status: snapshot.status === "read" ? "read" : "unavailable",
@@ -185,24 +185,82 @@ export const consoleCellLabelIndex = (
 export const consoleCellLabelsSummary = (
   index: ConsoleCellLabelIndex,
 ): ConsoleCellLabelsSummary => {
-  // Entity ids and refs both key the same labels, so counting the map's
-  // values would count most cells twice. The distinct label objects are the
-  // cells.
-  const cells = new Set(index.byAddress.values());
+  const cells = [...index.byAddress.values()];
   return {
     status: index.status,
     ...(index.detail !== undefined ? { detail: index.detail } : {}),
     ...(index.space !== undefined ? { space: index.space } : {}),
-    cellsRead: cells.size,
-    cellsLabelled: [...cells].filter((labels) => labels.entries.length > 0)
-      .length,
+    cellsRead: cells.length,
+    cellsLabelled: cells.filter((labels) => labels.entries.length > 0).length,
+  };
+};
+
+/** The entity a reference names, and the path inside it the reference walks. */
+const addressOf = (
+  ref: string,
+): { entityId: string; path: string[] } | undefined => {
+  const segments = ref.split("/").filter((segment) => segment !== "");
+  const at = segments.findIndex((segment) =>
+    segment.startsWith("of:") || segment.startsWith("computed:")
+  );
+  return at < 0 ? undefined : {
+    entityId: segments[at].split("@")[0],
+    path: segments.slice(at + 1),
   };
 };
 
 /**
- * The labels for the cell a reference names. A reference may address a path
- * inside a document while the labels are stored for the document, so a ref
- * that misses is retried against the document it sits in.
+ * The labels of one document, narrowed to a path inside it.
+ *
+ * Labels are stored per document, and a run holds a reference per cell — two
+ * cells of one piece are two references into one document. Handing both the
+ * document's whole label set would put one cell's atom on the other, which is
+ * the same mistake as coloring a plain input by the label of the object it
+ * was reached through. So an entry counts for a reference only where the
+ * reference's path reaches it: an entry at or under that path, re-rooted to
+ * it, or an entry above it, which governs everything beneath.
+ */
+const narrow = (
+  labels: ConsoleCellLabels,
+  path: readonly string[],
+): ConsoleCellLabels => {
+  if (path.length === 0) {
+    return labels;
+  }
+  const prefix = path.join("/");
+  const entries: ConsoleCellLabelEntry[] = [];
+  for (const entry of labels.entries) {
+    if (entry.path === prefix) {
+      entries.push({ ...entry, path: "" });
+      continue;
+    }
+    if (entry.path.startsWith(`${prefix}/`)) {
+      entries.push({ ...entry, path: entry.path.slice(prefix.length + 1) });
+      continue;
+    }
+    // An entry above the reference covers it: a label on the document itself
+    // reaches every cell of it.
+    if (entry.path === "" || prefix.startsWith(`${entry.path}/`)) {
+      entries.push({ ...entry, path: "" });
+    }
+  }
+  return {
+    confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
+    integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
+    derived: entries.some((entry) => entry.origin === "derived"),
+    transformedBy: dedupe(
+      entries.flatMap((entry) =>
+        entry.transformedBy === undefined ? [] : [entry.transformedBy]
+      ),
+    ),
+    entries,
+  };
+};
+
+/**
+ * The labels for the cell a reference names. A reference addresses a path
+ * inside a document while the labels are stored for the document, so the
+ * document's labels are found first and then narrowed to the path.
  */
 export const cellLabelsAt = (
   index: ConsoleCellLabelIndex,
@@ -211,17 +269,10 @@ export const cellLabelsAt = (
   if (ref === undefined) {
     return undefined;
   }
-  const direct = index.byAddress.get(ref);
-  if (direct !== undefined) {
-    return direct;
+  const address = addressOf(ref);
+  if (address === undefined) {
+    return index.byAddress.get(ref);
   }
-  // The entity id inside the reference: the segment carrying a URI scheme,
-  // which a cross-space link puts after its space DID and a path puts before
-  // its own segments.
-  const segment = ref.split("/").find((part) =>
-    part.startsWith("of:") || part.startsWith("computed:")
-  );
-  return segment === undefined
-    ? undefined
-    : index.byAddress.get(segment.split("@")[0]);
+  const document = index.byAddress.get(address.entityId);
+  return document === undefined ? undefined : narrow(document, address.path);
 };

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -21,6 +21,8 @@
  *   report a plain input as tainted.
  */
 
+import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
+
 import type {
   HarnessCellLabelEntry,
   HarnessCellLabelRecord,
@@ -30,8 +32,14 @@ import type {
 
 /** The labels at one path of a cell, named for showing. */
 export interface ConsoleCellLabelEntry {
-  /** The path inside the cell, `/`-joined; empty for the cell itself. */
-  path: string;
+  /**
+   * The path inside the cell, segment by segment; empty for the cell itself.
+   * Kept as segments rather than joined, because a segment may hold the
+   * separator and a stored path may hold the `*` that stands for every
+   * member of a container — both of which a joined string loses. Joining is
+   * for showing, and belongs to whoever shows it.
+   */
+  path: readonly string[];
   confidentiality: readonly string[];
   integrity: readonly string[];
   origin?: string;
@@ -124,7 +132,7 @@ const producerOf = (atom: HarnessCfcAtom | undefined): string | undefined => {
 const entryOf = (entry: HarnessCellLabelEntry): ConsoleCellLabelEntry => {
   const producer = producerOf(entry.transformedBy);
   return {
-    path: entry.path.join("/"),
+    path: [...entry.path],
     confidentiality: entry.confidentiality.map((atom) => atom.name),
     integrity: entry.integrity.map((atom) => atom.name),
     ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
@@ -133,23 +141,25 @@ const entryOf = (entry: HarnessCellLabelEntry): ConsoleCellLabelEntry => {
   };
 };
 
+/** The cell-level facts a set of entries adds up to. */
+const labelsOfEntries = (
+  entries: readonly ConsoleCellLabelEntry[],
+): ConsoleCellLabels => ({
+  confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
+  integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
+  derived: entries.some((entry) => entry.origin === "derived"),
+  transformedBy: dedupe(
+    entries.flatMap((entry) =>
+      entry.transformedBy === undefined ? [] : [entry.transformedBy]
+    ),
+  ),
+  entries,
+});
+
 /** One recorded cell, reduced to what a chip and a card show. */
 export const consoleCellLabels = (
   record: HarnessCellLabelRecord,
-): ConsoleCellLabels => {
-  const entries = record.entries.map(entryOf);
-  return {
-    confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
-    integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
-    derived: entries.some((entry) => entry.origin === "derived"),
-    transformedBy: dedupe(
-      entries.flatMap((entry) =>
-        entry.transformedBy === undefined ? [] : [entry.transformedBy]
-      ),
-    ),
-    entries,
-  };
-};
+): ConsoleCellLabels => labelsOfEntries(record.entries.map(entryOf));
 
 /**
  * The whole snapshot, indexed. A run that wrote no snapshot is `absent`
@@ -169,6 +179,14 @@ export const consoleCellLabelIndex = (
   // its references would hand every cell of it the same answer.
   const byAddress = new Map<string, ConsoleCellLabels>();
   for (const record of snapshot.cells) {
+    // A cell nothing was asked about is left out of the index rather than
+    // entered with no labels. Absent, it reads as a cell this run says
+    // nothing about, which is what it is; entered, it would read as one the
+    // space holds no label for — and, keyed by entity, it would answer for a
+    // cell of the same id in the space that was read.
+    if (record.unreadReason !== undefined) {
+      continue;
+    }
     byAddress.set(record.entityId, consoleCellLabels(record));
   }
   return {
@@ -196,18 +214,89 @@ export const consoleCellLabelsSummary = (
 };
 
 /** The entity a reference names, and the path inside it the reference walks. */
-const addressOf = (
-  ref: string,
-): { entityId: string; path: string[] } | undefined => {
-  const segments = ref.split("/").filter((segment) => segment !== "");
+interface ConsoleCellAddress {
+  entityId: string;
+  path: readonly string[];
+  space?: string;
+}
+
+/**
+ * A JSON Pointer split into its segments, `~1` decoding to `/` and `~0` to
+ * `~`. Mirrors `parsePointer` in `packages/memory/v2/path.ts`, which is the
+ * definition; two lines of it are restated rather than imported, so that the
+ * module the page reads its cell types from takes on no package for one
+ * string function.
+ */
+const pointerSegments = (pointer: string): string[] =>
+  pointer.split("/").slice(1).map((segment) =>
+    segment.replaceAll("~1", "/").replaceAll("~0", "~")
+  );
+
+/**
+ * The address of a reference the canonical parser will not take — one whose
+ * id is shorter than a minted handle, which it reads as a human name. The
+ * pointer is decoded by the same rule either way, so a segment holding a
+ * separator survives the fallback as it does the parse.
+ */
+const looseAddressOf = (ref: string): ConsoleCellAddress | undefined => {
+  const segments = pointerSegments(ref.startsWith("/") ? ref : `/${ref}`);
   const at = segments.findIndex((segment) =>
     segment.startsWith("of:") || segment.startsWith("computed:")
   );
-  return at < 0 ? undefined : {
+  if (at < 0) {
+    return undefined;
+  }
+  const space = segments.slice(0, at).find((segment) =>
+    segment.startsWith("@")
+  );
+  return {
     entityId: segments[at].split("@")[0],
     path: segments.slice(at + 1),
+    ...(space === undefined ? {} : { space: space.slice(1) }),
   };
 };
+
+/**
+ * The address a reference resolves to. Parsed rather than split: a reference
+ * is a JSON Pointer, so a segment holding a `/` or a `~` is escaped in it,
+ * and splitting on the separator would cut such a segment in two and leave
+ * neither half matching anything.
+ */
+const addressOf = (ref: string): ConsoleCellAddress | undefined => {
+  const trimmed = ref.trim();
+  try {
+    const link = parseLLMFriendlyLink(
+      trimmed.startsWith("/") ? trimmed : `/${trimmed}`,
+    );
+    return link.id === undefined ? undefined : {
+      entityId: link.id,
+      path: link.path,
+      ...(link.space ? { space: link.space } : {}),
+    };
+  } catch {
+    return looseAddressOf(trimmed);
+  }
+};
+
+/**
+ * Whether `prefix` covers `path`, over the segments a stored label path is
+ * written in: `*` stands for every member of a container, so it matches any
+ * concrete segment and any concrete segment matches it.
+ *
+ * Mirrors `cfcLabelPathPrefixMatches` in
+ * `packages/runner/src/cfc/label-view-core.ts`, which is the definition of
+ * this relation and of the re-rooting below it in `rebaseCfcLabelView`. It is
+ * not exported from `@commonfabric/runner/cfc`, so it is restated here; the
+ * two are one rule and a change to that one belongs here too.
+ */
+const pathPrefixMatches = (
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) =>
+    segment === path[index] || segment === "*" || path[index] === "*"
+  );
 
 /**
  * The labels of one document, narrowed to a path inside it.
@@ -227,40 +316,32 @@ const narrow = (
   if (path.length === 0) {
     return labels;
   }
-  const prefix = path.join("/");
   const entries: ConsoleCellLabelEntry[] = [];
   for (const entry of labels.entries) {
-    if (entry.path === prefix) {
-      entries.push({ ...entry, path: "" });
+    if (pathPrefixMatches(path, entry.path)) {
+      entries.push({ ...entry, path: entry.path.slice(path.length) });
       continue;
     }
-    if (entry.path.startsWith(`${prefix}/`)) {
-      entries.push({ ...entry, path: entry.path.slice(prefix.length + 1) });
-      continue;
-    }
-    // An entry above the reference covers it: a label on the document itself
-    // reaches every cell of it.
-    if (entry.path === "" || prefix.startsWith(`${entry.path}/`)) {
-      entries.push({ ...entry, path: "" });
+    // An entry above the reference covers it: a label on the document itself,
+    // or on anything the reference is reached through, reaches every cell
+    // beneath it, and re-roots to the reference's own path.
+    if (pathPrefixMatches(entry.path, path)) {
+      entries.push({ ...entry, path: [] });
     }
   }
-  return {
-    confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
-    integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
-    derived: entries.some((entry) => entry.origin === "derived"),
-    transformedBy: dedupe(
-      entries.flatMap((entry) =>
-        entry.transformedBy === undefined ? [] : [entry.transformedBy]
-      ),
-    ),
-    entries,
-  };
+  return labelsOfEntries(entries);
 };
 
 /**
  * The labels for the cell a reference names. A reference addresses a path
  * inside a document while the labels are stored for the document, so the
  * document's labels are found first and then narrowed to the path.
+ *
+ * The index is keyed by entity, and an entity id names a document within its
+ * own space, so a reference naming a space other than the one the snapshot
+ * was taken in has no answer here: the id it carries would find whichever
+ * cell of the read space happens to share it. Such a reference reads as a
+ * cell nothing is known about, the same as one the snapshot never covered.
  */
 export const cellLabelsAt = (
   index: ConsoleCellLabelIndex,
@@ -272,6 +353,9 @@ export const cellLabelsAt = (
   const address = addressOf(ref);
   if (address === undefined) {
     return index.byAddress.get(ref);
+  }
+  if (address.space !== undefined && address.space !== index.space?.did) {
+    return undefined;
   }
   const document = index.byAddress.get(address.entityId);
   return document === undefined ? undefined : narrow(document, address.path);

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -138,6 +138,15 @@ export interface ConsoleCellLabelsSummary {
   /** How many cells the snapshot read, and how many of them carry a label. */
   cellsRead: number;
   cellsLabelled: number;
+
+  /**
+   * How many of those cells it read only part of — one holding a path it
+   * declined to follow, or one whose read ran out before it finished. It is
+   * what stops the count beside it reading as a complete reading: a cell
+   * counted here may hold a label at a path nothing was read at, so
+   * `cellsLabelled` is a floor rather than a total wherever this is not zero.
+   */
+  cellsPartial: number;
 }
 
 const dedupe = (names: readonly string[]): string[] => [...new Set(names)];
@@ -252,6 +261,15 @@ export const consoleCellLabelIndex = (
   };
 };
 
+/**
+ * Whether a record holds either of the two facts that make its entries some
+ * of what the space holds rather than all of it — a path nothing was read at,
+ * or a read that stopped before it finished.
+ */
+const readInPart = (record: HarnessCellLabelRecord): boolean =>
+  record.truncationReason !== undefined ||
+  (record.unreadPaths ?? []).length > 0;
+
 /** The run-level fact the map and the run header state. */
 export const consoleCellLabelsSummary = (
   index: ConsoleCellLabelIndex,
@@ -263,6 +281,7 @@ export const consoleCellLabelsSummary = (
     ...(index.space !== undefined ? { space: index.space } : {}),
     cellsRead: cells.length,
     cellsLabelled: cells.filter((record) => record.entries.length > 0).length,
+    cellsPartial: cells.filter(readInPart).length,
   };
 };
 

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -1,0 +1,227 @@
+/**
+ * The per-cell CFC labels a run recorded, as the page reads them.
+ *
+ * A run's `cell-labels.json` is the join between the run's artifact tree and
+ * the space it wrote into: the tree knows which cells the run touched, the
+ * space knows what each of them is labelled. This module turns that artifact
+ * into something a cell chip can show — an index keyed by the address a cell
+ * goes by, and per-cell facts already reduced to the names a badge writes.
+ *
+ * Two distinctions are kept rather than flattened, because collapsing either
+ * one makes the page lie:
+ *
+ * - **Read against unread.** A cell with no atoms under a snapshot that was
+ *   taken is a cell the space holds no label for. The same cell under a run
+ *   whose space could not be read is a cell nobody asked about.
+ * - **Derived against carried.** A value's label may be the join of the
+ *   fields it was built from, so a plain input reached through a labelled
+ *   object carries a confidentiality atom without having been derived from
+ *   anything confidential. `origin` and the provenance atom beside it are
+ *   what separate the two, and a reader that colored by the atom alone would
+ *   report a plain input as tainted.
+ */
+
+import type {
+  HarnessCellLabelEntry,
+  HarnessCellLabelRecord,
+  HarnessCellLabels,
+  HarnessCfcAtom,
+} from "../src/contracts/cell-labels.ts";
+
+/** The labels at one path of a cell, named for showing. */
+export interface ConsoleCellLabelEntry {
+  /** The path inside the cell, `/`-joined; empty for the cell itself. */
+  path: string;
+  confidentiality: readonly string[];
+  integrity: readonly string[];
+  origin?: string;
+  observes?: string;
+
+  /** The implementation that produced this value, when one is recorded. */
+  transformedBy?: string;
+}
+
+/** Everything the space says about one cell. */
+export interface ConsoleCellLabels {
+  /** Every confidentiality atom at any path, deduplicated. */
+  confidentiality: readonly string[];
+
+  /** Every integrity atom at any path, deduplicated. */
+  integrity: readonly string[];
+
+  /**
+   * Whether any of it was computed from what a function read, rather than
+   * declared on a schema or carried in on a reference. This is the fact a
+   * confidentiality atom on its own does not establish.
+   */
+  derived: boolean;
+
+  /** The implementations that produced the derived paths, if any. */
+  transformedBy: readonly string[];
+
+  /** The labels path by path, for a reader that wants the whole of it. */
+  entries: readonly ConsoleCellLabelEntry[];
+}
+
+/** Why a run shows no labels on any cell, when it shows none. */
+export type ConsoleCellLabelsStatus = "read" | "unavailable" | "absent";
+
+/**
+ * The run's labels, indexed by the cell they belong to.
+ *
+ * `byAddress` is keyed by both the entity id and the canonical reference the
+ * run held, because a cell is named one way in a handle table and another in
+ * an argument written as a whole link, and both have to find the same labels.
+ */
+export interface ConsoleCellLabelIndex {
+  status: ConsoleCellLabelsStatus;
+
+  /** What an `unavailable` status was, in the words the snapshot used. */
+  detail?: string;
+
+  /** The space the labels were read from, once a run finally names one. */
+  space?: { configured: string; did?: string; dbPath?: string };
+
+  byAddress: ReadonlyMap<string, ConsoleCellLabels>;
+}
+
+/** The run-level fact, without the index — what crosses to the page. */
+export interface ConsoleCellLabelsSummary {
+  status: ConsoleCellLabelsStatus;
+  detail?: string;
+  space?: { configured: string; did?: string; dbPath?: string };
+
+  /** How many cells the snapshot read, and how many of them carry a label. */
+  cellsRead: number;
+  cellsLabelled: number;
+}
+
+const dedupe = (names: readonly string[]): string[] => [...new Set(names)];
+
+/** What a provenance atom's identity resolves to, in as few words as carry it. */
+const producerOf = (atom: HarnessCfcAtom | undefined): string | undefined => {
+  const identity = atom?.fields?.identity;
+  if (typeof identity !== "object" || identity === null) {
+    return undefined;
+  }
+  const fields = identity as Record<string, unknown>;
+  const named = (key: string): string | undefined =>
+    typeof fields[key] === "string" ? fields[key] as string : undefined;
+  // A builtin names itself; a verified implementation is named by its symbol
+  // within its module, and by its module alone when the symbol is absent.
+  const builtin = named("builtinId");
+  if (builtin !== undefined) {
+    return builtin;
+  }
+  const symbol = named("symbol");
+  const module = named("moduleIdentity");
+  if (symbol !== undefined) {
+    return module === undefined ? symbol : `${symbol} in ${module}`;
+  }
+  return module ?? named("className");
+};
+
+const entryOf = (entry: HarnessCellLabelEntry): ConsoleCellLabelEntry => {
+  const producer = producerOf(entry.transformedBy);
+  return {
+    path: entry.path.join("/"),
+    confidentiality: entry.confidentiality.map((atom) => atom.name),
+    integrity: entry.integrity.map((atom) => atom.name),
+    ...(entry.origin !== undefined ? { origin: entry.origin } : {}),
+    ...(entry.observes !== undefined ? { observes: entry.observes } : {}),
+    ...(producer !== undefined ? { transformedBy: producer } : {}),
+  };
+};
+
+/** One recorded cell, reduced to what a chip and a card show. */
+export const consoleCellLabels = (
+  record: HarnessCellLabelRecord,
+): ConsoleCellLabels => {
+  const entries = record.entries.map(entryOf);
+  return {
+    confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
+    integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
+    derived: entries.some((entry) => entry.origin === "derived"),
+    transformedBy: dedupe(
+      entries.flatMap((entry) =>
+        entry.transformedBy === undefined ? [] : [entry.transformedBy]
+      ),
+    ),
+    entries,
+  };
+};
+
+/**
+ * The whole snapshot, indexed. A run that wrote no snapshot is `absent`
+ * rather than empty: the artifact is written after a turn, so a run still
+ * going has not reached one, and that is not the same as a space with
+ * nothing to say.
+ */
+export const consoleCellLabelIndex = (
+  snapshot: HarnessCellLabels | undefined,
+): ConsoleCellLabelIndex => {
+  if (snapshot === undefined) {
+    return { status: "absent", byAddress: new Map() };
+  }
+  const byAddress = new Map<string, ConsoleCellLabels>();
+  for (const record of snapshot.cells) {
+    const labels = consoleCellLabels(record);
+    byAddress.set(record.entityId, labels);
+    if (record.ref !== undefined) {
+      byAddress.set(record.ref, labels);
+    }
+  }
+  return {
+    status: snapshot.status === "read" ? "read" : "unavailable",
+    ...(snapshot.unavailableDetail !== undefined
+      ? { detail: snapshot.unavailableDetail }
+      : {}),
+    ...(snapshot.space !== undefined ? { space: snapshot.space } : {}),
+    byAddress,
+  };
+};
+
+/** The run-level fact the map and the run header state. */
+export const consoleCellLabelsSummary = (
+  index: ConsoleCellLabelIndex,
+): ConsoleCellLabelsSummary => {
+  // Entity ids and refs both key the same labels, so counting the map's
+  // values would count most cells twice. The distinct label objects are the
+  // cells.
+  const cells = new Set(index.byAddress.values());
+  return {
+    status: index.status,
+    ...(index.detail !== undefined ? { detail: index.detail } : {}),
+    ...(index.space !== undefined ? { space: index.space } : {}),
+    cellsRead: cells.size,
+    cellsLabelled: [...cells].filter((labels) => labels.entries.length > 0)
+      .length,
+  };
+};
+
+/**
+ * The labels for the cell a reference names. A reference may address a path
+ * inside a document while the labels are stored for the document, so a ref
+ * that misses is retried against the document it sits in.
+ */
+export const cellLabelsAt = (
+  index: ConsoleCellLabelIndex,
+  ref: string | undefined,
+): ConsoleCellLabels | undefined => {
+  if (ref === undefined) {
+    return undefined;
+  }
+  const direct = index.byAddress.get(ref);
+  if (direct !== undefined) {
+    return direct;
+  }
+  // The entity id inside the reference: the segment carrying a URI scheme,
+  // which a cross-space link puts after its space DID and a path puts before
+  // its own segments.
+  const segment = ref.split("/").find((part) =>
+    part.startsWith("of:") || part.startsWith("computed:")
+  );
+  return segment === undefined
+    ? undefined
+    : index.byAddress.get(segment.split("@")[0]);
+};

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -12,7 +12,9 @@
  *
  * - **Read against unread.** A cell with no atoms under a snapshot that was
  *   taken is a cell the space holds no label for. The same cell under a run
- *   whose space could not be read is a cell nobody asked about.
+ *   whose space could not be read is a cell nobody asked about. It holds per
+ *   path as well as per run: a link the snapshot could not follow leaves the
+ *   path it sat at unread, and every cell at or under that path with it.
  * - **Derived against carried.** A value's label may be the join of the
  *   fields it was built from, so a plain input reached through a labelled
  *   object carries a confidentiality atom without having been derived from
@@ -21,6 +23,14 @@
  *   report a plain input as tainted.
  */
 
+import {
+  canonicalizeCfcLogicalPath,
+  cfcLabelPathPrefixMatches,
+  type CfcLabelView,
+  type IFCLabel,
+  type LabelObservationClass,
+  rebaseCfcLabelView,
+} from "@commonfabric/runner/cfc/label-view-core";
 import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
 
 import type {
@@ -69,6 +79,16 @@ export interface ConsoleCellLabels {
 
   /** The labels path by path, for a reader that wants the whole of it. */
   entries: readonly ConsoleCellLabelEntry[];
+
+  /**
+   * The paths beneath this cell that nothing was read for, each a link the
+   * snapshot could not follow, and absent where it followed every one. A
+   * reference landing at or under one of them has no answer here at all —
+   * {@link cellLabelsAt} returns nothing for it — and the cell itself keeps
+   * them so that what is missing from `entries` is on the record rather than
+   * inferred from its absence.
+   */
+  unreadPaths?: readonly (readonly string[])[];
 }
 
 /** Why a run shows no labels on any cell, when it shows none. */
@@ -77,9 +97,11 @@ export type ConsoleCellLabelsStatus = "read" | "unavailable" | "absent";
 /**
  * The run's labels, indexed by the cell they belong to.
  *
- * `byAddress` is keyed by entity, because that is what a label is stored per.
+ * `byAddress` is keyed by entity, because that is what a label is stored per,
+ * and holds the artifact's own record rather than the names a badge writes.
  * A reference names a path inside a document as well as the document, and
- * `cellLabelsAt` is what turns one into the other.
+ * `cellLabelsAt` is what turns one into the other — narrowing over the
+ * structural labels the space stored, and reducing to names after.
  */
 export interface ConsoleCellLabelIndex {
   status: ConsoleCellLabelsStatus;
@@ -90,7 +112,7 @@ export interface ConsoleCellLabelIndex {
   /** The space the labels were read from, once a run finally names one. */
   space?: { configured: string; did?: string; dbPath?: string };
 
-  byAddress: ReadonlyMap<string, ConsoleCellLabels>;
+  byAddress: ReadonlyMap<string, HarnessCellLabelRecord>;
 }
 
 /** The run-level fact, without the index — what crosses to the page. */
@@ -144,6 +166,7 @@ const entryOf = (entry: HarnessCellLabelEntry): ConsoleCellLabelEntry => {
 /** The cell-level facts a set of entries adds up to. */
 const labelsOfEntries = (
   entries: readonly ConsoleCellLabelEntry[],
+  unreadPaths: readonly (readonly string[])[],
 ): ConsoleCellLabels => ({
   confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
   integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
@@ -154,12 +177,22 @@ const labelsOfEntries = (
     ),
   ),
   entries,
+  ...(unreadPaths.length > 0 ? { unreadPaths } : {}),
 });
+
+/** The paths of one record nothing was read for, as the page compares them. */
+const unreadPathsOf = (
+  record: HarnessCellLabelRecord,
+): readonly string[][] =>
+  (record.unreadPaths ?? []).map((unread) =>
+    canonicalizeCfcLogicalPath(unread.path)
+  );
 
 /** One recorded cell, reduced to what a chip and a card show. */
 export const consoleCellLabels = (
   record: HarnessCellLabelRecord,
-): ConsoleCellLabels => labelsOfEntries(record.entries.map(entryOf));
+): ConsoleCellLabels =>
+  labelsOfEntries(record.entries.map(entryOf), unreadPathsOf(record));
 
 /**
  * The whole snapshot, indexed. A run that wrote no snapshot is `absent`
@@ -177,7 +210,7 @@ export const consoleCellLabelIndex = (
   // document as well as the document, and two references into one document
   // narrow to different cells. Keying a whole document's labels under one of
   // its references would hand every cell of it the same answer.
-  const byAddress = new Map<string, ConsoleCellLabels>();
+  const byAddress = new Map<string, HarnessCellLabelRecord>();
   for (const record of snapshot.cells) {
     // A cell nothing was asked about is left out of the index rather than
     // entered with no labels. Absent, it reads as a cell this run says
@@ -187,7 +220,7 @@ export const consoleCellLabelIndex = (
     if (record.unreadReason !== undefined) {
       continue;
     }
-    byAddress.set(record.entityId, consoleCellLabels(record));
+    byAddress.set(record.entityId, record);
   }
   return {
     status: snapshot.status === "read" ? "read" : "unavailable",
@@ -209,7 +242,7 @@ export const consoleCellLabelsSummary = (
     ...(index.detail !== undefined ? { detail: index.detail } : {}),
     ...(index.space !== undefined ? { space: index.space } : {}),
     cellsRead: cells.length,
-    cellsLabelled: cells.filter((labels) => labels.entries.length > 0).length,
+    cellsLabelled: cells.filter((record) => record.entries.length > 0).length,
   };
 };
 
@@ -279,24 +312,37 @@ const addressOf = (ref: string): ConsoleCellAddress | undefined => {
 };
 
 /**
- * Whether `prefix` covers `path`, over the segments a stored label path is
- * written in: `*` stands for every member of a container, so it matches any
- * concrete segment and any concrete segment matches it.
+ * One stored entry as a label view of its own, which is the form
+ * {@link rebaseCfcLabelView} narrows. One entry per view rather than the
+ * whole set in one: the canonical rebase merges the labels of entries that
+ * land on one path, and `origin` and the provenance beside it belong to the
+ * entry that carried them, so a merged label could no longer say which of
+ * them was computed and which was declared.
  *
- * Mirrors `cfcLabelPathPrefixMatches` in
- * `packages/runner/src/cfc/label-view-core.ts`, which is the definition of
- * this relation and of the re-rooting below it in `rebaseCfcLabelView`. It is
- * not exported from `@commonfabric/runner/cfc`, so it is restated here; the
- * two are one rule and a change to that one belongs here too.
+ * The atoms are the ones the space stored. The contract widens them to carry
+ * fields no reader has a name for, which the atom types do not describe, and
+ * the rebase reads no atom's interior — only whether a label carries any. So
+ * they cross as they are, rather than as the names a badge writes: reducing
+ * first would rebase over the last segment of a type URL, which is a display
+ * string and not the atom.
  */
-const pathPrefixMatches = (
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean =>
-  prefix.length <= path.length &&
-  prefix.every((segment, index) =>
-    segment === path[index] || segment === "*" || path[index] === "*"
-  );
+const labelViewOfEntry = (entry: HarnessCellLabelEntry): CfcLabelView => ({
+  version: 1,
+  entries: [{
+    path: entry.path,
+    label: {
+      confidentiality: [...entry.confidentiality],
+      integrity: [...entry.integrity],
+    } as unknown as IFCLabel,
+    // The space is the authority on what it observed, so the recorded class
+    // crosses as it stands. One it named that CFC has no rule for is not a
+    // content observation, and the rebase treats it as one it cannot inherit
+    // down — which is the reading that grafts no label onto a cell beneath.
+    ...(entry.observes !== undefined
+      ? { observes: entry.observes as LabelObservationClass }
+      : {}),
+  }],
+});
 
 /**
  * The labels of one document, narrowed to a path inside it.
@@ -305,31 +351,42 @@ const pathPrefixMatches = (
  * cells of one piece are two references into one document. Handing both the
  * document's whole label set would put one cell's atom on the other, which is
  * the same mistake as coloring a plain input by the label of the object it
- * was reached through. So an entry counts for a reference only where the
- * reference's path reaches it: an entry at or under that path, re-rooted to
- * it, or an entry above it, which governs everything beneath.
+ * was reached through. So an entry counts for a reference only where CFC's
+ * own re-rooting says it reaches: `rebaseCfcLabelView` is the definition of
+ * that relation, and the page answers by it so that what the console shows at
+ * a path is what the runtime enforces there.
+ *
+ * A reference at or under a path nothing was read for has no answer at all.
+ * That is the read-against-unread distinction one level down from the
+ * snapshot: a link the walk could not follow leaves its key holding no entry,
+ * and an empty label set there would read as a cell the space holds no label
+ * for.
  */
 const narrow = (
-  labels: ConsoleCellLabels,
+  record: HarnessCellLabelRecord,
   path: readonly string[],
-): ConsoleCellLabels => {
-  if (path.length === 0) {
-    return labels;
+): ConsoleCellLabels | undefined => {
+  const unread = unreadPathsOf(record);
+  const logical = canonicalizeCfcLogicalPath(path);
+  if (unread.some((each) => cfcLabelPathPrefixMatches(each, logical))) {
+    return undefined;
   }
   const entries: ConsoleCellLabelEntry[] = [];
-  for (const entry of labels.entries) {
-    if (pathPrefixMatches(path, entry.path)) {
-      entries.push({ ...entry, path: entry.path.slice(path.length) });
-      continue;
-    }
-    // An entry above the reference covers it: a label on the document itself,
-    // or on anything the reference is reached through, reaches every cell
-    // beneath it, and re-roots to the reference's own path.
-    if (pathPrefixMatches(entry.path, path)) {
-      entries.push({ ...entry, path: [] });
+  for (const entry of record.entries) {
+    const rebased = rebaseCfcLabelView(labelViewOfEntry(entry), path)
+      ?.entries[0];
+    if (rebased !== undefined) {
+      entries.push({ ...entryOf(entry), path: [...rebased.path] });
     }
   }
-  return labelsOfEntries(entries);
+  return labelsOfEntries(
+    entries,
+    unread.flatMap((each) =>
+      cfcLabelPathPrefixMatches(logical, each)
+        ? [each.slice(logical.length)]
+        : []
+    ),
+  );
 };
 
 /**
@@ -341,7 +398,8 @@ const narrow = (
  * own space, so a reference naming a space other than the one the snapshot
  * was taken in has no answer here: the id it carries would find whichever
  * cell of the read space happens to share it. Such a reference reads as a
- * cell nothing is known about, the same as one the snapshot never covered.
+ * cell nothing is known about, the same as one the snapshot never covered —
+ * and so does one landing at or under a path the snapshot left unread.
  */
 export const cellLabelsAt = (
   index: ConsoleCellLabelIndex,
@@ -352,7 +410,8 @@ export const cellLabelsAt = (
   }
   const address = addressOf(ref);
   if (address === undefined) {
-    return index.byAddress.get(ref);
+    const keyed = index.byAddress.get(ref);
+    return keyed === undefined ? undefined : consoleCellLabels(keyed);
   }
   if (address.space !== undefined && address.space !== index.space?.did) {
     return undefined;

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -14,7 +14,9 @@
  *   taken is a cell the space holds no label for. The same cell under a run
  *   whose space could not be read is a cell nobody asked about. It holds per
  *   path as well as per run: a link the snapshot could not follow leaves the
- *   path it sat at unread, and every cell at or under that path with it.
+ *   path it sat at unread, and every cell at or under that path with it. A
+ *   cell whose read ran out partway states less again — that its labels are
+ *   some of what the space holds, without naming which paths it missed.
  * - **Derived against carried.** A value's label may be the join of the
  *   fields it was built from, so a plain input reached through a labelled
  *   object carries a confidentiality atom without having been derived from
@@ -37,6 +39,7 @@ import type {
   HarnessCellLabelEntry,
   HarnessCellLabelRecord,
   HarnessCellLabels,
+  HarnessCellLabelTruncationReason,
   HarnessCfcAtom,
 } from "../src/contracts/cell-labels.ts";
 
@@ -81,14 +84,25 @@ export interface ConsoleCellLabels {
   entries: readonly ConsoleCellLabelEntry[];
 
   /**
-   * The paths beneath this cell that nothing was read for, each a link the
-   * snapshot could not follow, and absent where it followed every one. A
-   * reference landing at or under one of them has no answer here at all —
-   * {@link cellLabelsAt} returns nothing for it — and the cell itself keeps
-   * them so that what is missing from `entries` is on the record rather than
-   * inferred from its absence.
+   * The paths beneath this cell that nothing was read for — a link the
+   * snapshot could not follow, or a path lying deeper than it descends — and
+   * absent where it read every one. A reference landing at or under one of
+   * them has no answer here at all — {@link cellLabelsAt} returns nothing for
+   * it — and the cell itself keeps them so that what is missing from
+   * `entries` is on the record rather than inferred from its absence.
    */
   unreadPaths?: readonly (readonly string[])[];
+
+  /**
+   * Why the snapshot did not finish reading this cell, when it did not. It
+   * says less than `unreadPaths` and about the cell rather than about a path:
+   * the snapshot stopped before enumerating what it had left, so it can name
+   * no path, and everything here is some of what the space holds rather than
+   * all of it. A path with no entry under it is unknown, and a reader that
+   * showed this cell as fully labelled would be reporting the reading it did
+   * not finish as the answer.
+   */
+  truncationReason?: HarnessCellLabelTruncationReason;
 }
 
 /** Why a run shows no labels on any cell, when it shows none. */
@@ -167,6 +181,7 @@ const entryOf = (entry: HarnessCellLabelEntry): ConsoleCellLabelEntry => {
 const labelsOfEntries = (
   entries: readonly ConsoleCellLabelEntry[],
   unreadPaths: readonly (readonly string[])[],
+  truncationReason: HarnessCellLabelTruncationReason | undefined,
 ): ConsoleCellLabels => ({
   confidentiality: dedupe(entries.flatMap((entry) => entry.confidentiality)),
   integrity: dedupe(entries.flatMap((entry) => entry.integrity)),
@@ -178,6 +193,7 @@ const labelsOfEntries = (
   ),
   entries,
   ...(unreadPaths.length > 0 ? { unreadPaths } : {}),
+  ...(truncationReason !== undefined ? { truncationReason } : {}),
 });
 
 /** The paths of one record nothing was read for, as the page compares them. */
@@ -192,7 +208,11 @@ const unreadPathsOf = (
 export const consoleCellLabels = (
   record: HarnessCellLabelRecord,
 ): ConsoleCellLabels =>
-  labelsOfEntries(record.entries.map(entryOf), unreadPathsOf(record));
+  labelsOfEntries(
+    record.entries.map(entryOf),
+    unreadPathsOf(record),
+    record.truncationReason,
+  );
 
 /**
  * The whole snapshot, indexed. A run that wrote no snapshot is `absent`
@@ -368,9 +388,15 @@ const labelViewOfEntry = (entry: HarnessCellLabelEntry): CfcLabelView => ({
  *
  * A reference at or under a path nothing was read for has no answer at all.
  * That is the read-against-unread distinction one level down from the
- * snapshot: a link the walk could not follow leaves its key holding no entry,
- * and an empty label set there would read as a cell the space holds no label
- * for.
+ * snapshot: a link the walk could not follow, or a path it sat too shallow to
+ * reach, leaves its key holding no entry, and an empty label set there would
+ * read as a cell the space holds no label for.
+ *
+ * A cell the walk did not finish carries its {@link
+ * ConsoleCellLabels.truncationReason} down to every path instead. The paths
+ * it missed were never enumerated, so no path can be refused on their
+ * account; what the reader owes such a cell is to show its labels as partial
+ * rather than to show them as all there is.
  */
 const narrow = (
   record: HarnessCellLabelRecord,
@@ -389,6 +415,9 @@ const narrow = (
       entries.push({ ...entryOf(entry), path: [...rebased.path] });
     }
   }
+  // The cell's truncation crosses to every path inside it: the walk that did
+  // not finish did not finish for any of them, and where it stopped is not
+  // something a path can be compared against.
   return labelsOfEntries(
     entries,
     unread.flatMap((each) =>
@@ -396,6 +425,7 @@ const narrow = (
         ? [each.slice(logical.length)]
         : []
     ),
+    record.truncationReason,
   );
 };
 

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -312,6 +312,14 @@ const addressOf = (ref: string): ConsoleCellAddress | undefined => {
 };
 
 /**
+ * The label a stored entry crosses the rebase under, standing for "this entry
+ * carries one". Its only job is to be non-empty, because
+ * {@link rebaseCfcLabelView} keeps an entry only while its label holds
+ * something; nothing reads its interior, and no atom of it reaches the page.
+ */
+const ENTRY_PRESENT: IFCLabel = { integrity: ["cf-harness/label-entry"] };
+
+/**
  * One stored entry as a label view of its own, which is the form
  * {@link rebaseCfcLabelView} narrows. One entry per view rather than the
  * whole set in one: the canonical rebase merges the labels of entries that
@@ -319,21 +327,23 @@ const addressOf = (ref: string): ConsoleCellAddress | undefined => {
  * entry that carried them, so a merged label could no longer say which of
  * them was computed and which was declared.
  *
- * The atoms are the ones the space stored. The contract widens them to carry
- * fields no reader has a name for, which the atom types do not describe, and
- * the rebase reads no atom's interior — only whether a label carries any. So
- * they cross as they are, rather than as the names a badge writes: reducing
- * first would rebase over the last segment of a type URL, which is a display
- * string and not the atom.
+ * What crosses is {@link ENTRY_PRESENT} rather than the atoms the space
+ * stored, because the two facts this caller takes from the rebase — whether
+ * the entry reaches the path asked about, and what path it re-roots to —
+ * depend on a label only through its being non-empty. The atoms the page
+ * shows are read back off the stored entry, so the normalization and
+ * structural deduplication the rebase performs on a label it merges reach
+ * nothing a reader sees. An entry the space stored with no atoms in either
+ * dimension crosses under an empty label, which the rebase drops: a path
+ * labelled with nothing stays a path with no entry.
  */
 const labelViewOfEntry = (entry: HarnessCellLabelEntry): CfcLabelView => ({
   version: 1,
   entries: [{
     path: entry.path,
-    label: {
-      confidentiality: [...entry.confidentiality],
-      integrity: [...entry.integrity],
-    } as unknown as IFCLabel,
+    label: entry.confidentiality.length > 0 || entry.integrity.length > 0
+      ? ENTRY_PRESENT
+      : {},
     // The space is the authority on what it observed, so the recorded class
     // crosses as it stands. One it named that CFC has no rule for is not a
     // content observation, and the rebase treats it as one it cannot inherit

--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -262,28 +262,143 @@ export const consoleCellLabelIndex = (
 };
 
 /**
- * Whether a record holds either of the two facts that make its entries some
+ * The identity of one entry: the whole of what it states, canonically
+ * written. It is what {@link foldCellLabels} calls "the same entry".
+ *
+ * Keying on the path alone and merging the atom lists beneath it would have
+ * to answer for `origin`, `observes` and `transformedBy` wherever two
+ * readings differed — and any answer there is one neither reading recorded.
+ * Two readings of one space's stored label at one path state the same thing,
+ * so identical entries collapse and the union is the list either of them
+ * held; where they are not identical, each stands as its reader wrote it
+ * rather than being averaged into a third entry nobody saw.
+ *
+ * The atom lists are sorted first, because they are sets: two readings that
+ * hold the same atoms in different orders hold the same entry, and the
+ * canonical order is what lets the union say so.
+ */
+const canonicalEntry = (
+  entry: ConsoleCellLabelEntry,
+): ConsoleCellLabelEntry => ({
+  ...entry,
+  confidentiality: [...entry.confidentiality].sort(),
+  integrity: [...entry.integrity].sort(),
+});
+
+const entryIdentity = (entry: ConsoleCellLabelEntry): string =>
+  JSON.stringify([
+    entry.path,
+    entry.confidentiality,
+    entry.integrity,
+    entry.origin ?? null,
+    entry.observes ?? null,
+    entry.transformedBy ?? null,
+  ]);
+
+const pathIdentity = (path: readonly string[]): string => JSON.stringify(path);
+
+/** The union of two keyed sets, in the canonical order of their keys. */
+const unionBy = <T>(
+  left: readonly T[],
+  right: readonly T[],
+  key: (value: T) => string,
+): T[] =>
+  [...new Map([...left, ...right].map((value) => [key(value), value]))]
+    .sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
+    .map(([, value]) => value);
+
+/**
+ * Two readings of one cell, folded into the reading that claims no more than
+ * both of them together support.
+ *
+ * A family reads one space from several runs, so one address can arrive twice
+ * — a root that ran out of nodes partway through a cell and a child that read
+ * the same cell whole. They are two partial views of one cell, and choosing
+ * between them can choose the more flattering: the whole reading would bury
+ * the root's truncation, and a cell one reader did not finish would be
+ * counted as fully read.
+ *
+ * **The fold is a commutative monoid, and every field is an OR or a union.**
+ * Its identity is a reading with no entries, no unread paths and no
+ * truncation, which returns its partner in the canonical order the fold
+ * writes — an order, and not part of what a reading states, because each of
+ * these fields is a set. `unreadPaths` and `entries` are set unions;
+ * `truncationReason`
+ * is the disjunction of two options, taken in a fixed order so that it does
+ * not depend on which member is seen first. Boolean OR and set union are both
+ * commutative and associative, which is what makes folding a family of any
+ * size independent of the order its members are visited in — commutativity
+ * alone would only settle a family of two. A field that picks a winner rather
+ * than merging would destroy that silently, so a new field belongs here only
+ * if it is an OR or a union too.
+ *
+ * `entries` is the one field whose union is a judgement rather than an
+ * algebra: what makes two entries the same is decided by
+ * {@link entryIdentity}, above. Given that identity it is an ordinary set
+ * union, so the property above holds of it as well.
+ *
+ * The cell-level readings — the atoms, `derived`, `transformedBy` — are
+ * recomputed from the folded entries rather than folded beside them, so they
+ * cannot state anything the entries do not.
+ */
+export const foldCellLabels = (
+  a: ConsoleCellLabels,
+  b: ConsoleCellLabels,
+): ConsoleCellLabels =>
+  labelsOfEntries(
+    unionBy(
+      a.entries.map(canonicalEntry),
+      b.entries.map(canonicalEntry),
+      entryIdentity,
+    ),
+    unionBy(a.unreadPaths ?? [], b.unreadPaths ?? [], pathIdentity),
+    [a.truncationReason, b.truncationReason]
+      .filter((reason) => reason !== undefined)
+      .sort()[0],
+  );
+
+/**
+ * Whether a reading holds either of the two facts that make its entries some
  * of what the space holds rather than all of it — a path nothing was read at,
  * or a read that stopped before it finished.
  */
-const readInPart = (record: HarnessCellLabelRecord): boolean =>
-  record.truncationReason !== undefined ||
-  (record.unreadPaths ?? []).length > 0;
+const readingInPart = (labels: ConsoleCellLabels): boolean =>
+  labels.truncationReason !== undefined ||
+  (labels.unreadPaths ?? []).length > 0;
+
+/**
+ * The run-level fact the map and the run header state, counted over cells
+ * already reduced to one reading each.
+ *
+ * A cell is read where any member read it, labelled where any member found an
+ * entry, and partial where any member's reading was partial — which is the
+ * fold above, carried up into the counting. Counting is where the invariant
+ * hides best: a header that says a cell was fully read misrepresents it just
+ * as a card would.
+ */
+export const cellLabelsSummaryOf = (
+  reading: Omit<ConsoleCellLabelIndex, "byAddress">,
+  cells: Iterable<ConsoleCellLabels>,
+): ConsoleCellLabelsSummary => {
+  const folded = [...cells];
+  return {
+    status: reading.status,
+    ...(reading.detail !== undefined ? { detail: reading.detail } : {}),
+    ...(reading.space !== undefined ? { space: reading.space } : {}),
+    cellsRead: folded.length,
+    cellsLabelled: folded.filter((labels) => labels.entries.length > 0).length,
+    cellsPartial: folded.filter(readingInPart).length,
+  };
+};
 
 /** The run-level fact the map and the run header state. */
 export const consoleCellLabelsSummary = (
   index: ConsoleCellLabelIndex,
-): ConsoleCellLabelsSummary => {
-  const cells = [...index.byAddress.values()];
-  return {
-    status: index.status,
-    ...(index.detail !== undefined ? { detail: index.detail } : {}),
-    ...(index.space !== undefined ? { space: index.space } : {}),
-    cellsRead: cells.length,
-    cellsLabelled: cells.filter((record) => record.entries.length > 0).length,
-    cellsPartial: cells.filter(readInPart).length,
-  };
-};
+): ConsoleCellLabelsSummary =>
+  cellLabelsSummaryOf(
+    index,
+    [...index.byAddress.values()].map(consoleCellLabels),
+  );
 
 /** The entity a reference names, and the path inside it the reference walks. */
 interface ConsoleCellAddress {

--- a/packages/cf-harness/console/flow.ts
+++ b/packages/cf-harness/console/flow.ts
@@ -12,6 +12,10 @@
 
 import type { ConsoleHandle, ConsoleStep, ConsoleStepStatus } from "./steps.ts";
 import { consoleStepArguments, handleTokensIn } from "./steps.ts";
+import type {
+  ConsoleCellLabels,
+  ConsoleCellLabelsSummary,
+} from "./cell-labels.ts";
 
 /** What a node in the map stands for. */
 export type ConsoleFlowKind =
@@ -33,8 +37,10 @@ export interface ConsoleFlowCell {
   producedByStep?: number;
   /** The shape the pattern that made it declared, for the chip's card. */
   schema?: unknown;
-  /** Confidentiality atoms riding on it. */
+  /** Confidentiality atoms the invocation context put where it was used. */
   confidentiality: readonly string[];
+  /** The labels the space holds for the cell itself, where the run read them. */
+  labels?: ConsoleCellLabels;
   /** The argument name it came in as, for a cell a call read. */
   as?: string;
 }
@@ -116,6 +122,14 @@ export interface ConsoleFlow {
    * run — flow labels off record none, and persist records them.
    */
   cfc?: ConsoleFlowCfc;
+
+  /**
+   * Whether the run's space was read for per-cell labels, and what it said.
+   * The map states this once beside the posture, because a cell drawn with no
+   * labels means one thing under a snapshot that was taken and another under a
+   * run whose space could not be read.
+   */
+  cellLabels?: ConsoleCellLabelsSummary;
   /** Calls that failed, across the whole family. */
   failures: number;
   /** Calls CFC refused, across the whole family. */
@@ -162,6 +176,7 @@ const cellOf = (
     : {}),
   ...(handle?.schema !== undefined ? { schema: handle.schema } : {}),
   confidentiality: handle?.confidentiality ?? [],
+  ...(handle?.labels !== undefined ? { labels: handle.labels } : {}),
   ...(as !== undefined ? { as } : {}),
 });
 
@@ -314,6 +329,7 @@ export const consoleRunFlow = (
   root: ConsoleFlowRunInput,
   descendants: readonly ConsoleFlowRunInput[] = [],
   cfc?: ConsoleFlowCfc,
+  cellLabels?: ConsoleCellLabelsSummary,
 ): ConsoleFlow => {
   const byRunId = new Map(descendants.map((run) => [run.runId, run]));
   const nodes = runNodes(root, byRunId, 0, new Set());
@@ -350,6 +366,7 @@ export const consoleRunFlow = (
   return {
     turns,
     ...(cfc !== undefined ? { cfc } : {}),
+    ...(cellLabels !== undefined ? { cellLabels } : {}),
     failures: countIf(nodes, (node) => node.status === "error"),
     denials: countIf(
       nodes,

--- a/packages/cf-harness/console/graph.ts
+++ b/packages/cf-harness/console/graph.ts
@@ -16,7 +16,7 @@
 import type { ConsoleDisclosure, ConsoleHandle, ConsoleStep } from "./steps.ts";
 import { matchLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { HANDLE_TOKEN_PATTERN } from "../src/contracts/handle-table.ts";
-import type { ConsoleCellLabels } from "./cell-labels.ts";
+import { type ConsoleCellLabels, foldCellLabels } from "./cell-labels.ts";
 
 /** A pattern that ran, or a cell in the space. */
 export type ConsoleGraphNodeKind = "pattern" | "cell";
@@ -387,6 +387,17 @@ export const consoleRunFamilyGraph = (
         nodes.set(node.id, dated);
         continue;
       }
+      // Two runs' readings of one cell are two partial views of it, folded
+      // conservatively rather than chosen between: a run that read the cell
+      // whole does not answer for one that stopped partway through it, so
+      // the fold keeps the truncation and the unread paths of either. A
+      // sighting with no reading at all is a run that never covered the
+      // cell, which the other run's reading stands for on its own.
+      const labels = held.labels === undefined
+        ? dated.labels
+        : dated.labels === undefined
+        ? held.labels
+        : foldCellLabels(held.labels, dated.labels);
       // One cell reached from two runs: keep the earliest sighting, and take
       // whichever facts either run established about it.
       nodes.set(node.id, {
@@ -399,12 +410,7 @@ export const consoleRunFamilyGraph = (
         confidentiality: [
           ...new Set([...held.confidentiality, ...dated.confidentiality]),
         ],
-        // Both runs read the same space for the same cell, so a sighting
-        // that carries labels is the one to keep, and two that carry them
-        // agree.
-        ...(held.labels ?? dated.labels) !== undefined
-          ? { labels: held.labels ?? dated.labels }
-          : {},
+        ...(labels !== undefined ? { labels } : {}),
       });
     }
     for (const edge of graph.edges) {

--- a/packages/cf-harness/console/graph.ts
+++ b/packages/cf-harness/console/graph.ts
@@ -16,6 +16,7 @@
 import type { ConsoleDisclosure, ConsoleHandle, ConsoleStep } from "./steps.ts";
 import { matchLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { HANDLE_TOKEN_PATTERN } from "../src/contracts/handle-table.ts";
+import type { ConsoleCellLabels } from "./cell-labels.ts";
 
 /** A pattern that ran, or a cell in the space. */
 export type ConsoleGraphNodeKind = "pattern" | "cell";
@@ -48,8 +49,14 @@ export interface ConsoleGraphNode {
   /** Whether any step asked what shape this cell's referent has. */
   described?: boolean;
 
-  /** Confidentiality atoms the run's labels attached to this node. */
+  /** Confidentiality atoms the invocation context attached to this node. */
   confidentiality: readonly string[];
+
+  /**
+   * For a cell: the labels the space holds for it. A fact about the cell,
+   * where `confidentiality` is a fact about the calls that touched it.
+   */
+  labels?: ConsoleCellLabels;
 }
 
 /**
@@ -183,6 +190,23 @@ export const consoleRunGraph = (
       handle.ref === undefined ? [] : [[handle.token, handle.ref] as const]
     ),
   );
+  // The same handles, read for what the space says about the cell rather than
+  // for its address: a token names one, and a whole link names the other by
+  // the address it shares with a handle's `ref`.
+  const labelsByToken = new Map(
+    handles.flatMap((handle) =>
+      handle.labels === undefined
+        ? []
+        : [[handle.token, handle.labels] as const]
+    ),
+  );
+  const labelsByAddress = new Map(
+    handles.flatMap((handle) =>
+      handle.ref === undefined || handle.labels === undefined
+        ? []
+        : [[handle.ref, handle.labels] as const]
+    ),
+  );
   const cellId = (token: string): string =>
     `cell:${addressByToken.get(token) ?? token}`;
 
@@ -196,6 +220,8 @@ export const consoleRunGraph = (
       return held;
     }
     const address = addressByToken.get(token);
+    const labels = labelsByToken.get(token) ??
+      (address === undefined ? undefined : labelsByAddress.get(address));
     const node: ConsoleGraphNode = {
       id,
       kind: "cell",
@@ -204,6 +230,7 @@ export const consoleRunGraph = (
       token,
       ...(address !== undefined ? { address } : {}),
       confidentiality: [],
+      ...(labels !== undefined ? { labels } : {}),
     };
     nodes.set(id, node);
     return node;
@@ -256,6 +283,7 @@ export const consoleRunGraph = (
           if (document !== undefined) {
             const linkId = `cell:${document}`;
             if (!nodes.has(linkId)) {
+              const linkLabels = labelsByAddress.get(document);
               nodes.set(linkId, {
                 id: linkId,
                 kind: "cell",
@@ -263,6 +291,7 @@ export const consoleRunGraph = (
                 atStep: step.index,
                 address: document,
                 confidentiality: [],
+                ...(linkLabels !== undefined ? { labels: linkLabels } : {}),
               });
             }
             read(linkId);
@@ -370,6 +399,12 @@ export const consoleRunFamilyGraph = (
         confidentiality: [
           ...new Set([...held.confidentiality, ...dated.confidentiality]),
         ],
+        // Both runs read the same space for the same cell, so a sighting
+        // that carries labels is the one to keep, and two that carry them
+        // agree.
+        ...(held.labels ?? dated.labels) !== undefined
+          ? { labels: held.labels ?? dated.labels }
+          : {},
       });
     }
     for (const edge of graph.edges) {

--- a/packages/cf-harness/console/public/styles/console.css
+++ b/packages/cf-harness/console/public/styles/console.css
@@ -989,6 +989,20 @@ button[disabled] {
   border-color: #1f4fa8;
 }
 
+/*
+ * A value the space says was computed from what a function read, which an
+ * atom on its own never says: a plain input reached through a labelled object
+ * carries an atom too. Its own color, so the two never read as one state.
+ */
+.cell.derived {
+  background: #fff6ed;
+  border-color: #b54708;
+}
+
+.cell.derived .cell-dot {
+  background: #b54708;
+}
+
 .cell-dot {
   background: var(--ok);
   border-radius: 50%;
@@ -1049,13 +1063,14 @@ button[disabled] {
   padding: 0.12rem 0;
 }
 
+/* Wide enough for `transformed by`, the longest row name the card holds. */
 .cell-label {
   color: var(--muted);
   flex: none;
   font-size: 0.7rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  width: 4.2rem;
+  width: 5.6rem;
 }
 
 .cell-mono {
@@ -1070,6 +1085,35 @@ button[disabled] {
 .cell-none {
   color: var(--muted);
   font-size: 0.75rem;
+}
+
+/* The space saying a value was computed, in the derived chip's own color. */
+.cell-derived {
+  color: #b54708;
+  font-size: 0.75rem;
+}
+
+/* The space's labels read path by path, one line each, wrapping inside it. */
+.cell-paths {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.cell-path {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.path-origin {
+  color: var(--muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 /* The conversation map, read top to bottom. */
@@ -1249,6 +1293,14 @@ button[disabled] {
 }
 
 .flow-posture {
+  color: var(--muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  width: 100%;
+}
+
+/* Beneath the posture, on its own line: what the space said about the cells. */
+.flow-labels {
   color: var(--muted);
   font-size: 0.7rem;
   letter-spacing: 0.03em;

--- a/packages/cf-harness/console/public/styles/console.css
+++ b/packages/cf-harness/console/public/styles/console.css
@@ -1087,6 +1087,16 @@ button[disabled] {
   font-size: 0.75rem;
 }
 
+/* What a reading of one cell missed, one line per fact it can state. */
+.cell-reading {
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
 /* The space saying a value was computed, in the derived chip's own color. */
 .cell-derived {
   color: #b54708;

--- a/packages/cf-harness/console/run-store.ts
+++ b/packages/cf-harness/console/run-store.ts
@@ -30,16 +30,17 @@ import {
 } from "./graph.ts";
 import { type ConsoleFlow, consoleRunFlow } from "./flow.ts";
 import {
+  cellLabelsSummaryOf,
   type ConsoleCellLabelIndex,
   consoleCellLabelIndex,
+  type ConsoleCellLabels,
+  consoleCellLabels,
   type ConsoleCellLabelsStatus,
   type ConsoleCellLabelsSummary,
   consoleCellLabelsSummary,
+  foldCellLabels,
 } from "./cell-labels.ts";
-import type {
-  HarnessCellLabelRecord,
-  HarnessCellLabels,
-} from "../src/contracts/cell-labels.ts";
+import type { HarnessCellLabels } from "../src/contracts/cell-labels.ts";
 
 /**
  * A single path segment of the characters the artifact store itself writes.
@@ -419,15 +420,22 @@ const statusTally = (
  * A member that minted no handle had no cell to snapshot, and its missing
  * snapshot is that rather than a gap, so it is left out of the reckoning.
  * The cells themselves are merged by address, so a cell a parent and its
- * child both hold is one cell of the family rather than two.
+ * child both hold is one cell of the family rather than two — and merged by
+ * {@link foldCellLabels}, so that a cell one member did not finish reading is
+ * counted as partial however whole another member's reading of it was.
  */
 const familyCellLabels = (
   members: readonly FamilyLabelReading[],
 ): ConsoleCellLabelsSummary => {
-  const byAddress = new Map<string, HarnessCellLabelRecord>();
+  const byAddress = new Map<string, ConsoleCellLabels>();
   for (const member of members) {
     for (const [address, record] of member.labels.byAddress) {
-      byAddress.set(address, record);
+      const held = byAddress.get(address);
+      const reading = consoleCellLabels(record);
+      byAddress.set(
+        address,
+        held === undefined ? reading : foldCellLabels(held, reading),
+      );
     }
   }
   const speaking = members.filter((member) =>
@@ -438,14 +446,13 @@ const familyCellLabels = (
   if (new Set(statuses).size > 1) {
     const space = members.find((member) => member.labels.space !== undefined)
       ?.labels.space;
-    return consoleCellLabelsSummary({
+    return cellLabelsSummaryOf({
       status: "unavailable",
       detail: `the runs in this family disagree: ${statusTally(statuses)}`,
       ...(space !== undefined ? { space } : {}),
-      byAddress,
-    });
+    }, byAddress.values());
   }
-  return consoleCellLabelsSummary({ ...agreed.labels, byAddress });
+  return cellLabelsSummaryOf(agreed.labels, byAddress.values());
 };
 
 /**

--- a/packages/cf-harness/console/run-store.ts
+++ b/packages/cf-harness/console/run-store.ts
@@ -29,6 +29,13 @@ import {
   consoleRunFamilyGraph,
 } from "./graph.ts";
 import { type ConsoleFlow, consoleRunFlow } from "./flow.ts";
+import {
+  type ConsoleCellLabelIndex,
+  consoleCellLabelIndex,
+  type ConsoleCellLabelsSummary,
+  consoleCellLabelsSummary,
+} from "./cell-labels.ts";
+import type { HarnessCellLabels } from "../src/contracts/cell-labels.ts";
 
 /**
  * A single path segment of the characters the artifact store itself writes.
@@ -57,6 +64,18 @@ const readJson = async <Value>(path: string): Promise<Value | undefined> => {
   }
 };
 
+/**
+ * The per-cell labels a run recorded, indexed by the addresses its cells go
+ * by. A run that wrote no snapshot indexes as `absent`, which is not the same
+ * reading as a space that had nothing to say.
+ */
+const cellLabelIndex = async (
+  root: string,
+): Promise<ConsoleCellLabelIndex> =>
+  consoleCellLabelIndex(
+    await readJson<HarnessCellLabels>(join(root, "cell-labels.json")),
+  );
+
 /** Everything `/api/runs/<run-id>` answers with. */
 export interface ConsoleRunDetail {
   summary: ConsoleRunSummary;
@@ -72,6 +91,14 @@ export interface ConsoleRunDetail {
    * that cell would otherwise read as coming from nowhere.
    */
   handles: readonly ConsoleHandle[];
+
+  /**
+   * Whether the run's space was read for per-cell labels, and what it said.
+   * The run states this once because the per-cell fact cannot: a cell with no
+   * labels means the space holds none for it under a snapshot that was taken,
+   * and means nobody asked under a run whose space could not be read.
+   */
+  cellLabels: ConsoleCellLabelsSummary;
   /** The artifacts this run wrote, by name, for the raw pane to fetch. */
   artifactNames: readonly string[];
   /** The files under `tool-outputs/`, newest call last. */
@@ -94,6 +121,7 @@ const RUN_ARTIFACT_NAMES = [
   "skill-activations.json",
   "skill-resource-reads.json",
   "skill-script-executions.json",
+  "cell-labels.json",
 ] as const;
 
 const namesPresent = async (
@@ -215,6 +243,10 @@ export const readConsoleRun = async (
   // from nowhere. The neighbours' tables are what give it an address, and so a
   // name and an origin.
   const neighbours = await neighbouringHandles(artifactRoot);
+  // The index is the run's own, and it is applied to every handle the run
+  // introduced — so a cell whose address only a neighbour's entry supplies is
+  // labelled here all the same, while the neighbour's own handles stay bare.
+  const labels = await cellLabelIndex(root);
   const table: HarnessHandleTable = {
     type: "cf-harness.handle-table",
     version: 1,
@@ -237,7 +269,8 @@ export const readConsoleRun = async (
     transcript,
     lens: consoleRunLens(transcript),
     steps,
-    handles: consoleRunHandles(steps, table),
+    handles: consoleRunHandles(steps, table, labels),
+    cellLabels: consoleCellLabelsSummary(labels),
     artifactNames: await namesPresent(root, RUN_ARTIFACT_NAMES),
     toolOutputNames: await toolOutputNames(root),
   };
@@ -283,13 +316,16 @@ export const readConsoleRunFlow = async (
       flowLabels: posture.flowLabels,
       ...(posture.posture !== undefined ? { posture: posture.posture } : {}),
     },
+    family.cellLabels,
   );
 };
 
 /**
  * A run and its `delegate_task` descendants, each reading its handles against
- * the neighbours' tables as well as its own. Both the map and the graph are
- * built from this, and neither wants to know how a family is found on disk.
+ * the neighbours' tables as well as its own, and each against its own label
+ * snapshot — a child writes its own, so a cell a child produced carries the
+ * space's labels in the family graph and in the map. Both are built from this,
+ * and neither wants to know how a family is found on disk.
  */
 const readConsoleRunFamily = async (
   artifactRoot: string,
@@ -299,6 +335,7 @@ const readConsoleRunFamily = async (
     root: ConsoleGraphRunInput;
     descendants: ConsoleGraphRunInput[];
     runState: HarnessRunState;
+    cellLabels: ConsoleCellLabelsSummary;
   }
   | undefined
 > => {
@@ -334,6 +371,7 @@ const readConsoleRunFamily = async (
     root: withNeighbours({ runId, steps: root.steps, handles: root.handles }),
     descendants: descendants.map(withNeighbours),
     runState: root.runState,
+    cellLabels: root.cellLabels,
   };
 };
 
@@ -417,7 +455,8 @@ const readNeighbouringHandles = async (
           addressKey: entryHandle.addressKey,
           introducedAtStep: 0,
           // A neighbour's entry resolves an address and nothing more; what the
-          // handle was used for belongs to the run that used it.
+          // handle was used for, and what its cell is labelled, belong to the
+          // run that used it and are left absent rather than invented here.
           uses: [],
           confidentiality: [],
         });

--- a/packages/cf-harness/console/run-store.ts
+++ b/packages/cf-harness/console/run-store.ts
@@ -32,12 +32,14 @@ import { type ConsoleFlow, consoleRunFlow } from "./flow.ts";
 import {
   type ConsoleCellLabelIndex,
   consoleCellLabelIndex,
-  type ConsoleCellLabels,
   type ConsoleCellLabelsStatus,
   type ConsoleCellLabelsSummary,
   consoleCellLabelsSummary,
 } from "./cell-labels.ts";
-import type { HarnessCellLabels } from "../src/contracts/cell-labels.ts";
+import type {
+  HarnessCellLabelRecord,
+  HarnessCellLabels,
+} from "../src/contracts/cell-labels.ts";
 
 /**
  * A single path segment of the characters the artifact store itself writes.
@@ -422,10 +424,10 @@ const statusTally = (
 const familyCellLabels = (
   members: readonly FamilyLabelReading[],
 ): ConsoleCellLabelsSummary => {
-  const byAddress = new Map<string, ConsoleCellLabels>();
+  const byAddress = new Map<string, HarnessCellLabelRecord>();
   for (const member of members) {
-    for (const [address, labels] of member.labels.byAddress) {
-      byAddress.set(address, labels);
+    for (const [address, record] of member.labels.byAddress) {
+      byAddress.set(address, record);
     }
   }
   const speaking = members.filter((member) =>

--- a/packages/cf-harness/console/run-store.ts
+++ b/packages/cf-harness/console/run-store.ts
@@ -32,6 +32,8 @@ import { type ConsoleFlow, consoleRunFlow } from "./flow.ts";
 import {
   type ConsoleCellLabelIndex,
   consoleCellLabelIndex,
+  type ConsoleCellLabels,
+  type ConsoleCellLabelsStatus,
   type ConsoleCellLabelsSummary,
   consoleCellLabelsSummary,
 } from "./cell-labels.ts";
@@ -343,6 +345,10 @@ const readConsoleRunFamily = async (
   if (root === undefined) {
     return undefined;
   }
+  const members: FamilyLabelReading[] = [{
+    runState: root.runState,
+    labels: await cellLabelIndex(join(artifactRoot, runId)),
+  }];
   const descendants: ConsoleGraphRunInput[] = [];
   try {
     for await (const entry of Deno.readDir(artifactRoot)) {
@@ -355,6 +361,10 @@ const readConsoleRunFamily = async (
           runId: entry.name,
           steps: child.steps,
           handles: child.handles,
+        });
+        members.push({
+          runState: child.runState,
+          labels: await cellLabelIndex(join(artifactRoot, entry.name)),
         });
       }
     }
@@ -371,8 +381,69 @@ const readConsoleRunFamily = async (
     root: withNeighbours({ runId, steps: root.steps, handles: root.handles }),
     descendants: descendants.map(withNeighbours),
     runState: root.runState,
-    cellLabels: root.cellLabels,
+    cellLabels: familyCellLabels(members),
   };
+};
+
+/** One member of a family, as the family's own reading is folded from. */
+interface FamilyLabelReading {
+  runState: HarnessRunState;
+  labels: ConsoleCellLabelIndex;
+}
+
+/** The members that each status was read for, in the words a header uses. */
+const statusTally = (
+  statuses: readonly ConsoleCellLabelsStatus[],
+): string =>
+  (["read", "unavailable", "absent"] as const)
+    .flatMap((status) => {
+      const count = statuses.filter((each) => each === status).length;
+      return count === 0 ? [] : [`${count} ${status}`];
+    })
+    .join(", ");
+
+/**
+ * What the whole family read of the space, folded from what each member read.
+ *
+ * The status is the sentence every bare cell on the map is read under: no
+ * labels means the space holds none where the snapshot was taken, and means
+ * nobody asked where it was not. So a family whose members disagree cannot be
+ * reported as any one member's status — the root's `read` would speak for a
+ * child's cells that nothing was read for, and the root's `absent` would deny
+ * a child's cells the labels its own snapshot holds. A disagreement is stated
+ * as one instead: `unavailable`, with the split in its detail, which claims
+ * nothing about any member's cells.
+ *
+ * A member that minted no handle had no cell to snapshot, and its missing
+ * snapshot is that rather than a gap, so it is left out of the reckoning.
+ * The cells themselves are merged by address, so a cell a parent and its
+ * child both hold is one cell of the family rather than two.
+ */
+const familyCellLabels = (
+  members: readonly FamilyLabelReading[],
+): ConsoleCellLabelsSummary => {
+  const byAddress = new Map<string, ConsoleCellLabels>();
+  for (const member of members) {
+    for (const [address, labels] of member.labels.byAddress) {
+      byAddress.set(address, labels);
+    }
+  }
+  const speaking = members.filter((member) =>
+    (member.runState.handleTable?.entries ?? []).length > 0
+  );
+  const statuses = speaking.map((member) => member.labels.status);
+  const agreed = speaking[0] ?? members[0];
+  if (new Set(statuses).size > 1) {
+    const space = members.find((member) => member.labels.space !== undefined)
+      ?.labels.space;
+    return consoleCellLabelsSummary({
+      status: "unavailable",
+      detail: `the runs in this family disagree: ${statusTally(statuses)}`,
+      ...(space !== undefined ? { space } : {}),
+      byAddress,
+    });
+  }
+  return consoleCellLabelsSummary({ ...agreed.labels, byAddress });
 };
 
 /**

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -93,7 +93,6 @@ import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
 import type { HarnessChatSessionStore } from "../src/session-store.ts";
 import { FileSystemHarnessArtifactStore } from "../src/artifacts.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
-import { readSpaceCellLabels } from "../src/space-labels.ts";
 import {
   listConsoleRuns,
   readConsoleRun,
@@ -644,6 +643,16 @@ interface StreamClient {
 
 const encoder = new TextEncoder();
 
+/**
+ * The events that close a turn. The run behind one is settled on disk once it
+ * is emitted, and the page re-reads the run when it arrives.
+ */
+const TERMINAL_TURN_EVENT_KINDS: ReadonlySet<string> = new Set([
+  "turn_completed",
+  "turn_failed",
+  "turn_canceled",
+]);
+
 /** The live event fan-out, and the routes that read and write through it. */
 export class ConsoleServer {
   readonly #clients = new Set<StreamClient>();
@@ -653,6 +662,14 @@ export class ConsoleServer {
   readonly #patternIndexClientFactory:
     | HarnessPatternIndexClientFactory
     | undefined;
+  readonly #recordCellLabels: (sessionId: string) => Promise<void>;
+
+  /**
+   * The tail of the fan-out a terminal event is holding, or `undefined` when
+   * nothing is waiting — which is the ordinary case, and the one where an
+   * envelope reaches the streams on the call that broadcast it.
+   */
+  #heldFanOut: Promise<void> | undefined;
   #beats = 0;
 
   /**
@@ -664,7 +681,9 @@ export class ConsoleServer {
    *
    * The index client is the other way round: it reads the fabric identity from
    * disk to sign with, so it is built lazily, cached once healthy, and handed
-   * in by a test that has no keyfile to read.
+   * in by a test that has no keyfile to read. The cell-label snapshot is
+   * handed in for the same reason — it reads a space database this host may
+   * not hold, and it is what a terminal event waits on.
    */
   constructor(
     config: ConsoleConfig,
@@ -672,8 +691,11 @@ export class ConsoleServer {
       onEvent: HarnessInteractiveChatEventListener,
     ) => HarnessInteractiveChatService,
     patternIndexClientFactory?: HarnessPatternIndexClientFactory,
+    recordCellLabels?: (sessionId: string) => Promise<void>,
   ) {
     this.#config = config;
+    this.#recordCellLabels = recordCellLabels ??
+      ((sessionId) => this.#snapshotCellLabels(sessionId));
     this.#service = createService((envelope) => this.broadcast(envelope));
     const factory = patternIndexClientFactory ??
       (config.patternIndex !== undefined
@@ -692,24 +714,45 @@ export class ConsoleServer {
     return this.#service;
   }
 
-  /** Writes one envelope to every stream that has not already seen it. */
+  /**
+   * Writes one envelope to every stream that has not already seen it.
+   *
+   * The run's cells are settled once its turn is, so a terminal event is what
+   * the snapshot is taken on — and the page re-reads the run on that same
+   * event, so the event is held until the snapshot has landed. An event that
+   * overtook its own snapshot would hand the page a run whose labels read
+   * `absent`, with no later event to correct it. Nothing of the turn waits
+   * behind the event that closes it, and an envelope broadcast while one is
+   * held queues behind it, so the stream stays in sequence order — which is
+   * the order it delivers in or not at all. A snapshot this server could not
+   * write still lets the event through: the run stands as it is, and the page
+   * is owed the turn either way.
+   */
   broadcast(envelope: HarnessChatEventEnvelope): void {
-    if (
-      envelope.event.kind === "turn_completed" ||
-      envelope.event.kind === "turn_failed" ||
-      envelope.event.kind === "turn_canceled"
-    ) {
-      // The run's cells are settled once its turn is, and the page re-reads
-      // the run on the same event, so the snapshot is taken here rather than
-      // on the read that wants it. A failure to read the space is a snapshot
-      // that says so; a failure to write one leaves the run as it stands.
-      this.#recordCellLabels(envelope.sessionId).catch((error: unknown) => {
+    const snapshot = TERMINAL_TURN_EVENT_KINDS.has(envelope.event.kind)
+      ? this.#recordCellLabels(envelope.sessionId).catch((error: unknown) => {
         console.error(
           `cell label snapshot failed for session ${envelope.sessionId}:`,
           error,
         );
-      });
+      })
+      : undefined;
+    if (snapshot === undefined && this.#heldFanOut === undefined) {
+      this.#fanOut(envelope);
+      return;
     }
+    const held = (this.#heldFanOut ?? Promise.resolve())
+      .then(() => snapshot)
+      .then(() => this.#fanOut(envelope), () => this.#fanOut(envelope));
+    this.#heldFanOut = held;
+    void held.finally(() => {
+      if (this.#heldFanOut === held) {
+        this.#heldFanOut = undefined;
+      }
+    });
+  }
+
+  #fanOut(envelope: HarnessChatEventEnvelope): void {
     for (const client of this.#clients) {
       if (
         client.sessionId !== undefined &&
@@ -740,7 +783,7 @@ export class ConsoleServer {
    * writes a snapshot that says so, which is a different page from a run whose
    * cells carry no label.
    */
-  async #recordCellLabels(sessionId: string): Promise<void> {
+  async #snapshotCellLabels(sessionId: string): Promise<void> {
     const [session] = this.#service.status(sessionId).sessions;
     const runId = session?.harnessRunId;
     if (runId === undefined) {
@@ -768,6 +811,8 @@ export class ConsoleServer {
       if (refs.length === 0) {
         continue;
       }
+      // deno-lint-ignore cf-imports/no-inline-module-import -- reading a space database opens SQLite's native library, and a console process whose runs have no cell to snapshot must be able to serve its page without `--allow-ffi`
+      const { readSpaceCellLabels } = await import("../src/space-labels.ts");
       const labels = await readSpaceCellLabels({
         space: this.#config.fabricSession.space,
         ...(this.#config.spaceDbPath !== undefined
@@ -1314,6 +1359,14 @@ export const startConsoleServer = async (
               : "off")
         }, ${config.fabricSession.cfcEnforcementMode ?? "enforce-explicit"}`,
       );
+      // The two sidecar transports a run's mediation moves over. The engine's
+      // guard asks only that they are named, so a console pointed at
+      // directories no sandbox sidecar writes starts cleanly and then denies
+      // every observation of the run; printing them is what lets an operator
+      // read at startup which directories that depends on, for the same
+      // reason the posture is printed rather than left to be inferred.
+      console.log(`  results:    ${config.cfcResultDir}`);
+      console.log(`  contexts:   ${config.cfcInvocationContextDir}`);
       console.log(`  workspace:  ${config.workspacePath}`);
       console.log(`  artifacts:  ${config.artifactRoot}\n`);
     },

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -91,6 +91,9 @@ import {
 } from "../src/sandbox/docker-runsc.ts";
 import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
 import type { HarnessChatSessionStore } from "../src/session-store.ts";
+import { FileSystemHarnessArtifactStore } from "../src/artifacts.ts";
+import type { HarnessRunState } from "../src/run-state.ts";
+import { readSpaceCellLabels } from "../src/space-labels.ts";
 import {
   listConsoleRuns,
   readConsoleRun,
@@ -307,6 +310,13 @@ interface ConsoleConfig {
   fabricSession: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
   sessionDbPath?: string;
+
+  /**
+   * The space database the per-cell label snapshot reads, for a host whose
+   * store is not where the discovery walk looks. Absent, the space the
+   * fabric session names is resolved against the caches on this host.
+   */
+  spaceDbPath?: string;
   maxModelTurns?: number;
   skillsRoot?: string;
 }
@@ -353,6 +363,7 @@ export const resolveConsoleConfig = (
       "fabric-space",
       "pattern-index-url",
       "session-db",
+      "space-db",
       "max-model-turns",
       "fabric-cfc-enforcement-mode",
       "fabric-cfc-flow-labels",
@@ -478,6 +489,9 @@ export const resolveConsoleConfig = (
   const maxModelTurns = flag("max-model-turns") ??
     nonEmpty(env.CF_HARNESS_CONSOLE_MAX_MODEL_TURNS) ?? "32";
 
+  const spaceDb = flag("space-db") ?? nonEmpty(env.CF_HARNESS_SPACE_DB);
+  const spaceDbPath = spaceDb === undefined ? undefined : resolve(cwd, spaceDb);
+
   return {
     port,
     workspacePath,
@@ -490,6 +504,7 @@ export const resolveConsoleConfig = (
     ),
     model: flag("model") ?? nonEmpty(env.CF_HARNESS_MODEL) ?? DEFAULT_MODEL,
     fabricSession,
+    ...(spaceDbPath !== undefined ? { spaceDbPath } : {}),
     ...(patternIndexUrl !== undefined
       ? {
         patternIndex: {
@@ -679,6 +694,22 @@ export class ConsoleServer {
 
   /** Writes one envelope to every stream that has not already seen it. */
   broadcast(envelope: HarnessChatEventEnvelope): void {
+    if (
+      envelope.event.kind === "turn_completed" ||
+      envelope.event.kind === "turn_failed" ||
+      envelope.event.kind === "turn_canceled"
+    ) {
+      // The run's cells are settled once its turn is, and the page re-reads
+      // the run on the same event, so the snapshot is taken here rather than
+      // on the read that wants it. A failure to read the space is a snapshot
+      // that says so; a failure to write one leaves the run as it stands.
+      this.#recordCellLabels(envelope.sessionId).catch((error: unknown) => {
+        console.error(
+          `cell label snapshot failed for session ${envelope.sessionId}:`,
+          error,
+        );
+      });
+    }
     for (const client of this.#clients) {
       if (
         client.sessionId !== undefined &&
@@ -691,6 +722,62 @@ export class ConsoleServer {
         continue;
       }
       this.#write(client, envelope);
+    }
+  }
+
+  /**
+   * Reads the run's space for what it holds about the cells a finished turn
+   * touched, and records it beside the run.
+   *
+   * The run's own artifacts say which cells it made and read; the space says
+   * what each of them is labelled, and nothing else joins the two. A turn is
+   * its own run, so this runs once per turn, over that run and the
+   * `delegate_task` children beneath it — a parent commonly names a cell its
+   * child produced, and a snapshot of the parent alone would leave that cell
+   * unlabelled in the family map.
+   *
+   * The space is read read-only and best-effort: a host holding no copy of it
+   * writes a snapshot that says so, which is a different page from a run whose
+   * cells carry no label.
+   */
+  async #recordCellLabels(sessionId: string): Promise<void> {
+    const [session] = this.#service.status(sessionId).sessions;
+    const runId = session?.harnessRunId;
+    if (runId === undefined) {
+      return;
+    }
+    const artifactRoot = session.artifactRoot ?? this.#config.artifactRoot;
+    // The harness ids a child `<parent>.subagent.N`, so the family is a
+    // directory listing rather than a walk of every run's state.
+    const family: string[] = [];
+    for await (const entry of Deno.readDir(artifactRoot)) {
+      if (
+        entry.isDirectory &&
+        (entry.name === runId || entry.name.startsWith(`${runId}.`))
+      ) {
+        family.push(entry.name);
+      }
+    }
+    for (const name of family) {
+      const runState = JSON.parse(
+        await Deno.readTextFile(join(artifactRoot, name, "run-state.json")),
+      ) as HarnessRunState;
+      const refs = (runState.handleTable?.entries ?? []).map((entry) =>
+        entry.ref
+      );
+      if (refs.length === 0) {
+        continue;
+      }
+      const labels = await readSpaceCellLabels({
+        space: this.#config.fabricSession.space,
+        ...(this.#config.spaceDbPath !== undefined
+          ? { dbPath: this.#config.spaceDbPath }
+          : {}),
+        refs,
+        generatedAt: new Date().toISOString(),
+      });
+      await new FileSystemHarnessArtifactStore({ artifactRoot, runId: name })
+        .persistCellLabels(labels);
     }
   }
 

--- a/packages/cf-harness/console/src/cell-chip.ts
+++ b/packages/cf-harness/console/src/cell-chip.ts
@@ -120,6 +120,23 @@ export const cellLabelView = (cell: ConsoleCellFacts): ConsoleCellLabelView => {
  * `derived` is the space saying the value was computed, which no count of
  * atoms establishes.
  */
+/**
+ * Whether the card may say the space holds no label for this cell.
+ *
+ * The one positive claim the card makes about the space, and the only state
+ * entitled to make it: a reading that covered the whole of the cell and found
+ * nothing. Every other state — a cell no reading recorded, one whose reading
+ * stopped at a path, one whose reading ran out — knows less than that, and
+ * saying it would turn what nobody established into what the space asserts.
+ *
+ * It is a conjunction, which is what makes it worth naming and pinning: a
+ * later edit that drops one term widens the claim silently, and the card goes
+ * on reading as though it had been established.
+ */
+export const spaceHoldsNoLabel = (view: ConsoleCellLabelView): boolean =>
+  view.recorded && !view.partial &&
+  view.confidentiality.length === 0 && view.integrity.length === 0;
+
 export const cellChipClasses = (cell: ConsoleCellFacts): string => {
   const view = cellLabelView(cell);
   const labelled = view.onCall.length > 0 || view.confidentiality.length > 0 ||
@@ -300,12 +317,12 @@ export class ConsoleCell extends LitElement {
             ? html`<span class="cell-none">
               no label read for this cell; the map heads with what this run read
             </span>`
+            : spaceHoldsNoLabel(view)
+            ? html`<span class="cell-none">
+              the space holds no label for this cell
+            </span>`
             : view.confidentiality.length === 0 && view.integrity.length === 0
-            ? view.partial
-              ? html`<span class="cell-none">no label read for this cell</span>`
-              : html`<span class="cell-none">
-                the space holds no label for this cell
-              </span>`
+            ? html`<span class="cell-none">no label read for this cell</span>`
             : html`
               ${view.confidentiality.map((name) =>
                 html`<span class="atom conf">${name}</span>`
@@ -316,6 +333,14 @@ export class ConsoleCell extends LitElement {
             `}
         </span>
       </span>
+      <!--
+        A partial reading is stated whether or not the cell carries atoms, and
+        the cell that carries them is the one that needs it most: atoms read as
+        an answer, so a reader who sees them stops asking. A cell showing
+        nothing at least invites the question of why; a cell showing something
+        invites none, and the labels it shows are some of what the space holds
+        rather than all of it.
+      -->
       ${!view.partial ? nothing : html`
         <span class="cell-row">
           <span class="cell-label">reading</span>

--- a/packages/cf-harness/console/src/cell-chip.ts
+++ b/packages/cf-harness/console/src/cell-chip.ts
@@ -8,6 +8,10 @@
  */
 
 import { html, LitElement, nothing, type TemplateResult } from "lit";
+import type {
+  ConsoleCellLabelEntry,
+  ConsoleCellLabels,
+} from "../cell-labels.ts";
 
 /** What a chip needs to know to draw a cell. */
 export interface ConsoleCellFacts {
@@ -15,9 +19,86 @@ export interface ConsoleCellFacts {
   ref?: string;
   slug?: string;
   producedByStep?: number;
+
+  /**
+   * The atoms the sandbox's invocation context recorded on the arguments of
+   * the call this sighting belongs to.
+   */
   confidentiality?: readonly string[];
   schema?: unknown;
+
+  /** What the space stores for the cell itself, where the run read it. */
+  labels?: ConsoleCellLabels;
 }
+
+/**
+ * The label facts a chip draws, held apart.
+ *
+ * `onCall` is what one call's invocation context recorded; the rest is what
+ * the space stores for the cell itself. They answer different questions — what
+ * a sandbox saw crossing into a call, and what the cell is — so the card names
+ * them apart and joins them into no single list.
+ */
+export interface ConsoleCellLabelView {
+  onCall: readonly string[];
+
+  /** Every confidentiality atom the space holds at any path of the cell. */
+  confidentiality: readonly string[];
+
+  /** Every integrity atom the space holds at any path of the cell. */
+  integrity: readonly string[];
+
+  /**
+   * Whether the space says a path of this cell was computed from what a
+   * function read.
+   *
+   * This is the fact a confidentiality atom does not carry. A value's label
+   * may be the join of the fields of the object it was reached through, so a
+   * plain input reached through a labelled object holds an atom without having
+   * been derived from anything confidential. A chip that read the atom as
+   * taint reports that input as tainted; `derived`, and the provenance beside
+   * it, is what separates a computed value from a carried one, and it is why
+   * the two are separate chip states rather than degrees of one badge.
+   */
+  derived: boolean;
+
+  /** The implementations the space names as producing the derived paths. */
+  transformedBy: readonly string[];
+
+  /** The paths the space labelled, so a card can read path by path. */
+  paths: readonly ConsoleCellLabelEntry[];
+
+  /** Whether this run's labels hold a record for this cell at all. */
+  recorded: boolean;
+}
+
+/** The two facts, reduced to what the chip and its card draw. */
+export const cellLabelView = (cell: ConsoleCellFacts): ConsoleCellLabelView => {
+  const labels = cell.labels;
+  return {
+    onCall: cell.confidentiality ?? [],
+    confidentiality: labels?.confidentiality ?? [],
+    integrity: labels?.integrity ?? [],
+    derived: labels?.derived ?? false,
+    transformedBy: labels?.transformedBy ?? [],
+    paths: labels?.entries ?? [],
+    recorded: labels !== undefined,
+  };
+};
+
+/**
+ * The classes the chip wears. `labelled` is an atom from either fact;
+ * `derived` is the space saying the value was computed, which no count of
+ * atoms establishes.
+ */
+export const cellChipClasses = (cell: ConsoleCellFacts): string => {
+  const view = cellLabelView(cell);
+  const labelled = view.onCall.length > 0 || view.confidentiality.length > 0 ||
+    view.integrity.length > 0;
+  return ["cell", labelled ? "labelled" : "", view.derived ? "derived" : ""]
+    .filter((name) => name !== "")
+    .join(" ");
+};
 
 /**
  * What to call a cell. The name a person gave it wins, then the handle the
@@ -27,7 +108,8 @@ export interface ConsoleCellFacts {
 export const cellName = (cell: ConsoleCellFacts): string =>
   cell.slug ?? cell.token ?? cell.ref ?? "cell";
 
-const schemaSummary = (schema: unknown): string | undefined => {
+/** The shape a pattern declared, in as few characters as read as a shape. */
+export const schemaSummary = (schema: unknown): string | undefined => {
   const record = typeof schema === "object" && schema !== null
     ? schema as { type?: unknown; properties?: Record<string, unknown> }
     : undefined;
@@ -44,12 +126,9 @@ let cardSequence = 0;
 export class ConsoleCell extends LitElement {
   static override properties = {
     cell: { attribute: false },
-    origin: { attribute: false },
   };
 
   declare cell: ConsoleCellFacts | undefined;
-  /** Whether to offer the jump back to where the cell was produced. */
-  declare origin: boolean;
 
   /**
    * The card's id, so the chip can name it as its description rather than
@@ -57,11 +136,6 @@ export class ConsoleCell extends LitElement {
    * address and the atoms as the structure they are.
    */
   readonly #cardId = `cell-card-${++cardSequence}`;
-
-  constructor() {
-    super();
-    this.origin = true;
-  }
 
   protected override createRenderRoot(): HTMLElement {
     return this;
@@ -162,16 +236,105 @@ export class ConsoleCell extends LitElement {
     this.#close();
   }
 
+  /**
+   * The labels, as the two facts they are: what the invocation context of one
+   * call recorded, and what the space holds for the cell. The second reads
+   * path by path, because a cell labelled at one field and not at another is
+   * two different things to a reader and one blurred thing to a badge.
+   */
+  #labels(view: ConsoleCellLabelView): TemplateResult {
+    return html`
+      <span class="cell-row">
+        <span class="cell-label">cfc</span>
+        <span class="label-atoms" title="atoms recorded on this call">
+          ${view.onCall.length === 0
+            ? html`<span class="cell-none">no atom on this call</span>`
+            : view.onCall.map((name) =>
+              html`<span class="atom conf">${name}</span>`
+            )}
+        </span>
+      </span>
+      <span class="cell-row">
+        <span class="cell-label">space</span>
+        <span class="label-atoms" title="what the space holds for this cell">
+          ${!view.recorded
+            ? html`<span class="cell-none">
+              no label read for this cell; the map heads with what this run read
+            </span>`
+            : view.confidentiality.length === 0 && view.integrity.length === 0
+            ? html`<span class="cell-none">
+              the space holds no label for this cell
+            </span>`
+            : html`
+              ${view.confidentiality.map((name) =>
+                html`<span class="atom conf">${name}</span>`
+              )}
+              ${view.integrity.map((name) =>
+                html`<span class="atom integ">${name}</span>`
+              )}
+            `}
+        </span>
+      </span>
+      ${view.paths.length === 0 ? nothing : html`
+        <span class="cell-row">
+          <span class="cell-label">derived</span>
+          ${view.derived
+            ? html`<span class="cell-derived">
+              computed from what a function read
+            </span>`
+            : html`<span class="cell-none">
+              carried, not computed from a read
+            </span>`}
+        </span>
+      `}
+      ${view.transformedBy.length === 0 ? nothing : html`
+        <span class="cell-row">
+          <span class="cell-label">transformed by</span>
+          <span class="cell-mono cell-wrap">
+            ${view.transformedBy.join(", ")}
+          </span>
+        </span>
+      `}
+      ${view.paths.length === 0 ? nothing : html`
+        <span class="cell-row">
+          <span class="cell-label">paths</span>
+          <span class="cell-paths">
+            ${view.paths.map((entry) =>
+              html`
+                <span class="cell-path">
+                  <span class="label-path">
+                    ${entry.path === "" ? "(the cell)" : entry.path}
+                  </span>
+                  ${entry.origin === undefined
+                    ? nothing
+                    : html`<span class="path-origin">${entry.origin}</span>`}
+                  <span class="label-atoms">
+                    ${entry.confidentiality.map((name) =>
+                      html`<span class="atom conf">${name}</span>`
+                    )}
+                    ${entry.integrity.map((name) =>
+                      html`<span class="atom integ">${name}</span>`
+                    )}
+                  </span>
+                </span>
+              `
+            )}
+          </span>
+        </span>
+      `}
+    `;
+  }
+
   protected override render(): TemplateResult | typeof nothing {
     const cell = this.cell;
     if (cell === undefined) {
       return nothing;
     }
     const shape = schemaSummary(cell.schema);
-    const atoms = cell.confidentiality ?? [];
+    const view = cellLabelView(cell);
     return html`
       <span
-        class="cell ${atoms.length > 0 ? "labelled" : ""}"
+        class=${cellChipClasses(cell)}
         tabindex="0"
         aria-describedby=${this.#cardId}
         @mouseenter=${() => this.#open("hover")}
@@ -181,9 +344,9 @@ export class ConsoleCell extends LitElement {
       >
         <span class="cell-dot"></span>
         <span class="cell-name">${cellName(cell)}</span>
-        ${atoms.length === 0
+        ${view.onCall.length === 0
           ? nothing
-          : html`<span class="cell-atoms">${atoms.length}</span>`}
+          : html`<span class="cell-atoms">${view.onCall.length}</span>`}
         <span class="cell-card" id=${this.#cardId} role="tooltip">
           ${cell.slug === undefined ? nothing : html`
             <span class="cell-row">
@@ -209,16 +372,7 @@ export class ConsoleCell extends LitElement {
               <span class="cell-mono">${shape}</span>
             </span>
           `}
-          <span class="cell-row">
-            <span class="cell-label">cfc</span>
-            <span>
-              ${atoms.length === 0
-                ? html`<span class="cell-none">no labels recorded</span>`
-                : atoms.map((name) =>
-                  html`<span class="atom conf">${name}</span>`
-                )}
-            </span>
-          </span>
+          ${this.#labels(view)}
           ${cell.producedByStep === undefined ? nothing : html`
             <span class="cell-row">
               <span class="cell-label">from</span>

--- a/packages/cf-harness/console/src/cell-chip.ts
+++ b/packages/cf-harness/console/src/cell-chip.ts
@@ -303,7 +303,9 @@ export class ConsoleCell extends LitElement {
               html`
                 <span class="cell-path">
                   <span class="label-path">
-                    ${entry.path === "" ? "(the cell)" : entry.path}
+                    ${entry.path.length === 0
+                      ? "(the cell)"
+                      : entry.path.join("/")}
                   </span>
                   ${entry.origin === undefined
                     ? nothing

--- a/packages/cf-harness/console/src/cell-chip.ts
+++ b/packages/cf-harness/console/src/cell-chip.ts
@@ -70,11 +70,37 @@ export interface ConsoleCellLabelView {
 
   /** Whether this run's labels hold a record for this cell at all. */
   recorded: boolean;
+
+  /**
+   * The paths inside this cell nothing was read at, named. Each is a place
+   * the reading declined to go — a link out of the space it opened, or a path
+   * below the depth it descends to — so a path under one of them is unknown
+   * while every other path of the cell was read.
+   */
+  unreadPaths: readonly (readonly string[])[];
+
+  /**
+   * Whether the reading of this cell stopped before it had finished. It says
+   * less than a named unread path does: what was left was never enumerated,
+   * so the entries are some of what the space holds and any path carrying no
+   * entry is unknown rather than unlabelled.
+   */
+  unfinished: boolean;
+
+  /**
+   * Whether either of the two above holds. A card reads it as the licence to
+   * say what the space holds: without it an empty entry list is the space
+   * holding no label, and with it an empty entry list is a reading that did
+   * not cover the cell.
+   */
+  partial: boolean;
 }
 
 /** The two facts, reduced to what the chip and its card draw. */
 export const cellLabelView = (cell: ConsoleCellFacts): ConsoleCellLabelView => {
   const labels = cell.labels;
+  const unreadPaths = labels?.unreadPaths ?? [];
+  const unfinished = labels?.truncationReason !== undefined;
   return {
     onCall: cell.confidentiality ?? [],
     confidentiality: labels?.confidentiality ?? [],
@@ -83,6 +109,9 @@ export const cellLabelView = (cell: ConsoleCellFacts): ConsoleCellLabelView => {
     transformedBy: labels?.transformedBy ?? [],
     paths: labels?.entries ?? [],
     recorded: labels !== undefined,
+    unreadPaths,
+    unfinished,
+    partial: unreadPaths.length > 0 || unfinished,
   };
 };
 
@@ -119,6 +148,10 @@ export const schemaSummary = (schema: unknown): string | undefined => {
   }
   return typeof record?.type === "string" ? record.type : undefined;
 };
+
+/** A path inside a cell, joined for showing; the cell itself names itself. */
+const pathText = (path: readonly string[]): string =>
+  path.length === 0 ? "(the cell)" : path.join("/");
 
 /** Distinguishes one chip's card from another's, for `aria-describedby`. */
 let cardSequence = 0;
@@ -241,6 +274,12 @@ export class ConsoleCell extends LitElement {
    * call recorded, and what the space holds for the cell. The second reads
    * path by path, because a cell labelled at one field and not at another is
    * two different things to a reader and one blurred thing to a badge.
+   *
+   * Only a cell read whole says what the space holds. A reading that covered
+   * part of the cell says no label was read for it — the same words as a cell
+   * the run's labels name nowhere, because it is the same claim — and the
+   * `reading` row beneath says which part it missed and what a path with no
+   * entry means under it.
    */
   #labels(view: ConsoleCellLabelView): TemplateResult {
     return html`
@@ -262,9 +301,11 @@ export class ConsoleCell extends LitElement {
               no label read for this cell; the map heads with what this run read
             </span>`
             : view.confidentiality.length === 0 && view.integrity.length === 0
-            ? html`<span class="cell-none">
-              the space holds no label for this cell
-            </span>`
+            ? view.partial
+              ? html`<span class="cell-none">no label read for this cell</span>`
+              : html`<span class="cell-none">
+                the space holds no label for this cell
+              </span>`
             : html`
               ${view.confidentiality.map((name) =>
                 html`<span class="atom conf">${name}</span>`
@@ -275,6 +316,26 @@ export class ConsoleCell extends LitElement {
             `}
         </span>
       </span>
+      ${!view.partial ? nothing : html`
+        <span class="cell-row">
+          <span class="cell-label">reading</span>
+          <span class="cell-reading">
+            ${view.unreadPaths.length === 0 ? nothing : html`
+              <span>
+                read but for ${view.unreadPaths.map(pathText).join(", ")} —
+                a path under one of those is unknown, and every other one was
+                read
+              </span>
+            `}
+            ${!view.unfinished ? nothing : html`
+              <span>
+                did not finish — these are some of the labels the space holds,
+                and a path with no entry is unknown
+              </span>
+            `}
+          </span>
+        </span>
+      `}
       ${view.paths.length === 0 ? nothing : html`
         <span class="cell-row">
           <span class="cell-label">derived</span>
@@ -302,11 +363,7 @@ export class ConsoleCell extends LitElement {
             ${view.paths.map((entry) =>
               html`
                 <span class="cell-path">
-                  <span class="label-path">
-                    ${entry.path.length === 0
-                      ? "(the cell)"
-                      : entry.path.join("/")}
-                  </span>
+                  <span class="label-path">${pathText(entry.path)}</span>
                   ${entry.origin === undefined
                     ? nothing
                     : html`<span class="path-origin">${entry.origin}</span>`}

--- a/packages/cf-harness/console/src/flow-view.ts
+++ b/packages/cf-harness/console/src/flow-view.ts
@@ -8,11 +8,32 @@
  */
 
 import { html, LitElement, nothing, type TemplateResult } from "lit";
+import type { ConsoleCellLabelsSummary } from "../cell-labels.ts";
 import type { ConsoleFlow, ConsoleFlowNode } from "./api.ts";
 import "./cell-chip.ts";
 
 /** How long a numeric run has to be before it reads as a channel. */
 const WIDE_NUMERIC_RUN = 32;
+
+/**
+ * What the run's per-cell labels amount to, in one line.
+ *
+ * A cell drawn with no atoms says one thing under a run whose space was read
+ * and another under a run where nobody asked, and the chip cannot tell those
+ * apart on its own. The header carries the difference, so an empty chip is
+ * read against a stated regime rather than as an absence of secrets.
+ */
+const labelRegime = (labels: ConsoleCellLabelsSummary): string => {
+  if (labels.status === "absent") {
+    return "cell labels not read";
+  }
+  if (labels.status === "unavailable") {
+    return `cell labels unavailable${
+      labels.detail === undefined ? "" : ` · ${labels.detail}`
+    }`;
+  }
+  return `cell labels read · ${labels.cellsLabelled} of ${labels.cellsRead} carry one`;
+};
 
 export class ConsoleFlowView extends LitElement {
   static override properties = {
@@ -129,6 +150,12 @@ export class ConsoleFlowView extends LitElement {
               ${flow.cfc.posture ?? "first-party"} ·
               labels ${flow.cfc.flowLabels} · ${flow.cfc.enforcementMode}
             </span>
+          `}
+          ${flow.cellLabels === undefined ? nothing : html`
+            <span
+              class="flow-labels"
+              title="what the space said about the cells this run touched"
+            >${labelRegime(flow.cellLabels)}</span>
           `}
           ${flow.failures === 0
             ? nothing

--- a/packages/cf-harness/console/src/flow-view.ts
+++ b/packages/cf-harness/console/src/flow-view.ts
@@ -22,8 +22,13 @@ const WIDE_NUMERIC_RUN = 32;
  * and another under a run where nobody asked, and the chip cannot tell those
  * apart on its own. The header carries the difference, so an empty chip is
  * read against a stated regime rather than as an absence of secrets.
+ *
+ * "So many of so many carry one" is a count over a reading that covered every
+ * cell it names. Where a cell of the run was read only in part, the count is
+ * a floor — another label may sit at a path nothing was read at — so the line
+ * leads with the reading being partial rather than with a total.
  */
-const labelRegime = (labels: ConsoleCellLabelsSummary): string => {
+export const labelRegime = (labels: ConsoleCellLabelsSummary): string => {
   if (labels.status === "absent") {
     return "cell labels not read";
   }
@@ -32,7 +37,10 @@ const labelRegime = (labels: ConsoleCellLabelsSummary): string => {
       labels.detail === undefined ? "" : ` · ${labels.detail}`
     }`;
   }
-  return `cell labels read · ${labels.cellsLabelled} of ${labels.cellsRead} carry one`;
+  const carry = `${labels.cellsLabelled} of ${labels.cellsRead} carry one`;
+  return labels.cellsPartial === 0
+    ? `cell labels read · ${carry}`
+    : `cell labels read in part · ${carry}, ${labels.cellsPartial} only partly read`;
 };
 
 export class ConsoleFlowView extends LitElement {

--- a/packages/cf-harness/console/steps.ts
+++ b/packages/cf-harness/console/steps.ts
@@ -24,6 +24,11 @@ import type { ToolResultRef } from "../src/contracts/tool-result.ts";
 import type { HarnessPolicyEvent } from "../src/contracts/policy.ts";
 import type { HarnessPolicyDecisionRecord } from "../src/contracts/policy-trace.ts";
 import type { HarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
+import {
+  cellLabelsAt,
+  type ConsoleCellLabelIndex,
+  type ConsoleCellLabels,
+} from "./cell-labels.ts";
 
 /** One place a handle was passed into a call. */
 export interface ConsoleHandleUse {
@@ -73,8 +78,20 @@ export interface ConsoleHandle {
   /** Every call this handle was passed into. */
   uses: readonly ConsoleHandleUse[];
 
-  /** Confidentiality atoms the run's labels attached where it was used. */
+  /**
+   * Confidentiality atoms the sandbox invocation context put on the arguments
+   * this handle was passed as. A fact about the calls that spent it: what the
+   * runtime labelled a position with at the moment a call went through it.
+   */
   confidentiality: readonly string[];
+
+  /**
+   * The labels the space holds for the cell this handle names. A fact about
+   * the cell, which is why it stands beside `confidentiality` rather than
+   * replacing it: a cell the space labels may be passed to a call that carries
+   * no atom, and a call may carry one on a cell the space labels with nothing.
+   */
+  labels?: ConsoleCellLabels;
 }
 
 /**
@@ -108,8 +125,11 @@ export interface ConsoleArgumentRef {
   /** The shape the pattern that made it declared. */
   schema?: unknown;
 
-  /** Confidentiality atoms the run's labels put on this argument. */
+  /** Confidentiality atoms the invocation context put on this argument. */
   confidentiality: readonly string[];
+
+  /** The labels the space holds for the cell this argument names. */
+  labels?: ConsoleCellLabels;
 
   /** The argument as written, for one that names nothing. */
   value?: unknown;
@@ -544,14 +564,15 @@ export const consoleRunSteps = (
 };
 
 /**
- * The handles a run introduced, each resolved against the run's own table.
- * A token the table no longer holds is still reported: that the run passed a
- * handle is the fact, and an address it did not keep is not a reason to hide
- * it.
+ * The handles a run introduced, each resolved against the run's own table and
+ * against the labels the run's space holds for what it names. A token the
+ * table no longer holds is still reported: that the run passed a handle is the
+ * fact, and an address it did not keep is not a reason to hide it.
  */
 export const consoleRunHandles = (
   steps: readonly ConsoleStep[],
   handleTable?: HarnessHandleTable,
+  labels?: ConsoleCellLabelIndex,
 ): readonly ConsoleHandle[] => {
   const entries = new Map<string, HarnessHandleEntry>(
     (handleTable?.entries ?? []).map((entry) => [entry.token, entry]),
@@ -562,6 +583,9 @@ export const consoleRunHandles = (
     for (const token of step.handlesIntroduced) {
       const entry = entries.get(token);
       const known = provenance.get(token);
+      const cellLabels = labels === undefined
+        ? undefined
+        : cellLabelsAt(labels, entry?.ref);
       handles.push({
         token,
         ...(entry?.ref !== undefined ? { ref: entry.ref } : {}),
@@ -577,6 +601,7 @@ export const consoleRunHandles = (
         ...(entry?.schema !== undefined ? { schema: entry.schema } : {}),
         uses: known?.uses ?? [],
         confidentiality: known?.confidentiality ?? [],
+        ...(cellLabels !== undefined ? { labels: cellLabels } : {}),
       });
     }
   }
@@ -749,10 +774,14 @@ const parsesAsLink = (text: string): boolean => {
  * that takes one takes it as a named argument, so both are read here. A
  * reference resolves against the run's handles whichever way it was written:
  * by token directly, and by link through the address the token stands for.
+ *
+ * The label index is what gives an argument the cell's own labels when the
+ * link names a cell no handle stands for.
  */
 export const consoleStepArguments = (
   step: ConsoleStep,
   handles: readonly ConsoleHandle[] = [],
+  labels?: ConsoleCellLabelIndex,
 ): readonly ConsoleArgumentRef[] => {
   if (step.kind !== "tool") {
     return [];
@@ -778,6 +807,11 @@ export const consoleStepArguments = (
         value,
       };
     }
+    // The handle carries the cell's labels already; an argument written as a
+    // whole link the run holds no handle for is looked up by the address the
+    // link itself names, so both spellings reach the same labels.
+    const cellLabels = handle?.labels ??
+      (labels === undefined ? undefined : cellLabelsAt(labels, ref));
     return {
       key,
       isReference: true,
@@ -789,6 +823,7 @@ export const consoleStepArguments = (
         : {}),
       ...(handle?.schema !== undefined ? { schema: handle.schema } : {}),
       confidentiality: argumentAtomNames(step, key, argumentKeys),
+      ...(cellLabels !== undefined ? { labels: cellLabels } : {}),
     };
   });
 };

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -24,7 +24,10 @@ The runtime has four main boundaries:
    configured space.
 4. The artifact store records run state, transcript, reports, capability and
    policy snapshots, tool outputs, child references, skills provenance, and
-   optional product run manifests.
+   optional product run manifests. It also records the per-cell CFC labels the
+   run's space holds for the cells the run touched — the one artifact a run does
+   not write out of its own knowledge, read back from the space so a reader
+   working from the tree alone can see what a cell is labelled.
 
 The Common Fabric runner or another trusted mediator owns authoritative CFC
 meaning. The harness transports prompt-slot and invocation evidence, applies the

--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -8,6 +8,7 @@ import {
   resolve,
 } from "@std/path";
 import type { HarnessRunState } from "./run-state.ts";
+import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessPolicyTrace } from "./contracts/policy-trace.ts";
 import { createHarnessPolicyEvent } from "./contracts/policy.ts";
@@ -100,6 +101,15 @@ export interface HarnessArtifactStore {
   persistPolicyTrace?(
     trace: HarnessPolicyTrace,
   ): Promise<string>;
+
+  /**
+   * Records what the run's space holds for the cells the run touched. A
+   * store that cannot answer omits it, and the run keeps its labels in state
+   * without a file beside them.
+   */
+  persistCellLabels?(
+    labels: HarnessCellLabels,
+  ): Promise<string>;
   persistRunReport(
     report: HarnessRunReport,
   ): Promise<string>;
@@ -179,6 +189,15 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
     await ensureDir(this.runRoot);
     const path = join(this.runRoot, "policy-trace.json");
     await writeJsonFile(path, trace);
+    return path;
+  }
+
+  async persistCellLabels(
+    labels: HarnessCellLabels,
+  ): Promise<string> {
+    await ensureDir(this.runRoot);
+    const path = join(this.runRoot, "cell-labels.json");
+    await writeJsonFile(path, labels);
     return path;
   }
 

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -3503,6 +3503,20 @@ export const runCfHarnessCli = async (
         onTranscriptEvent,
       });
     }
+    // A run's own artifacts say which cells it made and read; the space says
+    // what each of them is labelled, and nothing else joins the two. The
+    // cells are settled once the loop is, so the space is read here — and a
+    // snapshot that cannot be written leaves a finished run finished, since
+    // the record of what the run did is already on disk.
+    try {
+      await activeEngine?.snapshotCellLabels();
+    } catch (error) {
+      io.stderr(
+        `cell label snapshot failed: ${
+          error instanceof Error ? error.message : String(error)
+        }\n`,
+      );
+    }
     const durationMs = Date.now() - startedAt;
     const structuredResultValidation = parsed.structuredResult === undefined
       ? undefined

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -97,25 +97,53 @@ export interface HarnessCellLabelEntry {
 
 /**
  * Why a cell or a path of a read snapshot holds no labels because none were
- * looked for. Both reasons are the same hazard: an entity id addresses a
+ * looked for. Each names a place the reader did not look, and asserts that it
+ * looked everywhere else it says it read.
+ *
+ * `cross-space` and `space-unproven` are one hazard: an entity id addresses a
  * document within its own space, so asking the opened store for an id that
  * belongs to another answers with whatever local document shares it.
+ * `cross-space` is an address in a space the opened store is known not to be.
+ * `space-unproven` is an address in a space the opened store cannot be shown
+ * to be either way, which is every spaced address against a file whose name is
+ * not a DID — a fixture, or a copy taken by hand.
  *
- * `cross-space` is an address in a space the opened store is known not to
- * be. `space-unproven` is an address in a space the opened store cannot be
- * shown to be either way, which is every spaced address against a file whose
- * name is not a DID — a fixture, or a copy taken by hand.
+ * `below-read-depth` is a path sitting deeper inside a document than the
+ * reader descends into one. Nothing was read at it or beneath it, and the
+ * path names exactly where that begins.
  */
-export type HarnessCellLabelUnreadReason = "cross-space" | "space-unproven";
+export type HarnessCellLabelUnreadReason =
+  | "cross-space"
+  | "space-unproven"
+  | "below-read-depth";
+
+/**
+ * Why a cell's labels are some of what the space holds rather than all of it.
+ *
+ * `node-budget-exhausted` is a reader that ran out of value nodes partway
+ * through one document and stopped. It states less than an unread path does,
+ * and states it of the whole record rather than of a path, because that is
+ * the whole of what is true: the values left unwalked were never enumerated,
+ * so nothing names them, and a path cannot be produced for a place never
+ * reached. Wherever it is set, every path of the record that carries no entry
+ * is unknown rather than unlabelled.
+ *
+ * A document a pattern writes sits far below the budget. Reaching it is
+ * evidence of the value the budget exists against — a restored graph with a
+ * cycle in it, or a row no reader could enumerate the paths of — so it is
+ * something to investigate rather than something to expect.
+ */
+export type HarnessCellLabelTruncationReason = "node-budget-exhausted";
 
 /**
  * One path inside a cell whose labels were not looked for, and why.
  *
  * A link one hop out of a cell is followed only where the store it addresses
- * is the opened one, and the path the unfollowed link sits at holds no entry
- * as a result. Recording that path is what keeps it readable as a cell
- * nobody asked about: an entry list carries no gaps of its own, so a path
- * missing from one is otherwise a path the space holds no label for.
+ * is the opened one, and a path deeper than the reader descends is not
+ * reached at all; either way the path holds no entry. Recording it is what
+ * keeps it readable as a cell nobody asked about: an entry list carries no
+ * gaps of its own, so a path missing from one is otherwise a path the space
+ * holds no label for.
  */
 export interface HarnessCellLabelUnreadPath {
   /** The path inside the document, as an entry at it would be written. */
@@ -162,10 +190,21 @@ export interface HarnessCellLabelRecord {
   unreadPaths?: readonly HarnessCellLabelUnreadPath[];
 
   /**
+   * Set where the reader did not finish this cell, naming why. It is weaker
+   * than `unreadPaths` and no substitute for one: `unreadPaths` names each
+   * path nothing was read at and thereby vouches for every other path, while
+   * this says only that something was missed and cannot say where. A reader
+   * that meets it takes `entries` as some of what the space holds for this
+   * cell, and every path with no entry as unknown.
+   */
+  truncationReason?: HarnessCellLabelTruncationReason;
+
+  /**
    * The labels, one entry per labelled path. An empty list is a positive
    * finding — the space was read and holds no label for this cell — except
-   * where `unreadReason` is set, which says nothing was asked, and at the
-   * paths `unreadPaths` names, which say the same of one path each.
+   * where `unreadReason` is set, which says nothing was asked, at the paths
+   * `unreadPaths` names, which say the same of one path each, and under a
+   * `truncationReason`, which says the same of paths it cannot name.
    */
   entries: readonly HarnessCellLabelEntry[];
 }

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -1,0 +1,152 @@
+/**
+ * Contract shape of the per-cell CFC label snapshot a run records.
+ *
+ * A run's artifact tree knows which cells it touched and what the sandbox
+ * decided about each tool call; the space knows what each of those cells is
+ * labelled. Nothing joined the two, so a reader working from artifacts alone
+ * saw no label on any cell. This artifact is that join, taken at the run's own
+ * space and written beside the run: an entity id, the labels the space holds
+ * for it, and the space it was read from.
+ *
+ * Shapes only — reading the space DB lives in `../space-labels.ts`, and
+ * persisting the artifact in `../artifacts.ts`.
+ */
+
+/** Discriminator value of a {@link HarnessCellLabels}. */
+export const HARNESS_CELL_LABELS_TYPE = "cf-harness.cell-labels";
+
+/**
+ * One CFC atom, as the space stored it. `type` is the atom's full type URL
+ * for an object atom and the whole string for a bare string atom; `name` is
+ * the last segment of that URL, which is what a label reads as. `fields`
+ * carries everything else the atom said about itself — a `TransformedBy`
+ * atom's `identity`, a `Resource` atom's `class` and `subject` — so an atom
+ * this contract has no name for still arrives whole. A field the space
+ * committed rather than stored reads as its commitment object, so nothing
+ * here may be assumed to be a string.
+ */
+export interface HarnessCfcAtom {
+  type: string;
+  name: string;
+  fields?: Record<string, unknown>;
+
+  /**
+   * The alternatives of a disjunctive confidentiality clause, when this
+   * stands for one. A clause satisfied by any one of its atoms is not the
+   * same requirement as the atoms listed side by side, so it arrives as one
+   * atom naming its alternatives rather than as several.
+   */
+  anyOf?: readonly HarnessCfcAtom[];
+}
+
+/**
+ * How a label came to sit at a path, as the space recorded it. `declared` is
+ * an author's own label on a schema; `derived` is one the runtime computed
+ * from what a lifted function read; `link` is one that rode in on a
+ * reference. The distinction is the whole reading: a value's label may be the
+ * join of the fields it was built from, so an input that carries a
+ * confidentiality atom is not by itself a value that was derived from
+ * anything. `derived` and the provenance atom beside it are what say that.
+ */
+export type HarnessCellLabelOrigin =
+  | "declared"
+  | "derived"
+  | "link"
+  | "structure"
+  | "external-ingest"
+  | "label-metadata";
+
+/** The labels the space holds at one path inside one cell. */
+export interface HarnessCellLabelEntry {
+  /** The path inside the document, empty for the document itself. */
+  path: readonly string[];
+  confidentiality: readonly HarnessCfcAtom[];
+  integrity: readonly HarnessCfcAtom[];
+
+  /**
+   * The recorded origin. Typed as the union this contract knows plus the
+   * open string, because the space is the authority on what it wrote and a
+   * name added there must still reach a reader rather than being dropped.
+   */
+  origin?: HarnessCellLabelOrigin | string;
+
+  /**
+   * What the entry observed, when it observed something narrower than the
+   * value: its shape, its members, or the reference it followed. An entry
+   * with none covers the value at its path.
+   */
+  observes?: string;
+
+  /**
+   * The provenance atom lifted out of `integrity`, when one rides at this
+   * path: which implementation produced the value. Its `identity` resolves a
+   * derived value to the exact lifted function, which is what makes a derived
+   * label something to follow rather than something to take on trust.
+   */
+  transformedBy?: HarnessCfcAtom;
+}
+
+/** Every label the space holds for one cell. */
+export interface HarnessCellLabelRecord {
+  /** The entity the labels belong to, as the store ids it (`of:fid1:…`). */
+  entityId: string;
+
+  /**
+   * The canonical reference the run held for this cell, when the run held
+   * one. A cell reached only by a whole link carries the link instead.
+   */
+  ref?: string;
+
+  /** The hash of the schema the labels were computed against, if recorded. */
+  schemaHash?: string;
+
+  /**
+   * The labels, one entry per labelled path. An empty list is a positive
+   * finding: the space was read and holds no label for this cell.
+   */
+  entries: readonly HarnessCellLabelEntry[];
+}
+
+/** Why a snapshot holds no labels, when it holds none. */
+export type HarnessCellLabelsUnavailableReason =
+  /** No space DB for the run's space was found on this host. */
+  | "space-not-found"
+  /** The DB was found but could not be opened or read. */
+  | "read-failed";
+
+/**
+ * The run's per-cell labels, read from the space it wrote into.
+ *
+ * `status` is load-bearing. A cell with no atoms under a `read` snapshot is a
+ * cell the space holds no label for; the same cell under an `unavailable`
+ * snapshot is a cell nobody asked about. Collapsing the two would make every
+ * unreadable host look like a space with nothing to hide.
+ */
+export interface HarnessCellLabels {
+  type: typeof HARNESS_CELL_LABELS_TYPE;
+  version: 1;
+  generatedAt: string;
+  status: "read" | "unavailable";
+
+  /** Set when `status` is `unavailable`, naming which of the two it was. */
+  unavailableReason?: HarnessCellLabelsUnavailableReason;
+
+  /** What the reason above says in prose, for a reader to show as it stands. */
+  unavailableDetail?: string;
+
+  /**
+   * The space the labels were read from. Recorded even for an unavailable
+   * snapshot, because "which space" is the first question a reader asks and
+   * a run's other artifacts name no space at all.
+   */
+  space?: {
+    /** The space as the run was configured with it: a name, or a DID. */
+    configured: string;
+    did?: string;
+
+    /** The database file read, for a reader that wants to open it too. */
+    dbPath?: string;
+  };
+
+  cells: readonly HarnessCellLabelRecord[];
+}

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -84,6 +84,15 @@ export interface HarnessCellLabelEntry {
    * label something to follow rather than something to take on trust.
    */
   transformedBy?: HarnessCfcAtom;
+
+  /**
+   * The entity the entry was read from, when the path crosses a link rather
+   * than sitting inside one document. A pattern's results are their own
+   * cells, linked from the piece that names them, and the derived label is on
+   * the cell — so a snapshot that read only the document a run holds a
+   * reference to would report a result with nothing on it.
+   */
+  source?: string;
 }
 
 /** Every label the space holds for one cell. */

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -95,6 +95,14 @@ export interface HarnessCellLabelEntry {
   source?: string;
 }
 
+/**
+ * Why one cell of a read snapshot holds no labels because none were looked
+ * for. `cross-space` is a reference into a space other than the one opened:
+ * an entity id addresses a document within its own space, so asking the
+ * opened store for it answers with whatever local document shares that id.
+ */
+export type HarnessCellLabelUnreadReason = "cross-space";
+
 /** Every label the space holds for one cell. */
 export interface HarnessCellLabelRecord {
   /** The entity the labels belong to, as the store ids it (`of:fid1:…`). */
@@ -106,12 +114,28 @@ export interface HarnessCellLabelRecord {
    */
   ref?: string;
 
+  /**
+   * The space the reference named, when it named one. An id is unique only
+   * within its space, so this is what says which cell the record is about
+   * when the id alone does not — and, where it differs from the space the
+   * snapshot was taken in, it is why the cell went unread.
+   */
+  space?: string;
+
   /** The hash of the schema the labels were computed against, if recorded. */
   schemaHash?: string;
 
   /**
+   * Set when this cell's labels were not looked for, naming which of the
+   * reasons it was. It is what separates the two readings of an empty
+   * `entries`, at the granularity of one cell rather than of the snapshot.
+   */
+  unreadReason?: HarnessCellLabelUnreadReason;
+
+  /**
    * The labels, one entry per labelled path. An empty list is a positive
-   * finding: the space was read and holds no label for this cell.
+   * finding — the space was read and holds no label for this cell — except
+   * where `unreadReason` is set, which says nothing was asked.
    */
   entries: readonly HarnessCellLabelEntry[];
 }

--- a/packages/cf-harness/src/contracts/cell-labels.ts
+++ b/packages/cf-harness/src/contracts/cell-labels.ts
@@ -96,12 +96,32 @@ export interface HarnessCellLabelEntry {
 }
 
 /**
- * Why one cell of a read snapshot holds no labels because none were looked
- * for. `cross-space` is a reference into a space other than the one opened:
- * an entity id addresses a document within its own space, so asking the
- * opened store for it answers with whatever local document shares that id.
+ * Why a cell or a path of a read snapshot holds no labels because none were
+ * looked for. Both reasons are the same hazard: an entity id addresses a
+ * document within its own space, so asking the opened store for an id that
+ * belongs to another answers with whatever local document shares it.
+ *
+ * `cross-space` is an address in a space the opened store is known not to
+ * be. `space-unproven` is an address in a space the opened store cannot be
+ * shown to be either way, which is every spaced address against a file whose
+ * name is not a DID — a fixture, or a copy taken by hand.
  */
-export type HarnessCellLabelUnreadReason = "cross-space";
+export type HarnessCellLabelUnreadReason = "cross-space" | "space-unproven";
+
+/**
+ * One path inside a cell whose labels were not looked for, and why.
+ *
+ * A link one hop out of a cell is followed only where the store it addresses
+ * is the opened one, and the path the unfollowed link sits at holds no entry
+ * as a result. Recording that path is what keeps it readable as a cell
+ * nobody asked about: an entry list carries no gaps of its own, so a path
+ * missing from one is otherwise a path the space holds no label for.
+ */
+export interface HarnessCellLabelUnreadPath {
+  /** The path inside the document, as an entry at it would be written. */
+  path: readonly string[];
+  reason: HarnessCellLabelUnreadReason;
+}
 
 /** Every label the space holds for one cell. */
 export interface HarnessCellLabelRecord {
@@ -133,9 +153,19 @@ export interface HarnessCellLabelRecord {
   unreadReason?: HarnessCellLabelUnreadReason;
 
   /**
+   * The paths of this cell that were not looked for, where the cell itself
+   * was. It is the same separation as `unreadReason` one level down, and a
+   * reader owes it the same reading: a reference the run held that lands at
+   * or under one of these paths is a cell nothing is known about, not a cell
+   * with no label.
+   */
+  unreadPaths?: readonly HarnessCellLabelUnreadPath[];
+
+  /**
    * The labels, one entry per labelled path. An empty list is a positive
    * finding — the space was read and holds no label for this cell — except
-   * where `unreadReason` is set, which says nothing was asked.
+   * where `unreadReason` is set, which says nothing was asked, and at the
+   * paths `unreadPaths` names, which say the same of one path each.
    */
   entries: readonly HarnessCellLabelEntry[];
 }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -94,7 +94,6 @@ import type {
 } from "./contracts/input-cells.ts";
 import { mintInputCellHandles } from "./input-cells.ts";
 import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
-import { readSpaceCellLabels } from "./space-labels.ts";
 import {
   appendHarnessCfcModelContextObservations,
   appendHarnessFailureRecord,
@@ -1035,6 +1034,8 @@ export class CfHarnessEngine {
       return undefined;
     }
     const generatedAt = this.#now();
+    // deno-lint-ignore cf-imports/no-inline-module-import -- costs at import time: reading a space database is the one thing the engine does through a native library, and a process that never takes a snapshot must not load one to run
+    const { readSpaceCellLabels } = await import("./space-labels.ts");
     const cellLabels = await readSpaceCellLabels({
       space,
       ...(this.#spaceDbPath !== undefined ? { dbPath: this.#spaceDbPath } : {}),

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -93,6 +93,8 @@ import type {
   HarnessInputCellSpec,
 } from "./contracts/input-cells.ts";
 import { mintInputCellHandles } from "./input-cells.ts";
+import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
+import { readSpaceCellLabels } from "./space-labels.ts";
 import {
   appendHarnessCfcModelContextObservations,
   appendHarnessFailureRecord,
@@ -262,6 +264,13 @@ export interface CreateHarnessEngineOptions
    * its space.
    */
   inputCells?: readonly HarnessInputCellSpec[];
+
+  /**
+   * The space database `snapshotCellLabels` reads, for a host where the
+   * store is not where the discovery walk looks. Absent, the space named by
+   * the fabric session is resolved against the caches on this host.
+   */
+  spaceDbPath?: string;
   now?: () => string;
 }
 
@@ -386,6 +395,7 @@ export class CfHarnessEngine {
   readonly #patternIndexClientFactory?: HarnessPatternIndexClientFactory;
   readonly #taskText?: string;
   readonly #inputCells: readonly HarnessInputCellSpec[];
+  readonly #spaceDbPath?: string;
   readonly #hostMounts: readonly HostSandboxMount[];
   readonly #ownedRunscConfig?: DockerRunscSandboxConfig;
   readonly #resumedRun: boolean;
@@ -539,6 +549,7 @@ export class CfHarnessEngine {
       : cacheHarnessPatternIndexClientFactory(patternIndexClientFactory);
     this.#taskText = options.taskText;
     this.#inputCells = options.inputCells ?? [];
+    this.#spaceDbPath = options.spaceDbPath;
     const sandboxConfig = options.sandboxRuntime === undefined
       ? resolveSandboxConfig(this.config, {
         workspaceHostPath: options.workspaceHostPath,
@@ -993,6 +1004,53 @@ export class CfHarnessEngine {
     );
     await this.persistRunState();
     return minted.inputCells;
+  }
+
+  /**
+   * Reads the run's space for what it holds about the cells this run touched,
+   * and records the answer beside the run.
+   *
+   * The run's own artifacts say which cells it made and read and what the
+   * sandbox decided about each call; the space says what each of those cells
+   * is labelled. Nothing else joins the two, so a reader working from the
+   * tree alone sees an unlabelled cell whatever the run was enforcing. The
+   * snapshot is that join, taken at the run's own space, over every cell the
+   * handle table names.
+   *
+   * Read-only and best-effort by construction: the space database is opened
+   * read-only, and a host that holds no copy of it yields an unavailable
+   * snapshot rather than a failed run. What it must never do is yield a bare
+   * one — "the space holds no label for this cell" and "nobody asked" are
+   * different findings, and the snapshot's `status` is what keeps them apart.
+   *
+   * A run with no fabric session names no space and touches no cell, so it
+   * takes no snapshot at all.
+   */
+  async snapshotCellLabels(): Promise<HarnessCellLabels | undefined> {
+    const space = this.config.fabricSession?.space;
+    const refs = (this.#runState.handleTable?.entries ?? []).map((entry) =>
+      entry.ref
+    );
+    if (space === undefined || refs.length === 0) {
+      return undefined;
+    }
+    const generatedAt = this.#now();
+    const cellLabels = await readSpaceCellLabels({
+      space,
+      ...(this.#spaceDbPath !== undefined ? { dbPath: this.#spaceDbPath } : {}),
+      refs,
+      generatedAt,
+    });
+    const cellLabelsPath = await this.artifactStore?.persistCellLabels?.(
+      cellLabels,
+    );
+    this.#runState = patchHarnessRunState(
+      this.#runState,
+      { cellLabels, cellLabelsPath },
+      generatedAt,
+    );
+    await this.persistRunState();
+    return cellLabels;
   }
 
   async ensureRunManifestPersisted(): Promise<string | undefined> {

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -5,6 +5,7 @@ import {
   type HarnessCfcModelContext,
   type HarnessCfcModelContextObservationInput,
 } from "./contracts/cfc-model-context.ts";
+import type { HarnessCellLabels } from "./contracts/cell-labels.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessHandleTable } from "./contracts/handle-table.ts";
 import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
@@ -122,6 +123,15 @@ export interface HarnessRunState {
   policyTracePath?: string;
   cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
+
+  /**
+   * The per-cell CFC labels the run's space holds for the cells it touched.
+   * Every other artifact a run writes is the run's own record of itself; this
+   * one is read out of the space, and it is the only place a reader working
+   * from the tree can learn what a cell is labelled.
+   */
+  cellLabels?: HarnessCellLabels;
+  cellLabelsPath?: string;
   handleTable?: HarnessHandleTable;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
@@ -170,6 +180,8 @@ export interface CreateHarnessRunStateOptions {
   policyTracePath?: string;
   cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
+  cellLabels?: HarnessCellLabels;
+  cellLabelsPath?: string;
   handleTable?: HarnessHandleTable;
   wellKnownGrants?: HarnessWellKnownGrant[];
   inputCells?: HarnessInputCell[];
@@ -278,6 +290,12 @@ export const createHarnessRunState = (
       : {}),
     ...(options.cfcInvocationContexts !== undefined
       ? { cfcInvocationContexts: [...options.cfcInvocationContexts] }
+      : {}),
+    ...(options.cellLabels !== undefined
+      ? { cellLabels: structuredClone(options.cellLabels) }
+      : {}),
+    ...(options.cellLabelsPath !== undefined
+      ? { cellLabelsPath: options.cellLabelsPath }
       : {}),
     ...(options.handleTable !== undefined
       ? { handleTable: structuredClone(options.handleTable) }

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -14,8 +14,9 @@
  */
 
 import {
-  decodedLinkOf,
   discoverSpaceDbs,
+  linksWithPaths,
+  type LinkWalkBounds,
   openSpace,
   reconstructOutcome,
   resolveSpace,
@@ -242,14 +243,40 @@ const unreadReasonOf = (
   return space === did ? undefined : "cross-space";
 };
 
+/** One cell a document links to, and the path inside the document it sat at. */
+interface LinkedCell {
+  path: readonly string[];
+  id: string;
+}
+
+// How far into one document's value this reader walks for links. A link it
+// stops short of renders as a path holding no entry, which is how a path the
+// space holds no label for reads — so a truncated walk here reports a cell
+// nothing looked at as a cell the space says nothing about. That is why this
+// reader buys completeness with work rather than the other way round, and why
+// both bounds sit far above the shape of any document a pattern writes: a
+// document reaching either is one no reader could enumerate the paths of
+// anyway. `LinkWalkBounds` covers why a node count is needed alongside a depth
+// this large.
+const LINK_WALK: LinkWalkBounds = {
+  maxDepth: 64,
+  maxNodes: 100_000,
+};
+
 /**
- * The cells one document links to, by the key that names each, and the keys
- * whose links were not followed. A pattern's results are their own cells
- * rather than paths inside the piece that names them, so following these one
- * hop is what puts a derived label where a reader looks for it.
+ * The cells one document links to, each at the path inside the document it
+ * sits at, and the paths whose links were not followed. A pattern's results
+ * are their own cells rather than paths inside the piece that names them, so
+ * following these one hop is what puts a derived label where a reader looks
+ * for it.
+ *
+ * The walk descends through the objects and arrays of the value — an array
+ * index is a path segment like any other — and stops at each link it meets:
+ * the read is one hop wide, so a linked document's own links are not the
+ * business of this document's labels.
  *
  * A link this store cannot answer for is returned as an unread path rather
- * than dropped. Dropped, it would leave the key holding no entry, which is
+ * than dropped. Dropped, it would leave its path holding no entry, which is
  * how a path the space holds no label for reads — so the cell nobody looked
  * at and the cell the space says nothing about would render alike.
  */
@@ -257,25 +284,20 @@ const linkedCellsOf = (
   document: Record<string, unknown> | undefined,
   space: string | undefined,
 ): {
-  linked: { key: string; id: string }[];
+  linked: LinkedCell[];
   unreadPaths: HarnessCellLabelUnreadPath[];
 } => {
-  const value = document?.value;
-  if (!isRecord(value)) {
-    return { linked: [], unreadPaths: [] };
-  }
-  const linked: { key: string; id: string }[] = [];
+  const linked: LinkedCell[] = [];
   const unreadPaths: HarnessCellLabelUnreadPath[] = [];
-  for (const [key, held] of Object.entries(value)) {
-    const link = decodedLinkOf(held as never);
-    if (link?.id === undefined || link.id === null) {
+  for (const { link, at } of linksWithPaths(document?.value, LINK_WALK)) {
+    if (link.id === undefined) {
       continue;
     }
     const reason = unreadReasonOf(link.space, space);
     if (reason === undefined) {
-      linked.push({ key, id: link.id });
+      linked.push({ path: at, id: link.id });
     } else {
-      unreadPaths.push({ path: [key], reason });
+      unreadPaths.push({ path: at, reason });
     }
   }
   return { linked, unreadPaths };
@@ -294,8 +316,9 @@ export interface SpaceLabelReader {
 
   /**
    * The labels stored for one cell, and for the cells it links to one hop
-   * out. A linked cell's entries arrive under the key that named it, and say
-   * which cell they were read from, so the two are never confused.
+   * out. A linked cell's entries arrive under the path the link sat at,
+   * however deep inside the value that was, and say which cell they were read
+   * from, so the two are never confused.
    *
    * An entity that holds no document — never written, deleted, or
    * undecodable — reads as no labels, the same as one whose document carries
@@ -305,11 +328,9 @@ export interface SpaceLabelReader {
    * An address in another space is not looked up at all: the answer comes
    * back `unread`, which is a different fact from a document with no labels.
    * A link into another space is the same fact one level down, and comes
-   * back as an `unreadPaths` entry at the key that held it.
+   * back as an `unreadPaths` entry at the path that held it.
    */
-  read(address: CellAddress): StoredCellLabels & {
-    linked: { key: string; id: string }[];
-  };
+  read(address: CellAddress): StoredCellLabels & { linked: LinkedCell[] };
   close(): void;
 }
 
@@ -350,13 +371,17 @@ export const openSpaceLabelReader = async (
       const own = labelsOf(outcome.document);
       const { linked, unreadPaths } = linkedCellsOf(outcome.document, did);
       const entries = [...own.entries];
-      for (const { key, id } of linked) {
+      for (const { path, id } of linked) {
         const target = reconstructOutcome(opened, { id, scope: "space" });
         if (target.status !== "present") {
           continue;
         }
         for (const entry of labelsOf(target.document).entries) {
-          entries.push({ ...entry, path: [key, ...entry.path], source: id });
+          entries.push({
+            ...entry,
+            path: [...path, ...entry.path],
+            source: id,
+          });
         }
       }
       return {
@@ -394,7 +419,7 @@ export interface SpaceLabelSnapshotRequest {
  * space does address a cell, so it is recorded and marked unread instead of
  * dropped: the run held it, and a reader that saw it vanish would take the
  * snapshot to cover every cell the run touched. A link the walk could not
- * follow is the same, held as an unread path at the key it sat at. Every
+ * follow is the same, held as an unread path at the path it sat at. Every
  * other failure lands on the snapshot as a whole, so a reader can tell "no
  * labels" from "not read".
  */

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -1,0 +1,307 @@
+/**
+ * Reading a space's per-cell CFC labels, offline and read-only.
+ *
+ * The labels a run's cells carry live in the space's own durable store, not in
+ * the run's artifact tree, so a reader working from artifacts alone sees a
+ * cell with no label on it however loudly the run was enforcing. This module
+ * opens the space SQLite the server already wrote — the same read-only lens
+ * `cf inspect` uses — and answers "what is this cell labelled" for the cells a
+ * run held a reference to.
+ *
+ * Nothing here writes: the database is opened read-only, and a failure is
+ * returned as an unavailable snapshot rather than thrown, because a run whose
+ * space cannot be read is still a run to record.
+ */
+
+import {
+  discoverSpaceDbs,
+  openSpace,
+  reconstructOutcome,
+  resolveSpace,
+  type SpaceDb,
+} from "@commonfabric/state-inspector";
+import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
+import {
+  HARNESS_CELL_LABELS_TYPE,
+  type HarnessCellLabelEntry,
+  type HarnessCellLabelRecord,
+  type HarnessCellLabels,
+  type HarnessCfcAtom,
+} from "./contracts/cell-labels.ts";
+
+/** The atom type whose identity resolves a derived value to its producer. */
+const TRANSFORMED_BY = "https://commonfabric.org/cfc/atom/TransformedBy";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * One stored atom, normalized. A string atom is its own type and its own
+ * name; an object atom names its type by URL and keeps every other field it
+ * carried, so an atom this module has no special reading for still arrives
+ * whole at whoever shows it.
+ *
+ * A disjunctive confidentiality clause — the one record shape whose sole key
+ * is `anyOf` — is one requirement satisfiable several ways, so it arrives as
+ * one atom carrying its alternatives rather than as several atoms, which
+ * would read as several requirements.
+ */
+const atomOf = (value: unknown): HarnessCfcAtom | undefined => {
+  if (typeof value === "string") {
+    return { type: value, name: value };
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const keys = Object.keys(value);
+  if (keys.length === 1 && keys[0] === "anyOf" && Array.isArray(value.anyOf)) {
+    const alternatives = atomsOf(value.anyOf);
+    return {
+      type: "anyOf",
+      name: alternatives.map((atom) => atom.name).join(" or ") || "anyOf",
+      anyOf: alternatives,
+    };
+  }
+  if (typeof value.type !== "string") {
+    return undefined;
+  }
+  const { type, ...fields } = value;
+  const name = type.split("/").pop() ?? type;
+  return Object.keys(fields).length === 0
+    ? { type, name }
+    : { type, name, fields };
+};
+
+const atomsOf = (value: unknown): HarnessCfcAtom[] =>
+  Array.isArray(value)
+    ? value.flatMap((clause) => {
+      const atom = atomOf(clause);
+      return atom === undefined ? [] : [atom];
+    })
+    : [];
+
+/** The labels one stored document holds, and the schema they were cut to. */
+interface StoredCellLabels {
+  entries: HarnessCellLabelEntry[];
+  schemaHash?: string;
+}
+
+/**
+ * The labelled paths of one stored document. The document's `cfc` path holds
+ * a `labelMap` whose entries each name a path and the label sitting at it; a
+ * document with no `cfc` path has no labels, which is a finding rather than a
+ * failure. Several entries may name one path, differing in what produced them
+ * and what they observed, and all of them are kept: the effective label at a
+ * path is the join of its components, so dropping one changes the answer.
+ */
+const labelsOf = (
+  document: Record<string, unknown> | undefined,
+): StoredCellLabels => {
+  const cfc = document?.cfc;
+  if (!isRecord(cfc)) {
+    return { entries: [] };
+  }
+  const labelMap = cfc.labelMap;
+  const stored = isRecord(labelMap) && Array.isArray(labelMap.entries)
+    ? labelMap.entries
+    : [];
+  const entries: HarnessCellLabelEntry[] = [];
+  for (const raw of stored) {
+    if (!isRecord(raw)) {
+      continue;
+    }
+    const label = isRecord(raw.label) ? raw.label : {};
+    const integrity = atomsOf(label.integrity);
+    const transformedBy = integrity.find((atom) =>
+      atom.type === TRANSFORMED_BY
+    );
+    entries.push({
+      path: Array.isArray(raw.path)
+        ? raw.path.filter((segment): segment is string =>
+          typeof segment === "string"
+        )
+        : [],
+      confidentiality: atomsOf(label.confidentiality),
+      integrity,
+      ...(typeof raw.origin === "string" ? { origin: raw.origin } : {}),
+      ...(typeof raw.observes === "string" ? { observes: raw.observes } : {}),
+      ...(transformedBy !== undefined ? { transformedBy } : {}),
+    });
+  }
+  return {
+    entries,
+    ...(typeof cfc.schemaHash === "string"
+      ? { schemaHash: cfc.schemaHash }
+      : {}),
+  };
+};
+
+/** The document and scope a reference names, or `undefined` for a non-link. */
+export interface CellAddress {
+  /** The entity as the store ids it (`of:fid1:…`). */
+  id: string;
+
+  /**
+   * The scope the document is partitioned under. A labelMap is written at the
+   * same scope as the document it labels, so a per-user cell's labels are not
+   * in the space scope and reading only that scope would report the cell
+   * unlabelled.
+   */
+  scope: string;
+}
+
+/**
+ * The cell a reference addresses. The harness holds an LLM-friendly link
+ * (`/of:fid1:…/path`, or `/@did:key:…/of:fid1:…` across spaces); labels are
+ * stored per document, so the document is what a lookup keys on and a path
+ * inside one resolves to the document that holds it.
+ */
+export const cellAddressOfRef = (ref: string): CellAddress | undefined => {
+  const trimmed = ref.trim();
+  try {
+    const link = parseLLMFriendlyLink(
+      trimmed.startsWith("/") ? trimmed : `/${trimmed}`,
+    );
+    return link.id === undefined
+      ? undefined
+      : { id: link.id, scope: link.scope ?? "space" };
+  } catch {
+    return undefined;
+  }
+};
+
+/** A space DB opened for reading labels, and the space it was resolved from. */
+export interface SpaceLabelReader {
+  readonly dbPath: string;
+  readonly did?: string;
+
+  /**
+   * The labels stored for one cell. An entity that holds no document — never
+   * written, deleted, or undecodable — reads as no labels, the same as one
+   * whose document carries no `cfc` path: neither is a label this reader can
+   * report, and one corrupt entity does not end the walk.
+   */
+  read(address: CellAddress): StoredCellLabels;
+  close(): void;
+}
+
+/**
+ * Opens the space named by a run's fabric session configuration — a space
+ * name, a DID, a DID prefix, or a path to the file itself. Throws when no
+ * database on this host matches, which is the caller's cue to record an
+ * unavailable snapshot rather than a bare one.
+ */
+export const openSpaceLabelReader = async (
+  space: string,
+  options: { dbPath?: string } = {},
+): Promise<SpaceLabelReader> => {
+  const discovered = options.dbPath === undefined
+    ? discoverSpaceDbs()
+    : undefined;
+  const dbPath = options.dbPath ?? await resolveSpace(space, discovered);
+  const opened: SpaceDb = openSpace(dbPath);
+  const did = discovered?.find((entry) => entry.path === dbPath)?.did;
+  return {
+    dbPath,
+    ...(did !== undefined ? { did } : {}),
+    read: (address) => {
+      const outcome = reconstructOutcome(opened, {
+        id: address.id,
+        scope: address.scope,
+      });
+      return outcome.status === "present"
+        ? labelsOf(outcome.document)
+        : { entries: [] };
+    },
+    close: () => opened.close(),
+  };
+};
+
+/** What a snapshot is taken over: the cells a run held a reference to. */
+export interface SpaceLabelSnapshotRequest {
+  /** The space as the run was configured with it. */
+  space: string;
+
+  /** An explicit database file, for a host whose store is not discoverable. */
+  dbPath?: string;
+
+  /** The references the run held, in the order it minted them. */
+  refs: readonly string[];
+
+  generatedAt: string;
+}
+
+/**
+ * The label snapshot for one run: every reference it held, resolved to the
+ * document it names and read against the space.
+ *
+ * A reference that names no document is dropped rather than recorded empty —
+ * it addresses nothing this reader can ask about, and an empty record would
+ * read as a cell the space holds no label for. Every other failure lands on
+ * the snapshot as a whole, so a reader can tell "no labels" from "not read".
+ */
+export const readSpaceCellLabels = async (
+  request: SpaceLabelSnapshotRequest,
+): Promise<HarnessCellLabels> => {
+  const base = {
+    type: HARNESS_CELL_LABELS_TYPE,
+    version: 1,
+    generatedAt: request.generatedAt,
+  } as const;
+  let reader: SpaceLabelReader;
+  try {
+    reader = await openSpaceLabelReader(request.space, {
+      ...(request.dbPath !== undefined ? { dbPath: request.dbPath } : {}),
+    });
+  } catch (error) {
+    return {
+      ...base,
+      status: "unavailable",
+      unavailableReason: "space-not-found",
+      unavailableDetail: error instanceof Error ? error.message : String(error),
+      space: { configured: request.space },
+      cells: [],
+    };
+  }
+  const space = {
+    configured: request.space,
+    ...(reader.did !== undefined ? { did: reader.did } : {}),
+    dbPath: reader.dbPath,
+  };
+  try {
+    const cells: HarnessCellLabelRecord[] = [];
+    const seen = new Set<string>();
+    for (const ref of request.refs) {
+      const address = cellAddressOfRef(ref);
+      if (address === undefined) {
+        continue;
+      }
+      const key = `${address.scope} ${address.id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      const read = reader.read(address);
+      cells.push({
+        entityId: address.id,
+        ref,
+        ...(read.schemaHash !== undefined
+          ? { schemaHash: read.schemaHash }
+          : {}),
+        entries: read.entries,
+      });
+    }
+    return { ...base, status: "read", space, cells };
+  } catch (error) {
+    return {
+      ...base,
+      status: "unavailable",
+      unavailableReason: "read-failed",
+      unavailableDetail: error instanceof Error ? error.message : String(error),
+      space,
+      cells: [],
+    };
+  } finally {
+    reader.close();
+  }
+};

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -27,6 +27,7 @@ import {
   type HarnessCellLabelEntry,
   type HarnessCellLabelRecord,
   type HarnessCellLabels,
+  type HarnessCellLabelUnreadReason,
   type HarnessCfcAtom,
 } from "./contracts/cell-labels.ts";
 
@@ -85,6 +86,13 @@ const atomsOf = (value: unknown): HarnessCfcAtom[] =>
 interface StoredCellLabels {
   entries: HarnessCellLabelEntry[];
   schemaHash?: string;
+
+  /**
+   * Set when nothing was looked for, naming why. An entry list is otherwise
+   * a positive finding about the opened store, so a lookup that never
+   * reached it says so rather than reading as a document with no label.
+   */
+  unread?: HarnessCellLabelUnreadReason;
 }
 
 /**
@@ -143,6 +151,14 @@ export interface CellAddress {
   id: string;
 
   /**
+   * The space the reference named, when it named one. An entity id is only
+   * unique within its space, so a reference that carries a space addresses a
+   * document in that space and nowhere else; one that carries none addresses
+   * the store it was read out of.
+   */
+  space?: string;
+
+  /**
    * The scope kind the reference names, `space` unless it says otherwise. A
    * labelMap is written at the same scope as the document it labels, so a
    * per-user override's labels are not in the space scope.
@@ -168,13 +184,47 @@ export const cellAddressOfRef = (ref: string): CellAddress | undefined => {
     const link = parseLLMFriendlyLink(
       trimmed.startsWith("/") ? trimmed : `/${trimmed}`,
     );
-    return link.id === undefined
-      ? undefined
-      : { id: link.id, scope: link.scope ?? "space" };
+    return link.id === undefined ? undefined : {
+      id: link.id,
+      ...(link.space ? { space: link.space } : {}),
+      scope: link.scope ?? "space",
+    };
   } catch {
     return undefined;
   }
 };
+
+/** A space DID, as a store file is named after one and a reference spells one. */
+const SPACE_DID = /^did:[a-z0-9]+:[A-Za-z0-9._%-]+$/;
+
+/**
+ * The DID of the space a database file holds, from the file's own name: a
+ * space store is named for its space, which is how `discoverSpaceDbs` in
+ * `@commonfabric/state-inspector` reads a DID off one. A file named anything
+ * else — a fixture, a copy taken by hand — proves no DID, and answering
+ * `undefined` is what keeps a cross-space reference from being read against
+ * it.
+ */
+const spaceDidOfDbPath = (dbPath: string): string | undefined => {
+  const name = (dbPath.split("/").pop() ?? dbPath).replace(/\.sqlite$/, "");
+  return SPACE_DID.test(name) ? name : undefined;
+};
+
+/**
+ * Whether an address is one the opened store can answer. A reference naming
+ * no space names the store it came from, and is read. A reference naming a
+ * space is read only where the opened store's own DID is known and is that
+ * space: an entity id names a document within its space, so reading a foreign
+ * id here would answer with whatever local document shares the id and graft
+ * its labels onto the foreign cell. An unknown DID proves nothing, so it
+ * fails closed.
+ */
+const addressesOpenedSpace = (
+  space: string | undefined | null,
+  did: string | undefined,
+): boolean =>
+  space === undefined || space === null ||
+  (did !== undefined && space === did);
 
 /**
  * The cells one document links to, by the key that names each. A pattern's
@@ -196,12 +246,10 @@ const linkedCellsOf = (
     if (link?.id === undefined || link.id === null) {
       continue;
     }
-    // A link naming another space addresses a store this reader did not
-    // open. One naming this space, or naming none, is a cell here.
-    if (
-      link.space === undefined || link.space === null || space === undefined ||
-      link.space === space
-    ) {
+    // A link naming another space addresses a store this reader did not open,
+    // and one naming a space against an unknown DID cannot be shown to be
+    // this one. Only a link naming this space, or naming none, is a cell here.
+    if (addressesOpenedSpace(link.space, space)) {
       linked.push({ key, id: link.id });
     }
   }
@@ -211,6 +259,12 @@ const linkedCellsOf = (
 /** A space DB opened for reading labels, and the space it was resolved from. */
 export interface SpaceLabelReader {
   readonly dbPath: string;
+
+  /**
+   * The DID of the space the opened file holds, when the file proves one.
+   * Nothing but this establishes which space an id is being looked up in, so
+   * a reader without it can answer for no reference that names a space.
+   */
   readonly did?: string;
 
   /**
@@ -222,6 +276,9 @@ export interface SpaceLabelReader {
    * undecodable — reads as no labels, the same as one whose document carries
    * no `cfc` path: neither is a label this reader can report, and one corrupt
    * entity does not end the walk.
+   *
+   * An address in another space is not looked up at all: the answer comes
+   * back `unread`, which is a different fact from a document with no labels.
    */
   read(address: CellAddress): StoredCellLabels & {
     linked: { key: string; id: string }[];
@@ -244,11 +301,14 @@ export const openSpaceLabelReader = async (
     : undefined;
   const dbPath = options.dbPath ?? await resolveSpace(space, discovered);
   const opened: SpaceDb = openSpace(dbPath);
-  const did = discovered?.find((entry) => entry.path === dbPath)?.did;
+  const did = spaceDidOfDbPath(dbPath);
   return {
     dbPath,
     ...(did !== undefined ? { did } : {}),
     read: (address) => {
+      if (!addressesOpenedSpace(address.space, did)) {
+        return { entries: [], linked: [], unread: "cross-space" };
+      }
       // The named scope, then the base scope it inherits from: a reference
       // carries a scope kind rather than a principal, so a scoped one
       // addresses no stored row and would otherwise read as unlabelled.
@@ -297,7 +357,10 @@ export interface SpaceLabelSnapshotRequest {
  *
  * A reference that names no document is dropped rather than recorded empty —
  * it addresses nothing this reader can ask about, and an empty record would
- * read as a cell the space holds no label for. Every other failure lands on
+ * read as a cell the space holds no label for. A reference into another
+ * space does address a cell, so it is recorded and marked unread instead of
+ * dropped: the run held it, and a reader that saw it vanish would take the
+ * snapshot to cover every cell the run touched. Every other failure lands on
  * the snapshot as a whole, so a reader can tell "no labels" from "not read".
  */
 export const readSpaceCellLabels = async (
@@ -336,7 +399,9 @@ export const readSpaceCellLabels = async (
       if (address === undefined) {
         continue;
       }
-      const key = `${address.scope}\x00${address.id}`;
+      // Keyed by the space as well as the entity: one id can name a cell in
+      // the opened space and a cell in another, and they are two cells.
+      const key = `${address.space ?? ""}\x00${address.scope}\x00${address.id}`;
       if (seen.has(key)) {
         continue;
       }
@@ -345,9 +410,11 @@ export const readSpaceCellLabels = async (
       cells.push({
         entityId: address.id,
         ref,
+        ...(address.space !== undefined ? { space: address.space } : {}),
         ...(read.schemaHash !== undefined
           ? { schemaHash: read.schemaHash }
           : {}),
+        ...(read.unread !== undefined ? { unreadReason: read.unread } : {}),
         entries: read.entries,
       });
     }

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -27,6 +27,7 @@ import {
   type HarnessCellLabelEntry,
   type HarnessCellLabelRecord,
   type HarnessCellLabels,
+  type HarnessCellLabelUnreadPath,
   type HarnessCellLabelUnreadReason,
   type HarnessCfcAtom,
 } from "./contracts/cell-labels.ts";
@@ -93,6 +94,13 @@ interface StoredCellLabels {
    * reached it says so rather than reading as a document with no label.
    */
   unread?: HarnessCellLabelUnreadReason;
+
+  /**
+   * The paths of this document nothing was looked for at, where the document
+   * itself was read: one per link the walk could not follow. The same
+   * distinction as `unread`, held per path rather than per document.
+   */
+  unreadPaths?: readonly HarnessCellLabelUnreadPath[];
 }
 
 /**
@@ -211,49 +219,66 @@ const spaceDidOfDbPath = (dbPath: string): string | undefined => {
 };
 
 /**
- * Whether an address is one the opened store can answer. A reference naming
- * no space names the store it came from, and is read. A reference naming a
- * space is read only where the opened store's own DID is known and is that
- * space: an entity id names a document within its space, so reading a foreign
- * id here would answer with whatever local document shares the id and graft
- * its labels onto the foreign cell. An unknown DID proves nothing, so it
- * fails closed.
+ * Why an address is one the opened store cannot answer, or `undefined` where
+ * it can. A reference naming no space names the store it came from, and is
+ * read. A reference naming a space is read only where the opened store's own
+ * DID is known and is that space: an entity id names a document within its
+ * space, so reading a foreign id here would answer with whatever local
+ * document shares the id and graft its labels onto the foreign cell. An
+ * unknown DID proves nothing, so it fails closed — and says which of the two
+ * it was, because a store that cannot name itself is a fact about this host
+ * rather than about the reference.
  */
-const addressesOpenedSpace = (
+const unreadReasonOf = (
   space: string | undefined | null,
   did: string | undefined,
-): boolean =>
-  space === undefined || space === null ||
-  (did !== undefined && space === did);
+): HarnessCellLabelUnreadReason | undefined => {
+  if (space === undefined || space === null) {
+    return undefined;
+  }
+  if (did === undefined) {
+    return "space-unproven";
+  }
+  return space === did ? undefined : "cross-space";
+};
 
 /**
- * The cells one document links to, by the key that names each. A pattern's
- * results are their own cells rather than paths inside the piece that names
- * them, so following these one hop is what puts a derived label where a
- * reader looks for it.
+ * The cells one document links to, by the key that names each, and the keys
+ * whose links were not followed. A pattern's results are their own cells
+ * rather than paths inside the piece that names them, so following these one
+ * hop is what puts a derived label where a reader looks for it.
+ *
+ * A link this store cannot answer for is returned as an unread path rather
+ * than dropped. Dropped, it would leave the key holding no entry, which is
+ * how a path the space holds no label for reads — so the cell nobody looked
+ * at and the cell the space says nothing about would render alike.
  */
 const linkedCellsOf = (
   document: Record<string, unknown> | undefined,
   space: string | undefined,
-): { key: string; id: string }[] => {
+): {
+  linked: { key: string; id: string }[];
+  unreadPaths: HarnessCellLabelUnreadPath[];
+} => {
   const value = document?.value;
   if (!isRecord(value)) {
-    return [];
+    return { linked: [], unreadPaths: [] };
   }
   const linked: { key: string; id: string }[] = [];
+  const unreadPaths: HarnessCellLabelUnreadPath[] = [];
   for (const [key, held] of Object.entries(value)) {
     const link = decodedLinkOf(held as never);
     if (link?.id === undefined || link.id === null) {
       continue;
     }
-    // A link naming another space addresses a store this reader did not open,
-    // and one naming a space against an unknown DID cannot be shown to be
-    // this one. Only a link naming this space, or naming none, is a cell here.
-    if (addressesOpenedSpace(link.space, space)) {
+    const reason = unreadReasonOf(link.space, space);
+    if (reason === undefined) {
       linked.push({ key, id: link.id });
+    } else {
+      unreadPaths.push({ path: [key], reason });
     }
   }
-  return linked;
+  return { linked, unreadPaths };
 };
 
 /** A space DB opened for reading labels, and the space it was resolved from. */
@@ -279,6 +304,8 @@ export interface SpaceLabelReader {
    *
    * An address in another space is not looked up at all: the answer comes
    * back `unread`, which is a different fact from a document with no labels.
+   * A link into another space is the same fact one level down, and comes
+   * back as an `unreadPaths` entry at the key that held it.
    */
   read(address: CellAddress): StoredCellLabels & {
     linked: { key: string; id: string }[];
@@ -306,8 +333,9 @@ export const openSpaceLabelReader = async (
     dbPath,
     ...(did !== undefined ? { did } : {}),
     read: (address) => {
-      if (!addressesOpenedSpace(address.space, did)) {
-        return { entries: [], linked: [], unread: "cross-space" };
+      const unread = unreadReasonOf(address.space, did);
+      if (unread !== undefined) {
+        return { entries: [], linked: [], unread };
       }
       // The named scope, then the base scope it inherits from: a reference
       // carries a scope kind rather than a principal, so a scoped one
@@ -320,7 +348,7 @@ export const openSpaceLabelReader = async (
         return { entries: [], linked: [] };
       }
       const own = labelsOf(outcome.document);
-      const linked = linkedCellsOf(outcome.document, did);
+      const { linked, unreadPaths } = linkedCellsOf(outcome.document, did);
       const entries = [...own.entries];
       for (const { key, id } of linked) {
         const target = reconstructOutcome(opened, { id, scope: "space" });
@@ -331,7 +359,12 @@ export const openSpaceLabelReader = async (
           entries.push({ ...entry, path: [key, ...entry.path], source: id });
         }
       }
-      return { ...own, entries, linked };
+      return {
+        ...own,
+        entries,
+        linked,
+        ...(unreadPaths.length > 0 ? { unreadPaths } : {}),
+      };
     },
     close: () => opened.close(),
   };
@@ -360,8 +393,10 @@ export interface SpaceLabelSnapshotRequest {
  * read as a cell the space holds no label for. A reference into another
  * space does address a cell, so it is recorded and marked unread instead of
  * dropped: the run held it, and a reader that saw it vanish would take the
- * snapshot to cover every cell the run touched. Every other failure lands on
- * the snapshot as a whole, so a reader can tell "no labels" from "not read".
+ * snapshot to cover every cell the run touched. A link the walk could not
+ * follow is the same, held as an unread path at the key it sat at. Every
+ * other failure lands on the snapshot as a whole, so a reader can tell "no
+ * labels" from "not read".
  */
 export const readSpaceCellLabels = async (
   request: SpaceLabelSnapshotRequest,
@@ -415,6 +450,9 @@ export const readSpaceCellLabels = async (
           ? { schemaHash: read.schemaHash }
           : {}),
         ...(read.unread !== undefined ? { unreadReason: read.unread } : {}),
+        ...(read.unreadPaths !== undefined
+          ? { unreadPaths: read.unreadPaths }
+          : {}),
         entries: read.entries,
       });
     }

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -28,6 +28,7 @@ import {
   type HarnessCellLabelEntry,
   type HarnessCellLabelRecord,
   type HarnessCellLabels,
+  type HarnessCellLabelTruncationReason,
   type HarnessCellLabelUnreadPath,
   type HarnessCellLabelUnreadReason,
   type HarnessCfcAtom,
@@ -98,10 +99,20 @@ interface StoredCellLabels {
 
   /**
    * The paths of this document nothing was looked for at, where the document
-   * itself was read: one per link the walk could not follow. The same
-   * distinction as `unread`, held per path rather than per document.
+   * itself was read: one per link the walk could not follow, and one per path
+   * it sits too deep to descend to. The same distinction as `unread`, held
+   * per path rather than per document.
    */
   unreadPaths?: readonly HarnessCellLabelUnreadPath[];
+
+  /**
+   * Set where the walk over this document stopped before the end of it and
+   * cannot say where, naming why. The paths it never reached were never
+   * enumerated, so this states of the document as a whole what an unread path
+   * states of one path: a path carrying no entry may still be one the space
+   * labels.
+   */
+  truncation?: HarnessCellLabelTruncationReason;
 }
 
 /**
@@ -249,15 +260,14 @@ interface LinkedCell {
   id: string;
 }
 
-// How far into one document's value this reader walks for links. A link it
-// stops short of renders as a path holding no entry, which is how a path the
-// space holds no label for reads — so a truncated walk here reports a cell
-// nothing looked at as a cell the space says nothing about. That is why this
-// reader buys completeness with work rather than the other way round, and why
-// both bounds sit far above the shape of any document a pattern writes: a
-// document reaching either is one no reader could enumerate the paths of
-// anyway. `LinkWalkBounds` covers why a node count is needed alongside a depth
-// this large.
+// How far into one document's value this reader walks for links. Both bounds
+// sit far above the shape of any document a pattern writes, because this
+// reader buys completeness with work rather than the other way round;
+// `LinkWalkBounds` covers why a node count is needed alongside a depth this
+// large. Where a bound does stop the walk, what it stopped short of is
+// recorded — as an unread path where the walk can name one, and as a
+// truncation of the whole cell where it cannot — so a link never looked at
+// never reads as a cell the space says nothing about.
 const LINK_WALK: LinkWalkBounds = {
   maxDepth: 64,
   maxNodes: 100_000,
@@ -265,10 +275,10 @@ const LINK_WALK: LinkWalkBounds = {
 
 /**
  * The cells one document links to, each at the path inside the document it
- * sits at, and the paths whose links were not followed. A pattern's results
- * are their own cells rather than paths inside the piece that names them, so
- * following these one hop is what puts a derived label where a reader looks
- * for it.
+ * sits at, the paths whose links were not followed, and whether the walk ran
+ * out before the end of the value. A pattern's results are their own cells
+ * rather than paths inside the piece that names them, so following these one
+ * hop is what puts a derived label where a reader looks for it.
  *
  * The walk descends through the objects and arrays of the value — an array
  * index is a path segment like any other — and stops at each link it meets:
@@ -276,20 +286,29 @@ const LINK_WALK: LinkWalkBounds = {
  * business of this document's labels.
  *
  * A link this store cannot answer for is returned as an unread path rather
- * than dropped. Dropped, it would leave its path holding no entry, which is
- * how a path the space holds no label for reads — so the cell nobody looked
- * at and the cell the space says nothing about would render alike.
+ * than dropped, and so is a path the walk sat too shallow to reach. Dropped,
+ * either would leave its path holding no entry, which is how a path the space
+ * holds no label for reads — so the cell nobody looked at and the cell the
+ * space says nothing about would render alike.
+ *
+ * A walk that exhausted its node budget can name no path, because it stopped
+ * before enumerating what was left, so it says so of the whole document
+ * instead. That is the weaker statement, and it is deliberately weaker: the
+ * paths it missed are not knowledge this reader has.
  */
 const linkedCellsOf = (
   document: Record<string, unknown> | undefined,
   space: string | undefined,
+  bounds: LinkWalkBounds,
 ): {
   linked: LinkedCell[];
   unreadPaths: HarnessCellLabelUnreadPath[];
+  truncation?: HarnessCellLabelTruncationReason;
 } => {
   const linked: LinkedCell[] = [];
   const unreadPaths: HarnessCellLabelUnreadPath[] = [];
-  for (const { link, at } of linksWithPaths(document?.value, LINK_WALK)) {
+  const walk = linksWithPaths(document?.value, bounds);
+  for (const { link, at } of walk.links) {
     if (link.id === undefined) {
       continue;
     }
@@ -300,7 +319,16 @@ const linkedCellsOf = (
       unreadPaths.push({ path: at, reason });
     }
   }
-  return { linked, unreadPaths };
+  for (const at of walk.tooDeep) {
+    unreadPaths.push({ path: at, reason: "below-read-depth" });
+  }
+  return {
+    linked,
+    unreadPaths,
+    ...(walk.budgetExhausted
+      ? { truncation: "node-budget-exhausted" as const }
+      : {}),
+  };
 };
 
 /** A space DB opened for reading labels, and the space it was resolved from. */
@@ -328,10 +356,27 @@ export interface SpaceLabelReader {
    * An address in another space is not looked up at all: the answer comes
    * back `unread`, which is a different fact from a document with no labels.
    * A link into another space is the same fact one level down, and comes
-   * back as an `unreadPaths` entry at the path that held it.
+   * back as an `unreadPaths` entry at the path that held it — as does a path
+   * lying deeper in the value than the walk descends.
    */
   read(address: CellAddress): StoredCellLabels & { linked: LinkedCell[] };
   close(): void;
+}
+
+/** What an opened reader may be told, beyond which space to open. */
+export interface SpaceLabelReaderOptions {
+  /** An explicit database file, for a host whose store is not discoverable. */
+  dbPath?: string;
+
+  /**
+   * How far into each document's value the link walk reaches. {@link
+   * LINK_WALK} is what a run records under, and sits far above the shape of
+   * any document a pattern writes; a caller reading a store whose shape it
+   * knows may trade that reach for work. Either way what a bound stopped
+   * short of is reported rather than dropped, so a narrower reach costs
+   * knowledge and never truthfulness.
+   */
+  linkWalk?: LinkWalkBounds;
 }
 
 /**
@@ -342,7 +387,7 @@ export interface SpaceLabelReader {
  */
 export const openSpaceLabelReader = async (
   space: string,
-  options: { dbPath?: string } = {},
+  options: SpaceLabelReaderOptions = {},
 ): Promise<SpaceLabelReader> => {
   const discovered = options.dbPath === undefined
     ? discoverSpaceDbs()
@@ -350,6 +395,7 @@ export const openSpaceLabelReader = async (
   const dbPath = options.dbPath ?? await resolveSpace(space, discovered);
   const opened: SpaceDb = openSpace(dbPath);
   const did = spaceDidOfDbPath(dbPath);
+  const bounds = options.linkWalk ?? LINK_WALK;
   return {
     dbPath,
     ...(did !== undefined ? { did } : {}),
@@ -369,7 +415,24 @@ export const openSpaceLabelReader = async (
         return { entries: [], linked: [] };
       }
       const own = labelsOf(outcome.document);
-      const { linked, unreadPaths } = linkedCellsOf(outcome.document, did);
+      const { linked, unreadPaths, truncation } = linkedCellsOf(
+        outcome.document,
+        did,
+        bounds,
+      );
+      if (truncation !== undefined) {
+        // Said out loud as well as recorded. The budget is what makes a
+        // restored graph with a cycle in it finite, so a document that
+        // reaches it is the shape the budget exists against rather than a
+        // large honest value, and the labels of every cell beneath it are
+        // now unknown.
+        console.warn(
+          `cf-harness read only part of "${address.id}" in ${dbPath}: the ` +
+            `value walk stopped after ${bounds.maxNodes} nodes, so the ` +
+            `labels of the cells it links to below that point are unknown ` +
+            `rather than absent. A value this large is usually a cycle.`,
+        );
+      }
       const entries = [...own.entries];
       for (const { path, id } of linked) {
         const target = reconstructOutcome(opened, { id, scope: "space" });
@@ -389,6 +452,7 @@ export const openSpaceLabelReader = async (
         entries,
         linked,
         ...(unreadPaths.length > 0 ? { unreadPaths } : {}),
+        ...(truncation !== undefined ? { truncation } : {}),
       };
     },
     close: () => opened.close(),
@@ -402,6 +466,9 @@ export interface SpaceLabelSnapshotRequest {
 
   /** An explicit database file, for a host whose store is not discoverable. */
   dbPath?: string;
+
+  /** How far into each cell's value the read walks; see {@link LINK_WALK}. */
+  linkWalk?: LinkWalkBounds;
 
   /** The references the run held, in the order it minted them. */
   refs: readonly string[];
@@ -419,9 +486,11 @@ export interface SpaceLabelSnapshotRequest {
  * space does address a cell, so it is recorded and marked unread instead of
  * dropped: the run held it, and a reader that saw it vanish would take the
  * snapshot to cover every cell the run touched. A link the walk could not
- * follow is the same, held as an unread path at the path it sat at. Every
- * other failure lands on the snapshot as a whole, so a reader can tell "no
- * labels" from "not read".
+ * follow is the same, held as an unread path at the path it sat at, as is a
+ * path it sat too shallow to reach. A walk that ran out of nodes names no
+ * path — it stopped before enumerating what it had left — so it marks the
+ * whole cell truncated instead. Every other failure lands on the snapshot as
+ * a whole, so a reader can tell "no labels" from "not read".
  */
 export const readSpaceCellLabels = async (
   request: SpaceLabelSnapshotRequest,
@@ -435,6 +504,7 @@ export const readSpaceCellLabels = async (
   try {
     reader = await openSpaceLabelReader(request.space, {
       ...(request.dbPath !== undefined ? { dbPath: request.dbPath } : {}),
+      ...(request.linkWalk !== undefined ? { linkWalk: request.linkWalk } : {}),
     });
   } catch (error) {
     return {
@@ -477,6 +547,9 @@ export const readSpaceCellLabels = async (
         ...(read.unread !== undefined ? { unreadReason: read.unread } : {}),
         ...(read.unreadPaths !== undefined
           ? { unreadPaths: read.unreadPaths }
+          : {}),
+        ...(read.truncation !== undefined
+          ? { truncationReason: read.truncation }
           : {}),
         entries: read.entries,
       });

--- a/packages/cf-harness/src/space-labels.ts
+++ b/packages/cf-harness/src/space-labels.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  decodedLinkOf,
   discoverSpaceDbs,
   openSpace,
   reconstructOutcome,
@@ -142,10 +143,15 @@ export interface CellAddress {
   id: string;
 
   /**
-   * The scope the document is partitioned under. A labelMap is written at the
-   * same scope as the document it labels, so a per-user cell's labels are not
-   * in the space scope and reading only that scope would report the cell
-   * unlabelled.
+   * The scope kind the reference names, `space` unless it says otherwise. A
+   * labelMap is written at the same scope as the document it labels, so a
+   * per-user override's labels are not in the space scope.
+   *
+   * A reference names the kind and not the principal, though, while the store
+   * partitions by principal — `user:<did>`, not `user`. So a scoped reference
+   * addresses no row on its own, and the read falls back to the base scope,
+   * whose labels every scope inherits. What that cannot report is a label an
+   * override introduced and the base scope does not carry.
    */
   scope: string;
 }
@@ -170,18 +176,56 @@ export const cellAddressOfRef = (ref: string): CellAddress | undefined => {
   }
 };
 
+/**
+ * The cells one document links to, by the key that names each. A pattern's
+ * results are their own cells rather than paths inside the piece that names
+ * them, so following these one hop is what puts a derived label where a
+ * reader looks for it.
+ */
+const linkedCellsOf = (
+  document: Record<string, unknown> | undefined,
+  space: string | undefined,
+): { key: string; id: string }[] => {
+  const value = document?.value;
+  if (!isRecord(value)) {
+    return [];
+  }
+  const linked: { key: string; id: string }[] = [];
+  for (const [key, held] of Object.entries(value)) {
+    const link = decodedLinkOf(held as never);
+    if (link?.id === undefined || link.id === null) {
+      continue;
+    }
+    // A link naming another space addresses a store this reader did not
+    // open. One naming this space, or naming none, is a cell here.
+    if (
+      link.space === undefined || link.space === null || space === undefined ||
+      link.space === space
+    ) {
+      linked.push({ key, id: link.id });
+    }
+  }
+  return linked;
+};
+
 /** A space DB opened for reading labels, and the space it was resolved from. */
 export interface SpaceLabelReader {
   readonly dbPath: string;
   readonly did?: string;
 
   /**
-   * The labels stored for one cell. An entity that holds no document — never
-   * written, deleted, or undecodable — reads as no labels, the same as one
-   * whose document carries no `cfc` path: neither is a label this reader can
-   * report, and one corrupt entity does not end the walk.
+   * The labels stored for one cell, and for the cells it links to one hop
+   * out. A linked cell's entries arrive under the key that named it, and say
+   * which cell they were read from, so the two are never confused.
+   *
+   * An entity that holds no document — never written, deleted, or
+   * undecodable — reads as no labels, the same as one whose document carries
+   * no `cfc` path: neither is a label this reader can report, and one corrupt
+   * entity does not end the walk.
    */
-  read(address: CellAddress): StoredCellLabels;
+  read(address: CellAddress): StoredCellLabels & {
+    linked: { key: string; id: string }[];
+  };
   close(): void;
 }
 
@@ -205,13 +249,29 @@ export const openSpaceLabelReader = async (
     dbPath,
     ...(did !== undefined ? { did } : {}),
     read: (address) => {
-      const outcome = reconstructOutcome(opened, {
-        id: address.id,
-        scope: address.scope,
-      });
-      return outcome.status === "present"
-        ? labelsOf(outcome.document)
-        : { entries: [] };
+      // The named scope, then the base scope it inherits from: a reference
+      // carries a scope kind rather than a principal, so a scoped one
+      // addresses no stored row and would otherwise read as unlabelled.
+      const outcome = [address.scope, "space"]
+        .filter((scope, index, scopes) => scopes.indexOf(scope) === index)
+        .map((scope) => reconstructOutcome(opened, { id: address.id, scope }))
+        .find((candidate) => candidate.status === "present");
+      if (outcome === undefined || outcome.status !== "present") {
+        return { entries: [], linked: [] };
+      }
+      const own = labelsOf(outcome.document);
+      const linked = linkedCellsOf(outcome.document, did);
+      const entries = [...own.entries];
+      for (const { key, id } of linked) {
+        const target = reconstructOutcome(opened, { id, scope: "space" });
+        if (target.status !== "present") {
+          continue;
+        }
+        for (const entry of labelsOf(target.document).entries) {
+          entries.push({ ...entry, path: [key, ...entry.path], source: id });
+        }
+      }
+      return { ...own, entries, linked };
     },
     close: () => opened.close(),
   };
@@ -276,7 +336,7 @@ export const readSpaceCellLabels = async (
       if (address === undefined) {
         continue;
       }
-      const key = `${address.scope} ${address.id}`;
+      const key = `${address.scope}\x00${address.id}`;
       if (seen.has(key)) {
         continue;
       }

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -149,6 +149,70 @@ const wildSnapshot = snapshot([
   ]),
 ]);
 
+const VALUED = entity("valued");
+
+/**
+ * A document whose label path is written with the `value` segment an envelope
+ * holds its content under. A reference reaches the same cell with the segment
+ * or without it, so the two spellings are one path.
+ */
+const valuedSnapshot = snapshot([
+  record(VALUED, `/${VALUED}`, [{
+    path: ["value", "secret"],
+    confidentiality: [atom("stored-under-value")],
+    integrity: [],
+    origin: "declared",
+  }]),
+]);
+
+const OBSERVED = entity("observed");
+
+/**
+ * A container labelled twice over: once for what its shape gives away, and
+ * once for what it holds. The two reach differently — a label on a
+ * container's shape is about the container, while a label on its content
+ * covers everything under it.
+ */
+const observedSnapshot = snapshot([
+  record(OBSERVED, `/${OBSERVED}`, [
+    {
+      path: ["container"],
+      confidentiality: [atom("shape-secret")],
+      integrity: [],
+      origin: "declared",
+      observes: "shape",
+    },
+    {
+      path: ["container"],
+      confidentiality: [atom("content-secret")],
+      integrity: [],
+      origin: "declared",
+    },
+  ]),
+]);
+
+const LINKER = entity("linker");
+
+/**
+ * A cell holding three links: one the snapshot followed, one into another
+ * space, and one whose space the opened store could not be shown to be.
+ */
+const linkerSnapshot = snapshot([{
+  entityId: LINKER,
+  ref: `/${LINKER}`,
+  schemaHash: SCHEMA_HASH,
+  unreadPaths: [
+    { path: ["theirs"], reason: "cross-space" },
+    { path: ["ours"], reason: "space-unproven" },
+  ],
+  entries: [{
+    path: ["mine"],
+    confidentiality: [atom("linked-secret")],
+    integrity: [],
+    origin: "declared",
+  }],
+}]);
+
 describe("console/cell-labels", () => {
   describe("consoleCellLabels()", () => {
     it("returns every atom of every path, deduplicated", () => {
@@ -218,6 +282,11 @@ describe("console/cell-labels", () => {
         ]),
       );
       expect(labels.transformedBy).toEqual(["cf:module/abc"]);
+    });
+
+    it("returns the paths the snapshot left unread on the cell that holds them", () => {
+      expect(consoleCellLabels(linkerSnapshot.cells[0]).unreadPaths)
+        .toEqual([["theirs"], ["ours"]]);
     });
   });
 
@@ -306,8 +375,8 @@ describe("console/cell-labels", () => {
     });
 
     it("strips the scope suffix of a scoped id to find the document", () => {
-      expect(cellLabelsAt(index, `/${LABELLED}@user`)).toBe(
-        index.byAddress.get(LABELLED),
+      expect(cellLabelsAt(index, `/${LABELLED}@user`)).toEqual(
+        consoleCellLabels(record(LABELLED, `/${LABELLED}`, [declared])),
       );
     });
 
@@ -322,8 +391,8 @@ describe("console/cell-labels", () => {
         ...readSnapshot,
         space: { configured: "demo-space", did: OWN_DID },
       });
-      expect(cellLabelsAt(inSpace, `/@${OWN_DID}/${LABELLED}`)).toBe(
-        inSpace.byAddress.get(LABELLED),
+      expect(cellLabelsAt(inSpace, `/@${OWN_DID}/${LABELLED}`)).toEqual(
+        consoleCellLabels(record(LABELLED, `/${LABELLED}`, [declared])),
       );
     });
 
@@ -389,6 +458,67 @@ describe("console/cell-labels", () => {
         const labels = cellLabelsAt(piece, `/${PIECE}/briefing`);
         expect(labels?.derived).toBe(true);
         expect(labels?.transformedBy).toEqual(["llm"]);
+      });
+
+      it("returns the atom at a path the reference reaches through a `value` segment", () => {
+        expect(cellLabelsAt(piece, `/${PIECE}/value/secret`)?.confidentiality)
+          .toEqual(["demo-secret"]);
+      });
+
+      it("returns the atom of an entry stored under `value` for a reference spelling no such segment", () => {
+        const valued = consoleCellLabelIndex(valuedSnapshot);
+        const labels = cellLabelsAt(valued, `/${VALUED}/secret`);
+        expect(labels?.confidentiality).toEqual(["stored-under-value"]);
+        expect(labels?.entries.map((entry) => entry.path)).toEqual([[]]);
+      });
+    });
+
+    describe("reaching down from an entry above the reference", () => {
+      const observed = consoleCellLabelIndex(observedSnapshot);
+
+      it("returns both atoms for a reference naming the path the entries sit at", () => {
+        expect(
+          cellLabelsAt(observed, `/${OBSERVED}/container`)?.confidentiality,
+        )
+          .toEqual(["shape-secret", "content-secret"]);
+      });
+
+      it("returns no atom of a `shape` entry on a strict ancestor of the reference", () => {
+        const labels = cellLabelsAt(observed, `/${OBSERVED}/container/public`);
+        expect(labels?.confidentiality).toEqual(["content-secret"]);
+        expect(labels?.entries.map((entry) => entry.observes)).toEqual([
+          undefined,
+        ]);
+      });
+    });
+
+    describe("a path the snapshot could not read", () => {
+      const linker = consoleCellLabelIndex(linkerSnapshot);
+
+      it("returns `undefined` for a reference at the path an unfollowed link sits at", () => {
+        expect(cellLabelsAt(linker, `/${LINKER}/theirs`)).toBe(undefined);
+      });
+
+      it("returns `undefined` for a reference beneath the path an unfollowed link sits at", () => {
+        expect(cellLabelsAt(linker, `/${LINKER}/theirs/summary`)).toBe(
+          undefined,
+        );
+      });
+
+      it("returns `undefined` for a reference under a link whose space the store could not be shown to be its own", () => {
+        expect(cellLabelsAt(linker, `/${LINKER}/ours`)).toBe(undefined);
+      });
+
+      it("returns the labels of a path beside the links it could not follow", () => {
+        const labels = cellLabelsAt(linker, `/${LINKER}/mine`);
+        expect(labels?.confidentiality).toEqual(["linked-secret"]);
+        expect(labels?.unreadPaths).toBe(undefined);
+      });
+
+      it("names the unread paths on the cell that holds the links", () => {
+        const labels = cellLabelsAt(linker, `/${LINKER}`);
+        expect(labels?.unreadPaths).toEqual([["theirs"], ["ours"]]);
+        expect(labels?.confidentiality).toEqual(["linked-secret"]);
       });
     });
 

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -213,6 +213,41 @@ const linkerSnapshot = snapshot([{
   }],
 }]);
 
+const NESTER = entity("nester");
+
+/**
+ * A cell whose links sit inside its value rather than at its top: one was
+ * followed and one reaches another space, each recorded at the whole path it
+ * sits at.
+ */
+const nesterSnapshot = snapshot([{
+  entityId: NESTER,
+  ref: `/${NESTER}`,
+  schemaHash: SCHEMA_HASH,
+  unreadPaths: [{ path: ["nested", "theirs"], reason: "cross-space" }],
+  entries: [{
+    path: ["nested", "mine"],
+    confidentiality: [atom("linked-secret")],
+    integrity: [],
+    origin: "declared",
+  }],
+}]);
+
+const BARELY = entity("barely");
+
+/**
+ * A cell the space labelled at a path with nothing in either dimension, which
+ * is a labelled path holding no label at all.
+ */
+const barelySnapshot = snapshot([
+  record(BARELY, `/${BARELY}`, [{
+    path: ["empty"],
+    confidentiality: [],
+    integrity: [],
+    origin: "declared",
+  }]),
+]);
+
 describe("console/cell-labels", () => {
   describe("consoleCellLabels()", () => {
     it("returns every atom of every path, deduplicated", () => {
@@ -519,6 +554,48 @@ describe("console/cell-labels", () => {
         const labels = cellLabelsAt(linker, `/${LINKER}`);
         expect(labels?.unreadPaths).toEqual([["theirs"], ["ours"]]);
         expect(labels?.confidentiality).toEqual(["linked-secret"]);
+      });
+    });
+
+    describe("a nested path the snapshot could not read", () => {
+      const nester = consoleCellLabelIndex(nesterSnapshot);
+
+      it("returns `undefined` for a reference at the whole path a nested unfollowed link sits at", () => {
+        expect(cellLabelsAt(nester, `/${NESTER}/nested/theirs`)).toBe(
+          undefined,
+        );
+      });
+
+      it("returns `undefined` for a reference beneath a nested unfollowed link", () => {
+        expect(cellLabelsAt(nester, `/${NESTER}/nested/theirs/summary`)).toBe(
+          undefined,
+        );
+      });
+
+      it("returns the labels of a nested link the snapshot followed", () => {
+        const labels = cellLabelsAt(nester, `/${NESTER}/nested/mine`);
+        expect(labels?.confidentiality).toEqual(["linked-secret"]);
+        expect(labels?.unreadPaths).toBe(undefined);
+      });
+
+      it("names the unread path under the container that holds it", () => {
+        const labels = cellLabelsAt(nester, `/${NESTER}/nested`);
+        expect(labels?.unreadPaths).toEqual([["theirs"]]);
+        expect(labels?.entries.map((entry) => entry.path)).toEqual([["mine"]]);
+      });
+    });
+
+    describe("an entry the space labelled with nothing", () => {
+      const barely = consoleCellLabelIndex(barelySnapshot);
+
+      it("returns no entry for the path it was stored at", () => {
+        const labels = cellLabelsAt(barely, `/${BARELY}/empty`);
+        expect(labels?.entries).toEqual([]);
+        expect(labels?.derived).toBe(false);
+      });
+
+      it("returns no entry for the cell that holds it", () => {
+        expect(cellLabelsAt(barely, `/${BARELY}`)?.entries).toEqual([]);
       });
     });
 

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -233,6 +233,45 @@ const nesterSnapshot = snapshot([{
   }],
 }]);
 
+const DEEPER = entity("deeper");
+
+/**
+ * A cell whose value runs deeper than the snapshot descends: the link it
+ * reached is labelled, and the path it stopped at is recorded like any other
+ * path nothing was read for.
+ */
+const deeperSnapshot = snapshot([{
+  entityId: DEEPER,
+  ref: `/${DEEPER}`,
+  schemaHash: SCHEMA_HASH,
+  unreadPaths: [{ path: ["deep", "down"], reason: "below-read-depth" }],
+  entries: [{
+    path: ["shallow"],
+    confidentiality: [atom("linked-secret")],
+    integrity: [],
+    origin: "declared",
+  }],
+}]);
+
+const TRUNCATED = entity("truncated");
+
+/**
+ * A cell the snapshot stopped reading partway through, having spent its node
+ * budget. It names no unread path, because what it missed it never reached.
+ */
+const truncatedSnapshot = snapshot([{
+  entityId: TRUNCATED,
+  ref: `/${TRUNCATED}`,
+  schemaHash: SCHEMA_HASH,
+  truncationReason: "node-budget-exhausted",
+  entries: [{
+    path: ["shallow"],
+    confidentiality: [atom("linked-secret")],
+    integrity: [],
+    origin: "declared",
+  }],
+}]);
+
 const BARELY = entity("barely");
 
 /**
@@ -582,6 +621,72 @@ describe("console/cell-labels", () => {
         const labels = cellLabelsAt(nester, `/${NESTER}/nested`);
         expect(labels?.unreadPaths).toEqual([["theirs"]]);
         expect(labels?.entries.map((entry) => entry.path)).toEqual([["mine"]]);
+      });
+    });
+
+    describe("a path the snapshot sat too shallow to reach", () => {
+      const deeper = consoleCellLabelIndex(deeperSnapshot);
+
+      it("returns `undefined` for a reference at the path the walk stopped short of", () => {
+        expect(cellLabelsAt(deeper, `/${DEEPER}/deep/down`)).toBe(undefined);
+      });
+
+      it("returns `undefined` for a reference beneath the path the walk stopped short of", () => {
+        expect(cellLabelsAt(deeper, `/${DEEPER}/deep/down/summary`)).toBe(
+          undefined,
+        );
+      });
+
+      it("returns the labels of a path the walk reached before it stopped", () => {
+        const labels = cellLabelsAt(deeper, `/${DEEPER}/shallow`);
+        expect(labels?.confidentiality).toEqual(["linked-secret"]);
+        expect(labels?.unreadPaths).toBe(undefined);
+      });
+
+      it("names the path the walk stopped short of on the cell that holds it", () => {
+        const labels = cellLabelsAt(deeper, `/${DEEPER}`);
+        expect(labels?.unreadPaths).toEqual([["deep", "down"]]);
+        expect(labels?.truncationReason).toBe(undefined);
+      });
+    });
+
+    describe("a cell the snapshot did not finish reading", () => {
+      const truncated = consoleCellLabelIndex(truncatedSnapshot);
+
+      it("names why the reading stopped short on the cell", () => {
+        expect(consoleCellLabels(truncatedSnapshot.cells[0]).truncationReason)
+          .toBe("node-budget-exhausted");
+      });
+
+      it("names it on a reference into the cell as well as on the cell", () => {
+        expect(
+          cellLabelsAt(truncated, `/${TRUNCATED}/shallow`)?.truncationReason,
+        )
+          .toBe("node-budget-exhausted");
+      });
+
+      it("returns the labels it did read rather than nothing", () => {
+        expect(
+          cellLabelsAt(truncated, `/${TRUNCATED}/shallow`)?.confidentiality,
+        )
+          .toEqual(["linked-secret"]);
+      });
+
+      it("names no unread path, having never reached what it missed", () => {
+        expect(cellLabelsAt(truncated, `/${TRUNCATED}`)?.unreadPaths).toBe(
+          undefined,
+        );
+      });
+
+      it("counts the cell as read, unlike one nothing was asked about", () => {
+        expect(consoleCellLabelsSummary(truncated).cellsRead).toBe(1);
+      });
+
+      it("names no reason on a cell the snapshot finished reading", () => {
+        expect(
+          cellLabelsAt(consoleCellLabelIndex(readSnapshot), `/${LABELLED}`)
+            ?.truncationReason,
+        ).toBe(undefined);
       });
     });
 

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -412,6 +412,29 @@ describe("console/cell-labels", () => {
       expect(summary.cellsLabelled).toBe(1);
     });
 
+    it("counts a cell the reading did not finish as one read in part", () => {
+      // The header reads this count as its licence to state a total: a cell
+      // here may hold a label at a path nothing was read at.
+      expect(
+        consoleCellLabelsSummary(consoleCellLabelIndex(truncatedSnapshot))
+          .cellsPartial,
+      ).toBe(1);
+    });
+
+    it("counts a cell holding a path nothing was read at as one read in part", () => {
+      expect(
+        consoleCellLabelsSummary(consoleCellLabelIndex(linkerSnapshot))
+          .cellsPartial,
+      ).toBe(1);
+    });
+
+    it("counts no cell of a snapshot read whole as read in part", () => {
+      expect(
+        consoleCellLabelsSummary(consoleCellLabelIndex(readSnapshot))
+          .cellsPartial,
+      ).toBe(0);
+    });
+
     it("carries the status, detail and space of the index it summarizes", () => {
       const summary = consoleCellLabelsSummary(
         consoleCellLabelIndex(readSnapshot),

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -1,0 +1,337 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  cellLabelsAt,
+  consoleCellLabelIndex,
+  consoleCellLabels,
+  consoleCellLabelsSummary,
+} from "../../console/cell-labels.ts";
+import {
+  HARNESS_CELL_LABELS_TYPE,
+  type HarnessCellLabelEntry,
+  type HarnessCellLabelRecord,
+  type HarnessCellLabels,
+} from "../../src/contracts/cell-labels.ts";
+
+const TRANSFORMED_BY = "https://commonfabric.org/cfc/atom/TransformedBy";
+const SCHEMA_HASH = "fid1:C4ajDsLKcfdMDDs3lbNShZBcQCVA4qhVo5mRoBcgpB0";
+
+/** An entity id in the store's own shape: `of:fid1:` and 44 base64url chars. */
+const entity = (name: string) => `of:fid1:${name.padEnd(44, "0")}`;
+
+const LABELLED = entity("labelled");
+const BARE = entity("bare");
+
+const atom = (name: string) => ({ type: name, name });
+
+/** The provenance atom for one identity arm, as the space stores it. */
+const provenance = (identity: Record<string, unknown>) => ({
+  type: TRANSFORMED_BY,
+  name: "TransformedBy",
+  fields: { identity },
+});
+
+const declared: HarnessCellLabelEntry = {
+  path: [],
+  confidentiality: [atom("demo-secret")],
+  integrity: [atom("cf-compiled-by:cf-compiler")],
+  origin: "declared",
+};
+
+const derived = (identity: Record<string, unknown>): HarnessCellLabelEntry => ({
+  path: ["summary"],
+  confidentiality: [atom("demo-secret")],
+  integrity: [atom("cf-compiled-by:cf-compiler"), provenance(identity)],
+  origin: "derived",
+  observes: "members",
+  transformedBy: provenance(identity),
+});
+
+const record = (
+  entityId: string,
+  ref: string,
+  entries: readonly HarnessCellLabelEntry[],
+): HarnessCellLabelRecord => ({
+  entityId,
+  ref,
+  schemaHash: SCHEMA_HASH,
+  entries,
+});
+
+const snapshot = (
+  cells: readonly HarnessCellLabelRecord[],
+): HarnessCellLabels => ({
+  type: HARNESS_CELL_LABELS_TYPE,
+  version: 1,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  status: "read",
+  space: { configured: "demo-space", dbPath: "/spaces/demo.sqlite" },
+  cells,
+});
+
+const readSnapshot = snapshot([
+  record(LABELLED, `/${LABELLED}`, [declared]),
+  record(BARE, `/${BARE}`, []),
+]);
+
+const PIECE = entity("piece");
+const ROOTED = entity("rooted");
+
+const LIFT = { kind: "builtin", builtinId: "llm" };
+
+/**
+ * Two documents to narrow into. `PIECE` labels two of its paths and leaves a
+ * third unlabelled, which is the shape a run holding one reference per cell of
+ * a piece produces; `ROOTED` labels the document itself.
+ */
+const pieceSnapshot = snapshot([
+  record(PIECE, `/${PIECE}`, [
+    {
+      path: ["secret"],
+      confidentiality: [atom("demo-secret")],
+      integrity: [],
+      origin: "declared",
+    },
+    {
+      path: ["briefing"],
+      confidentiality: [atom("demo-secret")],
+      integrity: [atom("cf-compiled-by:cf-compiler"), provenance(LIFT)],
+      origin: "derived",
+      transformedBy: provenance(LIFT),
+    },
+    {
+      path: ["briefing", "inner"],
+      confidentiality: [atom("inner-only")],
+      integrity: [],
+      origin: "declared",
+    },
+  ]),
+  record(ROOTED, `/${ROOTED}`, [{
+    path: [],
+    confidentiality: [atom("org-only")],
+    integrity: [],
+    origin: "declared",
+  }]),
+]);
+
+describe("console/cell-labels", () => {
+  describe("consoleCellLabels()", () => {
+    it("returns every atom of every path, deduplicated", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [
+          declared,
+          derived({ kind: "builtin", builtinId: "llm" }),
+        ]),
+      );
+      expect(labels.confidentiality).toEqual(["demo-secret"]);
+      expect(labels.integrity).toEqual([
+        "cf-compiled-by:cf-compiler",
+        "TransformedBy",
+      ]);
+      expect(labels.entries.map((entry) => entry.path)).toEqual([
+        "",
+        "summary",
+      ]);
+      expect(labels.entries[1].observes).toBe("members");
+    });
+
+    it("returns `derived` false when no entry was derived", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [declared]),
+      );
+      expect(labels.derived).toBe(false);
+      expect(labels.transformedBy).toEqual([]);
+    });
+
+    it("returns `derived` true when an entry names `derived` as its origin", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [
+          declared,
+          derived({ kind: "builtin", builtinId: "llm" }),
+        ]),
+      );
+      expect(labels.derived).toBe(true);
+    });
+
+    it("returns the builtin's own id as the producer of a builtin identity", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [
+          derived({ kind: "builtin", builtinId: "llm" }),
+        ]),
+      );
+      expect(labels.transformedBy).toEqual(["llm"]);
+      expect(labels.entries[0].transformedBy).toBe("llm");
+    });
+
+    it("returns `<symbol> in <module>` as the producer of a verified identity carrying both", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [
+          derived({
+            kind: "verified",
+            moduleIdentity: "cf:module/abc",
+            symbol: "__cfLift_2",
+          }),
+        ]),
+      );
+      expect(labels.transformedBy).toEqual(["__cfLift_2 in cf:module/abc"]);
+    });
+
+    it("returns the module as the producer of a verified identity carrying no symbol", () => {
+      const labels = consoleCellLabels(
+        record(LABELLED, `/${LABELLED}`, [
+          derived({ kind: "verified", moduleIdentity: "cf:module/abc" }),
+        ]),
+      );
+      expect(labels.transformedBy).toEqual(["cf:module/abc"]);
+    });
+  });
+
+  describe("consoleCellLabelIndex()", () => {
+    it("keys each cell by its entity id alone, and not by the reference the run held", () => {
+      const index = consoleCellLabelIndex(readSnapshot);
+      expect([...index.byAddress.keys()]).toEqual([LABELLED, BARE]);
+      expect(index.byAddress.get(`/${LABELLED}`)).toBe(undefined);
+    });
+
+    it("returns `absent` as the status of a run that wrote no snapshot", () => {
+      const index = consoleCellLabelIndex(undefined);
+      expect(index.status).toBe("absent");
+      expect(index.byAddress.size).toBe(0);
+      expect(index.space).toBe(undefined);
+    });
+
+    it("returns `unavailable` as the status of an unavailable snapshot, with its detail", () => {
+      const index = consoleCellLabelIndex({
+        ...snapshot([]),
+        status: "unavailable",
+        unavailableReason: "space-not-found",
+        unavailableDetail: `no space matches "demo-space"`,
+      });
+      expect(index.status).toBe("unavailable");
+      expect(index.detail).toBe(`no space matches "demo-space"`);
+      expect(index.space).toEqual({
+        configured: "demo-space",
+        dbPath: "/spaces/demo.sqlite",
+      });
+    });
+
+    it("returns `read` as the status of a snapshot the space was read for", () => {
+      expect(consoleCellLabelIndex(readSnapshot).status).toBe("read");
+    });
+  });
+
+  describe("consoleCellLabelsSummary()", () => {
+    it("counts one cell for each entity the snapshot read", () => {
+      const index = consoleCellLabelIndex(readSnapshot);
+      expect(index.byAddress.size).toBe(2);
+      expect(consoleCellLabelsSummary(index).cellsRead).toBe(2);
+    });
+
+    it("counts only the cells that carry an entry as labelled", () => {
+      const summary = consoleCellLabelsSummary(
+        consoleCellLabelIndex(readSnapshot),
+      );
+      expect(summary.cellsLabelled).toBe(1);
+    });
+
+    it("carries the status, detail and space of the index it summarizes", () => {
+      const summary = consoleCellLabelsSummary(
+        consoleCellLabelIndex(readSnapshot),
+      );
+      expect(summary.status).toBe("read");
+      expect(summary.detail).toBe(undefined);
+      expect(summary.space).toEqual({
+        configured: "demo-space",
+        dbPath: "/spaces/demo.sqlite",
+      });
+    });
+  });
+
+  describe("cellLabelsAt()", () => {
+    const index = consoleCellLabelIndex(readSnapshot);
+
+    it("returns `undefined` for no reference", () => {
+      expect(cellLabelsAt(index, undefined)).toBe(undefined);
+    });
+
+    it("returns the labels a reference is keyed under", () => {
+      expect(cellLabelsAt(index, `/${LABELLED}`)?.confidentiality).toEqual([
+        "demo-secret",
+      ]);
+    });
+
+    it("narrows a reference addressing a path inside a document to that path", () => {
+      expect(cellLabelsAt(index, `/${LABELLED}/value/secret`)?.entries)
+        .toEqual([{
+          path: "",
+          confidentiality: ["demo-secret"],
+          integrity: ["cf-compiled-by:cf-compiler"],
+          origin: "declared",
+        }]);
+    });
+
+    it("strips the scope suffix of a scoped id to find the document", () => {
+      expect(cellLabelsAt(index, `/${LABELLED}@user`)).toBe(
+        index.byAddress.get(LABELLED),
+      );
+    });
+
+    it("returns the document's labels for a cross-space link", () => {
+      const did = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
+      expect(cellLabelsAt(index, `/@${did}/${LABELLED}`)).toBe(
+        index.byAddress.get(LABELLED),
+      );
+    });
+
+    it("returns `undefined` for a reference naming no entity", () => {
+      expect(cellLabelsAt(index, "my notebook")).toBe(undefined);
+    });
+
+    describe("narrowing to the path the reference names", () => {
+      const piece = consoleCellLabelIndex(pieceSnapshot);
+
+      it("returns the atom declared at the path the reference names", () => {
+        expect(cellLabelsAt(piece, `/${PIECE}/secret`)?.confidentiality)
+          .toEqual(["demo-secret"]);
+      });
+
+      it("returns no atom for a sibling cell of a labelled one in the same document", () => {
+        const labels = cellLabelsAt(piece, `/${PIECE}/city`);
+        expect(labels?.entries).toEqual([]);
+        expect(labels?.confidentiality).toEqual([]);
+      });
+
+      it("keeps the suffix of an entry under the named path, re-rooted to it", () => {
+        const labels = cellLabelsAt(piece, `/${PIECE}/briefing`);
+        expect(labels?.entries.map((entry) => entry.path)).toEqual([
+          "",
+          "inner",
+        ]);
+        expect(labels?.confidentiality).toEqual(["demo-secret", "inner-only"]);
+      });
+
+      it("returns an entry at the document root for every reference into the document", () => {
+        const labels = cellLabelsAt(piece, `/${ROOTED}/anything/deeper`);
+        expect(labels?.entries).toEqual([{
+          path: "",
+          confidentiality: ["org-only"],
+          integrity: [],
+          origin: "declared",
+        }]);
+      });
+
+      it("returns `derived` false when the narrowed path holds no derived entry", () => {
+        const labels = cellLabelsAt(piece, `/${PIECE}/secret`);
+        expect(labels?.derived).toBe(false);
+        expect(labels?.transformedBy).toEqual([]);
+      });
+
+      it("returns `derived` true and the producer when the narrowed path holds one", () => {
+        const labels = cellLabelsAt(piece, `/${PIECE}/briefing`);
+        expect(labels?.derived).toBe(true);
+        expect(labels?.transformedBy).toEqual(["llm"]);
+      });
+    });
+  });
+});

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -4,8 +4,10 @@ import { expect } from "@std/expect";
 import {
   cellLabelsAt,
   consoleCellLabelIndex,
+  type ConsoleCellLabels,
   consoleCellLabels,
   consoleCellLabelsSummary,
+  foldCellLabels,
 } from "../../console/cell-labels.ts";
 import {
   HARNESS_CELL_LABELS_TYPE,
@@ -445,6 +447,84 @@ describe("console/cell-labels", () => {
         configured: "demo-space",
         dbPath: "/spaces/demo.sqlite",
       });
+    });
+  });
+
+  describe("foldCellLabels()", () => {
+    /** Three readings of one cell, no two of them stating the same thing. */
+    const whole: ConsoleCellLabels = {
+      confidentiality: ["Secret"],
+      integrity: [],
+      derived: false,
+      transformedBy: [],
+      entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
+    };
+    const truncated: ConsoleCellLabels = {
+      confidentiality: [],
+      integrity: [],
+      derived: false,
+      transformedBy: [],
+      entries: [],
+      truncationReason: "node-budget-exhausted",
+    };
+    const unread: ConsoleCellLabels = {
+      confidentiality: [],
+      integrity: [],
+      derived: false,
+      transformedBy: [],
+      entries: [],
+      unreadPaths: [["theirs"]],
+    };
+
+    const fold = (
+      readings: readonly ConsoleCellLabels[],
+    ): ConsoleCellLabels => readings.reduce(foldCellLabels);
+
+    it("folds three readings to one answer in every order they arrive in", () => {
+      // Every field is a set union or a disjunction, so the fold is
+      // associative as well as commutative: a family is a root and any
+      // number of children, and reassociating three is what commutativity
+      // alone would not settle.
+      const orders = [
+        [whole, truncated, unread],
+        [whole, unread, truncated],
+        [truncated, whole, unread],
+        [truncated, unread, whole],
+        [unread, whole, truncated],
+        [unread, truncated, whole],
+      ];
+      for (const order of orders) {
+        expect(fold(order)).toEqual(fold(orders[0]));
+      }
+    });
+
+    it("keeps the atoms of the reading that found them", () => {
+      expect(fold([truncated, whole]).confidentiality).toEqual(["Secret"]);
+      expect(fold([truncated, whole]).entries).toEqual(whole.entries);
+    });
+
+    it("keeps the truncation of a reading that did not finish", () => {
+      expect(fold([whole, truncated]).truncationReason).toBe(
+        "node-budget-exhausted",
+      );
+    });
+
+    it("keeps the unread paths of every reading that named one", () => {
+      expect(fold([whole, unread]).unreadPaths).toEqual([["theirs"]]);
+    });
+
+    it("names no truncation where neither reading stopped short", () => {
+      expect(fold([whole, unread]).truncationReason).toBe(undefined);
+    });
+
+    it("holds no entry where no reading found one", () => {
+      const folded = fold([truncated, unread]);
+      expect(folded.entries).toEqual([]);
+      expect(folded.confidentiality).toEqual([]);
+    });
+
+    it("states one entry both readings hold once", () => {
+      expect(fold([whole, whole]).entries).toEqual(whole.entries);
     });
   });
 

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -23,6 +23,10 @@ const entity = (name: string) => `of:fid1:${name.padEnd(44, "0")}`;
 const LABELLED = entity("labelled");
 const BARE = entity("bare");
 
+/** The space a snapshot is taken in, and one it is not. */
+const OWN_DID = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
+const FOREIGN_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
 const atom = (name: string) => ({ type: name, name });
 
 /** The provenance atom for one identity arm, as the space stores it. */
@@ -115,6 +119,36 @@ const pieceSnapshot = snapshot([
   }]),
 ]);
 
+const WILD = entity("wild");
+
+/**
+ * A document labelled the way the runtime writes one: `*` stands for every
+ * member of `items`, and two of its keys hold the characters a reference
+ * escapes — `/`, which is the separator itself, and `~`, which escapes it.
+ */
+const wildSnapshot = snapshot([
+  record(WILD, `/${WILD}`, [
+    {
+      path: ["items", "*"],
+      confidentiality: [atom("member-secret")],
+      integrity: [],
+      origin: "declared",
+    },
+    {
+      path: ["a/b"],
+      confidentiality: [atom("slash-secret")],
+      integrity: [],
+      origin: "declared",
+    },
+    {
+      path: ["c~d"],
+      confidentiality: [atom("tilde-secret")],
+      integrity: [],
+      origin: "declared",
+    },
+  ]),
+]);
+
 describe("console/cell-labels", () => {
   describe("consoleCellLabels()", () => {
     it("returns every atom of every path, deduplicated", () => {
@@ -130,8 +164,8 @@ describe("console/cell-labels", () => {
         "TransformedBy",
       ]);
       expect(labels.entries.map((entry) => entry.path)).toEqual([
-        "",
-        "summary",
+        [],
+        ["summary"],
       ]);
       expect(labels.entries[1].observes).toBe("members");
     });
@@ -264,7 +298,7 @@ describe("console/cell-labels", () => {
     it("narrows a reference addressing a path inside a document to that path", () => {
       expect(cellLabelsAt(index, `/${LABELLED}/value/secret`)?.entries)
         .toEqual([{
-          path: "",
+          path: [],
           confidentiality: ["demo-secret"],
           integrity: ["cf-compiled-by:cf-compiler"],
           origin: "declared",
@@ -277,11 +311,35 @@ describe("console/cell-labels", () => {
       );
     });
 
-    it("returns the document's labels for a cross-space link", () => {
-      const did = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
-      expect(cellLabelsAt(index, `/@${did}/${LABELLED}`)).toBe(
-        index.byAddress.get(LABELLED),
+    it("returns `undefined` for a link into a space the snapshot was not taken in", () => {
+      expect(cellLabelsAt(index, `/@${FOREIGN_DID}/${LABELLED}`)).toBe(
+        undefined,
       );
+    });
+
+    it("returns the labels for a link naming the space the snapshot was taken in", () => {
+      const inSpace = consoleCellLabelIndex({
+        ...readSnapshot,
+        space: { configured: "demo-space", did: OWN_DID },
+      });
+      expect(cellLabelsAt(inSpace, `/@${OWN_DID}/${LABELLED}`)).toBe(
+        inSpace.byAddress.get(LABELLED),
+      );
+    });
+
+    it("leaves a cell the snapshot marked unread out of the index it answers from", () => {
+      const unread = consoleCellLabelIndex(snapshot([
+        record(LABELLED, `/${LABELLED}`, [declared]),
+        {
+          entityId: BARE,
+          ref: `/@${FOREIGN_DID}/${BARE}`,
+          space: FOREIGN_DID,
+          unreadReason: "cross-space",
+          entries: [],
+        },
+      ]));
+      expect([...unread.byAddress.keys()]).toEqual([LABELLED]);
+      expect(consoleCellLabelsSummary(unread).cellsRead).toBe(1);
     });
 
     it("returns `undefined` for a reference naming no entity", () => {
@@ -305,8 +363,8 @@ describe("console/cell-labels", () => {
       it("keeps the suffix of an entry under the named path, re-rooted to it", () => {
         const labels = cellLabelsAt(piece, `/${PIECE}/briefing`);
         expect(labels?.entries.map((entry) => entry.path)).toEqual([
-          "",
-          "inner",
+          [],
+          ["inner"],
         ]);
         expect(labels?.confidentiality).toEqual(["demo-secret", "inner-only"]);
       });
@@ -314,7 +372,7 @@ describe("console/cell-labels", () => {
       it("returns an entry at the document root for every reference into the document", () => {
         const labels = cellLabelsAt(piece, `/${ROOTED}/anything/deeper`);
         expect(labels?.entries).toEqual([{
-          path: "",
+          path: [],
           confidentiality: ["org-only"],
           integrity: [],
           origin: "declared",
@@ -331,6 +389,37 @@ describe("console/cell-labels", () => {
         const labels = cellLabelsAt(piece, `/${PIECE}/briefing`);
         expect(labels?.derived).toBe(true);
         expect(labels?.transformedBy).toEqual(["llm"]);
+      });
+    });
+
+    describe("matching the segments a label path is written in", () => {
+      const wild = consoleCellLabelIndex(wildSnapshot);
+
+      it("returns the atom of a `*` entry for a reference to a member under it", () => {
+        const labels = cellLabelsAt(wild, `/${WILD}/items/0`);
+        expect(labels?.confidentiality).toEqual(["member-secret"]);
+        expect(labels?.entries.map((entry) => entry.path)).toEqual([[]]);
+      });
+
+      it("keeps the `*` of an entry under the container a reference names", () => {
+        const labels = cellLabelsAt(wild, `/${WILD}/items`);
+        expect(labels?.entries.map((entry) => entry.path)).toEqual([["*"]]);
+      });
+
+      it("returns the atom of a key holding the separator for the reference that escapes it", () => {
+        expect(cellLabelsAt(wild, `/${WILD}/a~1b`)?.confidentiality)
+          .toEqual(["slash-secret"]);
+      });
+
+      it("returns the atom of a key holding a tilde for the reference that escapes it", () => {
+        expect(cellLabelsAt(wild, `/${WILD}/c~0d`)?.confidentiality)
+          .toEqual(["tilde-secret"]);
+      });
+
+      it("returns no atom of a key holding the separator for a reference naming two segments", () => {
+        const labels = cellLabelsAt(wild, `/${WILD}/a/b`);
+        expect(labels?.entries).toEqual([]);
+        expect(labels?.confidentiality).toEqual([]);
       });
     });
   });

--- a/packages/cf-harness/test/console/flow.test.ts
+++ b/packages/cf-harness/test/console/flow.test.ts
@@ -4,6 +4,7 @@ import { consoleRunFlow } from "../../console/flow.ts";
 import { type ConsoleHandle, consoleRunSteps } from "../../console/steps.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
 import type { HarnessPolicyEvent } from "../../src/contracts/policy.ts";
+import type { ConsoleCellLabels } from "../../console/cell-labels.ts";
 
 const call = (
   id: string,
@@ -40,6 +41,15 @@ const handle = (token: string, ref: string): ConsoleHandle => ({
   uses: [],
   confidentiality: [],
 });
+
+/** What the space says about a cell it labels `Secret` at its root. */
+const secretLabels: ConsoleCellLabels = {
+  confidentiality: ["Secret"],
+  integrity: [],
+  derived: false,
+  transformedBy: [],
+  entries: [{ path: "", confidentiality: ["Secret"], integrity: [] }],
+};
 
 describe("console/flow", () => {
   it("cuts the map into a turn for each thing a person asked", () => {
@@ -139,6 +149,47 @@ describe("console/flow", () => {
     expect(node.produces).toHaveLength(1);
     expect(node.produces[0].ref).toBe("/of:fid1:def");
     expect(flow.unwiredPatterns).toBe(0);
+  });
+
+  it("carries the labels the space holds on a cell a call read", () => {
+    const steps = consoleRunSteps([
+      { role: "user", content: "go" },
+      call("c1", "run_pattern", {
+        sourceText: "y",
+        inputs: { source: "cfh:a:aaaaa" },
+      }),
+      result("c1", "run_pattern", { status: "ok", resultRef: "cfh:a:bbbbb" }),
+    ]);
+    const flow = consoleRunFlow({
+      runId: "r",
+      steps,
+      handles: [
+        { ...handle("cfh:a:aaaaa", "/of:fid1:abc"), labels: secretLabels },
+        handle("cfh:a:bbbbb", "/of:fid1:def"),
+      ],
+    });
+    const node = flow.turns[0].nodes[0];
+    expect(node.reads[0].labels?.confidentiality).toEqual(["Secret"]);
+    // The cell the call produced carries no label of its own.
+    expect(node.produces[0].labels).toBeUndefined();
+  });
+
+  it("states the label regime once for the whole map", () => {
+    const steps = consoleRunSteps([{ role: "user", content: "go" }]);
+    const flow = consoleRunFlow(
+      { runId: "r", steps, handles: [] },
+      [],
+      undefined,
+      {
+        status: "unavailable",
+        detail: "no space database on this host",
+        cellsRead: 0,
+        cellsLabelled: 0,
+      },
+    );
+    // Without this a cell drawn bare would read as a space with nothing to say.
+    expect(flow.cellLabels?.status).toBe("unavailable");
+    expect(flow.cellLabels?.detail).toBe("no space database on this host");
   });
 
   it("holds a run that delegates to itself to one visit", () => {

--- a/packages/cf-harness/test/console/flow.test.ts
+++ b/packages/cf-harness/test/console/flow.test.ts
@@ -48,7 +48,7 @@ const secretLabels: ConsoleCellLabels = {
   integrity: [],
   derived: false,
   transformedBy: [],
-  entries: [{ path: "", confidentiality: ["Secret"], integrity: [] }],
+  entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
 };
 
 describe("console/flow", () => {

--- a/packages/cf-harness/test/console/flow.test.ts
+++ b/packages/cf-harness/test/console/flow.test.ts
@@ -185,6 +185,7 @@ describe("console/flow", () => {
         detail: "no space database on this host",
         cellsRead: 0,
         cellsLabelled: 0,
+        cellsPartial: 0,
       },
     );
     // Without this a cell drawn bare would read as a space with nothing to say.

--- a/packages/cf-harness/test/console/graph.test.ts
+++ b/packages/cf-harness/test/console/graph.test.ts
@@ -51,7 +51,7 @@ const secretLabels: ConsoleCellLabels = {
   integrity: [],
   derived: false,
   transformedBy: [],
-  entries: [{ path: "", confidentiality: ["Secret"], integrity: [] }],
+  entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
 };
 
 describe("console/graph", () => {

--- a/packages/cf-harness/test/console/graph.test.ts
+++ b/packages/cf-harness/test/console/graph.test.ts
@@ -54,6 +54,65 @@ const secretLabels: ConsoleCellLabels = {
   entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
 };
 
+/** What a reader that ran out of nodes partway through that cell says. */
+const truncatedLabels: ConsoleCellLabels = {
+  confidentiality: [],
+  integrity: [],
+  derived: false,
+  transformedBy: [],
+  entries: [],
+  unreadPaths: [["theirs"]],
+  truncationReason: "node-budget-exhausted",
+};
+
+/** The reading the two above together support, in either order. */
+const foldedLabels: ConsoleCellLabels = {
+  confidentiality: ["Secret"],
+  integrity: [],
+  derived: false,
+  transformedBy: [],
+  entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
+  unreadPaths: [["theirs"]],
+  truncationReason: "node-budget-exhausted",
+};
+
+/**
+ * A parent and one child that both touch `/of:same`, each carrying its own
+ * reading of it, reduced to what the coalesced cell node says.
+ */
+const familyCellLabels = (
+  rootLabels: ConsoleCellLabels,
+  childLabels: ConsoleCellLabels,
+): ConsoleCellLabels | undefined => {
+  const parentSteps = consoleRunSteps([
+    call("c1", "delegate_task", { goal: "build it" }),
+    result("c1", "delegate_task", {
+      subagent: { childRunId: "r.subagent.1", status: "completed" },
+    }),
+    call("c2", "assign_slug", { token: "cfh:a:ppppp", slug: "books" }),
+    result("c2", "assign_slug", { status: "ok", slug: "books" }),
+  ]);
+  const childSteps = consoleRunSteps([
+    call("d1", "run_pattern", { sourceText: "x" }),
+    result("d1", "run_pattern", { status: "ok", resultRef: "cfh:a:kkkkk" }),
+  ]);
+  const graph = consoleRunFamilyGraph(
+    {
+      runId: "r",
+      steps: parentSteps,
+      handles: [{ ...handle("cfh:a:ppppp", "/of:same"), labels: rootLabels }],
+    },
+    [{
+      runId: "r.subagent.1",
+      steps: childSteps,
+      handles: [{ ...handle("cfh:a:kkkkk", "/of:same"), labels: childLabels }],
+    }],
+  );
+  const cells = graph.nodes.filter((node) => node.kind === "cell");
+  expect(cells).toHaveLength(1);
+  return cells[0].labels;
+};
+
 describe("console/graph", () => {
   describe("consoleRunGraph()", () => {
     it("draws a pattern producing the cell its result addressed", () => {
@@ -259,6 +318,22 @@ describe("console/graph", () => {
       // One cell, and the child is the run that read the space for it.
       expect(cells).toHaveLength(1);
       expect(cells[0].labels?.confidentiality).toEqual(["Secret"]);
+    });
+
+    it("keeps a cell partial when the root did not finish reading it", () => {
+      // The child read the cell whole. Taking its reading alone would drop
+      // the root's truncation and show the cell as fully read.
+      expect(familyCellLabels(truncatedLabels, secretLabels)).toEqual(
+        foldedLabels,
+      );
+    });
+
+    it("keeps a cell partial when a child did not finish reading it", () => {
+      // The same two readings, met in the other order. Every field of the
+      // fold is an OR or a union, so the answer cannot depend on the order.
+      expect(familyCellLabels(secretLabels, truncatedLabels)).toEqual(
+        foldedLabels,
+      );
     });
 
     it("visits a run once when a delegation points back at an ancestor", () => {

--- a/packages/cf-harness/test/console/graph.test.ts
+++ b/packages/cf-harness/test/console/graph.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../console/graph.ts";
 import { type ConsoleHandle, consoleRunSteps } from "../../console/steps.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
+import type { ConsoleCellLabels } from "../../console/cell-labels.ts";
 
 const call = (
   id: string,
@@ -43,6 +44,15 @@ const handle = (token: string, ref: string): ConsoleHandle => ({
   uses: [],
   confidentiality: [],
 });
+
+/** What the space says about a cell it labels `Secret` at its root. */
+const secretLabels: ConsoleCellLabels = {
+  confidentiality: ["Secret"],
+  integrity: [],
+  derived: false,
+  transformedBy: [],
+  entries: [{ path: "", confidentiality: ["Secret"], integrity: [] }],
+};
 
 describe("console/graph", () => {
   describe("consoleRunGraph()", () => {
@@ -153,6 +163,36 @@ describe("console/graph", () => {
     });
   });
 
+  describe("cell labels", () => {
+    it("carries the labels the space holds on a cell a token named", () => {
+      const steps = consoleRunSteps([
+        call("c1", "run_pattern", { sourceText: "x" }),
+        result("c1", "run_pattern", { status: "ok", resultRef: "cfh:a:aaaaa" }),
+      ]);
+      const graph = consoleRunGraph(steps, [
+        { ...handle("cfh:a:aaaaa", "/of:a"), labels: secretLabels },
+      ]);
+      const cell = graph.nodes.find((node) => node.kind === "cell");
+      expect(cell?.labels?.confidentiality).toEqual(["Secret"]);
+    });
+
+    it("carries them onto a cell an input named by whole link", () => {
+      const steps = consoleRunSteps([
+        call("c1", "run_pattern", {
+          sourceText: "x",
+          inputs: { source: "/of:fid1:abc" },
+        }),
+        result("c1", "run_pattern", { status: "ok" }),
+      ]);
+      const graph = consoleRunGraph(steps, [
+        { ...handle("cfh:a:aaaaa", "/of:fid1:abc"), labels: secretLabels },
+      ]);
+      const cell = graph.nodes.find((node) => node.kind === "cell");
+      expect(cell?.address).toBe("/of:fid1:abc");
+      expect(cell?.labels?.confidentiality).toEqual(["Secret"]);
+    });
+  });
+
   describe("consoleRunFamilyGraph()", () => {
     it("joins a parent's named cell to the child pattern that made it", () => {
       const parentSteps = consoleRunSteps([
@@ -186,6 +226,39 @@ describe("console/graph", () => {
       // per-run graph would have split in two.
       expect(graph.edges.filter((edge) => edge.kind === "produces"))
         .toHaveLength(1);
+    });
+
+    it("keeps the labels whichever run of the family read them", () => {
+      const parentSteps = consoleRunSteps([
+        call("c1", "delegate_task", { goal: "build it" }),
+        result("c1", "delegate_task", {
+          subagent: { childRunId: "r.subagent.1", status: "completed" },
+        }),
+        call("c2", "assign_slug", { token: "cfh:a:ppppp", slug: "books" }),
+        result("c2", "assign_slug", { status: "ok", slug: "books" }),
+      ]);
+      const childSteps = consoleRunSteps([
+        call("d1", "run_pattern", { sourceText: "x" }),
+        result("d1", "run_pattern", { status: "ok", resultRef: "cfh:a:kkkkk" }),
+      ]);
+      const graph = consoleRunFamilyGraph(
+        {
+          runId: "r",
+          steps: parentSteps,
+          handles: [handle("cfh:a:ppppp", "/of:same")],
+        },
+        [{
+          runId: "r.subagent.1",
+          steps: childSteps,
+          handles: [
+            { ...handle("cfh:a:kkkkk", "/of:same"), labels: secretLabels },
+          ],
+        }],
+      );
+      const cells = graph.nodes.filter((node) => node.kind === "cell");
+      // One cell, and the child is the run that read the space for it.
+      expect(cells).toHaveLength(1);
+      expect(cells[0].labels?.confidentiality).toEqual(["Secret"]);
     });
 
     it("visits a run once when a delegation points back at an ancestor", () => {

--- a/packages/cf-harness/test/console/runs.test.ts
+++ b/packages/cf-harness/test/console/runs.test.ts
@@ -82,6 +82,27 @@ const labelSnapshot = (entityId = "of:fid1:abc"): HarnessCellLabels => ({
   ],
 });
 
+/** The same cell, under a reader that ran out of nodes partway through it. */
+const truncatedLabelSnapshot = (
+  entityId = "of:fid1:abc",
+): HarnessCellLabels => ({
+  ...labelSnapshot(entityId),
+  cells: [
+    {
+      entityId,
+      ref: `/${entityId}`,
+      entries: [],
+      truncationReason: "node-budget-exhausted",
+    },
+  ],
+});
+
+/** The same cell, read through and found to carry no label. */
+const bareLabelSnapshot = (entityId = "of:fid1:abc"): HarnessCellLabels => ({
+  ...labelSnapshot(entityId),
+  cells: [{ entityId, ref: `/${entityId}`, entries: [] }],
+});
+
 /** A snapshot taken on a host that holds no copy of the run's space. */
 const unreadSnapshot = (): HarnessCellLabels => ({
   type: HARNESS_CELL_LABELS_TYPE,
@@ -489,6 +510,72 @@ describe("console/runs", () => {
         expect(await familyCellLabels(root, "r1")).toMatchObject({
           status: "read",
           cellsRead: 1,
+        });
+      });
+    });
+
+    it("counts a cell as partial when the root did not finish reading it", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: truncatedLabelSnapshot("of:fid1:abc"),
+        });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: labelSnapshot("of:fid1:abc"),
+        });
+
+        // The child read the cell whole; the root did not finish it. Counting
+        // the child's reading alone would state the cell as fully read.
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "read",
+          cellsRead: 1,
+          cellsLabelled: 1,
+          cellsPartial: 1,
+        });
+      });
+    });
+
+    it("counts a cell as partial when a child did not finish reading it", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: labelSnapshot("of:fid1:abc"),
+        });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: truncatedLabelSnapshot("of:fid1:abc"),
+        });
+
+        // The same two readings, met in the other order, and the same answer:
+        // the fold is a union, so which member arrives first cannot matter.
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "read",
+          cellsRead: 1,
+          cellsLabelled: 1,
+          cellsPartial: 1,
+        });
+      });
+    });
+
+    it("reports a cell no member found a label for as unlabelled", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: bareLabelSnapshot("of:fid1:abc"),
+        });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: bareLabelSnapshot("of:fid1:abc"),
+        });
+
+        // Both read it through and neither found an entry, which is a cell
+        // the space holds no label for rather than one nobody finished.
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "read",
+          cellsRead: 1,
+          cellsLabelled: 0,
+          cellsPartial: 0,
         });
       });
     });

--- a/packages/cf-harness/test/console/runs.test.ts
+++ b/packages/cf-harness/test/console/runs.test.ts
@@ -10,6 +10,10 @@ import {
 } from "../../console/run-store.ts";
 import { createHarnessRunState } from "../../src/run-state.ts";
 import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts";
+import {
+  HARNESS_CELL_LABELS_TYPE,
+  type HarnessCellLabels,
+} from "../../src/contracts/cell-labels.ts";
 
 const runState = (runId: string, updatedAt: string) => ({
   ...createHarnessRunState({
@@ -46,6 +50,31 @@ const result = (
   toolCallId,
   toolName,
   content: typeof content === "string" ? content : JSON.stringify(content),
+});
+
+/** A snapshot the space was read for, naming one cell it labels. */
+const labelSnapshot = (): HarnessCellLabels => ({
+  type: HARNESS_CELL_LABELS_TYPE,
+  version: 1,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  status: "read",
+  space: { configured: "my-space" },
+  cells: [
+    {
+      entityId: "of:fid1:abc",
+      ref: "/of:fid1:abc",
+      entries: [
+        {
+          path: [],
+          confidentiality: [
+            { type: "https://common.tools/cfc/Secret", name: "Secret" },
+          ],
+          integrity: [],
+          origin: "declared",
+        },
+      ],
+    },
+  ],
 });
 
 /** A run that searched, failed to compile, fixed, and named the piece. */
@@ -191,6 +220,7 @@ describe("console/runs", () => {
       root: string,
       runId: string,
       updatedAt: string,
+      cellLabels?: HarnessCellLabels,
     ): Promise<void> => {
       const runRoot = join(root, runId);
       await Deno.mkdir(join(runRoot, "tool-outputs"), { recursive: true });
@@ -198,6 +228,12 @@ describe("console/runs", () => {
         join(runRoot, "run-state.json"),
         JSON.stringify(runState(runId, updatedAt)),
       );
+      if (cellLabels !== undefined) {
+        await Deno.writeTextFile(
+          join(runRoot, "cell-labels.json"),
+          JSON.stringify(cellLabels),
+        );
+      }
       await Deno.writeTextFile(
         join(runRoot, "transcript.json"),
         JSON.stringify(buildTranscript()),
@@ -291,6 +327,33 @@ describe("console/runs", () => {
         expect(
           await readConsoleRunArtifact(root, "r1", "../transcript.json"),
         ).toBeUndefined();
+      });
+    });
+
+    it("reports no label snapshot for a run that wrote none", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(root, "r1", "2026-01-01T00:00:01.000Z");
+        const detail = await readConsoleRun(root, "r1");
+        // Nobody asked the space, which is not a space with nothing to say.
+        expect(detail?.cellLabels.status).toBe("absent");
+        expect(detail?.cellLabels.cellsRead).toBe(0);
+      });
+    });
+
+    it("reads the label snapshot a run wrote, and offers it as an artifact", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeRun(
+          root,
+          "r1",
+          "2026-01-01T00:00:01.000Z",
+          labelSnapshot(),
+        );
+        const detail = await readConsoleRun(root, "r1");
+        expect(detail?.cellLabels.status).toBe("read");
+        expect(detail?.cellLabels.cellsRead).toBe(1);
+        expect(detail?.cellLabels.cellsLabelled).toBe(1);
+        expect(detail?.cellLabels.space?.configured).toBe("my-space");
+        expect(detail?.artifactNames).toContain("cell-labels.json");
       });
     });
 

--- a/packages/cf-harness/test/console/runs.test.ts
+++ b/packages/cf-harness/test/console/runs.test.ts
@@ -6,6 +6,7 @@ import {
   listConsoleRuns,
   readConsoleRun,
   readConsoleRunArtifact,
+  readConsoleRunFlow,
   readConsoleToolOutput,
 } from "../../console/run-store.ts";
 import { createHarnessRunState } from "../../src/run-state.ts";
@@ -14,6 +15,10 @@ import {
   HARNESS_CELL_LABELS_TYPE,
   type HarnessCellLabels,
 } from "../../src/contracts/cell-labels.ts";
+import {
+  HARNESS_HANDLE_TABLE_TYPE,
+  type HarnessHandleTable,
+} from "../../src/contracts/handle-table.ts";
 
 const runState = (runId: string, updatedAt: string) => ({
   ...createHarnessRunState({
@@ -53,7 +58,7 @@ const result = (
 });
 
 /** A snapshot the space was read for, naming one cell it labels. */
-const labelSnapshot = (): HarnessCellLabels => ({
+const labelSnapshot = (entityId = "of:fid1:abc"): HarnessCellLabels => ({
   type: HARNESS_CELL_LABELS_TYPE,
   version: 1,
   generatedAt: "2026-01-01T00:00:00.000Z",
@@ -61,8 +66,8 @@ const labelSnapshot = (): HarnessCellLabels => ({
   space: { configured: "my-space" },
   cells: [
     {
-      entityId: "of:fid1:abc",
-      ref: "/of:fid1:abc",
+      entityId,
+      ref: `/${entityId}`,
       entries: [
         {
           path: [],
@@ -75,6 +80,18 @@ const labelSnapshot = (): HarnessCellLabels => ({
       ],
     },
   ],
+});
+
+/** A snapshot taken on a host that holds no copy of the run's space. */
+const unreadSnapshot = (): HarnessCellLabels => ({
+  type: HARNESS_CELL_LABELS_TYPE,
+  version: 1,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  status: "unavailable",
+  unavailableReason: "space-not-found",
+  unavailableDetail: "no space database for my-space on this host",
+  space: { configured: "my-space" },
+  cells: [],
 });
 
 /** A run that searched, failed to compile, fixed, and named the piece. */
@@ -354,6 +371,125 @@ describe("console/runs", () => {
         expect(detail?.cellLabels.cellsLabelled).toBe(1);
         expect(detail?.cellLabels.space?.configured).toBe("my-space");
         expect(detail?.artifactNames).toContain("cell-labels.json");
+      });
+    });
+
+    /**
+     * A run of a family: the cells it minted, and the snapshot it recorded
+     * for them. A run with no refs minted no cell, so it never records one.
+     */
+    const writeMember = async (
+      root: string,
+      runId: string,
+      options: {
+        refs?: readonly string[];
+        cellLabels?: HarnessCellLabels;
+      } = {},
+    ): Promise<void> => {
+      const runRoot = join(root, runId);
+      await Deno.mkdir(runRoot, { recursive: true });
+      const handleTable: HarnessHandleTable = {
+        type: HARNESS_HANDLE_TABLE_TYPE,
+        version: 1,
+        salt: runId,
+        entries: (options.refs ?? []).map((ref, index) => ({
+          token: `cfh:a:abcd${index + 2}`,
+          kind: "address",
+          ref,
+          addressKey: ref,
+        })),
+      };
+      await Deno.writeTextFile(
+        join(runRoot, "run-state.json"),
+        JSON.stringify({
+          ...runState(runId, "2026-01-01T00:00:01.000Z"),
+          handleTable,
+        }),
+      );
+      if (options.cellLabels !== undefined) {
+        await Deno.writeTextFile(
+          join(runRoot, "cell-labels.json"),
+          JSON.stringify(options.cellLabels),
+        );
+      }
+    };
+
+    /** What the map's header states about the space, for the family of `runId`. */
+    const familyCellLabels = async (root: string, runId: string) =>
+      (await readConsoleRunFlow(root, runId))?.cellLabels;
+
+    it("counts the cells of every run in a family that read its space", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: labelSnapshot("of:fid1:abc"),
+        });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:def"],
+          cellLabels: labelSnapshot("of:fid1:def"),
+        });
+
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "read",
+          cellsRead: 2,
+          cellsLabelled: 2,
+        });
+      });
+    });
+
+    it("refuses to read a child whose space went unread under the root's status", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: labelSnapshot("of:fid1:abc"),
+        });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:def"],
+          cellLabels: unreadSnapshot(),
+        });
+
+        // The root's `read` would say the child's cells carry no label; they
+        // are cells nobody asked about.
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "unavailable",
+          detail: "the runs in this family disagree: 1 read, 1 unavailable",
+        });
+      });
+    });
+
+    it("refuses to read a child that read its space under the root's absent snapshot", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", { refs: ["/of:fid1:abc"] });
+        await writeMember(root, "r1.subagent.0", {
+          refs: ["/of:fid1:def"],
+          cellLabels: labelSnapshot("of:fid1:def"),
+        });
+
+        // The root's `absent` would say nobody asked about the child's cell,
+        // and the child's own snapshot says what the space holds for it.
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "unavailable",
+          detail: "the runs in this family disagree: 1 read, 1 absent",
+          cellsRead: 1,
+          cellsLabelled: 1,
+        });
+      });
+    });
+
+    it("leaves a run that minted no cell out of the family's reading", async () => {
+      await withArtifactRoot(async (root) => {
+        await writeMember(root, "r1", {
+          refs: ["/of:fid1:abc"],
+          cellLabels: labelSnapshot("of:fid1:abc"),
+        });
+        // A child with no cell of its own takes no snapshot, which is not a
+        // reading of the space to disagree with.
+        await writeMember(root, "r1.subagent.0");
+
+        expect(await familyCellLabels(root, "r1")).toMatchObject({
+          status: "read",
+          cellsRead: 1,
+        });
       });
     });
 

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { join, resolve, toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { ConsoleServer, resolveConsoleConfig } from "../../console/server.ts";
 import type { ConsoleSessionListing } from "../../console/sessions.ts";
+import {
+  createHarnessChatEventEnvelope,
+  type HarnessChatEventEnvelope,
+  type HarnessChatStructuredEvent,
+} from "../../src/contracts/interactive-chat.ts";
 import type { HarnessFetch } from "../../src/contracts/http-fetch.ts";
 import { PatternIndexClient } from "../../src/pattern-index/client.ts";
 import {
@@ -194,6 +201,143 @@ describe("console/server", () => {
       requests,
     };
   };
+
+  /**
+   * A server whose cell-label snapshot the test releases by hand, and an
+   * event stream already open on it. The snapshot is handed in because it
+   * reads a space database this test has none of, and because when it settles
+   * is the whole of what these tests are about.
+   */
+  const snapshotServer = async (
+    recordCellLabels: (sessionId: string) => Promise<void>,
+  ): Promise<{ server: ConsoleServer; stream: Response }> => {
+    const held = new ConsoleServer(
+      config(),
+      (onEvent) =>
+        new HarnessInteractiveChatService({
+          createPromptLoop: answeringLoop,
+          now: advancingClock(),
+          onEvent,
+        }),
+      undefined,
+      recordCellLabels,
+    );
+    const page = await held.handle(getRequest("/"));
+    await page.body?.cancel();
+    const streamCookie = page.headers.get("set-cookie")!.split(";")[0];
+    return {
+      server: held,
+      stream: await held.handle(
+        getRequest("/api/events?afterSequence=0", { cookie: streamCookie }),
+      ),
+    };
+  };
+
+  const envelope = (
+    sequence: number,
+    event: HarnessChatStructuredEvent,
+  ): HarnessChatEventEnvelope =>
+    createHarnessChatEventEnvelope({
+      sessionId: "session-1",
+      sequence,
+      event,
+    });
+
+  describe("the cell-label snapshot a terminal event waits on", () => {
+    it("writes a terminal event to a stream only once its snapshot has landed", async () => {
+      let land: (() => void) | undefined;
+      const snapshot = new Promise<void>((resolve) => {
+        land = resolve;
+      });
+      const held = await snapshotServer(() => snapshot);
+      const frames = frameReader(held.stream);
+      try {
+        held.server.broadcast(
+          envelope(1, { kind: "assistant_completed", text: "built it" }),
+        );
+        // Reading that frame back is what says the stream has drained its
+        // backfill: until it has, an envelope is buffered rather than written.
+        expect(await frames.next()).toBe("chat:assistant_completed");
+
+        held.server.broadcast(
+          envelope(2, { kind: "turn_completed", turnId: "turn-1" }),
+        );
+        // A frame written while the terminal event is still waiting. A stream
+        // delivers in the order it was written, so the terminal event arriving
+        // after this one is what says it did not overtake its snapshot.
+        held.server.ping();
+        land!();
+
+        expect(await frames.next()).toBe("ping");
+        expect(await frames.next()).toBe("chat:turn_completed");
+      } finally {
+        await frames.cancel();
+      }
+    });
+
+    it("writes a terminal event whose snapshot could not be taken", async () => {
+      const held = await snapshotServer(() =>
+        Promise.reject(new Error("no space database for console-test"))
+      );
+      const frames = frameReader(held.stream);
+      try {
+        held.server.broadcast(
+          envelope(1, { kind: "assistant_completed", text: "built it" }),
+        );
+        expect(await frames.next()).toBe("chat:assistant_completed");
+
+        held.server.broadcast(envelope(2, {
+          kind: "turn_failed",
+          turnId: "turn-1",
+          error: { code: "internal_error", message: "the model gave up" },
+        }));
+
+        expect(await frames.next()).toBe("chat:turn_failed");
+      } finally {
+        await frames.cancel();
+      }
+    });
+
+    it("loads the server module on a host with no FFI permission", async () => {
+      // The console promises a machine without the SQLite native library can
+      // serve its page, and a run whose cells there are none of takes no
+      // snapshot. So evaluating this module must not open that library.
+      const repoRoot = resolve(import.meta.dirname!, "..", "..", "..", "..");
+      const wrapperDir = await Deno.makeTempDir({
+        prefix: "cf-harness-console-import-",
+      });
+      try {
+        const wrapper = join(wrapperDir, "import-console-server.ts");
+        await Deno.writeTextFile(
+          wrapper,
+          `import ${
+            JSON.stringify(
+              toFileUrl(join(repoRoot, "packages/cf-harness/console/server.ts"))
+                .href,
+            )
+          };\n`,
+        );
+        const output = await runDenoCommandWithTemporaryLock({
+          root: repoRoot,
+          args: (lock) => [
+            "run",
+            `--lock=${lock}`,
+            // The entry sits outside the workspace, so it names the config
+            // rather than finding one beside itself.
+            `--config=${join(repoRoot, "deno.jsonc")}`,
+            "--allow-env",
+            wrapper,
+          ],
+        });
+        if (!output.success) {
+          console.error(new TextDecoder().decode(output.stderr));
+        }
+        expect(output.code).toBe(0);
+      } finally {
+        await Deno.remove(wrapperDir, { recursive: true });
+      }
+    });
+  });
 
   describe("GET /api/sessions", () => {
     it("answers with no sessions before a task is started", async () => {
@@ -709,6 +853,55 @@ const envelopesUntil = async (
   } finally {
     await reader.cancel();
   }
+};
+
+/**
+ * One SSE frame at a time, named `<event>` for a frame the server writes
+ * itself and `chat:<kind>` for a chat envelope. Each read resolves on the
+ * chunk the server enqueued, so it ends when a frame is written rather than
+ * after any span of time.
+ */
+const frameReader = (response: Response): {
+  next: () => Promise<string>;
+  cancel: () => Promise<void>;
+} => {
+  const reader = response.body!.pipeThrough(new TextDecoderStream())
+    .getReader();
+  const named = (frame: string): string | undefined => {
+    const lines = frame.split("\n");
+    const event = lines.find((line) => line.startsWith("event: "))?.slice(7);
+    if (event === undefined) {
+      return undefined;
+    }
+    if (event !== "chat") {
+      return event;
+    }
+    const data = lines.find((line) => line.startsWith("data: "))!.slice(6);
+    return `chat:${(JSON.parse(data) as StreamedEnvelope).event.kind}`;
+  };
+  const read: string[] = [];
+  let buffered = "";
+  return {
+    next: async (): Promise<string> => {
+      while (read.length === 0) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          throw new Error("the stream closed before it wrote another frame");
+        }
+        buffered += chunk.value;
+        const frames = buffered.split("\n\n");
+        buffered = frames.pop() ?? "";
+        for (const frame of frames) {
+          const name = named(frame);
+          if (name !== undefined) {
+            read.push(name);
+          }
+        }
+      }
+      return read.shift()!;
+    },
+    cancel: () => reader.cancel(),
+  };
 };
 
 const kindsUntil = async (

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -86,6 +86,60 @@ describe("console/src/cell-chip", () => {
       expect(view.confidentiality).toEqual([]);
     });
 
+    it("reads a cell the whole of which was read as read in full", () => {
+      const view = cellLabelView({
+        labels: {
+          confidentiality: [],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+        },
+      });
+      // The card says the space holds no label for such a cell, which is a
+      // claim only a reading that covered the whole of it can make.
+      expect(view.partial).toBe(false);
+      expect(view.unfinished).toBe(false);
+      expect(view.unreadPaths).toEqual([]);
+    });
+
+    it("reads a cell whose reading ran out as read in part", () => {
+      const view = cellLabelView({
+        labels: {
+          confidentiality: [],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+          truncationReason: "node-budget-exhausted",
+        },
+      });
+      // An empty entry list under a reading that stopped is not a space with
+      // no label for the cell; it is a reading that cannot say either way.
+      expect(view.partial).toBe(true);
+      expect(view.unfinished).toBe(true);
+      // What it missed it never reached, so it names no path.
+      expect(view.unreadPaths).toEqual([]);
+    });
+
+    it("reads a cell holding a path nothing was read at as read in part", () => {
+      const view = cellLabelView({
+        labels: {
+          confidentiality: [],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+          unreadPaths: [["notes"]],
+        },
+      });
+      expect(view.partial).toBe(true);
+      // A declined path is named, which is more than a reading that ran out
+      // can say, so the two reach the card as separate facts.
+      expect(view.unreadPaths).toEqual([["notes"]]);
+      expect(view.unfinished).toBe(false);
+    });
+
     it("carries the paths and the implementations that produced them", () => {
       const view = cellLabelView({
         labels: {

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -4,7 +4,9 @@ import {
   cellChipClasses,
   cellLabelView,
   cellName,
+  type ConsoleCellLabelView,
   schemaSummary,
+  spaceHoldsNoLabel,
 } from "../../../console/src/cell-chip.ts";
 
 describe("console/src/cell-chip", () => {
@@ -218,6 +220,53 @@ describe("console/src/cell-chip", () => {
         },
       });
       expect(carried).not.toBe(derived);
+    });
+  });
+
+  describe("spaceHoldsNoLabel()", () => {
+    const view = (over: Partial<ConsoleCellLabelView> = {}) =>
+      ({
+        onCall: [],
+        confidentiality: [],
+        integrity: [],
+        derived: false,
+        transformedBy: [],
+        paths: [],
+        unreadPaths: [],
+        unfinished: false,
+        partial: false,
+        recorded: true,
+        ...over,
+      }) as ConsoleCellLabelView;
+
+    it("lets a reading that covered the whole of a bare cell say so", () => {
+      expect(spaceHoldsNoLabel(view())).toBe(true);
+    });
+
+    // The negative half, stated state by state. The claim is a conjunction,
+    // so an edit that drops one of its terms widens it without failing
+    // anything that only checks the positive case.
+    it("refuses a cell no reading recorded", () => {
+      expect(spaceHoldsNoLabel(view({ recorded: false }))).toBe(false);
+    });
+
+    it("refuses a cell whose reading stopped at a path", () => {
+      expect(
+        spaceHoldsNoLabel(
+          view({ partial: true, unreadPaths: [["inner"]] }),
+        ),
+      ).toBe(false);
+    });
+
+    it("refuses a cell whose reading ran out", () => {
+      expect(spaceHoldsNoLabel(view({ partial: true, unfinished: true })))
+        .toBe(false);
+    });
+
+    it("refuses a cell the space labelled", () => {
+      expect(spaceHoldsNoLabel(view({ confidentiality: ["secret"] })))
+        .toBe(false);
+      expect(spaceHoldsNoLabel(view({ integrity: ["signed"] }))).toBe(false);
     });
   });
 });

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -1,0 +1,169 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cellChipClasses,
+  cellLabelView,
+  cellName,
+  schemaSummary,
+} from "../../../console/src/cell-chip.ts";
+
+describe("console/src/cell-chip", () => {
+  describe("cellName", () => {
+    it("calls a cell by the name a person gave it", () => {
+      expect(cellName({ slug: "reading-list", token: "cfh:a:1", ref: "of:x" }))
+        .toBe("reading-list");
+    });
+
+    it("falls back to the handle the model held", () => {
+      expect(cellName({ token: "cfh:a:1", ref: "of:x" })).toBe("cfh:a:1");
+    });
+
+    it("falls back to the address when nothing else names it", () => {
+      expect(cellName({ ref: "of:x" })).toBe("of:x");
+    });
+
+    it("says cell for one nothing names", () => {
+      expect(cellName({})).toBe("cell");
+    });
+  });
+
+  describe("schemaSummary", () => {
+    it("summarizes an object by its property names", () => {
+      expect(schemaSummary({ properties: { title: {}, done: {} } }))
+        .toBe("{ title, done }");
+    });
+
+    it("elides the properties past the fourth", () => {
+      expect(
+        schemaSummary({ properties: { a: {}, b: {}, c: {}, d: {}, e: {} } }),
+      )
+        .toBe("{ a, b, c, d, … }");
+    });
+
+    it("names the type of a schema declaring no properties", () => {
+      expect(schemaSummary({ type: "string" })).toBe("string");
+    });
+
+    it("summarizes nothing for a schema that is not one", () => {
+      expect(schemaSummary("string")).toBeUndefined();
+    });
+  });
+
+  describe("cellLabelView", () => {
+    it("keeps what a call recorded apart from what the space holds", () => {
+      const view = cellLabelView({
+        confidentiality: ["prompt"],
+        labels: {
+          confidentiality: ["private"],
+          integrity: ["verified"],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+        },
+      });
+      expect(view.onCall).toEqual(["prompt"]);
+      expect(view.confidentiality).toEqual(["private"]);
+      expect(view.integrity).toEqual(["verified"]);
+    });
+
+    it("reads a cell the run holds no labels record for as unrecorded", () => {
+      expect(cellLabelView({ confidentiality: ["prompt"] }).recorded).toBe(
+        false,
+      );
+    });
+
+    it("reads a cell the space labelled nothing on as recorded", () => {
+      const view = cellLabelView({
+        labels: {
+          confidentiality: [],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+        },
+      });
+      expect(view.recorded).toBe(true);
+      expect(view.confidentiality).toEqual([]);
+    });
+
+    it("carries the paths and the implementations that produced them", () => {
+      const view = cellLabelView({
+        labels: {
+          confidentiality: ["private"],
+          integrity: [],
+          derived: true,
+          transformedBy: ["summarize in inbox.tsx"],
+          entries: [
+            {
+              path: "notes/0",
+              confidentiality: ["private"],
+              integrity: [],
+              origin: "derived",
+              transformedBy: "summarize in inbox.tsx",
+            },
+          ],
+        },
+      });
+      expect(view.derived).toBe(true);
+      expect(view.transformedBy).toEqual(["summarize in inbox.tsx"]);
+      expect(view.paths.map((entry) => entry.path)).toEqual(["notes/0"]);
+    });
+  });
+
+  describe("cellChipClasses", () => {
+    it("wears no state for a cell no atom rides on", () => {
+      expect(cellChipClasses({ token: "cfh:a:1" })).toBe("cell");
+    });
+
+    it("wears the labelled state for an atom a call recorded", () => {
+      expect(cellChipClasses({ confidentiality: ["prompt"] }))
+        .toBe("cell labelled");
+    });
+
+    it("wears the labelled state for an atom only the space holds", () => {
+      expect(cellChipClasses({
+        labels: {
+          confidentiality: ["private"],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+        },
+      })).toBe("cell labelled");
+    });
+
+    it("wears the derived state for a value computed from a read", () => {
+      expect(cellChipClasses({
+        labels: {
+          confidentiality: ["private"],
+          integrity: [],
+          derived: true,
+          transformedBy: [],
+          entries: [],
+        },
+      })).toBe("cell labelled derived");
+    });
+
+    it("marks a carried atom apart from a derived one", () => {
+      const carried = cellChipClasses({
+        labels: {
+          confidentiality: ["private"],
+          integrity: [],
+          derived: false,
+          transformedBy: [],
+          entries: [],
+        },
+      });
+      const derived = cellChipClasses({
+        labels: {
+          confidentiality: ["private"],
+          integrity: [],
+          derived: true,
+          transformedBy: [],
+          entries: [],
+        },
+      });
+      expect(carried).not.toBe(derived);
+    });
+  });
+});

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -95,7 +95,7 @@ describe("console/src/cell-chip", () => {
           transformedBy: ["summarize in inbox.tsx"],
           entries: [
             {
-              path: "notes/0",
+              path: ["notes", "0"],
               confidentiality: ["private"],
               integrity: [],
               origin: "derived",
@@ -106,7 +106,7 @@ describe("console/src/cell-chip", () => {
       });
       expect(view.derived).toBe(true);
       expect(view.transformedBy).toEqual(["summarize in inbox.tsx"]);
-      expect(view.paths.map((entry) => entry.path)).toEqual(["notes/0"]);
+      expect(view.paths.map((entry) => entry.path)).toEqual([["notes", "0"]]);
     });
   });
 

--- a/packages/cf-harness/test/console/src/flow-view.test.ts
+++ b/packages/cf-harness/test/console/src/flow-view.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { labelRegime } from "../../../console/src/flow-view.ts";
+
+describe("console/src/flow-view", () => {
+  describe("labelRegime", () => {
+    it("counts the cells that carry a label when every one was read whole", () => {
+      expect(labelRegime({
+        status: "read",
+        cellsRead: 3,
+        cellsLabelled: 2,
+        cellsPartial: 0,
+      })).toBe("cell labels read · 2 of 3 carry one");
+    });
+
+    it("states a partial reading where a cell was read only in part", () => {
+      // The count is a floor under a partial reading — another label may sit
+      // at a path nothing was read at — so the line may not lead with it as a
+      // total.
+      expect(labelRegime({
+        status: "read",
+        cellsRead: 3,
+        cellsLabelled: 2,
+        cellsPartial: 1,
+      })).toBe(
+        "cell labels read in part · 2 of 3 carry one, 1 only partly read",
+      );
+    });
+
+    it("says nobody asked where the run recorded no snapshot", () => {
+      expect(labelRegime({
+        status: "absent",
+        cellsRead: 0,
+        cellsLabelled: 0,
+        cellsPartial: 0,
+      })).toBe("cell labels not read");
+    });
+
+    it("names why the space could not be read", () => {
+      expect(labelRegime({
+        status: "unavailable",
+        detail: "no space database on this host",
+        cellsRead: 0,
+        cellsLabelled: 0,
+        cellsPartial: 0,
+      })).toBe("cell labels unavailable · no space database on this host");
+    });
+  });
+});

--- a/packages/cf-harness/test/console/steps.test.ts
+++ b/packages/cf-harness/test/console/steps.test.ts
@@ -10,6 +10,12 @@ import type { HarnessTranscriptMessage } from "../../src/contracts/transcript.ts
 import type { HarnessHandleTable } from "../../src/contracts/handle-table.ts";
 import type { HarnessCfcInvocationContext } from "../../src/contracts/cfc-invocation-context.ts";
 import { createToolOutputId } from "../../src/contracts/tool-result.ts";
+import {
+  HARNESS_CELL_LABELS_TYPE,
+  type HarnessCellLabelRecord,
+  type HarnessCellLabels,
+} from "../../src/contracts/cell-labels.ts";
+import { consoleCellLabelIndex } from "../../console/cell-labels.ts";
 
 const call = (
   id: string,
@@ -39,6 +45,36 @@ const result = (
   toolCallId,
   toolName,
   content: typeof content === "string" ? content : JSON.stringify(content),
+});
+
+/** A snapshot the space was read for, holding these cells and no others. */
+const labelSnapshot = (
+  cells: readonly HarnessCellLabelRecord[],
+): HarnessCellLabels => ({
+  type: HARNESS_CELL_LABELS_TYPE,
+  version: 1,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  status: "read",
+  cells,
+});
+
+/** One cell the space labels `Secret` at its root. */
+const secretCell = (
+  entityId: string,
+  ref: string,
+): HarnessCellLabelRecord => ({
+  entityId,
+  ref,
+  entries: [
+    {
+      path: [],
+      confidentiality: [
+        { type: "https://common.tools/cfc/Secret", name: "Secret" },
+      ],
+      integrity: [],
+      origin: "declared",
+    },
+  ],
 });
 
 describe("console/steps", () => {
@@ -185,6 +221,49 @@ describe("console/steps", () => {
       expect(handles).toHaveLength(1);
       expect(handles[0].token).toBe("cfh:a:zzzzz");
       expect(handles[0].ref).toBeUndefined();
+    });
+
+    it("carries the labels the space holds for the cell a handle names", () => {
+      const steps = consoleRunSteps([
+        call("c1", "run_pattern", {}),
+        result("c1", "run_pattern", { resultRef: "cfh:a:aaaaa" }),
+      ]);
+      const handles = consoleRunHandles(
+        steps,
+        table,
+        consoleCellLabelIndex(
+          labelSnapshot([secretCell("of:fid1:aaa", "/of:fid1:aaa")]),
+        ),
+      );
+      expect(handles[0].labels?.confidentiality).toEqual(["Secret"]);
+      // What a call put on the argument is a different fact, and stays its
+      // own field: this run made no call carrying an atom.
+      expect(handles[0].confidentiality).toEqual([]);
+    });
+
+    it("tells a cell the snapshot holds no label for from one it never read", () => {
+      const steps = consoleRunSteps([
+        call("c1", "run_pattern", {}),
+        result("c1", "run_pattern", { resultRef: "cfh:a:aaaaa" }),
+      ]);
+      const read = consoleRunHandles(
+        steps,
+        table,
+        consoleCellLabelIndex(
+          labelSnapshot([
+            { entityId: "of:fid1:aaa", ref: "/of:fid1:aaa", entries: [] },
+          ]),
+        ),
+      );
+      // The space was asked and holds nothing for this cell.
+      expect(read[0].labels?.entries).toEqual([]);
+      const unread = consoleRunHandles(
+        steps,
+        table,
+        consoleCellLabelIndex(undefined),
+      );
+      // Nobody asked, which is not the same reading.
+      expect(unread[0].labels).toBeUndefined();
     });
   });
 });
@@ -741,6 +820,46 @@ describe("console/steps provenance", () => {
       const handles = consoleRunHandles(steps, table);
       const args = consoleStepArguments(steps[2], handles);
       expect(args[0].schema).toEqual(table.entries[0].schema);
+    });
+
+    it("takes an argument's labels from the handle it resolved to", () => {
+      const steps = composed("cfh:a:aaaaa");
+      const handles = consoleRunHandles(
+        steps,
+        table,
+        consoleCellLabelIndex(
+          labelSnapshot([secretCell("of:fid1:abc", "/of:fid1:abc")]),
+        ),
+      );
+      const args = consoleStepArguments(steps[2], handles);
+      expect(args[0].labels?.confidentiality).toEqual(["Secret"]);
+    });
+
+    it("labels an argument written as a whole link the run holds no handle for", () => {
+      const steps = composed("/of:fid1:zzz");
+      const args = consoleStepArguments(
+        steps[2],
+        [],
+        consoleCellLabelIndex(
+          labelSnapshot([secretCell("of:fid1:zzz", "/of:fid1:zzz")]),
+        ),
+      );
+      expect(args[0].token).toBeUndefined();
+      expect(args[0].labels?.confidentiality).toEqual(["Secret"]);
+    });
+
+    it("labels a link naming a path inside a document from the document", () => {
+      const steps = composed("/of:fid1:zzz/numbers");
+      const args = consoleStepArguments(
+        steps[2],
+        [],
+        consoleCellLabelIndex(
+          labelSnapshot([secretCell("of:fid1:zzz", "/of:fid1:zzz")]),
+        ),
+      );
+      // The labels are stored for the document, and the path resolves to it.
+      expect(args[0].ref).toBe("/of:fid1:zzz/numbers");
+      expect(args[0].labels?.confidentiality).toEqual(["Secret"]);
     });
   });
 });

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -48,6 +48,31 @@ const DISJUNCTIVE = entity("disjunctive");
 const COMMITTED = entity("committed");
 const NEVER_WRITTEN = entity("neverWritten");
 
+/**
+ * The space the DID-named database holds, and one this host never opened. The
+ * store names its file after its space, so a file named for {@link OWN_DID} is
+ * the only proof this reader has of which space its ids belong to.
+ */
+const OWN_DID = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
+const FOREIGN_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+/**
+ * An id the seeded space holds a label for, standing for the id collision a
+ * cross-space reference invites: the same id in another space is another cell
+ * entirely, and reading it here would answer with this one's label.
+ */
+const COLLIDING = entity("colliding");
+
+/** A document whose links reach the colliding id in three spaces. */
+const LINKER = entity("linker");
+
+/** One stored link, in the at-rest sigil form the store holds. */
+const link = (id: string, space?: string) => ({
+  "/": {
+    "link@1": { id, path: [], ...(space === undefined ? {} : { space }) },
+  },
+});
+
 /** One `labelMap` entry, in the shape the space stores it. */
 const stored = (
   path: string[],
@@ -130,6 +155,28 @@ const documents: Record<string, unknown> = {
       },
     },
   },
+  [COLLIDING]: {
+    value: { secret: "local, and labelled" },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored([], {
+            confidentiality: ["foreign-secret"],
+            integrity: [],
+          }, "declared"),
+        ],
+      },
+    },
+  },
+  [LINKER]: {
+    value: {
+      mine: link(COLLIDING),
+      ours: link(COLLIDING, OWN_DID),
+      theirs: link(COLLIDING, FOREIGN_DID),
+    },
+  },
   [COMMITTED]: {
     value: { attachment: "…" },
     cfc: {
@@ -153,13 +200,18 @@ const documents: Record<string, unknown> = {
   },
 };
 
+/** The documents written as plain JSON rather than through the codec. */
+const PLAIN = new Set([UNLABELLED, LINKER]);
+
 /**
- * A stored `revision.data` payload. Every document but {@link UNLABELLED} goes
- * in through the codec, which tags its envelope (`fvj1:…`) the way the server
- * writes one; that one goes in as plain JSON, which the store also holds.
+ * A stored `revision.data` payload. Most documents go in through the codec,
+ * which tags their envelope (`fvj1:…`) the way the server writes one; the
+ * {@link PLAIN} ones go in as plain JSON, which the store also holds — one to
+ * show that a legacy row still reads, and one to keep its links in the sigil
+ * form a reader meets them in.
  */
 const payload = (id: string, document: unknown): string =>
-  id === UNLABELLED
+  PLAIN.has(id)
     ? JSON.stringify(document)
     : jsonFromFabricValue(document as FabricValue);
 
@@ -186,17 +238,28 @@ const seed = (path: string) => {
 describe("space-labels", () => {
   let directory: string;
   let dbPath: string;
+  let didDbPath: string;
   let reader: SpaceLabelReader;
+  let didReader: SpaceLabelReader;
 
   beforeAll(async () => {
     directory = await Deno.makeTempDir({ prefix: "cf-harness-space-labels-" });
     dbPath = `${directory}/space.sqlite`;
     seed(dbPath);
     reader = await openSpaceLabelReader("demo-space", { dbPath });
+    // The same store under the name the server gives one, so the reader can
+    // prove which space its ids belong to. Every space-naming reference is
+    // answerable only against this one.
+    didDbPath = `${directory}/${OWN_DID}.sqlite`;
+    seed(didDbPath);
+    didReader = await openSpaceLabelReader("demo-space", {
+      dbPath: didDbPath,
+    });
   });
 
   afterAll(async () => {
     reader.close();
+    didReader.close();
     await Deno.remove(directory, { recursive: true });
   });
 
@@ -215,10 +278,10 @@ describe("space-labels", () => {
       });
     });
 
-    it("returns the entity named after the space of a cross-space link", () => {
-      const did = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
-      expect(cellAddressOfRef(`/@${did}/${DECLARED}/title`)).toEqual({
+    it("returns the entity and the space a cross-space link names", () => {
+      expect(cellAddressOfRef(`/@${FOREIGN_DID}/${DECLARED}/title`)).toEqual({
         id: DECLARED,
+        space: FOREIGN_DID,
         scope: "space",
       });
     });
@@ -314,6 +377,84 @@ describe("space-labels", () => {
         },
       }]);
     });
+
+    it("returns the space DID the opened file is named for", () => {
+      expect(didReader.did).toBe(OWN_DID);
+    });
+
+    it("returns no space DID for an opened file whose name is not one", () => {
+      expect(reader.did).toBe(undefined);
+    });
+
+    it("returns the labels of an address naming the space that was opened", () => {
+      const read = didReader.read({
+        id: COLLIDING,
+        space: OWN_DID,
+        scope: "space",
+      });
+      expect(read.unread).toBe(undefined);
+      expect(read.entries.map((entry) => entry.confidentiality)).toEqual([
+        [{ type: "foreign-secret", name: "foreign-secret" }],
+      ]);
+    });
+
+    it("returns no labels and `cross-space` for an address in another space holding an id this space also holds", () => {
+      const read = didReader.read({
+        id: COLLIDING,
+        space: FOREIGN_DID,
+        scope: "space",
+      });
+      expect(read.unread).toBe("cross-space");
+      expect(read.entries).toEqual([]);
+    });
+
+    it("returns no labels for an address naming any space when the opened file proves none", () => {
+      const read = reader.read({
+        id: COLLIDING,
+        space: OWN_DID,
+        scope: "space",
+      });
+      expect(read.unread).toBe("cross-space");
+      expect(read.entries).toEqual([]);
+    });
+
+    it("returns the labels of the linked cells naming no space and naming the opened one", () => {
+      const read = didReader.read({ id: LINKER, scope: "space" });
+      expect(read.linked).toEqual([
+        { key: "mine", id: COLLIDING },
+        { key: "ours", id: COLLIDING },
+      ]);
+      expect(read.entries).toEqual([
+        {
+          path: ["mine"],
+          confidentiality: [{ type: "foreign-secret", name: "foreign-secret" }],
+          integrity: [],
+          origin: "declared",
+          source: COLLIDING,
+        },
+        {
+          path: ["ours"],
+          confidentiality: [{ type: "foreign-secret", name: "foreign-secret" }],
+          integrity: [],
+          origin: "declared",
+          source: COLLIDING,
+        },
+      ]);
+    });
+
+    it("returns no entry under a link into another space holding an id this space also holds", () => {
+      const read = didReader.read({ id: LINKER, scope: "space" });
+      expect(read.linked.map((cell) => cell.key)).not.toContain("theirs");
+      expect(read.entries.map((entry) => entry.path[0])).not.toContain(
+        "theirs",
+      );
+    });
+
+    it("returns only the link naming no space when the opened file proves no DID", () => {
+      const read = reader.read({ id: LINKER, scope: "space" });
+      expect(read.linked).toEqual([{ key: "mine", id: COLLIDING }]);
+      expect(read.entries.map((entry) => entry.path)).toEqual([["mine"]]);
+    });
   });
 
   describe("readSpaceCellLabels()", () => {
@@ -353,6 +494,48 @@ describe("space-labels", () => {
     it("drops a reference that names no document", async () => {
       const snapshot = await read(["my notebook", `/${DECLARED}`]);
       expect(snapshot.cells.map((cell) => cell.entityId)).toEqual([DECLARED]);
+    });
+
+    const readAgainstDid = (refs: readonly string[]) =>
+      readSpaceCellLabels({
+        space: "demo-space",
+        dbPath: didDbPath,
+        refs,
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    it("names the space DID of a database named for its space", async () => {
+      const snapshot = await readAgainstDid([`/${DECLARED}`]);
+      expect(snapshot.space).toEqual({
+        configured: "demo-space",
+        did: OWN_DID,
+        dbPath: didDbPath,
+      });
+    });
+
+    it("records a reference into another space as unread rather than reading its id here", async () => {
+      const ref = `/@${FOREIGN_DID}/${COLLIDING}`;
+      const snapshot = await readAgainstDid([ref]);
+      expect(snapshot.cells).toEqual([{
+        entityId: COLLIDING,
+        ref,
+        space: FOREIGN_DID,
+        unreadReason: "cross-space",
+        entries: [],
+      }]);
+    });
+
+    it("records one cell per space for an id referenced in two", async () => {
+      const snapshot = await readAgainstDid([
+        `/${COLLIDING}`,
+        `/@${FOREIGN_DID}/${COLLIDING}`,
+      ]);
+      expect(snapshot.cells.map((cell) => cell.unreadReason)).toEqual([
+        undefined,
+        "cross-space",
+      ]);
+      expect(snapshot.cells[0].entries.map((entry) => entry.confidentiality))
+        .toEqual([[{ type: "foreign-secret", name: "foreign-secret" }]]);
     });
 
     it("returns an unavailable snapshot naming the space when no database is found", async () => {

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -4,6 +4,8 @@ import { Database } from "@db/sqlite";
 import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
+import type { LinkWalkBounds } from "@commonfabric/state-inspector";
+
 import {
   cellAddressOfRef,
   openSpaceLabelReader,
@@ -73,6 +75,14 @@ const LINKER = entity("linker");
  * either followed or recorded unread at the whole path it sits at.
  */
 const NESTER = entity("nester");
+
+/**
+ * A document holding one link at its surface and one below it. A reader that
+ * descends one level reaches the first and stops short of the second; a
+ * reader with two nodes to spend stops before it has looked at either the
+ * second link or the container holding it.
+ */
+const DEEPER = entity("deeper");
 
 /** One stored link, in the at-rest sigil form the store holds. */
 const link = (id: string, space?: string) => ({
@@ -195,6 +205,12 @@ const documents: Record<string, unknown> = {
       plain: "no link here",
     },
   },
+  [DEEPER]: {
+    value: {
+      shallow: link(COLLIDING),
+      deep: { down: link(COLLIDING) },
+    },
+  },
   [COMMITTED]: {
     value: { attachment: "…" },
     cfc: {
@@ -218,8 +234,20 @@ const documents: Record<string, unknown> = {
   },
 };
 
+/**
+ * Bounds narrower than the ones a run records under, each stopping at a place
+ * {@link DEEPER} reaches: {@link SHALLOW} descends one level, so the link
+ * below that is a path it refuses; {@link SPENT} has two values to spend, so
+ * it runs out with the rest of the document unenumerated.
+ */
+const SHALLOW: LinkWalkBounds = {
+  maxDepth: 1,
+  maxNodes: Number.POSITIVE_INFINITY,
+};
+const SPENT: LinkWalkBounds = { maxDepth: 64, maxNodes: 2 };
+
 /** The documents written as plain JSON rather than through the codec. */
-const PLAIN = new Set([UNLABELLED, LINKER, NESTER]);
+const PLAIN = new Set([UNLABELLED, LINKER, NESTER, DEEPER]);
 
 /**
  * A stored `revision.data` payload. Most documents go in through the codec,
@@ -280,6 +308,42 @@ describe("space-labels", () => {
     didReader.close();
     await Deno.remove(directory, { recursive: true });
   });
+
+  /** Reads the DID-named store under bounds narrower than a run's own. */
+  const withBoundedReader = async (
+    linkWalk: LinkWalkBounds,
+    body: (bounded: SpaceLabelReader) => void,
+  ): Promise<void> => {
+    const bounded = await openSpaceLabelReader("demo-space", {
+      dbPath: didDbPath,
+      linkWalk,
+    });
+    try {
+      body(bounded);
+    } finally {
+      bounded.close();
+    }
+  };
+
+  /** What `body` warned, alongside what it returned. */
+  const collectWarningsOf = async <T>(
+    body: () => Promise<T>,
+  ): Promise<[T, string[]]> => {
+    const warned: string[] = [];
+    const printed = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warned.push(args.map((arg) => String(arg)).join(" "));
+    };
+    try {
+      return [await body(), warned];
+    } finally {
+      console.warn = printed;
+    }
+  };
+
+  const collectWarnings = async (
+    body: () => Promise<unknown>,
+  ): Promise<string[]> => (await collectWarningsOf(body))[1];
 
   describe("cellAddressOfRef()", () => {
     it("returns the entity at the space scope for a bare `of:` id", () => {
@@ -530,6 +594,72 @@ describe("space-labels", () => {
       expect(didReader.read({ id: DECLARED, scope: "space" }).unreadPaths)
         .toBe(undefined);
     });
+
+    it("returns no truncation for a document the walk reached the end of", () => {
+      expect(didReader.read({ id: DEEPER, scope: "space" }).truncation)
+        .toBe(undefined);
+    });
+
+    it("returns the labels of every link of a document both bounds reach", () => {
+      const read = didReader.read({ id: DEEPER, scope: "space" });
+      expect(read.linked.map((cell) => cell.path)).toEqual([
+        ["shallow"],
+        ["deep", "down"],
+      ]);
+    });
+
+    it("returns the path a shallower walk stopped short of as unread", async () => {
+      await withBoundedReader(SHALLOW, (bounded) => {
+        const read = bounded.read({ id: DEEPER, scope: "space" });
+        expect(read.unreadPaths).toEqual([
+          { path: ["deep", "down"], reason: "below-read-depth" },
+        ]);
+        expect(read.truncation).toBe(undefined);
+      });
+    });
+
+    it("returns the labels of the link a shallower walk did reach", async () => {
+      await withBoundedReader(SHALLOW, (bounded) => {
+        const read = bounded.read({ id: DEEPER, scope: "space" });
+        expect(read.linked).toEqual([{ path: ["shallow"], id: COLLIDING }]);
+        expect(read.entries.map((entry) => entry.path)).toEqual([["shallow"]]);
+      });
+    });
+
+    it("returns the whole document truncated when the walk runs out of nodes", async () => {
+      await collectWarnings(() =>
+        withBoundedReader(SPENT, (bounded) => {
+          const read = bounded.read({ id: DEEPER, scope: "space" });
+          expect(read.truncation).toBe("node-budget-exhausted");
+          // No path for what it missed: it stopped before enumerating what
+          // it had left, so the statement is about the document as a whole.
+          expect(read.unreadPaths).toBe(undefined);
+          expect(read.entries.map((entry) => entry.path)).toEqual([
+            ["shallow"],
+          ]);
+        })
+      );
+    });
+
+    it("warns naming the document when the walk runs out of nodes", async () => {
+      const warnings = await collectWarnings(() =>
+        withBoundedReader(SPENT, (bounded) => {
+          bounded.read({ id: DEEPER, scope: "space" });
+        })
+      );
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toContain(DEEPER);
+      expect(warnings[0]).toContain(didDbPath);
+    });
+
+    it("warns for no document the walk reached the end of", async () => {
+      const warnings = await collectWarnings(() =>
+        withBoundedReader(SHALLOW, (bounded) => {
+          bounded.read({ id: DEEPER, scope: "space" });
+        })
+      );
+      expect(warnings).toEqual([]);
+    });
   });
 
   describe("readSpaceCellLabels()", () => {
@@ -643,6 +773,40 @@ describe("space-labels", () => {
     it("records no unread path for a cell whose links were all followed", async () => {
       const snapshot = await readAgainstDid([`/${DECLARED}`]);
       expect(snapshot.cells[0].unreadPaths).toBe(undefined);
+    });
+
+    it("records the path of a link below the depth the read descends to", async () => {
+      const snapshot = await readSpaceCellLabels({
+        space: "demo-space",
+        dbPath: didDbPath,
+        linkWalk: SHALLOW,
+        refs: [`/${DEEPER}`],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(snapshot.cells[0].unreadPaths).toEqual([
+        { path: ["deep", "down"], reason: "below-read-depth" },
+      ]);
+      expect(snapshot.cells[0].truncationReason).toBe(undefined);
+    });
+
+    it("records the cell as truncated when the read runs out of nodes", async () => {
+      const [snapshot, warnings] = await collectWarningsOf(() =>
+        readSpaceCellLabels({
+          space: "demo-space",
+          dbPath: didDbPath,
+          linkWalk: SPENT,
+          refs: [`/${DEEPER}`],
+          generatedAt: "2026-01-01T00:00:00.000Z",
+        })
+      );
+      expect(snapshot.cells[0].truncationReason).toBe("node-budget-exhausted");
+      expect(snapshot.cells[0].unreadPaths).toBe(undefined);
+      expect(warnings.length).toBe(1);
+    });
+
+    it("records no truncation for a cell the read reached the end of", async () => {
+      const snapshot = await readAgainstDid([`/${DEEPER}`]);
+      expect(snapshot.cells[0].truncationReason).toBe(undefined);
     });
 
     it("returns an unavailable snapshot naming the space when no database is found", async () => {

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -1,0 +1,372 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+import {
+  cellAddressOfRef,
+  openSpaceLabelReader,
+  readSpaceCellLabels,
+  type SpaceLabelReader,
+} from "../src/space-labels.ts";
+import { HARNESS_CELL_LABELS_TYPE } from "../src/contracts/cell-labels.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 5, 'active');
+`;
+
+const TRANSFORMED_BY = "https://commonfabric.org/cfc/atom/TransformedBy";
+const RESOURCE = "https://commonfabric.org/cfc/atom/Resource";
+const SCHEMA_HASH = "fid1:C4ajDsLKcfdMDDs3lbNShZBcQCVA4qhVo5mRoBcgpB0";
+
+/** An entity id in the store's own shape: `of:fid1:` and 44 base64url chars. */
+const entity = (name: string) => `of:fid1:${name.padEnd(44, "0")}`;
+
+const DECLARED = entity("declared");
+const DERIVED = entity("derived");
+const UNLABELLED = entity("unlabelled");
+const DISJUNCTIVE = entity("disjunctive");
+const COMMITTED = entity("committed");
+const NEVER_WRITTEN = entity("neverWritten");
+
+/** One `labelMap` entry, in the shape the space stores it. */
+const stored = (
+  path: string[],
+  label: Record<string, unknown>,
+  origin: string,
+  observes?: string,
+) => ({
+  path,
+  label,
+  origin,
+  ...(observes === undefined ? {} : { observes }),
+});
+
+const documents: Record<string, unknown> = {
+  [DECLARED]: {
+    value: { secret: "the combination is 1234" },
+    cfc: {
+      version: 1,
+      schemaHash: SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored([], {
+            confidentiality: ["demo-secret"],
+            integrity: ["cf-compiled-by:cf-compiler"],
+          }, "declared"),
+        ],
+      },
+    },
+  },
+  [DERIVED]: {
+    value: { summary: "a redaction of the above" },
+    cfc: {
+      version: 1,
+      schemaHash: SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored(
+            ["summary"],
+            {
+              confidentiality: ["demo-secret"],
+              integrity: [
+                "cf-compiled-by:cf-compiler",
+                {
+                  type: TRANSFORMED_BY,
+                  identity: {
+                    kind: "verified",
+                    moduleIdentity: "cf:module/abc",
+                    symbol: "__cfLift_2",
+                  },
+                },
+              ],
+            },
+            "derived",
+            "members",
+          ),
+        ],
+      },
+    },
+  },
+  // Stored as plain JSON rather than through the codec: a durable file holds
+  // both at-rest forms, and a reader that only decoded the tagged one would
+  // report every legacy row as an entity with no document.
+  [UNLABELLED]: { value: { title: "nothing is labelled here" } },
+  [DISJUNCTIVE]: {
+    value: { note: "reachable two ways" },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored([], {
+            confidentiality: [
+              { anyOf: [{ type: RESOURCE, class: "A", subject: "s" }, "b"] },
+            ],
+            integrity: [],
+          }, "declared"),
+        ],
+      },
+    },
+  },
+  [COMMITTED]: {
+    value: { attachment: "…" },
+    cfc: {
+      version: 1,
+      labelMap: {
+        version: 1,
+        entries: [
+          stored([], {
+            confidentiality: [
+              {
+                type: RESOURCE,
+                class: "attachment",
+                subject: { digestOf: SCHEMA_HASH },
+              },
+            ],
+            integrity: [],
+          }, "declared"),
+        ],
+      },
+    },
+  },
+};
+
+/**
+ * A stored `revision.data` payload. Every document but {@link UNLABELLED} goes
+ * in through the codec, which tags its envelope (`fvj1:…`) the way the server
+ * writes one; that one goes in as plain JSON, which the store also holds.
+ */
+const payload = (id: string, document: unknown): string =>
+  id === UNLABELLED
+    ? JSON.stringify(document)
+    : jsonFromFabricValue(document as FabricValue);
+
+const seed = (path: string) => {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, 'session:did:key:zX:u', ?, '{}', '{}')`,
+  );
+  const revision = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  for (const [id, document] of Object.entries(documents)) {
+    seq += 1;
+    commit.run(seq, seq);
+    revision.run(id, seq, payload(id, document), seq);
+  }
+  db.close();
+};
+
+describe("space-labels", () => {
+  let directory: string;
+  let dbPath: string;
+  let reader: SpaceLabelReader;
+
+  beforeAll(async () => {
+    directory = await Deno.makeTempDir({ prefix: "cf-harness-space-labels-" });
+    dbPath = `${directory}/space.sqlite`;
+    seed(dbPath);
+    reader = await openSpaceLabelReader("demo-space", { dbPath });
+  });
+
+  afterAll(async () => {
+    reader.close();
+    await Deno.remove(directory, { recursive: true });
+  });
+
+  describe("cellAddressOfRef()", () => {
+    it("returns the entity at the space scope for a bare `of:` id", () => {
+      expect(cellAddressOfRef(DECLARED)).toEqual({
+        id: DECLARED,
+        scope: "space",
+      });
+    });
+
+    it("returns the document for a link naming a path inside it", () => {
+      expect(cellAddressOfRef(`/${DECLARED}/value/secret`)).toEqual({
+        id: DECLARED,
+        scope: "space",
+      });
+    });
+
+    it("returns the entity named after the space of a cross-space link", () => {
+      const did = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
+      expect(cellAddressOfRef(`/@${did}/${DECLARED}/title`)).toEqual({
+        id: DECLARED,
+        scope: "space",
+      });
+    });
+
+    it("returns the scope of a scoped id, which a label map is stored at", () => {
+      expect(cellAddressOfRef(`/${DECLARED}@user`)).toEqual({
+        id: DECLARED,
+        scope: "user",
+      });
+    });
+
+    it("returns `undefined` for a string that is not a link", () => {
+      expect(cellAddressOfRef("my notebook")).toBe(undefined);
+    });
+  });
+
+  describe("openSpaceLabelReader()", () => {
+    it("returns the atoms, origin and schema hash of a declared label", () => {
+      const read = reader.read({ id: DECLARED, scope: "space" });
+      expect(read.schemaHash).toBe(SCHEMA_HASH);
+      expect(read.entries).toEqual([{
+        path: [],
+        confidentiality: [{ type: "demo-secret", name: "demo-secret" }],
+        integrity: [{
+          type: "cf-compiled-by:cf-compiler",
+          name: "cf-compiled-by:cf-compiler",
+        }],
+        origin: "declared",
+      }]);
+    });
+
+    it("lifts a `TransformedBy` atom out of `integrity` and leaves it there", () => {
+      const [entry] = reader.read({ id: DERIVED, scope: "space" }).entries;
+      const provenance = {
+        type: TRANSFORMED_BY,
+        name: "TransformedBy",
+        fields: {
+          identity: {
+            kind: "verified",
+            moduleIdentity: "cf:module/abc",
+            symbol: "__cfLift_2",
+          },
+        },
+      };
+      expect(entry.path).toEqual(["summary"]);
+      expect(entry.origin).toBe("derived");
+      expect(entry.observes).toBe("members");
+      expect(entry.transformedBy).toEqual(provenance);
+      expect(entry.integrity).toEqual([
+        {
+          type: "cf-compiled-by:cf-compiler",
+          name: "cf-compiled-by:cf-compiler",
+        },
+        provenance,
+      ]);
+    });
+
+    it("returns an empty entry list for a document with no `cfc` path", () => {
+      const read = reader.read({ id: UNLABELLED, scope: "space" });
+      expect(read.entries).toEqual([]);
+      expect(read.schemaHash).toBe(undefined);
+    });
+
+    it("returns an empty entry list for an entity the space never wrote", () => {
+      expect(reader.read({ id: NEVER_WRITTEN, scope: "space" }).entries)
+        .toEqual([]);
+    });
+
+    it("returns a disjunctive confidentiality clause as one atom carrying its alternatives", () => {
+      const [entry] = reader.read({ id: DISJUNCTIVE, scope: "space" }).entries;
+      expect(entry.confidentiality).toEqual([{
+        type: "anyOf",
+        name: "Resource or b",
+        anyOf: [
+          {
+            type: RESOURCE,
+            name: "Resource",
+            fields: { class: "A", subject: "s" },
+          },
+          { type: "b", name: "b" },
+        ],
+      }]);
+    });
+
+    it("keeps an object atom's non-`type` fields, including a committed one", () => {
+      const [entry] = reader.read({ id: COMMITTED, scope: "space" }).entries;
+      expect(entry.confidentiality).toEqual([{
+        type: RESOURCE,
+        name: "Resource",
+        fields: {
+          class: "attachment",
+          subject: { digestOf: SCHEMA_HASH },
+        },
+      }]);
+    });
+  });
+
+  describe("readSpaceCellLabels()", () => {
+    const read = (refs: readonly string[]) =>
+      readSpaceCellLabels({
+        space: "demo-space",
+        dbPath,
+        refs,
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      });
+
+    it("records one cell per entity, naming the reference the run held", async () => {
+      const snapshot = await read([`/${DECLARED}`, `/${UNLABELLED}`]);
+      expect(snapshot.type).toBe(HARNESS_CELL_LABELS_TYPE);
+      expect(snapshot.status).toBe("read");
+      expect(snapshot.space).toEqual({ configured: "demo-space", dbPath });
+      expect(snapshot.cells.map((cell) => cell.entityId)).toEqual([
+        DECLARED,
+        UNLABELLED,
+      ]);
+      expect(snapshot.cells[0].ref).toBe(`/${DECLARED}`);
+      expect(snapshot.cells[0].schemaHash).toBe(SCHEMA_HASH);
+      expect(snapshot.cells[1].entries).toEqual([]);
+    });
+
+    it("records one cell for a reference the run held more than once", async () => {
+      const snapshot = await read([`/${DECLARED}`, `/${DECLARED}`]);
+      expect(snapshot.cells.length).toBe(1);
+    });
+
+    it("resolves a reference naming a path inside a document to the document", async () => {
+      const snapshot = await read([`/${DECLARED}/value/secret`]);
+      expect(snapshot.cells.map((cell) => cell.entityId)).toEqual([DECLARED]);
+      expect(snapshot.cells[0].ref).toBe(`/${DECLARED}/value/secret`);
+    });
+
+    it("drops a reference that names no document", async () => {
+      const snapshot = await read(["my notebook", `/${DECLARED}`]);
+      expect(snapshot.cells.map((cell) => cell.entityId)).toEqual([DECLARED]);
+    });
+
+    it("returns an unavailable snapshot naming the space when no database is found", async () => {
+      const snapshot = await readSpaceCellLabels({
+        space: "demo-space",
+        dbPath: `${directory}/absent.sqlite`,
+        refs: [`/${DECLARED}`],
+        generatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      expect(snapshot.status).toBe("unavailable");
+      expect(snapshot.unavailableReason).toBe("space-not-found");
+      expect(snapshot.space).toEqual({ configured: "demo-space" });
+      expect(snapshot.cells).toEqual([]);
+      expect(typeof snapshot.unavailableDetail).toBe("string");
+    });
+  });
+});

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -408,13 +408,13 @@ describe("space-labels", () => {
       expect(read.entries).toEqual([]);
     });
 
-    it("returns no labels for an address naming any space when the opened file proves none", () => {
+    it("returns no labels and `space-unproven` for an address naming any space when the opened file proves none", () => {
       const read = reader.read({
         id: COLLIDING,
         space: OWN_DID,
         scope: "space",
       });
-      expect(read.unread).toBe("cross-space");
+      expect(read.unread).toBe("space-unproven");
       expect(read.entries).toEqual([]);
     });
 
@@ -450,10 +450,30 @@ describe("space-labels", () => {
       );
     });
 
+    it("returns the path of a link into another space as unread rather than dropping it", () => {
+      const read = didReader.read({ id: LINKER, scope: "space" });
+      expect(read.unreadPaths).toEqual([
+        { path: ["theirs"], reason: "cross-space" },
+      ]);
+    });
+
     it("returns only the link naming no space when the opened file proves no DID", () => {
       const read = reader.read({ id: LINKER, scope: "space" });
       expect(read.linked).toEqual([{ key: "mine", id: COLLIDING }]);
       expect(read.entries.map((entry) => entry.path)).toEqual([["mine"]]);
+    });
+
+    it("returns every spaced link as unread when the opened file proves no DID", () => {
+      const read = reader.read({ id: LINKER, scope: "space" });
+      expect(read.unreadPaths).toEqual([
+        { path: ["ours"], reason: "space-unproven" },
+        { path: ["theirs"], reason: "space-unproven" },
+      ]);
+    });
+
+    it("returns no unread path for a document whose links were all followed", () => {
+      expect(didReader.read({ id: DECLARED, scope: "space" }).unreadPaths)
+        .toBe(undefined);
     });
   });
 
@@ -536,6 +556,27 @@ describe("space-labels", () => {
       ]);
       expect(snapshot.cells[0].entries.map((entry) => entry.confidentiality))
         .toEqual([[{ type: "foreign-secret", name: "foreign-secret" }]]);
+    });
+
+    it("records the path of a link the walk could not follow", async () => {
+      const snapshot = await readAgainstDid([`/${LINKER}`]);
+      expect(snapshot.cells[0].unreadPaths).toEqual([
+        { path: ["theirs"], reason: "cross-space" },
+      ]);
+      expect(snapshot.cells[0].unreadReason).toBe(undefined);
+    });
+
+    it("records every spaced link of a cell as unread against a database naming no space", async () => {
+      const snapshot = await read([`/${LINKER}`]);
+      expect(snapshot.cells[0].unreadPaths).toEqual([
+        { path: ["ours"], reason: "space-unproven" },
+        { path: ["theirs"], reason: "space-unproven" },
+      ]);
+    });
+
+    it("records no unread path for a cell whose links were all followed", async () => {
+      const snapshot = await readAgainstDid([`/${DECLARED}`]);
+      expect(snapshot.cells[0].unreadPaths).toBe(undefined);
     });
 
     it("returns an unavailable snapshot naming the space when no database is found", async () => {

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -66,6 +66,14 @@ const COLLIDING = entity("colliding");
 /** A document whose links reach the colliding id in three spaces. */
 const LINKER = entity("linker");
 
+/**
+ * A document holding no link at its top level: one sits inside an object, one
+ * beside it reaches another space, and a third sits inside an array. Each is
+ * one hop from this document however deep in its value it sits, so each is
+ * either followed or recorded unread at the whole path it sits at.
+ */
+const NESTER = entity("nester");
+
 /** One stored link, in the at-rest sigil form the store holds. */
 const link = (id: string, space?: string) => ({
   "/": {
@@ -177,6 +185,16 @@ const documents: Record<string, unknown> = {
       theirs: link(COLLIDING, FOREIGN_DID),
     },
   },
+  [NESTER]: {
+    value: {
+      nested: {
+        mine: link(COLLIDING),
+        theirs: link(COLLIDING, FOREIGN_DID),
+      },
+      list: [{ ours: link(COLLIDING, OWN_DID) }],
+      plain: "no link here",
+    },
+  },
   [COMMITTED]: {
     value: { attachment: "…" },
     cfc: {
@@ -201,7 +219,7 @@ const documents: Record<string, unknown> = {
 };
 
 /** The documents written as plain JSON rather than through the codec. */
-const PLAIN = new Set([UNLABELLED, LINKER]);
+const PLAIN = new Set([UNLABELLED, LINKER, NESTER]);
 
 /**
  * A stored `revision.data` payload. Most documents go in through the codec,
@@ -421,8 +439,8 @@ describe("space-labels", () => {
     it("returns the labels of the linked cells naming no space and naming the opened one", () => {
       const read = didReader.read({ id: LINKER, scope: "space" });
       expect(read.linked).toEqual([
-        { key: "mine", id: COLLIDING },
-        { key: "ours", id: COLLIDING },
+        { path: ["mine"], id: COLLIDING },
+        { path: ["ours"], id: COLLIDING },
       ]);
       expect(read.entries).toEqual([
         {
@@ -444,7 +462,9 @@ describe("space-labels", () => {
 
     it("returns no entry under a link into another space holding an id this space also holds", () => {
       const read = didReader.read({ id: LINKER, scope: "space" });
-      expect(read.linked.map((cell) => cell.key)).not.toContain("theirs");
+      expect(read.linked.map((cell) => cell.path)).not.toContainEqual([
+        "theirs",
+      ]);
       expect(read.entries.map((entry) => entry.path[0])).not.toContain(
         "theirs",
       );
@@ -459,7 +479,7 @@ describe("space-labels", () => {
 
     it("returns only the link naming no space when the opened file proves no DID", () => {
       const read = reader.read({ id: LINKER, scope: "space" });
-      expect(read.linked).toEqual([{ key: "mine", id: COLLIDING }]);
+      expect(read.linked).toEqual([{ path: ["mine"], id: COLLIDING }]);
       expect(read.entries.map((entry) => entry.path)).toEqual([["mine"]]);
     });
 
@@ -468,6 +488,41 @@ describe("space-labels", () => {
       expect(read.unreadPaths).toEqual([
         { path: ["ours"], reason: "space-unproven" },
         { path: ["theirs"], reason: "space-unproven" },
+      ]);
+    });
+
+    it("returns the labels of a link nested inside the value under its whole path", () => {
+      const read = didReader.read({ id: NESTER, scope: "space" });
+      expect(read.entries).toEqual([
+        {
+          path: ["nested", "mine"],
+          confidentiality: [{ type: "foreign-secret", name: "foreign-secret" }],
+          integrity: [],
+          origin: "declared",
+          source: COLLIDING,
+        },
+        {
+          path: ["list", "0", "ours"],
+          confidentiality: [{ type: "foreign-secret", name: "foreign-secret" }],
+          integrity: [],
+          origin: "declared",
+          source: COLLIDING,
+        },
+      ]);
+    });
+
+    it("returns an array index as a path segment of a link held in an array", () => {
+      const read = didReader.read({ id: NESTER, scope: "space" });
+      expect(read.linked).toEqual([
+        { path: ["nested", "mine"], id: COLLIDING },
+        { path: ["list", "0", "ours"], id: COLLIDING },
+      ]);
+    });
+
+    it("returns the whole path of a nested link into another space as unread", () => {
+      const read = didReader.read({ id: NESTER, scope: "space" });
+      expect(read.unreadPaths).toEqual([
+        { path: ["nested", "theirs"], reason: "cross-space" },
       ]);
     });
 
@@ -564,6 +619,17 @@ describe("space-labels", () => {
         { path: ["theirs"], reason: "cross-space" },
       ]);
       expect(snapshot.cells[0].unreadReason).toBe(undefined);
+    });
+
+    it("records the whole path of a nested link the walk could not follow", async () => {
+      const snapshot = await readAgainstDid([`/${NESTER}`]);
+      expect(snapshot.cells[0].unreadPaths).toEqual([
+        { path: ["nested", "theirs"], reason: "cross-space" },
+      ]);
+      expect(snapshot.cells[0].entries.map((entry) => entry.path)).toEqual([
+        ["nested", "mine"],
+        ["list", "0", "ours"],
+      ]);
     });
 
     it("records every spaced link of a cell as unread against a database naming no space", async () => {

--- a/packages/patterns/baselines/cfc-input-cell-demo/briefing.tsx/20260828T041445Z-xK1PX5XOqtJknIj6.json
+++ b/packages/patterns/baselines/cfc-input-cell-demo/briefing.tsx/20260828T041445Z-xK1PX5XOqtJknIj6.json
@@ -1,0 +1,78 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "city": {
+        "type": "string"
+      },
+      "secret": {
+        "ifc": {
+          "confidentiality": [
+            "demo-secret"
+          ]
+        },
+        "type": "string"
+      }
+    },
+    "required": [
+      "secret",
+      "city"
+    ],
+    "type": "object"
+  },
+  "pattern": "cfc-input-cell-demo/briefing.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "ifc": {
+      "confidentiality": [
+        "demo-secret"
+      ]
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "briefing": {
+        "type": "string"
+      },
+      "climate": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "briefing",
+      "climate"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cfc-input-cell-demo/seed.tsx/20260828T041445Z-77e4kMM67vF8OWFf.json
+++ b/packages/patterns/baselines/cfc-input-cell-demo/seed.tsx/20260828T041445Z-77e4kMM67vF8OWFf.json
@@ -1,0 +1,91 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "city": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Lisbon",
+        "type": "string"
+      },
+      "secret": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "codeword osprey",
+        "ifc": {
+          "confidentiality": [
+            "demo-secret"
+          ]
+        },
+        "type": "string"
+      }
+    },
+    "required": [
+      "secret",
+      "city"
+    ],
+    "type": "object"
+  },
+  "pattern": "cfc-input-cell-demo/seed.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "ifc": {
+      "confidentiality": [
+        "demo-secret"
+      ]
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "city": {
+        "type": "string"
+      },
+      "secret": {
+        "ifc": {
+          "confidentiality": [
+            "demo-secret"
+          ]
+        },
+        "type": "string"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "secret",
+      "city"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/cfc-input-cell-demo/README.md
+++ b/packages/patterns/cfc-input-cell-demo/README.md
@@ -1,0 +1,85 @@
+# CFC input-cell demo
+
+Two patterns that put a labelled cell in front of a cf-harness run and let it
+compose over one without reading it, so the console has something to draw. The
+pair is the smallest arrangement that separates the two facts a per-cell label
+carries: what a cell is labelled, and whether that label was derived or merely
+carried in.
+
+- **`seed.tsx`** — the cells the run is pointed at, deployed before the run
+  exists. `secret` declares a confidentiality atom; `city` declares none.
+- **`briefing.tsx`** — what the run composes. `briefing` mixes both cells, so
+  the space derives a label for it and records the lifted function that did the
+  deriving; `climate` reads only `city`, so it derives nothing.
+
+## Running it
+
+A local toolshed and a matched client, per
+[`LOCAL_DEV_SERVERS.md`](../../../docs/development/LOCAL_DEV_SERVERS.md). Every
+command below wants `-i <keyfile> -a http://localhost:8000 -s <space>`; the
+space is named by name, because the console composes a URL from it.
+
+Deploy the seed and read the address of each cell it exposes:
+
+```sh
+deno task cf piece new packages/patterns/cfc-input-cell-demo/seed.tsx \
+  --root . -i "$CF_KEY" -a http://localhost:8000 -s "$CF_SPACE"
+
+deno task cf get --piece "$SEED_PIECE" --select 'secret@,city@' \
+  -i "$CF_KEY" -a http://localhost:8000 -s "$CF_SPACE"
+```
+
+Hand both to a run as input cells. The names are operator-authored prose and are
+the whole of what the model is told each token stands for — the values
+themselves never enter the prompt:
+
+The sandbox's two CFC transport directories are named explicitly: an enforcing
+run refuses to start without them rather than degrading quietly.
+
+```sh
+deno task --cwd packages/cf-harness run \
+  --fabric-api-url http://localhost:8000 \
+  --fabric-identity "$CF_KEY" \
+  --fabric-space "$CF_SPACE" \
+  --fabric-cfc-posture max-enforcement \
+  --cfc-result-dir .cf-harness-console/cfc/results \
+  --cfc-invocation-context-dir .cf-harness-console/cfc/invocation-context \
+  --input-cell secret="$SECRET_LINK" \
+  --input-cell city="$CITY_LINK" \
+  --artifact-root .cf-harness-console/runs \
+  --prompt "Run a Common Fabric pattern over the two cells you hold handles for.
+Call run_pattern once, passing sourceText exactly as given below and wiring
+secret and city to the handles of those names. Do not restate any value.
+
+sourceText:
+$(cat packages/patterns/cfc-input-cell-demo/briefing.tsx)"
+```
+
+The pattern's source rides in the prompt because it is the pattern that is
+checked in — a run that composed one for itself would be demonstrating the model
+rather than the labels. Source is not what the arrangement withholds; the cells
+are.
+
+`--artifact-root` points at the console's own run tree, so the console reads the
+run back without being told where it is. Then open the run:
+
+```sh
+deno task --cwd packages/cf-harness console
+```
+
+## What the console shows
+
+The `run_pattern` call reads two cells and produces one. Opening the produced
+cell's chip:
+
+- `secret` carries its declared atom, `origin: declared`.
+- `city` carries no label, under a run whose snapshot was taken — which the map
+  header states, so the empty chip reads as a fact about the cell rather than
+  about the page.
+- The result carries the atom `secret` contributed, `origin: derived`, and the
+  provenance atom naming the lifted function that derived it.
+
+That last line is the one worth checking against the second and third. A result
+object's label is the join of its fields, so a confidentiality atom on its own
+does not say a value was computed from something confidential. The `derived`
+origin and the provenance beside it do.

--- a/packages/patterns/cfc-input-cell-demo/briefing.test.tsx
+++ b/packages/patterns/cfc-input-cell-demo/briefing.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Test Pattern: CFC input-cell demo briefing
+ *
+ * The pair of results is the point of the pattern: `briefing` reads both cells
+ * and `climate` reads only `city`. A test can hold that to the data it can
+ * see — `briefing` carries both operands, `climate` is unmoved by the secret
+ * and takes each of its branches — while the labels the two results carry are
+ * store state a pattern never returns, and are covered where that state lives.
+ *
+ * Run: deno task cf test packages/patterns/cfc-input-cell-demo/briefing.test.tsx --verbose
+ */
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
+import Briefing from "./briefing.tsx";
+
+export default pattern(() => {
+  const lisbon = Briefing({ secret: "codeword osprey", city: "Lisbon" });
+  // Same city, different secret: `climate` must not move, `briefing` must.
+  const lisbonOtherSecret = Briefing({
+    secret: "codeword kestrel",
+    city: "Lisbon",
+  });
+  // Odd-length city, for `climate`'s other branch.
+  const porto = Briefing({ secret: "codeword osprey", city: "Porto" });
+
+  // A city held in a cell, so both results can be watched across a rewrite.
+  const cityCell = new Writable("Lisbon");
+  const reseeded = Briefing({ secret: "codeword petrel", city: cityCell });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_move_to_an_odd_length_city = action(() => {
+    cityCell.set("Porto");
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_briefing_composes_both_inputs = assert(() =>
+    lisbon.briefing === "Agent stationed in Lisbon; codeword is codeword osprey"
+  );
+  const assert_briefing_names_the_city = assert(() =>
+    lisbon.briefing.includes("Lisbon")
+  );
+  const assert_briefing_carries_the_secret = assert(() =>
+    lisbon.briefing.includes("codeword osprey")
+  );
+  const assert_briefing_follows_the_secret = assert(() =>
+    lisbonOtherSecret.briefing ===
+      "Agent stationed in Lisbon; codeword is codeword kestrel"
+  );
+
+  const assert_climate_ignores_the_secret = assert(() =>
+    lisbon.climate === lisbonOtherSecret.climate
+  );
+  const assert_climate_omits_the_secret = assert(() =>
+    !lisbon.climate.includes("osprey")
+  );
+  const assert_even_length_city_is_coastal = assert(() =>
+    lisbon.climate === "coastal"
+  );
+  const assert_odd_length_city_is_inland = assert(() =>
+    porto.climate === "inland"
+  );
+
+  const assert_reseeded_starts_coastal = assert(() =>
+    reseeded.climate === "coastal"
+  );
+  const assert_reseeded_turns_inland = assert(() =>
+    reseeded.climate === "inland"
+  );
+  const assert_reseeded_briefing_follows_the_city = assert(() =>
+    reseeded.briefing ===
+      "Agent stationed in Porto; codeword is codeword petrel"
+  );
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    [TESTS]: [
+      { assertion: assert_briefing_composes_both_inputs },
+      { assertion: assert_briefing_names_the_city },
+      { assertion: assert_briefing_carries_the_secret },
+      { assertion: assert_briefing_follows_the_secret },
+
+      { assertion: assert_climate_ignores_the_secret },
+      { assertion: assert_climate_omits_the_secret },
+      { assertion: assert_even_length_city_is_coastal },
+      { assertion: assert_odd_length_city_is_inland },
+
+      { assertion: assert_reseeded_starts_coastal },
+      { action: action_move_to_an_odd_length_city },
+      { assertion: assert_reseeded_turns_inland },
+      { assertion: assert_reseeded_briefing_follows_the_city },
+    ],
+    lisbon,
+    lisbonOtherSecret,
+    porto,
+    reseeded,
+  };
+});

--- a/packages/patterns/cfc-input-cell-demo/briefing.tsx
+++ b/packages/patterns/cfc-input-cell-demo/briefing.tsx
@@ -1,0 +1,34 @@
+/**
+ * The pattern a cf-harness run composes over the seeded cells.
+ *
+ * `run_pattern` is given this source and the two handles the operator seeded,
+ * so the run reads both cells without the model ever holding either value.
+ *
+ * Two results, deliberately unalike. `briefing` mixes the confidential cell
+ * with the plain one, so the space derives a label for it and records the
+ * lifted function that did the deriving. `climate` reads only the plain cell,
+ * so it derives no label at all. A reader that colored a cell by the label its
+ * containing object carries would call both confidential; the difference lives
+ * in each cell's own derived label.
+ */
+import { type Confidential, lift, NAME, pattern, UI } from "commonfabric";
+
+interface State {
+  secret: Confidential<string, readonly ["demo-secret"]>;
+  city: string;
+}
+
+const briefingOf = lift<{ city: string; secret: string }, string>(
+  ({ city, secret }) => `Agent stationed in ${city}; codeword is ${secret}`,
+);
+
+const climateOf = lift<{ city: string }, string>(({ city }) =>
+  city.length % 2 === 0 ? "coastal" : "inland"
+);
+
+export default pattern<State>(({ secret, city }) => ({
+  [NAME]: "CFC input-cell demo briefing",
+  [UI]: <div>A briefing was derived for {city}.</div>,
+  briefing: briefingOf({ city, secret }),
+  climate: climateOf({ city }),
+}));

--- a/packages/patterns/cfc-input-cell-demo/seed.test.tsx
+++ b/packages/patterns/cfc-input-cell-demo/seed.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Test Pattern: CFC input-cell demo seed
+ *
+ * The seed's whole job is to put two named cells in front of a run, so what a
+ * test holds it to is that both are exposed and that each reads back what the
+ * operator seeded: the declared default when nothing was passed, and the cell
+ * itself when one was. The confidentiality atom `secret` declares is a fact
+ * about that cell in the space rather than about this pattern's output, so
+ * nothing here asserts on it.
+ *
+ * Run: deno task cf test packages/patterns/cfc-input-cell-demo/seed.test.tsx --verbose
+ */
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
+import Seed from "./seed.tsx";
+
+export default pattern(() => {
+  // `seed.tsx` declares both inputs as required properties, so a bare `{}` is
+  // not assignable to the factory's argument even though each input carries a
+  // `Default<>`. Naming the argument type is what lets a test observe the
+  // declared defaults at all.
+  const unseeded = Seed({} as Parameters<typeof Seed>[0]);
+
+  const secretCell = new Writable("codeword kestrel");
+  const cityCell = new Writable("Porto");
+  const seeded = Seed({ secret: secretCell, city: cityCell });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_reseed_city = action(() => {
+    cityCell.set("Reykjavik");
+  });
+
+  const action_reseed_secret = action(() => {
+    secretCell.set("codeword petrel");
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_default_secret = assert(() =>
+    unseeded.secret === "codeword osprey"
+  );
+  const assert_default_city = assert(() => unseeded.city === "Lisbon");
+
+  const assert_seeded_secret = assert(() =>
+    seeded.secret === "codeword kestrel"
+  );
+  const assert_seeded_city = assert(() => seeded.city === "Porto");
+
+  // Each cell is exposed as itself, not as a copy taken at instantiation, so a
+  // write through the cell an operator holds is what the run reads back.
+  const assert_city_follows_its_cell = assert(() =>
+    seeded.city === "Reykjavik"
+  );
+  const assert_secret_follows_its_cell = assert(() =>
+    seeded.secret === "codeword petrel"
+  );
+
+  // Seeding one instantiation leaves another's defaults where they were.
+  const assert_defaults_are_independent = assert(() =>
+    unseeded.secret === "codeword osprey" && unseeded.city === "Lisbon"
+  );
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    [TESTS]: [
+      { assertion: assert_default_secret },
+      { assertion: assert_default_city },
+      { assertion: assert_seeded_secret },
+      { assertion: assert_seeded_city },
+      { action: action_reseed_city },
+      { assertion: assert_city_follows_its_cell },
+      { action: action_reseed_secret },
+      { assertion: assert_secret_follows_its_cell },
+      { assertion: assert_defaults_are_independent },
+    ],
+    unseeded,
+    seeded,
+  };
+});

--- a/packages/patterns/cfc-input-cell-demo/seed.tsx
+++ b/packages/patterns/cfc-input-cell-demo/seed.tsx
@@ -1,0 +1,39 @@
+/**
+ * The cells a cf-harness run is pointed at, before the run exists.
+ *
+ * An operator deploys this piece, then names two of its cells to a run with
+ * `--input-cell secret=<link> --input-cell city=<link>`. The model holds a
+ * handle for each and never the value behind it.
+ *
+ * The pair is the point: `secret` carries a declared confidentiality atom and
+ * `city` carries none, so a pattern run over both derives a value the space
+ * labels and a value it does not. Reading the two back is what says a
+ * per-cell label is a fact about that cell rather than about the run.
+ */
+import {
+  type Confidential,
+  Default,
+  NAME,
+  pattern,
+  UI,
+  Writable,
+} from "commonfabric";
+
+interface State {
+  secret: Writable<
+    | Confidential<string, readonly ["demo-secret"]>
+    | Default<"codeword osprey">
+  >;
+  city: Writable<string | Default<"Lisbon">>;
+}
+
+export default pattern<State>(({ secret, city }) => ({
+  [NAME]: "CFC input-cell demo seed",
+  [UI]: (
+    <div>
+      <p>Seeded for {city}. The confidential cell is not rendered here.</p>
+    </div>
+  ),
+  secret,
+  city,
+}));

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -20,7 +20,7 @@ import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isPlainObject } from "@commonfabric/utils/types";
+import { isObjectNotArray, isPlainObject } from "@commonfabric/utils/types";
 
 /** Decode a stored payload string, routing the `data-model` codec envelope. */
 export function decodeStored(data: string): unknown {
@@ -642,6 +642,95 @@ export function summarize(v: Json): string {
     return quoteTerminalText(preview);
   }
   return escapeTerminalText(String(v));
+}
+
+/** One link found inside a value, and the path within that value it sits at. */
+export interface LinkAtPath {
+  link: DecodedLink;
+
+  /**
+   * Where the link sits, as path segments from the walked value's root. An
+   * array index is a segment like any other.
+   *
+   * Segments arrive as an array rather than as one joined string because a
+   * segment is an arbitrary key: one holding `/`, or `~`, is a key the store
+   * writes like any other, and joining it makes it indistinguishable from two
+   * segments. A caller that wants a joined form joins at the point it knows
+   * what the joined form is for.
+   */
+  at: readonly string[];
+}
+
+/**
+ * How far a link walk reaches. There is no default here, because the two
+ * bounds trade completeness against work and only the caller knows which way
+ * it wants that traded. A caller rendering a value for a reader may stop
+ * early, since a link it never shows costs the reader nothing. A caller for
+ * which a link missed is indistinguishable from a value that holds no link
+ * cannot, and sets bounds far above any value it expects to meet.
+ */
+export interface LinkWalkBounds {
+  /**
+   * The longest path the walk descends to. A value at a deeper path is not
+   * visited, so a link sitting there is not reported.
+   */
+  maxDepth: number;
+
+  /**
+   * The most values the walk visits.
+   *
+   * A decoded document is plain JSON — finite and acyclic — so the walk ends
+   * on its own, and its cost is the size of a value the store has already
+   * decoded into memory. This bound is against the value that is not that: a
+   * malformed row, or an at-rest form restoring as an object graph with a
+   * cycle in it, is otherwise walked forever. `maxDepth` settles that on its
+   * own only while it is small, because a cycle that branches two ways costs
+   * exponentially in the depth — so the node count is what makes the work
+   * finite at a large depth, and the depth is what keeps one deep chain cheap.
+   */
+  maxNodes: number;
+}
+
+/**
+ * Every link in a value, in either at-rest form, each with the path inside the
+ * value it sits at. The walk descends the objects and arrays of the value and
+ * stops at each link it meets, so a linked value's own links belong to that
+ * value rather than to this one.
+ *
+ * It is generic over shape rather than over an enumeration of the places a
+ * link may appear: `decodedLinkOf` is the whole of the link knowledge in it,
+ * which is why no caller keeps a list of link-bearing keys in step with the
+ * ones the store writes. Every link reachable within `bounds` is found.
+ *
+ * Links come back in the order the walk meets them, depth first, with an
+ * object's keys in `Object.entries` order and an array's items in index order.
+ */
+export function linksWithPaths(
+  v: Json,
+  bounds: LinkWalkBounds,
+): LinkAtPath[] {
+  const found: LinkAtPath[] = [];
+  let budget = bounds.maxNodes;
+  const walk = (held: Json, at: readonly string[]): void => {
+    if (budget <= 0 || at.length > bounds.maxDepth) return;
+    budget -= 1;
+    const link = decodedLinkOf(held);
+    if (link) {
+      found.push({ link, at });
+      return;
+    }
+    if (Array.isArray(held)) {
+      held.forEach((item, index) => walk(item, [...at, String(index)]));
+      return;
+    }
+    if (isObjectNotArray(held)) {
+      for (const [key, child] of Object.entries(held)) {
+        walk(child, [...at, key]);
+      }
+    }
+  };
+  walk(v, []);
+  return found;
 }
 
 /** Collect every link reachable in a value (does not descend into links). */

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -692,15 +692,50 @@ export interface LinkWalkBounds {
 }
 
 /**
- * Every link in a value, in either at-rest form, each with the path inside the
- * value it sits at. The walk descends the objects and arrays of the value and
- * stops at each link it meets, so a linked value's own links belong to that
- * value rather than to this one.
+ * What a bounded walk found, and where it stopped short of finding more. The
+ * two ways it stops are separate fields because they state different things,
+ * and a caller that treated either as the other would overstate what it knows.
+ */
+export interface LinkWalk {
+  /** The links found, in the order the walk met them. */
+  links: LinkAtPath[];
+
+  /**
+   * The paths the walk did not descend into because they sit deeper than
+   * `maxDepth`, one per value it refused at. Nothing was read at such a path
+   * or under it, so a link there is neither reported nor ruled out — and the
+   * statement is exact, because every path of the value not at or under one
+   * of these was walked.
+   */
+  tooDeep: readonly (readonly string[])[];
+
+  /**
+   * Whether `maxNodes` ran out, which stops the walk wherever it had reached.
+   * This is a statement about the walk rather than about a path: the values
+   * it never visited were never enumerated, so nothing names them, and
+   * `links` is some of the value's links rather than all of them. A caller
+   * may not read a path's absence from `links` as the value holding no link
+   * there.
+   */
+  budgetExhausted: boolean;
+}
+
+/**
+ * Every link in a value that `bounds` reaches, in either at-rest form, each
+ * with the path inside the value it sits at — and, beside them, where the
+ * bounds stopped the walk. The walk descends the objects and arrays of the
+ * value and stops at each link it meets, so a linked value's own links belong
+ * to that value rather than to this one.
  *
  * It is generic over shape rather than over an enumeration of the places a
  * link may appear: `decodedLinkOf` is the whole of the link knowledge in it,
  * which is why no caller keeps a list of link-bearing keys in step with the
- * ones the store writes. Every link reachable within `bounds` is found.
+ * ones the store writes.
+ *
+ * A link past `bounds` is not found, and a caller for which a link missed and
+ * a value holding none read alike must take `tooDeep` and `budgetExhausted`
+ * with the links: they are what say that the found set is partial, and which
+ * part of the value the walk can say nothing about.
  *
  * Links come back in the order the walk meets them, depth first, with an
  * object's keys in `Object.entries` order and an array's items in index order.
@@ -708,15 +743,28 @@ export interface LinkWalkBounds {
 export function linksWithPaths(
   v: Json,
   bounds: LinkWalkBounds,
-): LinkAtPath[] {
-  const found: LinkAtPath[] = [];
+): LinkWalk {
+  const links: LinkAtPath[] = [];
+  const tooDeep: (readonly string[])[] = [];
   let budget = bounds.maxNodes;
+  let budgetExhausted = false;
   const walk = (held: Json, at: readonly string[]): void => {
-    if (budget <= 0 || at.length > bounds.maxDepth) return;
+    if (budgetExhausted) return;
+    // Budget before depth: once the budget is gone the walk is over, and a
+    // path it declines from there is one it never reached rather than one it
+    // reached and refused, which is not a fact `tooDeep` may carry.
+    if (budget <= 0) {
+      budgetExhausted = true;
+      return;
+    }
+    if (at.length > bounds.maxDepth) {
+      tooDeep.push(at);
+      return;
+    }
     budget -= 1;
     const link = decodedLinkOf(held);
     if (link) {
-      found.push({ link, at });
+      links.push({ link, at });
       return;
     }
     if (Array.isArray(held)) {
@@ -730,7 +778,7 @@ export function linksWithPaths(
     }
   };
   walk(v, []);
-  return found;
+  return { links, tooDeep, budgetExhausted };
 }
 
 /** Collect every link reachable in a value (does not descend into links). */

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -20,8 +20,9 @@ import {
 import type { SpaceDb } from "./db.ts";
 import {
   annotate,
-  type DecodedLink,
   decodedLinkOf,
+  linksWithPaths,
+  type LinkWalkBounds,
   parseSigilLink,
   summarize,
 } from "./decode.ts";
@@ -269,30 +270,18 @@ function declaredSchemaFor(
   return undefined;
 }
 
-/** Collect every link in a value, in either at-rest form, with its JSON path. */
-function linksWithPaths(
-  v: unknown,
-  base: string[] = [],
-  out: { link: DecodedLink; at: string }[] = [],
-  depth = 10,
-): { link: DecodedLink; at: string }[] {
-  if (depth < 0) return out;
-  const link = decodedLinkOf(v);
-  if (link) {
-    out.push({ link, at: base.join("/") });
-    return out;
-  }
-  if (isObjectNotArray(v)) {
-    for (const [k, val] of Object.entries(v)) {
-      linksWithPaths(val, [...base, k], out, depth - 1);
-    }
-  } else if (Array.isArray(v)) {
-    v.forEach((val, i) =>
-      linksWithPaths(val, [...base, String(i)], out, depth - 1)
-    );
-  }
-  return out;
-}
+/**
+ * How far a detail's link walks reach. A detail describes ONE entity for a
+ * reader, and the rendering it feeds is itself depth-bounded, so a link past
+ * ten levels of nesting is one no reader of this output would have seen
+ * anyway. That depth is small enough to bound the walk's work on its own —
+ * see `LinkWalkBounds` for why a larger one would not be — so no node count is
+ * imposed on top of it.
+ */
+const DETAIL_LINK_WALK: LinkWalkBounds = {
+  maxDepth: 10,
+  maxNodes: Number.POSITIVE_INFINITY,
+};
 
 interface DetailContext {
   ownDid: string;
@@ -353,7 +342,7 @@ function detailFromDoc(
   if (c.kind === "piece" && c.regime === "legacy" && isObjectNotArray(value)) {
     const rid = legacyResultId(value);
     if (rid) lineage.result = refTo(rid, ctx);
-    const internalIds = linksWithPaths(value.internal)
+    const internalIds = linksWithPaths(value.internal, DETAIL_LINK_WALK)
       .map((l) => l.link.id).filter((x): x is string => !!x);
     if (internalIds.length) {
       lineage.internal = internalIds.map((cid) => refTo(cid, ctx)!);
@@ -380,19 +369,21 @@ function detailFromDoc(
   }
 
   // outgoing links, resolved
-  const outLinks: LinkRef[] = linksWithPaths(value).map(({ link, at }) => {
-    const external = !!link.space && link.space !== ctx.ownDid &&
-      link.space !== `did:key:${ctx.ownDid}`;
-    return {
-      id: link.id ?? "?",
-      label: link.id ? ctx.labelOf.get(link.id)?.label : undefined,
-      kind: link.id ? ctx.labelOf.get(link.id)?.kind : undefined,
-      space: link.space,
-      path: link.path ? [...link.path] : undefined,
-      external,
-      at,
-    };
-  });
+  const outLinks: LinkRef[] = linksWithPaths(value, DETAIL_LINK_WALK).map(
+    ({ link, at }) => {
+      const external = !!link.space && link.space !== ctx.ownDid &&
+        link.space !== `did:key:${ctx.ownDid}`;
+      return {
+        id: link.id ?? "?",
+        label: link.id ? ctx.labelOf.get(link.id)?.label : undefined,
+        kind: link.id ? ctx.labelOf.get(link.id)?.kind : undefined,
+        space: link.space,
+        path: link.path ? [...link.path] : undefined,
+        external,
+        at: at.join("/"),
+      };
+    },
+  );
 
   // module source
   let code: string | undefined;

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -342,7 +342,10 @@ function detailFromDoc(
   if (c.kind === "piece" && c.regime === "legacy" && isObjectNotArray(value)) {
     const rid = legacyResultId(value);
     if (rid) lineage.result = refTo(rid, ctx);
-    const internalIds = linksWithPaths(value.internal, DETAIL_LINK_WALK)
+    // The links alone: a detail is a rendering, and this one is bounded to a
+    // depth its own output would not have shown past, so where the walk
+    // stopped changes nothing a reader of it could act on.
+    const internalIds = linksWithPaths(value.internal, DETAIL_LINK_WALK).links
       .map((l) => l.link.id).filter((x): x is string => !!x);
     if (internalIds.length) {
       lineage.internal = internalIds.map((cid) => refTo(cid, ctx)!);
@@ -368,8 +371,9 @@ function detailFromDoc(
     lineage.pattern = ref;
   }
 
-  // outgoing links, resolved
-  const outLinks: LinkRef[] = linksWithPaths(value, DETAIL_LINK_WALK).map(
+  // outgoing links, resolved. The links alone, for the reason above: this
+  // list is shown to a reader rather than reasoned over.
+  const outLinks: LinkRef[] = linksWithPaths(value, DETAIL_LINK_WALK).links.map(
     ({ link, at }) => {
       const external = !!link.space && link.space !== ctx.ownDid &&
         link.space !== `did:key:${ctx.ownDid}`;

--- a/packages/state-inspector/test/linksWithPaths.test.ts
+++ b/packages/state-inspector/test/linksWithPaths.test.ts
@@ -18,7 +18,7 @@ const unbounded = {
 
 describe("linksWithPaths()", () => {
   it("returns the empty path for a link that is the whole value", () => {
-    expect(linksWithPaths(linkTo("of:root"), unbounded)).toEqual([
+    expect(linksWithPaths(linkTo("of:root"), unbounded).links).toEqual([
       { link: { id: "of:root" }, at: [] },
     ]);
   });
@@ -27,7 +27,7 @@ describe("linksWithPaths()", () => {
     const found = linksWithPaths(
       { outer: { inner: linkTo("of:nested") } },
       unbounded,
-    );
+    ).links;
     expect(found.map(({ link, at }) => [link.id, at])).toEqual([
       ["of:nested", ["outer", "inner"]],
     ]);
@@ -37,7 +37,7 @@ describe("linksWithPaths()", () => {
     const found = linksWithPaths(
       { items: ["first", linkTo("of:second"), { deep: linkTo("of:third") }] },
       unbounded,
-    );
+    ).links;
     expect(found.map(({ link, at }) => [link.id, at])).toEqual([
       ["of:second", ["items", "1"]],
       ["of:third", ["items", "2", "deep"]],
@@ -46,7 +46,8 @@ describe("linksWithPaths()", () => {
 
   it("returns a key containing `/` and `~` as a single segment", () => {
     const key = "a/b~c";
-    const found = linksWithPaths({ [key]: linkTo("of:awkward") }, unbounded);
+    const found = linksWithPaths({ [key]: linkTo("of:awkward") }, unbounded)
+      .links;
     expect(found).toEqual([{ link: { id: "of:awkward" }, at: [key] }]);
     // The whole point of segment arrays: joined, this key is indistinguishable
     // from the two-segment path `["a", "b~c"]`.
@@ -58,22 +59,66 @@ describe("linksWithPaths()", () => {
       a: { b: linkTo("of:at-two"), c: { d: linkTo("of:at-three") } },
     };
     const found = linksWithPaths(value, { ...unbounded, maxDepth: 2 });
-    expect(found.map(({ link }) => link.id)).toEqual(["of:at-two"]);
+    expect(found.links.map(({ link }) => link.id)).toEqual(["of:at-two"]);
+  });
+
+  it("reports the path it refused to descend to as too deep", () => {
+    const value = {
+      a: { b: linkTo("of:at-two"), c: { d: linkTo("of:at-three") } },
+    };
+    const found = linksWithPaths(value, { ...unbounded, maxDepth: 2 });
+    // The path of the value it declined to visit, not of the container it
+    // declined from: the container was read, and reported as holding no link.
+    expect(found.tooDeep).toEqual([["a", "c", "d"]]);
+    expect(found.budgetExhausted).toBe(false);
+  });
+
+  it("reports nothing stopped early for a walk that reached every value", () => {
+    const found = linksWithPaths(
+      { a: { b: linkTo("of:reached") } },
+      unbounded,
+    );
+    expect(found.tooDeep).toEqual([]);
+    expect(found.budgetExhausted).toBe(false);
   });
 
   it("stops at `maxNodes`, so a link past the budget is not returned", () => {
     const value = { a: linkTo("of:first"), b: linkTo("of:second") };
     // The root object is one node, and each of its two children is another.
     expect(
-      linksWithPaths(value, { ...unbounded, maxNodes: 2 }).map((f) =>
+      linksWithPaths(value, { ...unbounded, maxNodes: 2 }).links.map((f) =>
         f.link.id
       ),
     ).toEqual(["of:first"]);
     expect(
-      linksWithPaths(value, { ...unbounded, maxNodes: 3 }).map((f) =>
+      linksWithPaths(value, { ...unbounded, maxNodes: 3 }).links.map((f) =>
         f.link.id
       ),
     ).toEqual(["of:first", "of:second"]);
+  });
+
+  it("reports the budget as exhausted when a link is left past it", () => {
+    const value = { a: linkTo("of:first"), b: linkTo("of:second") };
+    const found = linksWithPaths(value, { ...unbounded, maxNodes: 2 });
+    expect(found.budgetExhausted).toBe(true);
+    // No path for what it missed: the walk stopped before enumerating what
+    // was left, so `b` is not a path it can claim to have declined.
+    expect(found.tooDeep).toEqual([]);
+  });
+
+  it("reports the budget as intact for a walk that spent all of it and finished", () => {
+    const value = { a: linkTo("of:first"), b: linkTo("of:second") };
+    expect(
+      linksWithPaths(value, { ...unbounded, maxNodes: 3 }).budgetExhausted,
+    ).toBe(false);
+  });
+
+  it("reports an exhausted budget rather than a depth stop when both bounds bite", () => {
+    const value = { a: { b: { c: linkTo("of:deep") } } };
+    const found = linksWithPaths(value, { maxDepth: 1, maxNodes: 2 });
+    expect(found.links).toEqual([]);
+    expect(found.budgetExhausted).toBe(true);
+    expect(found.tooDeep).toEqual([]);
   });
 
   it("stops at each link, so a link-shaped value inside a link is not walked", () => {
@@ -81,6 +126,6 @@ describe("linksWithPaths()", () => {
       { "/": { "link@1": { id: "of:outer", schema: linkTo("of:inner") } } },
       unbounded,
     );
-    expect(found.map(({ link }) => link.id)).toEqual(["of:outer"]);
+    expect(found.links.map(({ link }) => link.id)).toEqual(["of:outer"]);
   });
 });

--- a/packages/state-inspector/test/linksWithPaths.test.ts
+++ b/packages/state-inspector/test/linksWithPaths.test.ts
@@ -1,0 +1,86 @@
+// The generic link traversal: what it finds, where it says the link sat, and
+// where the caller's bounds stop it.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { linksWithPaths } from "../decode.ts";
+
+/** A link in the legacy at-rest sigil form. */
+const linkTo = (id: string) => ({ "/": { "link@1": { id } } });
+
+/** Bounds that reach every value in these fixtures, so a test that pins a
+ * bound sets only the one it is about. */
+const unbounded = {
+  maxDepth: Number.POSITIVE_INFINITY,
+  maxNodes: Number.POSITIVE_INFINITY,
+};
+
+describe("linksWithPaths()", () => {
+  it("returns the empty path for a link that is the whole value", () => {
+    expect(linksWithPaths(linkTo("of:root"), unbounded)).toEqual([
+      { link: { id: "of:root" }, at: [] },
+    ]);
+  });
+
+  it("returns one segment per key for a link nested in objects", () => {
+    const found = linksWithPaths(
+      { outer: { inner: linkTo("of:nested") } },
+      unbounded,
+    );
+    expect(found.map(({ link, at }) => [link.id, at])).toEqual([
+      ["of:nested", ["outer", "inner"]],
+    ]);
+  });
+
+  it("returns the index as a segment for a link nested in an array", () => {
+    const found = linksWithPaths(
+      { items: ["first", linkTo("of:second"), { deep: linkTo("of:third") }] },
+      unbounded,
+    );
+    expect(found.map(({ link, at }) => [link.id, at])).toEqual([
+      ["of:second", ["items", "1"]],
+      ["of:third", ["items", "2", "deep"]],
+    ]);
+  });
+
+  it("returns a key containing `/` and `~` as a single segment", () => {
+    const key = "a/b~c";
+    const found = linksWithPaths({ [key]: linkTo("of:awkward") }, unbounded);
+    expect(found).toEqual([{ link: { id: "of:awkward" }, at: [key] }]);
+    // The whole point of segment arrays: joined, this key is indistinguishable
+    // from the two-segment path `["a", "b~c"]`.
+    expect(found[0].at.length).toBe(1);
+  });
+
+  it("stops at `maxDepth`, so a link deeper than it is not returned", () => {
+    const value = {
+      a: { b: linkTo("of:at-two"), c: { d: linkTo("of:at-three") } },
+    };
+    const found = linksWithPaths(value, { ...unbounded, maxDepth: 2 });
+    expect(found.map(({ link }) => link.id)).toEqual(["of:at-two"]);
+  });
+
+  it("stops at `maxNodes`, so a link past the budget is not returned", () => {
+    const value = { a: linkTo("of:first"), b: linkTo("of:second") };
+    // The root object is one node, and each of its two children is another.
+    expect(
+      linksWithPaths(value, { ...unbounded, maxNodes: 2 }).map((f) =>
+        f.link.id
+      ),
+    ).toEqual(["of:first"]);
+    expect(
+      linksWithPaths(value, { ...unbounded, maxNodes: 3 }).map((f) =>
+        f.link.id
+      ),
+    ).toEqual(["of:first", "of:second"]);
+  });
+
+  it("stops at each link, so a link-shaped value inside a link is not walked", () => {
+    const found = linksWithPaths(
+      { "/": { "link@1": { id: "of:outer", schema: linkTo("of:inner") } } },
+      unbounded,
+    );
+    expect(found.map(({ link }) => link.id)).toEqual(["of:outer"]);
+  });
+});


### PR DESCRIPTION
## The gap

Per-cell CFC labels exist today, and CT-2076 (E3) proved the whole taint story reconstructs offline. But the labels live in the **space DB**, and the run's artifact tree does not cross-reference them. So every reader working from artifacts alone — the console run reader (#6453) among them — draws a cell with no confidentiality atoms on it, under `max-enforcement` with `cfcFlowLabels: persist`, whatever the run was enforcing. The only labels the console could show sat on `bash` arguments, because `HarnessCfcInvocationContext` is recorded for sandbox operations only.

CT-2076's own framing: *the story is split across the artifact tree and the space DB, which don't cross-reference each other.* This is the cross-reference.

## What this does

- **`src/space-labels.ts`** — a read-only reader over the space SQLite, through `@commonfabric/state-inspector`'s lens. Resolves the run's space by name/DID/path, reads each cell's `cfc` labelMap, and normalizes atoms, `origin`, `observes`, and the `TransformedBy` provenance atom.
- **`src/contracts/cell-labels.ts`** + **`artifacts.ts`** + **`engine.ts`** — `cell-labels.json`, written beside the run. The CLI takes the snapshot when a run's loop ends; the console when a turn does, over the run and its `delegate_task` children.
- **`console/`** — the run reader carries the labels onto every cell it draws, and the map heads with what the run read.
- **`packages/patterns/cfc-input-cell-demo/`** — a checked-in seed (`secret` declared confidential, `city` plain) and a briefing pattern deriving from both, plus the runbook.

## Verified end to end, against a live space

A matched-build toolshed, the seed deployed with `cf piece new`, both cells handed to a real cf-harness run as `--input-cell`, `max-enforcement` with flow labels persisting. The run's `cell-labels.json`:

| cell | atoms | origin | producer |
|---|---|---|---|
| seed `secret` | `demo-secret` | `declared` | — |
| seed `city` | — | — | — |
| piece registry | `demo-secret` | `link` (+ `LinkReference`) | — |
| result `briefing` | `demo-secret` | `derived` | `briefingOf` |
| result `climate` | — | — | — |

That is CT-2076's reconstruction — entry labels, entry edges, the transform, and the negative space — collapsed into one artifact, and rendered in the console: the result chip reads `cell labelled derived` with `transformed by briefingOf`, the seed chips read labelled but carried, and `city` reads bare under a header that says the labels *were* read.

## Three things the design turns on

**Read vs unread.** A cell with no atoms under a snapshot that was taken is a cell the space holds no label for. The same cell on a host with no copy of the space is a cell nobody asked about. `status` keeps them apart, and the map header states the run-level fact so a bare cell reads as a finding rather than a hole.

**Derived vs carried.** CT-2076's second run flagged this (F4): a result object's label is the join of its fields, so a plain input reached through a labelled object carries a confidentiality atom without having been derived. *A renderer that colors by the confidentiality label alone would mislabel plain inputs as tainted.* The chip keys on `origin` and the `TransformedBy` atom, and gives a derived cell its own state.

**A reference is not a document.** Labels are stored per document; a run holds a reference per cell, so a piece's `secret` and `city` are two references into one label set. Lookup narrows to the path a reference walks. Caught by rendering the live run — without it, `city` wore `secret`'s atom, which is F4 one level down.

## Also closes, incidentally

CT-2076 gap 1 — *artifacts never name the space (no `did:key:` anywhere)*. The snapshot records the space it read, its DID, and the database file.

## Hand-offs

- **Thread C (#6471):** `CfcRefusalDetail` (`gate`/`inputs`/`attribution`) renders in the same two places this PR establishes — the cell chip's card and the map header. The label plumbing here is the shape to follow; no change to this PR is needed first.
- **Follow-up, not done here:** `console/src/steps-view.ts` calls `consoleStepArguments(step, this.handles)` without the label index, so an argument written as a whole link that the run holds *no handle for* shows no labels in the timeline pane. Every cell reached through a handle is covered, which is every cell in practice.
- A scoped reference (`/of:…@user`) names a scope kind, not a principal, while the store partitions by principal — so a per-user override's own labels are not addressable from a reference alone, and the read falls back to the base scope. Documented at the point it matters.

## Review

Codex review returned five blocking findings, all verified and all now fixed — four of which had the page state something it could not support:

- **Cross-space references read from the wrong store.** Content-addressed ids repeat across spaces, so resolving a foreign reference against the opened store answers with a different cell's labels. Reproduced by the reviewer with a seeded local collision. Now fail-closed: the opened store's DID is established from the file it was opened from (so an explicit `--space-db` proves its space too), and any reference or one-hop link whose space cannot be *proven* equal is recorded `unreadReason: "cross-space"` and excluded from the console index — nothing known, rather than read-and-unlabelled.
- **Wildcard and JSON Pointer paths were lost to string joining**, so an entry at `items/*` and a key holding a separator each narrowed to nothing — a labelled cell drawn **bare** under a snapshot that read it. Paths are segment arrays end to end now, refs parse through `parseLLMFriendlyLink`, and matching mirrors the runner's `cfcLabelPathPrefixMatches`.
- **A family claimed the root's status for every descendant.** A family whose runs did not all read the space is now read for none of them, with the split in its detail; a run that minted no handle is left out of the vote.
- **The terminal event outran the snapshot**, so the page's one re-read could observe `absent` and stay stale. That envelope's fan-out is now deferred until the snapshot settles, chained so stream order holds, and a failed snapshot still lets the event through.
- **The console loaded sqlite eagerly**, bypassing the engine's lazy import. Now imported at the point of use, after the zero-ref guard.

## Coverage

flush-left marker below accepts the residual rise.

The original rise was 148 lines. Pattern tests for the demo pair paid off all 42 of `packages/patterns` — a pattern file with no LCOV record has every tracked line counted uncovered, so testing them removed the group entirely — and tests for the reader, the run store and the console server took `packages/cf-harness` down to **+22**.

What remains is dominated by the Lit render bodies of `console/src/cell-chip.ts` (50) and `console/src/flow-view.ts` (18). cf-harness has no browser-test setup; `packages/ui` reaches its components through `deno-web-test`, and adding that lane to cf-harness's suite for two view components — with the browser launches it brings — is not proportionate to what it would buy. The pure logic behind both views is unit-tested directly (`cellLabelView`, `cellChipClasses`, `cellName`, `schemaSummary`).

ACCEPT_COVERAGE_DEBT: packages/cf-harness +22 lines

Refs CT-2100, CT-2076, CT-2066 (item 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



