### PR TITLE
refactor: `#` private members in `memory` and `cf-harness`

### DIFF
--- a/docs/development/waiting-in-tests-rationale.md
+++ b/docs/development/waiting-in-tests-rationale.md
@@ -521,7 +521,7 @@ out.
 ### Production reconnect backoff
 
 One loop that looks like a violation is a deliberate exception:
-`MemoryClient.reconnect()` in `packages/memory/v2/client.ts`. When the
+`MemoryClient.#reconnect()` in `packages/memory/v2/client.ts`. When the
 websocket to the memory server drops, the client loops — it re-runs the
 `hello` handshake, re-opens every mounted space's session, and, when an
 attempt fails, waits a short, growing delay before trying again. That

--- a/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
+++ b/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
@@ -154,7 +154,7 @@ idempotently.)
 The v2 protocol is a discriminated union of message `type`s
 ([`packages/memory/v2.ts`](../../../packages/memory/v2.ts), `ClientMessage` /
 server messages; parsed in `parseClientMessage`, routed in
-`Connection.receiveOrdered`, correlated by `requestId` in
+`Connection.#receiveOrdered`, correlated by `requestId` in
 [`packages/memory/v2/client.ts`](../../../packages/memory/v2/client.ts)). It is
 extensible by adding variants. We add **one new read verb** and **fold writes
 into the existing `transact` commit**.
@@ -194,7 +194,7 @@ interface SqliteQueryWireResult {
 
 Server handling (mirrors `Server.transact` / `Server.queryGraph`):
 
-1. Route the new `type` in `Connection.receiveOrdered`, guarded by
+1. Route the new `type` in `Connection.#receiveOrdered`, guarded by
    `requireSession`.
 2. **Apply the statement guard** (above): single `SELECT`/read-only CTE; reject
    DML/DDL, schema-qualified references, `PRAGMA`/`ATTACH`/`DETACH`, and multiple

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -540,10 +540,14 @@ const cfcResultFromRunscSidecar = (
 };
 
 export class DockerRunscSandboxRuntime implements SandboxRuntime {
+  readonly #runner: ProcessRunner;
+
   constructor(
     readonly config: DockerRunscSandboxConfig,
-    private readonly runner: ProcessRunner = new DenoProcessRunner(),
-  ) {}
+    runner: ProcessRunner = new DenoProcessRunner(),
+  ) {
+    this.#runner = runner;
+  }
 
   defaultWorkingDirectory(): string {
     return normalizeWorkspacePath(this.config.workspaceMountPath);
@@ -648,7 +652,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       this.config.image,
       ...request.argv,
     ];
-    const createResult = await this.runner.run({
+    const createResult = await this.#runner.run({
       command: this.config.dockerBinary,
       args: createArgs,
     });
@@ -668,7 +672,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     }
 
     try {
-      const sidecarFailure = await this.writeCfcInvocationContextSidecar(
+      const sidecarFailure = await this.#writeCfcInvocationContextSidecar(
         containerID,
         request,
         createResult,
@@ -676,7 +680,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       if (sidecarFailure !== undefined) {
         return sidecarFailure;
       }
-      const startResult = await this.runner.run({
+      const startResult = await this.#runner.run({
         command: this.config.dockerBinary,
         args: [
           "start",
@@ -687,7 +691,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
         stdinText: request.stdinText,
         timeoutMs: request.timeoutMs,
       });
-      const waitResult = await this.runner.run({
+      const waitResult = await this.#runner.run({
         command: this.config.dockerBinary,
         args: ["wait", containerID],
       });
@@ -700,7 +704,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
           : appendStderr(startResult.stderr, waitResult.stderr),
         exitCode,
       };
-      const cfcResult = await this.readCfcResultSidecar(
+      const cfcResult = await this.#readCfcResultSidecar(
         containerID,
         commandResult,
       );
@@ -708,7 +712,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
         ? commandResult
         : { ...commandResult, cfcResult };
     } finally {
-      await this.runner.run({
+      await this.#runner.run({
         command: this.config.dockerBinary,
         args: ["rm", "-f", containerID],
       });
@@ -732,7 +736,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     });
   }
 
-  private async readCfcResultSidecar(
+  async #readCfcResultSidecar(
     containerID: string,
     commandResult: SandboxCommandResult,
   ): Promise<CfcSandboxResult | undefined> {
@@ -785,7 +789,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     }
   }
 
-  private async writeCfcInvocationContextSidecar(
+  async #writeCfcInvocationContextSidecar(
     containerID: string,
     request: SandboxCommandRequest,
     createResult: SandboxCommandResult,

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -33,9 +33,13 @@ import {
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
 
+  readonly #shellResults: SandboxCommandResult[];
+
   constructor(
-    private readonly shellResults: SandboxCommandResult[] = [],
-  ) {}
+    shellResults: SandboxCommandResult[] = [],
+  ) {
+    this.#shellResults = shellResults;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -83,7 +87,7 @@ class FakeSandboxRuntime implements SandboxRuntime {
       });
     }
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }

--- a/packages/cf-harness/test/browser.test.ts
+++ b/packages/cf-harness/test/browser.test.ts
@@ -90,17 +90,21 @@ class FakeSandboxRuntime implements SandboxRuntime {
 class FakeProcessRunner implements ProcessRunner {
   readonly calls: ProcessRunRequest[] = [];
 
+  readonly #results: (ProcessRunResult | Error)[];
+
   constructor(
-    private readonly results: (ProcessRunResult | Error)[] = [{
+    results: (ProcessRunResult | Error)[] = [{
       stdout: "",
       stderr: "",
       exitCode: 0,
     }],
-  ) {}
+  ) {
+    this.#results = results;
+  }
 
   run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     this.calls.push(request);
-    const next = this.results.shift() ??
+    const next = this.#results.shift() ??
       { stdout: "", stderr: "", exitCode: 0 };
     // An `Error` in the script stands for a run that never produced a result
     // at all — no binary on the host, a spawn the OS refused.

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -71,8 +71,11 @@ class FakeSandboxRuntime implements SandboxRuntime {
 }
 
 class FakeFabricSandboxRuntime extends FakeSandboxRuntime {
-  constructor(private readonly fabricStatusJson?: string) {
+  readonly #fabricStatusJson?: string;
+
+  constructor(fabricStatusJson?: string) {
     super();
+    this.#fabricStatusJson = fabricStatusJson;
   }
 
   override runShell(
@@ -80,10 +83,10 @@ class FakeFabricSandboxRuntime extends FakeSandboxRuntime {
   ): Promise<SandboxCommandResult> {
     if (request.command.includes(FABRIC_STATUS_PROBE_SENTINEL)) {
       return Promise.resolve(
-        this.fabricStatusJson === undefined
+        this.#fabricStatusJson === undefined
           ? { stdout: "missing\t\n", stderr: "", exitCode: 0 }
           : {
-            stdout: `present\t${this.fabricStatusJson}\n`,
+            stdout: `present\t${this.#fabricStatusJson}\n`,
             stderr: "",
             exitCode: 0,
           },

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -18,11 +18,15 @@ import type {
 class FakeProcessRunner implements ProcessRunner {
   requests: ProcessRunRequest[] = [];
 
-  constructor(private readonly results: ProcessRunResult[]) {}
+  readonly #results: ProcessRunResult[];
+
+  constructor(results: ProcessRunResult[]) {
+    this.#results = results;
+  }
 
   run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     this.requests.push(request);
-    const result = this.results.shift();
+    const result = this.#results.shift();
     if (result === undefined) {
       throw new Error(`unexpected process request: ${request.command}`);
     }

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -32,10 +32,16 @@ import type {
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
 
+  readonly #shellResults: SandboxCommandResult[];
+  readonly #shellError?: Error;
+
   constructor(
-    private readonly shellResults: SandboxCommandResult[] = [],
-    private readonly shellError?: Error,
-  ) {}
+    shellResults: SandboxCommandResult[] = [],
+    shellError?: Error,
+  ) {
+    this.#shellResults = shellResults;
+    this.#shellError = shellError;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -82,11 +88,11 @@ class FakeSandboxRuntime implements SandboxRuntime {
         exitCode: 0,
       });
     }
-    if (this.shellError) {
-      return Promise.reject(this.shellError);
+    if (this.#shellError) {
+      return Promise.reject(this.#shellError);
     }
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }
@@ -94,18 +100,22 @@ class FakeSandboxRuntime implements SandboxRuntime {
 class FakeProcessRunner implements ProcessRunner {
   readonly calls: ProcessRunRequest[] = [];
 
+  readonly #results: ProcessRunResult[];
+
   constructor(
-    private readonly results: ProcessRunResult[] = [{
+    results: ProcessRunResult[] = [{
       stdout: "",
       stderr: "",
       exitCode: 0,
     }],
-  ) {}
+  ) {
+    this.#results = results;
+  }
 
   run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     this.calls.push(request);
     return Promise.resolve(
-      this.results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }

--- a/packages/cf-harness/test/interactive-chat.test.ts
+++ b/packages/cf-harness/test/interactive-chat.test.ts
@@ -23,8 +23,8 @@ import {
 
 class InMemoryInteractiveChatContract {
   readonly events: HarnessChatEventEnvelope[] = [];
-  private readonly sessions = new Map<string, HarnessChatSessionStatus>();
-  private sequence = 0;
+  readonly #sessions = new Map<string, HarnessChatSessionStatus>();
+  #sequence = 0;
 
   startSession(params: HarnessChatStartSessionParams) {
     const session = createHarnessChatSessionStatus({
@@ -38,8 +38,8 @@ class InMemoryInteractiveChatContract {
       browserAccess: params.browserAccess,
       metadata: params.metadata,
     });
-    this.sessions.set(session.sessionId, session);
-    this.emit(session.sessionId, undefined, {
+    this.#sessions.set(session.sessionId, session);
+    this.#emit(session.sessionId, undefined, {
       kind: "session_started",
       session,
     });
@@ -47,9 +47,9 @@ class InMemoryInteractiveChatContract {
   }
 
   startTurn(params: HarnessChatStartTurnParams) {
-    const session = this.requireSession(params.sessionId);
+    const session = this.#requireSession(params.sessionId);
     const turnId = params.turnId ?? `turn-${session.turnCount + 1}`;
-    this.emit(params.sessionId, turnId, {
+    this.#emit(params.sessionId, turnId, {
       kind: "turn_started",
       turn: {
         turnId,
@@ -58,61 +58,61 @@ class InMemoryInteractiveChatContract {
         updatedAt: "2026-05-22T00:01:00.000Z",
       },
     });
-    return this.requireSession(params.sessionId).activeTurn;
+    return this.#requireSession(params.sessionId).activeTurn;
   }
 
   cancelTurn(sessionId: string, reason: string) {
-    const session = this.requireSession(sessionId);
+    const session = this.#requireSession(sessionId);
     const turnId = session.activeTurnId ?? "turn-unknown";
-    this.emit(sessionId, turnId, {
+    this.#emit(sessionId, turnId, {
       kind: "turn_canceled",
       turnId,
       reason,
     });
-    return this.requireSession(sessionId);
+    return this.#requireSession(sessionId);
   }
 
   completeTurn(sessionId: string, finalText: string) {
-    const session = this.requireSession(sessionId);
+    const session = this.#requireSession(sessionId);
     const turnId = session.activeTurnId ?? "turn-unknown";
-    this.emit(sessionId, turnId, {
+    this.#emit(sessionId, turnId, {
       kind: "assistant_delta",
       text: finalText,
     });
-    this.emit(sessionId, turnId, {
+    this.#emit(sessionId, turnId, {
       kind: "assistant_completed",
       text: finalText,
     });
-    this.emit(sessionId, turnId, {
+    this.#emit(sessionId, turnId, {
       kind: "turn_completed",
       turnId,
       finalText,
     });
-    return this.requireSession(sessionId);
+    return this.#requireSession(sessionId);
   }
 
   closeSession(sessionId: string, reason: string) {
-    this.requireSession(sessionId);
-    this.emit(sessionId, undefined, {
+    this.#requireSession(sessionId);
+    this.#emit(sessionId, undefined, {
       kind: "session_closed",
       reason,
     });
-    return this.requireSession(sessionId);
+    return this.#requireSession(sessionId);
   }
 
   status() {
-    return Array.from(this.sessions.values());
+    return Array.from(this.#sessions.values());
   }
 
-  private requireSession(sessionId: string) {
-    const session = this.sessions.get(sessionId);
+  #requireSession(sessionId: string) {
+    const session = this.#sessions.get(sessionId);
     if (!session) {
       throw new Error(`missing session ${sessionId}`);
     }
     return session;
   }
 
-  private emit(
+  #emit(
     sessionId: string,
     turnId: string | undefined,
     event: HarnessChatEventEnvelope["event"],
@@ -120,16 +120,16 @@ class InMemoryInteractiveChatContract {
     const envelope = createHarnessChatEventEnvelope({
       sessionId,
       ...(turnId !== undefined ? { turnId } : {}),
-      sequence: ++this.sequence,
+      sequence: ++this.#sequence,
       emittedAt: `2026-05-22T00:00:${
-        String(this.sequence).padStart(2, "0")
+        String(this.#sequence).padStart(2, "0")
       }.000Z`,
       event,
     });
     this.events.push(envelope);
-    const current = this.sessions.get(sessionId);
+    const current = this.#sessions.get(sessionId);
     if (current) {
-      this.sessions.set(
+      this.#sessions.set(
         sessionId,
         reduceHarnessChatSessionStatus(current, envelope),
       );

--- a/packages/cf-harness/test/prompt-loop-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-handles.test.ts
@@ -48,7 +48,11 @@ const LINK_B = `/of:fid1:${HASH_B}/items/0`;
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
 
-  constructor(private readonly shellResults: SandboxCommandResult[] = []) {}
+  readonly #shellResults: SandboxCommandResult[];
+
+  constructor(shellResults: SandboxCommandResult[] = []) {
+    this.#shellResults = shellResults;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -88,7 +92,7 @@ class FakeSandboxRuntime implements SandboxRuntime {
       });
     }
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }

--- a/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
@@ -48,7 +48,11 @@ const URI_C = `of:fid1:${HASH_C}`;
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
 
-  constructor(private readonly shellResults: SandboxCommandResult[] = []) {}
+  readonly #shellResults: SandboxCommandResult[];
+
+  constructor(shellResults: SandboxCommandResult[] = []) {
+    this.#shellResults = shellResults;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -88,7 +92,7 @@ class FakeSandboxRuntime implements SandboxRuntime {
       });
     }
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -79,10 +79,16 @@ const contextPromptSlotBinding: PromptSlotBinding = {
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly shellRequests: SandboxShellRequest[] = [];
 
+  readonly #shellResults: SandboxCommandResult[];
+  readonly #shellError?: Error;
+
   constructor(
-    private readonly shellResults: SandboxCommandResult[] = [],
-    private readonly shellError?: Error,
-  ) {}
+    shellResults: SandboxCommandResult[] = [],
+    shellError?: Error,
+  ) {
+    this.#shellResults = shellResults;
+    this.#shellError = shellError;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -129,11 +135,11 @@ class FakeSandboxRuntime implements SandboxRuntime {
         exitCode: 0,
       });
     }
-    if (this.shellError) {
-      return Promise.reject(this.shellError);
+    if (this.#shellError) {
+      return Promise.reject(this.#shellError);
     }
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }
@@ -157,12 +163,16 @@ class FakeRunSandboxRuntime extends FakeSandboxRuntime {
 class FakeProcessRunner implements ProcessRunner {
   readonly requests: ProcessRunRequest[] = [];
 
-  constructor(private readonly results: ProcessRunResult[] = []) {}
+  readonly #results: ProcessRunResult[];
+
+  constructor(results: ProcessRunResult[] = []) {
+    this.#results = results;
+  }
 
   run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     this.requests.push(request);
     return Promise.resolve(
-      this.results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }
@@ -850,7 +860,10 @@ class RecordingArtifactStore implements HarnessArtifactStore {
     path: string;
   }> = [];
 
-  constructor(readonly artifactRoot: string, private readonly runId: string) {
+  readonly #runId: string;
+
+  constructor(readonly artifactRoot: string, runId: string) {
+    this.#runId = runId;
     this.runRoot = `${artifactRoot}/${runId}`;
   }
 

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -121,13 +121,17 @@ class FakeSandboxRuntime implements SandboxRuntime {
     | { type: "runShell"; request: SandboxShellRequest }
   > = [];
 
+  readonly #shellResults: SandboxCommandResult[];
+
   constructor(
-    private readonly shellResults: SandboxCommandResult[] = [{
+    shellResults: SandboxCommandResult[] = [{
       stdout: "",
       stderr: "",
       exitCode: 0,
     }],
-  ) {}
+  ) {
+    this.#shellResults = shellResults;
+  }
 
   describe(): SandboxRuntimeDescription {
     return {
@@ -156,14 +160,14 @@ class FakeSandboxRuntime implements SandboxRuntime {
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult> {
     this.calls.push({ type: "run", request });
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.calls.push({ type: "runShell", request });
     return Promise.resolve(
-      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }
@@ -189,18 +193,22 @@ class MultiRootFakeSandboxRuntime extends FakeSandboxRuntime {
 class FakeProcessRunner implements ProcessRunner {
   readonly calls: ProcessRunRequest[] = [];
 
+  readonly #results: ProcessRunResult[];
+
   constructor(
-    private readonly results: ProcessRunResult[] = [{
+    results: ProcessRunResult[] = [{
       stdout: "",
       stderr: "",
       exitCode: 0,
     }],
-  ) {}
+  ) {
+    this.#results = results;
+  }
 
   run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     this.calls.push(request);
     return Promise.resolve(
-      this.results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+      this.#results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
   }
 }

--- a/packages/memory/test/v2-client-reconnect-auth.test.ts
+++ b/packages/memory/test/v2-client-reconnect-auth.test.ts
@@ -47,12 +47,19 @@ class ScriptedOpenTransport implements Transport {
   #receiver: (payload: string) => void = () => {};
   #openCount = 0;
 
+  readonly #openResponse: (
+    count: number,
+    requestId: string,
+  ) => FabricValue;
+
   constructor(
-    private readonly openResponse: (
+    openResponse: (
       count: number,
       requestId: string,
     ) => FabricValue,
-  ) {}
+  ) {
+    this.#openResponse = openResponse;
+  }
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -71,7 +78,7 @@ class ScriptedOpenTransport implements Transport {
         return Promise.resolve();
       case "session.open":
         this.#openCount += 1;
-        this.#respond(this.openResponse(this.#openCount, message.requestId!));
+        this.#respond(this.#openResponse(this.#openCount, message.requestId!));
         return Promise.resolve();
       default:
         throw new Error(`Unhandled scripted message: ${message.type}`);

--- a/packages/memory/test/v2-client.test.ts
+++ b/packages/memory/test/v2-client.test.ts
@@ -1630,11 +1630,15 @@ class ReconnectableLoopbackTransport implements Transport {
   watchSetCount = 0;
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
-  #connection: ReturnType<Server["connect"]> | null = null;
+  #connectionCache: ReturnType<Server["connect"]> | null = null;
   #reconnected = defer<void>();
   #secondWatchSet = defer<void>();
 
-  constructor(private readonly server: Server) {}
+  readonly #server: Server;
+
+  constructor(server: Server) {
+    this.#server = server;
+  }
 
   /** Resolves when a second connection is opened (reconnect). */
   get reconnected(): Promise<void> {
@@ -1648,7 +1652,7 @@ class ReconnectableLoopbackTransport implements Transport {
 
   async send(payload: string): Promise<void> {
     const message = decodeMemoryBoundary(payload) as { type?: string };
-    await this.connection().receive(payload);
+    await this.#connection().receive(payload);
     if (message.type === "session.watch.set") {
       this.watchSetCount++;
       if (this.watchSetCount >= 2) {
@@ -1671,22 +1675,22 @@ class ReconnectableLoopbackTransport implements Transport {
   }
 
   disconnect(): void {
-    this.#connection?.close();
-    this.#connection = null;
+    this.#connectionCache?.close();
+    this.#connectionCache = null;
     this.#closeReceiver(new Error("disconnect"));
   }
 
-  private connection(): ReturnType<Server["connect"]> {
-    if (this.#connection === null) {
+  #connection(): ReturnType<Server["connect"]> {
+    if (this.#connectionCache === null) {
       this.connectionCount++;
       if (this.connectionCount >= 2) {
         this.#reconnected.resolve();
       }
-      this.#connection = this.server.connect((message) => {
+      this.#connectionCache = this.#server.connect((message) => {
         this.#receiver(encodeMemoryBoundary(message));
       });
     }
-    return this.#connection;
+    return this.#connectionCache;
   }
 }
 
@@ -1698,7 +1702,11 @@ class ScriptedReconnectTransport implements Transport {
   #connected = false;
   #dropped = new Set<number>();
 
-  constructor(private readonly dropOnFirstLocalSeqs: number[] = []) {}
+  readonly #dropOnFirstLocalSeqs: number[];
+
+  constructor(dropOnFirstLocalSeqs: number[] = []) {
+    this.#dropOnFirstLocalSeqs = dropOnFirstLocalSeqs;
+  }
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -1748,7 +1756,7 @@ class ScriptedReconnectTransport implements Transport {
         const localSeq = message.commit?.localSeq ?? -1;
         this.transactLocalSeqs.push(localSeq);
         if (
-          this.dropOnFirstLocalSeqs.includes(localSeq) &&
+          this.#dropOnFirstLocalSeqs.includes(localSeq) &&
           !this.#dropped.has(localSeq)
         ) {
           this.#dropped.add(localSeq);

--- a/packages/memory/test/v2-operation-client.test.ts
+++ b/packages/memory/test/v2-operation-client.test.ts
@@ -31,13 +31,17 @@ class ReconnectableOperationTransport implements Transport {
   lastOperationAfter: { epoch: number; version: number } | undefined;
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
-  #connection: ReturnType<Server["connect"]> | null = null;
+  #connectionCache: ReturnType<Server["connect"]> | null = null;
   #reconnected = defer<void>();
   #secondWatchSet = defer<void>();
   #reconnectGate: ReturnType<typeof defer<void>> | undefined;
   #failNextEffect = false;
 
-  constructor(private readonly server: Server) {}
+  readonly #server: Server;
+
+  constructor(server: Server) {
+    this.#server = server;
+  }
 
   get reconnected(): Promise<void> {
     return this.#reconnected.promise;
@@ -56,13 +60,13 @@ class ReconnectableOperationTransport implements Transport {
       }>;
     };
     if (
-      this.#connection === null && this.connectionCount > 0 &&
+      this.#connectionCache === null && this.connectionCount > 0 &&
       this.#reconnectGate !== undefined
     ) {
       await this.#reconnectGate.promise;
       this.#reconnectGate = undefined;
     }
-    await this.connection().receive(payload);
+    await this.#connection().receive(payload);
     if (message.type === "session.watch.set") {
       this.watchSetCount++;
       this.lastOperationAfter = message.watches?.find((watch) =>
@@ -86,8 +90,8 @@ class ReconnectableOperationTransport implements Transport {
   }
 
   disconnect(): void {
-    this.#connection?.close();
-    this.#connection = null;
+    this.#connectionCache?.close();
+    this.#connectionCache = null;
     this.#closeReceiver(new Error("disconnect"));
   }
 
@@ -103,11 +107,11 @@ class ReconnectableOperationTransport implements Transport {
     this.#failNextEffect = true;
   }
 
-  private connection(): ReturnType<Server["connect"]> {
-    if (this.#connection === null) {
+  #connection(): ReturnType<Server["connect"]> {
+    if (this.#connectionCache === null) {
       this.connectionCount++;
       if (this.connectionCount >= 2) this.#reconnected.resolve();
-      this.#connection = this.server.connect((message) => {
+      this.#connectionCache = this.#server.connect((message) => {
         if (this.#failNextEffect && message.type === "session/effect") {
           this.#failNextEffect = false;
           throw new Error("synthetic operation effect failure");
@@ -115,7 +119,7 @@ class ReconnectableOperationTransport implements Transport {
         this.#receiver(encodeMemoryBoundary(message));
       });
     }
-    return this.#connection;
+    return this.#connectionCache;
   }
 }
 

--- a/packages/memory/test/v2-restore-flush.test.ts
+++ b/packages/memory/test/v2-restore-flush.test.ts
@@ -19,7 +19,7 @@ class ReconnectableTransport implements Transport {
   connectionCount = 0;
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
-  #connection: ReturnType<Server["connect"]> | null = null;
+  #connectionCache: ReturnType<Server["connect"]> | null = null;
   #delayTransacts = false;
   #transactRequestLocalSeqById = new Map<string, number>();
   #delayedTransactResponses: Array<{
@@ -29,7 +29,11 @@ class ReconnectableTransport implements Transport {
   #deliveredTransactLocalSeqs: number[] = [];
   #firstPendingTransact = defer<void>();
 
-  constructor(private readonly server: Server) {}
+  readonly #server: Server;
+
+  constructor(server: Server) {
+    this.#server = server;
+  }
 
   async send(payload: string): Promise<void> {
     const message = decodeMemoryBoundary(payload) as {
@@ -64,8 +68,8 @@ class ReconnectableTransport implements Transport {
   }
 
   disconnect(): void {
-    this.#connection?.close();
-    this.#connection = null;
+    this.#connectionCache?.close();
+    this.#connectionCache = null;
     queueMicrotask(() => this.#closeReceiver(new Error("disconnect")));
   }
 
@@ -104,13 +108,13 @@ class ReconnectableTransport implements Transport {
     if (typeof message.commit?.localSeq === "number") {
       this.#deliveredTransactLocalSeqs.push(message.commit.localSeq);
     }
-    await this.connection().receive(payload);
+    await this.#connection().receive(payload);
   }
 
-  private connection(): ReturnType<Server["connect"]> {
-    if (this.#connection === null) {
+  #connection(): ReturnType<Server["connect"]> {
+    if (this.#connectionCache === null) {
       this.connectionCount++;
-      this.#connection = this.server.connect((message) => {
+      this.#connectionCache = this.#server.connect((message) => {
         const response = message as { requestId?: string };
         const requestId = response.requestId;
         const localSeq = typeof requestId === "string"
@@ -133,7 +137,7 @@ class ReconnectableTransport implements Transport {
         this.#receiver(payload);
       });
     }
-    return this.#connection;
+    return this.#connectionCache;
   }
 }
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -516,7 +516,7 @@ export class Client {
       return;
     }
     await this.#reconnect();
-    // reconnect() resolves without connecting when it gives up on a permanent
+    // #reconnect() resolves without connecting when it gives up on a permanent
     // handshake failure; surface it here rather than returning as if connected.
     if (this.#fatalError) {
       throw this.#fatalError;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -184,11 +184,14 @@ export class Client {
   // for other spaces on this client alive.
   #fatalError: Error | null = null;
 
+  readonly #transport: Transport;
+
   private constructor(
-    private readonly transport: Transport,
+    transport: Transport,
   ) {
-    this.transport.setReceiver((payload) => this.onMessage(payload));
-    this.transport.setCloseReceiver?.((error) => this.onClose(error));
+    this.#transport = transport;
+    this.#transport.setReceiver((payload) => this.#onMessage(payload));
+    this.#transport.setCloseReceiver?.((error) => this.#onClose(error));
   }
 
   static async connect(options: ConnectOptions): Promise<Client> {
@@ -203,7 +206,7 @@ export class Client {
     options.signal?.addEventListener("abort", closeForAbort, { once: true });
     try {
       if (options.signal?.aborted) throw abortError();
-      await client.hello();
+      await client.#hello();
       if (options.signal?.aborted) throw abortError();
       return client;
     } catch (error) {
@@ -225,10 +228,10 @@ export class Client {
     this.#closed = true;
     this.#connected = false;
     this.#cancelReconnectDelay?.();
-    this.rejectPending(new Error("memory client closed"));
+    this.#rejectPending(new Error("memory client closed"));
     await Promise.all([...this.#spaces].map((space) => space.close()));
     this.#spaces.clear();
-    await this.transport.close();
+    await this.#transport.close();
     await this.#reconnecting?.catch(() => undefined);
   }
 
@@ -283,7 +286,7 @@ export class Client {
   }
 
   async request<Result>(message: FabricPlainObject): Promise<Result> {
-    await this.ensureConnected();
+    await this.#ensureConnected();
     // `ensureConnected()` is async even when the transport is already live, so
     // close() can run while this request is suspended there. Recheck before
     // registering the request; otherwise it can miss close()'s rejectPending()
@@ -301,7 +304,7 @@ export class Client {
     // observes the rejection.
     pending.promise.catch(() => {});
     this.#pending.set(requestId, pending);
-    await this.transport.send(encodeMemoryBoundary(message));
+    await this.#transport.send(encodeMemoryBoundary(message));
     const result = await pending.promise as ResponseMessage<Result>;
     if (result.error) {
       const error = new Error(result.error.message);
@@ -338,12 +341,12 @@ export class Client {
   ): Promise<SessionOpenResult> {
     const result = await this.request<SessionOpenResult>({
       type: "session.open",
-      requestId: this.nextRequestId(),
+      requestId: this.#nextRequestId(),
       space,
       session,
       ...(auth ? auth : {}),
     });
-    this.updateSessionOpenAuthContext(result.sessionOpen);
+    this.#updateSessionOpenAuthContext(result.sessionOpen);
     return result;
   }
 
@@ -362,20 +365,20 @@ export class Client {
     return this.#sessionOpenAuthContext;
   }
 
-  private updateSessionOpenAuthContext(sessionOpen: unknown): void {
+  #updateSessionOpenAuthContext(sessionOpen: unknown): void {
     this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(sessionOpen);
   }
 
   async restoreConnection(): Promise<void> {
-    await this.ensureConnected();
+    await this.#ensureConnected();
   }
 
-  private async hello(): Promise<void> {
+  async #hello(): Promise<void> {
     const ack = Promise.withResolvers<void>();
     this.#helloPending = ack;
     try {
       await Promise.all([
-        this.transport.send(encodeMemoryBoundary({
+        this.#transport.send(encodeMemoryBoundary({
           type: "hello",
           protocol: MEMORY_PROTOCOL,
           flags: getMemoryProtocolFlags(),
@@ -388,7 +391,7 @@ export class Client {
     }
   }
 
-  private onMessage(payload: string): void {
+  #onMessage(payload: string): void {
     let message: unknown;
     try {
       message = decodeMemoryBoundary(payload);
@@ -407,7 +410,7 @@ export class Client {
       if (this.#helloPending !== null) {
         this.#helloPending.reject(error);
       } else {
-        this.rejectPending(error);
+        this.#rejectPending(error);
       }
       return;
     }
@@ -498,11 +501,11 @@ export class Client {
     }
   }
 
-  private nextRequestId(): string {
+  #nextRequestId(): string {
     return `req:${this.#nextRequest++}`;
   }
 
-  private async ensureConnected(): Promise<void> {
+  async #ensureConnected(): Promise<void> {
     if (this.#closed) {
       throw new Error("memory client is closed");
     }
@@ -512,7 +515,7 @@ export class Client {
     if (this.#connected) {
       return;
     }
-    await this.reconnect();
+    await this.#reconnect();
     // reconnect() resolves without connecting when it gives up on a permanent
     // handshake failure; surface it here rather than returning as if connected.
     if (this.#fatalError) {
@@ -520,7 +523,7 @@ export class Client {
     }
   }
 
-  private onClose(error?: Error): void {
+  #onClose(error?: Error): void {
     if (this.#closed) {
       return;
     }
@@ -528,11 +531,11 @@ export class Client {
     for (const session of this.#spaces) {
       session.handleDisconnect();
     }
-    this.rejectPending(toConnectionError(error));
-    void this.reconnect().catch(() => undefined);
+    this.#rejectPending(toConnectionError(error));
+    void this.#reconnect().catch(() => undefined);
   }
 
-  private async reconnect(): Promise<void> {
+  async #reconnect(): Promise<void> {
     if (this.#closed) {
       throw new Error("memory client is closed");
     }
@@ -546,7 +549,7 @@ export class Client {
       let attempt = 0;
       while (!this.#closed) {
         try {
-          await this.hello();
+          await this.#hello();
           for (const session of this.#spaces) {
             await session.restore();
           }
@@ -559,11 +562,11 @@ export class Client {
             // protocol-flag mismatch). Stop looping and remember the failure so
             // every present and future request fails fast with it.
             this.#fatalError = err;
-            this.rejectPending(err);
+            this.#rejectPending(err);
             return;
           }
-          this.rejectPending(err);
-          await this.waitForReconnectDelay(reconnectDelayMs(attempt));
+          this.#rejectPending(err);
+          await this.#waitForReconnectDelay(reconnectDelayMs(attempt));
           attempt += 1;
         }
       }
@@ -581,7 +584,7 @@ export class Client {
   // runs on a timer, since a returning server raises no event to await. The
   // delay bounds the retry rate, and `close()` ends it through the stored
   // canceller.
-  private waitForReconnectDelay(delayMs: number): Promise<void> {
+  #waitForReconnectDelay(delayMs: number): Promise<void> {
     if (this.#closed) {
       return Promise.resolve();
     }
@@ -598,7 +601,7 @@ export class Client {
     });
   }
 
-  private rejectPending(error: Error): void {
+  #rejectPending(error: Error): void {
     for (const pending of this.#pending.values()) {
       pending.reject(error);
     }
@@ -660,16 +663,25 @@ export class SpaceSession {
     pending: PromiseWithResolvers<void>;
   }[] = [];
 
+  readonly #client: Client;
+  readonly #openAuthFactory?: SessionOpenAuthFactory;
+  readonly #routeSignal?: AbortSignal;
+  readonly #actingAs?: "space-owner";
+
   constructor(
-    private readonly client: Client,
+    client: Client,
     readonly space: string,
     sessionId: string,
     sessionToken: string | undefined,
     serverSeq: number,
-    private readonly openAuthFactory?: SessionOpenAuthFactory,
-    private readonly routeSignal?: AbortSignal,
-    private readonly actingAs?: "space-owner",
+    openAuthFactory?: SessionOpenAuthFactory,
+    routeSignal?: AbortSignal,
+    actingAs?: "space-owner",
   ) {
+    this.#client = client;
+    this.#openAuthFactory = openAuthFactory;
+    this.#routeSignal = routeSignal;
+    this.#actingAs = actingAs;
     this.#sessionId = sessionId;
     this.#sessionToken = sessionToken;
     this.#serverSeq = serverSeq;
@@ -715,7 +727,7 @@ export class SpaceSession {
     if (
       commit.operations.some((operation) =>
         operation.op === "apply-op" || operation.op === "release-op-field"
-      ) && this.client.serverFlags?.applyOp !== true
+      ) && this.#client.serverFlags?.applyOp !== true
     ) {
       throw protocolError("memory server does not support apply-op");
     }
@@ -734,13 +746,13 @@ export class SpaceSession {
     const outstanding = this.#outstandingCommits.get(commit.localSeq);
     if (
       outstanding !== undefined &&
-      this.client.isConnected() &&
+      this.#client.isConnected() &&
       this.#readyOnConnection &&
       !this.#restoring
     ) {
-      this.sendOutstandingCommit(commit.localSeq, outstanding);
+      this.#sendOutstandingCommit(commit.localSeq, outstanding);
     } else {
-      void this.client.restoreConnection();
+      void this.#client.restoreConnection();
     }
 
     return await pending.promise;
@@ -748,7 +760,7 @@ export class SpaceSession {
 
   async queryGraph(query: GraphQuery): Promise<GraphQueryResult> {
     this.#assertOpen();
-    const result = await this.client.request<GraphQueryResult>({
+    const result = await this.#client.request<GraphQueryResult>({
       type: "graph.query",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -756,7 +768,7 @@ export class SpaceSession {
       query,
     });
 
-    this.noteResult(result.serverSeq);
+    this.#noteResult(result.serverSeq);
     return result;
   }
 
@@ -764,17 +776,17 @@ export class SpaceSession {
     query: Omit<OperationFieldQuery, "principal" | "sessionId">,
   ): Promise<OperationFieldQueryResult> {
     this.#assertOpen();
-    if (this.client.serverFlags?.applyOp !== true) {
+    if (this.#client.serverFlags?.applyOp !== true) {
       throw protocolError("memory server does not support apply-op");
     }
-    const result = await this.client.request<OperationFieldQueryResult>({
+    const result = await this.#client.request<OperationFieldQueryResult>({
       type: "op.query",
       requestId: crypto.randomUUID(),
       space: this.space,
       sessionId: this.#sessionId,
       query,
     });
-    this.noteResult(result.serverSeq);
+    this.#noteResult(result.serverSeq);
     return result;
   }
 
@@ -785,7 +797,7 @@ export class SpaceSession {
     action: "retry" | "dismiss",
   ): Promise<EventAttentionResolveResult> {
     this.#assertOpen();
-    const result = await this.client.request<EventAttentionResolveResult>({
+    const result = await this.#client.request<EventAttentionResolveResult>({
       type: "event.attention.resolve",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -795,7 +807,7 @@ export class SpaceSession {
       sidecarId,
       action,
     });
-    this.noteResult(result.serverSeq);
+    this.#noteResult(result.serverSeq);
     return result;
   }
 
@@ -803,14 +815,14 @@ export class SpaceSession {
     options: EntityIdListOptions = {},
   ): Promise<EntityIdListResult | undefined> {
     this.#assertOpen();
-    if (this.client.serverFlags?.entityIdListing !== true) {
+    if (this.#client.serverFlags?.entityIdListing !== true) {
       return undefined;
     }
-    const pagination = this.client.serverFlags.entityIdPagination === true;
+    const pagination = this.#client.serverFlags.entityIdPagination === true;
     if (!pagination && Object.keys(options).length > 0) {
       return undefined;
     }
-    const result = await this.client.request<EntityIdListResult>({
+    const result = await this.#client.request<EntityIdListResult>({
       type: "entity-id.list",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -820,7 +832,7 @@ export class SpaceSession {
         : {}),
     });
 
-    this.noteResult(result.serverSeq);
+    this.#noteResult(result.serverSeq);
     return result;
   }
 
@@ -828,10 +840,10 @@ export class SpaceSession {
     id: EntityId,
   ): Promise<EntityIdLookupResult | undefined> {
     this.#assertOpen();
-    if (this.client.serverFlags?.entityIdLookup !== true) {
+    if (this.#client.serverFlags?.entityIdLookup !== true) {
       return undefined;
     }
-    const result = await this.client.request<EntityIdLookupResult>({
+    const result = await this.#client.request<EntityIdLookupResult>({
       type: "entity-id.exists",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -839,7 +851,7 @@ export class SpaceSession {
       id,
     });
 
-    this.noteResult(result.serverSeq);
+    this.#noteResult(result.serverSeq);
     return result;
   }
 
@@ -855,7 +867,7 @@ export class SpaceSession {
       : !Array.isArray(params) && unsafeObjectKeyIn(params) !== undefined
       ? { namedParams: Object.entries(params) }
       : { params };
-    const result = await this.client.request<SqliteQueryWireResult>({
+    const result = await this.#client.request<SqliteQueryWireResult>({
       type: "sqlite.query",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -887,7 +899,7 @@ export class SpaceSession {
     this.#assertOpen();
     const requestId = crypto.randomUUID();
     beforeIssue?.();
-    return await this.client.request<SqliteRegisterDiskSourceResult>({
+    return await this.#client.request<SqliteRegisterDiskSourceResult>({
       type: "sqlite.register-disk-source",
       requestId,
       space: this.space,
@@ -909,9 +921,9 @@ export class SpaceSession {
 
   async watchSetSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
-    return await this.runWatchMutation(
+    return await this.#runWatchMutation(
       () =>
-        this.client.request<WatchSetResult>({
+        this.#client.request<WatchSetResult>({
           type: "session.watch.set",
           requestId: crypto.randomUUID(),
           space: this.space,
@@ -919,18 +931,18 @@ export class SpaceSession {
           watches,
         }),
       (result) => {
-        this.noteResult(result.serverSeq);
+        this.#noteResult(result.serverSeq);
         this.#watchSpecs = watches;
-        this.noteOperationWatchCursors(result.sync);
+        this.#noteOperationWatchCursors(result.sync);
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(result.sync);
         } else {
           this.#watchView.applySync(result.sync, false);
         }
-        this.scheduleAck(result.serverSeq);
+        this.#scheduleAck(result.serverSeq);
         return {
           view: this.#watchView,
-          precedingSyncs: this.takePrecedingWatchSyncs(),
+          precedingSyncs: this.#takePrecedingWatchSyncs(),
           sync: result.sync,
         };
       },
@@ -949,9 +961,9 @@ export class SpaceSession {
 
   async watchAddSync(watches: WatchSpec[]): Promise<WatchMutationResult> {
     this.#assertOpen();
-    return await this.runWatchMutation(
+    return await this.#runWatchMutation(
       () =>
-        this.client.request<WatchAddResult>({
+        this.#client.request<WatchAddResult>({
           type: "session.watch.add",
           requestId: crypto.randomUUID(),
           space: this.space,
@@ -959,22 +971,22 @@ export class SpaceSession {
           watches,
         }),
       (result) => {
-        this.noteResult(result.serverSeq);
+        this.#noteResult(result.serverSeq);
         this.#watchSpecs = [
           ...new Map(
             [...this.#watchSpecs, ...watches].map((watch) => [watch.id, watch]),
           ).values(),
         ];
-        this.noteOperationWatchCursors(result.sync);
+        this.#noteOperationWatchCursors(result.sync);
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(result.sync);
         } else {
           this.#watchView.applySync(result.sync, false);
         }
-        this.scheduleAck(result.serverSeq);
+        this.#scheduleAck(result.serverSeq);
         return {
           view: this.#watchView,
-          precedingSyncs: this.takePrecedingWatchSyncs(),
+          precedingSyncs: this.#takePrecedingWatchSyncs(),
           sync: result.sync,
         };
       },
@@ -986,7 +998,7 @@ export class SpaceSession {
     watchIds: readonly string[],
   ): Promise<WatchMutationResult> {
     const removed = new Set(watchIds);
-    return await this.runWatchMutation(
+    return await this.#runWatchMutation(
       () => {
         const watches = this.#watchSpecs.filter((watch) =>
           !removed.has(watch.id)
@@ -994,7 +1006,7 @@ export class SpaceSession {
         // Cancellation is local intent even when the request fails: a later
         // reconnect must not restore a watch its last subscriber removed.
         this.#watchSpecs = watches;
-        return this.client.request<WatchSetResult>({
+        return this.#client.request<WatchSetResult>({
           type: "session.watch.set",
           requestId: crypto.randomUUID(),
           space: this.space,
@@ -1003,17 +1015,17 @@ export class SpaceSession {
         });
       },
       (result) => {
-        this.noteResult(result.serverSeq);
-        this.noteOperationWatchCursors(result.sync);
+        this.#noteResult(result.serverSeq);
+        this.#noteOperationWatchCursors(result.sync);
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(result.sync);
         } else {
           this.#watchView.applySync(result.sync, false);
         }
-        this.scheduleAck(result.serverSeq);
+        this.#scheduleAck(result.serverSeq);
         return {
           view: this.#watchView,
-          precedingSyncs: this.takePrecedingWatchSyncs(),
+          precedingSyncs: this.#takePrecedingWatchSyncs(),
           sync: result.sync,
         };
       },
@@ -1024,11 +1036,11 @@ export class SpaceSession {
     if (this.#closed) {
       return;
     }
-    if (!this.client.isConnected() || seenSeq <= this.#ackedSeq) {
+    if (!this.#client.isConnected() || seenSeq <= this.#ackedSeq) {
       this.#ackedSeq = Math.max(this.#ackedSeq, seenSeq);
       return;
     }
-    await this.client.request({
+    await this.#client.request({
       type: "session.ack",
       requestId: crypto.randomUUID(),
       space: this.space,
@@ -1042,8 +1054,8 @@ export class SpaceSession {
     if (this.#closed) {
       return;
     }
-    this.noteResult(effect.toSeq);
-    this.noteOperationWatchCursors(effect);
+    this.#noteResult(effect.toSeq);
+    this.#noteOperationWatchCursors(effect);
     if (this.#watchView === null) {
       this.#watchView = WatchView.fromSync(effect);
       this.#precedingWatchSyncs.push(effect);
@@ -1053,8 +1065,8 @@ export class SpaceSession {
     } else {
       this.#watchView.applySync(effect, true);
     }
-    this.scheduleAck(effect.toSeq);
-    this.noteCaughtUpLocalSeq(effect.caughtUpLocalSeq);
+    this.#scheduleAck(effect.toSeq);
+    this.#noteCaughtUpLocalSeq(effect.caughtUpLocalSeq);
   }
 
   async restore(): Promise<void> {
@@ -1067,7 +1079,7 @@ export class SpaceSession {
     try {
       let restored: SessionOpenResult;
       try {
-        restored = await this.reopen();
+        restored = await this.#reopen();
       } catch (error) {
         if (isSessionRevokedError(error)) {
           this.handleRevoked("taken-over");
@@ -1086,13 +1098,13 @@ export class SpaceSession {
       const replayTasks = [...this.#outstandingCommits.entries()].map((
         [localSeq, pendingCommit],
       ) =>
-        this.sendOutstandingCommit(localSeq, pendingCommit, {
+        this.#sendOutstandingCommit(localSeq, pendingCommit, {
           throwOnConnectionError: true,
         })
       );
       if (restored.sync) {
-        this.noteCaughtUpLocalSeq(restored.sync.caughtUpLocalSeq);
-        this.noteOperationWatchCursors(restored.sync);
+        this.#noteCaughtUpLocalSeq(restored.sync.caughtUpLocalSeq);
+        this.#noteOperationWatchCursors(restored.sync);
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(restored.sync);
         } else {
@@ -1110,15 +1122,15 @@ export class SpaceSession {
             );
           }
         }
-        this.scheduleAck(restored.serverSeq);
+        this.#scheduleAck(restored.serverSeq);
       } else if (restored.resumed === true && this.#watchSpecs.length > 0) {
-        this.scheduleAck(restored.serverSeq);
+        this.#scheduleAck(restored.serverSeq);
       }
-      this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
+      this.#noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
       // Forward a top-level-only caught-up marker (resume with no sync) to
       // WatchView subscribers; the guard above suppresses a duplicate when a
       // real sync already carried it.
-      this.forwardCaughtUpLocalSeqToWatchers(restored.caughtUpLocalSeq);
+      this.#forwardCaughtUpLocalSeqToWatchers(restored.caughtUpLocalSeq);
       if (restored.resumed !== true && this.#watchSpecs.length > 0) {
         const { view, sync } = await this.watchSetSync(this.#watchSpecs);
         if (!isEmptySync(sync)) {
@@ -1135,14 +1147,14 @@ export class SpaceSession {
       // reconnect loop, which would then fail sessions for other spaces on the
       // same client. Every other error propagates so the loop retries it.
       if (isPermanentAuthorizationError(error)) {
-        this.terminateSession(error as Error);
+        this.#terminateSession(error as Error);
         return;
       }
       throw error;
     } finally {
       this.#restoring = false;
       if (!this.#closed && this.#outstandingCommits.size > 0) {
-        this.replayOutstandingCommits(replayedThroughLocalSeq);
+        this.#replayOutstandingCommits(replayedThroughLocalSeq);
       }
     }
   }
@@ -1154,8 +1166,8 @@ export class SpaceSession {
     this.#closed = true;
     this.#closeError = new Error("memory session closed");
     this.#readyOnConnection = false;
-    this.client.forgetSession(this);
-    this.rejectCaughtUpLocalSeqWaiters(this.#closeError);
+    this.#client.forgetSession(this);
+    this.#rejectCaughtUpLocalSeqWaiters(this.#closeError);
     const background = [...this.#background];
     this.#background.clear();
     await Promise.allSettled(background);
@@ -1174,7 +1186,7 @@ export class SpaceSession {
     }
     const error = new Error(`memory session revoked: ${reason}`);
     error.name = "SessionRevokedError";
-    this.terminateSession(error);
+    this.#terminateSession(error);
   }
 
   /**
@@ -1184,15 +1196,15 @@ export class SpaceSession {
    * storage subscriber observes the real cause on its next watch or transact.
    * Shared by session revocation and a permanent reopen authorization denial.
    */
-  private terminateSession(error: Error): void {
+  #terminateSession(error: Error): void {
     this.#closed = true;
     this.#closeError = error;
     this.#readyOnConnection = false;
-    this.client.forgetSession(this);
+    this.#client.forgetSession(this);
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(error);
     }
-    this.rejectCaughtUpLocalSeqWaiters(error);
+    this.#rejectCaughtUpLocalSeqWaiters(error);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -1206,14 +1218,14 @@ export class SpaceSession {
     this.#readyOnConnection = false;
   }
 
-  private queueBackground(task: Promise<void>): void {
+  #queueBackground(task: Promise<void>): void {
     const tracked = task
       .catch(() => undefined)
       .finally(() => this.#background.delete(tracked));
     this.#background.add(tracked);
   }
 
-  private scheduleAck(seenSeq: number): void {
+  #scheduleAck(seenSeq: number): void {
     if (this.#closed) {
       return;
     }
@@ -1222,37 +1234,37 @@ export class SpaceSession {
       return;
     }
     this.#ackScheduled = true;
-    this.queueBackground(
+    this.#queueBackground(
       (async () => {
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
         this.#ackScheduled = false;
         this.#ackFlushing = true;
         try {
-          await this.flushScheduledAcks();
+          await this.#flushScheduledAcks();
         } finally {
           this.#ackFlushing = false;
           if (
             this.#pendingAckSeq > this.#ackedSeq &&
             !this.#closed &&
-            this.client.isConnected()
+            this.#client.isConnected()
           ) {
-            this.scheduleAck(this.#pendingAckSeq);
+            this.#scheduleAck(this.#pendingAckSeq);
           }
         }
       })(),
     );
   }
 
-  private async flushScheduledAcks(): Promise<void> {
+  async #flushScheduledAcks(): Promise<void> {
     while (true) {
       const target = this.#pendingAckSeq;
       if (
-        this.#closed || target <= this.#ackedSeq || !this.client.isConnected()
+        this.#closed || target <= this.#ackedSeq || !this.#client.isConnected()
       ) {
         this.#ackedSeq = Math.max(this.#ackedSeq, target);
         return;
       }
-      await this.client.request({
+      await this.#client.request({
         type: "session.ack",
         requestId: crypto.randomUUID(),
         space: this.space,
@@ -1276,13 +1288,13 @@ export class SpaceSession {
     this.#concurrentWatchRefresh = enabled;
   }
 
-  private takePrecedingWatchSyncs(): SessionSync[] {
+  #takePrecedingWatchSyncs(): SessionSync[] {
     const syncs = this.#precedingWatchSyncs;
     this.#precedingWatchSyncs = [];
     // Effects can arrive between request issue and response application. They
     // were observed against the old watch spec, so replay their operation
     // cursors after the mutation has installed the new spec as well.
-    for (const sync of syncs) this.noteOperationWatchCursors(sync);
+    for (const sync of syncs) this.#noteOperationWatchCursors(sync);
     return syncs;
   }
 
@@ -1292,7 +1304,7 @@ export class SpaceSession {
    * from the response. Splitting them lets concurrent mode overlap the request
    * round trips while keeping application ordered.
    */
-  private async runWatchMutation<R, T>(
+  async #runWatchMutation<R, T>(
     send: () => Promise<R>,
     apply: (result: R) => T,
   ): Promise<T> {
@@ -1340,11 +1352,11 @@ export class SpaceSession {
     return await current;
   }
 
-  private noteResult(serverSeq: number): void {
+  #noteResult(serverSeq: number): void {
     this.#serverSeq = Math.max(this.#serverSeq, serverSeq);
   }
 
-  private noteOperationWatchCursors(sync: SessionSync): void {
+  #noteOperationWatchCursors(sync: SessionSync): void {
     if ((sync.operationFields?.length ?? 0) === 0) return;
     const delivered = new Map(
       sync.operationFields!.map((delivery) =>
@@ -1369,7 +1381,7 @@ export class SpaceSession {
     });
   }
 
-  private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
+  #noteCaughtUpLocalSeq(localSeq: number | undefined): void {
     if (localSeq === undefined) {
       return;
     }
@@ -1394,7 +1406,7 @@ export class SpaceSession {
   // than via a sync they already observed. Emits an empty caught-up sync so
   // downstream waiters (notably runner storage's read-repair gate) resolve
   // instead of stranding after a reconnect.
-  private forwardCaughtUpLocalSeqToWatchers(
+  #forwardCaughtUpLocalSeqToWatchers(
     localSeq: number | undefined,
   ): void {
     if (
@@ -1415,7 +1427,7 @@ export class SpaceSession {
     });
   }
 
-  private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
+  #waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
     if (this.#closed) {
       return Promise.reject(
         this.#closeError ?? new Error("memory session closed"),
@@ -1429,7 +1441,7 @@ export class SpaceSession {
     return pending.promise;
   }
 
-  private rejectCaughtUpLocalSeqWaiters(error: Error | null): void {
+  #rejectCaughtUpLocalSeqWaiters(error: Error | null): void {
     const waiters = this.#caughtUpLocalSeqWaiters;
     this.#caughtUpLocalSeqWaiters = [];
     for (const waiter of waiters) {
@@ -1437,7 +1449,7 @@ export class SpaceSession {
     }
   }
 
-  private async reopen(): Promise<SessionOpenResult> {
+  async #reopen(): Promise<SessionOpenResult> {
     const oldSessionId = this.#sessionId;
     const session = {
       sessionId: this.#sessionId,
@@ -1445,28 +1457,28 @@ export class SpaceSession {
       sessionToken: this.#sessionToken,
       // The delegated READ binding survives a route replacement (OW31):
       // a reopen without it would silently drop to envelope-only READ.
-      ...(this.actingAs !== undefined ? { actingAs: this.actingAs } : {}),
+      ...(this.#actingAs !== undefined ? { actingAs: this.#actingAs } : {}),
     };
     const auth = await runWithAbortSignal(
-      this.routeSignal,
+      this.#routeSignal,
       "memory session route cancelled",
       () =>
-        this.openAuthFactory?.(
+        this.#openAuthFactory?.(
           this.space,
           session,
-          this.client.sessionOpenAuthContext(),
+          this.#client.sessionOpenAuthContext(),
         ),
     );
     const restored = await runWithAbortSignal(
-      this.routeSignal,
+      this.#routeSignal,
       "memory session route cancelled",
-      () => this.client.openSession(this.space, session, auth),
+      () => this.#client.openSession(this.space, session, auth),
     );
     const sessionChanged = restored.sessionId !== oldSessionId;
     const sessionReplaced = sessionChanged || restored.resumed !== true;
     this.#sessionId = restored.sessionId;
     this.#sessionToken = restored.sessionToken ?? this.#sessionToken;
-    this.noteResult(restored.serverSeq);
+    this.#noteResult(restored.serverSeq);
 
     if (sessionReplaced) {
       const sessionChangedError = new Error(
@@ -1486,7 +1498,7 @@ export class SpaceSession {
       // epoch. A replacement establishes its own watch state and must not
       // apply that effect as though the new session delivered it.
       this.#precedingWatchSyncs = [];
-      this.rejectCaughtUpLocalSeqWaiters(sessionChangedError);
+      this.#rejectCaughtUpLocalSeqWaiters(sessionChangedError);
       // The marker epoch died with the old session: obligations it staged
       // are gone, and the fresh session's markers know nothing of the old
       // localSeqs. Consumers holding marker-keyed state (the runner's
@@ -1494,16 +1506,16 @@ export class SpaceSession {
       // than wait for markers that can never arrive.
       this.onSessionReplaced?.();
     }
-    this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
+    this.#noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
 
     return restored;
   }
 
-  private replayOutstandingCommits(minLocalSeqExclusive = 0): void {
+  #replayOutstandingCommits(minLocalSeqExclusive = 0): void {
     if (
       this.#outstandingCommits.size === 0 ||
       !this.#readyOnConnection ||
-      !this.client.isConnected()
+      !this.#client.isConnected()
     ) {
       return;
     }
@@ -1513,11 +1525,11 @@ export class SpaceSession {
       if (localSeq <= minLocalSeqExclusive) {
         continue;
       }
-      this.sendOutstandingCommit(localSeq, pendingCommit);
+      this.#sendOutstandingCommit(localSeq, pendingCommit);
     }
   }
 
-  private sendOutstandingCommit(
+  #sendOutstandingCommit(
     localSeq: number,
     pendingCommit: {
       commit: ClientCommit;
@@ -1531,20 +1543,20 @@ export class SpaceSession {
       if (
         this.#closed ||
         !this.#readyOnConnection ||
-        !this.client.isConnected()
+        !this.#client.isConnected()
       ) {
         return;
       }
 
       try {
-        const applied = await this.client.request<AppliedCommit>({
+        const applied = await this.#client.request<AppliedCommit>({
           type: "transact",
           requestId: crypto.randomUUID(),
           space: this.space,
           sessionId: this.#sessionId,
           commit: pendingCommit.commit,
         });
-        this.noteResult(applied.seq);
+        this.#noteResult(applied.seq);
         if (this.#outstandingCommits.get(localSeq) === pendingCommit) {
           this.#outstandingCommits.delete(localSeq);
         }
@@ -1563,14 +1575,14 @@ export class SpaceSession {
           this.#outstandingCommits.delete(localSeq);
         }
         if (isRetryableConflict(error)) {
-          error.readyToRetry = () => this.waitForCaughtUpLocalSeq(localSeq);
+          error.readyToRetry = () => this.#waitForCaughtUpLocalSeq(localSeq);
         }
         pendingCommit.pending.reject(
           error instanceof Error ? error : new Error(String(error)),
         );
       }
     })();
-    this.queueBackground(task);
+    this.#queueBackground(task);
     return task;
   }
 }
@@ -1593,7 +1605,7 @@ export class WatchView {
   #syncQueue: SessionSync[] = [];
   #syncPending = new Set<PromiseWithResolvers<IteratorResult<SessionSync>>>();
   #entities = new Map<string, EntitySnapshot>();
-  #orderedEntities: EntitySnapshot[] | null = null;
+  #orderedEntitiesCache: EntitySnapshot[] | null = null;
   #closed = false;
   #serverSeq = 0;
 
@@ -1604,7 +1616,7 @@ export class WatchView {
   }
 
   get entities(): EntitySnapshot[] {
-    return [...this.orderedEntities()];
+    return [...this.#orderedEntities()];
   }
 
   get serverSeq(): number {
@@ -1710,7 +1722,7 @@ export class WatchView {
     }
 
     if (changedEntities) {
-      this.#orderedEntities = null;
+      this.#orderedEntitiesCache = null;
     }
 
     this.#serverSeq = Math.max(this.#serverSeq, sync.toSeq);
@@ -1731,7 +1743,7 @@ export class WatchView {
   snapshot(): GraphQueryResult {
     return {
       serverSeq: this.#serverSeq,
-      entities: [...this.orderedEntities()],
+      entities: [...this.#orderedEntities()],
     };
   }
 
@@ -1805,12 +1817,12 @@ export class WatchView {
     this.#syncQueue = [];
   }
 
-  private orderedEntities(): EntitySnapshot[] {
-    if (this.#orderedEntities === null) {
-      this.#orderedEntities = [...this.#entities.values()]
+  #orderedEntities(): EntitySnapshot[] {
+    if (this.#orderedEntitiesCache === null) {
+      this.#orderedEntitiesCache = [...this.#entities.values()]
         .sort(compareEntitySnapshot);
     }
-    return this.#orderedEntities;
+    return this.#orderedEntitiesCache;
   }
 }
 

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -115,13 +115,21 @@ export class EngineObjectManager implements ObjectStorageManager {
   #missing = new Set<string>();
   #readCount = 0;
 
+  readonly #engine: Engine.Engine;
+  readonly #branch: string;
+  readonly #readSeq?: number;
+
   constructor(
-    private readonly engine: Engine.Engine,
-    private readonly branch: string,
+    engine: Engine.Engine,
+    branch: string,
     readonly principal?: string,
     readonly sessionId?: string,
-    private readonly readSeq?: number,
-  ) {}
+    readSeq?: number,
+  ) {
+    this.#engine = engine;
+    this.#branch = branch;
+    this.#readSeq = readSeq;
+  }
 
   /** The scope INSTANCE an address resolves to for this manager: the
    * explicit key where the caller named one (protocol.md §2's read row),
@@ -142,14 +150,14 @@ export class EngineObjectManager implements ObjectStorageManager {
     scope: CellScope = DEFAULT_SCOPE,
     scopeKey?: ScopeKey,
   ): Engine.EntityState | null {
-    return Engine.readState(this.engine, {
+    return Engine.readState(this.#engine, {
       id,
       scope,
       ...(scopeKey === undefined ? {} : { scopeKey }),
       principal: this.principal,
       sessionId: this.sessionId,
-      branch: this.branch,
-      ...(this.readSeq === undefined ? {} : { seq: this.readSeq }),
+      branch: this.#branch,
+      ...(this.#readSeq === undefined ? {} : { seq: this.#readSeq }),
     });
   }
 
@@ -158,7 +166,7 @@ export class EngineObjectManager implements ObjectStorageManager {
    * for seq 0 / an unknown seq. Memoized per engine; see
    * {@link Engine.commitClassOfSeq}. */
   coverClassOf(seq: number): CommitClass | undefined {
-    return Engine.commitClassOfSeq(this.engine, seq);
+    return Engine.commitClassOfSeq(this.#engine, seq);
   }
 
   load(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -621,14 +621,20 @@ class Connection {
   #pendingReceives = 0;
   #receiveIdle: PromiseWithResolvers<void> | null = null;
 
+  readonly #server: Server;
+  readonly #sendRaw: Send;
+
   constructor(
     readonly id: string,
-    private readonly server: Server,
-    private readonly sendRaw: Send,
-  ) {}
+    server: Server,
+    sendRaw: Send,
+  ) {
+    this.#server = server;
+    this.#sendRaw = sendRaw;
+  }
 
-  private send(message: ServerMessage): void {
-    this.sendRaw(
+  #send(message: ServerMessage): void {
+    this.#sendRaw(
       this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
     );
   }
@@ -637,26 +643,26 @@ class Connection {
     return this.#sessions.has(sessionKey(space, sessionId));
   }
 
-  private shouldSuppressSessionSend(
+  #shouldSuppressSessionSend(
     space: string,
     sessionId: string,
   ): boolean {
-    return this.server.isAclActive() &&
+    return this.#server.isAclActive() &&
       (!this.hasSession(space, sessionId) ||
-        !this.server.isSessionAttached(space, sessionId, this.id));
+        !this.#server.isSessionAttached(space, sessionId, this.id));
   }
 
-  private sendSessionResponse(
+  #sendSessionResponse(
     space: string,
     sessionId: string,
     requestId: string,
     response: ServerMessage,
   ): void {
-    if (this.shouldSuppressSessionSend(space, sessionId)) {
+    if (this.#shouldSuppressSessionSend(space, sessionId)) {
       // session/revoked is a lifecycle notification; it does not settle the
       // generic request promise. Always pair suppression of an in-flight RPC
       // result with a typed response error carrying the original request id.
-      this.send({
+      this.#send({
         type: "response",
         requestId,
         error: toError(
@@ -666,7 +672,7 @@ class Connection {
       });
       return;
     }
-    this.send(response);
+    this.#send(response);
   }
 
   addSession(space: string, sessionId: string): void {
@@ -686,7 +692,7 @@ class Connection {
     if (!this.#sessions.delete(key) || this.#closed) {
       return;
     }
-    this.send({
+    this.#send({
       type: "session/revoked",
       space,
       sessionId,
@@ -695,7 +701,7 @@ class Connection {
   }
 
   issueSessionOpenAuth(): SessionOpenAuthMetadata {
-    const sessionOpen = this.server.sessionOpenHandshake();
+    const sessionOpen = this.#server.sessionOpenHandshake();
     this.#sessionOpenChallenge = {
       ...sessionOpen.challenge,
       consumed: false,
@@ -704,7 +710,7 @@ class Connection {
   }
 
   sessionOpenAuthContext(message: SessionOpenRequest): SessionOpenAuthContext {
-    const audience = this.server.sessionOpenAudience();
+    const audience = this.#server.sessionOpenAudience();
     const invocation = isObjectNotArray(message.invocation)
       ? message.invocation
       : null;
@@ -726,7 +732,7 @@ class Connection {
         retriable: true,
       });
     }
-    if (challenge.expiresAt <= this.server.nowSeconds()) {
+    if (challenge.expiresAt <= this.#server.nowSeconds()) {
       throw authorizationError("memory session.open challenge expired", {
         retriable: true,
       });
@@ -774,7 +780,7 @@ class Connection {
         const startedAt = performance.now();
         timing.time(arrivedAt, startedAt, "memory", "frame", "queue");
         try {
-          await this.receiveOrdered(payload);
+          await this.#receiveOrdered(payload);
         } finally {
           timing.time(startedAt, "memory", "frame", "handle");
         }
@@ -819,7 +825,7 @@ class Connection {
     return true;
   }
 
-  private requireSession(
+  #requireSession(
     requestId: string,
     space: string,
     sessionId: string,
@@ -827,7 +833,7 @@ class Connection {
     if (this.hasSession(space, sessionId)) {
       return true;
     }
-    this.send({
+    this.#send({
       type: "response",
       requestId,
       error: toError(
@@ -838,14 +844,14 @@ class Connection {
     return false;
   }
 
-  private async receiveOrdered(payload: string): Promise<void> {
+  async #receiveOrdered(payload: string): Promise<void> {
     if (this.#closed) {
       return;
     }
 
     const parsed = parseClientMessage(payload);
     if (parsed === null) {
-      this.send({
+      this.#send({
         type: "response",
         requestId: "invalid",
         error: toError(
@@ -858,7 +864,7 @@ class Connection {
 
     if (!this.#ready) {
       if (parsed.type !== "hello") {
-        this.send({
+        this.#send({
           type: "response",
           requestId: "handshake",
           error: toError("ProtocolError", "memory hello is required first"),
@@ -867,12 +873,12 @@ class Connection {
       }
       const response = respondToHello(
         parsed,
-        this.server.memoryProtocolFlags(),
+        this.#server.memoryProtocolFlags(),
       );
       if (response.type === "hello.ok") {
         response.sessionOpen = this.issueSessionOpenAuth();
       }
-      this.send(response);
+      this.#send(response);
       if (response.type !== "hello.ok") {
         return;
       }
@@ -886,23 +892,23 @@ class Connection {
 
     switch (parsed.type) {
       case "hello":
-        this.send({
+        this.#send({
           type: "response",
           requestId: "handshake",
           error: toError("ProtocolError", "hello may only be sent once"),
         });
         return;
       case "session.open": {
-        const response = await this.server.openSession(parsed, this);
+        const response = await this.#server.openSession(parsed, this);
         if (response.ok?.sessionId) {
           this.addSession(parsed.space, response.ok.sessionId);
         }
-        this.send(response);
+        this.#send(response);
         return;
       }
       case "transact": {
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -912,12 +918,12 @@ class Connection {
         }
         // Publishing inside the per-space transaction lock makes the verdict
         // visible before any fan-out for the same space can acquire that lock.
-        await this.server.transact(parsed, (verdict) => {
-          this.send(verdict);
+        await this.#server.transact(parsed, (verdict) => {
+          this.#send(verdict);
         });
         // A self-deauthorizing ACL commit defers the writer's terminal
         // session/revoked until after its verdict; deliver it now.
-        this.server.deliverDeferredSelfRevocation(
+        this.#server.deliverDeferredSelfRevocation(
           parsed.space,
           parsed.sessionId,
         );
@@ -925,7 +931,7 @@ class Connection {
       }
       case "graph.query":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -934,8 +940,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.graphQuery(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.graphQuery(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -945,7 +951,7 @@ class Connection {
         return;
       case "op.query":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -954,8 +960,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.operationFieldQuery(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.operationFieldQuery(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -965,7 +971,7 @@ class Connection {
         return;
       case "entity-id.list":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -974,8 +980,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.listEntityIds(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.listEntityIds(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -985,7 +991,7 @@ class Connection {
         return;
       case "entity-id.exists":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -994,8 +1000,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.entityIdExists(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.entityIdExists(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1005,13 +1011,17 @@ class Connection {
         return;
       case "sqlite.query":
         if (
-          !this.requireSession(parsed.requestId, parsed.space, parsed.sessionId)
+          !this.#requireSession(
+            parsed.requestId,
+            parsed.space,
+            parsed.sessionId,
+          )
         ) {
           return;
         }
         {
-          const response = await this.server.sqliteQuery(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.sqliteQuery(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1021,13 +1031,17 @@ class Connection {
         return;
       case "sqlite.register-disk-source":
         if (
-          !this.requireSession(parsed.requestId, parsed.space, parsed.sessionId)
+          !this.#requireSession(
+            parsed.requestId,
+            parsed.space,
+            parsed.sessionId,
+          )
         ) {
           return;
         }
         {
-          const response = await this.server.sqliteRegisterDiskSource(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.sqliteRegisterDiskSource(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1037,7 +1051,7 @@ class Connection {
         return;
       case "session.watch.set":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -1046,8 +1060,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.watchSet(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.watchSet(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1057,7 +1071,7 @@ class Connection {
         return;
       case "session.watch.add":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -1066,8 +1080,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.watchAdd(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.watchAdd(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1077,7 +1091,7 @@ class Connection {
         return;
       case "session.ack":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -1086,8 +1100,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.ackSession(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.ackSession(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1097,7 +1111,7 @@ class Connection {
         return;
       case "event.attention.resolve":
         if (
-          !this.requireSession(
+          !this.#requireSession(
             parsed.requestId,
             parsed.space,
             parsed.sessionId,
@@ -1106,8 +1120,8 @@ class Connection {
           return;
         }
         {
-          const response = await this.server.resolveEventAttention(parsed);
-          this.sendSessionResponse(
+          const response = await this.#server.resolveEventAttention(parsed);
+          this.#sendSessionResponse(
             parsed.space,
             parsed.sessionId,
             parsed.requestId,
@@ -1156,7 +1170,7 @@ class Connection {
         // Membership is re-read per phase; a prioritized session keeps
         // tracking its delivered derived docs (trackedIds persist), so
         // the phases stay disjoint across the back-to-back calls.
-        const prioritized = this.server.sessionTracksAny(
+        const prioritized = this.#server.sessionTracksAny(
           space,
           sessionId,
           phase.derivedDirty,
@@ -1168,7 +1182,7 @@ class Connection {
       processed += 1;
       let effect: SessionEffectMessage | null;
       try {
-        effect = await this.server.syncSessionForConnection(
+        effect = await this.#server.syncSessionForConnection(
           space,
           sessionId,
           dirtyIds,
@@ -1189,7 +1203,7 @@ class Connection {
           `memory v2: watch refresh evaluation failed for session ${sessionId} in space ${space}; frame skipped`,
           error,
         );
-        this.server.markSessionForFullResync(space, sessionId);
+        this.#server.markSessionForFullResync(space, sessionId);
         continue;
       }
       if (this.#closed) {
@@ -1197,19 +1211,19 @@ class Connection {
         // roll the delivery state back so a later pass (or a resumed
         // session) recomputes and redelivers it.
         if (effect !== null) {
-          this.server.rollbackUndeliveredSync(space, sessionId, effect);
+          this.#server.rollbackUndeliveredSync(space, sessionId, effect);
         }
         return processed;
       }
       // ACL revocation can remove the session while watch evaluation awaits
       // its engine. Never emit the already-computed effect after that removal
       // (the session is gone from the registry — nothing to roll back into).
-      if (this.shouldSuppressSessionSend(space, sessionId)) {
+      if (this.#shouldSuppressSessionSend(space, sessionId)) {
         continue;
       }
       if (effect !== null) {
         try {
-          this.send(effect);
+          this.#send(effect);
         } catch (error) {
           // The send boundary is the commit point for sync state. A send
           // that throws is the only delivery failure visible in-process, so
@@ -1218,7 +1232,7 @@ class Connection {
           // roll back exactly what evaluation advanced, so the next pass
           // recomputes and redelivers from durable state (CT-1927 review,
           // rounds 5-6).
-          this.server.rollbackUndeliveredSync(space, sessionId, effect);
+          this.#server.rollbackUndeliveredSync(space, sessionId, effect);
           console.warn(
             "memory v2: sync send failed; delivery state rolled back for recomputation",
             error,
@@ -1235,9 +1249,9 @@ class Connection {
     }
     this.#closed = true;
     for (const { space, sessionId } of this.#sessions.values()) {
-      this.server.detachSession(space, sessionId, this.id);
+      this.#server.detachSession(space, sessionId, this.id);
     }
-    this.server.disconnect(this);
+    this.#server.disconnect(this);
   }
 }
 
@@ -1900,7 +1914,7 @@ export class Server {
   disconnect(connection: Connection): void {
     this.#connections.delete(connection.id);
     if (this.#connections.size === 0) {
-      this.cancelScheduledRefresh();
+      this.#cancelScheduledRefresh();
     }
   }
 
@@ -1925,9 +1939,9 @@ export class Server {
   }
 
   async close(): Promise<void> {
-    this.cancelScheduledRefresh();
+    this.#cancelScheduledRefresh();
     await this.#refreshing;
-    await this.drainSpacePublicationLocks();
+    await this.#drainSpacePublicationLocks();
     for (const engine of this.#engines.values()) {
       Engine.close(await engine);
     }
@@ -1951,7 +1965,7 @@ export class Server {
    * does not reschedule, so a single call is sufficient.
    */
   async idle(): Promise<void> {
-    await this.drainSpacePublicationLocks();
+    await this.#drainSpacePublicationLocks();
     // Dirty spaces with no timer armed are manual mode's held fan-out.
     // idle() is an explicit synchronization point exactly like
     // flushSessions(), so it drains them rather than returning with
@@ -2997,7 +3011,7 @@ export class Server {
       const lockWaitMs = performance.now() - requestedAt;
       let outcome = "threw";
       try {
-        const decision = await this.decideTransaction(message);
+        const decision = await this.#decideTransaction(message);
         outcome = decision.response.error?.name ?? "ok";
         let verdictError: { value: unknown } | undefined;
         try {
@@ -3347,7 +3361,7 @@ export class Server {
     });
   }
 
-  private async decideTransaction(
+  async #decideTransaction(
     message: TransactRequest,
   ): Promise<TransactDecision> {
     let postCommit: (() => Promise<void>) | undefined;
@@ -3643,7 +3657,7 @@ export class Server {
           let retryAfterSeq: number | undefined;
           if (error instanceof Engine.ConflictError) {
             span.setAttribute("ct.conflict", true);
-            this.stageConflictRefreshDirtyIds(
+            this.#stageConflictRefreshDirtyIds(
               message.space,
               session,
               message.commit,
@@ -4097,7 +4111,7 @@ export class Server {
         // frames are byte-identical to before.
         session.leaseHolderReads === true,
       );
-      await this.attachOperationFields(
+      await this.#attachOperationFields(
         message.space,
         message.sessionId,
         sync,
@@ -4337,7 +4351,7 @@ export class Server {
         ),
         removes: [],
       };
-      await this.attachOperationFields(
+      await this.#attachOperationFields(
         message.space,
         message.sessionId,
         sync,
@@ -4788,7 +4802,7 @@ export class Server {
               }
               sync.caughtUpLocalSeq = session.caughtUpLocalSeq;
             }
-            await this.attachOperationFields(space, sessionId, sync);
+            await this.#attachOperationFields(space, sessionId, sync);
             return {
               type: "session/effect",
               space,
@@ -5177,7 +5191,7 @@ export class Server {
     );
   }
 
-  private async attachOperationFields(
+  async #attachOperationFields(
     space: string,
     sessionId: string,
     sync: SessionSync,
@@ -5266,7 +5280,7 @@ export class Server {
       }
     }
     this.#dirtySpaces.add(space);
-    this.scheduleRefresh();
+    this.#scheduleRefresh();
   }
 
   /** Whether the space has ≥1 live client session (serving-loop.md §1's
@@ -5948,7 +5962,7 @@ export class Server {
     };
   }
 
-  private stageConflictRefreshDirtyIds(
+  #stageConflictRefreshDirtyIds(
     space: string,
     session: SessionState,
     commit: ClientCommit,
@@ -5981,7 +5995,7 @@ export class Server {
   }
 
   async flushSessions(spaces?: Iterable<string>): Promise<void> {
-    this.cancelScheduledRefresh();
+    this.#cancelScheduledRefresh();
     // The same waiting-against-working split the connection's receive keeps,
     // one level coarser: a flush PASS, not a frame. `memory/flush/queue` is
     // how long this pass waited for the flush in front of it,
@@ -5997,7 +6011,7 @@ export class Server {
       const startedAt = performance.now();
       timing.time(requestedAt, startedAt, "memory", "flush", "queue");
       try {
-        await this.refreshLoop(
+        await this.#refreshLoop(
           spaces === undefined ? undefined : new Set(spaces),
         );
       } finally {
@@ -6007,7 +6021,7 @@ export class Server {
           Date.now() - refreshStart,
         );
         if (spaces !== undefined && this.#dirtySpaces.size > 0) {
-          this.scheduleRefresh();
+          this.#scheduleRefresh();
         }
       }
     };
@@ -6021,7 +6035,7 @@ export class Server {
     await this.#refreshing;
   }
 
-  private scheduleRefresh(): void {
+  #scheduleRefresh(): void {
     if (
       this.options.subscriptionRefreshDelayMs === "manual" ||
       this.#dirtySpaces.size === 0 || this.#refreshTurn !== null
@@ -6037,8 +6051,13 @@ export class Server {
     );
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/v2-verdict-catchup.test.ts` reaches this member and a `#` name would
+   * put it out of reach.
+   */
   private async flushScheduledSessions(): Promise<void> {
-    await this.waitForConnectionQueuesToDrain(
+    await this.#waitForConnectionQueuesToDrain(
       Math.max(
         MIN_REFRESH_QUEUE_DRAIN_WAIT_MS,
         this.#lastRefreshDurationMs * 2,
@@ -6054,7 +6073,7 @@ export class Server {
     }
   }
 
-  private async waitForConnectionQueuesToDrain(
+  async #waitForConnectionQueuesToDrain(
     maxWaitMs: number,
   ): Promise<void> {
     const deadlineMs = Date.now() + maxWaitMs;
@@ -6082,7 +6101,7 @@ export class Server {
     }
   }
 
-  private cancelScheduledRefresh(): void {
+  #cancelScheduledRefresh(): void {
     if (this.#refreshTurn !== null) {
       this.#refreshTurn.cancel();
       this.#refreshTurn = null;
@@ -6101,6 +6120,9 @@ export class Server {
    * A transaction arriving during fan-out waits for that turn to finish. Locks
    * for other spaces remain independent, so the latency coupling is local to
    * one space.
+   *
+   * TypeScript-private rather than a `#` name, because `test/v2-server.test.ts`
+   * reaches this member and a `#` name would put it out of reach.
    */
   private async withSpacePublicationLock<T>(
     space: string,
@@ -6123,17 +6145,17 @@ export class Server {
   }
 
   /** Waits until every queued per-space publication turn has settled. */
-  private async drainSpacePublicationLocks(): Promise<void> {
+  async #drainSpacePublicationLocks(): Promise<void> {
     while (this.#publicationBySpace.size > 0) {
       await Promise.all(this.#publicationBySpace.values());
     }
   }
 
-  private async refreshLoop(initial?: Set<string>): Promise<void> {
+  async #refreshLoop(initial?: Set<string>): Promise<void> {
     let pending = initial;
     while (true) {
       if (initial === undefined && this.#dirtySpaces.size > 0) {
-        await this.waitForConnectionQueuesToDrain(
+        await this.#waitForConnectionQueuesToDrain(
           Math.max(
             MIN_REFRESH_QUEUE_DRAIN_WAIT_MS,
             this.#lastRefreshDurationMs * 2,
@@ -6295,7 +6317,7 @@ export class Server {
               }
               for (const id of derivedDirty) currentDerived.add(id);
             }
-            this.scheduleRefresh();
+            this.#scheduleRefresh();
             throw error;
           }
         });
@@ -6448,6 +6470,11 @@ export class Server {
     }
   }
 
+  /**
+   * TypeScript-private rather than a `#` name, because
+   * `test/v2-server-acl.test.ts` reaches this member and a `#` name would put
+   * it out of reach.
+   */
   private openEngine(space: string): Promise<Engine.Engine> {
     const existing = this.#engines.get(space);
     if (existing !== undefined) {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2903,10 +2903,10 @@ export class Server {
         : null;
       // A resumed session is registered before catch-up, and catch-up awaits
       // graph evaluation. An ACL commit (or takeover) can remove or replace it
-      // during that await, before Connection.receiveOrdered has added its local
-      // handle. In active ACL modes, never return catch-up data or let the
-      // connection add a ghost handle unless this exact token is still owned
-      // by this connection. Off mode preserves the legacy session timing.
+      // during that await, before Connection.#receiveOrdered has added its
+      // local handle. In active ACL modes, never return catch-up data or let
+      // the connection add a ghost handle unless this exact token is still
+      // owned by this connection. Off mode preserves the legacy session timing.
       const current = this.#sessions.get(message.space, opened.sessionId);
       if (
         this.isAclActive() &&

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -224,7 +224,7 @@ export function isStorageTransactionInconsistent(
  *    ATTEMPT does clears it, so every attempt still reuses the very handle the
  *    server just refused: the remount is driven by the ACL changing, not by the
  *    retry, which is exactly why it does not make this class retryable;
- *  - `SpaceSession.reopen()` (memory/v2/client.ts) runs only from `restore()`,
+ *  - `SpaceSession.#reopen()` (memory/v2/client.ts) runs only from `restore()`,
  *    which only the client's `reconnect()` calls — i.e. only after a TRANSPORT
  *    close;
  *  - `sendOutstandingCommit`'s catch (memory/v2/client.ts) keeps a commit
@@ -239,7 +239,7 @@ export function isStorageTransactionInconsistent(
  * SERVER dropped — an ACL de-authorization sweep (`#revokeDeauthorizedSessions`,
  * memory/v2/server.ts, whose own comment is "its next message fails closed
  * (Unknown session)"), or a takeover, both of which also delete the entry
- * `Connection.requireSession` checks. That is terminal for the session: the
+ * `Connection.#requireSession` checks. That is terminal for the session: the
  * client's remedy is the `session/revoked` frame, which CLOSES it
  * (`terminateSession`), not a reopen — and a reopen would be denied at
  * `session.open`.

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -388,8 +388,8 @@ Deno.test("a server ProtocolError reaches editWithRetry by name, once", async ()
 // session could land it. It fails on a fact about the RETRY PATH, not about the
 // error: nothing between two `editWithRetry` attempts remounts the session.
 // `SpaceReplica.sessionHandle()` memoizes the mount and clears it only in
-// `close()`/`closeNow()` (storage/v2.ts), and `SpaceSession.reopen()` runs only
-// from `restore()`, which only the client's transport `reconnect()` calls
+// `close()`/`closeNow()` (storage/v2.ts), and `SpaceSession.#reopen()` runs
+// only from `restore()`, which only the client's transport `reconnect()` calls
 // (memory/v2/client.ts). So every attempt re-sends over the very handle the
 // server just refused.
 //


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts every convertible TypeScript `private` class member in `memory` and
`cf-harness` to a JavaScript `#` private name, per
`docs/development/DEVELOPMENT.md` § Classes. The two spellings differ at
runtime: a `#` field is not an own property, whereas a field declared `private`
is, the modifier being erased. So an instance stops looking like a plain
object, and code that mistakes one for data fails where it stands.

`private` constructor parameter properties become the field declaration and the
assignment they stand for, which is that same change written out.

## Members that stay TypeScript-private

Three, all in `Server`, each carrying a doc comment that says so and names the
test reaching it: `openEngine`, `flushScheduledSessions`, and
`withSpacePublicationLock`. Those suites drive the members directly, and a `#`
name puts them out of reach of anything outside the class body.

## Renames

Four lazily-memoized accessors wanted the plain name their cache field was
holding — a `#x` field beside a `private x()` that fills it. The field takes a
`Cache` suffix so the accessor can have the name: `#connectionCache` in three
`memory` test transports, and `#orderedEntitiesCache` in `WatchView`. Both
members are private either way, so each rename is confined to its own class.

## Verification

The conversion was made by an AST tool that rewrites declarations along with
their `this.x`, `Cls.x`, and same-class `other.x` references, and refuses what
it cannot resolve syntactically. Its count was reconciled against an
independent census before the apply: 176 `private` members in the packages
originally scoped, 176 converted, no residue.

Which members a test genuinely reaches was settled by running the suites, not
by pattern-matching names. A name-based scan proposed seven candidates in these
two packages; four were false — three named a public accessor that shares its
name with the `#` field behind it, and one was `CustomEvent.detail`. The three
that remain are the three the suites actually named when they failed.

`deno fmt --check`, `deno lint`, and `deno task check` pass. `memory` matches
`origin/main` exactly at 584 passed, 0 failed; `cf-harness` is green at 857
passed, 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

