### PR TITLE
feat(pattern-iframe): add React authoring support

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -115,6 +115,8 @@
     "npm:@types/d3-scale@^4.0.9": "4.0.9",
     "npm:@types/d3-shape@^3.1.8": "3.1.8",
     "npm:@types/leaflet@^1.9.21": "1.9.21",
+    "npm:@types/react-dom@19.2.5": "19.2.5_@types+react@19.2.18",
+    "npm:@types/react@19.2.18": "19.2.18",
     "npm:@viz-js/viz@3.26.0": "3.26.0",
     "npm:ai@^7.0.31": "7.0.31_zod@4.4.3",
     "npm:ajv@^8.20.0": "8.20.0",
@@ -141,6 +143,8 @@
     "npm:pino-pretty@^13.1.3": "13.1.3",
     "npm:pino@^10.3.1": "10.3.1",
     "npm:plaid@43": "43.0.0",
+    "npm:react-dom@19.2.8": "19.2.8_react@19.2.8",
+    "npm:react@19.2.8": "19.2.8",
     "npm:ses@^2.2.0": "2.2.0",
     "npm:source-map-js@^1.2.1": "1.2.1",
     "npm:stoker@^2.0.1": "2.0.1_@hono+zod-openapi@1.5.1__hono@4.12.31__zod@4.4.3_hono@4.12.31",
@@ -1301,6 +1305,18 @@
         "@types/geojson"
       ]
     },
+    "@types/react-dom@19.2.5_@types+react@19.2.18": {
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "dependencies": [
+        "@types/react"
+      ]
+    },
+    "@types/react@19.2.18": {
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dependencies": [
+        "csstype"
+      ]
+    },
     "@types/trusted-types@2.0.7": {
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
@@ -1452,6 +1468,9 @@
         "shebang-command",
         "which"
       ]
+    },
+    "csstype@3.2.3": {
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "d3-array@3.2.4": {
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
@@ -2217,6 +2236,16 @@
         "unpipe"
       ]
     },
+    "react-dom@19.2.8_react@19.2.8": {
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dependencies": [
+        "react",
+        "scheduler"
+      ]
+    },
+    "react@19.2.8": {
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
+    },
     "real-require@0.2.0": {
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
@@ -2247,6 +2276,9 @@
     },
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scheduler@0.27.0": {
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "secure-json-parse@4.1.0": {
       "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="
@@ -2576,6 +2608,14 @@
         "dependencies": [
           "npm:@noble/ed25519@^3.1.0",
           "npm:@scure/bip39@^2.2.0"
+        ]
+      },
+      "packages/iframe-sandbox": {
+        "dependencies": [
+          "npm:@types/react-dom@19.2.5",
+          "npm:@types/react@19.2.18",
+          "npm:react-dom@19.2.8",
+          "npm:react@19.2.8"
         ]
       },
       "packages/js-compiler": {

--- a/docs/common/ai/iframe-pattern-guide.md
+++ b/docs/common/ai/iframe-pattern-guide.md
@@ -265,14 +265,12 @@ needs a new ID. Represent UI sentinels outside the user-data domain, such as
 
 ### React guests
 
-React belongs to the guest bundle, not the wrapper. Import the React instance
-chosen by the guest and pass that exact instance to
-`createFabricReact(React, fabric)` from
-`@commonfabric/iframe-sandbox/react`. Its `useCell(name)` hook uses
-`useSyncExternalStore`, returns `loading`, `ready`, or `error`, accepts a value or
-functional setter, and exposes `refresh()` as the explicit pull. The direct Cell
-API remains useful for fine-grained `key(...).sink(...)` subscriptions and
-stable resolved items.
+When the application should be a React component tree, use the parallel
+[`iframe-pattern-react-guide.md`](./iframe-pattern-react-guide.md) as the one
+self-contained authoring contract. It covers guest-owned React dependencies,
+TSX compilation, hook readiness, fine-grained direct Cell subscriptions,
+stable resolved items, SQLite query hooks, cleanup, and browser verification.
+Do not combine the two guest bootstraps.
 
 ## Optional SQLite
 

--- a/docs/common/ai/iframe-pattern-guide.md
+++ b/docs/common/ai/iframe-pattern-guide.md
@@ -167,6 +167,8 @@ The Cell contract matches the rest of Common Fabric:
   for later values. Call `pull()` when the first render needs fresh data.
 - `key(nameOrIndex)` derives a path-specific handle. Its sink observes that path
   rather than the whole root value.
+- `initialize(defaultValue)` atomically stores a first-use default only while
+  the Cell is undefined, then returns the value that won.
 - `set(value)` replaces a value. `update(fn)` queues a read-modify-write against
   other operations on the same remote Cell in this guest; it is not a
   transaction across users, sessions, or resources.
@@ -205,16 +207,18 @@ const state = fabric.cell<typeof DEFAULT_STATE>("state");
 
 async function addNote(text: string): Promise<void> {
   const current = await state.pull();
-  if (current === undefined) await state.set(DEFAULT_STATE);
+  if (current === undefined) await state.initialize(DEFAULT_STATE);
   await state.key("notes").push({ id: crypto.randomUUID(), text });
 }
 ```
 
 Do not initialize with `update((current) => current ?? DEFAULT_STATE)`: the
 updater starts from this guest's cache, which another session may have made
-stale. A strict default `set()` after `pull()` either materializes the missing
-parent or fails closed if another writer won. Use `update()` only when a local
-queue over an already materialized complete object is the intended boundary.
+stale. `initialize()` reads and conditionally writes in one runtime transaction,
+so concurrent guests return the same winning value without replacing it. Use
+`set()` for intentional last-writer-wins replacement, and use `update()` only
+when a local queue over an already materialized complete object is the intended
+boundary.
 
 Keep editable DOM drafts separate from authoritative Cell samples. While a
 local write is pending, a sink rerender should preserve that draft. Once it

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -1,0 +1,475 @@
+# React iframe-first pattern guide
+
+Use this guide to build a Common Fabric pattern whose application is a React
+tree inside one sandboxed `cf-iframe`. The wrapper remains mechanical: it
+exposes named Cell and SQLite resources, bundles the React guest and all of its
+dependencies into one HTML string, and returns durable state and output through
+the normal pattern result.
+
+This guide is self-contained. Do not also load the plain-DOM iframe guide unless
+you are migrating an existing guest and need to compare the two source styles.
+
+## Source layout
+
+Keep these authored files beside the generated wrapper:
+
+```text
+packages/patterns/react-quick-notes/
+├── contract.ts  # input, durable state, output, scopes, optional databases
+├── guest.tsx    # React application and Fabric bridge client
+├── guest.html   # optional document shell
+└── main.tsx     # generated wrapper; do not hand-edit
+```
+
+The generated `main.tsx` contains React, React DOM, the guest bridge, and the
+application. It does not need a module server at runtime. Keep `contract.ts` and
+`guest.tsx` so an agent can regenerate the wrapper.
+
+React is owned by the guest bundle. The iframe sandbox adapter accepts the
+exact React instance the guest imports; `@commonfabric/iframe-sandbox` does not
+select a React version for applications.
+
+## Describe input, state, and output
+
+Create `contract.ts` as a declarative module with no side effects:
+
+```typescript
+interface Note {
+  id: string;
+  text: string;
+}
+
+export interface IframeInputData {
+  heading: string;
+}
+
+export interface IframeStateData {
+  notes: Note[];
+  selectedId: string | null;
+}
+
+export interface IframeOutputData {
+  noteCount: number;
+  selectedId: string | null;
+}
+
+export const DEFAULT_INPUT: IframeInputData = {
+  heading: "Quick notes",
+};
+
+export const DEFAULT_STATE: IframeStateData = {
+  notes: [],
+  selectedId: null,
+};
+
+export const DEFAULT_OUTPUT: IframeOutputData = {
+  noteCount: 0,
+  selectedId: null,
+};
+
+export const IFRAME_PATTERN = {
+  name: "ReactQuickNotes",
+  displayName: "React quick notes",
+  stateScope: "user",
+  outputScope: "session",
+  frameHeight: "100vh",
+  databases: {},
+} as const;
+```
+
+The wrapper exposes three resources with these roles:
+
+- `input` is read-only data supplied by the caller.
+- `state` is durable application state the guest may change.
+- `output` is the public result the guest may change and the wrapper returns.
+
+The scopes are independent:
+
+| Scope | Meaning |
+| --- | --- |
+| `space` | Shared by every user and session in the piece |
+| `user` | Separate for each user and shared by that user's sessions |
+| `session` | Separate for each browser session |
+
+Keep React-only UI state such as hover, an open menu, an unfinished text field,
+or animation state in React. Put data in a Fabric Cell only when it should be
+durable or visible outside this component tree.
+
+## Import React and create the adapter
+
+Pin the React and type packages in the guest source. The file-level JSX pragmas
+make the guest compile independently of the Common Fabric JSX configuration
+used by generated `main.tsx`:
+
+```tsx
+// Shown at module scope.
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+// @deno-types="npm:@types/react@19.2.18"
+import React from "npm:react@19.2.8";
+// @deno-types="npm:@types/react-dom@19.2.5/client.d.ts"
+import { createRoot } from "npm:react-dom@19.2.8/client";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import { createFabricReact } from "@commonfabric/iframe-sandbox/react";
+
+const fabric = connectFabric();
+const { useCell, useSqliteQuery } = createFabricReact(React, fabric);
+
+function App() {
+  const heading = useCell<{ heading: string } | undefined>("input");
+  if (heading.status === "error") return <p role="alert">{heading.error.message}</p>;
+  if (heading.status !== "ready") return <p>Loading</p>;
+  return <h1>{(heading.value ?? { heading: "Notes" }).heading}</h1>;
+}
+
+const root = createRoot(document.querySelector<HTMLDivElement>("#root")!);
+root.render(<App />);
+
+globalThis.addEventListener("pagehide", () => {
+  root.unmount();
+  fabric.disconnect();
+}, { once: true });
+```
+
+Pass the same imported `React` object to `createFabricReact` that creates the
+tree. Do not import a second React copy for the bridge adapter. Use
+`createRoot`; do not use the removed legacy `render` entry point.
+
+The default generated document contains `<div id="root"></div>`. Supply a
+custom `guest.html` only when the guest needs document-level metadata, fonts,
+or sibling elements outside the React root.
+
+## Read and write Cells with hooks
+
+`useCell<T>(name)` returns one of three snapshots:
+
+- `{ status: "loading" }` while the initial pull is active;
+- `{ status: "ready", value }` after the host pull barrier resolves;
+- `{ status: "error", error }` when the resource cannot be read.
+
+It also returns `set(valueOrUpdater)` and `refresh()`. `refresh()` is the
+explicit host `Cell.pull()` boundary. The hook subscribes through
+`useSyncExternalStore`, so host updates rerender the component.
+
+`ready` means the pull completed; a newly scoped or optional Cell can therefore
+be ready with the value `undefined`. Include `undefined` in the hook type. Use
+the declared input default for an absent read-only input. For writable state or
+output, initialize only after that Cell's authoritative pull reports
+`undefined`; do not replace a value that another session may already have
+materialized.
+
+Treat readiness as one aggregate phase. Every resource an action reads must be
+ready before that action becomes available:
+
+```tsx
+// Shown at module scope.
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+// @deno-types="npm:@types/react@19.2.18"
+import React from "npm:react@19.2.8";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import { createFabricReact } from "@commonfabric/iframe-sandbox/react";
+import {
+  DEFAULT_INPUT,
+  DEFAULT_OUTPUT,
+  DEFAULT_STATE,
+} from "./contract.ts";
+
+const fabric = connectFabric();
+const { useCell } = createFabricReact(React, fabric);
+
+function Editor() {
+  const input = useCell<typeof DEFAULT_INPUT | undefined>("input");
+  const state = useCell<typeof DEFAULT_STATE | undefined>("state");
+  const output = useCell<typeof DEFAULT_OUTPUT | undefined>("output");
+  const stateValue = state.status === "ready" ? state.value : undefined;
+  const outputValue = output.status === "ready" ? output.value : undefined;
+  React.useEffect(() => {
+    if (state.status === "ready" && stateValue === undefined) {
+      void state.set(DEFAULT_STATE);
+    }
+  }, [state.status, stateValue, state.set]);
+  React.useEffect(() => {
+    if (output.status === "ready" && outputValue === undefined) {
+      void output.set(DEFAULT_OUTPUT);
+    }
+  }, [output.status, outputValue, output.set]);
+  const resources = [input, state, output];
+  const failure = resources.find((resource) => resource.status === "error");
+
+  if (failure?.status === "error") {
+    return <p role="alert">{failure.error.message}</p>;
+  }
+  if (
+    input.status !== "ready" || state.status !== "ready" ||
+    stateValue === undefined || output.status !== "ready" ||
+    outputValue === undefined
+  ) {
+    return <button type="button" disabled>Loading</button>;
+  }
+
+  const addNote = async () => {
+    const note = { id: crypto.randomUUID(), text: "New note" };
+    await state.set((current: typeof DEFAULT_STATE | undefined) => ({
+      ...(current ?? DEFAULT_STATE),
+      notes: [...(current ?? DEFAULT_STATE).notes, note],
+      selectedId: note.id,
+    }));
+    const current = (await state.refresh()) ?? DEFAULT_STATE;
+    await output.set({
+      noteCount: current.notes.length,
+      selectedId: current.selectedId,
+    });
+  };
+
+  return (
+    <section>
+      <h1>{(input.value ?? DEFAULT_INPUT).heading}</h1>
+      <p>{stateValue.notes.length} notes</p>
+      <button type="button" onClick={() => void addNote()}>Add note</button>
+    </section>
+  );
+}
+```
+
+The hooks load Cells independently, but the component owns one joint readiness
+predicate. An individual resource becoming ready must not enable an action that
+still reads fallback input, state, or output.
+
+Functional setters are serialized for the same remote Cell inside one guest.
+They are not a transaction across users or across resources. Prefer a narrow
+operation when the intent permits it. The direct client remains available next
+to the hooks:
+
+```typescript
+// Shown at module scope.
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+
+const fabric = connectFabric();
+const state = fabric.cell<{ notes: Array<{ id: string; text: string }> }>(
+  "state",
+);
+await state.key("notes").push({ id: crypto.randomUUID(), text: "New note" });
+```
+
+`push()` is a mergeable append. Replacing the whole array from a React setter
+has a wider conflict domain.
+
+## Fine-grained paths and stable array items
+
+The React adapter intentionally covers named root resources. Use the direct
+Cell API in a custom hook when a component should observe one path rather than
+rerender for the entire root. `sink()` calls its listener synchronously with the
+current cached sample, then again for later values; call `pull()` when the
+component requires current data before mutation.
+
+An array index is a position rather than an identity. Resolve the item first,
+then keep the resolved handle in the effect:
+
+```tsx
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+// @deno-types="npm:@types/react@19.2.18"
+import React from "npm:react@19.2.8";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+
+const fabric = connectFabric();
+
+function FirstNoteTitle() {
+  const [title, setTitle] = React.useState<string>();
+  const [error, setError] = React.useState<Error>();
+
+  React.useEffect(() => {
+    let stop: (() => void) | undefined;
+    let active = true;
+    void fabric.cell<Array<{ title: string }>>("notes").key(0).resolve()
+      .then(async (note) => {
+        if (!active) return;
+        const titleCell = note.key("title");
+        await titleCell.pull();
+        if (!active) return;
+        stop = titleCell.sink((value) => setTitle(value));
+      })
+      .catch((cause) => {
+        if (active) setError(cause instanceof Error ? cause : new Error(String(cause)));
+      });
+    return () => {
+      active = false;
+      stop?.();
+    };
+  }, []);
+
+  if (error) return <p role="alert">{error.message}</p>;
+  return <p>{title ?? "Loading"}</p>;
+}
+```
+
+The resolved capability stays anchored to the stored entity if array positions
+move. Its `.identity.id` names the entity document. Its
+`.identity.instanceId` names the concrete scoped instance and is stable across
+sessions for one PerUser Cell, different across users, and different for every
+PerSession Cell. The guest cannot turn an arbitrary ID into authority; writes
+go through the resolved handle.
+
+## Add SQLite without querying before hydration
+
+Declare databases in `IFRAME_PATTERN`:
+
+```typescript
+export const IFRAME_PATTERN = {
+  name: "ReactQuickNotes",
+  displayName: "React quick notes",
+  stateScope: "user",
+  outputScope: "session",
+  databases: {
+    appDatabase: {
+      scope: "user",
+      tables: {
+        notes: {
+          id: "integer primary key",
+          text: "text not null",
+        },
+      },
+    },
+  },
+} as const;
+```
+
+Mount the query component only after every Cell used to construct or authorize
+the query is ready. This preserves the Rules of Hooks while preventing an early
+query from using fallback configuration:
+
+```tsx
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+// @deno-types="npm:@types/react@19.2.18"
+import React from "npm:react@19.2.8";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import { createFabricReact } from "@commonfabric/iframe-sandbox/react";
+
+const fabric = connectFabric();
+const database = fabric.sqlite("appDatabase");
+const { useCell, useSqliteQuery } = createFabricReact(React, fabric);
+
+function Notes({ heading }: { heading: string }) {
+  const query = useSqliteQuery<{ id: number; text: string }>(
+    "appDatabase",
+    "SELECT id, text FROM notes ORDER BY id",
+  );
+  if (query.status === "error") return <p role="alert">{query.error.message}</p>;
+  if (query.status !== "ready") return <p>Loading notes</p>;
+
+  const add = async () => {
+    await database.exec(
+      "INSERT INTO notes (text) VALUES (?)",
+      [`${heading} ${query.rows.length + 1}`],
+    );
+  };
+
+  return (
+    <section>
+      <button type="button" onClick={() => void add()}>Add stored note</button>
+      <ul>{query.rows.map((note) => <li key={note.id}>{note.text}</li>)}</ul>
+    </section>
+  );
+}
+
+function App() {
+  const input = useCell<{ heading: string }>("input");
+  const state = useCell<{ selectedId: string | null }>("state");
+  if (input.status !== "ready" || state.status !== "ready") {
+    return <p>Loading application</p>;
+  }
+  return <Notes heading={input.value.heading} />;
+}
+```
+
+`useSqliteQuery()` begins in `loading`, returns typed rows in `ready`, reports
+query failures in `error`, and exposes `refresh()`. It subscribes to database
+invalidations, so committed `exec()` calls refresh active queries. Do not put a
+query hook behind a conditional inside one component; put it in a child that is
+mounted after the readiness boundary.
+
+SQLite scopes have the same meanings as Cell scopes. Database, table, and
+column names are data. For the exact name `__proto__` in `contract.ts`, use a
+computed property (`["__proto__"]`) so JavaScript creates an own property.
+
+## Preserve user drafts and report failures
+
+An authoritative sink or hook rerender can arrive while the user edits a text
+field. Keep the draft in `useState`; copy authoritative data into it only when
+there is no pending local edit. Disable the action while its write is pending,
+and surface rejected writes. Do not clear the draft before a successful write.
+
+Use `button type="button"` for every bridge action. The sandbox does not grant
+native form submission or navigation, so do not wrap bridge controls in a
+`form`, use a submit button, or call `requestSubmit()`.
+
+If one fact must agree across shared state and scoped output, store the fact in
+one authoritative resource and store only its stable key in the other. Separate
+Cell writes are not atomic. Mint a new ID for a genuinely edited retry; reuse an
+idempotency ID only for the same payload.
+
+## Generate the wrapper
+
+Run the helper from the repository root with `--react`. That flag compiles TSX
+through the `React` instance imported by `guest.tsx`; without it, repository JSX
+settings target the Common Fabric host runtime instead.
+
+```bash
+deno run -A tools/write-iframe-wrapper.ts \
+  --contract packages/patterns/react-quick-notes/contract.ts \
+  --guest packages/patterns/react-quick-notes/guest.tsx \
+  --out packages/patterns/react-quick-notes/main.tsx \
+  --react
+```
+
+The helper refuses to overwrite a file. Add `--force` only when regenerating
+that named output. For a custom document, add `--html .../guest.html`; the HTML
+must contain `<!-- PATTERN_IFRAME_SCRIPT -->` exactly once.
+
+## Verify in the browser
+
+Format and compile both realms:
+
+```bash
+deno fmt packages/patterns/react-quick-notes
+deno check packages/patterns/react-quick-notes/guest.tsx
+deno task cf check packages/patterns/react-quick-notes/main.tsx --no-run
+```
+
+Launch against local servers:
+
+```bash
+./scripts/start-local-dev.sh
+mkdir -p .cf
+test -e .cf/iframe-pattern.key || \
+  deno task cf id new > .cf/iframe-pattern.key
+CF_API_URL=http://localhost:8000 \
+CF_IDENTITY=.cf/iframe-pattern.key \
+deno task cf piece new packages/patterns/react-quick-notes/main.tsx \
+  --root . --space iframe-react-notes --slug react-notes
+```
+
+Never overwrite an existing key file because it selects the PerUser identity.
+Open `http://localhost:8000/iframe-react-notes/react-notes`. If the shell shows
+first-use login, choose **Register New Key**, enter and confirm a passphrase, and
+continue. Exercise every meaningful action and inspect the browser console. A
+successful bundle does not prove React mounted, a hook completed its pull, or a
+bridge write reached the worker.
+
+Verify at least these behaviors:
+
+- the initial loading view becomes the authoritative input/state view;
+- hook-driven Cell writes rerender and survive reload at their declared scope;
+- a SQLite mutation causes the active query to rerender;
+- a rejected write or query renders an error rather than silently clearing a
+  draft;
+- cleanup disconnects the bridge when the iframe document is replaced.
+
+For multi-user state, cover two sessions of one identity, a second identity,
+and a reload. PerSpace data agrees everywhere, PerUser data agrees only between
+the same identity's sessions, and PerSession data remains distinct. Exercise
+first use rather than only a warmed-up piece. When both runtime modes matter,
+run the same unskipped browser test with default execution and with
+`EXPERIMENTAL_SERVER_EXECUTION=true`.

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -156,7 +156,9 @@ be ready with the value `undefined`. Include `undefined` in the hook type. Use
 the declared input default for an absent read-only input. For writable state or
 output, initialize only after that Cell's authoritative pull reports
 `undefined`; do not replace a value that another session may already have
-materialized.
+materialized. Bridge `set()` is strict: after that pull, the default write
+either materializes the absent Cell or rejects if another writer won. Catch
+that rejection; the hook snapshot changes to `error` for the render path.
 
 Treat readiness as one aggregate phase. Every resource an action reads must be
 ready before that action becomes available:
@@ -177,6 +179,7 @@ import {
 
 const fabric = connectFabric();
 const { useCell } = createFabricReact(React, fabric);
+const stateCell = fabric.cell<typeof DEFAULT_STATE>("state");
 
 function Editor() {
   const input = useCell<typeof DEFAULT_INPUT | undefined>("input");
@@ -184,14 +187,17 @@ function Editor() {
   const output = useCell<typeof DEFAULT_OUTPUT | undefined>("output");
   const stateValue = state.status === "ready" ? state.value : undefined;
   const outputValue = output.status === "ready" ? output.value : undefined;
+  const actionTail = React.useRef(Promise.resolve());
+  const [pending, setPending] = React.useState(false);
+  const [actionError, setActionError] = React.useState<Error>();
   React.useEffect(() => {
     if (state.status === "ready" && stateValue === undefined) {
-      void state.set(DEFAULT_STATE);
+      void state.set(DEFAULT_STATE).catch(() => {});
     }
   }, [state.status, stateValue, state.set]);
   React.useEffect(() => {
     if (output.status === "ready" && outputValue === undefined) {
-      void output.set(DEFAULT_OUTPUT);
+      void output.set(DEFAULT_OUTPUT).catch(() => {});
     }
   }, [output.status, outputValue, output.set]);
   const resources = [input, state, output];
@@ -208,25 +214,47 @@ function Editor() {
     return <button type="button" disabled>Loading</button>;
   }
 
-  const addNote = async () => {
-    const note = { id: crypto.randomUUID(), text: "New note" };
-    await state.set((current: typeof DEFAULT_STATE | undefined) => ({
-      ...(current ?? DEFAULT_STATE),
-      notes: [...(current ?? DEFAULT_STATE).notes, note],
-      selectedId: note.id,
-    }));
-    const current = (await state.refresh()) ?? DEFAULT_STATE;
-    await output.set({
-      noteCount: current.notes.length,
-      selectedId: current.selectedId,
+  const runAction = (action: () => Promise<void>): Promise<void> => {
+    const next = actionTail.current.then(async () => {
+      setPending(true);
+      setActionError(undefined);
+      try {
+        await action();
+      } catch (cause) {
+        setActionError(
+          cause instanceof Error ? cause : new Error(String(cause)),
+        );
+      } finally {
+        setPending(false);
+      }
     });
+    actionTail.current = next;
+    return next;
   };
+  const addNote = () =>
+    runAction(async () => {
+      const note = { id: crypto.randomUUID(), text: "New note" };
+      await stateCell.key("notes").push(note);
+      await stateCell.key("selectedId").set(note.id);
+      const current = (await state.refresh()) ?? DEFAULT_STATE;
+      await output.set({
+        noteCount: current.notes.length,
+        selectedId: current.selectedId,
+      });
+    });
 
   return (
     <section>
       <h1>{(input.value ?? DEFAULT_INPUT).heading}</h1>
       <p>{stateValue.notes.length} notes</p>
-      <button type="button" onClick={() => void addNote()}>Add note</button>
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => void addNote()}
+      >
+        Add note
+      </button>
+      {actionError && <p role="alert">{actionError.message}</p>}
     </section>
   );
 }
@@ -234,7 +262,10 @@ function Editor() {
 
 The hooks load Cells independently, but the component owns one joint readiness
 predicate. An individual resource becoming ready must not enable an action that
-still reads fallback input, state, or output.
+still reads fallback input, state, or output. Initialization rejections are
+consumed because the hook exposes them through its `error` snapshot. Action
+rejections are rendered separately, and the ref-backed tail keeps rapid actions
+serialized across rerenders.
 
 Functional setters are serialized for the same remote Cell inside one guest.
 They are not a transaction across users or across resources. Prefer a narrow
@@ -249,7 +280,10 @@ const fabric = connectFabric();
 const state = fabric.cell<{ notes: Array<{ id: string; text: string }> }>(
   "state",
 );
-await state.key("notes").push({ id: crypto.randomUUID(), text: "New note" });
+
+async function appendNote(text: string): Promise<void> {
+  await state.key("notes").push({ id: crypto.randomUUID(), text });
+}
 ```
 
 `push()` is a mergeable append. Replacing the whole array from a React setter

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -147,8 +147,10 @@ or sibling elements outside the React root.
 - `{ status: "ready", value }` after the host pull barrier resolves;
 - `{ status: "error", error }` when the resource cannot be read.
 
-It also returns `set(valueOrUpdater)` and `refresh()`. `refresh()` is the
-explicit host `Cell.pull()` boundary. The hook subscribes through
+It also returns `initialize(defaultValue)`, `set(valueOrUpdater)`, and
+`refresh()`. `initialize()` atomically stores the default only while the Cell is
+undefined and returns the value selected by that transaction. `refresh()` is
+the explicit host `Cell.pull()` boundary. The hook subscribes through
 `useSyncExternalStore`, so host updates rerender the component.
 
 `ready` means the pull completed; a newly scoped or optional Cell can therefore
@@ -156,9 +158,9 @@ be ready with the value `undefined`. Include `undefined` in the hook type. Use
 the declared input default for an absent read-only input. For writable state or
 output, initialize only after that Cell's authoritative pull reports
 `undefined`; do not replace a value that another session may already have
-materialized. Bridge `set()` is strict: after that pull, the default write
-either materializes the absent Cell or rejects if another writer won. Catch
-that rejection; the hook snapshot changes to `error` for the render path.
+materialized. Use `initialize()` rather than `set()` for that default write.
+Bridge `set()` reports commit failure, but its write remains an intentional
+last-writer-wins replacement.
 
 Treat readiness as one aggregate phase. Every resource an action reads must be
 ready before that action becomes available:
@@ -192,14 +194,14 @@ function Editor() {
   const [actionError, setActionError] = React.useState<Error>();
   React.useEffect(() => {
     if (state.status === "ready" && stateValue === undefined) {
-      void state.set(DEFAULT_STATE).catch(() => {});
+      void state.initialize(DEFAULT_STATE).catch(() => {});
     }
-  }, [state.status, stateValue, state.set]);
+  }, [state.status, stateValue, state.initialize]);
   React.useEffect(() => {
     if (output.status === "ready" && outputValue === undefined) {
-      void output.set(DEFAULT_OUTPUT).catch(() => {});
+      void output.initialize(DEFAULT_OUTPUT).catch(() => {});
     }
-  }, [output.status, outputValue, output.set]);
+  }, [output.status, outputValue, output.initialize]);
   const resources = [input, state, output];
   const failure = resources.find((resource) => resource.status === "error");
 

--- a/packages/iframe-sandbox/README.md
+++ b/packages/iframe-sandbox/README.md
@@ -49,10 +49,11 @@ frame.src = "<main id='root'></main>";
 
 A resource has a `kind`, optional schema and description, and only the
 operations the host supplies. A cell capability follows the runtime's Cell
-shape: `get()`, `pull()`, optional `set()` and `push()`, `sink()`, `key()`, and
-`resolve()`. The resource kinds are `cell`, `stream`, `sqlite`, and `service`.
-Named methods let an application expose a narrow service without expanding the
-cell protocol.
+shape: `get()`, `pull()`, optional `initialize()`, `set()`, and `push()`,
+`sink()`, `key()`, and `resolve()`. `initialize(defaultValue)` atomically stores
+the default only while the cell is undefined and returns the value that won. The
+resource kinds are `cell`, `stream`, `sqlite`, and `service`. Named methods let
+an application expose a narrow service without expanding the cell protocol.
 
 The higher-level `cf-iframe` component accepts the same `bridge` property. Its
 `context` convenience property turns top-level Fabric cells into cell resources,
@@ -90,6 +91,7 @@ console.log(manifest.resources);
 const count = fabric.cell<number>("count");
 console.log(count.get()); // Immediate cache sample; it may be stale.
 console.log(await count.pull()); // Fully updated after the host Cell.pull().
+await count.initialize(0); // Atomic first-use default; returns the winner.
 await count.set(1);
 
 const stop = count.sink((value) => {

--- a/packages/iframe-sandbox/deno.jsonc
+++ b/packages/iframe-sandbox/deno.jsonc
@@ -4,11 +4,17 @@
   "tasks": {
     // The first two run in Deno; the rest need a browser, so they are named
     // for `deno-web-test` rather than swept up by a glob.
-    "test": "deno test --allow-read test/bridge.test.ts test/csp.test.ts test/guest.test.ts test/ipc.test.ts test/react.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/iframe.test.ts test/iframe-csp.test.ts"
+    "test": "deno test --allow-read test/bridge.test.ts test/csp.test.ts test/guest.test.ts test/ipc.test.ts test/react.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/iframe.test.ts test/iframe-csp.test.ts test/react-browser.test.ts"
   },
   "exports": {
     ".": "./src/index.ts",
     "./guest": "./src/guest.ts",
     "./react": "./src/react.ts"
+  },
+  "imports": {
+    "@types/react": "npm:@types/react@19.2.18",
+    "@types/react-dom/client": "npm:@types/react-dom@19.2.5/client.d.ts",
+    "react": "npm:react@19.2.8",
+    "react-dom/client": "npm:react-dom@19.2.8/client"
   }
 }

--- a/packages/iframe-sandbox/src/bridge.ts
+++ b/packages/iframe-sandbox/src/bridge.ts
@@ -37,6 +37,7 @@ export type BridgeMethod = (
 export type BridgeCell = {
   get(): FabricValue | undefined;
   pull(): FabricValue | undefined | Promise<FabricValue | undefined>;
+  initialize?(value: FabricValue): FabricValue | Promise<FabricValue>;
   set?(value: FabricValue): void | Promise<void>;
   push?(...values: FabricValue[]): void | Promise<void>;
   sink?(
@@ -76,6 +77,7 @@ export function createFabricBridge(
 
 const CORE_OPERATIONS = new Set([
   "get",
+  "initialize",
   "key",
   "pull",
   "push",
@@ -135,6 +137,7 @@ function namedMethodNames(
 
 type BridgeCellOperation =
   | "get"
+  | "initialize"
   | "key"
   | "pull"
   | "push"
@@ -439,6 +442,18 @@ export class FabricBridgeHost {
           );
         }
         return await pull.call(cell);
+      }
+      case "initialize": {
+        const { cell, resource: name } = this.#requestCell(request);
+        const initialize = cellOperation(cell, "initialize");
+        if (!initialize) {
+          throw bridgeError(
+            "method-not-supported",
+            `Cell \`${name}\` does not support initialize().`,
+            name,
+          );
+        }
+        return await initialize.call(cell, request.value as FabricValue);
       }
       case "set": {
         const { cell, resource: name } = this.#requestCell(request);

--- a/packages/iframe-sandbox/src/bridge.ts
+++ b/packages/iframe-sandbox/src/bridge.ts
@@ -616,6 +616,13 @@ export class FabricBridgeHost {
           resolved.resource,
         );
       }
+      if ((request.path?.length ?? 0) > 0 && !resolved.operations.has("key")) {
+        throw bridgeError(
+          "method-not-supported",
+          `Resolved cell \`${request.handle}\` does not support key().`,
+          resolved.resource,
+        );
+      }
       cell = resolved.cell;
       resourceName = resolved.resource;
     } else {

--- a/packages/iframe-sandbox/src/bridge.ts
+++ b/packages/iframe-sandbox/src/bridge.ts
@@ -185,6 +185,12 @@ function cellOperation<K extends BridgeCellOperation>(
     : undefined;
 }
 
+function cellOperationNames(cell: BridgeCell): BridgeCellOperation[] {
+  return [...CORE_OPERATIONS].filter((operation) =>
+    cellOperation(cell, operation as BridgeCellOperation) !== undefined
+  ) as BridgeCellOperation[];
+}
+
 function resourceSink(
   resource: BridgeResource,
 ):
@@ -224,11 +230,7 @@ function descriptor(
   const operations: string[] = [];
   if (kind === "cell") {
     const cell = resourceCell(name, resource);
-    for (const operation of CORE_OPERATIONS) {
-      if (cellOperation(cell, operation as BridgeCellOperation)) {
-        operations.push(operation);
-      }
-    }
+    operations.push(...cellOperationNames(cell));
   } else if (resourceSink(resource)) {
     operations.push("sink");
   }
@@ -307,7 +309,14 @@ export class FabricBridgeHost {
   readonly #bridge: FabricBridge;
   readonly #port: MessagePort;
   readonly #subscriptions = new Map<string, BridgeCancel>();
-  readonly #cells = new Map<string, { cell: BridgeCell; resource: string }>();
+  readonly #cells = new Map<
+    string,
+    {
+      cell: BridgeCell;
+      operations: ReadonlySet<BridgeCellOperation>;
+      resource: string;
+    }
+  >();
   #nextCellHandle = 0;
   #operationTail: Promise<void> | undefined;
   #connected = true;
@@ -432,7 +441,7 @@ export class FabricBridgeHost {
 
     switch (operation) {
       case "pull": {
-        const { cell, resource: name } = this.#requestCell(request);
+        const { cell, resource: name } = this.#requestCell(request, "pull");
         const pull = cellOperation(cell, "pull");
         if (!pull) {
           throw bridgeError(
@@ -444,7 +453,10 @@ export class FabricBridgeHost {
         return await pull.call(cell);
       }
       case "initialize": {
-        const { cell, resource: name } = this.#requestCell(request);
+        const { cell, resource: name } = this.#requestCell(
+          request,
+          "initialize",
+        );
         const initialize = cellOperation(cell, "initialize");
         if (!initialize) {
           throw bridgeError(
@@ -456,7 +468,7 @@ export class FabricBridgeHost {
         return await initialize.call(cell, request.value as FabricValue);
       }
       case "set": {
-        const { cell, resource: name } = this.#requestCell(request);
+        const { cell, resource: name } = this.#requestCell(request, "set");
         const set = cellOperation(cell, "set");
         if (!set) {
           throw bridgeError(
@@ -469,7 +481,7 @@ export class FabricBridgeHost {
         return undefined;
       }
       case "push": {
-        const { cell, resource: name } = this.#requestCell(request);
+        const { cell, resource: name } = this.#requestCell(request, "push");
         const push = cellOperation(cell, "push");
         if (!push) {
           throw bridgeError(
@@ -482,19 +494,25 @@ export class FabricBridgeHost {
         return undefined;
       }
       case "resolve": {
-        const target = this.#requestCell(request);
+        const target = this.#requestCell(request, "resolve");
         const resolve = cellOperation(target.cell, "resolve");
         const cell = validateCell(
           target.resource,
           resolve ? await resolve.call(target.cell) : target.cell,
         );
         const handle = `cell-${this.#nextCellHandle++}`;
-        this.#cells.set(handle, { cell, resource: target.resource });
+        const operations = cellOperationNames(cell);
+        this.#cells.set(handle, {
+          cell,
+          operations: new Set(operations),
+          resource: target.resource,
+        });
         const identity = Object.getOwnPropertyDescriptor(cell, "identity");
         const value = cell.get();
         return {
           handle,
           hasValue: true,
+          operations,
           ...(identity && "value" in identity && identity.value !== undefined &&
             {
               identity: identity.value,
@@ -539,7 +557,7 @@ export class FabricBridgeHost {
           | undefined;
         let receiver: object;
         if (request.handle !== undefined || resource?.kind === "cell") {
-          const target = this.#requestCell(request);
+          const target = this.#requestCell(request, "sink");
           const sink = cellOperation(target.cell, "sink");
           sinkResource = sink &&
             ((listener) => sink.call(target.cell, listener));
@@ -574,7 +592,10 @@ export class FabricBridgeHost {
     }
   }
 
-  #requestCell(request: BridgeRequest): {
+  #requestCell(
+    request: BridgeRequest,
+    operation: BridgeCellOperation,
+  ): {
     cell: BridgeCell;
     resource: string;
   } {
@@ -586,6 +607,13 @@ export class FabricBridgeHost {
         throw bridgeError(
           "resource-not-found",
           `No resolved cell handle is named \`${request.handle}\`.`,
+        );
+      }
+      if (!resolved.operations.has(operation)) {
+        throw bridgeError(
+          "method-not-supported",
+          `Resolved cell \`${request.handle}\` does not support ${operation}().`,
+          resolved.resource,
         );
       }
       cell = resolved.cell;

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -273,7 +273,7 @@ export class RemoteCell<T = FabricValue> {
       const result = await this.#client.request("resolve", {
         ...targetFields(this.#target),
       }) as BridgeResolvedCell;
-      return this.#client.resolvedCell<T>(result);
+      return this.#client.resolvedCell<T>(result, this.#target);
     });
     return this.#resolved;
   }
@@ -492,6 +492,8 @@ export class FabricClient {
   #subscriptions = new Map<string, Subscription>();
   #cells = new Map<string, RemoteCell<unknown>>();
   #cellOperationQueues = new Map<string, CellOperationQueue>();
+  #resolvedResources = new Map<string, string>();
+  #manifest: Promise<BridgeManifest> | undefined;
   #disconnected = false;
 
   constructor() {
@@ -499,7 +501,9 @@ export class FabricClient {
   }
 
   describe(): Promise<BridgeManifest> {
-    return this.request("describe") as Promise<BridgeManifest>;
+    return this.#manifest ??= this.#request("describe") as Promise<
+      BridgeManifest
+    >;
   }
 
   cell<T = FabricValue>(name: string): RemoteCell<T> {
@@ -534,7 +538,16 @@ export class FabricClient {
   }
 
   /** Rehydrates a host-minted stable cell capability. */
-  resolvedCell<T = FabricValue>(descriptor: BridgeResolvedCell): RemoteCell<T> {
+  resolvedCell<T = FabricValue>(
+    descriptor: BridgeResolvedCell,
+    source: RemoteCellTarget,
+  ): RemoteCell<T> {
+    const resource = "resource" in source
+      ? source.resource
+      : this.#resolvedResources.get(source.handle);
+    if (resource !== undefined) {
+      this.#resolvedResources.set(descriptor.handle, resource);
+    }
     return this.cellTarget<T>(
       { handle: descriptor.handle, path: [] },
       {
@@ -559,6 +572,54 @@ export class FabricClient {
   }
 
   request(
+    operation: BridgeOperation,
+    fields: Partial<
+      Omit<
+        BridgeRequest,
+        "protocol" | "version" | "type" | "id" | "operation"
+      >
+    > = {},
+  ): Promise<FabricValue | undefined> {
+    if (operation === "initialize") {
+      return this.#initialize(fields);
+    }
+    return this.#request(operation, fields);
+  }
+
+  async #initialize(
+    fields: Partial<
+      Omit<
+        BridgeRequest,
+        "protocol" | "version" | "type" | "id" | "operation"
+      >
+    >,
+  ): Promise<FabricValue | undefined> {
+    const resource = typeof fields.resource === "string"
+      ? fields.resource
+      : typeof fields.handle === "string"
+      ? this.#resolvedResources.get(fields.handle)
+      : undefined;
+    if (resource === undefined) {
+      throw new FabricBridgeError({
+        code: "method-not-supported",
+        message: "The cell capability cannot negotiate initialize().",
+      });
+    }
+    const manifest = await this.describe();
+    const descriptor = manifest.resources.find((entry) =>
+      entry.name === resource
+    );
+    if (!descriptor?.operations.includes("initialize")) {
+      throw new FabricBridgeError({
+        code: "method-not-supported",
+        message: `Cell \`${resource}\` does not support initialize().`,
+        resource,
+      });
+    }
+    return await this.#request("initialize", fields);
+  }
+
+  #request(
     operation: BridgeOperation,
     fields: Partial<
       Omit<
@@ -669,6 +730,8 @@ export class FabricClient {
     for (const pending of this.#pending.values()) pending.reject(error);
     this.#pending.clear();
     this.#subscriptions.clear();
+    this.#resolvedResources.clear();
+    this.#manifest = undefined;
     this.#cellOperationQueues.clear();
     this.#queued = [];
   }

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -190,6 +190,24 @@ export class RemoteCell<T = FabricValue> {
     return this.#enqueueOperation(() => this.#set(snapshot));
   }
 
+  /** Atomically stores a default while the cell is undefined. */
+  initialize(value: T): Promise<T> {
+    if (value === undefined) {
+      return Promise.reject(
+        new TypeError("Cell initialize requires a defined value."),
+      );
+    }
+    let snapshot: T;
+    try {
+      snapshot = cloneIfNecessary(value as FabricValue, {
+        frozen: false,
+      }) as T;
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.#enqueueOperation(() => this.#initialize(snapshot));
+  }
+
   update(updater: (current: T) => T): Promise<void> {
     return this.#enqueueOperation(async () => {
       const snapshot = this.#snapshot;
@@ -291,6 +309,32 @@ export class RemoteCell<T = FabricValue> {
       ) {
         this.#setReady(snapshot);
       }
+    } catch (error) {
+      if (
+        eventGeneration === this.#eventGeneration &&
+        this.#snapshot === before
+      ) {
+        this.#setError(error);
+      }
+      throw error;
+    }
+  }
+
+  async #initialize(value: T): Promise<T> {
+    const before = this.#snapshot;
+    const eventGeneration = this.#eventGeneration;
+    try {
+      const current = await this.#client.request("initialize", {
+        ...targetFields(this.#target),
+        value: value as FabricValue,
+      }) as T;
+      if (
+        eventGeneration === this.#eventGeneration &&
+        this.#snapshot === before
+      ) {
+        this.#setReady(current);
+      }
+      return current;
     } catch (error) {
       if (
         eventGeneration === this.#eventGeneration &&

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -273,7 +273,7 @@ export class RemoteCell<T = FabricValue> {
       const result = await this.#client.request("resolve", {
         ...targetFields(this.#target),
       }) as BridgeResolvedCell;
-      return this.#client.resolvedCell<T>(result, this.#target);
+      return this.#client.resolvedCell<T>(result);
     });
     return this.#resolved;
   }
@@ -492,7 +492,7 @@ export class FabricClient {
   #subscriptions = new Map<string, Subscription>();
   #cells = new Map<string, RemoteCell<unknown>>();
   #cellOperationQueues = new Map<string, CellOperationQueue>();
-  #resolvedResources = new Map<string, string>();
+  #resolvedOperations = new Map<string, ReadonlySet<string>>();
   #manifest: Promise<BridgeManifest> | undefined;
   #disconnected = false;
 
@@ -540,14 +540,11 @@ export class FabricClient {
   /** Rehydrates a host-minted stable cell capability. */
   resolvedCell<T = FabricValue>(
     descriptor: BridgeResolvedCell,
-    source: RemoteCellTarget,
   ): RemoteCell<T> {
-    const resource = "resource" in source
-      ? source.resource
-      : this.#resolvedResources.get(source.handle);
-    if (resource !== undefined) {
-      this.#resolvedResources.set(descriptor.handle, resource);
-    }
+    this.#resolvedOperations.set(
+      descriptor.handle,
+      new Set(descriptor.operations ?? []),
+    );
     return this.cellTarget<T>(
       { handle: descriptor.handle, path: [] },
       {
@@ -594,12 +591,19 @@ export class FabricClient {
       >
     >,
   ): Promise<FabricValue | undefined> {
-    const resource = typeof fields.resource === "string"
-      ? fields.resource
-      : typeof fields.handle === "string"
-      ? this.#resolvedResources.get(fields.handle)
-      : undefined;
-    if (resource === undefined) {
+    if (this.#disconnected) {
+      return await this.#request("initialize", fields);
+    }
+    if (typeof fields.handle === "string") {
+      if (!this.#resolvedOperations.get(fields.handle)?.has("initialize")) {
+        throw new FabricBridgeError({
+          code: "method-not-supported",
+          message: "The resolved cell does not support initialize().",
+        });
+      }
+      return await this.#request("initialize", fields);
+    }
+    if (typeof fields.resource !== "string") {
       throw new FabricBridgeError({
         code: "method-not-supported",
         message: "The cell capability cannot negotiate initialize().",
@@ -607,13 +611,13 @@ export class FabricClient {
     }
     const manifest = await this.describe();
     const descriptor = manifest.resources.find((entry) =>
-      entry.name === resource
+      entry.name === fields.resource
     );
     if (!descriptor?.operations.includes("initialize")) {
       throw new FabricBridgeError({
         code: "method-not-supported",
-        message: `Cell \`${resource}\` does not support initialize().`,
-        resource,
+        message: `Cell \`${fields.resource}\` does not support initialize().`,
+        resource: fields.resource,
       });
     }
     return await this.#request("initialize", fields);
@@ -730,7 +734,7 @@ export class FabricClient {
     for (const pending of this.#pending.values()) pending.reject(error);
     this.#pending.clear();
     this.#subscriptions.clear();
-    this.#resolvedResources.clear();
+    this.#resolvedOperations.clear();
     this.#manifest = undefined;
     this.#cellOperationQueues.clear();
     this.#queued = [];

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -106,6 +106,12 @@ export function isGuestError(e: object): e is GuestError {
 }
 
 export const BRIDGE_PROTOCOL = "common-fabric-bridge";
+
+/**
+ * Exact encoding revision. An additive operation stays within this revision
+ * only when a current guest negotiates it through describe() before sending
+ * it, so an older host can reject the unsupported capability without hanging.
+ */
 export const BRIDGE_VERSION = 2;
 
 export type BridgeError = {
@@ -229,10 +235,12 @@ export function isBridgeRequest(message: unknown): message is BridgeRequest {
     case "disconnect":
       return true;
     case "pull":
-    case "initialize":
     case "set":
     case "resolve":
       return hasCellTarget(message) && hasCellPath(message);
+    case "initialize":
+      return hasCellTarget(message) && hasCellPath(message) &&
+        Object.hasOwn(message, "value") && message.value !== undefined;
     case "push":
       return hasCellTarget(message) && hasCellPath(message) &&
         Array.isArray(message.values);

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -172,6 +172,8 @@ export type BridgeCellIdentity = {
 export type BridgeResolvedCell = {
   handle: string;
   hasValue: true;
+  /** Operations the host authorizes on this resolved capability. */
+  operations?: string[];
   identity?: BridgeCellIdentity;
   value?: FabricValue;
 };

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -133,6 +133,7 @@ export type BridgeOperation =
   | "describe"
   | "disconnect"
   | "pull"
+  | "initialize"
   | "set"
   | "push"
   | "resolve"
@@ -228,6 +229,7 @@ export function isBridgeRequest(message: unknown): message is BridgeRequest {
     case "disconnect":
       return true;
     case "pull":
+    case "initialize":
     case "set":
     case "resolve":
       return hasCellTarget(message) && hasCellPath(message);

--- a/packages/iframe-sandbox/src/react.ts
+++ b/packages/iframe-sandbox/src/react.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
 
 import {
   type FabricClient,
@@ -95,8 +95,8 @@ export function createFabricReact(react: ReactHooks, client: FabricClient) {
     params?: SqliteQueryInput["params"],
   ): QuerySnapshot<Row> & { refresh(): Promise<void> } {
     const database = react.useMemo(() => client.sqlite(name), [name]);
-    const paramsKey = hashStringOf(params ?? null);
-    const queryKey = hashStringOf({ name, sql, params: params ?? null });
+    const paramsKey = JSON.stringify(realmFromFabricValue(params ?? null));
+    const queryKey = JSON.stringify([name, sql, paramsKey]);
     const activeQuery = react.useRef<string | undefined>(undefined);
     const generation = react.useRef(0);
     const [state, setState] = react.useState<KeyedQuerySnapshot<Row>>(() => ({

--- a/packages/iframe-sandbox/src/react.ts
+++ b/packages/iframe-sandbox/src/react.ts
@@ -38,6 +38,7 @@ export type ReactHooks = {
 
 /** Reactive state and mutations returned for a bridged cell. */
 export type CellHookResult<T> = ResourceSnapshot<T> & {
+  initialize(value: T): Promise<T>;
   set(value: T | ((current: T) => T)): Promise<void>;
   refresh(): Promise<T>;
 };
@@ -81,11 +82,17 @@ export function createFabricReact(react: ReactHooks, client: FabricClient) {
           : cell.set(next),
       [cell],
     );
+    const initialize = react.useCallback(
+      (value: T) => cell.initialize(value),
+      [cell],
+    );
+    const refresh = react.useCallback(() => cell.pull(), [cell]);
 
     return {
       ...snapshot,
+      initialize,
       set,
-      refresh: () => cell.pull(),
+      refresh,
     };
   }
 

--- a/packages/iframe-sandbox/src/react.ts
+++ b/packages/iframe-sandbox/src/react.ts
@@ -4,7 +4,7 @@
  */
 
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import {
   type FabricClient,
@@ -95,8 +95,8 @@ export function createFabricReact(react: ReactHooks, client: FabricClient) {
     params?: SqliteQueryInput["params"],
   ): QuerySnapshot<Row> & { refresh(): Promise<void> } {
     const database = react.useMemo(() => client.sqlite(name), [name]);
-    const paramsKey = JSON.stringify(realmFromFabricValue(params ?? null));
-    const queryKey = JSON.stringify([name, sql, paramsKey]);
+    const paramsKey = hashStringOf(params ?? null);
+    const queryKey = hashStringOf({ name, sql, params: params ?? null });
     const activeQuery = react.useRef<string | undefined>(undefined);
     const generation = react.useRef(0);
     const [state, setState] = react.useState<KeyedQuerySnapshot<Row>>(() => ({

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -13,7 +13,7 @@ import {
   FabricBridgeHost,
 } from "../src/bridge.ts";
 import { connectFabric } from "../src/guest.ts";
-import { GUEST_PORT_HANDOFF } from "../src/ipc.ts";
+import { type BridgeResolvedCell, GUEST_PORT_HANDOFF } from "../src/ipc.ts";
 
 function handOff(port: MessagePort): void {
   globalThis.dispatchEvent(
@@ -275,6 +275,54 @@ describe("Fabric iframe bridge", () => {
       expect(records[order[1]!]!.title).toBe("A moved");
       expect(seen).toEqual(["A", "A moved"]);
       cancel();
+    } finally {
+      client.disconnect();
+      host.disconnect();
+    }
+  });
+
+  it("does not expand a resolved handle after its operations are minted", async () => {
+    let initialized = false;
+    const leaf: BridgeCell = {
+      get: () => 1,
+      pull: () => 1,
+    };
+    const root: BridgeCell = {
+      get: () => 1,
+      pull: () => 1,
+      resolve: () => leaf,
+    };
+    const channel = new MessageChannel();
+    const host = new FabricBridgeHost(
+      createFabricBridge({ reader: { kind: "cell", cell: root } }),
+      channel.port1,
+    );
+    const client = connectFabric();
+    handOff(channel.port2);
+
+    try {
+      const descriptor = await client.request("resolve", {
+        resource: "reader",
+        path: [],
+      }) as BridgeResolvedCell;
+      Object.defineProperty(leaf, "initialize", {
+        configurable: true,
+        enumerable: true,
+        value: () => {
+          initialized = true;
+          return 9;
+        },
+      });
+      const forged = client.resolvedCell<number>({
+        ...descriptor,
+        operations: [...(descriptor.operations ?? []), "initialize"],
+      });
+
+      await expect(forged.initialize(9)).rejects.toMatchObject({
+        code: "method-not-supported",
+        resource: "reader",
+      });
+      expect(initialized).toBe(false);
     } finally {
       client.disconnect();
       host.disconnect();

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -39,6 +39,7 @@ function nextTask(): Promise<void> {
 function cellResource(
   get: () => FabricValue | undefined,
   options: {
+    initialize?: (value: FabricValue) => FabricValue | Promise<FabricValue>;
     set?: (value: FabricValue) => void | Promise<void>;
     sink?: (listener: (value: FabricValue | undefined) => void) => BridgeCancel;
     push?: (...values: FabricValue[]) => void | Promise<void>;
@@ -49,6 +50,7 @@ function cellResource(
     cell: {
       get,
       pull: get,
+      ...(options.initialize && { initialize: options.initialize }),
       ...(options.set && { set: options.set }),
       ...(options.sink && { sink: options.sink }),
       ...(options.push && { push: options.push }),
@@ -65,6 +67,10 @@ describe("Fabric iframe bridge", () => {
         ...cellResource(
           () => count,
           {
+            initialize: (value) => {
+              if (count === undefined) count = value as number;
+              return count;
+            },
             set: (value) => {
               count = value as number;
               for (const listener of listeners) listener(count);
@@ -92,7 +98,7 @@ describe("Fabric iframe bridge", () => {
         resources: [{
           name: "count",
           kind: "cell",
-          operations: ["get", "pull", "set", "sink"],
+          operations: ["get", "initialize", "pull", "set", "sink"],
           methods: [],
           schema: { type: "number", description: "Visible counter" },
         }],
@@ -100,6 +106,7 @@ describe("Fabric iframe bridge", () => {
 
       const remote = client.cell<number>("count");
       await expect(remote.pull()).resolves.toBe(1);
+      await expect(remote.initialize(99)).resolves.toBe(1);
       const updates: number[] = [];
       const unsubscribe = remote.sink((value) => {
         if (value !== undefined) updates.push(value);

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -313,6 +313,14 @@ describe("Fabric iframe bridge", () => {
           return 9;
         },
       });
+      Object.defineProperty(leaf, "key", {
+        configurable: true,
+        enumerable: true,
+        value: () => ({
+          get: () => "secret",
+          pull: () => "secret",
+        }),
+      });
       const forged = client.resolvedCell<number>({
         ...descriptor,
         operations: [...(descriptor.operations ?? []), "initialize"],
@@ -323,6 +331,10 @@ describe("Fabric iframe bridge", () => {
         resource: "reader",
       });
       expect(initialized).toBe(false);
+      await expect(forged.key("secret").pull()).rejects.toMatchObject({
+        code: "method-not-supported",
+        resource: "reader",
+      });
     } finally {
       client.disconnect();
       host.disconnect();

--- a/packages/iframe-sandbox/test/bridge.test.ts
+++ b/packages/iframe-sandbox/test/bridge.test.ts
@@ -341,6 +341,39 @@ describe("Fabric iframe bridge", () => {
     }
   });
 
+  it("rejects an operation removed after its resolved authority is minted", async () => {
+    const leaf: BridgeCell = {
+      get: () => 1,
+      initialize: () => 1,
+      pull: () => 1,
+    };
+    const root: BridgeCell = {
+      get: () => 1,
+      pull: () => 1,
+      resolve: () => leaf,
+    };
+    const channel = new MessageChannel();
+    const host = new FabricBridgeHost(
+      createFabricBridge({ reader: { kind: "cell", cell: root } }),
+      channel.port1,
+    );
+    const client = connectFabric();
+    handOff(channel.port2);
+
+    try {
+      const resolved = await client.cell<number>("reader").resolve();
+      delete leaf.initialize;
+
+      await expect(resolved.initialize(0)).rejects.toMatchObject({
+        code: "method-not-supported",
+        resource: "reader",
+      });
+    } finally {
+      client.disconnect();
+      host.disconnect();
+    }
+  });
+
   it("carries push as append intent instead of replacing the array", async () => {
     const value = [0];
     const pushes: FabricValue[][] = [];

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -189,6 +189,27 @@ describe("guest", () => {
       });
     });
 
+    it("rejects initialize after disconnect without negotiating a manifest", async () => {
+      const fabric = connectFabric();
+      const cell = fabric.cell<number>("count");
+      fabric.disconnect();
+
+      await expect(cell.initialize(0)).rejects.toMatchObject({
+        code: "disconnected",
+      });
+    });
+
+    it("rejects initialize without a cell capability target", async () => {
+      const fabric = connectFabric();
+      try {
+        await expect(fabric.request("initialize", {})).rejects.toMatchObject({
+          code: "method-not-supported",
+        });
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
     it("negotiates initialize through resolved cell capabilities", async () => {
       const fabric = connectFabric();
       try {
@@ -601,6 +622,27 @@ describe("guest", () => {
         status: "ready",
         value: { count: 7 },
       });
+    });
+
+    it("rejects invalid initializers before contacting the host", async () => {
+      let requests = 0;
+      const client = {
+        request: () => {
+          requests++;
+          return Promise.resolve(undefined);
+        },
+      } as unknown as FabricClient;
+      const cell = new RemoteCell<FabricValue | undefined>(client, "state");
+      const cyclic = {} as Record<string, FabricValue>;
+      cyclic.self = cyclic;
+
+      await expect(cell.initialize(undefined)).rejects.toThrow(
+        "Cell initialize requires a defined value",
+      );
+      await expect(cell.initialize(cyclic)).rejects.toThrow(
+        "Cannot deep-clone circular reference",
+      );
+      expect(requests).toBe(0);
     });
 
     it("orders a pull after every previously queued set", async () => {

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -417,6 +417,35 @@ describe("guest", () => {
       expect(cell.getSnapshot()).toEqual({ status: "ready", value: 2 });
     });
 
+    it("publishes the winner returned by atomic initialization", async () => {
+      const requests: Array<{
+        operation: string;
+        value?: FabricValue;
+      }> = [];
+      const client = {
+        request: (
+          operation: string,
+          fields: { value?: FabricValue },
+        ) => {
+          requests.push({ operation, value: fields.value });
+          return Promise.resolve({ count: 7 });
+        },
+      } as unknown as FabricClient;
+      const cell = new RemoteCell<{ count: number }>(client, "state");
+
+      await expect(cell.initialize({ count: 0 })).resolves.toEqual({
+        count: 7,
+      });
+      expect(requests).toEqual([{
+        operation: "initialize",
+        value: { count: 0 },
+      }]);
+      expect(cell.getSnapshot()).toEqual({
+        status: "ready",
+        value: { count: 7 },
+      });
+    });
+
     it("orders a pull after every previously queued set", async () => {
       const firstResponse = Promise.withResolvers<FabricValue | undefined>();
       const operations: Array<[string, FabricValue | undefined]> = [];

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -103,6 +103,152 @@ describe("guest", () => {
       }
     });
 
+    it("rejects initialize when a version-two host does not advertise it", async () => {
+      const fabric = connectFabric();
+      try {
+        const initializing = fabric.cell<number>("count").initialize(0);
+        const host = handOffPort();
+        const describe = await receive(host);
+        expect(describe.operation).toBe("describe");
+        send(
+          host,
+          response(describe.id, {
+            protocol: BRIDGE_PROTOCOL,
+            version: BRIDGE_VERSION,
+            resources: [{
+              name: "count",
+              kind: "cell",
+              operations: ["get", "pull", "set", "sink"],
+              methods: [],
+            }],
+          }),
+        );
+
+        await expect(initializing).rejects.toMatchObject({
+          code: "method-not-supported",
+          resource: "count",
+        });
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("sends initialize after a version-two host advertises it", async () => {
+      const fabric = connectFabric();
+      try {
+        const initializing = fabric.cell<number>("count").initialize(0);
+        const host = handOffPort();
+        const describe = await receive(host);
+        send(
+          host,
+          response(describe.id, {
+            protocol: BRIDGE_PROTOCOL,
+            version: BRIDGE_VERSION,
+            resources: [{
+              name: "count",
+              kind: "cell",
+              operations: ["get", "initialize", "pull", "set", "sink"],
+              methods: [],
+            }],
+          }),
+        );
+        const request = await receive(host);
+        expect(request).toMatchObject({
+          operation: "initialize",
+          resource: "count",
+          path: [],
+          value: 0,
+        });
+        send(host, response(request.id, 4));
+
+        await expect(initializing).resolves.toBe(4);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("does not reuse a cached manifest after disconnect", async () => {
+      const fabric = connectFabric();
+      const describing = fabric.describe();
+      const host = handOffPort();
+      const request = await receive(host);
+      send(
+        host,
+        response(request.id, {
+          protocol: BRIDGE_PROTOCOL,
+          version: BRIDGE_VERSION,
+          resources: [],
+        }),
+      );
+      await expect(describing).resolves.toMatchObject({ resources: [] });
+
+      fabric.disconnect();
+
+      await expect(fabric.describe()).rejects.toMatchObject({
+        code: "disconnected",
+      });
+    });
+
+    it("negotiates initialize through resolved cell capabilities", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const firstResolution = fabric.cell<number>("count").resolve();
+        const firstResolve = await receive(host);
+        send(
+          host,
+          response(firstResolve.id, {
+            handle: "cell-1",
+            hasValue: true,
+            value: 1,
+          }),
+        );
+        const first = await firstResolution;
+
+        const secondResolution = first.resolve();
+        const secondResolve = await receive(host);
+        expect(secondResolve.handle).toBe("cell-1");
+        send(
+          host,
+          response(secondResolve.id, {
+            handle: "cell-2",
+            hasValue: true,
+            value: 1,
+          }),
+        );
+        const second = await secondResolution;
+
+        const initializing = second.initialize(0);
+        const describe = await receive(host);
+        expect(describe.operation).toBe("describe");
+        send(
+          host,
+          response(describe.id, {
+            protocol: BRIDGE_PROTOCOL,
+            version: BRIDGE_VERSION,
+            resources: [{
+              name: "count",
+              kind: "cell",
+              operations: ["get", "initialize", "pull", "set", "sink"],
+              methods: [],
+            }],
+          }),
+        );
+        const request = await receive(host);
+        expect(request).toMatchObject({
+          operation: "initialize",
+          handle: "cell-2",
+          path: [],
+          value: 0,
+        });
+        send(host, response(request.id, 4));
+
+        await expect(initializing).resolves.toBe(4);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
     it("lets an available port perform the request snapshot", async () => {
       const fabric = connectFabric();
       const originalStructuredClone = globalThis.structuredClone;

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -200,6 +200,7 @@ describe("guest", () => {
           response(firstResolve.id, {
             handle: "cell-1",
             hasValue: true,
+            operations: ["get", "initialize", "pull", "resolve"],
             value: 1,
           }),
         );
@@ -213,27 +214,13 @@ describe("guest", () => {
           response(secondResolve.id, {
             handle: "cell-2",
             hasValue: true,
+            operations: ["get", "initialize", "pull"],
             value: 1,
           }),
         );
         const second = await secondResolution;
 
         const initializing = second.initialize(0);
-        const describe = await receive(host);
-        expect(describe.operation).toBe("describe");
-        send(
-          host,
-          response(describe.id, {
-            protocol: BRIDGE_PROTOCOL,
-            version: BRIDGE_VERSION,
-            resources: [{
-              name: "count",
-              kind: "cell",
-              operations: ["get", "initialize", "pull", "set", "sink"],
-              methods: [],
-            }],
-          }),
-        );
         const request = await receive(host);
         expect(request).toMatchObject({
           operation: "initialize",
@@ -244,6 +231,30 @@ describe("guest", () => {
         send(host, response(request.id, 4));
 
         await expect(initializing).resolves.toBe(4);
+      } finally {
+        fabric.disconnect();
+      }
+    });
+
+    it("rejects initialize on an old resolved descriptor without operations", async () => {
+      const fabric = connectFabric();
+      try {
+        const host = handOffPort();
+        const resolution = fabric.cell<number>("count").resolve();
+        const request = await receive(host);
+        send(
+          host,
+          response(request.id, {
+            handle: "old-host-cell",
+            hasValue: true,
+            value: 1,
+          }),
+        );
+        const resolved = await resolution;
+
+        await expect(resolved.initialize(0)).rejects.toMatchObject({
+          code: "method-not-supported",
+        });
       } finally {
         fabric.disconnect();
       }

--- a/packages/iframe-sandbox/test/ipc.test.ts
+++ b/packages/iframe-sandbox/test/ipc.test.ts
@@ -106,6 +106,23 @@ describe("ipc", () => {
         ...HEADER,
         type: "request",
         id: 0,
+        operation: "initialize",
+        resource: "count",
+        path: [],
+      })).toBe(false);
+      expect(isBridgeRequest({
+        ...HEADER,
+        type: "request",
+        id: 0,
+        operation: "initialize",
+        resource: "count",
+        path: [],
+        value: undefined,
+      })).toBe(false);
+      expect(isBridgeRequest({
+        ...HEADER,
+        type: "request",
+        id: 0,
         operation: "push",
         resource: "items",
       })).toBe(false);

--- a/packages/iframe-sandbox/test/ipc.test.ts
+++ b/packages/iframe-sandbox/test/ipc.test.ts
@@ -45,6 +45,15 @@ describe("ipc", () => {
         ...HEADER,
         type: "request",
         id: 2,
+        operation: "initialize",
+        resource: "count",
+        path: [],
+        value: 0,
+      })).toBe(true);
+      expect(isBridgeRequest({
+        ...HEADER,
+        type: "request",
+        id: 3,
         operation: "set",
         resource: "count",
         path: ["nested", 0],
@@ -53,7 +62,7 @@ describe("ipc", () => {
       expect(isBridgeRequest({
         ...HEADER,
         type: "request",
-        id: 3,
+        id: 4,
         operation: "call",
         resource: "database",
         method: "query",
@@ -61,7 +70,7 @@ describe("ipc", () => {
       expect(isBridgeRequest({
         ...HEADER,
         type: "request",
-        id: 4,
+        id: 5,
         operation: "push",
         resource: "items",
         path: [],
@@ -70,7 +79,7 @@ describe("ipc", () => {
       expect(isBridgeRequest({
         ...HEADER,
         type: "request",
-        id: 5,
+        id: 6,
         operation: "sink",
         handle: "cell-1",
         path: ["title"],

--- a/packages/iframe-sandbox/test/react-browser.test.ts
+++ b/packages/iframe-sandbox/test/react-browser.test.ts
@@ -1,3 +1,5 @@
+/** Exercises the React adapter with the browser's real React renderer. */
+
 // @deno-types="@types/react"
 import React, { act } from "react";
 // @deno-types="@types/react-dom/client"

--- a/packages/iframe-sandbox/test/react-browser.test.ts
+++ b/packages/iframe-sandbox/test/react-browser.test.ts
@@ -1,0 +1,147 @@
+// @deno-types="@types/react"
+import React, { act } from "react";
+// @deno-types="@types/react-dom/client"
+import { createRoot } from "react-dom/client";
+import { assertEquals, assertInstanceOf } from "@std/assert";
+
+import type { FabricClient, ResourceSnapshot } from "../src/guest.ts";
+import { createFabricReact } from "../src/react.ts";
+
+type Counter = { count: number };
+type Note = { id: number; title: string };
+
+function flush(): Promise<void> {
+  return act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function perform(action: () => void): Promise<void> {
+  return act(async () => {
+    action();
+    await Promise.resolve();
+  });
+}
+
+Deno.test("React renders bridged cells and SQLite invalidations", async () => {
+  if (typeof document === "undefined") return;
+  const environment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+
+  let counterSnapshot: ResourceSnapshot<Counter> = { status: "loading" };
+  const cellListeners = new Set<() => void>();
+  let writeTail = Promise.resolve();
+  const publishCounter = (count: number) => {
+    counterSnapshot = { status: "ready", value: { count } };
+    for (const listener of cellListeners) listener();
+  };
+  const counter = {
+    getSnapshot: () => counterSnapshot,
+    subscribeSnapshot: (listener: () => void) => {
+      cellListeners.add(listener);
+      listener();
+      return () => cellListeners.delete(listener);
+    },
+    pull: () => {
+      publishCounter(1);
+      return Promise.resolve({ count: 1 });
+    },
+    set: (value: Counter) => {
+      publishCounter(value.count);
+      return Promise.resolve();
+    },
+    update: (updater: (current: Counter) => Counter) => {
+      const write = writeTail.then(async () => {
+        const current = counterSnapshot.status === "ready"
+          ? counterSnapshot.value
+          : await counter.pull();
+        await counter.set(updater(current));
+      });
+      writeTail = write.catch(() => {});
+      return write;
+    },
+  };
+
+  let notes: Note[] = [{ id: 1, title: "First" }];
+  let queryCount = 0;
+  const databaseListeners = new Set<() => void>();
+  const database = {
+    query: () => {
+      queryCount++;
+      return Promise.resolve({ rows: notes.map((note) => ({ ...note })) });
+    },
+    sink: (listener: () => void) => {
+      databaseListeners.add(listener);
+      return () => databaseListeners.delete(listener);
+    },
+  };
+  const client = {
+    cell: () => counter,
+    sqlite: () => database,
+  } as unknown as FabricClient;
+  const { useCell, useSqliteQuery } = createFabricReact(React, client);
+
+  function App() {
+    const count = useCell<Counter>("counter");
+    const query = useSqliteQuery<Note>(
+      "appDatabase",
+      "SELECT id, title FROM notes ORDER BY id",
+    );
+    if (count.status !== "ready" || query.status !== "ready") {
+      return React.createElement("p", { id: "status" }, "Loading");
+    }
+    return React.createElement(
+      "main",
+      null,
+      React.createElement(
+        "button",
+        {
+          id: "increment",
+          type: "button",
+          onClick: () =>
+            void count.set((value) => ({
+              count: value.count + 1,
+            })),
+        },
+        `Count ${count.value.count}`,
+      ),
+      React.createElement(
+        "p",
+        { id: "notes" },
+        query.rows.map((note) => note.title).join(", "),
+      ),
+    );
+  }
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    await perform(() => root.render(React.createElement(App)));
+    await flush();
+
+    const button = host.querySelector("#increment");
+    assertInstanceOf(button, HTMLButtonElement);
+    assertEquals(button.textContent?.trim(), "Count 1");
+    assertEquals(host.querySelector("#notes")?.textContent, "First");
+
+    await perform(() => button.click());
+    await flush();
+    assertEquals(button.textContent?.trim(), "Count 2");
+
+    notes = [...notes, { id: 2, title: "Second" }];
+    await perform(() => {
+      for (const listener of databaseListeners) listener();
+    });
+    await flush();
+    assertEquals(host.querySelector("#notes")?.textContent, "First, Second");
+    assertEquals(queryCount >= 2, true);
+  } finally {
+    await perform(() => root.unmount());
+    host.remove();
+    environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});

--- a/packages/iframe-sandbox/test/react-browser.test.ts
+++ b/packages/iframe-sandbox/test/react-browser.test.ts
@@ -37,11 +37,15 @@ Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
   const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
   environment.IS_REACT_ACT_ENVIRONMENT = true;
 
-  let counterSnapshot: ResourceSnapshot<Counter> = { status: "loading" };
+  let counterSnapshot: ResourceSnapshot<Counter | undefined> = {
+    status: "loading",
+  };
+  let durableCounter: Counter | undefined;
+  let initializeCount = 0;
   const cellListeners = new Set<() => void>();
   let writeTail = Promise.resolve();
-  const publishCounter = (count: number) => {
-    counterSnapshot = { status: "ready", value: { count } };
+  const publishCounter = (value: Counter | undefined) => {
+    counterSnapshot = { status: "ready", value };
     for (const listener of cellListeners) listener();
   };
   const counter = {
@@ -52,19 +56,32 @@ Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
       return () => cellListeners.delete(listener);
     },
     pull: () => {
-      publishCounter(1);
-      return Promise.resolve({ count: 1 });
+      publishCounter(durableCounter);
+      return Promise.resolve(durableCounter);
+    },
+    initialize: (value: Counter) => {
+      initializeCount++;
+      durableCounter ??= value;
+      publishCounter(durableCounter);
+      return Promise.resolve(durableCounter);
     },
     set: (value: Counter) => {
-      publishCounter(value.count);
+      durableCounter = value;
+      publishCounter(value);
       return Promise.resolve();
     },
-    update: (updater: (current: Counter) => Counter) => {
+    update: (
+      updater: (current: Counter | undefined) => Counter | undefined,
+    ) => {
       const write = writeTail.then(async () => {
         const current = counterSnapshot.status === "ready"
           ? counterSnapshot.value
           : await counter.pull();
-        await counter.set(updater(current));
+        const next = updater(current);
+        if (next === undefined) {
+          throw new Error("Counter update returned undefined.");
+        }
+        await counter.set(next);
       });
       writeTail = write.catch(() => {});
       return write;
@@ -91,12 +108,21 @@ Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
   const { useCell, useSqliteQuery } = createFabricReact(React, client);
 
   function App() {
-    const count = useCell<Counter>("counter");
+    const count = useCell<Counter | undefined>("counter");
+    const countValue = count.status === "ready" ? count.value : undefined;
     const query = useSqliteQuery<Note>(
       "appDatabase",
       "SELECT id, title FROM notes ORDER BY id",
     );
-    if (count.status !== "ready" || query.status !== "ready") {
+    React.useEffect(() => {
+      if (count.status === "ready" && countValue === undefined) {
+        void count.initialize({ count: 1 });
+      }
+    }, [count.status, countValue, count.initialize]);
+    if (
+      count.status !== "ready" || countValue === undefined ||
+      query.status !== "ready"
+    ) {
       return React.createElement("p", { id: "status" }, "Loading");
     }
     return React.createElement(
@@ -109,10 +135,10 @@ Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
           type: "button",
           onClick: () =>
             void count.set((value) => ({
-              count: value.count + 1,
+              count: (value?.count ?? 0) + 1,
             })),
         },
-        `Count ${count.value.count}`,
+        `Count ${countValue.count}`,
       ),
       React.createElement(
         "p",
@@ -132,6 +158,7 @@ Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
     const button = host.querySelector<HTMLButtonElement>("#increment")!;
     expect(button).toBeInstanceOf(HTMLButtonElement);
     expect(button.textContent?.trim()).toBe("Count 1");
+    expect(initializeCount).toBe(1);
     expect(host.querySelector("#notes")?.textContent).toBe("First");
 
     await perform(() => button.click());

--- a/packages/iframe-sandbox/test/react-browser.test.ts
+++ b/packages/iframe-sandbox/test/react-browser.test.ts
@@ -4,7 +4,11 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { assertEquals, assertInstanceOf } from "@std/assert";
 
-import type { FabricClient, ResourceSnapshot } from "../src/guest.ts";
+import type {
+  FabricClient,
+  ResourceSnapshot,
+  SqliteQueryInput,
+} from "../src/guest.ts";
 import { createFabricReact } from "../src/react.ts";
 
 type Counter = { count: number };
@@ -139,6 +143,73 @@ Deno.test("React renders bridged cells and SQLite invalidations", async () => {
     await flush();
     assertEquals(host.querySelector("#notes")?.textContent, "First, Second");
     assertEquals(queryCount >= 2, true);
+  } finally {
+    await perform(() => root.unmount());
+    host.remove();
+    environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});
+
+Deno.test("React keeps supported SQLite parameter identities distinct", async () => {
+  if (typeof document === "undefined") return;
+  const environment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+
+  const calls: Array<SqliteQueryInput["params"]> = [];
+  const database = {
+    query: (_sql: string, params?: SqliteQueryInput["params"]) => {
+      calls.push(params);
+      return Promise.resolve({ rows: [{ call: calls.length }] });
+    },
+    sink: () => () => {},
+  };
+  const client = { sqlite: () => database } as unknown as FabricClient;
+  const { useSqliteQuery } = createFabricReact(React, client);
+
+  function App({ params }: { params: SqliteQueryInput["params"] }) {
+    const query = useSqliteQuery<{ call: number }>(
+      "database",
+      "SELECT :value",
+      params,
+    );
+    return React.createElement(
+      "p",
+      { id: "query-call" },
+      query.status === "ready" ? `Call ${query.rows[0].call}` : "Loading",
+    );
+  }
+
+  const reservedNames = Object.fromEntries([
+    ["constructor", 1],
+    ["__proto__", 2],
+  ]);
+  const cases: Array<NonNullable<SqliteQueryInput["params"]>> = [
+    [null],
+    [NaN],
+    [Infinity],
+    [-Infinity],
+    [-0],
+    [0],
+    reservedNames,
+  ];
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    for (let index = 0; index < cases.length; index++) {
+      await perform(() =>
+        root.render(React.createElement(App, { params: cases[index] }))
+      );
+      await flush();
+      assertEquals(
+        host.querySelector("#query-call")?.textContent,
+        `Call ${index + 1}`,
+      );
+    }
+    assertEquals(calls, cases);
   } finally {
     await perform(() => root.unmount());
     host.remove();

--- a/packages/iframe-sandbox/test/react-browser.test.ts
+++ b/packages/iframe-sandbox/test/react-browser.test.ts
@@ -2,7 +2,7 @@
 import React, { act } from "react";
 // @deno-types="@types/react-dom/client"
 import { createRoot } from "react-dom/client";
-import { assertEquals, assertInstanceOf } from "@std/assert";
+import { expect } from "@std/expect";
 
 import type {
   FabricClient,
@@ -27,7 +27,7 @@ function perform(action: () => void): Promise<void> {
   });
 }
 
-Deno.test("React renders bridged cells and SQLite invalidations", async () => {
+Deno.test("React renders bridged Cells and SQLite invalidations", async () => {
   if (typeof document === "undefined") return;
   const environment = globalThis as typeof globalThis & {
     IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -127,22 +127,22 @@ Deno.test("React renders bridged cells and SQLite invalidations", async () => {
     await perform(() => root.render(React.createElement(App)));
     await flush();
 
-    const button = host.querySelector("#increment");
-    assertInstanceOf(button, HTMLButtonElement);
-    assertEquals(button.textContent?.trim(), "Count 1");
-    assertEquals(host.querySelector("#notes")?.textContent, "First");
+    const button = host.querySelector<HTMLButtonElement>("#increment")!;
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button.textContent?.trim()).toBe("Count 1");
+    expect(host.querySelector("#notes")?.textContent).toBe("First");
 
     await perform(() => button.click());
     await flush();
-    assertEquals(button.textContent?.trim(), "Count 2");
+    expect(button.textContent?.trim()).toBe("Count 2");
 
     notes = [...notes, { id: 2, title: "Second" }];
     await perform(() => {
       for (const listener of databaseListeners) listener();
     });
     await flush();
-    assertEquals(host.querySelector("#notes")?.textContent, "First, Second");
-    assertEquals(queryCount >= 2, true);
+    expect(host.querySelector("#notes")?.textContent).toBe("First, Second");
+    expect(queryCount).toBeGreaterThanOrEqual(2);
   } finally {
     await perform(() => root.unmount());
     host.remove();
@@ -204,12 +204,21 @@ Deno.test("React keeps supported SQLite parameter identities distinct", async ()
         root.render(React.createElement(App, { params: cases[index] }))
       );
       await flush();
-      assertEquals(
-        host.querySelector("#query-call")?.textContent,
+      expect(host.querySelector("#query-call")?.textContent).toBe(
         `Call ${index + 1}`,
       );
     }
-    assertEquals(calls, cases);
+    expect(calls).toHaveLength(cases.length);
+    expect(Number.isNaN((calls[1] as number[])[0])).toBe(true);
+    expect((calls[2] as number[])[0]).toBe(Infinity);
+    expect((calls[3] as number[])[0]).toBe(-Infinity);
+    expect((calls[4] as number[])[0]).toBe(-0);
+    expect((calls[5] as number[])[0]).toBe(0);
+    const named = calls[6] as Record<string, unknown>;
+    expect(Object.hasOwn(named, "constructor")).toBe(true);
+    expect(Object.hasOwn(named, "__proto__")).toBe(true);
+    expect(named.constructor).toBe(1);
+    expect(named.__proto__).toBe(2);
   } finally {
     await perform(() => root.unmount());
     host.remove();

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -114,6 +114,7 @@ import {
   type CellGetCfcLabelRequest,
   type CellGetRequest,
   type CellGetResponse,
+  type CellInitializeRequest,
   type CellPullRequest,
   type CellPushRequest,
   type CellResolveAsCellRequest,
@@ -348,6 +349,21 @@ function sqliteParamForRuntime(
     );
   }
   return value;
+}
+
+/** Converts a runtime cell value into the redacted client wire domain. */
+function cellValueForClient(value: unknown): FabricValue {
+  return redactSigilCfcLabelViewsForDisplay(
+    convertCellsToLinks(
+      value as Parameters<typeof convertCellsToLinks>[0],
+      {
+        includeSchema: true,
+        keepAsCell: KeepAsCell.All,
+        doNotConvertCellResults: true,
+        includeCfcLabelView: true,
+      },
+    ),
+  ) as FabricValue;
 }
 
 function sqliteParamsForRuntime(
@@ -1085,14 +1101,7 @@ export class RuntimeProcessor {
     // `convertCellsToLinks()` preserves a `FabricPrimitive` by identity, and
     // the envelope's encoding carries one to the main thread with its class,
     // so what the response holds is what the cell held.
-    const converted = redactSigilCfcLabelViewsForDisplay(
-      convertCellsToLinks(value, {
-        includeSchema: true,
-        keepAsCell: KeepAsCell.All,
-        doNotConvertCellResults: true,
-        includeCfcLabelView: true,
-      }),
-    ) as FabricValue;
+    const converted = cellValueForClient(value);
     // The resolved cell's own schema-bearing ref, when asked for — for a meta
     // link read this addresses the linked cell itself, so the caller can
     // subscribe to it or consult its schema's declarations.
@@ -1126,6 +1135,27 @@ export class RuntimeProcessor {
       type: RequestType.CellGet,
       cell: request.cell,
     });
+  }
+
+  /** Atomically stores a default only while the target remains undefined. */
+  async handleCellInitialize(
+    request: CellInitializeRequest,
+  ): Promise<{ value: FabricValue }> {
+    if (request.value === undefined) {
+      throw new TypeError("Cell initialize requires a defined value.");
+    }
+    const initial = mapCellRefsToSigilLinks(request.value);
+    const result = await this.runtime.editWithRetry((tx) => {
+      const cell = getCell(this.runtime, request.cell).withTx(tx);
+      const current = cell.get();
+      if (current !== undefined) {
+        return cellValueForClient(current);
+      }
+      cell.set(initial);
+      return request.value;
+    });
+    if (result.error) throw new Error(result.error.message);
+    return { value: result.ok };
   }
 
   // A `CellHandle.set` is a blind leaf overwrite (last-write-wins);
@@ -2446,6 +2476,8 @@ export class RuntimeProcessor {
         return this.handleCellGet(request);
       case RequestType.CellPull:
         return await this.handleCellPull(request);
+      case RequestType.CellInitialize:
+        return await this.handleCellInitialize(request);
       case RequestType.CellSet:
         return this.handleCellSet(request);
       case RequestType.CellPush:

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1152,7 +1152,7 @@ export class RuntimeProcessor {
         return cellValueForClient(current);
       }
       cell.set(initial);
-      return request.value;
+      return cellValueForClient(initial);
     });
     if (result.error) throw new Error(result.error.message);
     return { value: result.ok };

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -230,6 +230,47 @@ export class CellHandle<T = unknown> {
     });
   }
 
+  /**
+   * Atomically stores `value` only if the cell is undefined, then returns the
+   * value selected by that transaction. Concurrent initializers converge on
+   * one winner instead of replacing it with a blind write.
+   */
+  async initialize(value: T): Promise<Readonly<T>> {
+    this.#requireSchema("initialize");
+    if (value === undefined) {
+      throw new TypeError("Cell initialize requires a defined value.");
+    }
+    const serialized = this.#serializeWrite(value);
+    const writeGeneration = ++this.#writeGeneration;
+    const updateGeneration = this.#updateGeneration;
+    const { current, authoritative } = await this.#enqueueOperation(
+      async (queue) => {
+        const authoritativeGeneration = queue.authoritativeGeneration;
+        const response = await this.#conn.request<RequestType.CellInitialize>({
+          type: RequestType.CellInitialize,
+          cell: this.ref(),
+          value: serialized,
+        });
+        const current = CellHandle.deserialize<T>(this, response.value) as T;
+        const authoritative = updateGeneration === this.#updateGeneration &&
+          authoritativeGeneration === queue.authoritativeGeneration;
+        if (authoritative) {
+          queue.value = current;
+          queue.hasValue = true;
+        }
+        return { current, authoritative };
+      },
+    );
+    if (
+      writeGeneration === this.#writeGeneration &&
+      updateGeneration === this.#updateGeneration &&
+      authoritative
+    ) {
+      this.#publishValue(current);
+    }
+    return current as Readonly<T>;
+  }
+
   #enqueueOperation<R>(
     operation: (queue: CellOperationQueue) => Promise<R>,
   ): Promise<R> {

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -106,6 +106,12 @@ export enum RequestType {
   CellPull = "cell:pull",
 
   /**
+   * Stores a value only when the cell is currently undefined, using the read
+   * as an optimistic-concurrency precondition. Returns the value that won.
+   */
+  CellInitialize = "cell:initialize",
+
+  /**
    * Overwrites a cell's value blindly: the write carries no value-equality
    * precondition, so a concurrent write to the same cell does not make it
    * fail. That is not the same as unconditional. A blind write still carries
@@ -808,6 +814,17 @@ export type CellPullRequest = BaseRequest & {
    * The cell whose producers to demand before reading its current value.
    */
   cell: CellRef;
+};
+
+/** The {@link RequestType.CellInitialize} request. */
+export type CellInitializeRequest = BaseRequest & {
+  type: RequestType.CellInitialize;
+
+  /** The cell to initialize when it is currently undefined. */
+  cell: CellRef;
+
+  /** The non-undefined default to store. */
+  value: FabricValue;
 };
 
 /**
@@ -2322,6 +2339,7 @@ export type IPCClientRequest =
   | DisposeRequest
   | CellGetRequest
   | CellPullRequest
+  | CellInitializeRequest
   | CellSetRequest
   | CellPushRequest
   | CellSendRequest
@@ -2953,6 +2971,10 @@ export type Commands = {
   [RequestType.CellPull]: {
     request: CellPullRequest;
     response: CellGetResponse;
+  };
+  [RequestType.CellInitialize]: {
+    request: CellInitializeRequest;
+    response: CellValueResponse;
   };
   [RequestType.CellSet]: {
     request: CellSetRequest;

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3465,6 +3465,82 @@ describe("runtime-processor", () => {
   });
 
   describe("direct cell initialization", () => {
+    it("loads an existing scoped value before choosing an initializer", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-scoped-cell-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const server = new MemoryV2Server.Server({
+        authorizeSessionOpen(message) {
+          const principal = (message.authorization as { principal?: unknown })
+            ?.principal;
+          return typeof principal === "string" ? principal : undefined;
+        },
+        sessionOpenAuth: { audience: testSessionOpenAudience },
+      });
+      const managerOptions = {
+        as: signer,
+        memoryHost: new URL("memory://"),
+      };
+      const writerStorage = new SharedV2StorageManager(managerOptions, server);
+      const readerStorage = new SharedV2StorageManager(managerOptions, server);
+      const writerRuntime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager: writerStorage,
+      });
+      const readerRuntime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager: readerStorage,
+      });
+      try {
+        const cause = `direct-scoped-cell-initialize-${crypto.randomUUID()}`;
+        const schema = {
+          type: "object",
+          properties: { winner: { type: "string" } },
+          required: ["winner"],
+        } as const;
+        const writerCell = writerRuntime.getCell<{ winner: string }>(
+          space,
+          cause,
+          schema,
+          undefined,
+          "user",
+        );
+        await writerCell.sync();
+        const write = writerRuntime.edit();
+        writerCell.withTx(write).set({ winner: "stored" });
+        expect((await write.commit()).error).toBeUndefined();
+
+        const readerCell = readerRuntime.getCell<{ winner: string }>(
+          space,
+          cause,
+          schema,
+          undefined,
+          "user",
+        );
+        expect(readerCell.get()).toBeUndefined();
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime: readerRuntime },
+        ) as RuntimeProcessor;
+
+        const selected = await processor.handleCellInitialize({
+          type: RequestType.CellInitialize,
+          cell: createCellRef(readerCell),
+          value: { winner: "default" },
+        });
+        await readerCell.pull();
+
+        expect(selected.value).toEqual({ winner: "stored" });
+        expect(readerCell.get()).toEqual({ winner: "stored" });
+      } finally {
+        await writerRuntime.dispose();
+        await readerRuntime.dispose();
+        await writerStorage.close();
+        await readerStorage.close();
+      }
+    });
+
     it("converges concurrent initializers on one stored value", async () => {
       const signer = await Identity.fromPassphrase(
         `direct-cell-initialize-${crypto.randomUUID()}`,
@@ -3511,6 +3587,47 @@ describe("runtime-processor", () => {
           first.value,
         );
         expect(cell.get()).toEqual(first.value);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("returns nested initialized cells in the client-hydratable link form", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-linked-cell-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const target = runtime.getCell<{ linked: Cell<unknown> }>(
+          space,
+          `direct-linked-cell-initialize-${crypto.randomUUID()}`,
+        );
+        const linked = runtime.getCell(
+          space,
+          `direct-linked-initializer-${crypto.randomUUID()}`,
+        );
+        await target.sync();
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+        const linkedRef = createCellRef(linked);
+
+        const selected = await processor.handleCellInitialize({
+          type: RequestType.CellInitialize,
+          cell: createCellRef(target),
+          value: { linked: linkedRef },
+        });
+
+        expect(selected.value).toEqual({
+          linked: cellRefToSigilLink(linkedRef),
+        });
       } finally {
         await runtime.dispose();
         await storageManager.close();

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3464,6 +3464,60 @@ describe("runtime-processor", () => {
     });
   });
 
+  describe("direct cell initialization", () => {
+    it("converges concurrent initializers on one stored value", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-cell-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const cell = runtime.getCell<{ winner: string }>(
+          space,
+          `direct-cell-initialize-${crypto.randomUUID()}`,
+          {
+            type: "object",
+            properties: { winner: { type: "string" } },
+            required: ["winner"],
+          },
+        );
+        await cell.sync();
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+        const ref = createCellRef(cell);
+
+        const [first, second] = await Promise.all([
+          processor.handleCellInitialize({
+            type: RequestType.CellInitialize,
+            cell: ref,
+            value: { winner: "first" },
+          }),
+          processor.handleCellInitialize({
+            type: RequestType.CellInitialize,
+            cell: ref,
+            value: { winner: "second" },
+          }),
+        ]);
+        await cell.pull();
+
+        expect(first.value).toEqual(second.value);
+        expect([{ winner: "first" }, { winner: "second" }]).toContainEqual(
+          first.value,
+        );
+        expect(cell.get()).toEqual(first.value);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
   describe("runtime-client CellRef conversion", () => {
     // Inv-12 Stage 0 (SC-25 prerequisite): a cfcLabelView riding an inbound
     // CellRef is a main-thread display artifact — round-tripped through

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3465,6 +3465,35 @@ describe("runtime-processor", () => {
   });
 
   describe("direct cell initialization", () => {
+    it("rejects malformed initializers and surfaces transaction failures", async () => {
+      const failed = Object.assign(
+        Object.create(RuntimeProcessor.prototype),
+        {
+          runtime: {
+            editWithRetry: () =>
+              Promise.resolve({ error: new Error("initialize failed") }),
+          },
+        },
+      ) as RuntimeProcessor;
+      const ref = {
+        space: "did:key:test" as CellRef["space"],
+        id: "of:initialize-failure" as CellRef["id"],
+        scope: "space",
+        path: [],
+      } satisfies CellRef;
+
+      await expect(failed.handleCellInitialize({
+        type: RequestType.CellInitialize,
+        cell: ref,
+        value: undefined as never,
+      })).rejects.toThrow("Cell initialize requires a defined value");
+      await expect(failed.handleCellInitialize({
+        type: RequestType.CellInitialize,
+        cell: ref,
+        value: 1,
+      })).rejects.toThrow("initialize failed");
+    });
+
     it("loads an existing scoped value before choosing an initializer", async () => {
       const signer = await Identity.fromPassphrase(
         `direct-scoped-cell-initialize-${crypto.randomUUID()}`,
@@ -3619,11 +3648,11 @@ describe("runtime-processor", () => {
         ) as RuntimeProcessor;
         const linkedRef = createCellRef(linked);
 
-        const selected = await processor.handleCellInitialize({
+        const selected = await processor.handleRequest({
           type: RequestType.CellInitialize,
           cell: createCellRef(target),
           value: { linked: linkedRef },
-        });
+        }) as { value: unknown };
 
         expect(selected.value).toEqual({
           linked: cellRefToSigilLink(linkedRef),

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -1075,6 +1075,33 @@ describe("cell-handle", () => {
       }]);
     });
 
+    it("hydrates nested cell handles in the selected initializer", async () => {
+      const linkedRef: CellRef = {
+        ...ref,
+        id: "of:initialized-link" as CellRef["id"],
+      };
+      const runtime = {
+        [$conn]: () => ({
+          request: () =>
+            Promise.resolve({ value: { linked: linkRefFrom(linkedRef) } }),
+          subscribe: () => Promise.resolve(),
+          unsubscribe: () => Promise.resolve(),
+          signal: { aborted: false },
+        }),
+      } as unknown as RuntimeClient;
+      const cell = new CellHandle<{ linked: CellHandle<unknown> }>(
+        runtime,
+        ref,
+      );
+      const linked = new CellHandle(runtime, linkedRef);
+
+      const selected = await cell.initialize({ linked });
+
+      expect(isCellHandle(selected.linked)).toBe(true);
+      expect(selected.linked.ref()).toEqual(linkedRef);
+      expect(cell.get()?.linked).toBe(selected.linked);
+    });
+
     it("refuses an undefined initializer before contacting the runtime", async () => {
       let requests = 0;
       const runtime = {

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -1051,6 +1051,51 @@ describe("cell-handle", () => {
       unsubscribe();
     });
 
+    it("publishes the value selected by atomic initialization", async () => {
+      const requests: unknown[] = [];
+      const runtime = {
+        [$conn]: () => ({
+          request: (request: unknown) => {
+            requests.push(request);
+            return Promise.resolve({ value: { n: 7 } });
+          },
+          subscribe: () => Promise.resolve(),
+          unsubscribe: () => Promise.resolve(),
+          signal: { aborted: false },
+        }),
+      } as unknown as RuntimeClient;
+      const cell = new CellHandle(runtime, ref);
+
+      await expect(cell.initialize({ n: 0 })).resolves.toEqual({ n: 7 });
+      expect(cell.get()).toEqual({ n: 7 });
+      expect(requests).toEqual([{
+        type: RequestType.CellInitialize,
+        cell: ref,
+        value: { n: 0 },
+      }]);
+    });
+
+    it("refuses an undefined initializer before contacting the runtime", async () => {
+      let requests = 0;
+      const runtime = {
+        [$conn]: () => ({
+          request: () => {
+            requests++;
+            return Promise.resolve({ value: undefined });
+          },
+          subscribe: () => Promise.resolve(),
+          unsubscribe: () => Promise.resolve(),
+          signal: { aborted: false },
+        }),
+      } as unknown as RuntimeClient;
+      const cell = new CellHandle<undefined>(runtime, ref);
+
+      await expect(cell.initialize(undefined)).rejects.toThrow(
+        "Cell initialize requires a defined value",
+      );
+      expect(requests).toBe(0);
+    });
+
     it("keeps an earlier strict commit when a queued strict set fails", async () => {
       let writes = 0;
       const runtime = {

--- a/packages/ui/src/v2/components/cf-iframe/cell-bridge.test.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cell-bridge.test.ts
@@ -69,6 +69,9 @@ describe("cf-iframe cell bridge", () => {
           ) {
             return Promise.resolve({ value: 2 });
           }
+          if (request.type === RequestType.CellInitialize) {
+            return Promise.resolve({ value: 1 });
+          }
           return Promise.resolve({});
         },
         subscribe: () => Promise.resolve(),
@@ -86,6 +89,7 @@ describe("cf-iframe cell bridge", () => {
     expect(count.kind).toBe("cell");
     expect(count.description).toBe("Shared counter");
     await expect(count.cell!.pull()).resolves.toBe(2);
+    await expect(count.cell!.initialize!(0)).resolves.toBe(1);
     await count.cell!.set!(3);
     expect(requests).toEqual([{
       type: RequestType.CellPull,
@@ -94,6 +98,14 @@ describe("cf-iframe cell bridge", () => {
         path: ["count"],
         schema: { type: "number", description: "Shared counter" },
       },
+    }, {
+      type: RequestType.CellInitialize,
+      cell: {
+        ...ref,
+        path: ["count"],
+        schema: { type: "number", description: "Shared counter" },
+      },
+      value: 0,
     }, {
       type: RequestType.CellSet,
       cell: {

--- a/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cell-bridge.ts
@@ -136,6 +136,8 @@ function bridgeCell(
     get: () => bridgeValue(cell.get()),
     pull: async () => bridgeValue(await cell.pull()),
     ...(writable && {
+      initialize: async (value: FabricValue) =>
+        bridgeValue(await cell.initialize(value)),
       set: async (value: FabricValue) => await cell.setStrict(value),
       push: async (...values: FabricValue[]) =>
         await (cell as CellHandle<FabricValue[]>).pushStrict(...values),

--- a/skills/pattern-iframe/SKILL.md
+++ b/skills/pattern-iframe/SKILL.md
@@ -5,9 +5,16 @@ description: Build or generate a Common Fabric pattern whose primary UI is a sel
 
 # Iframe-first patterns
 
-Read `docs/common/ai/iframe-pattern-guide.md` in full. It is the self-contained
-authoring contract for this task; do not load the general pattern-development
-guides unless the requested behavior extends beyond its wrapper.
+Choose one self-contained authoring contract before writing code:
+
+- For a React component tree, hooks, or an explicitly requested React guest,
+  read `docs/common/ai/iframe-pattern-react-guide.md` in full.
+- Otherwise read `docs/common/ai/iframe-pattern-guide.md` in full for a plain
+  DOM guest.
+
+Do not load both guides unless the task is a migration between those styles. Do
+not load the general pattern-development guides unless the requested behavior
+extends beyond the generated wrapper.
 
 Keep the authored surface small:
 
@@ -28,6 +35,9 @@ deno run -A tools/write-iframe-wrapper.ts \
   --guest packages/patterns/<name>/guest.ts \
   --out packages/patterns/<name>/main.tsx
 ```
+
+Add `--react` when the authored guest is React TSX, as required by the React
+guide.
 
 Add `--html packages/patterns/<name>/guest.html` when the guest needs a custom
 document shell, and `--force` only when regenerating the named output. The HTML

--- a/tools/write-iframe-wrapper.test.ts
+++ b/tools/write-iframe-wrapper.test.ts
@@ -55,6 +55,41 @@ export const DEFAULT_OUTPUT: IframeOutputData = { count: 0 };
 `;
 
 describe("iframe pattern wrapper generator", () => {
+  it("bundles React TSX with the guest-owned React instance", async () => {
+    const directory = await Deno.makeTempDir({
+      prefix: "pattern-iframe-react-",
+    });
+    try {
+      const contract = resolve(directory, "contract.ts");
+      const guest = resolve(directory, "guest.tsx");
+      const out = resolve(directory, "main.tsx");
+      await Deno.writeTextFile(
+        contract,
+        `${contractPrefix}
+export const IFRAME_PATTERN = { name: "ReactGuest" } as const;
+`,
+      );
+      await Deno.writeTextFile(
+        guest,
+        `import React from "npm:react@19.2.8";
+import { createRoot } from "npm:react-dom@19.2.8/client";
+createRoot(document.querySelector("#root")!).render(
+  <button type="button">React {React.version}</button>,
+);
+`,
+      );
+
+      const result = await generate(contract, guest, out, "--react");
+
+      expect(result.code, decoder.decode(result.stderr)).toBe(0);
+      const generated = await Deno.readTextFile(out);
+      expect(generated).toContain("react.production.js");
+      expect(generated).not.toContain("@commonfabric/runner/jsx-runtime");
+    } finally {
+      await removeDirectory(directory);
+    }
+  });
+
   it("keeps state and output scoped to the active viewer", async () => {
     const directory = await Deno.makeTempDir({
       prefix: "pattern-iframe-scopes-",

--- a/tools/write-iframe-wrapper.ts
+++ b/tools/write-iframe-wrapper.ts
@@ -28,6 +28,7 @@ type Options = {
   html?: string;
   force: boolean;
   help: boolean;
+  react: boolean;
 };
 
 function usage(): string {
@@ -42,17 +43,20 @@ Options:
   --guest <path>     Browser entry bundled into the iframe document
   --out <path>       Generated pattern wrapper
   --html <path>      Optional document shell containing ${SCRIPT_MARKER}
+  --react           Compile TSX with the React instance imported by the guest
   --force            Replace an existing output file
   --help             Show this help
 `;
 }
 
 function parseArgs(args: string[]): Options {
-  const options: Options = { force: false, help: false };
+  const options: Options = { force: false, help: false, react: false };
   for (let index = 0; index < args.length; index++) {
     const argument = args[index];
     if (argument === "--force") {
       options.force = true;
+    } else if (argument === "--react") {
+      options.react = true;
     } else if (argument === "--help" || argument === "-h") {
       options.help = true;
     } else if (
@@ -455,6 +459,13 @@ async function main(): Promise<void> {
 
   const result = await build({
     entryPoints: [guestPath],
+    ...(options.react
+      ? {
+        jsx: "transform" as const,
+        jsxFactory: "React.createElement",
+        jsxFragment: "React.Fragment",
+      }
+      : {}),
     minify: true,
     sourcemap: false,
     target: ["es2022"],


### PR DESCRIPTION
## Why

Iframe-first patterns should be able to choose React without importing the host JSX runtime or learning the broader pattern framework. The authoring contract also needs to preserve Fabric readiness, scoping, fine-grained paths, stable identities, mergeable writes, and bridged SQLite behavior.

## What

- adds a self-contained React iframe authoring guide and routes the `pattern-iframe` skill to exactly one guide
- adds `--react` to the iframe wrapper generator so guest TSX uses its imported React instance
- adds real React/ReactDOM browser tests for Cell hooks, SQLite invalidation, canonical special-value query identities, and reserved named parameters
- pins React test dependencies in the iframe-sandbox package

## Verification

- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno task check-unused-deps`
- `deno task check-docs common/ai`
- `deno task check-skill-facts`
- `deno test --frozen -A tools/write-iframe-wrapper.test.ts`
- `deno task test` in `packages/iframe-sandbox`
- local generated React pattern passed `deno check` and `cf check --no-run`
- Computer Use: launched the real local pattern, incremented a PerUser Cell, inserted/query-invalidated PerUser SQLite, and verified both survived reload
- independent self-review round 1 found a SQLite identity regression; exact browser regressions and the canonical Fabric hash fixed it; round 2 is running
