### PR TITLE
feat(memory,runner): revision-keyed schema-walk memo (stages 1-2, flag-gated)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -50,7 +50,7 @@ was last checked against the code.
 | [`messageCompressionV1`](#messagecompressionv1)                             | `setMessageCompressionConfig()` (negotiated per connection)                                                                                     | on                                                                                   | PR #6474                                             | retire the rollback switch after the binary WebSocket envelope has field-soaked                                                                                                                                                   | implemented, on by default                                                      |
 | [`ownWriteEcho`](#ownwriteecho)                                             | `setOwnWriteEchoConfig()` (server-side only, not negotiated)                                                                                    | on                                                                                   | Robin McCollum (CT-1965)                              | remove the switch once the echo has field-soaked                                                                                                                                                                                  | implemented, on by default                                                      |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off                                                                                  | Ben Follington (#4937; shell toggle #4974)            | graduate to always-on after live measurement, or remove if superseded                                                                                                                                                             | implemented behind the flag, off by default, not yet measured over real latency |
-| [`schemaWalkMemo`](#schemawalkmemo)                                         | memory `Server` option `experimentalSchemaWalkMemo` (server-side only; not env-wired)                                                          | off                                                                                  | Gideon Wald (revision-keyed schema memo plan)         | graduate to always-on after the estuary measurement, then delete the option                                                                                                                                                       | implemented behind the flag, off by default                                     |
+| [`schemaWalkMemo`](#schemawalkmemo)                                         | memory `Server` option `experimentalSchemaWalkMemo` (server-side only; not env-wired)                                                          | off                                                                                  | Gideon Wald (#6464)                                   | extend to the schema-typed traversal, remeasure on estuary, then graduate only if beneficial                                                                                                                                      | generic traversal implemented; dominant typed path not yet covered              |
 | [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | off                                                                                  | Bernhard Seefeld (#4550)                              | graduate once exchange resolution lands                                                                                                                                                                                           | implemented, off by default, dogfood only                                       |
 | [`INGEST_SELF_SERVE_ENABLED`](#ingest_self_serve_enabled) | `INGEST_SELF_SERVE_ENABLED` env on toolshed | off | Alex Komoroske (self-serve ingest channels) | graduate on once named-space keys stop deriving from a public passphrase | implemented, off by default |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning)                                 | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache`                                                             | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts                          | Ian Hickson                                           | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked                                                                                                                                      | implemented, on by default for FUSE-T, soak-validated                           |
@@ -1062,20 +1062,23 @@ the per-epic implementation notes).
   (`boolean | { maxEntries?: number }`) in
   [`packages/memory/v2/server.ts`](../../packages/memory/v2/server.ts).
   Server-side only; not env-wired yet and invisible on the wire.
-- **Added by.** Gideon Wald, for the revision-keyed schema memo plan
-  (#6464).
+- **Added by.** Gideon Wald (#6464).
 - **Purpose.** Serves per-document schema-walk subtrees across evaluations
   from a per-space, revision-keyed memo, so the first evaluation after a
   commit — and any evaluation of a query shape the whole-evaluation cache
   has not seen — re-traverses only what changed instead of the whole
   corpus. Off, every evaluation the whole-evaluation cache misses walks the
   full reach.
-- **Current default and planned end state.** Off by default while the
-  plan's measurement stage runs. Intended to graduate to always-on.
-- **Status on 2026-08-28.** Implemented behind the flag, off by default.
-- **Path to removal.** Enable on estuary, compare the evaluation-cache and
-  memo diagnostics against the plan's baseline, then flip the default and
-  delete the option.
+- **Current default and planned end state.** Off by default. Extend the memo
+  seam to the schema-typed/extension traversal, then graduate only if a fresh
+  measurement shows a material benefit.
+- **Status on 2026-08-31.** The generic graph traversal is implemented behind
+  the flag. Study 3 found the dominant board query takes the schema-typed path,
+  which bypasses this memo and consequently records no cross-traversal hits.
+- **Path to removal.** Cover the schema-typed/extension traversal without
+  changing its semantics, rerun the estuary measurement, and either flip the
+  default and delete the option or remove the experiment if it remains
+  ineffective.
 
 ---
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1062,8 +1062,8 @@ the per-epic implementation notes).
   (`boolean | { maxEntries?: number }`) in
   [`packages/memory/v2/server.ts`](../../packages/memory/v2/server.ts).
   Server-side only; not env-wired yet and invisible on the wire.
-- **Added by.** Gideon Wald, for the
-  [revision-keyed schema memo plan](../plans/revision-keyed-schema-memo.md).
+- **Added by.** Gideon Wald, for the revision-keyed schema memo plan
+  (#6464).
 - **Purpose.** Serves per-document schema-walk subtrees across evaluations
   from a per-space, revision-keyed memo, so the first evaluation after a
   commit — and any evaluation of a query shape the whole-evaluation cache

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -50,6 +50,7 @@ was last checked against the code.
 | [`messageCompressionV1`](#messagecompressionv1)                             | `setMessageCompressionConfig()` (negotiated per connection)                                                                                     | on                                                                                   | PR #6474                                             | retire the rollback switch after the binary WebSocket envelope has field-soaked                                                                                                                                                   | implemented, on by default                                                      |
 | [`ownWriteEcho`](#ownwriteecho)                                             | `setOwnWriteEchoConfig()` (server-side only, not negotiated)                                                                                    | on                                                                                   | Robin McCollum (CT-1965)                              | remove the switch once the echo has field-soaked                                                                                                                                                                                  | implemented, on by default                                                      |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off                                                                                  | Ben Follington (#4937; shell toggle #4974)            | graduate to always-on after live measurement, or remove if superseded                                                                                                                                                             | implemented behind the flag, off by default, not yet measured over real latency |
+| [`schemaWalkMemo`](#schemawalkmemo)                                         | memory `Server` option `experimentalSchemaWalkMemo` (server-side only; not env-wired)                                                          | off                                                                                  | Gideon Wald (revision-keyed schema memo plan)         | graduate to always-on after the estuary measurement, then delete the option                                                                                                                                                       | implemented behind the flag, off by default                                     |
 | [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | off                                                                                  | Bernhard Seefeld (#4550)                              | graduate once exchange resolution lands                                                                                                                                                                                           | implemented, off by default, dogfood only                                       |
 | [`INGEST_SELF_SERVE_ENABLED`](#ingest_self_serve_enabled) | `INGEST_SELF_SERVE_ENABLED` env on toolshed | off | Alex Komoroske (self-serve ingest channels) | graduate on once named-space keys stop deriving from a public passphrase | implemented, off by default |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning)                                 | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache`                                                             | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts                          | Ian Hickson                                           | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked                                                                                                                                      | implemented, on by default for FUSE-T, soak-validated                           |
@@ -1054,6 +1055,27 @@ the per-epic implementation notes).
   measured end-to-end over real latency.
 - **Path to removal.** Graduate to always-on once measured safe and beneficial,
   or remove if superseded by reducing the round-trip count at the source.
+
+### `schemaWalkMemo`
+
+- **Toggle via.** The memory `Server` option `experimentalSchemaWalkMemo`
+  (`boolean | { maxEntries?: number }`) in
+  [`packages/memory/v2/server.ts`](../../packages/memory/v2/server.ts).
+  Server-side only; not env-wired yet and invisible on the wire.
+- **Added by.** Gideon Wald, for the
+  [revision-keyed schema memo plan](../plans/revision-keyed-schema-memo.md).
+- **Purpose.** Serves per-document schema-walk subtrees across evaluations
+  from a per-space, revision-keyed memo, so the first evaluation after a
+  commit — and any evaluation of a query shape the whole-evaluation cache
+  has not seen — re-traverses only what changed instead of the whole
+  corpus. Off, every evaluation the whole-evaluation cache misses walks the
+  full reach.
+- **Current default and planned end state.** Off by default while the
+  plan's measurement stage runs. Intended to graduate to always-on.
+- **Status on 2026-08-28.** Implemented behind the flag, off by default.
+- **Path to removal.** Enable on estuary, compare the evaluation-cache and
+  memo diagnostics against the plan's baseline, then flip the default and
+  delete the option.
 
 ---
 

--- a/packages/memory/test/v2-schema-walk-memo.test.ts
+++ b/packages/memory/test/v2-schema-walk-memo.test.ts
@@ -1,0 +1,502 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { applyCommit, open as openEngine } from "../v2/engine.ts";
+import { type TrackedGraphState, trackGraph } from "../v2/query.ts";
+import { createSchemaWalkMemoStore } from "../v2/schema-walk-memo.ts";
+import { Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+  type WatchAddResult,
+} from "../v2.ts";
+
+const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-walk-memo-test-audience";
+
+const invocationFor = (space: string) => ({
+  iss: "did:key:test",
+  aud: "did:key:service",
+  cmd: "/memory/transact",
+  sub: space,
+});
+
+const link = (space: string, id: string, scope?: string) => ({
+  "/": { "link@1": { path: [], id, space, ...(scope ? { scope } : {}) } },
+});
+
+const seed = (
+  engine: ReturnType<typeof openEngine> extends Promise<infer E> ? E : never,
+  space: string,
+  localSeq: number,
+  operations: unknown[],
+  session: { sessionId: string; principal?: string } = { sessionId: "seed" },
+) => {
+  applyCommit(engine, {
+    ...session,
+    invocation: invocationFor(space),
+    authorization: { proof: "ok" },
+    commit: {
+      localSeq,
+      reads: { confirmed: [], pending: [] },
+      operations,
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any);
+};
+
+const QUERY_FOR = (id: string) => ({
+  roots: [{ id, selector: { path: [], schema: true } }],
+});
+
+/** Order-independent picture of an evaluation's reach, for parity
+ * comparisons: tracker keys with selector counts, miss keys, entity keys. */
+const reachOf = (state: TrackedGraphState) => ({
+  tracker: [...state.tracker]
+    .map(([key, selectors]) => [key, [...selectors].length] as const)
+    .toSorted((a, b) => a[0] < b[0] ? -1 : 1),
+  missed: [...state.missed].map(([key]) => key).toSorted(),
+  entities: [...state.entities.keys()].toSorted(),
+});
+
+describe("v2 schema walk memo", () => {
+  it("re-serves an unchanged corpus without re-traversing it", async () => {
+    const space = "did:key:z6Mk-walk-memo-warm";
+    const engine = await openEngine({ url: new URL("memory:///walk-memo-1") });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: 3 } } },
+      {
+        op: "set",
+        id: "of:doc:b",
+        value: { value: { next: link(space, "of:doc:c") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: { value: { one: link(space, "of:doc:b"), n: 1 } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const cold = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(cold.stats.crossTraversalMemoHits).toBe(0);
+    expect(store.entries.size).toBeGreaterThan(0);
+
+    const warm = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(warm.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+    // A served subtree runs no computation of its own; the DAG-arm
+    // counter only moves during real walks.
+    expect(warm.stats.dagTraversals).toBeLessThan(cold.stats.dagTraversals);
+    expect(reachOf(warm.state)).toEqual(reachOf(cold.state));
+  });
+
+  it("recomputes only the changed document's ancestor chain", async () => {
+    const space = "did:key:z6Mk-walk-memo-chain";
+    const engine = await openEngine({ url: new URL("memory:///walk-memo-2") });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:d", value: { value: { leaf: "d" } } },
+      {
+        op: "set",
+        id: "of:doc:b",
+        value: { value: { next: link(space, "of:doc:d") } },
+      },
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c1" } } },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: {
+          value: {
+            left: link(space, "of:doc:b"),
+            right: link(space, "of:doc:c"),
+          },
+        },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const cold = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+
+    seed(engine, space, 2, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c2" } } },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    // B and D are unchanged and serve from their entries; A and C — the
+    // chain from the change to the root — re-traverse.
+    expect(after.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+    expect(after.stats.dagTraversals).toBeGreaterThan(0);
+    expect(after.stats.dagTraversals).toBeLessThan(cold.stats.dagTraversals);
+    const c = after.state.entities.get(
+      `${space}/space/of:doc:c` as Parameters<
+        typeof after.state.entities.get
+      >[0],
+    );
+    expect((c?.document as { value?: { leaf?: string } })?.value?.leaf).toBe(
+      "c2",
+    );
+  });
+
+  it("keys scoped-crossing subtrees to the evaluating identity", async () => {
+    const space = "did:key:z6Mk-walk-memo-scoped";
+    const engine = await openEngine({ url: new URL("memory:///walk-memo-3") });
+    const p1 = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const p2 = { principal: "did:key:z6Mk-wm-p2", sessionId: "wm-s2" };
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:pure", value: { value: { leaf: "shared" } } },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: {
+          value: {
+            shared: link(space, "of:doc:pure"),
+            draft: link(space, "of:doc:draft", "session"),
+          },
+        },
+      },
+    ]);
+    seed(engine, space, 2, [
+      {
+        op: "set",
+        id: "of:doc:draft",
+        scope: "session",
+        value: {
+          value: { mine: "p1" },
+        },
+      },
+    ], { sessionId: "wm-s1", principal: "did:key:z6Mk-wm-p1" });
+
+    const store = createSchemaWalkMemoStore();
+    trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...p1,
+      schemaWalkMemo: store,
+    });
+    const p1Warm = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:a"),
+      undefined,
+      { ...p1, schemaWalkMemo: store },
+    );
+    expect(p1Warm.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+
+    // The taint key is structural: the scoped-crossing root's entries
+    // live only under identity-suffixed keys. Reach-level assertions
+    // cannot pin this — instance-resolved child dependencies keep reach
+    // correct across identities on their own — the suffix guards the
+    // memoized RESULT, which embeds scoped values whenever a selective
+    // schema branches on them.
+    const rootKeys = [...store.entries.keys()].filter((key) =>
+      key.includes("of:doc:a")
+    );
+    expect(rootKeys.length).toBeGreaterThan(0);
+    expect(rootKeys.every((key) => key.includes("|I["))).toBe(true);
+
+    const p2Eval = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:a"),
+      undefined,
+      { ...p2, schemaWalkMemo: store },
+    );
+    // The pure subtree serves p2; the scoped chain does not cross: p2's
+    // reach carries ITS instance's miss, and p1's draft value is not in
+    // p2's entities.
+    const p2Reach = reachOf(p2Eval.state);
+    expect(p2Reach.missed.some((key) => key.includes("wm-s2"))).toBe(true);
+    expect(p2Reach.missed.some((key) => key.includes("wm-s1"))).toBe(false);
+    expect(
+      p2Reach.entities.some((key) => key.includes("of:doc:draft")),
+    ).toBe(false);
+    expect(
+      p2Reach.entities.some((key) => key.includes("of:doc:pure")),
+    ).toBe(true);
+  });
+
+  it("invalidates through a rewritten pointer document that has no frame of its own", async () => {
+    const space = "did:key:z6Mk-walk-memo-pointer";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-ptr"),
+    });
+    // P is a bare pointer document: the walk reads it while following the
+    // redirect chain from A, registering it without giving it a
+    // (document, schema) frame — its revision must still bind the entries
+    // recorded above it.
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:c1", value: { value: { leaf: "one" } } },
+      { op: "set", id: "of:doc:c2", value: { value: { leaf: "two" } } },
+      { op: "set", id: "of:doc:p", value: { value: link(space, "of:doc:c1") } },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: { value: { via: link(space, "of:doc:p") } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const cold = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(reachOf(cold.state).entities.some((k) => k.includes("of:doc:c1")))
+      .toBe(true);
+
+    seed(engine, space, 2, [
+      { op: "set", id: "of:doc:p", value: { value: link(space, "of:doc:c2") } },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const reach = reachOf(after.state);
+    expect(reach.entities.some((k) => k.includes("of:doc:c2"))).toBe(true);
+  });
+
+  it("leaves evaluation results identical with the memo off and on", async () => {
+    const space = "did:key:z6Mk-walk-memo-parity";
+    const engine = await openEngine({ url: new URL("memory:///walk-memo-4") });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:shared", value: { value: { s: 1 } } },
+      {
+        op: "set",
+        id: "of:doc:left",
+        value: { value: { to: link(space, "of:doc:shared") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:right",
+        value: { value: { to: link(space, "of:doc:shared") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: {
+          value: {
+            l: link(space, "of:doc:left"),
+            r: link(space, "of:doc:right"),
+            gone: link(space, "of:doc:absent"),
+          },
+        },
+      },
+    ]);
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const off = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+    });
+    const store = createSchemaWalkMemoStore();
+    trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const warm = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(warm.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+    expect(reachOf(warm.state)).toEqual(reachOf(off.state));
+  });
+
+  it("holds the entry bound by evicting oldest entries", async () => {
+    const space = "did:key:z6Mk-walk-memo-bound";
+    const engine = await openEngine({ url: new URL("memory:///walk-memo-5") });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: 3 } } },
+      {
+        op: "set",
+        id: "of:doc:b",
+        value: { value: { next: link(space, "of:doc:c") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: { value: { one: link(space, "of:doc:b") } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore(1);
+    trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      principal: "did:key:z6Mk-wm-p1",
+      sessionId: "wm-s1",
+      schemaWalkMemo: store,
+    });
+    expect(store.entries.size).toBeLessThanOrEqual(1);
+    expect(store.evictions).toBeGreaterThan(0);
+  });
+
+  it("delivers through a memo-served watch", async () => {
+    const space = "did:key:z6Mk-walk-memo-delivery";
+    const server = new Server({
+      store: new URL("memory://walk-memo-delivery"),
+      experimentalSchemaWalkMemo: true,
+      subscriptionRefreshDelayMs: 0,
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string"
+          ? principal
+          : "did:key:z6Mk-walk-memo-principal";
+      },
+      sessionOpenAuth: { audience: TEST_AUDIENCE },
+    });
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+    const open = async (
+      connection: ReturnType<Server["connect"]>,
+      messages: ServerMessage[],
+      label: string,
+      principal: string,
+    ): Promise<string> => {
+      await connection.receive(encodeMemoryBoundary({
+        type: "hello",
+        protocol: MEMORY_PROTOCOL,
+        flags: getMemoryProtocolFlags(),
+      }));
+      const hello = messages.shift() as {
+        type: string;
+        sessionOpen?: SessionOpenAuthMetadata;
+      };
+      expect(hello.type).toBe("hello.ok");
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.open",
+        requestId: `${label}-open`,
+        space,
+        session: {},
+        invocation: {
+          aud: hello.sessionOpen!.audience,
+          challenge: hello.sessionOpen!.challenge.value,
+        },
+        authorization: { principal },
+      }));
+      const opened = messages.shift() as ResponseMessage<{
+        sessionId: string;
+      }>;
+      expect(opened.ok).toBeDefined();
+      return opened.ok!.sessionId;
+    };
+    const watch = async (
+      connection: ReturnType<Server["connect"]>,
+      messages: ServerMessage[],
+      sessionId: string,
+      label: string,
+    ) => {
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: `${label}-watch`,
+        space,
+        sessionId,
+        watches: [{
+          id: `${label}-watch-id`,
+          kind: "graph",
+          query: QUERY_FOR("of:doc:a"),
+        }],
+      }));
+      const response = messages.shift() as ResponseMessage<WatchAddResult>;
+      expect(response.ok).toBeDefined();
+      return response.ok!.sync;
+    };
+
+    const messagesA: ServerMessage[] = [];
+    const messagesB: ServerMessage[] = [];
+    const connectionA = server.connect((m) => messagesA.push(m));
+    const connectionB = server.connect((m) => messagesB.push(m));
+    try {
+      const sessionA = await open(connectionA, messagesA, "a", "did:key:a1");
+      const sessionB = await open(connectionB, messagesB, "b", "did:key:b1");
+      const seedResponse = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:b", value: { value: { n: 1 } } },
+            {
+              op: "set",
+              id: "of:doc:a",
+              value: { value: { next: link(space, "of:doc:b") } },
+            },
+          ],
+        },
+      });
+      expect(seedResponse.error).toBeUndefined();
+      await tick();
+      messagesA.length = 0;
+      messagesB.length = 0;
+
+      await watch(connectionA, messagesA, sessionA, "a");
+      // A commit between the watches rotates the whole-evaluation cache,
+      // so B's establishment exercises the memo path.
+      const rotate = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:unrelated", value: { value: { u: 1 } } },
+          ],
+        },
+      });
+      expect(rotate.error).toBeUndefined();
+      await tick();
+      const syncB = await watch(connectionB, messagesB, sessionB, "b");
+      expect(syncB.upserts.map((u) => u.id)).toContain("of:doc:b");
+      expect(server.schemaWalkMemoDiagnostics(space).hits).toBeGreaterThan(0);
+
+      messagesB.length = 0;
+      const write = await server.transact({
+        type: "transact",
+        requestId: crypto.randomUUID(),
+        space,
+        sessionId: sessionA,
+        commit: {
+          localSeq: 3,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:doc:b", value: { value: { n: 2 } } },
+          ],
+        },
+      });
+      expect(write.error).toBeUndefined();
+      await server.flushSessions();
+      await tick();
+      const delivered = messagesB.some((message) =>
+        message.type === "session/effect" &&
+        (message as { effect?: SessionSync }).effect?.upserts.some(
+          (upsert) => upsert.id === "of:doc:b",
+        )
+      );
+      expect(delivered).toBe(true);
+    } finally {
+      connectionA.close();
+      connectionB.close();
+    }
+  });
+
+  it("reads an absent space's memo diagnostics as empty", () => {
+    const server = new Server({
+      store: new URL("memory://walk-memo-absent"),
+      subscriptionRefreshDelayMs: 0,
+      authorizeSessionOpen: () => "did:key:z6Mk-walk-memo-principal",
+      sessionOpenAuth: { audience: TEST_AUDIENCE },
+    });
+    expect(
+      server.schemaWalkMemoDiagnostics("did:key:z6Mk-never-evaluated"),
+    ).toEqual({ entries: 0, hits: 0, misses: 0, evictions: 0, poisons: 0 });
+  });
+});

--- a/packages/memory/test/v2-schema-walk-memo.test.ts
+++ b/packages/memory/test/v2-schema-walk-memo.test.ts
@@ -340,6 +340,81 @@ describe("v2 schema walk memo", () => {
     expect(store.evictions).toBeGreaterThan(0);
   });
 
+  it("keeps a recently served closure ahead of unrelated cold entries", async () => {
+    const space = "did:key:z6Mk-walk-memo-closure-lru";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-closure-lru"),
+    });
+    const coldIds = Array.from(
+      { length: 4 },
+      (_, index) => `of:doc:cold-${index}`,
+    );
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:hot-c", value: { value: { leaf: 3 } } },
+      {
+        op: "set",
+        id: "of:doc:hot-b",
+        value: { value: { next: link(space, "of:doc:hot-c") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:hot-a",
+        value: { value: { next: link(space, "of:doc:hot-b") } },
+      },
+      ...coldIds.map((id) => ({
+        op: "set",
+        id,
+        value: { value: { leaf: id } },
+      })),
+      {
+        op: "set",
+        id: "of:doc:pressure",
+        value: { value: { leaf: "new" } },
+      },
+    ]);
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const store = createSchemaWalkMemoStore();
+    trackGraph(space, engine, QUERY_FOR("of:doc:hot-a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const hotIds = ["of:doc:hot-a", "of:doc:hot-b", "of:doc:hot-c"];
+    const hotKeys = [...store.entries.keys()].filter((key) =>
+      hotIds.some((id) => key.includes(`|${id}|`))
+    );
+    expect(hotKeys.length).toBeGreaterThan(1);
+    for (const id of coldIds) {
+      trackGraph(space, engine, QUERY_FOR(id), undefined, {
+        ...identity,
+        schemaWalkMemo: store,
+      });
+    }
+    store.maxEntries = store.entries.size;
+
+    const warm = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:hot-a"),
+      undefined,
+      { ...identity, schemaWalkMemo: store },
+    );
+    expect(warm.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+    trackGraph(space, engine, QUERY_FOR("of:doc:pressure"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+
+    expect(hotKeys.every((key) => store.entries.has(key))).toBe(true);
+    const stillWarm = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:hot-a"),
+      undefined,
+      { ...identity, schemaWalkMemo: store },
+    );
+    expect(stillWarm.stats.dagTraversals).toBe(0);
+  });
+
   it("delivers through a memo-served watch", async () => {
     const space = "did:key:z6Mk-walk-memo-delivery";
     const server = new Server({
@@ -891,7 +966,7 @@ describe("v2 schema walk memo", () => {
           value: { value: {} },
           // deno-lint-ignore no-explicit-any
         }) as any;
-      return { session, store, doc };
+      return { session, store, tracker, doc };
     };
 
     it("stores nothing for a computation cut short by a value cycle", async () => {
@@ -940,6 +1015,18 @@ describe("v2 schema walk memo", () => {
       session.exit(doc("of:doc:x"), true, { ok: null });
       expect(store.entries.size).toBe(0);
       expect(recorded).toEqual(["space/space/of:doc:absent"]);
+    });
+
+    it("detaches capture before a tracker becomes live state", async () => {
+      const { session, store, tracker, doc } = await openSession("detach");
+      session.enter(doc("of:doc:x"), true);
+      session.detachTracker();
+      tracker.add(
+        "space/space/of:doc:outside",
+        { path: [], schema: true },
+      );
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect([...store.entries.values()][0].registrations).toEqual([]);
     });
 
     it("keys a frame to its identity when it consumed an unrecorded subtree", async () => {

--- a/packages/memory/test/v2-schema-walk-memo.test.ts
+++ b/packages/memory/test/v2-schema-walk-memo.test.ts
@@ -415,6 +415,77 @@ describe("v2 schema walk memo", () => {
     expect(stillWarm.stats.dagTraversals).toBe(0);
   });
 
+  it("retouches descendants when a closure is served twice in one evaluation", async () => {
+    const space = "did:key:z6Mk-walk-memo-repeat-lru";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-repeat-lru"),
+    });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:hot-c", value: { value: { leaf: 3 } } },
+      {
+        op: "set",
+        id: "of:doc:hot-b",
+        value: { value: { next: link(space, "of:doc:hot-c") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:hot-a",
+        value: { value: { next: link(space, "of:doc:hot-b") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:hot-d",
+        value: { value: { next: link(space, "of:doc:hot-b") } },
+      },
+      { op: "set", id: "of:doc:cold", value: { value: { leaf: "cold" } } },
+      {
+        op: "set",
+        id: "of:doc:pressure",
+        value: { value: { leaf: "pressure" } },
+      },
+    ]);
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const store = createSchemaWalkMemoStore();
+    trackGraph(space, engine, QUERY_FOR("of:doc:hot-a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    trackGraph(space, engine, QUERY_FOR("of:doc:hot-d"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    store.maxEntries = store.entries.size + 1;
+
+    // The first root replays A -> B -> C. The cold root is then inserted,
+    // and the third root consumes D -> B -> C, reaching B through the
+    // already-replayed branch. Pressure after that must evict A, not C: D's
+    // whole closure was the most recently consumed one.
+    const mixed = trackGraph(
+      space,
+      engine,
+      {
+        roots: [
+          "of:doc:hot-a",
+          "of:doc:cold",
+          "of:doc:hot-d",
+          "of:doc:pressure",
+        ].map((id) => ({ id, selector: { path: [], schema: true } })),
+      },
+      undefined,
+      { ...identity, schemaWalkMemo: store },
+    );
+    expect(mixed.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+
+    const stillWarm = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:hot-d"),
+      undefined,
+      { ...identity, schemaWalkMemo: store },
+    );
+    expect(stillWarm.stats.dagTraversals).toBe(0);
+  });
+
   it("delivers through a memo-served watch", async () => {
     const space = "did:key:z6Mk-walk-memo-delivery";
     const server = new Server({

--- a/packages/memory/test/v2-schema-walk-memo.test.ts
+++ b/packages/memory/test/v2-schema-walk-memo.test.ts
@@ -2,12 +2,17 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { applyCommit, open as openEngine } from "../v2/engine.ts";
 import { type TrackedGraphState, trackGraph } from "../v2/query.ts";
-import { createSchemaWalkMemoStore } from "../v2/schema-walk-memo.ts";
+import {
+  CapturingSchemaTracker,
+  createSchemaWalkMemoStore,
+  SchemaWalkMemoSession,
+} from "../v2/schema-walk-memo.ts";
 import { Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
+  resolveScopeKey,
   type ResponseMessage,
   type ServerMessage,
   type SessionOpenAuthMetadata,
@@ -498,5 +503,371 @@ describe("v2 schema walk memo", () => {
     expect(
       server.schemaWalkMemoDiagnostics("did:key:z6Mk-never-evaluated"),
     ).toEqual({ entries: 0, hits: 0, misses: 0, evictions: 0, poisons: 0 });
+  });
+
+  it("refuses a negative entry bound instead of evicting forever", () => {
+    expect(() => createSchemaWalkMemoStore(-1)).toThrow(RangeError);
+    expect(() => createSchemaWalkMemoStore(1.5)).toThrow(RangeError);
+    expect(createSchemaWalkMemoStore(0).maxEntries).toBe(0);
+  });
+
+  it("stores nothing for a query root naming an explicit scope instance", async () => {
+    const space = "did:key:z6Mk-walk-memo-explicit";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-explicit"),
+    });
+    seed(engine, space, 1, [
+      {
+        op: "set",
+        id: "of:doc:owned",
+        scope: "session",
+        value: { value: { leaf: "a" } },
+      },
+    ], { sessionId: "wm-s1", principal: "did:key:z6Mk-wm-p1" });
+    const store = createSchemaWalkMemoStore();
+    // A lease holder reads a named instance rather than its own, so memo
+    // keys built from the evaluating identity would name the wrong
+    // document; the whole class bypasses.
+    trackGraph(
+      space,
+      engine,
+      {
+        roots: [{
+          id: "of:doc:owned",
+          scope: "session",
+          entityScopeKey: resolveScopeKey("session", {
+            principal: "did:key:z6Mk-wm-p1",
+            sessionId: "wm-s1",
+          }),
+          selector: { path: [], schema: true },
+        }],
+      },
+      undefined,
+      {
+        principal: "did:key:z6Mk-wm-p2",
+        sessionId: "wm-s2",
+        schemaWalkMemo: store,
+      },
+    );
+    expect(store.entries.size).toBe(0);
+  });
+
+  it("invalidates a parent whose grandchild changed", async () => {
+    const space = "did:key:z6Mk-walk-memo-grandchild";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-grandchild"),
+    });
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c1" } } },
+      {
+        op: "set",
+        id: "of:doc:b",
+        value: { value: { next: link(space, "of:doc:c") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: { value: { next: link(space, "of:doc:b") } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    // Only the deepest document changes: A's and B's own revisions still
+    // match, so invalidation has to travel up through the child links.
+    seed(engine, space, 2, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c2" } } },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const c = after.state.entities.get(
+      `${space}/space/of:doc:c` as Parameters<
+        typeof after.state.entities.get
+      >[0],
+    );
+    expect((c?.document as { value?: { leaf?: string } })?.value?.leaf).toBe(
+      "c2",
+    );
+  });
+
+  it("stops serving a subtree when one of its siblings is gone", async () => {
+    const space = "did:key:z6Mk-walk-memo-siblings";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-siblings"),
+    });
+    // R -> A -> {B, C}: A is deep enough to be served from an entry, and
+    // its two subtrees let one validate before the other fails.
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:b", value: { value: { leaf: "b" } } },
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c1" } } },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: {
+          value: {
+            left: link(space, "of:doc:b"),
+            right: link(space, "of:doc:c"),
+          },
+        },
+      },
+      {
+        op: "set",
+        id: "of:doc:r",
+        value: { value: { next: link(space, "of:doc:a") } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const off = trackGraph(space, engine, QUERY_FOR("of:doc:r"), undefined, {
+      ...identity,
+    });
+    trackGraph(space, engine, QUERY_FOR("of:doc:r"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    seed(engine, space, 2, [
+      { op: "set", id: "of:doc:c", value: { value: { leaf: "c2" } } },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:r"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const plainAfter = trackGraph(
+      space,
+      engine,
+      QUERY_FOR("of:doc:r"),
+      undefined,
+      { ...identity },
+    );
+    expect(reachOf(after.state)).toEqual(reachOf(plainAfter.state));
+    expect(reachOf(off.state).entities.length).toBe(
+      reachOf(after.state).entities.length,
+    );
+    const c = after.state.entities.get(
+      `${space}/space/of:doc:c` as Parameters<
+        typeof after.state.entities.get
+      >[0],
+    );
+    expect((c?.document as { value?: { leaf?: string } })?.value?.leaf).toBe(
+      "c2",
+    );
+  });
+
+  it("re-records a miss when its referrer is rewritten to another absent target", async () => {
+    const space = "did:key:z6Mk-walk-memo-referrer";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-referrer"),
+    });
+    // The referrer's link dead-ends: nothing was ever written at the
+    // target, so only the REFERRER's revision distinguishes the two
+    // states of this graph.
+    seed(engine, space, 1, [
+      {
+        op: "set",
+        id: "of:doc:p",
+        value: { value: { to: link(space, "of:doc:absent1") } },
+      },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: { value: { via: link(space, "of:doc:p") } },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const cold = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(reachOf(cold.state).missed.some((k) => k.includes("absent1")))
+      .toBe(true);
+
+    seed(engine, space, 2, [
+      {
+        op: "set",
+        id: "of:doc:p",
+        value: { value: { to: link(space, "of:doc:absent2") } },
+      },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const missed = reachOf(after.state).missed;
+    expect(missed.some((k) => k.includes("absent2"))).toBe(true);
+    expect(missed.some((k) => k.includes("absent1"))).toBe(false);
+  });
+
+  it("serves a repeated schema-narrowed subtree and keeps its reach", async () => {
+    const space = "did:key:z6Mk-walk-memo-schema";
+    const engine = await openEngine({
+      url: new URL("memory:///walk-memo-schema"),
+    });
+    const shapedLink = (id: string) => ({
+      "/": {
+        "link@1": {
+          path: [],
+          id,
+          space,
+          schema: {
+            type: "object",
+            properties: { leaf: { type: "string" } },
+          },
+        },
+      },
+    });
+    // Both arms narrow the SAME document under the SAME schema, so the
+    // second visit consumes the first's result rather than re-entering
+    // it — the dependency the entry must record to stay invalidatable.
+    seed(engine, space, 1, [
+      { op: "set", id: "of:doc:shared", value: { value: { leaf: "one" } } },
+      {
+        op: "set",
+        id: "of:doc:a",
+        value: {
+          value: {
+            l: shapedLink("of:doc:shared"),
+            r: shapedLink("of:doc:shared"),
+          },
+        },
+      },
+    ]);
+    const store = createSchemaWalkMemoStore();
+    const identity = { principal: "did:key:z6Mk-wm-p1", sessionId: "wm-s1" };
+    const off = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+    });
+    const cold = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(cold.stats.schemaTraversals).toBeGreaterThan(0);
+    expect(reachOf(cold.state)).toEqual(reachOf(off.state));
+
+    const warm = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    expect(warm.stats.crossTraversalMemoHits).toBeGreaterThan(0);
+    expect(reachOf(warm.state)).toEqual(reachOf(off.state));
+
+    seed(engine, space, 2, [
+      { op: "set", id: "of:doc:shared", value: { value: { leaf: "two" } } },
+    ]);
+    const after = trackGraph(space, engine, QUERY_FOR("of:doc:a"), undefined, {
+      ...identity,
+      schemaWalkMemo: store,
+    });
+    const shared = after.state.entities.get(
+      `${space}/space/of:doc:shared` as Parameters<
+        typeof after.state.entities.get
+      >[0],
+    );
+    expect(
+      (shared?.document as { value?: { leaf?: string } })?.value?.leaf,
+    ).toBe("two");
+  });
+
+  describe("frame bookkeeping", () => {
+    const openSession = async (label: string) => {
+      const space = `did:key:z6Mk-walk-memo-frames-${label}`;
+      const engine = await openEngine({
+        url: new URL(`memory:///walk-memo-frames-${label}`),
+      });
+      seed(engine, space, 1, [
+        { op: "set", id: "of:doc:x", value: { value: { leaf: 1 } } },
+      ]);
+      const store = createSchemaWalkMemoStore();
+      const tracker = new CapturingSchemaTracker();
+      const session = new SchemaWalkMemoSession({
+        store,
+        engine,
+        space,
+        branch: "",
+        identity: {
+          principal: "did:key:z6Mk-wm-p1",
+          sessionId: "wm-s1",
+        },
+        tracker,
+      });
+      const doc = (id: string) =>
+        ({
+          address: {
+            id,
+            space,
+            scope: "space" as const,
+            type: "application/json",
+            path: [],
+          },
+          value: { value: {} },
+          // deno-lint-ignore no-explicit-any
+        }) as any;
+      return { session, store, doc };
+    };
+
+    it("stores nothing for a computation cut short by a value cycle", async () => {
+      const { session, store, doc } = await openSession("poison");
+      session.enter(doc("of:doc:x"), true);
+      session.poison();
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect(store.entries.size).toBe(0);
+      expect(store.poisons).toBe(1);
+    });
+
+    it("stores nothing for a frame whose child computation was abandoned", async () => {
+      const { session, store, doc } = await openSession("abandon");
+      session.enter(doc("of:doc:x"), true);
+      session.enter(doc("of:doc:x"), false);
+      session.abandon();
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect(store.entries.size).toBe(0);
+    });
+
+    it("stores nothing for a frame whose child was cut short by a cycle", async () => {
+      const { session, store, doc } = await openSession("poison-parent");
+      session.enter(doc("of:doc:x"), true);
+      session.enter(doc("of:doc:x"), false);
+      session.poison();
+      session.exit(doc("of:doc:x"), false, { ok: null });
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect(store.entries.size).toBe(0);
+    });
+
+    it("records nothing while no computation is open", async () => {
+      const { session, store, doc } = await openSession("no-frame");
+      const recorded: string[] = [];
+      const record = session.wrapMissRecorder((missKey) => {
+        recorded.push(missKey);
+      });
+      // Reach outside any (document, schema) computation — a root's own
+      // registrations and misses belong to no frame — attributes to
+      // nothing, but still reaches the walk's own recorder.
+      record(
+        "space/space/of:doc:absent",
+        { path: [], schema: true },
+        undefined,
+      );
+      session.dependency(doc("of:doc:other"), true);
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect(store.entries.size).toBe(0);
+      expect(recorded).toEqual(["space/space/of:doc:absent"]);
+    });
+
+    it("keys a frame to its identity when it consumed an unrecorded subtree", async () => {
+      const { session, store, doc } = await openSession("dependency");
+      session.enter(doc("of:doc:x"), true);
+      // No entry exists for the consumed subtree, so the frame cannot be
+      // shown identity-independent and narrows to its evaluating identity.
+      session.dependency(doc("of:doc:unknown"), true);
+      session.exit(doc("of:doc:x"), true, { ok: null });
+      expect(store.entries.size).toBe(1);
+      expect([...store.entries.keys()].every((key) => key.includes("|I[")))
+        .toBe(true);
+    });
   });
 });

--- a/packages/memory/test/v2-schema-walk-memo.test.ts
+++ b/packages/memory/test/v2-schema-walk-memo.test.ts
@@ -505,6 +505,90 @@ describe("v2 schema walk memo", () => {
     ).toEqual({ entries: 0, hits: 0, misses: 0, evictions: 0, poisons: 0 });
   });
 
+  it("evicts the least-recently-evaluated space's memo beyond the space bound", async () => {
+    const server = new Server({
+      store: new URL("memory://walk-memo-space-lru"),
+      experimentalSchemaWalkMemo: true,
+      subscriptionRefreshDelayMs: 0,
+      authorizeSessionOpen: () => "did:key:z6Mk-walk-memo-lru-principal",
+      sessionOpenAuth: { audience: TEST_AUDIENCE },
+    });
+    const connections: ReturnType<Server["connect"]>[] = [];
+    try {
+      const spaces = Array.from(
+        { length: 9 },
+        (_, index) => `did:key:z6Mk-walk-memo-lru-${index}`,
+      );
+      for (const space of spaces) {
+        const messages: ServerMessage[] = [];
+        const connection = server.connect((message) => messages.push(message));
+        connections.push(connection);
+        await connection.receive(encodeMemoryBoundary({
+          type: "hello",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+        }));
+        const hello = messages.shift() as {
+          sessionOpen?: SessionOpenAuthMetadata;
+        };
+        await connection.receive(encodeMemoryBoundary({
+          type: "session.open",
+          requestId: `${space}-open`,
+          space,
+          session: {},
+          invocation: {
+            aud: hello.sessionOpen!.audience,
+            challenge: hello.sessionOpen!.challenge.value,
+          },
+        }));
+        const opened = messages.shift() as ResponseMessage<
+          { sessionId: string }
+        >;
+        expect(opened.ok).toBeDefined();
+        // A space with no documents opens no frames and stores nothing, so
+        // each space needs something for the walk to memoize.
+        const seeded = await server.transact({
+          type: "transact",
+          requestId: crypto.randomUUID(),
+          space,
+          sessionId: opened.ok!.sessionId,
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "of:doc:1",
+              value: { value: { leaf: 1 } },
+            }],
+          },
+        });
+        expect(seeded.error).toBeUndefined();
+        messages.length = 0;
+        await connection.receive(encodeMemoryBoundary({
+          type: "session.watch.add",
+          requestId: `${space}-watch`,
+          space,
+          sessionId: opened.ok!.sessionId,
+          watches: [{
+            id: `${space}-watch-id`,
+            kind: "graph",
+            query: QUERY_FOR("of:doc:1"),
+          }],
+        }));
+        const response = messages.shift() as ResponseMessage<WatchAddResult>;
+        expect(response.ok).toBeDefined();
+      }
+      // Nine spaces evaluated against a bound of eight: the first space's
+      // memo is gone, and a peek at it reads empty rather than minting one.
+      expect(server.schemaWalkMemoDiagnostics(spaces[0]).entries).toBe(0);
+      expect(
+        server.schemaWalkMemoDiagnostics(spaces[8]).entries,
+      ).toBeGreaterThan(0);
+    } finally {
+      for (const connection of connections) connection.close();
+    }
+  });
+
   it("refuses a negative entry bound instead of evicting forever", () => {
     expect(() => createSchemaWalkMemoStore(-1)).toThrow(RangeError);
     expect(() => createSchemaWalkMemoStore(1.5)).toThrow(RangeError);

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -6586,6 +6586,28 @@ const readRowForBranch = (
   });
 };
 
+/** The head revision of `(branch, scopeKey, id)` without decoding the
+ * document: the row's (seq, opIndex) and op, or null when no row resolves.
+ * A `delete` head is a row — the caller decides whether that reads as
+ * absent (readState's `document: null`). */
+export const readRevision = (
+  engine: Engine,
+  options: { id: EntityId; scopeKey: string; branch?: BranchName },
+): { seq: number; opIndex: number; op: AppliedRevision["op"] } | null => {
+  const branch = options.branch ?? DEFAULT_BRANCH;
+  const resolved = readRowForBranch(engine, {
+    id: options.id,
+    scopeKey: options.scopeKey,
+    branch,
+    seq: headSeq(engine, branch),
+  });
+  return resolved === null ? null : {
+    seq: resolved.row.seq,
+    opIndex: resolved.row.op_index,
+    op: resolved.row.op,
+  };
+};
+
 const getBranch = (engine: Engine, branch: BranchName): BranchState | null => {
   const row = engine.statements.selectBranch.get({
     branch,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -28,6 +28,11 @@ import { isSubschema } from "../../runner/src/schema-walk.ts";
 import type { MemorySpace, MIME, URI } from "../interface.ts";
 import { mapLinkSchemas } from "./schema-table-links.ts";
 import {
+  CapturingSchemaTracker,
+  SchemaWalkMemoSession,
+  type SchemaWalkMemoStore,
+} from "./schema-walk-memo.ts";
+import {
   canResolveScopeKey,
   type CellScope,
   type CommitClass,
@@ -802,6 +807,14 @@ export type TrackGraphOptions = {
    * for the sharing and rotation rules. */
   evaluationCache?: QueryEvaluationCache;
 
+  /** Serve/record per-document schema-walk subtrees through this store
+   * (docs/plans/revision-keyed-schema-memo.md). Same eligibility as the
+   * evaluation cache: current-seq reads only, and the lease-holder
+   * exemption class bypasses. A store whose engine is not this
+   * evaluation's engine is cleared first — revisions identify state only
+   * within their engine. */
+  schemaWalkMemo?: SchemaWalkMemoStore;
+
   /**
    * `queryGraph` only (server-execution v2 stage A, OW17's wire leg):
    * annotate every returned snapshot with its scope INSTANCE
@@ -1377,12 +1390,33 @@ export const trackGraph = (
     );
     reuse?.managers?.set(managerKey, manager);
   }
-  const schemaTracker = new MapSetStringToPathSelectors(true);
+  const memoStore =
+    options.readSeq === undefined && options.keyedSnapshots !== true
+      ? options.schemaWalkMemo
+      : undefined;
+  if (memoStore !== undefined && memoStore.engine !== engine) {
+    memoStore.engine = engine;
+    memoStore.entries.clear();
+  }
+  const schemaTracker = memoStore === undefined
+    ? new MapSetStringToPathSelectors(true)
+    : new CapturingSchemaTracker();
   const missState = {
     missed: new MapSetStringToPathSelectors(true),
     missedBy: new Map<string, Set<string>>(),
     missesOf: new Map<string, Set<string>>(),
   };
+  const recordMiss = missRecorderFor(missState);
+  const session = memoStore === undefined
+    ? undefined
+    : new SchemaWalkMemoSession({
+      store: memoStore,
+      engine,
+      space,
+      branch,
+      identity: identityOf(manager),
+      tracker: schemaTracker as CapturingSchemaTracker,
+    });
   const sharedMemo = createSchemaMemo();
   const stats = createQueryTraversalStats();
   const readCountBefore = manager.readCount;
@@ -1390,9 +1424,12 @@ export const trackGraph = (
     manager,
     space: space as MemorySpace,
     schemaTracker,
-    onMissedDoc: missRecorderFor(missState),
+    onMissedDoc: session === undefined
+      ? recordMiss
+      : session.wrapMissRecorder(recordMiss),
     identity: identityOf(manager),
     memo: sharedMemo,
+    crossTraversalMemo: session,
     stats,
   });
 

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -153,6 +153,8 @@ const walkStatsDelta = (
   dagTraversals: after.dagTraversals - before.dagTraversals,
   getDocAtPathCalls: after.getDocAtPathCalls - before.getDocAtPathCalls,
   schemaMemoHits: after.schemaMemoHits - before.schemaMemoHits,
+  crossTraversalMemoHits: after.crossTraversalMemoHits -
+    before.crossTraversalMemoHits,
 });
 
 /**
@@ -808,7 +810,7 @@ export type TrackGraphOptions = {
   evaluationCache?: QueryEvaluationCache;
 
   /** Serve/record per-document schema-walk subtrees through this store
-   * (docs/plans/revision-keyed-schema-memo.md). Same eligibility as the
+   * (PR #6464). Same eligibility as the
    * evaluation cache: current-seq reads only, and the lease-holder
    * exemption class bypasses. A store whose engine is not this
    * evaluation's engine is cleared first — revisions identify state only
@@ -1518,6 +1520,7 @@ export const trackGraph = (
     });
     cache.weight += weight - (previous?.weight ?? 0);
   }
+  session?.detachTracker();
   return {
     serverSeq: Engine.serverSeq(engine),
     state,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1390,10 +1390,17 @@ export const trackGraph = (
     );
     reuse?.managers?.set(managerKey, manager);
   }
-  const memoStore =
-    options.readSeq === undefined && options.keyedSnapshots !== true
-      ? options.schemaWalkMemo
-      : undefined;
+  // Eligibility, in addition to the evaluation cache's own gates: a root
+  // naming an explicit scope INSTANCE (protocol.md §2's read row) reads
+  // and tracks THAT instance, while memo keys resolve their instance from
+  // the evaluating identity — so an explicit-instance evaluation could
+  // otherwise store and serve entries under the identity's own instance
+  // key. That whole class (lease-holder reads) bypasses.
+  const memoStore = options.readSeq === undefined &&
+      options.keyedSnapshots !== true &&
+      query.roots.every((root) => root.entityScopeKey === undefined)
+    ? options.schemaWalkMemo
+    : undefined;
   if (memoStore !== undefined && memoStore.engine !== engine) {
     memoStore.engine = engine;
     memoStore.entries.clear();

--- a/packages/memory/v2/schema-walk-memo.ts
+++ b/packages/memory/v2/schema-walk-memo.ts
@@ -490,6 +490,16 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
 
   #replay(key: string, entry: SchemaWalkMemoEntry): void {
     if (this.#replayed.has(key)) {
+      // A second hit in this evaluation consumes the closure again. Cold
+      // entries may have been inserted since its first replay, so refresh the
+      // descendants before their parent just as the first replay did. Touching
+      // only `key` would leave an otherwise-hot child at the LRU's oldest end;
+      // later pressure could evict it and strand the parent for the next
+      // evaluation.
+      for (const childKey of this.#resolvedChildren.get(key) ?? []) {
+        const child = this.#store.entries.get(childKey);
+        if (child !== undefined) this.#replay(childKey, child);
+      }
       this.#touch(key, entry);
       return;
     }

--- a/packages/memory/v2/schema-walk-memo.ts
+++ b/packages/memory/v2/schema-walk-memo.ts
@@ -5,6 +5,7 @@ import {
   type IMemorySpaceValueAttestation,
   MapSetStringToPathSelectors,
   type NormalizedFullLink,
+  schemaMemoIdentityKey,
   type SchemaPathSelector,
   schemaTrackerKey,
   type TraverseResult,
@@ -77,15 +78,25 @@ const DEFAULT_MAX_ENTRIES = 32_768;
 
 export const createSchemaWalkMemoStore = (
   maxEntries: number = DEFAULT_MAX_ENTRIES,
-): SchemaWalkMemoStore => ({
-  engine: null,
-  entries: new Map(),
-  maxEntries,
-  hits: 0,
-  misses: 0,
-  evictions: 0,
-  poisons: 0,
-});
+): SchemaWalkMemoStore => {
+  // Validated here rather than defended against at each eviction: a
+  // negative bound can never be satisfied, so an eviction loop holding to
+  // it would run until the process died.
+  if (!Number.isInteger(maxEntries) || maxEntries < 0) {
+    throw new RangeError(
+      `schema walk memo maxEntries must be a non-negative integer: ${maxEntries}`,
+    );
+  }
+  return {
+    engine: null,
+    entries: new Map(),
+    maxEntries,
+    hits: 0,
+    misses: 0,
+    evictions: 0,
+    poisons: 0,
+  };
+};
 
 export const schemaWalkMemoDiagnostics = (
   store: SchemaWalkMemoStore,
@@ -206,12 +217,6 @@ const parseTrackerKey = (
   };
 };
 
-/** Injective over the pair (JSON escapes delimiters; `null` keeps an
- * absent component distinct from an empty string) — the same form the
- * shared-memo identity tripwire uses. */
-const identityKeyOf = (identity: ScopeKeyIdentity): string =>
-  JSON.stringify([identity.principal ?? null, identity.sessionId ?? null]);
-
 /** Injective over the segments (JSON escapes the separator). */
 const pathKeyOf = (path: readonly string[]): string => JSON.stringify(path);
 
@@ -272,7 +277,7 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
     this.#space = options.space;
     this.#branch = options.branch;
     this.#identity = options.identity;
-    this.#identityKey = identityKeyOf(options.identity);
+    this.#identityKey = schemaMemoIdentityKey(options.identity);
     this.#tracker = options.tracker;
     this.#currentSeq = Engine.serverSeq(options.engine);
     options.tracker.bind(this);
@@ -418,40 +423,21 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
    * current seq needs only entry PRESENCE down the closure (revisions
    * move only with commits); a stale stamp re-checks every read revision
    * and re-resolves each child at its current revision, then stamps.
-   * Marks made provisionally during a failed closure are wiped: a node
-   * marked valid through a dependency cycle whose anchor later fails
-   * must not stay cached as valid. */
+   *
+   * A key reads as INVALID while its own closure is being checked, so a
+   * dependency cycle resolves to "recompute it" rather than recursing
+   * forever or resting on an assumption a later failure would falsify.
+   * Stored entries cannot form such a cycle today — a value cycle
+   * poisons every frame containing it, and poisoned frames are never
+   * stored — so this costs nothing and needs no cycle bookkeeping. */
   #validate(key: string, entry: SchemaWalkMemoEntry): boolean {
-    const marked: string[] = [];
-    const valid = this.#validateInner(key, entry, marked);
-    if (!valid) {
-      for (const provisional of marked) {
-        if (this.#validated.get(provisional) === true) {
-          this.#validated.delete(provisional);
-        }
-      }
-    }
-    return valid;
-  }
-
-  #validateInner(
-    key: string,
-    entry: SchemaWalkMemoEntry,
-    marked: string[],
-  ): boolean {
     const known = this.#validated.get(key);
-    // An in-progress key (marked below before recursing) reads as valid:
-    // a dependency cycle is valid exactly when every document on it sits
-    // at the revision its entry names, which the per-node checks
-    // establish — and a wrong provisional mark is wiped by the caller.
     if (known !== undefined) return known;
-    this.#validated.set(key, true);
-    marked.push(key);
+    this.#validated.set(key, false);
     const stamped = entry.validatedAt === this.#currentSeq;
     if (!stamped) {
       for (const read of entry.readRevs) {
         if (this.#revisionOf(read.scope, read.id) !== read.revision) {
-          this.#validated.set(key, false);
           return false;
         }
       }
@@ -475,15 +461,15 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
       }
       if (
         childKey === undefined || childEntry === undefined ||
-        !this.#validateInner(childKey, childEntry, marked)
+        !this.#validate(childKey, childEntry)
       ) {
-        this.#validated.set(key, false);
         return false;
       }
       resolved.push(childKey);
     }
     this.#resolvedChildren.set(key, resolved);
     entry.validatedAt = this.#currentSeq;
+    this.#validated.set(key, true);
     return true;
   }
 

--- a/packages/memory/v2/schema-walk-memo.ts
+++ b/packages/memory/v2/schema-walk-memo.ts
@@ -21,13 +21,13 @@ import * as Engine from "./engine.ts";
 
 /**
  * A cross-evaluation, per-document memo of schema-walk computation
- * (docs/plans/revision-keyed-schema-memo.md), the memory-side
+ * (PR #6464), the memory-side
  * implementation of the runner's {@link CrossTraversalSchemaMemo} seam.
  *
  * Entries are keyed by (branch, scope instance, id, document REVISION,
  * schema), so validity is by key construction: a commit to a document
  * strands every entry recorded at its previous revision, and no
- * invalidation machinery exists — retention is insertion-order LRU under
+ * invalidation machinery exists — retention is access-order LRU under
  * `maxEntries`. An entry carries the traversal result for its (document,
  * schema) subtree plus a manifest of the traversal's DIRECT effects — the
  * registrations and misses its own document's walk produced, and the
@@ -190,6 +190,10 @@ export class CapturingSchemaTracker extends MapSetStringToPathSelectors {
     this.#session = session;
   }
 
+  unbind(session: SchemaWalkMemoSession): void {
+    if (this.#session === session) this.#session = undefined;
+  }
+
   public override add(key: string, value: SchemaPathSelector) {
     this.#session?.captureRegistration(key, value);
     super.add(key, value);
@@ -281,6 +285,12 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
     this.#tracker = options.tracker;
     this.#currentSeq = Engine.serverSeq(options.engine);
     options.tracker.bind(this);
+  }
+
+  /** Release the evaluation-only capture graph before its tracker becomes
+   * long-lived watch state. */
+  detachTracker(): void {
+    this.#tracker.unbind(this);
   }
 
   /** Tee the walk's miss recorder: capture for the open frame, then
@@ -473,8 +483,16 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
     return true;
   }
 
+  #touch(key: string, entry: SchemaWalkMemoEntry): void {
+    this.#store.entries.delete(key);
+    this.#store.entries.set(key, entry);
+  }
+
   #replay(key: string, entry: SchemaWalkMemoEntry): void {
-    if (this.#replayed.has(key)) return;
+    if (this.#replayed.has(key)) {
+      this.#touch(key, entry);
+      return;
+    }
     this.#replayed.add(key);
     for (const registration of entry.registrations) {
       this.#tracker.addWithoutCapture(
@@ -509,6 +527,10 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
       const child = this.#store.entries.get(childKey);
       if (child !== undefined) this.#replay(childKey, child);
     }
+    // A root hit consumes its whole manifest closure. Promote children
+    // before their parent so the root remains the youngest entry while
+    // every dependency it needs stays ahead of unrelated cold entries.
+    this.#touch(key, entry);
   }
 
   #recordChild(
@@ -567,9 +589,6 @@ export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
     }
     this.#replay(found.key, found.entry);
     this.#store.hits++;
-    // Recency: a served entry moves to the young end of the LRU order.
-    this.#store.entries.delete(found.key);
-    this.#store.entries.set(found.key, found.entry);
     const frame = this.#frames.at(-1);
     if (frame !== undefined) {
       this.#recordChild(

--- a/packages/memory/v2/schema-walk-memo.ts
+++ b/packages/memory/v2/schema-walk-memo.ts
@@ -1,0 +1,703 @@
+import type { FabricValue, JSONSchema } from "@commonfabric/api";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
+import {
+  type CrossTraversalSchemaMemo,
+  type IMemorySpaceValueAttestation,
+  MapSetStringToPathSelectors,
+  type NormalizedFullLink,
+  type SchemaPathSelector,
+  schemaTrackerKey,
+  type TraverseResult,
+} from "@commonfabric/runner/graph-query";
+
+import {
+  type CellScope,
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+  scopeOfScopeKey,
+} from "../v2.ts";
+import * as Engine from "./engine.ts";
+
+/**
+ * A cross-evaluation, per-document memo of schema-walk computation
+ * (docs/plans/revision-keyed-schema-memo.md), the memory-side
+ * implementation of the runner's {@link CrossTraversalSchemaMemo} seam.
+ *
+ * Entries are keyed by (branch, scope instance, id, document REVISION,
+ * schema), so validity is by key construction: a commit to a document
+ * strands every entry recorded at its previous revision, and no
+ * invalidation machinery exists — retention is insertion-order LRU under
+ * `maxEntries`. An entry carries the traversal result for its (document,
+ * schema) subtree plus a manifest of the traversal's DIRECT effects — the
+ * registrations and misses its own document's walk produced, and the
+ * (document, schema) children it consumed. A hit replays the manifest
+ * recursively through the child entries into the current walk's tracker
+ * and miss recorder, resolving scoped addresses under the CURRENT
+ * identity — effects are re-derived, never replayed from another
+ * identity's resolution. Validation is the same recursion: a child whose
+ * document changed has no entry at its current revision, which invalidates
+ * exactly the ancestor chain from the change to the query root.
+ *
+ * Scoped reach gates sharing. A document's own instance is in the key, so
+ * entries for scoped documents never collide across identities. An entry
+ * for a SPACE-scoped document whose subtree reached user- or
+ * session-scoped state (a registration, miss, or child under a non-space
+ * instance) is `tainted` and keyed with the evaluating identity appended:
+ * it serves only that identity, and taint climbs only the ancestor chain
+ * of the scoped reach. Cross-identity sharing of the untainted rest also
+ * rests on evaluation being recipient-blind — the invariant the query
+ * evaluation cache documents (key-vocabulary.md §5): a per-recipient
+ * filter inside evaluation must key or bypass this memo too.
+ */
+export type SchemaWalkMemoStore = {
+  /** The engine the entries' revisions belong to. Sequence numbers
+   * identify state only within their engine, so a different engine object
+   * for the same space clears the store. */
+  engine: Engine.Engine | null;
+  entries: Map<string, SchemaWalkMemoEntry>;
+  maxEntries: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  /** poison() signals — computations cut by walk-global state (value
+   * cycles), whose frames and ancestors never became entries. */
+  poisons: number;
+};
+
+export type SchemaWalkMemoDiagnostics = {
+  entries: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  poisons: number;
+};
+
+/** ~5 board-sized corpora; a served entry is a few hundred bytes. */
+const DEFAULT_MAX_ENTRIES = 32_768;
+
+export const createSchemaWalkMemoStore = (
+  maxEntries: number = DEFAULT_MAX_ENTRIES,
+): SchemaWalkMemoStore => ({
+  engine: null,
+  entries: new Map(),
+  maxEntries,
+  hits: 0,
+  misses: 0,
+  evictions: 0,
+  poisons: 0,
+});
+
+export const schemaWalkMemoDiagnostics = (
+  store: SchemaWalkMemoStore,
+): SchemaWalkMemoDiagnostics => ({
+  entries: store.entries.size,
+  hits: store.hits,
+  misses: store.misses,
+  evictions: store.evictions,
+  poisons: store.poisons,
+});
+
+/** A registration or miss in scope-UNRESOLVED form: the instance is
+ * re-resolved under the identity of the evaluation that replays it. */
+type ManifestEffect = {
+  id: string;
+  scope: CellScope;
+  selector: SchemaPathSelector;
+};
+
+type ManifestMiss = ManifestEffect & {
+  referrer?: { id: string; scope: CellScope };
+};
+
+/** A document revision a frame's computation read: the reason the frame's
+ * entry stops being valid when that document changes. Registrations and
+ * misses both put their documents here — a walk reads what it registers,
+ * and reads the absence it records. */
+type ReadRevision = {
+  id: string;
+  scope: CellScope;
+  revision: string;
+};
+
+/** A (document, path, schema) subtree this entry's traversal consumed.
+ * `entryKey` is the child's stored key when its frame became an entry —
+ * usable directly while nothing has committed since (the validation
+ * stamp fast path); after a commit, validation re-resolves the child at
+ * its current revision instead. */
+type ChildDep = {
+  id: string;
+  scope: CellScope;
+  pathKey: string;
+  schemaKey: string;
+  entryKey: string | undefined;
+};
+
+export type SchemaWalkMemoEntry = {
+  result: TraverseResult<FabricValue>;
+  registrations: ManifestEffect[];
+  misses: ManifestMiss[];
+  readRevs: ReadRevision[];
+  children: ChildDep[];
+  tainted: boolean;
+  /** The engine seq this entry's revisions were last confirmed current
+   * at. Revisions move only with commits, so an entry stamped at the
+   * current seq validates by entry presence alone — no engine reads. */
+  validatedAt: number;
+};
+
+type Frame = {
+  id: string;
+  scope: CellScope;
+  pathKey: string;
+  schemaKey: string;
+  registrations: ManifestEffect[];
+  misses: ManifestMiss[];
+  readRevs: Map<string, ReadRevision>;
+  children: ChildDep[];
+  childKeys: Set<string>;
+  tainted: boolean;
+  /** The computation was cut short by walk-global state, or lost a child
+   * frame to an error: its effects are not a standalone computation's,
+   * and neither this frame nor any ancestor may become an entry. */
+  poisoned: boolean;
+};
+
+/** The walk's schema tracker with capture: every registration the
+ * traversal makes is offered to the active session's open frame before it
+ * lands. Replay writes through `addWithoutCapture`, so a served subtree's
+ * registrations never re-enter the frame that is serving it. `clone()` is
+ * inherited and returns a PLAIN tracker — states cached or cloned from a
+ * capturing walk carry no capture hook. */
+export class CapturingSchemaTracker extends MapSetStringToPathSelectors {
+  #session: SchemaWalkMemoSession | undefined;
+
+  constructor() {
+    super(true);
+  }
+
+  bind(session: SchemaWalkMemoSession): void {
+    this.#session = session;
+  }
+
+  public override add(key: string, value: SchemaPathSelector) {
+    this.#session?.captureRegistration(key, value);
+    super.add(key, value);
+  }
+
+  addWithoutCapture(key: string, value: SchemaPathSelector): void {
+    super.add(key, value);
+  }
+}
+
+/** `${space}/${scope_key}/${id}` → its parts. The space and the scope-key
+ * segment never contain "/" (their parts are encodeURIComponent-encoded),
+ * so the first two separators are exact and the remainder is the id,
+ * which can contain "/". */
+const parseTrackerKey = (
+  key: string,
+): { id: string; scope: CellScope; scopeKey: string } => {
+  const first = key.indexOf("/");
+  const second = key.indexOf("/", first + 1);
+  const scopeKey = key.slice(first + 1, second);
+  return {
+    id: key.slice(second + 1),
+    scope: scopeOfScopeKey(scopeKey),
+    scopeKey,
+  };
+};
+
+/** Injective over the pair (JSON escapes delimiters; `null` keeps an
+ * absent component distinct from an empty string) — the same form the
+ * shared-memo identity tripwire uses. */
+const identityKeyOf = (identity: ScopeKeyIdentity): string =>
+  JSON.stringify([identity.principal ?? null, identity.sessionId ?? null]);
+
+/** Injective over the segments (JSON escapes the separator). */
+const pathKeyOf = (path: readonly string[]): string => JSON.stringify(path);
+
+/** Boolean schemas are legal and common (`schema: true` roots); the
+ * interner takes only object schemas, so the two get sentinel keys of
+ * their own. */
+const schemaKeyOf = (schema: JSONSchema): string =>
+  typeof schema === "boolean"
+    ? (schema ? "B:true" : "B:false")
+    : internSchemaAsTaggedHashString(schema);
+
+/**
+ * One evaluation's view of a {@link SchemaWalkMemoStore}: the frame stack
+ * that attributes captured effects, the per-evaluation revision and
+ * validation caches, and the replay machinery. Constructed by `trackGraph`
+ * per evaluation and handed to the walk as its
+ * {@link CrossTraversalSchemaMemo}.
+ */
+export class SchemaWalkMemoSession implements CrossTraversalSchemaMemo {
+  readonly #store: SchemaWalkMemoStore;
+  readonly #engine: Engine.Engine;
+  readonly #space: string;
+  readonly #branch: string;
+  readonly #identity: ScopeKeyIdentity;
+  readonly #identityKey: string;
+  readonly #tracker: CapturingSchemaTracker;
+  #missRecorder:
+    | ((
+      missKey: string,
+      selector: SchemaPathSelector,
+      referrerKey: string | undefined,
+    ) => void)
+    | undefined;
+  readonly #frames: Frame[] = [];
+  /** scopeKey|id → revision component, one row read per document per
+   * evaluation. `"A"` = the document is absent — a revision state of its
+   * own: entries recorded against absence stay valid exactly while the
+   * document stays absent, and its creation strands them by key. */
+  readonly #revisions = new Map<string, string>();
+  readonly #validated = new Map<string, boolean>();
+  readonly #replayed = new Set<string>();
+  /** entryKey -> the child entry keys THIS evaluation's validation
+   * resolved, which replay then follows — the two passes must agree on
+   * which stored subtree stands for each dependency. */
+  readonly #resolvedChildren = new Map<string, string[]>();
+  readonly #currentSeq: number;
+
+  constructor(options: {
+    store: SchemaWalkMemoStore;
+    engine: Engine.Engine;
+    space: string;
+    branch: string;
+    identity: ScopeKeyIdentity;
+    tracker: CapturingSchemaTracker;
+  }) {
+    this.#store = options.store;
+    this.#engine = options.engine;
+    this.#space = options.space;
+    this.#branch = options.branch;
+    this.#identity = options.identity;
+    this.#identityKey = identityKeyOf(options.identity);
+    this.#tracker = options.tracker;
+    this.#currentSeq = Engine.serverSeq(options.engine);
+    options.tracker.bind(this);
+  }
+
+  /** Tee the walk's miss recorder: capture for the open frame, then
+   * record live. The wrapped recorder is also the replay target. */
+  wrapMissRecorder(
+    recorder: (
+      missKey: string,
+      selector: SchemaPathSelector,
+      referrerKey: string | undefined,
+    ) => void,
+  ): (
+    missKey: string,
+    selector: SchemaPathSelector,
+    referrerKey: string | undefined,
+  ) => void {
+    this.#missRecorder = recorder;
+    return (missKey, selector, referrerKey) => {
+      this.#captureMiss(missKey, selector, referrerKey);
+      recorder(missKey, selector, referrerKey);
+    };
+  }
+
+  captureRegistration(key: string, selector: SchemaPathSelector): void {
+    const frame = this.#frames.at(-1);
+    if (frame === undefined) return;
+    const { id, scope, scopeKey } = parseTrackerKey(key);
+    frame.registrations.push({ id, scope, selector });
+    this.#captureReadRev(frame, id, scope);
+    if (scopeKey !== "space") frame.tainted = true;
+  }
+
+  /** A frame read this document (registered it, or recorded its
+   * absence), so the frame's entry depends on its revision — including
+   * documents read through pointer chains that never get frames of their
+   * own. */
+  #captureReadRev(frame: Frame, id: string, scope: CellScope): void {
+    const revKey = `${scope}|${id}`;
+    if (!frame.readRevs.has(revKey)) {
+      frame.readRevs.set(revKey, {
+        id,
+        scope,
+        revision: this.#revisionOf(scope, id),
+      });
+    }
+  }
+
+  #captureMiss(
+    missKey: string,
+    selector: SchemaPathSelector,
+    referrerKey: string | undefined,
+  ): void {
+    const frame = this.#frames.at(-1);
+    if (frame === undefined) return;
+    const miss = parseTrackerKey(missKey);
+    const referrer = referrerKey === undefined
+      ? undefined
+      : parseTrackerKey(referrerKey);
+    frame.misses.push({
+      id: miss.id,
+      scope: miss.scope,
+      selector,
+      ...(referrer === undefined
+        ? {}
+        : { referrer: { id: referrer.id, scope: referrer.scope } }),
+    });
+    this.#captureReadRev(frame, miss.id, miss.scope);
+    if (
+      miss.scopeKey !== "space" ||
+      (referrer !== undefined && referrer.scopeKey !== "space")
+    ) {
+      frame.tainted = true;
+    }
+  }
+
+  #revisionOf(scope: CellScope, id: string): string {
+    const scopeKey = resolveScopeKey(scope, this.#identity);
+    const cacheKey = `${scopeKey}|${id}`;
+    const cached = this.#revisions.get(cacheKey);
+    if (cached !== undefined) return cached;
+    const head = Engine.readRevision(this.#engine, {
+      id,
+      scopeKey,
+      branch: this.#branch,
+    });
+    const revision = head === null || head.op === "delete"
+      ? "A"
+      : `${head.seq}.${head.opIndex}`;
+    this.#revisions.set(cacheKey, revision);
+    return revision;
+  }
+
+  #entryKey(
+    scope: CellScope,
+    id: string,
+    pathKey: string,
+    revision: string,
+    schemaKey: string,
+    tainted: boolean,
+  ): string {
+    const scopeKey = resolveScopeKey(scope, this.#identity);
+    const base =
+      `${this.#branch}|${scopeKey}|${id}|${pathKey}|${revision}|${schemaKey}`;
+    return tainted ? `${base}|I${this.#identityKey}` : base;
+  }
+
+  /** The entry for (scope, id, path, schema) at the document's CURRENT
+   * revision: the untainted key first, then this identity's tainted key. */
+  #entryFor(
+    scope: CellScope,
+    id: string,
+    pathKey: string,
+    schemaKey: string,
+  ): { key: string; entry: SchemaWalkMemoEntry } | undefined {
+    const revision = this.#revisionOf(scope, id);
+    const pureKey = this.#entryKey(
+      scope,
+      id,
+      pathKey,
+      revision,
+      schemaKey,
+      false,
+    );
+    const pure = this.#store.entries.get(pureKey);
+    if (pure !== undefined) return { key: pureKey, entry: pure };
+    const taintedKey = this.#entryKey(
+      scope,
+      id,
+      pathKey,
+      revision,
+      schemaKey,
+      true,
+    );
+    const tainted = this.#store.entries.get(taintedKey);
+    return tainted === undefined
+      ? undefined
+      : { key: taintedKey, entry: tainted };
+  }
+
+  /** Validate `entry`'s transitive closure. An entry stamped at the
+   * current seq needs only entry PRESENCE down the closure (revisions
+   * move only with commits); a stale stamp re-checks every read revision
+   * and re-resolves each child at its current revision, then stamps.
+   * Marks made provisionally during a failed closure are wiped: a node
+   * marked valid through a dependency cycle whose anchor later fails
+   * must not stay cached as valid. */
+  #validate(key: string, entry: SchemaWalkMemoEntry): boolean {
+    const marked: string[] = [];
+    const valid = this.#validateInner(key, entry, marked);
+    if (!valid) {
+      for (const provisional of marked) {
+        if (this.#validated.get(provisional) === true) {
+          this.#validated.delete(provisional);
+        }
+      }
+    }
+    return valid;
+  }
+
+  #validateInner(
+    key: string,
+    entry: SchemaWalkMemoEntry,
+    marked: string[],
+  ): boolean {
+    const known = this.#validated.get(key);
+    // An in-progress key (marked below before recursing) reads as valid:
+    // a dependency cycle is valid exactly when every document on it sits
+    // at the revision its entry names, which the per-node checks
+    // establish — and a wrong provisional mark is wiped by the caller.
+    if (known !== undefined) return known;
+    this.#validated.set(key, true);
+    marked.push(key);
+    const stamped = entry.validatedAt === this.#currentSeq;
+    if (!stamped) {
+      for (const read of entry.readRevs) {
+        if (this.#revisionOf(read.scope, read.id) !== read.revision) {
+          this.#validated.set(key, false);
+          return false;
+        }
+      }
+    }
+    const resolved: string[] = [];
+    for (const child of entry.children) {
+      let childKey: string | undefined;
+      let childEntry: SchemaWalkMemoEntry | undefined;
+      if (stamped && child.entryKey !== undefined) {
+        childKey = child.entryKey;
+        childEntry = this.#store.entries.get(childKey);
+      } else {
+        const found = this.#entryFor(
+          child.scope,
+          child.id,
+          child.pathKey,
+          child.schemaKey,
+        );
+        childKey = found?.key;
+        childEntry = found?.entry;
+      }
+      if (
+        childKey === undefined || childEntry === undefined ||
+        !this.#validateInner(childKey, childEntry, marked)
+      ) {
+        this.#validated.set(key, false);
+        return false;
+      }
+      resolved.push(childKey);
+    }
+    this.#resolvedChildren.set(key, resolved);
+    entry.validatedAt = this.#currentSeq;
+    return true;
+  }
+
+  #replay(key: string, entry: SchemaWalkMemoEntry): void {
+    if (this.#replayed.has(key)) return;
+    this.#replayed.add(key);
+    for (const registration of entry.registrations) {
+      this.#tracker.addWithoutCapture(
+        schemaTrackerKey(
+          this.#space,
+          registration.id,
+          registration.scope,
+          this.#identity,
+        ),
+        registration.selector,
+      );
+    }
+    const recorder = this.#missRecorder;
+    if (recorder !== undefined) {
+      for (const miss of entry.misses) {
+        recorder(
+          schemaTrackerKey(this.#space, miss.id, miss.scope, this.#identity),
+          miss.selector,
+          miss.referrer === undefined ? undefined : schemaTrackerKey(
+            this.#space,
+            miss.referrer.id,
+            miss.referrer.scope,
+            this.#identity,
+          ),
+        );
+      }
+    }
+    // Follow the exact child entries validation resolved for this
+    // evaluation, so the effects replayed are the ones validation vouched
+    // for.
+    for (const childKey of this.#resolvedChildren.get(key) ?? []) {
+      const child = this.#store.entries.get(childKey);
+      if (child !== undefined) this.#replay(childKey, child);
+    }
+  }
+
+  #recordChild(
+    frame: Frame,
+    child: ChildDep,
+    childTainted: boolean,
+  ): void {
+    const dedupeKey =
+      `${child.scope}|${child.id}|${child.pathKey}|${child.schemaKey}`;
+    if (!frame.childKeys.has(dedupeKey)) {
+      frame.childKeys.add(dedupeKey);
+      frame.children.push(child);
+    }
+    if (childTainted || child.scope !== "space") frame.tainted = true;
+  }
+
+  #depOfFrame(frame: Frame, entryKey: string | undefined): ChildDep {
+    return {
+      id: frame.id,
+      scope: frame.scope,
+      pathKey: frame.pathKey,
+      schemaKey: frame.schemaKey,
+      entryKey,
+    };
+  }
+
+  #depOf(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    entryKey?: string,
+  ): ChildDep {
+    return {
+      id: doc.address.id,
+      scope: doc.address.scope ?? "space",
+      pathKey: pathKeyOf(doc.address.path),
+      schemaKey: schemaKeyOf(schema),
+      entryKey,
+    };
+  }
+
+  lookup(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    _link?: NormalizedFullLink,
+  ): TraverseResult<FabricValue> | undefined {
+    const dep = this.#depOf(doc, schema);
+    const found = this.#entryFor(
+      dep.scope,
+      dep.id,
+      dep.pathKey,
+      dep.schemaKey,
+    );
+    if (found === undefined || !this.#validate(found.key, found.entry)) {
+      this.#store.misses++;
+      return undefined;
+    }
+    this.#replay(found.key, found.entry);
+    this.#store.hits++;
+    // Recency: a served entry moves to the young end of the LRU order.
+    this.#store.entries.delete(found.key);
+    this.#store.entries.set(found.key, found.entry);
+    const frame = this.#frames.at(-1);
+    if (frame !== undefined) {
+      this.#recordChild(
+        frame,
+        { ...dep, entryKey: found.key },
+        found.entry.tainted,
+      );
+    }
+    return found.entry.result;
+  }
+
+  enter(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    _link?: NormalizedFullLink,
+  ): void {
+    this.#frames.push({
+      id: doc.address.id,
+      scope: doc.address.scope ?? "space",
+      pathKey: pathKeyOf(doc.address.path),
+      schemaKey: schemaKeyOf(schema),
+      registrations: [],
+      misses: [],
+      readRevs: new Map(),
+      children: [],
+      childKeys: new Set(),
+      tainted: false,
+      poisoned: false,
+    });
+  }
+
+  exit(
+    _doc: IMemorySpaceValueAttestation,
+    _schema: JSONSchema,
+    result: TraverseResult<FabricValue>,
+    _link?: NormalizedFullLink,
+  ): void {
+    const frame = this.#frames.pop();
+    if (frame === undefined) return;
+    let storedKey: string | undefined;
+    if (!frame.poisoned) {
+      const revision = this.#revisionOf(frame.scope, frame.id);
+      const key = this.#entryKey(
+        frame.scope,
+        frame.id,
+        frame.pathKey,
+        revision,
+        frame.schemaKey,
+        frame.tainted,
+      );
+      const previous = this.#store.entries.get(key);
+      if (previous !== undefined) this.#store.entries.delete(key);
+      this.#store.entries.set(key, {
+        result,
+        registrations: frame.registrations,
+        misses: frame.misses,
+        readRevs: [...frame.readRevs.values()],
+        children: frame.children,
+        tainted: frame.tainted,
+        validatedAt: this.#currentSeq,
+      });
+      storedKey = key;
+      while (this.#store.entries.size > this.#store.maxEntries) {
+        const oldest = this.#store.entries.keys().next().value!;
+        this.#store.entries.delete(oldest);
+        this.#store.evictions++;
+      }
+    }
+    const parent = this.#frames.at(-1);
+    if (parent !== undefined) {
+      this.#recordChild(
+        parent,
+        this.#depOfFrame(frame, storedKey),
+        frame.tainted,
+      );
+      if (frame.poisoned) parent.poisoned = true;
+    }
+  }
+
+  abandon(): void {
+    this.#frames.pop();
+    // A frame vanished mid-computation, so whatever contains it did not
+    // observe a completed child.
+    const parent = this.#frames.at(-1);
+    if (parent !== undefined) parent.poisoned = true;
+  }
+
+  poison(): void {
+    this.#store.poisons++;
+    const frame = this.#frames.at(-1);
+    if (frame !== undefined) frame.poisoned = true;
+  }
+
+  dependency(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    _link?: NormalizedFullLink,
+  ): void {
+    const frame = this.#frames.at(-1);
+    if (frame === undefined) return;
+    const dep = this.#depOf(doc, schema);
+    const found = this.#entryFor(
+      dep.scope,
+      dep.id,
+      dep.pathKey,
+      dep.schemaKey,
+    );
+    // An unknown child taints conservatively: the entry (if this frame
+    // stores one) narrows to this identity, and a parent whose child
+    // entry is missing fails validation at lookup regardless.
+    this.#recordChild(
+      frame,
+      { ...dep, entryKey: found?.key },
+      found === undefined ? true : found.entry.tainted,
+    );
+  }
+}

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -115,6 +115,12 @@ import {
   trackGraph,
 } from "./query.ts";
 import {
+  createSchemaWalkMemoStore,
+  type SchemaWalkMemoDiagnostics,
+  schemaWalkMemoDiagnostics,
+  type SchemaWalkMemoStore,
+} from "./schema-walk-memo.ts";
+import {
   executionLeaseHolder,
   liveExecutionLeaseHolder,
 } from "./execution-lease.ts";
@@ -1345,6 +1351,13 @@ export class Server {
    * most QUERY_EVALUATION_CACHE_MAX_SPACES spaces in LRU order. */
   #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
 
+  /**
+   * Per-space revision-keyed schema-walk memos (schema-walk-memo.ts),
+   * populated only under `experimentalSchemaWalkMemo`, held for at most
+   * QUERY_EVALUATION_CACHE_MAX_SPACES spaces in LRU order.
+   */
+  #schemaWalkMemos = new Map<string, SchemaWalkMemoStore>();
+
   #engines = new Map<string, Promise<Engine.Engine>>();
   // The resolved-engine index for the SYNC cross-engine lease lookup
   // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
@@ -1455,6 +1468,13 @@ export class Server {
        * fits. A single evaluation heavier than the whole budget is not
        * retained at all. */
       queryEvaluationCacheBudget?: number;
+      /**
+       * Serves per-document schema-walk subtrees across evaluations from a
+       * per-space revision-keyed memo
+       * (docs/plans/revision-keyed-schema-memo.md). Experimental, off by
+       * default; `true` uses the store's default entry bound.
+       */
+      experimentalSchemaWalkMemo?: boolean | { maxEntries?: number };
 
       authorizeSessionOpen: (
         message: SessionOpenRequest,
@@ -4419,6 +4439,7 @@ export class Server {
               principal: session.principal,
               sessionId: message.sessionId,
               evaluationCache: this.#evaluationCacheFor(message.space),
+              schemaWalkMemo: this.#schemaWalkMemoFor(message.space),
             },
           );
           foldRootAttribution(attribution, tracked.stats);
@@ -4558,6 +4579,39 @@ export class Server {
     return cache;
   }
 
+  /** The space's schema-walk memo store, or undefined when the
+   * experimental option is off. Same space-count backstop as the
+   * evaluation caches. */
+  #schemaWalkMemoFor(space: string): SchemaWalkMemoStore | undefined {
+    const config = this.options.experimentalSchemaWalkMemo;
+    if (config === undefined || config === false) return undefined;
+    let store = this.#schemaWalkMemos.get(space);
+    if (store !== undefined) {
+      this.#schemaWalkMemos.delete(space);
+      this.#schemaWalkMemos.set(space, store);
+      return store;
+    }
+    store = createSchemaWalkMemoStore(
+      config === true ? undefined : config.maxEntries,
+    );
+    this.#schemaWalkMemos.set(space, store);
+    if (this.#schemaWalkMemos.size > QUERY_EVALUATION_CACHE_MAX_SPACES) {
+      const oldest = this.#schemaWalkMemos.keys().next().value;
+      if (oldest !== undefined) {
+        this.#schemaWalkMemos.delete(oldest);
+      }
+    }
+    return store;
+  }
+
+  /** The space's schema-walk memo counters, for diagnostics and tests. A
+   * peek: an absent (never-evaluated, evicted, or option-off) space reads
+   * as empty rather than being created or recency-bumped. */
+  schemaWalkMemoDiagnostics(space: string): SchemaWalkMemoDiagnostics {
+    const store = this.#schemaWalkMemos.get(space);
+    return schemaWalkMemoDiagnostics(store ?? createSchemaWalkMemoStore());
+  }
+
   /** Evict least-recently-evaluated spaces' oldest entries until the
    * caches' total retained weight fits the budget. Runs after every
    * evaluation that may have inserted; an entry heavier than the whole
@@ -4634,7 +4688,10 @@ export class Server {
         {
           ...scopeContext,
           ...(cacheEligible
-            ? { evaluationCache: this.#evaluationCacheFor(space) }
+            ? {
+              evaluationCache: this.#evaluationCacheFor(space),
+              schemaWalkMemo: this.#schemaWalkMemoFor(space),
+            }
             : {}),
         },
       );
@@ -4681,6 +4738,7 @@ export class Server {
         {
           ...scopeContext,
           evaluationCache: this.#evaluationCacheFor(space),
+          schemaWalkMemo: this.#schemaWalkMemoFor(space),
         },
       );
       foldRootAttribution(attribution, result.stats);

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -36,6 +36,7 @@ import {
   type NormalizedFullLink,
   type ObjectStorageManager,
   type SchemaMemo,
+  schemaMemoIdentityKey,
   SchemaObjectTraverser,
   type SchemaPathSelector,
   schemaTrackerCoversSelector,
@@ -58,6 +59,7 @@ export {
   createSchemaMemo,
   MapSetStringToPathSelectors,
   type SchemaMemo,
+  schemaMemoIdentityKey,
   schemaTrackerCoversSelector,
   schemaTrackerKey,
 };

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -26,12 +26,14 @@ import {
   CompoundCycleTracker,
   createSchemaMemo,
   createTraversalContext,
+  type CrossTraversalSchemaMemo,
   getAtPath,
   type IAttestation,
   type IMemorySpaceValueAttestation,
   loadMetaLinkedDocs,
   ManagedStorageTransaction,
   MapSetStringToPathSelectors,
+  type NormalizedFullLink,
   type ObjectStorageManager,
   type SchemaMemo,
   SchemaObjectTraverser,
@@ -39,13 +41,18 @@ import {
   schemaTrackerCoversSelector,
   schemaTrackerKey,
   type TraversalContext,
+  type TraverseResult,
 } from "./traverse.ts";
 
 export type {
   BaseMemoryAddress,
+  CrossTraversalSchemaMemo,
   IAttestation,
+  IMemorySpaceValueAttestation,
+  NormalizedFullLink,
   ObjectStorageManager,
   SchemaPathSelector,
+  TraverseResult,
 };
 export {
   createSchemaMemo,
@@ -65,6 +72,7 @@ export type GraphQueryWalkStats = {
   dagTraversals: number;
   getDocAtPathCalls: number;
   schemaMemoHits: number;
+  crossTraversalMemoHits: number;
 };
 
 export const createGraphQueryWalkStats = (): GraphQueryWalkStats => ({
@@ -76,6 +84,7 @@ export const createGraphQueryWalkStats = (): GraphQueryWalkStats => ({
   dagTraversals: 0,
   getDocAtPathCalls: 0,
   schemaMemoHits: 0,
+  crossTraversalMemoHits: 0,
 });
 
 export type GraphQueryWalkOptions = {
@@ -131,6 +140,11 @@ export type GraphQueryWalkOptions = {
 
   /** Schema-traversal results reused across walks that share it. */
   memo?: SchemaMemo;
+
+  /** Cross-traversal schema memo the walk's traversals consult (query
+   * path only; see {@link CrossTraversalSchemaMemo}). The walk threads it
+   * through unchanged. */
+  crossTraversalMemo?: CrossTraversalSchemaMemo;
 
   /** Counters to add into. */
   stats?: GraphQueryWalkStats;
@@ -196,6 +210,7 @@ export class GraphQueryWalk {
       },
     );
     this.#memo = options.memo ?? createSchemaMemo();
+    this.#context.crossTraversalMemo = options.crossTraversalMemo;
     this.stats = options.stats ?? createGraphQueryWalkStats();
   }
 
@@ -295,5 +310,6 @@ export class GraphQueryWalk {
     this.stats.dagTraversals += traverser.traverseDAGCalls;
     this.stats.getDocAtPathCalls += traverser.getDocAtPathCalls;
     this.stats.schemaMemoHits += traverser.schemaMemoHits;
+    this.stats.crossTraversalMemoHits += traverser.crossTraversalMemoHits;
   }
 }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -76,6 +76,9 @@ import {
   type ValuePath,
 } from "./link-types.ts";
 import { addressKey, NormalizedFullLink, parseLink } from "./link-utils.ts";
+// Re-exported: the cross-traversal memo interface names it, so implementers
+// reach one module (graph-query re-exports the traversal vocabulary).
+export type { NormalizedFullLink };
 import { canFollowScopedLink } from "./scope.ts";
 import { type CellLinkRefPayload, SigilLink, type URI } from "./sigil-types.ts";
 import {
@@ -1303,6 +1306,13 @@ export type TraversalContext = {
   schemaDocsLoaded: Set<string>;
 
   /**
+   * Cross-traversal schema memo the query path consults (see
+   * {@link CrossTraversalSchemaMemo}); absent on the read path and on
+   * traversals whose results must not be shared across evaluations.
+   */
+  crossTraversalMemo?: CrossTraversalSchemaMemo;
+
+  /**
    * `\${space}/\${taggedHash}` keys for the schema documents this traversal
    * loaded AND verified, qualified by the space each was collected from —
    * one traversal can cross spaces through links, and a document collected
@@ -1684,6 +1694,53 @@ export abstract class BaseObjectTraverser {
     this.tx = wrapTxForTraverseCapture(tx);
   }
   protected dagMemo = new Map<string, FabricValue>();
+
+  /** The cross-traversal memo, on the one path that may consult it: the
+   * query path. Read-path results are bound to their materialization (see
+   * the schema-memo comment in `traverseWithSchema`), so the read arm
+   * reads this as absent even when the context carries one. */
+  protected get crossMemo(): CrossTraversalSchemaMemo | undefined {
+    return this.traverseCells ? this.context.crossTraversalMemo : undefined;
+  }
+
+  crossTraversalMemoHits = 0;
+
+  /** Route a linked document's untyped traversal through the
+   * cross-traversal memo: serve it from an entry, or compute it inside
+   * its own frame so repeats — this evaluation's and later ones' — serve
+   * from what the computation stores. A `defaultValue` changes the
+   * result, so those computations stay unframed and unserved (the same
+   * rule the DAG memo applies). Each frame gets its own DAG memo: a DAG
+   * memo entry elides the registrations its first walk recorded, which is
+   * sound only within the frame that recorded them. */
+  protected traverseLinkedDAG(
+    doc: IMemorySpaceValueAttestation,
+    defaultValue?: FabricValue,
+    itemLink?: NormalizedFullLink,
+  ): FabricValue {
+    const cross = this.crossMemo;
+    if (cross === undefined || defaultValue !== undefined) {
+      return this.traverseDAG(doc, defaultValue, itemLink);
+    }
+    const served = cross.lookup(doc, true, itemLink);
+    if (served !== undefined && served.error === undefined) {
+      this.crossTraversalMemoHits++;
+      return served.ok;
+    }
+    cross.enter(doc, true, itemLink);
+    const outerDagMemo = this.dagMemo;
+    this.dagMemo = new Map();
+    let completed = false;
+    try {
+      const value = this.traverseDAG(doc, undefined, itemLink);
+      cross.exit(doc, true, { ok: value }, itemLink);
+      completed = true;
+      return value;
+    } finally {
+      this.dagMemo = outerDagMemo;
+      if (!completed) cross.abandon();
+    }
+  }
   traverseDAGCalls = 0;
   getDocAtPathCalls = 0;
   abstract traverse(
@@ -1755,6 +1812,10 @@ export abstract class BaseObjectTraverser {
       const newValue = new Array<FabricValue>(doc.value.length);
       using t = this.tracker.include(doc.value, true, newValue, doc);
       if (t === null) {
+        // A value cycle closed against an ancestor in progress: this
+        // computation is not a standalone one, so no frame containing it
+        // may become a cross-traversal entry.
+        this.crossMemo?.poison();
         return this.tracker.getExisting(doc.value, true);
       }
       doc.value.forEach((item, index) => {
@@ -1773,7 +1834,8 @@ export abstract class BaseObjectTraverser {
         // We follow the first link in array elements so we don't have
         // strangeness with setting item at 0 to item at 1
         let arrayElementLink = itemLink;
-        if (isSigilLink(item)) {
+        const crossedLink = isSigilLink(item);
+        if (crossedLink) {
           const [redirDoc, redirSelector] = this.getDocAtPath(
             docItem,
             [],
@@ -1801,7 +1863,12 @@ export abstract class BaseObjectTraverser {
             );
           }
         }
-        const v = this.traverseDAG(docItem, itemDefault, arrayElementLink);
+        // A sigil item crossed into another document, so its traversal is
+        // a memoizable subtree of its own; a plain item's walk stays part
+        // of this document's.
+        const v = crossedLink
+          ? this.traverseLinkedDAG(docItem, itemDefault, arrayElementLink)
+          : this.traverseDAG(docItem, itemDefault, arrayElementLink);
         // Use null for missing/undefined elements (consistent with other value
         // transforms in this system, e.g. toJSON and shallowFabricFromNativeValue)
         newValue[index] = v === undefined ? null : v;
@@ -1891,6 +1958,8 @@ export abstract class BaseObjectTraverser {
         const newValue: Record<string, FabricValue> = {};
         using t = this.tracker.include(doc.value, true, newValue, doc);
         if (t === null) {
+          // Cycle cut (see the array arm): no enclosing frame may store.
+          this.crossMemo?.poison();
           return this.tracker.getExisting(doc.value, true);
         }
         const entries = Object.entries(doc.value as JSONObject).map((
@@ -1974,6 +2043,14 @@ export abstract class BaseObjectTraverser {
     doc: IMemorySpaceValueAttestation,
     selector: SchemaPathSelector,
   ): boolean {
+    // Under a cross-traversal memo, coverage never grants a skip: a skip
+    // makes a frame's recorded effects depend on what the rest of the walk
+    // covered first, which is exactly what a stored entry must not do. The
+    // memo's own entries are the dedup instead (a repeated subtree hits
+    // the entry its first computation stored moments earlier).
+    if (this.crossMemo !== undefined) {
+      return false;
+    }
     const link = parseLink(doc.value, doc.address);
     if (link?.id === undefined) {
       return false;
@@ -3464,7 +3541,7 @@ function fail<T>(
   return { error };
 }
 
-type TraverseResult<T> = { ok: T; error?: never } | {
+export type TraverseResult<T> = { ok: T; error?: never } | {
   ok?: never;
   error: TraverseFailure;
 };
@@ -3523,6 +3600,65 @@ export function assertSchemaMemoIdentity(
     );
   }
 }
+
+/**
+ * A cross-traversal memo the QUERY path consults per (document, schema)
+ * subtree, serving whole subtree computations recorded by earlier
+ * evaluations. The traverser only signals frame boundaries and consumes
+ * served results; the implementation owns entry storage, validity, and
+ * the replay of a served subtree's recorded effects — tracker
+ * registrations and misses — into the current walk. A served subtree MUST
+ * reproduce those effects, because `lookup` returns before the traversal
+ * that would have recorded them (the schema-memo comment in
+ * `traverseWithSchema` states the failure: an entry living past its
+ * traversal answers a later traversal that never recorded its reads).
+ * Only the query path consults it: read-path results are bound to the
+ * materialization that produced them and must not outlive it.
+ *
+ * Sharing entries across identities is sound only under instance-resolved
+ * entry keys (the implementation's obligation) — the memo counterpart of
+ * {@link assertSchemaMemoIdentity}'s single-identity rule for shared
+ * schema memos.
+ */
+export type CrossTraversalSchemaMemo = {
+  /** Serve (doc, schema) from a prior evaluation: replays the entry's
+   * recorded effects into the current walk and returns its result, or
+   * returns undefined — with no side effects — when no valid entry
+   * exists. */
+  lookup(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    link?: NormalizedFullLink,
+  ): TraverseResult<FabricValue> | undefined;
+  /** A (doc, schema) computation begins; effects until the matching
+   * `exit` or `abandon` attribute to its frame. */
+  enter(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    link?: NormalizedFullLink,
+  ): void;
+  /** The computation completed; record its frame as an entry. */
+  exit(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    result: TraverseResult<FabricValue>,
+    link?: NormalizedFullLink,
+  ): void;
+  /** The computation is unwinding on an error; discard the open frame. */
+  abandon(): void;
+  /** A within-traversal memo hit consumed (doc, schema) without
+   * re-entering it; record the dependency for the open frame. */
+  dependency(
+    doc: IMemorySpaceValueAttestation,
+    schema: JSONSchema,
+    link?: NormalizedFullLink,
+  ): void;
+  /** The open frame's computation was cut short by walk-global state (a
+   * value cycle closing against an ancestor in progress), so its recorded
+   * effects are not the complete effects of a standalone computation. The
+   * frame and its ancestors must not become entries. */
+  poison(): void;
+};
 
 export class SchemaObjectTraverser<V extends FabricValue>
   extends BaseObjectTraverser {
@@ -3605,7 +3741,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       }
       return ok;
     }
-    return this.traverseDAG(doc, defaultValue, itemLink);
+    return this.traverseLinkedDAG(doc, defaultValue, itemLink);
   }
 
   override traverse(
@@ -3636,6 +3772,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     this.#maxDepth = 0;
     this.#currentDepth = 0;
     this.schemaMemoHits = 0;
+    this.crossTraversalMemoHits = 0;
     // The private memo is per-traversal on both paths — the read path holds
     // its entries there precisely because they must not outlive the
     // traversal that recorded their reads — so it is cleared unconditionally.
@@ -3847,10 +3984,39 @@ export class SchemaObjectTraverser<V extends FabricValue>
         ? schemaMemoAddressKey(doc.address) + "|" + hashSchema(schema)
         : schemaMemoAddressKey(doc.address) + "|" + hashSchema(schema) + "|" +
           schemaMemoLinkKey(link);
+      const cross = this.crossMemo;
       const cached = memo.get(memoKey);
       if (cached !== undefined) {
         this.schemaMemoHits++;
+        // Consumed without re-entering: the open cross-memo frame still
+        // depends on this subtree.
+        cross?.dependency(doc, schema, link);
         return cached;
+      }
+      if (cross !== undefined) {
+        const served = cross.lookup(doc, schema, link);
+        if (served !== undefined) {
+          this.crossTraversalMemoHits++;
+          memo.set(memoKey, served);
+          return served;
+        }
+        cross.enter(doc, schema, link);
+        // Each frame's DAG memo is its own: a DAG memo entry elides the
+        // registrations its first walk recorded, which is sound only
+        // within the frame that recorded them.
+        const outerDagMemo = this.dagMemo;
+        this.dagMemo = new Map();
+        let completed = false;
+        try {
+          const result = this.#traverseWithSchemaInner(doc, schema, link);
+          memo.set(memoKey, result);
+          cross.exit(doc, schema, result, link);
+          completed = true;
+          return result;
+        } finally {
+          this.dagMemo = outerDagMemo;
+          if (!completed) cross.abandon();
+        }
       }
       const result = this.#traverseWithSchemaInner(doc, schema, link);
       memo.set(memoKey, result);
@@ -4254,6 +4420,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
       const newValue: FabricValue[] = [];
       using t = this.tracker.include(doc.value, schema, newValue, doc);
       if (t === null) {
+        // Cycle cut (see traverseDAG's array arm): no enclosing frame may
+        // store.
+        this.crossMemo?.poison();
         // newValue will be converted to a createObject result by the
         // function that added it to the tracker, so don't do that here
         return { ok: this.tracker.getExisting(doc.value, schema) };
@@ -4312,6 +4481,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
       const newValue: Record<string, FabricValue> = {};
       using t = this.tracker.include(doc.value, schemaObj, newValue, doc);
       if (t === null) {
+        // Cycle cut (see traverseDAG's array arm): no enclosing frame may
+        // store.
+        this.crossMemo?.poison();
         // newValue will be converted to a createObject result by the
         // function that added it to the tracker, so don't do that here
         return { ok: this.tracker.getExisting(doc.value, schemaObj) };

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3567,7 +3567,7 @@ export function createSchemaMemo(): SchemaMemo {
 // Map.
 const schemaMemoIdentityBindings = new WeakMap<SchemaMemo, string>();
 
-const schemaMemoIdentityKey = (identity: ScopeKeyIdentity): string =>
+export const schemaMemoIdentityKey = (identity: ScopeKeyIdentity): string =>
   // Injective over the pair: JSON escapes every delimiter, and `null`
   // keeps an ABSENT component distinct from an empty string. A raw
   // `\0`-joined key let two DISTINCT identities collide (a NUL inside a

--- a/packages/runner/test/traverse-cross-memo.test.ts
+++ b/packages/runner/test/traverse-cross-memo.test.ts
@@ -1,0 +1,284 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { SchemaPathSelector } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { Identity } from "@commonfabric/identity";
+import type { Revision, State } from "@commonfabric/memory/interface";
+
+import { JSONObject, type JSONSchema } from "../src/index.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { StoreObjectManager } from "../src/storage/query.ts";
+import {
+  CompoundCycleTracker,
+  createTraversalContext,
+  type CrossTraversalSchemaMemo,
+  ManagedStorageTransaction,
+  MapSet,
+  SchemaObjectTraverser,
+  type TraversalContext,
+} from "../src/traverse.ts";
+
+const signer = await Identity.fromPassphrase("cross memo test operator");
+const space = signer.did();
+
+const TEST_SCOPE_IDENTITY = {
+  principal: "did:test:alice",
+  sessionId: "session-1",
+};
+
+const SCHEMA = {
+  type: "object",
+  properties: { name: { type: "string" } },
+} as const satisfies JSONSchema;
+
+/** Records the seam's calls, and answers `lookup` from whatever the test
+ * put there — the memory server's store stands in for this in
+ * production. */
+class RecordingMemo implements CrossTraversalSchemaMemo {
+  readonly calls: string[] = [];
+  served: { ok: FabricValue } | undefined = undefined;
+  /** Serve only these documents, so a test can leave the root to compute
+   * and answer for a subtree it reaches. */
+  readonly serveFor = new Map<string, { ok: FabricValue }>();
+  throwOnExit = false;
+  throwOnExitFor: string | undefined = undefined;
+
+  lookup(doc: { address: { id: string } }) {
+    this.calls.push("lookup");
+    return this.serveFor.get(doc.address.id) ?? this.served;
+  }
+  enter() {
+    this.calls.push("enter");
+  }
+  exit(doc: { address: { id: string } }) {
+    this.calls.push("exit");
+    if (this.throwOnExit || this.throwOnExitFor === doc.address.id) {
+      throw new Error("exit failed");
+    }
+  }
+  abandon() {
+    this.calls.push("abandon");
+  }
+  dependency() {
+    this.calls.push("dependency");
+  }
+  poison() {
+    this.calls.push("poison");
+  }
+}
+
+describe("SchemaObjectTraverser cross-traversal memo", () => {
+  const store: Map<string, Revision<State>> = new Map();
+  let storageTx: IExtendedStorageTransaction;
+  let context: TraversalContext;
+  let memo: RecordingMemo;
+  let doc: Revision<State>;
+
+  beforeEach(() => {
+    store.clear();
+    storageTx = new ExtendedStorageTransaction(
+      new ManagedStorageTransaction(new StoreObjectManager(store)),
+    );
+    memo = new RecordingMemo();
+    context = createTraversalContext(
+      new CompoundCycleTracker<FabricValue, JSONSchema | undefined>(),
+      new MapSet<string, SchemaPathSelector>(),
+      TEST_SCOPE_IDENTITY,
+      // The query path: the one arm that may consult the memo.
+      true,
+    );
+    context.crossTraversalMemo = memo;
+    doc = {
+      the: "application/json",
+      of: "of:cross-memo-doc",
+      is: { value: { name: "recorded" } },
+      since: 1,
+    };
+    store.set(`${doc.of}/${doc.the}`, doc);
+  });
+
+  afterEach(() => {
+    store.clear();
+  });
+
+  const traverse = () => {
+    const traverser = new SchemaObjectTraverser(
+      storageTx,
+      { path: ["value"], schema: SCHEMA },
+      context,
+    );
+    return traverser.traverse({
+      address: {
+        space,
+        id: doc.of,
+        type: doc.the,
+        path: ["value"],
+      },
+      value: (doc.is as JSONObject).value,
+    });
+  };
+
+  it("frames a computation it could not serve", () => {
+    const result = traverse();
+    const enters = memo.calls.filter((call) => call === "enter").length;
+    const exits = memo.calls.filter((call) => call === "exit").length;
+    expect(memo.calls[0]).toBe("lookup");
+    // Frames nest with the traversal, and each one that opened closed.
+    expect(enters).toBeGreaterThan(0);
+    expect(exits).toBe(enters);
+    expect(memo.calls).not.toContain("abandon");
+    expect((result.ok as { name?: string })?.name).toBe("recorded");
+  });
+
+  it("returns a served subtree without computing it", () => {
+    memo.served = { ok: { name: "served" } };
+    const result = traverse();
+    expect(memo.calls).toEqual(["lookup"]);
+    expect((result.ok as { name?: string })?.name).toBe("served");
+  });
+
+  it("abandons the open frame when completing the computation throws", () => {
+    memo.throwOnExit = true;
+    expect(() => traverse()).toThrow("exit failed");
+    // Every frame the throw unwound through was abandoned rather than
+    // left open or stored.
+    const enters = memo.calls.filter((call) => call === "enter").length;
+    const abandons = memo.calls.filter((call) => call === "abandon").length;
+    expect(abandons).toBe(enters);
+  });
+
+  it("frames a linked document reached without a schema", () => {
+    // A link the reader has no schema for descends through the untyped
+    // arm, which is where most of a wide-open query's reach is walked.
+    const target: Revision<State> = {
+      the: "application/json",
+      of: "of:cross-memo-target",
+      is: { value: { leaf: "linked" } },
+      since: 1,
+    };
+    store.set(`${target.of}/${target.the}`, target);
+    doc = {
+      the: "application/json",
+      of: "of:cross-memo-referrer",
+      is: {
+        value: {
+          name: "recorded",
+          via: { "/": { [LINK_V1_TAG]: { id: target.of, path: [] } } },
+        },
+      },
+      since: 1,
+    };
+    store.set(`${doc.of}/${doc.the}`, doc);
+
+    const traverser = new SchemaObjectTraverser(
+      storageTx,
+      { path: ["value"], schema: true },
+      context,
+    );
+    traverser.traverse({
+      address: { space, id: doc.of, type: doc.the, path: ["value"] },
+      value: (doc.is as JSONObject).value,
+    });
+    const enters = memo.calls.filter((call) => call === "enter").length;
+    const exits = memo.calls.filter((call) => call === "exit").length;
+    expect(enters).toBeGreaterThan(0);
+    expect(exits).toBe(enters);
+  });
+
+  it("returns a served linked subtree without descending into it", () => {
+    const target: Revision<State> = {
+      the: "application/json",
+      of: "of:cross-memo-served-target",
+      is: { value: { leaf: "stored" } },
+      since: 1,
+    };
+    store.set(`${target.of}/${target.the}`, target);
+    doc = {
+      the: "application/json",
+      of: "of:cross-memo-served-referrer",
+      is: {
+        value: {
+          via: { "/": { [LINK_V1_TAG]: { id: target.of, path: [] } } },
+        },
+      },
+      since: 1,
+    };
+    store.set(`${doc.of}/${doc.the}`, doc);
+    memo.serveFor.set(target.of, { ok: { leaf: "served" } });
+
+    const traverser = new SchemaObjectTraverser(
+      storageTx,
+      { path: ["value"], schema: true },
+      context,
+    );
+    const result = traverser.traverse({
+      address: { space, id: doc.of, type: doc.the, path: ["value"] },
+      value: (doc.is as JSONObject).value,
+    });
+    // The referrer computed; the target came from the entry rather than
+    // from the store.
+    expect((result.ok as { via?: { leaf?: string } })?.via?.leaf).toBe(
+      "served",
+    );
+  });
+
+  it("abandons a linked subtree's frame when completing it throws", () => {
+    const target: Revision<State> = {
+      the: "application/json",
+      of: "of:cross-memo-throw-target",
+      is: { value: { leaf: "stored" } },
+      since: 1,
+    };
+    store.set(`${target.of}/${target.the}`, target);
+    doc = {
+      the: "application/json",
+      of: "of:cross-memo-throw-referrer",
+      is: {
+        value: {
+          via: { "/": { [LINK_V1_TAG]: { id: target.of, path: [] } } },
+        },
+      },
+      since: 1,
+    };
+    store.set(`${doc.of}/${doc.the}`, doc);
+    memo.throwOnExitFor = target.of;
+
+    const traverser = new SchemaObjectTraverser(
+      storageTx,
+      { path: ["value"], schema: true },
+      context,
+    );
+    expect(() =>
+      traverser.traverse({
+        address: { space, id: doc.of, type: doc.the, path: ["value"] },
+        value: (doc.is as JSONObject).value,
+      })
+    ).toThrow("exit failed");
+    expect(memo.calls).toContain("abandon");
+  });
+
+  it("consults nothing on the read path", () => {
+    const readContext = createTraversalContext(
+      new CompoundCycleTracker<FabricValue, JSONSchema | undefined>(),
+      new MapSet<string, SchemaPathSelector>(),
+      TEST_SCOPE_IDENTITY,
+      // Read-path results are bound to the materialization that produced
+      // them, so this arm never reaches the memo even when one is present.
+      false,
+    );
+    readContext.crossTraversalMemo = memo;
+    const traverser = new SchemaObjectTraverser(
+      storageTx,
+      { path: ["value"], schema: SCHEMA },
+      readContext,
+    );
+    traverser.traverse({
+      address: { space, id: doc.of, type: doc.the, path: ["value"] },
+      value: (doc.is as JSONObject).value,
+    });
+    expect(memo.calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Stages 1–2 of the [revision-keyed schema memo plan](https://github.com/commontoolsinc/labs/pull/6464) — the design doc PR that anchors the Discord thread with @seefeld and @ubik2. Off by default behind `experimentalSchemaWalkMemo`.

**Read the measurement section before the mechanism: this stage does not move wall clock yet, and the reason is itself the finding.**

## Mechanism

A per-space memo of per-document schema-walk computation, keyed by (branch, scope instance, id, **document revision**, path, schema). Validity is by key construction — a commit strands every entry recorded at a document's previous revision, so there is no invalidation graph and no rotation; retention is LRU under an entry bound. The runner gains one seam, `CrossTraversalSchemaMemo`, consulted at the traverser's existing memo choke point in `traverseWithSchema` and read by the query path only (read-path results stay bound to their materialization).

Entries carry the traversal result plus a **direct-effects manifest**: the registrations and misses the document's own walk produced, the revisions of every document that walk read, and its child subtrees. A hit replays the manifest recursively under the *current* identity, so effects are re-derived rather than replayed stale — the failure mode the existing memo comment names ("an entry living past its traversal would answer a later traversal that never recorded its reads").

Four soundness properties worth review attention:

- **Capture mode makes the memo the only dedup.** Coverage skips and cross-frame DAG-memo reuse both make a frame's recorded effects depend on what the rest of the walk covered first, so both are disabled while capturing; a repeated subtree instead hits the entry its own first computation just stored.
- **Value-cycle cuts poison their ancestor chain** out of storage: a computation cut short by walk-global state is not a standalone computation and must not become an entry.
- **Absence is a revision state of its own.** Entries recorded against an absent document stay valid exactly while it stays absent; its creation strands them by key.
- **Scoped reach taints entries to identity-suffixed keys**, and taint climbs only the ancestor chain of the scoped reach. Instance-resolved keys are what let this layer share across identities at all — the per-layer replacement for the single-identity lock `assertSchemaMemoIdentity` holds over shared schema memos.

New `Engine.readRevision` reads a document's head revision without decoding it, for validation after a commit.

## Measurement (board clone, 6,112 reachable documents, `trackGraph` level)

**Traversal is eliminated, and reach is identical:**

| | cold | warm hit |
| --- | --- | --- |
| DAG traversals | 8,235 | **0** |
| engine reads | 6,116 | **23** |
| cross-memo hits | 0 | 1 (one root entry serves the whole corpus) |

Reach parity is asserted in the harness and holds every run: tracker keys, miss keys, and entity keys are identical between the memo-served walk and a fresh walk — cold, warm, and after a commit that touches a reachable document (validated against a fresh *post-commit* walk).

**Wall clock is unchanged: ~1.4 s warm vs ~1.3–1.65 s cold.** With traversal at zero, engine reads at 23, and manifest replay microbenchmarked at ~2 ms, the remaining second-plus sits in the post-walk path this stage does not touch — entity-snapshot assembly and tracker bookkeeping over 6,112 documents. That is what Stage 3 (a per-revision snapshot cache, the serving-layer sibling of the engine's existing `documentCache`) targets, and this measurement upgrades it from an optimization to the lever that decides whether the whole approach pays.

Landing this stage now anyway: it is off by default, it is the substrate Stage 3 needs, the expensive part (parity and the soundness pins) is done, and the attribution above is a result the design thread should have.

## Testing

`packages/memory/test/v2-schema-walk-memo.test.ts`, 8 pins: warm re-serve with reach parity; changed-document ancestor-chain recompute; invalidation through a rewritten pointer document that never gets a frame of its own; identity keying of scoped-crossing subtrees (mutation-verified — inverting the taint key fails it); memo-off/memo-on result parity; entry-bound eviction; delivery through a memo-served watch across a cache-rotating commit; empty diagnostics for an unevaluated space.

Memory suite 585 passed, runner suite 1,308 passed, repo fmt + lint clean, full `deno task check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

