### PR TITLE
Say that the measurement batch publishes into the corpus it measures (CT-2110)

### DIFF
--- a/packages/cf-harness/docs/pattern-index-measurement.md
+++ b/packages/cf-harness/docs/pattern-index-measurement.md
@@ -182,6 +182,28 @@ count a composition of seeded work as evidence against the seeding.
 
 Hops beyond the first are not resolved, and the report says so.
 
+## The batch publishes into the corpus it is measuring
+
+It does, and that is deliberate rather than an oversight. The loop under
+measurement **is** the publishing loop: a session that builds something
+contributes it, and a run made publish-inert would measure a different system
+from the one the question is about. The console cannot be made inert in any case
+— `--no-pattern-index-publish` is the `cf-harness` CLI's flag and the console
+never reads it (CT-2119).
+
+What makes the reading sound is the ordering, not stillness. The index snapshot
+is taken **before the first task** and again **after the last**, so the "before"
+reading is of a corpus that was verified, and everything the batch adds appears
+as the difference between the two rather than as an unexplained delta. A reader
+who sees "the batch publishes into the corpus it is measuring" without that
+ordering will reasonably conclude someone made a mistake.
+
+Two consequences worth stating. A batch is not repeatable against the same
+corpus — the second run starts from what the first one left, and its "index
+before" will say so. And a batch run before a publish gate lands accumulates
+entries that gate never saw, which is a fact about the corpus that outlives the
+batch; where that is the case, the report's preamble should say it.
+
 ## What the report holds
 
 Per task: the exact text the session was given, the session and run identifiers,


### PR DESCRIPTION
The protocol document never said that a measurement batch publishes into the index it is measuring. It does, and a reader meeting that fact without the ordering will reasonably conclude someone made a mistake.

The ordering is the answer: the index snapshot is taken **before the first task** and again **after the last**, so the "before" reading is of a verified corpus and everything the batch adds appears as the difference between the two rather than as an unexplained delta.

Also stated, because both bear on reading a report:

- The loop under measurement **is** the publishing loop, so a publish-inert run would measure a different system — and the console cannot be made inert in any case, since `--no-pattern-index-publish` is the `cf-harness` CLI's flag and the console never reads it (CT-2119).
- A batch is not repeatable against the same corpus; the second run starts from what the first left, and its "index before" will say so.
- A batch run before a publish gate lands accumulates entries that gate never saw, which is a fact about the corpus that outlives the batch.

Documentation only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

