### PR TITLE
feat(runtime-client): `CellHandle.toSigilLink()`, so a caller need not ask JSON

### DIFF
--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -725,17 +725,22 @@ export class CellHandle<T = unknown> {
     };
   }
 
-  toJSON(): SigilLink {
-    // Wrap in sigil link format so the runtime recognizes this as a link
-    // and dereferences it (e.g., when passed through event.detail.sourceCell).
-    //
-    // The ref-carried `cfcLabelView` is deliberately NOT serialized (inv-12
-    // Stage 0, like `toWireString`): toJSON output is exactly what
-    // JSON.stringify hands the VDOM event path when a handle lands in
-    // CustomEvent.detail, and that raw sigil link re-enters the worker
-    // without passing getCell/cellRefToSigilLink — a main-thread display
-    // copy must not ride back in as label state (codex/cubic review on the
-    // Stage 0 PR; the worker also strips inbound views defensively).
+  /**
+   * Returns the sigil link naming this cell.
+   *
+   * The link is what stands in for a cell wherever a cell itself has no
+   * representation, and this is how a caller that has already recognized the
+   * value as a handle asks for it -- by name, rather than by reaching for a
+   * serialization protocol that happens to yield one. `Cell` is arranged the
+   * same way, its `toSigilLinkOrNull()` answering the callers that have
+   * recognized a cell and its `toJSON()` answering the protocol.
+   *
+   * The ref-carried `cfcLabelView` is deliberately not included, as
+   * `toWireString()` omits it: what this produces re-enters the worker without
+   * passing `getCell()` or `cellRefToSigilLink()`, and a main-thread display
+   * copy must not ride back in as label state (inv-12 Stage 0).
+   */
+  toSigilLink(): SigilLink {
     return linkRefFrom<CfcCellLinkRefPayload>({
       id: this.#ref.id,
       space: this.#ref.space,
@@ -745,6 +750,16 @@ export class CellHandle<T = unknown> {
       ...(this.#ref.overwrite !== undefined &&
         { overwrite: this.#ref.overwrite }),
     });
+  }
+
+  /**
+   * Returns the same link under the JSON protocol's name, so a handle reads as
+   * the cell it names wherever a renderer honors that protocol -- which is what
+   * carries one through `JSON.stringify()`. A caller that has recognized the
+   * handle asks {@link toSigilLink} instead.
+   */
+  toJSON(): SigilLink {
+    return this.toSigilLink();
   }
 
   /**

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -324,12 +324,10 @@ describe("cell-handle", () => {
       }]);
     });
 
-    // Inv-12 Stage 0: toJSON output is what JSON.stringify emits when a handle
-    // lands in CustomEvent.detail (drag/drop sourceCell) — a raw sigil link
-    // that re-enters the worker through the VDOM event path, bypassing
-    // getCell/cellRefToSigilLink. The ref's display view must not ride it
-    // (codex/cubic review on the Stage 0 PR); like toWireString, only
-    // addressing fields (+schema) serialize.
+    // Inv-12 Stage 0: the link a handle names itself by re-enters the worker
+    // without passing getCell/cellRefToSigilLink, so the ref's display view
+    // must not ride it (codex/cubic review on the Stage 0 PR). Like
+    // toWireString, only addressing fields (+schema) go.
     it("does not serialize the ref-carried label view into sigil links", () => {
       const runtime = {
         [$conn]: () => ({
@@ -362,6 +360,28 @@ describe("cell-handle", () => {
           },
         },
       });
+    });
+
+    it("names the same link whichever of the two names asks for it", () => {
+      // `toSigilLink()` is for a caller that has recognized the handle, and
+      // `toJSON()` for the protocol that reaches one without recognizing it.
+      // They are two names, not two answers.
+      const runtime = {
+        [$conn]: () => ({
+          request: () => Promise.resolve({}),
+          subscribe: () => Promise.resolve(),
+          unsubscribe: () => Promise.resolve(),
+        }),
+      } as unknown as RuntimeClient;
+      const cell = new CellHandle(runtime, {
+        id: "of:two-names" as CellRef["id"],
+        space: "did:key:test" as CellRef["space"],
+        scope: "space",
+        path: ["value"],
+      } as CellRef);
+
+      expect(cell.toSigilLink()).toEqual(cell.toJSON());
+      expect(JSON.parse(JSON.stringify(cell))).toEqual(cell.toSigilLink());
     });
 
     it("encodes its link to an fcl1: wire string with only addressing fields", () => {

--- a/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
@@ -38,7 +38,7 @@ function cellKind(schema: JSONSchema | undefined): string | undefined {
 }
 
 function bridgeValue(value: unknown): FabricValue {
-  if (isCellHandle(value)) return value.toJSON();
+  if (isCellHandle(value)) return value.toSigilLink();
   if (Array.isArray(value)) return value.map(bridgeValue);
   if (value && typeof value === "object") {
     if (Object.getPrototypeOf(value) !== Object.prototype) {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`Cell` carries its link under a name for each kind of caller that asks:

| name | for |
| --- | --- |
| `toSigilLinkOrNull()` | a storage boundary that has already recognized a cell |
| `toEncodableForm()` | a walk over an arbitrary graph that has recognized nothing |
| `toJSON()` | the JSON protocol |

`CellHandle` had only the last. So a caller holding a handle it had *already
identified* still had to reach for a serialization protocol to get the link out
of it — which is the shape earlier work in this area set out to remove.

`toSigilLink()` is the missing name, and `toJSON()` returns what it returns. Two
names for one answer, which a test pins directly, including through
`JSON.stringify()`.

No `OrNull` here, unlike `Cell`'s: a handle always has a ref, where a cell may
not have been created yet.

## The caller

`cf-iframe`'s cell bridge is the one site that had recognized a handle and then
asked for its JSON. It asks for the link.

What is left for `toJSON()` is what its name says: `JSON.stringify()` reaching a
handle somewhere that honors that protocol, without having recognized it as
anything.

## Tests

A new one pins that the two names agree. The existing coverage is already load
bearing for the body they share — corrupting the link that `toSigilLink()`
returns fails `cell-handle` and `CellHandle CFC label IPC`, and nothing else.

One comment moved with the code: the label-view test explained itself by naming
the VDOM event path as what `JSON.stringify` hands a handle to. It now says what
it pins — that the link a handle names itself by re-enters the worker without
passing `getCell()` or `cellRefToSigilLink()`, so the ref's display view must
not ride it.

## Gates

`deno task check`, `deno fmt`, `deno lint` green, and full suites green for
`runtime-client` and `html`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

