### PR TITLE
docs(pattern-iframe): add visual framework guides

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -75,6 +75,7 @@
     "npm:@anthropic-ai/claude-agent-sdk@0.3.206": "0.3.206_@anthropic-ai+sdk@0.112.3__zod@4.4.3_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_zod@4.4.3",
     "npm:@arizeai/openinference-semantic-conventions@^2.5.0": "2.5.0",
     "npm:@arizeai/openinference-vercel@^3.1.0": "3.1.0_@ai-sdk+otel@1.0.31__zod@4.4.3_@opentelemetry+api@1.9.1_ai@7.0.31__zod@4.4.3_zod@4.4.3",
+    "npm:@babylonjs/core@9.23.0": "9.23.0",
     "npm:@codemirror/autocomplete@^6.20.3": "6.20.3",
     "npm:@codemirror/collab@6.1.1": "6.1.1",
     "npm:@codemirror/collab@^6.1.1": "6.1.1",
@@ -123,6 +124,7 @@
     "npm:d3-array@^3.2.4": "3.2.4",
     "npm:d3-scale@^4.0.2": "4.0.2",
     "npm:d3-shape@^3.2.0": "3.2.0",
+    "npm:d3@7.9.0": "7.9.0",
     "npm:dagre@~0.8.5": "0.8.5",
     "npm:dom-serializer@3.1.1": "3.1.1",
     "npm:domhandler@6.0.1": "6.0.1",
@@ -140,6 +142,7 @@
     "npm:lit@^3.3.3": "3.3.3",
     "npm:marked@^18.0.6": "18.0.6",
     "npm:multiformats@^14.0.4": "14.0.4",
+    "npm:phaser@4.2.1": "4.2.1",
     "npm:pino-pretty@^13.1.3": "13.1.3",
     "npm:pino@^10.3.1": "10.3.1",
     "npm:plaid@43": "43.0.0",
@@ -576,6 +579,9 @@
     },
     "@babel/runtime@7.29.7": {
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+    },
+    "@babylonjs/core@9.23.0": {
+      "integrity": "sha512-FpDaTPx485J1H0AEJpoJ785Z1CwCkEPNnZFu7WzHTy0ByGCy75bkZZILh4QFU4LLnzK1iuHwUfecCguATIeKSA=="
     },
     "@codemirror/autocomplete@6.20.3": {
       "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
@@ -1400,7 +1406,7 @@
         "content-type@2.0.0",
         "debug",
         "http-errors",
-        "iconv-lite",
+        "iconv-lite@0.7.3",
         "on-finished",
         "qs",
         "raw-body",
@@ -1435,6 +1441,9 @@
       "dependencies": [
         "delayed-stream"
       ]
+    },
+    "commander@7.2.0": {
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
     },
     "content-disposition@1.1.0": {
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
@@ -1478,11 +1487,87 @@
         "internmap"
       ]
     },
+    "d3-axis@3.0.0": {
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+    },
+    "d3-brush@3.0.0": {
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": [
+        "d3-dispatch",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3-chord@3.0.1": {
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": [
+        "d3-path"
+      ]
+    },
     "d3-color@3.1.0": {
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
+    "d3-contour@4.0.2": {
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": [
+        "d3-array"
+      ]
+    },
+    "d3-delaunay@6.0.4": {
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": [
+        "delaunator"
+      ]
+    },
+    "d3-dispatch@3.0.1": {
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-drag@3.0.0": {
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": [
+        "d3-dispatch",
+        "d3-selection"
+      ]
+    },
+    "d3-dsv@3.0.1": {
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": [
+        "commander",
+        "iconv-lite@0.6.3",
+        "rw"
+      ],
+      "bin": true
+    },
+    "d3-ease@3.0.1": {
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-fetch@3.0.1": {
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": [
+        "d3-dsv"
+      ]
+    },
+    "d3-force@3.0.0": {
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": [
+        "d3-dispatch",
+        "d3-quadtree",
+        "d3-timer"
+      ]
+    },
     "d3-format@3.1.2": {
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="
+    },
+    "d3-geo@3.1.1": {
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": [
+        "d3-array"
+      ]
+    },
+    "d3-hierarchy@3.1.2": {
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
     },
     "d3-interpolate@3.0.1": {
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
@@ -1493,6 +1578,22 @@
     "d3-path@3.1.0": {
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
     },
+    "d3-polygon@3.0.1": {
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+    },
+    "d3-quadtree@3.0.1": {
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-random@3.0.1": {
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-scale-chromatic@3.1.0": {
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": [
+        "d3-color",
+        "d3-interpolate"
+      ]
+    },
     "d3-scale@4.0.2": {
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": [
@@ -1502,6 +1603,9 @@
         "d3-time",
         "d3-time-format"
       ]
+    },
+    "d3-selection@3.0.0": {
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-shape@3.2.0": {
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
@@ -1519,6 +1623,65 @@
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": [
         "d3-array"
+      ]
+    },
+    "d3-timer@3.0.1": {
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition@3.0.1_d3-selection@3.0.0": {
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": [
+        "d3-color",
+        "d3-dispatch",
+        "d3-ease",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-timer"
+      ]
+    },
+    "d3-zoom@3.0.0": {
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": [
+        "d3-dispatch",
+        "d3-drag",
+        "d3-interpolate",
+        "d3-selection",
+        "d3-transition"
+      ]
+    },
+    "d3@7.9.0": {
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": [
+        "d3-array",
+        "d3-axis",
+        "d3-brush",
+        "d3-chord",
+        "d3-color",
+        "d3-contour",
+        "d3-delaunay",
+        "d3-dispatch",
+        "d3-drag",
+        "d3-dsv",
+        "d3-ease",
+        "d3-fetch",
+        "d3-force",
+        "d3-format",
+        "d3-geo",
+        "d3-hierarchy",
+        "d3-interpolate",
+        "d3-path",
+        "d3-polygon",
+        "d3-quadtree",
+        "d3-random",
+        "d3-scale",
+        "d3-scale-chromatic",
+        "d3-selection",
+        "d3-shape",
+        "d3-time",
+        "d3-time-format",
+        "d3-timer",
+        "d3-transition",
+        "d3-zoom"
       ]
     },
     "dagre@0.8.5": {
@@ -1542,6 +1705,12 @@
     },
     "defu@6.1.7": {
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="
+    },
+    "delaunator@5.1.0": {
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dependencies": [
+        "robust-predicates"
+      ]
     },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
@@ -1662,6 +1831,9 @@
     },
     "etag@1.8.1": {
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventemitter3@5.0.4": {
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "eventsource-parser@1.1.2": {
       "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="
@@ -1937,6 +2109,12 @@
         "debug"
       ]
     },
+    "iconv-lite@0.6.3": {
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
     "iconv-lite@0.7.3": {
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dependencies": [
@@ -2140,6 +2318,12 @@
     "path-to-regexp@8.4.2": {
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
+    "phaser@4.2.1": {
+      "integrity": "sha512-WUNwCPJpdjvZiuT6SgCfYVW8Qw/3j0jJ4ws7P2QkhFLFu74sbGuyHJcbFueGkY/AYO4Pi47bNQXn1OCJeLX//w==",
+      "dependencies": [
+        "eventemitter3"
+      ]
+    },
     "pino-abstract-transport@3.0.0": {
       "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "dependencies": [
@@ -2232,7 +2416,7 @@
       "dependencies": [
         "bytes",
         "http-errors",
-        "iconv-lite",
+        "iconv-lite@0.7.3",
         "unpipe"
       ]
     },
@@ -2258,6 +2442,9 @@
     "robot3@0.4.1": {
       "integrity": "sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ=="
     },
+    "robust-predicates@3.0.3": {
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="
+    },
     "router@2.2.0": {
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "dependencies": [
@@ -2267,6 +2454,9 @@
         "parseurl",
         "path-to-regexp"
       ]
+    },
+    "rw@1.3.3": {
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -25,7 +25,7 @@ on the Common Fabric runtime.
 | Task | Read |
 |------|------|
 | Build a pattern | [ai/pattern-development-guide.md](ai/pattern-development-guide.md) |
-| Build an iframe-first pattern | [ai/iframe-pattern-guide.md](ai/iframe-pattern-guide.md) |
+| Build an iframe-first pattern | [plain DOM](ai/iframe-pattern-guide.md), [React](ai/iframe-pattern-react-guide.md), [D3](ai/iframe-pattern-d3-guide.md), [Phaser](ai/iframe-pattern-phaser-guide.md), or [Babylon.js](ai/iframe-pattern-babylon-guide.md) |
 | Write tests | [ai/pattern-testing-guide.md](ai/pattern-testing-guide.md) (mechanics: [workflows/pattern-testing.md](workflows/pattern-testing.md)) |
 | Review / critique a pattern | [ai/pattern-critique-guide.md](ai/pattern-critique-guide.md) |
 | Manual / runtime testing | [ai/manual-testing-guide.md](ai/manual-testing-guide.md) |

--- a/docs/common/ai/iframe-pattern-babylon-guide.md
+++ b/docs/common/ai/iframe-pattern-babylon-guide.md
@@ -194,24 +194,13 @@ const cancelOutput = output.sink((value) => {
   renderAuthoritativeState();
 });
 
-await Promise.all([
-  input.pull(),
-  state.pull(),
-  output.pull(),
-]);
-if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
-inputValue = input.get() ?? DEFAULT_INPUT;
-stateValue = state.get() ?? DEFAULT_STATE;
-outputValue = output.get() ?? DEFAULT_OUTPUT;
-hydrated = true;
-addButton.disabled = false;
-renderAuthoritativeState();
-
 engine.runRenderLoop(() => scene.render());
 const resize = () => engine.resize();
 globalThis.addEventListener("resize", resize);
-globalThis.addEventListener("pagehide", () => {
+let disposed = false;
+function dispose(): void {
+  if (disposed) return;
+  disposed = true;
   cancelInput();
   cancelState();
   cancelOutput();
@@ -219,7 +208,27 @@ globalThis.addEventListener("pagehide", () => {
   scene.dispose();
   engine.dispose();
   fabric.disconnect();
-}, { once: true });
+}
+globalThis.addEventListener("pagehide", dispose, { once: true });
+
+try {
+  await Promise.all([
+    input.pull(),
+    state.pull(),
+    output.pull(),
+  ]);
+  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  inputValue = input.get() ?? DEFAULT_INPUT;
+  stateValue = state.get() ?? DEFAULT_STATE;
+  outputValue = output.get() ?? DEFAULT_OUTPUT;
+  hydrated = true;
+  addButton.disabled = false;
+  renderAuthoritativeState();
+} catch (cause) {
+  showError(cause);
+  dispose();
+}
 ```
 
 Use one `Engine` and one `Scene` per guest. Dispose both on teardown. Handle
@@ -235,6 +244,8 @@ undefined writable Cell.
 Use the pulls only as a joint readiness barrier. Read values with `get()` after
 every pull and initialization has settled, so a newer sink event that arrives
 during the barrier cannot be replaced by an older individual pull result.
+Install idempotent teardown before starting the barrier, and catch bootstrap
+failures so they remain visible while subscriptions and the scene are released.
 
 ## Reconcile entities by stable ID
 

--- a/docs/common/ai/iframe-pattern-babylon-guide.md
+++ b/docs/common/ai/iframe-pattern-babylon-guide.md
@@ -1,0 +1,332 @@
+# Babylon.js iframe-first pattern guide
+
+Use this guide to build a Common Fabric pattern whose primary interface is a
+3D Babylon.js scene inside one sandboxed `cf-iframe`. The generated wrapper
+bundles the guest and its selected Babylon.js modules into one HTML string,
+exposes named Cell and SQLite resources, and returns durable state and output
+through the normal pattern result.
+
+This guide is self-contained. Use Phaser instead for a primarily 2D game. Do
+not load another iframe guide unless the task is an explicit migration or
+hybrid.
+
+## Source layout and durable model
+
+```text
+packages/patterns/babylon-shared-scene/
+├── contract.ts
+├── guest.ts
+├── guest.html
+└── main.tsx     # generated; do not hand-edit
+```
+
+Give every durable scene entity a stable ID. Store semantic state, not renderer
+objects or every animation frame:
+
+```typescript
+export interface SceneEntity {
+  id: string;
+  position: [number, number, number];
+  color: [number, number, number];
+}
+
+export interface IframeInputData {
+  title: string;
+}
+
+export interface IframeStateData {
+  entities: SceneEntity[];
+}
+
+export interface IframeOutputData {
+  selectedId: string | null;
+}
+
+export const DEFAULT_INPUT: IframeInputData = { title: "Shared scene" };
+export const DEFAULT_STATE: IframeStateData = {
+  entities: [{
+    id: "starter",
+    position: [0, 0.5, 0],
+    color: [0.22, 0.74, 0.97],
+  }],
+};
+export const DEFAULT_OUTPUT: IframeOutputData = { selectedId: null };
+
+export const IFRAME_PATTERN = {
+  name: "BabylonSharedScene",
+  displayName: "Babylon shared scene",
+  stateScope: "space",
+  outputScope: "session",
+  frameHeight: "100vh",
+  databases: {},
+} as const;
+```
+
+Use `space` for a collaborative world, `user` for one user's durable settings,
+and `session` for one browser's selection or camera mode. Keep camera matrices,
+hover state, interpolation, particle state, and render-loop timing in the guest
+unless another component must observe or restore them.
+
+## Import only the Babylon.js modules the scene uses
+
+Pin package subpath imports so the guest bundle contains the required engine
+features without importing the whole package namespace:
+
+```typescript
+// Shown at module scope.
+import { ArcRotateCamera } from "npm:@babylonjs/core@9.23.0/Cameras/arcRotateCamera.js";
+import { Engine } from "npm:@babylonjs/core@9.23.0/Engines/engine.js";
+import { HemisphericLight } from "npm:@babylonjs/core@9.23.0/Lights/hemisphericLight.js";
+import { Color3 } from "npm:@babylonjs/core@9.23.0/Maths/math.color.js";
+import { Vector3 } from "npm:@babylonjs/core@9.23.0/Maths/math.vector.js";
+import { CreateBox } from "npm:@babylonjs/core@9.23.0/Meshes/Builders/boxBuilder.js";
+import { StandardMaterial } from "npm:@babylonjs/core@9.23.0/Materials/standardMaterial.js";
+import { Scene } from "npm:@babylonjs/core@9.23.0/scene.js";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import {
+  DEFAULT_INPUT,
+  DEFAULT_OUTPUT,
+  DEFAULT_STATE,
+  type IframeInputData,
+  type IframeOutputData,
+  type IframeStateData,
+} from "./contract.ts";
+
+const fabric = connectFabric();
+const input = fabric.cell<IframeInputData | undefined>("input");
+const state = fabric.cell<IframeStateData | undefined>("state");
+const output = fabric.cell<IframeOutputData | undefined>("output");
+const stateWrite = fabric.cell<IframeStateData>("state");
+const outputWrite = fabric.cell<IframeOutputData>("output");
+
+const canvas = document.querySelector<HTMLCanvasElement>("#scene")!;
+const engine = new Engine(canvas, true);
+const scene = new Scene(engine);
+const camera = new ArcRotateCamera(
+  "camera",
+  Math.PI / 2,
+  Math.PI / 3,
+  8,
+  Vector3.Zero(),
+  scene,
+);
+camera.attachControl(canvas, true);
+new HemisphericLight("light", new Vector3(0, 1, 0), scene);
+
+let hydrated = false;
+let inputValue = DEFAULT_INPUT;
+let stateValue = DEFAULT_STATE;
+let outputValue = DEFAULT_OUTPUT;
+type Entity = {
+  id: string;
+  position: [number, number, number];
+  color: [number, number, number];
+};
+
+function showError(cause: unknown): void {
+  const error = cause instanceof Error ? cause : new Error(String(cause));
+  document.querySelector<HTMLElement>("[role=alert]")!.textContent =
+    error.message;
+}
+
+function renderAuthoritativeState(): void {
+  if (!hydrated) return;
+  document.querySelector("h1")!.textContent = inputValue.title;
+  document.querySelector("output")!.textContent =
+    outputValue.selectedId ?? "None";
+
+  const wanted = new Set(
+    stateValue.entities.map((entity: Entity) => entity.id),
+  );
+  for (const mesh of scene.meshes) {
+    if (mesh.metadata?.fabricEntity && !wanted.has(mesh.name)) mesh.dispose();
+  }
+  for (const entity of stateValue.entities as Entity[]) {
+    const mesh = scene.getMeshByName(entity.id) ?? CreateBox(
+      entity.id,
+      { size: 1 },
+      scene,
+    );
+    mesh.metadata = { fabricEntity: true, id: entity.id };
+    mesh.position.copyFrom(Vector3.FromArray(entity.position));
+    let material = mesh.material as StandardMaterial | null;
+    if (!material) {
+      material = new StandardMaterial(`${entity.id}-material`, scene);
+      mesh.material = material;
+    }
+    material.diffuseColor = Color3.FromArray(entity.color);
+    mesh.actionManager = null;
+    mesh.isPickable = true;
+  }
+}
+
+async function addBox(): Promise<void> {
+  await stateWrite.key("entities").push({
+    id: crypto.randomUUID(),
+    position: [0, 0.5, 0],
+    color: [0.22, 0.74, 0.97],
+  });
+}
+
+scene.onPointerPick = (_event, pick) => {
+  const id = pick.pickedMesh?.metadata?.id;
+  if (typeof id === "string") {
+    void outputWrite.set({ selectedId: id }).catch(showError);
+  }
+};
+const addButton = document.querySelector<HTMLButtonElement>("#add")!;
+addButton.addEventListener("click", () => {
+  void addBox().catch(showError);
+});
+
+const cancelInput = input.sink((value) => {
+  inputValue = value ?? DEFAULT_INPUT;
+  renderAuthoritativeState();
+});
+const cancelState = state.sink((value) => {
+  stateValue = value ?? DEFAULT_STATE;
+  renderAuthoritativeState();
+});
+const cancelOutput = output.sink((value) => {
+  outputValue = value ?? DEFAULT_OUTPUT;
+  renderAuthoritativeState();
+});
+
+const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+  input.pull(),
+  state.pull(),
+  output.pull(),
+]);
+inputValue = pulledInput ?? DEFAULT_INPUT;
+stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
+outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+hydrated = true;
+addButton.disabled = false;
+renderAuthoritativeState();
+
+engine.runRenderLoop(() => scene.render());
+const resize = () => engine.resize();
+globalThis.addEventListener("resize", resize);
+globalThis.addEventListener("pagehide", () => {
+  cancelInput();
+  cancelState();
+  cancelOutput();
+  globalThis.removeEventListener("resize", resize);
+  scene.dispose();
+  engine.dispose();
+  fabric.disconnect();
+}, { once: true });
+```
+
+Use one `Engine` and one `Scene` per guest. Dispose both on teardown. Handle
+resize explicitly, and test context loss/recovery for scenes that matter in
+long-lived tabs.
+
+`sink()` invokes its listener synchronously with the guest's current sample;
+that callback does not prove the worker has delivered current state. Keep scene
+actions disabled until a joint `Promise.all` of `pull()` calls resolves for all
+resources they read. Use `initialize()` for atomic first materialization of an
+undefined writable Cell.
+
+## Reconcile entities by stable ID
+
+Cell state is the authoritative scene model. Reuse Babylon objects with names
+or metadata derived from stable durable IDs, update their properties from each
+snapshot, and dispose objects whose IDs disappeared. Never use the current
+array index as a mesh identity.
+
+Keep render-loop work local. Do not write transforms to Cells every frame.
+Persist meaningful intent at interaction boundaries: place an object, finish a
+drag, claim an entity, change a durable material, or end a turn. Interpolate
+between accepted snapshots inside Babylon.js.
+
+The iframe CSP does not grant arbitrary network access. Prefer procedural
+geometry and materials in a self-contained guest. If a scene needs external
+models or textures, include them as supported pattern data rather than fetching
+from a CDN at runtime.
+
+## Use narrow and mergeable operations
+
+Independent entity creation is a mergeable `push()`, as the complete guest
+above demonstrates.
+
+Resolve a moving array member before a drag or edit and write through the
+stable handle:
+
+```typescript
+// Shown at module scope.
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+const fabric = connectFabric();
+const stateWrite = fabric.cell<{
+  entities: Array<{
+    id: string;
+    position: [number, number, number];
+    color: [number, number, number];
+  }>;
+}>("state");
+async function placeEntity(
+  index: number,
+  position: [number, number, number],
+): Promise<void> {
+  const entity = await stateWrite.key("entities").key(index).resolve();
+  await entity.key("position").set(position);
+}
+```
+
+Resolve at interaction start, not after retaining an index across frames.
+Redundant sets are deduplicated by the Cell system. A multi-write sequence is
+ordered but not atomic, so choose one canonical durable fact when selections,
+receipts, and scene state must agree.
+
+Serialize guest actions, expose pending state in ordinary HTML, and show
+rejections. A failed durable write must not be hidden behind a successful local
+animation.
+
+## Accessible shell
+
+Keep important state and actions outside the canvas as accessible HTML:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shared scene</title>
+  </head>
+  <body>
+    <main>
+      <h1>Loading</h1>
+      <p>Selected: <output aria-live="polite">None</output></p>
+      <button id="add" type="button" disabled>Add box</button>
+      <p role="alert"></p>
+      <canvas id="scene" aria-label="Collaborative 3D scene"></canvas>
+    </main>
+    <!-- PATTERN_IFRAME_SCRIPT -->
+  </body>
+</html>
+```
+
+Use `type="button"`; a scene action must never submit a form or navigate the
+frame. The custom shell must contain `<!-- PATTERN_IFRAME_SCRIPT -->` exactly
+once.
+
+## Generate and validate
+
+```bash
+deno run -A tools/write-iframe-wrapper.ts \
+  --contract packages/patterns/babylon-shared-scene/contract.ts \
+  --guest packages/patterns/babylon-shared-scene/guest.ts \
+  --html packages/patterns/babylon-shared-scene/guest.html \
+  --out packages/patterns/babylon-shared-scene/main.tsx
+
+deno fmt packages/patterns/babylon-shared-scene
+deno check packages/patterns/babylon-shared-scene/guest.ts
+deno task cf check packages/patterns/babylon-shared-scene/main.tsx --no-run
+```
+
+Verify in a real browser that WebGL renders, picking and camera controls work,
+shared updates reconcile without recreating the Engine, concurrent additions
+compose, a stable entity survives reordering, declared user/session scopes stay
+isolated, reload restores durable scene state, errors are visible, resizing
+works, and teardown stops the render loop and bridge subscriptions.

--- a/docs/common/ai/iframe-pattern-babylon-guide.md
+++ b/docs/common/ai/iframe-pattern-babylon-guide.md
@@ -217,8 +217,8 @@ try {
     state.pull(),
     output.pull(),
   ]);
-  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  await stateWrite.initialize(DEFAULT_STATE);
+  await outputWrite.initialize(DEFAULT_OUTPUT);
   inputValue = input.get() ?? DEFAULT_INPUT;
   stateValue = state.get() ?? DEFAULT_STATE;
   outputValue = output.get() ?? DEFAULT_OUTPUT;
@@ -238,8 +238,9 @@ long-lived tabs.
 `sink()` invokes its listener synchronously with the guest's current sample;
 that callback does not prove the worker has delivered current state. Keep scene
 actions disabled until a joint `Promise.all` of `pull()` calls resolves for all
-resources they read. Use `initialize()` for atomic first materialization of an
-undefined writable Cell.
+resources they read. Use `initialize()` for atomic first materialization of a
+writable Cell with no backing value. Call it even when `get()` exposes a
+compiled schema fallback, so a later path write starts from durable state.
 
 Use the pulls only as a joint readiness barrier. Read values with `get()` after
 every pull and initialization has settled, so a newer sink event that arrives

--- a/docs/common/ai/iframe-pattern-babylon-guide.md
+++ b/docs/common/ai/iframe-pattern-babylon-guide.md
@@ -138,8 +138,10 @@ function renderAuthoritativeState(): void {
   const wanted = new Set(
     stateValue.entities.map((entity: Entity) => entity.id),
   );
-  for (const mesh of scene.meshes) {
-    if (mesh.metadata?.fabricEntity && !wanted.has(mesh.name)) mesh.dispose();
+  for (const mesh of [...scene.meshes]) {
+    if (mesh.metadata?.fabricEntity && !wanted.has(mesh.name)) {
+      mesh.dispose(false, true);
+    }
   }
   for (const entity of stateValue.entities as Entity[]) {
     const mesh = scene.getMeshByName(entity.id) ?? CreateBox(
@@ -192,14 +194,16 @@ const cancelOutput = output.sink((value) => {
   renderAuthoritativeState();
 });
 
-const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+await Promise.all([
   input.pull(),
   state.pull(),
   output.pull(),
 ]);
-inputValue = pulledInput ?? DEFAULT_INPUT;
-stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
-outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+inputValue = input.get() ?? DEFAULT_INPUT;
+stateValue = state.get() ?? DEFAULT_STATE;
+outputValue = output.get() ?? DEFAULT_OUTPUT;
 hydrated = true;
 addButton.disabled = false;
 renderAuthoritativeState();
@@ -227,6 +231,10 @@ that callback does not prove the worker has delivered current state. Keep scene
 actions disabled until a joint `Promise.all` of `pull()` calls resolves for all
 resources they read. Use `initialize()` for atomic first materialization of an
 undefined writable Cell.
+
+Use the pulls only as a joint readiness barrier. Read values with `get()` after
+every pull and initialization has settled, so a newer sink event that arrives
+during the barrier cannot be replaced by an older individual pull result.
 
 ## Reconcile entities by stable ID
 

--- a/docs/common/ai/iframe-pattern-d3-guide.md
+++ b/docs/common/ai/iframe-pattern-d3-guide.md
@@ -205,8 +205,8 @@ try {
     state.pull(),
     output.pull(),
   ]);
-  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  await stateWrite.initialize(DEFAULT_STATE);
+  await outputWrite.initialize(DEFAULT_OUTPUT);
   inputValue = input.get() ?? DEFAULT_INPUT;
   stateValue = state.get() ?? DEFAULT_STATE;
   outputValue = output.get() ?? DEFAULT_OUTPUT;
@@ -230,9 +230,10 @@ during the barrier cannot be replaced by an older individual pull result.
 Install idempotent teardown before starting the barrier, and catch bootstrap
 failures so they remain visible while subscriptions are released.
 
-`initialize()` atomically supplies a default only while the Cell is undefined.
-Use it for first materialization; never issue a whole-state `set()` merely to
-ensure a value exists.
+`initialize()` atomically supplies a default only while the Cell has no backing
+value. Call it even when `get()` exposes a compiled schema fallback: the
+idempotent operation materializes that fallback before a path write. Never
+issue a whole-state `set()` merely to ensure a value exists.
 
 ## Render D3 from authoritative state
 

--- a/docs/common/ai/iframe-pattern-d3-guide.md
+++ b/docs/common/ai/iframe-pattern-d3-guide.md
@@ -1,0 +1,331 @@
+# D3 iframe-first pattern guide
+
+Use this guide to build a Common Fabric pattern whose primary interface is a
+D3 visualization inside one sandboxed `cf-iframe`. The generated wrapper is
+mechanical: it exposes named Cell and SQLite resources, bundles the guest and
+D3 into one HTML string, and returns durable state and output through the
+normal pattern result.
+
+This guide is self-contained. Do not also load the plain-DOM or React iframe
+guide unless the request explicitly combines D3 with an existing guest in one
+of those styles.
+
+## Source layout
+
+Keep the authored contract and guest beside the generated wrapper:
+
+```text
+packages/patterns/d3-shared-bars/
+├── contract.ts  # input, durable state, output, scopes, optional databases
+├── guest.ts     # D3 application and Fabric bridge client
+├── guest.html   # optional document shell
+└── main.tsx     # generated wrapper; do not hand-edit
+```
+
+The generated `main.tsx` contains D3, the guest bridge, and the application. It
+does not fetch JavaScript at runtime. Keep `contract.ts` and `guest.ts` so an
+agent can regenerate the wrapper.
+
+## Describe input, state, and output
+
+Create `contract.ts` as a side-effect-free declarative module. Every array
+member that can move carries a stable application ID:
+
+```typescript
+export interface BarDatum {
+  id: string;
+  label: string;
+  value: number;
+}
+
+export interface IframeInputData {
+  heading: string;
+}
+
+export interface IframeStateData {
+  points: BarDatum[];
+}
+
+export interface IframeOutputData {
+  selectedId: string | null;
+}
+
+export const DEFAULT_INPUT: IframeInputData = { heading: "Shared bars" };
+export const DEFAULT_STATE: IframeStateData = {
+  points: [
+    { id: "alpha", label: "Alpha", value: 3 },
+    { id: "beta", label: "Beta", value: 5 },
+  ],
+};
+export const DEFAULT_OUTPUT: IframeOutputData = { selectedId: null };
+
+export const IFRAME_PATTERN = {
+  name: "D3SharedBars",
+  displayName: "D3 shared bars",
+  stateScope: "space",
+  outputScope: "session",
+  frameHeight: "100vh",
+  databases: {},
+} as const;
+```
+
+The wrapper exposes three resources:
+
+- `input` is read-only caller data.
+- `state` is durable data the visualization may change.
+- `output` is the public selection or result the wrapper returns.
+
+Choose each writable resource's scope independently:
+
+| Scope | Meaning |
+| --- | --- |
+| `space` | Shared by every user and browser session in the piece |
+| `user` | Separate for each user and shared by that user's sessions |
+| `session` | Separate for each browser session |
+
+Keep hover coordinates, drag previews, zoom transforms, animation progress,
+and temporary tooltips in guest memory. Persist only state that must survive a
+reload or be observed elsewhere.
+
+## Connect the bridge and pass one readiness barrier
+
+Pin D3 in `guest.ts`, connect once, and keep resource handles at module scope:
+
+```typescript
+// Shown at module scope.
+import {
+  max,
+  scaleBand,
+  scaleLinear,
+  select,
+} from "npm:d3@7.9.0";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import {
+  DEFAULT_INPUT,
+  DEFAULT_OUTPUT,
+  DEFAULT_STATE,
+  type IframeInputData,
+  type IframeOutputData,
+  type IframeStateData,
+} from "./contract.ts";
+
+const fabric = connectFabric();
+const input = fabric.cell<IframeInputData | undefined>("input");
+const state = fabric.cell<IframeStateData | undefined>("state");
+const output = fabric.cell<IframeOutputData | undefined>("output");
+const stateWrite = fabric.cell<IframeStateData>("state");
+const outputWrite = fabric.cell<IframeOutputData>("output");
+const svg = select<SVGSVGElement, unknown>("#chart");
+type Point = { id: string; label: string; value: number };
+
+let hydrated = false;
+let inputValue = DEFAULT_INPUT;
+let stateValue = DEFAULT_STATE;
+let outputValue = DEFAULT_OUTPUT;
+
+function render(): void {
+  if (!hydrated) return;
+  const width = 640;
+  const height = 360;
+  const x = scaleBand<string>()
+    .domain(stateValue.points.map((point: Point) => point.id))
+    .range([0, width])
+    .padding(0.15);
+  const y = scaleLinear()
+    .domain([0, max(stateValue.points, (point: Point) => point.value) ?? 1])
+    .nice()
+    .range([height, 0]);
+
+  svg.attr("viewBox", `0 0 ${width} ${height}`)
+    .selectAll<SVGRectElement, Point>("rect")
+    .data(stateValue.points, (point: Point) => point.id)
+    .join("rect")
+    .attr("x", (point: Point) => x(point.id) ?? 0)
+    .attr("y", (point: Point) => y(point.value))
+    .attr("width", x.bandwidth())
+    .attr("height", (point: Point) => height - y(point.value))
+    .attr("aria-label", (point: Point) => `${point.label}: ${point.value}`)
+    .attr(
+      "data-selected",
+      (point: Point) => point.id === outputValue.selectedId,
+    )
+    .on("click", (_event: PointerEvent, point: Point) => {
+      void outputWrite.set({ selectedId: point.id }).catch(showError);
+    });
+
+  document.querySelector("h1")!.textContent = inputValue.heading;
+}
+
+function showError(cause: unknown): void {
+  const error = cause instanceof Error ? cause : new Error(String(cause));
+  document.querySelector<HTMLElement>("[role=alert]")!.textContent =
+    error.message;
+}
+
+async function addPoint(): Promise<void> {
+  await stateWrite.key("points").push({
+    id: crypto.randomUUID(),
+    label: "New",
+    value: 1,
+  });
+}
+
+const addButton = document.querySelector<HTMLButtonElement>("#add")!;
+addButton.addEventListener("click", () => {
+  void addPoint().catch(showError);
+});
+
+const cancelInput = input.sink((value) => {
+  inputValue = value ?? DEFAULT_INPUT;
+  render();
+});
+const cancelState = state.sink((value) => {
+  stateValue = value ?? DEFAULT_STATE;
+  render();
+});
+const cancelOutput = output.sink((value) => {
+  outputValue = value ?? DEFAULT_OUTPUT;
+  render();
+});
+
+const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+  input.pull(),
+  state.pull(),
+  output.pull(),
+]);
+inputValue = pulledInput ?? DEFAULT_INPUT;
+stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
+outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+hydrated = true;
+addButton.disabled = false;
+render();
+
+globalThis.addEventListener("pagehide", () => {
+  cancelInput();
+  cancelState();
+  cancelOutput();
+  fabric.disconnect();
+}, { once: true });
+```
+
+`sink()` calls its listener synchronously with the guest's current sample, then
+again after host updates. That first call does not prove the host has supplied
+the latest value. Keep all actions disabled until one joint `Promise.all` of
+`pull()` calls resolves for every resource the action reads.
+
+`initialize()` atomically supplies a default only while the Cell is undefined.
+Use it for first materialization; never issue a whole-state `set()` merely to
+ensure a value exists.
+
+## Render D3 from authoritative state
+
+Use one render function and keyed joins. The D3 key must be the durable member
+ID, never the array index. An index follows a position; it does not identify the
+same member after sorting or concurrent inserts.
+
+Keep rendering one-way:
+
+1. A Cell sink replaces the guest's authoritative snapshot.
+2. `render()` derives scales, axes, marks, and accessible text from that
+   snapshot.
+3. A user event performs one narrow Cell operation.
+4. The resulting sink update renders the confirmed shared state.
+
+Do not write from `render()` or from a sink callback. That forms a feedback
+loop. D3 transitions may interpolate the DOM, but they do not become durable
+state.
+
+## Prefer mergeable and path-scoped writes
+
+Append new members with `push()` as the complete guest above does, so
+concurrent additions compose.
+
+When an interaction starts from an array position, resolve that position to a
+stable Cell before subscribing or writing. The returned handle remains attached
+to the same item even when it moves:
+
+```typescript
+// Shown at module scope.
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+const fabric = connectFabric();
+const stateWrite = fabric.cell<{
+  points: Array<{ id: string; label: string; value: number }>;
+}>("state");
+async function incrementPoint(index: number): Promise<void> {
+  const point = await stateWrite.key("points").key(index).resolve();
+  const current = await point.pull();
+  if (current === undefined) return;
+  await point.key("value").set(current.value + 1);
+}
+```
+
+Resolve before a drag or edit begins. Do not remember an index and resolve it
+later. Redundant writes are deduplicated by the underlying Cell machinery, so a
+simple authoritative set is preferable to a guest-side equality protocol.
+
+Serialize multi-step actions in the guest, expose a pending state, and show
+rejections in an element with `role="alert"`. A sequence of writes is ordered,
+not atomic; choose one Cell as the canonical source when multiple views must
+agree.
+
+## Document shell and CSP
+
+The default generated shell supplies `<div id="root"></div>`. A D3 chart
+normally benefits from explicit accessible HTML:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shared bars</title>
+  </head>
+  <body>
+    <main>
+      <h1>Loading</h1>
+      <button id="add" type="button" disabled>Add point</button>
+      <p role="alert"></p>
+      <svg id="chart" role="img" aria-label="Shared bar chart"></svg>
+    </main>
+    <!-- PATTERN_IFRAME_SCRIPT -->
+  </body>
+</html>
+```
+
+The sandbox does not grant arbitrary network access. Bundle modules, generate
+small assets locally, or pass data through `input`; do not depend on a CDN,
+`fetch()`, or remote fonts. A custom shell must contain
+`<!-- PATTERN_IFRAME_SCRIPT -->` exactly once. Buttons must use `type="button"`
+so an accidental form ancestor cannot trigger navigation.
+
+## Generate and validate
+
+Generate the wrapper without the React flag:
+
+```bash
+deno run -A tools/write-iframe-wrapper.ts \
+  --contract packages/patterns/d3-shared-bars/contract.ts \
+  --guest packages/patterns/d3-shared-bars/guest.ts \
+  --html packages/patterns/d3-shared-bars/guest.html \
+  --out packages/patterns/d3-shared-bars/main.tsx
+```
+
+Then validate the authored guest and generated pattern:
+
+```bash
+deno fmt packages/patterns/d3-shared-bars
+deno check packages/patterns/d3-shared-bars/guest.ts
+deno task cf check packages/patterns/d3-shared-bars/main.tsx --no-run
+```
+
+In a real browser, verify all of the following:
+
+- loading controls remain disabled until the joint pull barrier resolves;
+- every mark has accessible text and a stable D3 key;
+- a shared update rerenders without a reload;
+- concurrent appends preserve every new member;
+- an item resolved before a reorder still edits the same durable ID;
+- PerUser and PerSession resources remain isolated as declared;
+- reload restores durable state but not hover, zoom, or animation state;
+- errors are visible, and page teardown cancels sinks and disconnects.

--- a/docs/common/ai/iframe-pattern-d3-guide.md
+++ b/docs/common/ai/iframe-pattern-d3-guide.md
@@ -188,26 +188,35 @@ const cancelOutput = output.sink((value) => {
   render();
 });
 
-await Promise.all([
-  input.pull(),
-  state.pull(),
-  output.pull(),
-]);
-if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
-inputValue = input.get() ?? DEFAULT_INPUT;
-stateValue = state.get() ?? DEFAULT_STATE;
-outputValue = output.get() ?? DEFAULT_OUTPUT;
-hydrated = true;
-addButton.disabled = false;
-render();
-
-globalThis.addEventListener("pagehide", () => {
+let disposed = false;
+function dispose(): void {
+  if (disposed) return;
+  disposed = true;
   cancelInput();
   cancelState();
   cancelOutput();
   fabric.disconnect();
-}, { once: true });
+}
+globalThis.addEventListener("pagehide", dispose, { once: true });
+
+try {
+  await Promise.all([
+    input.pull(),
+    state.pull(),
+    output.pull(),
+  ]);
+  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  inputValue = input.get() ?? DEFAULT_INPUT;
+  stateValue = state.get() ?? DEFAULT_STATE;
+  outputValue = output.get() ?? DEFAULT_OUTPUT;
+  hydrated = true;
+  addButton.disabled = false;
+  render();
+} catch (cause) {
+  showError(cause);
+  dispose();
+}
 ```
 
 `sink()` calls its listener synchronously with the guest's current sample, then
@@ -218,6 +227,8 @@ the latest value. Keep all actions disabled until one joint `Promise.all` of
 Use the pulls only as a joint readiness barrier. Read values with `get()` after
 every pull and initialization has settled, so a newer sink event that arrives
 during the barrier cannot be replaced by an older individual pull result.
+Install idempotent teardown before starting the barrier, and catch bootstrap
+failures so they remain visible while subscriptions are released.
 
 `initialize()` atomically supplies a default only while the Cell is undefined.
 Use it for first materialization; never issue a whole-state `set()` merely to

--- a/docs/common/ai/iframe-pattern-d3-guide.md
+++ b/docs/common/ai/iframe-pattern-d3-guide.md
@@ -188,14 +188,16 @@ const cancelOutput = output.sink((value) => {
   render();
 });
 
-const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+await Promise.all([
   input.pull(),
   state.pull(),
   output.pull(),
 ]);
-inputValue = pulledInput ?? DEFAULT_INPUT;
-stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
-outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+inputValue = input.get() ?? DEFAULT_INPUT;
+stateValue = state.get() ?? DEFAULT_STATE;
+outputValue = output.get() ?? DEFAULT_OUTPUT;
 hydrated = true;
 addButton.disabled = false;
 render();
@@ -212,6 +214,10 @@ globalThis.addEventListener("pagehide", () => {
 again after host updates. That first call does not prove the host has supplied
 the latest value. Keep all actions disabled until one joint `Promise.all` of
 `pull()` calls resolves for every resource the action reads.
+
+Use the pulls only as a joint readiness barrier. Read values with `get()` after
+every pull and initialization has settled, so a newer sink event that arrives
+during the barrier cannot be replaced by an older individual pull result.
 
 `initialize()` atomically supplies a default only while the Cell is undefined.
 Use it for first materialization; never issue a whole-state `set()` merely to

--- a/docs/common/ai/iframe-pattern-guide.md
+++ b/docs/common/ai/iframe-pattern-guide.md
@@ -104,7 +104,8 @@ such as hover or an open tooltip in a Fabric Cell; keep that inside the guest.
 The generated wrapper owns `space`-scoped state and output inside the piece. It
 declares `user`- and `session`-scoped state or output as optional scoped pattern
 inputs, so the runtime resolves them for the active user or browser session.
-Callers normally omit those inputs and let their `Default` value materialize.
+Callers normally omit those inputs. Their `Default` supplies the readable
+schema fallback; the guest materializes each writable value after pulling it.
 This distinction stays in the wrapper; the guest always addresses the same
 `state` and `output` resources by name.
 
@@ -126,21 +127,33 @@ const output = fabric.cell<typeof DEFAULT_OUTPUT>("output");
 const root = document.querySelector<HTMLDivElement>("#root")!;
 const heading = document.createElement("h1");
 const add = document.createElement("button");
+const error = document.createElement("p");
 add.type = "button";
 add.textContent = "Add note";
-root.append(heading, add);
+error.role = "alert";
+root.append(heading, add, error);
 
 let hydrated = false;
 const render = () => {
   heading.textContent = input.get()?.heading ?? "Loading";
   add.disabled = !hydrated;
 };
+const showError = (cause: unknown) => {
+  error.textContent = cause instanceof Error ? cause.message : String(cause);
+};
 
 const stops = [input.sink(render), state.sink(render), output.sink(render)];
-void Promise.all([input.pull(), state.pull(), output.pull()]).then(() => {
-  hydrated = true;
-  render();
-});
+void (async () => {
+  try {
+    await Promise.all([input.pull(), state.pull(), output.pull()]);
+    await state.initialize(DEFAULT_STATE);
+    await output.initialize(DEFAULT_OUTPUT);
+    hydrated = true;
+    render();
+  } catch (cause) {
+    showError(cause);
+  }
+})();
 
 add.addEventListener("click", () => {
   const note = { id: crypto.randomUUID(), text: "New note" };
@@ -150,7 +163,7 @@ add.addEventListener("click", () => {
       noteCount: current.notes.length,
       selectedId: current.selectedId,
     });
-  });
+  }).catch(showError);
 });
 
 globalThis.addEventListener("pagehide", () => {
@@ -174,7 +187,8 @@ The Cell contract matches the rest of Common Fabric:
 - `key(nameOrIndex)` derives a path-specific handle. Its sink observes that path
   rather than the whole root value.
 - `initialize(defaultValue)` atomically stores a first-use default only while
-  the Cell is undefined, then returns the value that won.
+  the Cell has no backing value, then returns the value that won. A schema
+  fallback visible through `get()` does not count as stored.
 - `set(value)` replaces a value. `update(fn)` queues a read-modify-write against
   other operations on the same remote Cell in this guest; it is not a
   transaction across users, sessions, or resources.
@@ -199,9 +213,10 @@ after the joint `Promise.all(...)` resolves, then render from the complete set.
 
 A newly resolved `user`- or `session`-scoped input can also be `undefined` while
 its default is materializing. Pull before the first mutation. If a child write
-needs its parent object to exist, initialize only when the authoritative pull
-still reports absence, await that write, and then use the narrow child
-operation:
+needs its parent object to exist, call `initialize()` after the authoritative
+pull, await it, and then use the narrow child operation. Call it even when
+`get()` exposes the compiled schema fallback: initialization is idempotent and
+materializes that fallback before the child write.
 
 ```typescript
 // Shown at module scope.
@@ -212,19 +227,19 @@ const fabric = connectFabric();
 const state = fabric.cell<typeof DEFAULT_STATE>("state");
 
 async function addNote(text: string): Promise<void> {
-  const current = await state.pull();
-  if (current === undefined) await state.initialize(DEFAULT_STATE);
+  await state.pull();
+  await state.initialize(DEFAULT_STATE);
   await state.key("notes").push({ id: crypto.randomUUID(), text });
 }
 ```
 
 Do not initialize with `update((current) => current ?? DEFAULT_STATE)`: the
 updater starts from this guest's cache, which another session may have made
-stale. `initialize()` reads and conditionally writes in one runtime transaction,
-so concurrent guests return the same winning value without replacing it. Use
-`set()` for intentional last-writer-wins replacement, and use `update()` only
-when a local queue over an already materialized complete object is the intended
-boundary.
+stale. `initialize()` reads raw backing state and conditionally writes in one
+runtime transaction, so concurrent guests return the same winning value
+without replacing it. Use `set()` for intentional last-writer-wins replacement,
+and use `update()` only when a local queue over an already materialized complete
+object is the intended boundary.
 
 Keep editable DOM drafts separate from authoritative Cell samples. While a
 local write is pending, a sink rerender should preserve that draft. Once it

--- a/docs/common/ai/iframe-pattern-phaser-guide.md
+++ b/docs/common/ai/iframe-pattern-phaser-guide.md
@@ -187,14 +187,16 @@ const cancelOutput = output.sink((value) => {
   outputValue = value ?? DEFAULT_OUTPUT;
 });
 
-const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+await Promise.all([
   input.pull(),
   state.pull(),
   output.pull(),
 ]);
-inputValue = pulledInput ?? DEFAULT_INPUT;
-stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
-outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+inputValue = input.get() ?? DEFAULT_INPUT;
+stateValue = state.get() ?? DEFAULT_STATE;
+outputValue = output.get() ?? DEFAULT_OUTPUT;
 hydrated = true;
 spawnButton.disabled = false;
 renderAuthoritativeState();
@@ -212,6 +214,10 @@ globalThis.addEventListener("pagehide", () => {
 host changes. Its first callback is not a readiness signal. Keep controls and
 gameplay disabled until one joint `Promise.all` of `pull()` calls has resolved
 for every resource an action reads.
+
+Use the pulls only as a joint readiness barrier. Read values with `get()` after
+every pull and initialization has settled, so a newer sink event that arrives
+during the barrier cannot be replaced by an older individual pull result.
 
 `initialize()` is the atomic first-use operation. It stores a default only
 while the Cell is undefined and returns the transaction's winner. Never blind-

--- a/docs/common/ai/iframe-pattern-phaser-guide.md
+++ b/docs/common/ai/iframe-pattern-phaser-guide.md
@@ -187,27 +187,36 @@ const cancelOutput = output.sink((value) => {
   outputValue = value ?? DEFAULT_OUTPUT;
 });
 
-await Promise.all([
-  input.pull(),
-  state.pull(),
-  output.pull(),
-]);
-if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
-inputValue = input.get() ?? DEFAULT_INPUT;
-stateValue = state.get() ?? DEFAULT_STATE;
-outputValue = output.get() ?? DEFAULT_OUTPUT;
-hydrated = true;
-spawnButton.disabled = false;
-renderAuthoritativeState();
-
-globalThis.addEventListener("pagehide", () => {
+let disposed = false;
+function dispose(): void {
+  if (disposed) return;
+  disposed = true;
   cancelInput();
   cancelState();
   cancelOutput();
   game.destroy(true);
   fabric.disconnect();
-}, { once: true });
+}
+globalThis.addEventListener("pagehide", dispose, { once: true });
+
+try {
+  await Promise.all([
+    input.pull(),
+    state.pull(),
+    output.pull(),
+  ]);
+  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
+  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  inputValue = input.get() ?? DEFAULT_INPUT;
+  stateValue = state.get() ?? DEFAULT_STATE;
+  outputValue = output.get() ?? DEFAULT_OUTPUT;
+  hydrated = true;
+  spawnButton.disabled = false;
+  renderAuthoritativeState();
+} catch (cause) {
+  showError(cause);
+  dispose();
+}
 ```
 
 `sink()` calls synchronously with the guest's current sample and later with
@@ -218,6 +227,8 @@ for every resource an action reads.
 Use the pulls only as a joint readiness barrier. Read values with `get()` after
 every pull and initialization has settled, so a newer sink event that arrives
 during the barrier cannot be replaced by an older individual pull result.
+Install idempotent teardown before starting the barrier, and catch bootstrap
+failures so they remain visible while subscriptions and the game are released.
 
 `initialize()` is the atomic first-use operation. It stores a default only
 while the Cell is undefined and returns the transaction's winner. Never blind-

--- a/docs/common/ai/iframe-pattern-phaser-guide.md
+++ b/docs/common/ai/iframe-pattern-phaser-guide.md
@@ -205,8 +205,8 @@ try {
     state.pull(),
     output.pull(),
   ]);
-  if (state.get() === undefined) await stateWrite.initialize(DEFAULT_STATE);
-  if (output.get() === undefined) await outputWrite.initialize(DEFAULT_OUTPUT);
+  await stateWrite.initialize(DEFAULT_STATE);
+  await outputWrite.initialize(DEFAULT_OUTPUT);
   inputValue = input.get() ?? DEFAULT_INPUT;
   stateValue = state.get() ?? DEFAULT_STATE;
   outputValue = output.get() ?? DEFAULT_OUTPUT;
@@ -231,8 +231,10 @@ Install idempotent teardown before starting the barrier, and catch bootstrap
 failures so they remain visible while subscriptions and the game are released.
 
 `initialize()` is the atomic first-use operation. It stores a default only
-while the Cell is undefined and returns the transaction's winner. Never blind-
-set the whole world merely to ensure it exists.
+while the Cell has no backing value and returns the transaction's winner. Call
+it even when `get()` exposes a compiled schema fallback, so the fallback is
+materialized before a path write. Never blind-set the whole world merely to
+ensure it exists.
 
 ## Separate the simulation from durable state
 

--- a/docs/common/ai/iframe-pattern-phaser-guide.md
+++ b/docs/common/ai/iframe-pattern-phaser-guide.md
@@ -1,0 +1,320 @@
+# Phaser iframe-first pattern guide
+
+Use this guide to build a Common Fabric pattern whose primary interface is a
+2D Phaser game inside one sandboxed `cf-iframe`. The generated wrapper bundles
+Phaser and the guest into one HTML string, exposes named Cell and SQLite
+resources, and returns durable state and output through the normal pattern
+result.
+
+This guide is self-contained. Use Babylon.js instead when the requested scene
+is fundamentally 3D. Do not load the other iframe guides unless the task is an
+explicit migration or hybrid.
+
+## Source layout and data contract
+
+Keep the authored sources beside generated `main.tsx`:
+
+```text
+packages/patterns/phaser-shared-targets/
+├── contract.ts
+├── guest.ts
+├── guest.html   # optional; useful for a canvas parent and status UI
+└── main.tsx     # generated; do not hand-edit
+```
+
+Durable game entities need stable IDs. Persist game rules and meaningful
+world state, not frame-by-frame presentation state:
+
+```typescript
+export interface Target {
+  id: string;
+  x: number;
+  y: number;
+  color: number;
+}
+
+export interface IframeInputData {
+  title: string;
+}
+
+export interface IframeStateData {
+  targets: Target[];
+  hits: Array<{ id: string; targetId: string }>;
+}
+
+export interface IframeOutputData {
+  lastTargetId: string | null;
+}
+
+export const DEFAULT_INPUT: IframeInputData = { title: "Shared targets" };
+export const DEFAULT_STATE: IframeStateData = {
+  targets: [{ id: "starter", x: 320, y: 180, color: 0x38bdf8 }],
+  hits: [],
+};
+export const DEFAULT_OUTPUT: IframeOutputData = { lastTargetId: null };
+
+export const IFRAME_PATTERN = {
+  name: "PhaserSharedTargets",
+  displayName: "Phaser shared targets",
+  stateScope: "space",
+  outputScope: "session",
+  frameHeight: "100vh",
+  databases: {},
+} as const;
+```
+
+Use `space` for a shared world, `user` for one player's durable progress, and
+`session` for state that belongs only to one browser session. Input, state,
+output, and each SQLite database choose their scopes independently.
+
+Keep camera position, pointer state, tweens, particles, interpolation, physics
+contacts, and the current animation frame in Phaser. Persist them only when
+they are actual application data that must survive a reload.
+
+## Create one game and one bridge client
+
+Pin Phaser in `guest.ts`. Create exactly one `Phaser.Game`, keep the Fabric
+client outside the Scene, and destroy both on page teardown:
+
+```typescript
+// Shown at module scope.
+import Phaser from "npm:phaser@4.2.1";
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+import {
+  DEFAULT_INPUT,
+  DEFAULT_OUTPUT,
+  DEFAULT_STATE,
+  type IframeInputData,
+  type IframeOutputData,
+  type IframeStateData,
+} from "./contract.ts";
+
+const fabric = connectFabric();
+const input = fabric.cell<IframeInputData | undefined>("input");
+const state = fabric.cell<IframeStateData | undefined>("state");
+const output = fabric.cell<IframeOutputData | undefined>("output");
+const stateWrite = fabric.cell<IframeStateData>("state");
+const outputWrite = fabric.cell<IframeOutputData>("output");
+
+let hydrated = false;
+let inputValue = DEFAULT_INPUT;
+let stateValue = DEFAULT_STATE;
+let outputValue = DEFAULT_OUTPUT;
+let scene: Phaser.Scene | undefined;
+
+function showError(cause: unknown): void {
+  const error = cause instanceof Error ? cause : new Error(String(cause));
+  document.querySelector<HTMLElement>("[role=alert]")!.textContent =
+    error.message;
+}
+
+function renderAuthoritativeState(): void {
+  if (!hydrated || !scene) return;
+  document.querySelector("h1")!.textContent = inputValue.title;
+  document.querySelector("output")!.textContent = String(
+    stateValue.hits.length,
+  );
+
+  const existing = new Map(
+    scene.children.list
+      .filter((child) => child.getData("fabricEntity") === true)
+      .map((child) => [child.name, child]),
+  );
+  for (const target of stateValue.targets) {
+    let object = existing.get(target.id) as Phaser.GameObjects.Arc | undefined;
+    if (!object) {
+      object = scene.add.circle(target.x, target.y, 18, target.color)
+        .setName(target.id)
+        .setData("fabricEntity", true)
+        .setInteractive();
+      object.on("pointerdown", () => {
+        void hitTarget(target.id).catch(showError);
+      });
+    }
+    object.setPosition(target.x, target.y).setFillStyle(target.color);
+    existing.delete(target.id);
+  }
+  for (const stale of existing.values()) stale.destroy();
+}
+
+async function hitTarget(id: string): Promise<void> {
+  await stateWrite.key("hits").push({
+    id: crypto.randomUUID(),
+    targetId: id,
+  });
+  await outputWrite.set({ lastTargetId: id });
+}
+
+async function spawnTarget(): Promise<void> {
+  await stateWrite.key("targets").push({
+    id: crypto.randomUUID(),
+    x: 80 + Math.random() * 480,
+    y: 60 + Math.random() * 240,
+    color: 0x38bdf8,
+  });
+}
+
+class MainScene extends Phaser.Scene {
+  create(): void {
+    scene = this;
+    renderAuthoritativeState();
+  }
+}
+
+const game = new Phaser.Game({
+  type: Phaser.AUTO,
+  parent: "game",
+  width: 640,
+  height: 360,
+  backgroundColor: "#111827",
+  scene: MainScene,
+  scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH },
+});
+const spawnButton = document.querySelector<HTMLButtonElement>("#spawn")!;
+spawnButton.addEventListener("click", () => {
+  void spawnTarget().catch(showError);
+});
+
+const cancelInput = input.sink((value) => {
+  inputValue = value ?? DEFAULT_INPUT;
+  renderAuthoritativeState();
+});
+const cancelState = state.sink((value) => {
+  stateValue = value ?? DEFAULT_STATE;
+  renderAuthoritativeState();
+});
+const cancelOutput = output.sink((value) => {
+  outputValue = value ?? DEFAULT_OUTPUT;
+});
+
+const [pulledInput, pulledState, pulledOutput] = await Promise.all([
+  input.pull(),
+  state.pull(),
+  output.pull(),
+]);
+inputValue = pulledInput ?? DEFAULT_INPUT;
+stateValue = pulledState ?? await stateWrite.initialize(DEFAULT_STATE);
+outputValue = pulledOutput ?? await outputWrite.initialize(DEFAULT_OUTPUT);
+hydrated = true;
+spawnButton.disabled = false;
+renderAuthoritativeState();
+
+globalThis.addEventListener("pagehide", () => {
+  cancelInput();
+  cancelState();
+  cancelOutput();
+  game.destroy(true);
+  fabric.disconnect();
+}, { once: true });
+```
+
+`sink()` calls synchronously with the guest's current sample and later with
+host changes. Its first callback is not a readiness signal. Keep controls and
+gameplay disabled until one joint `Promise.all` of `pull()` calls has resolved
+for every resource an action reads.
+
+`initialize()` is the atomic first-use operation. It stores a default only
+while the Cell is undefined and returns the transaction's winner. Never blind-
+set the whole world merely to ensure it exists.
+
+## Separate the simulation from durable state
+
+Treat Cell state as an authoritative model and Phaser as its renderer:
+
+1. A sink replaces the guest's authoritative snapshot.
+2. Reconcile Phaser objects by stable entity ID.
+3. Pointer, keyboard, or collision events issue explicit intent writes.
+4. The next sink update reconciles the accepted shared result.
+
+Do not write a Cell from `update()` on every frame. A 60 Hz write loop creates
+contention, unnecessary commits, and feedback between the simulation and its
+authoritative model. Interpolate locally between accepted states and persist
+only meaningful actions such as spawning, claiming, scoring, or ending a turn.
+
+Generate textures and simple audio locally when practical. The iframe CSP does
+not allow arbitrary network fetches, so do not load assets from a CDN. For
+larger assets, include data files through the supported pattern program rather
+than inventing a side channel.
+
+## Use operations that match player intent
+
+Append independently created entities with mergeable `push()`, as the complete
+guest above does. The same principle makes `hits` an append-only intent log and
+derives the displayed score from `hits.length`; concurrent hits compose instead
+of racing two last-writer-wins numeric replacements.
+
+When an input starts from an array position, resolve it immediately to a stable
+Cell and then write paths on that handle:
+
+```typescript
+// Shown at module scope.
+import { connectFabric } from "@commonfabric/iframe-sandbox/guest";
+const fabric = connectFabric();
+const stateWrite = fabric.cell<{
+  targets: Array<{ id: string; x: number; y: number; color: number }>;
+}>("state");
+async function moveTarget(index: number, x: number, y: number): Promise<void> {
+  const target = await stateWrite.key("targets").key(index).resolve();
+  await target.key("x").set(x);
+  await target.key("y").set(y);
+}
+```
+
+The resolved handle follows the same durable member if concurrent changes move
+it in the array. Do not retain a numeric index across frames and resolve it
+later. Multiple writes are ordered but not atomic; store one canonical fact
+when a derived score, receipt, and animation must agree.
+
+Serialize guest actions, disable the relevant control while one is pending,
+and surface failures in visible status text. Redundant authoritative writes are
+deduplicated by the Cell layer.
+
+## Accessible shell and lifecycle
+
+Canvas content alone is not enough for browser automation or assistive
+technology. Mirror important state and controls in ordinary HTML:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shared targets</title>
+  </head>
+  <body>
+    <main>
+      <h1>Loading</h1>
+      <p>Score: <output aria-live="polite">0</output></p>
+      <button id="spawn" type="button" disabled>Spawn target</button>
+      <p role="alert"></p>
+      <div id="game" aria-label="Shared targets game"></div>
+    </main>
+    <!-- PATTERN_IFRAME_SCRIPT -->
+  </body>
+</html>
+```
+
+Use `type="button"`; game controls must never rely on form submission. Pause or
+mute on `visibilitychange` when appropriate. On `pagehide`, cancel every sink,
+destroy the game, remove global listeners, and disconnect the bridge.
+
+## Generate and validate
+
+```bash
+deno run -A tools/write-iframe-wrapper.ts \
+  --contract packages/patterns/phaser-shared-targets/contract.ts \
+  --guest packages/patterns/phaser-shared-targets/guest.ts \
+  --html packages/patterns/phaser-shared-targets/guest.html \
+  --out packages/patterns/phaser-shared-targets/main.tsx
+
+deno fmt packages/patterns/phaser-shared-targets
+deno check packages/patterns/phaser-shared-targets/guest.ts
+deno task cf check packages/patterns/phaser-shared-targets/main.tsx --no-run
+```
+
+Verify in a real browser that the canvas renders, pointer and keyboard controls
+work, shared changes reconcile without recreating the game, concurrent spawns
+compose, stable entities survive reordering, declared user/session scopes stay
+isolated, reload restores durable progress, errors are visible, and teardown
+leaves no render loop or bridge subscription running.

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -148,17 +148,19 @@ or sibling elements outside the React root.
 - `{ status: "error", error }` when the resource cannot be read.
 
 It also returns `initialize(defaultValue)`, `set(valueOrUpdater)`, and
-`refresh()`. `initialize()` atomically stores the default only while the Cell is
-undefined and returns the value selected by that transaction. `refresh()` is
-the explicit host `Cell.pull()` boundary. The hook subscribes through
-`useSyncExternalStore`, so host updates rerender the component.
+`refresh()`. `initialize()` atomically stores the default only while the Cell
+has no backing value and returns the value selected by that transaction. A
+readable schema fallback does not count as stored. `refresh()` is the explicit
+host `Cell.pull()` boundary. The hook subscribes through `useSyncExternalStore`,
+so host updates rerender the component.
 
 `ready` means the pull completed; a newly scoped or optional Cell can therefore
 be ready with the value `undefined`. Include `undefined` in the hook type. Use
 the declared input default for an absent read-only input. For writable state or
-output, initialize only after that Cell's authoritative pull reports
-`undefined`; do not replace a value that another session may already have
-materialized. Use `initialize()` rather than `set()` for that default write.
+output, initialize only after that Cell's authoritative pull completes. Call
+`initialize()` once even when the compiled schema fallback is already visible:
+the idempotent operation materializes the backing value without replacing a
+value another session won.
 Bridge `set()` reports commit failure, but its write remains an intentional
 last-writer-wins replacement.
 
@@ -191,17 +193,38 @@ function Editor() {
   const outputValue = output.status === "ready" ? output.value : undefined;
   const actionTail = React.useRef(Promise.resolve());
   const [pending, setPending] = React.useState(false);
+  const [materialized, setMaterialized] = React.useState(false);
   const [actionError, setActionError] = React.useState<Error>();
   React.useEffect(() => {
-    if (state.status === "ready" && stateValue === undefined) {
-      void state.initialize(DEFAULT_STATE).catch(() => {});
+    if (
+      input.status !== "ready" || state.status !== "ready" ||
+      output.status !== "ready"
+    ) {
+      return;
     }
-  }, [state.status, stateValue, state.initialize]);
-  React.useEffect(() => {
-    if (output.status === "ready" && outputValue === undefined) {
-      void output.initialize(DEFAULT_OUTPUT).catch(() => {});
-    }
-  }, [output.status, outputValue, output.initialize]);
+    let active = true;
+    void Promise.all([
+      state.initialize(DEFAULT_STATE),
+      output.initialize(DEFAULT_OUTPUT),
+    ]).then(() => {
+      if (active) setMaterialized(true);
+    }).catch((cause) => {
+      if (active) {
+        setActionError(
+          cause instanceof Error ? cause : new Error(String(cause)),
+        );
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [
+    input.status,
+    state.status,
+    output.status,
+    state.initialize,
+    output.initialize,
+  ]);
   const resources = [input, state, output];
   const failure = resources.find((resource) => resource.status === "error");
 
@@ -210,7 +233,7 @@ function Editor() {
   }
   if (
     input.status !== "ready" || state.status !== "ready" ||
-    stateValue === undefined || output.status !== "ready" ||
+    stateValue === undefined || output.status !== "ready" || !materialized ||
     outputValue === undefined
   ) {
     return <button type="button" disabled>Loading</button>;
@@ -264,10 +287,10 @@ function Editor() {
 
 The hooks load Cells independently, but the component owns one joint readiness
 predicate. An individual resource becoming ready must not enable an action that
-still reads fallback input, state, or output. Initialization rejections are
-consumed because the hook exposes them through its `error` snapshot. Action
-rejections are rendered separately, and the ref-backed tail keeps rapid actions
-serialized across rerenders.
+still reads fallback input, state, or output. The materialization phase keeps
+actions disabled until both writable initializers settle, and renders an
+initialization rejection. Action rejections use the same visible error region,
+and the ref-backed tail keeps rapid actions serialized across rerenders.
 
 Functional setters are serialized for the same remote Cell inside one guest.
 They are not a transaction across users or across resources. Prefer a narrow

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -194,6 +194,7 @@ function Editor() {
   const actionTail = React.useRef(Promise.resolve());
   const [pending, setPending] = React.useState(false);
   const [materialized, setMaterialized] = React.useState(false);
+  const [initializationError, setInitializationError] = React.useState<Error>();
   const [actionError, setActionError] = React.useState<Error>();
   React.useEffect(() => {
     if (
@@ -210,7 +211,7 @@ function Editor() {
       if (active) setMaterialized(true);
     }).catch((cause) => {
       if (active) {
-        setActionError(
+        setInitializationError(
           cause instanceof Error ? cause : new Error(String(cause)),
         );
       }
@@ -230,6 +231,9 @@ function Editor() {
 
   if (failure?.status === "error") {
     return <p role="alert">{failure.error.message}</p>;
+  }
+  if (initializationError) {
+    return <p role="alert">{initializationError.message}</p>;
   }
   if (
     input.status !== "ready" || state.status !== "ready" ||

--- a/packages/iframe-sandbox/README.md
+++ b/packages/iframe-sandbox/README.md
@@ -51,7 +51,9 @@ A resource has a `kind`, optional schema and description, and only the
 operations the host supplies. A cell capability follows the runtime's Cell
 shape: `get()`, `pull()`, optional `initialize()`, `set()`, and `push()`,
 `sink()`, `key()`, and `resolve()`. `initialize(defaultValue)` atomically stores
-the default only while the cell is undefined and returns the value that won. The
+the default only while the cell has no backing value and returns the value that
+won. A readable schema fallback does not count as stored, so calling
+`initialize()` after `pull()` safely materializes it before a child write. The
 resource kinds are `cell`, `stream`, `sqlite`, and `service`. Named methods let
 an application expose a narrow service without expanding the cell protocol.
 

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -190,7 +190,7 @@ export class RemoteCell<T = FabricValue> {
     return this.#enqueueOperation(() => this.#set(snapshot));
   }
 
-  /** Atomically stores a default while the cell is undefined. */
+  /** Atomically stores a default while the cell has no backing value. */
   initialize(value: T): Promise<T> {
     if (value === undefined) {
       return Promise.reject(

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1138,7 +1138,7 @@ export class RuntimeProcessor {
     });
   }
 
-  /** Atomically stores a default only while the target remains undefined. */
+  /** Atomically stores a default only while the target has no backing value. */
   async handleCellInitialize(
     request: CellInitializeRequest,
   ): Promise<{ value: FabricValue }> {
@@ -1148,9 +1148,15 @@ export class RuntimeProcessor {
     const initial = mapCellRefsToSigilLinks(request.value);
     const result = await this.runtime.editWithRetry((tx) => {
       const cell = getCell(this.runtime, request.cell).withTx(tx);
-      const current = cell.get();
-      if (current !== undefined) {
-        return cellValueForClient(current);
+      // Initialization materializes a backing value. A schema default is a
+      // readable fallback, not proof that the cell has been stored: treating
+      // it as an existing value leaves a later child write with no durable
+      // parent and can replace the visible default. Drop the view schema only
+      // for this existence check, then return the normal projected value when
+      // storage already won.
+      const stored = cell.asSchema(undefined).getRaw();
+      if (stored !== undefined) {
+        return cellValueForClient(cell.get());
       }
       cell.set(initial);
       return cellValueForClient(initial);

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1153,10 +1153,11 @@ export class RuntimeProcessor {
       // cell has been stored, and a write redirect is an address rather than
       // backing data. Treating either as an existing value leaves a later
       // child write with no durable parent and can replace the visible default.
-      // Drop the view schema and follow a final write redirect only for this
-      // existence check, then return the normal projected value when storage
-      // already won.
-      const stored = cell.asSchema(undefined).getRaw({
+      // Follow a final write redirect only for this existence check, while
+      // retaining the view schema because its scope cap controls whether that
+      // redirect is reachable. Then return the normal projected value when
+      // storage already won.
+      const stored = cell.getRaw({
         lastNode: "writeRedirect",
       });
       if (stored !== undefined) {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1148,15 +1148,25 @@ export class RuntimeProcessor {
     const initial = mapCellRefsToSigilLinks(request.value);
     const result = await this.runtime.editWithRetry((tx) => {
       const cell = getCell(this.runtime, request.cell).withTx(tx);
-      // Initialization materializes a backing value. A schema default is a
-      // readable fallback, not proof that the cell has been stored: treating
-      // it as an existing value leaves a later child write with no durable
-      // parent and can replace the visible default. Drop the view schema only
-      // for this existence check, then return the normal projected value when
-      // storage already won.
-      const stored = cell.asSchema(undefined).getRaw();
+      // Initialization materializes the same backing value a whole-cell write
+      // targets. A schema default is a readable fallback, not proof that the
+      // cell has been stored, and a write redirect is an address rather than
+      // backing data. Treating either as an existing value leaves a later
+      // child write with no durable parent and can replace the visible default.
+      // Drop the view schema and follow a final write redirect only for this
+      // existence check, then return the normal projected value when storage
+      // already won.
+      const stored = cell.asSchema(undefined).getRaw({
+        lastNode: "writeRedirect",
+      });
       if (stored !== undefined) {
-        return cellValueForClient(cell.get());
+        const projected = cell.get();
+        if (projected === undefined) {
+          throw new TypeError(
+            "Cell backing value is incompatible with its schema.",
+          );
+        }
+        return cellValueForClient(projected);
       }
       cell.set(initial);
       return cellValueForClient(initial);

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -231,9 +231,10 @@ export class CellHandle<T = unknown> {
   }
 
   /**
-   * Atomically stores `value` only if the cell is undefined, then returns the
-   * value selected by that transaction. Concurrent initializers converge on
-   * one winner instead of replacing it with a blind write.
+   * Atomically stores `value` only if the cell has no backing value, then
+   * returns the value selected by that transaction. A readable schema fallback
+   * does not count as stored. Concurrent initializers converge on one winner
+   * instead of replacing it with a blind write.
    */
   async initialize(value: T): Promise<Readonly<T>> {
     this.#requireSchema("initialize");

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -106,8 +106,9 @@ export enum RequestType {
   CellPull = "cell:pull",
 
   /**
-   * Stores a value only when the cell is currently undefined, using the read
-   * as an optimistic-concurrency precondition. Returns the value that won.
+   * Stores a value only when the cell has no backing value, using the raw read
+   * as an optimistic-concurrency precondition. A schema fallback does not
+   * count as stored. Returns the value that won.
    */
   CellInitialize = "cell:initialize",
 
@@ -823,7 +824,7 @@ export type CellPullRequest = BaseRequest & {
 export type CellInitializeRequest = BaseRequest & {
   type: RequestType.CellInitialize;
 
-  /** The cell to initialize when it is currently undefined. */
+  /** The cell to initialize when it has no backing value. */
   cell: CellRef;
 
   /** The non-undefined default to store. */

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3622,6 +3622,77 @@ describe("runtime-processor", () => {
       }
     });
 
+    it("materializes a schema default before a nested append", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-default-cell-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const initial = {
+          bars: [
+            { id: "alpha", value: 3 },
+            { id: "beta", value: 5 },
+          ],
+        };
+        const schema = {
+          type: "object",
+          properties: {
+            bars: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  value: { type: "number" },
+                },
+                required: ["id", "value"],
+              },
+            },
+          },
+          required: ["bars"],
+          default: initial,
+        } as const;
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+        for (const scope of ["user", "session"] as const) {
+          const cell = runtime.getCell<typeof initial>(
+            space,
+            `direct-default-cell-initialize-${scope}-${crypto.randomUUID()}`,
+            schema,
+            undefined,
+            scope,
+          );
+          await cell.sync();
+          expect(cell.get()).toEqual(initial);
+          expect(cell.asSchema(undefined).getRaw()).toBeUndefined();
+
+          await expect(processor.handleCellInitialize({
+            type: RequestType.CellInitialize,
+            cell: createCellRef(cell),
+            value: initial,
+          })).resolves.toEqual({ value: initial });
+          expect(cell.asSchema(undefined).getRaw()).not.toBeUndefined();
+
+          const append = runtime.edit();
+          cell.withTx(append).key("bars").push({ id: "gamma", value: 7 });
+          expect((await append.commit()).error).toBeUndefined();
+          expect(cell.get()).toEqual({
+            bars: [...initial.bars, { id: "gamma", value: 7 }],
+          });
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("returns nested initialized cells in the client-hydratable link form", async () => {
       const signer = await Identity.fromPassphrase(
         `direct-linked-cell-initialize-${crypto.randomUUID()}`,

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3693,6 +3693,124 @@ describe("runtime-processor", () => {
       }
     });
 
+    it("materializes a write-redirect target before a nested append", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-linked-default-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const initial = {
+          bars: [
+            { id: "alpha", value: 3 },
+            { id: "beta", value: 5 },
+          ],
+        };
+        const schema = {
+          type: "object",
+          properties: {
+            bars: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  value: { type: "number" },
+                },
+                required: ["id", "value"],
+              },
+            },
+          },
+          required: ["bars"],
+          default: initial,
+        } as const;
+        const target = runtime.getCell<typeof initial>(
+          space,
+          `direct-linked-default-target-${crypto.randomUUID()}`,
+          schema,
+        );
+        const alias = runtime.getCell<typeof initial>(
+          space,
+          `direct-linked-default-alias-${crypto.randomUUID()}`,
+          schema,
+        );
+        await Promise.all([target.sync(), alias.sync()]);
+        const link = runtime.edit();
+        alias.withTx(link).setRawUntyped(
+          target.getAsWriteRedirectLink({ includeSchema: false }),
+        );
+        expect((await link.commit()).error).toBeUndefined();
+        expect(alias.get()).toEqual(initial);
+        expect(target.asSchema(undefined).getRaw()).toBeUndefined();
+
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+        await expect(processor.handleCellInitialize({
+          type: RequestType.CellInitialize,
+          cell: createCellRef(alias),
+          value: initial,
+        })).resolves.toEqual({ value: initial });
+        expect(target.asSchema(undefined).getRaw()).not.toBeUndefined();
+
+        const append = runtime.edit();
+        alias.withTx(append).key("bars").push({ id: "gamma", value: 7 });
+        expect((await append.commit()).error).toBeUndefined();
+        expect(alias.get()).toEqual({
+          bars: [...initial.bars, { id: "gamma", value: 7 }],
+        });
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects backing values incompatible with the requested schema", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-incompatible-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const cause = `direct-incompatible-initialize-${crypto.randomUUID()}`;
+        const raw = runtime.getCell<number>(space, cause);
+        await raw.sync();
+        const seed = runtime.edit();
+        raw.withTx(seed).set(42);
+        expect((await seed.commit()).error).toBeUndefined();
+
+        const projected = raw.asSchema<{ n: number }>({
+          type: "object",
+          properties: { n: { type: "number" } },
+          required: ["n"],
+          default: { n: 1 },
+        });
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+
+        await expect(processor.handleCellInitialize({
+          type: RequestType.CellInitialize,
+          cell: createCellRef(projected),
+          value: { n: 1 },
+        })).rejects.toThrow("incompatible with its schema");
+        expect(raw.get()).toBe(42);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("returns nested initialized cells in the client-hydratable link form", async () => {
       const signer = await Identity.fromPassphrase(
         `direct-linked-cell-initialize-${crypto.randomUUID()}`,

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3770,6 +3770,63 @@ describe("runtime-processor", () => {
       }
     });
 
+    it("does not initialize through a scope-capped write redirect", async () => {
+      const signer = await Identity.fromPassphrase(
+        `direct-capped-initialize-${crypto.randomUUID()}`,
+      );
+      const space = signer.did();
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("http://localhost/"),
+        storageManager,
+      });
+      try {
+        const schema = {
+          type: "object",
+          properties: { n: { type: "number" } },
+          required: ["n"],
+          default: { n: 1 },
+          scope: "space",
+        } as const;
+        const processor = Object.assign(
+          Object.create(RuntimeProcessor.prototype),
+          { runtime },
+        ) as RuntimeProcessor;
+
+        for (const existing of [undefined, { n: 7 }] as const) {
+          const target = runtime.getCell<{ n: number }>(
+            space,
+            `direct-capped-target-${crypto.randomUUID()}`,
+            undefined,
+            undefined,
+            "session",
+          );
+          const alias = runtime.getCell<{ n: number }>(
+            space,
+            `direct-capped-alias-${crypto.randomUUID()}`,
+          );
+          await Promise.all([target.sync(), alias.sync()]);
+          const seed = runtime.edit();
+          if (existing !== undefined) target.withTx(seed).set(existing);
+          alias.withTx(seed).setRawUntyped(
+            target.getAsWriteRedirectLink({ includeSchema: false }),
+          );
+          expect((await seed.commit()).error).toBeUndefined();
+
+          const capped = alias.asSchema<{ n: number }>(schema);
+          await expect(processor.handleCellInitialize({
+            type: RequestType.CellInitialize,
+            cell: createCellRef(capped),
+            value: { n: 1 },
+          })).rejects.toThrow("Cannot write to read-only address");
+          expect(target.asSchema(undefined).getRaw()).toEqual(existing);
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("rejects backing values incompatible with the requested schema", async () => {
       const signer = await Identity.fromPassphrase(
         `direct-incompatible-initialize-${crypto.randomUUID()}`,

--- a/skills/pattern-iframe/SKILL.md
+++ b/skills/pattern-iframe/SKILL.md
@@ -1,19 +1,28 @@
 ---
 name: pattern-iframe
-description: Build or generate a Common Fabric pattern whose primary UI is a self-contained `cf-iframe` guest. Use when an agent should turn an input-data shape and a small state/output contract into a working iframe-first pattern without learning the broader pattern framework, including React guests, PerSpace/PerUser/PerSession data, path-scoped Cell access, stable array-item handles, mergeable pushes, or bridged SQLite.
+description: Build or generate a Common Fabric pattern whose primary UI is a self-contained `cf-iframe` guest. Use when an agent should turn an input-data shape and a small state/output contract into a working iframe-first pattern without learning the broader pattern framework, including plain DOM, React, D3, Phaser 2D games, Babylon.js 3D scenes, PerSpace/PerUser/PerSession data, path-scoped Cell access, stable array-item handles, mergeable pushes, or bridged SQLite.
 ---
 
 # Iframe-first patterns
 
-Choose one self-contained authoring contract before writing code:
+Choose one self-contained authoring contract before writing code. Route by the
+primary rendering owner, in this order:
 
+- For a 3D game, world, simulation, or WebGL scene, read
+  `docs/common/ai/iframe-pattern-babylon-guide.md` in full.
+- For a primarily 2D HTML5 game, read
+  `docs/common/ai/iframe-pattern-phaser-guide.md` in full.
+- For a data visualization whose DOM or SVG is owned by D3, read
+  `docs/common/ai/iframe-pattern-d3-guide.md` in full.
 - For a React component tree, hooks, or an explicitly requested React guest,
   read `docs/common/ai/iframe-pattern-react-guide.md` in full.
 - Otherwise read `docs/common/ai/iframe-pattern-guide.md` in full for a plain
   DOM guest.
 
-Do not load both guides unless the task is a migration between those styles. Do
-not load the general pattern-development guides unless the requested behavior
+For an explicit hybrid, choose the guide for the framework that owns the DOM or
+canvas lifecycle. Load a second guide only when the request genuinely combines
+two owners, such as React mounting and unmounting a D3-managed subtree. Do not
+load the general pattern-development guides unless the requested behavior
 extends beyond the generated wrapper.
 
 Keep the authored surface small:

--- a/tools/write-iframe-wrapper.test.ts
+++ b/tools/write-iframe-wrapper.test.ts
@@ -7,6 +7,12 @@ const ROOT = resolve(import.meta.dirname!, "..");
 const SCRIPT = resolve(import.meta.dirname!, "write-iframe-wrapper.ts");
 const decoder = new TextDecoder();
 
+function generatedGuestHtml(source: string): string {
+  const literal = source.match(/^const GUEST_HTML = (.*);$/m)?.[1];
+  expect(literal).toBeDefined();
+  return JSON.parse(literal!);
+}
+
 async function removeDirectory(path: string): Promise<void> {
   try {
     await Deno.remove(path, { recursive: true });
@@ -122,6 +128,10 @@ export const IFRAME_PATTERN = {
       expect(generated).toMatch(
         /\(\(\{\s*input,\s*state,\s*output,\s*\}\) => \{/,
       );
+      expect(generated).toContain(
+        "const iframeInput = input ?? DEFAULT_INPUT;",
+      );
+      expect(generated).toContain("input: iframeInput,");
       expect(generated).not.toContain("new Writable.perUser");
       expect(generated).not.toContain("new Writable.perSession");
     } finally {
@@ -400,6 +410,75 @@ export const IFRAME_PATTERN = {
       expect(format.code, decoder.decode(format.stderr)).toBe(0);
     } finally {
       await removeDirectory(directory);
+    }
+  });
+
+  it("bundles D3, Phaser, and Babylon.js guests", async () => {
+    const frameworks = [
+      {
+        name: "D3Guest",
+        marker: "d3-guide-probe",
+        source: `import { select } from "npm:d3@7.9.0";
+select(document.body).append("svg").attr("data-framework", "d3-guide-probe");
+`,
+      },
+      {
+        name: "PhaserGuest",
+        marker: "phaser-guide-probe",
+        source: `import Phaser from "npm:phaser@4.2.1";
+new Phaser.Game({
+  type: Phaser.CANVAS,
+  width: 320,
+  height: 180,
+  scene: { create() { this.add.text(16, 16, "phaser-guide-probe"); } },
+});
+`,
+      },
+      {
+        name: "BabylonGuest",
+        marker: "babylon-guide-probe",
+        source:
+          `import { Engine } from "npm:@babylonjs/core@9.23.0/Engines/engine.js";
+import { CreateBox } from "npm:@babylonjs/core@9.23.0/Meshes/Builders/boxBuilder.js";
+import { Scene } from "npm:@babylonjs/core@9.23.0/scene.js";
+const canvas = document.createElement("canvas");
+canvas.dataset.framework = "babylon-guide-probe";
+document.body.append(canvas);
+const engine = new Engine(canvas);
+const scene = new Scene(engine);
+CreateBox("box", {}, scene);
+engine.runRenderLoop(() => scene.render());
+`,
+      },
+    ] as const;
+
+    for (const framework of frameworks) {
+      const directory = await Deno.makeTempDir({
+        prefix: `pattern-iframe-${framework.name.toLowerCase()}-`,
+      });
+      try {
+        const contract = resolve(directory, "contract.ts");
+        const guest = resolve(directory, "guest.ts");
+        const out = resolve(directory, "main.tsx");
+        await Deno.writeTextFile(
+          contract,
+          `${contractPrefix}
+export const IFRAME_PATTERN = { name: "${framework.name}" } as const;
+`,
+        );
+        await Deno.writeTextFile(guest, framework.source);
+
+        const result = await generate(contract, guest, out);
+
+        expect(result.code, decoder.decode(result.stderr)).toBe(0);
+        const generated = await Deno.readTextFile(out);
+        expect(generated).toContain(framework.marker);
+        expect(generated).toContain("const GUEST_HTML =");
+        const guestHtml = generatedGuestHtml(generated);
+        expect(guestHtml.match(/<!doctype html>/gi)).toHaveLength(1);
+      } finally {
+        await removeDirectory(directory);
+      }
     }
   });
 });

--- a/tools/write-iframe-wrapper.test.ts
+++ b/tools/write-iframe-wrapper.test.ts
@@ -280,7 +280,8 @@ export const IFRAME_PATTERN = { name: "ModuleString" } as const;
       );
       await Deno.writeTextFile(
         guest,
-        `document.body.dataset.syntax = "import(";\n`,
+        `document.body.dataset.syntax = "import(";\n` +
+          `document.body.dataset.replacement = "$& $\` $'";\n`,
       );
       await Deno.writeTextFile(
         html,
@@ -298,6 +299,8 @@ export const IFRAME_PATTERN = { name: "ModuleString" } as const;
       expect(moduleString).toContain("\\u0069mport");
       expect(moduleString).toContain("\\u003c!--");
       expect(moduleString).toContain("--\\u003e");
+      expect(generatedGuestHtml(generated).match(/<!doctype html>/gi))
+        .toHaveLength(1);
     } finally {
       await removeDirectory(directory);
     }

--- a/tools/write-iframe-wrapper.ts
+++ b/tools/write-iframe-wrapper.ts
@@ -352,8 +352,11 @@ ${
     config.outputScope === "space"
       ? "  const output = new Writable<IframeOutputData>(DEFAULT_OUTPUT);\n"
       : ""
-  }${databaseSource(config.databases)}  const context = IframeContext({
-    input,
+  }${
+    databaseSource(config.databases)
+  }  const iframeInput = input ?? DEFAULT_INPUT;
+  const context = IframeContext({
+    input: iframeInput,
     state,
     output,
 ${contextDatabaseValues}
@@ -488,7 +491,7 @@ async function main(): Promise<void> {
         `${htmlPath} must contain ${SCRIPT_MARKER} exactly once; found ${markerCount}.`,
       );
     }
-    guestHtml = html.replace(SCRIPT_MARKER, script);
+    guestHtml = html.replace(SCRIPT_MARKER, () => script);
   } else {
     guestHtml = `<!doctype html>
 <html lang="en">


### PR DESCRIPTION
## Why

Iframe-first pattern agents need self-contained paths for D3 visualizations and for 2D and 3D games without learning the rest of the pattern stack. Real framework bundles also exercise generator seams that small guests miss.

## What

- add standalone D3, Phaser, and Babylon.js iframe authoring guides
- route the `pattern-iframe` skill by the renderer that owns the DOM or canvas
- pin and bundle D3 7.9.0, Phaser 4.2.1, and Babylon.js 9.23.0 in generator coverage
- materialize default input before the generated context subpattern
- insert custom-shell scripts with a replacement callback so bundled `$` replacement tokens cannot corrupt the document

## Verification

- `deno test --frozen -A tools/write-iframe-wrapper.test.ts`
- `deno task check-docs`
- `deno task check-skill-facts`
- `deno task check`
- `deno fmt --check`
- `deno lint`
- generated all three probes and passed `deno task cf check ... --no-run`
- launched all three locally and used real Chrome Computer Use to verify canvas/SVG rendering, interaction, PerUser persistence, and PerSession reset across reload

The local probes were validation-only and are not part of this PR.