### PR TITLE
refactor(utils): reading an object's class is an object utility

### DIFF
--- a/packages/connectors/agents/connector/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/connector/src/stable-fabric-value.ts
@@ -14,8 +14,8 @@ import {
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import {
-  NATIVE_TAGS,
   tagFromNativeValue,
+  VALUE_TAGS,
 } from "@commonfabric/data-model/native-type-tags";
 import {
   getCellOrThrow,
@@ -80,7 +80,7 @@ function replaceCellsWithLinks(
     return converted;
   }
   const nativeTag = tagFromNativeValue(value);
-  if (nativeTag === NATIVE_TAGS.Error) {
+  if (nativeTag === VALUE_TAGS.Error) {
     const error = value as Error;
     const existing = seen.get(error);
     if (existing) return existing;
@@ -103,8 +103,8 @@ function replaceCellsWithLinks(
   }
   if (
     nativeTag !== null &&
-    nativeTag !== NATIVE_TAGS.Object &&
-    nativeTag !== NATIVE_TAGS.Primitive
+    nativeTag !== VALUE_TAGS.Object &&
+    nativeTag !== VALUE_TAGS.Primitive
   ) {
     return value;
   }

--- a/packages/connectors/agents/connector/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/connector/src/stable-fabric-value.ts
@@ -13,10 +13,8 @@ import {
   type FabricPlainObject,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import {
-  tagFromNativeValue,
-  VALUE_TAGS,
-} from "@commonfabric/data-model/native-type-tags";
+import { VALUE_TAGS } from "@commonfabric/data-model/VALUE_TAGS";
+import { tagFromNativeValue } from "@commonfabric/data-model/native-type-tags";
 import {
   getCellOrThrow,
   isCell,

--- a/packages/data-model/deno.jsonc
+++ b/packages/data-model/deno.jsonc
@@ -40,6 +40,7 @@
   },
   "exports": {
     "./api": "./src/api.ts",
+    "./VALUE_TAGS": "./src/VALUE_TAGS.ts",
     "./cell-rep": "./src/cell-rep.ts",
     "./codec-common": "./src/codec-common/index.ts",
     "./codec-json": "./src/codec-json/index.ts",

--- a/packages/data-model/src/NATIVE_TAGS.ts
+++ b/packages/data-model/src/NATIVE_TAGS.ts
@@ -1,0 +1,44 @@
+/**
+ * The tag vocabulary: the names a dispatch answers with when asked what a
+ * value already is.
+ *
+ * Which classes a given dispatch recognizes varies with where that dispatch is
+ * layered -- recognizing a `FabricBytes` means holding the `FabricBytes` class,
+ * which not every module can. The vocabulary does not vary, so it is here
+ * rather than inside any one of them.
+ */
+
+/**
+ * Tags identifying classes that the fabric system recognizes for dispatch.
+ * These are distinct from wire-format `TAGS` -- they identify *what the value
+ * is*, not what fabric type it becomes after conversion.
+ *
+ * Covers two categories:
+ * - **Native JS builtins**: standard JS types that the fabric system converts.
+ * - **System-defined value types**: classes defined by this system that
+ *   behave like primitives (always frozen, pass through conversion
+ *   unchanged) but aren't under the open-ended `FabricInstance` umbrella.
+ */
+export const NATIVE_TAGS = Object.freeze(
+  {
+    Array: "Array",
+    Object: "Object",
+    Error: "Error",
+    Map: "Map",
+    Set: "Set",
+    Date: "Date",
+    Uint8Array: "Uint8Array",
+    RegExp: "RegExp",
+    EpochNsec: "EpochNsec",
+    EpochDay: "EpochDay",
+    Hash: "Hash",
+    FabricBytes: "FabricBytes",
+    FabricKeyPair: "FabricKeyPair",
+    FabricRegExp: "FabricRegExp",
+    FabricInstance: "FabricInstance",
+    Primitive: "Primitive",
+  } as const,
+);
+
+/** One of the native-instance tag strings. */
+export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];

--- a/packages/data-model/src/VALUE_TAGS.ts
+++ b/packages/data-model/src/VALUE_TAGS.ts
@@ -10,7 +10,7 @@
 
 /**
  * Tags identifying the classes this system recognizes for dispatch. These are
- * distinct from wire-format `TAGS` -- they identify *what the value is*, not
+ * distinct from wire-format `TAGS` -- they identify _what the value is_, not
  * what fabric type it becomes after conversion.
  *
  * Covers two categories:

--- a/packages/data-model/src/VALUE_TAGS.ts
+++ b/packages/data-model/src/VALUE_TAGS.ts
@@ -9,9 +9,9 @@
  */
 
 /**
- * Tags identifying classes that the fabric system recognizes for dispatch.
- * These are distinct from wire-format `TAGS` -- they identify *what the value
- * is*, not what fabric type it becomes after conversion.
+ * Tags identifying the classes this system recognizes for dispatch. These are
+ * distinct from wire-format `TAGS` -- they identify *what the value is*, not
+ * what fabric type it becomes after conversion.
  *
  * Covers two categories:
  * - **Native JS builtins**: standard JS types that the fabric system converts.
@@ -19,7 +19,7 @@
  *   behave like primitives (always frozen, pass through conversion
  *   unchanged) but aren't under the open-ended `FabricInstance` umbrella.
  */
-export const NATIVE_TAGS = Object.freeze(
+export const VALUE_TAGS = Object.freeze(
   {
     Array: "Array",
     Object: "Object",
@@ -40,5 +40,5 @@ export const NATIVE_TAGS = Object.freeze(
   } as const,
 );
 
-/** One of the native-instance tag strings. */
-export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];
+/** One of the tag strings. */
+export type ValueTag = typeof VALUE_TAGS[keyof typeof VALUE_TAGS];

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -41,7 +41,7 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
-import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeValue } from "./native-type-tags.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
@@ -178,12 +178,12 @@ export function isValidFabricNativeObject(
   value: unknown,
 ): value is FabricNativeObject {
   switch (tagFromNativeValue(value)) {
-    case NATIVE_TAGS.Error:
-    case NATIVE_TAGS.Map:
-    case NATIVE_TAGS.Set:
-    case NATIVE_TAGS.Date:
-    case NATIVE_TAGS.Uint8Array:
-    case NATIVE_TAGS.RegExp:
+    case VALUE_TAGS.Error:
+    case VALUE_TAGS.Map:
+    case VALUE_TAGS.Set:
+    case VALUE_TAGS.Date:
+    case VALUE_TAGS.Uint8Array:
+    case VALUE_TAGS.RegExp:
       return true;
     default:
       return false;
@@ -230,15 +230,15 @@ export function shallowFabricFromNativeValue(
   switch (tag) {
     // `FabricPrimitive`s are direct `FabricValue` members -- always frozen,
     // pass through as-is regardless of the `freeze` argument.
-    case NATIVE_TAGS.EpochNsec:
-    case NATIVE_TAGS.EpochDay:
-    case NATIVE_TAGS.FabricBytes:
-    case NATIVE_TAGS.FabricKeyPair:
-    case NATIVE_TAGS.FabricRegExp:
-    case NATIVE_TAGS.Hash:
+    case VALUE_TAGS.EpochNsec:
+    case VALUE_TAGS.EpochDay:
+    case VALUE_TAGS.FabricBytes:
+    case VALUE_TAGS.FabricKeyPair:
+    case VALUE_TAGS.FabricRegExp:
+    case VALUE_TAGS.Hash:
       return value as FabricValueLayer;
 
-    case NATIVE_TAGS.Error: {
+    case VALUE_TAGS.Error: {
       // Shallow conversion: wrap the native `Error` without recursing into its
       // internals (`cause`, custom properties). The result is therefore only a
       // *shallow* `FabricError` -- its `.cause` may still be a raw `Error`.
@@ -250,7 +250,7 @@ export function shallowFabricFromNativeValue(
       return wrapped;
     }
 
-    case NATIVE_TAGS.Date: {
+    case VALUE_TAGS.Date: {
       // `Date` instances are converted to `FabricEpochNsec` (nanoseconds from
       // epoch). Extra enumerable properties cause rejection ("death before
       // confusion").
@@ -261,19 +261,19 @@ export function shallowFabricFromNativeValue(
       return wrapped;
     }
 
-    case NATIVE_TAGS.RegExp: {
+    case VALUE_TAGS.RegExp: {
       // `RegExp` instances are converted to `FabricRegExp`, which rejects extra
       // enumerable properties and is frozen at construction.
       return new FabricRegExp(value as RegExp);
     }
 
-    case NATIVE_TAGS.Uint8Array: {
+    case VALUE_TAGS.Uint8Array: {
       // Native `Uint8Array` instances are wrapped in `FabricBytes`.
       // `FabricBytes` is frozen at construction (`FabricPrimitive` contract).
       return new FabricBytes(value as Uint8Array);
     }
 
-    case NATIVE_TAGS.Array: {
+    case VALUE_TAGS.Array: {
       // An array in this system is _inert_: a direct `Array` instance, which
       // may only carry numeric index properties, each a data property. A named
       // or symbol-keyed property has no fabric representation, and an
@@ -298,7 +298,7 @@ export function shallowFabricFromNativeValue(
       );
     }
 
-    case NATIVE_TAGS.Object: {
+    case VALUE_TAGS.Object: {
       // A plain object in this system is _inert_: `FabricPlainObject` is keyed
       // by `string`, so a symbol key has no fabric representation, and neither
       // does a non-enumerable string key; an accessor-backed property is live
@@ -332,7 +332,7 @@ export function shallowFabricFromNativeValue(
       );
     }
 
-    case NATIVE_TAGS.FabricInstance: {
+    case VALUE_TAGS.FabricInstance: {
       // `FabricInstance` values (`FabricError`, `UnknownValue`, etc.) are
       // already valid `FabricValue` members. Delegate frozenness handling to
       // `cloneHelper()`.
@@ -346,7 +346,7 @@ export function shallowFabricFromNativeValue(
     }
 
     // deno-lint-ignore no-fallthrough
-    case NATIVE_TAGS.Primitive: {
+    case VALUE_TAGS.Primitive: {
       // Primitives: `null`, `undefined`, `boolean`, `string`, `number`,
       // `bigint`, `symbol`, `function`. `null` is the only value here with
       // `typeof "object"` (actual objects are routed to other tags by

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -41,7 +41,8 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
-import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
+import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { tagFromNativeValue } from "./native-type-tags.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -13,6 +13,9 @@
  * alone.
  */
 
+import { constructorFromObject } from "@commonfabric/utils/objects";
+
+import { NATIVE_TAGS, type NativeTag } from "./NATIVE_TAGS.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
@@ -21,40 +24,7 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricInstance } from "./interface.ts";
 
-/**
- * Tags identifying classes that the fabric system recognizes for dispatch.
- * These are distinct from wire-format `TAGS` -- they identify *what the value
- * is*, not what fabric type it becomes after conversion.
- *
- * Covers two categories:
- * - **Native JS builtins**: standard JS types that the fabric system converts.
- * - **System-defined value types**: classes defined by this system that
- *   behave like primitives (always frozen, pass through conversion
- *   unchanged) but aren't under the open-ended `FabricInstance` umbrella.
- */
-export const NATIVE_TAGS = Object.freeze(
-  {
-    Array: "Array",
-    Object: "Object",
-    Error: "Error",
-    Map: "Map",
-    Set: "Set",
-    Date: "Date",
-    Uint8Array: "Uint8Array",
-    RegExp: "RegExp",
-    EpochNsec: "EpochNsec",
-    EpochDay: "EpochDay",
-    Hash: "Hash",
-    FabricBytes: "FabricBytes",
-    FabricKeyPair: "FabricKeyPair",
-    FabricRegExp: "FabricRegExp",
-    FabricInstance: "FabricInstance",
-    Primitive: "Primitive",
-  } as const,
-);
-
-/** One of the native-instance tag strings. */
-export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];
+export { NATIVE_TAGS, type NativeTag } from "./NATIVE_TAGS.ts";
 
 /**
  * Checks whether a value is a native `Error`.
@@ -162,19 +132,12 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     return NATIVE_TAGS.Array;
   }
 
-  // The constructor is read from the _prototype_, not from the value. What is
-  // being asked is which class the value is an instance of, and that is a fact
-  // about its prototype; an own `constructor` property is ordinary data that
-  // happens to share the name, and must not decide the value's type. Reading
-  // it off the value would let `{constructor: Error}` -- a plain record -- be
-  // tagged `Error` and silently rebuilt as one.
-  //
-  // Guard: a null-prototype object has no constructor to find, and an exotic
-  // one may not have a callable one.
-  const proto = Object.getPrototypeOf(value);
-  const ctor = proto === null ? undefined : proto.constructor;
+  // `constructorFromObject()` reads the class off the value's PROTOTYPE, which
+  // is what keeps an own `constructor` property -- ordinary data that happens
+  // to share the name -- from deciding the value's type.
+  const ctor = constructorFromObject(value);
 
-  if (typeof ctor === "function") {
+  if (ctor !== undefined) {
     const tag = tagFromNativeClass(ctor);
     if (tag !== null) return tag;
   }
@@ -193,7 +156,7 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   // Null-prototype objects (`Object.create(null)`), which have no constructor
   // to have been recognized. Tagged `Object` so the object rule decides them
   // by name, the same way an indirect array is tagged `Array`.
-  if (proto === null) return NATIVE_TAGS.Object;
+  if (Object.getPrototypeOf(value) === null) return NATIVE_TAGS.Object;
 
   return null;
 }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -13,6 +13,8 @@
  * alone.
  */
 
+import { constructorOfPrototype } from "@commonfabric/utils/objects";
+
 import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -128,43 +130,41 @@ export function tagFromNativeValue(value: unknown): ValueTag | null {
     return VALUE_TAGS.Array;
   }
 
-  // The constructor is read from the _prototype_, not from the value. What is
-  // being asked is which class the value is an instance of, and that is a fact
-  // about its prototype; an own `constructor` property is ordinary data that
-  // happens to share the name, and must not decide the value's type. Reading
-  // it off the value would let `{constructor: Error}` -- a plain record -- be
-  // tagged `Error` and silently rebuilt as one.
-  //
-  // Guard: a null-prototype object has no constructor to find, and an exotic
-  // one may not have a callable one.
-  //
-  // Read ONCE, and used twice: the null-prototype fallback below tests this
-  // same result rather than asking again, so that a value whose prototype is
-  // answered by a trap cannot be one thing to the class lookup and another to
-  // the fallback.
   const proto = Object.getPrototypeOf(value);
-  const ctor = proto === null ? undefined : proto.constructor;
 
-  if (typeof ctor === "function") {
+  // A `null` prototype settles the value here, both ways it can go. It names
+  // no class, so nothing below could recognize one; and `instanceof` walks a
+  // chain that is empty, so the `FabricInstance` test below cannot claim it
+  // either. What is left is an `Error` whose prototype was severed -- still an
+  // error, and `Error.isError()` is what sees it -- or a bare record, which is
+  // tagged `Object` so the object rule decides it by name, the same way an
+  // indirect array is decided by the array rule.
+  if (proto === null) {
+    return isNativeError(value) ? VALUE_TAGS.Error : VALUE_TAGS.Object;
+  }
+
+  // The class is read from the PROTOTYPE, not from the value. What is being
+  // asked is which class the value is an instance of, and that is a fact about
+  // its prototype; an own `constructor` property is ordinary data that happens
+  // to share the name, and must not decide the value's type. Reading it off
+  // the value would let `{constructor: Error}` -- a plain record -- be tagged
+  // `Error` and silently rebuilt as one.
+  const ctor = constructorOfPrototype(proto);
+
+  if (ctor !== undefined) {
     const tag = tagFromNativeClass(ctor);
     if (tag !== null) return tag;
   }
 
   // Fallbacks for values whose constructor wasn't recognized.
 
-  // `Error`s with no reachable constructor -- e.g. one whose prototype has
-  // been severed, or one from another realm. An ordinary subclass (including
-  // `DOMException`) never gets here: `tagFromNativeClass()` matches it via
-  // `prototype instanceof Error`.
+  // `Error`s with no reachable constructor -- e.g. one from another realm. An
+  // ordinary subclass (including `DOMException`) never gets here:
+  // `tagFromNativeClass()` matches it via `prototype instanceof Error`.
   if (isNativeError(value)) return VALUE_TAGS.Error;
 
   // `FabricInstance` values (object-like protocol types).
   if (value instanceof FabricInstance) return VALUE_TAGS.FabricInstance;
-
-  // Null-prototype objects (`Object.create(null)`), which have no constructor
-  // to have been recognized. Tagged `Object` so the object rule decides them
-  // by name, the same way an indirect array is tagged `Array`.
-  if (proto === null) return VALUE_TAGS.Object;
 
   return null;
 }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -13,9 +13,7 @@
  * alone.
  */
 
-import { constructorFromObject } from "@commonfabric/utils/objects";
-
-import { NATIVE_TAGS, type NativeTag } from "./NATIVE_TAGS.ts";
+import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
@@ -24,7 +22,7 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricInstance } from "./interface.ts";
 
-export { NATIVE_TAGS, type NativeTag } from "./NATIVE_TAGS.ts";
+export { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
 
 /**
  * Checks whether a value is a native `Error`.
@@ -53,7 +51,7 @@ export function isNativeError(value: unknown): value is Error {
  */
 export function tagFromNativeClass(
   constructorFn: { prototype: unknown },
-): NativeTag | null {
+): ValueTag | null {
   switch (constructorFn) {
     // `Error` and standard subclasses all map to the `Error` tag.
     case Error:
@@ -63,34 +61,34 @@ export function tagFromNativeClass(
     case ReferenceError:
     case URIError:
     case EvalError:
-      return NATIVE_TAGS.Error;
+      return VALUE_TAGS.Error;
 
     case Array:
-      return NATIVE_TAGS.Array;
+      return VALUE_TAGS.Array;
     case Object:
-      return NATIVE_TAGS.Object;
+      return VALUE_TAGS.Object;
     case Map:
-      return NATIVE_TAGS.Map;
+      return VALUE_TAGS.Map;
     case Set:
-      return NATIVE_TAGS.Set;
+      return VALUE_TAGS.Set;
     case Date:
-      return NATIVE_TAGS.Date;
+      return VALUE_TAGS.Date;
     case Uint8Array:
-      return NATIVE_TAGS.Uint8Array;
+      return VALUE_TAGS.Uint8Array;
     case RegExp:
-      return NATIVE_TAGS.RegExp;
+      return VALUE_TAGS.RegExp;
     case FabricBytes:
-      return NATIVE_TAGS.FabricBytes;
+      return VALUE_TAGS.FabricBytes;
     case FabricEpochNsec:
-      return NATIVE_TAGS.EpochNsec;
+      return VALUE_TAGS.EpochNsec;
     case FabricEpochDay:
-      return NATIVE_TAGS.EpochDay;
+      return VALUE_TAGS.EpochDay;
     case FabricHash:
-      return NATIVE_TAGS.Hash;
+      return VALUE_TAGS.Hash;
     case FabricKeyPair:
-      return NATIVE_TAGS.FabricKeyPair;
+      return VALUE_TAGS.FabricKeyPair;
     case FabricRegExp:
-      return NATIVE_TAGS.FabricRegExp;
+      return VALUE_TAGS.FabricRegExp;
 
     default:
       // Catch exotic `Error` subclasses (e.g. custom subclasses with
@@ -100,7 +98,7 @@ export function tagFromNativeClass(
         typeof constructorFn === "function" &&
         constructorFn.prototype instanceof Error
       ) {
-        return NATIVE_TAGS.Error;
+        return VALUE_TAGS.Error;
       }
       return null;
   }
@@ -122,22 +120,34 @@ export function tagFromNativeClass(
  * constructor is unreachable -- a severed prototype, or another realm -- and to
  * a prototype check for null-prototype objects.
  */
-export function tagFromNativeValue(value: unknown): NativeTag | null {
+export function tagFromNativeValue(value: unknown): ValueTag | null {
   if (value === null || typeof value !== "object") {
-    return NATIVE_TAGS.Primitive;
+    return VALUE_TAGS.Primitive;
   }
 
   // Arrays first, and unconditionally: see above.
   if (Array.isArray(value)) {
-    return NATIVE_TAGS.Array;
+    return VALUE_TAGS.Array;
   }
 
-  // `constructorFromObject()` reads the class off the value's PROTOTYPE, which
-  // is what keeps an own `constructor` property -- ordinary data that happens
-  // to share the name -- from deciding the value's type.
-  const ctor = constructorFromObject(value);
+  // The constructor is read from the _prototype_, not from the value. What is
+  // being asked is which class the value is an instance of, and that is a fact
+  // about its prototype; an own `constructor` property is ordinary data that
+  // happens to share the name, and must not decide the value's type. Reading
+  // it off the value would let `{constructor: Error}` -- a plain record -- be
+  // tagged `Error` and silently rebuilt as one.
+  //
+  // Guard: a null-prototype object has no constructor to find, and an exotic
+  // one may not have a callable one.
+  //
+  // Read ONCE, and used twice: the null-prototype fallback below tests this
+  // same result rather than asking again, so that a value whose prototype is
+  // answered by a trap cannot be one thing to the class lookup and another to
+  // the fallback.
+  const proto = Object.getPrototypeOf(value);
+  const ctor = proto === null ? undefined : proto.constructor;
 
-  if (ctor !== undefined) {
+  if (typeof ctor === "function") {
     const tag = tagFromNativeClass(ctor);
     if (tag !== null) return tag;
   }
@@ -148,15 +158,15 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   // been severed, or one from another realm. An ordinary subclass (including
   // `DOMException`) never gets here: `tagFromNativeClass()` matches it via
   // `prototype instanceof Error`.
-  if (isNativeError(value)) return NATIVE_TAGS.Error;
+  if (isNativeError(value)) return VALUE_TAGS.Error;
 
   // `FabricInstance` values (object-like protocol types).
-  if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
+  if (value instanceof FabricInstance) return VALUE_TAGS.FabricInstance;
 
   // Null-prototype objects (`Object.create(null)`), which have no constructor
   // to have been recognized. Tagged `Object` so the object rule decides them
   // by name, the same way an indirect array is tagged `Array`.
-  if (Object.getPrototypeOf(value) === null) return NATIVE_TAGS.Object;
+  if (proto === null) return VALUE_TAGS.Object;
 
   return null;
 }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -22,8 +22,6 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricInstance } from "./interface.ts";
 
-export { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
-
 /**
  * Checks whether a value is a native `Error`.
  *

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -26,7 +26,8 @@ import {
   MutableFabricContainerValueLayer,
   MutableFabricPlainObjectLayer,
 } from "./interface.ts";
-import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
+import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 import {
   isFabricContainerValue,

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -26,7 +26,7 @@ import {
   MutableFabricContainerValueLayer,
   MutableFabricPlainObjectLayer,
 } from "./interface.ts";
-import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 import {
@@ -206,16 +206,16 @@ export function cloneHelper(
   switch (tagFromNativeValue(value)) {
     // Inherently immutable types -- frozenness is irrelevant, no cloning
     // needed regardless of force.
-    case NATIVE_TAGS.Primitive:
-    case NATIVE_TAGS.EpochNsec:
-    case NATIVE_TAGS.EpochDay:
-    case NATIVE_TAGS.FabricBytes:
-    case NATIVE_TAGS.FabricKeyPair:
-    case NATIVE_TAGS.FabricRegExp:
-    case NATIVE_TAGS.Hash:
+    case VALUE_TAGS.Primitive:
+    case VALUE_TAGS.EpochNsec:
+    case VALUE_TAGS.EpochDay:
+    case VALUE_TAGS.FabricBytes:
+    case VALUE_TAGS.FabricKeyPair:
+    case VALUE_TAGS.FabricRegExp:
+    case VALUE_TAGS.Hash:
       return value;
 
-    case NATIVE_TAGS.FabricInstance: {
+    case VALUE_TAGS.FabricInstance: {
       // Identity optimization: already-correct frozenness needs no clone.
       if (canReturnAsIs(value)) {
         return value;
@@ -226,7 +226,7 @@ export function cloneHelper(
       }
     }
 
-    case NATIVE_TAGS.Array: {
+    case VALUE_TAGS.Array: {
       if (canReturnAsIs(value)) return value;
       const arr = value as FabricValue[];
       if (deep) seen = trackForCircularity(arr, seen);
@@ -243,7 +243,7 @@ export function cloneHelper(
       return copy;
     }
 
-    case NATIVE_TAGS.Object: {
+    case VALUE_TAGS.Object: {
       if (canReturnAsIs(value)) return value;
       const obj = value as object;
       if (deep) seen = trackForCircularity(obj, seen);

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -20,7 +20,7 @@ import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 import { isDeepFrozen } from "./deep-freeze.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
-import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeValue } from "./native-type-tags.ts";
 import { BaseFabricInstance } from "@/fabric-bases/BaseFabricInstance.ts";
 import { codecOf, NULL_LIVE_ENVIRONMENT } from "@/codec-common/index.ts";
@@ -254,7 +254,7 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
 /**
  * Feed an object-typed value (`FabricPrimitive`, `FabricInstance`, `Array`,
  * or plain object) into the hasher. Dispatches via `tagFromNativeValue()` /
- * `NATIVE_TAGS` for recognized types. The `null` case is handled by the
+ * `VALUE_TAGS` for recognized types. The `null` case is handled by the
  * caller (`feedValue()`).
  */
 function feedObjectValue(
@@ -264,7 +264,7 @@ function feedObjectValue(
   const nativeTag = tagFromNativeValue(value);
 
   switch (nativeTag) {
-    case NATIVE_TAGS.EpochNsec: {
+    case VALUE_TAGS.EpochNsec: {
       hasher.update(TAG_EPOCH_NSEC_BYTES);
       const bytes = bigintToMinimalTwosComplement(
         (value as { value: bigint }).value,
@@ -274,7 +274,7 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.EpochDay: {
+    case VALUE_TAGS.EpochDay: {
       hasher.update(TAG_EPOCH_DAY_BYTES);
       const bytes = bigintToMinimalTwosComplement(
         (value as { value: bigint }).value,
@@ -284,7 +284,7 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.Hash: {
+    case VALUE_TAGS.Hash: {
       const cid = value as FabricHash;
       hasher.update(TAG_HASH_BYTES);
       hasher.update(getStringRep(cid.tag));
@@ -296,15 +296,15 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.Array:
+    case VALUE_TAGS.Array:
       feedArray(hasher, value as unknown[]);
       return;
 
-    case NATIVE_TAGS.Object:
+    case VALUE_TAGS.Object:
       feedPlainObject(hasher, value as Record<string, unknown>);
       return;
 
-    case NATIVE_TAGS.FabricBytes: {
+    case VALUE_TAGS.FabricBytes: {
       hasher.update(TAG_BYTES_BYTES);
       const fab = value as FabricBytes;
       feedLength(hasher, fab.length);
@@ -312,7 +312,7 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.FabricInstance: {
+    case VALUE_TAGS.FabricInstance: {
       const fabInst = value as BaseFabricInstance;
       hasher.update(TAG_INSTANCE_BYTES);
       const codec = codecOf(fabInst);
@@ -322,7 +322,7 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.FabricKeyPair: {
+    case VALUE_TAGS.FabricKeyPair: {
       const fab = value as FabricKeyPair;
       if (!fab.hasMaterial) {
         // A pair holding handles has no content to hash: its material is
@@ -339,7 +339,7 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.FabricRegExp: {
+    case VALUE_TAGS.FabricRegExp: {
       const fab = value as FabricRegExp;
       hasher.update(TAG_REGEXP_BYTES);
       feedValue(hasher, fab.source);
@@ -348,9 +348,9 @@ function feedObjectValue(
       return;
     }
 
-    case NATIVE_TAGS.Date:
-    case NATIVE_TAGS.RegExp:
-    case NATIVE_TAGS.Uint8Array: {
+    case VALUE_TAGS.Date:
+    case VALUE_TAGS.RegExp:
+    case VALUE_TAGS.Uint8Array: {
       // Native instances that have a well-defined `FabricValue` conversion.
       // Convert on-the-fly and hash the converted value.
       const converted = shallowFabricFromNativeValue(value, false);

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -20,7 +20,8 @@ import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 import { isDeepFrozen } from "./deep-freeze.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
-import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
+import { NATIVE_TAGS } from "./NATIVE_TAGS.ts";
+import { tagFromNativeValue } from "./native-type-tags.ts";
 import { BaseFabricInstance } from "@/fabric-bases/BaseFabricInstance.ts";
 import { codecOf, NULL_LIVE_ENVIRONMENT } from "@/codec-common/index.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -30,11 +30,8 @@ import {
 } from "@/fabric-value.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 import { isValidFabricNativeObject } from "@/native-conversion.ts";
-import {
-  tagFromNativeClass,
-  tagFromNativeValue,
-  VALUE_TAGS,
-} from "@/native-type-tags.ts";
+import { tagFromNativeClass, tagFromNativeValue } from "@/native-type-tags.ts";
+import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricRegExp", () => {

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -31,9 +31,9 @@ import {
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 import { isValidFabricNativeObject } from "@/native-conversion.ts";
 import {
-  NATIVE_TAGS,
   tagFromNativeClass,
   tagFromNativeValue,
+  VALUE_TAGS,
 } from "@/native-type-tags.ts";
 import { hashOf } from "@/value-hash.ts";
 
@@ -344,13 +344,13 @@ describe("FabricRegExp", () => {
   describe("tag functions", () => {
     describe("tagFromNativeValue()", () => {
       it("returns the `RegExp` tag for `RegExp` instances", () => {
-        expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
+        expect(tagFromNativeValue(/abc/)).toBe(VALUE_TAGS.RegExp);
       });
     });
 
     describe("tagFromNativeClass()", () => {
       it("returns the `RegExp` tag for the `RegExp` constructor", () => {
-        expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
+        expect(tagFromNativeClass(RegExp)).toBe(VALUE_TAGS.RegExp);
       });
     });
 

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -9,7 +9,9 @@
  * including a run with `Error.isError` removed, to reach the fallback beneath
  * it.
  *
- * A separate group pins something the classifier deliberately does not do:
+ * One group pins where the class is read FROM: a value's own `constructor`
+ * property is data, and must not be able to present a plain record as an
+ * `Error`. Another pins something the classifier deliberately does not do:
  * `toJSON()` has no bearing on what a value is. An object carrying one is
  * still an object and a class instance carrying one is still unrecognized,
  * whether the member is own or inherited.
@@ -18,12 +20,13 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { NATIVE_TAGS } from "@/NATIVE_TAGS.ts";
 import {
   isNativeError,
-  NATIVE_TAGS,
   tagFromNativeClass,
   tagFromNativeValue,
 } from "@/native-type-tags.ts";
+import { isValidFabricNativeObject } from "@/native-conversion.ts";
 
 describe("native-type-tags", () => {
   describe("tagFromNativeValue()", () => {
@@ -153,6 +156,39 @@ describe("native-type-tags", () => {
     // classifier that consulted it would let one assignment --
     // `Array.prototype.toJSON`, an own key on a record -- redirect values
     // wholesale.
+    // An own `constructor` property is ordinary data that happens to share a
+    // name with the thing that decides a value's class. Reading the class off
+    // the value rather than off its prototype would let a plain record present
+    // itself as an `Error` -- and be rebuilt as one, by a conversion doing
+    // exactly what it was told.
+    describe("an own `constructor` property does not decide the class", () => {
+      for (
+        const [label, forged] of [
+          ["`Error`", Error],
+          ["`Map`", Map],
+          ["`Date`", Date],
+          ["`Uint8Array`", Uint8Array],
+        ] as ReadonlyArray<[string, unknown]>
+      ) {
+        it(`returns \`Object\` for a record claiming ${label}`, () => {
+          expect(tagFromNativeValue({ constructor: forged, a: 1 }))
+            .toBe(NATIVE_TAGS.Object);
+        });
+
+        it(`returns \`false\` from the membership check for one claiming ${label}`, () => {
+          expect(isValidFabricNativeObject({ constructor: forged, a: 1 }))
+            .toBe(false);
+        });
+      }
+
+      it("reads an inherited `constructor`, which is the real one", () => {
+        // The counterpart: what the prototype says IS the answer, so a value
+        // whose class is reachable only through its prototype is tagged by it.
+        expect(tagFromNativeValue(new Map())).toBe(NATIVE_TAGS.Map);
+        expect(isValidFabricNativeObject(new Map())).toBe(true);
+      });
+    });
+
     describe("`toJSON()` is intentionally not supported", () => {
       it("returns `Object` tag for a plain object carrying `toJSON()`", () => {
         expect(tagFromNativeValue({ toJSON: () => "converted" })).toBe(

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -20,7 +20,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { NATIVE_TAGS } from "@/NATIVE_TAGS.ts";
+import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import {
   isNativeError,
   tagFromNativeClass,
@@ -41,7 +41,7 @@ describe("native-type-tags", () => {
         ["EvalError", new EvalError("test")],
       ];
       for (const [_name, value] of cases) {
-        expect(tagFromNativeValue(value)).toBe(NATIVE_TAGS.Error);
+        expect(tagFromNativeValue(value)).toBe(VALUE_TAGS.Error);
       }
     });
 
@@ -56,7 +56,7 @@ describe("native-type-tags", () => {
       // Recognized by class: `tagFromNativeClass()` walks the prototype chain,
       // so an `Error` subclass is tagged without reaching the value-level
       // fallbacks below.
-      expect(tagFromNativeValue(exotic)).toBe(NATIVE_TAGS.Error);
+      expect(tagFromNativeValue(exotic)).toBe(VALUE_TAGS.Error);
     });
 
     it("returns `Error` tag for an `Error` whose prototype was severed", () => {
@@ -68,56 +68,56 @@ describe("native-type-tags", () => {
       expect((severed as { constructor?: unknown }).constructor).toBe(
         undefined,
       );
-      expect(tagFromNativeValue(severed)).toBe(NATIVE_TAGS.Error);
+      expect(tagFromNativeValue(severed)).toBe(VALUE_TAGS.Error);
     });
 
     it("returns `Array` tag for an `Array` subclass", () => {
       class MyArray extends Array {}
 
       expect(tagFromNativeClass(MyArray)).toBe(null);
-      expect(tagFromNativeValue(new MyArray())).toBe(NATIVE_TAGS.Array);
+      expect(tagFromNativeValue(new MyArray())).toBe(VALUE_TAGS.Array);
     });
 
     it("returns `Array` tag for an array whose prototype was severed", () => {
       const severed = [1, 2];
       Object.setPrototypeOf(severed, null);
 
-      expect(tagFromNativeValue(severed)).toBe(NATIVE_TAGS.Array);
+      expect(tagFromNativeValue(severed)).toBe(VALUE_TAGS.Array);
     });
 
     it("returns `Map` tag for `Map` instances", () => {
-      expect(tagFromNativeValue(new Map())).toBe(NATIVE_TAGS.Map);
+      expect(tagFromNativeValue(new Map())).toBe(VALUE_TAGS.Map);
     });
 
     it("returns `Set` tag for `Set` instances", () => {
-      expect(tagFromNativeValue(new Set())).toBe(NATIVE_TAGS.Set);
+      expect(tagFromNativeValue(new Set())).toBe(VALUE_TAGS.Set);
     });
 
     it("returns `Date` tag for `Date` instances", () => {
-      expect(tagFromNativeValue(new Date())).toBe(NATIVE_TAGS.Date);
+      expect(tagFromNativeValue(new Date())).toBe(VALUE_TAGS.Date);
     });
 
     it("returns `Uint8Array` tag for `Uint8Array` instances", () => {
       expect(tagFromNativeValue(new Uint8Array())).toBe(
-        NATIVE_TAGS.Uint8Array,
+        VALUE_TAGS.Uint8Array,
       );
     });
 
     it("returns `Object` tag for plain objects", () => {
-      expect(tagFromNativeValue({})).toBe(NATIVE_TAGS.Object);
+      expect(tagFromNativeValue({})).toBe(VALUE_TAGS.Object);
     });
 
     it("returns `Array` tag for arrays", () => {
-      expect(tagFromNativeValue([])).toBe(NATIVE_TAGS.Array);
+      expect(tagFromNativeValue([])).toBe(VALUE_TAGS.Array);
     });
 
     it("returns `RegExp` tag for `RegExp` instances", () => {
-      expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
+      expect(tagFromNativeValue(/abc/)).toBe(VALUE_TAGS.RegExp);
     });
 
     it("returns `Object` tag for null-prototype objects (no constructor)", () => {
       const obj = Object.create(null);
-      expect(tagFromNativeValue(obj)).toBe(NATIVE_TAGS.Object);
+      expect(tagFromNativeValue(obj)).toBe(VALUE_TAGS.Object);
     });
 
     it("classifies values when `Error.isError` is unavailable", () => {
@@ -131,7 +131,7 @@ describe("native-type-tags", () => {
       try {
         expect(isNativeError(new Error("test"))).toBe(true);
         expect(tagFromNativeValue(Object.create(null))).toBe(
-          NATIVE_TAGS.Object,
+          VALUE_TAGS.Object,
         );
       } finally {
         if (descriptor) {
@@ -148,7 +148,7 @@ describe("native-type-tags", () => {
     });
 
     it("returns `Primitive` for functions", () => {
-      expect(tagFromNativeValue(() => {})).toBe(NATIVE_TAGS.Primitive);
+      expect(tagFromNativeValue(() => {})).toBe(VALUE_TAGS.Primitive);
     });
 
     // `toJSON` is an ordinary property name here, with no say in what a value
@@ -172,7 +172,7 @@ describe("native-type-tags", () => {
       ) {
         it(`returns \`Object\` for a record claiming ${label}`, () => {
           expect(tagFromNativeValue({ constructor: forged, a: 1 }))
-            .toBe(NATIVE_TAGS.Object);
+            .toBe(VALUE_TAGS.Object);
         });
 
         it(`returns \`false\` from the membership check for one claiming ${label}`, () => {
@@ -184,7 +184,7 @@ describe("native-type-tags", () => {
       it("reads an inherited `constructor`, which is the real one", () => {
         // The counterpart: what the prototype says IS the answer, so a value
         // whose class is reachable only through its prototype is tagged by it.
-        expect(tagFromNativeValue(new Map())).toBe(NATIVE_TAGS.Map);
+        expect(tagFromNativeValue(new Map())).toBe(VALUE_TAGS.Map);
         expect(isValidFabricNativeObject(new Map())).toBe(true);
       });
     });
@@ -192,14 +192,14 @@ describe("native-type-tags", () => {
     describe("`toJSON()` is intentionally not supported", () => {
       it("returns `Object` tag for a plain object carrying `toJSON()`", () => {
         expect(tagFromNativeValue({ toJSON: () => "converted" })).toBe(
-          NATIVE_TAGS.Object,
+          VALUE_TAGS.Object,
         );
       });
 
       it("returns `Array` tag for an array carrying an own `toJSON()`", () => {
         const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
         arr.toJSON = () => "custom array";
-        expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.Array);
+        expect(tagFromNativeValue(arr)).toBe(VALUE_TAGS.Array);
       });
 
       it("returns `Array` tag despite an inherited `toJSON()`", () => {
@@ -208,7 +208,7 @@ describe("native-type-tags", () => {
           proto.toJSON = () => "hijacked";
           const arr = [1, 2];
           expect(Object.hasOwn(arr, "toJSON")).toBe(false);
-          expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.Array);
+          expect(tagFromNativeValue(arr)).toBe(VALUE_TAGS.Array);
         } finally {
           delete proto.toJSON;
         }
@@ -220,7 +220,7 @@ describe("native-type-tags", () => {
             return [7, 8];
           }
         }
-        expect(tagFromNativeValue(new ProtoJson())).toBe(NATIVE_TAGS.Array);
+        expect(tagFromNativeValue(new ProtoJson())).toBe(VALUE_TAGS.Array);
       });
 
       it("returns `null` for a class instance carrying `toJSON()`", () => {
@@ -234,7 +234,7 @@ describe("native-type-tags", () => {
 
       it("returns `Primitive` for a function carrying `toJSON()`", () => {
         const fn = Object.assign(() => {}, { toJSON: () => "converted" });
-        expect(tagFromNativeValue(fn)).toBe(NATIVE_TAGS.Primitive);
+        expect(tagFromNativeValue(fn)).toBe(VALUE_TAGS.Primitive);
       });
     });
   });
@@ -251,7 +251,7 @@ describe("native-type-tags", () => {
         EvalError,
       ];
       for (const ctor of constructors) {
-        expect(tagFromNativeClass(ctor)).toBe(NATIVE_TAGS.Error);
+        expect(tagFromNativeClass(ctor)).toBe(VALUE_TAGS.Error);
       }
     });
 
@@ -259,20 +259,20 @@ describe("native-type-tags", () => {
       class ExoticError extends Error {}
       // Constructor is ExoticError, not in the switch -- falls back to
       // Error.isError(prototype) check.
-      expect(tagFromNativeClass(ExoticError)).toBe(NATIVE_TAGS.Error);
+      expect(tagFromNativeClass(ExoticError)).toBe(VALUE_TAGS.Error);
     });
 
     it("returns correct tags for `Array`, `Object`, `Map`, `Set`, `Date`, `Uint8Array`", () => {
-      expect(tagFromNativeClass(Array)).toBe(NATIVE_TAGS.Array);
-      expect(tagFromNativeClass(Object)).toBe(NATIVE_TAGS.Object);
-      expect(tagFromNativeClass(Map)).toBe(NATIVE_TAGS.Map);
-      expect(tagFromNativeClass(Set)).toBe(NATIVE_TAGS.Set);
-      expect(tagFromNativeClass(Date)).toBe(NATIVE_TAGS.Date);
-      expect(tagFromNativeClass(Uint8Array)).toBe(NATIVE_TAGS.Uint8Array);
+      expect(tagFromNativeClass(Array)).toBe(VALUE_TAGS.Array);
+      expect(tagFromNativeClass(Object)).toBe(VALUE_TAGS.Object);
+      expect(tagFromNativeClass(Map)).toBe(VALUE_TAGS.Map);
+      expect(tagFromNativeClass(Set)).toBe(VALUE_TAGS.Set);
+      expect(tagFromNativeClass(Date)).toBe(VALUE_TAGS.Date);
+      expect(tagFromNativeClass(Uint8Array)).toBe(VALUE_TAGS.Uint8Array);
     });
 
     it("returns `RegExp` tag for `RegExp` constructor", () => {
-      expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
+      expect(tagFromNativeClass(RegExp)).toBe(VALUE_TAGS.RegExp);
     });
 
     it("returns `null` for unrecognized constructors", () => {
@@ -306,7 +306,7 @@ describe("native-type-tags", () => {
       });
 
       it("returns `Date` tag for `Date`, whose `toJSON` is not consulted", () => {
-        expect(tagFromNativeClass(Date)).toBe(NATIVE_TAGS.Date);
+        expect(tagFromNativeClass(Date)).toBe(VALUE_TAGS.Date);
       });
     });
   });

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -151,11 +151,6 @@ describe("native-type-tags", () => {
       expect(tagFromNativeValue(() => {})).toBe(VALUE_TAGS.Primitive);
     });
 
-    // `toJSON` is an ordinary property name here, with no say in what a value
-    // is. These pin that at each of the shapes it can be carried on, because a
-    // classifier that consulted it would let one assignment --
-    // `Array.prototype.toJSON`, an own key on a record -- redirect values
-    // wholesale.
     // An own `constructor` property is ordinary data that happens to share a
     // name with the thing that decides a value's class. Reading the class off
     // the value rather than off its prototype would let a plain record present
@@ -189,6 +184,11 @@ describe("native-type-tags", () => {
       });
     });
 
+    // `toJSON` is an ordinary property name here, with no say in what a value
+    // is. These pin that at each of the shapes it can be carried on, because a
+    // classifier that consulted it would let one assignment --
+    // `Array.prototype.toJSON`, an own key on a record -- redirect values
+    // wholesale.
     describe("`toJSON()` is intentionally not supported", () => {
       it("returns `Object` tag for a plain object carrying `toJSON()`", () => {
         expect(tagFromNativeValue({ toJSON: () => "converted" })).toBe(

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -151,12 +151,12 @@ describe("native-type-tags", () => {
       expect(tagFromNativeValue(() => {})).toBe(VALUE_TAGS.Primitive);
     });
 
-    // An own `constructor` property is ordinary data that happens to share a
-    // name with the thing that decides a value's class. Reading the class off
-    // the value rather than off its prototype would let a plain record present
-    // itself as an `Error` -- and be rebuilt as one, by a conversion doing
-    // exactly what it was told.
     describe("an own `constructor` property does not decide the class", () => {
+      // An own `constructor` property is ordinary data that happens to share a
+      // name with the thing that decides a value's class. Reading the class off
+      // the value rather than off its prototype would let a plain record present
+      // itself as an `Error` -- and be rebuilt as one, by a conversion doing
+      // exactly what it was told.
       for (
         const [label, forged] of [
           ["`Error`", Error],
@@ -184,12 +184,12 @@ describe("native-type-tags", () => {
       });
     });
 
-    // `toJSON` is an ordinary property name here, with no say in what a value
-    // is. These pin that at each of the shapes it can be carried on, because a
-    // classifier that consulted it would let one assignment --
-    // `Array.prototype.toJSON`, an own key on a record -- redirect values
-    // wholesale.
     describe("`toJSON()` is intentionally not supported", () => {
+      // `toJSON` is an ordinary property name here, with no say in what a value
+      // is. These pin that at each of the shapes it can be carried on, because a
+      // classifier that consulted it would let one assignment --
+      // `Array.prototype.toJSON`, an own key on a record -- redirect values
+      // wholesale.
       it("returns `Object` tag for a plain object carrying `toJSON()`", () => {
         expect(tagFromNativeValue({ toJSON: () => "converted" })).toBe(
           VALUE_TAGS.Object,

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -1,5 +1,6 @@
 /**
- * Pure utility functions for checking the property-key shape of plain objects.
+ * Pure utility functions for asking what an object is: the shape of its
+ * property keys, and the class it is an instance of.
  */
 
 import type { ReadonlyRecord } from "./types.ts";
@@ -89,4 +90,28 @@ export function isInertPlainObject(
   }
 
   return true;
+}
+
+/**
+ * Returns the constructor the given object is an instance of, or `undefined`
+ * where there is none to read: a null-prototype object has no constructor to
+ * find, and an exotic one may have a `constructor` that is not callable.
+ *
+ * The constructor is read from the object's _prototype_, deliberately, and not
+ * from the object. What is being asked is which class the object is an
+ * instance of, and that is a fact about its prototype; an own `constructor`
+ * property is ordinary data that happens to share the name, and must not be
+ * able to answer for it. Reading it off the object would let
+ * `{constructor: Error}` -- a plain record -- pass for an `Error`, which is
+ * exactly what a caller dispatching on the answer must not allow.
+ *
+ * @param value The object whose constructor is wanted.
+ */
+export function constructorFromObject(
+  value: object,
+): { prototype: unknown } | undefined {
+  const proto = Object.getPrototypeOf(value);
+  const ctor = proto === null ? undefined : proto.constructor;
+
+  return (typeof ctor === "function") ? ctor : undefined;
 }

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -93,9 +93,10 @@ export function isInertPlainObject(
 }
 
 /**
- * Returns the constructor the given object is an instance of, or `undefined`
- * where there is none to read: a null-prototype object has no constructor to
- * find, and an exotic one may have a `constructor` that is not callable.
+ * Returns the constructor the given object is an instance of -- the class it
+ * already has, rather than anything derived from it -- or `undefined` where
+ * there is none to read: a null-prototype object has no constructor to find,
+ * and an exotic one may have a `constructor` that is not callable.
  *
  * The constructor is read from the object's _prototype_, deliberately, and not
  * from the object. What is being asked is which class the object is an
@@ -107,7 +108,7 @@ export function isInertPlainObject(
  *
  * @param value The object whose constructor is wanted.
  */
-export function constructorFromObject(
+export function constructorOfObject(
   value: object,
 ): { prototype: unknown } | undefined {
   const proto = Object.getPrototypeOf(value);

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -93,10 +93,29 @@ export function isInertPlainObject(
 }
 
 /**
+ * Returns the constructor named by the given prototype -- the class an object
+ * having it is an instance of -- or `undefined` where there is none to read: a
+ * `null` prototype names no constructor, and an exotic one may have a
+ * `constructor` that is not callable.
+ *
+ * This is the form for a caller that has the prototype in hand and wants
+ * something else from it too, which is why the prototype is the parameter
+ * rather than a local.
+ *
+ * @param proto The prototype whose constructor is wanted.
+ */
+export function constructorOfPrototype(
+  proto: object | null,
+): { prototype: unknown } | undefined {
+  const ctor = (proto === null) ? undefined : proto.constructor;
+
+  return (typeof ctor === "function") ? ctor : undefined;
+}
+
+/**
  * Returns the constructor the given object is an instance of -- the class it
  * already has, rather than anything derived from it -- or `undefined` where
- * there is none to read: a null-prototype object has no constructor to find,
- * and an exotic one may have a `constructor` that is not callable.
+ * there is none to read.
  *
  * The constructor is read from the object's _prototype_, deliberately, and not
  * from the object. What is being asked is which class the object is an
@@ -111,8 +130,5 @@ export function isInertPlainObject(
 export function constructorOfObject(
   value: object,
 ): { prototype: unknown } | undefined {
-  const proto = Object.getPrototypeOf(value);
-  const ctor = proto === null ? undefined : proto.constructor;
-
-  return (typeof ctor === "function") ? ctor : undefined;
+  return constructorOfPrototype(Object.getPrototypeOf(value));
 }

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -1,6 +1,13 @@
 /**
- * What `isInertPlainObject()` accepts, and the accepting cases are the
- * surprising ones. A frozen object qualifies, and so does a key whose value is
+ * Asking what an object is: the shape of its property keys, and the class it
+ * is an instance of.
+ *
+ * The second question has one case that carries the whole point -- an own
+ * `constructor` property must not answer it -- and the rest are the shapes
+ * where there is no answer to give.
+ *
+ * For the first: what `isInertPlainObject()` accepts, and the accepting cases
+ * are the surprising ones. A frozen object qualifies, and so does a key whose value is
  * `undefined` and one whose name is index-shaped -- none of those disturbs the
  * property that the predicate is actually about.
  *
@@ -11,7 +18,10 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isInertPlainObject } from "@commonfabric/utils/objects";
+import {
+  constructorFromObject,
+  isInertPlainObject,
+} from "@commonfabric/utils/objects";
 
 describe("objects", () => {
   describe("isInertPlainObject()", () => {
@@ -228,6 +238,69 @@ describe("objects", () => {
             : Object.getOwnPropertyDescriptor(target, key),
       });
       expect(isInertPlainObject(ghosted)).toBe(false);
+    });
+  });
+
+  describe("constructorFromObject()", () => {
+    it("returns the class an ordinary instance was built from", () => {
+      expect(constructorFromObject({})).toBe(Object);
+      expect(constructorFromObject([])).toBe(Array);
+      expect(constructorFromObject(new Map())).toBe(Map);
+      expect(constructorFromObject(new Date())).toBe(Date);
+      expect(constructorFromObject(/x/)).toBe(RegExp);
+    });
+
+    it("returns the subclass, not the base", () => {
+      class Sub extends Map {}
+      expect(constructorFromObject(new Sub())).toBe(Sub);
+    });
+
+    it("returns the class of an instance whose prototype was replaced", () => {
+      // The prototype is the whole of the answer, so re-pointing it re-points
+      // the answer -- which is the property, not a wrinkle in it.
+      const value = Object.setPrototypeOf({}, Map.prototype);
+      expect(constructorFromObject(value)).toBe(Map);
+    });
+
+    // The case the function exists for. An own `constructor` is ordinary data
+    // that happens to share a name with the thing that decides a class, and a
+    // caller dispatching on the answer would otherwise let a plain record pass
+    // for whatever it named.
+    describe("an own `constructor` property does not answer", () => {
+      for (
+        const [label, forged] of [
+          ["`Error`", Error],
+          ["`Map`", Map],
+          ["`Date`", Date],
+        ] as ReadonlyArray<[string, unknown]>
+      ) {
+        it(`returns \`Object\` for a record claiming ${label}`, () => {
+          expect(constructorFromObject({ constructor: forged, a: 1 }))
+            .toBe(Object);
+        });
+      }
+
+      it("is not fooled by one that shadows the real class either", () => {
+        const value = Object.assign(new Map(), { constructor: Error });
+        expect(constructorFromObject(value)).toBe(Map);
+      });
+    });
+
+    describe("returns `undefined` where there is no class to read", () => {
+      it("returns `undefined` for a null-prototype object", () => {
+        expect(constructorFromObject(Object.create(null))).toBe(undefined);
+      });
+
+      it("returns `undefined` for an object whose prototype was severed", () => {
+        const value = Object.setPrototypeOf({ a: 1 }, null);
+        expect(constructorFromObject(value)).toBe(undefined);
+      });
+
+      it("returns `undefined` when the constructor is not callable", () => {
+        const proto = Object.create(null) as { constructor?: unknown };
+        proto.constructor = "not a function";
+        expect(constructorFromObject(Object.create(proto))).toBe(undefined);
+      });
     });
   });
 });

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -19,7 +19,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
-  constructorFromObject,
+  constructorOfObject,
   isInertPlainObject,
 } from "@commonfabric/utils/objects";
 
@@ -241,25 +241,25 @@ describe("objects", () => {
     });
   });
 
-  describe("constructorFromObject()", () => {
+  describe("constructorOfObject()", () => {
     it("returns the class an ordinary instance was built from", () => {
-      expect(constructorFromObject({})).toBe(Object);
-      expect(constructorFromObject([])).toBe(Array);
-      expect(constructorFromObject(new Map())).toBe(Map);
-      expect(constructorFromObject(new Date())).toBe(Date);
-      expect(constructorFromObject(/x/)).toBe(RegExp);
+      expect(constructorOfObject({})).toBe(Object);
+      expect(constructorOfObject([])).toBe(Array);
+      expect(constructorOfObject(new Map())).toBe(Map);
+      expect(constructorOfObject(new Date())).toBe(Date);
+      expect(constructorOfObject(/x/)).toBe(RegExp);
     });
 
     it("returns the subclass, not the base", () => {
       class Sub extends Map {}
-      expect(constructorFromObject(new Sub())).toBe(Sub);
+      expect(constructorOfObject(new Sub())).toBe(Sub);
     });
 
     it("returns the class of an instance whose prototype was replaced", () => {
       // The prototype is the whole of the answer, so re-pointing it re-points
       // the answer -- which is the property, not a wrinkle in it.
       const value = Object.setPrototypeOf({}, Map.prototype);
-      expect(constructorFromObject(value)).toBe(Map);
+      expect(constructorOfObject(value)).toBe(Map);
     });
 
     describe("an own `constructor` property does not answer", () => {
@@ -275,31 +275,31 @@ describe("objects", () => {
         ] as ReadonlyArray<[string, unknown]>
       ) {
         it(`returns \`Object\` for a record claiming ${label}`, () => {
-          expect(constructorFromObject({ constructor: forged, a: 1 }))
+          expect(constructorOfObject({ constructor: forged, a: 1 }))
             .toBe(Object);
         });
       }
 
       it("is not fooled by one that shadows the real class either", () => {
         const value = Object.assign(new Map(), { constructor: Error });
-        expect(constructorFromObject(value)).toBe(Map);
+        expect(constructorOfObject(value)).toBe(Map);
       });
     });
 
     describe("returns `undefined` where there is no class to read", () => {
       it("returns `undefined` for a null-prototype object", () => {
-        expect(constructorFromObject(Object.create(null))).toBe(undefined);
+        expect(constructorOfObject(Object.create(null))).toBe(undefined);
       });
 
       it("returns `undefined` for an object whose prototype was severed", () => {
         const value = Object.setPrototypeOf({ a: 1 }, null);
-        expect(constructorFromObject(value)).toBe(undefined);
+        expect(constructorOfObject(value)).toBe(undefined);
       });
 
       it("returns `undefined` when the constructor is not callable", () => {
         const proto = Object.create(null) as { constructor?: unknown };
         proto.constructor = "not a function";
-        expect(constructorFromObject(Object.create(proto))).toBe(undefined);
+        expect(constructorOfObject(Object.create(proto))).toBe(undefined);
       });
     });
   });

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -20,6 +20,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   constructorOfObject,
+  constructorOfPrototype,
   isInertPlainObject,
 } from "@commonfabric/utils/objects";
 
@@ -238,6 +239,40 @@ describe("objects", () => {
             : Object.getOwnPropertyDescriptor(target, key),
       });
       expect(isInertPlainObject(ghosted)).toBe(false);
+    });
+  });
+
+  describe("constructorOfPrototype()", () => {
+    // The form for a caller holding the prototype already, which the value-tag
+    // dispatch is: it needs the prototype for its own null test, so asking it
+    // to hand the object over and have the prototype read again would be one
+    // read too many and a second answer to disagree with.
+    it("returns the constructor a prototype names", () => {
+      expect(constructorOfPrototype(Object.prototype)).toBe(Object);
+      expect(constructorOfPrototype(Map.prototype)).toBe(Map);
+      expect(constructorOfPrototype(Object.getPrototypeOf(new Date())))
+        .toBe(Date);
+    });
+
+    it("returns `undefined` for a `null` prototype", () => {
+      expect(constructorOfPrototype(null)).toBe(undefined);
+    });
+
+    it("returns `undefined` when the constructor is not callable", () => {
+      const proto = Object.create(null) as { constructor?: unknown };
+      proto.constructor = "not a function";
+      expect(constructorOfPrototype(proto)).toBe(undefined);
+    });
+
+    it("agrees with `constructorOfObject()` on the same object", () => {
+      // The two are one question asked from two places, so an object's answer
+      // must not depend on which of them was asked.
+      for (
+        const value of [{}, [], new Map(), new Date(), Object.create(null)]
+      ) {
+        expect(constructorOfPrototype(Object.getPrototypeOf(value)))
+          .toBe(constructorOfObject(value));
+      }
     });
   });
 

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -262,11 +262,11 @@ describe("objects", () => {
       expect(constructorFromObject(value)).toBe(Map);
     });
 
-    // The case the function exists for. An own `constructor` is ordinary data
-    // that happens to share a name with the thing that decides a class, and a
-    // caller dispatching on the answer would otherwise let a plain record pass
-    // for whatever it named.
     describe("an own `constructor` property does not answer", () => {
+      // The case the function exists for. An own `constructor` is ordinary data
+      // that happens to share a name with the thing that decides a class, and a
+      // caller dispatching on the answer would otherwise let a plain record pass
+      // for whatever it named.
       for (
         const [label, forged] of [
           ["`Error`", Error],


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Two small structural pieces, split out of #6491 so that the change needing them
does not have to carry them. No behavior moves.

## Reading an object's class

```ts
constructorOfPrototype(proto: object | null): { prototype: unknown } | undefined
constructorOfObject(value: object):          { prototype: unknown } | undefined
```

The class an object is an instance of, read from its **prototype** and never
from the object. An own `constructor` property is ordinary data that happens to
share the name, and a caller dispatching on the answer must not let
`{constructor: Error}` pass for an `Error`. `undefined` comes back where there
is no class to read: a `null` prototype names no constructor, and an exotic
prototype may have one that is not callable.

Two forms, because a caller that already holds a prototype should not have it
read again. `constructorOfObject()` is `constructorOfPrototype()` plus the read.

Neither asks anything about fabric values, so they live in `utils/objects`,
beside the other question one asks of an object.

**On the name**, since it was solicited. `Of` rather than `From` because the
constructor is an attribute the object *already has* — `From` in this repo
names a thing made out of another thing (`fabricFromNativeValue`,
`errorClassFromType`), while `Of` names one retrieved or projected (`codecOf`,
`atomOf`, `encodableFormOf`, `cellAddressOfRef`). It is also one hop from
`Object.getPrototypeOf()` and reads as its sibling. The `Object` half earns its
place over a bare `constructorOf()`: the one confusion available here is passing
a class where an instance is meant, and naming the domain settles it, as
`detailOfMeasure` and `entityKindOfIdString` do.

### Its caller reads the prototype once

`tagFromNativeValue()` needs the prototype for its own `null` test, which is why
`constructorOfPrototype()` exists. It now settles that case immediately after
reading, where both outcomes are decidable on the spot: a `null` prototype names
no class, so nothing further down could recognize one, and `instanceof` walks an
empty chain, so the `FabricInstance` test cannot claim it either. What remains
is an `Error` whose prototype was severed, or a bare record. Previously those
two were settled thirty lines apart, the second by a second read.

That reorder had a trap in it, which measuring is what caught: a severed `Error`
has a `null` prototype **and** is a native error, so deciding `Object` on the
`null` test alone would have silently retagged it. The branch asks
`Error.isError()` first for exactly that. Every null-prototype outcome measured
identical to `main`:

| | main | branch |
| --- | --- | --- |
| `Error` with severed prototype | `Error` | `Error` |
| `Object.create(null)` | `Object` | `Object` |
| null-prototype record with data | `Object` | `Object` |

### The rule had no test

Corrupting the read to consult the object rather than its prototype left the
**whole suite green**, before this change and after. That is the rule keeping a
plain record from presenting itself as an `Error` and being rebuilt as one, and
nothing checked it.

It has tests at both levels now, and they are independent — the utility and the
dispatch each do their own read, so either could regress alone:

| ablation | reddens |
| --- | --- |
| `constructorOfObject()` reads the value | 4 in `objects.test.ts`, 0 elsewhere |
| `tagFromNativeValue()` reads the value | 8 in `native-type-tags.test.ts`, 0 elsewhere |
| `constructorOfPrototype()` drops its callable guard | the not-callable case, at both levels |
| the `null`-prototype branch stops asking about errors | the severed-`Error` test, alone |

The utility's group also covers the ordinary answers, a subclass, a re-pointed
prototype, a forged property that *shadows* a real class
(`Object.assign(new Map(), { constructor: Error })` still answers `Map`), and
that the two forms agree on the same object.

## `VALUE_TAGS.ts`

Renamed from `NATIVE_TAGS`, @danfuzz's call: half the list names classes this
system defines rather than native ones, so `VALUE_TAGS`/`ValueTag` say what it
is — the names a dispatch answers with when asked what a value already is.

Which classes a given dispatch recognizes varies with where that dispatch is
layered — recognizing a `FabricBytes` means holding the `FabricBytes` class,
which not every module can. The vocabulary does not vary, so it does not live
inside any one of them. The file is named for its single export, as
`SchemaAndHash.ts` and the `Fabric*` classes are.

**No re-export.** `native-type-tags.ts` does not forward it, per this repo's
practice of not keeping re-exports merely to spare existing importers — least of
all across a rename, where the old module would be answering to a name it no
longer defines. `VALUE_TAGS.ts` gets an export path instead, and every importer
names the file the value is in.

That export path is `./VALUE_TAGS`, which is the first non-kebab one in the
workspace. Every path in this package is its file's base name, and every one is
kebab only because every file is; this file is not, by the single-export naming
rule, so path-matches-file is what gives.

## Evidence it is a move

Measured at this branch's own base (4d8b59007) rather than remembered:

| suite | base | branch |
| --- | --- | --- |
| `data-model` | 48 / 2534 steps | 48 / 2544 |
| `utils` | 99 / 693 | 99 / 711 |
| `runner` | 1319 / 7804 | 1319 / 7804 |

The `data-model` and `utils` deltas are exactly the new tests. `runner` is
untouched, and its number is stated because an earlier revision of this
description quoted a stale one from a different base.

## Gates

`deno task check` (46 package groups), `deno lint`, `deno fmt --check`,
`deno task check-docs`, `deno task check-package-cycles`, and the three suites
above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




