### PR TITLE
fix(html): a DOM event carries a `FabricValue` or a cell link, and refuses the rest

### DIFF
--- a/packages/html/bench/dom-event-crossing.bench.ts
+++ b/packages/html/bench/dom-event-crossing.bench.ts
@@ -1,0 +1,155 @@
+/**
+ * What a DOM event costs to reach its handler, main thread to worker.
+ *
+ * Every `on*` a pattern puts on a rendered node installs a listener that runs
+ * `serializeEvent()` and posts what it returns, so this is the inbound half of
+ * the connection and the busiest one a user drives: it runs on every keystroke
+ * an input reports and every click a handler is bound to.
+ *
+ * Nothing else measures it. `data-model`'s IPC benchmarks time the encoding
+ * across a boundary with no application walk on either side; `html`'s reconciler
+ * benchmark times the outbound render. What this adds is the walk at each end --
+ * `serializeEvent()` before the send, and the decode plus the ingress strip
+ * after it -- around the same crossing.
+ *
+ * One message is in flight at a time. That is what a `Deno.bench()` iteration
+ * can measure, an iteration being one round trip, and it is the shape a DOM
+ * event actually takes.
+ *
+ * **What this can and cannot resolve.** A round trip through a real `Worker`
+ * costs about 12us before any payload, and run-to-run variance on that floor
+ * runs to a fifth of the measurement. A subject sitting near it therefore
+ * cannot separate a change worth a microsecond or two, and adding runs does not
+ * help -- the spread is scheduling variance rather than sampling error, and
+ * holds steady from three runs to six. The `200 records` subject is here
+ * because it sits far enough above the floor to resolve one; the small subjects
+ * are here to show what a change does *not* reach, which is most of what a user
+ * generates. Attribute a difference to a phase before believing it: measure the
+ * phase directly and check the trip moved by about what that predicts.
+ *
+ * Run with:
+ *
+ *     deno task bench
+ */
+
+import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
+import { serializeEvent } from "../src/main/events.ts";
+import type { EventAck, EventRequest } from "./fixtures/dom-event-far-side.ts";
+
+/** The outstanding request's settlement, held while it is in flight. */
+type PendingRequest = {
+  readonly resolve: () => void;
+  readonly reject: (reason: Error) => void;
+};
+
+/** One worker for the whole run, one message outstanding at a time. */
+class FarSide {
+  readonly #worker: Worker;
+  #pending: PendingRequest | undefined;
+
+  constructor() {
+    this.#worker = new Worker(
+      import.meta.resolve("./fixtures/dom-event-far-side.ts"),
+      { type: "module" },
+    );
+
+    this.#worker.onmessage = (ev: MessageEvent<EventAck>) => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      if (ev.data.ok) pending?.resolve();
+      else pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
+    };
+
+    // A worker that fails to start, or throws where nothing catches, sends no
+    // ack -- and a benchmark waiting on one that will never arrive hangs rather
+    // than failing, which is the worst way for a measurement to end.
+    this.#worker.onerror = (ev: ErrorEvent) => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      pending?.reject(new Error(`Far side failed: ${ev.message}`));
+    };
+
+    this.#worker.onmessageerror = () => {
+      const pending = this.#pending;
+      this.#pending = undefined;
+      pending?.reject(new Error("Far side could not deserialize the message"));
+    };
+  }
+
+  /**
+   * Sends one request and settles when the far side acks.
+   *
+   * @throws If the far side reports failure. An unexamined ack is what makes a
+   *   benchmark measure the wrong thing silently.
+   */
+  send(request: EventRequest): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.#pending = { resolve, reject };
+      this.#worker.postMessage(request);
+    });
+  }
+
+  close(): void {
+    this.#worker.terminate();
+  }
+}
+
+const farSide = new FarSide();
+
+/** An event, as the applicator's listener receives one. */
+class BenchEvent {
+  isTrusted = false;
+  constructor(readonly type: string, readonly target: unknown) {}
+}
+
+/** A custom event, whose `detail` is whatever a component chose to expose. */
+class BenchCustomEvent extends BenchEvent {
+  constructor(type: string, readonly detail: unknown, target: unknown = {}) {
+    super(type, target);
+  }
+}
+
+/** A detail of `items` records, each with a few scalar fields. */
+function makeDetail(items: number): unknown {
+  const list: unknown[] = [];
+
+  for (let i = 0; i < items; i++) {
+    list.push({ title: `item number ${i}`, count: i, done: (i % 3) === 0 });
+  }
+
+  return { items: list, total: items };
+}
+
+/**
+ * A spread of the shapes a handler is actually bound to: a bare click, the
+ * input event a keystroke produces, and a custom detail at two sizes.
+ */
+const SUBJECTS: readonly (readonly [string, BenchEvent])[] = [
+  ["click", new BenchEvent("click", { value: "" })],
+  [
+    "input keystroke",
+    new BenchEvent("input", { value: "hello world", name: "title" }),
+  ],
+  ["detail, 10 records", new BenchCustomEvent("cf-change", makeDetail(10))],
+  ["detail, 200 records", new BenchCustomEvent("cf-change", makeDetail(200))],
+];
+
+for (const [name, event] of SUBJECTS) {
+  Deno.bench({ name, group: name }, async () => {
+    // Everything the main thread does for one event: the seam, then the
+    // transport's encode, then the post.
+    const serialized = serializeEvent(event as unknown as Event);
+    const message = {
+      type: "dom-event",
+      handlerId: 1,
+      nodeId: 1,
+      event: serialized,
+    } as unknown as FabricValue;
+
+    await farSide.send({ payload: realmFromFabricValue(message) });
+  });
+}
+
+globalThis.addEventListener("unload", () => farSide.close());

--- a/packages/html/bench/fixtures/dom-event-far-side.ts
+++ b/packages/html/bench/fixtures/dom-event-far-side.ts
@@ -1,0 +1,44 @@
+/**
+ * The worker side of a DOM-event crossing: it decodes what the main thread
+ * posted, does what the event ingress does with it, and acks.
+ *
+ * Under `fixtures/` rather than beside the benchmark because a file here is
+ * neither a `*.bench.ts` nor a test, and the coverage tooling counts anything
+ * else under `packages/` as source a suite failed to reach.
+ *
+ * The ack carries one boolean. What the benchmark wants to know is what the
+ * send and this side's work cost, and a reply carrying any part of the received
+ * event would put a second clone of it on the return leg and bury exactly that.
+ */
+
+import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
+import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
+import { stripSigilCfcLabelViews } from "@commonfabric/runner/cfc";
+
+/** What the benchmark posts, in the shape the connection posts it. */
+export type EventRequest = {
+  /** The `dom-event` message, encoded as the transport encodes it. */
+  readonly payload: RealmEncodedValue;
+};
+
+/** What this side reports. One boolean, so the return leg costs nothing. */
+export type EventAck = { readonly ok: boolean; readonly error?: string };
+
+self.onmessage = (ev: MessageEvent<EventRequest>) => {
+  try {
+    // What `handleVDomEvent()` does before the reconciler sees the event: the
+    // transport's decode, then the ingress strip that keeps a main-thread
+    // label view from becoming worker label state.
+    const message = fabricFromRealmValue(ev.data.payload) as {
+      event: unknown;
+    };
+
+    stripSigilCfcLabelViews(message.event);
+
+    self.postMessage({ ok: true } satisfies EventAck);
+  } catch (e) {
+    self.postMessage(
+      { ok: false, error: (e as Error).message } satisfies EventAck,
+    );
+  }
+};

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -7,7 +7,7 @@
 
 import {
   type FabricValue,
-  isValidFabricValue,
+  isValidFabricValueLayer,
 } from "@commonfabric/data-model/fabric-value";
 import type { SigilLink } from "@commonfabric/runner/shared";
 import { isCellHandle } from "@commonfabric/runtime-client";
@@ -352,12 +352,19 @@ function carriedTargetValue(
  * it can be carried further is the encoding's question at the crossing rather
  * than this seam's.
  *
+ * Only the top layer is examined, which is what keeps this off the per-event
+ * cost of a walk. A container whose members are not fabric is the producer's
+ * bug and fails at the crossing, where the encoding names the member it cannot
+ * take -- so a deep check here would spend a walk on every correct value to
+ * reach a verdict the encoding reaches anyway.
+ *
  * A `CellHandle` is the one thing a component exposes that is not fabric and
  * has a representation anyway: the link that reaches its cell. Recognized by
  * its class, so that nothing else defining a `toJSON()` is taken for a cell.
  *
- * Anything else is refused. What reaches the refusal is enumerable, and none of
- * it is something a handler could act on:
+ * Anything else is refused: a value whose very top layer has no fabric form.
+ * What reaches this is enumerable, and none of it is something a handler could
+ * act on:
  *
  * * an `Error`, from `cf-error` -- `cf-code-editor` raises six, and
  *   `cf-file-input`, `cf-file-download` and `cf-copy-button` one apiece.
@@ -387,7 +394,7 @@ function carriedTargetValue(
  *   browser suites failing a test on any uncaught page exception.
  */
 function toSerializableValue(value: unknown): FabricValue {
-  if (isValidFabricValue(value)) return value;
+  if (isValidFabricValueLayer(value)) return value as FabricValue;
 
   if (isCellHandle(value)) return value.toJSON();
 

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -331,7 +331,7 @@ function carriedTargetValue(
   prop: typeof ALLOWLISTED_TARGET_PROPERTIES[number],
   value: unknown,
 ): FabricValue | undefined {
-  if (isCellHandle(value)) return value.toJSON();
+  if (isCellHandle(value)) return value.toSigilLink();
 
   const scalar: DomScalar | undefined = TARGET_PROPERTY_SCALARS[
     prop as keyof typeof TARGET_PROPERTY_SCALARS
@@ -360,7 +360,8 @@ function carriedTargetValue(
  *
  * A `CellHandle` is the one thing a component exposes that is not fabric and
  * has a representation anyway: the link that reaches its cell. Recognized by
- * its class, so that nothing else defining a `toJSON()` is taken for a cell.
+ * its class, and asked for its link by name -- nothing here reaches for a
+ * serialization protocol that happens to yield one.
  *
  * Anything else is refused: a value whose very top layer has no fabric form.
  * What reaches this is enumerable, and none of it is something a handler could
@@ -396,7 +397,7 @@ function carriedTargetValue(
 function toSerializableValue(value: unknown): FabricValue {
   if (isValidFabricValueLayer(value)) return value as FabricValue;
 
-  if (isCellHandle(value)) return value.toJSON();
+  if (isCellHandle(value)) return value.toSigilLink();
 
   throw new Error(
     "Cannot yet carry this value on a DOM event, it being neither a " +

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -5,7 +5,10 @@
  * sent to the worker thread for dispatch to the appropriate handler.
  */
 
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type FabricValue,
+  isValidFabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import type { SigilLink } from "@commonfabric/runner/shared";
 import { isCellHandle } from "@commonfabric/runtime-client";
 import {
@@ -340,18 +343,43 @@ function carriedTargetValue(
 }
 
 /**
- * Converts one value a component exposed to the event into a form the VDOM
- * event notification can carry, substituting a description for anything with
- * no conversion at all. Handing the pattern something is the point: an event
- * whose value cannot cross is still an event the handler should see.
+ * Converts one value a component exposed to the event into the form the VDOM
+ * event notification carries.
+ *
+ * A `FabricValue` crosses as itself. The connection carries that whole domain,
+ * so there is nothing to convert, and walking one would only be a chance to
+ * lose something -- which the round trip below does lose: a `bigint` throws out
+ * of `JSON.stringify()`, taking the whole value with it, and a `FabricBytes`
+ * renders as `{}`, its state not being enumerable properties. A cycle is a
+ * `FabricValue` too, and crosses as one; whether it can be carried further is
+ * the encoding's question at the crossing rather than this seam's.
+ *
+ * A `CellHandle` is the one thing a component exposes that is not fabric and
+ * has a representation anyway: the link that reaches its cell. Recognized by
+ * its class, so that nothing else defining a `toJSON()` is taken for a cell.
+ *
+ * Everything else is a native with no fabric form, and the round trip is what
+ * renders it -- `{}` for an `Error` or a file, and a description where even
+ * that fails. Handing the pattern something is the point: an event whose value
+ * cannot cross whole is still an event the handler should see.
+ *
+ * TODO(danfuzz): a `FabricInstance` is a `FabricValue`, so one exposed directly
+ * crosses here and is then refused by the worker's event ingress
+ * (`stripSigilCfcLabelViews()` in `@commonfabric/runner/cfc`), which drops the
+ * event. No component exposes one -- what they raise is a native `Error`, which
+ * is not fabric and takes the round trip -- so nothing arrives there today. It
+ * resolves when that ingress descends an instance rather than refusing one,
+ * which is the next step its own refusal records.
  */
 function toSerializableValue(value: unknown): FabricValue {
+  if (isValidFabricValue(value)) return value;
+
+  if (isCellHandle(value)) return value.toJSON();
+
   try {
-    // The round trip resolves whatever `toJSON()` a value defines -- a
-    // `CellHandle` becomes its sigil link -- and drops what JSON has no
-    // representation for. `undefined` comes back from `JSON.stringify()` for a
-    // function or a symbol, and a circular reference or a throwing `toJSON()`
-    // throws out of it.
+    // Resolves whatever `toJSON()` the value defines, and drops what JSON has
+    // no representation for. `undefined` comes back for a function or an
+    // uninterned symbol, and a throwing `toJSON()` throws out of it.
     const jsonString = JSON.stringify(value);
     if (jsonString !== undefined) return JSON.parse(jsonString);
   } catch {

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -344,49 +344,57 @@ function carriedTargetValue(
 
 /**
  * Converts one value a component exposed to the event into the form the VDOM
- * event notification carries.
+ * event notification carries, and refuses what has no such form.
  *
  * A `FabricValue` crosses as itself. The connection carries that whole domain,
  * so there is nothing to convert, and walking one would only be a chance to
- * lose something -- which the round trip below does lose: a `bigint` throws out
- * of `JSON.stringify()`, taking the whole value with it, and a `FabricBytes`
- * renders as `{}`, its state not being enumerable properties. A cycle is a
- * `FabricValue` too, and crosses as one; whether it can be carried further is
- * the encoding's question at the crossing rather than this seam's.
+ * lose something. A cycle is a `FabricValue` too, and crosses as one; whether
+ * it can be carried further is the encoding's question at the crossing rather
+ * than this seam's.
  *
  * A `CellHandle` is the one thing a component exposes that is not fabric and
  * has a representation anyway: the link that reaches its cell. Recognized by
  * its class, so that nothing else defining a `toJSON()` is taken for a cell.
  *
- * Everything else is a native with no fabric form, and the round trip is what
- * renders it -- `{}` for an `Error` or a file, and a description where even
- * that fails. Handing the pattern something is the point: an event whose value
- * cannot cross whole is still an event the handler should see.
+ * Anything else is refused. What reaches the refusal is enumerable, and none of
+ * it is something a handler could act on:
  *
- * TODO(danfuzz): a `FabricInstance` is a `FabricValue`, so one exposed directly
- * crosses here and is then refused by the worker's event ingress
- * (`stripSigilCfcLabelViews()` in `@commonfabric/runner/cfc`), which drops the
- * event. No component exposes one -- what they raise is a native `Error`, which
- * is not fabric and takes the round trip -- so nothing arrives there today. It
- * resolves when that ingress descends an instance rather than refusing one,
- * which is the next step its own refusal records.
+ * * an `Error`, from `cf-error` -- `cf-code-editor` raises six, and
+ *   `cf-file-input`, `cf-file-download` and `cf-copy-button` one apiece.
+ * * a `Blob`, from `cf-voice-input`'s `cf-recording-stop`, as `audioData`.
+ * * a `FileList`, from `cf-input`'s own `cf-input` event, which carries `files`
+ *   when the input's `type` is `file`.
+ * * an `Element`, from `cf-radio`, `cf-tab` and `cf-tab-bar-item`, each of
+ *   which puts itself in its own detail.
+ * * a `Date`, a `Map`, a `Set`, a `RegExp`, or an object that merely defines a
+ *   `toJSON()`. No component exposes one.
+ *
+ * Nothing binds a handler to any of those events, so nothing reaches this
+ * today. Deliberately absent from the list, being already answered above: the
+ * file inputs' `cf-change`, which carries `StoredFile` records -- plain records
+ * of scalars, which cross as themselves.
+ *
+ * The refusal is a tripwire rather than a verdict on any of them. The set this
+ * accepts is expected to grow, and where each refused value should go instead
+ * is undecided: a `Blob` and a `FileList` want records or `FabricBytes` at the
+ * producer, an `Error` wants a `FabricError` once the worker's event ingress
+ * descends an instance rather than refusing one, and an `Element` cannot cross
+ * at all and wants its producer to name what it means instead.
+ *
+ * @throws If the value is neither of the two that cross. It leaves the DOM
+ *   listener that called this, which loses the event and reports as an uncaught
+ *   page error -- and which is what makes a reachable case unmissable, the
+ *   browser suites failing a test on any uncaught page exception.
  */
 function toSerializableValue(value: unknown): FabricValue {
   if (isValidFabricValue(value)) return value;
 
   if (isCellHandle(value)) return value.toJSON();
 
-  try {
-    // Resolves whatever `toJSON()` the value defines, and drops what JSON has
-    // no representation for. `undefined` comes back for a function or an
-    // uninterned symbol, and a throwing `toJSON()` throws out of it.
-    const jsonString = JSON.stringify(value);
-    if (jsonString !== undefined) return JSON.parse(jsonString);
-  } catch {
-    // Described below, as a value with no JSON form at all is.
-  }
-
-  return describeUnconvertible(value);
+  throw new Error(
+    "Cannot yet carry this value on a DOM event, it being neither a " +
+      `\`FabricValue\` nor a \`CellHandle\`: ${describeUnconvertible(value)}`,
+  );
 }
 
 /**

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -2,7 +2,7 @@
  * Tests for VDOM event serialization.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
@@ -203,24 +203,21 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.target?.value, handle.toJSON());
   });
 
-  await t.step("resolves a `toJSON()` on a target's `value`", () => {
-    // `value` is the one target property no scalar covers, so what is neither a
-    // cell nor a scalar still reaches the general conversion -- which resolves
-    // a `toJSON()`. The other four judge such a value by their own scalar and
-    // leave it out instead.
-    const link = { "/": { "link@1": { id: "of:fid1:abc" } } };
+  await t.step("refuses a value that merely defines a `toJSON()`", () => {
+    // The whole of "no wide-open `toJSON()`": a cell is recognized by its
+    // class, and something that only knows how to render itself as JSON is not
+    // one. `value` is the property with no scalar to fall back on, so nothing
+    // catches this short of the refusal.
     const speaksForItself = new (class {
       toJSON() {
-        return link;
+        return { "/": { "link@1": { id: "of:fid1:abc" } } };
       }
     })();
     const event = new MockEvent("input", {
       target: { value: speaksForItself },
     }) as unknown as Event;
 
-    const serialized = serializeEvent(event);
-
-    assertEquals(serialized.target?.value, link);
+    assertThrows(() => serializeEvent(event), Error, "Cannot yet carry");
   });
 
   await t.step("carries a circular target value through untouched", () => {
@@ -238,19 +235,17 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.target?.value, circular as FabricValue);
   });
 
-  await t.step("describes a target value that refuses coercion too", () => {
-    // `String()` reaches for `toString` and `valueOf`; a null-prototype object
-    // has neither, and a circular one has no JSON form either, so both routes
-    // out of the conversion throw. The event still has to reach the worker.
+  await t.step("names a value that refuses even to be described", () => {
+    // The refusal has to say what it refused, and `String()` reaches for
+    // `toString` and `valueOf`, which an object made with `Object.create(null)`
+    // has neither of. A fixed token stands in, so the refusal does not fail in
+    // turn from inside its own message.
     const bare = Object.create(null);
-    bare.self = bare;
     const event = new MockEvent("input", {
       target: { value: bare },
     }) as unknown as Event;
 
-    const serialized = serializeEvent(event);
-
-    assertEquals(serialized.target?.value, "/unconvertible");
+    assertThrows(() => serializeEvent(event), Error, "/unconvertible");
   });
 
   await t.step("captures trusted provenance", () => {
@@ -524,18 +519,16 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals((serialized.detail as { blob: unknown }).blob, bytes);
   });
 
-  await t.step("renders an `Error` in a detail as a bare record", () => {
-    // An `Error` is not a `FabricValue` and is not a cell, so it reaches the
-    // round trip, whose rendering of one is `{}` -- its state living in
-    // properties JSON does not enumerate. `cf-file-input` dispatches `cf-error`
-    // with one.
+  await t.step("refuses an `Error` handed over in a detail", () => {
+    // The shape most likely to reach the refusal: `cf-error` carries one, and
+    // `cf-code-editor` alone raises six. Nothing binds a handler to that event,
+    // so nothing arrives here -- and an uncaught page exception fails any
+    // browser test, so a case that starts arriving says so at once.
     const event = new MockCustomEvent("cf-error", {
       detail: { error: new Error("boom"), message: "upload failed" },
     }) as unknown as Event;
 
-    const serialized = serializeEvent(event);
-
-    assertEquals(serialized.detail, { error: {}, message: "upload failed" });
+    assertThrows(() => serializeEvent(event), Error, "Cannot yet carry");
   });
 
   await t.step("omits undefined properties", () => {

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -497,6 +497,20 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.target?.value, 42n);
   });
 
+  await t.step("carries a `CellHandle` handed over as a whole detail", () => {
+    // The one way a handle reaches the general conversion: a target property is
+    // checked for one before delegating, so this is a component emitting a
+    // handle as the detail itself rather than inside a record.
+    const handle = makeHandle();
+    const event = new MockCustomEvent("custom", {
+      detail: handle,
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.detail, handle.toJSON());
+  });
+
   await t.step("carries a `FabricBytes` in a detail as its own bytes", () => {
     // A fabric primitive's state is not enumerable properties, so the round
     // trip rendered one as `{}`.

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -201,7 +201,7 @@ Deno.test("events - serializeEvent", async (t) => {
 
     const serialized = serializeEvent(event);
 
-    assertEquals(serialized.target?.value, handle.toJSON());
+    assertEquals(serialized.target?.value, handle.toSigilLink());
   });
 
   await t.step("refuses a value that merely defines a `toJSON()`", () => {
@@ -434,7 +434,7 @@ Deno.test("events - serializeEvent", async (t) => {
 
     const serialized = serializeEvent(event);
 
-    assertEquals(serialized.target?.selected, handle.toJSON());
+    assertEquals(serialized.target?.selected, handle.toSigilLink());
   });
 
   await t.step("does not take a `toJSON()` of its own for a cell", () => {
@@ -504,7 +504,7 @@ Deno.test("events - serializeEvent", async (t) => {
 
     const serialized = serializeEvent(event);
 
-    assertEquals(serialized.detail, handle.toJSON());
+    assertEquals(serialized.detail, handle.toSigilLink());
   });
 
   await t.step("carries a `FabricBytes` in a detail as its own bytes", () => {

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { assertEquals, assertThrows } from "@std/assert";
+import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
@@ -519,17 +520,33 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals((serialized.detail as { blob: unknown }).blob, bytes);
   });
 
-  await t.step("refuses an `Error` handed over in a detail", () => {
-    // The shape most likely to reach the refusal: `cf-error` carries one, and
-    // `cf-code-editor` alone raises six. Nothing binds a handler to that event,
-    // so nothing arrives here -- and an uncaught page exception fails any
-    // browser test, so a case that starts arriving says so at once.
-    const event = new MockCustomEvent("cf-error", {
-      detail: { error: new Error("boom"), message: "upload failed" },
-    }) as unknown as Event;
+  await t.step(
+    "hands on a detail the crossing will refuse, unfabricated",
+    () => {
+      // `cf-error` carries an `Error`, and `cf-code-editor` alone raises six. Its
+      // top layer is a plain record, so it crosses this seam; the member with no
+      // fabric form is the producer's bug and is named by the encoding, which is
+      // where a deep check here would have reached the same verdict at the cost
+      // of a walk on every correct value.
+      //
+      // What matters is the half this seam owns: the value is handed on as it
+      // was, not rendered into an empty record that a handler cannot tell from
+      // real data.
+      const error = new Error("boom");
+      const event = new MockCustomEvent("cf-error", {
+        detail: { error, message: "upload failed" },
+      }) as unknown as Event;
 
-    assertThrows(() => serializeEvent(event), Error, "Cannot yet carry");
-  });
+      const serialized = serializeEvent(event);
+
+      assertEquals((serialized.detail as { error: unknown }).error, error);
+      assertThrows(
+        () => realmFromFabricValue(serialized.detail!),
+        Error,
+        "Cannot encode instance",
+      );
+    },
+  );
 
   await t.step("omits undefined properties", () => {
     const event = new MockEvent("click") as unknown as Event;

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   $conn,
   CellHandle,
@@ -221,7 +223,10 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.target?.value, link);
   });
 
-  await t.step("describes a target value with no JSON form", () => {
+  await t.step("carries a circular target value through untouched", () => {
+    // A value with cycles is a `FabricValue`, so it crosses as one. Whether it
+    // can be carried further is the encoding's question at the crossing, and
+    // nothing here walks a value looking for one.
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     const event = new MockEvent("input", {
@@ -230,7 +235,7 @@ Deno.test("events - serializeEvent", async (t) => {
 
     const serialized = serializeEvent(event);
 
-    assertEquals(serialized.target?.value, "[object Object]");
+    assertEquals(serialized.target?.value, circular as FabricValue);
   });
 
   await t.step("describes a target value that refuses coercion too", () => {
@@ -462,6 +467,61 @@ Deno.test("events - serializeEvent", async (t) => {
 
     assertEquals(serialized.target?.name, undefined);
     assertEquals(serialized.target?.value, "kept");
+  });
+
+  await t.step(
+    "carries a `bigint` in a detail rather than losing the detail",
+    () => {
+      // The whole detail used to go: a `bigint` throws out of `JSON.stringify()`,
+      // and what answered was a description of the value it was handed rather
+      // than of the member that could not be rendered.
+      const event = new MockCustomEvent("custom", {
+        detail: { message: "hello", count: 42n },
+      }) as unknown as Event;
+
+      const serialized = serializeEvent(event);
+
+      assertEquals(serialized.detail, { message: "hello", count: 42n });
+    },
+  );
+
+  await t.step("carries a `bigint` exposed as a target's value", () => {
+    // Quieter than losing a detail and worse for it: this used to arrive as the
+    // string `"42"`, which a handler has no way to tell from a real one.
+    const event = new MockEvent("input", {
+      target: { value: 42n },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.target?.value, 42n);
+  });
+
+  await t.step("carries a `FabricBytes` in a detail as its own bytes", () => {
+    // A fabric primitive's state is not enumerable properties, so the round
+    // trip rendered one as `{}`.
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+    const event = new MockCustomEvent("custom", {
+      detail: { blob: bytes },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals((serialized.detail as { blob: unknown }).blob, bytes);
+  });
+
+  await t.step("renders an `Error` in a detail as a bare record", () => {
+    // An `Error` is not a `FabricValue` and is not a cell, so it reaches the
+    // round trip, whose rendering of one is `{}` -- its state living in
+    // properties JSON does not enumerate. `cf-file-input` dispatches `cf-error`
+    // with one.
+    const event = new MockCustomEvent("cf-error", {
+      detail: { error: new Error("boom"), message: "upload failed" },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.detail, { error: {}, message: "upload failed" });
   });
 
   await t.step("omits undefined properties", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Every value a component exposes to a DOM event — a `detail`, and a target's
`value` — went through `JSON.parse(JSON.stringify(...))`, with a failure
answered by describing the value as a whole. The connection moves
`FabricValue`s, `postMessage` rather than JSON text being what it runs on, so
that conversion both loses what the crossing can carry and invents something
where it cannot.

Two values cross, and nothing else does.

## What this costs a crossing, and what it does not

The inbound half of the connection had no benchmark, so one is added here:
`packages/html/bench/dom-event-crossing.bench.ts` times the whole trip —
`serializeEvent()`, the encode, the post, the worker's decode, and the ingress
strip that `handleVDomEvent()` does before the reconciler sees the event. Six
runs per arm, alternating, p75 per run and the median across runs, in
microseconds:

| subject | `main` | here | delta | spread | |
| --- | --- | --- | --- | --- | --- |
| click | 12.0 | 11.9 | −0.9% | ±15.5% / ±5.4% | within spread |
| input keystroke | 12.0 | 11.9 | −1.4% | ±9.5% / ±8.2% | within spread |
| detail, 10 records | 21.1 | 17.1 | −19.1% | ±18.3% / ±20.6% | **within spread** |
| detail, 200 records | 135.1 | 111.1 | **−17.7%** | ±10.2% / ±5.7% | **clear** |

**Only the last row is a result.** A round trip costs about 12us before any
payload and its run-to-run variance reaches a fifth of the measurement, so a
subject near that floor cannot resolve a change worth a microsecond or two.
Adding runs does not help: the spread is scheduling variance rather than
sampling error, and held steady from three runs to six.

The `10 records` row is the one to be careful about. It moves in the right
direction by a large-looking amount, and it should not be believed, because the
mechanism predicts something much smaller. The seam's own work, measured
directly:

| | was, a JSON round trip | now | saved |
| --- | --- | --- | --- |
| 10 records | 1.18 us | 0.09 us | ~1.1 us |
| 200 records | 16.84 us | 0.06 us | ~16.8 us |

At two hundred records that predicts ~17us off a 135us trip, and the observed
24us is that plus the copy no longer being there for the encode and the clone to
walk — consistent. At ten records it predicts ~1.1us off 21us, about 5%, which
is a quarter of the noise floor. So the −19.1% there is noise that happens to
point the right way.

**The honest summary: invisible on small events, worth about 18% on large
details, and the crossover is where a detail's copy cost climbs past the
round-trip noise.** That is the right shape, the saving being exactly the copy
that no longer happens — so it is zero when there is nothing to copy, which is
most of what a user generates.

## A `FabricValue` crosses as itself

Nothing walks it, so there is nothing to lose. Three things the round trip lost:

| exposed | reached the handler as |
| --- | --- |
| `{ message: "hello", count: 42n }` | `"[object Object]"` — one member with no JSON form took the whole value |
| `42n` as a target's `value` | the string `"42"`, indistinguishable from a real one |
| a `FabricBytes` in a detail | `{}`, its state not living in enumerable properties |

A cycle is a `FabricValue` too and crosses as one. Whether it can be carried
further is the encoding's question at the crossing rather than this seam's.

## A `CellHandle` crosses as the link to its cell

That is what a bound property holds: the applicator installs the handle on the
element and the components leave it there. It is recognized by its class and
asked for its link by name — `CellHandle.toSigilLink()`, added in #6500 — so
`toJSON()` is out of the path in both senses. Nothing duck-types a `toJSON()` to
find a cell, and nothing calls one to get a link from a cell it has already
found. A value that merely defines a `toJSON()` is refused like any other.

## Everything else is refused

The round trip rendered a native as something rather than nothing, and what it
rendered was never usable. `{}` for an `Error`, a `Blob`, a `File` — their state
does not live in enumerable properties — and a description of the whole value
where even that failed. A handler receiving `{}` cannot tell it from an empty
record, so what looked like best-effort delivery was a value built on a lie.

**Nothing consumes one.** Across the pattern corpus:

| | |
| --- | --- |
| `oncf-error`, `oncf-recording-stop`, `ontab-click`, `ontab-bar-click` | no bindings at all |
| `oncf-input` | three bindings, none targeting a file-typed input, so `files` is `undefined` and omitted |
| the eight readers of `detail?.files` | all on the file inputs' `cf-change`, which carries `StoredFile` records — plain records of scalars, which cross as themselves |
| the two readers of `detail.error` | a browser test's own `addEventListener`, which never passes through here |

A value whose top layer is fabric but whose members are not — a record holding
an `Error`, say — is not refused here. It is handed on as it was and refused by
the encoding, which loses the event and raises the same uncaught page error. The
half this seam owns is that such a value is never *rendered* into an empty record
a handler could not tell from data.

So the refusal costs nothing today, and stops a future consumer building on a
rendering that means nothing. The doc comment enumerates what reaches it and
where each wants to go instead: records or a `FabricBytes` at the producer for a
`Blob` and a `FileList`; a `FabricError` for an `Error`, once the worker's event
ingress descends an instance rather than refusing one; and for an `Element`, a
producer that names what it means, an element being unable to cross at all.

## What the refusal does, and why uncaught

The throw leaves the DOM listener, losing the event and reporting as an uncaught
page error. In a page that is a lost click and a console line — there is no
global error handler in the shell. In CI it is unmissable:
`packages/integration/shell-utils.ts` registers a `pageerror` listener and fails
the test at teardown on any uncaught page exception, *regardless* of
`failOnConsoleError`.

That is what makes this a tripwire rather than a silent narrowing. It is
unreachable in a default configuration, and the browser suites turn any case
that starts arriving into a red test immediately — which is the detector the
enumeration above would otherwise depend on being complete forever.

## One behavior worth a reviewer's attention

A `FabricInstance` is a `FabricValue`, so one exposed directly crosses, and the
worker's event ingress then refuses it and drops the event. Measured against the
real ingress:

```
Error in a detail                  ingress: refused here, before the crossing
Error alongside a bigint           ingress: refused here, before the crossing
a FabricError exposed directly     ingress: THREW
plain data                         ingress: OK
```

Nothing exposes one — components raise native `Error`s, which are refused at
this seam instead. Guarding it means walking every value for something no
producer constructs. A `TODO` records it, and it resolves where that ingress's
own refusal already says it will.

## Tests

Ten, each with a control. Removing the pass-through fails four and nothing else;
removing the handle arm fails the two that pin it. Two refusals — a duck-typed
`toJSON()`, and a value that refuses even to be described — pin the contract's
other half, and one test pins the end-to-end case: an `Error` in a detail is
handed on as itself, and encoding that detail throws.

## Gates

`deno task check`, `deno fmt`, `deno lint` green; full suites green for `html`
and `runtime-client`; `events.ts` at zero uncovered lines.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->






