### PR TITLE
The :133 stall: UI cell writes consume the conflict-retry protocol (value-following lanes), S-G wait at the host send

### DIFF
--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,6 +38,25 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
+**Delta 2026-08-28 (#6477): the co-resident debt is PAID —
+`cfc-group-chat-demo.test.ts:133` root-caused and green.** The unlisted
+flip-blocker the surface-reading delta below leaves live is fixed. NOT
+§2b's standing echo: a `stale confirmed read` conflict on the blind
+draft write (the room-add wave's first `/cfc` stamp + sibling structure
+add on the argument doc, racing a pre-wave client basis), dropped
+because no UI-write path consumed the RETRYABLE rejection — compounded
+by the fill's second same-value write succeeding vacuously against the
+first's optimistic layer, so even a token-guarded retry declined toward
+a no-op owner. Fixed red-first in the runner: `Runtime.commitUiCellWrite`
+(`editWithRetry` + value-following supersede lanes for BLIND writes — a
+conflicted CAS push takes one attempt, never a retry — + the counted
+`runtime.ui-cell-write`/`lost` channel), `applyCellWrite` rewired, the
+S-G wait added at `:133`. Baseline 5/6 red running alone → 18/18 green
+across three post-fix gate rounds, the draft durable in every store.
+The file was never skip-listed — NO census change; the flip's
+green-ON-lane bar loses this blocker. Full mechanism + evidence:
+verification-coverage.md OW45's PHASE-3 block (the FIXED paragraph).
+
 **Delta 2026-08-28: the probe bar's OPEN interpretation question is RULED —
 "lane green" means the probed SURFACE — and default-app's reload STEP entry
 LIFTED on it. The ON skip list is now ONE entry: lunch-poll-vote's FILE

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7401,6 +7401,50 @@ supply; OW29/OW32/OW34 closed):
     lift — it is a separate unlisted defect carrying its own
     accountability, and it is still a flip blocker.**
 
+    **FIXED 2026-08-28 (PR #6477, branch
+    `claude/server-exec-v2-groupchat-stall`; red-first, store/probe-proven
+    at `23cf68e7d`).** The mechanism MIGRATED from §2b's recorded shape —
+    not the OW47 standing echo (no `speculative-basis-refused` anywhere; a
+    refill after a 300 s hang landed and enabled the button: one-shot
+    loss, not poison; the "recorded-not-built" S-E/S-F/S-G reading above
+    was stale — OW47 closed them 2026-08-21, S-G for Bob's click only).
+    Two parts, both instrumented-red-proven (4/4 taps): (1) the `:128`
+    fill's blind write is engine-rejected `stale confirmed read` — the
+    room-add wave's consequence stamps the argument doc's FIRST `/cfc`
+    labelMap and adds `/value/rooms`, structure at/above the blind write's
+    shape-read parent, against a pre-wave client basis — a RETRYABLE
+    ConflictError (the ruled vocabulary) that NO UI-write path consumed:
+    `applyCellWrite` fire-and-forgot `tx.commit()` (never pending, no log,
+    no retry; the S-G wait alone hung 300 s ×3). (2) each fill issues TWO
+    same-value writes (change-event + commit()); the second succeeds
+    VACUOUSLY (zero ops against the first's standing optimistic layer,
+    `{ok}` before any verdict), so a token-guarded retry of the first
+    declined toward a no-op owner and the revert erased the only copy
+    (8/8 red at that intermediate head). Fix: `Runtime.commitUiCellWrite`
+    — UI cell writes commit through `editWithRetry`, blind marks +
+    structural parent re-threaded per attempt, VALUE-FOLLOWING lanes
+    (every attempt writes the lane's newest requested value; refcounted
+    entry) closing LWW inversion AND the vacuous owner; a finally-lost
+    write is logged+counted (`runtime.ui-cell-write`/`lost`, the OW46-class
+    detectability); `applyCellWrite` rewired; the S-G wait added at `:133`
+    (mirrors `:203`). Pins red-first in
+    `runner/test/ui-cell-write-conflict-retry.test.ts` (the engine half
+    already pinned by `memory/test/cellset-structural-precondition.test.ts`).
+    Lift evidence: baseline 5/6 red running alone → post-fix 8/8 green →
+    6/6 green on the probe-stripped shipped binary, the draft durable in
+    every store (14/14); runner suite 1309/1310 (the one red re-ran green
+    alone — load flake). The file was never skip-listed: NO census change.
+    The surface-ruled default-app lift (the LIFT block below) never
+    waited on this fix; what it retires is the standing unlisted
+    flip-blocker itself. Review round on the PR: cubic P1/codex P1
+    (a retried CAS push could erase an intervening append) fixed —
+    non-blind writes take ONE attempt, no lane; the processor
+    set/push harness re-pinned at the new routing seam; final tally
+    18/18 green across three gate rounds. Live-class note for the
+    flip: the same race silently ate a real user's keystroke commit
+    wherever a wave landed structure mid-typing — the fix is
+    product-side, not test-side.
+
     **LIFT — default-app's reload STEP entry is REMOVED, 2026-08-28, under
     the ruled SURFACE reading of the local-plus-CI-probe bar.** The entry
     (`integration/default-app.test.ts` :: "should persist and reload every

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -130,6 +130,24 @@ describe("cfc group chat demo integration test", () => {
       "#host-message-draft",
       "Fake hello from Alice",
     );
+    // PROBE (temporary, diagnosis branch only): discriminate the two §2b
+    // candidate mechanisms for the 4/6 red at the click below — (a) the
+    // served hostSendDisabled flip is merely still in flight when the click
+    // loop gives up, vs (b) the draft write is wedged client-side and the
+    // flip never comes (rootcause §2b / OW47 S-E shape). If (a), the wait
+    // below resolves quickly and the file goes green; if (b), it hangs to
+    // waitForCondition's 300 s net with the write absent from the store.
+    const fillDiag = await page.evaluate(() =>
+      JSON.stringify(
+        (globalThis as unknown as { __cfFillDiag?: unknown }).__cfFillDiag ??
+          null,
+      )
+    );
+    console.log(`PROBE host-draft fillDiag: ${fillDiag}`);
+    await waitForRuntimeIdle(page);
+    console.log("PROBE runtime idle returned after host-draft fill");
+    await waitForDisabled(page, "#host-send-button", false);
+    console.log("PROBE host-send-button ENABLED");
     await clickCfButton(page, "#host-send-button");
     await waitForRuntimeIdle(page);
     await waitForTextAbsent(

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -130,75 +130,13 @@ describe("cfc group chat demo integration test", () => {
       "#host-message-draft",
       "Fake hello from Alice",
     );
-    // PROBE (temporary, diagnosis branch only): discriminate the two §2b
-    // candidate mechanisms for the 4/6 red at the click below — (a) the
-    // served hostSendDisabled flip is merely still in flight when the click
-    // loop gives up, vs (b) the draft write is wedged client-side and the
-    // flip never comes (rootcause §2b / OW47 S-E shape). If (a), the wait
-    // below resolves quickly and the file goes green; if (b), it hangs to
-    // waitForCondition's 300 s net with the write absent from the store.
-    const fillDiag = await page.evaluate(() =>
-      JSON.stringify(
-        (globalThis as unknown as { __cfFillDiag?: unknown }).__cfFillDiag ??
-          null,
-      )
-    );
-    console.log(`PROBE host-draft fillDiag: ${fillDiag}`);
-    await waitForRuntimeIdle(page);
-    console.log("PROBE runtime idle returned after host-draft fill");
-    try {
-      await waitForDisabled(page, "#host-send-button", false);
-      console.log("PROBE host-send-button ENABLED");
-    } catch (err) {
-      // The served enable never came (the wedge). Census the worker's logger
-      // counts — the silent drop classes (e.g. commit-conflict) are counted
-      // even when they do not log — then refill the draft to discriminate a
-      // one-shot loss (fresh write lands, button enables) from a standing
-      // poison (every subsequent write dies too, §2b's Bob shape).
-      const counts = await page.evaluate(async () => {
-        const rt = (globalThis as unknown as {
-          commonfabric?: {
-            rt?: { getLoggerCounts?: () => Promise<unknown> };
-          };
-        }).commonfabric?.rt;
-        const all = await rt?.getLoggerCounts?.();
-        return JSON.stringify(
-          (all as { counts?: unknown })?.counts ?? all ?? null,
-        );
-      });
-      console.log(`PROBE loggerCounts at hang: ${counts}`);
-      await fillCfInput(page, "#host-message-draft", "Fake hello retry");
-      const refill = await page.evaluate(() => {
-        const findHost = (root: Document | ShadowRoot): Element | undefined => {
-          for (const element of root.querySelectorAll("*")) {
-            if (element.id === "host-send-button") return element;
-            if (element.shadowRoot) {
-              const match = findHost(element.shadowRoot);
-              if (match) return match;
-            }
-          }
-          return undefined;
-        };
-        return new Promise<string>((resolve) => {
-          const deadline = Date.now() + 15_000;
-          const check = () => {
-            const host = findHost(document);
-            const button = host?.shadowRoot?.querySelector("button");
-            const disabled = button instanceof HTMLButtonElement
-              ? button.disabled
-              : undefined;
-            if (disabled === false) return resolve("ENABLED");
-            if (Date.now() > deadline) {
-              return resolve(`still-disabled (${String(disabled)})`);
-            }
-            setTimeout(check, 250);
-          };
-          check();
-        });
-      });
-      console.log(`PROBE after refill: ${String(refill)}`);
-      throw err;
-    }
+    // Wait for the send button to ENABLE before clicking, exactly like the
+    // trusted sends below (S-G, rootcause §2b): `hostSendDisabled` derives
+    // from the draft, and under the server-execution ON arm that derivation
+    // is a served round trip — clicking an interim-disabled cf-button
+    // retargets the click to the host element and the send never fires.
+    // Correct under the OFF arm too (the enable is just immediate there).
+    await waitForDisabled(page, "#host-send-button", false);
     await clickCfButton(page, "#host-send-button");
     await waitForRuntimeIdle(page);
     await waitForTextAbsent(

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -146,8 +146,59 @@ describe("cfc group chat demo integration test", () => {
     console.log(`PROBE host-draft fillDiag: ${fillDiag}`);
     await waitForRuntimeIdle(page);
     console.log("PROBE runtime idle returned after host-draft fill");
-    await waitForDisabled(page, "#host-send-button", false);
-    console.log("PROBE host-send-button ENABLED");
+    try {
+      await waitForDisabled(page, "#host-send-button", false);
+      console.log("PROBE host-send-button ENABLED");
+    } catch (err) {
+      // The served enable never came (the wedge). Census the worker's logger
+      // counts — the silent drop classes (e.g. commit-conflict) are counted
+      // even when they do not log — then refill the draft to discriminate a
+      // one-shot loss (fresh write lands, button enables) from a standing
+      // poison (every subsequent write dies too, §2b's Bob shape).
+      const counts = await page.evaluate(async () => {
+        const rt = (globalThis as unknown as {
+          commonfabric?: {
+            rt?: { getLoggerCounts?: () => Promise<unknown> };
+          };
+        }).commonfabric?.rt;
+        const all = await rt?.getLoggerCounts?.();
+        return JSON.stringify(
+          (all as { counts?: unknown })?.counts ?? all ?? null,
+        );
+      });
+      console.log(`PROBE loggerCounts at hang: ${counts}`);
+      await fillCfInput(page, "#host-message-draft", "Fake hello retry");
+      const refill = await page.evaluate(() => {
+        const findHost = (root: Document | ShadowRoot): Element | undefined => {
+          for (const element of root.querySelectorAll("*")) {
+            if (element.id === "host-send-button") return element;
+            if (element.shadowRoot) {
+              const match = findHost(element.shadowRoot);
+              if (match) return match;
+            }
+          }
+          return undefined;
+        };
+        return new Promise<string>((resolve) => {
+          const deadline = Date.now() + 15_000;
+          const check = () => {
+            const host = findHost(document);
+            const button = host?.shadowRoot?.querySelector("button");
+            const disabled = button instanceof HTMLButtonElement
+              ? button.disabled
+              : undefined;
+            if (disabled === false) return resolve("ENABLED");
+            if (Date.now() > deadline) {
+              return resolve(`still-disabled (${String(disabled)})`);
+            }
+            setTimeout(check, 250);
+          };
+          check();
+        });
+      });
+      console.log(`PROBE after refill: ${String(refill)}`);
+      throw err;
+    }
     await clickCfButton(page, "#host-send-button");
     await waitForRuntimeIdle(page);
     await waitForTextAbsent(

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -127,6 +127,13 @@ import { snapshotQueryResult } from "./query-result-proxy.ts";
 import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
 import { type PieceSourceTransition, Runner } from "./runner.ts";
 import { ExtendedStorageTransaction } from "./storage/extended-storage-transaction.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+import {
+  markRendererInputTx,
+  markUiInputBlindWriteTx,
+  setBlindStructuralTarget,
+  unmarkUiInputBlindWriteTx,
+} from "./storage/reactivity-log.ts";
 import { isRetryableCommitRejection } from "./storage/rejection.ts";
 import { isCellScope, normalizeCellScope, scopeRank } from "./scope.ts";
 import { toURI } from "./uri-utils.ts";
@@ -176,6 +183,15 @@ const WriteDebugContextStorage = (isDeno()
 Error.stackTraceLimit = 500;
 
 export const DEFAULT_MAX_RETRIES = 5;
+
+// Loud, counted channel for UI writes that are finally lost — see
+// `Runtime.commitUiCellWrite`. Error level so a dropped user input is
+// visible in any console, and counted regardless of level so a run's
+// census (`getLoggerCounts`) can see it even where consoles are off.
+const uiCellWriteLogger = getLogger("runtime.ui-cell-write", {
+  enabled: true,
+  level: "error",
+});
 
 export type { IExtendedStorageTransaction, MemorySpace };
 
@@ -2513,6 +2529,131 @@ export class Runtime {
         );
       } catch {
         // Pull failed — the retry's commit decides.
+      }
+    }
+  }
+
+  /**
+   * The latest UI write issued per supersede lane (one lane per UI control's
+   * cell address). A conflict retry re-runs only while its own token is
+   * still the lane's latest — see {@link commitUiCellWrite}.
+   */
+  #uiWriteLanes = new Map<string, object>();
+
+  /**
+   * Commit a UI-originated cell write — the renderer `$value`/input path
+   * (handleCellSet/handleCellPush in the runtime-client backends) — with
+   * the commit-retry protocol every other consumer of the retryable
+   * rejection classes already uses ({@link editWithRetry}; the event
+   * path's conflict catch-up-then-requeue in scheduler/events.ts; the
+   * reactive path's re-queue).
+   *
+   * Why this exists (the cfc-group-chat-demo `:133` stall —
+   * verification-coverage.md OW45's PHASE-3 groupchat observation,
+   * rootcause §2b): a blind UI-input write threads a SHAPE precondition at
+   * its cell's PARENT (`setBlindStructuralTarget`). Under server execution
+   * a serving wave routinely lands structure on the same document
+   * concurrently with typing — the first `/cfc` labelMap stamp, a sibling
+   * key add on the piece argument doc — and the engine then rejects the
+   * input's commit as `stale confirmed read`: a ConflictError the ruled
+   * vocabulary classifies RETRYABLE (storage/rejection.ts — catch-up, then
+   * a fresh read converges). The previous call sites fired `tx.commit()`
+   * and dropped the result, so the rejection's `readyToRetry` gate had no
+   * consumer and the USER'S INPUT was silently, permanently lost — while
+   * the served derivations over it (a send button's `disabled`) stayed
+   * correctly stale forever.
+   *
+   * Semantics:
+   * - `blind: true` is the LWW leaf-overwrite class (every renderer
+   *   `$value` input write). The blind marking and the structural target
+   *   are re-threaded PER ATTEMPT on the attempt's own fresh transaction,
+   *   so a retry re-resolves the cell and bases its shape read on the
+   *   caught-up state ("the retry's write carries its true version" —
+   *   {@link awaitCommitRetryReadiness}).
+   * - `blind: false` is the CAS class (`CellHandle.push`): the value was
+   *   resolved by the caller and the value-equality reads stay in place, so
+   *   re-running against fresh state is ordinary compare-and-set retry.
+   * - `supersedeKey` makes writes to one UI control one LANE. Each attempt
+   *   re-checks, BEFORE staging, that its write is still the lane's
+   *   latest; a superseded retry resolves `ok: "superseded"` instead of
+   *   re-asserting an older input over a newer one — the LWW-inversion
+   *   hazard the OW47 report recorded against unguarded auto-retry, closed
+   *   by ordering rather than by refusing to retry.
+   * - a write that exhausts the budget or is refused non-retryably resolves
+   *   `{ error }` and is LOUD: `ui-cell-write.lost` is logged at error
+   *   level and counted, so a run's census can see dropped user input (the
+   *   silent-loss detectability lesson of OW46/S-D). Callers that must not
+   *   block (cell IPC) fire-and-forget the returned promise; the loss
+   *   report does not depend on them.
+   */
+  async commitUiCellWrite(
+    cell: Cell<unknown>,
+    value: unknown,
+    options: { blind: boolean; supersedeKey?: string },
+  ): Promise<
+    | { ok: "committed" | "superseded"; error?: undefined }
+    | { ok?: undefined; error: CommitError }
+  > {
+    const { blind, supersedeKey } = options;
+    const token = {};
+    if (supersedeKey !== undefined) {
+      this.#uiWriteLanes.set(supersedeKey, token);
+    }
+    const superseded = (): boolean =>
+      supersedeKey !== undefined &&
+      this.#uiWriteLanes.get(supersedeKey) !== token;
+    try {
+      const result = await this.editWithRetry<"committed" | "superseded">(
+        (tx) => {
+          // Per attempt, BEFORE staging: a superseded retry declines (the
+          // editWithRetry convention — nothing staged, `ok` carries it).
+          if (superseded()) return "superseded";
+          if (blind) {
+            markUiInputBlindWriteTx(tx);
+            // Renderer-input provenance that survives to commit, so the
+            // scheduler can shape the resulting subscriber wake (timing
+            // side-channel mitigation, channels 4/5).
+            markRendererInputTx(tx);
+            // The resolved storage address of the write target; its parent
+            // is the structural existence/shape precondition for the blind
+            // write. Resolved on THIS attempt's transaction, so a retry
+            // bases on the caught-up state.
+            const link = cell.withTx(tx).resolveAsCell()
+              .getAsNormalizedFullLink();
+            setBlindStructuralTarget(tx, {
+              id: link.id,
+              space: link.space,
+              scope: link.scope,
+              path: link.path.slice(0, -1),
+            });
+          }
+          cell.withTx(tx).set(value);
+          if (blind) unmarkUiInputBlindWriteTx(tx);
+          return "committed";
+        },
+      );
+      if (result.error !== undefined) {
+        uiCellWriteLogger.error("lost", () => [
+          "a UI cell write was refused and its retries are spent — the " +
+          "user's input is dropped",
+          {
+            blind,
+            supersedeKey,
+            error: {
+              name: (result.error as { name?: string }).name,
+              message: (result.error as { message?: string }).message,
+            },
+          },
+        ]);
+        return { error: result.error };
+      }
+      return { ok: result.ok ?? "committed" };
+    } finally {
+      if (
+        supersedeKey !== undefined &&
+        this.#uiWriteLanes.get(supersedeKey) === token
+      ) {
+        this.#uiWriteLanes.delete(supersedeKey);
       }
     }
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2551,11 +2551,15 @@ export class Runtime {
   }
 
   /**
-   * The latest UI write issued per supersede lane (one lane per UI control's
-   * cell address). A conflict retry re-runs only while its own token is
-   * still the lane's latest — see {@link commitUiCellWrite}.
+   * Per-lane state for UI writes (one lane per UI control's cell address):
+   * the NEWEST requested value and how many write loops are still in
+   * flight. A conflict retry writes the lane's newest value — never its
+   * own — so a delayed retry can only ever re-assert the user's latest
+   * input; the entry lives until every loop that might still write settles
+   * (deleting it earlier would hand a late retry a stale fallback). See
+   * {@link commitUiCellWrite}.
    */
-  #uiWriteLanes = new Map<string, object>();
+  #uiWriteLanes = new Map<string, { value: unknown; inFlight: number }>();
 
   /**
    * Commit a UI-originated cell write — the renderer `$value`/input path
@@ -2590,12 +2594,18 @@ export class Runtime {
    * - `blind: false` is the CAS class (`CellHandle.push`): the value was
    *   resolved by the caller and the value-equality reads stay in place, so
    *   re-running against fresh state is ordinary compare-and-set retry.
-   * - `supersedeKey` makes writes to one UI control one LANE. Each attempt
-   *   re-checks, BEFORE staging, that its write is still the lane's
-   *   latest; a superseded retry resolves `ok: "superseded"` instead of
-   *   re-asserting an older input over a newer one — the LWW-inversion
-   *   hazard the OW47 report recorded against unguarded auto-retry, closed
-   *   by ordering rather than by refusing to retry.
+   * - `supersedeKey` makes writes to one UI control one LANE, and each
+   *   attempt writes the lane's NEWEST requested value rather than the
+   *   value this call was issued with. That closes both failure shapes at
+   *   once: a delayed retry can never re-assert an older input over a
+   *   newer one (the LWW-inversion hazard the OW47 report recorded
+   *   against unguarded auto-retry), and a newer same-lane call that
+   *   resolves VACUOUSLY — its `set` no-ops against the older write's
+   *   still-standing optimistic layer, so it holds no ops of its own —
+   *   cannot strand the value when that older layer is reverted: the
+   *   older call's retry is still live and re-issues the newest value on
+   *   the repaired base (the d05-diagnosed remainder of the :133 stall,
+   *   where token-based decline left the value owned by a no-op).
    * - a write that exhausts the budget or is refused non-retryably resolves
    *   `{ error }` and is LOUD: `ui-cell-write.lost` is logged at error
    *   level and counted, so a run's census can see dropped user input (the
@@ -2608,29 +2618,30 @@ export class Runtime {
     value: unknown,
     options: { blind: boolean; supersedeKey?: string },
   ): Promise<
-    | { ok: "committed" | "superseded"; error?: undefined }
+    | { ok: "committed"; error?: undefined }
     | { ok?: undefined; error: CommitError }
   > {
     const { blind, supersedeKey } = options;
-    const token = {};
+    let lane: { value: unknown; inFlight: number } | undefined;
     if (supersedeKey !== undefined) {
-      this.#uiWriteLanes.set(supersedeKey, token);
+      lane = this.#uiWriteLanes.get(supersedeKey);
+      if (lane === undefined) {
+        lane = { value, inFlight: 0 };
+        this.#uiWriteLanes.set(supersedeKey, lane);
+      } else {
+        // This call is now the lane's newest input; every still-running
+        // loop's next attempt writes this value.
+        lane.value = value;
+      }
+      lane.inFlight++;
     }
-    const superseded = (): boolean =>
-      supersedeKey !== undefined &&
-      this.#uiWriteLanes.get(supersedeKey) !== token;
     try {
-      let attempt = 0;
-      const result = await this.editWithRetry<"committed" | "superseded">(
+      const result = await this.editWithRetry<"committed">(
         (tx) => {
-          attempt++;
-          // PROBE (temporary): name the parked stage of the :133 retry.
-          console.error(
-            `[PROBE uiWrite] attempt=${attempt} superseded=${superseded()} lane=${supersedeKey}`,
-          );
-          // Per attempt, BEFORE staging: a superseded retry declines (the
-          // editWithRetry convention — nothing staged, `ok` carries it).
-          if (superseded()) return "superseded";
+          // Per attempt: write the lane's NEWEST requested value (see the
+          // supersedeKey semantics above). Without a lane, this call's own
+          // value.
+          const attemptValue = lane === undefined ? value : lane.value;
           if (blind) {
             markUiInputBlindWriteTx(tx);
             // Renderer-input provenance that survives to commit, so the
@@ -2650,15 +2661,10 @@ export class Runtime {
               path: link.path.slice(0, -1),
             });
           }
-          cell.withTx(tx).set(value);
+          cell.withTx(tx).set(attemptValue);
           if (blind) unmarkUiInputBlindWriteTx(tx);
           return "committed";
         },
-      );
-      console.error(
-        `[PROBE uiWrite] SETTLED ok=${result.ok ?? "none"} error=${
-          (result.error as { name?: string } | undefined)?.name ?? "none"
-        } lane=${supersedeKey}`,
       );
       if (result.error !== undefined) {
         uiCellWriteLogger.error("lost", () => [
@@ -2675,13 +2681,16 @@ export class Runtime {
         ]);
         return { error: result.error };
       }
-      return { ok: result.ok ?? "committed" };
+      return { ok: "committed" };
     } finally {
-      if (
-        supersedeKey !== undefined &&
-        this.#uiWriteLanes.get(supersedeKey) === token
-      ) {
-        this.#uiWriteLanes.delete(supersedeKey);
+      if (supersedeKey !== undefined && lane !== undefined) {
+        lane.inFlight--;
+        if (
+          lane.inFlight <= 0 &&
+          this.#uiWriteLanes.get(supersedeKey) === lane
+        ) {
+          this.#uiWriteLanes.delete(supersedeKey);
+        }
       }
     }
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2575,8 +2575,14 @@ export class Runtime {
    *   caught-up state ("the retry's write carries its true version" —
    *   {@link awaitCommitRetryReadiness}).
    * - `blind: false` is the CAS class (`CellHandle.push`): the value was
-   *   resolved by the caller and the value-equality reads stay in place, so
-   *   re-running against fresh state is ordinary compare-and-set retry.
+   *   resolved by the caller (read-modify-write on the main thread) and
+   *   the value-equality reads stay in place. A conflicted CAS write takes
+   *   ONE attempt and surfaces the loss loudly — re-running `set` with the
+   *   same already-resolved value against fresh state could erase an
+   *   intervening writer's append (cubic/codex P1 on #6477); the modify
+   *   step is not re-runnable here, so retrying is the caller's decision.
+   *   CAS writes also never join a supersede lane: a blind set's retry
+   *   must never write a push's resolved value or vice versa.
    * - `supersedeKey` makes writes to one UI control one LANE, and each
    *   attempt writes the lane's NEWEST requested value rather than the
    *   value this call was issued with. That closes both failure shapes at
@@ -2606,7 +2612,7 @@ export class Runtime {
   > {
     const { blind, supersedeKey } = options;
     let lane: { value: unknown; inFlight: number } | undefined;
-    if (supersedeKey !== undefined) {
+    if (blind && supersedeKey !== undefined) {
       lane = this.#uiWriteLanes.get(supersedeKey);
       if (lane === undefined) {
         lane = { value, inFlight: 0 };
@@ -2621,6 +2627,7 @@ export class Runtime {
     try {
       const result = await this.editWithRetry<"committed">(
         (tx) => {
+          // (retry budget: blind writes only — see the CAS bullet above.)
           // Per attempt: write the lane's NEWEST requested value (see the
           // supersedeKey semantics above). Without a lane, this call's own
           // value.
@@ -2648,6 +2655,7 @@ export class Runtime {
           if (blind) unmarkUiInputBlindWriteTx(tx);
           return "committed";
         },
+        blind ? DEFAULT_MAX_RETRIES : 0,
       );
       if (result.error !== undefined) {
         uiCellWriteLogger.error("lost", () => [
@@ -2666,7 +2674,7 @@ export class Runtime {
       }
       return { ok: "committed" };
     } finally {
-      if (supersedeKey !== undefined && lane !== undefined) {
+      if (blind && supersedeKey !== undefined && lane !== undefined) {
         lane.inFlight--;
         if (
           lane.inFlight <= 0 &&

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2457,26 +2457,9 @@ export class Runtime {
     }
     this.prepareTxForCommit(tx);
     return tx.commit().then(async ({ error }) => {
-      // PROBE (temporary): name the parked stage of the :133 retry.
-      console.error(
-        `[PROBE editWithRetry] settled error=${
-          (error as { name?: string } | undefined)?.name ?? "none"
-        } retriesLeft=${maxRetries}`,
-      );
       if (error) {
         if (maxRetries > 0 && isRetryableCommitRejection(error)) {
-          // PROBE (temporary): name the parked stage of the :133 retry.
-          console.error(
-            `[PROBE editWithRetry] rejected name=${
-              (error as { name?: string }).name
-            } msg=${
-              String((error as { message?: string }).message ?? "").slice(0, 80)
-            } retriesLeft=${maxRetries} awaiting readiness`,
-          );
           await this.awaitCommitRetryReadiness(error);
-          console.error(
-            `[PROBE editWithRetry] readiness RESOLVED retriesLeft=${maxRetries}`,
-          );
           return this.editWithRetry<T>(fn, maxRetries - 1);
         } else {
           return { error };

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2457,9 +2457,26 @@ export class Runtime {
     }
     this.prepareTxForCommit(tx);
     return tx.commit().then(async ({ error }) => {
+      // PROBE (temporary): name the parked stage of the :133 retry.
+      console.error(
+        `[PROBE editWithRetry] settled error=${
+          (error as { name?: string } | undefined)?.name ?? "none"
+        } retriesLeft=${maxRetries}`,
+      );
       if (error) {
         if (maxRetries > 0 && isRetryableCommitRejection(error)) {
+          // PROBE (temporary): name the parked stage of the :133 retry.
+          console.error(
+            `[PROBE editWithRetry] rejected name=${
+              (error as { name?: string }).name
+            } msg=${
+              String((error as { message?: string }).message ?? "").slice(0, 80)
+            } retriesLeft=${maxRetries} awaiting readiness`,
+          );
           await this.awaitCommitRetryReadiness(error);
+          console.error(
+            `[PROBE editWithRetry] readiness RESOLVED retriesLeft=${maxRetries}`,
+          );
           return this.editWithRetry<T>(fn, maxRetries - 1);
         } else {
           return { error };
@@ -2603,8 +2620,14 @@ export class Runtime {
       supersedeKey !== undefined &&
       this.#uiWriteLanes.get(supersedeKey) !== token;
     try {
+      let attempt = 0;
       const result = await this.editWithRetry<"committed" | "superseded">(
         (tx) => {
+          attempt++;
+          // PROBE (temporary): name the parked stage of the :133 retry.
+          console.error(
+            `[PROBE uiWrite] attempt=${attempt} superseded=${superseded()} lane=${supersedeKey}`,
+          );
           // Per attempt, BEFORE staging: a superseded retry declines (the
           // editWithRetry convention — nothing staged, `ok` carries it).
           if (superseded()) return "superseded";
@@ -2631,6 +2654,11 @@ export class Runtime {
           if (blind) unmarkUiInputBlindWriteTx(tx);
           return "committed";
         },
+      );
+      console.error(
+        `[PROBE uiWrite] SETTLED ok=${result.ok ?? "none"} error=${
+          (result.error as { name?: string } | undefined)?.name ?? "none"
+        } lane=${supersedeKey}`,
       );
       if (result.error !== undefined) {
         uiCellWriteLogger.error("lost", () => [

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5020,7 +5020,15 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
           commit,
           source,
           { commitOptions },
-        ),
+        ).then((result) => {
+          // PROBE (temporary): name the parked stage of the :133 retry.
+          console.error(
+            `[PROBE pushCommit] returned localSeq=${localSeq} error=${
+              (result.error as { name?: string } | undefined)?.name ?? "none"
+            }`,
+          );
+          return result;
+        }),
     );
     this.#commitPromises.add(promise);
     // Keyed registration for the old-server scalarization hold: a later
@@ -5583,6 +5591,12 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     rejection: StorageTransactionRejected,
     identity?: ScopeKeyIdentity,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
+    // PROBE (temporary): name the parked stage of the :133 retry.
+    console.error(
+      `[PROBE finalizeRejection] enter localSeq=${localSeq} name=${rejection.name} msg=${
+        String((rejection as { message?: string }).message ?? "").slice(0, 70)
+      }`,
+    );
     // The verdict is known from here on, but this commit's optimistic layer
     // stands in `record.pending` for as long as the read repair below runs.
     // Mark the layer dead for that window so no new commit is minted and sent
@@ -5612,7 +5626,13 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
           this.#scopeKeyIdentity(),
         )
         : undefined;
+      console.error(
+        `[PROBE finalizeRejection] read-repair ENTER localSeq=${localSeq}`,
+      );
       await this.waitForConflictReadRepair(rejection);
+      console.error(
+        `[PROBE finalizeRejection] read-repair EXIT localSeq=${localSeq}`,
+      );
       this.dropPending(localSeq);
       // Every drop funnels through here (server conflict, preempt, cascade,
       // reset — this is dropPending's only call site), so scanning right

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5020,15 +5020,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
           commit,
           source,
           { commitOptions },
-        ).then((result) => {
-          // PROBE (temporary): name the parked stage of the :133 retry.
-          console.error(
-            `[PROBE pushCommit] returned localSeq=${localSeq} error=${
-              (result.error as { name?: string } | undefined)?.name ?? "none"
-            }`,
-          );
-          return result;
-        }),
+        ),
     );
     this.#commitPromises.add(promise);
     // Keyed registration for the old-server scalarization hold: a later
@@ -5591,12 +5583,6 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     rejection: StorageTransactionRejected,
     identity?: ScopeKeyIdentity,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    // PROBE (temporary): name the parked stage of the :133 retry.
-    console.error(
-      `[PROBE finalizeRejection] enter localSeq=${localSeq} name=${rejection.name} msg=${
-        String((rejection as { message?: string }).message ?? "").slice(0, 70)
-      }`,
-    );
     // The verdict is known from here on, but this commit's optimistic layer
     // stands in `record.pending` for as long as the read repair below runs.
     // Mark the layer dead for that window so no new commit is minted and sent
@@ -5626,13 +5612,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
           this.#scopeKeyIdentity(),
         )
         : undefined;
-      console.error(
-        `[PROBE finalizeRejection] read-repair ENTER localSeq=${localSeq}`,
-      );
       await this.waitForConflictReadRepair(rejection);
-      console.error(
-        `[PROBE finalizeRejection] read-repair EXIT localSeq=${localSeq}`,
-      );
       this.dropPending(localSeq);
       // Every drop funnels through here (server conflict, preempt, cascade,
       // reset — this is dropPending's only call site), so scanning right

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -55,6 +55,12 @@ installFakeClock({
     // (the serving side of the client-loses-derivation-commit journey)
     // under the same wall-clock policies.
     "speculation-overlay",
+    // The UI-cell-write conflict-retry suite (the group-chat :133 stall's
+    // mechanism) drives a live shared memory server with manual fan-out
+    // and waits on pull/flush edges with bounded timeouts — the same
+    // live-transport class as the executor suites above; its retry path's
+    // catch-up rides transport edges, not virtual time.
+    "ui-cell-write-conflict-retry",
     // Stage C W3.1 (S1): the drain-settle quiescence-advance pins drive
     // a live ExecutorHost under the same wall-clock policies (flush
     // deadline, renew cadence), and pins 3/5 assert QUIET-window

--- a/packages/runner/test/ui-cell-write-conflict-retry.test.ts
+++ b/packages/runner/test/ui-cell-write-conflict-retry.test.ts
@@ -233,7 +233,7 @@ describe("UI cell write conflict retry (the :133 stall's consumer seam)", () => 
     }
   });
 
-  it("a superseded retry declines instead of clobbering newer input (no LWW inversion)", async () => {
+  it("a retry writes the lane's newest value, never its own (no LWW inversion, no vacuous-owner strand)", async () => {
     const seed = runtime.edit();
     const cell = runtime.getCell<Doc>(space, "ui-write-lww", schema, seed);
     cell.withTx(seed).set({ drafts: { message: "seed" } });
@@ -266,11 +266,16 @@ describe("UI cell write conflict retry (the :133 stall's consumer seam)", () => 
         supersedeKey: "ui-write-lww-lane",
       });
       expect(w2Outcome.error).toBeUndefined();
-      // Release w1's retry: it must decline, not re-assert "old" over "new".
+      // Release w1's retry: it re-issues the lane's NEWEST value ("new"),
+      // never its own "old" — the LWW-inversion guard. And because the
+      // retry re-issues rather than declining, a newer call that resolved
+      // VACUOUSLY (its set no-oped against the older write's optimistic
+      // layer — the d05-diagnosed live shape) cannot strand the value:
+      // the older loop still lands the newest value on the repaired base.
       releaseRetry();
       const w1Outcome = await w1;
       expect(w1Outcome.error).toBeUndefined();
-      expect(w1Outcome.ok).toBe("superseded");
+      expect(w1Outcome.ok).toBe("committed");
     } finally {
       injection.restore();
     }
@@ -279,7 +284,7 @@ describe("UI cell write conflict retry (the :133 stall's consumer seam)", () => 
       () => leaf.get() === "new",
       "the newest input to be the surviving value",
     );
-    // And it stays "new": the released retry must not have re-landed "old".
+    // And it stays "new": the released retry re-landed "new", not "old".
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(leaf.get()).toBe("new");
   });

--- a/packages/runner/test/ui-cell-write-conflict-retry.test.ts
+++ b/packages/runner/test/ui-cell-write-conflict-retry.test.ts
@@ -289,6 +289,41 @@ describe("UI cell write conflict retry (the :133 stall's consumer seam)", () => 
     expect(leaf.get()).toBe("new");
   });
 
+  it("a conflicted CAS push is NOT retried — the stale read-modify-write premise must not re-commit (cubic/codex P1 on #6477)", async () => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell<Doc>(space, "ui-write-cas", schema, seed);
+    cell.withTx(seed).set({ drafts: { message: "seed" } });
+    const seeded = await seed.commit();
+    expect(seeded.error).toBeUndefined();
+
+    const leaf = cell.key("drafts").key("message");
+    const lostBefore = uiWriteLostCount();
+    const injection = injectConflictOnNextCommits(
+      runtime,
+      1,
+      () => staleReadConflict(),
+    );
+    try {
+      // A push's value embeds a read-modify-write premise resolved on the
+      // main thread; a conflict means that premise is stale, and re-running
+      // `set` with the same resolved value against fresh state could erase
+      // an intervening writer's append. So the CAS class takes ONE attempt:
+      // the conflict surfaces loudly instead of retrying.
+      const outcome = await runtime.commitUiCellWrite(leaf, "stale-cas", {
+        blind: false,
+      });
+      expect(outcome.error?.name).toBe("ConflictError");
+      expect(injection.intercepted()).toBe(1);
+    } finally {
+      injection.restore();
+    }
+    expect(uiWriteLostCount()).toBeGreaterThan(lostBefore);
+    // The stale value never lands — not on the first attempt (rejected) and
+    // not through any retry.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(leaf.get()).toBe("seed");
+  });
+
   it("an exhausted retry budget surfaces the loss loudly instead of silently", async () => {
     const seed = runtime.edit();
     const cell = runtime.getCell<Doc>(space, "ui-write-loss", schema, seed);

--- a/packages/runner/test/ui-cell-write-conflict-retry.test.ts
+++ b/packages/runner/test/ui-cell-write-conflict-retry.test.ts
@@ -1,0 +1,314 @@
+// The cfc-group-chat-demo :133 stall's missing CONSUMER, pinned at the
+// runner seam (register: verification-coverage.md OW45's PHASE-3 groupchat
+// observation; rootcause §2b; live evidence: 4/4 tap-instrumented reds,
+// each `stale confirmed read … conflicted with …` on the piece argument
+// doc's `hostMessageDraft`, 2026-08-27).
+//
+// Mechanism, in three layers:
+//  1. ENGINE (already pinned in
+//     packages/memory/test/cellset-structural-precondition.test.ts): a
+//     blind `$value` write threads a shape precondition at its cell's
+//     PARENT; a concurrent structure change there admits first and the
+//     engine refuses the write as `stale confirmed read` — a ConflictError
+//     the ruled vocabulary classifies RETRYABLE (storage/rejection.ts:
+//     catch-up, then a fresh read converges). Under server execution a
+//     serving wave routinely lands exactly such structure (the first /cfc
+//     labelMap stamp, a sibling key add) on the argument doc concurrently
+//     with typing.
+//  2. CONSUMER (this file): the UI write path (handleCellSet/handleCellPush
+//     → applyCellWrite) fired `tx.commit()` and dropped the result, so the
+//     retryable rejection's readyToRetry gate had no consumer: the USER'S
+//     INPUT was silently and permanently lost — no retry, no log, no
+//     counter — while every served derivation over the draft (the send
+//     button's disabled state) stayed correctly stale forever.
+//  3. LIVE (the integration file): cfc-group-chat-demo.test.ts:133 red
+//     5/6 at 23cf68e7d running alone, every red store missing the draft.
+//
+// The cross-replica staleness itself cannot be manufactured in this
+// in-process harness — it propagates shared state synchronously (the
+// recorded limitation in the engine test's own header) — so the conflict
+// here is INJECTED on the first commit attempt in the engine's exact
+// stale-read shape, and a vocabulary pin below keeps the injected shape
+// honest against the classifier the retry protocol actually consults.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { DEFAULT_MAX_RETRIES, Runtime } from "../src/runtime.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+import {
+  isRetryableCommitRejection,
+  isStaleReadConflict,
+} from "../src/storage/rejection.ts";
+
+const spaceSigner = await Identity.fromPassphrase("ui-cell-write space");
+const space = spaceSigner.did() as MemorySpace;
+const aliceSigner = await Identity.fromPassphrase("ui-cell-write alice");
+
+const schema = {
+  type: "object",
+  properties: {
+    drafts: {
+      type: "object",
+      properties: {
+        message: { type: "string" },
+        other: { type: "string" },
+      },
+    },
+  },
+} as const;
+
+type Doc = { drafts: { message?: string; other?: string } };
+
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 15_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+/**
+ * The engine's stale-read rejection, byte-shaped like the live tap evidence
+ * (`stale confirmed read: <id> at seq N conflicted with seq M`), with the
+ * catch-up gate a real rejection carries. `readyToRetry` resolves when the
+ * given release does, so a pin can hold a retry in the readiness wait while
+ * a newer write overtakes it.
+ */
+const staleReadConflict = (release: Promise<void> = Promise.resolve()) => ({
+  name: "ConflictError" as const,
+  message: "stale confirmed read: of:test-doc at seq 1 conflicted with seq 2",
+  readyToRetry: () => release,
+});
+
+/**
+ * Intercept the commits of the next `count` transactions `runtime.edit()`
+ * creates: each intercepted commit aborts its transaction (discarding the
+ * staged ops, exactly like a refused export) and reports the injected
+ * stale-read conflict instead of reaching storage. Later transactions
+ * commit for real.
+ */
+const injectConflictOnNextCommits = (
+  runtime: Runtime,
+  count: number,
+  makeRejection: () => ReturnType<typeof staleReadConflict>,
+): { intercepted: () => number; restore: () => void } => {
+  const realEdit = runtime.edit.bind(runtime);
+  let remaining = count;
+  let intercepted = 0;
+  const patched = (): IExtendedStorageTransaction => {
+    const tx = realEdit();
+    if (remaining > 0) {
+      remaining--;
+      const realCommit = tx.commit.bind(tx);
+      let used = false;
+      tx.commit = (options?: Parameters<typeof realCommit>[0]) => {
+        if (used) return realCommit(options);
+        used = true;
+        intercepted++;
+        const rejection = makeRejection();
+        tx.abort(rejection);
+        return Promise.resolve({ error: rejection as never });
+      };
+    }
+    return tx;
+  };
+  (runtime as unknown as { edit: () => IExtendedStorageTransaction }).edit =
+    patched;
+  return {
+    intercepted: () => intercepted,
+    restore: () => {
+      (runtime as unknown as { edit: () => IExtendedStorageTransaction })
+        .edit = realEdit;
+    },
+  };
+};
+
+const uiWriteLostCount = (): number => {
+  const breakdown = getLoggerCountsBreakdown() as Record<
+    string,
+    Record<string, { total?: number } | number | undefined> | undefined
+  >;
+  const entry = breakdown["runtime.ui-cell-write"]?.["lost"];
+  if (entry === undefined) return 0;
+  return typeof entry === "number" ? entry : entry.total ?? 0;
+};
+
+describe("UI cell write conflict retry (the :133 stall's consumer seam)", () => {
+  let server: MemoryV2Server.Server;
+  let manager: EmulatedStorageManager;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    manager = EmulatedStorageManager.connectTo(server, { as: aliceSigner });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await manager.close();
+    await server.close();
+  });
+
+  it("keeps the injected rejection honest against the ruled vocabulary", () => {
+    const rejection = staleReadConflict();
+    expect(isRetryableCommitRejection(rejection)).toBe(true);
+    expect(isStaleReadConflict(rejection)).toBe(true);
+  });
+
+  it("a blind UI write whose commit is conflict-rejected still lands durably (retried, not dropped)", async () => {
+    // Seed the doc so the write below edits established state.
+    const seed = runtime.edit();
+    const cell = runtime.getCell<Doc>(space, "ui-write-retry", schema, seed);
+    cell.withTx(seed).set({ drafts: { message: "seed" } });
+    const seeded = await seed.commit();
+    expect(seeded.error).toBeUndefined();
+
+    const leaf = cell.key("drafts").key("message");
+    const injection = injectConflictOnNextCommits(
+      runtime,
+      1,
+      () => staleReadConflict(),
+    );
+    try {
+      // THE USER ACT: the UI write path's blind shape. The first commit
+      // attempt is rejected exactly the way the live race rejects it; the
+      // pin is that the typed value still becomes durable. Pre-fix the
+      // write path fire-and-forgets the commit, so the value is simply
+      // gone — the watched RED of the :133 stall.
+      const outcome = await runtime.commitUiCellWrite(leaf, "typed", {
+        blind: true,
+        supersedeKey: "ui-write-retry-lane",
+      });
+      expect(outcome.error).toBeUndefined();
+      expect(injection.intercepted()).toBe(1);
+    } finally {
+      injection.restore();
+    }
+
+    await waitUntil(
+      () => leaf.get() === "typed",
+      "the typed value to land despite the conflicted first attempt",
+    );
+
+    // Durable, not overlay: a fresh reader session sees it.
+    const readerManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerManager,
+    });
+    try {
+      const readerCell = readerRuntime.getCell<Doc>(
+        space,
+        "ui-write-retry",
+        schema,
+      );
+      await readerCell.sync();
+      await waitUntil(
+        () => readerCell.key("drafts").key("message").get() === "typed",
+        "the typed value to be durable for a fresh reader",
+      );
+    } finally {
+      await readerRuntime.dispose();
+      await readerManager.close();
+    }
+  });
+
+  it("a superseded retry declines instead of clobbering newer input (no LWW inversion)", async () => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell<Doc>(space, "ui-write-lww", schema, seed);
+    cell.withTx(seed).set({ drafts: { message: "seed" } });
+    const seeded = await seed.commit();
+    expect(seeded.error).toBeUndefined();
+
+    const leaf = cell.key("drafts").key("message");
+    let releaseRetry!: () => void;
+    const held = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    const injection = injectConflictOnNextCommits(
+      runtime,
+      1,
+      () => staleReadConflict(held),
+    );
+    try {
+      // w1 ("old") conflicts and parks in the readiness wait...
+      const w1 = runtime.commitUiCellWrite(leaf, "old", {
+        blind: true,
+        supersedeKey: "ui-write-lww-lane",
+      });
+      await waitUntil(
+        () => injection.intercepted() === 1,
+        "w1's first attempt to be rejected",
+      );
+      // ...while w2 ("new") lands on the same lane.
+      const w2Outcome = await runtime.commitUiCellWrite(leaf, "new", {
+        blind: true,
+        supersedeKey: "ui-write-lww-lane",
+      });
+      expect(w2Outcome.error).toBeUndefined();
+      // Release w1's retry: it must decline, not re-assert "old" over "new".
+      releaseRetry();
+      const w1Outcome = await w1;
+      expect(w1Outcome.error).toBeUndefined();
+      expect(w1Outcome.ok).toBe("superseded");
+    } finally {
+      injection.restore();
+    }
+
+    await waitUntil(
+      () => leaf.get() === "new",
+      "the newest input to be the surviving value",
+    );
+    // And it stays "new": the released retry must not have re-landed "old".
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(leaf.get()).toBe("new");
+  });
+
+  it("an exhausted retry budget surfaces the loss loudly instead of silently", async () => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell<Doc>(space, "ui-write-loss", schema, seed);
+    cell.withTx(seed).set({ drafts: { message: "seed" } });
+    const seeded = await seed.commit();
+    expect(seeded.error).toBeUndefined();
+
+    const leaf = cell.key("drafts").key("message");
+    const lostBefore = uiWriteLostCount();
+    const injection = injectConflictOnNextCommits(
+      runtime,
+      DEFAULT_MAX_RETRIES + 1,
+      () => staleReadConflict(),
+    );
+    try {
+      const outcome = await runtime.commitUiCellWrite(leaf, "doomed", {
+        blind: true,
+        supersedeKey: "ui-write-loss-lane",
+      });
+      expect(outcome.error?.name).toBe("ConflictError");
+      expect(injection.intercepted()).toBe(DEFAULT_MAX_RETRIES + 1);
+    } finally {
+      injection.restore();
+    }
+    // The loss is COUNTED (visible to a run's census) — never silent again.
+    expect(uiWriteLostCount()).toBeGreaterThan(lostBefore);
+  });
+});

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -53,19 +53,15 @@ import {
   type IOperationStorageCapability,
   isCell,
   isCellResult,
-  markRendererInputTx,
-  markUiInputBlindWriteTx,
   normalizeSpaceHost,
   PatternCoverageCollector,
   Runtime,
   runtimePresets,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
-  setBlindStructuralTarget,
   setPatternEnvironment,
   type SigilLink,
   SpaceHostValidationError,
-  unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
 import type { RuntimeOptions } from "@commonfabric/runner";
 import {
@@ -1282,67 +1278,23 @@ export class RuntimeProcessor {
     request: CellSetRequest | CellPushRequest,
     blind: boolean,
   ): void {
-    const tx = this.runtime.edit();
     const cell = getCell(this.runtime, request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
-    if (blind) {
-      markUiInputBlindWriteTx(tx);
-      // Renderer-input provenance that survives to commit, so the scheduler can
-      // shape the resulting subscriber wake (timing side-channel mitigation,
-      // channels 4/5). A `blind` write is exactly a renderer `$value` input write.
-      markRendererInputTx(tx);
-      // The resolved storage address of the write target; its parent is the
-      // structural existence/shape precondition for the blind write.
-      const link = cell.withTx(tx).resolveAsCell().getAsNormalizedFullLink();
-      setBlindStructuralTarget(tx, {
-        id: link.id,
-        space: link.space,
-        scope: link.scope,
-        path: link.path.slice(0, -1),
-      });
-    }
-    cell.withTx(tx).set(value);
-    if (blind) unmarkUiInputBlindWriteTx(tx);
-    this.runtime.prepareTxForCommit(tx);
-    // Local visibility is established by commit(); the promise tracks remote
-    // confirmation/rollback and must not block cell IPC.
-    // PROBE (temporary, diagnosis branch only): the result of this commit is
-    // otherwise dropped on the floor, and several of its failure arms
-    // (rejectCommitBeforeStorage's CFC gates; the storage conflict drop) are
-    // zero-log — a lost USER input dies with no console trace. Surface every
-    // failed UI cell write with its error class so the group-chat :133 red
-    // names its mechanism.
-    void tx.commit().then((result) => {
-      if (result?.error !== undefined) {
-        console.error(
-          "[PROBE ui-cell-write-failed]",
-          JSON.stringify({
-            blind,
-            error: {
-              name: (result.error as { name?: string }).name,
-              message: (result.error as { message?: string }).message,
-            },
-            cell: {
-              id: request.cell.id,
-              path: request.cell.path,
-              scope: request.cell.scope ?? "space",
-            },
-          }),
-        );
-      }
-    }).catch((cause) => {
-      console.error(
-        "[PROBE ui-cell-write-failed]",
-        JSON.stringify({
-          blind,
-          thrown: String(cause),
-          cell: {
-            id: request.cell.id,
-            path: request.cell.path,
-            scope: request.cell.scope ?? "space",
-          },
-        }),
-      );
+    // The commit-retry seam for UI writes (Runtime.commitUiCellWrite): the
+    // blind marking, the structural-parent precondition, and the commit run
+    // there, per attempt, under the ruled retryable-rejection vocabulary —
+    // a `stale confirmed read` conflict (a serving wave landing structure
+    // on the doc mid-typing) is retried after catch-up instead of silently
+    // dropping the user's input, and a finally-lost write is loudly counted
+    // (`runtime.ui-cell-write` / `lost`). One lane per cell address, so a
+    // retry never re-asserts an older input over a newer one.
+    //
+    // Local visibility is established by the first commit attempt; the
+    // returned promise tracks remote confirmation, retries, and the loss
+    // report, and must not block cell IPC.
+    void this.runtime.commitUiCellWrite(cell, value, {
+      blind,
+      supersedeKey: this.operationSessionKey(request.cell),
     });
   }
 

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1291,10 +1291,14 @@ export class RuntimeProcessor {
     //
     // Local visibility is established by the first commit attempt; the
     // returned promise tracks remote confirmation, retries, and the loss
-    // report, and must not block cell IPC.
+    // report, and must not block cell IPC. Only BLIND writes join a
+    // supersede lane: a CAS push carries a read-modify-write premise its
+    // lane-mates must never overwrite (cubic P2 on #6477).
     void this.runtime.commitUiCellWrite(cell, value, {
       blind,
-      supersedeKey: this.operationSessionKey(request.cell),
+      ...(blind
+        ? { supersedeKey: this.operationSessionKey(request.cell) }
+        : {}),
     });
   }
 

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1306,7 +1306,44 @@ export class RuntimeProcessor {
     this.runtime.prepareTxForCommit(tx);
     // Local visibility is established by commit(); the promise tracks remote
     // confirmation/rollback and must not block cell IPC.
-    tx.commit();
+    // PROBE (temporary, diagnosis branch only): the result of this commit is
+    // otherwise dropped on the floor, and several of its failure arms
+    // (rejectCommitBeforeStorage's CFC gates; the storage conflict drop) are
+    // zero-log — a lost USER input dies with no console trace. Surface every
+    // failed UI cell write with its error class so the group-chat :133 red
+    // names its mechanism.
+    void tx.commit().then((result) => {
+      if (result?.error !== undefined) {
+        console.error(
+          "[PROBE ui-cell-write-failed]",
+          JSON.stringify({
+            blind,
+            error: {
+              name: (result.error as { name?: string }).name,
+              message: (result.error as { message?: string }).message,
+            },
+            cell: {
+              id: request.cell.id,
+              path: request.cell.path,
+              scope: request.cell.scope ?? "space",
+            },
+          }),
+        );
+      }
+    }).catch((cause) => {
+      console.error(
+        "[PROBE ui-cell-write-failed]",
+        JSON.stringify({
+          blind,
+          thrown: String(cause),
+          cell: {
+            id: request.cell.id,
+            path: request.cell.path,
+            scope: request.cell.scope ?? "space",
+          },
+        }),
+      );
+    });
   }
 
   handleCellSend(request: CellSendRequest): void {

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3062,7 +3062,85 @@ describe("runtime-processor", () => {
       },
     };
 
+    // Set/push route through Runtime.commitUiCellWrite now (the :133
+    // retry seam), which owns the marks, the structural precondition, and
+    // the prepare-before-commit ordering (structurally, inside
+    // editWithRetry — pinned by the runner's
+    // ui-cell-write-conflict-retry suite). What is the PROCESSOR's to get
+    // right — and what these pins hold — is the routing contract: the
+    // resolved cell, the mapped value, the blind flag by METHOD, and the
+    // per-address supersede lane (blind writes only; a CAS push must
+    // never share a lane with blind sets, or a delayed set retry could
+    // overwrite a push's compare-and-set semantics).
     const createProcessor = () => {
+      const calls: Array<{
+        cell: unknown;
+        value: unknown;
+        options: { blind: boolean; supersedeKey?: string };
+      }> = [];
+      const resolvedCell = { marker: "resolved-cell" };
+      return {
+        calls,
+        processor: {
+          // handleCellSet/handleCellPush delegate to the shared applyCellWrite.
+          applyCellWrite: RuntimeProcessor.prototype.applyCellWrite,
+          operationSessionKey: (RuntimeProcessor.prototype as unknown as {
+            operationSessionKey: (cell: CellRef) => string;
+          }).operationSessionKey,
+          runtime: {
+            getCellFromLink: (candidate: unknown) => {
+              expect(candidate).toBe(ref);
+              return resolvedCell;
+            },
+            commitUiCellWrite: (
+              cell: unknown,
+              value: unknown,
+              options: { blind: boolean; supersedeKey?: string },
+            ) => {
+              calls.push({ cell, value, options });
+              return Promise.resolve({ ok: "committed" });
+            },
+          },
+        } as unknown as RuntimeProcessor,
+        resolvedCell,
+      };
+    };
+
+    it("routes a cell set as a BLIND laned write through commitUiCellWrite", () => {
+      const { processor, calls, resolvedCell } = createProcessor();
+
+      RuntimeProcessor.prototype.handleCellSet.call(processor, {
+        type: RequestType.CellSet,
+        cell: ref,
+        value: "new value",
+      });
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].cell).toBe(resolvedCell);
+      expect(calls[0].value).toBe("new value");
+      expect(calls[0].options.blind).toBe(true);
+      expect(calls[0].options.supersedeKey).toBe(
+        JSON.stringify([ref.space, ref.id, ref.scope, ref.path]),
+      );
+    });
+
+    it("routes a cell push as a NON-blind, lane-free write (CAS keeps its own fate)", () => {
+      const { processor, calls, resolvedCell } = createProcessor();
+
+      RuntimeProcessor.prototype.handleCellPush.call(processor, {
+        type: RequestType.CellPush,
+        cell: ref,
+        value: "new value",
+      });
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].cell).toBe(resolvedCell);
+      expect(calls[0].value).toBe("new value");
+      expect(calls[0].options.blind).toBe(false);
+      expect(calls[0].options.supersedeKey).toBeUndefined();
+    });
+
+    it("prepares cell send transactions before committing", async () => {
       let prepared = false;
       const tx = {
         commit: () => {
@@ -3070,70 +3148,28 @@ describe("runtime-processor", () => {
           return Promise.resolve({ ok: {} });
         },
       };
-      const cellWithTx = {
-        set: (value: unknown) => {
-          expect(value).toBe("new value");
-        },
-        send: (value: unknown) => {
-          expect(value).toBe("new value");
-        },
-        // A blind `set` resolves the write target to thread its parent as the
-        // structural precondition (see applyCellWrite).
-        resolveAsCell: () => ({
-          getAsNormalizedFullLink: () => ({
-            id: ref.id,
-            space: ref.space,
-            scope: ref.scope,
-            path: ref.path,
-          }),
-        }),
-      };
-      return {
-        processor: {
-          // handleCellSet/handleCellPush delegate to the shared applyCellWrite.
-          applyCellWrite: RuntimeProcessor.prototype.applyCellWrite,
-          runtime: {
-            edit: () => tx,
-            prepareTxForCommit: (candidate: unknown) => {
-              expect(candidate).toBe(tx);
-              prepared = true;
-            },
-            getCellFromLink: (candidate: unknown) => {
-              expect(candidate).toBe(ref);
-              return {
-                withTx: (candidateTx: unknown) => {
-                  expect(candidateTx).toBe(tx);
-                  return cellWithTx;
-                },
-              };
-            },
+      const processor = {
+        runtime: {
+          edit: () => tx,
+          prepareTxForCommit: (candidate: unknown) => {
+            expect(candidate).toBe(tx);
+            prepared = true;
           },
-        } as unknown as RuntimeProcessor,
-      };
-    };
-
-    it("prepares cell set transactions before committing", async () => {
-      const { processor } = createProcessor();
-
-      await RuntimeProcessor.prototype.handleCellSet.call(processor, {
-        type: RequestType.CellSet,
-        cell: ref,
-        value: "new value",
-      });
-    });
-
-    it("prepares cell push transactions before committing (non-blind path)", async () => {
-      const { processor } = createProcessor();
-
-      await RuntimeProcessor.prototype.handleCellPush.call(processor, {
-        type: RequestType.CellPush,
-        cell: ref,
-        value: "new value",
-      });
-    });
-
-    it("prepares cell send transactions before committing", async () => {
-      const { processor } = createProcessor();
+          getCellFromLink: (candidate: unknown) => {
+            expect(candidate).toBe(ref);
+            return {
+              withTx: (candidateTx: unknown) => {
+                expect(candidateTx).toBe(tx);
+                return {
+                  send: (value: unknown) => {
+                    expect(value).toBe("new value");
+                  },
+                };
+              },
+            };
+          },
+        },
+      } as unknown as RuntimeProcessor;
 
       await RuntimeProcessor.prototype.handleCellSend.call(processor, {
         type: RequestType.CellSend,


### PR DESCRIPTION
## Why

`cfc-group-chat-demo.test.ts:133` reds the ON pattern lane shard carrying default-app (the register's shard-5 co-resident hold): 5/6 red at `23cf68e7d795edab3a9d99d7a965af45c3e356ea` running the file alone at the phase-3 gate posture, the click on `#host-send-button` retargeting to the cf-button host — the disabled-inner-button signature of rootcause §2b. The file is UNLISTED (never skip-listed), so it is a flip blocker in its own right.

The recorded §2b mechanism has MIGRATED. This is not the OW47 standing-echo shape (no `speculative-basis-refused` anywhere; a refill after a 300 s hang landed and enabled the button — one-shot loss, not standing poison). Instrumented reds (4/4) named the real, two-part mechanism:

1. **The retryable rejection had no consumer on the UI write path.** The `:128` fill's blind write is rejected by the engine as `stale confirmed read: <arg-doc> at seq N conflicted with seq M` — the room-add wave's served consequence stamps the argument doc's FIRST `/cfc` labelMap and adds `/value/rooms`, structure at/above the blind write's shape-read parent, while the client's basis still sits pre-wave. That ConflictError is RETRYABLE by the ruled vocabulary (storage/rejection.ts: catch-up, then a fresh read converges; the event path requeues it, `editWithRetry` retries it) — but `applyCellWrite` fired `tx.commit()` and dropped the result: no retry, no log (`commit-conflict` is debug/counted-only), never in the pending set (`idleWithPendingCommits` returned instantly). The user's input was silently, permanently lost, and the served `hostSendDisabled` stayed correctly true forever. The wait-for-enable (S-G) alone was proven insufficient: three 300 s hangs with the write absent from the store.

2. **The vacuous lane owner.** Every fill issues TWO same-value writes (the cf-input change-event write plus the `commit()` write). The second resolves ok VACUOUSLY — its `set` no-ops against the first write's still-standing optimistic layer (zero ops; `{ok}` before any verdict; `pushCommit` never runs for it). A first-cut token-based supersede guard therefore made things worse (8/8 red): the conflicted first write's retry declined in favor of the no-op "latest", and the revert erased the only copy.

Under ON, waves stamping/extending the argument doc concurrently with typing is a routine state, so this is a live product input-loss class, not a test artifact: the same race silently eats a real user's keystroke commit.

## What changed

- **`Runtime.commitUiCellWrite`** (packages/runner/src/runtime.ts): UI cell writes commit through `editWithRetry` — the blind marking and the structural-parent precondition are re-threaded PER ATTEMPT on the attempt's own fresh transaction, so a retry bases on the caught-up state ("the retry's write carries its true version", `awaitCommitRetryReadiness`). **Value-following lanes** (`#uiWriteLanes: Map<key, {value, inFlight}>`): every attempt of every loop writes the lane's NEWEST requested value, closing both failure shapes at once — LWW inversion (a delayed retry can never re-assert older input; the hazard the OW47 report recorded against unguarded auto-retry) and the vacuous owner (an older loop's retry re-issues the newest value on the repaired base). The refcounted entry lives until the last loop settles. A finally-lost write resolves `{error}` and is loudly counted: `runtime.ui-cell-write` / `lost` (the OW46/S-D silent-loss detectability lesson).
- **`applyCellWrite`** (packages/runtime-client/src/backends/runtime-processor.ts) routes through it — one lane per cell address (`operationSessionKey`), fire-and-forget preserved for cell IPC. This is the single implementation (the web-worker backend runs this processor).
- **S-G wait at `:133`** (packages/patterns/integration/cfc-group-chat-demo.test.ts): `waitForDisabled(false)` before the host-send click, mirroring the ruled `:203` precedent. Necessary alongside the product fix — the enable is a served round trip the click loop's two-dispatch window can lose — and insufficient alone (proven above).
- **Pins**: packages/runner/test/ui-cell-write-conflict-retry.test.ts — durable-after-conflict, retry-writes-newest-value (LWW + vacuous-owner), exhaustion-is-loud, plus a vocabulary pin keeping the injected rejection honest against `isRetryableCommitRejection`/`isStaleReadConflict`. Watched RED at f072eeaef, green after. The engine half of the mechanism was already pinned by packages/memory/test/cellset-structural-precondition.test.ts; the in-process harness cannot hold a stale replica (that test's own recorded limitation), hence injection at the commit seam. New suite registered on the runner clock-preload real-clock list.

## Test plan

- Baseline watched red: gate runs (fresh store, ensure-ON default, posture probes green, PID-only teardown, `gtimeout 600` never raised) r01–r06 at `23cf68e7d`: **5/6 red**, all at `:133`, all with the retarget chain, the draft write absent from every red store; probe runs p01/p03/p04: 300 s hangs (enable never arrives); tap runs t01–t04: 4/4 `stale confirmed read` on `hostMessageDraft`.
- Post-fix: **g01–g08 8/8 green** (9–10 s) and, after stripping every diagnostic probe, **h01–h06 6/6 green on the shipped binary** (`c7f905e8a74b9a0bcc328c8c59fe60b9ed88d4244f0b756e5ae9ce9b3fb7db13`), the draft write durable in every store (14/14 total).
- `deno check` clean on all touched files. Unit: the new suite + OW47 neighborhood (speculation-overlay, blind-write-structural-precondition, runtime-edit-with-retry, edit-with-retry-classification) — 7 passed / 54 steps. Full runner suite: 1309/1310; the one red (executor-effect-channel, a live-host wall-clock suite) re-ran green alone — load flake from the concurrent gate runs, not this change.

## Flags for review (observed, deliberately not touched)

- `handleCellSend` (event appends) keeps its fire-and-forget commit; event appends ride the event-append-queue's own retry/backoff, but the seam is the same shape.
- `awaitCommitRetryReadiness` awaits `readyToRetry` with no timeout (pre-existing for all `editWithRetry` callers; the storage-side read-repair caps at 30 s).
- Routing UI writes through `editWithRetry` now sets `tx.immediate = true` + `deferRunnerStartUntilCommit = true` on them — `immediate` is documented as intended for user-interactive paths.
- The general storage semantics behind failure shape 2 — a zero-op commit that is vacuously satisfied by a standing optimistic layer reports `ok` and is exempt from dependency cascade ("designed to survive a parent drop") — remains as-is; this PR closes it for the UI-lane case only. Whether the no-op decision should be basis-aware is an owner-class question.

The register (verification-coverage.md OW45 PHASE-3 block + the plans delta) is updated in this PR. The file was never skip-listed, so there is NO census change; the shard-5 co-resident hold on default-app's lift should clear on its next probe.

Do not merge — independent review follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
