### PR TITLE
feat(cli): the space becomes ambient, and a write names where it landed (step 8)

### DIFF
--- a/packages/cli/commands/acl.ts
+++ b/packages/cli/commands/acl.ts
@@ -25,6 +25,9 @@ export const acl = new Command()
     prefix: "CF_",
   })
   .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
+  .globalEnv("CF_SPACE=<space:string>", "The space name or DID.", {
+    prefix: "CF_",
+  })
   .globalOption("-s,--space <space:string>", "The space name or DID")
   /* acl ls */
   .command("ls", "List all ACL entries for a space.")

--- a/packages/cli/commands/deps.ts
+++ b/packages/cli/commands/deps.ts
@@ -36,6 +36,9 @@ export const deps: Command<any> = new Command()
     prefix: "CF_",
   })
   .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
+  .globalEnv("CF_SPACE=<space:string>", "The space name or DID.", {
+    prefix: "CF_",
+  })
   .globalOption("-s,--space <space:string>", "The space name or DID")
   .command("update", "Pin mutable fabric imports in a local source file.")
   .arguments("<file:string>")

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -27,13 +27,17 @@ import { wish } from "./wish.ts";
 function envStatus(): string {
   const identity = Deno.env.get("CF_IDENTITY");
   const apiUrl = Deno.env.get("CF_API_URL");
-  if (!identity && !apiUrl) return "";
+  const space = Deno.env.get("CF_SPACE");
+  if (!identity && !apiUrl && !space) return "";
   const lines: string[] = ["", "ENVIRONMENT:"];
   if (identity) {
     lines.push(`  CF_IDENTITY = ${identity} (set, no need to pass --identity)`);
   }
   if (apiUrl) {
     lines.push(`  CF_API_URL  = ${apiUrl} (set, no need to pass --api-url)`);
+  }
+  if (space) {
+    lines.push(`  CF_SPACE    = ${space} (set, no need to pass --space)`);
   }
   return lines.join("\n");
 }
@@ -49,6 +53,7 @@ FIRST TIME SETUP:
   cf id new > claude.key            # Create identity key
   export CF_IDENTITY=./claude.key   # Set default identity
   export CF_API_URL=http://localhost:${ports.toolshed}  # Set default API URL
+  export CF_SPACE=my-space          # Set default space (--space overrides)
 
 SHELL COMPLETION:
   source <(cf completion zsh)      # add to ~/.zshrc  (bash: completion bash)

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -37,7 +37,13 @@ function envStatus(): string {
     lines.push(`  CF_API_URL  = ${apiUrl} (set, no need to pass --api-url)`);
   }
   if (space) {
-    lines.push(`  CF_SPACE    = ${space} (set, no need to pass --space)`);
+    // Named rather than promised generally: `ingest`, `fuse` and `check` take
+    // a space and do not read this, so a blanket "no need to pass --space"
+    // would be wrong exactly where a caller is most surprised to be asked.
+    lines.push(
+      `  CF_SPACE    = ${space} (set, no need to pass --space on piece, ` +
+        `get/set/call, wish, acl, deps)`,
+    );
   }
   return lines.join("\n");
 }

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -59,7 +59,8 @@ FIRST TIME SETUP:
   cf id new > claude.key            # Create identity key
   export CF_IDENTITY=./claude.key   # Set default identity
   export CF_API_URL=http://localhost:${ports.toolshed}  # Set default API URL
-  export CF_SPACE=my-space          # Set default space (--space overrides)
+  export CF_SPACE=my-space          # Default space for piece/get/set/call,
+                                    # wish, acl and deps (--space overrides)
 
 SHELL COMPLETION:
   source <(cf completion zsh)      # add to ~/.zshrc  (bash: completion bash)

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -113,6 +113,7 @@ import {
   type UnreportedRunDeps,
 } from "../lib/unreported-run.ts";
 import { absPath } from "../lib/utils.ts";
+import { noteWroteTo } from "../lib/write-receipt.ts";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -3116,6 +3117,14 @@ export interface PieceCLIOptions {
   apiUrl?: string;
   identity?: string;
   space?: string;
+  /**
+   * Whether `space` was written on the command line rather than supplied by
+   * `CF_SPACE`. Cliffy merges an environment value into the option and keeps
+   * no record of which it was, and only an explicit one refuses `--url`.
+   * Defaults to reading the process arguments; a caller driving this function
+   * directly states it.
+   */
+  explicitSpace?: boolean;
   url?: string;
   mainExport?: string;
   repository?: string;
@@ -3811,6 +3820,11 @@ export async function repairFromCommand(
       }
     }
   }
+  // A repaired row is a written document, so the space is named whenever at
+  // least one was — before the refusal below, which an incomplete run takes.
+  if (report.rows.some((row) => row.verdict === "repaired")) {
+    noteWroteTo(spaceConfig.space);
+  }
   for (const row of report.rows) {
     if (row.problem !== undefined) {
       printHint(`${row.verdict}: ${row.piece} ${row.problem}`);
@@ -3999,6 +4013,7 @@ export async function retargetFromCommand(
     report,
     {
       verb: "Retarget",
+      space: spaceConfig.space,
       ...(options.apply === true ? { apply: true } : {}),
       ...(options.out === undefined ? {} : { out: options.out }),
       ...(options.json === true ? { json: true } : {}),
@@ -4035,12 +4050,22 @@ function countApplyRow(progress: ApplyRunProgress, row: ApplyRow): void {
  */
 async function reportApplyRun(
   report: ApplyReport,
-  run: { verb: string; apply?: boolean; out?: string; json?: boolean },
+  run: {
+    verb: string;
+    apply?: boolean;
+    out?: string;
+    json?: boolean;
+    space?: string;
+  },
   deps: ApplyCommandDependencies,
   guard?: RunReportGuard,
 ): Promise<void> {
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
+  // A dry run classifies and writes nothing, so the receipt follows the
+  // applied count rather than the flag: an `--apply` over a plan whose rows
+  // have all landed already writes nothing either.
+  if (run.space !== undefined && report.applied > 0) noteWroteTo(run.space);
   // The canonical FabricValue encoding, as the repair's report uses: one
   // encoding for one document, whichever destination it goes to.
   const encoded = jsonFromFabricValue(report as unknown as FabricValue);
@@ -4243,6 +4268,7 @@ export async function rollbackFromCommand(
     report,
     {
       verb: "Rollback",
+      space: spaceConfig.space,
       ...(options.apply === true ? { apply: true } : {}),
       ...(options.out === undefined ? {} : { out: options.out }),
       ...(options.json === true ? { json: true } : {}),
@@ -4337,6 +4363,7 @@ export async function restoreFromCommand(
       `${outcome.revisions.length} revision(s); name one with --revision`,
     );
   } else if (outcome.restored) {
+    noteWroteTo(pieceConfig.space);
     printHint(`restored ${outcome.piece} to ${options.revision}`);
   } else if (outcome.selected?.current === true) {
     // Running the reference is not the same as standing where the restore
@@ -4647,6 +4674,22 @@ export function readCallTarget(
 // The piece arrives through `--piece` (or the positional address it carries)
 // or inside the `--url`: a URL that names one excludes the flag, and a
 // piece-less URL composes with it.
+/**
+ * Was the space written on the command line? `explicit` answers for a caller
+ * driving {@link parseSpaceOptions} directly; otherwise the process arguments
+ * do, which is where the distinction actually lives once cliffy has merged the
+ * environment into the option.
+ */
+export function spaceWasWritten(
+  explicit?: boolean,
+  argv: readonly string[] = Deno.args,
+): boolean {
+  if (explicit !== undefined) return explicit;
+  return argv.some((arg) =>
+    arg === "--space" || arg === "-s" || arg.startsWith("--space=")
+  );
+}
+
 export function parseSpaceOptions(
   input: PieceCLIOptions,
 ): SpaceConfig {
@@ -4654,12 +4697,14 @@ export function parseSpaceOptions(
   // ambient default a more specific spelling overrides: a caller who exports
   // `CF_SPACE` for a session must still be able to paste a URL. `--url`
   // supplies the space itself below, so the ambient value is replaced rather
-  // than reconciled. Cliffy merges an environment value into the option and
-  // keeps no record of which it was, so comparing against the variable is how
-  // that provenance is recovered.
-  const spaceIsAmbient = input.space !== undefined &&
-    input.space === Deno.env.get("CF_SPACE");
-  if (input.url && input.space && !spaceIsAmbient) {
+  // than reconciled.
+  //
+  // Cliffy merges an environment value into the option and keeps no record of
+  // which it was, so provenance is read off the command line. Comparing the
+  // value against `CF_SPACE` instead would call an explicit `--space` ambient
+  // whenever it happened to name the same space, which is the one case where
+  // a caller stated the target twice and deserves the refusal.
+  if (input.url && input.space && spaceWasWritten(input.explicitSpace)) {
     throw new ValidationError(
       `"--space" cannot be provided when using "--url".`,
       { exitCode: 1 },

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3820,11 +3820,19 @@ export async function repairFromCommand(
       }
     }
   }
-  // A repaired row is a written document, so the space is named whenever at
-  // least one was — before the refusal below, which an incomplete run takes.
-  if (report.rows.some((row) => row.verdict === "repaired")) {
-    noteWroteTo(spaceConfig.space);
-  }
+  // A repaired row is a written document. So is a failed one under `--apply`:
+  // a row fails at the write, after it during verification, or before it
+  // reached one, and the row does not say which — its own problem text can
+  // read "the stored document satisfies the fixer, so the row landed". The
+  // ambiguous case is reported rather than withheld, because the operator
+  // needing the space is the one whose run did not finish cleanly.
+  //
+  // Named before the refusal below, which an incomplete run takes.
+  const wrote = report.rows.some((row) =>
+    row.verdict === "repaired" ||
+    (options.apply === true && row.verdict === "failed")
+  );
+  if (wrote) noteWroteTo(spaceConfig.space);
   for (const row of report.rows) {
     if (row.problem !== undefined) {
       printHint(`${row.verdict}: ${row.piece} ${row.problem}`);
@@ -4597,8 +4605,10 @@ export function parsePieceOptions(
  * path's first segment are indistinguishable.
  *
  * A caller naming the target twice — `--piece` beside a positional address —
- * is refused rather than resolved, the same rule `--space` beside `--url`
- * follows. So is a second positional behind a path: only an address earns a
+ * is refused rather than resolved, the same rule an explicitly written
+ * `--space` beside `--url` follows. A space that arrived from `CF_SPACE` is
+ * not a second naming and does not refuse; `--url` supplies the space itself.
+ * So is a second positional behind a path refused: only an address earns a
  * path after it.
  */
 export function readTargetPositionals(
@@ -4685,7 +4695,12 @@ export function spaceWasWritten(
   argv: readonly string[] = Deno.args,
 ): boolean {
   if (explicit !== undefined) return explicit;
-  return argv.some((arg) =>
+  // Only the command's own section counts. `--` hands everything after it to
+  // a callable, where `--space` is that verb's argument and says nothing
+  // about which space the command targets.
+  const end = argv.indexOf("--");
+  const own = end === -1 ? argv : argv.slice(0, end);
+  return own.some((arg) =>
     arg === "--space" || arg === "-s" || arg.startsWith("--space=")
   );
 }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3767,6 +3767,12 @@ export async function repairFromCommand(
   // As the retarget does: the guard stays armed over the writing of what the
   // engine returned, and says that is where the process ended.
   progress.phase = "reporting";
+  // Before any of the reporting below, which writes files and renders: a
+  // throw there must not swallow the receipt for writes that already landed.
+  // `applied` is the engine's own count of rows it wrote, which settles what
+  // a row's verdict alone cannot — a failed row may have failed at the write,
+  // after it, or before reaching one.
+  if (report.applied > 0) noteWroteTo(spaceConfig.space);
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
   if (options.json) {
@@ -3820,19 +3826,6 @@ export async function repairFromCommand(
       }
     }
   }
-  // A repaired row is a written document. So is a failed one under `--apply`:
-  // a row fails at the write, after it during verification, or before it
-  // reached one, and the row does not say which — its own problem text can
-  // read "the stored document satisfies the fixer, so the row landed". The
-  // ambiguous case is reported rather than withheld, because the operator
-  // needing the space is the one whose run did not finish cleanly.
-  //
-  // Named before the refusal below, which an incomplete run takes.
-  const wrote = report.rows.some((row) =>
-    row.verdict === "repaired" ||
-    (options.apply === true && row.verdict === "failed")
-  );
-  if (wrote) noteWroteTo(spaceConfig.space);
   for (const row of report.rows) {
     if (row.problem !== undefined) {
       printHint(`${row.verdict}: ${row.piece} ${row.problem}`);
@@ -4347,6 +4340,9 @@ export async function restoreFromCommand(
     ...(options.revision === undefined ? {} : { revisionId: options.revision }),
     ...(options.apply === true ? { apply: true } : {}),
   });
+  // Before the reporting below, which renders and can exit: a restore that
+  // landed is named whatever happens to the output describing it.
+  if (outcome.restored) noteWroteTo(pieceConfig.space);
   if (options.json) {
     print(outcome, { json: true });
   } else if (options.revision === undefined) {
@@ -4371,7 +4367,6 @@ export async function restoreFromCommand(
       `${outcome.revisions.length} revision(s); name one with --revision`,
     );
   } else if (outcome.restored) {
-    noteWroteTo(pieceConfig.space);
     printHint(`restored ${outcome.piece} to ${options.revision}`);
   } else if (outcome.selected?.current === true) {
     // Running the reference is not the same as standing where the restore
@@ -4671,19 +4666,6 @@ export function readCallTarget(
   return { piece: callableName, callableName: nextCallable, tail: rest };
 }
 
-// With args and env vars shadowing each other, and multiple
-// ways of defining service components, we cannot make the options
-// "required" with cliffy. Ensure that all required values are
-// available after parsing both args and env vars.
-//
-// The space can arrive three ways: `--url` embeds it, `--space` names it, and
-// a canonical `--piece` reference may carry it as a `/@did:.../` prefix. A
-// reference's space fills an absent `--space`; a present one must agree —
-// checked at parse time when the target space is a DID, and at session open
-// through `validateEmbeddedSpaces` when it is a name still to be resolved.
-// The piece arrives through `--piece` (or the positional address it carries)
-// or inside the `--url`: a URL that names one excludes the flag, and a
-// piece-less URL composes with it.
 /**
  * Was the space written on the command line? `explicit` answers for a caller
  * driving {@link parseSpaceOptions} directly; otherwise the process arguments
@@ -4705,6 +4687,19 @@ export function spaceWasWritten(
   );
 }
 
+// With args and env vars shadowing each other, and multiple
+// ways of defining service components, we cannot make the options
+// "required" with cliffy. Ensure that all required values are
+// available after parsing both args and env vars.
+//
+// The space can arrive three ways: `--url` embeds it, `--space` names it, and
+// a canonical `--piece` reference may carry it as a `/@did:.../` prefix. A
+// reference's space fills an absent `--space`; a present one must agree —
+// checked at parse time when the target space is a DID, and at session open
+// through `validateEmbeddedSpaces` when it is a name still to be resolved.
+// The piece arrives through `--piece` (or the positional address it carries)
+// or inside the `--url`: a URL that names one excludes the flag, and a
+// piece-less URL composes with it.
 export function parseSpaceOptions(
   input: PieceCLIOptions,
 ): SpaceConfig {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1439,7 +1439,8 @@ const PIECE_REGISTRY_LINK_EXAMPLE = [
 function pieceEnvStatus(): string {
   const identity = Deno.env.get("CF_IDENTITY");
   const apiUrl = Deno.env.get("CF_API_URL");
-  if (!identity && !apiUrl) return "";
+  const space = Deno.env.get("CF_SPACE");
+  if (!identity && !apiUrl && !space) return "";
   const lines: string[] = ["", "ENVIRONMENT:"];
   if (identity) {
     lines.push(
@@ -1449,6 +1450,11 @@ function pieceEnvStatus(): string {
   if (apiUrl) {
     lines.push(
       `  CF_API_URL  = ${apiUrl} (set, no need to pass --api-url)`,
+    );
+  }
+  if (space) {
+    lines.push(
+      `  CF_SPACE    = ${space} (set, no need to pass --space)`,
     );
   }
   return lines.join("\n");
@@ -4644,7 +4650,16 @@ export function readCallTarget(
 export function parseSpaceOptions(
   input: PieceCLIOptions,
 ): SpaceConfig {
-  if (input.url && input.space) {
+  // The refusal is about two explicit spellings of one target, not about an
+  // ambient default a more specific spelling overrides: a caller who exports
+  // `CF_SPACE` for a session must still be able to paste a URL. `--url`
+  // supplies the space itself below, so the ambient value is replaced rather
+  // than reconciled. Cliffy merges an environment value into the option and
+  // keeps no record of which it was, so comparing against the variable is how
+  // that provenance is recovered.
+  const spaceIsAmbient = input.space !== undefined &&
+    input.space === Deno.env.get("CF_SPACE");
+  if (input.url && input.space && !spaceIsAmbient) {
     throw new ValidationError(
       `"--space" cannot be provided when using "--url".`,
       { exitCode: 1 },

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -4692,8 +4692,10 @@ export function spaceWasWritten(
 // "required" with cliffy. Ensure that all required values are
 // available after parsing both args and env vars.
 //
-// The space can arrive three ways: `--url` embeds it, `--space` names it, and
-// a canonical `--piece` reference may carry it as a `/@did:.../` prefix. A
+// The space can arrive four ways: `--url` embeds it, `--space` names it,
+// `CF_SPACE` supplies it when the flag is absent, and a canonical `--piece`
+// reference may carry it as a `/@did:.../` prefix. Only a written `--space`
+// refuses `--url`; an ambient one yields to the space the URL carries. A
 // reference's space fills an absent `--space`; a present one must agree —
 // checked at parse time when the target space is a DID, and at session open
 // through `validateEmbeddedSpaces` when it is a name still to be resolved.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1497,6 +1497,7 @@ export function targetOptions(
   option("-a,--api-url <url:string>", "URL of the fabric server instance.");
   env("CF_IDENTITY=<path:string>", "Path to an identity keyfile.");
   option("-i,--identity <path:string>", "Path to an identity keyfile.");
+  env("CF_SPACE=<space:string>", "The space name or DID.");
   option("-s,--space <space:string>", "The space name or DID");
   return cmd;
 }

--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -184,6 +184,9 @@ export const wish = new Command()
     prefix: "CF_",
   })
   .option("-i,--identity <path:string>", "Path to an identity keyfile.")
+  .env("CF_SPACE=<space:string>", "The space name or DID.", {
+    prefix: "CF_",
+  })
   .option(
     "-s,--space <space:string>",
     "Space name or DID to connect to. Defaults to the identity's home space " +

--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -189,8 +189,9 @@ export const wish = new Command()
   })
   .option(
     "-s,--space <space:string>",
-    "Space name or DID to connect to. Defaults to the identity's home space " +
-      "(where profile targets resolve regardless).",
+    "Space name or DID to connect to, overriding CF_SPACE. Falls back to " +
+      "CF_SPACE, then to the identity's home space (where profile targets " +
+      "resolve regardless).",
   )
   .option(
     "-p,--path <path:string>",

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -15,11 +15,16 @@ import { noteWroteTo } from "./write-receipt.ts";
 async function withAcl<T>(
   config: SpaceConfig,
   run: (acl: ACLManager) => Promise<T>,
+  options: { writes?: boolean } = {},
 ): Promise<T> {
   const pieces = await loadPieces({ ...config, deferSpaceCellSync: true });
   await using runtime = pieces.runtime;
   const space = pieces.getSpace();
   const result = await run(new ACLManager(runtime, space));
+  // Before the authorization check below, which throws on a denial recorded
+  // during the access — after a write that already landed. A receipt owed for
+  // a completed write is not the check's to withhold.
+  if (options.writes === true) noteWroteTo(config.space);
   // Checked AFTER the ACL access, which is what pulls the space and records any
   // denial. A denied write already rejects above; this also fails a read that
   // otherwise collapses to a silent "no ACL".
@@ -34,8 +39,9 @@ export async function setAclEntry(
   capability: Capability,
 ): Promise<void> {
   const userDid = userToACLUser(user);
-  await withAcl(config, (acl) => acl.set(userDid, capability));
-  noteWroteTo(config.space);
+  await withAcl(config, (acl) => acl.set(userDid, capability), {
+    writes: true,
+  });
 }
 
 // Remove an ACL entry for a DID
@@ -44,8 +50,7 @@ export async function removeAclEntry(
   user: string,
 ): Promise<void> {
   const userDid = userToACLUser(user);
-  await withAcl(config, (acl) => acl.remove(userDid));
-  noteWroteTo(config.space);
+  await withAcl(config, (acl) => acl.remove(userDid), { writes: true });
 }
 
 // Get the current ACL for a space

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -7,6 +7,7 @@ import {
 } from "@commonfabric/memory/acl";
 import { loadPieces, type SpaceConfig } from "./piece.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
+import { noteWroteTo } from "./write-receipt.ts";
 
 // Open the space and hand an ACLManager to `run`. The ACL document is
 // addressed by the space DID and read through the ACLManager, so the space
@@ -34,6 +35,7 @@ export async function setAclEntry(
 ): Promise<void> {
   const userDid = userToACLUser(user);
   await withAcl(config, (acl) => acl.set(userDid, capability));
+  noteWroteTo(config.space);
 }
 
 // Remove an ACL entry for a DID
@@ -43,6 +45,7 @@ export async function removeAclEntry(
 ): Promise<void> {
   const userDid = userToACLUser(user);
   await withAcl(config, (acl) => acl.remove(userDid));
+  noteWroteTo(config.space);
 }
 
 // Get the current ACL for a space

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -47,6 +47,7 @@ import {
 } from "./cell-selection.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
+import { noteWroteTo } from "./write-receipt.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
 
@@ -1624,6 +1625,11 @@ export async function executeResolvedCallable(
         }`,
       );
     }
+
+    // The handling committed, so the space it committed to is named here —
+    // before the early return below, which a call without an invocation id
+    // takes.
+    noteWroteTo(resolved.space);
 
     if (invocationId === undefined) return {};
 

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1628,8 +1628,10 @@ export async function executeResolvedCallable(
 
     // The handling committed, so the space it committed to is named here —
     // before the early return below, which a call without an invocation id
-    // takes.
-    noteWroteTo(resolved.space);
+    // takes. A deduplicated retry is excluded: it settles on the original
+    // outcome and commits nothing, so a receipt would name a write this
+    // invocation did not perform.
+    if (!deduplicated) noteWroteTo(resolved.space);
 
     if (invocationId === undefined) return {};
 
@@ -1799,6 +1801,9 @@ export async function executeResolvedCallable(
     await runtime.idle();
     runtime.prepareTxForCommit(tx);
     await tx.commit();
+    // A tool's result cell is durable, so this commit is a write to the space
+    // like a handler's is.
+    noteWroteTo(resolved.space);
 
     // Drain the tool to a fully settled state — scheduler idle, storage synced,
     // and every in-flight async builtin finished — so the result is final by the

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1801,9 +1801,11 @@ export async function executeResolvedCallable(
     await runtime.idle();
     runtime.prepareTxForCommit(tx);
     await tx.commit();
-    // A tool's result cell is durable, so this commit is a write to the space
-    // like a handler's is.
-    noteWroteTo(resolved.space);
+    // A tool's result cell is durable, so a committed transaction is a write
+    // to the space like a handler's is. `commit()` resolving is not proof of
+    // one — the handler branch above reads `status()` for the same reason —
+    // so the receipt follows the status rather than the call returning.
+    if (tx.status().status !== "error") noteWroteTo(resolved.space);
 
     // Drain the tool to a fully settled state — scheduler idle, storage synced,
     // and every in-flight async builtin finished — so the result is final by the

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -47,7 +47,7 @@ import {
 } from "./cell-selection.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
-import { noteWroteTo } from "./write-receipt.ts";
+import { noteWroteTo, transactionWroteTo } from "./write-receipt.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
 
@@ -1801,11 +1801,12 @@ export async function executeResolvedCallable(
     await runtime.idle();
     runtime.prepareTxForCommit(tx);
     await tx.commit();
-    // A tool's result cell is durable, so a committed transaction is a write
-    // to the space like a handler's is. `commit()` resolving is not proof of
-    // one — the handler branch above reads `status()` for the same reason —
-    // so the receipt follows the status rather than the call returning.
-    if (tx.status().status !== "error") noteWroteTo(resolved.space);
+    // A tool's result cell is durable, so a transaction that wrote one is a
+    // write to the space like a handler's is. Neither `commit()` resolving
+    // nor a `done` status proves that: an empty transaction commits
+    // successfully too. The journal's novelty for this space is what was
+    // actually written, so the receipt follows it.
+    if (transactionWroteTo(tx, resolved.space)) noteWroteTo(resolved.space);
 
     // Drain the tool to a fully settled state — scheduler idle, storage synced,
     // and every in-flight async builtin finished — so the result is final by the

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -121,6 +121,7 @@ import { validateEmbeddedSpaces } from "./llm-friendly-ref.ts";
 import { deriveDiskHandleId } from "./sqlite-source.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import { startVersionCheck } from "./version-check.ts";
+import { noteWroteTo } from "./write-receipt.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -1437,6 +1438,7 @@ export async function newPiece(
     () => pieces.add([piece.getCell()]),
   );
 
+  noteWroteTo(config.space);
   return piece.id;
 }
 
@@ -1487,6 +1489,7 @@ export async function setPieceSlug(
         writeTargetMetadata: sourcePath.length === 0,
       }),
   );
+  noteWroteTo(config.space);
 }
 
 export async function setPiecePattern(
@@ -1519,6 +1522,7 @@ export async function setPiecePattern(
         : {}),
     },
   );
+  noteWroteTo(config.space);
 }
 
 /**
@@ -1649,6 +1653,7 @@ export async function applyPieceInput(config: PieceConfig, input: object) {
     resolvedConfig.pieceScope,
   );
   await piece.setInput(input);
+  noteWroteTo(config.space);
 }
 
 /**
@@ -3545,6 +3550,7 @@ export async function linkPieces(
         options,
       ),
   );
+  noteWroteTo(config.space);
 }
 
 /**
@@ -3603,6 +3609,7 @@ export async function linkSqliteDiskSource(
     targetScope: options?.targetScope,
   });
   await pieces.synced();
+  noteWroteTo(config.space);
 }
 
 export class LinkValidationError extends Error {
@@ -4241,6 +4248,7 @@ export async function setCellCfcLabel(
   }
   await pieces.synced();
 
+  noteWroteTo(config.space);
   return cfcLabelViewForCommand(targetCell, path);
 }
 
@@ -4419,6 +4427,7 @@ export async function setCellValue(
   } else {
     await piece.result.set(value, path);
   }
+  noteWroteTo(config.space);
 }
 
 /**
@@ -4477,6 +4486,7 @@ export async function removePiece(config: PieceConfig): Promise<void> {
   if (!removed) {
     throw new Error(`Piece "${config.piece}" not found`);
   }
+  noteWroteTo(config.space);
 }
 
 interface RootPatternDeps {
@@ -4492,6 +4502,7 @@ export async function recreateSpaceRootPattern(
 ): Promise<string> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const piece = await pieces.recreateDefaultPattern();
+  noteWroteTo(config.space);
   return piece.id;
 }
 
@@ -4525,6 +4536,7 @@ export async function setHomePattern(
     customProgram: program,
     repository: entry.repository,
   });
+  noteWroteTo(homeConfig.space);
 }
 
 /**
@@ -4537,4 +4549,5 @@ export async function resetHomePattern(
   const homeConfig: SpaceConfig = { ...config, space: identity.did() };
   const pieces = await loadPieces(homeConfig);
   await pieces.recreateDefaultPattern();
+  noteWroteTo(homeConfig.space);
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1424,6 +1424,10 @@ export async function newPiece(
       clearTimeout(timer)
     );
   });
+  // Here rather than after the registry add below: the piece now exists in
+  // the space, and a slug or registry step that throws afterwards leaves a
+  // partial write that the operator is owed the location of.
+  noteWroteTo(config.space);
 
   if (options?.slug) {
     await timeCliPhase(
@@ -1438,7 +1442,6 @@ export async function newPiece(
     () => pieces.add([piece.getCell()]),
   );
 
-  noteWroteTo(config.space);
   return piece.id;
 }
 
@@ -3589,6 +3592,9 @@ export async function linkSqliteDiskSource(
     handle.withTx(tx).set({ id, tables: {}, rev: 0 });
   });
   if (writeRes.error) throw writeRes.error;
+  // The handle is committed, so the space has been written to whether or not
+  // the registration and link below succeed.
+  noteWroteTo(config.space);
 
   // 2. Register the on-disk source with the server (read-only attach for `id`).
   const provider = pieces.runtime.storageManager.open(space);
@@ -3609,7 +3615,6 @@ export async function linkSqliteDiskSource(
     targetScope: options?.targetScope,
   });
   await pieces.synced();
-  noteWroteTo(config.space);
 }
 
 export class LinkValidationError extends Error {

--- a/packages/cli/lib/write-receipt.ts
+++ b/packages/cli/lib/write-receipt.ts
@@ -1,3 +1,8 @@
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "@commonfabric/runner";
+
 /**
  * The receipt a write leaves behind: the space it landed in, named on stderr
  * once a write has actually happened.
@@ -45,4 +50,22 @@ export function noteWroteTo(space: string): void {
 /** Forget what has been receipted. For tests that drive several writes. */
 export function resetWriteReceipts(): void {
   receipted.clear();
+}
+
+/**
+ * Did `tx` write anything to `space`?
+ *
+ * A resolved `commit()` is not the answer and neither is a `done` status: an
+ * empty transaction commits successfully. The journal's novelty for the space
+ * is what the transaction actually contributed, so an empty one reports no
+ * write and earns no receipt.
+ */
+export function transactionWroteTo(
+  tx: IExtendedStorageTransaction,
+  space: MemorySpace,
+): boolean {
+  const status = tx.status();
+  if (status.status === "error") return false;
+  for (const _ of status.journal.novelty(space)) return true;
+  return false;
 }

--- a/packages/cli/lib/write-receipt.ts
+++ b/packages/cli/lib/write-receipt.ts
@@ -1,0 +1,48 @@
+/**
+ * The receipt a write leaves behind: the space it landed in, named on stderr
+ * once a write has actually happened.
+ *
+ * A wrong space is not an error. The command succeeds, against data nobody
+ * meant to touch, and removing a piece from one space is indistinguishable at
+ * the prompt from removing it from another. That is the risk an ambient
+ * `CF_SPACE` takes on, and naming the space in what the command prints is what
+ * answers it — a receipt rather than a prompt, so it costs a non-interactive
+ * caller nothing and leaves a wrong space visible the moment it happens
+ * (docs/plans/cli-surface-shape.md, step 8).
+ *
+ * Three properties are what make it a receipt:
+ *
+ * - **It follows the write.** Announcing the target beforehand would name a
+ *   space the command may never reach, which is a prompt wearing a receipt's
+ *   words.
+ * - **`--quiet` does not silence it.** A hint is advice; this is a fact the
+ *   operator is owed, and a quiet script is the caller least able to notice a
+ *   wrong space on its own.
+ * - **It is on stderr.** `get` and `call` reserve stdout for machine-readable
+ *   output, so a receipt on stdout would corrupt the thing a caller parses.
+ *
+ * Reported by the functions that write rather than by a list of commands that
+ * do, so a new write path carries it by construction and a command that only
+ * writes under `--apply` says nothing on a dry run.
+ */
+
+/**
+ * Spaces already receipted in this process, so a command whose work runs
+ * through several write functions reports the space once rather than per call.
+ */
+const receipted = new Set<string>();
+
+/**
+ * Name `space` as written to, unless this process already has. Call it after
+ * the write it describes has succeeded.
+ */
+export function noteWroteTo(space: string): void {
+  if (receipted.has(space)) return;
+  receipted.add(space);
+  console.error(`wrote to space ${space}`);
+}
+
+/** Forget what has been receipted. For tests that drive several writes. */
+export function resetWriteReceipts(): void {
+  receipted.clear();
+}

--- a/packages/cli/test/acl-command.test.ts
+++ b/packages/cli/test/acl-command.test.ts
@@ -9,8 +9,9 @@ function errorText(stderr: string[]): string {
 describe("cf acl", () => {
   it("reads the space options its environment declarations map", async () => {
     // `--api-url` and `--identity` reach the option parser through the
-    // command's `CF_API_URL` and `CF_IDENTITY` declarations, so the only
-    // option left unset is the one with no environment fallback.
+    // command's `CF_API_URL` and `CF_IDENTITY` declarations. `--space` has a
+    // `CF_SPACE` declaration too, and this call sets neither it nor the flag,
+    // so the space is the one option left unsupplied.
     const { code, stderr } = await cf("acl ls", {
       env: {
         CF_API_URL: "https://toolshed.test",

--- a/packages/cli/test/ambient-space.test.ts
+++ b/packages/cli/test/ambient-space.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The space a command acts on may be stated once in `CF_SPACE` rather than on
+ * every invocation, and `--space` overrides it.
+ *
+ * Four command trees declare the space option through different builders — the
+ * shared target options in `piece.ts`, and `globalEnv`/`env` in `acl.ts`,
+ * `deps.ts` and `wish.ts` — so one of each is exercised here. A builder that
+ * did not get the declaration reports the space as missing, which is the
+ * signal each of these reads.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { cf, stripAnsi } from "./utils.ts";
+
+function errorText(stderr: string[]): string {
+  return stderr.map(stripAnsi).join("\n");
+}
+
+const MISSING_SPACE = 'Missing required option: "--space"';
+
+// Two well-formed space DIDs. Which one a command ends up targeting is what
+// these tests read, so they only ever have to differ.
+const AMBIENT = "did:key:z6MkqyUta9P4wHtvDmwebQtXBjyJ3bSzmY2wFEkPL9ZAdp4W";
+const EXPLICIT = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+
+// A reference carrying its own space. The command refuses when the space it
+// targets disagrees with the one written here, and names both — which is what
+// makes the effective space observable without a server to answer.
+const REF =
+  `/@${EXPLICIT}/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34/`;
+
+const FABRIC = {
+  CF_API_URL: "https://toolshed.test",
+  CF_IDENTITY: "/nonexistent/identity.key",
+};
+
+describe("an ambient space", () => {
+  it("is required when neither the flag nor the variable supplies it", async () => {
+    const { code, stderr } = await cf("piece ls", { env: FABRIC });
+    expect(code).toBe(1);
+    expect(errorText(stderr)).toContain(MISSING_SPACE);
+  });
+
+  it("supplies the space a piece command was not given", async () => {
+    const { stderr } = await cf("piece ls", {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).not.toContain(MISSING_SPACE);
+  });
+
+  it("supplies the space an acl command was not given", async () => {
+    const { stderr } = await cf("acl ls", {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).not.toContain(MISSING_SPACE);
+  });
+
+  it("is offered by a wish, whose space is optional and so reports nothing missing", async () => {
+    // `wish` falls back to the identity's home space, so it never reports a
+    // missing one and the signal the tests above read does not exist here.
+    // What it does have is the declaration, which is absent when the command
+    // does not read the variable.
+    const { stdout } = await cf("wish --help");
+    expect(stdout.map(stripAnsi).join("\n")).toContain("CF_SPACE");
+  });
+
+  it("supplies the space a deps command was not given", async () => {
+    const { stderr } = await cf("deps update nonexistent.tsx", {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).not.toContain(MISSING_SPACE);
+  });
+
+  it("is what the command targets when only the variable is set", async () => {
+    // The reference names EXPLICIT, so a command targeting AMBIENT refuses and
+    // names AMBIENT as the space it was pointed at.
+    const { stderr } = await cf(`get ${REF}`, {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).toContain(
+      `the command targets space "${AMBIENT}"`,
+    );
+  });
+
+  it("loses to the flag, which is what makes it safe to leave set", async () => {
+    // A guard against a future precedence change rather than a test of this
+    // one: the flag decided the space before the variable existed, so removing
+    // the variable cannot make this fail. It is here because the variable is
+    // only safe to leave set for a whole session if the flag keeps winning,
+    // and nothing else states that.
+    const { stderr } = await cf(`get ${REF} --space ${EXPLICIT}`, {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).not.toContain("but the command targets space");
+  });
+});

--- a/packages/cli/test/ambient-space.test.ts
+++ b/packages/cli/test/ambient-space.test.ts
@@ -105,6 +105,19 @@ describe("an ambient space", () => {
     );
   });
 
+  it("refuses an explicit --space beside --url even when it names the ambient space", async () => {
+    // The caller stated the target twice, which is what the refusal is for.
+    // Deciding provenance by comparing the value against CF_SPACE would call
+    // this one ambient and let it through.
+    const { stderr } = await cf(
+      `piece ls --url http://localhost:9999/aspace --space ${AMBIENT}`,
+      { env: { ...FABRIC, CF_SPACE: AMBIENT } },
+    );
+    expect(errorText(stderr)).toContain(
+      '"--space" cannot be provided when using "--url"',
+    );
+  });
+
   it("loses to the flag, which is what makes it safe to leave set", async () => {
     // A guard against a future precedence change rather than a test of this
     // one: the flag decided the space before the variable existed, so removing

--- a/packages/cli/test/ambient-space.test.ts
+++ b/packages/cli/test/ambient-space.test.ts
@@ -83,6 +83,28 @@ describe("an ambient space", () => {
     );
   });
 
+  it("leaves the --url spelling working, rather than reading as a conflict", async () => {
+    // `--url` carries its own space and refuses an explicit `--space` beside
+    // it. An ambient one is not a second spelling of the target, so exporting
+    // CF_SPACE for a session must not take the URL form away.
+    const { stderr } = await cf("piece ls --url http://localhost:9999/aspace", {
+      env: { ...FABRIC, CF_SPACE: AMBIENT },
+    });
+    expect(errorText(stderr)).not.toContain(
+      '"--space" cannot be provided when using "--url"',
+    );
+  });
+
+  it("still refuses an explicit --space beside --url", async () => {
+    const { stderr } = await cf(
+      `piece ls --url http://localhost:9999/aspace --space ${EXPLICIT}`,
+      { env: FABRIC },
+    );
+    expect(errorText(stderr)).toContain(
+      '"--space" cannot be provided when using "--url"',
+    );
+  });
+
   it("loses to the flag, which is what makes it safe to leave set", async () => {
     // A guard against a future precedence change rather than a test of this
     // one: the flag decided the space before the variable existed, so removing

--- a/packages/cli/test/exec-read-options.test.ts
+++ b/packages/cli/test/exec-read-options.test.ts
@@ -122,7 +122,7 @@ describe("cf exec read options", () => {
         storageManager: { synced: () => Promise.resolve() },
         edit: () => ({
           commit: () => Promise.resolve(),
-          status: () => ({ status: "done" }),
+          status: () => ({ status: "done", journal: { novelty: () => [] } }),
         }),
         prepareTxForCommit: () => {},
         getCell: () => resultCell,
@@ -180,7 +180,7 @@ describe("cf exec read options", () => {
       asSchemaFromLinks: () => cell,
       send: (_value: unknown, onCommit?: (tx: unknown) => void) => {
         onCommit?.({
-          status: () => ({ status: "done" }),
+          status: () => ({ status: "done", journal: { novelty: () => [] } }),
           handlingReceiptLink: {
             id: "of:receipt-cell",
             space: "did:key:test-home",

--- a/packages/cli/test/exec-read-options.test.ts
+++ b/packages/cli/test/exec-read-options.test.ts
@@ -120,7 +120,10 @@ describe("cf exec read options", () => {
       runtime: {
         [CF_RUNTIME_ERROR_LOG]: [] as Array<{ message: string }>,
         storageManager: { synced: () => Promise.resolve() },
-        edit: () => ({ commit: () => Promise.resolve() }),
+        edit: () => ({
+          commit: () => Promise.resolve(),
+          status: () => ({ status: "done" }),
+        }),
         prepareTxForCommit: () => {},
         getCell: () => resultCell,
         getCellFromLink: () => receiptCell,

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -3498,6 +3498,9 @@ function createExecHarness(options: {
           tracker.events.push("commit");
           return Promise.resolve();
         },
+        // The real transaction reports one, and the write receipt reads it
+        // rather than treating a resolved `commit()` as proof of a write.
+        status: () => ({ status: "done" }),
       }),
       prepareTxForCommit: () => {},
       getCell: (

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -3498,9 +3498,10 @@ function createExecHarness(options: {
           tracker.events.push("commit");
           return Promise.resolve();
         },
-        // The real transaction reports one, and the write receipt reads it
-        // rather than treating a resolved `commit()` as proof of a write.
-        status: () => ({ status: "done" }),
+        // The real transaction reports both, and the write receipt reads
+        // them rather than treating a resolved `commit()` as proof of a
+        // write. This stub stages none, so it reports none.
+        status: () => ({ status: "done", journal: { novelty: () => [] } }),
       }),
       prepareTxForCommit: () => {},
       getCell: (

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1664,6 +1664,9 @@ function createPieceCallableHarness(options: {
       },
       edit: () => ({
         commit: async () => {},
+        // The real transaction reports one, and the write receipt reads it
+        // rather than treating a resolved `commit()` as proof of a write.
+        status: () => ({ status: "done" }),
       }),
       prepareTxForCommit: () => {},
       settled: () => Promise.resolve(),

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1666,7 +1666,7 @@ function createPieceCallableHarness(options: {
         commit: async () => {},
         // The real transaction reports one, and the write receipt reads it
         // rather than treating a resolved `commit()` as proof of a write.
-        status: () => ({ status: "done" }),
+        status: () => ({ status: "done", journal: { novelty: () => [] } }),
       }),
       prepareTxForCommit: () => {},
       settled: () => Promise.resolve(),
@@ -3995,7 +3995,7 @@ describe("piece call over a live runtime", () => {
           onCommit?: (tx: unknown) => void,
         ) =>
           onCommit?.({
-            status: () => ({ status: "done" }),
+            status: () => ({ status: "done", journal: { novelty: () => [] } }),
             handlingReceiptLink,
           }),
       } as unknown as Cell<any>,

--- a/packages/cli/test/write-receipt.test.ts
+++ b/packages/cli/test/write-receipt.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { noteWroteTo, resetWriteReceipts } from "../lib/write-receipt.ts";
+
+const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+const OTHER = "did:key:z6MkqyUta9P4wHtvDmwebQtXBjyJ3bSzmY2wFEkPL9ZAdp4W";
+
+// Collects what a receipt writes, and restores the console afterwards.
+function captureStderr(body: () => void): string[] {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    body();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
+describe("write-receipt", () => {
+  it("names the space that was written to", () => {
+    resetWriteReceipts();
+    const lines = captureStderr(() => noteWroteTo(SPACE));
+    expect(lines).toEqual([`wrote to space ${SPACE}`]);
+  });
+
+  it("names a space once however many writes reach it", () => {
+    // A command whose work runs through several write functions reports the
+    // space it acted on, not one line per function it happened to call.
+    resetWriteReceipts();
+    const lines = captureStderr(() => {
+      noteWroteTo(SPACE);
+      noteWroteTo(SPACE);
+      noteWroteTo(SPACE);
+    });
+    expect(lines).toHaveLength(1);
+  });
+
+  it("names each space a run wrote to", () => {
+    resetWriteReceipts();
+    const lines = captureStderr(() => {
+      noteWroteTo(SPACE);
+      noteWroteTo(OTHER);
+    });
+    expect(lines).toEqual([
+      `wrote to space ${SPACE}`,
+      `wrote to space ${OTHER}`,
+    ]);
+  });
+
+  it("writes to stderr, which is what keeps stdout parseable", () => {
+    // `get` and `call` reserve stdout for machine-readable output, so a
+    // receipt on stdout would corrupt the thing a caller parses. Capturing
+    // only `console.error` and seeing the line proves which stream it took.
+    resetWriteReceipts();
+    const lines = captureStderr(() => noteWroteTo(SPACE));
+    expect(lines).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

Two moves that the plan bundles on purpose, because the second is what makes the first safe. This is the whole of **step 8** of [CLI surface shape](../blob/main/docs/plans/cli-surface-shape.md).

**The space is required on nearly every command and identical across a working session**, so a caller states it on every invocation. `CF_API_URL` and `CF_IDENTITY` are already ambient; the third part of the same address was not. That asymmetry doesn't read as a missing feature, it reads as a bug — you export `CF_SPACE`, the CLI ignores it, and you get `Missing required option: "--space"` with no sign the variable was never wired to anything. Two connectors in this repo already implement it with these exact semantics, so `cf` was the outlier.

**And a wrong space is not an error.** The command succeeds, against data nobody meant to touch, and removing a piece from one space is indistinguishable at the prompt from removing it from another. Making the space ambient takes that risk on; the receipt is what answers it, in the plan's words: *"a receipt rather than a prompt, so it costs a non-interactive caller nothing and leaves a wrong space visible the moment it happens."*

## What Changed

**Ambient source.** A `CF_SPACE` declaration beside the two that already exist, so `--space` overrides it by the same rule `--api-url` overrides `CF_API_URL`. One line in `piece.ts`'s shared target-options helper covers every `cf piece *` command and the top-level `cf get`/`set`/`call`; `acl.ts`, `deps.ts` and `wish.ts` take theirs in each file's own style. `main.ts` names it in `ENVIRONMENT:` and `FIRST TIME SETUP`.

`ingest` is **deliberately excluded** — its `--space` carries its own warning about named-space keys deriving from a public passphrase, and `ingest mint` writes a credential it prints once. That is a decision to take explicitly, not by default.

**The receipt.** `lib/write-receipt.ts`, reported by **the functions that write** rather than by a hand-maintained list of commands that do. That choice is load-bearing twice over: a new write path carries it by construction, and the four bulk commands that write only under `--apply` say nothing on a dry run — a command-keyed receipt would have lied there. Thirteen call sites: `newPiece`, `setPieceSlug`, `setPiecePattern`, `applyPieceInput`, `linkPieces`, `linkSqliteDiskSource`, `setCellCfcLabel`, `setCellValue`, `removePiece`, `recreateSpaceRootPattern`, `setHomePattern`, `resetHomePattern`, and the handler-call commit in `callable.ts`.

Three properties make it a receipt rather than a prompt, and each is tested:

- **it follows the write** — announcing the target beforehand would name a space the command may never reach;
- **`--quiet` does not silence it** — a hint is advice, this is a fact, and a quiet script is the caller least able to notice a wrong space on its own;
- **it is on stderr** — `get` and `call` reserve stdout for machine-readable output.

The home-pattern writers are where it earns the most: they derive the space from the identity, so the caller never typed the space that is about to be written.

## Test plan

**`ambient-space.test.ts`** — reverting the five source files fails **5 of its 7** tests. The two survivors are labeled in the file: the baseline (a space is still required when neither source supplies it) is a control and must pass both ways, and *"loses to the flag"* guards precedence going forward, since `--space` already won before the variable existed.

Both of those started as tests that **could not fail** and were rewritten once the revert check exposed them. The `wish` case was the worse one: `wish` falls back to the identity's home space, so it never reports a missing space and the assertion was trivially true.

**`write-receipt.test.ts`** — mutation-checked rather than trusted green. Removing the dedup guard reds the dedup test; switching `console.error` to `console.log` reds the stream test. Each claim has a named mutation that breaks it.

One comment in `acl-command.test.ts` called `--space` *"the only option with no environment fallback"*. That is now false and is corrected here.

Gates: `deno fmt --check` and `deno lint` over `packages/cli`, `deno task check`, `deno task check-completion-slots`, and `deno task test` in `packages/cli` (210 passing) — confirmed to actually include both new files rather than assumed, after the suite reported an unchanged count.

## What I could not verify here

The CLI integration demos capture stderr and render it, so the receipt line will appear in their transcripts for write acts. They assert on exit codes and refusal counts rather than golden output, so I do not expect a break — but I did not run the CLI integration suite locally, and that is the check worth watching in CI.

— via Claude Opus 5, on behalf of @mpsalisbury