### PR TITLE
fix(cli): a narrow declared result bounds a readback that closes a circle

### DIFF
--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -311,24 +311,60 @@ cf call --piece "$EPIC" addChild -- --title "Session cookie handling"
 ```
 
 That address is the one a `$link` marker would have produced by hand, so the
-derived answer and a written one agree. A shape you asked for wins wherever it
-renders: `--filter`, `--select` and `--schema` are applied to the receipt first,
-and one that narrows past the circle — `--select item.title` — comes back
-exactly as written, with nothing derived added to it. One that keeps the circle
-— `--select item`, which names the re-entering subtree whole — is bounded on the
-way out, and the bound is a cut into what you selected rather than a shape that
-replaces it: the closing position renders its address, and no position you did
-not name comes back beside it. `--select item.parent` names the closing position
-itself, and answers with that one address alone.
+derived answer and a written one agree.
 
-Where nothing bounds it — the verb declares no result, the declaration leaves
-the closing position wide, or a `--filter` is in play, whose surviving elements
-no longer say which positions they came from and so cannot carry an address —
-the call names the position the circle closes at and the receipt to collect the
-outcome from, and exits nonzero. Read that as the result being unrenderable,
-never as the mutation having failed: **the write landed**, and the message says
-so. A `--filter` reaches a renderable answer by naming a projection beside it
-that narrows past the circle.
+A verb whose declared result is narrower than the value behind it is bounded a
+second way. `addTopic` is the case: it hands back the topic it created and
+declares a compact row over it, so a create does not expand that topic's prose,
+its thread, and every sibling it references. The row re-enters nowhere, and the
+circle a readback of the topic closes — through its view, into a profile, into
+that profile's own view — is at no position the row names. There is nothing
+there for a recursion cut to land on, and the bound is the declared shape
+itself: every object position is held to the fields it declares, and what comes
+back is the row its author wrote.
+
+```bash
+cf call --piece "$BOARD" addTopic -- --title "Session cookie handling" \
+  --agent-name b7
+```
+
+```json
+{
+  "invocation": "9a71…",
+  "status": "settled",
+  "result": {
+    "topic": {
+      "title": "Session cookie handling",
+      "createdAt": 1756400000000,
+      "createdBy": { "kind": "agent", "name": "b7" },
+      "commentCount": 0
+    }
+  }
+}
+```
+
+The two bounds are tried weakest first, so neither narrows anything it does not
+have to: a result the recursion cut renders is never held to the declared shape
+as well.
+
+A shape you asked for wins wherever it renders: `--filter`, `--select` and
+`--schema` are applied to the receipt first, and one that narrows past the
+circle — `--select item.title` — comes back exactly as written, with nothing
+derived added to it. One that keeps the circle — `--select item`, which names
+the re-entering subtree whole — is bounded on the way out, and the bound is a
+cut into what you selected rather than a shape that replaces it: the closing
+position renders its address, and no position you did not name comes back
+beside it. `--select item.parent` names the closing position itself, and answers
+with that one address alone.
+
+Where nothing bounds it — the verb declares no result, the declaration
+describes no less than the value does, or a `--filter` is in play, whose
+surviving elements no longer say which positions they came from and so cannot
+carry an address — the call names the position the circle closes at and the
+receipt to collect the outcome from, and exits nonzero. Read that as the result
+being unrenderable, never as the mutation having failed: **the write landed**,
+and the message says so. A `--filter` reaches a renderable answer by naming a
+projection beside it that narrows past the circle.
 
 ### Retries are safe, and cheap to reason about
 

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -320,8 +320,10 @@ its thread, and every sibling it references. The row re-enters nowhere, and the
 circle a readback of the topic closes — through its view, into a profile, into
 that profile's own view — is at no position the row names. There is nothing
 there for a recursion cut to land on, and the bound is the declared shape
-itself: every object position is held to the fields it declares, and what comes
-back is the row its author wrote.
+itself: every object position the declaration closes is held to the fields it
+declares, and what comes back is the row its author wrote. A position the
+declaration leaves open — an index signature beside its named members — still
+reads every key stored at it, because those keys are declared too.
 
 ```bash
 cf call --piece "$BOARD" addTopic -- --title "Session cookie handling" \
@@ -354,8 +356,10 @@ derived added to it. One that keeps the circle — `--select item`, which names
 the re-entering subtree whole — is bounded on the way out, and the bound is a
 cut into what you selected rather than a shape that replaces it: the closing
 position renders its address, and no position you did not name comes back
-beside it. `--select item.parent` names the closing position itself, and answers
-with that one address alone.
+beside it. A position you asked for the address of — `--select
+'item@,item.parent'` — still answers with that address, which was your whole
+answer there rather than a field of what sits behind it. `--select item.parent`
+names the closing position itself, and answers with that one address alone.
 
 Where nothing bounds it — the verb declares no result, the declaration
 describes no less than the value does, or a `--filter` is in play, whose

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -757,6 +757,18 @@ position renders its address and everything else reads as it always did.
 }
 ```
 
+A verb can also declare a result far narrower than the value behind it — a
+compact row over the piece it hands back, which is how an author keeps a create
+from expanding that piece's prose and every sibling it references. The circle a
+readback of that piece closes is then at a position the declaration does not
+name at all, and the declaration re-enters nowhere, so there is no address to
+render anywhere in it. The bound for that one is the declared shape itself:
+every object position is held to the fields it declares, and the row comes back.
+
+```json
+{ "topic": { "title": "Rotate signing key", "createdAt": 1756400000000 } }
+```
+
 Three things follow:
 
 - **It is the same `$link` a caller writes by hand.** The derived bound composes
@@ -779,11 +791,11 @@ Three things follow:
   address walk a written `$link` is composed through as the only work beside it.
 
 Where nothing bounds the circle — the verb declares no result, the declaration
-it made leaves the closing position wide, or a `--filter` is in play — the call
-reports the position the circle closes at, states that the handling committed,
-and names the receipt to collect the outcome from. It exits nonzero: the outcome
-could not be rendered. The write still landed, which is the property the message
-leads with.
+it made describes no less than the value does, or a `--filter` is in play — the
+call reports the position the circle closes at, states that the handling
+committed, and names the receipt to collect the outcome from. It exits nonzero:
+the outcome could not be rendered. The write still landed, which is the property
+the message leads with.
 
 A `--filter` is the case with no bound to reach for rather than one that failed:
 the predicate hands back the elements themselves, which no longer say which

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -763,7 +763,10 @@ from expanding that piece's prose and every sibling it references. The circle a
 readback of that piece closes is then at a position the declaration does not
 name at all, and the declaration re-enters nowhere, so there is no address to
 render anywhere in it. The bound for that one is the declared shape itself:
-every object position is held to the fields it declares, and the row comes back.
+every object position the declaration closes is held to the fields it declares,
+and the row comes back. A position the declaration leaves open — an index
+signature beside its named members — still reads every key stored at it, because
+those keys are declared too.
 
 ```json
 { "topic": { "title": "Rotate signing key", "createdAt": 1756400000000 } }
@@ -782,8 +785,11 @@ Three things follow:
   whole — `--select item` — keeps the circle it selected and is bounded on the
   way out, but the bound is a cut into what was selected rather than a shape
   that replaces it: the closing position renders its address, and no position
-  the caller did not name comes back beside it. `--select item.parent` names the
-  closing position itself, and is answered with that one address alone.
+  the caller did not name comes back beside it. A position they asked for the
+  address of — `--select 'item@,item.parent'` — is still answered with that
+  address, which was their whole answer there and is not a field of what sits
+  behind it. `--select item.parent` names the closing position itself, and is
+  answered with that one address alone.
 - **Nothing else pays for it.** A result that renders is written out exactly as
   it was read, and the compiled pattern a declared result is matched through is
   loaded only where a readback cannot render. The bound itself is a cut into the

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1489,8 +1489,8 @@ function circularResultPath(value: unknown): string | undefined {
  * it hands back is the case: the row re-enters nowhere, and the piece carries
  * a view that reaches every piece it renders and back again. The stronger
  * bound answers that one by reading the declaration as the shape it states —
- * each object position held to the fields it declares, which is the boundary
- * an author writing a narrow result already believes they drew.
+ * each object position it CLOSES held to the fields it declares, which is the
+ * boundary an author writing a narrow result already believes they drew.
  *
  * Both are applied to `value` — the result already in hand — and never read a
  * second one. That is what lets them bound a result a caller ALREADY shaped

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1476,15 +1476,24 @@ function circularResultPath(value: unknown): string | undefined {
  * Bound a readback that closes a circle with the verb's own declared result,
  * and hand back the value that bounds to.
  *
- * The declaration is the boundary the AUTHOR drew: the position where the
- * declared type re-enters itself is the position that closes the circle, so
- * rendering an address there cuts exactly where the shape says it should, and
- * leaves every other position reading as it already did. The addresses are
- * written by the same walk `--select`/`--schema` compose theirs with, so a
- * derived bound and a hand-written one name the same position the same way.
+ * The declaration is the boundary the AUTHOR drew, and it is applied in two
+ * strengths, the weaker first. Where the declared type re-enters itself, that
+ * position IS the one that closes the circle, so rendering an address there
+ * cuts exactly where the shape says it should and leaves every other position
+ * reading as it already did; the addresses are written by the same walk
+ * `--select`/`--schema` compose theirs with, so a derived bound and a
+ * hand-written one name the same position the same way.
  *
- * The cut is applied to `value` — the result already in hand — and never reads
- * a second one. That is what lets it bound a result a caller ALREADY shaped
+ * Where the circle is somewhere the declaration does not describe at all, that
+ * cut has nowhere to land. A verb that declares a compact row over the piece
+ * it hands back is the case: the row re-enters nowhere, and the piece carries
+ * a view that reaches every piece it renders and back again. The stronger
+ * bound answers that one by reading the declaration as the shape it states —
+ * each object position held to the fields it declares, which is the boundary
+ * an author writing a narrow result already believes they drew.
+ *
+ * Both are applied to `value` — the result already in hand — and never read a
+ * second one. That is what lets them bound a result a caller ALREADY shaped
  * without widening it: a projection can name the re-entering subtree whole,
  * which selects the circle rather than cutting past it, and the cut then
  * removes the closing position from what they selected rather than answering
@@ -1492,11 +1501,11 @@ function circularResultPath(value: unknown): string | undefined {
  * renders, this is never reached at all.
  *
  * Refuses where nothing in reach bounds it: no declaration at all, a
- * declaration whose recursion does not reach the closing position, or a
- * `--filter` beside it — a filtered array's elements no longer say which
- * positions they came from, and the bound is written in addresses, which name
- * positions. A refusal names where the circle closes and how to collect the
- * outcome, which beats a stack trace for a handling that already committed.
+ * declaration that describes no less than the value does, or a `--filter`
+ * beside it — a filtered array's elements no longer say which positions they
+ * came from, and a bound is written in addresses, which name positions. A
+ * refusal names where the circle closes and how to collect the outcome, which
+ * beats a stack trace for a handling that already committed.
  */
 async function boundCyclicResult(
   resolved: CallableResolution,
@@ -1522,17 +1531,30 @@ async function boundCyclicResult(
       "the addresses a bound is written in cannot be composed beside it.";
   } else {
     const declared = await resolved.declaredResult?.();
-    const bounded = await boundReadValue(
-      receiptCell,
-      declared,
-      value,
-      resolved.space,
-    );
-    // The bound is only as good as the declaration: a position the declaration
-    // left wide can still expand into the circle, and answering with a value
-    // that cannot be written would move the same failure one step later.
-    if (bounded !== undefined && circularResultPath(bounded) === undefined) {
-      return bounded;
+    // Two bounds, weakest first, and the order is what keeps the stronger one
+    // from narrowing anything it does not have to. `"recursion"` cuts where
+    // the declared type re-enters itself and leaves every other position
+    // reading what it read; `"shape"` reads the whole declaration as the shape
+    // it states, which is the only bound in reach when the circle is somewhere
+    // the declaration does not describe at all — a verb declaring a compact
+    // row over the piece it returns, whose piece carries a view that reaches
+    // back to it. A value that renders under the weaker one never reaches the
+    // stronger.
+    for (const bound of ["recursion", "shape"] as const) {
+      const bounded = await boundReadValue(
+        receiptCell,
+        declared,
+        value,
+        resolved.space,
+        bound,
+      );
+      // The bound is only as good as the declaration: a position the
+      // declaration left wide can still expand into the circle, and answering
+      // with a value that cannot be written would move the same failure one
+      // step later.
+      if (bounded !== undefined && circularResultPath(bounded) === undefined) {
+        return bounded;
+      }
     }
     if (declared === undefined) {
       whyUnbounded = "This verb declares no result for `cf` to bound the " +

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1216,6 +1216,25 @@ function carriesStreamMarker(schema: { readonly asCell?: unknown }): boolean {
 const DERIVED_PROJECTION_SOURCE = "<the verb's declared result>";
 
 /**
+ * How much of a declaration a derived bound applies.
+ *
+ * `"recursion"` bounds the recursion and narrows nothing else: only the
+ * position where the declared type re-enters itself is cut, and every other
+ * position reads exactly what an unbounded readback reads there. That is the
+ * bound a result which merely closes a circle needs, and applying more of the
+ * declaration than that would narrow a value the caller can already read.
+ *
+ * `"shape"` holds every object position to the fields the declaration gives
+ * it as well. A value can reach far past what its declaration describes — a
+ * verb declaring a compact row over a piece hands back that piece, and the
+ * piece carries its view, and the view reaches every piece it renders — and a
+ * circle out there is at no position the declaration names, so cutting the
+ * declaration's own recursion does not reach it. Reading the declaration as
+ * the shape it states does: what the author declared is what comes back.
+ */
+export type DeclaredBound = "recursion" | "shape";
+
+/**
  * One position of a derivation, and whether the walk cut anything at or below
  * it. An absent `schema` drops the position: nothing is read there and no
  * address stands in for it.
@@ -1223,7 +1242,9 @@ const DERIVED_PROJECTION_SOURCE = "<the verb's declared result>";
 interface DerivedPosition {
   schema?: unknown;
 
-  /** A `$link` marker was emitted at or below this position. */
+  /** The derivation reads less at this position than an unbounded readback
+   * does: a `$link` marker stands in for a subtree at or below it, or an
+   * object at or below it is held to the fields the declaration gives it. */
   cut: boolean;
 }
 
@@ -1249,9 +1270,9 @@ const DERIVED_DROPPED: DerivedPosition = { cut: false };
  * with the scope root it was followed under: the same spelling in two `$defs`
  * scopes names two definitions, so only a reference repeated in ITS OWN scope
  * is the cut — the declared type re-enters itself there, and following it
- * once more is what closes the circle. Every other position is left as wide
- * as it was declared — the derivation bounds a recursion and narrows nothing
- * else.
+ * once more is what closes the circle. Under `"recursion"` every other
+ * position is left as wide as it was declared; under `"shape"` an object
+ * position is additionally held to the fields it declares.
  *
  * Reference resolution is the canonical resolver's, one hop per recursion —
  * never a private pointer parser, whose recorded divergence class (escaped
@@ -1264,6 +1285,7 @@ function derivePosition(
   schema: JSONSchema | undefined,
   root: JSONSchema,
   following: ReadonlyArray<{ root: JSONSchema; ref: string }>,
+  bound: DeclaredBound,
 ): DerivedPosition {
   if (schema === undefined || typeof schema === "boolean") return DERIVED_WHOLE;
   // A subtree carrying its own `$defs` opens a new local-ref scope; every
@@ -1285,6 +1307,7 @@ function derivePosition(
       target,
       isEmbeddedCfcSchemaRef(ref) ? target : root,
       [...following, { root, ref }],
+      bound,
     );
   }
 
@@ -1304,19 +1327,25 @@ function derivePosition(
     // every branch, since an address names the position rather than describing
     // what sits at it. `parent: Item | null` is the case — a root's null still
     // has a position, and it is the position the caller would follow.
+    //
+    // Re-entry alone decides that, under either bound: the branches are read
+    // as `"recursion"` reads them whatever this walk is applying, because a
+    // union of shapes the declaration merely states is not a position an
+    // address answers — it is a position no single shape describes, which is
+    // the same reason `allOf` above is left wide.
     return branches.some((branch) =>
-        derivePosition(branch, root, following).cut
+        derivePosition(branch, root, following, "recursion").cut
       )
       ? DERIVED_ADDRESS
       : DERIVED_WHOLE;
   }
 
   if (schema.type === "array" || schema.items !== undefined) {
-    const items = derivePosition(schema.items, root, following);
+    const items = derivePosition(schema.items, root, following, bound);
     if (!items.cut) return DERIVED_WHOLE;
-    // The elements are what re-enter, so each renders its own address rather
-    // than the array position's — a caller wants the children, not the slot
-    // holding them.
+    // The elements are what the bound reaches, so each is written in its own
+    // right rather than the array position standing in for all of them — a
+    // caller wants the children, not the slot holding them.
     return items.schema === undefined
       ? DERIVED_DROPPED
       : { schema: { type: "array", items: items.schema }, cut: true };
@@ -1324,17 +1353,32 @@ function derivePosition(
 
   if (schema.type === "object" || schema.properties !== undefined) {
     const declared = schema.properties;
-    if (!isObjectNotArray(declared)) return DERIVED_WHOLE;
+    // An object that names no fields describes no less than the value at it
+    // does, under either bound: there is nothing to cut and nothing to hold it
+    // to, so it reads whatever is stored.
+    if (!isObjectNotArray(declared) || Object.keys(declared).length === 0) {
+      return DERIVED_WHOLE;
+    }
     const properties: Record<string, unknown> = {};
-    let cut = false;
+    // An object the declaration gives fields to IS the bound under `"shape"`:
+    // a written `properties` closes the position to what it lists
+    // (`normalizeProjectionSchema` supplies the `additionalProperties: false`),
+    // so writing this position out is itself the narrowing, with no marker
+    // anywhere below needed to make it one.
+    let cut = bound === "shape";
     for (const [key, child] of Object.entries(declared)) {
-      const derived = derivePosition(child as JSONSchema, root, following);
+      const derived = derivePosition(
+        child as JSONSchema,
+        root,
+        following,
+        bound,
+      );
       cut ||= derived.cut;
       if (derived.schema !== undefined) properties[key] = derived.schema;
     }
-    // Only where something below re-enters. An object that holds no recursion
-    // is left whole, so the positions this derivation does not need to bound
-    // read exactly as an unbounded readback reads them.
+    // Under `"recursion"`, only where something below re-enters. An object
+    // that holds no recursion is left whole, so the positions that bound does
+    // not need to reach read exactly as an unbounded readback reads them.
     return cut
       ? { schema: { type: "object", properties }, cut }
       : DERIVED_WHOLE;
@@ -1355,19 +1399,29 @@ function derivePosition(
  * address instead of being followed. That is a cut at the boundary the author
  * drew, and it is the same `$link` vocabulary a caller writes by hand.
  *
- * `undefined` where nothing re-enters: a declaration that describes a finite
- * value is not a bound, and answering with one would narrow a result that
- * renders perfectly well. The caller's own `--select`/`--schema` is the wider
- * instrument and stays the only thing that narrows a result on request.
+ * Under `"recursion"`, `undefined` where nothing re-enters: a declaration that
+ * describes a finite value is not a bound, and answering with one would narrow
+ * a result that renders perfectly well. The caller's own `--select`/`--schema`
+ * is the wider instrument and stays the only thing that narrows a result on
+ * request.
+ *
+ * Under `"shape"` the finite declaration IS the bound, because the value under
+ * it is not: a verb hands back a piece and declares a compact row over it, and
+ * the piece reaches its view and every piece that view renders. That circle is
+ * at no position the declaration names, so there is no re-entry to cut and
+ * nothing narrower in reach than the shape the author wrote. `undefined` still
+ * where that shape reads no less than the value does — a declaration of bare
+ * types, or one whose every object position declares no fields.
  *
  * The derived projection is written in the `--schema` language and reports
  * itself as that flag, which is the flag that replaces it.
  */
 export function declaredResultProjection(
   declared: JSONSchema | undefined,
+  bound: DeclaredBound = "recursion",
 ): SelectionProjection | undefined {
   if (declared === undefined || typeof declared === "boolean") return undefined;
-  const derived = derivePosition(declared, declared, []);
+  const derived = derivePosition(declared, declared, [], bound);
   if (!derived.cut || derived.schema === undefined) return undefined;
   return {
     source: DERIVED_PROJECTION_SOURCE,
@@ -3363,17 +3417,18 @@ function markersHeldBy(
 }
 
 /**
- * `value`, read from `sourceCell`, with the positions `declared` re-enters
- * rendered as their addresses — or `undefined` where the declaration bounds
- * nothing.
+ * `value`, read from `sourceCell`, held to what `declared` describes — or
+ * `undefined` where the declaration bounds nothing.
  *
  * A value that closes a circle has no JSON rendering, and the declaration is
- * the boundary its author drew: the position where the declared type re-enters
- * itself is the position that closes the circle, so an address there cuts
- * exactly where the shape says it should. The addresses are composed by the
- * same walk {@link deriveSelectedValue} composes its own with, off the same
- * cell, so a derived bound and a hand-written `$link` name the same position
- * the same way.
+ * the boundary its author drew. `bound` says how much of that boundary to
+ * apply, and {@link DeclaredBound} says what each answer means: `"recursion"`
+ * cuts the position where the declared type re-enters itself, and `"shape"`
+ * additionally holds every object position to the fields it declares. The
+ * addresses `"recursion"` composes are composed by the same walk
+ * {@link deriveSelectedValue} composes its own with, off the same cell, so a
+ * derived bound and a hand-written `$link` name the same position the same
+ * way.
  *
  * Applied to the value already in hand rather than read afresh, which is what
  * lets it bound a result a caller has ALREADY shaped without widening it: the
@@ -3393,8 +3448,9 @@ export async function boundReadValue(
   declared: JSONSchema | undefined,
   value: unknown,
   contextSpace: MemorySpace,
+  bound: DeclaredBound = "recursion",
 ): Promise<unknown> {
-  const projection = declaredResultProjection(declared);
+  const projection = declaredResultProjection(declared, bound);
   if (projection === undefined) return undefined;
   // The derived projection is written at fixed depth, so it is applied at
   // fixed depth: `kind` is `"json"` for everything `declaredResultProjection`

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1224,13 +1224,18 @@ const DERIVED_PROJECTION_SOURCE = "<the verb's declared result>";
  * bound a result which merely closes a circle needs, and applying more of the
  * declaration than that would narrow a value the caller can already read.
  *
- * `"shape"` holds every object position to the fields the declaration gives
- * it as well. A value can reach far past what its declaration describes — a
- * verb declaring a compact row over a piece hands back that piece, and the
- * piece carries its view, and the view reaches every piece it renders — and a
- * circle out there is at no position the declaration names, so cutting the
- * declaration's own recursion does not reach it. Reading the declaration as
- * the shape it states does: what the author declared is what comes back.
+ * `"shape"` holds every object position the declaration CLOSES to the fields
+ * it gives that position as well — none of them, for a declaration that says
+ * the value has no keys. One the declaration leaves open — an index signature
+ * beside its named members, or an empty interface, which names no fields and
+ * accepts whatever is stored — keeps reading every key stored at it, because
+ * those keys are declared too. A value can reach far past what its
+ * declaration describes — a verb declaring a compact row over a piece hands
+ * back that piece, and the piece carries its view, and the view reaches every
+ * piece it renders — and a circle out there is at no position the declaration
+ * names, so cutting the declaration's own recursion does not reach it. Reading
+ * the declaration as the shape it states does: what the author declared is
+ * what comes back.
  */
 export type DeclaredBound = "recursion" | "shape";
 
@@ -1352,20 +1357,42 @@ function derivePosition(
   }
 
   if (schema.type === "object" || schema.properties !== undefined) {
-    const declared = schema.properties;
-    // An object that names no fields describes no less than the value at it
-    // does, under either bound: there is nothing to cut and nothing to hold it
-    // to, so it reads whatever is stored.
-    if (!isObjectNotArray(declared) || Object.keys(declared).length === 0) {
+    const declared = isObjectNotArray(schema.properties)
+      ? schema.properties
+      : {};
+    // A declaration naming fields can still say the value holds keys beside
+    // them: an interface carrying an index signature over its own members
+    // lowers to `properties` AND `additionalProperties`. Written out,
+    // `properties` alone would close the position to what it lists —
+    // `normalizeProjectionSchema` supplies the `additionalProperties: false` a
+    // projection states none of — and the keys the declaration allows would
+    // come back missing, which is a narrower answer than the author declared.
+    // The open answer is written instead, so those keys read what an unbounded
+    // readback reads at them. A declaration that states `false` closed the
+    // position itself and is written closed.
+    const open = schema.additionalProperties !== undefined &&
+      schema.additionalProperties !== false;
+    // Naming no fields and saying the value has none are different
+    // statements, and only the first leaves the position unbounded. An empty
+    // interface names no fields and accepts whatever is stored — as does an
+    // index signature with nothing beside it — so there is nothing to hold
+    // the position to and it reads what an unbounded readback reads.
+    // `Record<string, never>` lowers to that same empty `properties` beside
+    // `additionalProperties: false`, which says the value has no keys at all;
+    // `"shape"` holds the position to it below, and the answer is `{}`.
+    if (
+      Object.keys(declared).length === 0 &&
+      schema.additionalProperties !== false
+    ) {
       return DERIVED_WHOLE;
     }
     const properties: Record<string, unknown> = {};
-    // An object the declaration gives fields to IS the bound under `"shape"`:
-    // a written `properties` closes the position to what it lists
-    // (`normalizeProjectionSchema` supplies the `additionalProperties: false`),
-    // so writing this position out is itself the narrowing, with no marker
-    // anywhere below needed to make it one.
-    let cut = bound === "shape";
+    // An object the declaration CLOSES is the bound under `"shape"`: a written
+    // `properties` holds the position to what it lists, so writing it out is
+    // itself the narrowing, with no marker anywhere below needed to make it
+    // one. An open one narrows nothing on its own — every key stored at it
+    // still reads — so only a cut below makes it a bound.
+    let cut = bound === "shape" && !open;
     for (const [key, child] of Object.entries(declared)) {
       const derived = derivePosition(
         child as JSONSchema,
@@ -1380,7 +1407,12 @@ function derivePosition(
     // that holds no recursion is left whole, so the positions that bound does
     // not need to reach read exactly as an unbounded readback reads them.
     return cut
-      ? { schema: { type: "object", properties }, cut }
+      ? {
+        schema: open
+          ? { type: "object", properties, additionalProperties: true }
+          : { type: "object", properties },
+        cut,
+      }
       : DERIVED_WHOLE;
   }
 
@@ -1411,7 +1443,8 @@ function derivePosition(
  * at no position the declaration names, so there is no re-entry to cut and
  * nothing narrower in reach than the shape the author wrote. `undefined` still
  * where that shape reads no less than the value does — a declaration of bare
- * types, or one whose every object position declares no fields.
+ * types, or one whose every object position declares itself open or names no
+ * fields without closing itself.
  *
  * The derived projection is written in the `--schema` language and reports
  * itself as that flag, which is the flag that replaces it.
@@ -2049,10 +2082,27 @@ function unheldSelectionFieldError(
   );
 }
 
+/**
+ * `value` held to `schema`, in the projection vocabulary.
+ *
+ * `implicitArrayTraversal` states that the schema came from a concise field
+ * list, which names a field wherever the value holds one rather than at a
+ * fixed depth.
+ *
+ * `keepComposedAddresses` states that the value may ALREADY carry addresses a
+ * caller's own projection composed into it — which is the case a derived bound
+ * meets, and only that one. An address is the caller's whole answer at the
+ * position holding it, not a field of what sits behind it, and a schema
+ * describes what sits behind it, so a position closed over declared fields
+ * would drop the one thing named there and answer with contents where an
+ * address was asked for. There is nothing inside an address to hold to a
+ * shape, so it is carried across instead.
+ */
 function projectValue(
   value: unknown,
   schema: JSONSchema,
   implicitArrayTraversal = false,
+  keepComposedAddresses = false,
 ): unknown {
   if (typeof schema === "boolean") return schema ? value : undefined;
   if (value === null) return value;
@@ -2060,12 +2110,22 @@ function projectValue(
     const itemSchema = schema.items ??
       (implicitArrayTraversal ? schema : true);
     return value.map((item) =>
-      projectValue(item, itemSchema, implicitArrayTraversal)
+      projectValue(
+        item,
+        itemSchema,
+        implicitArrayTraversal,
+        keepComposedAddresses,
+      )
     );
   }
   if (!isObjectOrArray(value)) return value;
   if (implicitArrayTraversal && schema.items !== undefined) {
-    return projectValue(value, schema.items, implicitArrayTraversal);
+    return projectValue(
+      value,
+      schema.items,
+      implicitArrayTraversal,
+      keepComposedAddresses,
+    );
   }
 
   const properties = schema.properties ?? {};
@@ -2078,6 +2138,7 @@ function projectValue(
         child,
         childSchema,
         implicitArrayTraversal,
+        keepComposedAddresses,
       );
     }
     return projected;
@@ -2088,8 +2149,16 @@ function projectValue(
         value[key],
         childSchema,
         implicitArrayTraversal,
+        keepComposedAddresses,
       );
     }
+  }
+  // The address a caller already asked for at this position, carried past the
+  // closing. A composed one is a string, which is what tells it apart from a
+  // field of the same spelling in stored data.
+  const address = value[LINK_MARKER_KEY];
+  if (keepComposedAddresses && typeof address === "string") {
+    projected[LINK_MARKER_KEY] = address;
   }
   return projected;
 }
@@ -3433,12 +3502,17 @@ function markersHeldBy(
  * Applied to the value already in hand rather than read afresh, which is what
  * lets it bound a result a caller has ALREADY shaped without widening it: the
  * cut removes positions and never adds one, so whatever `--select`/`--schema`
- * narrowed to stays narrowed. Reading a second time through the derived
- * projection cannot do that — it answers with the declaration's whole shape,
- * which for a caller who named one field is a projection handing back the
- * fields they did not name. Working off the value in hand also runs no pattern
- * graph and commits no transaction; what remains is the address walk itself,
- * which is the same one a hand-written `$link` is composed through.
+ * narrowed to stays narrowed. An address that shape composed is one of the
+ * positions it narrowed to, and stays with the rest: nothing behind an address
+ * was read, so there is nothing there for a bound to hold to a shape, and
+ * closing an object over the declared fields instead would answer with
+ * contents where an address was asked for. Reading a second time through the
+ * derived projection cannot do any of that — it answers with the declaration's
+ * whole shape, which for a caller who named one field is a projection handing
+ * back the fields they did not name. Working off the value in hand also runs
+ * no pattern graph and commits no transaction; what remains is the address
+ * walk itself, which is the same one a hand-written `$link` is composed
+ * through.
  *
  * `contextSpace` is the space the reader is working in, which decides whether
  * a composed address carries a `@did` prefix.
@@ -3455,8 +3529,11 @@ export async function boundReadValue(
   // The derived projection is written at fixed depth, so it is applied at
   // fixed depth: `kind` is `"json"` for everything `declaredResultProjection`
   // returns, and a concise field list's implicit array traversal has no part
-  // in a shape derived from a declaration.
-  const projected = projectValue(value, projection.schema);
+  // in a shape derived from a declaration. The value it is applied to may
+  // already hold addresses a caller's own shape composed, and those are that
+  // caller's answers rather than fields of what sits behind them, so they are
+  // carried across the shape rather than closed out of it.
+  const projected = projectValue(value, projection.schema, false, true);
   const markers = projection.markers === undefined
     ? undefined
     : markersHeldBy(projection.markers, [value]);

--- a/packages/cli/test/declaredResultProjection.test.ts
+++ b/packages/cli/test/declaredResultProjection.test.ts
@@ -154,6 +154,35 @@ describe("declaredResultProjection", () => {
     });
   });
 
+  it("keeps the keys an index signature declares beside the position it cuts", () => {
+    // An interface carrying an index signature over its own members lowers to
+    // `properties` AND `additionalProperties`, which says the value holds keys
+    // the declaration does not name. A projection stating no
+    // `additionalProperties` of its own is supplied `false`, so writing
+    // `properties` alone would close the position and drop them — an answer
+    // narrower than the verb declared, over a bound that is only supposed to
+    // remove the circle.
+    const declared: JSONSchema = {
+      type: "object",
+      properties: { item: { $ref: "#/$defs/Item" } },
+      additionalProperties: { type: "string" },
+      $defs: {
+        Item: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            parent: { $ref: "#/$defs/Item" },
+          },
+        },
+      },
+    };
+    expect(declaredResultProjection(declared)?.schema).toEqual({
+      type: "object",
+      properties: { item: CUT_ITEM },
+      additionalProperties: true,
+    });
+  });
+
   describe('the `"shape"` bound', () => {
     /**
      * A verb that hands back a piece and declares a compact row over it: two
@@ -189,6 +218,149 @@ describe("declaredResultProjection", () => {
       });
     });
 
+    it("reads every key stored at an object the declaration leaves open", () => {
+      // The shape bound holds an object to the fields it declares, and a
+      // declaration carrying an index signature declares the rest of them too.
+      // Closing that position would hand back less than the verb states it
+      // returns, which is the one thing a bound over a committed handling must
+      // not do.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            row: {
+              type: "object",
+              properties: { title: { type: "string" } },
+              additionalProperties: { type: "string" },
+            },
+            other: {
+              type: "object",
+              properties: { note: { type: "string" } },
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {
+          // Nothing below `row` narrows and the position itself narrows
+          // nothing, so it reads whatever is stored — the same answer an
+          // unbounded readback gives there.
+          row: true,
+          other: {
+            type: "object",
+            properties: { note: true },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it("writes an open object open where something below it narrows", () => {
+      // The position still has to be written, because the closed object under
+      // it is the bound. Written closed it would drop the keys the index
+      // signature declares; written open they read as they always did, and the
+      // narrowing below still stands.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            row: {
+              type: "object",
+              properties: {
+                inner: {
+                  type: "object",
+                  properties: { note: { type: "string" } },
+                },
+              },
+              additionalProperties: { type: "string" },
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {
+          row: {
+            type: "object",
+            properties: {
+              inner: {
+                type: "object",
+                properties: { note: true },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it("holds an object the declaration closes with `false` to its fields", () => {
+      // A declaration writing `additionalProperties: false` closed the
+      // position itself, so the shape bound is stating what the author already
+      // stated rather than narrowing anything.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            row: {
+              type: "object",
+              properties: { title: { type: "string" } },
+              additionalProperties: false,
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {
+          row: {
+            type: "object",
+            properties: { title: true },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it("holds an object the declaration closes over no fields to `{}`", () => {
+      // Naming no fields and saying the value has none are different
+      // statements. `Record<string, never>` lowers to `properties: {}` beside
+      // `additionalProperties: false` and is the second, so the shape bound
+      // has something to hold the position to and `{}` is what comes back —
+      // which is a bound, and bounds a circle sitting at that position.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      });
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            ack: {
+              type: "object",
+              properties: {},
+              additionalProperties: false,
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {
+          ack: { type: "object", properties: {}, additionalProperties: false },
+        },
+        additionalProperties: false,
+      });
+    });
+
     it("derives nothing from the same declaration under the recursion bound", () => {
       // The contrast is the whole reason the stronger bound exists, and the
       // default is the weaker one: a declaration that re-enters nowhere bounds
@@ -213,7 +385,9 @@ describe("declaredResultProjection", () => {
       // Bare types and an unconstrained object read no less than the value
       // does, so there is nothing here that a readback does not already do —
       // and answering with a projection that changes nothing would report a
-      // bound where none was found.
+      // bound where none was found. `{ type: "object", properties: {} }` is
+      // what an empty interface lowers to: it names no fields and closes
+      // nothing, which accepts whatever is stored.
       expect(declaredResultProjection({ type: "object" }, "shape"))
         .toBeUndefined();
       expect(declaredResultProjection({}, "shape")).toBeUndefined();
@@ -225,6 +399,16 @@ describe("declaredResultProjection", () => {
       ).toBeUndefined();
       expect(declaredResultProjection({ type: "string" }, "shape"))
         .toBeUndefined();
+      // An object naming fields beside an index signature reads every key
+      // stored at it, which is what a readback already does, so a projection
+      // written from it would report a bound that bounds nothing.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: { title: { type: "string" } },
+          additionalProperties: { type: "string" },
+        }, "shape"),
+      ).toBeUndefined();
     });
 
     it("leaves a union position as wide as it was declared", () => {

--- a/packages/cli/test/declaredResultProjection.test.ts
+++ b/packages/cli/test/declaredResultProjection.test.ts
@@ -154,6 +154,150 @@ describe("declaredResultProjection", () => {
     });
   });
 
+  describe('the `"shape"` bound', () => {
+    /**
+     * A verb that hands back a piece and declares a compact row over it: two
+     * scalars, re-entering nowhere. The circle a readback of that piece closes
+     * is at no position this declaration names, so there is nothing for the
+     * recursion bound to cut and the shape itself is the only boundary in
+     * reach.
+     */
+    const ROW: JSONSchema = {
+      type: "object",
+      properties: {
+        row: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            createdAt: { type: "number" },
+          },
+        },
+      },
+    };
+
+    it("holds every object position to the fields it declares", () => {
+      expect(declaredResultProjection(ROW, "shape")?.schema).toEqual({
+        type: "object",
+        properties: {
+          row: {
+            type: "object",
+            properties: { title: true, createdAt: true },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it("derives nothing from the same declaration under the recursion bound", () => {
+      // The contrast is the whole reason the stronger bound exists, and the
+      // default is the weaker one: a declaration that re-enters nowhere bounds
+      // nothing on its own, so a result that renders is never narrowed.
+      expect(declaredResultProjection(ROW)).toBeUndefined();
+      expect(declaredResultProjection(ROW, "recursion")).toBeUndefined();
+    });
+
+    it("still renders the address where the declaration does re-enter", () => {
+      // The stronger bound adds to the weaker one rather than replacing it:
+      // `parent` is where the declared type re-enters, and it renders its
+      // address under both.
+      expect(declaredResultProjection(declarationBeside({}), "shape")?.schema)
+        .toEqual({
+          type: "object",
+          properties: { item: CUT_ITEM },
+          additionalProperties: false,
+        });
+    });
+
+    it("returns `undefined` for a declaration whose positions state no fields", () => {
+      // Bare types and an unconstrained object read no less than the value
+      // does, so there is nothing here that a readback does not already do —
+      // and answering with a projection that changes nothing would report a
+      // bound where none was found.
+      expect(declaredResultProjection({ type: "object" }, "shape"))
+        .toBeUndefined();
+      expect(declaredResultProjection({}, "shape")).toBeUndefined();
+      expect(
+        declaredResultProjection(
+          { type: "object", properties: {} },
+          "shape",
+        ),
+      ).toBeUndefined();
+      expect(declaredResultProjection({ type: "string" }, "shape"))
+        .toBeUndefined();
+    });
+
+    it("leaves a union position as wide as it was declared", () => {
+      // A projection states one shape per position and a union does not, so
+      // the position is left wide under this bound too — the same answer
+      // `allOf` gets, and for the same reason. Only re-entry turns a union
+      // into an address.
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            author: {
+              anyOf: [
+                { type: "object", properties: { name: { type: "string" } } },
+                { type: "null" },
+              ],
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: { author: true },
+        additionalProperties: false,
+      });
+    });
+
+    it("holds an array's elements to the fields they declare", () => {
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            rows: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { title: { type: "string" } },
+              },
+            },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { title: true },
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it("drops a stream position, which holds no value to read", () => {
+      expect(
+        declaredResultProjection({
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            rename: { asCell: ["stream"] },
+          },
+        }, "shape")?.schema,
+      ).toEqual({
+        type: "object",
+        properties: { title: true },
+        additionalProperties: false,
+      });
+    });
+  });
+
   it("returns `undefined` where the verb declares no result to bound with", () => {
     expect(declaredResultProjection(undefined)).toBeUndefined();
     expect(declaredResultProjection(true)).toBeUndefined();

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -342,6 +342,70 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
+  // The pair below is the other half of "a caller's own shape wins": a
+  // selection that asks for an ADDRESS at one position and keeps the circle at
+  // another. The address is the caller's whole answer where they asked for it,
+  // and a bound that closed the object over the declared fields instead would
+  // answer `{}` there — contents where an address was asked for, which reads
+  // as a successful answer to a question nobody asked. Both bounds reach that
+  // position, so both halves are here.
+  it("keeps an address the caller asked for while the shape bounds the rest", async () => {
+    await withTracker("cyclic-compact-marked", async ({ call }) => {
+      const result = await call("addChildRow", ["--title", "Marked"], {
+        selection: {
+          projection: parseSelectProjection("row@,row.parent"),
+        },
+      }) as any;
+
+      // `row.parent` is the container, which files the row under `children`,
+      // so the caller's own shape still closes a circle and the compact
+      // declaration is what bounds it. `row@` is the address of the row, and
+      // it survives that bound.
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(typeof result.row.$link).toBe("string");
+      // The row is a piece of its own, so the deepest link the walk crossed is
+      // that piece's document and there is no path below it.
+      const row = parseLLMFriendlyLink(result.row.$link);
+      expect(row.id?.startsWith("of:")).toBe(true);
+      expect(row.path).toEqual([]);
+      // `parent` is where the circle was, and the declaration does not name
+      // it, so the bound removes it. Nothing the caller did not name comes
+      // back in its place.
+      expect(Object.keys(result.row)).toEqual(["$link"]);
+    });
+  });
+
+  it("keeps an address the caller asked for while the recursion bounds the rest", async () => {
+    await withTracker("cyclic-container-marked", async ({ call }) => {
+      await call("addChildSelf", ["--title", "First"]);
+      const result = await call("addChildSelf", ["--title", "Second"], {
+        selection: {
+          projection: parseSelectProjection("container@,container.children"),
+        },
+      }) as any;
+
+      // `container.children` holds the pieces that point back at the
+      // container, so the caller's shape keeps the circle and the declared
+      // recursion cuts it: each child renders its own address. The
+      // container's own address is the caller's, and stands beside them.
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(typeof result.container.$link).toBe("string");
+      expect(parseLLMFriendlyLink(result.container.$link).id?.startsWith("of:"))
+        .toBe(true);
+      expect(
+        result.container.children.map((child: any) =>
+          parseLLMFriendlyLink(child.$link).id?.startsWith("of:")
+        ),
+      ).toEqual([true, true]);
+      // And no position the caller did not name: `title` is declared, was not
+      // selected, and does not come back.
+      expect(Object.keys(result.container).sort()).toEqual([
+        "$link",
+        "children",
+      ]);
+    });
+  });
+
   // The pair below is one contrast, and it is the whole point of both halves:
   // `item.title` narrows PAST the position where the declared type re-enters,
   // so the value it produces holds no circle and nothing derived touches it;

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -28,13 +28,17 @@ import { executePieceCallable } from "../lib/piece.ts";
  * whose recursion is spelled with `$ref`/`$defs` that no hand-written schema
  * would predict.
  *
- * Four verbs, for the answers a readback can give:
+ * Five verbs, for the answers a readback can give:
  *
  * - `addChild` returns the new item, and its declared result re-enters itself.
  * - `addChildSelf` returns the CONTAINER, so the circle closes through a
  *   collection rather than through a single field.
  * - `addChildLoose` returns the same container behind `unknown`, which
  *   declares a shape that bounds nothing.
+ * - `addChildRow` returns the new item behind a COMPACT declaration — two
+ *   scalars, re-entering nowhere — which is the shape a verb takes when its
+ *   author means the result to be a row rather than the whole piece. Its
+ *   circle is at no position that declaration names.
  * - `addChildren` returns an ARRAY of items, which is the one root a
  *   `--filter` can be applied to and so the only way to reach a filtered
  *   readback of a value that closes a circle.
@@ -54,6 +58,8 @@ const PROGRAM = {
       "interface AddChildResult { item: ItemOutput; }",
       "interface ContainerResult { container: ItemOutput; }",
       "interface LooseResult { container: unknown; }",
+      "interface ItemRow { title: string; status: string; }",
+      "interface RowResult { row: ItemRow; }",
       "interface FinishEvent { note: string; }",
       "interface FinishResult { status: string; note: string; }",
       "",
@@ -62,6 +68,7 @@ const PROGRAM = {
       "  addChild: Stream<AddChildEvent, AddChildResult>;",
       "  addChildSelf: Stream<AddChildEvent, ContainerResult>;",
       "  addChildLoose: Stream<AddChildEvent, LooseResult>;",
+      "  addChildRow: Stream<AddChildEvent, RowResult>;",
       "  finish: Stream<FinishEvent, FinishResult>;",
       "  [NAME]: string;",
       "  title: string;",
@@ -97,6 +104,11 @@ const PROGRAM = {
       "      children.push(Item({ title: event.title, parent: self }));",
       "      return { container: self as unknown };",
       "    });",
+      "    const addChildRow = action<AddChildEvent, RowResult>((event) => {",
+      "      const item = Item({ title: event.title, parent: self });",
+      "      children.push(item);",
+      "      return { row: item };",
+      "    });",
       "    const finish = action<FinishEvent, FinishResult>((event) => {",
       "      status.set('done');",
       "      return { status: 'done', note: event.note };",
@@ -111,6 +123,7 @@ const PROGRAM = {
       "      addChild,",
       "      addChildSelf,",
       "      addChildLoose,",
+      "      addChildRow,",
       "      finish,",
       "    };",
       "  },",
@@ -290,6 +303,42 @@ describe("cf piece call on a piece that points back at its container", () => {
       expect(ids.length).toBe(2);
       expect(new Set(ids).size).toBe(2);
       expect(ids.every((id: string) => id.startsWith("of:"))).toBe(true);
+    });
+  });
+
+  it("renders a compact declaration's shape where the circle is past it", async () => {
+    await withTracker("cyclic-compact-declaration", async ({ call, root }) => {
+      const result = await call("addChildRow", ["--title", "Filed"]) as any;
+
+      // `RowResult` declares two scalars over a value that is a whole piece,
+      // so the circle is at `row.parent.children[0]` — a position the
+      // declaration does not name and its recursion cannot reach, because it
+      // has none. The declaration read as the shape it states is what bounds
+      // this: the row comes back, and nothing the row does not declare comes
+      // back beside it.
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result).toEqual({ row: { title: "Filed", status: "open" } });
+      // No address anywhere, and that is the distinction from the recursion
+      // bound rather than a detail: nothing here re-enters, so there is no
+      // position for a `$link` to stand in for.
+      expect(JSON.stringify(result)).not.toContain("$link");
+      // And the write landed. A bound is a rendering, so the handling it
+      // renders is the same one either way.
+      expect(childTitles(root)).toEqual(["Filed"]);
+    });
+  });
+
+  it("leaves a caller's own shape in charge over a compact declaration", async () => {
+    await withTracker("cyclic-compact-selection", async ({ call }) => {
+      const result = await call("addChildRow", ["--title", "Named"], {
+        selection: { projection: parseSelectProjection("row.title") },
+      }) as any;
+
+      // The caller narrowed past the circle, so their shape renders on its own
+      // and no bound engages. An implementation that applied the declaration
+      // to every result would hand back `status` here, which the caller did
+      // not name.
+      expect(result).toEqual({ row: { title: "Named" } });
     });
   });
 


### PR DESCRIPTION
Fixes #6495.

## Why

`addTopic` is the Topics board's primary verb, and every caller that renders
its result — the CLI by default — got a nonzero exit for a write that landed:

```
Cannot render the result of "addTopic": it closes a circle at
"/topic/$UI/children/0/.../props/$profile/$UI", and JSON has no way to write
one. The handling COMMITTED … This verb's declared result leaves the closing
position unbounded.
```

`cf` already bounds an unrenderable readback with the verb's declared result,
but only at the position where the DECLARED TYPE re-enters itself. `addTopic`
declares `{ topic: TopicIndexRow }` — a compact row, deliberately narrow so a
create does not expand the topic's prose, thread and every referenced sibling
(#6143) — and that row re-enters nowhere. The circle is out in the value, at
`$UI → $profile → $UI`, a position the declaration does not name at all, so
the cut had nothing to land on and the call refused.

Verified against the real compiled pattern: for `addTopic`'s declared result
the existing derivation returns `undefined`, and the new one derives
`{"topic":{"properties":{"title":true,"createdAt":true,"createdBy":true,
"commentCount":true,"lastActivityAt":true},"additionalProperties":false}}` —
which is the row, with `$UI` gone.

**It also repairs shipped behavior.** A derived bound writes a closed
`properties` object at every position on the way to its cut, and closing a
position drops every key not named there. On `main` that silently swallowed a
caller's own composed address: `--select 'item@,item.parent'` over a verb
whose declared result re-enters came back `{"item":{"parent":{"$link":…}}}`
with `item@` gone. Measured, not inferred — the loss needed a declared result,
no `--filter`, a selection that kept a circle, an object at the marked
position, and the declared type re-entering below it. Narrow, but wrong in a
way that reads as a successful answer to a different question.

## What Changed

`declaredResultProjection` / `boundReadValue` take a `DeclaredBound`:

- `"recursion"` (the default, and what existed) cuts only where the declared
  type re-enters itself and leaves every other position as wide as it read.
- `"shape"` additionally holds every object position the declaration *closes*
  to the fields it declares there.

`boundCyclicResult` tries them weakest first, so a result the recursion cut
renders is never held to the declared shape as well, and a caller's own
`--select`/`--schema` still wins wherever it renders. A union stays wide under
both — re-entry alone turns one into an address — for the reason `allOf`
already is: a projection states one shape per position and a union does not.

What a bound must not remove, and no longer does:

- **Keys a declaration allows.** An interface with an index signature over its
  own members lowers to `properties` AND `additionalProperties`; that position
  is written open, and narrows nothing on its own. One stating
  `additionalProperties: false` closed itself and is written closed.
  `Record<string, never>` lowers to a closed object naming no fields — which
  says the value has no keys, a different statement from naming none, and the
  only one of the two that bounds.
- **Addresses the caller composed.** `projectValue` carries a `$link` a
  caller's projection already placed across a closed object, under both bounds.

Docs: `packages/cli/README.md` and `docs/common/verbs/over-the-cli.md`.

## Test plan

- `piece-call-cyclic-result-live.test.ts` gains `addChildRow` — a verb
  returning the piece behind a two-scalar declaration, the Topics shape — plus
  cases for the caller-address pair under each bound. Each was watched failing
  against base for the stated reason.
- `declaredResultProjection.test.ts` gains a `"shape"` group and the
  open/closed/zero-field derivation cases.
- `deno task test` in `packages/cli` (1733 + 210 passed, 0 failed),
  `deno task check`, `deno task check-docs`, repo-wide `deno fmt --check` and
  `deno lint`. Full CI was green on the first revision.

Both cubic P2 threads are addressed in code, and they shared one root cause —
the closed `properties` object above — so the fix is to that shape rather than
to the two instances.

## Open question, deliberately not settled here

The readback still *reads* the whole piece and narrows on the way out; the
declaration bounds the rendering, not the read. Making the declared result
bound the default readback outright — which is what `AddTopicResult.topic`'s
own doc comment claims happens — would also stop paying for the expansion,
but it changes what every declared verb prints and is a verb-contract call
rather than a bug fix. Worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFkYXgPxuuQANujLvEdthY
