### PR TITLE
refactor: `#` private members in `runtime-client` and `background-piece-service`

### DIFF
--- a/packages/background-piece-service/src/service.ts
+++ b/packages/background-piece-service/src/service.ts
@@ -29,58 +29,58 @@ export interface BackgroundPieceServiceOptions {
 }
 
 export class BackgroundPieceService {
-  private piecesCell: Cell<Cell<BGPieceEntry>[]> | null = null;
-  private isRunning = false;
-  private pieceSchedulers: Map<string, SpaceManagerLike> = new Map();
-  private identity: Identity;
-  private toolshedUrl: string;
-  private runtime: Runtime;
-  private bgSpace: MemorySpace;
-  private bgCause: string;
-  private workerTimeoutMs?: number;
-  private createSpaceManager: (
+  #piecesCell: Cell<Cell<BGPieceEntry>[]> | null = null;
+  #isRunning = false;
+  #pieceSchedulers: Map<string, SpaceManagerLike> = new Map();
+  #identity: Identity;
+  #toolshedUrl: string;
+  #runtime: Runtime;
+  #bgSpace: MemorySpace;
+  #bgCause: string;
+  #workerTimeoutMs?: number;
+  #createSpaceManager: (
     options: ConstructorParameters<typeof SpaceManager>[0],
   ) => SpaceManagerLike;
 
   constructor(options: BackgroundPieceServiceOptions) {
-    this.identity = options.identity;
-    this.toolshedUrl = options.toolshedUrl;
-    this.runtime = options.runtime;
-    this.bgSpace = options.bgSpace ?? BG_SYSTEM_SPACE_ID;
-    this.bgCause = options.bgCause ?? BG_CELL_CAUSE;
-    this.workerTimeoutMs = options.workerTimeoutMs;
-    this.createSpaceManager = options.createSpaceManager ??
+    this.#identity = options.identity;
+    this.#toolshedUrl = options.toolshedUrl;
+    this.#runtime = options.runtime;
+    this.#bgSpace = options.bgSpace ?? BG_SYSTEM_SPACE_ID;
+    this.#bgCause = options.bgCause ?? BG_CELL_CAUSE;
+    this.#workerTimeoutMs = options.workerTimeoutMs;
+    this.#createSpaceManager = options.createSpaceManager ??
       ((managerOptions) => new SpaceManager(managerOptions));
   }
 
   async initialize() {
-    if (this.isRunning) {
+    if (this.#isRunning) {
       console.log("Service is already running");
       return;
     }
 
     // Storage URL and signer are already configured in the Runtime
-    this.piecesCell = await getBGPieces({
-      bgSpace: this.bgSpace,
-      bgCause: this.bgCause,
-      runtime: this.runtime,
+    this.#piecesCell = await getBGPieces({
+      bgSpace: this.#bgSpace,
+      bgCause: this.#bgCause,
+      runtime: this.#runtime,
     });
-    await this.piecesCell.sync();
-    await this.runtime.storageManager.synced();
+    await this.#piecesCell.sync();
+    await this.#runtime.storageManager.synced();
 
-    this.isRunning = true;
-    this.piecesCell.sink((cs) => this.ensurePieces(cs));
+    this.#isRunning = true;
+    this.#piecesCell.sink((cs) => this.#ensurePieces(cs));
   }
 
   stop(): Promise<PromiseSettledResult<void>[]> {
     // FIXME(ja): stop listening to the pieces cell ?
-    if (!this.isRunning) {
+    if (!this.#isRunning) {
       console.log("Service is not running");
       return Promise.resolve([]);
     }
 
-    this.isRunning = false;
-    const promises = Array.from(this.pieceSchedulers.values()).map(
+    this.#isRunning = false;
+    const promises = Array.from(this.#pieceSchedulers.values()).map(
       (scheduler) => scheduler.stop(),
     );
     return Promise.allSettled(promises);
@@ -89,8 +89,8 @@ export class BackgroundPieceService {
   // FIXME(ja): space managers should watch their own pieces!
   // Note(ja): this assumes that sync won't return an empty
   // array / partial results!
-  private ensurePieces(pieces: readonly Cell<BGPieceEntry>[]) {
-    if (!this.isRunning) {
+  #ensurePieces(pieces: readonly Cell<BGPieceEntry>[]) {
+    if (!this.#isRunning) {
       console.log("ignoring pieces update because service asked to stop");
       return;
     }
@@ -106,18 +106,18 @@ export class BackgroundPieceService {
     const [cancel, addCancel] = useCancelGroup();
 
     for (const did of dids) {
-      let scheduler = this.pieceSchedulers.get(did);
+      let scheduler = this.#pieceSchedulers.get(did);
       if (!scheduler) {
         // Should send a derived/non-top-level key
         // to each space once delegation is working.
-        scheduler = this.createSpaceManager({
+        scheduler = this.#createSpaceManager({
           did,
-          toolshedUrl: this.toolshedUrl,
-          identity: this.identity,
-          timeoutMs: this.workerTimeoutMs,
-          experimental: this.runtime.experimental,
+          toolshedUrl: this.#toolshedUrl,
+          identity: this.#identity,
+          timeoutMs: this.#workerTimeoutMs,
+          experimental: this.#runtime.experimental,
         });
-        this.pieceSchedulers.set(did, scheduler);
+        this.#pieceSchedulers.set(did, scheduler);
         scheduler.start();
       }
 
@@ -126,11 +126,13 @@ export class BackgroundPieceService {
       addCancel(scheduler.watch(didPieces));
     }
 
-    const removedSpaces = new Set(this.pieceSchedulers.keys()).difference(dids);
+    const removedSpaces = new Set(this.#pieceSchedulers.keys()).difference(
+      dids,
+    );
     for (const did of removedSpaces.values()) {
       // we are no longer monitoring this space
-      const scheduler = this.pieceSchedulers.get(did);
-      this.pieceSchedulers.delete(did);
+      const scheduler = this.#pieceSchedulers.get(did);
+      this.#pieceSchedulers.delete(did);
       // we can't await this in our callback, but we can at least catch and log errors
       scheduler?.stop().catch((e) =>
         console.error(`Error stopping scheduler: ${e}`)

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -23,34 +23,40 @@ type Task = {
 export class SpaceManager {
   #did: string;
   #pollingIntervalMs: number;
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
   private enabledPieces = new Map<string, Cell<BGPieceEntry>>();
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
   private activePiece: Cell<BGPieceEntry> | null = null;
   #deactivationTimeoutMs: number;
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
   private workerController!: WorkerController;
   #rerunIntervalMs: number;
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
   private pendingTasks: Task[] = [];
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
   private failureTracking = new Map<string, number>();
   #workerOptions: WorkerOptions;
+
   /**
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -21,37 +21,61 @@ type Task = {
 };
 
 export class SpaceManager {
-  private did: string;
-  private pollingIntervalMs: number;
+  #did: string;
+  #pollingIntervalMs: number;
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private enabledPieces = new Map<string, Cell<BGPieceEntry>>();
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private activePiece: Cell<BGPieceEntry> | null = null;
-  private deactivationTimeoutMs: number;
+  #deactivationTimeoutMs: number;
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private workerController!: WorkerController;
-  private rerunIntervalMs: number;
+  #rerunIntervalMs: number;
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private pendingTasks: Task[] = [];
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private failureTracking = new Map<string, number>();
-  private workerOptions: WorkerOptions;
+  #workerOptions: WorkerOptions;
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private isRunning = false;
 
   constructor(options: PieceSchedulerOptions) {
-    this.did = options.did;
-    this.pollingIntervalMs = options.pollingIntervalMs ?? 100;
-    this.deactivationTimeoutMs = options.deactivationTimeoutMs ?? 10000;
-    this.rerunIntervalMs = options.rerunIntervalMs ?? 60000;
-    this.workerOptions = options;
+    this.#did = options.did;
+    this.#pollingIntervalMs = options.pollingIntervalMs ?? 100;
+    this.#deactivationTimeoutMs = options.deactivationTimeoutMs ?? 10000;
+    this.#rerunIntervalMs = options.rerunIntervalMs ?? 60000;
+    this.#workerOptions = options;
     this.setupWorkerController();
 
     console.log(
-      `${this.did} Piece scheduler initialized | pollingIntervalMs: ${this.pollingIntervalMs} | deactivationTimeoutMs: ${this.deactivationTimeoutMs} | rerunIntervalMs: ${this.rerunIntervalMs}`,
+      `${this.#did} Piece scheduler initialized | pollingIntervalMs: ${this.#pollingIntervalMs} | deactivationTimeoutMs: ${this.#deactivationTimeoutMs} | rerunIntervalMs: ${this.#rerunIntervalMs}`,
     );
   }
 
-  private pushTask(
+  #pushTask(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
     whenInMs?: number,
   ) {
-    const when = whenInMs ?? this.rerunIntervalMs;
+    const when = whenInMs ?? this.#rerunIntervalMs;
     const timestamp = Date.now() + when;
     this.pendingTasks.push({
       pieceId,
@@ -62,7 +86,7 @@ export class SpaceManager {
     this.pendingTasks.sort((a, b) => a.timestamp - b.timestamp);
   }
 
-  private updatePieceStatus(b: BGPieceEntry, c: Cell<BGPieceEntry>) {
+  #updatePieceStatus(b: BGPieceEntry, c: Cell<BGPieceEntry>) {
     const pieceId = b.pieceId;
     const enabled = !b.disabledAt;
     const currentlyScheduled = this.enabledPieces.has(pieceId) ||
@@ -72,7 +96,7 @@ export class SpaceManager {
       // if we aren't already scheduling this piece, add it to the list
       if (!currentlyScheduled) {
         this.enabledPieces.set(pieceId, c);
-        this.pushTask(pieceId, c, 0);
+        this.#pushTask(pieceId, c, 0);
       }
     } else {
       // if we are disabling a piece, remove it from the list
@@ -94,7 +118,7 @@ export class SpaceManager {
 
     for (const entry of entries) {
       const raw = entry.get();
-      addCancel(entry.sink((value) => this.updatePieceStatus(value, entry)));
+      addCancel(entry.sink((value) => this.#updatePieceStatus(value, entry)));
 
       if (!raw.disabledAt) {
         desired.add(raw.pieceId);
@@ -111,7 +135,7 @@ export class SpaceManager {
     }
 
     console.log(
-      `${this.did} Piece scheduling ${this.enabledPieces.size} piece updaters`,
+      `${this.#did} Piece scheduling ${this.enabledPieces.size} piece updaters`,
     );
     return cancel;
   }
@@ -121,25 +145,25 @@ export class SpaceManager {
       return;
     }
     this.isRunning = true;
-    console.log(`${this.did} Piece scheduler starting...`);
+    console.log(`${this.#did} Piece scheduler starting...`);
     this.execLoop();
   }
 
   async stop(): Promise<void> {
-    console.log(`${this.did} Stopping piece scheduler...`);
+    console.log(`${this.#did} Stopping piece scheduler...`);
     this.isRunning = false;
 
     // Wait for active jobs to finish with a timeout
     if (this.activePiece) {
       await Promise.race([
-        sleep(this.deactivationTimeoutMs),
+        sleep(this.#deactivationTimeoutMs),
         new Promise((resolve) => {
           const checkInterval = setInterval(() => {
             if (!this.activePiece) {
               clearInterval(checkInterval);
               resolve(true);
             }
-          }, this.pollingIntervalMs);
+          }, this.#pollingIntervalMs);
         }),
       ]);
     }
@@ -147,15 +171,19 @@ export class SpaceManager {
     await this.workerController.shutdown();
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private async execLoop(): Promise<void> {
     while (this.isRunning) {
       if (!this.workerController.isReady()) {
-        await sleep(this.pollingIntervalMs);
+        await sleep(this.#pollingIntervalMs);
         continue;
       }
 
       if (this.activePiece) {
-        await sleep(this.pollingIntervalMs);
+        await sleep(this.#pollingIntervalMs);
         continue;
       }
 
@@ -163,7 +191,7 @@ export class SpaceManager {
         this.pendingTasks.length === 0 ||
         this.pendingTasks[0].timestamp > Date.now()
       ) {
-        await sleep(this.pollingIntervalMs);
+        await sleep(this.#pollingIntervalMs);
         continue;
       }
 
@@ -173,32 +201,36 @@ export class SpaceManager {
     }
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private async processPiece(pieceId: string, entry: Cell<BGPieceEntry>) {
     const raw = entry.get();
 
     if (raw.disabledAt) {
-      console.log(`${this.did} Piece ${pieceId} is disabled, skipping`);
+      console.log(`${this.#did} Piece ${pieceId} is disabled, skipping`);
       return;
     }
 
-    console.log(`${this.did} Starting ${raw.integration} ${raw.pieceId}`);
+    console.log(`${this.#did} Starting ${raw.integration} ${raw.pieceId}`);
 
     this.activePiece = entry;
 
     try {
       await this.workerController.runPiece(entry);
-      this.onProcessSuccess(pieceId, entry);
+      this.#onProcessSuccess(pieceId, entry);
     } catch (error) {
       const errorString = error instanceof Error
         ? error.message
         : String(error);
-      console.error(`${this.did} ${errorString}`);
-      this.onProcessFail(pieceId, entry, errorString);
+      console.error(`${this.#did} ${errorString}`);
+      this.#onProcessFail(pieceId, entry, errorString);
     }
     this.activePiece = null;
   }
 
-  private onProcessSuccess(pieceId: string, entry: Cell<BGPieceEntry>) {
+  #onProcessSuccess(pieceId: string, entry: Cell<BGPieceEntry>) {
     // If previous runs have failed, clear out the counter
     if (this.failureTracking.has(pieceId)) {
       this.failureTracking.delete(pieceId);
@@ -212,11 +244,11 @@ export class SpaceManager {
     });
 
     if (this.enabledPieces.has(pieceId)) {
-      this.pushTask(pieceId, entry);
+      this.#pushTask(pieceId, entry);
     }
   }
 
-  private onProcessFail(
+  #onProcessFail(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
     error: string,
@@ -227,7 +259,7 @@ export class SpaceManager {
     // disable the piece.
     if (failureCount >= 3) {
       this.failureTracking.delete(pieceId);
-      this.disablePiece(pieceId, entry, error);
+      this.#disablePiece(pieceId, entry, error);
     } else {
       this.failureTracking.set(pieceId, failureCount);
       entry.runtime.editWithRetry((tx) => {
@@ -239,16 +271,16 @@ export class SpaceManager {
 
       if (this.enabledPieces.has(pieceId)) {
         // Apply a linear backoff for the next attempts
-        this.pushTask(
+        this.#pushTask(
           pieceId,
           entry,
-          this.rerunIntervalMs * (failureCount + 1),
+          this.#rerunIntervalMs * (failureCount + 1),
         );
       }
     }
   }
 
-  private disablePiece(
+  #disablePiece(
     pieceId: string,
     entry: Cell<BGPieceEntry>,
     error: string,
@@ -265,10 +297,10 @@ export class SpaceManager {
     this.pendingTasks = this.pendingTasks.filter((r) => r.pieceId !== pieceId);
   }
 
-  private disableSpace(reason: string) {
-    console.log(`${this.did} Disabling space: ${reason}`);
+  #disableSpace(reason: string) {
+    console.log(`${this.#did} Disabling space: ${reason}`);
     for (const [pieceId, entry] of this.enabledPieces.entries()) {
-      this.disablePiece(pieceId, entry, reason);
+      this.#disablePiece(pieceId, entry, reason);
     }
   }
 
@@ -282,45 +314,49 @@ export class SpaceManager {
   //
   // Attempt to recreate the worker environment, which should only occur once per
   // space-wide disabling.
-  private onTerminalError = (event: WorkerControllerErrorEvent) => {
+  #onTerminalError = (event: WorkerControllerErrorEvent) => {
     console.error(
-      `${this.did} Terminal error received: ${event.error?.message}`,
+      `${this.#did} Terminal error received: ${event.error?.message}`,
     );
 
     const reason =
       `TerminalError: All pieces in this space have been disabled: ${event.error?.message}`;
-    this.disableSpace(reason);
+    this.#disableSpace(reason);
     this.setupWorkerController();
   };
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private async setupWorkerController() {
     const previousWorker = this.workerController;
-    const newWorker = new WorkerController(this.workerOptions);
+    const newWorker = new WorkerController(this.#workerOptions);
     newWorker.addEventListener(
       "error",
-      this.onTerminalError,
+      this.#onTerminalError,
     );
     this.workerController = newWorker;
 
     if (previousWorker) {
-      console.log(`${this.did} Restarting Worker Controller`);
-      previousWorker.removeEventListener("error", this.onTerminalError);
+      console.log(`${this.#did} Restarting Worker Controller`);
+      previousWorker.removeEventListener("error", this.#onTerminalError);
       previousWorker.shutdown().catch((e) => {
         console.warn(
-          `Could not shutdown old worker ${this.did} after restarting: ${e}`,
+          `Could not shutdown old worker ${this.#did} after restarting: ${e}`,
         );
       });
     }
 
     try {
       await newWorker.initializeResolve;
-      console.log(`${this.did} Worker controller ready for work`);
+      console.log(`${this.#did} Worker controller ready for work`);
     } catch (e) {
       // Initialization error. This "should not" occur, but is seen on invalid IPC requests
       // during initialization.
       // Disable all pieces in this space and attempt to recreate the worker.
-      console.error(`${this.did} failed to initialize: ${e}`);
-      this.disableSpace(`Failed to initialize worker.`);
+      console.error(`${this.#did} failed to initialize: ${e}`);
+      this.#disableSpace(`Failed to initialize worker.`);
       this.setupWorkerController();
     }
   }

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -60,8 +60,14 @@ export class WorkerController extends EventTarget {
     number,
     Task
   >();
-  // Promise that resolves when the worker is fully initialized
+
+  /**
+   * Settled when `startInitialize()` finishes: resolved once the worker is
+   * ready, rejected with the error that stopped it.
+   */
   #initializeDeferred = defer();
+
+  /** Promise that resolves when the worker is fully initialized. */
   public initializeResolve = this.#initializeDeferred.promise;
   #state = WorkerState.Uninitialized;
 

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -146,10 +146,11 @@ export class WorkerController extends EventTarget {
   }
 
   /**
+   * Sends a message and returns a promise that resolves with the response.
+   *
    * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
    * drives this member directly.
    */
-  // send a message and return a promise that resolves with the response
   private exec(type: WorkerIPCMessageType, data?: unknown): Promise<void> {
     const msgId = this.#msgId++;
 

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -49,58 +49,58 @@ interface Task {
  * @event error A terminal error occurred in the worker.
  */
 export class WorkerController extends EventTarget {
-  private worker: Worker;
-  private did: string;
-  private toolshedUrl: string;
-  private identity: Identity;
-  private timeoutMs: number;
-  private experimental?: WorkerOptions["experimental"];
-  private msgId: number = 0;
-  private pending = new Map<
+  #worker: Worker;
+  #did: string;
+  #toolshedUrl: string;
+  #identity: Identity;
+  #timeoutMs: number;
+  #experimental?: WorkerOptions["experimental"];
+  #msgId: number = 0;
+  #pending = new Map<
     number,
     Task
   >();
   // Promise that resolves when the worker is fully initialized
-  private initializeDeferred = defer();
-  public initializeResolve = this.initializeDeferred.promise;
-  private state = WorkerState.Uninitialized;
+  #initializeDeferred = defer();
+  public initializeResolve = this.#initializeDeferred.promise;
+  #state = WorkerState.Uninitialized;
 
   constructor(options: WorkerOptions) {
     super();
-    this.did = options.did;
-    this.identity = options.identity;
-    this.toolshedUrl = options.toolshedUrl;
-    this.timeoutMs = options.timeoutMs ?? DEFAULT_TASK_TIMEOUT;
-    this.experimental = options.experimental;
+    this.#did = options.did;
+    this.#identity = options.identity;
+    this.#toolshedUrl = options.toolshedUrl;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TASK_TIMEOUT;
+    this.#experimental = options.experimental;
 
-    console.log(`${this.did}: Creating worker controller`);
+    console.log(`${this.#did}: Creating worker controller`);
 
-    this.worker = new Worker(
+    this.#worker = new Worker(
       new URL("./worker.ts", import.meta.url).href,
       {
         type: "module",
-        name: `worker-${this.did}`,
+        name: `worker-${this.#did}`,
       },
     );
-    this.worker.addEventListener("message", this.onWorkerMessage);
-    this.worker.addEventListener("error", this.onWorkerError);
+    this.#worker.addEventListener("message", this.onWorkerMessage);
+    this.#worker.addEventListener("error", this.#onWorkerError);
   }
 
   async startInitialize() {
-    if (this.state !== WorkerState.Uninitialized) {
+    if (this.#state !== WorkerState.Uninitialized) {
       throw new Error("Worker is not uninitialized.");
     }
-    this.state = WorkerState.Initializing;
+    this.#state = WorkerState.Initializing;
     try {
       await this.exec(WorkerIPCMessageType.Initialize, {
-        did: this.did,
-        toolshedUrl: this.toolshedUrl,
-        encodedIdentity: realmValueFromKeyPair(this.identity.keyPair),
-        experimental: this.experimental,
+        did: this.#did,
+        toolshedUrl: this.#toolshedUrl,
+        encodedIdentity: realmValueFromKeyPair(this.#identity.keyPair),
+        experimental: this.#experimental,
       });
-      this.state = WorkerState.Ready;
+      this.#state = WorkerState.Ready;
     } catch (e) {
-      this.state = WorkerState.Error;
+      this.#state = WorkerState.Error;
       throw e;
     }
   }
@@ -108,7 +108,7 @@ export class WorkerController extends EventTarget {
   async runPiece(
     bg: Cell<BGPieceEntry>,
   ): Promise<void> {
-    if (this.state !== WorkerState.Ready) {
+    if (this.#state !== WorkerState.Ready) {
       throw new Error("Worker not ready.");
     }
     return await this.exec(WorkerIPCMessageType.Run, {
@@ -118,17 +118,17 @@ export class WorkerController extends EventTarget {
 
   async shutdown() {
     if (
-      this.state === WorkerState.Terminating ||
-      this.state === WorkerState.Terminated
+      this.#state === WorkerState.Terminating ||
+      this.#state === WorkerState.Terminated
     ) {
-      throw new Error(`Worker is already ${this.state}.`);
+      throw new Error(`Worker is already ${this.#state}.`);
     }
-    this.state = WorkerState.Terminating;
+    this.#state = WorkerState.Terminating;
 
-    for (const [_, task] of this.pending.entries()) {
+    for (const [_, task] of this.#pending.entries()) {
       task.deferred.reject(new Error("Worker shutting down."));
     }
-    this.pending.clear();
+    this.#pending.clear();
 
     try {
       await this.exec(WorkerIPCMessageType.Cleanup);
@@ -137,17 +137,21 @@ export class WorkerController extends EventTarget {
         `Failed to shutdown worker gracefully: ${err}`,
       );
     }
-    this.worker.terminate();
-    this.state = WorkerState.Terminated;
+    this.#worker.terminate();
+    this.#state = WorkerState.Terminated;
   }
 
   isReady(): boolean {
-    return this.state === WorkerState.Ready;
+    return this.#state === WorkerState.Ready;
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   // send a message and return a promise that resolves with the response
   private exec(type: WorkerIPCMessageType, data?: unknown): Promise<void> {
-    const msgId = this.msgId++;
+    const msgId = this.#msgId++;
 
     const message: Record<string, unknown> = {
       msgId,
@@ -167,7 +171,7 @@ export class WorkerController extends EventTarget {
       // Whatever processing is occurring in the worker graph should be
       // terminated and recreated in the future.
       deferred.reject(new Error(`Worker timed out.`));
-    }, this.timeoutMs);
+    }, this.#timeoutMs);
 
     const task = {
       startTime: performance.now(),
@@ -175,41 +179,45 @@ export class WorkerController extends EventTarget {
       type,
       deferred,
     };
-    this.pending.set(msgId, task);
+    this.#pending.set(msgId, task);
 
-    this.worker.postMessage(message);
+    this.#worker.postMessage(message);
 
     return deferred.promise.then(() => {
-      this.logTaskResults(task);
+      this.#logTaskResults(task);
     }, (error: Error) => {
-      this.logTaskResults(task, error.message);
+      this.#logTaskResults(task, error.message);
       throw new Error(error.message);
     }).finally(() => {
       clearTimeout(timeout);
-      this.pending.delete(msgId);
+      this.#pending.delete(msgId);
     });
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/service-modules.test.ts`
+   * drives this member directly.
+   */
   private onWorkerMessage = (event: MessageEvent) => {
     const response = event.data;
     if (!isWorkerIPCResponse(response)) {
       console.error(
-        `${this.did}: Received malformed WorkerIPCResponse: ${response}`,
+        `${this.#did}: Received malformed WorkerIPCResponse: ${response}`,
       );
       return;
     }
 
     if (response.type === "ready") {
       this.startInitialize().then(
-        () => this.initializeDeferred.resolve(),
-        (error) => this.initializeDeferred.reject(error),
+        () => this.#initializeDeferred.resolve(),
+        (error) => this.#initializeDeferred.reject(error),
       );
       return;
     }
-    const pending = this.pending.get(response.msgId);
+    const pending = this.#pending.get(response.msgId);
     if (!pending) {
       console.error(
-        `${this.did}: WorkerIPCResponse does not match a request: ${response.msgId}`,
+        `${this.#did}: WorkerIPCResponse does not match a request: ${response.msgId}`,
       );
       return;
     }
@@ -218,28 +226,28 @@ export class WorkerController extends EventTarget {
     } else {
       pending.deferred.resolve();
     }
-    this.pending.delete(response.msgId);
+    this.#pending.delete(response.msgId);
   };
 
-  private onWorkerError = (err: ErrorEvent) => {
-    console.error(`${this.did}: Worker error:`, err);
+  #onWorkerError = (err: ErrorEvent) => {
+    console.error(`${this.#did}: Worker error:`, err);
     // If not prevented, error is rethrown in this context.
     err.preventDefault();
 
     // Set state to `Error`, terminating the worker immediately
-    this.state = WorkerState.Error;
-    this.worker.terminate();
+    this.#state = WorkerState.Error;
+    this.#worker.terminate();
 
     this.dispatchEvent(new WorkerControllerErrorEvent(err));
   };
 
-  private logTaskResults(task: Task, error?: string) {
+  #logTaskResults(task: Task, error?: string) {
     const errorMessage = error ? `: ${error}` : "";
     const state = error ? "failed" : "completed";
     const id = `"${task.type}/${task.msgId}"`;
     const duration = (performance.now() - task.startTime).toFixed(0);
     const message =
-      `${this.did}: Worker task ${state}: ${id} (${duration}ms)${errorMessage}`;
+      `${this.#did}: Worker task ${state}: ${id} (${duration}ms)${errorMessage}`;
     if (error) {
       console.warn(message);
     } else {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -618,18 +618,16 @@ type RuntimeOperationSession = {
   subscriptions: Set<string>;
 };
 
-/**
- * Serves one runtime's requests on behalf of a client.
- *
- * Its members stay TypeScript-private rather than becoming `#` names, which is
- * the convention elsewhere. `test/backends/runtime-processor.test.ts` drives
- * this class by calling methods off `RuntimeProcessor.prototype` against a
- * stand-in receiver — in places a plain object literal holding just the one
- * field a handler reads. A `#` name is scoped to real instances, so every such
- * call would throw `Receiver must be an instance of class RuntimeProcessor`.
- * Converting the class means rewriting that suite to build real instances.
- */
 export class RuntimeProcessor {
+  // These members stay TypeScript-private rather than becoming `#` names, which
+  // is the convention elsewhere. `test/backends/runtime-processor.test.ts`
+  // drives this class by calling methods off `RuntimeProcessor.prototype`
+  // against a stand-in receiver — in places a plain object literal holding just
+  // the one field a handler reads. A `#` name is scoped to real instances, so
+  // every such call would throw `Receiver must be an instance of class
+  // RuntimeProcessor`. Converting the class means rewriting that suite to build
+  // real instances.
+
   private runtime: Runtime;
   private cc: PiecesController;
   private spaces = new Map<DID, PiecesController>();

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -618,6 +618,17 @@ type RuntimeOperationSession = {
   subscriptions: Set<string>;
 };
 
+/**
+ * Serves one runtime's requests on behalf of a client.
+ *
+ * Its members stay TypeScript-private rather than becoming `#` names, which is
+ * the convention elsewhere. `test/backends/runtime-processor.test.ts` drives
+ * this class by calling methods off `RuntimeProcessor.prototype` against a
+ * stand-in receiver — in places a plain object literal holding just the one
+ * field a handler reads. A `#` name is scoped to real instances, so every such
+ * call would throw `Receiver must be an instance of class RuntimeProcessor`.
+ * Converting the class means rewriting that suite to build real instances.
+ */
 export class RuntimeProcessor {
   private runtime: Runtime;
   private cc: PiecesController;

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -363,7 +363,7 @@ export class CellHandle<T = unknown> {
    * Returns a new CellHandle with an extended path.
    */
   key<K extends keyof T>(valueKey: K): CellHandle<T[K]> {
-    const childRef = this._extendPath(String(valueKey));
+    const childRef = this.#extendPath(String(valueKey));
     const child = new CellHandle<T[K]>(this.#rt, childRef);
 
     // If we have a cached value, pre-populate the child's cache
@@ -652,7 +652,7 @@ export class CellHandle<T = unknown> {
   ): Promise<Row[]> {
     const serializedParams = params === undefined
       ? undefined
-      : CellHandle.serializeSqliteParams(params);
+      : CellHandle.#serializeSqliteParams(params);
     const response = await this.#enqueueOperation(() =>
       this.#conn.request<RequestType.SqliteQuery>({
         type: RequestType.SqliteQuery,
@@ -680,7 +680,7 @@ export class CellHandle<T = unknown> {
   ): Promise<void> {
     const serializedParams = params === undefined
       ? undefined
-      : CellHandle.serializeSqliteParams(params);
+      : CellHandle.#serializeSqliteParams(params);
     await this.#enqueueOperation(() =>
       this.#conn.request<RequestType.SqliteExec>({
         type: RequestType.SqliteExec,
@@ -712,7 +712,7 @@ export class CellHandle<T = unknown> {
     return newCell as CellHandle<U>;
   }
 
-  private _extendPath(key: string): CellRef {
+  #extendPath(key: string): CellRef {
     return {
       id: this.#ref.id,
       space: this.#ref.space,
@@ -866,11 +866,11 @@ export class CellHandle<T = unknown> {
     return value;
   }
 
-  private static serializeSqliteParams(
+  static #serializeSqliteParams(
     params: ReadonlyArray<ClientCellValue> | Record<string, ClientCellValue>,
   ): SqliteParams {
     const serialize = (value: ClientCellValue) =>
-      CellHandle.sqliteFabricValue(value);
+      CellHandle.#sqliteFabricValue(value);
     return Array.isArray(params)
       ? { kind: "positional", values: params.map(serialize) }
       : {
@@ -882,7 +882,7 @@ export class CellHandle<T = unknown> {
       };
   }
 
-  private static sqliteFabricValue(value: ClientCellValue): FabricValue {
+  static #sqliteFabricValue(value: ClientCellValue): FabricValue {
     if (isCellHandle(value)) return value.ref();
     if (value instanceof FabricBytes) return value;
     if (value instanceof FabricSpecialObject) {
@@ -892,13 +892,13 @@ export class CellHandle<T = unknown> {
       );
     }
     if (Array.isArray(value)) {
-      return value.map((member) => CellHandle.sqliteFabricValue(member));
+      return value.map((member) => CellHandle.#sqliteFabricValue(member));
     }
     if (isObjectOrArray(value)) {
       return Object.fromEntries(
         Object.entries(value).map(([key, member]) => [
           key,
-          CellHandle.sqliteFabricValue(member),
+          CellHandle.#sqliteFabricValue(member),
         ]),
       );
     }

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -174,7 +174,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
   constructor(transport: RuntimeTransport) {
     super();
     this.#transport = transport;
-    this.#transport.on("message", this._handleMessage);
+    this.#transport.on("message", this.#handleMessage);
     // Main-thread event-loop lag probe: records into the "runtime-client"
     // timing stats as `loop/mainLag`, next to the `ipc/*` round-trips it
     // contextualizes. A slow round-trip with a quiet mainLag histogram is
@@ -520,7 +520,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     this.#subscriptionDiagnostics.clear();
   }
 
-  private _handleMessage = (message: IPCRemoteMessage): void => {
+  #handleMessage = (message: IPCRemoteMessage): void => {
     // Once dead (disposed), the connection ignores incoming messages without
     // warning: notifications are dropped here, stray/late messages are dropped
     // below. The one exception is a reply to a still-pending request — the
@@ -537,7 +537,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
         console.log(`[IPC\x1B[92m<=\x1B[0m]`, message);
       }
       if (isCellUpdateNotification(message)) {
-        this._handleCellUpdate(message);
+        this.#handleCellUpdate(message);
       } else if (isConsoleNotification(message)) {
         this.emit("console", message);
       } else if (isNavigateRequestNotification(message)) {
@@ -618,7 +618,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     }
   };
 
-  private _handleCellUpdate(message: CellUpdateNotification): void {
+  #handleCellUpdate(message: CellUpdateNotification): void {
     const { cell: cellRef, value } = message;
     if (value === undefined) {
       // A value can be reported as `undefined` only when there's been a

--- a/packages/runtime-client/src/client/emitter.ts
+++ b/packages/runtime-client/src/client/emitter.ts
@@ -15,7 +15,7 @@
  * ```
  */
 export class EventEmitter<Events extends Record<string, unknown[]>> {
-  private listeners = new Map<
+  #listeners = new Map<
     keyof Events,
     Set<(...args: unknown[]) => void>
   >();
@@ -24,10 +24,10 @@ export class EventEmitter<Events extends Record<string, unknown[]>> {
     event: K,
     listener: (...args: Events[K]) => void,
   ): this {
-    let set = this.listeners.get(event);
+    let set = this.#listeners.get(event);
     if (!set) {
       set = new Set();
-      this.listeners.set(event, set);
+      this.#listeners.set(event, set);
     }
     set.add(listener as (...args: unknown[]) => void);
     return this;
@@ -37,7 +37,9 @@ export class EventEmitter<Events extends Record<string, unknown[]>> {
     event: K,
     listener: (...args: Events[K]) => void,
   ): this {
-    this.listeners.get(event)?.delete(listener as (...args: unknown[]) => void);
+    this.#listeners.get(event)?.delete(
+      listener as (...args: unknown[]) => void,
+    );
     return this;
   }
 
@@ -53,7 +55,7 @@ export class EventEmitter<Events extends Record<string, unknown[]>> {
   }
 
   emit<K extends keyof Events>(event: K, ...args: Events[K]): boolean {
-    const set = this.listeners.get(event);
+    const set = this.#listeners.get(event);
     if (!set || set.size === 0) return false;
     for (const listener of set) {
       listener(...args);
@@ -63,14 +65,14 @@ export class EventEmitter<Events extends Record<string, unknown[]>> {
 
   removeAllListeners<K extends keyof Events>(event?: K): this {
     if (event === undefined) {
-      this.listeners.clear();
+      this.#listeners.clear();
     } else {
-      this.listeners.delete(event);
+      this.#listeners.delete(event);
     }
     return this;
   }
 
   listenerCount<K extends keyof Events>(event: K): number {
-    return this.listeners.get(event)?.size ?? 0;
+    return this.#listeners.get(event)?.size ?? 0;
   }
 }

--- a/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
@@ -29,9 +29,9 @@ export interface WebWorkerRuntimeTransportOptions {
 export class WebWorkerRuntimeTransport
   extends EventEmitter<RuntimeTransportEvents>
   implements RuntimeTransport {
-  private _ready = false;
-  private _readyPromise = defer<void>();
-  private _worker: Worker;
+  #ready = false;
+  #readyPromise = defer<void>();
+  #worker: Worker;
   constructor(options: WebWorkerRuntimeTransportOptions = {}) {
     super();
     const workerUrl = options.workerUrl ??
@@ -43,15 +43,15 @@ export class WebWorkerRuntimeTransport
         "RuntimeClient `workerUrl` must be explicitly defined in non-Deno environments.",
       );
     }
-    this._worker = new Worker(
+    this.#worker = new Worker(
       workerUrl,
       {
         type: "module",
         name: "runtime-worker",
       },
     );
-    this._worker.addEventListener("message", this._handleMessage);
-    this._worker.addEventListener("error", this._handleError);
+    this.#worker.addEventListener("message", this._handleMessage);
+    this.#worker.addEventListener("error", this._handleError);
   }
 
   /** @inheritDoc */
@@ -68,13 +68,13 @@ export class WebWorkerRuntimeTransport
     // record rather than aliasing it. What is exposed is a value handed to the
     // connection without passing through one of those, of which
     // `PageCreateRequest.argument` is the field to know about.
-    this._worker.postMessage(realmFromFabricValue(data));
+    this.#worker.postMessage(realmFromFabricValue(data));
   }
 
   /** @inheritDoc */
   dispose(): Promise<void> {
     this.removeAllListeners();
-    this._worker.terminate();
+    this.#worker.terminate();
     return Promise.resolve();
   }
 
@@ -83,7 +83,7 @@ export class WebWorkerRuntimeTransport
   }
 
   ready(): Promise<void> {
-    return this._readyPromise.promise;
+    return this.#readyPromise.promise;
   }
 
   /**
@@ -114,6 +114,11 @@ export class WebWorkerRuntimeTransport
 
   // What a decode returns is deep-frozen, so a consumer of a response or a
   // notification reads it rather than reshaping it in place.
+  /**
+   * TypeScript-private rather than a `#` name, and keeping the `_` the rest
+   * of this sweep drops, because `test/client/transport-web-worker.test.ts`
+   * reaches it under exactly that name to deliver a message by hand.
+   */
   private _handleMessage = (event: MessageEvent): void => {
     let data: IPCRemotePost;
 
@@ -133,8 +138,8 @@ export class WebWorkerRuntimeTransport
       // there is `ready()` never settling, and a caller waiting on a promise
       // that will not resolve has no way back. So the failure lands where
       // `_handleError()` puts a pre-ready one, on the promise itself.
-      if (!this._ready) {
-        this._readyPromise.reject(
+      if (!this.#ready) {
+        this.#readyPromise.reject(
           new Error(
             `Undecodable message from the worker: ${describeFailure(error)}`,
           ),
@@ -160,9 +165,9 @@ export class WebWorkerRuntimeTransport
       return;
     }
 
-    if (!this._ready && isWorkerReadyNotification(data)) {
-      this._ready = true;
-      this._readyPromise.resolve();
+    if (!this.#ready && isWorkerReadyNotification(data)) {
+      this.#ready = true;
+      this.#readyPromise.resolve();
       return;
     }
 
@@ -171,6 +176,11 @@ export class WebWorkerRuntimeTransport
     this.emit("message", data as IPCRemoteMessage);
   };
 
+  /**
+   * TypeScript-private rather than a `#` name, and keeping the `_` the rest
+   * of this sweep drops, because `test/client/transport-web-worker.test.ts`
+   * reaches it under exactly that name to deliver a message by hand.
+   */
   private _handleError = (event: ErrorEvent): void => {
     event.preventDefault();
 
@@ -186,8 +196,8 @@ export class WebWorkerRuntimeTransport
       error.stack = event.error.stack;
     }
 
-    if (!this._ready) {
-      this._readyPromise.reject(error);
+    if (!this.#ready) {
+      this.#readyPromise.reject(error);
       return;
     }
 

--- a/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
@@ -112,11 +112,13 @@ export class WebWorkerRuntimeTransport
     return transport;
   }
 
-  // What a decode returns is deep-frozen, so a consumer of a response or a
-  // notification reads it rather than reshaping it in place.
   /**
-   * TypeScript-private rather than a `#` name, and keeping the `_` the rest
-   * of this sweep drops, because `test/client/transport-web-worker.test.ts`
+   * Handles one message from the worker. What a decode returns is deep-frozen,
+   * so a consumer of a response or a notification reads it rather than
+   * reshaping it in place.
+   *
+   * TypeScript-private rather than a `#` name, and keeping the `_` the rest of
+   * this sweep drops, because `test/client/transport-web-worker.test.ts`
    * reaches it under exactly that name to deliver a message by hand.
    */
   private _handleMessage = (event: MessageEvent): void => {

--- a/packages/runtime-client/src/page-handle.ts
+++ b/packages/runtime-client/src/page-handle.ts
@@ -11,19 +11,19 @@ export type PageType = {
 };
 
 export class PageHandle<T = PageType> {
-  private _conn: InitializedRuntimeConnection;
-  private _cell: CellHandle<T>;
+  #conn: InitializedRuntimeConnection;
+  #cell: CellHandle<T>;
 
   constructor(
     rt: RuntimeClient,
     ref: PageRef,
   ) {
-    this._conn = rt[$conn]();
-    this._cell = new CellHandle<T>(rt, ref.cell);
+    this.#conn = rt[$conn]();
+    this.#cell = new CellHandle<T>(rt, ref.cell);
   }
 
   cell(): CellHandle<T> {
-    return this._cell;
+    return this.#cell;
   }
 
   /**
@@ -36,32 +36,32 @@ export class PageHandle<T = PageType> {
    * identity, use `cell().id()` — the full schemed URI.
    */
   id(): string {
-    return this._cell.id().replace(/^of:/, "");
+    return this.#cell.id().replace(/^of:/, "");
   }
 
   name(): string | undefined {
-    const data = this._cell.get() as Record<string, unknown> | undefined;
+    const data = this.#cell.get() as Record<string, unknown> | undefined;
     if (data && typeof data === "object" && NAME in data) {
       return data[NAME] as string;
     }
   }
 
   async start(): Promise<boolean> {
-    const res = await this._conn.request<RequestType.PageStart>({
+    const res = await this.#conn.request<RequestType.PageStart>({
       type: RequestType.PageStart,
       pageId: this.id(),
       // The page's cell knows its space — start/stop route to that
       // space's piece context.
-      space: this._cell.space(),
+      space: this.#cell.space(),
     });
     return res.value;
   }
 
   async stop(): Promise<boolean> {
-    const res = await this._conn.request<RequestType.PageStop>({
+    const res = await this.#conn.request<RequestType.PageStop>({
       type: RequestType.PageStop,
       pageId: this.id(),
-      space: this._cell.space(),
+      space: this.#cell.space(),
     });
     return res.value;
   }

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -111,13 +111,13 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     super();
     this.#conn = conn;
     this.#principal = _options.identity?.did();
-    this.#conn.on("console", this._onConsole);
-    this.#conn.on("navigaterequest", this._onNavigateRequest);
-    this.#conn.on("error", this._onError);
-    this.#conn.on("telemetry", this._onTelemetry);
-    this.#conn.on("pendingwriteschange", this._onPendingWritesChange);
-    this.#conn.on("operationupdate", this._onOperationUpdate);
-    this.#conn.on("eventneedsattention", this._onEventNeedsAttention);
+    this.#conn.on("console", this.#onConsole);
+    this.#conn.on("navigaterequest", this.#onNavigateRequest);
+    this.#conn.on("error", this.#onError);
+    this.#conn.on("telemetry", this.#onTelemetry);
+    this.#conn.on("pendingwriteschange", this.#onPendingWritesChange);
+    this.#conn.on("operationupdate", this.#onOperationUpdate);
+    this.#conn.on("eventneedsattention", this.#onEventNeedsAttention);
   }
 
   /** Returns an opaque identity for the scoped document instance in `ref`. */
@@ -973,38 +973,38 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     return this.#conn;
   }
 
-  private _onConsole = (data: ConsoleMessage): void => {
+  #onConsole = (data: ConsoleMessage): void => {
     this.emit("console", data);
   };
 
-  private _onNavigateRequest = (data: NavigateRequestNotification): void => {
+  #onNavigateRequest = (data: NavigateRequestNotification): void => {
     this.emit("navigaterequest", {
       cell: new CellHandle(this, data.targetCellRef),
     });
   };
 
-  private _onError = (data: ErrorNotification): void => {
+  #onError = (data: ErrorNotification): void => {
     this.emit("error", data);
   };
 
-  private _onTelemetry = (data: TelemetryNotification): void => {
+  #onTelemetry = (data: TelemetryNotification): void => {
     this.emit("telemetry", data.marker);
   };
 
-  private _onPendingWritesChange = (
+  #onPendingWritesChange = (
     data: PendingWritesNotification,
   ): void => {
     this.#pendingWrites = data.pending;
     this.emit("pendingwriteschange", { pending: data.pending });
   };
 
-  private _onOperationUpdate = (data: OperationUpdateNotification): void => {
+  #onOperationUpdate = (data: OperationUpdateNotification): void => {
     this.#operationSubscriptions.get(data.subscriptionId)?.(
       data.field,
     );
   };
 
-  private _onEventNeedsAttention = (
+  #onEventNeedsAttention = (
     data: EventNeedsAttentionNotification,
   ): void => {
     const { type: _type, ...notice } = data;

--- a/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/test/backends/cell-set-echo-race.test.ts
@@ -54,11 +54,15 @@ const testSessionOpenAudience = "did:key:z6Mk-cell-set-echo-race-audience";
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 class SharedV2SessionFactory implements V2Storage.SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   async create(sessionSpace: MemorySpace) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       sessionSpace,
@@ -114,8 +118,11 @@ class InProcessWorkerTransport extends EventEmitter<RuntimeTransportEvents>
   implements RuntimeTransport {
   readonly outbox: IPCRemoteMessage[] = [];
 
-  constructor(private readonly processor: RuntimeProcessor) {
+  readonly #processor: RuntimeProcessor;
+
+  constructor(processor: RuntimeProcessor) {
     super();
+    this.#processor = processor;
   }
 
   send(original: IPCClientMessage | IPCClientNotification): void {
@@ -143,7 +150,7 @@ class InProcessWorkerTransport extends EventEmitter<RuntimeTransportEvents>
     }
     void Promise.resolve()
       .then(() =>
-        RuntimeProcessor.prototype.handleRequest.call(this.processor, data)
+        RuntimeProcessor.prototype.handleRequest.call(this.#processor, data)
       )
       .then(
         (response) =>

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -78,11 +78,15 @@ const cfcSigner = await Identity.fromPassphrase(
 const testSessionOpenAudience = "did:key:z6Mk-runtime-processor-test-audience";
 
 class SharedV2SessionFactory implements V2Storage.SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   async create(space: MemorySpace) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,

--- a/packages/runtime-client/test/client/connection.test.ts
+++ b/packages/runtime-client/test/client/connection.test.ts
@@ -33,8 +33,11 @@ class FakeTransport extends EventEmitter<RuntimeTransportEvents>
   readonly sent: Array<IPCClientMessage | IPCClientNotification> = [];
   disposeCalls = 0;
 
-  constructor(private holdTypes: RequestType[] = []) {
+  #holdTypes: RequestType[];
+
+  constructor(holdTypes: RequestType[] = []) {
     super();
+    this.#holdTypes = holdTypes;
   }
 
   send(original: IPCClientMessage | IPCClientNotification): void {
@@ -50,7 +53,7 @@ class FakeTransport extends EventEmitter<RuntimeTransportEvents>
     this.sent.push(message);
     // Notifications carry no msgId and get no reply.
     if (!("msgId" in message)) return;
-    if (this.holdTypes.includes(message.data.type)) return;
+    if (this.#holdTypes.includes(message.data.type)) return;
     // Acknowledge asynchronously, like a real worker round-trip.
     queueMicrotask(() => {
       this.emit("message", { msgId: message.msgId, data: undefined });
@@ -78,13 +81,16 @@ async function initializedConnection(
  */
 class ThrowingTransport extends EventEmitter<RuntimeTransportEvents>
   implements RuntimeTransport {
-  constructor(private readonly failOn: RequestType) {
+  readonly #failOn: RequestType;
+
+  constructor(failOn: RequestType) {
     super();
+    this.#failOn = failOn;
   }
 
   send(message: IPCClientMessage | IPCClientNotification): void {
     if (!("msgId" in message)) return;
-    if (message.data.type === this.failOn) {
+    if (message.data.type === this.#failOn) {
       throw new Error("no encoding for value");
     }
     // Everything else is acknowledged, so the connection can initialize.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The two packages held back from the earlier sweeps, both for having heavily
white-box suites. `background-piece-service` goes from 46 TypeScript-`private`
members to 11, `runtime-client` from 49 to 26.

`docs/development/DEVELOPMENT.md` § Classes asks for `#` because the two
spellings differ at runtime: a `#` field is not an own property, whereas a
field declared `private` is, the modifier being erased. That difference is also
exactly why a suite reaching through `private` stops working, which is what
governs everything left alone here.

## What stays TypeScript-private, and why

Each such member carries the reason on its own declaration.

`SpaceManager` keeps nine and `WorkerController` two, all driven directly by
`test/service-modules.test.ts`. `TransportWebWorker` keeps `_handleMessage` and
`_handleError`, and keeps the leading `_` this sweep drops everywhere else,
because the test delivers a message by hand under exactly that name.

`RuntimeProcessor` is left whole, with the reason on the class rather than
repeated across thirty members. Its suite calls methods off
`RuntimeProcessor.prototype` against a stand-in receiver — in places a plain
object literal holding just the one field the handler reads:

```ts
(RuntimeProcessor.prototype as any).handlePieceUpdateSource.call(
  { pieceSourceConfirmations: new Map() },
  ...
```

A `#` name is scoped to real instances, so every one of those 133 prototype
calls throws `Receiver must be an instance of class RuntimeProcessor`.
Converting the class means rewriting the suite to build real instances, which
is a change of its own rather than a rename.

## How the exempt set was found

Not by pattern-matching names, which over-reports badly. A syntactic scan
proposed 17 members; resolving each cast's actual receiver cut that to 13.
`msgId` reads off a captured message rather than the controller, and
`isRunning`, `runtime`, and `operationSubscriptions` each matched a second
class that no cast targets.

The scan also missed two, and the way it missed them is worth recording: it
compared test text against post-conversion names, so a member whose leading `_`
had been stripped no longer matched what the test still called it. Those
surfaced only when the suite failed. Running the suites remains the ground
truth; the scan narrows where to look.

## Verification

The conversion tool's count was reconciled against an independent census
before the apply — 95 `private` members, 95 converted, no residue — and every
exemption below was then subtracted with the suite as the judge.

`deno fmt --check`, `deno lint`, `deno task check`, and `deno task check-docs`
pass. Both packages' suites are green. A sweep for prose still naming a member
that became `#`-private reports none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

