### PR TITLE
fix(patterns): write changed fields with update(), not a whole-object set

### DIFF
--- a/packages/patterns/base/contacts.test.tsx
+++ b/packages/patterns/base/contacts.test.tsx
@@ -21,6 +21,7 @@ import {
   Writable,
 } from "commonfabric";
 import {
+  findElement,
   findElementByText,
   hasText,
   propsOf,
@@ -40,6 +41,16 @@ function clickButton(root: unknown, label: string): void {
   const onClick = propsOf(button)?.onClick;
   if (typeof onClick === "object" && onClick !== null && "send" in onClick) {
     (onClick as ClickStream).send({});
+  }
+}
+
+// A field bound with `oncf-change` is reached the same way a button is: walk
+// to the element and send its stream.
+function sendChange(root: unknown, element: string, detail: unknown): void {
+  const node = findElement(root, element);
+  const onChange = propsOf(node)?.["oncf-change"];
+  if (typeof onChange === "object" && onChange !== null && "send" in onChange) {
+    (onChange as { send: (event: unknown) => void }).send({ detail });
   }
 }
 
@@ -82,6 +93,29 @@ export default pattern(() => {
   });
   const member = FamilyMember({ member: memberCell });
 
+  // Person reads through the `Person` interface, which has no `relationship`.
+  // This cell stores one anyway, standing in for the every-day case of a
+  // record that carries more than the reader it is handed to declares.
+  const widerCell = new Writable({
+    firstName: "Ada",
+    lastName: "Lovelace",
+    middleName: "",
+    nickname: "",
+    prefix: "",
+    suffix: "",
+    pronouns: "",
+    birthday: { month: 12, day: 10, year: 1815 },
+    photo: "",
+    email: "ada@example.com",
+    phone: "",
+    notes: "",
+    tags: [],
+    addresses: [],
+    socialProfiles: [],
+    relationship: "cousin",
+  });
+  const widerPerson = Person({ person: widerCell });
+
   // ==========================================================================
   // Actions
   // ==========================================================================
@@ -92,6 +126,12 @@ export default pattern(() => {
 
   const action_add_family_member = action(() => {
     clickButton(contacts[UI], "+ Family");
+  });
+
+  // Editing tags writes one field. Everything the writer cannot see has to
+  // still be there afterwards.
+  const action_edit_wider_tags = action(() => {
+    sendChange(widerPerson[UI], "cf-tags", { tags: ["colleague"] });
   });
 
   const action_rename_person = action(() => {
@@ -131,6 +171,17 @@ export default pattern(() => {
     member.member.relationship === "cousin"
   );
 
+  const assert_wider_intact = assert(() =>
+    widerCell.get().relationship === "cousin"
+  );
+
+  const assert_tags_written_and_wider_intact = assert(() =>
+    widerCell.get().tags.length === 1 &&
+    widerCell.get().tags[0] === "colleague" &&
+    widerCell.get().relationship === "cousin" &&
+    widerCell.get().email === "ada@example.com"
+  );
+
   // Each record builds a form with the fields it holds.
   const assert_forms_render = assert(() =>
     hasText(person[UI], "First Name") &&
@@ -153,9 +204,14 @@ export default pattern(() => {
 
       { action: action_rename_person },
       { assertion: assert_person_renamed },
+
+      { assertion: assert_wider_intact },
+      { action: action_edit_wider_tags },
+      { assertion: assert_tags_written_and_wider_intact },
     ],
     contacts,
     person,
     member,
+    widerPerson,
   };
 });

--- a/packages/patterns/base/family-member.tsx
+++ b/packages/patterns/base/family-member.tsx
@@ -88,35 +88,28 @@ const updateDietaryRestrictions = handler<
   { detail: { tags: string[] } },
   { member: Writable<FamilyMember> }
 >(({ detail }, { member }) => {
-  const current = member.get();
-  member.set({
-    ...current,
-    dietaryRestrictions: detail?.tags ?? [],
-  });
+  member.update({ dietaryRestrictions: detail?.tags ?? [] });
 });
 
 const updateTags = handler<
   { detail: { tags: string[] } },
   { member: Writable<FamilyMember> }
 >(({ detail }, { member }) => {
-  const current = member.get();
-  member.set({ ...current, tags: detail?.tags ?? [] });
+  member.update({ tags: detail?.tags ?? [] });
 });
 
 const updateAllergies = handler<
   { detail: { tags: string[] } },
   { member: Writable<FamilyMember> }
 >(({ detail }, { member }) => {
-  const current = member.get();
-  member.set({ ...current, allergies: detail?.tags ?? [] });
+  member.update({ allergies: detail?.tags ?? [] });
 });
 
 const updateGiftIdeas = handler<
   { detail: { tags: string[] } },
   { member: Writable<FamilyMember> }
 >(({ detail }, { member }) => {
-  const current = member.get();
-  member.set({ ...current, giftIdeas: detail?.tags ?? [] });
+  member.update({ giftIdeas: detail?.tags ?? [] });
 });
 
 // sameAs handlers
@@ -126,15 +119,13 @@ const selectSameAs = handler<
 >(({ detail }, { member, showPicker }) => {
   const linked = detail?.data;
   if (!linked) return;
-  const current = member.get();
-  member.set({ ...current, sameAs: linked });
+  member.update({ sameAs: linked });
   showPicker.set(false);
 });
 
 const clearSameAs = handler<unknown, { member: Writable<FamilyMember> }>(
   (_event, { member }) => {
-    const current = member.get();
-    member.set({ ...current, sameAs: undefined });
+    member.update({ sameAs: undefined });
   },
 );
 

--- a/packages/patterns/base/person.tsx
+++ b/packages/patterns/base/person.tsx
@@ -100,15 +100,13 @@ const selectSameAs = handler<
 >(({ detail }, { person, showPicker }) => {
   const linked = detail?.data;
   if (!linked) return;
-  const current = person.get();
-  person.set({ ...current, sameAs: linked });
+  person.update({ sameAs: linked });
   showPicker.set(false);
 });
 
 const clearSameAs = handler<unknown, { person: Writable<Person> }>(
   (_event, { person }) => {
-    const current = person.get();
-    person.set({ ...current, sameAs: undefined });
+    person.update({ sameAs: undefined });
   },
 );
 
@@ -128,14 +126,12 @@ const updateTags = handler<
   { detail: { tags: string[] } },
   { person: Writable<Person> }
 >(({ detail }, { person }) => {
-  const current = person.get();
-  person.set({ ...current, tags: detail?.tags ?? [] });
+  person.update({ tags: detail?.tags ?? [] });
 });
 
 const addAddress = handler<unknown, { person: Writable<Person> }>(
   (_event, { person }) => {
-    const current = person.get();
-    const addresses = [...(current.addresses || [])];
+    const addresses = [...(person.get().addresses || [])];
     addresses.push({
       label: "",
       street: "",
@@ -144,7 +140,7 @@ const addAddress = handler<unknown, { person: Writable<Person> }>(
       zip: "",
       country: "",
     });
-    person.set({ ...current, addresses });
+    person.update({ addresses });
   },
 );
 
@@ -152,18 +148,16 @@ const removeAddress = handler<
   unknown,
   { person: Writable<Person>; index: number }
 >((_event, { person, index }) => {
-  const current = person.get();
-  const addresses = [...(current.addresses || [])];
+  const addresses = [...(person.get().addresses || [])];
   addresses.splice(index, 1);
-  person.set({ ...current, addresses });
+  person.update({ addresses });
 });
 
 const addSocialProfile = handler<unknown, { person: Writable<Person> }>(
   (_event, { person }) => {
-    const current = person.get();
-    const socialProfiles = [...(current.socialProfiles || [])];
+    const socialProfiles = [...(person.get().socialProfiles || [])];
     socialProfiles.push({ platform: "", url: "" });
-    person.set({ ...current, socialProfiles });
+    person.update({ socialProfiles });
   },
 );
 
@@ -171,10 +165,9 @@ const removeSocialProfile = handler<
   unknown,
   { person: Writable<Person>; index: number }
 >((_event, { person, index }) => {
-  const current = person.get();
-  const socialProfiles = [...(current.socialProfiles || [])];
+  const socialProfiles = [...(person.get().socialProfiles || [])];
   socialProfiles.splice(index, 1);
-  person.set({ ...current, socialProfiles });
+  person.update({ socialProfiles });
 });
 
 // ============================================================================

--- a/packages/patterns/battleship/pass-and-play/main.tsx
+++ b/packages/patterns/battleship/pass-and-play/main.tsx
@@ -112,8 +112,7 @@ export default pattern<Input, Output>((_input) => {
     const allSunk = areAllShipsSunk(targetBoard.ships, newShots);
 
     if (allSunk) {
-      game.set({
-        ...state,
+      game.update({
         player1: targetPlayer === 1 ? newTargetBoard : state.player1,
         player2: targetPlayer === 2 ? newTargetBoard : state.player2,
         phase: "finished",
@@ -124,8 +123,7 @@ export default pattern<Input, Output>((_input) => {
       });
     } else {
       const nextTurn = state.currentTurn === 1 ? 2 : 1;
-      game.set({
-        ...state,
+      game.update({
         player1: targetPlayer === 1 ? newTargetBoard : state.player1,
         player2: targetPlayer === 2 ? newTargetBoard : state.player2,
         currentTurn: nextTurn as 1 | 2,
@@ -140,8 +138,7 @@ export default pattern<Input, Output>((_input) => {
     const state = game.get();
     if (state.phase === "finished") return;
     if (!state.awaitingPass) return;
-    game.set({
-      ...state,
+    game.update({
       viewingAs: null,
       awaitingPass: false,
     });
@@ -151,8 +148,7 @@ export default pattern<Input, Output>((_input) => {
     const state = game.get();
     if (state.phase === "finished") return;
     if (state.viewingAs !== null) return;
-    game.set({
-      ...state,
+    game.update({
       viewingAs: state.currentTurn,
       awaitingPass: false,
       lastMessage:

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -453,8 +453,7 @@ const searchGmailHandler = handler<
     if (input.result) {
       input.result.set(authErrorResult);
     }
-    state.progress.set({
-      ...currentProgress,
+    state.progress.update({
       status: "auth_error",
       authError: "Authentication required",
     });
@@ -482,8 +481,7 @@ const searchGmailHandler = handler<
     if (input.result) {
       input.result.set(limitResult);
     }
-    state.progress.set({
-      ...currentProgress,
+    state.progress.update({
       status: "limit_reached",
     });
     return limitResult;
@@ -504,8 +502,7 @@ const searchGmailHandler = handler<
   }
 
   // Update progress: starting new search
-  state.progress.set({
-    ...currentProgress,
+  state.progress.update({
     currentQuery: input.query,
     status: "searching",
   });
@@ -713,9 +710,7 @@ const searchGmailHandler = handler<
       // token refresh. If we still get here with a 401, the refresh failed
       // (possibly because auth cell is derived/read-only, or no refresh token)
       if (errorStr.includes("401")) {
-        const updatedProgress = state.progress.get();
-        state.progress.set({
-          ...updatedProgress,
+        state.progress.update({
           status: "auth_error",
           authError:
             "Gmail token expired and refresh failed. Please re-authenticate.",
@@ -1076,8 +1071,7 @@ const GmailAgenticSearch = pattern<
           const currentCount = tracker[queryId] || 0;
           const newCount = currentCount + 1;
 
-          foundItemsTracker.set({
-            ...tracker,
+          foundItemsTracker.update({
             [queryId]: newCount,
           });
 

--- a/packages/patterns/google/core/experimental/google-docs-comment-confirm.ts
+++ b/packages/patterns/google/core/experimental/google-docs-comment-confirm.ts
@@ -192,8 +192,7 @@ export const executeAction = handler<
 
     // Update local state - mark as accepted
     const currentStates = commentStates.get() ?? {};
-    commentStates.set({
-      ...currentStates,
+    commentStates.update({
       [pendingAction.commentId]: {
         ...(currentStates[pendingAction.commentId] ?? { regenerateNonce: 0 }),
         status: "accepted",

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -456,8 +456,7 @@ const regenerateResponse = handler<
 >((_, { commentStates, commentId }) => {
   const current = commentStates.get() ?? {};
   const state = current[commentId] ?? { regenerateNonce: 0, status: "pending" };
-  commentStates.set({
-    ...current,
+  commentStates.update({
     [commentId]: {
       ...state,
       regenerateNonce: state.regenerateNonce + 1,
@@ -523,8 +522,7 @@ const skipComment = handler<
   }
 >((_, { commentId, commentStates, expandedCommentId }) => {
   const current = commentStates.get() ?? {};
-  commentStates.set({
-    ...current,
+  commentStates.update({
     [commentId]: {
       ...(current[commentId] ?? { regenerateNonce: 0 }),
       status: "skipped",

--- a/packages/patterns/google/core/gmail-importer.tsx
+++ b/packages/patterns/google/core/gmail-importer.tsx
@@ -1032,24 +1032,21 @@ const toggleDebugMode = handler<
   { target: { checked: boolean } },
   { settings: Writable<Settings> }
 >(({ target }, { settings }) => {
-  const current = settings.get();
-  settings.set({ ...current, debugMode: target.checked });
+  settings.update({ debugMode: target.checked });
 });
 
 const toggleAutoFetch = handler<
   { target: { checked: boolean } },
   { settings: Writable<Settings> }
 >(({ target }, { settings }) => {
-  const current = settings.get();
-  settings.set({ ...current, autoFetchOnAuth: target.checked });
+  settings.update({ autoFetchOnAuth: target.checked });
 });
 
 const toggleResolveInlineImages = handler<
   { target: { checked: boolean } },
   { settings: Writable<Settings> }
 >(({ target }, { settings }) => {
-  const current = settings.get();
-  settings.set({ ...current, resolveInlineImages: target.checked });
+  settings.update({ resolveInlineImages: target.checked });
 });
 
 const EmailCard = pattern<

--- a/packages/patterns/google/core/google-calendar-importer.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.tsx
@@ -403,8 +403,7 @@ const toggleDebugMode = handler<
   { settings: Writable<Settings> }
 >(
   ({ target }, { settings }) => {
-    const current = settings.get();
-    settings.set({ ...current, debugMode: target.checked });
+    settings.update({ debugMode: target.checked });
   },
 );
 

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -265,8 +265,7 @@ const updateContext = handler<
   const existing = current[threadId];
   const defaults = DEFAULT_SETTINGS[newContext];
 
-  threadMetadata.set({
-    ...current,
+  threadMetadata.update({
     [threadId]: {
       pingCount: existing?.pingCount || 0,
       settings: {
@@ -293,8 +292,7 @@ const updateDaysThreshold = handler<
   const current = threadMetadata.get();
   const existing = current[threadId];
 
-  threadMetadata.set({
-    ...current,
+  threadMetadata.update({
     [threadId]: {
       pingCount: existing?.pingCount || 0,
       settings: {
@@ -323,8 +321,7 @@ const updateMaxPings = handler<
   const current = threadMetadata.get();
   const existing = current[threadId];
 
-  threadMetadata.set({
-    ...current,
+  threadMetadata.update({
     [threadId]: {
       pingCount: existing?.pingCount || 0,
       settings: {
@@ -344,9 +341,7 @@ const updateDraft = handler<
   { target: { value: string } },
   { drafts: Writable<Record<string, string>>; threadId: string }
 >(({ target }, { drafts, threadId }) => {
-  const current = drafts.get();
-  drafts.set({
-    ...current,
+  drafts.update({
     [threadId]: target.value,
   });
 });
@@ -830,8 +825,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
       const current = drafts.get();
       // Idempotent check: only mutate if value changed
       if (current[threadId] !== result) {
-        drafts.set({
-          ...current,
+        drafts.update({
           [threadId]: result,
         });
       }
@@ -855,8 +849,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
       // Increment ping count
       const currentMeta = threadMetadata.get();
       const existing = currentMeta[threadId];
-      threadMetadata.set({
-        ...currentMeta,
+      threadMetadata.update({
         [threadId]: {
           ...existing,
           pingCount: (existing?.pingCount || 0) + 1,

--- a/packages/patterns/google/extractors/usps-informed-delivery.tsx
+++ b/packages/patterns/google/extractors/usps-informed-delivery.tsx
@@ -350,8 +350,7 @@ const confirmMember = handler<
   unknown,
   { member: Writable<HouseholdMember> }
 >((_event, { member }) => {
-  const current = member.get();
-  member.set({ ...current, isConfirmed: true });
+  member.update({ isConfirmed: true });
 });
 
 // Handler to delete a household member

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -964,8 +964,7 @@ const toggleSourceHandler = handler<
   const current = sourceSelectionsCell.get() || {};
   // Default is selected (true), so toggle means: if undefined or true -> false, if false -> true
   const currentValue = current[index] !== false;
-  sourceSelectionsCell.set({
-    ...current,
+  sourceSelectionsCell.update({
     [index]: !currentValue,
   });
 });
@@ -985,8 +984,7 @@ const toggleTrashHandler = handler<
   const current = trashSelectionsCell.get() || {};
   // Default is not selected (false)
   const currentValue = current[index] === true;
-  trashSelectionsCell.set({
-    ...current,
+  trashSelectionsCell.update({
     [index]: !currentValue,
   });
 });
@@ -1009,8 +1007,7 @@ const toggleFieldHandler = handler<
   const currentValue = current[fieldKey] !== undefined
     ? current[fieldKey] !== false
     : defaultSelected;
-  selectionsCell.set({
-    ...current,
+  selectionsCell.update({
     [fieldKey]: !currentValue,
   });
 });

--- a/packages/patterns/self-improving-classifier.tsx
+++ b/packages/patterns/self-improving-classifier.tsx
@@ -594,8 +594,7 @@ const updateFieldHandler = handler<
   }
 >((event, { fieldKey, newItemFields }) => {
   const value = event.detail?.value ?? "";
-  const current = newItemFields.get();
-  newItemFields.set({ ...current, [fieldKey]: value });
+  newItemFields.update({ [fieldKey]: value });
 });
 
 // =============================================================================
@@ -1180,8 +1179,7 @@ const addFieldToNewItemHandler = handler<
   const key = newFieldKey.get().trim();
   const value = newFieldValue.get().trim();
   if (key && value) {
-    const current = newItemFields.get();
-    newItemFields.set({ ...current, [key]: value });
+    newItemFields.update({ [key]: value });
     newFieldKey.set("");
     newFieldValue.set("");
   }

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -429,8 +429,7 @@ export const removeValueCardByIndex = handler<
   { selfModel: Writable<SelfModel>; index: number }
 >((_event, { selfModel, index }) => {
   const current = selfModel.get();
-  selfModel.set({
-    ...current,
+  selfModel.update({
     values: current.values.filter((_, i) => i !== index),
   });
 });


### PR DESCRIPTION
## What

A handler that read a cell, spread the snapshot, and set the result back wrote every property the reader could see — and only those. A property the reader's schema does not declare is absent from the snapshot, so the write deletes it.

`update()` writes each named key through `.key(k).set(v)` and touches nothing else, so a field the writer cannot see survives the write. This converts 35 whole-object round trips to it across 13 files, and drops the snapshot reads that existed only to feed the spread.

One rule throughout — `X.set({ ...current, k: v })` → `X.update({ k: v })` — so every hunk is behavior-identical and reads the same way.

## What this reaches, and what it does not

**Inline data, yes.** A record stored under a wider shape than the handler reads it through loses the excess on the next edit of any field. `Person` is the live case: it reads through the `Person` interface, so a record carrying the extra fields a sub-type adds (`relationship`, `allergies`, `giftIdeas`) is stripped back to `Person` when its tags are edited. The write does not merely drop those fields — it leaves the cell in a state where the next read throws.

**Links, no.** I checked this rather than assuming it. A field holding a reference to another piece reads back as that reference and writes back as the same link, so the piece it addresses survives the round trip intact. I verified it two ways: holding a note array at `NoteOutput` width while `Notebook` wrote to it through `Writable<NotePiece[]>` (`[UI]`, `mentioned` and the note's streams all survived both a bare round trip and the real append), and linking two `Person` records through `sameAs` and editing one under the old code (the target came back whole).

So the remaining conversions here are robustness rather than live bug fixes: their element types are complete and pattern-owned today. They are still worth making — `update()` is the idiom that cannot go wrong as those types widen, and it matches the "write through element cells, never slot replacement" rule in [`primitives.md`](docs/common/patterns/primitives.md).

## Test

`base/contacts.test.tsx` hands `Person` a record storing a field `Person` does not declare, drives the tag field through the rendered UI, and asserts the field is still there afterwards. Checked against the old code before keeping it: it fails there with `Cannot read properties of undefined (reading 'tags')`.

## Not included

- `self-improving-classifier.tsx:2035` reads `config.get() || DEFAULT_CONFIG`, so the `set` also seeds defaults when config is absent. `update()` would write only `question` — a behavior change, not a refactor.
- `self-improving-classifier.tsx:585` deletes a key, which `update()` cannot express.
- The append sites (`person.update({ addresses })` after a local `push`) would be better as `person.key("addresses").push(...)`, which avoids rewriting sibling elements at all. Left for a separate change.

## Checks

`deno fmt --check` and `deno lint` clean repo-wide, `deno task cfcheck` (422 pattern files) passes, the `packages/patterns` unit lane passes, and the pattern tests for every file touched pass — 95 assertions.

## Doc gap

[`writable.md`](docs/common/concepts/types-and-schemas/writable.md) §"Schemas Filter Visibility" documents the read half of this — a narrow schema hides properties — but not the write half, that a whole-object write through the same schema deletes them. Worth a paragraph; happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

