### PR TITLE
refactor: `#` private members in `html` and `fuse`

### DIFF
--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -487,10 +487,16 @@ export function cfcDirectoryEntryNameDigest(name: string): string {
 }
 
 export class CfcProjectionAnnotator {
+  readonly #tree: AnnotatableTree;
+  readonly #base: CfcProjectionBase;
+
   constructor(
-    private readonly tree: AnnotatableTree,
-    private readonly base: CfcProjectionBase,
-  ) {}
+    tree: AnnotatableTree,
+    base: CfcProjectionBase,
+  ) {
+    this.#tree = tree;
+    this.#base = base;
+  }
 
   jsonContext(path: CfcPathSegment[]): CfcJsonAnnotationContext {
     return { annotator: this, path: [...path] };
@@ -510,15 +516,15 @@ export class CfcProjectionAnnotator {
   ): CfcProjectionRef {
     const ref: CfcProjectionRef = {
       type: "common-fabric-fuse-ref-v1",
-      space: this.base.space,
-      ...(this.base.entity === undefined ? {} : { entity: this.base.entity }),
-      ...(this.base.rootKind === undefined
+      space: this.#base.space,
+      ...(this.#base.entity === undefined ? {} : { entity: this.#base.entity }),
+      ...(this.#base.rootKind === undefined
         ? {}
-        : { rootKind: this.base.rootKind }),
-      ...(this.base.cell === undefined ? {} : { cell: this.base.cell }),
+        : { rootKind: this.#base.rootKind }),
+      ...(this.#base.cell === undefined ? {} : { cell: this.#base.cell }),
       path: [...path],
       projection,
-      generation: this.base.generation,
+      generation: this.#base.generation,
     };
     for (
       const [key, value] of Object.entries(overrides) as Array<
@@ -535,7 +541,7 @@ export class CfcProjectionAnnotator {
   }
 
   labelAt(path: readonly CfcPathSegment[]): CfcLabel {
-    const labels = labelViewEntriesAt(this.base.labelView, path);
+    const labels = labelViewEntriesAt(this.#base.labelView, path);
     if (labels.length === 0) {
       return failClosedLabel();
     }
@@ -637,11 +643,11 @@ export class CfcProjectionAnnotator {
     value: unknown,
   ): void {
     const contentLabel = this.subtreeLabel(value, path);
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref("value", path),
       contentLabel,
       metadataLabels: defaultMetadataLabels(contentLabel),
-      incomplete: this.incompleteIfFailClosed(contentLabel, path),
+      incomplete: this.#incompleteIfFailClosed(contentLabel, path),
     });
   }
 
@@ -651,12 +657,12 @@ export class CfcProjectionAnnotator {
     value: unknown,
   ): void {
     const namespaceLabel = this.namespaceLabel(value, path);
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref("dir", path),
       namespaceLabel,
       entries: { version: 1, entries: [] },
       metadataLabels: defaultMetadataLabels(namespaceLabel),
-      incomplete: this.incompleteIfFailClosed(namespaceLabel, path),
+      incomplete: this.#incompleteIfFailClosed(namespaceLabel, path),
     });
   }
 
@@ -666,11 +672,11 @@ export class CfcProjectionAnnotator {
     value: unknown,
   ): void {
     const contentLabel = this.subtreeLabel(value, path);
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref("aggregate-json", path),
       contentLabel,
       metadataLabels: defaultMetadataLabels(contentLabel),
-      incomplete: this.incompleteIfFailClosed(contentLabel, path),
+      incomplete: this.#incompleteIfFailClosed(contentLabel, path),
     });
   }
 
@@ -682,7 +688,7 @@ export class CfcProjectionAnnotator {
     const linkTextLabel = this.labelAt(path);
     const targetLabel = targetIdentityLabel(target);
     const contentLabel = joinLabels(linkTextLabel, targetLabel);
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref("symlink", path),
       contentLabel,
       metadataLabels: defaultMetadataLabels(contentLabel),
@@ -692,7 +698,7 @@ export class CfcProjectionAnnotator {
         linkTextLabel,
         targetIdentityLabel: targetLabel,
       },
-      incomplete: this.incompleteIfFailClosed(contentLabel, path),
+      incomplete: this.#incompleteIfFailClosed(contentLabel, path),
     });
   }
 
@@ -710,7 +716,7 @@ export class CfcProjectionAnnotator {
       ? cloneLabel(options.schemaLabel)
       : CFC_PUBLIC_LABEL;
     const descriptorLabel = joinLabels(schemaLabel);
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref("callable", path, { cell: options.cellProp }),
       contentLabel: descriptorLabel,
       metadataLabels: defaultMetadataLabels(descriptorLabel),
@@ -721,7 +727,7 @@ export class CfcProjectionAnnotator {
         key: options.cellKey,
         descriptor: {
           contentLabel: descriptorLabel,
-          generation: this.base.generation,
+          generation: this.#base.generation,
         },
         schemaLabel,
         invocation: {
@@ -743,12 +749,12 @@ export class CfcProjectionAnnotator {
     },
   ): void {
     const contentLabel = options.contentLabel ?? failClosedLabel();
-    this.setNodeAnnotation(ino, {
+    this.#setNodeAnnotation(ino, {
       ref: this.ref(options.projection, options.path, options.ref),
       contentLabel,
       namespaceLabel: options.namespaceLabel,
       metadataLabels: defaultMetadataLabels(contentLabel),
-      incomplete: this.incompleteIfFailClosed(contentLabel, options.path),
+      incomplete: this.#incompleteIfFailClosed(contentLabel, options.path),
     });
   }
 
@@ -762,11 +768,11 @@ export class CfcProjectionAnnotator {
       existenceLabel?: CfcLabel;
     } = {},
   ): void {
-    const child = this.tree.getNode(childIno);
+    const child = this.#tree.getNode(childIno);
     if (!child?.cfc) return;
     const labelPath = options.labelPath ?? child.cfc.ref.path;
     const defaultEntryLabel = this.labelAt(labelPath);
-    this.tree.setCfcEntryAnnotation(parentIno, name, {
+    this.#tree.setCfcEntryAnnotation(parentIno, name, {
       name,
       nameDigest: cfcDirectoryEntryNameDigest(name),
       childRef: child.cfc.ref,
@@ -777,22 +783,22 @@ export class CfcProjectionAnnotator {
     });
   }
 
-  private setNodeAnnotation(
+  #setNodeAnnotation(
     ino: bigint,
     annotation: Omit<
       CfcNodeAnnotation,
       "version" | "generation" | "derivedSlots"
     >,
   ): void {
-    this.tree.setCfcAnnotation(ino, {
+    this.#tree.setCfcAnnotation(ino, {
       version: 1,
-      generation: this.base.generation,
+      generation: this.#base.generation,
       derivedSlots: emptyDerivedSlots(),
       ...annotation,
     });
   }
 
-  private incompleteIfFailClosed(
+  #incompleteIfFailClosed(
     label: CfcLabel,
     path: readonly CfcPathSegment[],
   ): CfcIncompleteAnnotation | undefined {

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -97,18 +97,18 @@ class SinkableCell {
   _value: unknown;
   _sinks: Array<(v: unknown) => void> = [];
   schema = undefined;
-  private root: SinkableCell;
-  private path: string[];
+  #root: SinkableCell;
+  #path: string[];
 
   constructor(value: unknown, root?: SinkableCell, path: string[] = []) {
     this._value = value;
-    this.root = root ?? this;
-    this.path = path;
+    this.#root = root ?? this;
+    this.#path = path;
   }
 
   get() {
-    let current = this.root._value;
-    for (const segment of this.path) {
+    let current = this.#root._value;
+    for (const segment of this.#path) {
       if (
         typeof current !== "object" || current === null ||
         Array.isArray(current)
@@ -125,7 +125,7 @@ class SinkableCell {
   }
 
   set(v: unknown) {
-    if (this.root !== this) {
+    if (this.#root !== this) {
       throw new Error("set() is only supported on the root SinkableCell");
     }
     this._value = v;
@@ -137,15 +137,15 @@ class SinkableCell {
   }
 
   key(segment: string): FakeCell {
-    return new SinkableCell(undefined, this.root, [
-      ...this.path,
+    return new SinkableCell(undefined, this.#root, [
+      ...this.#path,
       segment,
     ]) as unknown as FakeCell;
   }
 
   sink(fn: (v: unknown) => void): () => void {
-    if (this.root !== this) {
-      return this.root.sink(() => fn(this.get()));
+    if (this.#root !== this) {
+      return this.#root.sink(() => fn(this.get()));
     }
     this._sinks.push(fn);
     return () => {

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -357,6 +357,12 @@ interface PropRebuildJob {
 }
 
 export class CellBridge {
+  // A member below declared `private` rather than `#` is one
+  // `cell-bridge.test.ts` reaches and drives directly; a `#` name would put
+  // it out of that test's reach. Three also keep a leading `_` that this
+  // convention otherwise drops, `_attemptReconnect`, `_disconnected`, and
+  // `_reconnectTimer` being the names the test uses.
+
   tree: FsTree;
   spaces: Map<string, SpaceState> = new Map();
 
@@ -370,22 +376,12 @@ export class CellBridge {
   #apiUrl: string = "";
   #connecting = new Map<string, Promise<SpaceState>>();
 
-  /** In-flight piece-list synchronization keyed by space name. *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** In-flight piece-list synchronization keyed by space name. */
   private pieceSyncs = new Map<string, Promise<void>>();
 
-  /** Flag: re-run sync after current pass completes. *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** Flag: re-run sync after current pass completes. */
   private syncAgain: Set<string> = new Set();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private pendingPieceHydrations = new Map<string, Promise<void>>();
 
   /** Coalesced subtree rebuilds keyed by piece inode + prop name. */
@@ -407,57 +403,29 @@ export class CellBridge {
   #execCli: string;
   #pieceRoots = new Map<bigint, PieceRootInfo>();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private unhydratedEntityRoots = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private pendingEntityHydrations = new Map<bigint, Promise<boolean>>();
   #pendingEntityDirectorySnapshots = new Map<
     SpaceState,
     Promise<readonly DirectorySnapshotEntry[]>
   >();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entityProjectionLru = new Map<bigint, UnhydratedEntityRootInfo>();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entityProjectionEvictionCandidates = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entityProjectionUseOrder = new Map<bigint, number>();
   #nextEntityProjectionUseOrder = 0;
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entityProjectionLookupRefs = new Map<bigint, bigint>();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entityProjectionLookupOwners = new Map<
     bigint,
     EntityProjectionLookupOwner
@@ -470,16 +438,8 @@ export class CellBridge {
   >();
   #entityProjectionOpenOwnerInodes = new Map<bigint, Set<bigint>>();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private pendingEntityRemovals = new Map<bigint, UnhydratedEntityRootInfo>();
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private entitySubscriptions = new Map<bigint, Cancel[]>();
   #piecePropRoots = new Map<bigint, PiecePropRootInfo>();
   #hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
@@ -511,18 +471,11 @@ export class CellBridge {
    * Once disconnected, all files appear read-only (EACCES on write)
    * so agents get immediate feedback rather than silent data loss.
    * Reconnection is attempted automatically with exponential backoff.
-   *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
    */
   private _disconnected = false;
   #disconnectCount = 0;
   #lastDisconnectReason: string | null = null;
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   get disconnected(): boolean {
@@ -558,10 +511,6 @@ export class CellBridge {
     this._reconnectTimer = timerId;
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private async _attemptReconnect(): Promise<void> {
     const spaces = [...this.spaces];
     let allSpacesRestored = spaces.length > 0;
@@ -849,10 +798,7 @@ export class CellBridge {
     this.#updatePieceManifest(state, piece.id, { summary, patternRef });
   }
 
-  /** Refresh synthetic pattern metadata after an in-place pattern swap. *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** Refresh synthetic pattern metadata after an in-place pattern swap. */
   private async refreshPiecePatternMetadata(
     state: SpaceState,
     piece: PieceController,
@@ -1866,10 +1812,6 @@ export class CellBridge {
     this.#hydrationEpochs.set(key, (this.#hydrationEpochs.get(key) ?? 0) + 1);
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private async rebuildPieceProp(args: {
     cell: Cell<unknown>;
     newValue: unknown;
@@ -2136,10 +2078,6 @@ export class CellBridge {
     this.#debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private async enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void> {
     const key = this.#propRebuildKey(args.pieceIno, args.propName);
     const previous = this.#pendingPropRebuildQueues.get(key) ??
@@ -2159,10 +2097,6 @@ export class CellBridge {
 
   static readonly #MAX_HYDRATION_RETRIES = 3;
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private hydratePieceProp(
     pieceIno: bigint,
     propName: "input" | "result",
@@ -2568,10 +2502,6 @@ export class CellBridge {
     );
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private buildSpaceTree(
     spaceName: string,
     pieces: PiecesController,
@@ -3122,9 +3052,6 @@ export class CellBridge {
   /**
    * Add a single piece to a space's tree.
    * Returns the assigned display name.
-   *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
    */
   private async addPieceToSpace(
     state: SpaceState,
@@ -3254,10 +3181,7 @@ export class CellBridge {
     } while (this.syncAgain.has(spaceName));
   }
 
-  /** Single pass of piece list sync (called by guarded syncPieceList). *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** Single pass of piece list sync (called by guarded syncPieceList). */
   private async syncPieceListOnce(
     state: SpaceState,
     spaceName: string,
@@ -3321,10 +3245,7 @@ export class CellBridge {
     }
   }
 
-  /** Update the pieces/pieces.json manifest for a space. *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** Update the pieces/pieces.json manifest for a space. */
   private updatePiecesJson(state: SpaceState): void {
     const entries = this.#buildPiecesManifestEntries(state);
     const existingIno = this.tree.lookup(state.piecesIno, "pieces.json");
@@ -3352,10 +3273,7 @@ export class CellBridge {
     );
   }
 
-  /** Update the pieces/.index.json file for a space. *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
+  /** Update the pieces/.index.json file for a space. */
   private updateIndexJson(state: SpaceState): void {
     const existingIno = this.tree.lookup(state.piecesIno, ".index.json");
     if (existingIno !== undefined) {
@@ -3964,9 +3882,6 @@ export class CellBridge {
   /**
    * Subscribe to cell changes for hydration-cache invalidation and
    * projected name changes for a piece.
-   *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
    */
   private async subscribePiece(
     piece: PieceController,
@@ -4260,9 +4175,6 @@ export class CellBridge {
    *   Same-space + id:  "../".repeat(depth+2) + "entities/<hash>[/<path>]"
    *   Cross-space:      "../".repeat(depth+3) + "<spaceName>/entities/<hash>[/<path>]"
    *   Self-ref (no id): relative path within the same piece
-   *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
    */
   private makeLinkResolver(
     spaceName: string,
@@ -4327,10 +4239,6 @@ export class CellBridge {
     };
   }
 
-  /**
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
-   */
   private async loadPieceTree(
     piece: PieceController,
     parentIno: bigint,
@@ -4418,9 +4326,6 @@ export class CellBridge {
    * authored source files (recovered from the content-addressed
    * `pattern:<identity>` source-doc closure). Skips system pieces that have no
    * recoverable source.
-   *
-   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
-   * this member directly.
    */
   private async buildSourceTree(
     pieceIno: bigint,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -366,26 +366,37 @@ export class CellBridge {
   /** Callback for kernel cache invalidation (set by mod.ts after mount). */
   onInvalidate: InvalidateCallback | null = null;
   onInvalidateInode: InvalidateInodeCallback | null = null;
-  private identity: string = "";
-  private apiUrl: string = "";
-  private connecting = new Map<string, Promise<SpaceState>>();
+  #identity: string = "";
+  #apiUrl: string = "";
+  #connecting = new Map<string, Promise<SpaceState>>();
 
-  /** In-flight piece-list synchronization keyed by space name. */
+  /** In-flight piece-list synchronization keyed by space name. *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private pieceSyncs = new Map<string, Promise<void>>();
 
-  /** Flag: re-run sync after current pass completes. */
+  /** Flag: re-run sync after current pass completes. *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private syncAgain: Set<string> = new Set();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private pendingPieceHydrations = new Map<string, Promise<void>>();
 
   /** Coalesced subtree rebuilds keyed by piece inode + prop name. */
-  private pendingPropRebuilds = new Map<
+  #pendingPropRebuilds = new Map<
     string,
     ScheduledPropRebuild
   >();
-  private activePropRebuilds = new Set<string>();
-  private deferredPropRebuilds = new Map<string, PropRebuildJob>();
-  private debug = false;
-  private rebuildStats = {
+  #activePropRebuilds = new Set<string>();
+  #deferredPropRebuilds = new Map<string, PropRebuildJob>();
+  #debug = false;
+  #rebuildStats = {
     scheduled: 0,
     coalesced: 0,
     completed: 0,
@@ -393,72 +404,125 @@ export class CellBridge {
     maxPending: 0,
     lastDurationMs: 0,
   };
-  private execCli: string;
-  private pieceRoots = new Map<bigint, PieceRootInfo>();
+  #execCli: string;
+  #pieceRoots = new Map<bigint, PieceRootInfo>();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private unhydratedEntityRoots = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private pendingEntityHydrations = new Map<bigint, Promise<boolean>>();
-  private pendingEntityDirectorySnapshots = new Map<
+  #pendingEntityDirectorySnapshots = new Map<
     SpaceState,
     Promise<readonly DirectorySnapshotEntry[]>
   >();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entityProjectionLru = new Map<bigint, UnhydratedEntityRootInfo>();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entityProjectionEvictionCandidates = new Map<
     bigint,
     UnhydratedEntityRootInfo
   >();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entityProjectionUseOrder = new Map<bigint, number>();
-  private nextEntityProjectionUseOrder = 0;
+  #nextEntityProjectionUseOrder = 0;
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entityProjectionLookupRefs = new Map<bigint, bigint>();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entityProjectionLookupOwners = new Map<
     bigint,
     EntityProjectionLookupOwner
   >();
-  private entityProjectionLookupOwnerInodes = new Map<bigint, Set<bigint>>();
-  private entityProjectionOpenRefs = new Map<bigint, number>();
-  private entityProjectionOpenOwners = new Map<
+  #entityProjectionLookupOwnerInodes = new Map<bigint, Set<bigint>>();
+  #entityProjectionOpenRefs = new Map<bigint, number>();
+  #entityProjectionOpenOwners = new Map<
     bigint,
     EntityProjectionOpenOwner
   >();
-  private entityProjectionOpenOwnerInodes = new Map<bigint, Set<bigint>>();
+  #entityProjectionOpenOwnerInodes = new Map<bigint, Set<bigint>>();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private pendingEntityRemovals = new Map<bigint, UnhydratedEntityRootInfo>();
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private entitySubscriptions = new Map<bigint, Cancel[]>();
-  private piecePropRoots = new Map<bigint, PiecePropRootInfo>();
-  private hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
+  #piecePropRoots = new Map<bigint, PiecePropRootInfo>();
+  #hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
 
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
-  private pendingHydrations = new Map<string, Promise<boolean>>();
-  private pendingPropRebuildQueues = new Map<string, Promise<void>>();
+  #pendingHydrations = new Map<string, Promise<boolean>>();
+  #pendingPropRebuildQueues = new Map<string, Promise<void>>();
 
   /** Monotonic invalidation epoch per hydration key. */
-  private hydrationEpochs = new Map<string, number>();
+  #hydrationEpochs = new Map<string, number>();
 
   /**
    * Tracks root-level entries created by [FS] projections so they can be
    * cleared when the result switches back to the default result/ tree.
    */
-  private fsProjectionEntries: Map<bigint, Set<string>> = new Map();
-  private cfcAnnotationsEnabled = false;
-  private explicitCfcProjectionGeneration: string | undefined;
-  private statusProvider: (() => Record<string, unknown>) | undefined;
-  private onCfcProjectionRebuilt: (() => void) | undefined;
-  private reconnectPiecesLoader: CellBridgeOptions["reconnectPiecesLoader"];
-  private piecesLoader: CellBridgeOptions["loadPieces"];
-  private maxEntityProjections: number;
+  #fsProjectionEntries: Map<bigint, Set<string>> = new Map();
+  #cfcAnnotationsEnabled = false;
+  #explicitCfcProjectionGeneration: string | undefined;
+  #statusProvider: (() => Record<string, unknown>) | undefined;
+  #onCfcProjectionRebuilt: (() => void) | undefined;
+  #reconnectPiecesLoader: CellBridgeOptions["reconnectPiecesLoader"];
+  #piecesLoader: CellBridgeOptions["loadPieces"];
+  #maxEntityProjections: number;
 
-  private startedAt = new Date().toISOString();
+  #startedAt = new Date().toISOString();
 
   /**
    * Set to true when a write fails due to a transport/connection error.
    * Once disconnected, all files appear read-only (EACCES on write)
    * so agents get immediate feedback rather than silent data loss.
    * Reconnection is attempted automatically with exponential backoff.
+   *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
    */
   private _disconnected = false;
-  private _disconnectCount = 0;
-  private _lastDisconnectReason: string | null = null;
+  #disconnectCount = 0;
+  #lastDisconnectReason: string | null = null;
+
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   get disconnected(): boolean {
@@ -469,46 +533,50 @@ export class CellBridge {
   markDisconnected(reason: string): void {
     if (this._disconnected) return;
     this._disconnected = true;
-    this._disconnectCount++;
-    this._lastDisconnectReason = reason;
+    this.#disconnectCount++;
+    this.#lastDisconnectReason = reason;
     console.error(
       `[FUSE] Backend connection lost (${reason}) — mount is READ-ONLY. ` +
-        `Will attempt reconnection in ${this._reconnectDelayMs()}ms.`,
+        `Will attempt reconnection in ${this.#reconnectDelayMs()}ms.`,
     );
-    this._scheduleReconnect();
+    this.#scheduleReconnect();
   }
 
-  private _reconnectDelayMs(): number {
+  #reconnectDelayMs(): number {
     // Exponential backoff: 2s, 4s, 8s, 16s, cap at 30s
-    return Math.min(2000 * Math.pow(2, this._disconnectCount - 1), 30_000);
+    return Math.min(2000 * Math.pow(2, this.#disconnectCount - 1), 30_000);
   }
 
-  private _scheduleReconnect(): void {
+  #scheduleReconnect(): void {
     if (this._reconnectTimer !== null) clearTimeout(this._reconnectTimer);
     const timerId = setTimeout(() => {
       this._reconnectTimer = null;
       this._attemptReconnect();
-    }, this._reconnectDelayMs());
+    }, this.#reconnectDelayMs());
     // Don't prevent Deno process from exiting while waiting to reconnect
     Deno.unrefTimer(timerId);
     this._reconnectTimer = timerId;
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async _attemptReconnect(): Promise<void> {
     const spaces = [...this.spaces];
     let allSpacesRestored = spaces.length > 0;
     for (const [spaceName, state] of spaces) {
       try {
-        const loadPieces = this.reconnectPiecesLoader ??
-          this.piecesLoader ?? openSpacePieces;
+        const loadPieces = this.#reconnectPiecesLoader ??
+          this.#piecesLoader ?? openSpacePieces;
         const probe = await loadPieces({
-          apiUrl: this.apiUrl,
+          apiUrl: this.#apiUrl,
           space: spaceName,
-          identity: this.identity,
+          identity: this.#identity,
           deferSpaceCellSync: true,
         });
         try {
-          await this.verifyPiecesConnection(probe);
+          await this.#verifyPiecesConnection(probe);
           if (state.piecesHydrated) {
             await state.pieces.getRegisteredPieces();
           }
@@ -535,7 +603,7 @@ export class CellBridge {
     }
     if (allSpacesRestored) {
       this._disconnected = false;
-      this._disconnectCount = 0;
+      this.#disconnectCount = 0;
       console.error(
         `[FUSE] Backend connection restored — write access resumed.`,
       );
@@ -543,27 +611,27 @@ export class CellBridge {
     }
 
     // At least one probe failed — retry with increasing backoff
-    this._disconnectCount++;
+    this.#disconnectCount++;
     console.error(
-      `[FUSE] Reconnect failed, retrying in ${this._reconnectDelayMs()}ms`,
+      `[FUSE] Reconnect failed, retrying in ${this.#reconnectDelayMs()}ms`,
     );
-    this._scheduleReconnect();
+    this.#scheduleReconnect();
   }
 
   constructor(tree: FsTree, execCli = "", options: CellBridgeOptions = {}) {
     this.tree = tree;
-    this.execCli = execCli;
-    this.cfcAnnotationsEnabled = options.cfcAnnotations ?? false;
-    this.explicitCfcProjectionGeneration = options.projectionGeneration;
-    this.statusProvider = options.statusProvider;
-    this.onCfcProjectionRebuilt = options.onCfcProjectionRebuilt;
-    this.reconnectPiecesLoader = options.reconnectPiecesLoader;
-    this.piecesLoader = options.loadPieces;
-    this.maxEntityProjections = options.maxEntityProjections ??
+    this.#execCli = execCli;
+    this.#cfcAnnotationsEnabled = options.cfcAnnotations ?? false;
+    this.#explicitCfcProjectionGeneration = options.projectionGeneration;
+    this.#statusProvider = options.statusProvider;
+    this.#onCfcProjectionRebuilt = options.onCfcProjectionRebuilt;
+    this.#reconnectPiecesLoader = options.reconnectPiecesLoader;
+    this.#piecesLoader = options.loadPieces;
+    this.#maxEntityProjections = options.maxEntityProjections ??
       DEFAULT_MAX_ENTITY_PROJECTIONS;
     if (
-      !Number.isSafeInteger(this.maxEntityProjections) ||
-      this.maxEntityProjections < 1
+      !Number.isSafeInteger(this.#maxEntityProjections) ||
+      this.#maxEntityProjections < 1
     ) {
       throw new RangeError("maxEntityProjections must be a positive integer");
     }
@@ -573,11 +641,11 @@ export class CellBridge {
     apiUrl: string;
     identity: string;
   }): void {
-    this.apiUrl = config.apiUrl;
-    this.identity = config.identity;
+    this.#apiUrl = config.apiUrl;
+    this.#identity = config.identity;
   }
 
-  private async verifyPiecesConnection(
+  async #verifyPiecesConnection(
     pieces: PiecesController,
   ): Promise<void> {
     await pieces.ensureSpaceSession?.();
@@ -588,34 +656,34 @@ export class CellBridge {
     if (authorizationError) throw authorizationError;
   }
 
-  private async createSpacePieces(
+  async #createSpacePieces(
     spaceName: string,
   ): Promise<PiecesController> {
-    const loadPieces = this.piecesLoader ?? openSpacePieces;
+    const loadPieces = this.#piecesLoader ?? openSpacePieces;
     return await loadPieces({
-      apiUrl: this.apiUrl,
+      apiUrl: this.#apiUrl,
       space: spaceName,
-      identity: this.identity,
+      identity: this.#identity,
       deferSpaceCellSync: true,
     });
   }
 
   setDebug(debug: boolean): void {
-    this.debug = debug;
+    this.#debug = debug;
   }
 
-  private debugLog(message: string): void {
-    if (this.debug) {
+  #debugLog(message: string): void {
+    if (this.#debug) {
       console.log(message);
     }
   }
 
-  private cfcSpaceDid(spaceName: string): string {
+  #cfcSpaceDid(spaceName: string): string {
     return this.spaces.get(spaceName)?.did ?? this.knownSpaces.get(spaceName) ??
       spaceName;
   }
 
-  private spaceNameForState(state: SpaceState): string | undefined {
+  #spaceNameForState(state: SpaceState): string | undefined {
     for (const [name, candidate] of this.spaces) {
       if (candidate === state) return name;
     }
@@ -625,8 +693,8 @@ export class CellBridge {
     return undefined;
   }
 
-  private cfcLabelViewForCell(cell: Cell<unknown>): CfcLabelView | undefined {
-    if (!this.cfcAnnotationsEnabled) return undefined;
+  #cfcLabelViewForCell(cell: Cell<unknown>): CfcLabelView | undefined {
+    if (!this.#cfcAnnotationsEnabled) return undefined;
     try {
       return cfcLabelViewForCell(cell) as CfcLabelView | undefined;
     } catch {
@@ -634,7 +702,7 @@ export class CellBridge {
     }
   }
 
-  private makeCfcAnnotator(options: {
+  #makeCfcAnnotator(options: {
     spaceName: string;
     spaceDid?: string;
     pieceId?: string;
@@ -643,9 +711,9 @@ export class CellBridge {
     labelView?: CfcLabelView;
     value?: unknown;
   }): CfcProjectionAnnotator | undefined {
-    if (!this.cfcAnnotationsEnabled) return undefined;
-    const space = options.spaceDid ?? this.cfcSpaceDid(options.spaceName);
-    const generation = this.explicitCfcProjectionGeneration ??
+    if (!this.#cfcAnnotationsEnabled) return undefined;
+    const space = options.spaceDid ?? this.#cfcSpaceDid(options.spaceName);
+    const generation = this.#explicitCfcProjectionGeneration ??
       deriveCfcProjectionGeneration({
         space,
         entity: options.pieceId,
@@ -664,7 +732,7 @@ export class CellBridge {
     });
   }
 
-  private annotateSyntheticNode(
+  #annotateSyntheticNode(
     annotator: CfcProjectionAnnotator | undefined,
     ino: bigint,
     projection: CfcProjectionKind,
@@ -691,13 +759,13 @@ export class CellBridge {
     this.tree.addGeneratedFile(
       this.tree.rootIno,
       ".status",
-      () => this.getStatusJson(),
+      () => this.#getStatusJson(),
       "object",
     );
   }
 
   /** Generate current status as JSON. */
-  private getStatusJson(): string {
+  #getStatusJson(): string {
     const spaces: Record<
       string,
       { did: string; pieces: number; piecesLoaded: boolean }
@@ -709,28 +777,28 @@ export class CellBridge {
         piecesLoaded: state.piecesHydrated,
       };
     }
-    const extra = this.statusProvider?.() ?? {};
+    const extra = this.#statusProvider?.() ?? {};
     return JSON.stringify(
       {
-        apiUrl: this.apiUrl,
-        debug: this.debug,
+        apiUrl: this.#apiUrl,
+        debug: this.#debug,
         rebuilds: {
-          pending: this.pendingPropRebuilds.size +
-            this.activePropRebuilds.size +
-            this.deferredPropRebuilds.size,
-          scheduled: this.rebuildStats.scheduled,
-          coalesced: this.rebuildStats.coalesced,
-          completed: this.rebuildStats.completed,
-          errors: this.rebuildStats.errors,
-          maxPending: this.rebuildStats.maxPending,
-          lastDurationMs: this.rebuildStats.lastDurationMs,
+          pending: this.#pendingPropRebuilds.size +
+            this.#activePropRebuilds.size +
+            this.#deferredPropRebuilds.size,
+          scheduled: this.#rebuildStats.scheduled,
+          coalesced: this.#rebuildStats.coalesced,
+          completed: this.#rebuildStats.completed,
+          errors: this.#rebuildStats.errors,
+          maxPending: this.#rebuildStats.maxPending,
+          lastDurationMs: this.#rebuildStats.lastDurationMs,
         },
-        startedAt: this.startedAt,
+        startedAt: this.#startedAt,
         spaces,
         connection: {
           disconnected: this._disconnected,
-          disconnectCount: this._disconnectCount,
-          lastDisconnectReason: this._lastDisconnectReason,
+          disconnectCount: this.#disconnectCount,
+          lastDisconnectReason: this.#lastDisconnectReason,
         },
         ...extra,
       },
@@ -739,15 +807,15 @@ export class CellBridge {
     );
   }
 
-  private noteCfcProjectionRebuilt(): void {
+  #noteCfcProjectionRebuilt(): void {
     try {
-      this.onCfcProjectionRebuilt?.();
+      this.#onCfcProjectionRebuilt?.();
     } catch (e) {
       console.warn(`[fuse] CFC writeback reconciliation error: ${e}`);
     }
   }
 
-  private extractSummary(value: unknown): string {
+  #extractSummary(value: unknown): string {
     if (
       typeof value !== "object" || value === null || Array.isArray(value)
     ) {
@@ -758,7 +826,7 @@ export class CellBridge {
       : "";
   }
 
-  private async refreshPieceManifest(
+  async #refreshPieceManifest(
     state: SpaceState,
     piece: PieceController,
   ): Promise<void> {
@@ -767,7 +835,7 @@ export class CellBridge {
 
     try {
       const result = await piece.result.get();
-      summary = this.extractSummary(result);
+      summary = this.#extractSummary(result);
     } catch {
       // Summary is best-effort only.
     }
@@ -778,10 +846,13 @@ export class CellBridge {
       // Pattern source is best-effort; identity-less pieces remain listable.
     }
 
-    this.updatePieceManifest(state, piece.id, { summary, patternRef });
+    this.#updatePieceManifest(state, piece.id, { summary, patternRef });
   }
 
-  /** Refresh synthetic pattern metadata after an in-place pattern swap. */
+  /** Refresh synthetic pattern metadata after an in-place pattern swap. *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async refreshPiecePatternMetadata(
     state: SpaceState,
     piece: PieceController,
@@ -795,17 +866,17 @@ export class CellBridge {
     }
     if (patternRef === undefined) return;
 
-    const manifestChanged = this.updatePieceManifest(state, piece.id, {
+    const manifestChanged = this.#updatePieceManifest(state, piece.id, {
       patternRef,
     });
-    this.updatePieceMetaPatternRef(pieceIno, patternRef);
+    this.#updatePieceMetaPatternRef(pieceIno, patternRef);
 
     const entityIno = this.tree.lookup(
       state.entitiesIno,
       encodeFuseComponent(piece.id),
     );
     if (entityIno !== undefined) {
-      this.updatePieceMetaPatternRef(entityIno, patternRef);
+      this.#updatePieceMetaPatternRef(entityIno, patternRef);
     }
 
     if (manifestChanged) {
@@ -822,7 +893,7 @@ export class CellBridge {
     }
   }
 
-  private updatePieceManifest(
+  #updatePieceManifest(
     state: SpaceState,
     pieceId: string,
     updates: Partial<{ summary: string; patternRef: PiecePatternRef }>,
@@ -844,7 +915,7 @@ export class CellBridge {
     return changed;
   }
 
-  private buildPiecesManifestEntries(state: SpaceState): Array<{
+  #buildPiecesManifestEntries(state: SpaceState): Array<{
     id: string;
     name: string;
     summary: string;
@@ -880,35 +951,35 @@ export class CellBridge {
     const existing = this.spaces.get(spaceName);
     if (existing) return existing;
 
-    const existingConnection = this.connecting.get(spaceName);
+    const existingConnection = this.#connecting.get(spaceName);
     if (existingConnection) return await existingConnection;
 
-    const connection = this.connectSpaceOnce(spaceName).finally(() => {
-      if (this.connecting.get(spaceName) === connection) {
-        this.connecting.delete(spaceName);
+    const connection = this.#connectSpaceOnce(spaceName).finally(() => {
+      if (this.#connecting.get(spaceName) === connection) {
+        this.#connecting.delete(spaceName);
       }
     });
-    this.connecting.set(spaceName, connection);
+    this.#connecting.set(spaceName, connection);
     return await connection;
   }
 
-  private async connectSpaceOnce(spaceName: string): Promise<SpaceState> {
+  async #connectSpaceOnce(spaceName: string): Promise<SpaceState> {
     let pieces: PiecesController | undefined;
     let state: SpaceState | undefined;
     try {
-      pieces = await this.createSpacePieces(spaceName);
-      await this.verifyPiecesConnection(pieces);
+      pieces = await this.#createSpacePieces(spaceName);
+      await this.#verifyPiecesConnection(pieces);
       state = this.buildSpaceTree(spaceName, pieces);
 
       this.updateIndexJson(state);
       this.updatePiecesJson(state);
       this.spaces.set(spaceName, state);
       this.knownSpaces.set(spaceName, state.did);
-      this.updateSpacesJson();
+      this.#updateSpacesJson();
       return state;
     } catch (error) {
       if (state) {
-        this.removeFailedSpaceTree(spaceName, state);
+        this.#removeFailedSpaceTree(spaceName, state);
       } else {
         this.tree.removeChild(
           this.tree.rootIno,
@@ -932,27 +1003,27 @@ export class CellBridge {
     }
   }
 
-  private removeFailedSpaceTree(spaceName: string, state: SpaceState): void {
+  #removeFailedSpaceTree(spaceName: string, state: SpaceState): void {
     for (const cancel of state.unsubscribes) cancel();
     for (const subscriptions of state.pieceSubs.values()) {
       for (const cancel of subscriptions) cancel();
     }
     for (const [, ino] of this.tree.getChildren(state.piecesIno)) {
-      this.unregisterPieceRoot(ino);
+      this.#unregisterPieceRoot(ino);
     }
     for (const [, ino] of this.tree.getChildren(state.entitiesIno)) {
-      this.cancelEntitySubscriptions(ino);
+      this.#cancelEntitySubscriptions(ino);
       this.unhydratedEntityRoots.delete(ino);
       this.pendingEntityHydrations.delete(ino);
       this.entityProjectionLru.delete(ino);
       this.entityProjectionEvictionCandidates.delete(ino);
       this.entityProjectionUseOrder.delete(ino);
-      this.clearEntityProjectionReferences(ino);
+      this.#clearEntityProjectionReferences(ino);
       this.pendingEntityRemovals.delete(ino);
-      this.unregisterPieceRoot(ino);
+      this.#unregisterPieceRoot(ino);
     }
     this.pendingPieceHydrations.delete(spaceName);
-    this.pendingEntityDirectorySnapshots.delete(state);
+    this.#pendingEntityDirectorySnapshots.delete(state);
     this.pieceSyncs.delete(spaceName);
     this.syncAgain.delete(spaceName);
     this.tree.removeChild(
@@ -962,20 +1033,20 @@ export class CellBridge {
   }
 
   isConnecting(spaceName: string): boolean {
-    return this.connecting.has(spaceName);
+    return this.#connecting.has(spaceName);
   }
 
-  private registerPieceRoot(
+  #registerPieceRoot(
     pieceIno: bigint,
     info: PieceRootInfo,
   ): void {
-    this.pieceRoots.set(pieceIno, info);
-    if (!this.hydratedPieceProps.has(pieceIno)) {
-      this.hydratedPieceProps.set(pieceIno, new Set());
+    this.#pieceRoots.set(pieceIno, info);
+    if (!this.#hydratedPieceProps.has(pieceIno)) {
+      this.#hydratedPieceProps.set(pieceIno, new Set());
     }
   }
 
-  private ensurePiecePropStub(
+  #ensurePiecePropStub(
     pieceIno: bigint,
     propName: "input" | "result",
     annotator?: CfcProjectionAnnotator,
@@ -987,7 +1058,7 @@ export class CellBridge {
     }
     annotator?.annotateJsonDirectory(propIno, [], {});
     annotator?.annotateEntry(pieceIno, propName, propIno);
-    this.piecePropRoots.set(propIno, { pieceIno, propName });
+    this.#piecePropRoots.set(propIno, { pieceIno, propName });
     // Also ensure a stub JSON file so lookups for result.json / input.json
     // can reply immediately from tree while hydration runs in the background.
     const jsonName = `${propName}.json`;
@@ -999,64 +1070,64 @@ export class CellBridge {
     return propIno;
   }
 
-  private unregisterPieceRoot(pieceIno: bigint): void {
+  #unregisterPieceRoot(pieceIno: bigint): void {
     for (const propName of ["input", "result"] as const) {
       const propIno = this.tree.lookup(pieceIno, propName);
-      if (propIno !== undefined) this.piecePropRoots.delete(propIno);
+      if (propIno !== undefined) this.#piecePropRoots.delete(propIno);
       const key = `${pieceIno}-${propName}`;
-      this.pendingHydrations.delete(key);
-      this.hydrationEpochs.delete(key);
+      this.#pendingHydrations.delete(key);
+      this.#hydrationEpochs.delete(key);
     }
-    this.hydratedPieceProps.delete(pieceIno);
-    this.pieceRoots.delete(pieceIno);
+    this.#hydratedPieceProps.delete(pieceIno);
+    this.#pieceRoots.delete(pieceIno);
   }
 
-  private markPiecePropHydrated(
+  #markPiecePropHydrated(
     pieceIno: bigint,
     propName: "input" | "result",
   ): void {
-    let hydrated = this.hydratedPieceProps.get(pieceIno);
+    let hydrated = this.#hydratedPieceProps.get(pieceIno);
     if (!hydrated) {
       hydrated = new Set();
-      this.hydratedPieceProps.set(pieceIno, hydrated);
+      this.#hydratedPieceProps.set(pieceIno, hydrated);
     }
     hydrated.add(propName);
 
     const propIno = this.tree.lookup(pieceIno, propName);
     if (propIno !== undefined) {
-      this.piecePropRoots.set(propIno, { pieceIno, propName });
+      this.#piecePropRoots.set(propIno, { pieceIno, propName });
     }
   }
 
-  private markPiecePropCleared(
+  #markPiecePropCleared(
     pieceIno: bigint,
     propName: "input" | "result",
   ): void {
     const propIno = this.tree.lookup(pieceIno, propName);
     if (propIno !== undefined) {
-      this.piecePropRoots.delete(propIno);
+      this.#piecePropRoots.delete(propIno);
     }
-    this.hydratedPieceProps.get(pieceIno)?.delete(propName);
+    this.#hydratedPieceProps.get(pieceIno)?.delete(propName);
   }
 
-  private getPieceInfo(
+  #getPieceInfo(
     pieceIno: bigint,
   ): (PieceRootInfo & { state?: SpaceState }) | null {
-    const info = this.pieceRoots.get(pieceIno);
+    const info = this.#pieceRoots.get(pieceIno);
     if (!info) return null;
     return { ...info, state: this.spaces.get(info.spaceName) };
   }
 
-  private isEntityProjectionRoot(ino: bigint): boolean {
+  #isEntityProjectionRoot(ino: bigint): boolean {
     return this.unhydratedEntityRoots.has(ino) ||
       this.pendingEntityRemovals.has(ino) ||
-      this.pieceRoots.get(ino)?.rootKind === "entities";
+      this.#pieceRoots.get(ino)?.rootKind === "entities";
   }
 
-  private entityProjectionRootForInode(ino: bigint): bigint | undefined {
+  #entityProjectionRootForInode(ino: bigint): bigint | undefined {
     let current: bigint | undefined = ino;
     while (current !== undefined) {
-      if (this.isEntityProjectionRoot(current)) return current;
+      if (this.#isEntityProjectionRoot(current)) return current;
       current = this.tree.parents.get(current);
     }
     return undefined;
@@ -1065,11 +1136,11 @@ export class CellBridge {
   retainEntityProjectionLookup(ino: bigint, count = 1n): void {
     if (count <= 0n) return;
     const owner = this.entityProjectionLookupOwners.get(ino);
-    const rootIno = owner?.rootIno ?? this.entityProjectionRootForInode(ino);
+    const rootIno = owner?.rootIno ?? this.#entityProjectionRootForInode(ino);
     if (rootIno === undefined) return;
     if (owner === undefined) {
-      this.indexEntityProjectionOwner(
-        this.entityProjectionLookupOwnerInodes,
+      this.#indexEntityProjectionOwner(
+        this.#entityProjectionLookupOwnerInodes,
         rootIno,
         ino,
       );
@@ -1098,8 +1169,8 @@ export class CellBridge {
       });
     } else {
       this.entityProjectionLookupOwners.delete(ino);
-      this.unindexEntityProjectionOwner(
-        this.entityProjectionLookupOwnerInodes,
+      this.#unindexEntityProjectionOwner(
+        this.#entityProjectionLookupOwnerInodes,
         owner.rootIno,
         ino,
       );
@@ -1111,62 +1182,62 @@ export class CellBridge {
     } else {
       this.entityProjectionLookupRefs.delete(owner.rootIno);
     }
-    this.finishPendingEntityRemoval(owner.rootIno);
-    this.refreshEntityProjectionEvictionCandidate(owner.rootIno);
-    this.trimEntityProjectionCache();
+    this.#finishPendingEntityRemoval(owner.rootIno);
+    this.#refreshEntityProjectionEvictionCandidate(owner.rootIno);
+    this.#trimEntityProjectionCache();
   }
 
   retainEntityProjectionOpen(ino: bigint): void {
-    const owner = this.entityProjectionOpenOwners.get(ino);
-    const rootIno = owner?.rootIno ?? this.entityProjectionRootForInode(ino);
+    const owner = this.#entityProjectionOpenOwners.get(ino);
+    const rootIno = owner?.rootIno ?? this.#entityProjectionRootForInode(ino);
     if (rootIno === undefined) return;
     if (owner === undefined) {
-      this.indexEntityProjectionOwner(
-        this.entityProjectionOpenOwnerInodes,
+      this.#indexEntityProjectionOwner(
+        this.#entityProjectionOpenOwnerInodes,
         rootIno,
         ino,
       );
     }
-    this.entityProjectionOpenOwners.set(ino, {
+    this.#entityProjectionOpenOwners.set(ino, {
       rootIno,
       count: (owner?.count ?? 0) + 1,
     });
-    this.entityProjectionOpenRefs.set(
+    this.#entityProjectionOpenRefs.set(
       rootIno,
-      (this.entityProjectionOpenRefs.get(rootIno) ?? 0) + 1,
+      (this.#entityProjectionOpenRefs.get(rootIno) ?? 0) + 1,
     );
     this.entityProjectionEvictionCandidates.delete(rootIno);
   }
 
   releaseEntityProjectionOpen(ino: bigint): void {
-    const owner = this.entityProjectionOpenOwners.get(ino);
+    const owner = this.#entityProjectionOpenOwners.get(ino);
     if (owner === undefined) return;
     if (owner.count > 1) {
-      this.entityProjectionOpenOwners.set(ino, {
+      this.#entityProjectionOpenOwners.set(ino, {
         rootIno: owner.rootIno,
         count: owner.count - 1,
       });
     } else {
-      this.entityProjectionOpenOwners.delete(ino);
-      this.unindexEntityProjectionOwner(
-        this.entityProjectionOpenOwnerInodes,
+      this.#entityProjectionOpenOwners.delete(ino);
+      this.#unindexEntityProjectionOwner(
+        this.#entityProjectionOpenOwnerInodes,
         owner.rootIno,
         ino,
       );
     }
-    const remaining = (this.entityProjectionOpenRefs.get(owner.rootIno) ?? 0) -
+    const remaining = (this.#entityProjectionOpenRefs.get(owner.rootIno) ?? 0) -
       1;
     if (remaining > 0) {
-      this.entityProjectionOpenRefs.set(owner.rootIno, remaining);
+      this.#entityProjectionOpenRefs.set(owner.rootIno, remaining);
     } else {
-      this.entityProjectionOpenRefs.delete(owner.rootIno);
+      this.#entityProjectionOpenRefs.delete(owner.rootIno);
     }
-    this.finishPendingEntityRemoval(owner.rootIno);
-    this.refreshEntityProjectionEvictionCandidate(owner.rootIno);
-    this.trimEntityProjectionCache();
+    this.#finishPendingEntityRemoval(owner.rootIno);
+    this.#refreshEntityProjectionEvictionCandidate(owner.rootIno);
+    this.#trimEntityProjectionCache();
   }
 
-  private indexEntityProjectionOwner(
+  #indexEntityProjectionOwner(
     index: Map<bigint, Set<bigint>>,
     rootIno: bigint,
     ino: bigint,
@@ -1179,7 +1250,7 @@ export class CellBridge {
     inodes.add(ino);
   }
 
-  private unindexEntityProjectionOwner(
+  #unindexEntityProjectionOwner(
     index: Map<bigint, Set<bigint>>,
     rootIno: bigint,
     ino: bigint,
@@ -1190,55 +1261,57 @@ export class CellBridge {
     if (inodes.size === 0) index.delete(rootIno);
   }
 
-  private clearEntityProjectionReferences(rootIno: bigint): void {
+  #clearEntityProjectionReferences(rootIno: bigint): void {
     this.entityProjectionLookupRefs.delete(rootIno);
-    this.entityProjectionOpenRefs.delete(rootIno);
+    this.#entityProjectionOpenRefs.delete(rootIno);
     for (
-      const ino of this.entityProjectionLookupOwnerInodes.get(rootIno) ??
+      const ino of this.#entityProjectionLookupOwnerInodes.get(rootIno) ??
         []
     ) {
       this.entityProjectionLookupOwners.delete(ino);
     }
-    this.entityProjectionLookupOwnerInodes.delete(rootIno);
-    for (const ino of this.entityProjectionOpenOwnerInodes.get(rootIno) ?? []) {
-      this.entityProjectionOpenOwners.delete(ino);
+    this.#entityProjectionLookupOwnerInodes.delete(rootIno);
+    for (
+      const ino of this.#entityProjectionOpenOwnerInodes.get(rootIno) ?? []
+    ) {
+      this.#entityProjectionOpenOwners.delete(ino);
     }
-    this.entityProjectionOpenOwnerInodes.delete(rootIno);
+    this.#entityProjectionOpenOwnerInodes.delete(rootIno);
   }
 
-  private isEntityProjectionDirectory(ino: bigint): boolean {
-    if (this.isEntityProjectionRoot(ino)) return true;
-    const prop = this.piecePropRoots.get(ino);
-    return prop !== undefined && this.isEntityProjectionRoot(prop.pieceIno);
+  #isEntityProjectionDirectory(ino: bigint): boolean {
+    if (this.#isEntityProjectionRoot(ino)) return true;
+    const prop = this.#piecePropRoots.get(ino);
+    return prop !== undefined && this.#isEntityProjectionRoot(prop.pieceIno);
   }
 
   shouldPrepareLookup(parentIno: bigint, name: string): boolean {
-    if (this.stateForPiecesDir(parentIno)) return true;
+    if (this.#stateForPiecesDir(parentIno)) return true;
     if (name.startsWith(".") && name !== ".handlers") return false;
     if (this.isEntitiesDir(parentIno)) return true;
     if (this.unhydratedEntityRoots.has(parentIno)) return true;
-    if (this.pieceRoots.has(parentIno)) return true;
-    if (this.piecePropRoots.has(parentIno)) return true;
+    if (this.#pieceRoots.has(parentIno)) return true;
+    if (this.#piecePropRoots.has(parentIno)) return true;
     return false;
   }
 
   shouldPrepareDirectory(ino: bigint): boolean {
-    return this.stateForPiecesDir(ino) !== undefined ||
+    return this.#stateForPiecesDir(ino) !== undefined ||
       this.isEntitiesDir(ino) || this.unhydratedEntityRoots.has(ino) ||
-      this.pieceRoots.has(ino) || this.piecePropRoots.has(ino);
+      this.#pieceRoots.has(ino) || this.#piecePropRoots.has(ino);
   }
 
   shouldSynchronizeLookup(parentIno: bigint): boolean {
-    return this.stateForPiecesDir(parentIno) !== undefined ||
+    return this.#stateForPiecesDir(parentIno) !== undefined ||
       this.isEntitiesDir(parentIno) ||
-      this.isEntityProjectionDirectory(parentIno) ||
-      this.piecePropRoots.has(parentIno);
+      this.#isEntityProjectionDirectory(parentIno) ||
+      this.#piecePropRoots.has(parentIno);
   }
 
   async prepareLookup(parentIno: bigint, name: string): Promise<boolean> {
-    const pieces = this.stateForPiecesDir(parentIno);
+    const pieces = this.#stateForPiecesDir(parentIno);
     if (pieces) {
-      await this.materializePieces(pieces.state, pieces.spaceName);
+      await this.#materializePieces(pieces.state, pieces.spaceName);
       return this.tree.lookup(parentIno, name) !== undefined;
     }
 
@@ -1247,10 +1320,10 @@ export class CellBridge {
     }
 
     if (this.unhydratedEntityRoots.has(parentIno)) {
-      if (!await this.hydrateEntityRoot(parentIno)) return false;
+      if (!await this.#hydrateEntityRoot(parentIno)) return false;
     }
 
-    const pieceInfo = this.getPieceInfo(parentIno);
+    const pieceInfo = this.#getPieceInfo(parentIno);
     if (pieceInfo) {
       if (name === "input" || name === "input.json") {
         await this.hydratePieceProp(parentIno, "input");
@@ -1266,7 +1339,7 @@ export class CellBridge {
       return this.tree.lookup(parentIno, name) !== undefined;
     }
 
-    const propInfo = this.piecePropRoots.get(parentIno);
+    const propInfo = this.#piecePropRoots.get(parentIno);
     if (propInfo) {
       await this.hydratePieceProp(propInfo.pieceIno, propInfo.propName);
       return true;
@@ -1282,7 +1355,7 @@ export class CellBridge {
   ): Promise<bigint | undefined> {
     let ino: bigint | undefined;
     if (this.isEntitiesDir(parentIno)) {
-      return await this.resolveEntityInode(parentIno, name, true);
+      return await this.#resolveEntityInode(parentIno, name, true);
     } else {
       if (!await this.prepareLookup(parentIno, name)) return undefined;
       ino = this.tree.lookup(parentIno, name);
@@ -1295,29 +1368,29 @@ export class CellBridge {
   }
 
   async prepareDirectory(ino: bigint): Promise<boolean> {
-    const pieces = this.stateForPiecesDir(ino);
+    const pieces = this.#stateForPiecesDir(ino);
     if (pieces) {
-      await this.materializePieces(pieces.state, pieces.spaceName);
+      await this.#materializePieces(pieces.state, pieces.spaceName);
       return true;
     }
 
-    const entities = this.stateForEntitiesDir(ino);
+    const entities = this.#stateForEntitiesDir(ino);
     if (entities) {
       return true;
     }
 
-    if (this.isEntityProjectionDirectory(ino)) {
+    if (this.#isEntityProjectionDirectory(ino)) {
       return true;
     }
 
-    const pieceInfo = this.getPieceInfo(ino);
+    const pieceInfo = this.#getPieceInfo(ino);
     if (pieceInfo) {
       await this.hydratePieceProp(ino, "input");
       await this.hydratePieceProp(ino, "result");
       return true;
     }
 
-    const propInfo = this.piecePropRoots.get(ino);
+    const propInfo = this.#piecePropRoots.get(ino);
     if (propInfo) {
       await this.hydratePieceProp(propInfo.pieceIno, propInfo.propName);
       return true;
@@ -1329,12 +1402,12 @@ export class CellBridge {
   async prepareDirectorySnapshot(
     ino: bigint,
   ): Promise<readonly DirectorySnapshotEntry[] | undefined> {
-    const entities = this.stateForEntitiesDir(ino);
+    const entities = this.#stateForEntitiesDir(ino);
     if (entities) {
-      return await this.entityDirectorySnapshot(entities.state);
+      return await this.#entityDirectorySnapshot(entities.state);
     }
 
-    if (this.isEntityProjectionDirectory(ino)) {
+    if (this.#isEntityProjectionDirectory(ino)) {
       return collectVirtualDirectorySnapshot(this.tree, ino, []);
     }
 
@@ -1517,7 +1590,7 @@ export class CellBridge {
     const space = this.spaces.get(parsed.spaceName);
     if (!space) return null;
 
-    const piece = this.resolvePieceController(space, parsed);
+    const piece = this.#resolvePieceController(space, parsed);
     if (!piece) return null;
 
     return {
@@ -1540,7 +1613,7 @@ export class CellBridge {
     await target.piece.pieces().synced();
   }
 
-  private resolvePieceController(
+  #resolvePieceController(
     space: SpaceState,
     parsed: ReturnType<typeof parseMountedCallablePath>,
   ): PieceController | undefined {
@@ -1566,14 +1639,14 @@ export class CellBridge {
     return undefined;
   }
 
-  private propRebuildKey(
+  #propRebuildKey(
     pieceIno: bigint,
     propName: "input" | "result",
   ): string {
     return `${pieceIno}:${propName}`;
   }
 
-  private schedulePropRebuild(args: {
+  #schedulePropRebuild(args: {
     cell: Cell<unknown>;
     newValue: unknown;
     pieceId: string;
@@ -1583,17 +1656,17 @@ export class CellBridge {
     resolveLink: ResolveLink;
     spaceName: string;
   }): void {
-    const key = this.propRebuildKey(args.pieceIno, args.propName);
-    const pending = this.pendingPropRebuilds.get(key);
+    const key = this.#propRebuildKey(args.pieceIno, args.propName);
+    const pending = this.#pendingPropRebuilds.get(key);
     if (pending) {
       pending.latestValue = args.newValue;
       pending.pieceName = args.pieceName;
-      this.rebuildStats.coalesced++;
+      this.#rebuildStats.coalesced++;
       return;
     }
 
-    if (this.activePropRebuilds.has(key)) {
-      this.deferredPropRebuilds.set(key, {
+    if (this.#activePropRebuilds.has(key)) {
+      this.#deferredPropRebuilds.set(key, {
         cell: args.cell,
         newValue: args.newValue,
         pieceId: args.pieceId,
@@ -1603,17 +1676,17 @@ export class CellBridge {
         resolveLink: args.resolveLink,
         spaceName: args.spaceName,
       });
-      this.rebuildStats.coalesced++;
-      this.rebuildStats.maxPending = Math.max(
-        this.rebuildStats.maxPending,
-        this.pendingPropRebuilds.size +
-          this.activePropRebuilds.size +
-          this.deferredPropRebuilds.size,
+      this.#rebuildStats.coalesced++;
+      this.#rebuildStats.maxPending = Math.max(
+        this.#rebuildStats.maxPending,
+        this.#pendingPropRebuilds.size +
+          this.#activePropRebuilds.size +
+          this.#deferredPropRebuilds.size,
       );
       return;
     }
 
-    this.rebuildStats.scheduled++;
+    this.#rebuildStats.scheduled++;
     const entry = {
       cell: args.cell,
       latestValue: args.newValue,
@@ -1624,8 +1697,8 @@ export class CellBridge {
       resolveLink: args.resolveLink,
       spaceName: args.spaceName,
       timer: setTimeout(() => {
-        this.pendingPropRebuilds.delete(key);
-        this.activePropRebuilds.add(key);
+        this.#pendingPropRebuilds.delete(key);
+        this.#activePropRebuilds.add(key);
         void this.enqueuePiecePropRebuild({
           cell: entry.cell,
           newValue: entry.latestValue,
@@ -1636,26 +1709,26 @@ export class CellBridge {
           resolveLink: entry.resolveLink,
           spaceName: entry.spaceName,
         }).catch((e) => {
-          this.rebuildStats.errors++;
+          this.#rebuildStats.errors++;
           console.error(
             `[${entry.spaceName}] Error rebuilding ${entry.pieceName}/${entry.propName}: ${e}`,
           );
         }).finally(() => {
-          this.activePropRebuilds.delete(key);
-          const deferred = this.deferredPropRebuilds.get(key);
-          this.deferredPropRebuilds.delete(key);
+          this.#activePropRebuilds.delete(key);
+          const deferred = this.#deferredPropRebuilds.get(key);
+          this.#deferredPropRebuilds.delete(key);
           if (deferred) {
-            this.schedulePropRebuild(deferred);
+            this.#schedulePropRebuild(deferred);
           }
         });
       }, 0),
     };
-    this.pendingPropRebuilds.set(key, entry);
-    this.rebuildStats.maxPending = Math.max(
-      this.rebuildStats.maxPending,
-      this.pendingPropRebuilds.size +
-        this.activePropRebuilds.size +
-        this.deferredPropRebuilds.size,
+    this.#pendingPropRebuilds.set(key, entry);
+    this.#rebuildStats.maxPending = Math.max(
+      this.#rebuildStats.maxPending,
+      this.#pendingPropRebuilds.size +
+        this.#activePropRebuilds.size +
+        this.#deferredPropRebuilds.size,
     );
   }
 
@@ -1673,7 +1746,7 @@ export class CellBridge {
    * This runs synchronously, so no filesystem request observes a half-swapped
    * tree.
    */
-  private swapPending(
+  #swapPending(
     parentIno: bigint,
     liveName: string,
     pendingName: string,
@@ -1685,7 +1758,7 @@ export class CellBridge {
     if (pendingIno === undefined) {
       if (oldIno !== undefined) {
         this.tree.clear(oldIno);
-        this.recordEntryChange(changes, parentIno, liveName);
+        this.#recordEntryChange(changes, parentIno, liveName);
       }
       return;
     }
@@ -1696,7 +1769,7 @@ export class CellBridge {
     if (oldNode && pendingNode && oldNode.kind === pendingNode.kind) {
       // Same path, same kind: the live inode survives, so its entry under the
       // parent is unchanged and is left cached.
-      this.mergeTransplantChanges(
+      this.#mergeTransplantChanges(
         changes,
         this.tree.transplantSubtree(oldIno!, pendingIno),
       );
@@ -1710,11 +1783,11 @@ export class CellBridge {
       if (movedIno !== undefined) {
         annotator?.annotateEntry(parentIno, liveName, movedIno);
       }
-      this.recordEntryChange(changes, parentIno, liveName);
+      this.#recordEntryChange(changes, parentIno, liveName);
     }
   }
 
-  private recordEntryChange(
+  #recordEntryChange(
     changes: TransplantChanges,
     parentIno: bigint,
     name: string,
@@ -1727,7 +1800,7 @@ export class CellBridge {
     names.add(name);
   }
 
-  private mergeTransplantChanges(
+  #mergeTransplantChanges(
     into: TransplantChanges,
     from: TransplantChanges,
   ): void {
@@ -1736,7 +1809,7 @@ export class CellBridge {
     }
     for (const [parentIno, names] of from.entryChanges) {
       for (const name of names) {
-        this.recordEntryChange(into, parentIno, name);
+        this.#recordEntryChange(into, parentIno, name);
       }
     }
   }
@@ -1747,7 +1820,7 @@ export class CellBridge {
    * left untouched stay cached, so a client that walked into the piece does
    * not have its cached dentries invalidated by an unrelated rebuild.
    */
-  private emitInvalidations(changes: TransplantChanges): void {
+  #emitInvalidations(changes: TransplantChanges): void {
     if (this.onInvalidateInode) {
       for (const ino of changes.changedInodes) {
         this.onInvalidateInode(ino);
@@ -1766,7 +1839,7 @@ export class CellBridge {
    * (same name, new inode) does not count while a prop appearing or an
    * `index.md` replacing the result tree does.
    */
-  private touchPieceDirIfEntriesChanged(
+  #touchPieceDirIfEntriesChanged(
     pieceIno: bigint,
     namesBefore: Set<string>,
   ): void {
@@ -1785,14 +1858,18 @@ export class CellBridge {
    * arrives: the mounted tree is rebuilt in place rather than torn down, so
    * this is all the reactive path needs to stay consistent.
    */
-  private bumpHydrationEpoch(
+  #bumpHydrationEpoch(
     rootIno: bigint,
     propName: "input" | "result",
   ): void {
     const key = `${rootIno}-${propName}`;
-    this.hydrationEpochs.set(key, (this.hydrationEpochs.get(key) ?? 0) + 1);
+    this.#hydrationEpochs.set(key, (this.#hydrationEpochs.get(key) ?? 0) + 1);
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async rebuildPieceProp(args: {
     cell: Cell<unknown>;
     newValue: unknown;
@@ -1823,8 +1900,8 @@ export class CellBridge {
     const jsonIno = this.tree.lookup(pieceIno, `${propName}.json`);
     const pendingPropName = `.${propName}.pending`;
     const pendingJsonName = `${pendingPropName}.json`;
-    const rootInfo = this.pieceRoots.get(pieceIno);
-    const labelView = this.cfcLabelViewForCell(cell);
+    const rootInfo = this.#pieceRoots.get(pieceIno);
+    const labelView = this.#cfcLabelViewForCell(cell);
     const pendingIno = this.tree.lookup(pieceIno, pendingPropName);
     if (pendingIno !== undefined) {
       this.tree.clear(pendingIno);
@@ -1834,8 +1911,8 @@ export class CellBridge {
       this.tree.clear(pendingJsonIno);
     }
 
-    const treeValue = this.materializeTreeValue(cell, newValue);
-    const cfcAnnotator = this.makeCfcAnnotator({
+    const treeValue = this.#materializeTreeValue(cell, newValue);
+    const cfcAnnotator = this.#makeCfcAnnotator({
       spaceName,
       pieceId,
       rootKind: rootInfo?.rootKind ?? "pieces",
@@ -1868,19 +1945,19 @@ export class CellBridge {
         callables: discoveredCallables,
         classifyEntry,
         skipEntry,
-      } = this.discoverCallableEntries(cell, treeValue);
+      } = this.#discoverCallableEntries(cell, treeValue);
       callables = discoveredCallables;
 
       if (propName === "result") {
-        const fsValue = this.readFsValue(cell, treeValue);
+        const fsValue = this.#readFsValue(cell, treeValue);
         if (fsValue !== null) {
-          this.markPiecePropCleared(pieceIno, propName);
+          this.#markPiecePropCleared(pieceIno, propName);
 
           // The projection entries currently at the piece root; a rebuild
           // adopts the ones that survive with the same kind and removes the
           // rest.
           const oldFsNames = new Set<string>(
-            this.fsProjectionEntries.get(pieceIno) ?? [],
+            this.#fsProjectionEntries.get(pieceIno) ?? [],
           );
           oldFsNames.add("index.md");
           oldFsNames.add("index.json");
@@ -1889,11 +1966,11 @@ export class CellBridge {
           // the result directory and its .json sibling.
           if (existingIno !== undefined) {
             this.tree.clear(existingIno);
-            this.recordEntryChange(changes, pieceIno, propName);
+            this.#recordEntryChange(changes, pieceIno, propName);
           }
           if (jsonIno !== undefined) {
             this.tree.clear(jsonIno);
-            this.recordEntryChange(changes, pieceIno, `${propName}.json`);
+            this.#recordEntryChange(changes, pieceIno, `${propName}.json`);
           }
 
           // Build the projection under a staging container, then reconcile it
@@ -1903,7 +1980,7 @@ export class CellBridge {
             this.tree.clear(staleStage);
           }
           const stageIno = this.tree.addDir(pieceIno, ".fs.pending");
-          this.buildFsProjectionTree(
+          this.#buildFsProjectionTree(
             stageIno,
             pieceId,
             fsValue,
@@ -1914,22 +1991,22 @@ export class CellBridge {
             classifyEntry,
             cfcAnnotator,
           );
-          const newFsNames = this.swapFsProjection(
+          const newFsNames = this.#swapFsProjection(
             pieceIno,
             stageIno,
             oldFsNames,
             changes,
             cfcAnnotator,
           );
-          this.fsProjectionEntries.set(pieceIno, newFsNames);
+          this.#fsProjectionEntries.set(pieceIno, newFsNames);
 
-          this.buildHandlersFile(pieceIno, callables, cfcAnnotator);
-          this.recordEntryChange(changes, pieceIno, ".handlers");
+          this.#buildHandlersFile(pieceIno, callables, cfcAnnotator);
+          this.#recordEntryChange(changes, pieceIno, ".handlers");
 
           const state = this.spaces.get(spaceName);
           if (state) {
-            const summaryChanged = this.updatePieceManifest(state, pieceId, {
-              summary: this.extractSummary(treeValue),
+            const summaryChanged = this.#updatePieceManifest(state, pieceId, {
+              summary: this.#extractSummary(treeValue),
             });
             if (summaryChanged) {
               this.updatePiecesJson(state);
@@ -1938,12 +2015,12 @@ export class CellBridge {
               }
             }
           }
-          this.touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
-          this.emitInvalidations(changes);
-          this.markPiecePropHydrated(pieceIno, "result");
-          this.rebuildStats.completed++;
-          this.rebuildStats.lastDurationMs = Date.now() - startedAt;
-          this.noteCfcProjectionRebuilt();
+          this.#touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
+          this.#emitInvalidations(changes);
+          this.#markPiecePropHydrated(pieceIno, "result");
+          this.#rebuildStats.completed++;
+          this.#rebuildStats.lastDurationMs = Date.now() - startedAt;
+          this.#noteCfcProjectionRebuilt();
           return;
         }
       }
@@ -1974,19 +2051,19 @@ export class CellBridge {
           classifyEntry,
           cfcAnnotator?.jsonContext([]),
         );
-      this.addCallableFiles(propIno, callables, propName, cfcAnnotator);
+      this.#addCallableFiles(propIno, callables, propName, cfcAnnotator);
       if (propName === "result") {
-        this.addVNodeJsonFiles(propIno, treeValue, cfcAnnotator);
+        this.#addVNodeJsonFiles(propIno, treeValue, cfcAnnotator);
       }
       if (buildRootName === pendingPropName) {
-        this.markPiecePropCleared(pieceIno, propName);
+        this.#markPiecePropCleared(pieceIno, propName);
         if (propName === "result") {
-          this.clearFsProjectionEntries(pieceIno, changes);
+          this.#clearFsProjectionEntries(pieceIno, changes);
         }
         // Reconcile the freshly built staging subtree onto the existing one,
         // reusing the existing inodes rather than swapping in fresh ones, so a
         // path that still exists keeps its inode across the rebuild.
-        this.swapPending(
+        this.#swapPending(
           pieceIno,
           propName,
           pendingPropName,
@@ -1994,7 +2071,7 @@ export class CellBridge {
           changes,
           cfcAnnotator,
         );
-        this.swapPending(
+        this.#swapPending(
           pieceIno,
           `${propName}.json`,
           pendingJsonName,
@@ -2004,45 +2081,45 @@ export class CellBridge {
         );
       } else {
         if (propName === "result") {
-          this.clearFsProjectionEntries(pieceIno, changes);
+          this.#clearFsProjectionEntries(pieceIno, changes);
         }
         // First hydration: the prop directory and its `.json` sibling are new
         // to any cache, so their entries under the piece are invalidated.
-        this.recordEntryChange(changes, pieceIno, propName);
+        this.#recordEntryChange(changes, pieceIno, propName);
         if (this.tree.lookup(pieceIno, `${propName}.json`) !== undefined) {
-          this.recordEntryChange(changes, pieceIno, `${propName}.json`);
+          this.#recordEntryChange(changes, pieceIno, `${propName}.json`);
         }
       }
-      this.markPiecePropHydrated(pieceIno, propName);
+      this.#markPiecePropHydrated(pieceIno, propName);
     } else {
-      this.markPiecePropCleared(pieceIno, propName);
+      this.#markPiecePropCleared(pieceIno, propName);
       if (existingIno !== undefined) {
         this.tree.clear(existingIno);
-        this.recordEntryChange(changes, pieceIno, propName);
+        this.#recordEntryChange(changes, pieceIno, propName);
       }
       if (jsonIno !== undefined) {
         this.tree.clear(jsonIno);
-        this.recordEntryChange(changes, pieceIno, `${propName}.json`);
+        this.#recordEntryChange(changes, pieceIno, `${propName}.json`);
       }
       if (propName === "result") {
-        this.clearFsProjectionEntries(pieceIno, changes);
+        this.#clearFsProjectionEntries(pieceIno, changes);
       }
     }
     if (propName === "result") {
       // `.handlers` is rebuilt on the piece directory, outside the prop
       // subtree the transplant reconciled, so its entry is invalidated here.
-      this.buildHandlersFile(pieceIno, callables, cfcAnnotator);
-      this.recordEntryChange(changes, pieceIno, ".handlers");
+      this.#buildHandlersFile(pieceIno, callables, cfcAnnotator);
+      this.#recordEntryChange(changes, pieceIno, ".handlers");
     }
 
-    this.touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
-    this.emitInvalidations(changes);
+    this.#touchPieceDirIfEntriesChanged(pieceIno, pieceNamesBefore);
+    this.#emitInvalidations(changes);
 
     if (propName === "result") {
       const state = this.spaces.get(spaceName);
       if (state) {
-        const summaryChanged = this.updatePieceManifest(state, pieceId, {
-          summary: this.extractSummary(treeValue),
+        const summaryChanged = this.#updatePieceManifest(state, pieceId, {
+          summary: this.#extractSummary(treeValue),
         });
         if (summaryChanged) {
           this.updatePiecesJson(state);
@@ -2053,50 +2130,58 @@ export class CellBridge {
       }
     }
 
-    this.rebuildStats.completed++;
-    this.rebuildStats.lastDurationMs = Date.now() - startedAt;
-    this.noteCfcProjectionRebuilt();
-    this.debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
+    this.#rebuildStats.completed++;
+    this.#rebuildStats.lastDurationMs = Date.now() - startedAt;
+    this.#noteCfcProjectionRebuilt();
+    this.#debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void> {
-    const key = this.propRebuildKey(args.pieceIno, args.propName);
-    const previous = this.pendingPropRebuildQueues.get(key) ??
+    const key = this.#propRebuildKey(args.pieceIno, args.propName);
+    const previous = this.#pendingPropRebuildQueues.get(key) ??
       Promise.resolve();
     const current = previous.catch(() => {}).then(() =>
       this.rebuildPieceProp(args)
     );
-    this.pendingPropRebuildQueues.set(key, current);
+    this.#pendingPropRebuildQueues.set(key, current);
     try {
       await current;
     } finally {
-      if (this.pendingPropRebuildQueues.get(key) === current) {
-        this.pendingPropRebuildQueues.delete(key);
+      if (this.#pendingPropRebuildQueues.get(key) === current) {
+        this.#pendingPropRebuildQueues.delete(key);
       }
     }
   }
 
-  private static readonly MAX_HYDRATION_RETRIES = 3;
+  static readonly #MAX_HYDRATION_RETRIES = 3;
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private hydratePieceProp(
     pieceIno: bigint,
     propName: "input" | "result",
     retries = 0,
   ): Promise<boolean> {
-    const info = this.getPieceInfo(pieceIno);
+    const info = this.#getPieceInfo(pieceIno);
     if (!info) return Promise.resolve(false);
-    if (this.hydratedPieceProps.get(pieceIno)?.has(propName)) {
+    if (this.#hydratedPieceProps.get(pieceIno)?.has(propName)) {
       return Promise.resolve(true);
     }
 
     const key = `${pieceIno}-${propName}`;
-    const existing = this.pendingHydrations.get(key);
+    const existing = this.#pendingHydrations.get(key);
     if (existing) return existing;
-    const startedEpoch = this.hydrationEpochs.get(key) ?? 0;
+    const startedEpoch = this.#hydrationEpochs.get(key) ?? 0;
 
     const cleanup = () => {
-      if (this.pendingHydrations.get(key) === handle.promise) {
-        this.pendingHydrations.delete(key);
+      if (this.#pendingHydrations.get(key) === handle.promise) {
+        this.#pendingHydrations.delete(key);
       }
     };
     const handle: { promise: Promise<boolean> } = {
@@ -2114,12 +2199,12 @@ export class CellBridge {
             resolveLink: this.makeLinkResolver(info.spaceName),
             spaceName: info.spaceName,
           });
-          const currentEpoch = this.hydrationEpochs.get(key) ?? 0;
+          const currentEpoch = this.#hydrationEpochs.get(key) ?? 0;
           const stillHydrated =
-            this.hydratedPieceProps.get(pieceIno)?.has(propName) ?? false;
+            this.#hydratedPieceProps.get(pieceIno)?.has(propName) ?? false;
           if (currentEpoch !== startedEpoch || !stillHydrated) {
             cleanup();
-            if (retries >= CellBridge.MAX_HYDRATION_RETRIES) {
+            if (retries >= CellBridge.#MAX_HYDRATION_RETRIES) {
               return false;
             }
             return await this.hydratePieceProp(
@@ -2135,23 +2220,23 @@ export class CellBridge {
       })(),
     };
 
-    this.pendingHydrations.set(key, handle.promise);
+    this.#pendingHydrations.set(key, handle.promise);
     return handle.promise;
   }
 
   /** Collect all inode IDs in a subtree (including the root). */
-  private collectDescendantInos(ino: bigint): bigint[] {
+  #collectDescendantInos(ino: bigint): bigint[] {
     const result: bigint[] = [ino];
     const node = this.tree.getNode(ino);
     if (node?.kind === "dir") {
       for (const [, childIno] of this.tree.getChildren(ino)) {
-        result.push(...this.collectDescendantInos(childIno));
+        result.push(...this.#collectDescendantInos(childIno));
       }
     }
     return result;
   }
 
-  private invalidateRootPropCache(
+  #invalidateRootPropCache(
     rootIno: bigint,
     propName: "input" | "result",
   ): boolean {
@@ -2159,8 +2244,8 @@ export class CellBridge {
 
     const invalidatedNames = new Set<string>([propName, `${propName}.json`]);
     const key = `${rootIno}-${propName}`;
-    this.hydrationEpochs.set(key, (this.hydrationEpochs.get(key) ?? 0) + 1);
-    this.markPiecePropCleared(rootIno, propName);
+    this.#hydrationEpochs.set(key, (this.#hydrationEpochs.get(key) ?? 0) + 1);
+    this.#markPiecePropCleared(rootIno, propName);
 
     // Collect all descendant inodes BEFORE clearing (tree.clear removes
     // them), so the invalidation below can name every inode whose cached
@@ -2168,7 +2253,7 @@ export class CellBridge {
     const staleInos: bigint[] = [];
     const propIno = this.tree.lookup(rootIno, propName);
     if (propIno !== undefined) {
-      staleInos.push(...this.collectDescendantInos(propIno));
+      staleInos.push(...this.#collectDescendantInos(propIno));
       this.tree.clear(propIno);
     }
     const jsonIno = this.tree.lookup(rootIno, `${propName}.json`);
@@ -2176,20 +2261,20 @@ export class CellBridge {
       staleInos.push(jsonIno);
       this.tree.clear(jsonIno);
     }
-    this.ensurePiecePropStub(rootIno, propName);
+    this.#ensurePiecePropStub(rootIno, propName);
 
     if (propName === "result") {
-      const fsEntries = this.fsProjectionEntries.get(rootIno);
+      const fsEntries = this.#fsProjectionEntries.get(rootIno);
       if (fsEntries) {
         for (const name of fsEntries) {
           invalidatedNames.add(name);
           const fsIno = this.tree.lookup(rootIno, name);
           if (fsIno !== undefined) {
-            staleInos.push(...this.collectDescendantInos(fsIno));
+            staleInos.push(...this.#collectDescendantInos(fsIno));
           }
         }
       }
-      this.clearFsProjectionEntries(rootIno);
+      this.#clearFsProjectionEntries(rootIno);
 
       const handlersIno = this.tree.lookup(rootIno, ".handlers");
       if (handlersIno !== undefined) {
@@ -2211,7 +2296,7 @@ export class CellBridge {
     return true;
   }
 
-  private invalidatePieceIdPropCache(
+  #invalidatePieceIdPropCache(
     pieceId: string,
     propName: "input" | "result",
   ): void {
@@ -2220,7 +2305,7 @@ export class CellBridge {
         if (id !== pieceId) continue;
         const pieceIno = state.pieceInos.get(name);
         if (pieceIno !== undefined) {
-          this.invalidateRootPropCache(pieceIno, propName);
+          this.#invalidateRootPropCache(pieceIno, propName);
         }
       }
 
@@ -2229,13 +2314,13 @@ export class CellBridge {
         encodeFuseComponent(pieceId),
       );
       if (entityIno !== undefined) {
-        this.invalidateRootPropCache(entityIno, propName);
+        this.#invalidateRootPropCache(entityIno, propName);
       }
     }
   }
 
   invalidateWritePath(writePath: WritePath): void {
-    this.invalidatePieceIdPropCache(writePath.piece.id, writePath.cell);
+    this.#invalidatePieceIdPropCache(writePath.piece.id, writePath.cell);
   }
 
   async finalizeWritePath(writePath: WritePath): Promise<void> {
@@ -2277,7 +2362,7 @@ export class CellBridge {
   }
 
   invalidateHandlerTarget(target: HandlerTarget): void {
-    this.invalidatePieceIdPropCache(target.piece.id, target.cellProp);
+    this.#invalidatePieceIdPropCache(target.piece.id, target.cellProp);
   }
 
   /**
@@ -2453,7 +2538,7 @@ export class CellBridge {
   }
 
   /** Update the root .spaces.json file. */
-  private updateSpacesJson(): void {
+  #updateSpacesJson(): void {
     const obj: Record<string, string> = {};
     for (const [name, did] of this.knownSpaces) {
       obj[name] = did;
@@ -2470,12 +2555,12 @@ export class CellBridge {
       JSON.stringify(obj, null, 2),
       "object",
     );
-    const annotator = this.makeCfcAnnotator({
+    const annotator = this.#makeCfcAnnotator({
       spaceName: "common-fabric:mount",
       spaceDid: "common-fabric:mount",
       value: obj,
     });
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       annotator,
       spacesIno,
       "space-meta",
@@ -2483,6 +2568,10 @@ export class CellBridge {
     );
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private buildSpaceTree(
     spaceName: string,
     pieces: PiecesController,
@@ -2498,18 +2587,18 @@ export class CellBridge {
     // space.json: DID + name
     const spaceDid = pieces.getSpace();
     const spaceMeta = { did: spaceDid, name: spaceName };
-    const spaceAnnotator = this.makeCfcAnnotator({
+    const spaceAnnotator = this.#makeCfcAnnotator({
       spaceName,
       spaceDid,
       value: spaceMeta,
     });
-    const piecesAnnotator = this.makeCfcAnnotator({
+    const piecesAnnotator = this.#makeCfcAnnotator({
       spaceName,
       spaceDid,
       rootKind: "pieces",
       value: { rootKind: "pieces" },
     });
-    const entitiesAnnotator = this.makeCfcAnnotator({
+    const entitiesAnnotator = this.#makeCfcAnnotator({
       spaceName,
       spaceDid,
       rootKind: "entities",
@@ -2527,7 +2616,7 @@ export class CellBridge {
       JSON.stringify(spaceMeta, null, 2),
       "object",
     );
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       spaceAnnotator,
       spaceJsonIno,
       "space-meta",
@@ -2561,7 +2650,7 @@ export class CellBridge {
     return state;
   }
 
-  private stateForEntitiesDir(
+  #stateForEntitiesDir(
     ino: bigint,
   ): { state: SpaceState; spaceName: string } | undefined {
     for (const [spaceName, state] of this.spaces) {
@@ -2570,7 +2659,7 @@ export class CellBridge {
     return undefined;
   }
 
-  private stateForPiecesDir(
+  #stateForPiecesDir(
     ino: bigint,
   ): { state: SpaceState; spaceName: string } | undefined {
     for (const [spaceName, state] of this.spaces) {
@@ -2579,7 +2668,7 @@ export class CellBridge {
     return undefined;
   }
 
-  private materializePieces(
+  #materializePieces(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
@@ -2590,8 +2679,8 @@ export class CellBridge {
     const pending = (async () => {
       state.piecesMaterializing = true;
       try {
-        await this.subscribePieceList(state, spaceName);
-        await this.syncPieceList(state, spaceName);
+        await this.#subscribePieceList(state, spaceName);
+        await this.#syncPieceList(state, spaceName);
         state.piecesHydrated = true;
       } finally {
         state.piecesMaterializing = false;
@@ -2605,7 +2694,7 @@ export class CellBridge {
     return pending;
   }
 
-  private async subscribePieceList(
+  async #subscribePieceList(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
@@ -2614,7 +2703,7 @@ export class CellBridge {
     const piecesCell = await state.pieces.getPieceRegistry();
     const piecesListCancel = piecesCell.sink(() => {
       setTimeout(() => {
-        this.syncPieceList(state, spaceName).catch((e) => {
+        this.#syncPieceList(state, spaceName).catch((e) => {
           console.error(`[${spaceName}] Piece list sync error: ${e}`);
         });
       }, 0);
@@ -2623,7 +2712,7 @@ export class CellBridge {
     state.pieceListSubscribed = true;
   }
 
-  private ensureEntityProjection(
+  #ensureEntityProjection(
     state: SpaceState,
     spaceName: string,
     entityId: string,
@@ -2632,16 +2721,16 @@ export class CellBridge {
     const info = { state, spaceName, entityId };
     const existingIno = this.tree.lookup(state.entitiesIno, entityName);
     if (existingIno !== undefined) {
-      if (!this.pieceRoots.has(existingIno)) {
+      if (!this.#pieceRoots.has(existingIno)) {
         this.unhydratedEntityRoots.set(existingIno, info);
       }
       state.entityIds.add(entityId);
-      this.touchEntityProjection(existingIno, info);
+      this.#touchEntityProjection(existingIno, info);
       return existingIno;
     }
 
     const entityIno = this.tree.addDir(state.entitiesIno, entityName);
-    const annotator = this.makeCfcAnnotator({
+    const annotator = this.#makeCfcAnnotator({
       spaceName,
       spaceDid: state.did,
       pieceId: entityId,
@@ -2652,11 +2741,11 @@ export class CellBridge {
     annotator?.annotateEntry(state.entitiesIno, entityName, entityIno);
     this.unhydratedEntityRoots.set(entityIno, info);
     state.entityIds.add(entityId);
-    this.touchEntityProjection(entityIno, info);
+    this.#touchEntityProjection(entityIno, info);
     return entityIno;
   }
 
-  private touchEntityProjection(
+  #touchEntityProjection(
     ino: bigint,
     info: UnhydratedEntityRootInfo,
   ): void {
@@ -2664,26 +2753,26 @@ export class CellBridge {
     this.entityProjectionLru.set(ino, info);
     this.entityProjectionUseOrder.set(
       ino,
-      ++this.nextEntityProjectionUseOrder,
+      ++this.#nextEntityProjectionUseOrder,
     );
-    this.refreshEntityProjectionEvictionCandidate(ino);
-    this.trimEntityProjectionCache(ino);
+    this.#refreshEntityProjectionEvictionCandidate(ino);
+    this.#trimEntityProjectionCache(ino);
   }
 
-  private refreshEntityProjectionEvictionCandidate(ino: bigint): void {
+  #refreshEntityProjectionEvictionCandidate(ino: bigint): void {
     this.entityProjectionEvictionCandidates.delete(ino);
     const info = this.entityProjectionLru.get(ino);
     if (
       info === undefined || this.pendingEntityHydrations.has(ino) ||
-      this.entityProjectionHasReferences(ino)
+      this.#entityProjectionHasReferences(ino)
     ) {
       return;
     }
     this.entityProjectionEvictionCandidates.set(ino, info);
   }
 
-  private trimEntityProjectionCache(protectedIno?: bigint): void {
-    while (this.entityProjectionLru.size > this.maxEntityProjections) {
+  #trimEntityProjectionCache(protectedIno?: bigint): void {
+    while (this.entityProjectionLru.size > this.#maxEntityProjections) {
       let oldestIno: bigint | undefined;
       let oldestInfo: UnhydratedEntityRootInfo | undefined;
       let oldestUseOrder = Number.POSITIVE_INFINITY;
@@ -2697,27 +2786,27 @@ export class CellBridge {
         }
       }
       if (oldestIno === undefined || oldestInfo === undefined) return;
-      this.removeEntityProjection(oldestInfo.state, oldestInfo.entityId);
+      this.#removeEntityProjection(oldestInfo.state, oldestInfo.entityId);
     }
   }
 
-  private entityProjectionHasReferences(ino: bigint): boolean {
+  #entityProjectionHasReferences(ino: bigint): boolean {
     return (this.entityProjectionLookupRefs.get(ino) ?? 0n) > 0n ||
-      (this.entityProjectionOpenRefs.get(ino) ?? 0) > 0;
+      (this.#entityProjectionOpenRefs.get(ino) ?? 0) > 0;
   }
 
-  private cancelEntitySubscriptions(ino: bigint): void {
+  #cancelEntitySubscriptions(ino: bigint): void {
     const subscriptions = this.entitySubscriptions.get(ino);
     if (!subscriptions) return;
     this.entitySubscriptions.delete(ino);
     for (const cancel of subscriptions) cancel();
   }
 
-  private finishPendingEntityRemoval(ino: bigint): void {
+  #finishPendingEntityRemoval(ino: bigint): void {
     const info = this.pendingEntityRemovals.get(ino);
     if (
       !info || this.pendingEntityHydrations.has(ino) ||
-      this.entityProjectionHasReferences(ino)
+      this.#entityProjectionHasReferences(ino)
     ) {
       return;
     }
@@ -2727,10 +2816,10 @@ export class CellBridge {
     this.entityProjectionEvictionCandidates.delete(ino);
     this.entityProjectionUseOrder.delete(ino);
     this.unhydratedEntityRoots.delete(ino);
-    this.cancelEntitySubscriptions(ino);
-    this.unregisterPieceRoot(ino);
-    this.fsProjectionEntries.delete(ino);
-    this.clearEntityProjectionReferences(ino);
+    this.#cancelEntitySubscriptions(ino);
+    this.#unregisterPieceRoot(ino);
+    this.#fsProjectionEntries.delete(ino);
+    this.#clearEntityProjectionReferences(ino);
     this.tree.clear(ino);
 
     const currentIno = this.tree.lookup(
@@ -2742,7 +2831,7 @@ export class CellBridge {
     }
   }
 
-  private removeEntityProjection(
+  #removeEntityProjection(
     state: SpaceState,
     entityId: string,
     invalidate = true,
@@ -2757,14 +2846,14 @@ export class CellBridge {
     const info = this.entityProjectionLru.get(entityIno) ??
       this.unhydratedEntityRoots.get(entityIno) ?? {
       state,
-      spaceName: this.pieceRoots.get(entityIno)?.spaceName ?? "",
+      spaceName: this.#pieceRoots.get(entityIno)?.spaceName ?? "",
       entityId,
     };
     this.entityProjectionLru.delete(entityIno);
     this.entityProjectionEvictionCandidates.delete(entityIno);
     this.entityProjectionUseOrder.delete(entityIno);
     this.unhydratedEntityRoots.delete(entityIno);
-    this.cancelEntitySubscriptions(entityIno);
+    this.#cancelEntitySubscriptions(entityIno);
     this.pendingEntityRemovals.set(entityIno, info);
     this.tree.detachChild(state.entitiesIno, entityName);
     state.entityIds.delete(entityId);
@@ -2773,18 +2862,18 @@ export class CellBridge {
       this.onInvalidate?.(state.entitiesIno, [entityName]);
       this.onInvalidateInode?.(state.entitiesIno);
     }
-    this.finishPendingEntityRemoval(entityIno);
+    this.#finishPendingEntityRemoval(entityIno);
     return entityName;
   }
 
-  private pruneEntityProjections(
+  #pruneEntityProjections(
     state: SpaceState,
     sortedLiveIds: readonly string[],
   ): void {
     const removed: string[] = [];
     for (const entityId of [...state.entityIds]) {
-      if (this.sortedEntityIdsInclude(sortedLiveIds, entityId)) continue;
-      const name = this.removeEntityProjection(state, entityId, false);
+      if (this.#sortedEntityIdsInclude(sortedLiveIds, entityId)) continue;
+      const name = this.#removeEntityProjection(state, entityId, false);
       if (name !== undefined) removed.push(name);
     }
     if (removed.length > 0) {
@@ -2794,7 +2883,7 @@ export class CellBridge {
     }
   }
 
-  private sortedEntityIdsInclude(
+  #sortedEntityIdsInclude(
     sortedIds: readonly string[],
     target: string,
   ): boolean {
@@ -2810,25 +2899,25 @@ export class CellBridge {
     return false;
   }
 
-  private entityDirectorySnapshot(
+  #entityDirectorySnapshot(
     state: SpaceState,
   ): Promise<readonly DirectorySnapshotEntry[]> {
-    const existing = this.pendingEntityDirectorySnapshots.get(state);
+    const existing = this.#pendingEntityDirectorySnapshots.get(state);
     if (existing) return existing;
-    const pending = this.loadEntityDirectorySnapshot(state).finally(() => {
-      if (this.pendingEntityDirectorySnapshots.get(state) === pending) {
-        this.pendingEntityDirectorySnapshots.delete(state);
+    const pending = this.#loadEntityDirectorySnapshot(state).finally(() => {
+      if (this.#pendingEntityDirectorySnapshots.get(state) === pending) {
+        this.#pendingEntityDirectorySnapshots.delete(state);
       }
     });
-    this.pendingEntityDirectorySnapshots.set(state, pending);
+    this.#pendingEntityDirectorySnapshots.set(state, pending);
     return pending;
   }
 
-  private async loadEntityDirectorySnapshot(
+  async #loadEntityDirectorySnapshot(
     state: SpaceState,
   ): Promise<readonly DirectorySnapshotEntry[]> {
-    const ids = await this.listEntityIdsForSnapshot(state);
-    this.pruneEntityProjections(state, ids);
+    const ids = await this.#listEntityIdsForSnapshot(state);
+    this.#pruneEntityProjections(state, ids);
     return collectVirtualDirectorySnapshot(
       this.tree,
       state.entitiesIno,
@@ -2836,7 +2925,7 @@ export class CellBridge {
     );
   }
 
-  private async listEntityIdsForSnapshot(state: SpaceState): Promise<string[]> {
+  async #listEntityIdsForSnapshot(state: SpaceState): Promise<string[]> {
     if (typeof state.pieces.listEntityIdPage !== "function") {
       throw new Error(
         "memory server does not support paginated entity identifier listing",
@@ -2883,17 +2972,17 @@ export class CellBridge {
     }
   }
 
-  private hydrateEntityRoot(entityIno: bigint): Promise<boolean> {
-    if (this.pieceRoots.has(entityIno)) {
+  #hydrateEntityRoot(entityIno: bigint): Promise<boolean> {
+    if (this.#pieceRoots.has(entityIno)) {
       const info = this.entityProjectionLru.get(entityIno);
-      if (info) this.touchEntityProjection(entityIno, info);
+      if (info) this.#touchEntityProjection(entityIno, info);
       return Promise.resolve(true);
     }
     const existing = this.pendingEntityHydrations.get(entityIno);
     if (existing) return existing;
     const info = this.unhydratedEntityRoots.get(entityIno);
     if (!info) return Promise.resolve(false);
-    this.touchEntityProjection(entityIno, info);
+    this.#touchEntityProjection(entityIno, info);
 
     const pending = (async () => {
       const piece = info.state.entityControllers.get(info.entityId) ??
@@ -2927,9 +3016,9 @@ export class CellBridge {
       if (this.pendingEntityHydrations.get(entityIno) === pending) {
         this.pendingEntityHydrations.delete(entityIno);
       }
-      this.finishPendingEntityRemoval(entityIno);
-      this.refreshEntityProjectionEvictionCandidate(entityIno);
-      this.trimEntityProjectionCache();
+      this.#finishPendingEntityRemoval(entityIno);
+      this.#refreshEntityProjectionEvictionCandidate(entityIno);
+      this.#trimEntityProjectionCache();
     });
     this.pendingEntityHydrations.set(entityIno, pending);
     this.entityProjectionEvictionCandidates.delete(entityIno);
@@ -2946,10 +3035,10 @@ export class CellBridge {
     entitiesIno: bigint,
     entityId: string,
   ): Promise<boolean> {
-    return await this.resolveEntityInode(entitiesIno, entityId) !== undefined;
+    return await this.#resolveEntityInode(entitiesIno, entityId) !== undefined;
   }
 
-  private async resolveEntityInode(
+  async #resolveEntityInode(
     entitiesIno: bigint,
     entityId: string,
     retainForReply = false,
@@ -2959,7 +3048,7 @@ export class CellBridge {
       return undefined;
     }
 
-    const entities = this.stateForEntitiesDir(entitiesIno);
+    const entities = this.#stateForEntitiesDir(entitiesIno);
     if (!entities) return undefined;
     const existingIno = this.tree.lookup(entitiesIno, entityId);
     const exists = typeof entities.state.pieces.entityIdExists === "function"
@@ -2972,11 +3061,11 @@ export class CellBridge {
       ) {
         await this.pendingEntityHydrations.get(existingIno)?.catch(() => false);
       }
-      this.removeEntityProjection(entities.state, decodedEntityId);
+      this.#removeEntityProjection(entities.state, decodedEntityId);
       return undefined;
     }
     if (exists === true) {
-      const ino = this.ensureEntityProjection(
+      const ino = this.#ensureEntityProjection(
         entities.state,
         entities.spaceName,
         decodedEntityId,
@@ -2986,7 +3075,7 @@ export class CellBridge {
     }
 
     if (existingIno !== undefined) {
-      this.touchEntityProjection(existingIno, {
+      this.#touchEntityProjection(existingIno, {
         state: entities.state,
         spaceName: entities.spaceName,
         entityId: decodedEntityId,
@@ -2999,7 +3088,7 @@ export class CellBridge {
       (candidate) => candidate.id === decodedEntityId,
     );
     if (!piece || encodeFuseComponent(piece.id) !== entityId) return undefined;
-    const ino = this.ensureEntityProjection(
+    const ino = this.#ensureEntityProjection(
       entities.state,
       entities.spaceName,
       piece.id,
@@ -3011,7 +3100,7 @@ export class CellBridge {
 
   /** Check whether an inode is any space's entities/ directory. */
   isEntitiesDir(ino: bigint): boolean {
-    return this.stateForEntitiesDir(ino) !== undefined;
+    return this.#stateForEntitiesDir(ino) !== undefined;
   }
 
   /**
@@ -3021,7 +3110,7 @@ export class CellBridge {
    * `piece.name()` races the doc load and would fall back to the opaque
    * id-derived directory name — permanently, if no later change event fires.
    */
-  private async syncPieceName(piece: PieceController): Promise<void> {
+  async #syncPieceName(piece: PieceController): Promise<void> {
     if (typeof piece.getCell !== "function") return;
     try {
       await (piece.getCell() as Cell<unknown>).asSchema(nameSchema).sync();
@@ -3033,6 +3122,9 @@ export class CellBridge {
   /**
    * Add a single piece to a space's tree.
    * Returns the assigned display name.
+   *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
    */
   private async addPieceToSpace(
     state: SpaceState,
@@ -3045,10 +3137,10 @@ export class CellBridge {
     // would be created under the opaque id-derived fallback name — and never
     // renamed if no further change event arrives. Await the NAME through the
     // same schema path `name()` reads before choosing the directory name.
-    await this.syncPieceName(piece);
+    await this.#syncPieceName(piece);
     const rawName = piece.name();
     let name = resolveProjectedPieceName(rawName, piece.id);
-    this.debugLog(
+    this.#debugLog(
       `[${spaceName}] addPieceToSpace: id=${piece.id} rawName=${
         JSON.stringify(rawName)
       } resolved=${name}`,
@@ -3073,7 +3165,7 @@ export class CellBridge {
     );
     state.pieceInos.set(name, pieceIno);
     await this.buildSourceTree(pieceIno, piece, state, name);
-    await this.refreshPieceManifest(state, piece);
+    await this.#refreshPieceManifest(state, piece);
 
     const subs = await this.subscribePiece(
       piece,
@@ -3093,12 +3185,12 @@ export class CellBridge {
   /**
    * Remove a piece from a space's tree and clean up subscriptions.
    */
-  private removePieceFromSpace(state: SpaceState, name: string): void {
+  #removePieceFromSpace(state: SpaceState, name: string): void {
     const pieceId = state.pieceMap.get(name);
     const pieceIno = this.tree.lookup(state.piecesIno, name);
     if (pieceIno !== undefined) {
-      this.unregisterPieceRoot(pieceIno);
-      this.fsProjectionEntries.delete(pieceIno);
+      this.#unregisterPieceRoot(pieceIno);
+      this.#fsProjectionEntries.delete(pieceIno);
     }
 
     // Cancel piece-level subscriptions
@@ -3133,7 +3225,7 @@ export class CellBridge {
    * sink events). This prevents concurrent async interleaving from producing
    * duplicate tree entries or double-removal errors.
    */
-  private syncPieceList(
+  #syncPieceList(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
@@ -3143,7 +3235,7 @@ export class CellBridge {
       return existing;
     }
 
-    const pending = this.runPieceListSync(state, spaceName).finally(() => {
+    const pending = this.#runPieceListSync(state, spaceName).finally(() => {
       if (this.pieceSyncs.get(spaceName) === pending) {
         this.pieceSyncs.delete(spaceName);
       }
@@ -3152,7 +3244,7 @@ export class CellBridge {
     return pending;
   }
 
-  private async runPieceListSync(
+  async #runPieceListSync(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
@@ -3162,14 +3254,17 @@ export class CellBridge {
     } while (this.syncAgain.has(spaceName));
   }
 
-  /** Single pass of piece list sync (called by guarded syncPieceList). */
+  /** Single pass of piece list sync (called by guarded syncPieceList). *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async syncPieceListOnce(
     state: SpaceState,
     spaceName: string,
   ): Promise<void> {
     const registeredPieces = await state.pieces.getRegisteredPieces();
     state.allPieceIds = new Set(registeredPieces.map((piece) => piece.id));
-    this.debugLog(
+    this.#debugLog(
       `[${spaceName}] syncPieceListOnce: live=${registeredPieces.length} tracked=${state.pieceMap.size}`,
     );
 
@@ -3191,13 +3286,13 @@ export class CellBridge {
     if (toRemove.length === 0 && toAdd.length === 0) return;
 
     for (const name of toRemove) {
-      this.removePieceFromSpace(state, name);
-      this.debugLog(`[${spaceName}] Removed piece: ${name}`);
+      this.#removePieceFromSpace(state, name);
+      this.#debugLog(`[${spaceName}] Removed piece: ${name}`);
     }
 
     for (const piece of toAdd) {
       const name = await this.addPieceToSpace(state, piece, spaceName);
-      this.debugLog(`[${spaceName}] Added piece: ${name}`);
+      this.#debugLog(`[${spaceName}] Added piece: ${name}`);
     }
 
     // Update index and invalidate
@@ -3226,9 +3321,12 @@ export class CellBridge {
     }
   }
 
-  /** Update the pieces/pieces.json manifest for a space. */
+  /** Update the pieces/pieces.json manifest for a space. *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private updatePiecesJson(state: SpaceState): void {
-    const entries = this.buildPiecesManifestEntries(state);
+    const entries = this.#buildPiecesManifestEntries(state);
     const existingIno = this.tree.lookup(state.piecesIno, "pieces.json");
     if (existingIno !== undefined) {
       this.tree.clear(existingIno);
@@ -3239,13 +3337,13 @@ export class CellBridge {
       JSON.stringify(entries, null, 2),
       "object",
     );
-    const annotator = this.makeCfcAnnotator({
-      spaceName: this.spaceNameForState(state) ?? state.did,
+    const annotator = this.#makeCfcAnnotator({
+      spaceName: this.#spaceNameForState(state) ?? state.did,
       spaceDid: state.did,
       rootKind: "pieces",
       value: entries,
     });
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       annotator,
       piecesJsonIno,
       "pieces-manifest",
@@ -3254,7 +3352,10 @@ export class CellBridge {
     );
   }
 
-  /** Update the pieces/.index.json file for a space. */
+  /** Update the pieces/.index.json file for a space. *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private updateIndexJson(state: SpaceState): void {
     const existingIno = this.tree.lookup(state.piecesIno, ".index.json");
     if (existingIno !== undefined) {
@@ -3270,13 +3371,13 @@ export class CellBridge {
       JSON.stringify(indexObj, null, 2),
       "object",
     );
-    const annotator = this.makeCfcAnnotator({
-      spaceName: this.spaceNameForState(state) ?? state.did,
+    const annotator = this.#makeCfcAnnotator({
+      spaceName: this.#spaceNameForState(state) ?? state.did,
       spaceDid: state.did,
       rootKind: "pieces",
       value: indexObj,
     });
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       annotator,
       indexIno,
       "pieces-manifest",
@@ -3285,18 +3386,18 @@ export class CellBridge {
     );
   }
 
-  private updatePieceMetaName(parentIno: bigint, name: string): void {
-    this.updatePieceMeta(parentIno, { name });
+  #updatePieceMetaName(parentIno: bigint, name: string): void {
+    this.#updatePieceMeta(parentIno, { name });
   }
 
-  private updatePieceMetaPatternRef(
+  #updatePieceMetaPatternRef(
     parentIno: bigint,
     patternRef: PiecePatternRef,
   ): void {
-    this.updatePieceMeta(parentIno, { patternRef });
+    this.#updatePieceMeta(parentIno, { patternRef });
   }
 
-  private updatePieceMeta(
+  #updatePieceMeta(
     parentIno: bigint,
     updates: Record<string, unknown>,
   ): void {
@@ -3332,19 +3433,19 @@ export class CellBridge {
    * `.fs.pending` staging container is internal and never has a cached entry,
    * so it is cleared but not recorded.
    */
-  private clearFsProjectionEntries(
+  #clearFsProjectionEntries(
     pieceIno: bigint,
     changes?: TransplantChanges,
   ): void {
-    const entries = this.fsProjectionEntries.get(pieceIno);
-    this.fsProjectionEntries.delete(pieceIno);
+    const entries = this.#fsProjectionEntries.get(pieceIno);
+    this.#fsProjectionEntries.delete(pieceIno);
 
     for (const name of ["index.md", "index.json", ".fs.pending"]) {
       const ino = this.tree.lookup(pieceIno, name);
       if (ino !== undefined) {
         this.tree.clear(ino);
         if (changes && name !== ".fs.pending") {
-          this.recordEntryChange(changes, pieceIno, name);
+          this.#recordEntryChange(changes, pieceIno, name);
         }
       }
     }
@@ -3354,7 +3455,7 @@ export class CellBridge {
       const ino = this.tree.lookup(pieceIno, name);
       if (ino !== undefined) {
         this.tree.clear(ino);
-        if (changes) this.recordEntryChange(changes, pieceIno, name);
+        if (changes) this.#recordEntryChange(changes, pieceIno, name);
       }
     }
   }
@@ -3366,7 +3467,7 @@ export class CellBridge {
    * of entry names produced, so the caller can swap them into place and record
    * which piece-root names the projection now owns.
    */
-  private buildFsProjectionTree(
+  #buildFsProjectionTree(
     parentIno: bigint,
     pieceId: string,
     fsValue: FsValue,
@@ -3394,7 +3495,7 @@ export class CellBridge {
         if (siblingParentIno === parentIno) {
           entries.add(encodeFuseComponent(name, { reserveJsonSuffix: true }));
         }
-        this.makeFsSubtreeBuilder(
+        this.#makeFsSubtreeBuilder(
           resolveLink,
           skipEntry,
           classifyEntry,
@@ -3403,7 +3504,7 @@ export class CellBridge {
       },
     );
     const projectionLabel = annotator?.subtreeLabel(treeValue, []);
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       annotator,
       indexIno,
       "fs-projection",
@@ -3412,7 +3513,7 @@ export class CellBridge {
       projectionLabel,
     );
 
-    this.addVNodeJsonFiles(parentIno, treeValue, annotator);
+    this.#addVNodeJsonFiles(parentIno, treeValue, annotator);
     if (
       typeof treeValue === "object" && treeValue !== null &&
       !Array.isArray(treeValue)
@@ -3422,7 +3523,7 @@ export class CellBridge {
       }
     }
 
-    this.addCallableFiles(parentIno, callables, "result", annotator);
+    this.#addCallableFiles(parentIno, callables, "result", annotator);
     for (const { key, callableKind } of callables) {
       entries.add(`${encodeFuseComponent(key)}.${callableKind}`);
     }
@@ -3436,7 +3537,7 @@ export class CellBridge {
    * projection entries keep their inode across a rebuild. Old projection entries
    * absent from the rebuild are removed. Returns the entry names now present.
    */
-  private swapFsProjection(
+  #swapFsProjection(
     pieceIno: bigint,
     stageIno: bigint,
     oldNames: Iterable<string>,
@@ -3452,7 +3553,7 @@ export class CellBridge {
         : undefined;
       const stagedNode = this.tree.getNode(stagedIno);
       if (oldNode && stagedNode && oldNode.kind === stagedNode.kind) {
-        this.mergeTransplantChanges(
+        this.#mergeTransplantChanges(
           changes,
           this.tree.transplantSubtree(oldIno!, stagedIno),
         );
@@ -3466,7 +3567,7 @@ export class CellBridge {
         if (movedIno !== undefined) {
           annotator?.annotateEntry(pieceIno, name, movedIno);
         }
-        this.recordEntryChange(changes, pieceIno, name);
+        this.#recordEntryChange(changes, pieceIno, name);
       }
     }
     for (const name of oldNames) {
@@ -3474,14 +3575,14 @@ export class CellBridge {
       const oldIno = this.tree.lookup(pieceIno, name);
       if (oldIno !== undefined) {
         this.tree.clear(oldIno);
-        this.recordEntryChange(changes, pieceIno, name);
+        this.#recordEntryChange(changes, pieceIno, name);
       }
     }
     this.tree.clear(stageIno);
     return newNames;
   }
 
-  private discoverCallableEntries(
+  #discoverCallableEntries(
     rootCell: Cell<unknown>,
     value: unknown,
   ): {
@@ -3575,7 +3676,7 @@ export class CellBridge {
     };
   }
 
-  private materializeTreeValue(
+  #materializeTreeValue(
     rootCell: Cell<unknown>,
     value: unknown,
   ): unknown {
@@ -3636,7 +3737,7 @@ export class CellBridge {
     return Object.keys(materialized).length > 0 ? materialized : value;
   }
 
-  private addCallableFiles(
+  #addCallableFiles(
     propIno: bigint,
     callables: Array<
       { key: string; callableKind: CallableKind; schema?: JSONSchema }
@@ -3646,7 +3747,7 @@ export class CellBridge {
   ): void {
     for (const { key, callableKind, schema } of callables) {
       const typeStr = displayCallableInputType(callableKind, schema);
-      const script = buildCallableScript(this.execCli, schema, typeStr);
+      const script = buildCallableScript(this.#execCli, schema, typeStr);
       const fileName = `${encodeFuseComponent(key)}.${callableKind}`;
       const callableIno = this.tree.addCallable(
         propIno,
@@ -3678,7 +3779,7 @@ export class CellBridge {
    * Also removes any previously-projected `<key>.json` files for VNode
    * properties that no longer exist in the current value.
    */
-  private addVNodeJsonFiles(
+  #addVNodeJsonFiles(
     parentIno: bigint,
     value: unknown,
     annotator?: CfcProjectionAnnotator,
@@ -3702,7 +3803,7 @@ export class CellBridge {
             "object",
           );
           const contentLabel = annotator?.subtreeLabel(val, [key]);
-          this.annotateSyntheticNode(
+          this.#annotateSyntheticNode(
             annotator,
             vnodeIno,
             "aggregate-json",
@@ -3737,7 +3838,7 @@ export class CellBridge {
    * One line per callable: "<name>.<handler|tool>  <input-schema-json>"
    * Dot-prefixed so it's hidden from plain `ls` but readable with `cat`.
    */
-  private buildHandlersFile(
+  #buildHandlersFile(
     pieceIno: bigint,
     callables: Array<
       { key: string; callableKind: CallableKind; schema?: JSONSchema }
@@ -3760,7 +3861,7 @@ export class CellBridge {
     const schemaLabels = callables.map(({ key, schema }) =>
       schema === undefined ? undefined : annotator?.subtreeLabel(schema, [key])
     );
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       annotator,
       handlersIno,
       "piece-meta",
@@ -3775,7 +3876,7 @@ export class CellBridge {
    * Complex frontmatter fields (arrays of entities, nested objects) are
    * rendered as sibling directories using the standard `buildJsonTree` path.
    */
-  private makeFsSubtreeBuilder(
+  #makeFsSubtreeBuilder(
     resolveLink: (v: unknown, depth: number) => string | null,
     skipEntry: (v: unknown) => boolean,
     classifyEntry: (k: string, v: unknown) => CallableKind | null,
@@ -3802,7 +3903,7 @@ export class CellBridge {
    * Read [FS] projection values from a result cell.
    * Returns null if the result does not declare [FS].
    */
-  private readFsValue(
+  #readFsValue(
     resultCell: Cell<unknown>,
     result: unknown,
   ): FsValue | null {
@@ -3863,6 +3964,9 @@ export class CellBridge {
   /**
    * Subscribe to cell changes for hydration-cache invalidation and
    * projected name changes for a piece.
+   *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
    */
   private async subscribePiece(
     piece: PieceController,
@@ -3909,7 +4013,7 @@ export class CellBridge {
               // The rebuild reconciles onto the mounted tree in place, so the
               // tree is not torn down first; advancing the hydration epoch is
               // enough to make an in-flight hydration re-read the new value.
-              this.bumpHydrationEpoch(pieceIno, propName);
+              this.#bumpHydrationEpoch(pieceIno, propName);
               await this.enqueuePiecePropRebuild({
                 cell,
                 newValue: rebuildValue,
@@ -4023,7 +4127,7 @@ export class CellBridge {
               piece.id,
             );
 
-            this.debugLog(
+            this.#debugLog(
               `[${spaceName}] Rename check: current=${currentName} raw=${rawName} normalized=${normalizedRawName}`,
             );
 
@@ -4072,7 +4176,7 @@ export class CellBridge {
             state.pieceInos.delete(currentName);
             if (trackedPieceIno !== undefined) {
               state.pieceInos.set(newName, trackedPieceIno);
-              const rootInfo = this.pieceRoots.get(trackedPieceIno);
+              const rootInfo = this.#pieceRoots.get(trackedPieceIno);
               if (rootInfo) {
                 rootInfo.rootName = newName;
               }
@@ -4096,14 +4200,14 @@ export class CellBridge {
 
             const renamedPieceIno = this.tree.lookup(state.piecesIno, newName);
             if (renamedPieceIno !== undefined) {
-              this.updatePieceMetaName(renamedPieceIno, newName);
+              this.#updatePieceMetaName(renamedPieceIno, newName);
             }
             const entityIno = this.tree.lookup(
               state.entitiesIno,
               encodeFuseComponent(piece.id),
             );
             if (entityIno !== undefined) {
-              this.updatePieceMetaName(entityIno, newName);
+              this.#updatePieceMetaName(entityIno, newName);
             }
 
             // Rebuild .index.json and pieces.json.
@@ -4127,7 +4231,7 @@ export class CellBridge {
               }
             }
 
-            this.debugLog(
+            this.#debugLog(
               `[${spaceName}] Renamed piece: ${currentName} → ${newName}`,
             );
           } catch (e) {
@@ -4156,6 +4260,9 @@ export class CellBridge {
    *   Same-space + id:  "../".repeat(depth+2) + "entities/<hash>[/<path>]"
    *   Cross-space:      "../".repeat(depth+3) + "<spaceName>/entities/<hash>[/<path>]"
    *   Self-ref (no id): relative path within the same piece
+   *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
    */
   private makeLinkResolver(
     spaceName: string,
@@ -4220,6 +4327,10 @@ export class CellBridge {
     };
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
+   */
   private async loadPieceTree(
     piece: PieceController,
     parentIno: bigint,
@@ -4243,7 +4354,7 @@ export class CellBridge {
       name: piece.name() || "",
       ...(patternRef === undefined ? {} : { patternRef }),
     };
-    const pieceAnnotator = this.makeCfcAnnotator({
+    const pieceAnnotator = this.#makeCfcAnnotator({
       spaceName,
       pieceId: piece.id,
       rootKind,
@@ -4262,24 +4373,24 @@ export class CellBridge {
       JSON.stringify(metaObject, null, 2),
       "object",
     );
-    this.annotateSyntheticNode(
+    this.#annotateSyntheticNode(
       pieceAnnotator,
       metaIno,
       "piece-meta",
       ["meta.json"],
       { ino: pieceIno, name: "meta.json" },
     );
-    this.registerPieceRoot(pieceIno, {
+    this.#registerPieceRoot(pieceIno, {
       spaceName,
       rootKind,
       rootName: name,
       pieceId: piece.id,
       piece,
     });
-    this.ensurePiecePropStub(
+    this.#ensurePiecePropStub(
       pieceIno,
       "input",
-      this.makeCfcAnnotator({
+      this.#makeCfcAnnotator({
         spaceName,
         pieceId: piece.id,
         rootKind,
@@ -4287,10 +4398,10 @@ export class CellBridge {
         value: {},
       }),
     );
-    this.ensurePiecePropStub(
+    this.#ensurePiecePropStub(
       pieceIno,
       "result",
-      this.makeCfcAnnotator({
+      this.#makeCfcAnnotator({
         spaceName,
         pieceId: piece.id,
         rootKind,
@@ -4307,6 +4418,9 @@ export class CellBridge {
    * authored source files (recovered from the content-addressed
    * `pattern:<identity>` source-doc closure). Skips system pieces that have no
    * recoverable source.
+   *
+   * TypeScript-private rather than a `#` name: `cell-bridge.test.ts` drives
+   * this member directly.
    */
   private async buildSourceTree(
     pieceIno: bigint,
@@ -4327,8 +4441,8 @@ export class CellBridge {
     }
     const files = sourceFiles;
 
-    const annotator = this.makeCfcAnnotator({
-      spaceName: this.spaceNameForState(state) ?? state.did,
+    const annotator = this.#makeCfcAnnotator({
+      spaceName: this.#spaceNameForState(state) ?? state.did,
       spaceDid: state.did,
       pieceId: piece.id,
       rootKind: "pieces",
@@ -4378,7 +4492,7 @@ export class CellBridge {
         "string",
       );
       const sourcePath = [".src", ...parts];
-      this.annotateSyntheticNode(
+      this.#annotateSyntheticNode(
         annotator,
         sourceIno,
         "source",
@@ -4392,7 +4506,7 @@ export class CellBridge {
     // (a real source file named error.log must remain writable).
     if (this.tree.lookup(srcIno, "error.log") === undefined) {
       const errorLogIno = this.tree.addFile(srcIno, "error.log", "", "string");
-      this.annotateSyntheticNode(
+      this.#annotateSyntheticNode(
         annotator,
         errorLogIno,
         "source",
@@ -4401,6 +4515,6 @@ export class CellBridge {
       );
       state.srcErrorLogInos.set(pieceName, errorLogIno);
     }
-    this.noteCfcProjectionRebuilt();
+    this.#noteCfcProjectionRebuilt();
   }
 }

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -879,14 +879,14 @@ const RECOVERY_STATUSES: CfcPreparedWritebackStatus[] = [
 ];
 
 export class CfcWritebackStore {
-  private prepared = new Map<string, CfcPreparedWriteback>();
-  private records = new Map<string, CfcWritebackRecoveryRecord>();
-  private malformedCounter = 0;
-  private storagePath: string | undefined;
+  #prepared = new Map<string, CfcPreparedWriteback>();
+  #records = new Map<string, CfcWritebackRecoveryRecord>();
+  #malformedCounter = 0;
+  #storagePath: string | undefined;
 
   constructor(options: { storagePath?: string } = {}) {
-    this.storagePath = options.storagePath;
-    this.load();
+    this.#storagePath = options.storagePath;
+    this.#load();
   }
 
   setPreparedXattr(
@@ -898,18 +898,18 @@ export class CfcWritebackStore {
     reason: string;
   } {
     if (normalizeCfcWritebackXattrName(name) !== CFC_WRITEBACK_PREPARE_XATTR) {
-      this.recordMalformed(ino, name, "unsupported writeback xattr");
+      this.#recordMalformed(ino, name, "unsupported writeback xattr");
       return { ok: false, reason: "unsupported writeback xattr" };
     }
     const parsed = parsePreparedWriteback(value);
     if (!parsed) {
-      this.recordMalformed(ino, name, "invalid prepare metadata");
+      this.#recordMalformed(ino, name, "invalid prepare metadata");
       return { ok: false, reason: "invalid prepare metadata" };
     }
-    const key = this.key(ino, parsed.operation, preparedKeyName(parsed));
-    this.prepared.set(key, parsed);
+    const key = this.#key(ino, parsed.operation, preparedKeyName(parsed));
+    this.#prepared.set(key, parsed);
     const now = new Date().toISOString();
-    this.records.set(key, {
+    this.#records.set(key, {
       version: 1,
       key,
       status: "pending-prepare",
@@ -924,7 +924,7 @@ export class CfcWritebackStore {
       createdAt: now,
       updatedAt: now,
     });
-    this.persist();
+    this.#persist();
     return { ok: true, prepared: parsed };
   }
 
@@ -943,7 +943,7 @@ export class CfcWritebackStore {
     }
     const parsed = parseFinalizedWriteback(value);
     if (!parsed) return { ok: false, reason: "invalid finalize metadata" };
-    const names = this.preparedNamesForOperation(ino, parsed.operation);
+    const names = this.#preparedNamesForOperation(ino, parsed.operation);
     if (names.length === 0) {
       this.markFinalizedPendingCleanup(ino, parsed.operation);
       this.deletePrepared(ino, parsed.operation);
@@ -961,7 +961,7 @@ export class CfcWritebackStore {
     operation: CfcWritebackOperation,
     name?: string,
   ): CfcPreparedWriteback | undefined {
-    return this.prepared.get(this.key(ino, operation, name));
+    return this.#prepared.get(this.#key(ino, operation, name));
   }
 
   deletePrepared(
@@ -969,21 +969,21 @@ export class CfcWritebackStore {
     operation: CfcWritebackOperation,
     name?: string,
   ): void {
-    const key = this.key(ino, operation, name);
-    this.prepared.delete(key);
-    this.records.delete(key);
-    this.persist();
+    const key = this.#key(ino, operation, name);
+    this.#prepared.delete(key);
+    this.#records.delete(key);
+    this.#persist();
   }
 
   deleteAllForIno(ino: bigint): void {
     const prefix = `${ino}:`;
-    for (const key of [...this.prepared.keys()]) {
-      if (key.startsWith(prefix)) this.prepared.delete(key);
+    for (const key of [...this.#prepared.keys()]) {
+      if (key.startsWith(prefix)) this.#prepared.delete(key);
     }
-    for (const key of [...this.records.keys()]) {
-      if (key.startsWith(prefix)) this.records.delete(key);
+    for (const key of [...this.#records.keys()]) {
+      if (key.startsWith(prefix)) this.#records.delete(key);
     }
-    this.persist();
+    this.#persist();
   }
 
   markMutationApplied(
@@ -992,7 +992,7 @@ export class CfcWritebackStore {
     name?: string,
     options: { requestedFields?: CfcMetadataLabelKey[] } = {},
   ): void {
-    const record = this.findRecord(ino, operation, name);
+    const record = this.#findRecord(ino, operation, name);
     if (!record) return;
     const now = new Date().toISOString();
     record.status = "mutation-applied";
@@ -1001,7 +1001,7 @@ export class CfcWritebackStore {
     if (options.requestedFields) {
       record.requestedFields = [...options.requestedFields].sort();
     }
-    this.persist();
+    this.#persist();
   }
 
   markRunnerCommitFailed(
@@ -1010,14 +1010,14 @@ export class CfcWritebackStore {
     reason: string,
     name?: string,
   ): void {
-    const record = this.findRecord(ino, operation, name);
+    const record = this.#findRecord(ino, operation, name);
     if (!record) return;
     const now = new Date().toISOString();
     record.status = "runner-commit-failed";
     record.commitFailedAt = now;
     record.updatedAt = now;
     record.diagnostics.push(reason);
-    this.persist();
+    this.#persist();
   }
 
   markReadyForExactRecomputation(
@@ -1025,13 +1025,13 @@ export class CfcWritebackStore {
     operation: CfcWritebackOperation,
     name?: string,
   ): void {
-    const record = this.findRecord(ino, operation, name);
+    const record = this.#findRecord(ino, operation, name);
     if (!record) return;
     const now = new Date().toISOString();
     record.status = "ready-for-exact-recomputation";
     record.readyAt = now;
     record.updatedAt = now;
-    this.persist();
+    this.#persist();
   }
 
   markFinalizedPendingCleanup(
@@ -1039,13 +1039,13 @@ export class CfcWritebackStore {
     operation: CfcWritebackOperation,
     name?: string,
   ): void {
-    const record = this.findRecord(ino, operation, name);
+    const record = this.#findRecord(ino, operation, name);
     if (!record) return;
     const now = new Date().toISOString();
     record.status = "finalized-pending-cleanup";
     record.finalizedAt = now;
     record.updatedAt = now;
-    this.persist();
+    this.#persist();
   }
 
   reconcileTree(tree: FsTree): CfcWritebackReconciliationResult {
@@ -1058,7 +1058,7 @@ export class CfcWritebackStore {
       diagnostics: [],
     };
 
-    for (const record of [...this.records.values()]) {
+    for (const record of [...this.#records.values()]) {
       if (!record.prepared) continue;
       result.inspected++;
       const match = findPreparedNode(tree, record.prepared);
@@ -1069,19 +1069,19 @@ export class CfcWritebackStore {
         continue;
       }
 
-      const reboundKey = this.key(
+      const reboundKey = this.#key(
         match.ino,
         record.prepared.operation,
         preparedKeyName(record.prepared),
       );
       if (record.key !== reboundKey) {
-        this.records.delete(record.key);
-        this.prepared.delete(record.key);
+        this.#records.delete(record.key);
+        this.#prepared.delete(record.key);
         record.key = reboundKey;
         record.ino = match.ino.toString();
         record.updatedAt = new Date().toISOString();
-        this.records.set(reboundKey, record);
-        this.prepared.set(reboundKey, record.prepared);
+        this.#records.set(reboundKey, record);
+        this.#prepared.set(reboundKey, record.prepared);
         result.rebound++;
       }
 
@@ -1090,8 +1090,8 @@ export class CfcWritebackStore {
           record.status === "finalized-pending-cleanup") &&
         isCoherentExactAnnotation(match.annotation)
       ) {
-        this.records.delete(record.key);
-        this.prepared.delete(record.key);
+        this.#records.delete(record.key);
+        this.#prepared.delete(record.key);
         result.finalized++;
         continue;
       }
@@ -1111,12 +1111,12 @@ export class CfcWritebackStore {
       result.reapplied++;
     }
 
-    this.persist();
+    this.#persist();
     return result;
   }
 
   snapshot(): CfcWritebackSnapshot {
-    const records = [...this.records.values()].map((record) =>
+    const records = [...this.#records.values()].map((record) =>
       cloneRecoveryRecord(record, true)
     );
     const counts = Object.fromEntries(
@@ -1127,7 +1127,7 @@ export class CfcWritebackStore {
     }
     return {
       version: 1,
-      storagePath: this.storagePath,
+      storagePath: this.#storagePath,
       records,
       counts,
     };
@@ -1150,7 +1150,7 @@ export class CfcWritebackStore {
     };
   }
 
-  private key(
+  #key(
     ino: bigint,
     operation: CfcWritebackOperation,
     name?: string,
@@ -1158,20 +1158,20 @@ export class CfcWritebackStore {
     return `${ino}:${operation}:${name ?? ""}`;
   }
 
-  private findRecord(
+  #findRecord(
     ino: bigint,
     operation: CfcWritebackOperation,
     name?: string,
   ): CfcWritebackRecoveryRecord | undefined {
-    return this.records.get(this.key(ino, operation, name));
+    return this.#records.get(this.#key(ino, operation, name));
   }
 
-  private preparedNamesForOperation(
+  #preparedNamesForOperation(
     ino: bigint,
     operation: CfcWritebackOperation,
   ): Array<string | undefined> {
     const prefix = `${ino}:${operation}:`;
-    return [...this.prepared.keys()]
+    return [...this.#prepared.keys()]
       .filter((key) => key.startsWith(prefix))
       .map((key) => {
         const name = key.slice(prefix.length);
@@ -1179,10 +1179,10 @@ export class CfcWritebackStore {
       });
   }
 
-  private recordMalformed(ino: bigint, name: string, reason: string): void {
+  #recordMalformed(ino: bigint, name: string, reason: string): void {
     const now = new Date().toISOString();
-    const key = `malformed:${ino}:${this.malformedCounter++}`;
-    this.records.set(key, {
+    const key = `malformed:${ino}:${this.#malformedCounter++}`;
+    this.#records.set(key, {
       version: 1,
       key,
       status: "malformed-prepare",
@@ -1192,14 +1192,14 @@ export class CfcWritebackStore {
       createdAt: now,
       updatedAt: now,
     });
-    this.persist();
+    this.#persist();
   }
 
-  private load(): void {
-    if (!this.storagePath) return;
+  #load(): void {
+    if (!this.#storagePath) return;
     let text: string;
     try {
-      text = Deno.readTextFileSync(this.storagePath);
+      text = Deno.readTextFileSync(this.#storagePath);
     } catch {
       return;
     }
@@ -1208,35 +1208,43 @@ export class CfcWritebackStore {
     try {
       parsed = JSON.parse(text);
     } catch {
-      this.recordMalformed(0n, this.storagePath, "invalid recovery store JSON");
+      this.#recordMalformed(
+        0n,
+        this.#storagePath,
+        "invalid recovery store JSON",
+      );
       return;
     }
     if (
       !isObjectNotArray(parsed) || parsed.version !== 1 ||
       !Array.isArray(parsed.records)
     ) {
-      this.recordMalformed(0n, this.storagePath, "unsupported recovery store");
+      this.#recordMalformed(
+        0n,
+        this.#storagePath,
+        "unsupported recovery store",
+      );
       return;
     }
     for (const record of parsed.records) {
       if (!isRecoveryRecord(record)) continue;
       const cloned = cloneRecoveryRecord(record, false);
-      this.records.set(cloned.key, cloned);
-      if (cloned.prepared) this.prepared.set(cloned.key, cloned.prepared);
+      this.#records.set(cloned.key, cloned);
+      if (cloned.prepared) this.#prepared.set(cloned.key, cloned.prepared);
     }
   }
 
-  private persist(): void {
-    if (!this.storagePath) return;
-    const slash = this.storagePath.lastIndexOf("/");
+  #persist(): void {
+    if (!this.#storagePath) return;
+    const slash = this.#storagePath.lastIndexOf("/");
     if (slash > 0) {
-      Deno.mkdirSync(this.storagePath.slice(0, slash), { recursive: true });
+      Deno.mkdirSync(this.#storagePath.slice(0, slash), { recursive: true });
     }
     Deno.writeTextFileSync(
-      this.storagePath,
+      this.#storagePath,
       canonicalCfcJsonStringify({
         version: 1,
-        records: [...this.records.values()],
+        records: [...this.#records.values()],
       }),
     );
   }

--- a/packages/fuse/directory-handles.ts
+++ b/packages/fuse/directory-handles.ts
@@ -173,15 +173,23 @@ export class DirectoryHandleMap {
 export class FuseOperationState {
   readonly directoryHandles = new DirectoryHandleMap();
 
+  readonly #tree: FsTree;
+  readonly #preparer: FuseOperationPreparer | null | undefined;
+  readonly #isWritable: (ino: bigint) => boolean;
+
   constructor(
-    private readonly tree: FsTree,
-    private readonly preparer: FuseOperationPreparer | null | undefined,
-    private readonly isWritable: (ino: bigint) => boolean = () => false,
-  ) {}
+    tree: FsTree,
+    preparer: FuseOperationPreparer | null | undefined,
+    isWritable: (ino: bigint) => boolean = () => false,
+  ) {
+    this.#tree = tree;
+    this.#preparer = preparer;
+    this.#isWritable = isWritable;
+  }
 
   lookup(parentIno: bigint, name: string): bigint | undefined {
-    const ino = this.tree.lookup(parentIno, name);
-    return ino !== undefined && this.tree.getNode(ino) !== undefined
+    const ino = this.#tree.lookup(parentIno, name);
+    return ino !== undefined && this.#tree.getNode(ino) !== undefined
       ? ino
       : undefined;
   }
@@ -190,32 +198,32 @@ export class FuseOperationState {
     parentIno: bigint,
     name: string,
   ): Promise<bigint | undefined> {
-    if (this.preparer?.prepareLookupForReply) {
-      return await this.preparer.prepareLookupForReply(parentIno, name);
+    if (this.#preparer?.prepareLookupForReply) {
+      return await this.#preparer.prepareLookupForReply(parentIno, name);
     }
-    if (!this.preparer?.shouldPrepareLookup(parentIno, name)) {
+    if (!this.#preparer?.shouldPrepareLookup(parentIno, name)) {
       const ino = this.lookup(parentIno, name);
       if (ino !== undefined) this.retainLookup(ino);
       return ino;
     }
-    if (!await this.preparer.prepareLookup(parentIno, name)) return undefined;
+    if (!await this.#preparer.prepareLookup(parentIno, name)) return undefined;
     const ino = this.lookup(parentIno, name);
     if (ino !== undefined) this.retainLookup(ino);
     return ino;
   }
 
   retainLookup(ino: bigint): void {
-    this.preparer?.retainEntityProjectionLookup?.(ino);
+    this.#preparer?.retainEntityProjectionLookup?.(ino);
   }
 
   forget(ino: bigint, nlookup: bigint): void {
-    this.preparer?.releaseEntityProjectionLookup?.(ino, nlookup);
+    this.#preparer?.releaseEntityProjectionLookup?.(ino, nlookup);
   }
 
   openDirectory(ino: bigint): bigint | undefined {
-    if (this.tree.getNode(ino)?.kind !== "dir") return undefined;
+    if (this.#tree.getNode(ino)?.kind !== "dir") return undefined;
     const fh = this.directoryHandles.open(ino);
-    this.preparer?.retainEntityProjectionOpen?.(ino);
+    this.#preparer?.retainEntityProjectionOpen?.(ino);
     return fh;
   }
 
@@ -227,7 +235,7 @@ export class FuseOperationState {
       this.directoryHandles,
       fh,
       ino,
-      this.preparer,
+      this.#preparer,
     );
   }
 
@@ -240,14 +248,14 @@ export class FuseOperationState {
       this.directoryHandles.snapshot(
         fh,
         ino,
-        () => collectDirectorySnapshot(this.tree, ino, this.isWritable),
+        () => collectDirectorySnapshot(this.#tree, ino, this.#isWritable),
       );
   }
 
   closeDirectory(fh: bigint, ino: bigint): void {
     if (!this.directoryHandles.has(fh, ino)) return;
     this.directoryHandles.close(fh);
-    this.preparer?.releaseEntityProjectionOpen?.(ino);
+    this.#preparer?.releaseEntityProjectionOpen?.(ino);
   }
 }
 

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -65,8 +65,8 @@ export function handleHasBufferedContent(
 }
 
 export class HandleMap {
-  private nextFh = 1n;
-  private handles = new Map<bigint, HandleState>();
+  #nextFh = 1n;
+  #handles = new Map<bigint, HandleState>();
 
   /**
    * Open a file handle. Copies current content into buffer if writable.
@@ -87,10 +87,10 @@ export class HandleMap {
       readSnapshotMtime?: number;
     },
   ): bigint {
-    const fh = this.nextFh++;
+    const fh = this.#nextFh++;
     const isWritable = (flags & O_WRONLY) !== 0 || (flags & O_RDWR) !== 0;
     const snapshot = options?.readSnapshot;
-    this.handles.set(fh, {
+    this.#handles.set(fh, {
       ino,
       flags,
       dirty: false,
@@ -110,13 +110,13 @@ export class HandleMap {
   }
 
   get(fh: bigint): HandleState | undefined {
-    return this.handles.get(fh);
+    return this.#handles.get(fh);
   }
 
   close(fh: bigint): HandleState | undefined {
-    const state = this.handles.get(fh);
+    const state = this.#handles.get(fh);
     if (state) {
-      this.handles.delete(fh);
+      this.#handles.delete(fh);
     }
     return state;
   }
@@ -125,7 +125,7 @@ export class HandleMap {
     fh: bigint,
     operation: CfcExistingWritebackOperation,
   ): boolean {
-    return this.handles.get(fh)?.cfcAuthorizedOperations.has(operation) ??
+    return this.#handles.get(fh)?.cfcAuthorizedOperations.has(operation) ??
       false;
   }
 
@@ -133,7 +133,7 @@ export class HandleMap {
     fh: bigint,
     operation: CfcExistingWritebackOperation,
   ): boolean {
-    const state = this.handles.get(fh);
+    const state = this.#handles.get(fh);
     if (!state) return false;
     state.cfcAuthorizedOperations.add(operation);
     return true;
@@ -141,7 +141,7 @@ export class HandleMap {
 
   /** Write data into the handle's buffer at offset, extending if needed. */
   write(fh: bigint, data: Uint8Array, offset: number): boolean {
-    const state = this.handles.get(fh);
+    const state = this.#handles.get(fh);
     if (!state) return false;
 
     if (!validateVirtualFileRange(offset, data.length).ok) return false;
@@ -158,7 +158,7 @@ export class HandleMap {
     state.truncatePending = false;
     state.version++;
 
-    for (const [otherFh, otherState] of this.handles) {
+    for (const [otherFh, otherState] of this.#handles) {
       if (otherFh !== fh && otherState.ino === state.ino) {
         otherState.truncatePending = false;
       }
@@ -169,7 +169,7 @@ export class HandleMap {
 
   /** Mark a handle as truncated to an empty buffer without committing yet. */
   markTruncated(fh: bigint): boolean {
-    const state = this.handles.get(fh);
+    const state = this.#handles.get(fh);
     if (!state) return false;
     state.buffer = new Uint8Array(0);
     state.bufferValid = true;
@@ -186,7 +186,7 @@ export class HandleMap {
     options?: { pendingFh?: bigint },
   ): boolean {
     if (!validateVirtualFileRange(0, size).ok) return false;
-    for (const [fh, state] of this.handles) {
+    for (const [fh, state] of this.#handles) {
       if (state.ino === ino) {
         const shouldFlush = options?.pendingFh === undefined ||
           options.pendingFh === fh;
@@ -215,7 +215,7 @@ export class HandleMap {
 
   /** Truncate the handle's buffer to the given size. */
   truncate(fh: bigint, size: number): boolean {
-    const state = this.handles.get(fh);
+    const state = this.#handles.get(fh);
     if (!state) return false;
     if (!validateVirtualFileRange(0, size).ok) return false;
 

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -66,30 +66,35 @@ export class FsTree {
   paths: Map<string, bigint> = new Map();
 
   /** Reverse map: inode → path string (O(1) lookup). */
-  private inoPaths: Map<bigint, string> = new Map();
+  #inoPaths: Map<bigint, string> = new Map();
 
   /**
    * Reverse map from inode to registered child name for constant-time lookup.
    */
-  private inoNames: Map<bigint, string> = new Map();
+  #inoNames: Map<bigint, string> = new Map();
 
   /** Renderers for inodes added by `addGeneratedFile`. */
-  private generated: Map<bigint, () => Uint8Array | string> = new Map();
+  #generated: Map<bigint, () => Uint8Array | string> = new Map();
+
+  /**
+   * TypeScript-private rather than a `#` name: `tree.test.ts` drives this
+   * member directly.
+   */
   private cfcEntryIndexes = new Map<bigint, Map<string, number>>();
-  private unsortedCfcEntryDirectories = new Set<bigint>();
-  private nextIno = 2n;
-  private now: () => number;
+  #unsortedCfcEntryDirectories = new Set<bigint>();
+  #nextIno = 2n;
+  #now: () => number;
 
   constructor(now: () => number = () => Date.now()) {
-    this.now = now;
+    this.#now = now;
     // Create root directory (inode 1)
     this.inodes.set(ROOT_INO, {
       kind: "dir",
       children: new Map(),
-      mtime: this.now(),
+      mtime: this.#now(),
     });
     this.paths.set("/", ROOT_INO);
-    this.inoPaths.set(ROOT_INO, "/");
+    this.#inoPaths.set(ROOT_INO, "/");
   }
 
   get rootIno(): bigint {
@@ -97,7 +102,7 @@ export class FsTree {
   }
 
   allocInode(): bigint {
-    return this.nextIno++;
+    return this.#nextIno++;
   }
 
   /** The path an entry named `name` under `parentIno` has, or would have. */
@@ -106,25 +111,25 @@ export class FsTree {
     return parentPath === "/" ? `/${name}` : `${parentPath}/${name}`;
   }
 
-  private trackPath(ino: bigint, parentIno: bigint, name: string): void {
+  #trackPath(ino: bigint, parentIno: bigint, name: string): void {
     const path = this.childPath(parentIno, name);
     this.paths.set(path, ino);
-    this.inoPaths.set(ino, path);
-    this.inoNames.set(ino, name);
+    this.#inoPaths.set(ino, path);
+    this.#inoNames.set(ino, name);
   }
 
-  private untrackPath(ino: bigint): void {
-    const path = this.inoPaths.get(ino);
+  #untrackPath(ino: bigint): void {
+    const path = this.#inoPaths.get(ino);
     if (path !== undefined) {
       if (this.paths.get(path) === ino) {
         this.paths.delete(path);
       }
-      this.inoPaths.delete(ino);
-      this.inoNames.delete(ino);
+      this.#inoPaths.delete(ino);
+      this.#inoNames.delete(ino);
     }
   }
 
-  private unlinkFromParent(ino: bigint): void {
+  #unlinkFromParent(ino: bigint): void {
     const parentIno = this.parents.get(ino);
     if (parentIno === undefined) return;
     const parent = this.inodes.get(parentIno);
@@ -132,7 +137,7 @@ export class FsTree {
     for (const [name, childIno] of parent.children) {
       if (childIno === ino) {
         parent.children.delete(name);
-        this.removeCfcEntryAnnotation(parentIno, name);
+        this.#removeCfcEntryAnnotation(parentIno, name);
         break;
       }
     }
@@ -153,12 +158,12 @@ export class FsTree {
       kind: "dir",
       children: new Map(),
       jsonType,
-      mtime: this.now(),
+      mtime: this.#now(),
     };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
-    this.trackPath(ino, parentIno, name);
+    this.#trackPath(ino, parentIno, name);
 
     return ino;
   }
@@ -182,12 +187,12 @@ export class FsTree {
       kind: "file",
       content: data,
       jsonType,
-      mtime: this.now(),
+      mtime: this.#now(),
     };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
-    this.trackPath(ino, parentIno, name);
+    this.#trackPath(ino, parentIno, name);
 
     return ino;
   }
@@ -209,7 +214,7 @@ export class FsTree {
     jsonType: JsonType,
   ): bigint {
     const ino = this.addFile(parentIno, name, ownedRender(render), jsonType);
-    this.generated.set(ino, render);
+    this.#generated.set(ino, render);
     return ino;
   }
 
@@ -224,20 +229,20 @@ export class FsTree {
    * alone, so the mtime moves only when the bytes do, and then always forward.
    */
   refreshGenerated(ino: bigint): Uint8Array | undefined {
-    const render = this.generated.get(ino);
+    const render = this.#generated.get(ino);
     if (render === undefined) return undefined;
     const node = this.inodes.get(ino);
     if (!node || node.kind !== "file") return undefined;
     const bytes = ownedRender(render);
     if (bytesEqual(node.content, bytes)) return node.content;
-    this.bumpMtime(node);
+    this.#bumpMtime(node);
     node.content = bytes;
     return node.content;
   }
 
   /** True when `ino` was added by `addGeneratedFile`. */
   isGenerated(ino: bigint): boolean {
-    return this.generated.has(ino);
+    return this.#generated.has(ino);
   }
 
   addCallable(
@@ -260,12 +265,12 @@ export class FsTree {
       cellKey,
       cellProp,
       script,
-      mtime: this.now(),
+      mtime: this.#now(),
     };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
-    this.trackPath(ino, parentIno, name);
+    this.#trackPath(ino, parentIno, name);
 
     return ino;
   }
@@ -277,11 +282,11 @@ export class FsTree {
     }
 
     const ino = this.allocInode();
-    const node: FsNode = { kind: "symlink", target, mtime: this.now() };
+    const node: FsNode = { kind: "symlink", target, mtime: this.#now() };
     this.inodes.set(ino, node);
     parent.children.set(name, ino);
     this.parents.set(ino, parentIno);
-    this.trackPath(ino, parentIno, name);
+    this.#trackPath(ino, parentIno, name);
 
     return ino;
   }
@@ -304,7 +309,7 @@ export class FsTree {
    */
   touch(ino: bigint): void {
     const node = this.inodes.get(ino);
-    if (node) this.bumpMtime(node);
+    if (node) this.#bumpMtime(node);
   }
 
   setCfcAnnotation(ino: bigint, annotation: CfcNodeAnnotation): void {
@@ -313,19 +318,19 @@ export class FsTree {
       throw new Error(`Inode ${ino} does not exist`);
     }
     node.cfc = annotation;
-    this.rebuildCfcEntryIndex(ino, annotation);
+    this.#rebuildCfcEntryIndex(ino, annotation);
   }
 
   getCfcAnnotation(ino: bigint): CfcNodeAnnotation | undefined {
-    this.sortCfcEntries(ino);
+    this.#sortCfcEntries(ino);
     return this.inodes.get(ino)?.cfc;
   }
 
-  private rebuildCfcEntryIndex(
+  #rebuildCfcEntryIndex(
     ino: bigint,
     annotation: CfcNodeAnnotation | undefined,
   ): void {
-    this.unsortedCfcEntryDirectories.delete(ino);
+    this.#unsortedCfcEntryDirectories.delete(ino);
     const entries = annotation?.entries?.entries;
     if (!entries) {
       this.cfcEntryIndexes.delete(ino);
@@ -337,7 +342,7 @@ export class FsTree {
     );
   }
 
-  private cfcEntryIndex(
+  #cfcEntryIndex(
     ino: bigint,
     entries: readonly CfcDirectoryEntryAnnotation[],
   ): Map<string, number> {
@@ -349,14 +354,14 @@ export class FsTree {
     return index;
   }
 
-  private sortCfcEntries(ino: bigint): void {
-    if (!this.unsortedCfcEntryDirectories.delete(ino)) return;
+  #sortCfcEntries(ino: bigint): void {
+    if (!this.#unsortedCfcEntryDirectories.delete(ino)) return;
     const node = this.inodes.get(ino);
     if (!node || node.kind !== "dir" || !node.cfc?.entries) return;
     node.cfc.entries.entries.sort((left, right) =>
       left.nameDigest.localeCompare(right.nameDigest)
     );
-    this.rebuildCfcEntryIndex(ino, node.cfc);
+    this.#rebuildCfcEntryIndex(ino, node.cfc);
   }
 
   setCfcEntryAnnotation(
@@ -367,7 +372,7 @@ export class FsTree {
     const parent = this.inodes.get(parentIno);
     if (!parent || parent.kind !== "dir" || !parent.cfc?.entries) return;
     const entries = parent.cfc.entries.entries;
-    const index = this.cfcEntryIndex(parentIno, entries);
+    const index = this.#cfcEntryIndex(parentIno, entries);
     const existing = index.get(name);
     if (existing === undefined) {
       index.set(name, entries.length);
@@ -375,14 +380,14 @@ export class FsTree {
     } else {
       entries[existing] = entry;
     }
-    this.unsortedCfcEntryDirectories.add(parentIno);
+    this.#unsortedCfcEntryDirectories.add(parentIno);
   }
 
-  private removeCfcEntryAnnotation(parentIno: bigint, name: string): void {
+  #removeCfcEntryAnnotation(parentIno: bigint, name: string): void {
     const parent = this.inodes.get(parentIno);
     if (!parent || parent.kind !== "dir" || !parent.cfc?.entries) return;
     const entries = parent.cfc.entries.entries;
-    const index = this.cfcEntryIndex(parentIno, entries);
+    const index = this.#cfcEntryIndex(parentIno, entries);
     const removedIndex = index.get(name);
     if (removedIndex === undefined) return;
     const lastIndex = entries.length - 1;
@@ -393,10 +398,10 @@ export class FsTree {
       entries[removedIndex] = last;
       index.set(last.name, removedIndex);
     }
-    this.unsortedCfcEntryDirectories.add(parentIno);
+    this.#unsortedCfcEntryDirectories.add(parentIno);
   }
 
-  private getCfcEntryAnnotation(
+  #getCfcEntryAnnotation(
     parentIno: bigint,
     name: string,
   ): CfcDirectoryEntryAnnotation | undefined {
@@ -405,7 +410,7 @@ export class FsTree {
       return undefined;
     }
     const entries = parent.cfc.entries.entries;
-    const index = this.cfcEntryIndex(parentIno, entries).get(name);
+    const index = this.#cfcEntryIndex(parentIno, entries).get(name);
     return index === undefined ? undefined : entries[index];
   }
 
@@ -416,7 +421,7 @@ export class FsTree {
   }
 
   getPath(ino: bigint): string {
-    return this.inoPaths.get(ino) ?? "/";
+    return this.#inoPaths.get(ino) ?? "/";
   }
 
   /**
@@ -435,14 +440,14 @@ export class FsTree {
     if (!node || node.kind !== "file") {
       throw new Error(`Inode ${ino} is not a file`);
     }
-    if (this.generated.has(ino)) {
+    if (this.#generated.has(ino)) {
       throw new Error(`Inode ${ino} is a generated file`);
     }
     const data = typeof content === "string"
       ? encoder.encode(content)
       : content;
     if (!bytesEqual(node.content, data)) {
-      this.bumpMtime(node);
+      this.#bumpMtime(node);
     }
     node.content = data;
     if (jsonType !== undefined) {
@@ -457,9 +462,9 @@ export class FsTree {
     const childIno = parent.children.get(name);
     if (childIno === undefined) return undefined;
     // Don't use clear() since it also removes from parent — do it manually
-    this.clearSubtree(childIno);
+    this.#clearSubtree(childIno);
     parent.children.delete(name);
-    this.removeCfcEntryAnnotation(parentIno, name);
+    this.#removeCfcEntryAnnotation(parentIno, name);
     return childIno;
   }
 
@@ -476,25 +481,25 @@ export class FsTree {
     const childIno = parent.children.get(name);
     if (childIno === undefined) return undefined;
     parent.children.delete(name);
-    this.removeCfcEntryAnnotation(parentIno, name);
+    this.#removeCfcEntryAnnotation(parentIno, name);
     return childIno;
   }
 
   /** Recursively remove an inode and all its descendants from tracking maps. */
-  private clearSubtree(ino: bigint): void {
+  #clearSubtree(ino: bigint): void {
     const node = this.inodes.get(ino);
     if (!node) return;
     if (node.kind === "dir") {
       for (const [, childIno] of node.children) {
-        this.clearSubtree(childIno);
+        this.#clearSubtree(childIno);
       }
     }
     this.inodes.delete(ino);
     this.parents.delete(ino);
-    this.generated.delete(ino);
+    this.#generated.delete(ino);
     this.cfcEntryIndexes.delete(ino);
-    this.unsortedCfcEntryDirectories.delete(ino);
-    this.untrackPath(ino);
+    this.#unsortedCfcEntryDirectories.delete(ino);
+    this.#untrackPath(ino);
   }
 
   /** Move a node between parents (or rename within same parent). */
@@ -517,18 +522,18 @@ export class FsTree {
     if (!newParent || newParent.kind !== "dir") {
       throw new Error(`New parent ${newParentIno} is not a directory`);
     }
-    const movedCfcEntry = this.getCfcEntryAnnotation(oldParentIno, oldName);
+    const movedCfcEntry = this.#getCfcEntryAnnotation(oldParentIno, oldName);
 
     // If target exists, remove it first
     const existingIno = newParent.children.get(newName);
     if (existingIno !== undefined) {
-      this.clearSubtree(existingIno);
-      this.removeCfcEntryAnnotation(newParentIno, newName);
+      this.#clearSubtree(existingIno);
+      this.#removeCfcEntryAnnotation(newParentIno, newName);
     }
 
     // Move the child
     oldParent.children.delete(oldName);
-    this.removeCfcEntryAnnotation(oldParentIno, oldName);
+    this.#removeCfcEntryAnnotation(oldParentIno, oldName);
     newParent.children.set(newName, childIno);
     this.parents.set(childIno, newParentIno);
     const child = this.inodes.get(childIno);
@@ -546,28 +551,28 @@ export class FsTree {
     }
 
     // Update path tracking for moved node and all descendants
-    this.retrackSubtree(childIno, newParentIno, newName);
+    this.#retrackSubtree(childIno, newParentIno, newName);
   }
 
   /** Recursively update path tracking for an inode and all its descendants. */
-  private retrackSubtree(
+  #retrackSubtree(
     ino: bigint,
     parentIno: bigint,
     name: string,
   ): void {
-    this.untrackPath(ino);
-    this.trackPath(ino, parentIno, name);
+    this.#untrackPath(ino);
+    this.#trackPath(ino, parentIno, name);
     const node = this.inodes.get(ino);
     if (node?.kind === "dir") {
       for (const [childName, childIno] of node.children) {
-        this.retrackSubtree(childIno, ino, childName);
+        this.#retrackSubtree(childIno, ino, childName);
       }
     }
   }
 
   /** Get the registered child name for an inode. */
   getNameForIno(ino: bigint): string | undefined {
-    return this.inoNames.get(ino);
+    return this.#inoNames.get(ino);
   }
 
   /**
@@ -604,8 +609,8 @@ export class FsTree {
       changedInodes: new Set(),
       entryChanges: new Map(),
     };
-    this.transplantNode(oldIno, newIno, changes);
-    this.discardNodeShallow(newIno);
+    this.#transplantNode(oldIno, newIno, changes);
+    this.#discardNodeShallow(newIno);
     return changes;
   }
 
@@ -614,7 +619,7 @@ export class FsTree {
    * directory children. Assumes the two nodes share a kind. Leaves `newIno`'s
    * node in place for the caller to discard once its content has been adopted.
    */
-  private transplantNode(
+  #transplantNode(
     oldIno: bigint,
     newIno: bigint,
     changes: TransplantChanges,
@@ -625,15 +630,15 @@ export class FsTree {
     // Move the replacement's annotation onto the surviving node and clear it
     // from the replacement so discarding the replacement's children can't
     // mutate the now-shared entries list out from under the survivor.
-    this.sortCfcEntries(newIno);
+    this.#sortCfcEntries(newIno);
     oldNode.cfc = newNode.cfc;
     newNode.cfc = undefined;
-    this.rebuildCfcEntryIndex(oldIno, oldNode.cfc);
+    this.#rebuildCfcEntryIndex(oldIno, oldNode.cfc);
     this.cfcEntryIndexes.delete(newIno);
-    this.unsortedCfcEntryDirectories.delete(newIno);
+    this.#unsortedCfcEntryDirectories.delete(newIno);
 
-    if (this.adoptContent(oldNode, newNode)) {
-      this.bumpMtime(oldNode);
+    if (this.#adoptContent(oldNode, newNode)) {
+      this.#bumpMtime(oldNode);
       changes.changedInodes.add(oldIno);
     }
 
@@ -653,19 +658,19 @@ export class FsTree {
         this.inodes.get(oldChildIno)!.kind === newChildNode.kind
       ) {
         // Same path, same kind: the existing inode survives.
-        this.transplantNode(oldChildIno, newChildIno, changes);
-        this.discardNodeShallow(newChildIno);
+        this.#transplantNode(oldChildIno, newChildIno, changes);
+        this.#discardNodeShallow(newChildIno);
       } else {
         // New path, or a kind change that forces a new inode. Drop any old
         // node at this name, then splice the replacement's subtree in with
         // its freshly allocated inodes.
         if (oldChildIno !== undefined) {
-          this.clearSubtree(oldChildIno);
+          this.#clearSubtree(oldChildIno);
         }
         oldNode.children.set(name, newChildIno);
         this.parents.set(newChildIno, oldIno);
-        this.retrackSubtree(newChildIno, oldIno, name);
-        this.recordEntryChange(changes, oldIno, name);
+        this.#retrackSubtree(newChildIno, oldIno, name);
+        this.#recordEntryChange(changes, oldIno, name);
         entriesChanged = true;
       }
     }
@@ -673,16 +678,16 @@ export class FsTree {
     for (const [name, oldChildIno] of oldChildren) {
       if (newByName.has(name)) continue;
       // Present in the old tree, gone from the replacement: remove it.
-      this.clearSubtree(oldChildIno);
+      this.#clearSubtree(oldChildIno);
       oldNode.children.delete(name);
-      this.recordEntryChange(changes, oldIno, name);
+      this.#recordEntryChange(changes, oldIno, name);
       entriesChanged = true;
     }
 
     // A directory whose entry set changed has been modified; advance its mtime
     // so a client that revalidates by attribute sees the change.
     if (entriesChanged) {
-      this.bumpMtime(oldNode);
+      this.#bumpMtime(oldNode);
     }
   }
 
@@ -693,8 +698,8 @@ export class FsTree {
    * attribute always sees a newer mtime after a content change, even on a
    * backend that ignores the inode-invalidation notifications.
    */
-  private bumpMtime(node: FsNode): void {
-    node.mtime = Math.max(this.now(), node.mtime + 1);
+  #bumpMtime(node: FsNode): void {
+    node.mtime = Math.max(this.#now(), node.mtime + 1);
   }
 
   /**
@@ -703,7 +708,7 @@ export class FsTree {
    * caller can invalidate the inode's cached data. A directory returns false —
    * its listing changes are reported through `entryChanges` instead.
    */
-  private adoptContent(oldNode: FsNode, newNode: FsNode): boolean {
+  #adoptContent(oldNode: FsNode, newNode: FsNode): boolean {
     if (oldNode.kind === "dir" && newNode.kind === "dir") {
       oldNode.jsonType = newNode.jsonType;
       return false;
@@ -734,7 +739,7 @@ export class FsTree {
     return false;
   }
 
-  private recordEntryChange(
+  #recordEntryChange(
     changes: TransplantChanges,
     parentIno: bigint,
     name: string,
@@ -752,14 +757,14 @@ export class FsTree {
    * drop a replacement node once its content has been adopted; its children
    * have already been adopted or moved, so recursing would wrongly clear them.
    */
-  private discardNodeShallow(ino: bigint): void {
-    this.unlinkFromParent(ino);
+  #discardNodeShallow(ino: bigint): void {
+    this.#unlinkFromParent(ino);
     this.inodes.delete(ino);
     this.parents.delete(ino);
-    this.generated.delete(ino);
+    this.#generated.delete(ino);
     this.cfcEntryIndexes.delete(ino);
-    this.unsortedCfcEntryDirectories.delete(ino);
-    this.untrackPath(ino);
+    this.#unsortedCfcEntryDirectories.delete(ino);
+    this.#untrackPath(ino);
   }
 
   /** Remove a subtree rooted at `ino`, including the node itself. */
@@ -767,7 +772,7 @@ export class FsTree {
     const node = this.inodes.get(ino);
     if (!node) return;
 
-    this.unlinkFromParent(ino);
-    this.clearSubtree(ino);
+    this.#unlinkFromParent(ino);
+    this.#clearSubtree(ino);
   }
 }

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -73,32 +73,32 @@ export interface DomApplicatorOptions {
  * DOM applicator that applies VDomOps to the real DOM.
  */
 export class DomApplicator {
-  private readonly nodes = new Map<number, Node>();
-  private readonly eventListeners = new Map<
+  readonly #nodes = new Map<number, Node>();
+  readonly #eventListeners = new Map<
     number,
     Map<string, EventListener>
   >();
 
   /** Parent tracking: childId → parentId for O(1) descendant lookup */
-  private readonly nodeParents = new Map<number, number>();
+  readonly #nodeParents = new Map<number, number>();
 
   /** Children tracking: parentId → Set<childId> for O(n) descendant cleanup */
-  private readonly nodeChildren = new Map<number, Set<number>>();
-  private readonly document: Document;
-  private readonly onEvent: (message: DomEventMessage) => void;
-  private readonly runtimeClient?: RuntimeClient;
-  private readonly onError?: (error: Error) => void;
-  private readonly setPropHandler: SetPropHandler;
-  private pendingChildInserts: PendingChildInsert[] = [];
+  readonly #nodeChildren = new Map<number, Set<number>>();
+  readonly #document: Document;
+  readonly #onEvent: (message: DomEventMessage) => void;
+  readonly #runtimeClient?: RuntimeClient;
+  readonly #onError?: (error: Error) => void;
+  readonly #setPropHandler: SetPropHandler;
+  #pendingChildInserts: PendingChildInsert[] = [];
 
-  private rootNodeId: number | null = null;
+  #rootNodeId: number | null = null;
 
   constructor(options: DomApplicatorOptions) {
-    this.document = options.document ?? globalThis.document;
-    this.onEvent = options.onEvent;
-    this.runtimeClient = options.runtimeClient;
-    this.onError = options.onError;
-    this.setPropHandler = options.setProp ?? setPropDefault;
+    this.#document = options.document ?? globalThis.document;
+    this.#onEvent = options.onEvent;
+    this.#runtimeClient = options.runtimeClient;
+    this.#onError = options.onError;
+    this.#setPropHandler = options.setProp ?? setPropDefault;
   }
 
   /**
@@ -110,24 +110,24 @@ export class DomApplicator {
 
     for (const op of batch.ops) {
       try {
-        this.applyOp(op);
-        this.replayPendingChildInserts();
+        this.#applyOp(op);
+        this.#replayPendingChildInserts();
       } catch (error) {
-        this.onError?.(
+        this.#onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       }
     }
-    this.replayPendingChildInserts();
+    this.#replayPendingChildInserts();
 
     if (batch.rootId !== undefined) {
-      this.rootNodeId = batch.rootId;
+      this.#rootNodeId = batch.rootId;
     }
     const elapsed = logger.timeEnd("apply-batch");
     logger.debug("apply-batch", () => [
       `Applied ${opCount} ops in ${elapsed?.toFixed(2)}ms`,
       `(${((elapsed ?? 0) / opCount).toFixed(3)}ms/op)`,
-      `nodes=${this.nodes.size}`,
+      `nodes=${this.#nodes.size}`,
       { ops: batch.ops },
     ]);
   }
@@ -135,56 +135,56 @@ export class DomApplicator {
   /**
    * Apply a single VDOM operation.
    */
-  private applyOp(op: VDomOp): void {
+  #applyOp(op: VDomOp): void {
     switch (op.op) {
       case "create-element":
-        this.createElement(op.nodeId, op.tagName, op.space);
+        this.#createElement(op.nodeId, op.tagName, op.space);
         break;
 
       case "create-text":
-        this.createText(op.nodeId, op.text);
+        this.#createText(op.nodeId, op.text);
         break;
 
       case "update-text":
-        this.updateText(op.nodeId, op.text);
+        this.#updateText(op.nodeId, op.text);
         break;
 
       case "set-prop":
-        this.setProp(op.nodeId, op.key, op.value);
+        this.#setProp(op.nodeId, op.key, op.value);
         break;
 
       case "remove-prop":
-        this.removeProp(op.nodeId, op.key);
+        this.#removeProp(op.nodeId, op.key);
         break;
 
       case "set-event":
-        this.setEvent(op.nodeId, op.eventType, op.handlerId);
+        this.#setEvent(op.nodeId, op.eventType, op.handlerId);
         break;
 
       case "remove-event":
-        this.removeEvent(op.nodeId, op.eventType);
+        this.#removeEvent(op.nodeId, op.eventType);
         break;
 
       case "set-binding":
-        this.setBinding(op.nodeId, op.propName, op.cellRef);
+        this.#setBinding(op.nodeId, op.propName, op.cellRef);
         break;
 
       case "set-piece-boundary":
-        this.setPieceBoundary(op.nodeId, op.cellRef);
+        this.#setPieceBoundary(op.nodeId, op.cellRef);
         break;
 
       case "clear-piece-boundary":
-        this.clearPieceBoundary(op.nodeId);
+        this.#clearPieceBoundary(op.nodeId);
         break;
 
       case "insert-child":
-        if (!this.insertChild(op.parentId, op.childId, op.beforeId)) {
-          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
+        if (!this.#insertChild(op.parentId, op.childId, op.beforeId)) {
+          this.#deferChildInsert(op.parentId, op.childId, op.beforeId);
         }
         break;
 
       case "remove-node":
-        this.removeNode(op.nodeId);
+        this.#removeNode(op.nodeId);
         break;
     }
   }
@@ -193,8 +193,8 @@ export class DomApplicator {
    * Get the root DOM node.
    */
   getRootNode(): Node | null {
-    return this.rootNodeId !== null
-      ? this.nodes.get(this.rootNodeId) ?? null
+    return this.#rootNodeId !== null
+      ? this.#nodes.get(this.#rootNodeId) ?? null
       : null;
   }
 
@@ -202,7 +202,7 @@ export class DomApplicator {
    * Get a DOM node by ID.
    */
   getNode(nodeId: number): Node | undefined {
-    return this.nodes.get(nodeId);
+    return this.#nodes.get(nodeId);
   }
 
   /**
@@ -211,7 +211,7 @@ export class DomApplicator {
    * Must be called before applying any batches.
    */
   setContainer(container: HTMLElement): void {
-    this.nodes.set(CONTAINER_NODE_ID, container);
+    this.#nodes.set(CONTAINER_NODE_ID, container);
   }
 
   /**
@@ -219,23 +219,23 @@ export class DomApplicator {
    */
   dispose(): void {
     logger.timeStart("dispose");
-    const nodeCount = this.nodes.size;
-    const listenerCount = this.eventListeners.size;
+    const nodeCount = this.#nodes.size;
+    const listenerCount = this.#eventListeners.size;
 
     // Remove all event listeners (skip container)
-    for (const [nodeId, listeners] of this.eventListeners) {
+    for (const [nodeId, listeners] of this.#eventListeners) {
       if (nodeId === CONTAINER_NODE_ID) continue;
-      const node = this.nodes.get(nodeId);
+      const node = this.#nodes.get(nodeId);
       if (node) {
         for (const [eventType, listener] of listeners) {
           (node as EventTarget).removeEventListener(eventType, listener);
         }
       }
     }
-    this.eventListeners.clear();
+    this.#eventListeners.clear();
 
     // Remove all nodes except the container (it's owned by the caller)
-    for (const [nodeId, node] of this.nodes) {
+    for (const [nodeId, node] of this.#nodes) {
       if (nodeId === CONTAINER_NODE_ID) continue;
       if (isElementNode(node)) clearPieceBoundary(node);
       if (
@@ -246,11 +246,11 @@ export class DomApplicator {
         node.parentNode.removeChild(node);
       }
     }
-    this.nodes.clear();
-    this.nodeParents.clear();
-    this.nodeChildren.clear();
-    this.pendingChildInserts = [];
-    this.rootNodeId = null;
+    this.#nodes.clear();
+    this.#nodeParents.clear();
+    this.#nodeChildren.clear();
+    this.#pendingChildInserts = [];
+    this.#rootNodeId = null;
 
     const elapsed = logger.timeEnd("dispose");
     logger.debug("dispose", () => [
@@ -274,17 +274,17 @@ export class DomApplicator {
     nodeChildren: Map<number, Set<number>>;
   } {
     let totalListeners = 0;
-    for (const listeners of this.eventListeners.values()) {
+    for (const listeners of this.#eventListeners.values()) {
       totalListeners += listeners.size;
     }
     return {
-      nodeCount: this.nodes.size,
-      listenerCount: this.eventListeners.size,
+      nodeCount: this.#nodes.size,
+      listenerCount: this.#eventListeners.size,
       totalListeners,
-      rootNodeId: this.rootNodeId,
-      nodes: this.nodes,
-      nodeParents: this.nodeParents,
-      nodeChildren: this.nodeChildren,
+      rootNodeId: this.#rootNodeId,
+      nodes: this.#nodes,
+      nodeParents: this.#nodeParents,
+      nodeChildren: this.#nodeChildren,
     };
   }
 
@@ -292,40 +292,40 @@ export class DomApplicator {
   // Operation Implementations
   //
 
-  private createElement(nodeId: number, tagName: string, space?: string): void {
-    const element = this.document.createElement(tagName);
+  #createElement(nodeId: number, tagName: string, space?: string): void {
+    const element = this.#document.createElement(tagName);
     if (space !== undefined) {
       provideElementSpace(element, space);
     }
-    this.nodes.set(nodeId, element);
+    this.#nodes.set(nodeId, element);
   }
 
-  private createText(nodeId: number, text: string): void {
-    const textNode = this.document.createTextNode(text);
-    this.nodes.set(nodeId, textNode);
+  #createText(nodeId: number, text: string): void {
+    const textNode = this.#document.createTextNode(text);
+    this.#nodes.set(nodeId, textNode);
   }
 
-  private updateText(nodeId: number, text: string): void {
-    const node = this.nodes.get(nodeId);
+  #updateText(nodeId: number, text: string): void {
+    const node = this.#nodes.get(nodeId);
     if (isTextNode(node)) {
       node.textContent = text;
     }
   }
 
-  private setProp(nodeId: number, key: string, value: unknown): void {
-    const node = this.nodes.get(nodeId);
+  #setProp(nodeId: number, key: string, value: unknown): void {
+    const node = this.#nodes.get(nodeId);
     if (!isElementNode(node)) return;
 
     // Use the configured property setter (defaults to setPropDefault)
-    this.setPropHandler(node, key, value);
+    this.#setPropHandler(node, key, value);
   }
 
-  private removeProp(nodeId: number, key: string): void {
-    const node = this.nodes.get(nodeId);
+  #removeProp(nodeId: number, key: string): void {
+    const node = this.#nodes.get(nodeId);
     if (!isElementNode(node)) return;
 
     if (key.startsWith("on") && key.length > 2) {
-      this.removeEvent(nodeId, key.slice(2).toLowerCase());
+      this.#removeEvent(nodeId, key.slice(2).toLowerCase());
     } else if (key.startsWith("$") && key.length > 1) {
       (node as any)[key.slice(1)] = undefined;
     } else if (key.startsWith("data-")) {
@@ -337,13 +337,13 @@ export class DomApplicator {
     }
   }
 
-  private setEvent(nodeId: number, eventType: string, handlerId: number): void {
-    const node = this.nodes.get(nodeId);
+  #setEvent(nodeId: number, eventType: string, handlerId: number): void {
+    const node = this.#nodes.get(nodeId);
     if (!node) return;
 
     // Remove existing listener for this event type
-    this.removeEvent(nodeId, eventType);
-    this.removeEventForNode(node, eventType);
+    this.#removeEvent(nodeId, eventType);
+    this.#removeEventForNode(node, eventType);
 
     // Create new listener
     const listener: EventListener = (event: Event) => {
@@ -354,14 +354,14 @@ export class DomApplicator {
         event: serialized,
         nodeId,
       };
-      this.onEvent(message);
+      this.#onEvent(message);
     };
 
     // Track listener
-    let listeners = this.eventListeners.get(nodeId);
+    let listeners = this.#eventListeners.get(nodeId);
     if (!listeners) {
       listeners = new Map();
-      this.eventListeners.set(nodeId, listeners);
+      this.#eventListeners.set(nodeId, listeners);
     }
     listeners.set(eventType, listener);
 
@@ -369,9 +369,9 @@ export class DomApplicator {
     (node as EventTarget).addEventListener(eventType, listener);
   }
 
-  private removeEventForNode(node: Node, eventType: string): void {
-    for (const [trackedNodeId, listeners] of this.eventListeners) {
-      const trackedNode = this.nodes.get(trackedNodeId);
+  #removeEventForNode(node: Node, eventType: string): void {
+    for (const [trackedNodeId, listeners] of this.#eventListeners) {
+      const trackedNode = this.#nodes.get(trackedNodeId);
       if (trackedNode !== node) continue;
 
       const listener = listeners.get(eventType);
@@ -380,33 +380,33 @@ export class DomApplicator {
       (node as EventTarget).removeEventListener(eventType, listener);
       listeners.delete(eventType);
       if (listeners.size === 0) {
-        this.eventListeners.delete(trackedNodeId);
+        this.#eventListeners.delete(trackedNodeId);
       }
     }
   }
 
-  private removeEvent(nodeId: number, eventType: string): void {
-    const listeners = this.eventListeners.get(nodeId);
+  #removeEvent(nodeId: number, eventType: string): void {
+    const listeners = this.#eventListeners.get(nodeId);
     if (!listeners) return;
 
     const listener = listeners.get(eventType);
     if (!listener) return;
 
-    const node = this.nodes.get(nodeId);
+    const node = this.#nodes.get(nodeId);
     if (node) {
       (node as EventTarget).removeEventListener(eventType, listener);
     }
     listeners.delete(eventType);
   }
 
-  private setBinding(nodeId: number, propName: string, cellRef: CellRef): void {
-    const node = this.nodes.get(nodeId);
+  #setBinding(nodeId: number, propName: string, cellRef: CellRef): void {
+    const node = this.#nodes.get(nodeId);
     if (!isElementNode(node)) return;
 
-    if (!this.runtimeClient) {
+    if (!this.#runtimeClient) {
       // No client-side runtime to hand the element a live handle; the
       // reference is what this host can say about the binding.
-      this.setPropHandler(node, propName, cellRef);
+      this.#setPropHandler(node, propName, cellRef);
       return;
     }
 
@@ -419,26 +419,26 @@ export class DomApplicator {
     }
 
     // Create a CellHandle from the CellRef
-    const cellHandle = new CellHandle(this.runtimeClient, cellRef);
+    const cellHandle = new CellHandle(this.#runtimeClient, cellRef);
 
     // Set the CellHandle on the element's property
     // Custom elements like cf-input and cf-checkbox expect this
     (node as any)[propName] = cellHandle;
-    this.notifyBoundProperty(node, propName);
+    this.#notifyBoundProperty(node, propName);
   }
 
-  private setPieceBoundary(nodeId: number, cellRef: CellRef): void {
-    const node = this.nodes.get(nodeId);
-    if (!isElementNode(node) || !this.runtimeClient) return;
-    providePieceBoundary(node, new CellHandle(this.runtimeClient, cellRef));
+  #setPieceBoundary(nodeId: number, cellRef: CellRef): void {
+    const node = this.#nodes.get(nodeId);
+    if (!isElementNode(node) || !this.#runtimeClient) return;
+    providePieceBoundary(node, new CellHandle(this.#runtimeClient, cellRef));
   }
 
-  private clearPieceBoundary(nodeId: number): void {
-    const node = this.nodes.get(nodeId);
+  #clearPieceBoundary(nodeId: number): void {
+    const node = this.#nodes.get(nodeId);
     if (isElementNode(node)) clearPieceBoundary(node);
   }
 
-  private notifyBoundProperty(
+  #notifyBoundProperty(
     node: HTMLElement,
     propName: string,
   ): void {
@@ -460,36 +460,36 @@ export class DomApplicator {
     });
   }
 
-  private insertChild(
+  #insertChild(
     parentId: number,
     childId: number,
     beforeId: number | null,
   ): boolean {
-    const parent = this.nodes.get(parentId);
-    const child = this.nodes.get(childId);
+    const parent = this.#nodes.get(parentId);
+    const child = this.#nodes.get(childId);
     if (!parent || !child) return false;
 
-    const beforeNode = beforeId === null ? null : this.nodes.get(beforeId);
+    const beforeNode = beforeId === null ? null : this.#nodes.get(beforeId);
     if (
       beforeId !== null && (!beforeNode || beforeNode.parentNode !== parent)
     ) {
       return false;
     }
 
-    this.discardPendingForChild(childId);
+    this.#discardPendingForChild(childId);
 
     // Update parent/children tracking
     // Remove from old parent if any
-    const oldParentId = this.nodeParents.get(childId);
+    const oldParentId = this.#nodeParents.get(childId);
     if (oldParentId !== undefined) {
-      this.nodeChildren.get(oldParentId)?.delete(childId);
+      this.#nodeChildren.get(oldParentId)?.delete(childId);
     }
     // Add to new parent
-    this.nodeParents.set(childId, parentId);
-    let children = this.nodeChildren.get(parentId);
+    this.#nodeParents.set(childId, parentId);
+    let children = this.#nodeChildren.get(parentId);
     if (!children) {
       children = new Set();
-      this.nodeChildren.set(parentId, children);
+      this.#nodeChildren.set(parentId, children);
     }
     children.add(childId);
 
@@ -501,24 +501,24 @@ export class DomApplicator {
     return true;
   }
 
-  private deferChildInsert(
+  #deferChildInsert(
     parentId: number,
     childId: number,
     beforeId: number | null,
   ): void {
-    this.discardPendingForChild(childId);
-    this.pendingChildInserts.push({ parentId, childId, beforeId });
+    this.#discardPendingForChild(childId);
+    this.#pendingChildInserts.push({ parentId, childId, beforeId });
   }
 
-  private discardPendingForChild(childId: number): void {
-    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
+  #discardPendingForChild(childId: number): void {
+    this.#pendingChildInserts = this.#pendingChildInserts.filter((pending) =>
       pending.childId !== childId
     );
   }
 
-  private discardPendingForNodeIds(nodeIds: ReadonlySet<number>): void {
+  #discardPendingForNodeIds(nodeIds: ReadonlySet<number>): void {
     const remaining: PendingChildInsert[] = [];
-    for (const pending of this.pendingChildInserts) {
+    for (const pending of this.#pendingChildInserts) {
       if (nodeIds.has(pending.parentId) || nodeIds.has(pending.childId)) {
         continue;
       }
@@ -529,16 +529,16 @@ export class DomApplicator {
           : pending,
       );
     }
-    this.pendingChildInserts = remaining;
+    this.#pendingChildInserts = remaining;
   }
 
-  private replayPendingChildInserts(): void {
-    if (this.pendingChildInserts.length === 0) return;
+  #replayPendingChildInserts(): void {
+    if (this.#pendingChildInserts.length === 0) return;
 
     const remaining: PendingChildInsert[] = [];
-    for (const pending of this.pendingChildInserts) {
+    for (const pending of this.#pendingChildInserts) {
       if (
-        !this.insertChild(
+        !this.#insertChild(
           pending.parentId,
           pending.childId,
           pending.beforeId,
@@ -547,28 +547,28 @@ export class DomApplicator {
         remaining.push(pending);
       }
     }
-    this.pendingChildInserts = remaining;
+    this.#pendingChildInserts = remaining;
   }
 
-  private removeNode(nodeId: number): void {
-    const node = this.nodes.get(nodeId);
+  #removeNode(nodeId: number): void {
+    const node = this.#nodes.get(nodeId);
     const removedNodeIds = new Set([nodeId]);
-    this.collectDescendantNodeIds(nodeId, removedNodeIds);
-    this.discardPendingForNodeIds(removedNodeIds);
+    this.#collectDescendantNodeIds(nodeId, removedNodeIds);
+    this.#discardPendingForNodeIds(removedNodeIds);
     if (!node) return;
 
     logger.timeStart("remove-node", String(nodeId));
 
     // Recursively clean up descendants first (O(n) via parent/children tracking)
-    const descendantCount = this.cleanupDescendants(nodeId);
+    const descendantCount = this.#cleanupDescendants(nodeId);
 
     // Remove event listeners for this node
-    const listeners = this.eventListeners.get(nodeId);
+    const listeners = this.#eventListeners.get(nodeId);
     if (listeners) {
       for (const [eventType, listener] of listeners) {
         (node as EventTarget).removeEventListener(eventType, listener);
       }
-      this.eventListeners.delete(nodeId);
+      this.#eventListeners.delete(nodeId);
     }
 
     if (isElementNode(node)) clearPieceBoundary(node);
@@ -579,15 +579,15 @@ export class DomApplicator {
     }
 
     // Remove from parent tracking
-    const parentId = this.nodeParents.get(nodeId);
+    const parentId = this.#nodeParents.get(nodeId);
     if (parentId !== undefined) {
-      this.nodeChildren.get(parentId)?.delete(nodeId);
-      this.nodeParents.delete(nodeId);
+      this.#nodeChildren.get(parentId)?.delete(nodeId);
+      this.#nodeParents.delete(nodeId);
     }
-    this.nodeChildren.delete(nodeId);
+    this.#nodeChildren.delete(nodeId);
 
     // Remove from tracking
-    this.nodes.delete(nodeId);
+    this.#nodes.delete(nodeId);
 
     const elapsed = logger.timeEnd("remove-node", String(nodeId));
     if (descendantCount > 0) {
@@ -604,47 +604,47 @@ export class DomApplicator {
    * This is O(n) where n is the number of descendants, not O(n*m) like DOM traversal.
    * @returns The number of descendants cleaned up
    */
-  private cleanupDescendants(nodeId: number): number {
-    const children = this.nodeChildren.get(nodeId);
+  #cleanupDescendants(nodeId: number): number {
+    const children = this.#nodeChildren.get(nodeId);
     if (!children || children.size === 0) return 0;
 
     let count = 0;
     // Process children recursively (depth-first)
     for (const childId of children) {
       // Recurse first to clean up grandchildren
-      count += this.cleanupDescendants(childId);
+      count += this.#cleanupDescendants(childId);
 
       // Clean up this child
-      const childNode = this.nodes.get(childId);
+      const childNode = this.#nodes.get(childId);
 
       if (isElementNode(childNode)) clearPieceBoundary(childNode);
 
       // Remove event listeners
-      const listeners = this.eventListeners.get(childId);
+      const listeners = this.#eventListeners.get(childId);
       if (listeners && childNode) {
         for (const [eventType, listener] of listeners) {
           (childNode as EventTarget).removeEventListener(eventType, listener);
         }
-        this.eventListeners.delete(childId);
+        this.#eventListeners.delete(childId);
       }
 
       // Remove from tracking maps
-      this.nodes.delete(childId);
-      this.nodeParents.delete(childId);
-      this.nodeChildren.delete(childId);
+      this.#nodes.delete(childId);
+      this.#nodeParents.delete(childId);
+      this.#nodeChildren.delete(childId);
       count++;
     }
 
     return count;
   }
 
-  private collectDescendantNodeIds(nodeId: number, into: Set<number>): void {
-    const children = this.nodeChildren.get(nodeId);
+  #collectDescendantNodeIds(nodeId: number, into: Set<number>): void {
+    const children = this.#nodeChildren.get(nodeId);
     if (!children || children.size === 0) return;
 
     for (const childId of children) {
       into.add(childId);
-      this.collectDescendantNodeIds(childId, into);
+      this.#collectDescendantNodeIds(childId, into);
     }
   }
 }

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -60,25 +60,25 @@ export interface VDomRendererOptions {
  */
 export class VDomRenderer {
   /** Instance counter for unique mount IDs across all renderer instances */
-  private static nextMountId = 1;
+  static #nextMountId = 1;
 
-  private readonly applicator: DomApplicator;
-  private readonly session: VDomConnection;
-  private readonly onError?: (error: Error) => void;
+  readonly #applicator: DomApplicator;
+  readonly #session: VDomConnection;
+  readonly #onError?: (error: Error) => void;
 
-  private mountId: number | null = null;
-  private containerElement: HTMLElement | null = null;
-  private rootNodeId: number | null = null;
-  private disposed = false;
+  #mountId: number | null = null;
+  #containerElement: HTMLElement | null = null;
+  #rootNodeId: number | null = null;
+  #disposed = false;
 
   constructor(options: VDomRendererOptions) {
-    this.onError = options.onError;
+    this.#onError = options.onError;
 
     // Create the DOM applicator
-    this.applicator = new DomApplicator({
+    this.#applicator = new DomApplicator({
       document: options.document,
       runtimeClient: options.runtimeClient,
-      onEvent: (message) => this.handleDomEvent(message),
+      onEvent: (message) => this.#handleDomEvent(message),
       onError: options.onError,
       setProp: options.setProp,
     });
@@ -88,11 +88,11 @@ export class VDomRenderer {
     // and DOM without a per-mount unmount round-trip), and is the only way to
     // obtain VDOM capability — so a renderer cannot exist without being torn
     // down on disposal.
-    this.session = options.connection.attachVDom(() => this.disposeLocal());
+    this.#session = options.connection.attachVDom(() => this.#disposeLocal());
     // If the connection is already disposed, attachVDom runs the teardown
     // synchronously, so `disposed` is set before `session` is assigned above.
     // Subscribe to batches only while still live.
-    if (!this.disposed) this.session.onBatch(this.handleVDomBatch);
+    if (!this.#disposed) this.#session.onBatch(this.#handleVDomBatch);
   }
 
   /**
@@ -106,39 +106,39 @@ export class VDomRenderer {
     container: HTMLElement,
     cellRef: CellRef,
   ): Promise<() => Promise<void>> {
-    if (this.disposed) {
+    if (this.#disposed) {
       // The connection was disposed before this render began (its teardown ran
       // during construction). A torn-down renderer does not mount.
       return async () => {};
     }
-    if (this.mountId !== null) {
+    if (this.#mountId !== null) {
       throw new Error(
         "VDomRenderer already has an active mount. Call cancel first.",
       );
     }
 
-    this.containerElement = container;
-    this.mountId = VDomRenderer.nextMountId++;
+    this.#containerElement = container;
+    this.#mountId = VDomRenderer.#nextMountId++;
 
     // Register container so the worker can insert children directly into it
-    this.applicator.setContainer(container);
+    this.#applicator.setContainer(container);
 
     // Request the worker to start rendering
-    logger.timeStart("mount", String(this.mountId));
+    logger.timeStart("mount", String(this.#mountId));
     try {
-      const response = await this.session.mount(this.mountId, cellRef);
-      this.rootNodeId = response.rootId;
+      const response = await this.#session.mount(this.#mountId, cellRef);
+      this.#rootNodeId = response.rootId;
 
-      const elapsed = logger.timeEnd("mount", String(this.mountId));
+      const elapsed = logger.timeEnd("mount", String(this.#mountId));
       logger.debug("render-mount", () => [
-        `Mounted VDOM ${this.mountId} in ${elapsed?.toFixed(2)}ms`,
+        `Mounted VDOM ${this.#mountId} in ${elapsed?.toFixed(2)}ms`,
         `rootId=${response.rootId}`,
       ]);
     } catch (error) {
       // Reset state on failure so the renderer can be reused
-      logger.timeEnd("mount", String(this.mountId));
-      this.mountId = null;
-      this.containerElement = null;
+      logger.timeEnd("mount", String(this.#mountId));
+      this.#mountId = null;
+      this.#containerElement = null;
       throw error;
     }
 
@@ -152,31 +152,31 @@ export class VDomRenderer {
    * Stop rendering and clean up.
    */
   async stopRendering(): Promise<void> {
-    if (this.mountId === null) {
+    if (this.#mountId === null) {
       return;
     }
 
-    const mountId = this.mountId;
+    const mountId = this.#mountId;
     logger.timeStart("unmount", String(mountId));
-    this.mountId = null;
+    this.#mountId = null;
 
     // Request the worker to stop rendering
-    await this.session.unmount(mountId);
+    await this.#session.unmount(mountId);
 
     // Remove the root node from DOM
-    if (this.rootNodeId !== null) {
-      const rootNode = this.applicator.getNode(this.rootNodeId);
+    if (this.#rootNodeId !== null) {
+      const rootNode = this.#applicator.getNode(this.#rootNodeId);
       if (
         rootNode &&
-        rootNode !== this.containerElement &&
+        rootNode !== this.#containerElement &&
         rootNode.parentNode
       ) {
         rootNode.parentNode.removeChild(rootNode);
       }
-      this.rootNodeId = null;
+      this.#rootNodeId = null;
     }
 
-    this.containerElement = null;
+    this.#containerElement = null;
 
     const elapsed = logger.timeEnd("unmount", String(mountId));
     logger.debug("stop-rendering", () => [
@@ -190,14 +190,14 @@ export class VDomRenderer {
    * change), so it unmounts the worker-side mount before tearing down locally.
    */
   async dispose(): Promise<void> {
-    if (this.disposed) return;
+    if (this.#disposed) return;
     // We are tearing ourselves down, so detach from the connection's disposal.
-    this.session.detach();
+    this.#session.detach();
     try {
       await this.stopRendering();
     } finally {
       // Detach listeners and drop DOM even if the unmount round-trip failed.
-      this.disposeLocal();
+      this.#disposeLocal();
     }
   }
 
@@ -206,24 +206,24 @@ export class VDomRenderer {
    * an unmount round-trip. Safe to call during connection disposal, and run
    * directly from the connection's disposal hook.
    */
-  private disposeLocal = (): void => {
-    if (this.disposed) return;
-    this.disposed = true;
-    this.mountId = null;
-    this.rootNodeId = null;
-    this.containerElement = null;
+  #disposeLocal = (): void => {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.#mountId = null;
+    this.#rootNodeId = null;
+    this.#containerElement = null;
     // `session` is still unassigned when this runs as the synchronous teardown
     // during attachVDom against an already-disposed connection.
-    this.session?.offBatch(this.handleVDomBatch);
-    this.applicator.dispose();
+    this.#session?.offBatch(this.#handleVDomBatch);
+    this.#applicator.dispose();
   };
 
   /**
    * Get the root DOM node if available.
    */
   getRootNode(): Node | null {
-    return this.rootNodeId !== null
-      ? this.applicator.getNode(this.rootNodeId) ?? null
+    return this.#rootNodeId !== null
+      ? this.#applicator.getNode(this.#rootNodeId) ?? null
       : null;
   }
 
@@ -231,27 +231,27 @@ export class VDomRenderer {
    * Get the underlying DomApplicator for debug inspection.
    */
   getApplicator(): DomApplicator {
-    return this.applicator;
+    return this.#applicator;
   }
 
   /**
    * Get the current mount ID, or null if not mounted.
    */
   getMountId(): number | null {
-    return this.mountId;
+    return this.#mountId;
   }
 
   //
   // Private Methods
   //
 
-  private handleVDomBatch = (notification: VDomBatchNotification): void => {
-    if (this.disposed) return;
+  #handleVDomBatch = (notification: VDomBatchNotification): void => {
+    if (this.#disposed) return;
 
     // Filter for our mount ID
     if (
       notification.mountId !== undefined &&
-      notification.mountId !== this.mountId
+      notification.mountId !== this.#mountId
     ) {
       return;
     }
@@ -260,7 +260,7 @@ export class VDomRenderer {
     try {
       // Apply the batch to the DOM
       // Children are inserted directly into the container (CONTAINER_NODE_ID)
-      this.applicator.applyBatch({
+      this.#applicator.applyBatch({
         batchId: notification.batchId,
         ops: notification.ops,
         rootId: notification.rootId,
@@ -270,11 +270,11 @@ export class VDomRenderer {
       // about the root and leaves the tracked one standing; `null` is the
       // reconciler reporting a tree with no root child, and clears it.
       if (notification.rootId !== undefined) {
-        this.rootNodeId = notification.rootId;
+        this.#rootNodeId = notification.rootId;
       }
 
       if (notification.mountId !== undefined) {
-        this.session.ackBatch(
+        this.#session.ackBatch(
           notification.mountId,
           notification.batchId,
         );
@@ -288,18 +288,18 @@ export class VDomRenderer {
       ]);
     } catch (error) {
       logger.timeEnd("batch", String(notification.batchId));
-      this.onError?.(
+      this.#onError?.(
         error instanceof Error ? error : new Error(String(error)),
       );
     }
   };
 
-  private handleDomEvent(message: DomEventMessage): void {
-    if (this.disposed || this.mountId === null) return;
+  #handleDomEvent(message: DomEventMessage): void {
+    if (this.#disposed || this.#mountId === null) return;
 
     // Send the event to the worker via the VDOM session
-    this.session.sendEvent(
-      this.mountId,
+    this.#session.sendEvent(
+      this.#mountId,
       message.handlerId,
       message.event,
       message.nodeId,

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -190,47 +190,47 @@ function stationaryPositions(
  * Main reconciler class for worker-side VDOM rendering.
  */
 export class WorkerReconciler {
-  private nodeIdCounter = 0;
-  private handlerIdCounter = 0;
-  private handlers = new Map<
+  #nodeIdCounter = 0;
+  #handlerIdCounter = 0;
+  #handlers = new Map<
     number,
     (event: unknown) => void
   >();
-  private retiredHandlers = new Map<number, number>();
-  private pendingRetiredHandlers = new Set<number>();
-  private batchIdCounter = 0;
-  private pendingOps: VDomOp[] = [];
-  private flushScheduled = false;
+  #retiredHandlers = new Map<number, number>();
+  #pendingRetiredHandlers = new Set<number>();
+  #batchIdCounter = 0;
+  #pendingOps: VDomOp[] = [];
+  #flushScheduled = false;
 
   // Track the actual root child node (not the container)
-  private rootChildId: number | null = null;
-  private rootCancel: Cancel | null = null;
+  #rootChildId: number | null = null;
+  #rootCancel: Cancel | null = null;
 
-  private readonly onOps: (ops: VDomOp[]) => number | void;
-  private readonly onError?: (error: Error) => void;
-  private readonly renderDeclassificationPolicy: RenderDeclassificationPolicy;
+  readonly #onOps: (ops: VDomOp[]) => number | void;
+  readonly #onError?: (error: Error) => void;
+  readonly #renderDeclassificationPolicy: RenderDeclassificationPolicy;
   // Root-of-tree render policy: the host's default ceiling when configured
   // (spec §8.10.6), otherwise the historical unbounded policy. Authored
   // boundaries can only narrow from here.
-  private readonly rootRenderPolicy: RenderPolicy;
+  readonly #rootRenderPolicy: RenderPolicy;
   // Runner-side display-boundary resolver (Epic H3b): rewrites a cell's
   // confidentiality label through the exchange rules before the ceiling fit,
   // admitting `Space(...)`-via-`HasRole` principal forms. Undefined = H3a
   // exact-match behavior.
-  private readonly resolveRenderConfidentiality?: RenderConfidentialityResolver;
+  readonly #resolveRenderConfidentiality?: RenderConfidentialityResolver;
   // §4.9.3 Stage 2: the membership provider whose `subscribe` lets a gated
   // `Space(X)`-labeled cell re-render when X's ACL syncs/changes. Undefined =
   // no reactive upgrade (the Stage-1 sync snapshot still gates soundly).
-  private readonly membershipProvider?: SpaceMembershipProvider;
+  readonly #membershipProvider?: SpaceMembershipProvider;
 
   constructor(options: WorkerReconcilerOptions) {
-    this.onOps = options.onOps;
-    this.onError = options.onError;
-    this.resolveRenderConfidentiality = options.resolveRenderConfidentiality;
-    this.membershipProvider = options.membershipProvider;
+    this.#onOps = options.onOps;
+    this.#onError = options.onError;
+    this.#resolveRenderConfidentiality = options.resolveRenderConfidentiality;
+    this.#membershipProvider = options.membershipProvider;
     // Security knob: a present-but-unknown value fails closed to "deny";
     // only an absent option keeps the documented "allow" default.
-    this.renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
+    this.#renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
       options.renderDeclassificationPolicy,
     );
     // Same seam discipline: malformed ceilings normalize to the empty
@@ -238,7 +238,7 @@ export class WorkerReconciler {
     const ceiling = normalizeRenderConfidentialityCeiling(
       options.renderConfidentialityCeiling,
     );
-    this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
+    this.#rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
       maxConfidentiality: [...(ceiling.atoms ?? [])],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
@@ -248,21 +248,21 @@ export class WorkerReconciler {
   /**
    * Create a reconciliation context for this reconciler instance.
    */
-  private createContext(): ReconcileContext {
+  #createContext(): ReconcileContext {
     return {
-      emit: (ops) => this.queueOps(ops),
-      nextNodeId: () => ++this.nodeIdCounter,
+      emit: (ops) => this.#queueOps(ops),
+      nextNodeId: () => ++this.#nodeIdCounter,
       registerHandler: (handler) => {
-        const id = ++this.handlerIdCounter;
-        this.handlers.set(id, handler);
+        const id = ++this.#handlerIdCounter;
+        this.#handlers.set(id, handler);
         return id;
       },
-      getHandler: (id) => this.handlers.get(id),
+      getHandler: (id) => this.#handlers.get(id),
     };
   }
 
   /** Best-effort space of a cell; undefined when it can't name one. */
-  private spaceOfCell(cell: Cell<unknown>): string | undefined {
+  #spaceOfCell(cell: Cell<unknown>): string | undefined {
     try {
       return cell.space;
     } catch {
@@ -281,16 +281,16 @@ export class WorkerReconciler {
     logger.debug(
       "mount",
       () => ({
-        vnodeType: isCell(vnode) ? this.getCellDebugId(vnode) : typeof vnode,
+        vnodeType: isCell(vnode) ? this.#getCellDebugId(vnode) : typeof vnode,
       }),
     );
-    if (this.rootCancel) {
-      this.rootCancel();
+    if (this.#rootCancel) {
+      this.#rootCancel();
     }
 
-    let ctx = this.createContext();
+    let ctx = this.#createContext();
     if (isCell(vnode)) {
-      const rootSpace = this.spaceOfCell(vnode);
+      const rootSpace = this.#spaceOfCell(vnode);
       if (rootSpace) ctx = { ...ctx, space: rootSpace };
     }
     const [cancel, addCancel] = useCancelGroup();
@@ -298,7 +298,7 @@ export class WorkerReconciler {
     // Handle Cell<VNode> at the root
     if (isCell(vnode)) {
       // Create a wrapper state that tracks the current child in the container
-      const wrapperState = this.createWrapperState(ctx, CONTAINER_NODE_ID);
+      const wrapperState = this.#createWrapperState(ctx, CONTAINER_NODE_ID);
 
       // Ensure the current child is cancelled when the root is cancelled
       addCancel(() => wrapperState.cancel());
@@ -315,7 +315,7 @@ export class WorkerReconciler {
         logger.debug("root-cell-update", () => ({ resolvedVnode }));
         lastRootValue = resolvedVnode;
         rootHasRendered = true;
-        this.watchCellMembership(
+        this.#watchCellMembership(
           vnode as Cell<unknown>,
           rootWatchedSpaces,
           addCancel,
@@ -330,35 +330,35 @@ export class WorkerReconciler {
         if (
           !this.canRenderCellUnderPolicy(
             vnode as Cell<unknown>,
-            this.rootRenderPolicy,
+            this.#rootRenderPolicy,
           )
         ) {
-          this.reconcileIntoWrapper(
+          this.#reconcileIntoWrapper(
             ctx,
             wrapperState,
-            this.blockedPlaceholderVNode(),
-            this.rootRenderPolicy,
+            this.#blockedPlaceholderVNode(),
+            this.#rootRenderPolicy,
           );
-          this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
+          this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
           return;
         }
         // Validate that the resolved value is a valid render node
-        if (!this.isValidRenderNode(resolvedVnode)) {
-          this.onError?.(
+        if (!this.#isValidRenderNode(resolvedVnode)) {
+          this.#onError?.(
             new Error(
               `Invalid VDOM content: expected WorkerVNode, string, or number, got ${typeof resolvedVnode}`,
             ),
           );
           return;
         }
-        this.reconcileIntoWrapper(
+        this.#reconcileIntoWrapper(
           ctx,
           wrapperState,
           resolvedVnode as WorkerRenderNode,
-          this.rootRenderPolicy,
+          this.#rootRenderPolicy,
         );
         // Track the root child for cleanup
-        this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
+        this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
       };
 
       addCancel(
@@ -366,16 +366,16 @@ export class WorkerReconciler {
       );
     } else {
       // Static VNode - render directly into container
-      const state = this.renderNode(
+      const state = this.#renderNode(
         ctx,
         vnode,
         new Set(),
-        this.rootRenderPolicy,
+        this.#rootRenderPolicy,
       );
       if (state) {
         addCancel(state.cancel);
-        this.rootChildId = state.nodeId;
-        this.queueOps([
+        this.#rootChildId = state.nodeId;
+        this.#queueOps([
           {
             op: "insert-child",
             parentId: CONTAINER_NODE_ID,
@@ -387,22 +387,22 @@ export class WorkerReconciler {
     }
 
     // Flush any pending operations
-    this.scheduleFlush();
+    this.#scheduleFlush();
 
-    this.rootCancel = cancel;
+    this.#rootCancel = cancel;
     return cancel;
   }
 
   /**
    * Check if a value is a valid render node (VNode, string, number, object with [UI], or null/undefined).
    */
-  private isValidRenderNode(value: unknown): value is WorkerRenderNode {
+  #isValidRenderNode(value: unknown): value is WorkerRenderNode {
     if (value === null || value === undefined) return true;
     if (typeof value === "string" || typeof value === "number") return true;
     if (typeof value === "boolean") return true;
     if (isWorkerVNode(value)) return true;
     if (Array.isArray(value)) {
-      return value.every((item) => this.isValidRenderNode(item));
+      return value.every((item) => this.#isValidRenderNode(item));
     }
     if (isCell(value)) return true;
     // Accept objects with [UI] property - will be unwrapped in renderNode
@@ -414,16 +414,16 @@ export class WorkerReconciler {
    * Unmount the current VDOM tree.
    */
   unmount(): void {
-    logger.debug("unmount", () => ({ rootChildId: this.rootChildId }));
-    if (this.rootCancel) {
-      this.rootCancel();
-      this.rootCancel = null;
+    logger.debug("unmount", () => ({ rootChildId: this.#rootChildId }));
+    if (this.#rootCancel) {
+      this.#rootCancel();
+      this.#rootCancel = null;
     }
-    if (this.rootChildId !== null) {
-      this.queueOps([{ op: "remove-node", nodeId: this.rootChildId }]);
-      this.rootChildId = null;
+    if (this.#rootChildId !== null) {
+      this.#queueOps([{ op: "remove-node", nodeId: this.#rootChildId }]);
+      this.#rootChildId = null;
     }
-    this.flushOps();
+    this.#flushOps();
   }
 
   /**
@@ -433,16 +433,16 @@ export class WorkerReconciler {
    * into HTML — calls this first to make that moment definite.
    */
   flush(): void {
-    this.flushOps();
+    this.#flushOps();
   }
 
   acknowledgeBatchApplied(batchId: number): void {
-    for (const [handlerId, retiredAtBatch] of this.retiredHandlers) {
+    for (const [handlerId, retiredAtBatch] of this.#retiredHandlers) {
       if (retiredAtBatch > batchId) {
         continue;
       }
-      this.retiredHandlers.delete(handlerId);
-      this.handlers.delete(handlerId);
+      this.#retiredHandlers.delete(handlerId);
+      this.#handlers.delete(handlerId);
     }
   }
 
@@ -450,13 +450,13 @@ export class WorkerReconciler {
    * Dispatch a DOM event to its handler.
    */
   dispatchEvent(handlerId: number, event: unknown): boolean {
-    const handler = this.handlers.get(handlerId);
+    const handler = this.#handlers.get(handlerId);
     if (handler) {
       try {
         markRendererTrustedEvent(event);
         handler(event);
       } catch (error) {
-        this.onError?.(
+        this.#onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       }
@@ -469,7 +469,7 @@ export class WorkerReconciler {
    * Get the root child node ID (the actual rendered content).
    */
   getRootNodeId(): number | null {
-    return this.rootChildId;
+    return this.#rootChildId;
   }
 
   //
@@ -479,76 +479,76 @@ export class WorkerReconciler {
   /**
    * Queue operations to be sent to the main thread.
    */
-  private queueOps(ops: VDomOp[]): void {
-    this.pendingOps.push(...ops);
-    this.scheduleFlush();
+  #queueOps(ops: VDomOp[]): void {
+    this.#pendingOps.push(...ops);
+    this.#scheduleFlush();
   }
 
   /**
    * Schedule a flush of pending operations.
    */
-  private scheduleFlush(): void {
-    if (!this.flushScheduled) {
-      this.flushScheduled = true;
-      queueMicrotask(() => this.flushOps());
+  #scheduleFlush(): void {
+    if (!this.#flushScheduled) {
+      this.#flushScheduled = true;
+      queueMicrotask(() => this.#flushOps());
     }
   }
 
   /**
    * Flush all pending operations to the main thread.
    */
-  private flushOps(): void {
-    this.flushScheduled = false;
-    if (this.pendingOps.length > 0) {
-      const ops = this.pendingOps;
+  #flushOps(): void {
+    this.#flushScheduled = false;
+    if (this.#pendingOps.length > 0) {
+      const ops = this.#pendingOps;
       logger.debug("flush-ops", () => ({ count: ops.length, ops }));
-      this.pendingOps = [];
-      const batchId = this.onOps(ops) ?? this.batchIdCounter++;
-      this.assignPendingRetiredHandlers(batchId);
+      this.#pendingOps = [];
+      const batchId = this.#onOps(ops) ?? this.#batchIdCounter++;
+      this.#assignPendingRetiredHandlers(batchId);
     }
   }
 
   /**
    * Clean up event handlers for a node and its descendants.
    */
-  private cleanupNodeHandlers(state: NodeState | ChildNodeState): void {
+  #cleanupNodeHandlers(state: NodeState | ChildNodeState): void {
     // Clean up element state handlers if present
     const elementState = "elementState" in state ? state.elementState : state;
     if (elementState && "eventHandlers" in elementState) {
       for (const handlerId of elementState.eventHandlers.values()) {
-        this.retireHandlerId(handlerId);
+        this.#retireHandlerId(handlerId);
       }
       elementState.eventHandlers.clear();
 
       // Recursively clean up children
       if (elementState.children) {
         for (const child of elementState.children.values()) {
-          this.cleanupNodeHandlers(child);
+          this.#cleanupNodeHandlers(child);
         }
       }
     }
   }
 
-  private retireHandlerId(handlerId: number): void {
-    if (!this.handlers.has(handlerId)) {
+  #retireHandlerId(handlerId: number): void {
+    if (!this.#handlers.has(handlerId)) {
       return;
     }
     if (
-      !this.retiredHandlers.has(handlerId) &&
-      !this.pendingRetiredHandlers.has(handlerId)
+      !this.#retiredHandlers.has(handlerId) &&
+      !this.#pendingRetiredHandlers.has(handlerId)
     ) {
-      this.pendingRetiredHandlers.add(handlerId);
+      this.#pendingRetiredHandlers.add(handlerId);
     }
   }
 
-  private assignPendingRetiredHandlers(batchId: number): void {
-    for (const handlerId of this.pendingRetiredHandlers) {
-      this.retiredHandlers.set(handlerId, batchId);
+  #assignPendingRetiredHandlers(batchId: number): void {
+    for (const handlerId of this.#pendingRetiredHandlers) {
+      this.#retiredHandlers.set(handlerId, batchId);
     }
-    this.pendingRetiredHandlers.clear();
+    this.#pendingRetiredHandlers.clear();
   }
 
-  private retireEventHandler(
+  #retireEventHandler(
     state: NodeState,
     eventType: string,
   ): number | undefined {
@@ -558,7 +558,7 @@ export class WorkerReconciler {
     }
 
     state.eventHandlers.delete(eventType);
-    this.retireHandlerId(handlerId);
+    this.#retireHandlerId(handlerId);
     return handlerId;
   }
 
@@ -568,7 +568,7 @@ export class WorkerReconciler {
    * children reconciliation (same children have active sinks) or do a
    * full replace (children changed).
    */
-  private areChildrenSame(
+  #areChildrenSame(
     state: NodeState,
     newChildren: WorkerRenderNode | WorkerRenderNode[],
   ): boolean {
@@ -588,7 +588,7 @@ export class WorkerReconciler {
     return newKeys.every((key, i) => key === state.childOrder[i]);
   }
 
-  private childRenderPolicyForNode(
+  #childRenderPolicyForNode(
     node: WorkerVNode,
     parentPolicy: RenderPolicy,
     nodeId: number,
@@ -596,22 +596,22 @@ export class WorkerReconciler {
     let policy = parentPolicy;
 
     if (node.name === CFC_RENDER_BOUNDARY_TAG) {
-      const props = this.propsForRenderPolicy(node);
-      const localMax = this.normalizeAtomBound(
-        this.staticPropAsAtomList(props, "maxConfidentiality") ??
-          this.staticPropAsAtomList(props, "data-cfc-max-confidentiality"),
+      const props = this.#propsForRenderPolicy(node);
+      const localMax = this.#normalizeAtomBound(
+        this.#staticPropAsAtomList(props, "maxConfidentiality") ??
+          this.#staticPropAsAtomList(props, "data-cfc-max-confidentiality"),
       );
       // Author-supplied declassification is a fail-open capability (it releases
       // a secret upward). Honor it only when the render policy allows; under
       // "deny" the boundary keeps its fail-closed power to NARROW the bound but
       // cannot declassify (audit S15). Narrowing below is unaffected.
       const declassifyConfidentiality =
-        this.renderDeclassificationPolicy === "deny" ? [] : (
-          this.staticPropAsAtomList(
+        this.#renderDeclassificationPolicy === "deny" ? [] : (
+          this.#staticPropAsAtomList(
             props,
             "declassifyConfidentiality",
           ) ??
-            this.staticPropAsAtomList(
+            this.#staticPropAsAtomList(
               props,
               "data-cfc-declassify-confidentiality",
             ) ??
@@ -619,7 +619,7 @@ export class WorkerReconciler {
         );
 
       policy = {
-        maxConfidentiality: this.narrowMaxConfidentiality(
+        maxConfidentiality: this.#narrowMaxConfidentiality(
           parentPolicy.maxConfidentiality,
           localMax,
         ),
@@ -639,7 +639,7 @@ export class WorkerReconciler {
       return policy;
     }
 
-    const verifyTextIntegrity = this.nodePropAsBoolean(node, [
+    const verifyTextIntegrity = this.#nodePropAsBoolean(node, [
       "verifyTextIntegrity",
       "verify-text-integrity",
       "data-cfc-verify-text-integrity",
@@ -648,12 +648,12 @@ export class WorkerReconciler {
       return policy;
     }
 
-    const allowLiteralText = this.nodePropAsBoolean(node, [
+    const allowLiteralText = this.#nodePropAsBoolean(node, [
       "allowLiteralText",
       "allow-literal-text",
       "data-cfc-allow-literal-text",
     ]) ?? false;
-    const explicitRequiredIntegrity = this.nodePropAsAtomList(node, [
+    const explicitRequiredIntegrity = this.#nodePropAsAtomList(node, [
       "requiredTextIntegrity",
       "requiredIntegrity",
       "data-cfc-required-text-integrity",
@@ -661,7 +661,7 @@ export class WorkerReconciler {
     // Without an explicit requirement, a cell-backed author that represents a
     // principal makes the text boundary require authored-by for that principal.
     const requiredIntegrity = explicitRequiredIntegrity ??
-      this.requiredAuthorshipIntegrityFromAuthor(node) ??
+      this.#requiredAuthorshipIntegrityFromAuthor(node) ??
       [];
 
     // Compose (do not replace) the enclosing text-integrity policy so nesting
@@ -686,7 +686,7 @@ export class WorkerReconciler {
     };
   }
 
-  private propsForRenderPolicy(
+  #propsForRenderPolicy(
     node: WorkerVNode,
   ): WorkerProps | null | undefined {
     if (!isCell(node.props)) {
@@ -703,7 +703,7 @@ export class WorkerReconciler {
     }
   }
 
-  private staticPropAsAtomList(
+  #staticPropAsAtomList(
     props: WorkerProps | null | undefined,
     key: string,
   ): readonly CfcConfClause[] | undefined {
@@ -723,11 +723,11 @@ export class WorkerReconciler {
     return [value as CfcConfClause];
   }
 
-  private nodePropForRenderPolicy(
+  #nodePropForRenderPolicy(
     node: WorkerVNode,
     key: string,
   ): unknown {
-    const props = this.propsForRenderPolicy(node);
+    const props = this.#propsForRenderPolicy(node);
     if (!props || typeof props !== "object" || !(key in props)) {
       return undefined;
     }
@@ -736,7 +736,7 @@ export class WorkerReconciler {
       return value;
     }
     try {
-      return this.resolveCellPropsBindingTarget(
+      return this.#resolveCellPropsBindingTarget(
         node.props as Cell<WorkerProps>,
         key,
         value,
@@ -746,17 +746,17 @@ export class WorkerReconciler {
     }
   }
 
-  private nodePropAsBoolean(
+  #nodePropAsBoolean(
     node: WorkerVNode,
     keys: readonly string[],
   ): boolean | undefined {
     for (const key of keys) {
-      const rawValue = this.nodePropForRenderPolicy(node, key);
+      const rawValue = this.#nodePropForRenderPolicy(node, key);
       if (typeof rawValue === "function") {
         continue;
       }
       const value = isCell(rawValue)
-        ? this.readCellPolicyValue(rawValue as Cell<unknown>)
+        ? this.#readCellPolicyValue(rawValue as Cell<unknown>)
         : rawValue;
       if (typeof value === "boolean") {
         return value;
@@ -773,17 +773,17 @@ export class WorkerReconciler {
     return undefined;
   }
 
-  private nodePropAsAtomList(
+  #nodePropAsAtomList(
     node: WorkerVNode,
     keys: readonly string[],
   ): readonly CfcAtom[] | undefined {
     for (const key of keys) {
-      const value = this.nodePropForRenderPolicy(node, key);
+      const value = this.#nodePropForRenderPolicy(node, key);
       if (typeof value === "function") {
         continue;
       }
       const resolved = isCell(value)
-        ? this.readCellPolicyValue(value as Cell<unknown>)
+        ? this.#readCellPolicyValue(value as Cell<unknown>)
         : value;
       if (resolved === undefined) {
         continue;
@@ -793,15 +793,15 @@ export class WorkerReconciler {
     return undefined;
   }
 
-  private requiredAuthorshipIntegrityFromAuthor(
+  #requiredAuthorshipIntegrityFromAuthor(
     node: WorkerVNode,
   ): readonly CfcAtom[] | undefined {
-    const author = this.nodePropForRenderPolicy(node, "author") ??
-      this.nodePropForRenderPolicy(node, "$author");
+    const author = this.#nodePropForRenderPolicy(node, "author") ??
+      this.#nodePropForRenderPolicy(node, "$author");
     if (!isCell(author)) {
       return undefined;
     }
-    const subject = this.representsPrincipalSubjectForCell(
+    const subject = this.#representsPrincipalSubjectForCell(
       author as Cell<unknown>,
     );
     return subject === undefined
@@ -809,7 +809,7 @@ export class WorkerReconciler {
       : [{ kind: "authored-by", subject }];
   }
 
-  private bindingOpsForCell(
+  #bindingOpsForCell(
     state: NodeState,
     propName: string,
     cell: Cell<unknown>,
@@ -818,12 +818,12 @@ export class WorkerReconciler {
       op: "set-binding",
       nodeId: state.nodeId,
       propName,
-      cellRef: this.cellRefForBinding(cell),
+      cellRef: this.#cellRefForBinding(cell),
     }];
   }
 
   /** Keep the nested pattern's whole result cell on its existing root node. */
-  private updatePieceBoundary(
+  #updatePieceBoundary(
     childState: ChildNodeState,
     resolvedChild: unknown,
     resultCell: Cell<unknown>,
@@ -833,14 +833,14 @@ export class WorkerReconciler {
 
     if (shouldBind) {
       childState.hasPieceBoundary = true;
-      this.queueOps([{
+      this.#queueOps([{
         op: "set-piece-boundary",
         nodeId: childState.elementState.nodeId,
-        cellRef: this.cellRefForBinding(resultCell),
+        cellRef: this.#cellRefForBinding(resultCell),
       }]);
     } else if (childState.hasPieceBoundary) {
       childState.hasPieceBoundary = false;
-      this.queueOps([{
+      this.#queueOps([{
         op: "clear-piece-boundary",
         nodeId: childState.elementState.nodeId,
       }]);
@@ -848,7 +848,7 @@ export class WorkerReconciler {
   }
 
   /** Follow a link-valued child to the result cell whose UI is rendered. */
-  private resolveCellForBinding(cell: Cell<unknown>): Cell<unknown> {
+  #resolveCellForBinding(cell: Cell<unknown>): Cell<unknown> {
     try {
       return cell.resolveAsCell();
     } catch {
@@ -856,7 +856,7 @@ export class WorkerReconciler {
     }
   }
 
-  private cellRefForBinding(cell: Cell<unknown>): CellRef {
+  #cellRefForBinding(cell: Cell<unknown>): CellRef {
     const link = cell.getAsNormalizedFullLink();
     let labelView: CfcLabelView | undefined;
     try {
@@ -872,13 +872,13 @@ export class WorkerReconciler {
       space: link.space,
       scope: link.scope,
       path: [...link.path],
-      schema: this.bindingSchema(link.schema),
+      schema: this.#bindingSchema(link.schema),
       ...(link.overwrite !== undefined && { overwrite: link.overwrite }),
       ...(labelView !== undefined && { cfcLabelView: labelView }),
     };
   }
 
-  private bindingSchema(schema: CellRef["schema"] | undefined): CellRef[
+  #bindingSchema(schema: CellRef["schema"] | undefined): CellRef[
     "schema"
   ] {
     if (
@@ -900,24 +900,24 @@ export class WorkerReconciler {
    * represents-principal read, and the Stage-2 membership watcher
    * (`watchCellMembership`), so they can never drift out of lockstep.
    */
-  private resolveCellLabelView(cell: Cell<unknown>): CfcLabelView | undefined {
+  #resolveCellLabelView(cell: Cell<unknown>): CfcLabelView | undefined {
     return cfcLabelViewForCell(cell) ??
       cfcLabelViewForCell(cell.resolveAsCell());
   }
 
-  private representsPrincipalSubjectForCell(
+  #representsPrincipalSubjectForCell(
     cell: Cell<unknown>,
   ): string | undefined {
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = this.resolveCellLabelView(cell);
+      labelView = this.#resolveCellLabelView(cell);
     } catch {
       return undefined;
     }
     if (labelView === undefined) {
       return undefined;
     }
-    for (const atom of this.integrityLabels(labelView)) {
+    for (const atom of this.#integrityLabels(labelView)) {
       if (typeof atom !== "object" || atom === null || Array.isArray(atom)) {
         continue;
       }
@@ -932,7 +932,7 @@ export class WorkerReconciler {
     return undefined;
   }
 
-  private staticCellProp(
+  #staticCellProp(
     props: WorkerProps | null | undefined,
     key: string,
   ): Cell<unknown> | undefined {
@@ -943,7 +943,7 @@ export class WorkerReconciler {
     return isCell(value) ? value as Cell<unknown> : undefined;
   }
 
-  private childrenForRenderPolicy(
+  #childrenForRenderPolicy(
     node: WorkerVNode,
     policy: RenderPolicy,
   ): {
@@ -956,25 +956,25 @@ export class WorkerReconciler {
     if (node.children === undefined) {
       return { children: undefined, blocked: false };
     }
-    if (!this.shouldBlockBoundaryChildren(node, policy)) {
+    if (!this.#shouldBlockBoundaryChildren(node, policy)) {
       return { children: node.children, blocked: false };
     }
-    return { children: [this.blockedPlaceholderVNode()], blocked: true };
+    return { children: [this.#blockedPlaceholderVNode()], blocked: true };
   }
 
-  private shouldBlockBoundaryChildren(
+  #shouldBlockBoundaryChildren(
     node: WorkerVNode,
     policy: RenderPolicy,
   ): boolean {
     if (node.name !== CFC_RENDER_BOUNDARY_TAG) {
       return false;
     }
-    const protectedValue = this.boundaryProtectedValueCell(node);
+    const protectedValue = this.#boundaryProtectedValueCell(node);
     return protectedValue !== undefined &&
       !this.canRenderCellUnderPolicy(protectedValue, policy);
   }
 
-  private boundaryProtectedValueCell(
+  #boundaryProtectedValueCell(
     node: WorkerVNode,
   ): Cell<unknown> | undefined {
     if (isCell(node.props)) {
@@ -992,7 +992,7 @@ export class WorkerReconciler {
         return undefined;
       }
       try {
-        return this.resolveCellPropsBindingTarget(
+        return this.#resolveCellPropsBindingTarget(
           propsCell,
           "$value",
           (rawProps as Record<string, unknown>)["$value"],
@@ -1001,10 +1001,10 @@ export class WorkerReconciler {
         return undefined;
       }
     }
-    return this.staticCellProp(node.props, "$value");
+    return this.#staticCellProp(node.props, "$value");
   }
 
-  private blockedPlaceholderVNode(
+  #blockedPlaceholderVNode(
     reason: "policy" | "integrity" = "policy",
   ): WorkerVNode {
     const integrityBlocked = reason === "integrity";
@@ -1026,7 +1026,7 @@ export class WorkerReconciler {
     };
   }
 
-  private normalizeAtomBound(
+  #normalizeAtomBound(
     labels: readonly unknown[] | undefined,
   ): readonly CfcConfClause[] | undefined {
     if (labels === undefined) {
@@ -1035,7 +1035,7 @@ export class WorkerReconciler {
     return ContextualFlowControl.uniqueAtoms(labels);
   }
 
-  private narrowMaxConfidentiality(
+  #narrowMaxConfidentiality(
     parentMax: readonly CfcConfClause[] | undefined,
     localMax: readonly CfcConfClause[] | undefined,
   ): readonly CfcConfClause[] | undefined {
@@ -1050,14 +1050,14 @@ export class WorkerReconciler {
     );
   }
 
-  private renderPolicyEquals(
+  #renderPolicyEquals(
     left: RenderPolicy,
     right: RenderPolicy,
   ): boolean {
     const maxConfidentialityEquals = left.maxConfidentiality === undefined ||
         right.maxConfidentiality === undefined
       ? left.maxConfidentiality === right.maxConfidentiality
-      : this.atomListsEqual(
+      : this.#atomListsEqual(
         left.maxConfidentiality,
         right.maxConfidentiality,
       );
@@ -1069,14 +1069,14 @@ export class WorkerReconciler {
       );
 
     return maxConfidentialityEquals && caveatKindsEqual &&
-      this.atomListsEqual(
+      this.#atomListsEqual(
         left.declassifyConfidentiality,
         right.declassifyConfidentiality,
       ) &&
-      this.textIntegrityPolicyEquals(left, right);
+      this.#textIntegrityPolicyEquals(left, right);
   }
 
-  private textIntegrityPolicyEquals(
+  #textIntegrityPolicyEquals(
     left: RenderPolicy,
     right: RenderPolicy,
   ): boolean {
@@ -1085,18 +1085,18 @@ export class WorkerReconciler {
     if (leftPolicy === undefined || rightPolicy === undefined) {
       return leftPolicy === rightPolicy;
     }
-    return this.atomListsEqual(
+    return this.#atomListsEqual(
       leftPolicy.requiredIntegrity,
       rightPolicy.requiredIntegrity,
     ) &&
       leftPolicy.allowLiteralText === rightPolicy.allowLiteralText &&
-      this.boundaryNodeIdsEqual(
+      this.#boundaryNodeIdsEqual(
         leftPolicy.boundaryNodeIds,
         rightPolicy.boundaryNodeIds,
       );
   }
 
-  private boundaryNodeIdsEqual(
+  #boundaryNodeIdsEqual(
     left: ReadonlySet<number>,
     right: ReadonlySet<number>,
   ): boolean {
@@ -1104,7 +1104,7 @@ export class WorkerReconciler {
       [...left].every((id) => right.has(id));
   }
 
-  private atomListsEqual(
+  #atomListsEqual(
     left: readonly unknown[],
     right: readonly unknown[],
   ): boolean {
@@ -1112,6 +1112,11 @@ export class WorkerReconciler {
       left.every((value, index) => deepEqual(value, right[index]));
   }
 
+  /**
+   * TypeScript-private rather than a `#` name:
+   * `test/worker-reconciler-cfc-atom-admission.test.ts` drives this member
+   * directly.
+   */
   private canRenderCellUnderPolicy(
     cell: Cell<unknown>,
     policy: RenderPolicy,
@@ -1125,7 +1130,7 @@ export class WorkerReconciler {
 
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = this.resolveCellLabelView(cell);
+      labelView = this.#resolveCellLabelView(cell);
     } catch {
       return false;
     }
@@ -1134,7 +1139,7 @@ export class WorkerReconciler {
     // `Space(...)`-via-`HasRole` principal forms become admissible. Without a
     // resolver, or on a declassify-only boundary, fall back to the H3a
     // per-atom exact-match path.
-    const useResolver = this.resolveRenderConfidentiality !== undefined &&
+    const useResolver = this.#resolveRenderConfidentiality !== undefined &&
       policy.maxConfidentiality !== undefined;
 
     if (labelView === undefined) {
@@ -1144,7 +1149,7 @@ export class WorkerReconciler {
       // not carry the runtime `Space(...)` principals resolution targets, and
       // the per-atom exact-match fit stays fail-closed for anything it cannot
       // admit — the resolver drives the stored-label path below.
-      const schemaLabels = this.confidentialityLabelsFromCellSchema(cell);
+      const schemaLabels = this.#confidentialityLabelsFromCellSchema(cell);
       if (schemaLabels.length === 0) {
         return true;
       }
@@ -1153,11 +1158,11 @@ export class WorkerReconciler {
       );
     }
 
-    const confidentiality = this.confidentialityLabels(labelView);
+    const confidentiality = this.#confidentialityLabels(labelView);
     if (useResolver) {
-      return this.resolvedConfidentialityRenderable(
+      return this.#resolvedConfidentialityRenderable(
         confidentiality,
-        this.integrityLabels(labelView),
+        this.#integrityLabels(labelView),
         policy,
       );
     }
@@ -1180,12 +1185,12 @@ export class WorkerReconciler {
    * (audit item 22), author declassification and the caveat-kind allow-list
    * admit only bare atoms — an OR-clause never matches either, staying closed.
    */
-  private resolvedConfidentialityRenderable(
+  #resolvedConfidentialityRenderable(
     confidentiality: readonly CfcConfClause[],
     integrity: readonly CfcAtom[],
     policy: RenderPolicy,
   ): boolean {
-    const resolved = this.resolveRenderConfidentiality!({
+    const resolved = this.#resolveRenderConfidentiality!({
       confidentiality,
       integrity,
     });
@@ -1214,7 +1219,7 @@ export class WorkerReconciler {
       ) {
         continue;
       }
-      if (this.canRenderConfidentialityAtom(clause, policy)) {
+      if (this.#canRenderConfidentialityAtom(clause, policy)) {
         continue;
       }
       return false;
@@ -1228,6 +1233,10 @@ export class WorkerReconciler {
    * neither author declassification nor a ceiling entry — even one naming
    * the exported marker string — may admit it. Every other atom checks
    * declassification first, then the ceiling.
+   *
+   * TypeScript-private rather than a `#` name:
+   * `test/worker-reconciler-cfc-atom-admission.test.ts` drives this member
+   * directly.
    */
   private atomRenderableUnderPolicy(
     atom: unknown,
@@ -1243,10 +1252,10 @@ export class WorkerReconciler {
     ) {
       return true;
     }
-    return this.canRenderConfidentialityAtom(atom, policy);
+    return this.#canRenderConfidentialityAtom(atom, policy);
   }
 
-  private confidentialityLabels(
+  #confidentialityLabels(
     labelView: CfcLabelView,
   ): readonly CfcConfClause[] {
     return ContextualFlowControl.uniqueAtoms(
@@ -1268,13 +1277,13 @@ export class WorkerReconciler {
    * lockstep. Any label-read failure is swallowed (fail closed on watching —
    * the render fit itself stays fail-closed independently).
    */
-  private watchCellMembership(
+  #watchCellMembership(
     cell: Cell<unknown>,
     watched: Set<string>,
     addCancel: (cancel: Cancel) => void,
     reeval: () => void,
   ): void {
-    const provider = this.membershipProvider;
+    const provider = this.#membershipProvider;
     if (provider === undefined) {
       return;
     }
@@ -1284,7 +1293,7 @@ export class WorkerReconciler {
     // is watched, not silently left un-upgradable.
     let labelView: CfcLabelView | undefined;
     try {
-      labelView = this.resolveCellLabelView(cell);
+      labelView = this.#resolveCellLabelView(cell);
     } catch {
       labelView = undefined;
     }
@@ -1294,7 +1303,7 @@ export class WorkerReconciler {
     if (labelView === undefined) return;
     for (
       const space of spaceAtomIdsInConfidentiality(
-        this.confidentialityLabels(labelView),
+        this.#confidentialityLabels(labelView),
       )
     ) {
       if (watched.has(space)) continue;
@@ -1303,7 +1312,7 @@ export class WorkerReconciler {
     }
   }
 
-  private confidentialityLabelsFromCellSchema(
+  #confidentialityLabelsFromCellSchema(
     cell: Cell<unknown>,
   ): readonly unknown[] {
     const schema = (cell as { schema?: JSONSchema }).schema;
@@ -1319,11 +1328,11 @@ export class WorkerReconciler {
     return ContextualFlowControl.uniqueAtoms(joined);
   }
 
-  private canRenderConfidentialityAtom(
+  #canRenderConfidentialityAtom(
     atom: unknown,
     policy: RenderPolicy,
   ): boolean {
-    const max = this.normalizeAtomBound(policy.maxConfidentiality);
+    const max = this.#normalizeAtomBound(policy.maxConfidentiality);
     if (max === undefined) {
       return true;
     }
@@ -1345,7 +1354,7 @@ export class WorkerReconciler {
     return false;
   }
 
-  private refreshTextIntegrityBoundary(
+  #refreshTextIntegrityBoundary(
     ctx: ReconcileContext,
     state: NodeState,
   ): void {
@@ -1358,10 +1367,10 @@ export class WorkerReconciler {
       return;
     }
 
-    this.refreshBoundaryPolicyFromProps(ctx, state, state.sourceProps);
+    this.#refreshBoundaryPolicyFromProps(ctx, state, state.sourceProps);
   }
 
-  private isTextIntegrityPolicyProp(key: string): boolean {
+  #isTextIntegrityPolicyProp(key: string): boolean {
     return key === "requiredTextIntegrity" ||
       key === "requiredIntegrity" ||
       key === "data-cfc-required-text-integrity" ||
@@ -1375,14 +1384,14 @@ export class WorkerReconciler {
       key === "data-cfc-allow-literal-text";
   }
 
-  private initializeTextIntegrityBoundary(
+  #initializeTextIntegrityBoundary(
     policy: RenderPolicy,
     nodeId: number,
   ): void {
     if (!policy.textIntegrity?.boundaryNodeIds.has(nodeId)) {
       return;
     }
-    this.queueOps([{
+    this.#queueOps([{
       op: "set-prop",
       nodeId,
       key: "textIntegrityState",
@@ -1390,7 +1399,7 @@ export class WorkerReconciler {
     }]);
   }
 
-  private refreshTextIntegrityBoundaryState(
+  #refreshTextIntegrityBoundaryState(
     state: NodeState,
     policy: RenderPolicy,
   ): void {
@@ -1405,10 +1414,10 @@ export class WorkerReconciler {
     }
     const value = policy.textIntegrity === undefined
       ? "ok"
-      : this.hasTextIntegrityBlockForBoundary(state, state.nodeId)
+      : this.#hasTextIntegrityBlockForBoundary(state, state.nodeId)
       ? "blocked"
       : "ok";
-    this.queueOps([{
+    this.#queueOps([{
       op: "set-prop",
       nodeId: state.nodeId,
       key: "textIntegrityState",
@@ -1416,7 +1425,7 @@ export class WorkerReconciler {
     }]);
   }
 
-  private hasTextIntegrityBlockForBoundary(
+  #hasTextIntegrityBlockForBoundary(
     state: NodeState,
     boundaryNodeId: number,
   ): boolean {
@@ -1434,7 +1443,7 @@ export class WorkerReconciler {
     for (const child of state.children.values()) {
       if (
         child.elementState &&
-        this.hasTextIntegrityBlockForBoundary(
+        this.#hasTextIntegrityBlockForBoundary(
           child.elementState,
           boundaryNodeId,
         )
@@ -1445,7 +1454,7 @@ export class WorkerReconciler {
     return false;
   }
 
-  private markTextIntegrityBlocked(
+  #markTextIntegrityBlocked(
     policy: RenderPolicy,
   ): ReadonlySet<number> | undefined {
     const boundaryNodeIds = policy.textIntegrity?.boundaryNodeIds;
@@ -1454,7 +1463,7 @@ export class WorkerReconciler {
     }
     // Attribute the block to EVERY enclosing boundary, not just the nearest, so
     // an outer boundary cannot stay "ok" over content that failed its bar.
-    this.queueOps(
+    this.#queueOps(
       [...boundaryNodeIds].map((nodeId) => ({
         op: "set-prop" as const,
         nodeId,
@@ -1465,7 +1474,7 @@ export class WorkerReconciler {
     return boundaryNodeIds;
   }
 
-  private canRenderCellTextUnderPolicy(
+  #canRenderCellTextUnderPolicy(
     cell: Cell<unknown>,
     policy: RenderPolicy,
   ): boolean {
@@ -1490,13 +1499,13 @@ export class WorkerReconciler {
       return false;
     }
 
-    const integrity = this.integrityLabels(labelView);
+    const integrity = this.#integrityLabels(labelView);
     return textIntegrity.requiredIntegrity.every((required) =>
       integrity.some((atom) => deepEqual(atom, required))
     );
   }
 
-  private integrityLabels(labelView: CfcLabelView): readonly CfcAtom[] {
+  #integrityLabels(labelView: CfcLabelView): readonly CfcAtom[] {
     return ContextualFlowControl.uniqueAtoms(
       labelView.entries.flatMap((entry) =>
         entry.path.length === 0 ? [...(entry.label.integrity ?? [])] : []
@@ -1504,7 +1513,7 @@ export class WorkerReconciler {
     );
   }
 
-  private readCellValue(cell: Cell<unknown>): unknown {
+  #readCellValue(cell: Cell<unknown>): unknown {
     const readableCell = cell as Cell<unknown> & {
       get?: (options?: { traverseCells?: boolean }) => unknown;
       getRawUntyped?: (options?: { frozen?: false }) => unknown;
@@ -1523,7 +1532,7 @@ export class WorkerReconciler {
     }
   }
 
-  private readCellPolicyValue(cell: Cell<unknown>): unknown {
+  #readCellPolicyValue(cell: Cell<unknown>): unknown {
     const readableCell = cell as Cell<unknown> & {
       get?: (options?: { traverseCells?: boolean }) => unknown;
       getRawUntyped?: (options?: { frozen?: false }) => unknown;
@@ -1543,7 +1552,7 @@ export class WorkerReconciler {
     return undefined;
   }
 
-  private shouldBlockLiteralText(
+  #shouldBlockLiteralText(
     value: unknown,
     policy: RenderPolicy,
   ): boolean {
@@ -1551,10 +1560,10 @@ export class WorkerReconciler {
     if (textIntegrity === undefined || textIntegrity.allowLiteralText) {
       return false;
     }
-    return this.hasVisibleTextValue(value);
+    return this.#hasVisibleTextValue(value);
   }
 
-  private shouldBlockTextFromCell(
+  #shouldBlockTextFromCell(
     value: unknown,
     cell: Cell<unknown>,
     policy: RenderPolicy,
@@ -1562,18 +1571,18 @@ export class WorkerReconciler {
     if (policy.textIntegrity === undefined) {
       return false;
     }
-    if (isWorkerVNode(value) || this.isRenderableObject(value)) {
+    if (isWorkerVNode(value) || this.#isRenderableObject(value)) {
       return false;
     }
-    if (!this.hasVisibleTextValue(value)) return false;
-    return !this.canRenderCellTextUnderPolicy(cell, policy);
+    if (!this.#hasVisibleTextValue(value)) return false;
+    return !this.#canRenderCellTextUnderPolicy(cell, policy);
   }
 
-  private isRenderableObject(value: unknown): boolean {
+  #isRenderableObject(value: unknown): boolean {
     return value !== null && typeof value === "object" && UI in value;
   }
 
-  private hasVisibleTextValue(value: unknown): boolean {
+  #hasVisibleTextValue(value: unknown): boolean {
     if (value === null || value === undefined || value === false) {
       return false;
     }
@@ -1589,7 +1598,7 @@ export class WorkerReconciler {
     return typeof value === "object";
   }
 
-  private isTextIntegrityProp(state: NodeState, key: string): boolean {
+  #isTextIntegrityProp(state: NodeState, key: string): boolean {
     return TEXT_INTEGRITY_PROP_SINKS.get(state.tagName)?.has(key) ?? false;
   }
 
@@ -1613,7 +1622,7 @@ export class WorkerReconciler {
    * Assumes the default value-guarded setProp; a custom setProp with observable
    * same-value behavior would not be re-invoked on a skip.
    */
-  private canSkipUnchangedStaticProp(
+  #canSkipUnchangedStaticProp(
     state: NodeState,
     key: string,
     value: unknown,
@@ -1627,33 +1636,35 @@ export class WorkerReconciler {
       // `Object.is`, not `===`: an unchanged `NaN` prop must still be
       // skippable, and a `0` -> `-0` change is a real change.
       Object.is(existingState.currentValue, value) &&
-      !this.isTextIntegrityProp(state, key) &&
+      !this.#isTextIntegrityProp(state, key) &&
       !DOM_LIVE_PROPS.has(key);
   }
 
-  private transformPropValueForState(
+  #transformPropValueForState(
     state: NodeState,
     key: string,
     value: unknown,
     sourceCell?: Cell<unknown>,
     // deno-lint-ignore no-explicit-any
   ): any {
-    if (this.isTextIntegrityProp(state, key)) {
+    if (this.#isTextIntegrityProp(state, key)) {
       const shouldBlock = sourceCell
-        ? this.shouldBlockTextFromCell(value, sourceCell, state.renderPolicy)
-        : this.shouldBlockLiteralText(value, state.renderPolicy);
+        ? this.#shouldBlockTextFromCell(value, sourceCell, state.renderPolicy)
+        : this.#shouldBlockLiteralText(value, state.renderPolicy);
       if (!shouldBlock) {
         state.textIntegrityBlockedProps?.delete(key);
-        return this.transformPropValue(key, value);
+        return this.#transformPropValue(key, value);
       }
-      const boundaryNodeIds = this.markTextIntegrityBlocked(state.renderPolicy);
+      const boundaryNodeIds = this.#markTextIntegrityBlocked(
+        state.renderPolicy,
+      );
       if (boundaryNodeIds !== undefined) {
         if (state.textIntegrityBlockedProps === undefined) {
           state.textIntegrityBlockedProps = new Map();
         }
         state.textIntegrityBlockedProps.set(key, boundaryNodeIds);
       }
-      this.queueOps([{
+      this.#queueOps([{
         op: "set-prop",
         nodeId: state.nodeId,
         key: "data-cfc-blocked-props",
@@ -1661,13 +1672,13 @@ export class WorkerReconciler {
       }]);
       return CFC_TEXT_INTEGRITY_PLACEHOLDER;
     }
-    return this.transformPropValue(key, value);
+    return this.#transformPropValue(key, value);
   }
 
   /**
    * Create a wrapper state for reactive roots.
    */
-  private createWrapperState(_ctx: ReconcileContext, nodeId: number): {
+  #createWrapperState(_ctx: ReconcileContext, nodeId: number): {
     nodeId: number;
     currentChild: NodeState | null;
     cancel: Cancel;
@@ -1684,7 +1695,7 @@ export class WorkerReconciler {
    * Follows [UI] chains and returns the VNode, or null if not a VNode.
    * Includes cycle detection to prevent infinite loops.
    */
-  private extractVNode(node: unknown): WorkerVNode | null {
+  #extractVNode(node: unknown): WorkerVNode | null {
     if (isWorkerVNode(node)) return node;
 
     // Follow [UI] chain with cycle detection
@@ -1707,7 +1718,7 @@ export class WorkerReconciler {
    * Reconcile a VNode into a wrapper (for reactive roots).
    * Diffs old vs new VNodes and updates in place when possible.
    */
-  private reconcileIntoWrapper(
+  #reconcileIntoWrapper(
     ctx: ReconcileContext,
     wrapper: {
       nodeId: number;
@@ -1717,7 +1728,7 @@ export class WorkerReconciler {
     node: WorkerRenderNode,
     policy: RenderPolicy,
   ): void {
-    const newVNode = this.extractVNode(node);
+    const newVNode = this.#extractVNode(node);
     const oldState = wrapper.currentChild;
 
     // Get old element's tag name (if it exists and is an element)
@@ -1740,18 +1751,18 @@ export class WorkerReconciler {
 
     // Case 1: Same element type - update in place
     if (oldState && oldTagName && newTagName && oldTagName === newTagName) {
-      const sanitized = this.sanitizeNode(newVNode!);
+      const sanitized = this.#sanitizeNode(newVNode!);
       if (sanitized) {
-        const childPolicy = this.childRenderPolicyForNode(
+        const childPolicy = this.#childRenderPolicyForNode(
           sanitized,
           policy,
           oldState.nodeId,
         );
-        const policyChildren = this.childrenForRenderPolicy(
+        const policyChildren = this.#childrenForRenderPolicy(
           sanitized,
           childPolicy,
         );
-        const policyChanged = !this.renderPolicyEquals(
+        const policyChanged = !this.#renderPolicyEquals(
           oldState.childRenderPolicy,
           childPolicy,
         ) || oldState.childrenBlockedByPolicy !== policyChildren.blocked;
@@ -1766,15 +1777,15 @@ export class WorkerReconciler {
         oldState.sourceChildren = sanitized.children;
         oldState.sourceProps = sanitized.props;
         // Update props in place with proper diffing
-        this.updatePropsInPlace(ctx, oldState, sanitized.props);
+        this.#updatePropsInPlace(ctx, oldState, sanitized.props);
 
         // Update children in place with proper diffing
         if (policyChildren.children !== undefined) {
-          const childrenSame = this.areChildrenSame(
+          const childrenSame = this.#areChildrenSame(
             oldState,
             policyChildren.children,
           );
-          this.updateChildrenInPlace(
+          this.#updateChildrenInPlace(
             ctx,
             oldState,
             policyChildren.children,
@@ -1783,7 +1794,7 @@ export class WorkerReconciler {
             policyChanged,
           );
           if (!childrenSame || policyChanged) {
-            this.refreshTextIntegrityBoundaryState(oldState, childPolicy);
+            this.#refreshTextIntegrityBoundaryState(oldState, childPolicy);
           }
         }
         return;
@@ -1800,8 +1811,8 @@ export class WorkerReconciler {
         newTag: newTagName,
       }));
       wrapper.cancel();
-      this.cleanupNodeHandlers(wrapper.currentChild);
-      this.queueOps([{
+      this.#cleanupNodeHandlers(wrapper.currentChild);
+      this.#queueOps([{
         op: "remove-node",
         nodeId: wrapper.currentChild.nodeId,
       }]);
@@ -1810,10 +1821,10 @@ export class WorkerReconciler {
     }
 
     // Render new node - renderNode handles all render node types
-    const state = this.renderNode(ctx, node, new Set(), policy);
+    const state = this.#renderNode(ctx, node, new Set(), policy);
 
     if (state) {
-      this.queueOps([
+      this.#queueOps([
         {
           op: "insert-child",
           parentId: wrapper.nodeId,
@@ -1836,7 +1847,7 @@ export class WorkerReconciler {
    * - Different Cell → cancel old subscription, set up new one
    * - Missing prop → cancel subscription, remove prop from DOM
    */
-  private updatePropsInPlace(
+  #updatePropsInPlace(
     ctx: ReconcileContext,
     state: NodeState,
     newProps: WorkerProps | Cell<WorkerProps> | null | undefined,
@@ -1850,17 +1861,17 @@ export class WorkerReconciler {
         return;
       }
       // Different Cell - cancel all old subscriptions
-      this.removeAllProps(state);
+      this.#removeAllProps(state);
 
       // Set up new Cell<Props> binding
-      this.bindCellProps(ctx, state, newProps as Cell<WorkerProps>);
+      this.#bindCellProps(ctx, state, newProps as Cell<WorkerProps>);
       return;
     }
 
     // Handle static props object
     if (!newProps || typeof newProps !== "object") {
       // No props - remove all existing
-      this.removeAllProps(state);
+      this.#removeAllProps(state);
       return;
     }
 
@@ -1873,7 +1884,7 @@ export class WorkerReconciler {
         // Prop removed - cancel subscription and remove from DOM
         propState.cancel();
         state.propSubscriptions.delete(key);
-        this.removeSingleProp(state, key);
+        this.#removeSingleProp(state, key);
       }
     }
 
@@ -1883,10 +1894,10 @@ export class WorkerReconciler {
 
       if (isEventProp(key)) {
         // Event handlers - always re-register (they don't have Cell diffing)
-        this.updateEventProp(ctx, state, key, value, existingState);
+        this.#updateEventProp(ctx, state, key, value, existingState);
       } else if (isBindingProp(key)) {
         // Bindings - check if Cell is same
-        this.updateBindingProp(state, key, value, existingState);
+        this.#updateBindingProp(state, key, value, existingState);
       } else if (isCell(value)) {
         // Reactive prop - check if Cell is same
         if (existingState?.cell && areLinksSame(existingState.cell, value)) {
@@ -1903,20 +1914,20 @@ export class WorkerReconciler {
             "prop-update",
             () => ({ nodeId: state.nodeId, key, value: resolvedValue }),
           );
-          const propValue = this.transformPropValueForState(
+          const propValue = this.#transformPropValueForState(
             state,
             key,
             resolvedValue,
             value as Cell<unknown>,
           );
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-prop",
             nodeId: state.nodeId,
             key,
             value: propValue,
           }]);
-          if (this.isTextIntegrityPolicyProp(key)) {
-            this.refreshTextIntegrityBoundary(ctx, state);
+          if (this.#isTextIntegrityPolicyProp(key)) {
+            this.#refreshTextIntegrityBoundary(ctx, state);
           }
         });
         state.propSubscriptions.set(key, {
@@ -1930,14 +1941,16 @@ export class WorkerReconciler {
         // so this path now fires on every parent recompute even when captured
         // values are identical; damping it removes the op + JSON.stringify
         // churn (CT-1798).
-        if (this.canSkipUnchangedStaticProp(state, key, value, existingState)) {
+        if (
+          this.#canSkipUnchangedStaticProp(state, key, value, existingState)
+        ) {
           continue;
         }
         if (existingState) {
           existingState.cancel();
         }
-        const propValue = this.transformPropValueForState(state, key, value);
-        this.queueOps([{
+        const propValue = this.#transformPropValueForState(state, key, value);
+        this.#queueOps([{
           op: "set-prop",
           nodeId: state.nodeId,
           key,
@@ -1955,11 +1968,11 @@ export class WorkerReconciler {
   /**
    * Remove all props from a node.
    */
-  private removeAllProps(state: NodeState): void {
+  #removeAllProps(state: NodeState): void {
     for (const [key, propState] of state.propSubscriptions) {
       propState.cancel();
       if (key === CELL_PROPS_KEY) continue;
-      this.removeSingleProp(state, key);
+      this.#removeSingleProp(state, key);
     }
     state.propSubscriptions.clear();
     state.textIntegrityBlockedProps?.clear();
@@ -1968,7 +1981,7 @@ export class WorkerReconciler {
   /**
    * Helper to get a debug ID for a cell (space/id or similar).
    */
-  private getCellDebugId(cell: Cell<unknown>): string {
+  #getCellDebugId(cell: Cell<unknown>): string {
     try {
       // Accessing internal link info for debugging
       const link = cell.getAsNormalizedFullLink();
@@ -1982,7 +1995,7 @@ export class WorkerReconciler {
   /**
    * Update an event prop.
    */
-  private updateEventProp(
+  #updateEventProp(
     ctx: ReconcileContext,
     state: NodeState,
     key: string,
@@ -2012,13 +2025,13 @@ export class WorkerReconciler {
     // Log for debugging
     let valueId = "";
     if (isCell(value)) {
-      valueId = this.getCellDebugId(value as Cell<unknown>);
+      valueId = this.#getCellDebugId(value as Cell<unknown>);
     }
 
     let oldValueId = "";
     const oldValue = existingState?.currentValue;
     if (isCell(oldValue)) {
-      oldValueId = this.getCellDebugId(oldValue as Cell<unknown>);
+      oldValueId = this.#getCellDebugId(oldValue as Cell<unknown>);
     }
 
     logger.debug(
@@ -2037,8 +2050,8 @@ export class WorkerReconciler {
       existingState.cancel();
     }
 
-    if (this.retireEventHandler(state, eventType) !== undefined) {
-      this.queueOps([{
+    if (this.#retireEventHandler(state, eventType) !== undefined) {
+      this.#queueOps([{
         op: "remove-event",
         nodeId: state.nodeId,
         eventType,
@@ -2051,7 +2064,7 @@ export class WorkerReconciler {
         stream.withTx(undefined).send(event);
       });
       state.eventHandlers.set(eventType, handlerId);
-      this.queueOps([{
+      this.#queueOps([{
         op: "set-event",
         nodeId: state.nodeId,
         eventType,
@@ -2065,7 +2078,7 @@ export class WorkerReconciler {
     } else if (isEventHandler(value)) {
       const handlerId = ctx.registerHandler(value);
       state.eventHandlers.set(eventType, handlerId);
-      this.queueOps([{
+      this.#queueOps([{
         op: "set-event",
         nodeId: state.nodeId,
         eventType,
@@ -2083,8 +2096,8 @@ export class WorkerReconciler {
 
       const cancel = (value as Cell<(event: unknown) => void>).sink(
         (handler) => {
-          if (this.retireEventHandler(state, eventType) !== undefined) {
-            this.queueOps([{
+          if (this.#retireEventHandler(state, eventType) !== undefined) {
+            this.#queueOps([{
               op: "remove-event",
               nodeId: state.nodeId,
               eventType,
@@ -2096,7 +2109,7 @@ export class WorkerReconciler {
               handler as (event: unknown) => void,
             );
             state.eventHandlers.set(eventType, handlerId);
-            this.queueOps([{
+            this.#queueOps([{
               op: "set-event",
               nodeId: state.nodeId,
               eventType,
@@ -2116,7 +2129,7 @@ export class WorkerReconciler {
   /**
    * Update a binding prop ($prop).
    */
-  private updateBindingProp(
+  #updateBindingProp(
     state: NodeState,
     key: string,
     value: unknown,
@@ -2138,8 +2151,8 @@ export class WorkerReconciler {
       if (existingState) {
         existingState.cancel();
       }
-      this.queueOps(
-        this.bindingOpsForCell(state, propName, value as Cell<unknown>),
+      this.#queueOps(
+        this.#bindingOpsForCell(state, propName, value as Cell<unknown>),
       );
       state.propSubscriptions.set(key, {
         cell: value as Cell<unknown>,
@@ -2157,7 +2170,7 @@ export class WorkerReconciler {
    * - Other object/array props: per-prop sink via .key().asSchema(true)
    * - Primitive props: set directly from the resolved Cell<Props> value
    */
-  private bindCellProps(
+  #bindCellProps(
     ctx: ReconcileContext,
     state: NodeState,
     propsCell: Cell<WorkerProps>,
@@ -2169,9 +2182,9 @@ export class WorkerReconciler {
         state.childrenState !== undefined ||
         state.childOrder.length > 0;
       if (hasSeenInitialProps || childrenAlreadyBound) {
-        this.refreshBoundaryPolicyFromProps(ctx, state, propsCell);
+        this.#refreshBoundaryPolicyFromProps(ctx, state, propsCell);
       } else {
-        this.refreshInitialBoundaryPolicyFromProps(state, propsCell);
+        this.#refreshInitialBoundaryPolicyFromProps(state, propsCell);
       }
       hasSeenInitialProps = true;
     };
@@ -2187,7 +2200,7 @@ export class WorkerReconciler {
         for (const [key, propState] of state.propSubscriptions) {
           if (key === CELL_PROPS_KEY) continue;
           propState.cancel();
-          this.removeSingleProp(state, key);
+          this.#removeSingleProp(state, key);
         }
         // Keep only the Cell<Props> subscription itself
         const cellPropsSub = state.propSubscriptions.get(CELL_PROPS_KEY);
@@ -2207,7 +2220,7 @@ export class WorkerReconciler {
         if (key === CELL_PROPS_KEY) continue;
         if (!newKeys.has(key)) {
           propState.cancel();
-          this.removeSingleProp(state, key);
+          this.#removeSingleProp(state, key);
           state.propSubscriptions.delete(key);
         }
       }
@@ -2240,8 +2253,8 @@ export class WorkerReconciler {
 
           const eventType = getEventType(key);
 
-          if (this.retireEventHandler(state, eventType) !== undefined) {
-            this.queueOps([{
+          if (this.#retireEventHandler(state, eventType) !== undefined) {
+            this.#queueOps([{
               op: "remove-event",
               nodeId: state.nodeId,
               eventType,
@@ -2253,7 +2266,7 @@ export class WorkerReconciler {
             resolvedTarget.withTx(undefined).send(event)
           );
           state.eventHandlers.set(eventType, handlerId);
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-event",
             nodeId: state.nodeId,
             eventType,
@@ -2269,7 +2282,7 @@ export class WorkerReconciler {
           // resolving the props slot itself would bind an internal VDOM cell.
           let resolvedTarget: Cell<unknown>;
           try {
-            resolvedTarget = this.resolveCellPropsBindingTarget(
+            resolvedTarget = this.#resolveCellPropsBindingTarget(
               propsCell,
               key,
               value,
@@ -2293,8 +2306,8 @@ export class WorkerReconciler {
           if (existingState) existingState.cancel();
 
           const propName = getBindingPropName(key);
-          this.queueOps(
-            this.bindingOpsForCell(state, propName, resolvedTarget),
+          this.#queueOps(
+            this.#bindingOpsForCell(state, propName, resolvedTarget),
           );
           state.propSubscriptions.set(key, {
             cell: resolvedTarget,
@@ -2317,13 +2330,13 @@ export class WorkerReconciler {
           // Schema `true` = accept everything → enables deep traversal of this prop
           const propKeyCell = propsCell.key(key).asSchema(true);
           const propSinkCancel = propKeyCell.sink((deepValue: unknown) => {
-            const propValue = this.transformPropValueForState(
+            const propValue = this.#transformPropValueForState(
               state,
               key,
               deepValue,
-              this.resolveTextPropSourceCell(state, propsCell, key, value),
+              this.#resolveTextPropSourceCell(state, propsCell, key, value),
             );
-            this.queueOps([{
+            this.#queueOps([{
               op: "set-prop",
               nodeId: state.nodeId,
               key,
@@ -2350,18 +2363,18 @@ export class WorkerReconciler {
           // never skipped by the predicate, and cell prop states have no
           // currentValue, so transitions (e.g. to undefined) still emit.
           if (
-            this.canSkipUnchangedStaticProp(state, key, value, existingState)
+            this.#canSkipUnchangedStaticProp(state, key, value, existingState)
           ) {
             continue;
           }
 
-          const propValue = this.transformPropValueForState(
+          const propValue = this.#transformPropValueForState(
             state,
             key,
             value,
-            this.resolveTextPropSourceCell(state, propsCell, key, value),
+            this.#resolveTextPropSourceCell(state, propsCell, key, value),
           );
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-prop",
             nodeId: state.nodeId,
             key,
@@ -2386,7 +2399,7 @@ export class WorkerReconciler {
     return cancel;
   }
 
-  private refreshBoundaryPolicyFromProps(
+  #refreshBoundaryPolicyFromProps(
     ctx: ReconcileContext,
     state: NodeState,
     props: WorkerVNode["props"],
@@ -2407,13 +2420,13 @@ export class WorkerReconciler {
       props,
       children: state.sourceChildren,
     };
-    const childPolicy = this.childRenderPolicyForNode(
+    const childPolicy = this.#childRenderPolicyForNode(
       node,
       state.renderPolicy,
       state.nodeId,
     );
-    const policyChildren = this.childrenForRenderPolicy(node, childPolicy);
-    const policyChanged = !this.renderPolicyEquals(
+    const policyChildren = this.#childrenForRenderPolicy(node, childPolicy);
+    const policyChanged = !this.#renderPolicyEquals(
       state.childRenderPolicy,
       childPolicy,
     ) || state.childrenBlockedByPolicy !== policyChildren.blocked;
@@ -2425,9 +2438,9 @@ export class WorkerReconciler {
       return;
     }
 
-    const childrenSame = this.areChildrenSame(state, policyChildren.children);
+    const childrenSame = this.#areChildrenSame(state, policyChildren.children);
     if (!childrenSame || policyChanged) {
-      this.updateChildrenInPlace(
+      this.#updateChildrenInPlace(
         ctx,
         state,
         policyChildren.children,
@@ -2435,11 +2448,11 @@ export class WorkerReconciler {
         childPolicy,
         policyChanged,
       );
-      this.refreshTextIntegrityBoundaryState(state, childPolicy);
+      this.#refreshTextIntegrityBoundaryState(state, childPolicy);
     }
   }
 
-  private refreshInitialBoundaryPolicyFromProps(
+  #refreshInitialBoundaryPolicyFromProps(
     state: NodeState,
     props: WorkerVNode["props"],
   ): void {
@@ -2459,30 +2472,30 @@ export class WorkerReconciler {
       props,
       children: state.sourceChildren,
     };
-    const childPolicy = this.childRenderPolicyForNode(
+    const childPolicy = this.#childRenderPolicyForNode(
       node,
       state.renderPolicy,
       state.nodeId,
     );
-    const policyChildren = this.childrenForRenderPolicy(node, childPolicy);
+    const policyChildren = this.#childrenForRenderPolicy(node, childPolicy);
 
     state.sourceProps = props;
     state.childRenderPolicy = childPolicy;
     state.childrenBlockedByPolicy = policyChildren.blocked;
-    this.initializeTextIntegrityBoundary(childPolicy, state.nodeId);
+    this.#initializeTextIntegrityBoundary(childPolicy, state.nodeId);
   }
 
-  private resolveTextPropSourceCell(
+  #resolveTextPropSourceCell(
     state: NodeState,
     propsCell: Cell<WorkerProps>,
     key: string,
     value: unknown,
   ): Cell<unknown> | undefined {
-    if (!this.isTextIntegrityProp(state, key)) {
+    if (!this.#isTextIntegrityProp(state, key)) {
       return undefined;
     }
     try {
-      return this.resolveCellPropsBindingTarget(propsCell, key, value);
+      return this.#resolveCellPropsBindingTarget(propsCell, key, value);
     } catch {
       try {
         return propsCell.key(key).asSchema(true) as Cell<unknown>;
@@ -2492,13 +2505,13 @@ export class WorkerReconciler {
     }
   }
 
-  private resolveCellPropsBindingTarget(
+  #resolveCellPropsBindingTarget(
     propsCell: Cell<WorkerProps>,
     key: string,
     value: unknown,
   ): Cell<unknown> {
     const propCell = propsCell.key(key).asSchema(true);
-    const rawValue = this.readRawBindingPropValue(propsCell, propCell, key);
+    const rawValue = this.#readRawBindingPropValue(propsCell, propCell, key);
     let base:
       | ReturnType<Cell<WorkerProps>["getAsNormalizedFullLink"]>
       | undefined;
@@ -2519,7 +2532,7 @@ export class WorkerReconciler {
     return propCell.resolveAsCell();
   }
 
-  private readRawBindingPropValue(
+  #readRawBindingPropValue(
     propsCell: Cell<WorkerProps>,
     propCell: Cell<unknown>,
     key: string,
@@ -2544,24 +2557,24 @@ export class WorkerReconciler {
   /**
    * Remove a single prop from a node (DOM side + handler cleanup).
    */
-  private removeSingleProp(state: NodeState, key: string): void {
+  #removeSingleProp(state: NodeState, key: string): void {
     state.textIntegrityBlockedProps?.delete(key);
     if (isEventProp(key)) {
       const eventType = getEventType(key);
-      this.retireEventHandler(state, eventType);
-      this.queueOps([{
+      this.#retireEventHandler(state, eventType);
+      this.#queueOps([{
         op: "remove-event",
         nodeId: state.nodeId,
         eventType,
       }]);
     } else if (isBindingProp(key)) {
-      this.queueOps([{
+      this.#queueOps([{
         op: "remove-prop",
         nodeId: state.nodeId,
         key: getBindingPropName(key),
       }]);
     } else {
-      this.queueOps([{
+      this.#queueOps([{
         op: "remove-prop",
         nodeId: state.nodeId,
         key,
@@ -2573,7 +2586,7 @@ export class WorkerReconciler {
    * Update children in place with proper diffing.
    * If children Cell is the same, leave subscription in place.
    */
-  private updateChildrenInPlace(
+  #updateChildrenInPlace(
     ctx: ReconcileContext,
     state: NodeState,
     children: WorkerRenderNode | WorkerRenderNode[],
@@ -2608,7 +2621,7 @@ export class WorkerReconciler {
                 ? resolvedChildren.length
                 : 1,
             }));
-            this.updateChildren(
+            this.#updateChildren(
               ctx,
               state,
               resolvedChildren,
@@ -2630,14 +2643,14 @@ export class WorkerReconciler {
         state.childrenState = undefined;
       }
       // Update children directly
-      this.updateChildren(ctx, state, children, visited, policy, forceReplace);
+      this.#updateChildren(ctx, state, children, visited, policy, forceReplace);
     }
   }
 
   /**
    * Render any render node type and return its state.
    */
-  private renderNode(
+  #renderNode(
     ctx: ReconcileContext,
     inputNode: WorkerRenderNode,
     visited: Set<object>,
@@ -2650,12 +2663,12 @@ export class WorkerReconciler {
 
     // Handle text nodes (strings and numbers)
     if (typeof inputNode === "string" || typeof inputNode === "number") {
-      return this.createTextNode(ctx, String(inputNode), policy);
+      return this.#createTextNode(ctx, String(inputNode), policy);
     }
 
     // Handle arrays - render as fragment wrapper
     if (Array.isArray(inputNode)) {
-      return this.renderArrayAsFragment(ctx, inputNode, visited, policy);
+      return this.#renderArrayAsFragment(ctx, inputNode, visited, policy);
     }
 
     const [cancel, addCancel] = useCancelGroup();
@@ -2670,7 +2683,7 @@ export class WorkerReconciler {
       (node as any)[UI]
     ) {
       if (visited.has(node as object)) {
-        return this.createCyclePlaceholder(ctx, policy);
+        return this.#createCyclePlaceholder(ctx, policy);
       }
       visited.add(node as object);
       // deno-lint-ignore no-explicit-any
@@ -2679,13 +2692,13 @@ export class WorkerReconciler {
 
     // After following [UI] chain, node may have become a primitive
     if (typeof node === "string" || typeof node === "number") {
-      return this.createTextNode(ctx, String(node), policy);
+      return this.#createTextNode(ctx, String(node), policy);
     }
     if (node === null || node === undefined || typeof node === "boolean") {
       return null;
     }
     if (Array.isArray(node)) {
-      return this.renderArrayAsFragment(
+      return this.#renderArrayAsFragment(
         ctx,
         node as WorkerRenderNode[],
         visited,
@@ -2709,12 +2722,12 @@ export class WorkerReconciler {
 
     // Check for cycles
     if (visited.has(node as object)) {
-      return this.createCyclePlaceholder(ctx, policy);
+      return this.#createCyclePlaceholder(ctx, policy);
     }
     visited.add(node as object);
 
     // Sanitize node
-    const sanitized = this.sanitizeNode(node as WorkerVNode);
+    const sanitized = this.#sanitizeNode(node as WorkerVNode);
     if (!sanitized) {
       return null;
     }
@@ -2727,7 +2740,7 @@ export class WorkerReconciler {
       ? ctx.space
       : undefined;
     const nodeId = ctx.nextNodeId();
-    this.queueOps([{
+    this.#queueOps([{
       op: "create-element",
       nodeId,
       tagName: sanitized.name,
@@ -2736,12 +2749,12 @@ export class WorkerReconciler {
     if (stampSpace !== undefined) {
       ctx = { ...ctx, emittedSpace: stampSpace };
     }
-    const childPolicy = this.childRenderPolicyForNode(
+    const childPolicy = this.#childRenderPolicyForNode(
       sanitized,
       policy,
       nodeId,
     );
-    const policyChildren = this.childrenForRenderPolicy(
+    const policyChildren = this.#childrenForRenderPolicy(
       sanitized,
       childPolicy,
     );
@@ -2764,22 +2777,22 @@ export class WorkerReconciler {
       // this is what its descendants inherit.
       childEmittedSpace: ctx.emittedSpace,
     };
-    addCancel(() => this.cleanupNodeHandlers(state));
-    this.initializeTextIntegrityBoundary(childPolicy, nodeId);
+    addCancel(() => this.#cleanupNodeHandlers(state));
+    this.#initializeTextIntegrityBoundary(childPolicy, nodeId);
 
     // Bind props. Cell<Props> can synchronously resolve boundary policy props;
     // bind children from the current state policy after props are bound.
-    addCancel(this.bindProps(ctx, state, sanitized.props));
+    addCancel(this.#bindProps(ctx, state, sanitized.props));
 
     // Bind children
-    const activePolicyChildren = this.childrenForRenderPolicy(
+    const activePolicyChildren = this.#childrenForRenderPolicy(
       sanitized,
       state.childRenderPolicy,
     );
     state.childrenBlockedByPolicy = activePolicyChildren.blocked;
     if (activePolicyChildren.children !== undefined) {
       addCancel(
-        this.bindChildren(
+        this.#bindChildren(
           ctx,
           state,
           activePolicyChildren.children,
@@ -2795,12 +2808,12 @@ export class WorkerReconciler {
   /**
    * Create a placeholder for circular references.
    */
-  private createCyclePlaceholder(
+  #createCyclePlaceholder(
     ctx: ReconcileContext,
     policy: RenderPolicy = DEFAULT_RENDER_POLICY,
   ): NodeState {
     const nodeId = ctx.nextNodeId();
-    this.queueOps([
+    this.#queueOps([
       { op: "create-element", nodeId, tagName: "span" },
       { op: "set-prop", nodeId, key: "textContent", value: "\uD83D\uDD04" }, // 🔄
       {
@@ -2825,7 +2838,7 @@ export class WorkerReconciler {
     };
   }
 
-  private createBlockedPlaceholder(
+  #createBlockedPlaceholder(
     ctx: ReconcileContext,
     policy: RenderPolicy,
     reason: "policy" | "integrity" = "policy",
@@ -2837,9 +2850,9 @@ export class WorkerReconciler {
       ? CFC_TEXT_INTEGRITY_PLACEHOLDER
       : "Content hidden by policy";
     if (integrityBlocked) {
-      this.markTextIntegrityBlocked(policy);
+      this.#markTextIntegrityBlocked(policy);
     }
-    this.queueOps([
+    this.#queueOps([
       { op: "create-element", nodeId, tagName: CFC_BLOCKED_PLACEHOLDER_TAG },
       { op: "set-prop", nodeId, key: "data-cfc-blocked", value: "true" },
       {
@@ -2893,18 +2906,18 @@ export class WorkerReconciler {
   /**
    * Create a text node.
    */
-  private createTextNode(
+  #createTextNode(
     ctx: ReconcileContext,
     text: string,
     policy: RenderPolicy = DEFAULT_RENDER_POLICY,
     options?: { trustedText?: boolean },
   ): NodeState {
-    if (!options?.trustedText && this.shouldBlockLiteralText(text, policy)) {
-      return this.createBlockedPlaceholder(ctx, policy, "integrity");
+    if (!options?.trustedText && this.#shouldBlockLiteralText(text, policy)) {
+      return this.#createBlockedPlaceholder(ctx, policy, "integrity");
     }
 
     const nodeId = ctx.nextNodeId();
-    this.queueOps([{ op: "create-text", nodeId, text }]);
+    this.#queueOps([{ op: "create-text", nodeId, text }]);
 
     return {
       nodeId,
@@ -2923,14 +2936,14 @@ export class WorkerReconciler {
   /**
    * Render an array of nodes as a fragment wrapper.
    */
-  private renderArrayAsFragment(
+  #renderArrayAsFragment(
     ctx: ReconcileContext,
     nodes: WorkerRenderNode[],
     visited: Set<object>,
     policy: RenderPolicy,
   ): NodeState | null {
     const nodeId = ctx.nextNodeId();
-    this.queueOps([
+    this.#queueOps([
       { op: "create-element", nodeId, tagName: "cf-fragment" },
     ]);
 
@@ -2948,13 +2961,13 @@ export class WorkerReconciler {
       childRenderPolicy: policy,
       childrenBlockedByPolicy: false,
     };
-    addCancel(() => this.cleanupNodeHandlers(state));
+    addCancel(() => this.#cleanupNodeHandlers(state));
 
     // Array items use the same Cell-aware child path as VNode children.
     // rendererVDOMSchema projects array items as Cells, including at the root,
     // so handing them directly to renderNode would violate its invariant that
     // Cell children have already passed through renderCellChild.
-    addCancel(this.bindChildren(ctx, state, nodes, visited, policy));
+    addCancel(this.#bindChildren(ctx, state, nodes, visited, policy));
 
     return state;
   }
@@ -2962,7 +2975,7 @@ export class WorkerReconciler {
   /**
    * Sanitize a VNode, ensuring it has valid structure.
    */
-  private sanitizeNode(node: WorkerVNode): WorkerVNode | null {
+  #sanitizeNode(node: WorkerVNode): WorkerVNode | null {
     if (node.type !== "vnode" || node.name === "script") {
       return null;
     }
@@ -2993,7 +3006,7 @@ export class WorkerReconciler {
    * Bind props to an element, handling reactive values and events.
    * Tracks Cell references in propSubscriptions for later diffing.
    */
-  private bindProps(
+  #bindProps(
     ctx: ReconcileContext,
     state: NodeState,
     props: WorkerProps | Cell<WorkerProps> | null | undefined,
@@ -3004,7 +3017,7 @@ export class WorkerReconciler {
 
     // Handle Cell<Props>
     if (isCell(props)) {
-      const cellPropsCancel = this.bindCellProps(
+      const cellPropsCancel = this.#bindCellProps(
         ctx,
         state,
         props as Cell<WorkerProps>,
@@ -3029,7 +3042,7 @@ export class WorkerReconciler {
             stream.withTx(undefined).send(event);
           });
           state.eventHandlers.set(eventType, handlerId);
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-event",
             nodeId: state.nodeId,
             eventType,
@@ -3044,7 +3057,7 @@ export class WorkerReconciler {
           // Plain function event handler
           const handlerId = ctx.registerHandler(value);
           state.eventHandlers.set(eventType, handlerId);
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-event",
             nodeId: state.nodeId,
             eventType,
@@ -3060,8 +3073,8 @@ export class WorkerReconciler {
           const eventType = getEventType(key);
           const sinkCancel = (value as Cell<(event: unknown) => void>).sink(
             (handler) => {
-              if (this.retireEventHandler(state, eventType) !== undefined) {
-                this.queueOps([{
+              if (this.#retireEventHandler(state, eventType) !== undefined) {
+                this.#queueOps([{
                   op: "remove-event",
                   nodeId: state.nodeId,
                   eventType,
@@ -3074,7 +3087,7 @@ export class WorkerReconciler {
                   handler as (event: unknown) => void,
                 );
                 state.eventHandlers.set(eventType, handlerId);
-                this.queueOps([{
+                this.#queueOps([{
                   op: "set-event",
                   nodeId: state.nodeId,
                   eventType,
@@ -3094,8 +3107,8 @@ export class WorkerReconciler {
         // Bidirectional binding ($prop)
         const propName = getBindingPropName(key);
         if (isCell(value)) {
-          this.queueOps(
-            this.bindingOpsForCell(state, propName, value as Cell<unknown>),
+          this.#queueOps(
+            this.#bindingOpsForCell(state, propName, value as Cell<unknown>),
           );
           state.propSubscriptions.set(key, {
             cell: value as Cell<unknown>,
@@ -3105,20 +3118,20 @@ export class WorkerReconciler {
       } else if (isCell(value)) {
         // Reactive prop value
         const sinkCancel = (value as Cell<unknown>).sink((resolvedValue) => {
-          const propValue = this.transformPropValueForState(
+          const propValue = this.#transformPropValueForState(
             state,
             key,
             resolvedValue,
             value as Cell<unknown>,
           );
-          this.queueOps([{
+          this.#queueOps([{
             op: "set-prop",
             nodeId: state.nodeId,
             key,
             value: propValue,
           }]);
-          if (this.isTextIntegrityPolicyProp(key)) {
-            this.refreshTextIntegrityBoundary(ctx, state);
+          if (this.#isTextIntegrityPolicyProp(key)) {
+            this.#refreshTextIntegrityBoundary(ctx, state);
           }
         });
         addCancel(sinkCancel);
@@ -3128,8 +3141,8 @@ export class WorkerReconciler {
         });
       } else {
         // Static prop value
-        const propValue = this.transformPropValueForState(state, key, value);
-        this.queueOps([{
+        const propValue = this.#transformPropValueForState(state, key, value);
+        this.#queueOps([{
           op: "set-prop",
           nodeId: state.nodeId,
           key,
@@ -3153,7 +3166,7 @@ export class WorkerReconciler {
    * given as an object becoming a CSS string on the way.
    */
   // deno-lint-ignore no-explicit-any
-  private transformPropValue(key: string, value: unknown): any {
+  #transformPropValue(key: string, value: unknown): any {
     // TODO(danfuzz): the `typeof` gate admits a `FabricSpecialObject`, so a
     // fabric-valued `style` prop is routed into the `Object.entries` walk of
     // `styleObjectToCssString` — yielding an empty CSS string, silently —
@@ -3163,7 +3176,7 @@ export class WorkerReconciler {
       key === "style" && value && typeof value === "object" &&
       !Array.isArray(value)
     ) {
-      return this.styleObjectToCssString(value as Record<string, unknown>);
+      return this.#styleObjectToCssString(value as Record<string, unknown>);
     }
     // Use convertCellsToLinks to handle Cells, circular refs, and non-JSON values.
     // Pass doNotConvertCellResults to prevent already-resolved values (from .sink())
@@ -3182,7 +3195,7 @@ export class WorkerReconciler {
   /**
    * Convert a style object to a CSS string.
    */
-  private styleObjectToCssString(styleObject: Record<string, unknown>): string {
+  #styleObjectToCssString(styleObject: Record<string, unknown>): string {
     const unitlessProperties = new Set([
       "animation-iteration-count",
       "column-count",
@@ -3235,7 +3248,7 @@ export class WorkerReconciler {
    * Bind children to an element with keyed reconciliation.
    * Tracks the children Cell for later diffing.
    */
-  private bindChildren(
+  #bindChildren(
     ctx: ReconcileContext,
     state: NodeState,
     children: WorkerRenderNode | WorkerRenderNode[],
@@ -3249,7 +3262,7 @@ export class WorkerReconciler {
       const sinkCancel = (
         children as Cell<WorkerRenderNode | WorkerRenderNode[]>
       ).sink((resolvedChildren) => {
-        this.updateChildren(ctx, state, resolvedChildren, visited, policy);
+        this.#updateChildren(ctx, state, resolvedChildren, visited, policy);
       });
       addCancel(sinkCancel);
       // Track the children Cell for diffing
@@ -3259,7 +3272,7 @@ export class WorkerReconciler {
       };
     } else {
       // Static children
-      this.updateChildren(ctx, state, children, visited, policy);
+      this.#updateChildren(ctx, state, children, visited, policy);
       state.childrenState = undefined;
     }
 
@@ -3281,7 +3294,7 @@ export class WorkerReconciler {
    * Find the nodeId of the next sibling after the given key.
    * Used for position-aware insertion of reactive children.
    */
-  private findNextSiblingId(
+  #findNextSiblingId(
     children: Map<string, ChildNodeState>,
     afterKey: string,
   ): number | null {
@@ -3300,7 +3313,7 @@ export class WorkerReconciler {
   /**
    * Update children with keyed reconciliation.
    */
-  private updateChildren(
+  #updateChildren(
     ctx: ReconcileContext,
     state: NodeState,
     childrenValue:
@@ -3343,7 +3356,7 @@ export class WorkerReconciler {
       if (!forceReplace && state.children.has(key)) {
         // Reuse existing child
         const existingState = state.children.get(key)!;
-        const canReuse = this.reconcileReusedChild(
+        const canReuse = this.#reconcileReusedChild(
           ctx,
           existingState,
           child,
@@ -3356,10 +3369,10 @@ export class WorkerReconciler {
           keptInPlace.add(key);
         } else {
           existingState.cancel();
-          this.cleanupNodeHandlers(existingState);
-          this.queueOps([{ op: "remove-node", nodeId: existingState.nodeId }]);
+          this.#cleanupNodeHandlers(existingState);
+          this.#queueOps([{ op: "remove-node", nodeId: existingState.nodeId }]);
           hasNewChildren = true;
-          const childState = this.renderChild(
+          const childState = this.#renderChild(
             ctx,
             child,
             visited,
@@ -3374,7 +3387,7 @@ export class WorkerReconciler {
       } else {
         // Create new child, passing parent state and key for position tracking
         hasNewChildren = true;
-        const childState = this.renderChild(
+        const childState = this.#renderChild(
           ctx,
           child,
           visited,
@@ -3391,8 +3404,8 @@ export class WorkerReconciler {
     // Remove obsolete children
     for (const [_, oldState] of state.children) {
       oldState.cancel();
-      this.cleanupNodeHandlers(oldState);
-      this.queueOps([{ op: "remove-node", nodeId: oldState.nodeId }]);
+      this.#cleanupNodeHandlers(oldState);
+      this.#queueOps([{ op: "remove-node", nodeId: oldState.nodeId }]);
     }
 
     // Check if order needs update - only skip inserts when ALL children were
@@ -3436,7 +3449,7 @@ export class WorkerReconciler {
 
       if (!stationary.has(i)) {
         // Insert this child before the next one (or append if it's the last)
-        this.queueOps([
+        this.#queueOps([
           {
             op: "insert-child",
             parentId: state.nodeId,
@@ -3458,7 +3471,7 @@ export class WorkerReconciler {
    * ordering, but the VNode payload may still have fresh captured values from a
    * parent recomputation, so same-key reuse cannot blindly skip descendants.
    */
-  private reconcileReusedChild(
+  #reconcileReusedChild(
     ctx: ReconcileContext,
     childState: ChildNodeState,
     child: unknown,
@@ -3467,7 +3480,7 @@ export class WorkerReconciler {
   ): boolean {
     if (isCell(child)) {
       return childState.cell !== undefined &&
-        this.sameCellForReuse(childState.cell, child);
+        this.#sameCellForReuse(childState.cell, child);
     }
 
     if (
@@ -3485,24 +3498,24 @@ export class WorkerReconciler {
 
     if (!childState.elementState) return false;
 
-    const newVNode = this.extractVNode(child);
+    const newVNode = this.#extractVNode(child);
     if (!newVNode) return false;
 
-    const sanitized = this.sanitizeNode(newVNode);
+    const sanitized = this.#sanitizeNode(newVNode);
     if (!sanitized || sanitized.name !== childState.elementState.tagName) {
       return false;
     }
 
-    const childPolicy = this.childRenderPolicyForNode(
+    const childPolicy = this.#childRenderPolicyForNode(
       sanitized,
       policy,
       childState.elementState.nodeId,
     );
-    const policyChildren = this.childrenForRenderPolicy(
+    const policyChildren = this.#childrenForRenderPolicy(
       sanitized,
       childPolicy,
     );
-    const policyChanged = !this.renderPolicyEquals(
+    const policyChanged = !this.#renderPolicyEquals(
       childState.elementState.childRenderPolicy,
       childPolicy,
     ) || childState.elementState.childrenBlockedByPolicy !==
@@ -3520,14 +3533,14 @@ export class WorkerReconciler {
     childState.elementState.sourceChildren = sanitized.children;
     childState.elementState.sourceProps = sanitized.props;
 
-    this.updatePropsInPlace(ctx, childState.elementState, sanitized.props);
+    this.#updatePropsInPlace(ctx, childState.elementState, sanitized.props);
 
     if (policyChildren.children !== undefined) {
-      const childrenSame = this.areChildrenSame(
+      const childrenSame = this.#areChildrenSame(
         childState.elementState,
         policyChildren.children,
       );
-      this.updateChildrenInPlace(
+      this.#updateChildrenInPlace(
         ctx,
         childState.elementState,
         policyChildren.children,
@@ -3536,7 +3549,7 @@ export class WorkerReconciler {
         policyChanged,
       );
       if (!childrenSame || policyChanged) {
-        this.refreshTextIntegrityBoundaryState(
+        this.#refreshTextIntegrityBoundaryState(
           childState.elementState,
           childPolicy,
         );
@@ -3545,7 +3558,7 @@ export class WorkerReconciler {
     return true;
   }
 
-  private sameCellForReuse(left: Cell<unknown>, right: Cell<unknown>): boolean {
+  #sameCellForReuse(left: Cell<unknown>, right: Cell<unknown>): boolean {
     try {
       return areLinksSame(left, right);
     } catch {
@@ -3557,7 +3570,7 @@ export class WorkerReconciler {
    * Render a child node (which may be a VNode, text, or Cell).
    * For Cell children, uses position-aware insertion instead of wrapper elements.
    */
-  private renderChild(
+  #renderChild(
     ctx: ReconcileContext,
     child: unknown,
     visited: Set<object>,
@@ -3567,7 +3580,7 @@ export class WorkerReconciler {
   ): ChildNodeState | null {
     // Handle Cell children - no wrapper, track position dynamically
     if (isCell(child)) {
-      return this.renderCellChild(
+      return this.#renderCellChild(
         ctx,
         child as Cell<unknown>,
         visited,
@@ -3578,13 +3591,13 @@ export class WorkerReconciler {
     }
 
     // Handle non-Cell content
-    return this.renderChildContent(ctx, child, visited, policy);
+    return this.#renderChildContent(ctx, child, visited, policy);
   }
 
   /**
    * Render a Cell child with position-aware updates (no wrapper element).
    */
-  private renderCellChild(
+  #renderCellChild(
     ctx: ReconcileContext,
     cell: Cell<unknown>,
     visited: Set<object>,
@@ -3594,7 +3607,7 @@ export class WorkerReconciler {
   ): ChildNodeState {
     // A followed cell is a (potential) transclusion boundary: its
     // subtree renders in the CELL's space, not the surrounding one.
-    const cellSpace = this.spaceOfCell(cell);
+    const cellSpace = this.#spaceOfCell(cell);
     if (cellSpace !== undefined && cellSpace !== ctx.space) {
       ctx = { ...ctx, space: cellSpace };
     }
@@ -3625,13 +3638,13 @@ export class WorkerReconciler {
 
     const renderResolved = (resolvedChild: unknown, forced = false) => {
       const isInitialRender = childState.nodeId === -1;
-      const resultCell = this.resolveCellForBinding(cell);
+      const resultCell = this.#resolveCellForBinding(cell);
       const valueUnchanged = Object.is(
         resolvedChild,
         childState.currentValue,
       );
       childState.currentValue = resolvedChild;
-      this.watchCellMembership(
+      this.#watchCellMembership(
         cell,
         watchedSpaces,
         addCancel,
@@ -3639,7 +3652,7 @@ export class WorkerReconciler {
       );
       const blockedByPolicy = !this.canRenderCellUnderPolicy(cell, policy);
       const blockedByIntegrity = !blockedByPolicy &&
-        this.shouldBlockTextFromCell(resolvedChild, cell, policy);
+        this.#shouldBlockTextFromCell(resolvedChild, cell, policy);
 
       if (
         !forced && !isInitialRender && valueUnchanged
@@ -3656,7 +3669,7 @@ export class WorkerReconciler {
           !blockedByPolicy && !blockedByIntegrity &&
           currentContentState === "rendered"
         ) {
-          this.updatePieceBoundary(childState, resolvedChild, resultCell);
+          this.#updatePieceBoundary(childState, resolvedChild, resultCell);
           return;
         }
       }
@@ -3667,8 +3680,8 @@ export class WorkerReconciler {
             currentCancel();
             currentCancel = undefined;
           }
-          this.cleanupNodeHandlers(childState);
-          this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+          this.#cleanupNodeHandlers(childState);
+          this.#queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
         }
 
         childState.nodeId = -1;
@@ -3676,18 +3689,18 @@ export class WorkerReconciler {
         childState.isText = false;
         childState.hasPieceBoundary = false;
 
-        const blockedState = this.createBlockedPlaceholder(ctx, policy);
+        const blockedState = this.#createBlockedPlaceholder(ctx, policy);
         childState.nodeId = blockedState.nodeId;
         childState.elementState = blockedState;
         childState.isText = false;
         currentCancel = blockedState.cancel;
         currentContentState = "policy-blocked";
 
-        const beforeId = this.findNextSiblingId(
+        const beforeId = this.#findNextSiblingId(
           parentState.children,
           childKey,
         );
-        this.queueOps([{
+        this.#queueOps([{
           op: "insert-child",
           parentId: parentState.nodeId,
           childId: blockedState.nodeId,
@@ -3702,8 +3715,8 @@ export class WorkerReconciler {
             currentCancel();
             currentCancel = undefined;
           }
-          this.cleanupNodeHandlers(childState);
-          this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+          this.#cleanupNodeHandlers(childState);
+          this.#queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
         }
 
         childState.nodeId = -1;
@@ -3711,7 +3724,7 @@ export class WorkerReconciler {
         childState.isText = false;
         childState.hasPieceBoundary = false;
 
-        const blockedState = this.createBlockedPlaceholder(
+        const blockedState = this.#createBlockedPlaceholder(
           ctx,
           policy,
           "integrity",
@@ -3722,11 +3735,11 @@ export class WorkerReconciler {
         currentCancel = blockedState.cancel;
         currentContentState = "integrity-blocked";
 
-        const beforeId = this.findNextSiblingId(
+        const beforeId = this.#findNextSiblingId(
           parentState.children,
           childKey,
         );
-        this.queueOps([{
+        this.#queueOps([{
           op: "insert-child",
           parentId: parentState.nodeId,
           childId: blockedState.nodeId,
@@ -3746,7 +3759,7 @@ export class WorkerReconciler {
           (typeof resolvedChild === "string" ||
             typeof resolvedChild === "number")
         ) {
-          this.queueOps([{
+          this.#queueOps([{
             op: "update-text",
             nodeId: childState.nodeId,
             text: String(resolvedChild),
@@ -3758,25 +3771,25 @@ export class WorkerReconciler {
         if (
           childState.elementState && currentContentState === "rendered"
         ) {
-          const newVNode = this.extractVNode(
+          const newVNode = this.#extractVNode(
             resolvedChild as WorkerRenderNode,
           );
           if (newVNode) {
-            const sanitized = this.sanitizeNode(newVNode);
+            const sanitized = this.#sanitizeNode(newVNode);
             if (
               sanitized &&
               sanitized.name === childState.elementState.tagName
             ) {
-              const childPolicy = this.childRenderPolicyForNode(
+              const childPolicy = this.#childRenderPolicyForNode(
                 sanitized,
                 policy,
                 childState.elementState.nodeId,
               );
-              const policyChildren = this.childrenForRenderPolicy(
+              const policyChildren = this.#childrenForRenderPolicy(
                 sanitized,
                 childPolicy,
               );
-              const policyChanged = !this.renderPolicyEquals(
+              const policyChanged = !this.#renderPolicyEquals(
                 childState.elementState.childRenderPolicy,
                 childPolicy,
               ) ||
@@ -3793,20 +3806,20 @@ export class WorkerReconciler {
               // node stops being a wrapper, and a later array must not adopt
               // the authored props it now carries.
               childState.elementState.isArrayWrapper = false;
-              this.updatePieceBoundary(childState, resolvedChild, resultCell);
+              this.#updatePieceBoundary(childState, resolvedChild, resultCell);
               // Same tag - update props in place
-              this.updatePropsInPlace(
+              this.#updatePropsInPlace(
                 ctx,
                 childState.elementState,
                 sanitized.props,
               );
 
               if (policyChildren.children !== undefined) {
-                const childrenSame = this.areChildrenSame(
+                const childrenSame = this.#areChildrenSame(
                   childState.elementState,
                   policyChildren.children,
                 );
-                this.updateChildrenInPlace(
+                this.#updateChildrenInPlace(
                   ctx,
                   childState.elementState,
                   policyChildren.children,
@@ -3815,7 +3828,7 @@ export class WorkerReconciler {
                   policyChanged,
                 );
                 if (!childrenSame || policyChanged) {
-                  this.refreshTextIntegrityBoundaryState(
+                  this.#refreshTextIntegrityBoundaryState(
                     childState.elementState,
                     childPolicy,
                   );
@@ -3848,7 +3861,7 @@ export class WorkerReconciler {
           const wrapper = childState.elementState;
           const children = resolvedChild as WorkerRenderNode[];
           wrapper.sourceChildren = children;
-          this.updateChildrenInPlace(
+          this.#updateChildrenInPlace(
             // Rows render below the wrapper, so they inherit the space it
             // stamped; handing them the surrounding ctx would have each row
             // re-stamp a space the wrapper already carries.
@@ -3870,18 +3883,18 @@ export class WorkerReconciler {
           currentCancel = undefined;
         }
         // Clean up event handlers before removing node
-        this.cleanupNodeHandlers(childState);
+        this.#cleanupNodeHandlers(childState);
         // Log replacement
         logger.debug(
           "reconcile-cell-child",
           () => ({
             id: childState.nodeId,
-            cellId: this.getCellDebugId(cell),
+            cellId: this.#getCellDebugId(cell),
             type: "replace",
             reason: "fallback",
           }),
         );
-        this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+        this.#queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
       }
 
       // Reset nodeId
@@ -3898,21 +3911,21 @@ export class WorkerReconciler {
       // Render new content. Primitive text from a Cell has already passed
       // source-cell text integrity verification above, so do not reclassify
       // it as an untrusted literal.
-      const newState = this.hasVisibleTextValue(resolvedChild) &&
+      const newState = this.#hasVisibleTextValue(resolvedChild) &&
           (typeof resolvedChild === "string" ||
             typeof resolvedChild === "number" ||
             typeof resolvedChild === "boolean")
         ? {
-          nodeId: this.createTextNode(
+          nodeId: this.#createTextNode(
             ctx,
-            this.stringifyText(resolvedChild),
+            this.#stringifyText(resolvedChild),
             policy,
             { trustedText: true },
           ).nodeId,
           isText: true,
           cancel: () => {},
         }
-        : this.renderChildContent(
+        : this.#renderChildContent(
           ctx,
           resolvedChild,
           new Set(visited),
@@ -3924,18 +3937,18 @@ export class WorkerReconciler {
         childState.isText = newState.isText;
         currentCancel = newState.cancel;
         currentContentState = "rendered";
-        this.updatePieceBoundary(childState, resolvedChild, resultCell);
+        this.#updatePieceBoundary(childState, resolvedChild, resultCell);
 
         // Always insert the child into its parent. On initial render,
         // updateChildren also emits insert-child but may see nodeId=-1
         // (Cell hasn't resolved yet), making that op a no-op. This
         // ensures the node is inserted once it actually exists.
         // Double inserts are harmless (DOM appendChild/insertBefore is idempotent).
-        const beforeId = this.findNextSiblingId(
+        const beforeId = this.#findNextSiblingId(
           parentState.children,
           childKey,
         );
-        this.queueOps([
+        this.#queueOps([
           {
             op: "insert-child",
             parentId: parentState.nodeId,
@@ -3965,7 +3978,7 @@ export class WorkerReconciler {
   /**
    * Render non-Cell child content (VNode, array, text, etc).
    */
-  private renderChildContent(
+  #renderChildContent(
     ctx: ReconcileContext,
     child: unknown,
     visited: Set<object>,
@@ -3979,7 +3992,7 @@ export class WorkerReconciler {
         props: { style: "display:contents" },
         children: child,
       };
-      const state = this.renderNode(
+      const state = this.#renderNode(
         ctx,
         wrapperVNode,
         new Set(visited),
@@ -3998,7 +4011,7 @@ export class WorkerReconciler {
 
     // Handle VNode
     if (isWorkerVNode(child)) {
-      const state = this.renderNode(ctx, child, new Set(visited), policy);
+      const state = this.#renderNode(ctx, child, new Set(visited), policy);
       if (!state) return null;
 
       return {
@@ -4014,7 +4027,7 @@ export class WorkerReconciler {
     if (
       child && typeof child === "object" && UI in child && (child as any)[UI]
     ) {
-      const state = this.renderNode(
+      const state = this.#renderNode(
         ctx,
         child as WorkerRenderNode,
         new Set(visited),
@@ -4040,8 +4053,8 @@ export class WorkerReconciler {
     }
 
     // Handle primitive values (text nodes)
-    const text = this.stringifyText(child);
-    const state = this.createTextNode(ctx, text, policy);
+    const text = this.#stringifyText(child);
+    const state = this.#createTextNode(ctx, text, policy);
     const isText = state.tagName === "#text";
 
     return {
@@ -4055,7 +4068,7 @@ export class WorkerReconciler {
   /**
    * Convert a primitive value to text content.
    */
-  private stringifyText(value: unknown): string {
+  #stringifyText(value: unknown): string {
     if (typeof value === "string") {
       return value;
     } else if (value === null || value === undefined || value === false) {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -209,10 +209,16 @@ export class WorkerReconciler {
   readonly #onOps: (ops: VDomOp[]) => number | void;
   readonly #onError?: (error: Error) => void;
   readonly #renderDeclassificationPolicy: RenderDeclassificationPolicy;
+
+  /**
+   * TypeScript-private rather than a `#` name:
+   * `runtime-client/test/backends/runtime-processor.test.ts` reaches this
+   * member across the package boundary, through the reconciler a mount holds.
+   */
   // Root-of-tree render policy: the host's default ceiling when configured
   // (spec §8.10.6), otherwise the historical unbounded policy. Authored
   // boundaries can only narrow from here.
-  readonly #rootRenderPolicy: RenderPolicy;
+  private readonly rootRenderPolicy: RenderPolicy;
   // Runner-side display-boundary resolver (Epic H3b): rewrites a cell's
   // confidentiality label through the exchange rules before the ceiling fit,
   // admitting `Space(...)`-via-`HasRole` principal forms. Undefined = H3a
@@ -238,7 +244,7 @@ export class WorkerReconciler {
     const ceiling = normalizeRenderConfidentialityCeiling(
       options.renderConfidentialityCeiling,
     );
-    this.#rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
+    this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
       maxConfidentiality: [...(ceiling.atoms ?? [])],
       caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
@@ -330,14 +336,14 @@ export class WorkerReconciler {
         if (
           !this.canRenderCellUnderPolicy(
             vnode as Cell<unknown>,
-            this.#rootRenderPolicy,
+            this.rootRenderPolicy,
           )
         ) {
           this.#reconcileIntoWrapper(
             ctx,
             wrapperState,
             this.#blockedPlaceholderVNode(),
-            this.#rootRenderPolicy,
+            this.rootRenderPolicy,
           );
           this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
           return;
@@ -355,7 +361,7 @@ export class WorkerReconciler {
           ctx,
           wrapperState,
           resolvedVnode as WorkerRenderNode,
-          this.#rootRenderPolicy,
+          this.rootRenderPolicy,
         );
         // Track the root child for cleanup
         this.#rootChildId = wrapperState.currentChild?.nodeId ?? null;
@@ -370,7 +376,7 @@ export class WorkerReconciler {
         ctx,
         vnode,
         new Set(),
-        this.#rootRenderPolicy,
+        this.rootRenderPolicy,
       );
       if (state) {
         addCancel(state.cancel);

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -210,14 +210,12 @@ export class WorkerReconciler {
   readonly #onError?: (error: Error) => void;
   readonly #renderDeclassificationPolicy: RenderDeclassificationPolicy;
 
-  /**
-   * TypeScript-private rather than a `#` name:
-   * `runtime-client/test/backends/runtime-processor.test.ts` reaches this
-   * member across the package boundary, through the reconciler a mount holds.
-   */
   // Root-of-tree render policy: the host's default ceiling when configured
   // (spec §8.10.6), otherwise the historical unbounded policy. Authored
-  // boundaries can only narrow from here.
+  // boundaries can only narrow from here. TypeScript-private rather than a `#`
+  // name, because `runtime-client/test/backends/runtime-processor.test.ts`
+  // reaches it across the package boundary, through the reconciler a mount
+  // holds.
   private readonly rootRenderPolicy: RenderPolicy;
   // Runner-side display-boundary resolver (Epic H3b): rewrites a cell's
   // confidentiality label through the exchange rules before the ceiling fit,

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -11,8 +11,8 @@ import { VDomRenderer } from "../src/main/renderer.ts";
 import { getActiveRenders, render } from "../src/render.ts";
 
 class MockConnection {
-  private listeners = new Map<string, Set<(payload: unknown) => void>>();
-  private lifetime = new AbortController();
+  #listeners = new Map<string, Set<(payload: unknown) => void>>();
+  #lifetime = new AbortController();
   public unmountCalls: number[] = [];
   public acknowledgedBatches: Array<{ mountId: number; batchId: number }> = [];
   public sentEvents: Array<{
@@ -23,21 +23,21 @@ class MockConnection {
   }> = [];
 
   get signal(): AbortSignal {
-    return this.lifetime.signal;
+    return this.#lifetime.signal;
   }
 
   /** Dispose the connection, as a logout/runtime-swap would. */
   abort(): void {
-    this.lifetime.abort();
+    this.#lifetime.abort();
   }
 
   onDispose(teardown: () => void): () => void {
-    if (this.lifetime.signal.aborted) {
+    if (this.#lifetime.signal.aborted) {
       teardown();
       return () => {};
     }
-    this.lifetime.signal.addEventListener("abort", teardown, { once: true });
-    return () => this.lifetime.signal.removeEventListener("abort", teardown);
+    this.#lifetime.signal.addEventListener("abort", teardown, { once: true });
+    return () => this.#lifetime.signal.removeEventListener("abort", teardown);
   }
 
   // The renderer obtains VDOM capability only through attachVDom; the session
@@ -66,16 +66,16 @@ class MockConnection {
   }
 
   on(event: string, callback: (payload: unknown) => void): void {
-    let set = this.listeners.get(event);
+    let set = this.#listeners.get(event);
     if (!set) {
       set = new Set();
-      this.listeners.set(event, set);
+      this.#listeners.set(event, set);
     }
     set.add(callback);
   }
 
   off(event: string, callback: (payload: unknown) => void): void {
-    this.listeners.get(event)?.delete(callback);
+    this.#listeners.get(event)?.delete(callback);
   }
 
   /** What the next `mountVDom` reports as the tree's root. */
@@ -107,7 +107,7 @@ class MockConnection {
   }
 
   emit(event: string, payload: unknown): void {
-    for (const listener of this.listeners.get(event) ?? []) {
+    for (const listener of this.#listeners.get(event) ?? []) {
       listener(payload);
     }
   }

--- a/packages/html/test/worker-reconciler-alias-child.test.ts
+++ b/packages/html/test/worker-reconciler-alias-child.test.ts
@@ -51,7 +51,7 @@ Deno.test("worker reconciler - $alias records in child position", async (t) => {
 
   // Define MockCell extending CellImpl
   class MockCell extends (CellImplConstructor as any) {
-    private subscribers = new Set<(value: any) => void>();
+    #subscribers = new Set<(value: any) => void>();
 
     constructor(public value: any) {
       // CellImpl(runtime, tx, link, synced, causeContainer, kind)
@@ -60,16 +60,16 @@ Deno.test("worker reconciler - $alias records in child position", async (t) => {
     }
 
     sink(callback: (value: any) => void) {
-      this.subscribers.add(callback);
+      this.#subscribers.add(callback);
       callback(this.value);
       return () => {
-        this.subscribers.delete(callback);
+        this.#subscribers.delete(callback);
       };
     }
 
     set(newValue: any) {
       this.value = newValue;
-      for (const sub of this.subscribers) {
+      for (const sub of this.#subscribers) {
         sub(newValue);
       }
     }

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -95,7 +95,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
 
   // Define MockCell extending CellImpl
   class MockCell extends (CellImplConstructor as any) {
-    private subscribers = new Set<(value: any) => void>();
+    #subscribers = new Set<(value: any) => void>();
 
     constructor(public value: any) {
       // Pass dummy args to super to satisfy it
@@ -105,19 +105,19 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     }
 
     sink(callback: (value: any) => void) {
-      this.subscribers.add(callback);
+      this.#subscribers.add(callback);
       // Ensure callback is called asynchronously to match Reconciler expectations?
       // Actually reconciler doesn't rely on async usually for initial render.
       // But let's be safe and do it synchronously as it worked for others.
       callback(this.value);
       return () => {
-        this.subscribers.delete(callback);
+        this.#subscribers.delete(callback);
       };
     }
 
     set(newValue: any) {
       this.value = newValue;
-      for (const sub of this.subscribers) {
+      for (const sub of this.#subscribers) {
         sub(newValue);
       }
     }

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -57,7 +57,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
     // MockCell extending CellImpl for basic Cell behavior
     class MockCell extends (CellImplConstructor as any) {
-      private subscribers = new Set<(value: any) => void>();
+      #subscribers = new Set<(value: any) => void>();
 
       constructor(public value: any) {
         super(runtime, undefined, undefined, false, undefined, "cell");
@@ -65,16 +65,16 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       }
 
       sink(callback: (value: any) => void) {
-        this.subscribers.add(callback);
+        this.#subscribers.add(callback);
         callback(this.value);
         return () => {
-          this.subscribers.delete(callback);
+          this.#subscribers.delete(callback);
         };
       }
 
       set(newValue: any) {
         this.value = newValue;
-        for (const sub of this.subscribers) {
+        for (const sub of this.#subscribers) {
           sub(newValue);
         }
       }
@@ -90,38 +90,38 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
      */
     class MockPropsCell extends MockCell {
       static nextId = 0;
-      private propCells = new Map<string, MockPropCell>();
-      private readonly linkId = `test-props-${++MockPropsCell.nextId}`;
-      private rawValue: any;
+      #propCells = new Map<string, MockPropCell>();
+      readonly #linkId = `test-props-${++MockPropsCell.nextId}`;
+      #rawValue: any;
 
       constructor(value: any, rawValue: any = value) {
         super(value);
-        this.rawValue = rawValue;
+        this.#rawValue = rawValue;
       }
 
       key(propName: string) {
-        if (!this.propCells.has(propName)) {
-          this.propCells.set(
+        if (!this.#propCells.has(propName)) {
+          this.#propCells.set(
             propName,
             new MockPropCell(this.value?.[propName], this, propName),
           );
         }
-        return this.propCells.get(propName)!;
+        return this.#propCells.get(propName)!;
       }
 
       getRawUntyped() {
-        return this.rawValue;
+        return this.#rawValue;
       }
 
       getAsNormalizedFullLink() {
-        return { space: "test-space", id: this.linkId, path: [] };
+        return { space: "test-space", id: this.#linkId, path: [] };
       }
 
       override set(newValue: any) {
         super.set(newValue);
-        this.rawValue = newValue;
+        this.#rawValue = newValue;
         // Propagate updates to existing child prop cells
-        for (const [k, propCell] of this.propCells) {
+        for (const [k, propCell] of this.#propCells) {
           propCell.set(newValue?.[k]);
         }
       }
@@ -132,13 +132,13 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
      * Supports asSchema(), resolveAsCell(), getAsNormalizedFullLink().
      */
     class MockPropCell extends MockCell {
-      private parentCell?: MockPropsCell;
-      private propKey?: string;
+      #parentCell?: MockPropsCell;
+      #propKey?: string;
 
       constructor(value: any, parentCell?: MockPropsCell, propKey?: string) {
         super(value);
-        this.parentCell = parentCell;
-        this.propKey = propKey;
+        this.#parentCell = parentCell;
+        this.#propKey = propKey;
       }
 
       asSchema(_schema: any) {
@@ -148,8 +148,8 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       resolveAsCell() {
         // Read live value from parent (matches real Cell.key().resolveAsCell()
         // which navigates the live data, not a stale cache)
-        const liveValue = this.parentCell
-          ? this.parentCell.value?.[this.propKey!]
+        const liveValue = this.#parentCell
+          ? this.#parentCell.value?.[this.#propKey!]
           : this.value;
         if (
           liveValue && typeof liveValue === "object" && "sink" in liveValue
@@ -164,8 +164,8 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       }
 
       getRawUntyped() {
-        return this.parentCell
-          ? this.parentCell.value?.[this.propKey!]
+        return this.#parentCell
+          ? this.#parentCell.value?.[this.#propKey!]
           : this.value;
       }
     }
@@ -176,7 +176,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
     class MockStream extends MockCell {
       static nextId = 0;
       public sent: unknown[] = [];
-      private readonly linkId = `test-stream-${++MockStream.nextId}`;
+      readonly #linkId = `test-stream-${++MockStream.nextId}`;
 
       constructor() {
         super(undefined);
@@ -196,7 +196,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       }
 
       getAsNormalizedFullLink() {
-        return { space: "test-space", id: this.linkId, path: [] };
+        return { space: "test-space", id: this.#linkId, path: [] };
       }
 
       public usedTx: unknown;

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -267,21 +267,21 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     const CellImplConstructor = dummyCell.constructor;
 
     class MockCell extends (CellImplConstructor as any) {
-      private subscribers = new Set<(value: unknown) => void>();
+      #subscribers = new Set<(value: unknown) => void>();
 
       constructor(public value: unknown) {
         super(runtime, undefined, undefined, false, undefined, "cell");
       }
 
       sink(callback: (value: unknown) => void) {
-        this.subscribers.add(callback);
+        this.#subscribers.add(callback);
         callback(this.value);
-        return () => this.subscribers.delete(callback);
+        return () => this.#subscribers.delete(callback);
       }
 
       set(newValue: unknown) {
         this.value = newValue;
-        for (const subscriber of this.subscribers) {
+        for (const subscriber of this.#subscribers) {
           subscriber(newValue);
         }
       }
@@ -292,62 +292,70 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     }
 
     class MockPropsCell extends MockCell {
-      private propCells = new Map<string, MockPropCell>();
+      #propCells = new Map<string, MockPropCell>();
 
-      constructor(value: unknown, private rawValue: unknown = value) {
+      #rawValue: unknown;
+
+      constructor(value: unknown, rawValue: unknown = value) {
         super(value);
+        this.#rawValue = rawValue;
       }
 
       key(propName: string) {
-        if (!this.propCells.has(propName)) {
-          this.propCells.set(propName, new MockPropCell(this, propName));
+        if (!this.#propCells.has(propName)) {
+          this.#propCells.set(propName, new MockPropCell(this, propName));
         }
-        return this.propCells.get(propName)!;
+        return this.#propCells.get(propName)!;
       }
 
       getRawUntyped() {
-        return this.rawValue;
+        return this.#rawValue;
       }
 
       override set(newValue: unknown) {
-        this.rawValue = newValue;
+        this.#rawValue = newValue;
         super.set(newValue);
-        for (const propCell of this.propCells.values()) {
+        for (const propCell of this.#propCells.values()) {
           propCell.refresh();
         }
       }
     }
 
     class DeferredInitialPropsCell extends MockPropsCell {
-      private ready = false;
-      private propsSubscribers = new Set<(value: unknown) => void>();
+      #ready = false;
+      #propsSubscribers = new Set<(value: unknown) => void>();
 
       override sink(callback: (value: unknown) => void) {
-        this.propsSubscribers.add(callback);
-        if (this.ready) {
+        this.#propsSubscribers.add(callback);
+        if (this.#ready) {
           callback(this.value);
         }
-        return () => this.propsSubscribers.delete(callback);
+        return () => this.#propsSubscribers.delete(callback);
       }
 
       override getRawUntyped() {
-        if (!this.ready) {
+        if (!this.#ready) {
           throw new Error("props not loaded yet");
         }
         return super.getRawUntyped();
       }
 
       flushInitial() {
-        this.ready = true;
-        for (const subscriber of this.propsSubscribers) {
+        this.#ready = true;
+        for (const subscriber of this.#propsSubscribers) {
           subscriber(this.value);
         }
       }
     }
 
     class MockPropCell extends MockCell {
-      constructor(private parentCell: MockPropsCell, private propKey: string) {
+      #parentCell: MockPropsCell;
+      #propKey: string;
+
+      constructor(parentCell: MockPropsCell, propKey: string) {
         super((parentCell.value as Record<string, unknown>)?.[propKey]);
+        this.#parentCell = parentCell;
+        this.#propKey = propKey;
       }
 
       asSchema(_schema: unknown) {
@@ -360,8 +368,8 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       }
 
       getRawUntyped() {
-        return (this.parentCell.value as Record<string, unknown> | undefined)
-          ?.[this.propKey];
+        return (this.#parentCell.value as Record<string, unknown> | undefined)
+          ?.[this.#propKey];
       }
 
       refresh() {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`html` goes from 171 TypeScript-`private` members to 2, `fuse` from 183 to 29,
per `docs/development/DEVELOPMENT.md` § Classes. The two spellings differ at
runtime: a `#` field is not an own property, whereas a field declared `private`
is, the modifier being erased. `private` constructor parameter properties
become the field declaration and the assignment they stand for.

## Members that stay TypeScript-private

Each carries a note on its own declaration naming the test that drives it.

`WorkerReconciler` keeps `canRenderCellUnderPolicy` and
`atomRenderableUnderPolicy`. Its test states the reason plainly: the render
path reaches those methods only when a labeled value happens to be evaluated
inside a sink callback before teardown, so the branches cover
nondeterministically across runs, and calling the methods directly is what pins
them.

`CellBridge` keeps 28 of its 140, and `FsTree` one. Three of `CellBridge`'s
keep the leading `_` this sweep drops elsewhere, because the suite names
`_attemptReconnect`, `_disconnected`, and `_reconnectTimer` under exactly those
spellings.

## How the exempt set was found

Running the suites, with a syntactic scan only to narrow where to look. Two
gaps in that scan are worth naming, since both were found by a gate rather than
by reading:

The scan matches members named through a cast, and `html`'s test casts to a
named type alias rather than an inline type literal, so
`atomRenderableUnderPolicy` did not appear in its output at all. It surfaced
when the suite failed.

`CfcWritebackStore.key` did appear and is not a reach-in. Resolving each cast's
receiver settles it: those receivers are operation objects in `html` tests,
which carry an unrelated `key`.

## Verification

The tool's count was reconciled against an independent census before the
apply — 354 `private` members across the two packages, 354 converted, no
residue.

`deno fmt --check`, `deno lint`, and `deno task check` pass; both suites are
green. A sweep for prose still naming a member that became `#`-private reports
none, as do checks for a doc comment missing its blank line above and for a
`//` comment stranded beside one.


## Coverage

`packages/fuse` rises by six lines, all of them in `cfc-writeback.ts`, and no
code became uncovered. The change to that file is a rename and nothing else:
after normalizing away `private`, `#`, whitespace, and the trailing commas
`deno fmt` adds when it wraps, the file is character-identical to its
predecessor. It is eight lines longer, because `this.#x` is a character wider
than `this.x` and the formatter rewraps what that pushes past 80 columns.

Line-based coverage counts those extra lines. Function-level coverage does not,
and it is unchanged: 77 functions before and after, 4 never called before and
after, no function covered on one side and uncovered on the other. The six
lines sit inside regions already uncovered.

This is not flake, and was not assumed to be. Three successful `main` runs
score that file identically at 206 uncovered of 1384 instrumented, with no line
flipping between them.

ACCEPT_COVERAGE_DEBT: packages/fuse +6 lines

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


