### PR TITLE
docs(cli): say where the surface-shape plan stands

### DIFF
--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -9,6 +9,30 @@ does not make, which misdirects design work before it starts.
 This document is about the command surface, not the machinery underneath.
 Nothing here blocks [Shaped reads and verb results](shaped-reads-and-verb-results.md).
 
+## Where this stands — read this first
+
+This block is LIVE: the change that moves a step updates it here, so the plan
+says what the surface has rather than only what it wants. The steps themselves
+are in [How to get there](#how-to-get-there); this says only which of them
+have landed.
+
+**Arc one — what the commands are called.**
+
+| step | state |
+| --- | --- |
+| 1–5 — the shared read step, the read options on every arrival, `--piece` taking the `of:` form, positional addresses with the `#argument` suffix, and `cf get`/`set`/`call` | on main |
+| 6a — the old spellings warn, each naming its end date | on main |
+| 6b — the old spellings are removed | pending, on the date `PIECE_DATA_SPELLING_END_DATE` names |
+| 7 — the duplicated nouns are merged | not started; it is last because each pair is two working commands |
+
+**Arc two — how a caller writes what a command acts on.**
+
+| step | state |
+| --- | --- |
+| 8 — `CF_SPACE` is ambient, and a write names the space it wrote to | not started |
+| 9 — a reference takes a space by name and a piece by slug, positionally | not started |
+| 10 — the verb opens the callable's section and `--` closes it | not started; `PIECE_DATA_SPELLING_END_DATE` is the thing to check first |
+
 ## What the surface is for
 
 Sorting commands by what they are for makes the trouble visible. Seven

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -32,6 +32,7 @@ have landed.
 | 8 — `CF_SPACE` is ambient, and a write names the space it wrote to | not started |
 | 9 — a reference takes a space by name and a piece by slug, positionally | not started |
 | 10 — the verb opens the callable's section and `--` closes it | not started; `PIECE_DATA_SPELLING_END_DATE` is the thing to check first |
+| 11 — `--url` decomposes into the transport it names and the reference it carries | not started |
 
 ## What the surface is for
 


### PR DESCRIPTION
## Why

`docs/plans/cli-surface-shape.md` sequences ten steps across two arcs and
records nowhere which of them have landed. Re-orienting on it currently means
reading the CLI's actual surface and chasing pull requests — which is how the
question "do we have a doc including step 8?" gets asked about a document that
has step 8 in it.

Two plans in this tree already solve this: `server-execution-v2.md` carries a
live coordination block by owner directive, and `piece-bulk-operations.md`
carries ticked acceptance criteria. This plan spans the most calendar time of
the three and had neither.

## What Changed

A `## Where this stands — read this first` block above the design, marked live
so the change that moves a step updates it, with one table per arc.

Every row was verified against the CLI itself rather than from memory:

- steps 1–5 — `--select`/`--schema`/`--filter` present on both `cf piece call`
  and `cf wish`; `--piece` documents the `of:` reference form; `cf get` takes a
  positional `[addressOrPath]` and the `#argument` suffix is implemented in
  `llm-friendly-ref.ts`; `cf get`/`set`/`call` are mounted in `main.ts`
- step 6a — the dated notice and `PIECE_DATA_SPELLING_END_DATE` are in
  `packages/cli/commands/piece.ts`
- step 7 — both `inspect`s, both `view`s, `piece map` and `piece apply` are all
  still mounted, so it has not started
- steps 8–10 — `CF_SPACE` is read by neither `cf` nor anything it calls

6b is described by the date its own constant names rather than by a pull
request number, so the row does not go stale when that PR is replaced.

## Test plan

`deno task check-docs` — 571 blocks pass. The change adds prose and two tables
and touches no code block. `docs/` is excluded from `deno fmt`, so wrapping was
checked by hand.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

