### PR TITLE
Document required LLM gateway provenance

### DIFF
--- a/docs/features/gateway-request-provenance.md
+++ b/docs/features/gateway-request-provenance.md
@@ -33,6 +33,11 @@ request; both lists are written out in the infra repository, under
 `provenanceEntries` and not to those lists travels to the model vendor and
 appears in no log, so a new field is two changes across two repositories.
 
+The gateway requires the invoker, principal and session headers on every
+request to its LLM hostname. It returns HTTP 400 before forwarding upstream
+when any of the three is absent or empty. Browser CORS preflights do not
+require provenance.
+
 ## Two channels, one set of values
 
 The values travel twice: as `x-cf-harness-*` headers, and condensed into the


### PR DESCRIPTION
The infrastructure gateway now requires the invoker, principal, and session headers before it routes an LLM API request. Record that contract in the live feature documentation, including the HTTP 400 response and CORS-preflight exception.

Verified with the repository-wide formatter, linter, and documentation code block checker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

