### PR TITLE
refactor: `#` private members across thirteen packages

### DIFF
--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -47,35 +47,35 @@ export async function launchWithRetry(
 }
 
 export class BrowserController extends EventTarget {
-  private static readonly HARNESS_READY_TIMEOUT_MS = 10_000;
-  private static readonly HARNESS_READY_POLL_MS = 200;
-  private manifest: Manifest;
-  private page: Page | null;
-  private browser: AstralBrowser | null;
-  private serverPort: number;
+  static readonly #HARNESS_READY_TIMEOUT_MS = 10_000;
+  static readonly #HARNESS_READY_POLL_MS = 200;
+  #manifest: Manifest;
+  #page: Page | null;
+  #browser: AstralBrowser | null;
+  #serverPort: number;
 
   constructor(manifest: Manifest, serverPort: number) {
     super();
-    this.manifest = manifest;
-    this.browser = null;
-    this.page = null;
-    this.serverPort = serverPort;
+    this.#manifest = manifest;
+    this.#browser = null;
+    this.#page = null;
+    this.#serverPort = serverPort;
   }
 
   async load(filePath: string) {
-    const rootUrl = `http://localhost:${this.serverPort}`;
+    const rootUrl = `http://localhost:${this.#serverPort}`;
     const jsTestPath = tsToJs(filePath);
-    const config = this.manifest.config;
+    const config = this.#manifest.config;
     const testTimeout = config.testTimeout ?? DEFAULT_TEST_TIMEOUT_MS;
     const testUrl =
       `${rootUrl}/?test=/${jsTestPath}&testTimeout=${testTimeout}`;
 
-    if (this.page) {
-      await this.page.goto(testUrl);
+    if (this.#page) {
+      await this.#page.goto(testUrl);
     } else {
-      this.browser = await launchWithRetry(extractAstralConfig(config));
-      this.page = await this.browser.newPage(testUrl);
-      this.page.addEventListener("console", (e) => {
+      this.#browser = await launchWithRetry(extractAstralConfig(config));
+      this.#page = await this.#browser.newPage(testUrl);
+      this.#page.addEventListener("console", (e) => {
         // Not sure why this event needs reconstructed in order
         // to re-fire, rather than just passing it into `dispatchEvent`.
         this.dispatchEvent(
@@ -86,14 +86,14 @@ export class BrowserController extends EventTarget {
         );
       });
     }
-    await this.waitUntilReady();
+    await this.#waitUntilReady();
   }
 
   async getTestCount(): Promise<number> {
-    if (!this.page) {
+    if (!this.#page) {
       throw new Error("No page loaded.");
     }
-    return (await this.page.evaluate(() =>
+    return (await this.#page.evaluate(() =>
       // @ts-ignore This is defined in the JS harness
       globalThis.__denoWebTest.getTestCount()
     ))
@@ -101,26 +101,26 @@ export class BrowserController extends EventTarget {
   }
 
   async runNextTest(): Promise<TestResult | void> {
-    if (!this.page) {
+    if (!this.#page) {
       throw new Error("No page loaded.");
     }
 
-    return (await this.page.evaluate(() =>
+    return (await this.#page.evaluate(() =>
       // @ts-ignore This is defined in the JS harness
       globalThis.__denoWebTest.runNext()
     )).ok;
   }
 
-  private async waitUntilReady() {
-    if (!this.page) {
+  async #waitUntilReady() {
+    if (!this.#page) {
       throw new Error("No page loaded.");
     }
     const attempts = Math.ceil(
-      BrowserController.HARNESS_READY_TIMEOUT_MS /
-        BrowserController.HARNESS_READY_POLL_MS,
+      BrowserController.#HARNESS_READY_TIMEOUT_MS /
+        BrowserController.#HARNESS_READY_POLL_MS,
     );
     for (let i = 0; i < attempts; i++) {
-      const response = await this.page.evaluate(() =>
+      const response = await this.#page.evaluate(() =>
         // @ts-ignore This is defined in the JS harness
         globalThis.__denoWebTest && globalThis.__denoWebTest.isReady()
       );
@@ -130,18 +130,18 @@ export class BrowserController extends EventTarget {
       if (response.error) {
         throw new Error(response.error?.message ?? response.error);
       }
-      await sleep(BrowserController.HARNESS_READY_POLL_MS);
+      await sleep(BrowserController.#HARNESS_READY_POLL_MS);
     }
     throw new Error(
-      `Test harness not ready in ${BrowserController.HARNESS_READY_TIMEOUT_MS}ms.`,
+      `Test harness not ready in ${BrowserController.#HARNESS_READY_TIMEOUT_MS}ms.`,
     );
   }
 
   async close() {
-    this.page = null;
-    if (this.browser) {
-      await closeAstralBrowser(this.browser);
+    this.#page = null;
+    if (this.#browser) {
+      await closeAstralBrowser(this.#browser);
     }
-    this.browser = null;
+    this.#browser = null;
   }
 }

--- a/packages/deno-web-test/server.ts
+++ b/packages/deno-web-test/server.ts
@@ -2,23 +2,23 @@ import { serveDir } from "@std/http/file-server";
 import { Manifest } from "./manifest.ts";
 
 export class TestServer {
-  private server: Deno.HttpServer<Deno.NetAddr> | null;
-  private manifest: Manifest;
+  #server: Deno.HttpServer<Deno.NetAddr> | null;
+  #manifest: Manifest;
 
   // Takes the root dir of the current package `projectDir`,
   // and a directory to use as the root of the static
   // content server `serverDir`.
   constructor(manifest: Manifest) {
-    this.server = null;
-    this.manifest = manifest;
+    this.#server = null;
+    this.#manifest = manifest;
   }
 
   start(port: number) {
-    this.server = Deno.serve(
+    this.#server = Deno.serve(
       { port, hostname: "127.0.0.1", onListen() {} },
       (req: Request) =>
         serveDir(req, {
-          fsRoot: this.manifest.serverDir,
+          fsRoot: this.#manifest.serverDir,
           quiet: true,
           // A realm the test page creates -- a sandboxed iframe -- has an
           // opaque origin, and a module script is fetched in CORS mode, so
@@ -26,18 +26,18 @@ export class TestServer {
           enableCors: true,
         }),
     );
-    if (!this.server) throw new Error("Server creation failed");
-    this.server.unref();
+    if (!this.#server) throw new Error("Server creation failed");
+    this.#server.unref();
   }
 
   // Returns the listening port, if server running.
   port(): number | undefined {
-    return this.server?.addr?.port;
+    return this.#server?.addr?.port;
   }
 
   async stop() {
-    if (this.server) {
-      await this.server.shutdown();
+    if (this.#server) {
+      await this.#server.shutdown();
     }
   }
 }

--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -26,7 +26,7 @@ function formatFileSize(bytes: number): string {
 }
 
 export class Builder extends EventTarget {
-  private splitPassAuxiliaryOutputGenerations: Set<string>[] = [];
+  #splitPassAuxiliaryOutputGenerations: Set<string>[] = [];
 
   constructor(public manifest: ResolvedConfig) {
     super();
@@ -71,13 +71,13 @@ export class Builder extends EventTarget {
       // One esbuild service serves both passes; stop it once, after the last.
       try {
         if (plainEntries.length > 0) {
-          const metafile = await this.runPass(plainEntries, false);
+          const metafile = await this.#runPass(plainEntries, false);
           if (metafile) passMetafiles.push(metafile);
         }
         if (splitEntries.length > 0) {
-          const metafile = await this.runPass(splitEntries, true);
+          const metafile = await this.#runPass(splitEntries, true);
           if (metafile) {
-            await this.pruneStaleSplitOutputs(metafile, splitEntries);
+            await this.#pruneStaleSplitOutputs(metafile, splitEntries);
             passMetafiles.push(metafile);
           }
         }
@@ -96,7 +96,7 @@ export class Builder extends EventTarget {
 
       // Generate build manifest with content hashes of output files.
       // Used by the shell to cache-bust the worker bundle URL (?v=<hash>).
-      await this.writeBuildManifest();
+      await this.#writeBuildManifest();
 
       const buildTime = Math.round(performance.now() - startTime);
       console.log(`   ${dim(`Total build time: ${buildTime}ms`)}`);
@@ -119,7 +119,7 @@ export class Builder extends EventTarget {
    * The shared esbuild service is kept alive (`stop: false`); {@link build}
    * stops it once after the final pass.
    */
-  private async runPass(
+  async #runPass(
     entries: ResolvedEntryPoint[],
     splitting: boolean,
   ): Promise<esbuild.Metafile | undefined> {
@@ -167,7 +167,7 @@ export class Builder extends EventTarget {
   }
 
   /** Retain the current and previous split outputs, pruning anything older. */
-  private async pruneStaleSplitOutputs(
+  async #pruneStaleSplitOutputs(
     metafile: esbuild.Metafile,
     entries: ResolvedEntryPoint[],
   ): Promise<void> {
@@ -186,17 +186,17 @@ export class Builder extends EventTarget {
         .map(([outputPath]) => resolvePath(outputPath)),
     );
 
-    this.splitPassAuxiliaryOutputGenerations.push(nextOutputs);
+    this.#splitPassAuxiliaryOutputGenerations.push(nextOutputs);
     if (
-      this.splitPassAuxiliaryOutputGenerations.length <=
+      this.#splitPassAuxiliaryOutputGenerations.length <=
         RETAINED_SPLIT_OUTPUT_GENERATIONS
     ) {
       return;
     }
 
-    const staleOutputs = this.splitPassAuxiliaryOutputGenerations.shift()!;
+    const staleOutputs = this.#splitPassAuxiliaryOutputGenerations.shift()!;
     const retainedOutputs = new Set(
-      this.splitPassAuxiliaryOutputGenerations.flatMap((
+      this.#splitPassAuxiliaryOutputGenerations.flatMap((
         generation,
       ) => [...generation]),
     );
@@ -228,7 +228,7 @@ export class Builder extends EventTarget {
    * The manifest is used by the shell to cache-bust the worker bundle URL
    * (`?v=<hash>`), so a deploy always loads the fresh worker.
    */
-  private async writeBuildManifest(): Promise<void> {
+  async #writeBuildManifest(): Promise<void> {
     const manifest: Record<string, string> = {};
     for (const entry of this.manifest.entries) {
       // esbuild appends .js to entry.out; only .js outputs are hashed.

--- a/packages/felt/dev-server.ts
+++ b/packages/felt/dev-server.ts
@@ -4,7 +4,7 @@ import { serveDir } from "@std/http/file-server";
 const DEV_SOCKET = "DEV_SOCKET.js";
 
 export class DevServer {
-  #_server: Deno.HttpServer;
+  #server: Deno.HttpServer;
   #outDir: string;
   #sockets: WebSocket[] = [];
   #html: string;
@@ -36,7 +36,7 @@ export class DevServer {
     this.#staticDirs = staticDirs;
     this.#html = this.#getHtml({ useReloadSocket, outDir });
     this.#socketScript = this.#getSocketScript({ hostname, port });
-    this.#_server = Deno.serve(
+    this.#server = Deno.serve(
       {
         port,
         hostname,

--- a/packages/felt/dev-server.ts
+++ b/packages/felt/dev-server.ts
@@ -4,14 +4,14 @@ import { serveDir } from "@std/http/file-server";
 const DEV_SOCKET = "DEV_SOCKET.js";
 
 export class DevServer {
-  private _server: Deno.HttpServer;
-  private outDir: string;
-  private sockets: WebSocket[] = [];
-  private html: string;
-  private socketScript: string;
-  private useReloadSocket: boolean;
-  private redirectToIndex?: RegExp;
-  private staticDirs: Array<{ from: string; to: string }>;
+  #_server: Deno.HttpServer;
+  #outDir: string;
+  #sockets: WebSocket[] = [];
+  #html: string;
+  #socketScript: string;
+  #useReloadSocket: boolean;
+  #redirectToIndex?: RegExp;
+  #staticDirs: Array<{ from: string; to: string }>;
 
   constructor(
     {
@@ -30,13 +30,13 @@ export class DevServer {
       staticDirs?: Array<{ from: string; to: string }>;
     },
   ) {
-    this.useReloadSocket = useReloadSocket;
-    this.outDir = outDir;
-    this.redirectToIndex = redirectToIndex;
-    this.staticDirs = staticDirs;
-    this.html = this.getHtml({ useReloadSocket, outDir });
-    this.socketScript = this.getSocketScript({ hostname, port });
-    this._server = Deno.serve(
+    this.#useReloadSocket = useReloadSocket;
+    this.#outDir = outDir;
+    this.#redirectToIndex = redirectToIndex;
+    this.#staticDirs = staticDirs;
+    this.#html = this.#getHtml({ useReloadSocket, outDir });
+    this.#socketScript = this.#getSocketScript({ hostname, port });
+    this.#_server = Deno.serve(
       {
         port,
         hostname,
@@ -44,25 +44,25 @@ export class DevServer {
           console.log(`Dev server listening on http://${hostname}:${port}`);
         },
       },
-      this.onRequest.bind(this),
+      this.#onRequest.bind(this),
     );
   }
 
   reload() {
-    for (const socket of this.sockets) {
+    for (const socket of this.#sockets) {
       socket.send("reload");
     }
   }
 
-  private async onRequest(req: Request) {
+  async #onRequest(req: Request) {
     const url = new URL(req.url);
 
     if (req.headers.get("upgrade") === "websocket") {
-      return this.upgradeWebSocket(req);
+      return this.#upgradeWebSocket(req);
     }
 
-    if (this.useReloadSocket && url.pathname === `/${DEV_SOCKET}`) {
-      return new Response(this.socketScript, {
+    if (this.#useReloadSocket && url.pathname === `/${DEV_SOCKET}`) {
+      return new Response(this.#socketScript, {
         status: 200,
         headers: { "Content-Type": "text/javascript" },
       });
@@ -70,16 +70,16 @@ export class DevServer {
 
     if (
       url.pathname === "/" || url.pathname === "/index.html" ||
-      (this.redirectToIndex && this.redirectToIndex?.test(url.pathname))
+      (this.#redirectToIndex && this.#redirectToIndex?.test(url.pathname))
     ) {
-      return new Response(this.html, {
+      return new Response(this.#html, {
         status: 200,
         headers: { "Content-Type": "text/html" },
       });
     }
 
     // Check static directories
-    for (const { from, to } of this.staticDirs) {
+    for (const { from, to } of this.#staticDirs) {
       if (url.pathname.startsWith(to)) {
         // Handle OPTIONS requests for CORS
         if (req.method === "OPTIONS") {
@@ -117,26 +117,26 @@ export class DevServer {
     }
 
     return serveDir(req, {
-      fsRoot: this.outDir,
+      fsRoot: this.#outDir,
       quiet: true,
     });
   }
 
-  private upgradeWebSocket(req: Request): Response {
+  #upgradeWebSocket(req: Request): Response {
     const { socket, response } = Deno.upgradeWebSocket(req);
     socket.addEventListener("open", () => {
-      this.sockets.push(socket);
+      this.#sockets.push(socket);
     });
     socket.addEventListener("close", () => {
-      const index = this.sockets.findIndex((s) => s === socket);
+      const index = this.#sockets.findIndex((s) => s === socket);
       if (index > 0) {
-        this.sockets.splice(index, 1);
+        this.#sockets.splice(index, 1);
       }
     });
     return response;
   }
 
-  private getHtml(
+  #getHtml(
     { useReloadSocket, outDir }: { useReloadSocket?: boolean; outDir: string },
   ): string {
     const html = Deno.readTextFileSync(join(outDir, "index.html"));
@@ -148,7 +148,7 @@ export class DevServer {
       : html;
   }
 
-  private getSocketScript(
+  #getSocketScript(
     { hostname, port }: { hostname: string; port: number },
   ): string {
     let script = "";

--- a/packages/identity/src/key-store.ts
+++ b/packages/identity/src/key-store.ts
@@ -21,16 +21,15 @@ const DB_VERSION = 1;
 
 // An abstraction around storing key materials in IndexedDb.
 export class KeyStore {
-  static DEFAULT_DB_NAME = DEFAULT_DB_NAME;
-  private db: DB;
+  #db: DB;
 
   constructor(db: DB) {
-    this.db = db;
+    this.#db = db;
   }
 
   // Get the `name` keypair.
   async get(name: string): Promise<Identity | void> {
-    const result = await this.db.get(name);
+    const result = await this.#db.get(name);
     if (result) {
       return Identity.fromKeyPair(keyPairFromStored(result));
     }
@@ -39,12 +38,17 @@ export class KeyStore {
 
   // Set the `name` keypair with `value`.
   async set(name: string, value: Identity): Promise<undefined> {
-    await this.db.set(name, storedFromKeyPair(value.keyPair));
+    await this.#db.set(name, storedFromKeyPair(value.keyPair));
   }
 
   // Clear the key store's table.
   clear(): Promise<void> {
-    return this.db.clear();
+    return this.#db.clear();
+  }
+
+  /** The database name that `open()` uses when not given one. */
+  static get DEFAULT_DB_NAME(): string {
+    return DEFAULT_DB_NAME;
   }
 
   // Opens a new instance of `KeyStore`.
@@ -67,23 +71,23 @@ export class KeyStore {
 }
 
 class DB {
-  private db: IDBDatabase;
+  #db: IDBDatabase;
   constructor(db: IDBDatabase) {
-    this.db = db;
+    this.#db = db;
   }
 
   get(key: string): Promise<StoredKeyPair | void> {
-    const store = this.getStore(DEFAULT_STORE_NAME, "readonly");
+    const store = this.#getStore(DEFAULT_STORE_NAME, "readonly");
     return asyncWrap(store.get(key));
   }
 
   set(key: string, value: unknown): Promise<void> {
-    const store = this.getStore(DEFAULT_STORE_NAME, "readwrite");
+    const store = this.#getStore(DEFAULT_STORE_NAME, "readwrite");
     return asyncWrap(store.put(value, key)).then(() => undefined);
   }
 
   async clear() {
-    const store = this.getStore(DEFAULT_STORE_NAME, "readwrite");
+    const store = this.#getStore(DEFAULT_STORE_NAME, "readwrite");
     return await asyncWrap(store.clear());
   }
 
@@ -105,11 +109,11 @@ class DB {
     return new DB(db);
   }
 
-  private getStore(
+  #getStore(
     storeName: string,
     mode: "readonly" | "readwrite",
   ): IDBObjectStore {
-    const tx = this.db.transaction(storeName, mode);
+    const tx = this.#db.transaction(storeName, mode);
     return tx.objectStore(storeName);
   }
 }

--- a/packages/identity/src/pass-key.ts
+++ b/packages/identity/src/pass-key.ts
@@ -27,13 +27,13 @@ export interface PassKeyGetOptions {
 // A key must first be created for an origin, and then retrieved
 // as a `PassKey` instance. From there, a root key `Identity` can be derived/stored.
 export class PassKey {
-  private credentials: PublicKeyCredential;
+  #credentials: PublicKeyCredential;
   private constructor(credentials: PublicKeyCredential) {
-    this.credentials = credentials;
+    this.#credentials = credentials;
   }
 
   id() {
-    return this.credentials.id;
+    return this.#credentials.id;
   }
 
   // Generate a root key from a `PassKey`.
@@ -41,7 +41,7 @@ export class PassKey {
   // PRF output, a 32-byte hash, which is used as ed25519 key material.
   // Note: Root keys can only be created from PassKeys obtained via PassKey.get()
   async createRootKey(): Promise<Identity> {
-    const seed = this.prf();
+    const seed = this.#prf();
     if (!seed) {
       throw new Error(
         "common-identity: No PRF found. This PassKey appears to have just been created - root keys can only be generated from PassKeys obtained via PassKey.get()",
@@ -52,10 +52,10 @@ export class PassKey {
   }
 
   // Return the secret 32-bytes derived from the passkey's PRF data.
-  private prf(): Uint8Array | null {
+  #prf(): Uint8Array | null {
     // PRF results are only available when calling `get()`,
     // not during key creation.
-    const extResults = this.getCredentials().getClientExtensionResults();
+    const extResults = this.#getCredentials().getClientExtensionResults();
     const prf = extResults?.prf?.results?.first;
     if (prf) {
       return new Uint8Array(bufferSourceToArrayBuffer(prf));
@@ -153,7 +153,7 @@ export class PassKey {
     return new PassKey(credential);
   }
 
-  private getCredentials(): PublicKeyCredential {
-    return this.credentials;
+  #getCredentials(): PublicKeyCredential {
+    return this.#credentials;
   }
 }

--- a/packages/identity/test/key-store.test.ts
+++ b/packages/identity/test/key-store.test.ts
@@ -56,3 +56,23 @@ Deno.test("KeyStore recovers a key pair holding handles as one", async () => {
     "recovered as the arm it was stored as",
   );
 });
+
+// The database name is persisted browser state, so it is pinned to its literal
+// here rather than to the constant: reading the constant on both sides of the
+// comparison would agree with itself no matter what the name became, and a
+// silent change to it would orphan every key a user has already stored.
+Deno.test("KeyStore.open() with no name opens `common-key-store`", async () => {
+  assert(KeyStore.DEFAULT_DB_NAME === "common-key-store");
+
+  const defaulted = await KeyStore.open();
+  await defaulted.clear();
+
+  const key = await Identity.generate();
+  await defaulted.set("key", key);
+
+  const named = await KeyStore.open("common-key-store");
+  const recovered = await named.get("key");
+  assert(recovered && key.did() === recovered.did());
+
+  await named.clear();
+});

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -60,10 +60,14 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /** The capability session belonging to the currently loaded guest. */
   #guestHost: FabricBridgeHost | undefined;
-  // Reached into by `test/iframe.test.ts`, which asserts the outer-ready
-  // refusal where it is made: a frame reports itself ready once, and that
-  // message cannot be sent from anywhere else. `#` would make the assertion
-  // unreachable, so these three stay TypeScript-private.
+  /**
+   * The frame this element renders, held so the guest can be reached through
+   * it. TypeScript-private rather than `#`, as `readyWindow` and
+   * `onOuterReady` also are, because `test/iframe.test.ts` reaches for all
+   * three: it asserts the outer-ready refusal where the refusal is made, and
+   * a frame reports itself ready exactly once, from a window nothing outside
+   * this element can speak for.
+   */
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
 
   /**

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -60,6 +60,7 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /** The capability session belonging to the currently loaded guest. */
   #guestHost: FabricBridgeHost | undefined;
+
   /**
    * The frame this element renders, held so the guest can be reached through
    * it. TypeScript-private rather than `#`, as `readyWindow` and

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -24,7 +24,7 @@ export class CommonIframeSandboxElement extends LitElement {
     this.#src = value;
     this.requestUpdate("src", previousValue);
     if (this.readyWindow && value !== previousValue) {
-      this.loadInnerDoc();
+      this.#loadInnerDoc();
     }
   }
 
@@ -38,7 +38,7 @@ export class CommonIframeSandboxElement extends LitElement {
     this.#bridge = value;
     this.requestUpdate("bridge", previousValue);
     if (this.readyWindow && value !== previousValue && this.src) {
-      this.loadInnerDoc();
+      this.#loadInnerDoc();
     }
   }
 
@@ -59,7 +59,11 @@ export class CommonIframeSandboxElement extends LitElement {
   #bridge: FabricBridge | undefined;
 
   /** The capability session belonging to the currently loaded guest. */
-  private guestHost: FabricBridgeHost | undefined;
+  #guestHost: FabricBridgeHost | undefined;
+  // Reached into by `test/iframe.test.ts`, which asserts the outer-ready
+  // refusal where it is made: a frame reports itself ready once, and that
+  // message cannot be sent from anywhere else. `#` would make the assertion
+  // unreachable, so these three stay TypeScript-private.
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
 
   /**
@@ -93,9 +97,9 @@ export class CommonIframeSandboxElement extends LitElement {
       throw new Error(`common-iframe-sandbox: Already initialized.`);
     }
     this.readyWindow = source;
-    this.releaseGuest();
+    this.#releaseGuest();
     if (this.src) {
-      this.loadInnerDoc();
+      this.#loadInnerDoc();
     } else {
       this.loadState = "";
     }
@@ -106,8 +110,8 @@ export class CommonIframeSandboxElement extends LitElement {
    * other. Each document is its own realm, so each gets a port of its own, and
    * no earlier one is left open behind it.
    */
-  private openGuestPort() {
-    this.closeGuestPort();
+  #openGuestPort() {
+    this.#closeGuestPort();
 
     // The guest is the inner frame, which is a frame of the outer one. A
     // cross-origin frame is unreachable for anything but this: indexed access
@@ -119,7 +123,7 @@ export class CommonIframeSandboxElement extends LitElement {
     }
 
     const channel = new MessageChannel();
-    this.guestHost = new FabricBridgeHost(
+    this.#guestHost = new FabricBridgeHost(
       this.bridge ?? { resources: {} },
       channel.port1,
     );
@@ -131,13 +135,13 @@ export class CommonIframeSandboxElement extends LitElement {
    * afterwards reaches nothing, which is the point: the guest on the other end
    * of a closed port is one this element is done with.
    */
-  private closeGuestPort() {
-    this.guestHost?.disconnect();
-    this.guestHost = undefined;
+  #closeGuestPort() {
+    this.#guestHost?.disconnect();
+    this.#guestHost = undefined;
   }
 
   /** Handles a message from the outer frame. */
-  private onMessage = (event: MessageEvent) => {
+  #onMessage = (event: MessageEvent) => {
     if (event.source !== this.iframeRef.value?.contentWindow) {
       return;
     }
@@ -154,7 +158,7 @@ export class CommonIframeSandboxElement extends LitElement {
 
     switch (outerMessage.type) {
       case IPC.IPCGuestMessageType.Load: {
-        this.openGuestPort();
+        this.#openGuestPort();
         this.loadState = "loaded";
         this.dispatchEvent(new CustomEvent("load"));
         return;
@@ -172,7 +176,7 @@ export class CommonIframeSandboxElement extends LitElement {
         // had at it.
         const raised = outerMessage.data;
         if (IPC.isGuestAlarm(raised)) {
-          this.dispatchGuestError(raised.data);
+          this.#dispatchGuestError(raised.data);
         } else {
           console.error(
             "common-iframe-sandbox: Unreadable alarm from guest.",
@@ -192,7 +196,7 @@ export class CommonIframeSandboxElement extends LitElement {
    * Dispatches `common-iframe-error` for an error the guest raised, by either
    * of the routes one can arrive on.
    */
-  private dispatchGuestError(
+  #dispatchGuestError(
     { description, source, lineno, colno, stacktrace }: IPC.GuestError,
   ) {
     this.dispatchEvent(
@@ -219,8 +223,8 @@ export class CommonIframeSandboxElement extends LitElement {
    * element's, which is when one is asked to be replaced and when the frame
    * holding it has gone.
    */
-  private releaseGuest() {
-    this.closeGuestPort();
+  #releaseGuest() {
+    this.#closeGuestPort();
   }
 
   /**
@@ -230,35 +234,35 @@ export class CommonIframeSandboxElement extends LitElement {
    * the whole of what this end can promise about a document still running in a
    * frame it has asked to be rid of.
    */
-  private loadInnerDoc() {
+  #loadInnerDoc() {
     this.loadState = "loading";
-    this.releaseGuest();
-    this.toOuterFrame({
+    this.#releaseGuest();
+    this.#toOuterFrame({
       type: IPC.IPCHostMessageType.LoadDocument,
       data: this.src,
     });
   }
 
   /** Sends `message` to the outer frame. */
-  private toOuterFrame(message: IPC.IPCHostMessage) {
+  #toOuterFrame(message: IPC.IPCHostMessage) {
     this.iframeRef.value?.contentWindow?.postMessage(message, "*");
   }
 
   /** The outer frame's message listener, as `globalThis` holds it. */
-  private boundOnMessage = this.onMessage.bind(this);
+  #boundOnMessage = this.#onMessage.bind(this);
 
   /** @inheritDoc */
   override connectedCallback() {
     super.connectedCallback();
-    globalThis.addEventListener("message", this.boundOnMessage);
+    globalThis.addEventListener("message", this.#boundOnMessage);
   }
 
   /** @inheritDoc */
   override disconnectedCallback() {
     super.disconnectedCallback();
-    globalThis.removeEventListener("message", this.boundOnMessage);
+    globalThis.removeEventListener("message", this.#boundOnMessage);
     queueMicrotask(() => {
-      if (!this.isConnected) this.releaseGuest();
+      if (!this.isConnected) this.#releaseGuest();
     });
   }
 

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -31,7 +31,7 @@ export class ContextShim {
       resources: new Proxy<Record<string, BridgeResource>>({}, {
         get: (_target, key) =>
           typeof key === "string" && this.resourceNames.has(key)
-            ? this.resource(key)
+            ? this.#resource(key)
             : undefined,
         ownKeys: () => [...this.resourceNames],
         getOwnPropertyDescriptor: (_target, key) =>
@@ -39,21 +39,21 @@ export class ContextShim {
             ? {
               configurable: true,
               enumerable: true,
-              value: this.resource(key),
+              value: this.#resource(key),
             }
             : undefined,
       }),
     };
   }
 
-  private resource(key: string): BridgeResource {
+  #resource(key: string): BridgeResource {
     return {
       kind: "cell",
-      cell: this.cell(key),
+      cell: this.#cell(key),
     };
   }
 
-  private cell(key: string, path: Array<string | number> = []): BridgeCell {
+  #cell(key: string, path: Array<string | number> = []): BridgeCell {
     const get = (): FabricValue | undefined => {
       let value: unknown = this.get({} as CommonIframeSandboxElement, key);
       for (const part of path) {
@@ -106,7 +106,7 @@ export class ContextShim {
         return () =>
           this.unsubscribe({} as CommonIframeSandboxElement, receipt);
       },
-      key: (part) => this.cell(key, [...path, part]),
+      key: (part) => this.#cell(key, [...path, part]),
     };
   }
   set(_element: CommonIframeSandboxElement, key: string, value: FabricValue) {

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -12,15 +12,15 @@ const DEFAULT_ASTRAL_TIMEOUT = 60_000;
 
 // Wrapper around `@astral/astral`'s `Browser`.
 export class Browser {
-  private browser: AstralBrowser | null;
-  private timeout: number;
+  #browser: AstralBrowser | null;
+  #timeout: number;
 
   private constructor(
     browser: AstralBrowser,
     options: { timeout: number },
   ) {
-    this.browser = browser;
-    this.timeout = options.timeout;
+    this.#browser = browser;
+    this.#timeout = options.timeout;
   }
 
   static async launch(
@@ -43,28 +43,28 @@ export class Browser {
     url?: string,
     options?: WaitForOptions & SandboxOptions & UserAgentOptions,
   ): Promise<Page> {
-    this.checkIsOk();
-    const page = await this.browser!.newPage(url, options);
-    return new Page(page, { timeout: this.timeout });
+    this.#checkIsOk();
+    const page = await this.#browser!.newPage(url, options);
+    return new Page(page, { timeout: this.#timeout });
   }
 
   // The browser-level CDP websocket endpoint. Chrome supports multiple
   // concurrent CDP clients, so a second connection (e.g. for CPU profiling
   // via `cdp-profiler.ts`) can attach alongside Astral's.
   wsEndpoint(): string {
-    this.checkIsOk();
-    return this.browser!.wsEndpoint();
+    this.#checkIsOk();
+    return this.#browser!.wsEndpoint();
   }
 
   async close(): Promise<void> {
-    this.checkIsOk();
-    const browser = this.browser;
-    this.browser = null;
+    this.#checkIsOk();
+    const browser = this.#browser;
+    this.#browser = null;
     await closeAstralBrowser(browser!);
   }
 
-  private checkIsOk() {
-    if (!this.browser) {
+  #checkIsOk() {
+    if (!this.#browser) {
       throw new Error("Browser is already closed.");
     }
   }

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -70,27 +70,27 @@ export async function dismissDialogs(e: DialogEvent) {
 
 // Wrapper around `@astral/astral`'s `Page`.
 export class Page extends EventTarget {
-  private page: AstralPage | null;
-  private timeout: number;
-  private afterNavigation: Array<() => Promise<void> | void> = [];
-  private interactionObserver?: InteractionObserver;
-  private defaultTypeDelay = 0;
-  private decoratedElements = new WeakSet<AstralElementHandle>();
-  private patchedKeyboard?: Keyboard;
-  private originalKeyboardType?: Keyboard["type"];
-  private navigationQueue: Promise<void> = Promise.resolve();
+  #page: AstralPage | null;
+  #timeout: number;
+  #afterNavigation: Array<() => Promise<void> | void> = [];
+  #interactionObserver?: InteractionObserver;
+  #defaultTypeDelay = 0;
+  #decoratedElements = new WeakSet<AstralElementHandle>();
+  #patchedKeyboard?: Keyboard;
+  #originalKeyboardType?: Keyboard["type"];
+  #navigationQueue: Promise<void> = Promise.resolve();
 
   constructor(page: AstralPage, options: { timeout: number }) {
     super();
-    this.timeout = options.timeout;
+    this.#timeout = options.timeout;
     {
       const mutPage: Mutable<AstralPage> = page;
       // @ts-ignore We wrap Page in a Mutable
       // so we can override the readonly `timeout`
       // property. Type checker doesn't like this.
-      mutPage.timeout = this.timeout;
+      mutPage.timeout = this.#timeout;
     }
-    this.page = page;
+    this.#page = page;
   }
 
   // @ts-ignore Astral tightens the args for `EventTarget`
@@ -101,8 +101,8 @@ export class Page extends EventTarget {
     ) => void,
     options?: AddEventListenerOptions | boolean,
   ): void {
-    this.checkIsOk();
-    return this.page!.addEventListener(type, callback, options);
+    this.#checkIsOk();
+    return this.#page!.addEventListener(type, callback, options);
   }
 
   override removeEventListener(
@@ -110,13 +110,13 @@ export class Page extends EventTarget {
     callback: EventListenerOrEventListenerObject | null,
     options?: EventListenerOptions | boolean,
   ): void {
-    this.checkIsOk();
-    return this.page!.removeEventListener(type, callback, options);
+    this.#checkIsOk();
+    return this.#page!.removeEventListener(type, callback, options);
   }
 
   override dispatchEvent(event: Event): boolean {
-    this.checkIsOk();
-    return this.page!.dispatchEvent(event);
+    this.#checkIsOk();
+    return this.#page!.dispatchEvent(event);
   }
 
   // Extended method: Rewrites the contents' `console.*` methods to stringify
@@ -131,7 +131,7 @@ export class Page extends EventTarget {
   // a timeout error reports what the page logged around the stall without the
   // test having to pipe the whole console stream.
   async applyConsoleFormatter() {
-    this.checkIsOk();
+    this.#checkIsOk();
 
     const trueConsoleKey: string = "__common_integration_console";
     const methods: string[] = Object.values(ConsoleMethod);
@@ -194,21 +194,21 @@ export class Page extends EventTarget {
     filename: string,
     options?: ScreenshotOptions,
   ): Promise<void> {
-    this.checkIsOk();
-    const screenshot = await this.page!.screenshot(options);
+    this.#checkIsOk();
+    const screenshot = await this.#page!.screenshot(options);
     return Deno.writeFile(filename, screenshot);
   }
 
   // Extended method: Takes a screenshot and HTML capture, storing
   // the timestamped artifacts in the provided `snapshotDir`.
   async snapshot(snapshotName: string, snapshotDir: string): Promise<void> {
-    this.checkIsOk();
+    this.#checkIsOk();
     ensureDirSync(snapshotDir);
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const filePrefix = `${snapshotName}_${timestamp}`;
 
-    const screenshot = await this.page!.screenshot();
-    const html = await this.page!.content();
+    const screenshot = await this.#page!.screenshot();
+    const html = await this.#page!.content();
     await Deno.writeFile(
       path.join(snapshotDir, `${filePrefix}.png`),
       screenshot,
@@ -227,7 +227,7 @@ export class Page extends EventTarget {
     selector: string,
     text: string,
   ): Promise<ElementHandle> {
-    this.checkIsOk();
+    this.#checkIsOk();
     const start = globalThis.performance.now();
     while (true) {
       const el = await this.waitForSelector(selector);
@@ -235,7 +235,7 @@ export class Page extends EventTarget {
         return el;
       }
       await sleep(200);
-      if ((start + this.timeout) < globalThis.performance.now()) {
+      if ((start + this.#timeout) < globalThis.performance.now()) {
         throw new Error(
           `Timed out waiting for "${selector}" to have text "${text}".`,
         );
@@ -246,11 +246,11 @@ export class Page extends EventTarget {
   // Returns Astral's keyboard with `type` patched to apply the configured
   // default delay when a call omits one.
   get keyboard(): Keyboard {
-    this.checkIsOk();
-    const keyboard = this.page!.keyboard;
-    if (this.patchedKeyboard !== keyboard) {
-      this.patchedKeyboard = keyboard;
-      this.originalKeyboardType = keyboard.type.bind(keyboard);
+    this.#checkIsOk();
+    const keyboard = this.#page!.keyboard;
+    if (this.#patchedKeyboard !== keyboard) {
+      this.#patchedKeyboard = keyboard;
+      this.#originalKeyboardType = keyboard.type.bind(keyboard);
       Object.defineProperty(keyboard, "type", {
         configurable: true,
         writable: true,
@@ -258,9 +258,9 @@ export class Page extends EventTarget {
           text: Parameters<Keyboard["type"]>[0],
           options: KeyboardTypeOptions = {},
         ) =>
-          this.originalKeyboardType!(text, {
+          this.#originalKeyboardType!(text, {
             ...options,
-            delay: options.delay ?? this.defaultTypeDelay,
+            delay: options.delay ?? this.#defaultTypeDelay,
           }),
       });
     }
@@ -268,13 +268,13 @@ export class Page extends EventTarget {
   }
 
   setInteractionObserver(observer?: InteractionObserver): void {
-    this.checkIsOk();
-    this.interactionObserver = observer;
+    this.#checkIsOk();
+    this.#interactionObserver = observer;
   }
 
   setDefaultTypeDelay(delay: number): void {
-    this.checkIsOk();
-    this.defaultTypeDelay = delay;
+    this.#checkIsOk();
+    this.#defaultTypeDelay = delay;
   }
 
   // Registers `hook` to run after every navigation this page performs, once
@@ -283,19 +283,19 @@ export class Page extends EventTarget {
   // time: the shell driver waits here for the shell to finish booting, and a
   // presentation run starts its recorder here.
   addAfterNavigationHook(hook: () => Promise<void> | void): () => void {
-    this.afterNavigation.push(hook);
+    this.#afterNavigation.push(hook);
     return () => {
-      const index = this.afterNavigation.indexOf(hook);
-      if (index >= 0) this.afterNavigation.splice(index, 1);
+      const index = this.#afterNavigation.indexOf(hook);
+      if (index >= 0) this.#afterNavigation.splice(index, 1);
     };
   }
 
-  private async runAfterNavigationHooks(): Promise<void> {
+  async #runAfterNavigationHooks(): Promise<void> {
     // Over a snapshot, so a hook registered by a hook waits for the next
     // navigation. Each is re-checked against the live list, so a hook whose
     // remover ran while an earlier hook was awaiting does not run afterwards.
-    for (const hook of [...this.afterNavigation]) {
-      if (!this.afterNavigation.includes(hook)) continue;
+    for (const hook of [...this.#afterNavigation]) {
+      if (!this.#afterNavigation.includes(hook)) continue;
       await hook();
     }
   }
@@ -303,8 +303,8 @@ export class Page extends EventTarget {
   async setViewportSize(
     size: { width: number; height: number },
   ): Promise<void> {
-    this.checkIsOk();
-    await this.page!.setViewportSize(size);
+    this.#checkIsOk();
+    await this.#page!.setViewportSize(size);
   }
 
   async startScreencast(options: {
@@ -314,20 +314,20 @@ export class Page extends EventTarget {
     maxHeight?: number;
     everyNthFrame?: number;
   } = {}): Promise<void> {
-    this.checkIsOk();
-    await this.page!.unsafelyGetCelestialBindings().Page.startScreencast(
+    this.#checkIsOk();
+    await this.#page!.unsafelyGetCelestialBindings().Page.startScreencast(
       options,
     );
   }
 
   async stopScreencast(): Promise<void> {
-    this.checkIsOk();
-    await this.page!.unsafelyGetCelestialBindings().Page.stopScreencast();
+    this.#checkIsOk();
+    await this.#page!.unsafelyGetCelestialBindings().Page.stopScreencast();
   }
 
   async acknowledgeScreencastFrame(sessionId: number): Promise<void> {
-    this.checkIsOk();
-    await this.page!.unsafelyGetCelestialBindings().Page.screencastFrameAck({
+    this.#checkIsOk();
+    await this.#page!.unsafelyGetCelestialBindings().Page.screencastFrameAck({
       sessionId,
     });
   }
@@ -335,8 +335,8 @@ export class Page extends EventTarget {
   onScreencastFrame(
     listener: (frame: ScreencastFrame) => void,
   ): () => void {
-    this.checkIsOk();
-    const celestial = this.page!.unsafelyGetCelestialBindings();
+    this.#checkIsOk();
+    const celestial = this.#page!.unsafelyGetCelestialBindings();
     const handler: EventListener = (event) => {
       listener((event as CustomEvent<ScreencastFrame>).detail);
     };
@@ -349,21 +349,21 @@ export class Page extends EventTarget {
     evaluate: EvaluateFunction<T, R>,
     evaluateOptions?: EvaluateOptions<R>,
   ): Promise<T> {
-    this.checkIsOk();
-    return await this.page!.evaluate(evaluate, evaluateOptions);
+    this.#checkIsOk();
+    return await this.#page!.evaluate(evaluate, evaluateOptions);
   }
 
   // Navigates through the browser protocol and waits for the requested
   // lifecycle event.
   async goto(url: string, options?: NavigationOptions): Promise<void> {
-    this.checkIsOk();
-    await this.runNavigation(() => this.navigate(url, options));
+    this.#checkIsOk();
+    await this.#runNavigation(() => this.#navigate(url, options));
   }
 
-  private async runNavigation(operation: () => Promise<void>): Promise<void> {
-    const previousNavigation = this.navigationQueue;
+  async #runNavigation(operation: () => Promise<void>): Promise<void> {
+    const previousNavigation = this.#navigationQueue;
     let releaseNavigation!: () => void;
-    this.navigationQueue = new Promise((resolve) => {
+    this.#navigationQueue = new Promise((resolve) => {
       releaseNavigation = resolve;
     });
     await previousNavigation;
@@ -374,7 +374,7 @@ export class Page extends EventTarget {
     }
   }
 
-  private async navigate(
+  async #navigate(
     url: string,
     options?: NavigationOptions,
   ): Promise<void> {
@@ -383,11 +383,11 @@ export class Page extends EventTarget {
       ? { url }
       : { url, referrer: options.referrer };
 
-    const celestial = this.page!.unsafelyGetCelestialBindings();
+    const celestial = this.#page!.unsafelyGetCelestialBindings();
     if (waitUntil === "none") {
       const result = await celestial.Page.navigate(navigateOptions);
       if (result.errorText) throw new Error(result.errorText);
-      await this.runAfterNavigationHooks();
+      await this.#runAfterNavigationHooks();
       return;
     }
     const lifecycleNames = waitUntil === "load"
@@ -554,15 +554,15 @@ export class Page extends EventTarget {
     }
     if (navigationFailed) throw navigationError;
     if (cleanupFailed) throw cleanupError;
-    await this.runAfterNavigationHooks();
+    await this.#runAfterNavigationHooks();
   }
 
   // Passthru of `@astral/astral`'s `Page#reload`
   async reload(options?: WaitForOptions): Promise<void> {
-    this.checkIsOk();
-    await this.runNavigation(async () => {
-      await this.page!.reload(options);
-      await this.runAfterNavigationHooks();
+    this.#checkIsOk();
+    await this.#runNavigation(async () => {
+      await this.#page!.reload(options);
+      await this.#runAfterNavigationHooks();
     });
   }
 
@@ -575,22 +575,22 @@ export class Page extends EventTarget {
     selector: string,
     options?: WaitForSelectorOptions & SelectorOptions,
   ): Promise<ElementHandle> {
-    this.checkIsOk();
+    this.#checkIsOk();
     if (options?.strategy === "pierce") {
       if (options.timeout !== undefined) {
         throw new TypeError(
           "Pierce-selector waits are event-driven and do not accept a timeout",
         );
       }
-      return this.decorateElement(
-        await waitForPierceSelector(this.page!, selector),
+      return this.#decorateElement(
+        await waitForPierceSelector(this.#page!, selector),
       );
     }
     const astralOptions = options?.timeout === undefined
       ? undefined
       : { timeout: options.timeout };
-    return this.decorateElement(
-      await this.page!.waitForSelector(selector, astralOptions),
+    return this.#decorateElement(
+      await this.#page!.waitForSelector(selector, astralOptions),
     );
   }
 
@@ -599,8 +599,8 @@ export class Page extends EventTarget {
     func: EvaluateFunction<T, R>,
     evaluateOptions?: EvaluateOptions<R>,
   ): Promise<void> {
-    this.checkIsOk();
-    await this.page!.waitForFunction(func, evaluateOptions);
+    this.#checkIsOk();
+    await this.#page!.waitForFunction(func, evaluateOptions);
   }
 
   // Expose a CDP binding named `name` on the page's global object. Calling
@@ -609,8 +609,8 @@ export class Page extends EventTarget {
   // how an in-page notifier signals the moment a condition holds without the
   // test polling the DOM.
   async addBinding(name: string): Promise<void> {
-    this.checkIsOk();
-    await this.page!.unsafelyGetCelestialBindings().Runtime.addBinding({
+    this.#checkIsOk();
+    await this.#page!.unsafelyGetCelestialBindings().Runtime.addBinding({
       name,
     });
   }
@@ -619,8 +619,8 @@ export class Page extends EventTarget {
   // bound function may remain on the page's global object; the unique per-wait
   // name keeps that harmless.
   async removeBinding(name: string): Promise<void> {
-    this.checkIsOk();
-    await this.page!.unsafelyGetCelestialBindings().Runtime.removeBinding({
+    this.#checkIsOk();
+    await this.#page!.unsafelyGetCelestialBindings().Runtime.removeBinding({
       name,
     });
   }
@@ -630,8 +630,8 @@ export class Page extends EventTarget {
   onBindingCalled(
     listener: (name: string, payload: string) => void,
   ): () => void {
-    this.checkIsOk();
-    const celestial = this.page!.unsafelyGetCelestialBindings();
+    this.#checkIsOk();
+    const celestial = this.#page!.unsafelyGetCelestialBindings();
     const handler: EventListener = (event) => {
       const { name, payload } =
         (event as CustomEvent<{ name: string; payload: string }>).detail;
@@ -647,20 +647,20 @@ export class Page extends EventTarget {
     selector: string,
     opts?: SelectorOptions,
   ): Promise<ElementHandle | null> {
-    this.checkIsOk();
+    this.#checkIsOk();
     const element = opts?.strategy === "pierce"
-      ? await queryPierce(this.page!, selector)
-      : await this.page!.$(selector);
-    return this.decorateElement(element);
+      ? await queryPierce(this.#page!, selector)
+      : await this.#page!.$(selector);
+    return this.#decorateElement(element);
   }
 
   // Passthru of `@astral/astral`'s `Page#$$`
   async $$(selector: string, opts?: SelectorOptions): Promise<ElementHandle[]> {
-    this.checkIsOk();
+    this.#checkIsOk();
     const elements = opts?.strategy === "pierce"
-      ? await queryAllPierce(this.page!, selector)
-      : await this.page!.$$(selector);
-    return elements.map((element) => this.decorateElement(element));
+      ? await queryAllPierce(this.#page!, selector)
+      : await this.#page!.$$(selector);
+    return elements.map((element) => this.#decorateElement(element));
   }
 
   // Extended method: Dispatch one trusted click at a viewport point.
@@ -676,8 +676,8 @@ export class Page extends EventTarget {
     point: { x: number; y: number },
     options?: { refreshPoint?: () => Promise<{ x: number; y: number }> },
   ): Promise<void> {
-    this.checkIsOk();
-    await this.dispatchObservedClick(
+    this.#checkIsOk();
+    await this.#dispatchObservedClick(
       undefined,
       point,
       undefined,
@@ -687,29 +687,29 @@ export class Page extends EventTarget {
 
   // Passthru of `@astral/astral`'s `Page#close`
   async close() {
-    this.checkIsOk();
-    const page = this.page;
-    this.page = null;
+    this.#checkIsOk();
+    const page = this.#page;
+    this.#page = null;
     await page!.close();
   }
 
-  private checkIsOk() {
-    if (!this.page) {
+  #checkIsOk() {
+    if (!this.#page) {
       throw new Error("Page is already closed.");
     }
   }
 
-  private decorateElement(element: null): null;
-  private decorateElement(element: AstralElementHandle): ElementHandle;
-  private decorateElement(
+  #decorateElement(element: null): null;
+  #decorateElement(element: AstralElementHandle): ElementHandle;
+  #decorateElement(
     element: AstralElementHandle | null,
   ): ElementHandle | null;
-  private decorateElement(
+  #decorateElement(
     element: AstralElementHandle | null,
   ): ElementHandle | null {
     if (!element) return null;
-    if (this.decoratedElements.has(element)) return element as ElementHandle;
-    this.decoratedElements.add(element);
+    if (this.#decoratedElements.has(element)) return element as ElementHandle;
+    this.#decoratedElements.add(element);
 
     const nativeQuery = element.$.bind(element);
     const nativeQueryAll = element.$$.bind(element);
@@ -718,33 +718,33 @@ export class Page extends EventTarget {
       $: {
         configurable: true,
         value: async (selector: string, options?: SelectorOptions) => {
-          this.checkIsOk();
+          this.#checkIsOk();
           const child = options?.strategy === "pierce"
-            ? await queryPierce(this.page!, selector, element)
+            ? await queryPierce(this.#page!, selector, element)
             : await nativeQuery(selector);
-          return this.decorateElement(child);
+          return this.#decorateElement(child);
         },
       },
       $$: {
         configurable: true,
         value: async (selector: string, options?: SelectorOptions) => {
-          this.checkIsOk();
+          this.#checkIsOk();
           const children = options?.strategy === "pierce"
-            ? await queryAllPierce(this.page!, selector, false, element)
+            ? await queryAllPierce(this.#page!, selector, false, element)
             : await nativeQueryAll(selector);
-          return children.map((child) => this.decorateElement(child));
+          return children.map((child) => this.#decorateElement(child));
         },
       },
       click: {
         configurable: true,
         value: (
           options?: Parameters<AstralElementHandle["click"]>[0],
-        ) => this.clickElement(element, options),
+        ) => this.#clickElement(element, options),
       },
       type: {
         configurable: true,
         value: (text: string, options?: KeyboardTypeOptions) =>
-          this.typeIntoElement(element, text, options),
+          this.#typeIntoElement(element, text, options),
       },
       waitForSelector: {
         configurable: true,
@@ -752,21 +752,21 @@ export class Page extends EventTarget {
           selector: string,
           options?: WaitForSelectorOptions & SelectorOptions,
         ) => {
-          this.checkIsOk();
+          this.#checkIsOk();
           if (options?.strategy === "pierce") {
             if (options.timeout !== undefined) {
               throw new TypeError(
                 "Pierce-selector waits are event-driven and do not accept a timeout",
               );
             }
-            return this.decorateElement(
-              await waitForPierceSelector(this.page!, selector, element),
+            return this.#decorateElement(
+              await waitForPierceSelector(this.#page!, selector, element),
             );
           }
           const astralOptions = options?.timeout === undefined
             ? undefined
             : { timeout: options.timeout };
-          return this.decorateElement(
+          return this.#decorateElement(
             await nativeWaitForSelector(selector, astralOptions),
           );
         },
@@ -775,15 +775,15 @@ export class Page extends EventTarget {
     return element as ElementHandle;
   }
 
-  private async clickElement(
+  async #clickElement(
     element: AstralElementHandle,
     options?: Parameters<AstralElementHandle["click"]>[0],
   ): Promise<void> {
-    const aim = await aimAtElement(this.page!, element, options?.offset);
+    const aim = await aimAtElement(this.#page!, element, options?.offset);
     if ("unclickable" in aim) {
       throw new Error(`Cannot click ${describeAimTarget(aim)}`);
     }
-    await this.dispatchObservedClick(
+    await this.#dispatchObservedClick(
       element as ElementHandle,
       { x: aim.x, y: aim.y },
       options,
@@ -794,18 +794,18 @@ export class Page extends EventTarget {
   // before and after. The point can be refreshed after the observer has
   // finished. The observer's failure is reported only when the click itself
   // succeeded, so a recording problem never masks a click problem.
-  private async dispatchObservedClick(
+  async #dispatchObservedClick(
     element: ElementHandle | undefined,
     point: { x: number; y: number },
     options?: Parameters<AstralElementHandle["click"]>[0],
     refreshPoint?: () => Promise<{ x: number; y: number }>,
   ): Promise<void> {
-    await this.interactionObserver?.beforeClick?.(element, point);
+    await this.#interactionObserver?.beforeClick?.(element, point);
     let dispatchPoint = point;
     let actionError: unknown;
     try {
       dispatchPoint = await refreshPoint?.() ?? point;
-      await this.page!.mouse.click(
+      await this.#page!.mouse.click(
         dispatchPoint.x,
         dispatchPoint.y,
         options,
@@ -814,7 +814,7 @@ export class Page extends EventTarget {
       actionError = error;
     }
     try {
-      await this.interactionObserver?.afterClick?.(
+      await this.#interactionObserver?.afterClick?.(
         element,
         dispatchPoint,
         actionError,
@@ -825,13 +825,13 @@ export class Page extends EventTarget {
     if (actionError !== undefined) throw actionError;
   }
 
-  private async typeIntoElement(
+  async #typeIntoElement(
     element: AstralElementHandle,
     text: string,
     options?: KeyboardTypeOptions,
   ): Promise<void> {
     await element.focus();
-    await this.interactionObserver?.beforeType?.(
+    await this.#interactionObserver?.beforeType?.(
       element as ElementHandle,
       text,
     );
@@ -842,7 +842,7 @@ export class Page extends EventTarget {
       actionError = error;
     }
     try {
-      await this.interactionObserver?.afterType?.(
+      await this.#interactionObserver?.afterType?.(
         element as ElementHandle,
         text,
         actionError,

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -260,19 +260,19 @@ export class ShellIntegration {
   }
 
   page(): Page {
-    this.checkIsOk();
+    this.#checkIsOk();
     return this.#page!;
   }
 
   // Browser-level CDP websocket endpoint, for attaching a second CDP client
   // (e.g. `CdpWorkerProfiler`).
   wsEndpoint(): string {
-    this.checkIsOk();
+    this.#checkIsOk();
     return this.#browser!.wsEndpoint();
   }
 
   async newPage(url?: string): Promise<Page> {
-    this.checkIsOk();
+    this.#checkIsOk();
     const page = await this.#browser!.newPage(url);
     this.#attachPage(page);
     // Astral navigates to `url` inside its own `newPage`, before this wrapper
@@ -283,7 +283,7 @@ export class ShellIntegration {
   }
 
   async state(): Promise<AppStateSerialized | undefined> {
-    this.checkIsOk();
+    this.#checkIsOk();
     const page = this.page();
     return await page.evaluate(() => {
       return globalThis.app ? globalThis.app.serialize() : undefined;
@@ -322,7 +322,7 @@ export class ShellIntegration {
       );
     }
 
-    this.checkIsOk();
+    this.#checkIsOk();
 
     // The last state the poll below managed to read. A failure reports it, so
     // the message says what the wait actually saw rather than only that it
@@ -370,7 +370,7 @@ export class ShellIntegration {
       identity?: Identity;
     },
   ): Promise<void> {
-    this.checkIsOk();
+    this.#checkIsOk();
 
     // Strip the proceeding "/" in the url path
     const path = appViewToUrlPath(view).substring(1);
@@ -468,7 +468,7 @@ export class ShellIntegration {
     await this.#browser?.close();
   };
 
-  private checkIsOk() {
+  #checkIsOk() {
     if (!this.#page) throw new Error("Page not initialized.");
   }
 

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -34,23 +34,23 @@ function groundedSourceName(relativePath: string): string {
 }
 
 export class InMemoryProgram implements ProgramResolver {
-  private modules: Record<string, string>;
-  private _main: string;
+  #modules: Record<string, string>;
+  #_main: string;
   constructor(main: string, modules: Record<string, string>) {
-    this.modules = modules;
-    this._main = main;
+    this.#modules = modules;
+    this.#_main = main;
   }
 
   main(): Promise<Source> {
-    const main = this.modules[this._main];
+    const main = this.#modules[this.#_main];
     if (main === undefined) {
-      throw new Error(`${this._main} not in modules.`);
+      throw new Error(`${this.#_main} not in modules.`);
     }
-    return Promise.resolve({ name: this._main, contents: main });
+    return Promise.resolve({ name: this.#_main, contents: main });
   }
 
   resolveSource(identifier: string): Promise<Source | undefined> {
-    const contents = this.modules[identifier];
+    const contents = this.#modules[identifier];
     if (contents === undefined) return Promise.resolve(undefined);
     return Promise.resolve({ contents, name: identifier });
   }
@@ -116,33 +116,33 @@ export function decodeDataFile(bytes: Uint8Array, name: string): string {
 // Resolve a program using the file system.
 // Deno-only.
 export class FileSystemProgramResolver implements ProgramResolver {
-  private fsRoot: string;
-  private realFsRoot: string;
-  private _main: Source;
+  #fsRoot: string;
+  #realFsRoot: string;
+  #_main: Source;
   constructor(mainPath: string, rootPath?: string) {
-    this.fsRoot = normalize(rootPath ?? dirname(mainPath));
+    this.#fsRoot = normalize(rootPath ?? dirname(mainPath));
     const normalizedMainPath = normalize(mainPath);
-    const relativeMainPath = relative(this.fsRoot, normalizedMainPath);
+    const relativeMainPath = relative(this.#fsRoot, normalizedMainPath);
     if (rootPath && isOutsideRoot(relativeMainPath)) {
       throw new Error(
-        `Main file "${mainPath}" must be within root directory "${this.fsRoot}".`,
+        `Main file "${mainPath}" must be within root directory "${this.#fsRoot}".`,
       );
     }
-    this.realFsRoot = this.#realPath(this.fsRoot);
+    this.#realFsRoot = this.#realPath(this.#fsRoot);
     const realMainPath = this.#realPath(normalizedMainPath);
-    if (isOutsideRoot(relative(this.realFsRoot, realMainPath))) {
+    if (isOutsideRoot(relative(this.#realFsRoot, realMainPath))) {
       throw new Error(
-        `Main file "${mainPath}" must be within root directory "${this.fsRoot}".`,
+        `Main file "${mainPath}" must be within root directory "${this.#fsRoot}".`,
       );
     }
-    this._main = {
+    this.#_main = {
       name: groundedSourceName(relativeMainPath),
       contents: this.#readFile(realMainPath),
     };
   }
 
   main(): Promise<Source> {
-    return Promise.resolve(this._main);
+    return Promise.resolve(this.#_main);
   }
 
   resolveSource(specifier: string): Promise<Source | undefined> {
@@ -188,19 +188,19 @@ export class FileSystemProgramResolver implements ProgramResolver {
     if (!specifier || specifier[0] !== "/") return undefined;
     const absPath = normalize(
       join(
-        this.fsRoot,
+        this.#fsRoot,
         specifier.substring(1, specifier.length).replaceAll("/", SEPARATOR),
       ),
     );
-    if (isOutsideRoot(relative(this.fsRoot, absPath))) {
+    if (isOutsideRoot(relative(this.#fsRoot, absPath))) {
       throw new Error(
-        `${kind} "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+        `${kind} "${specifier}" resolves outside of root directory "${this.#fsRoot}".`,
       );
     }
     const realPath = this.#realPath(absPath);
-    if (isOutsideRoot(relative(this.realFsRoot, realPath))) {
+    if (isOutsideRoot(relative(this.#realFsRoot, realPath))) {
       throw new Error(
-        `${kind} "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+        `${kind} "${specifier}" resolves outside of root directory "${this.#fsRoot}".`,
       );
     }
     return realPath;

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -35,18 +35,18 @@ function groundedSourceName(relativePath: string): string {
 
 export class InMemoryProgram implements ProgramResolver {
   #modules: Record<string, string>;
-  #_main: string;
+  #main: string;
   constructor(main: string, modules: Record<string, string>) {
     this.#modules = modules;
-    this.#_main = main;
+    this.#main = main;
   }
 
   main(): Promise<Source> {
-    const main = this.#modules[this.#_main];
+    const main = this.#modules[this.#main];
     if (main === undefined) {
-      throw new Error(`${this.#_main} not in modules.`);
+      throw new Error(`${this.#main} not in modules.`);
     }
-    return Promise.resolve({ name: this.#_main, contents: main });
+    return Promise.resolve({ name: this.#main, contents: main });
   }
 
   resolveSource(identifier: string): Promise<Source | undefined> {
@@ -118,7 +118,7 @@ export function decodeDataFile(bytes: Uint8Array, name: string): string {
 export class FileSystemProgramResolver implements ProgramResolver {
   #fsRoot: string;
   #realFsRoot: string;
-  #_main: Source;
+  #main: Source;
   constructor(mainPath: string, rootPath?: string) {
     this.#fsRoot = normalize(rootPath ?? dirname(mainPath));
     const normalizedMainPath = normalize(mainPath);
@@ -135,14 +135,14 @@ export class FileSystemProgramResolver implements ProgramResolver {
         `Main file "${mainPath}" must be within root directory "${this.#fsRoot}".`,
       );
     }
-    this.#_main = {
+    this.#main = {
       name: groundedSourceName(relativeMainPath),
       contents: this.#readFile(realMainPath),
     };
   }
 
   main(): Promise<Source> {
-    return Promise.resolve(this.#_main);
+    return Promise.resolve(this.#main);
   }
 
   resolveSource(specifier: string): Promise<Source | undefined> {

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -394,10 +394,10 @@ const CF_INTERNAL = `    at <CF_INTERNAL>`;
 const UNMAPPED = `    at <UNMAPPED>`;
 
 export class SourceMapParser {
-  private sourceMaps = new LRUCache<string, SourceMap>({
+  #sourceMaps = new LRUCache<string, SourceMap>({
     capacity: MAX_SOURCE_MAP_CACHE_SIZE,
   });
-  private consumers = new WeakMap<SourceMap, SourceMapConsumer>();
+  #consumers = new WeakMap<SourceMap, SourceMapConsumer>();
   // Deferred registrations (CT-1819): the boot path registers a PROVIDER
   // instead of composing eagerly; the first lookup that needs the filename
   // materializes it. One-shot — the provider is dropped as soon as it runs,
@@ -407,15 +407,15 @@ export class SourceMapParser {
   // unbounded leak on long-lived runners — so cap it and evict the oldest.
   // Evicting an unused provider only means a later error in that (old) eval
   // goes unmapped, exactly as when the composed-map LRU evicts a stale entry.
-  private pendingProviders = new LRUCache<
+  #pendingProviders = new LRUCache<
     string,
     () => SourceMap | undefined
   >({ capacity: MAX_SOURCE_MAP_CACHE_SIZE });
 
   load(filename: string, sourceMap: SourceMap) {
     // An explicit map supersedes any pending provider for the same name.
-    this.pendingProviders.delete(filename);
-    this.sourceMaps.put(filename, sourceMap);
+    this.#pendingProviders.delete(filename);
+    this.#sourceMaps.put(filename, sourceMap);
   }
 
   /**
@@ -424,21 +424,21 @@ export class SourceMapParser {
    * compose) simply leaves the name unmapped, matching eager behavior.
    */
   loadLazy(filename: string, provider: () => SourceMap | undefined) {
-    this.pendingProviders.put(filename, provider);
+    this.#pendingProviders.put(filename, provider);
   }
 
   /** Tests-only: count of still-deferred (not-yet-materialized) providers. */
   pendingProviderCountForTesting(): number {
-    return this.pendingProviders.size;
+    return this.#pendingProviders.size;
   }
 
-  private materialize(filename: string): void {
-    const provider = this.pendingProviders.get(filename);
+  #materialize(filename: string): void {
+    const provider = this.#pendingProviders.get(filename);
     if (provider === undefined) return;
-    this.pendingProviders.delete(filename);
+    this.#pendingProviders.delete(filename);
     const sourceMap = provider();
     if (sourceMap !== undefined) {
-      this.sourceMaps.put(filename, sourceMap);
+      this.#sourceMaps.put(filename, sourceMap);
     }
   }
 
@@ -447,8 +447,8 @@ export class SourceMapParser {
    * Used for cleanup when the runtime is disposed.
    */
   clear(): void {
-    this.sourceMaps.clear();
-    this.pendingProviders.clear();
+    this.#sourceMaps.clear();
+    this.#pendingProviders.clear();
   }
 
   // Fixes stack traces to use source map from eval. Strangely, both Deno and
@@ -459,14 +459,14 @@ export class SourceMapParser {
       const match = line.match(stackTracePattern);
 
       if (match) {
-        return this.mapFrame(match[1], match[2], match[3], match[4], line);
+        return this.#mapFrame(match[1], match[2], match[3], match[4], line);
       }
 
       // V8 eval frames without a function name.
       // Try the nested pattern first (inner position is more precise).
       const nestedMatch = line.match(evalFrameNestedPattern);
       if (nestedMatch) {
-        return this.mapFrame(
+        return this.#mapFrame(
           "",
           nestedMatch[1],
           nestedMatch[2],
@@ -477,7 +477,7 @@ export class SourceMapParser {
 
       const evalMatch = line.match(evalFramePattern);
       if (evalMatch) {
-        return this.mapFrame(
+        return this.#mapFrame(
           "",
           evalMatch[1],
           evalMatch[2],
@@ -490,7 +490,7 @@ export class SourceMapParser {
     }).join("\n");
   }
 
-  private mapFrame(
+  #mapFrame(
     fnName: string,
     filename: string,
     lineStr: string,
@@ -500,11 +500,11 @@ export class SourceMapParser {
     const lineNum = parseInt(lineStr, 10);
     const columnNum = parseInt(colStr, 10);
 
-    this.materialize(filename);
-    const sourceMap = this.sourceMaps.get(filename);
+    this.#materialize(filename);
+    const sourceMap = this.#sourceMaps.get(filename);
     if (!sourceMap) return originalLine;
 
-    const consumer = this.getConsumer(sourceMap);
+    const consumer = this.#getConsumer(sourceMap);
     const originalPosition = consumer.originalPositionFor({
       line: lineNum,
       column: columnNum,
@@ -528,21 +528,21 @@ export class SourceMapParser {
     line: number,
     column: number,
   ): MappedPosition | null {
-    this.materialize(filename);
-    const sourceMap = this.sourceMaps.get(filename);
+    this.#materialize(filename);
+    const sourceMap = this.#sourceMaps.get(filename);
     if (!sourceMap) return null;
-    const consumer = this.getConsumer(sourceMap);
+    const consumer = this.#getConsumer(sourceMap);
     const pos = consumer.originalPositionFor({ line, column });
     return mapIsEmpty(pos) ? null : pos;
   }
 
-  private getConsumer(sourceMap: SourceMap): SourceMapConsumer {
-    let consumer = this.consumers.get(sourceMap);
+  #getConsumer(sourceMap: SourceMap): SourceMapConsumer {
+    let consumer = this.#consumers.get(sourceMap);
     if (consumer) {
       return consumer;
     }
     consumer = new SourceMapConsumer(sourceMap);
-    this.consumers.set(sourceMap, consumer);
+    this.#consumers.set(sourceMap, consumer);
     return consumer;
   }
 }

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -74,21 +74,21 @@ function surfaceTransformerWarnings(
 type TypeLibs = Record<string, string>;
 
 class VirtualFs implements ModuleResolutionHost {
-  private readonly types: Record<string, string>;
-  private readonly fsRead: Record<string, string>;
-  private readonly fsWrite: Record<string, string> = Object.create(null);
-  private readonly debug: boolean;
+  readonly #types: Record<string, string>;
+  readonly #fsRead: Record<string, string>;
+  readonly #fsWrite: Record<string, string> = Object.create(null);
+  readonly #debug: boolean;
   constructor(
     input: Program,
     typeLib: TypeLibs,
     debug?: boolean,
   ) {
-    this.fsRead = input.files.reduce((acc, file) => {
+    this.#fsRead = input.files.reduce((acc, file) => {
       acc[file.name] = file.contents;
       return acc;
     }, Object.create(null));
-    this.types = typeLib;
-    this.debug = !!debug;
+    this.#types = typeLib;
+    this.#debug = !!debug;
   }
 
   writeFile(fileName: unknown, content: unknown) {
@@ -102,7 +102,7 @@ class VirtualFs implements ModuleResolutionHost {
       "vfs",
       () => `writeFile - ${fileName} (${content.length} chars)`,
     );
-    this.fsWrite[fileName] = content;
+    this.#fsWrite[fileName] = content;
   }
 
   getCurrentDirectory(): string {
@@ -115,13 +115,13 @@ class VirtualFs implements ModuleResolutionHost {
   }
 
   fileExists(fileName: string): boolean {
-    const exists = !!this.innerRead(fileName);
+    const exists = !!this.#innerRead(fileName);
     vfsLogger.debug("vfs", () => `fileExists - ${fileName}: ${exists}`);
     return exists;
   }
 
   readFile(fileName: string): string | undefined {
-    const content = this.innerRead(fileName);
+    const content = this.#innerRead(fileName);
     vfsLogger.debug(
       "vfs",
       () =>
@@ -137,15 +137,15 @@ class VirtualFs implements ModuleResolutionHost {
   }
 
   getWrites(): Record<string, string> {
-    return this.fsWrite;
+    return this.#fsWrite;
   }
 
-  private innerRead(fileName: string): string | undefined {
+  #innerRead(fileName: string): string | undefined {
     let innerRecord;
     if (fileName.startsWith(VFS_TYPES_DIR)) {
-      innerRecord = this.types;
+      innerRecord = this.#types;
     } else {
-      innerRecord = this.fsRead;
+      innerRecord = this.#fsRead;
     }
     const content = innerRecord[fileName];
     vfsLogger.debug(
@@ -157,8 +157,8 @@ class VirtualFs implements ModuleResolutionHost {
 }
 
 class TypeScriptHost extends VirtualFs implements CompilerHost {
-  private allowedRuntimeModules: string[];
-  private specifierAliases?: ReadonlyMap<string, string>;
+  #allowedRuntimeModules: string[];
+  #specifierAliases?: ReadonlyMap<string, string>;
   constructor(
     source: Program,
     typeLibs: TypeLibs,
@@ -166,8 +166,8 @@ class TypeScriptHost extends VirtualFs implements CompilerHost {
     specifierAliases?: ReadonlyMap<string, string>,
   ) {
     super(source, typeLibs, DEBUG_VIRTUAL_FS);
-    this.allowedRuntimeModules = allowedRuntimeModules;
-    this.specifierAliases = specifierAliases;
+    this.#allowedRuntimeModules = allowedRuntimeModules;
+    this.#specifierAliases = specifierAliases;
   }
 
   getDefaultLibFileName(_options: CompilerOptions): string {
@@ -218,7 +218,7 @@ class TypeScriptHost extends VirtualFs implements CompilerHost {
   ): readonly ResolvedModuleWithFailedLookupLocations[] {
     return moduleLiterals.map((literal) => {
       const name = literal.text;
-      const aliased = this.specifierAliases?.get(name);
+      const aliased = this.#specifierAliases?.get(name);
       if (aliased !== undefined) {
         return {
           resolvedModule: {
@@ -242,7 +242,7 @@ class TypeScriptHost extends VirtualFs implements CompilerHost {
       // e.g. `@commonfabric/foo`. If a type definition was provided
       // with the same identifier with a `.d.ts` extension, that will be used
       // for types, leaving the module implementation resolution to runtime.
-      if (this.allowedRuntimeModules.includes(name)) {
+      if (this.#allowedRuntimeModules.includes(name)) {
         return {
           resolvedModule: {
             resolvedFileName: `${name}.d.ts`,
@@ -323,9 +323,9 @@ export interface TypeScriptCompilerOptions {
 }
 
 export class TypeScriptCompiler {
-  private typeLibs: TypeLibs;
+  #typeLibs: TypeLibs;
   constructor(typeLibs: TypeLibs) {
-    this.typeLibs = Object.keys(typeLibs).reduce((libs, libName) => {
+    this.#typeLibs = Object.keys(typeLibs).reduce((libs, libName) => {
       libs[`${VFS_TYPES_DIR}${libName}.d.ts`] = typeLibs[libName];
       return libs;
     }, {} as TypeLibs);
@@ -359,7 +359,7 @@ export class TypeScriptCompiler {
     program: Program,
     inputOptions: TypeScriptCompilerOptions = {},
   ): Map<string, CompiledTypeScriptModule> {
-    const steps = this.compileToModulesSteps(program, inputOptions);
+    const steps = this.#compileToModulesSteps(program, inputOptions);
     for (;;) {
       const next = steps.next();
       if (next.done) return next.value;
@@ -382,7 +382,7 @@ export class TypeScriptCompiler {
     program: Program,
     inputOptions: TypeScriptCompilerOptions = {},
   ): Promise<Map<string, CompiledTypeScriptModule>> {
-    const steps = this.compileToModulesSteps(program, inputOptions);
+    const steps = this.#compileToModulesSteps(program, inputOptions);
     for (;;) {
       const next = steps.next();
       if (next.done) return next.value;
@@ -404,7 +404,7 @@ export class TypeScriptCompiler {
    * aggregated across files before being checked — matching the single-call
    * shape. Only the event-loop yield points differ.
    */
-  private *compileToModulesSteps(
+  *#compileToModulesSteps(
     program: Program,
     inputOptions: TypeScriptCompilerOptions,
   ): Generator<void, Map<string, CompiledTypeScriptModule>, void> {
@@ -427,7 +427,7 @@ export class TypeScriptCompiler {
 
     const host = new TypeScriptHost(
       program,
-      this.typeLibs,
+      this.#typeLibs,
       runtimeModules,
       inputOptions.specifierAliases,
     );
@@ -592,7 +592,7 @@ export class TypeScriptCompiler {
 
     const host = new TypeScriptHost(
       program,
-      this.typeLibs,
+      this.#typeLibs,
       runtimeModules,
       inputOptions.specifierAliases,
     );

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -48,14 +48,14 @@ export const isNonFatalDiagnosticCode = (code: number): boolean =>
   code === UNUSED_TS_EXPECT_ERROR;
 
 export class Checker {
-  private program: Program;
-  private messageTransformer?: DiagnosticMessageTransformer;
-  private storedSource: boolean;
+  #program: Program;
+  #messageTransformer?: DiagnosticMessageTransformer;
+  #storedSource: boolean;
 
   constructor(program: Program, options: CheckerOptions = {}) {
-    this.program = program;
-    this.messageTransformer = options.messageTransformer;
-    this.storedSource = options.storedSource === true;
+    this.#program = program;
+    this.#messageTransformer = options.messageTransformer;
+    this.#storedSource = options.storedSource === true;
   }
 
   typeCheck() {
@@ -81,14 +81,14 @@ export class Checker {
    * error semantics via {@link throwIfErrors}.
    */
   checkableSources(): SourceFile[] {
-    return this.sources();
+    return this.#sources();
   }
 
   /** Per-file semantic diagnostics, as the error details typeCheck throws. */
   collectSemanticErrors(sourceFile: SourceFile): ErrorDetails[] {
-    return this.program.getSemanticDiagnostics(sourceFile)
+    return this.#program.getSemanticDiagnostics(sourceFile)
       .filter((diagnostic) =>
-        !this.storedSource || !isNonFatalDiagnosticCode(diagnostic.code)
+        !this.#storedSource || !isNonFatalDiagnosticCode(diagnostic.code)
       )
       .map(
         (diagnostic) => ({ diagnostic, source: sourceFile.text }),
@@ -103,7 +103,7 @@ export class Checker {
    * codes are semantic; a file that does not parse can never be loaded.
    */
   collectSyntacticErrors(sourceFile: SourceFile): ErrorDetails[] {
-    return this.program.getSyntacticDiagnostics(sourceFile).map(
+    return this.#program.getSyntacticDiagnostics(sourceFile).map(
       (diagnostic) => ({ diagnostic, source: sourceFile.text }),
     );
   }
@@ -111,8 +111,8 @@ export class Checker {
   /** Program-level (options + global) diagnostics, same fatality contract. */
   collectProgramErrors(): ErrorDetails[] {
     return [
-      ...this.program.getOptionsDiagnostics(),
-      ...this.program.getGlobalDiagnostics(),
+      ...this.#program.getOptionsDiagnostics(),
+      ...this.#program.getGlobalDiagnostics(),
     ].map((diagnostic) => ({ diagnostic }));
   }
 
@@ -123,7 +123,7 @@ export class Checker {
   collectDeclarationErrors(sourceFile: SourceFile): ErrorDetails[] {
     const errors: ErrorDetails[] = [];
     for (
-      const diagnostic of this.program.getDeclarationDiagnostics(sourceFile)
+      const diagnostic of this.#program.getDeclarationDiagnostics(sourceFile)
     ) {
       // Skip "private name" errors for known exported symbols
       const message = typeof diagnostic.messageText === "string"
@@ -142,7 +142,7 @@ export class Checker {
 
   throwIfErrors(errors: ErrorDetails[]) {
     if (errors.length) {
-      throw new CompilerError(errors, this.messageTransformer);
+      throw new CompilerError(errors, this.#messageTransformer);
     }
   }
 
@@ -152,19 +152,19 @@ export class Checker {
     // too.
     const fatal = (diagnostics ?? []).filter(
       (diagnostic) =>
-        !this.storedSource || !isNonFatalDiagnosticCode(diagnostic.code),
+        !this.#storedSource || !isNonFatalDiagnosticCode(diagnostic.code),
     );
     if (fatal.length === 0) {
       return;
     }
     throw new CompilerError(
       fatal.map((diagnostic) => ({ diagnostic })),
-      this.messageTransformer,
+      this.#messageTransformer,
     );
   }
 
-  private sources() {
-    return this.program.getSourceFiles().filter((source) =>
+  #sources() {
+    return this.#program.getSourceFiles().filter((source) =>
       !source.fileName.startsWith("$types/")
     );
   }

--- a/packages/js-compiler/typescript/diagnostics/errors.ts
+++ b/packages/js-compiler/typescript/diagnostics/errors.ts
@@ -73,7 +73,7 @@ export class CompilationError {
     messageTransformer?: DiagnosticMessageTransformer,
   ) {
     const { file, start } = diagnostic;
-    const { message, type } = this.parseMessage(
+    const { message, type } = this.#parseMessage(
       diagnostic.messageText,
       messageTransformer,
     );
@@ -93,7 +93,7 @@ export class CompilationError {
     }
   }
 
-  private parseMessage(
+  #parseMessage(
     input: string | DiagnosticMessageChain,
     messageTransformer?: DiagnosticMessageTransformer,
   ): { type: CompilationErrorType; message: string } {

--- a/packages/lib-shell/test/credentials.test.ts
+++ b/packages/lib-shell/test/credentials.test.ts
@@ -11,30 +11,30 @@ import {
 } from "@commonfabric/lib-shell/credentials";
 
 class MemoryStorage implements Storage {
-  private values = new Map<string, string>();
+  #values = new Map<string, string>();
 
   get length(): number {
-    return this.values.size;
+    return this.#values.size;
   }
 
   clear(): void {
-    this.values.clear();
+    this.#values.clear();
   }
 
   getItem(key: string): string | null {
-    return this.values.get(key) ?? null;
+    return this.#values.get(key) ?? null;
   }
 
   key(index: number): string | null {
-    return Array.from(this.values.keys())[index] ?? null;
+    return Array.from(this.#values.keys())[index] ?? null;
   }
 
   removeItem(key: string): void {
-    this.values.delete(key);
+    this.#values.delete(key);
   }
 
   setItem(key: string, value: string): void {
-    this.values.set(key, value);
+    this.#values.set(key, value);
   }
 }
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -25,7 +25,7 @@ class MockRuntimeClient {
   idleCalls = 0;
   syncedCalls = 0;
   slugByPageId = new Map<string, string | undefined>();
-  private handlers = new Map<
+  #handlers = new Map<
     keyof MockRuntimeClientEvents,
     Array<(...args: unknown[]) => void>
   >();
@@ -34,16 +34,16 @@ class MockRuntimeClient {
     event: K,
     handler: (...args: MockRuntimeClientEvents[K]) => void,
   ): void {
-    const handlers = this.handlers.get(event) ?? [];
+    const handlers = this.#handlers.get(event) ?? [];
     handlers.push(handler as (...args: unknown[]) => void);
-    this.handlers.set(event, handlers);
+    this.#handlers.set(event, handlers);
   }
 
   emit<K extends keyof MockRuntimeClientEvents>(
     event: K,
     ...args: MockRuntimeClientEvents[K]
   ): void {
-    for (const handler of this.handlers.get(event) ?? []) {
+    for (const handler of this.#handlers.get(event) ?? []) {
       handler(...args);
     }
   }

--- a/packages/llm/src/client.test.ts
+++ b/packages/llm/src/client.test.ts
@@ -12,6 +12,7 @@ import {
   LLMStreamError,
   loadConversationFixture,
   normalizeLLMResponse,
+  readLLMStream,
   resetMockMode,
   setMockResponseGate,
 } from "./client.ts";
@@ -32,14 +33,8 @@ function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
-function runClientStream(client: LLMClient, chunks: string[]) {
-  return (client as unknown as {
-    stream(
-      body: ReadableStream<Uint8Array>,
-      id: string,
-      callback?: (text: string) => void,
-    ): Promise<unknown>;
-  }).stream(streamFromChunks(chunks), "trace-1", () => {});
+function runClientStream(chunks: string[]) {
+  return readLLMStream(streamFromChunks(chunks), "trace-1", () => {});
 }
 
 describe("LLMClient test-environment guard", () => {
@@ -435,7 +430,7 @@ describe("LLMClient test-environment guard", () => {
       ]
     ) {
       try {
-        await runClientStream(client, chunks);
+        await runClientStream(chunks);
       } catch (error) {
         expect(error).toBeInstanceOf(LLMStreamError);
         expect((error as Error).message).toBe("boom");
@@ -455,7 +450,7 @@ describe("LLMClient test-environment guard", () => {
       sources: [{ url: "https://example.com" }],
     }];
 
-    const result = await runClientStream(client, [
+    const result = await runClientStream([
       JSON.stringify({ type: "text-delta", textDelta: "searched" }) + "\n",
       JSON.stringify({
         type: "finish",
@@ -479,7 +474,7 @@ describe("LLMClient test-environment guard", () => {
     };
 
     try {
-      const result = await runClientStream(client, [
+      const result = await runClientStream([
         JSON.stringify("hello") + "\n",
         "not json\n",
         "not final json",

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -96,19 +96,19 @@ type MockEntry =
   };
 
 class MockCatalog {
-  private mocks: MockEntry[] = [];
-  private enabled = false;
+  #mocks: MockEntry[] = [];
+  #enabled = false;
 
   enable(): void {
-    this.enabled = true;
+    this.#enabled = true;
   }
 
   disable(): void {
-    this.enabled = false;
+    this.#enabled = false;
   }
 
   clear(): void {
-    this.mocks = [];
+    this.#mocks = [];
   }
 
   reset(): void {
@@ -117,18 +117,18 @@ class MockCatalog {
   }
 
   isEnabled(): boolean {
-    return this.enabled;
+    return this.#enabled;
   }
 
   addResponse(matcher: MockResponseMatcher, response: LLMResponse): void {
-    this.mocks.push({ type: "sendRequest", matcher, response });
+    this.#mocks.push({ type: "sendRequest", matcher, response });
   }
 
   addObjectResponse(
     matcher: MockObjectResponseMatcher,
     response: LLMGenerateObjectResponse,
   ): void {
-    this.mocks.push({ type: "generateObject", matcher, response });
+    this.#mocks.push({ type: "generateObject", matcher, response });
   }
 
   /**
@@ -136,11 +136,11 @@ class MockCatalog {
    * Removes the matched mock (one-time use).
    */
   findResponse(request: LLMRequest): LLMResponse | undefined {
-    const index = this.mocks.findIndex((m) =>
+    const index = this.#mocks.findIndex((m) =>
       m.type === "sendRequest" && m.matcher(request)
     );
     if (index === -1) return undefined;
-    const [mock] = this.mocks.splice(index, 1);
+    const [mock] = this.#mocks.splice(index, 1);
     if (mock.type === "sendRequest") return mock.response;
   }
 
@@ -151,11 +151,11 @@ class MockCatalog {
   findObjectResponse(
     request: LLMGenerateObjectRequest,
   ): LLMGenerateObjectResponse | undefined {
-    const index = this.mocks.findIndex((m) =>
+    const index = this.#mocks.findIndex((m) =>
       m.type === "generateObject" && m.matcher(request)
     );
     if (index === -1) return undefined;
-    const [mock] = this.mocks.splice(index, 1);
+    const [mock] = this.#mocks.splice(index, 1);
     if (mock.type === "generateObject") return mock.response;
   }
 }
@@ -673,129 +673,131 @@ export class LLMClient {
       const data = await response.json();
       return normalizeLLMResponse(data, id);
     }
-    return await this.stream(response.body, id, callback);
+    return await readLLMStream(response.body, id, callback);
   }
+}
 
-  private async stream(
-    body: ReadableStream,
-    id: string,
-    callback?: PartialCallback,
-  ): Promise<LLMResponse> {
-    const reader = body.getReader();
-    const decoder = new TextDecoder();
+/**
+ * Reads one streamed LLM response to completion, reporting partial text
+ * to `callback` as it arrives.
+ */
+export async function readLLMStream(
+  body: ReadableStream,
+  id: string,
+  callback?: PartialCallback,
+): Promise<LLMResponse> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
 
-    let doneReading = false;
-    let buffer = "";
-    let text = "";
-    const toolCalls: LLMToolCall[] = [];
-    const toolResults: LLMToolResult[] = [];
-    let nativeModelToolResults: LLMNativeModelToolResult[] | undefined;
+  let doneReading = false;
+  let buffer = "";
+  let text = "";
+  const toolCalls: LLMToolCall[] = [];
+  const toolResults: LLMToolResult[] = [];
+  let nativeModelToolResults: LLMNativeModelToolResult[] | undefined;
 
-    while (!doneReading) {
-      const { value, done } = await reader.read();
-      doneReading = done;
-      if (value) {
-        const chunk = decoder.decode(value, { stream: true });
-        buffer += chunk;
+  while (!doneReading) {
+    const { value, done } = await reader.read();
+    doneReading = done;
+    if (value) {
+      const chunk = decoder.decode(value, { stream: true });
+      buffer += chunk;
 
-        let newlineIndex: number;
-        while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
-          const line = buffer.slice(0, newlineIndex).trim();
-          buffer = buffer.slice(newlineIndex + 1);
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
 
-          if (line) {
-            try {
-              const event = JSON.parse(line);
+        if (line) {
+          try {
+            const event = JSON.parse(line);
 
-              // Handle different event types from AI SDK fullStream
-              if (typeof event === "string") {
-                // Legacy text delta format
-                text += event;
-                if (callback) callback(text);
-              } else if (event.type === "text-delta") {
-                // New structured text delta
-                text += event.textDelta;
-                if (callback) callback(text);
-              } else if (event.type === "tool-call") {
-                // Tool call event
-                const toolCall: LLMToolCall = {
-                  id: event.toolCallId,
-                  name: event.toolName,
-                  input: event.args,
-                };
-                toolCalls.push(toolCall);
-              } else if (event.type === "tool-result") {
-                // Tool result event
-                const toolResult: LLMToolResult = {
-                  toolCallId: event.toolCallId,
-                  result: event.result,
-                  error: event.error,
-                };
-                toolResults.push(toolResult);
-              } else if (event.type === "finish") {
-                if (
-                  isLLMNativeModelToolResults(event.nativeModelToolResults)
-                ) {
-                  nativeModelToolResults = event.nativeModelToolResults;
-                }
-                // Stream finished
-                break;
-              } else if (event.type === "error") {
-                throw new LLMStreamError(event.error ?? "LLM stream error");
+            // Handle different event types from AI SDK fullStream
+            if (typeof event === "string") {
+              // Legacy text delta format
+              text += event;
+              if (callback) callback(text);
+            } else if (event.type === "text-delta") {
+              // New structured text delta
+              text += event.textDelta;
+              if (callback) callback(text);
+            } else if (event.type === "tool-call") {
+              // Tool call event
+              const toolCall: LLMToolCall = {
+                id: event.toolCallId,
+                name: event.toolName,
+                input: event.args,
+              };
+              toolCalls.push(toolCall);
+            } else if (event.type === "tool-result") {
+              // Tool result event
+              const toolResult: LLMToolResult = {
+                toolCallId: event.toolCallId,
+                result: event.result,
+                error: event.error,
+              };
+              toolResults.push(toolResult);
+            } else if (event.type === "finish") {
+              if (
+                isLLMNativeModelToolResults(event.nativeModelToolResults)
+              ) {
+                nativeModelToolResults = event.nativeModelToolResults;
               }
-            } catch (error) {
-              if (error instanceof LLMStreamError) throw error;
-              console.error("Failed to parse JSON line:", line, error);
+              // Stream finished
+              break;
+            } else if (event.type === "error") {
+              throw new LLMStreamError(event.error ?? "LLM stream error");
             }
+          } catch (error) {
+            if (error instanceof LLMStreamError) throw error;
+            console.error("Failed to parse JSON line:", line, error);
           }
         }
       }
     }
-
-    // Handle any remaining buffer
-    if (buffer.trim()) {
-      try {
-        const event = JSON.parse(buffer.trim());
-        if (typeof event === "string") {
-          text += event;
-          if (callback) callback(text);
-        } else if (event.type === "error") {
-          throw new LLMStreamError(event.error ?? "LLM stream error");
-        } else if (event.type === "finish") {
-          if (isLLMNativeModelToolResults(event.nativeModelToolResults)) {
-            nativeModelToolResults = event.nativeModelToolResults;
-          }
-        }
-      } catch (error) {
-        if (error instanceof LLMStreamError) throw error;
-        console.error("Failed to parse final JSON line:", buffer, error);
-      }
-    }
-
-    // Build content array with text and tool calls
-    const content: any[] = [];
-
-    if (text.trim()) {
-      content.push({ type: "text", text });
-    }
-
-    // Add tool calls as content parts
-    for (const toolCall of toolCalls) {
-      content.push({
-        type: "tool-call",
-        toolCallId: toolCall.id,
-        toolName: toolCall.name,
-        input: toolCall.input,
-      });
-    }
-
-    return {
-      role: "assistant",
-      content: content.length > 0 ? content : text,
-      id,
-      ...(nativeModelToolResults !== undefined
-        ? { nativeModelToolResults }
-        : {}),
-    };
   }
+
+  // Handle any remaining buffer
+  if (buffer.trim()) {
+    try {
+      const event = JSON.parse(buffer.trim());
+      if (typeof event === "string") {
+        text += event;
+        if (callback) callback(text);
+      } else if (event.type === "error") {
+        throw new LLMStreamError(event.error ?? "LLM stream error");
+      } else if (event.type === "finish") {
+        if (isLLMNativeModelToolResults(event.nativeModelToolResults)) {
+          nativeModelToolResults = event.nativeModelToolResults;
+        }
+      }
+    } catch (error) {
+      if (error instanceof LLMStreamError) throw error;
+      console.error("Failed to parse final JSON line:", buffer, error);
+    }
+  }
+
+  // Build content array with text and tool calls
+  const content: any[] = [];
+
+  if (text.trim()) {
+    content.push({ type: "text", text });
+  }
+
+  // Add tool calls as content parts
+  for (const toolCall of toolCalls) {
+    content.push({
+      type: "tool-call",
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      input: toolCall.input,
+    });
+  }
+
+  return {
+    role: "assistant",
+    content: content.length > 0 ? content : text,
+    id,
+    ...(nativeModelToolResults !== undefined ? { nativeModelToolResults } : {}),
+  };
 }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -203,11 +203,13 @@ export interface CreatePieceOptions {
  * the space's default root pattern. One instance serves one space.
  */
 export class PiecesController<T = unknown> {
-  private space: MemorySpace;
+  #session: Session;
 
-  private spaceCell: Cell<SpaceCellContents>;
+  #space: MemorySpace;
 
-  private diagnosticConsole: RuntimeConsole;
+  #spaceCell: Cell<SpaceCellContents>;
+
+  #diagnosticConsole: RuntimeConsole;
 
   /**
    * Promise resolved when the controller is ready.
@@ -215,23 +217,24 @@ export class PiecesController<T = unknown> {
   ready: Promise<void>;
 
   constructor(
-    private session: Session,
+    session: Session,
     public runtime: Runtime,
     options: PiecesControllerOptions = {},
   ) {
-    this.diagnosticConsole = new RuntimeConsole(runtime.harness);
-    this.space = this.session.space;
+    this.#session = session;
+    this.#diagnosticConsole = new RuntimeConsole(runtime.harness);
+    this.#space = this.#session.space;
 
     // Use the space DID as the cause - it's derived from the space name
     // and consistently available everywhere
-    const isHomeSpace = this.space === this.runtime.userIdentityDID;
-    this.spaceCell = isHomeSpace
+    const isHomeSpace = this.#space === this.runtime.userIdentityDID;
+    this.#spaceCell = isHomeSpace
       ? this.runtime.getHomeSpaceCell()
-      : this.runtime.getSpaceCell(this.space);
+      : this.runtime.getSpaceCell(this.#space);
 
     const syncSpaceCellContents = options.deferSpaceCellSync
       ? Promise.resolve()
-      : Promise.resolve(this.spaceCell.sync());
+      : Promise.resolve(this.#spaceCell.sync());
 
     // The piece registry is managed by the default pattern, not directly on
     // the space cell. The space cell only contains a link to defaultPattern.
@@ -377,11 +380,11 @@ export class PiecesController<T = unknown> {
   }
 
   getSpace(): MemorySpace {
-    return this.space;
+    return this.#space;
   }
 
   getSpaceName(): string | undefined {
-    return this.session.spaceName;
+    return this.#session.spaceName;
   }
 
   async synced(): Promise<void> {
@@ -391,19 +394,20 @@ export class PiecesController<T = unknown> {
 
   async ensureSpaceSession(): Promise<void> {
     await this.ready;
-    await this.runtime.storageManager.open(this.space).ensureSession?.();
+    await this.runtime.storageManager.open(this.#space).ensureSession?.();
   }
 
   async listEntityIds(): Promise<string[] | undefined> {
     await this.ready;
-    return await this.runtime.storageManager.open(this.space).listEntityIds?.();
+    return await this.runtime.storageManager.open(this.#space)
+      .listEntityIds?.();
   }
 
   async listEntityIdPage(
     options: EntityIdListOptions = {},
   ): Promise<EntityIdListResult | undefined> {
     await this.ready;
-    return await this.runtime.storageManager.open(this.space)
+    return await this.runtime.storageManager.open(this.#space)
       .listEntityIdPage?.(
         options,
       );
@@ -411,13 +415,13 @@ export class PiecesController<T = unknown> {
 
   async entityIdExists(id: string): Promise<boolean | undefined> {
     await this.ready;
-    return await this.runtime.storageManager.open(this.space).entityIdExists?.(
+    return await this.runtime.storageManager.open(this.#space).entityIdExists?.(
       id,
     );
   }
 
   getSpaceCellContents(): Cell<SpaceCellContents> {
-    return this.spaceCell;
+    return this.#spaceCell;
   }
 
   async dispose() {
@@ -433,7 +437,7 @@ export class PiecesController<T = unknown> {
     defaultPatternCell: Cell<any>,
   ): Promise<void> {
     const { error } = await this.runtime.editWithRetry((tx) => {
-      const spaceCellWithTx = this.spaceCell.withTx(tx);
+      const spaceCellWithTx = this.#spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(defaultPatternCell.withTx(tx));
     });
     if (error) {
@@ -451,7 +455,7 @@ export class PiecesController<T = unknown> {
    */
   async unlinkDefaultPattern(): Promise<void> {
     const { error } = await this.runtime.editWithRetry((tx) => {
-      const spaceCellWithTx = this.spaceCell.withTx(tx);
+      const spaceCellWithTx = this.#spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(undefined);
     });
     if (error) {
@@ -472,7 +476,7 @@ export class PiecesController<T = unknown> {
   ): Promise<Cell<NameSchema> | undefined> {
     const cell = await timePiecePhase(
       "getDefaultPattern.spaceCell.sync",
-      () => this.spaceCell.key("defaultPattern").sync(),
+      () => this.#spaceCell.key("defaultPattern").sync(),
     );
     const defaultPattern = cell.get();
     if (!defaultPattern) {
@@ -520,10 +524,10 @@ export class PiecesController<T = unknown> {
           await this.runtime.patternManager.loadPatternByIdentity(
             pinnedRef.identity,
             pinnedRef.symbol,
-            this.space,
+            this.#space,
           ) !== undefined
         ) throw error;
-        healed = await this.healDefaultRootByRollForward(
+        healed = await this.#healDefaultRootByRollForward(
           root,
           pinnedRef,
           error,
@@ -534,7 +538,7 @@ export class PiecesController<T = unknown> {
       }
       pieceUpdateLogger.warn("default-root-healed-on-load-failure", () => [
         "getDefaultPattern: start failed, the root rolled forward to the",
-        `space's official system root; retrying start once (${this.space})`,
+        `space's official system root; retrying start once (${this.#space})`,
       ]);
       try {
         await this.runtime.idle();
@@ -545,7 +549,7 @@ export class PiecesController<T = unknown> {
       } catch (retryError) {
         pieceUpdateLogger.warn("default-root-heal-retry-failed", () => [
           "getDefaultPattern: post-heal retry failed; surfacing the",
-          `original start failure (${this.space})`,
+          `original start failure (${this.#space})`,
           retryError,
         ]);
         throw error;
@@ -573,7 +577,7 @@ export class PiecesController<T = unknown> {
     if (this.runtime.cfcEnforcementMode === "disabled") return false;
     const origin = getPatternSource(root);
     return origin === undefined ||
-      origin === deriveSystemPatternSource(this.space, this.runtime);
+      origin === deriveSystemPatternSource(this.#space, this.runtime);
   }
 
   /**
@@ -588,10 +592,10 @@ export class PiecesController<T = unknown> {
       // subscription made against this placeholder never fires again, so a
       // cold-cache miss here silently freezes piece listings (e.g. FUSE).
       console.warn(
-        `getPieceRegistry: no default pattern found for space ${this.space}; ` +
+        `getPieceRegistry: no default pattern found for space ${this.#space}; ` +
           "returning detached empty piece list",
       );
-      return this.runtime.getCell(this.space, "empty-pieces", pieceListSchema);
+      return this.runtime.getCell(this.#space, "empty-pieces", pieceListSchema);
     }
 
     const cell = defaultPattern.asSchema({
@@ -704,7 +708,7 @@ export class PiecesController<T = unknown> {
     const addressed: Cell<unknown> = isCell(id)
       ? id
       : this.runtime.getCellFromEntityId(
-        this.space,
+        this.#space,
         entityIdFrom(id),
         [],
         undefined,
@@ -811,7 +815,7 @@ export class PiecesController<T = unknown> {
       try {
         argumentValue = argumentCell.getRaw();
       } catch (err) {
-        this.diagnosticConsole.debug("Error getting argument value:", err);
+        this.#diagnosticConsole.debug("Error getting argument value:", err);
         return result;
       }
 
@@ -882,7 +886,7 @@ export class PiecesController<T = unknown> {
 
             const resultCell = followCellToResult(
               this.runtime.getCellFromLink(link),
-              this.diagnosticConsole,
+              this.#diagnosticConsole,
               new Set(),
               0,
             );
@@ -898,7 +902,7 @@ export class PiecesController<T = unknown> {
                   depth + 1,
                 );
               } catch (err) {
-                this.diagnosticConsole.debug(
+                this.#diagnosticConsole.debug(
                   `Error processing array item at index ${i}:`,
                   err,
                 );
@@ -918,7 +922,7 @@ export class PiecesController<T = unknown> {
                   depth + 1,
                 );
               } catch (err) {
-                this.diagnosticConsole.debug(
+                this.#diagnosticConsole.debug(
                   `Error processing object property '${key}':`,
                   err,
                 );
@@ -926,7 +930,7 @@ export class PiecesController<T = unknown> {
             }
           }
         } catch (err) {
-          this.diagnosticConsole.debug("Error in processValue:", err);
+          this.#diagnosticConsole.debug("Error in processValue:", err);
         }
       };
 
@@ -940,7 +944,7 @@ export class PiecesController<T = unknown> {
         );
       }
     } catch (error) {
-      this.diagnosticConsole.debug(
+      this.#diagnosticConsole.debug(
         "Error finding references in piece arguments:",
         error,
       );
@@ -1023,13 +1027,13 @@ export class PiecesController<T = unknown> {
             // Check if cell link's source chain leads to our target
             const resultCell = followCellToResult(
               this.runtime.getCellFromLink(link),
-              this.diagnosticConsole,
+              this.#diagnosticConsole,
               new Set(),
               0,
             );
             if (resultCell?.sourceURI === piece.sourceURI) return true;
           } catch (err) {
-            this.diagnosticConsole.debug(
+            this.#diagnosticConsole.debug(
               "Error handling cell link in checkRefersToTarget:",
               err,
             );
@@ -1052,7 +1056,7 @@ export class PiecesController<T = unknown> {
                 return true;
               }
             } catch (err) {
-              this.diagnosticConsole.debug(
+              this.#diagnosticConsole.debug(
                 `Error checking array item at index ${i}:`,
                 err,
               );
@@ -1076,7 +1080,7 @@ export class PiecesController<T = unknown> {
                 return true;
               }
             } catch (err) {
-              this.diagnosticConsole.debug(
+              this.#diagnosticConsole.debug(
                 `Error checking object property '${key}':`,
                 err,
               );
@@ -1084,7 +1088,7 @@ export class PiecesController<T = unknown> {
           }
         }
       } catch (err) {
-        this.diagnosticConsole.debug("Error in checkRefersToTarget:", err);
+        this.#diagnosticConsole.debug("Error in checkRefersToTarget:", err);
       }
 
       return false;
@@ -1134,7 +1138,7 @@ export class PiecesController<T = unknown> {
     scope?: CellScope,
   ): Promise<Cell<T>> {
     const cell = this.runtime.getCellFromEntityId<T>(
-      this.space,
+      this.#space,
       id,
       path,
       schema,
@@ -1176,7 +1180,7 @@ export class PiecesController<T = unknown> {
    */
   async remove(pieceOrId: string | Cell<unknown>): Promise<boolean> {
     const piece = typeof pieceOrId === "string"
-      ? this.runtime.getCellFromEntityId(this.space, entityIdFrom(pieceOrId))
+      ? this.runtime.getCellFromEntityId(this.#space, entityIdFrom(pieceOrId))
       : pieceOrId;
     const piecesCell = await this.getPieceRegistry();
     await this.syncPieces(piecesCell);
@@ -1197,7 +1201,7 @@ export class PiecesController<T = unknown> {
       // state, and a link concurrently repointed at another piece must be
       // left in place (the same precondition-guard shape as the roll-forward
       // swap in startEnsuredDefaultPattern).
-      const defaultPatternCell = this.spaceCell.withTx(tx)
+      const defaultPatternCell = this.#spaceCell.withTx(tx)
         .key("defaultPattern");
       const linked = defaultPatternCell.get();
       if (linked && piece.resolveAsCell().equals(linked.resolveAsCell())) {
@@ -1284,7 +1288,7 @@ export class PiecesController<T = unknown> {
     },
   ): Promise<Cell<unknown>> {
     const piece = this.runtime.getCellFromEntityId(
-      this.space,
+      this.#space,
       entityIdFrom(pieceId),
     );
     await piece.sync();
@@ -1329,8 +1333,8 @@ export class PiecesController<T = unknown> {
       () => this.runtime.idle(),
     );
     const piece = this.runtime.getCell<T>(
-      this.space,
-      cause ?? { space: this.space, random: crypto.randomUUID() },
+      this.#space,
+      cause ?? { space: this.#space, random: crypto.randomUUID() },
       pattern.resultSchema,
     );
     // Fast path: the pattern's content-addressed entry ref, if it carries one
@@ -1476,7 +1480,7 @@ export class PiecesController<T = unknown> {
     const pattern = await this.runtime.patternManager.loadPatternByIdentity(
       ref.identity,
       ref.symbol,
-      this.space,
+      this.#space,
     );
     return pattern;
   }
@@ -1518,7 +1522,7 @@ export class PiecesController<T = unknown> {
   ): Promise<void> {
     const start = options?.start ?? true;
     let linkCell = this.runtime.getCellFromEntityId(
-      this.space,
+      this.#space,
       entityIdFrom(linkPieceId),
       [],
       undefined,
@@ -1548,7 +1552,7 @@ export class PiecesController<T = unknown> {
         // For pieces, target fields are in the result cell's argument
         const resultCell = followCellToResult(
           targetInputCell,
-          this.diagnosticConsole,
+          this.#diagnosticConsole,
         );
         if (!resultCell) {
           throw new Error("Target piece has no result cell");
@@ -1595,7 +1599,7 @@ export class PiecesController<T = unknown> {
    * Returns empty string if not configured, if the configured value cannot be
    * an origin, or if the home space is not accessible.
    */
-  private async getDefaultAppUrlFromHome(): Promise<string> {
+  async #getDefaultAppUrlFromHome(): Promise<string> {
     try {
       const homeSpaceCell = this.runtime.getHomeSpaceCell();
       await timePiecePhase(
@@ -1681,7 +1685,7 @@ export class PiecesController<T = unknown> {
           cause: `home-pattern-${Date.now()}`,
         };
       } else {
-        const customUrl = await this.getDefaultAppUrlFromHome();
+        const customUrl = await this.#getDefaultAppUrlFromHome();
         patternConfig = {
           name: "DefaultPieceList",
           source: customUrl || DEFAULT_APP_PATTERN_SOURCE,
@@ -1778,7 +1782,7 @@ export class PiecesController<T = unknown> {
     // origin has already replaced.
     const existingPattern = await this.getDefaultPattern(false);
     if (existingPattern) {
-      return await this.startEnsuredDefaultPattern(existingPattern, true);
+      return await this.#startEnsuredDefaultPattern(existingPattern, true);
     }
 
     // Determine which pattern to use based on space type
@@ -1795,7 +1799,7 @@ export class PiecesController<T = unknown> {
     } else {
       const customUrl = await timePiecePhase(
         "ensureDefaultPattern.getDefaultAppUrlFromHome",
-        () => this.getDefaultAppUrlFromHome(),
+        () => this.#getDefaultAppUrlFromHome(),
       );
       patternConfig = {
         name: "DefaultPieceList",
@@ -1836,7 +1840,7 @@ export class PiecesController<T = unknown> {
     // source immediately above. If another writer won the race, treat the
     // discovered root like every other persisted root and reconcile it before
     // start.
-    return await this.startEnsuredDefaultPattern(
+    return await this.#startEnsuredDefaultPattern(
       finalPattern,
       !createdByThisCall,
     );
@@ -1847,7 +1851,7 @@ export class PiecesController<T = unknown> {
    * from its source: following that origin again would fetch the route to
    * learn what was compiled from it moments ago.
    */
-  private async startEnsuredDefaultPattern(
+  async #startEnsuredDefaultPattern(
     root: Cell<NameSchema>,
     reconcileBeforeStart: boolean,
   ): Promise<PieceController<NameSchema>> {
@@ -1868,7 +1872,7 @@ export class PiecesController<T = unknown> {
       // that is simply wrong for it, and re-staging that one buys nothing the
       // repair below cannot do with the failure in hand.
       if (outcome === "current" || outcome === "migrated") {
-        rootToStart = await this.restageRootSetupIfStale(rootToStart);
+        rootToStart = await this.#restageRootSetupIfStale(rootToStart);
       }
     }
 
@@ -1933,7 +1937,7 @@ export class PiecesController<T = unknown> {
         if (!this.#rootNeedsRollForward(rootToStart)) throw startError;
         return new PieceController<NameSchema>(
           this,
-          await this.healDefaultRootByRollForward(
+          await this.#healDefaultRootByRollForward(
             rootToStart,
             ref,
             startError,
@@ -2026,7 +2030,7 @@ export class PiecesController<T = unknown> {
             repairError,
           ],
         );
-        rootToStart = await this.healDefaultRootByRollForward(
+        rootToStart = await this.#healDefaultRootByRollForward(
           rootToStart,
           ref,
           repairError,
@@ -2056,7 +2060,7 @@ export class PiecesController<T = unknown> {
    * start fail outright. Best-effort — a failed re-stage leaves the root as it
    * was, and the start reports whatever it reports.
    */
-  private async restageRootSetupIfStale(
+  async #restageRootSetupIfStale(
     root: Cell<NameSchema>,
   ): Promise<Cell<NameSchema>> {
     // Nothing to re-stage: a root with no pattern to stage from, or one whose
@@ -2097,7 +2101,7 @@ export class PiecesController<T = unknown> {
     } catch (error) {
       pieceUpdateLogger.warn("root-setup-restage-failed", () => [
         "startEnsuredDefaultPattern: could not re-stage a root whose setup",
-        `marker disagrees with its pinned pattern (${this.space})`,
+        `marker disagrees with its pinned pattern (${this.#space})`,
         error,
       ]);
       return root;
@@ -2136,7 +2140,7 @@ export class PiecesController<T = unknown> {
    * Returns the healed root cell so the caller starts/returns the swapped-in
    * pattern rather than the stale pinned view.
    */
-  private async healDefaultRootByRollForward(
+  async #healDefaultRootByRollForward(
     rootToStart: Cell<NameSchema>,
     pinnedRef: { identity: string; symbol: string },
     migrationError: unknown,
@@ -2247,7 +2251,7 @@ export class PiecesController<T = unknown> {
       // Nothing to swap: the root already names the entry the official source
       // compiles to, and that source has just been compiled into this space.
       // Materializing it over the document is the whole repair.
-      return await this.materializeHealedRoot(
+      return await this.#materializeHealedRoot(
         rootToStart,
         officialPattern,
         officialRef,
@@ -2342,7 +2346,7 @@ export class PiecesController<T = unknown> {
     // Re-resolve so the materialize observes the committed patternIdentity
     // (the caller's cell is a pre-swap transaction view), then materialize the
     // OFFICIAL pattern.
-    const swappedRoot = await this.materializeHealedRoot(
+    const swappedRoot = await this.#materializeHealedRoot(
       await this.getDefaultPattern(false) ?? rootToStart,
       officialPattern,
       officialRef,
@@ -2368,7 +2372,7 @@ export class PiecesController<T = unknown> {
    * continue — so an official pattern that also cannot migrate the document
    * surfaces as one clear error rather than a silently dead root.
    */
-  private async materializeHealedRoot(
+  async #materializeHealedRoot(
     root: Cell<NameSchema>,
     pattern: Pattern,
     ref: { identity: string; symbol: string },

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -150,7 +150,7 @@ function filterOutCell(
  * preserved input or unclassified document data onto a now-required field that
  * carries no default. Generated result fields are not in this class: pattern
  * setup materializes them. This is ONE of the two repair-failure classes the
- * runnability backstop ({@link PiecesController.healDefaultRootByRollForward})
+ * runnability backstop (`PiecesController.#healDefaultRootByRollForward`)
  * acts on — the other is a refused stored argument
  * ({@link isStoredArgumentSchemaRefusal}); every other failure stays
  * fail-closed.

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -89,10 +89,15 @@ import {
 } from "./vintage-layout.ts";
 
 class LoopbackSessions implements SessionFactory {
-  constructor(private readonly server: () => MemoryV2Server.Server) {}
+  readonly #server: () => MemoryV2Server.Server;
+
+  constructor(server: () => MemoryV2Server.Server) {
+    this.#server = server;
+  }
+
   async create(spaceId: string, signer?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server()),
+      transport: MemoryV2Client.loopback(this.#server()),
     });
     const session = await client.mount(
       spaceId,

--- a/packages/runner/src/cfc/migration-reason.ts
+++ b/packages/runner/src/cfc/migration-reason.ts
@@ -1,4 +1,4 @@
-// Why: the runnability backstop (`PiecesController.healDefaultRootByRollForward`)
+// Why: the runnability backstop (`PiecesController.#healDefaultRootByRollForward`)
 // must distinguish the ONE CFC-rejection class it can safely recover from — an
 // old document that cannot migrate onto a now-required field that carries no
 // default (the estuary `favorites` case) — from every OTHER CFC rejection

--- a/packages/static/cache.ts
+++ b/packages/static/cache.ts
@@ -30,14 +30,14 @@ export interface CachedAsset {
  * and elsewhere it is fetched over the network.
  */
 export class StaticCache {
-  private cache: Map<string, Promise<CachedAsset>> = new Map();
-  private baseUrl: URL;
+  #cache: Map<string, Promise<CachedAsset>> = new Map();
+  #baseUrl: URL;
 
   /**
    * Constructs an instance which resolves asset names against `baseUrl`.
    */
   constructor(baseUrl: URL) {
-    this.baseUrl = baseUrl;
+    this.#baseUrl = baseUrl;
   }
 
   /**
@@ -66,12 +66,12 @@ export class StaticCache {
    * it against.
    */
   getWithETag(assetName: string): Promise<CachedAsset> {
-    const currentValue = this.cache.get(assetName);
+    const currentValue = this.#cache.get(assetName);
     if (currentValue) {
       return currentValue;
     }
-    const promise = this.requestWithETag(assetName);
-    this.cache.set(assetName, promise);
+    const promise = this.#requestWithETag(assetName);
+    this.#cache.set(assetName, promise);
     return promise;
   }
 
@@ -91,7 +91,7 @@ export class StaticCache {
       throw new Error(`No static asset "${assetName}" found.`);
     }
 
-    const url = new URL(this.baseUrl);
+    const url = new URL(this.#baseUrl);
     url.pathname = join(url.pathname, assetName);
     return url;
   }
@@ -100,7 +100,7 @@ export class StaticCache {
    * Helper for `getWithETag()`, which reads an asset and generates its ETag,
    * off the file system under Deno and over the network elsewhere.
    */
-  private async requestWithETag(assetName: string): Promise<CachedAsset> {
+  async #requestWithETag(assetName: string): Promise<CachedAsset> {
     const url = this.getUrl(assetName);
     let buffer: Uint8Array;
 

--- a/packages/test-support/src/compile-byte-cache.ts
+++ b/packages/test-support/src/compile-byte-cache.ts
@@ -75,22 +75,22 @@ const cacheFiles = new WeakMap<ProcessModuleByteCache, string>();
 export class ProcessModuleByteCache implements ModuleByteCache {
   // Keyed by `${runtimeVersion}\0${identity}`. Map insertion order gives FIFO
   // eviction (recency-refreshed on read, so eviction is ~LRU).
-  private readonly entries = new Map<
+  readonly #entries = new Map<
     string,
     { artifact: CompiledModuleArtifact; size: number }
   >();
-  private totalBytes = 0;
-  private readonly maxBytes: number;
+  #totalBytes = 0;
+  readonly #maxBytes: number;
 
   constructor(maxBytes = 256 * 1024 * 1024) {
-    this.maxBytes = maxBytes;
+    this.#maxBytes = maxBytes;
   }
 
-  private static key(runtimeVersion: string, identity: string): string {
+  static #key(runtimeVersion: string, identity: string): string {
     return `${runtimeVersion}\0${identity}`;
   }
 
-  private static sizeOf(artifact: CompiledModuleArtifact): number {
+  static #sizeOf(artifact: CompiledModuleArtifact): number {
     let size = artifact.js.length;
     if (typeof artifact.sourceMap === "string") {
       size += artifact.sourceMap.length;
@@ -111,11 +111,11 @@ export class ProcessModuleByteCache implements ModuleByteCache {
     runtimeVersion: string,
     identity: string,
   ): CompiledModuleArtifact | undefined {
-    const key = ProcessModuleByteCache.key(runtimeVersion, identity);
-    const entry = this.entries.get(key);
+    const key = ProcessModuleByteCache.#key(runtimeVersion, identity);
+    const entry = this.#entries.get(key);
     if (entry === undefined) return undefined;
-    this.entries.delete(key);
-    this.entries.set(key, entry);
+    this.#entries.delete(key);
+    this.#entries.set(key, entry);
     return entry.artifact;
   }
 
@@ -137,32 +137,32 @@ export class ProcessModuleByteCache implements ModuleByteCache {
     identity: string,
     artifact: CompiledModuleArtifact,
   ): void {
-    this.insert(
-      ProcessModuleByteCache.key(runtimeVersion, identity),
+    this.#insert(
+      ProcessModuleByteCache.#key(runtimeVersion, identity),
       artifact,
       { replaceExisting: true },
     );
   }
 
-  private insert(
+  #insert(
     key: string,
     artifact: CompiledModuleArtifact,
     options: { replaceExisting: boolean },
   ): void {
-    const existing = this.entries.get(key);
+    const existing = this.#entries.get(key);
     if (existing !== undefined) {
-      this.entries.delete(key);
-      this.totalBytes -= existing.size;
+      this.#entries.delete(key);
+      this.#totalBytes -= existing.size;
       if (!options.replaceExisting) {
-        this.entries.set(key, existing);
-        this.totalBytes += existing.size;
+        this.#entries.set(key, existing);
+        this.#totalBytes += existing.size;
         return;
       }
     }
-    const size = ProcessModuleByteCache.sizeOf(artifact);
-    this.entries.set(key, { artifact, size });
-    this.totalBytes += size;
-    this.evictToCap();
+    const size = ProcessModuleByteCache.#sizeOf(artifact);
+    this.#entries.set(key, { artifact, size });
+    this.#totalBytes += size;
+    this.#evictToCap();
   }
 
   putAll(
@@ -174,20 +174,20 @@ export class ProcessModuleByteCache implements ModuleByteCache {
     }
   }
 
-  private evictToCap(): void {
-    while (this.totalBytes > this.maxBytes) {
-      const oldest = this.entries.keys().next().value;
+  #evictToCap(): void {
+    while (this.#totalBytes > this.#maxBytes) {
+      const oldest = this.#entries.keys().next().value;
       if (oldest === undefined) break;
-      const entry = this.entries.get(oldest);
-      this.entries.delete(oldest);
-      if (entry !== undefined) this.totalBytes -= entry.size;
+      const entry = this.#entries.get(oldest);
+      this.#entries.delete(oldest);
+      if (entry !== undefined) this.#totalBytes -= entry.size;
     }
   }
 
   /** A serializable dump of every cached module. Pairs with {@link restore}. */
   snapshot(): SerializedModuleBytes[] {
     const out: SerializedModuleBytes[] = [];
-    for (const [key, { artifact }] of this.entries) {
+    for (const [key, { artifact }] of this.#entries) {
       const serialized: SerializedModuleBytes = { key, js: artifact.js };
       if (artifact.sourceMap !== undefined) {
         serialized.sourceMap = artifact.sourceMap;
@@ -247,7 +247,7 @@ export class ProcessModuleByteCache implements ModuleByteCache {
       if (e.policyManifests !== undefined) {
         artifact.policyManifests = [...e.policyManifests];
       }
-      this.insert(
+      this.#insert(
         e.key,
         artifact,
         { replaceExisting: false },
@@ -256,12 +256,12 @@ export class ProcessModuleByteCache implements ModuleByteCache {
   }
 
   clear(): void {
-    this.entries.clear();
-    this.totalBytes = 0;
+    this.#entries.clear();
+    this.#totalBytes = 0;
   }
 
   stats(): { entries: number; bytes: number } {
-    return { entries: this.entries.size, bytes: this.totalBytes };
+    return { entries: this.#entries.size, bytes: this.#totalBytes };
   }
 }
 

--- a/packages/test-support/src/records/fragment.ts
+++ b/packages/test-support/src/records/fragment.ts
@@ -22,11 +22,16 @@ const encoder = new TextEncoder();
 export class FragmentWriter {
   #file: Deno.FsFile | undefined;
   #warned = false;
-  readonly path: string;
+  readonly #path: string;
 
   private constructor(path: string, file: Deno.FsFile) {
-    this.path = path;
+    this.#path = path;
     this.#file = file;
+  }
+
+  /** The fragment file this writer appends to. */
+  get path(): string {
+    return this.#path;
   }
 
   /**
@@ -77,7 +82,7 @@ export class FragmentWriter {
     } catch (error) {
       if (!this.#warned) {
         this.#warned = true;
-        warnOnce(`cannot append to ${this.path}: ${error}`);
+        warnOnce(`cannot append to ${this.#path}: ${error}`);
       }
       this.close();
     }

--- a/packages/toolshed/lib/test-support/memory-acl.ts
+++ b/packages/toolshed/lib/test-support/memory-acl.ts
@@ -27,7 +27,11 @@ const TEST_AUDIENCE = "did:key:z6Mk-toolshed-acl-harness-audience";
 /** Speaks the wire protocol in-process — no socket, no server process. */
 export class LoopbackSessionFactory implements SessionFactory {
   readonly supportsAclBootstrap = true;
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   async create(
     space: MemorySpace,
@@ -35,7 +39,7 @@ export class LoopbackSessionFactory implements SessionFactory {
     requested: MemoryV2Client.MountOptions = {},
   ) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,

--- a/packages/toolshed/routes/patterns/patterns-server.ts
+++ b/packages/toolshed/routes/patterns/patterns-server.ts
@@ -20,13 +20,13 @@ import { CONNECTOR_PATTERN_SOURCES } from "../../../connectors/pattern-sources.t
  * Works with both dev mode and compiled binaries.
  */
 export class PatternsServer {
-  private baseUrl: URL;
-  private connectorSources: Array<{ routePrefix: string; baseUrl: URL }>;
+  #baseUrl: URL;
+  #connectorSources: Array<{ routePrefix: string; baseUrl: URL }>;
   // Pattern files are fixed for the process's lifetime (baked into the binary
   // or static on disk), so each file's content identity is computed once and
   // cached forever. A rejected computation is evicted so a transient failure
   // (e.g. an incomplete closure during a partial deploy) can be retried.
-  private identityCache = new Map<string, Promise<string>>();
+  #identityCache = new Map<string, Promise<string>>();
 
   constructor() {
     const repositoryRoot = join(
@@ -36,24 +36,26 @@ export class PatternsServer {
       "..",
       "..",
     );
-    this.baseUrl = this.directoryUrl(join(repositoryRoot, "packages/patterns"));
-    this.connectorSources = CONNECTOR_PATTERN_SOURCES.map((source) => ({
+    this.#baseUrl = this.#directoryUrl(
+      join(repositoryRoot, "packages/patterns"),
+    );
+    this.#connectorSources = CONNECTOR_PATTERN_SOURCES.map((source) => ({
       routePrefix: `${source.keyPrefix}/`,
-      baseUrl: this.directoryUrl(join(repositoryRoot, source.directory)),
+      baseUrl: this.#directoryUrl(join(repositoryRoot, source.directory)),
     }));
   }
 
-  private directoryUrl(directory: string): URL {
+  #directoryUrl(directory: string): URL {
     const url = toFileUrl(directory);
     if (!url.href.endsWith("/")) url.href += "/";
     return url;
   }
 
-  private resolve(filename: string): URL {
-    const source = this.connectorSources.find(({ routePrefix }) =>
+  #resolve(filename: string): URL {
+    const source = this.#connectorSources.find(({ routePrefix }) =>
       filename.startsWith(routePrefix)
     );
-    const baseUrl = source?.baseUrl ?? this.baseUrl;
+    const baseUrl = source?.baseUrl ?? this.#baseUrl;
     const relative = source === undefined
       ? filename
       : filename.slice(source.routePrefix.length);
@@ -69,7 +71,7 @@ export class PatternsServer {
    * Get a pattern file's content as Uint8Array.
    */
   async get(filename: string): Promise<Uint8Array> {
-    const url = this.resolve(filename);
+    const url = this.#resolve(filename);
 
     try {
       return await Deno.readFile(url);
@@ -103,7 +105,7 @@ export class PatternsServer {
    * `cf:` fabric import (unsupported by the light path).
    */
   identity(filename: string): Promise<string> {
-    let cached = this.identityCache.get(filename);
+    let cached = this.#identityCache.get(filename);
     if (!cached) {
       // Name modules by their URL pathname so the identity equals the one the
       // worker computes when it compiles the same source over HTTP.
@@ -111,8 +113,8 @@ export class PatternsServer {
         `${PATTERNS_ROUTE_PREFIX}${filename}`,
         (name) => this.getText(name.slice(PATTERNS_ROUTE_PREFIX.length)),
       );
-      this.identityCache.set(filename, cached);
-      cached.catch(() => this.identityCache.delete(filename));
+      this.#identityCache.set(filename, cached);
+      cached.catch(() => this.#identityCache.delete(filename));
     }
     return cached;
   }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts every convertible TypeScript `private` class member to a JavaScript
`#` private name in thirteen packages: `deno-web-test`, `felt`, `identity`,
`iframe-sandbox`, `integration`, `js-compiler`, `lib-shell`, `llm`, `piece`,
`static`, `test-support`, and `toolshed`. `connectors` was already clear and
appears only in the census below.

`docs/development/DEVELOPMENT.md` § Classes asks for this, and the reason is
that the two spellings are not equivalent at runtime. A `#` field is not an own
property at all, whereas a field declared `private` is: the modifier is erased,
and the property it describes is as enumerable as any other. So an instance
stops looking like a plain object, and code that mistakes an instance for data
fails where it stands instead of quietly half-working.

Three `private` constructor parameter properties become a `#` field and an
assignment, which is the same change written out — a parameter property is a
field declaration in disguise. Two exported classes holding an enumerable field
become a getter over a `#` field: `KeyStore.DEFAULT_DB_NAME` and
`FragmentWriter.path`, neither of which anything writes to.

## Two places the rename did not fit

`LLMClient`'s stream reader was reached by its test through an
`as unknown as` cast, which `#` makes impossible. The reader touches no
instance state, so it moves out to a module-level `readLLMStream()` beside
`normalizeLLMResponse()` and `failureHint()` — helpers that file already
exports and exercises the same way. The test calls it directly and the cast is
gone.

`CommonIframeSandboxElement` keeps `iframeRef`, `readyWindow`, and
`onOuterReady` TypeScript-private, with the reason on the declaration.
`test/iframe.test.ts` asserts the outer-ready refusal where it is made: a frame
reports itself ready once, and nothing outside the element can send that
message, so `#` would put the assertion out of reach. Driving it properly needs
the test to forge a `MessageEvent` source, which is a test redesign rather than
a rename.

## Scope

Enumerable fields on exported classes are left alone here. That population is
mostly record-shaped classes, and converting a ten-field configuration record
to ten getters is a decision about those classes rather than a rename.
`Error` subclasses and Lit-bound reactive properties are likewise untouched:
Lit needs a declared class field, and there is no `#` form it can see.

## Verification

The conversion was made by an AST tool that rewrites declarations along with
their `this.x` and `Cls.x` references, and refuses what it cannot resolve
syntactically — constructor parameter properties, element access, and
cross-instance access off a receiver typed as the class. Its count was
reconciled against an independent census of the tree before each apply; the
one mismatch was an overloaded method whose signatures and implementation must
convert together.

Across the sixteen files of the larger batch, the change is a pure rename:
after normalizing away `private`, `#`, whitespace, and the trailing commas
`deno fmt` adds when a line wraps, every file is character-identical to its
predecessor. The same comparison without normalizing `private` differs in all
sixteen, which is the control.

`deno fmt --check`, `deno lint`, `deno task check`, and `deno task check-docs`
all pass, as does each touched package's own `deno task test`.
`iframe-sandbox` was compared against `origin/main` directly: 48 passed, 0
failed on both sides.

## Census

Measured over all tracked `.ts`/`.tsx` files with a TypeScript AST walk, so
nested and expression classes are included.

| | before | after |
|---|--:|--:|
| `private` members repo-wide | 3135 | 3028 |
| enumerable fields on exported classes | 295 | 274 |

Each of the thirteen packages is at zero `private` members, but for the three
named above.


## Coverage

Two groups regress, each attributed from the run's own LCOV rather than
guessed at, and each accepted below.

`packages/identity` rises by the two lines of the new `DEFAULT_DB_NAME`
getter. Those lines cannot be covered from where they live: `KeyStore` needs
`globalThis.indexedDB`, so only `deno-web-test` reaches `key-store.ts`, and a
browser run contributes nothing to the V8 coverage the metric reads. The file
scores 103 uncovered of 117 instrumented for that same reason. A test was
added for the getter regardless, because the default database name is
persisted browser state and deserves pinning, but it runs in the browser and
so cannot move this number.

`packages/runner` rises by one line, and the only `runner` file this branch
touches is a comment in `cfc/migration-reason.ts`, which adds no instrumented
line. Confirmed as flake against two successful `main` runs rather than
asserted: no line is uncovered here and covered in both of them, and the lines
uncovered here are exactly the two that flip between those two runs on
identical source — `executor/space-server.ts:3763` (102 then 0) and
`executor/wave.ts:1943` (0 then 2).

ACCEPT_COVERAGE_DEBT: packages/identity +2 lines
ACCEPT_COVERAGE_DEBT: packages/runner +1 line

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


