### PR TITLE
feat(memory): a slow watch or query names the root that cost the time

### DIFF
--- a/packages/memory/test/v2-query-evaluation-cache.test.ts
+++ b/packages/memory/test/v2-query-evaluation-cache.test.ts
@@ -834,6 +834,51 @@ describe("v2 query evaluation cache", () => {
     expect(hit.stats.managerReads).toBe(1);
   });
 
+  it("reports no visited roots when it serves the evaluation", async () => {
+    const space = "did:key:z6Mk-eval-cache-roots-visited";
+    const engine = await openEngine({
+      url: new URL("memory:///eval-cache-roots-visited"),
+    });
+    applyCommit(engine, {
+      sessionId: "session:test",
+      invocation: {
+        iss: "did:key:test",
+        aud: "did:key:service",
+        cmd: "/memory/transact",
+        sub: space,
+      },
+      authorization: { proof: "ok" },
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set" as const,
+          id: "of:doc:served",
+          value: { value: { n: 1 } },
+        }],
+      },
+    });
+    const cache = createQueryEvaluationCache();
+    const query = {
+      roots: [{ id: "of:doc:served", selector: { path: [], schema: true } }],
+    };
+    const miss = trackGraph(space, engine, query, undefined, {
+      evaluationCache: cache,
+    });
+    const hit = trackGraph(space, engine, query, undefined, {
+      evaluationCache: cache,
+    });
+
+    expect(queryEvaluationCacheDiagnostics(cache).hits).toBe(1);
+    expect(miss.stats.rootsVisited).toBe(1);
+    // A served evaluation walked nothing, and its stats have to say so:
+    // `rootsVisited: 0` beside a long duration is what tells a slow-query
+    // reader the time went somewhere other than traversal.
+    expect(hit.stats.rootsVisited).toBe(0);
+    expect(hit.stats.rootsElapsedMs).toBe(0);
+    expect(hit.stats.slowestRoot).toBeUndefined();
+  });
+
   it("evicts by weight across spaces until the budget fits", async () => {
     const server = createServer("memory://eval-cache-budget", 3);
     const spaces = [

--- a/packages/memory/test/v2-query.test.ts
+++ b/packages/memory/test/v2-query.test.ts
@@ -2145,3 +2145,184 @@ Deno.test("memory v2 refreshTrackedGraph double-role retirement: a key that is b
     await Deno.remove(path);
   }
 });
+
+Deno.test("memory v2 traversal stats charge one root's cost to that root", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-root-attribution-single";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:alice",
+      principal: "did:key:alice",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:attribution-root",
+          value: { value: { name: "board" } },
+        }],
+      },
+    });
+
+    const schema: JSONSchema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: "of:attribution-root",
+        selector: { path: ["value"], schema },
+      }],
+    });
+
+    const { stats } = tracked;
+    assertEquals(stats.rootsVisited, 1);
+    const slowest = stats.slowestRoot;
+    assertExists(slowest);
+    assertEquals(slowest.id, "of:attribution-root");
+    assertEquals(slowest.scope, "space");
+    assertEquals(slowest.path, "value");
+    assertEquals(slowest.schema, internSchemaAsTaggedHashString(schema));
+
+    // With one root, the root's share IS the evaluation's: anything else
+    // means the before/after deltas are being taken against the wrong
+    // baseline. This is what makes the two-root split below trustworthy.
+    assertEquals(slowest.reads, stats.managerReads);
+    assertEquals(slowest.walk.dagTraversals, stats.dagTraversals);
+    assertEquals(slowest.walk.schemaTraversals, stats.schemaTraversals);
+    assertEquals(slowest.walk.getDocAtPathCalls, stats.getDocAtPathCalls);
+    assert(slowest.reads > 0, "the root loaded its document");
+    assert(
+      slowest.elapsedMs <= stats.rootsElapsedMs,
+      "one root cannot outlast the sum of the visits",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 traversal stats name the root that spent the time", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-root-attribution-slowest";
+  const realNow = performance.now.bind(performance);
+  let nowOffsetMs = 0;
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:alice",
+      principal: "did:key:alice",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          { op: "set", id: "of:cheap-root", value: { value: { n: 1 } } },
+          { op: "set", id: "of:costly-root", value: { value: { n: 2 } } },
+        ],
+      },
+    });
+
+    // The clock advances when the costly root's document is loaded, which
+    // happens inside that root's charged window — the same "move time from
+    // inside the measured window" lever the slow-query tests use, aimed at
+    // one root instead of one request. Real elapsed time is never raced.
+    performance.now = () => realNow() + nowOffsetMs;
+    const manager = new EngineObjectManager(engine, "");
+    const realLoad = manager.load.bind(manager);
+    manager.load = ((address: Parameters<typeof realLoad>[0]) => {
+      if (address.id === "of:costly-root") nowOffsetMs += 500;
+      return realLoad(address);
+    }) as typeof manager.load;
+
+    // Keyed lookup would need the manager-key spelling; every key wants the
+    // same manager here, so answer them all with it.
+    class OneManager extends Map<string, EngineObjectManager> {
+      override get(_key: string): EngineObjectManager {
+        return manager;
+      }
+    }
+
+    const { stats } = trackGraph(
+      space,
+      engine,
+      {
+        roots: [
+          { id: "of:cheap-root", selector: { path: [], schema: true } },
+          { id: "of:costly-root", selector: { path: [], schema: true } },
+        ],
+      },
+      { managers: new OneManager() },
+    );
+
+    assertEquals(stats.rootsVisited, 2);
+    const slowest = stats.slowestRoot;
+    assertExists(slowest);
+    assertEquals(slowest.id, "of:costly-root");
+    assert(
+      slowest.elapsedMs >= 500,
+      `the costly root carries the advance, got ${slowest.elapsedMs}`,
+    );
+    assert(
+      stats.rootsElapsedMs >= slowest.elapsedMs,
+      "the sum covers the slowest",
+    );
+
+    // A root's reads and walk are its OWN, not the evaluation's running
+    // totals: both roots load and traverse here, so a share that failed to
+    // subtract its baseline would read as the total instead.
+    assert(
+      slowest.reads > 0 && slowest.reads < stats.managerReads,
+      `a share of ${stats.managerReads} reads, got ${slowest.reads}`,
+    );
+    assert(
+      slowest.walk.dagTraversals > 0 &&
+        slowest.walk.dagTraversals < stats.dagTraversals,
+      `a share of ${stats.dagTraversals} crossings, got ${slowest.walk.dagTraversals}`,
+    );
+  } finally {
+    performance.now = realNow;
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 extendTrackedGraph attributes the roots it adds", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-root-attribution-extend";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:alice",
+      principal: "did:key:alice",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          { op: "set", id: "of:extend-first", value: { value: { n: 1 } } },
+          { op: "set", id: "of:extend-second", value: { value: { n: 2 } } },
+        ],
+      },
+    });
+
+    const tracked = trackGraph(space, engine, {
+      roots: [{ id: "of:extend-first", selector: { path: [], schema: true } }],
+    });
+
+    // Extension walks its own roots against an existing graph, so it keeps
+    // its own attribution rather than inheriting the first evaluation's.
+    const extended = extendTrackedGraph(space, engine, tracked.state, {
+      roots: [{ id: "of:extend-second", selector: { path: [], schema: true } }],
+    });
+
+    assertEquals(extended.stats.rootsVisited, 1);
+    const slowest = extended.stats.slowestRoot;
+    assertExists(slowest);
+    assertEquals(slowest.id, "of:extend-second");
+    assertEquals(slowest.reads, extended.stats.managerReads);
+    assert(slowest.reads > 0, "the added root read its document");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -363,7 +363,8 @@ describe("v2 server slow queries", () => {
       expect(entry).toBeDefined();
       expect(entry!.watches).toBe(2);
       expect(entry!.rootsVisited).toBe(3);
-      expect(entry!.slowestRoot).toBeDefined();
+      expect(entry!.slowestRoot!.reads).toBeGreaterThan(0);
+      expect(entry!.slowestRoot!.walk.dagTraversals).toBeGreaterThan(0);
     } finally {
       connection.close();
     }

--- a/packages/memory/test/v2-server-slow-query.test.ts
+++ b/packages/memory/test/v2-server-slow-query.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { applyCommit, createBranch, open as openEngine } from "../v2/engine.ts";
 import { getSlowQueries, Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
@@ -227,6 +228,142 @@ describe("v2 server slow queries", () => {
       expect(entry!.outcome).toBe("ConflictError");
       expect(entry!.operations).toBe(1);
       expect(entry!.readsConfirmed).toBe(1);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("records the roots a slow watch.add visited and the costliest one", async () => {
+    const space = "did:key:z6Mk-slow-query-watch-roots";
+    const server = createServer("memory://slow-query-watch-roots");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      const sessionId = await openSession(connection, messages, space);
+      const seeded = await server.transact(
+        transactMessage(space, sessionId, {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:watched:one", value: { value: { n: 1 } } },
+            { op: "set", id: "of:watched:two", value: { value: { n: 2 } } },
+          ],
+        }),
+      );
+      expect(seeded.error).toBeUndefined();
+
+      // Every clock read advances the clock, so the evaluation crosses the
+      // recording threshold without sleeping and without racing real time.
+      // WHICH root wins is pinned in v2-query.test.ts against a lever aimed
+      // at one root; the question here is only whether the attribution
+      // reaches the recorded entry.
+      performance.now = () => {
+        nowOffsetMs += 60;
+        return realNow() + nowOffsetMs;
+      };
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch-roots",
+        space,
+        sessionId,
+        watches: [{
+          id: "watch-roots-id",
+          kind: "graph",
+          query: {
+            roots: [
+              { id: "of:watched:one", selector: { path: [], schema: true } },
+              { id: "of:watched:two", selector: { path: [], schema: true } },
+            ],
+          },
+        }],
+      }));
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "session.watch.add"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.watches).toBe(1);
+      // The watch count is 1 while the roots it carries are 2 — the whole
+      // reason the count cannot stand in for the cost.
+      expect(entry!.rootsVisited).toBe(2);
+      expect(entry!.rootsElapsedMs).toBeGreaterThan(0);
+      expect(entry!.rootsElapsedMs).toBeLessThanOrEqual(entry!.elapsed);
+      const slowest = entry!.slowestRoot;
+      expect(slowest).toBeDefined();
+      expect(["of:watched:one", "of:watched:two"]).toContain(slowest!.id);
+      expect(slowest!.scope).toBe("space");
+      expect(slowest!.path).toBe("");
+      expect(slowest!.reads).toBeGreaterThan(0);
+      expect(slowest!.walk.dagTraversals).toBeGreaterThan(0);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("sums the roots of every branch group a slow watch.set evaluated", async () => {
+    const space = "did:key:z6Mk-slow-query-watch-set-groups";
+    const server = createServer("memory://slow-query-watch-set-groups");
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    try {
+      await openSession(connection, messages, space);
+      // A second branch is what makes two groups, and no protocol message
+      // creates one — hence the engine `evaluateWatchSet` accepts.
+      const engine = await openEngine({
+        url: new URL("memory:///slow-query-watch-set-groups-engine"),
+      });
+      createBranch(engine, "feature");
+      applyCommit(engine, {
+        sessionId: "session:grouped",
+        principal: "did:key:z6Mk-memory-v2-slow-query-principal",
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [
+            { op: "set", id: "of:grouped:one", value: { value: { n: 1 } } },
+            { op: "set", id: "of:grouped:two", value: { value: { n: 2 } } },
+          ],
+        },
+      });
+
+      performance.now = () => {
+        nowOffsetMs += 60;
+        return realNow() + nowOffsetMs;
+      };
+      // Watches group by branch, so these are two evaluations in one
+      // request. The attribution has to accumulate across them: a fold
+      // that replaced instead of summing would report the last group's
+      // single root rather than all three.
+      await server.evaluateWatchSet(space, [
+        {
+          id: "grouped-default",
+          kind: "graph",
+          query: {
+            roots: [
+              { id: "of:grouped:one", selector: { path: [], schema: true } },
+              { id: "of:grouped:two", selector: { path: [], schema: true } },
+            ],
+          },
+        },
+        {
+          id: "grouped-other",
+          kind: "graph",
+          query: {
+            branch: "feature",
+            roots: [
+              { id: "of:grouped:one", selector: { path: [], schema: true } },
+            ],
+          },
+        },
+      ], engine);
+
+      const entry = getSlowQueries().find((slow) =>
+        slow.space === space && slow.operation === "session.watch.set"
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.watches).toBe(2);
+      expect(entry!.rootsVisited).toBe(3);
+      expect(entry!.slowestRoot).toBeDefined();
     } finally {
       connection.close();
     }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -106,7 +106,31 @@ export type SlowestQueryRoot = {
 
   /** Engine documents read while visiting this root. */
   reads: number;
+
+  /** The walk this root ran, as counters: how many documents it crossed
+   * (`dagTraversals`), what kind of structure it crossed them through, and
+   * how much the schema memo saved. `elapsedMs` says a root was expensive;
+   * this says what it did to get that way — a wide root crossing thousands
+   * of documents and one deep root re-walking a schema are the same
+   * duration and different bugs. */
+  walk: GraphQueryWalkStats;
 };
+
+/** One root's share of the walk counters its evaluation accumulated. */
+const walkStatsDelta = (
+  after: GraphQueryWalkStats,
+  before: GraphQueryWalkStats,
+): GraphQueryWalkStats => ({
+  coveredSelectorSkips: after.coveredSelectorSkips -
+    before.coveredSelectorSkips,
+  schemaTraversals: after.schemaTraversals - before.schemaTraversals,
+  pointerTraversals: after.pointerTraversals - before.pointerTraversals,
+  arrayTraversals: after.arrayTraversals - before.arrayTraversals,
+  objectTraversals: after.objectTraversals - before.objectTraversals,
+  dagTraversals: after.dagTraversals - before.dagTraversals,
+  getDocAtPathCalls: after.getDocAtPathCalls - before.getDocAtPathCalls,
+  schemaMemoHits: after.schemaMemoHits - before.schemaMemoHits,
+});
 
 /**
  * What one query cost: the walk's own counters, plus how many documents the
@@ -156,6 +180,7 @@ const chargeRootVisit = (
 ): void => {
   const startedAt = performance.now();
   const readsBefore = manager.readCount;
+  const walkBefore = { ...stats };
   try {
     visit();
   } finally {
@@ -177,6 +202,7 @@ const chargeRootVisit = (
         }),
         elapsedMs,
         reads: manager.readCount - readsBefore,
+        walk: walkStatsDelta(stats, walkBefore),
       };
     }
   }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -34,6 +34,7 @@ import {
   type EntitySnapshot,
   getServerExecutionConfig,
   type GraphQuery,
+  type GraphQueryRoot,
   isScopeKey,
   resolveScopeKey,
   type ScopeKey,
@@ -84,17 +85,102 @@ export type TrackedGraphState = {
 };
 
 /**
+ * The costliest single root of one query evaluation.
+ *
+ * A query's roots are the union of every watch's roots on a branch, so a
+ * slow `watch.add` reports its duration against a watch COUNT and says
+ * nothing about which declaration spent it. This names the root that did.
+ */
+export type SlowestQueryRoot = {
+  id: string;
+  scope: CellScope;
+
+  /** The selector's path, slash-joined; empty for a whole-document root. */
+  path: string;
+
+  /** The selector schema's interned tagged hash, absent when the root
+   * declares none. The hash rather than the schema itself: a board root's
+   * schema runs to kilobytes, and the hash is how the registry names it. */
+  schema?: string;
+  elapsedMs: number;
+
+  /** Engine documents read while visiting this root. */
+  reads: number;
+};
+
+/**
  * What one query cost: the walk's own counters, plus how many documents the
- * query read out of the engine.
+ * query read out of the engine, plus which of its roots was the expensive
+ * one.
  */
 export type QueryTraversalStats = GraphQueryWalkStats & {
   managerReads: number;
+
+  /** Roots this evaluation visited. A cache hit visits none. */
+  rootsVisited: number;
+
+  /** Summed elapsed time of those visits. Roots are visited in sequence,
+   * so this is directly comparable with the caller's own elapsed
+   * measurement, and what it leaves over is everything outside the root
+   * loop — entity assembly and schema-closure staging. Read the two
+   * together: they say whether a slow evaluation was slow at a root at
+   * all. */
+  rootsElapsedMs: number;
+
+  /** The costliest one, absent when no root was visited. */
+  slowestRoot?: SlowestQueryRoot;
 };
 
 const createQueryTraversalStats = (): QueryTraversalStats => ({
   managerReads: 0,
+  rootsVisited: 0,
+  rootsElapsedMs: 0,
   ...createGraphQueryWalkStats(),
 });
+
+/**
+ * Run one root's evaluation, charging what it cost to `stats` and keeping
+ * the costliest root seen so far.
+ *
+ * Two clock reads and one counter read per root, paid unconditionally,
+ * because which evaluation turns out to be the slow one is not knowable
+ * before it runs. The overhead is bounded by the same factor that makes a
+ * query large: a root cheap enough for two `performance.now()` calls to
+ * register against it did no document reads.
+ */
+const chargeRootVisit = (
+  root: GraphQueryRoot,
+  manager: EngineObjectManager,
+  stats: QueryTraversalStats,
+  visit: () => void,
+): void => {
+  const startedAt = performance.now();
+  const readsBefore = manager.readCount;
+  try {
+    visit();
+  } finally {
+    // Charged from `finally`, so a root that throws is attributed too: a
+    // slow failing root is at least as interesting as a slow passing one.
+    const elapsedMs = performance.now() - startedAt;
+    stats.rootsVisited++;
+    stats.rootsElapsedMs += elapsedMs;
+    if (
+      stats.slowestRoot === undefined ||
+      elapsedMs > stats.slowestRoot.elapsedMs
+    ) {
+      stats.slowestRoot = {
+        id: root.id,
+        scope: root.scope ?? DEFAULT_SCOPE,
+        path: root.selector.path.join("/"),
+        ...(root.selector.schema === undefined ? {} : {
+          schema: internSchemaAsTaggedHashString(root.selector.schema),
+        }),
+        elapsedMs,
+        reads: manager.readCount - readsBefore,
+      };
+    }
+  }
+};
 
 /**
  * The identity a manager's tracked-graph keys resolve against: the
@@ -1235,33 +1321,35 @@ export const trackGraph = (
   validateSelectorSchemaRefs(space, manager, branch, query.roots);
 
   for (const root of query.roots) {
-    const selector = toDocumentSelector(root.selector);
-    const rootScope = root.scope ?? DEFAULT_SCOPE;
-    // A root naming an explicit instance (protocol.md §2's read row —
-    // lease-holder only, admission enforced at the server layer) reads
-    // and tracks THAT instance; traversal beyond the root resolves under
-    // the session identity as today (per-run deep threading is the
-    // Phase 2 fan-out work).
-    const loaded = manager.load({
-      id: root.id,
-      scope: rootScope,
-      ...(root.entityScopeKey === undefined
-        ? {}
-        : { scopeKey: root.entityScopeKey }),
-      type: "application/json",
+    chargeRootVisit(root, manager, stats, () => {
+      const selector = toDocumentSelector(root.selector);
+      const rootScope = root.scope ?? DEFAULT_SCOPE;
+      // A root naming an explicit instance (protocol.md §2's read row —
+      // lease-holder only, admission enforced at the server layer) reads
+      // and tracks THAT instance; traversal beyond the root resolves under
+      // the session identity as today (per-run deep threading is the
+      // Phase 2 fan-out work).
+      const loaded = manager.load({
+        id: root.id,
+        scope: rootScope,
+        ...(root.entityScopeKey === undefined
+          ? {}
+          : { scopeKey: root.entityScopeKey }),
+        type: "application/json",
+      });
+      if (loaded !== null) {
+        walk.visit(
+          loaded,
+          selector,
+          rootDocKey(space, root, identityOf(manager)),
+        );
+      } else {
+        schemaTracker.add(
+          rootDocKey(space, root, identityOf(manager)),
+          selector,
+        );
+      }
     });
-    if (loaded !== null) {
-      walk.visit(
-        loaded,
-        selector,
-        rootDocKey(space, root, identityOf(manager)),
-      );
-    } else {
-      schemaTracker.add(
-        rootDocKey(space, root, identityOf(manager)),
-        selector,
-      );
-    }
   }
 
   const entities = entitiesFromTracker(space, schemaTracker, manager, branch);
@@ -1338,26 +1426,28 @@ export const extendTrackedGraph = (
   validateSelectorSchemaRefs(space, manager, state.branch, query.roots);
 
   for (const root of query.roots) {
-    const selector = toDocumentSelector(root.selector);
-    const rootScope = root.scope ?? DEFAULT_SCOPE;
-    const rootKey = rootDocKey(space, root, identityOf(manager));
-    touched.add(rootKey);
-    evaluateTrackedDocument(
-      space,
-      manager,
-      {
-        id: root.id,
-        scope: rootScope,
-        ...(root.entityScopeKey === undefined
-          ? {}
-          : { scopeKey: root.entityScopeKey }),
-      },
-      selector,
-      state.tracker,
-      missRecorderFor(state),
-      state.memo,
-      stats,
-    );
+    chargeRootVisit(root, manager, stats, () => {
+      const selector = toDocumentSelector(root.selector);
+      const rootScope = root.scope ?? DEFAULT_SCOPE;
+      const rootKey = rootDocKey(space, root, identityOf(manager));
+      touched.add(rootKey);
+      evaluateTrackedDocument(
+        space,
+        manager,
+        {
+          id: root.id,
+          scope: rootScope,
+          ...(root.entityScopeKey === undefined
+            ? {}
+            : { scopeKey: root.entityScopeKey }),
+        },
+        selector,
+        state.tracker,
+        missRecorderFor(state),
+        state.memo,
+        stats,
+      );
+    });
   }
 
   for (const address of manager.loadedAddresses()) {
@@ -1435,6 +1525,11 @@ export const queryGraph = (
 ): {
   serverSeq: number;
   entities: EntitySnapshot[];
+
+  /** What the evaluation cost. Carried out so the server can attribute a
+   * slow `graph.query` to a root; it is not part of the wire result, and
+   * the caller drops it before responding. */
+  stats: QueryTraversalStats;
 } => {
   const tracked = trackGraph(space, engine, query, reuse, {
     ...options,
@@ -1448,6 +1543,7 @@ export const queryGraph = (
     : [...tracked.state.entities.values()];
   return {
     serverSeq: tracked.serverSeq,
+    stats: tracked.stats,
     entities: entities
       .toSorted((left, right) => left.id.localeCompare(right.id)),
   };

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -90,10 +90,26 @@ export type TrackedGraphState = {
  * A query's roots are the union of every watch's roots on a branch, so a
  * slow `watch.add` reports its duration against a watch COUNT and says
  * nothing about which declaration spent it. This names the root that did.
+ *
+ * It names the root that PAID, which is not always the root to blame.
+ * Roots share coverage within an evaluation: the first to reach a document
+ * is charged for it, and a later root that would have reached the same
+ * document is skipped instead. So where several roots declare overlapping
+ * closures, the whole cost lands on whichever ran first, and bounding that
+ * one root moves the charge to the next rather than removing it. Read a
+ * large `slowestRoot` as "the cost is reachable from here", and confirm a
+ * suspected cause by checking that narrowing it lowers the request's own
+ * elapsed time — not merely that it lowers this root's.
  */
 export type SlowestQueryRoot = {
   id: string;
   scope: CellScope;
+
+  /** The explicit scope INSTANCE the root named, on the lease-holder reads
+   * that may name one. Roots alike in every other field but this one are
+   * different reads of different instances, so without it the record
+   * cannot say which instance cost the time. */
+  entityScopeKey?: ScopeKey;
 
   /** The selector's path, slash-joined; empty for a whole-document root. */
   path: string;
@@ -196,6 +212,9 @@ const chargeRootVisit = (
       stats.slowestRoot = {
         id: root.id,
         scope: root.scope ?? DEFAULT_SCOPE,
+        ...(root.entityScopeKey === undefined
+          ? {}
+          : { entityScopeKey: root.entityScopeKey }),
         path: root.selector.path.join("/"),
         ...(root.selector.schema === undefined ? {} : {
           schema: internSchemaAsTaggedHashString(root.selector.schema),

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -251,8 +251,16 @@ export type SlowQuery = {
   outcome?: string;
 
   /** Query and watch operations: how many roots the request's evaluations
-   * visited across every branch group. Zero means the evaluation cache
-   * served it, so none of the elapsed time was traversal. */
+   * visited across every branch group. Zero means no root was traversed,
+   * which has two causes and the same consequence: the evaluation cache
+   * served the request, or the session's existing graph already covered
+   * every added root. Either way none of the elapsed time was traversal,
+   * so a slow entry reporting zero spent it somewhere else — assembling
+   * the response, or attaching operation fields.
+   *
+   * `session.watch.refresh` carries none of these fields. It re-evaluates
+   * by dirty document rather than by root, so it has no roots to
+   * attribute; absent is the honest answer there, not zero. */
   rootsVisited?: number;
 
   /** Query and watch operations: summed elapsed time of those root visits.
@@ -264,7 +272,11 @@ export type SlowQuery = {
   /** Query and watch operations: the costliest single root, which is what
    * a watch COUNT cannot say. A `watch.add` unions the roots of every
    * watch it carries, so 78 watches and 5,377 watches are the same
-   * measurement until this names which declaration spent the time. */
+   * measurement until this names which declaration spent the time.
+   *
+   * The root that paid, not necessarily the root to blame — see
+   * {@link SlowestQueryRoot} for why overlapping closures charge whichever
+   * root ran first, and what to check before calling one the cause. */
   slowestRoot?: SlowestQueryRoot;
 };
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -107,7 +107,9 @@ import {
   queryEvaluationCacheDiagnostics,
   queryGraph,
   type QueryGraphReuseContext,
+  type QueryTraversalStats,
   refreshTrackedGraph,
+  type SlowestQueryRoot,
   toDirtyKey,
   type TrackedGraphState,
   trackGraph,
@@ -247,6 +249,64 @@ export type SlowQuery = {
    * that took this long is at least as interesting as an applied one), or
    * "threw" when evaluation raised instead of responding. */
   outcome?: string;
+
+  /** Query and watch operations: how many roots the request's evaluations
+   * visited across every branch group. Zero means the evaluation cache
+   * served it, so none of the elapsed time was traversal. */
+  rootsVisited?: number;
+
+  /** Query and watch operations: summed elapsed time of those root visits.
+   * Against the entry's own `elapsed` this is the share of the request
+   * that traversal accounts for; the remainder is entity assembly,
+   * schema-closure staging, and operation-field attachment. */
+  rootsElapsedMs?: number;
+
+  /** Query and watch operations: the costliest single root, which is what
+   * a watch COUNT cannot say. A `watch.add` unions the roots of every
+   * watch it carries, so 78 watches and 5,377 watches are the same
+   * measurement until this names which declaration spent the time. */
+  slowestRoot?: SlowestQueryRoot;
+};
+
+/** The root attribution accumulated across one request's branch groups. */
+type RootAttribution = {
+  rootsVisited: number;
+  rootsElapsedMs: number;
+  slowestRoot?: SlowestQueryRoot;
+};
+
+const createRootAttribution = (): RootAttribution => ({
+  rootsVisited: 0,
+  rootsElapsedMs: 0,
+});
+
+/**
+ * Fold one evaluation's root attribution into a request's running total.
+ *
+ * The counts sum because a request's groups are evaluated in sequence; the
+ * slowest root is a max rather than a sum, because it names one place in
+ * one query and merging two would name neither.
+ */
+const foldRootAttribution = (
+  into: RootAttribution,
+  stats: QueryTraversalStats,
+): void => {
+  into.rootsVisited += stats.rootsVisited;
+  into.rootsElapsedMs += stats.rootsElapsedMs;
+  if (
+    stats.slowestRoot !== undefined &&
+    (into.slowestRoot === undefined ||
+      stats.slowestRoot.elapsedMs > into.slowestRoot.elapsedMs)
+  ) {
+    into.slowestRoot = stats.slowestRoot;
+  }
+};
+
+/** The attribution for a request that evaluated exactly one query. */
+const rootAttributionOf = (stats: QueryTraversalStats): RootAttribution => {
+  const attribution = createRootAttribution();
+  foldRootAttribution(attribution, stats);
+  return attribution;
 };
 
 const slowQueries: SlowQuery[] = [];
@@ -4322,6 +4382,7 @@ export class Server {
           entry,
         );
       };
+      const attribution = createRootAttribution();
       for (const [branch, query] of groupedQueries(newWatches)) {
         const existing = graphs.get(branch);
         if (existing === undefined) {
@@ -4336,6 +4397,7 @@ export class Server {
               evaluationCache: this.#evaluationCacheFor(message.space),
             },
           );
+          foldRootAttribution(attribution, tracked.stats);
           // Enforced per evaluation, not per request: a later group's
           // failure (or a failing operation-field attachment) must not
           // leave an already-inserted entry over budget.
@@ -4359,6 +4421,7 @@ export class Server {
           staged,
           query,
         );
+        foldRootAttribution(attribution, extended.stats);
         for (const [docKey, entity] of extended.updates) {
           recordUpdate(docKey, entity);
         }
@@ -4416,7 +4479,7 @@ export class Server {
         "session.watch.add",
         message.space,
         startedAt,
-        { watches: message.watches.length },
+        { watches: message.watches.length, ...attribution },
       );
       return {
         type: "response",
@@ -4537,7 +4600,9 @@ export class Server {
     const cacheEligible = query.atSeq === undefined &&
       scopeContext.keyedSnapshots !== true;
     try {
-      const result = queryGraph(
+      // `stats` is diagnostics, not wire: split it off here so the
+      // response carries exactly the declared result shape.
+      const { stats, ...result } = queryGraph(
         space,
         engine ?? await this.openEngine(space),
         query,
@@ -4551,6 +4616,7 @@ export class Server {
       );
       recordSlowQueryDuration("graph.query", space, startedAt, {
         roots: query.roots.length,
+        ...rootAttributionOf(stats),
       });
       return result;
     } finally {
@@ -4581,6 +4647,7 @@ export class Server {
     const entities = new Map<string, SessionCacheEntry>();
     let serverSeq = Engine.serverSeq(resolvedEngine);
 
+    const attribution = createRootAttribution();
     for (const [branch, query] of groupedQueries(watches)) {
       const result = trackGraph(
         space,
@@ -4592,6 +4659,7 @@ export class Server {
           evaluationCache: this.#evaluationCacheFor(space),
         },
       );
+      foldRootAttribution(attribution, result.stats);
       serverSeq = result.serverSeq;
       this.#enforceEvaluationCacheBudget();
       graphs.set(branch, result.state);
@@ -4612,6 +4680,7 @@ export class Server {
 
     recordSlowQueryDuration("session.watch.set", space, startedAt, {
       watches: watches.length,
+      ...attribution,
     });
     return {
       serverSeq,


### PR DESCRIPTION
## Why

`/api/health/stats` on the shard serving the topics board records this, repeatedly:

| operation | watches | elapsed | per watch |
|---|---|---|---|
| `session.watch.add` | 248 | 218 ms | 0.9 ms |
| `session.watch.add` | 1,677 | 348 ms | 0.2 ms |
| `session.watch.add` | 3,699 | 687 ms | 0.19 ms |
| `session.watch.add` | **5,377** | **941 ms** | **0.17 ms** |
| `session.watch.add` | **78** | **8,522 ms** | **109 ms** |

Cost is not proportional to watch count — everything from 248 to 5,377 watches scales cleanly at ~0.17 ms each, and the 78-watch add costs 640x that per watch. A `watch.add` unions the roots of every watch it carries, so the entry reports a duration against a watch *count* and says nothing about which declaration spent it. Today the only way past that is to attach a debugger to a production process.

The same 8-9 s shows up from the client: a board load sends its `watch.add`, then nothing moves on the wire in either direction for ~9 s (worker event loop idle at 4.7 ms average lag), then one 13.4 MB response frame arrives and the board renders. Measured path throughput is 7.4 MB/s, so at most ~1.8 s of that gap is transfer. The rest is this.

## What

Charge each root's visit as it happens — elapsed, engine reads, and the walk it ran — in both the fresh (`trackGraph`) and extending (`extendTrackedGraph`) walks, and carry the costliest one out on `QueryTraversalStats`. `session.watch.add`, `session.watch.set` and `graph.query` fold it across their branch groups and record it beside the duration.

A slow entry now carries:

- `slowestRoot` — `{ id, scope, path, schema, elapsedMs, reads, walk }`. The schema's interned tagged hash rather than the schema itself: a board root's schema runs to kilobytes, and the hash is how the registry names it anyway.
- `slowestRoot.walk` — that root's own `dagTraversals`, per-structure traversal counts, `getDocAtPathCalls`, and `schemaMemoHits`. A duration says a root was expensive; this says what it did to get that way, and a wide root crossing thousands of documents and one deep root re-walking a schema are the same milliseconds and different bugs.
- `rootsVisited` — roots visited across every branch group. **Zero means the evaluation cache served the request**, so whatever the time was, it was not traversal.
- `rootsElapsedMs` — summed root-visit time. Against the entry's own `elapsed` this is the share traversal accounts for; the remainder is entity assembly, schema-closure staging, and operation-field attachment.

`rootsElapsedMs` is deliberately reported alongside `slowestRoot`, because the two answers it distinguishes have opposite fixes: one pathological root, or 78 mildly expensive ones. From the entry alone today you cannot tell which.

`queryGraph` now returns its `stats`; the server splits that off before responding, so the wire result keeps exactly its declared shape.

## Cost

Two `performance.now()` calls, one counter read, and one small object per root, paid unconditionally — which evaluation turns out to be the slow one is not knowable before it runs. The overhead is bounded by the same factor that makes a query large: a root cheap enough for two clock reads to register against it did no document reads. The largest observed evaluation (`watch.set`, 8,654 watches, 6-11 s) pays well under a millisecond for the whole loop.

## Tests

Six, each verified red under the inverse of the rule it pins — dropped reads baseline, dropped walk delta, inverted max comparison, uncarried selector path, unrecorded attribution on `watch.add`, and a fold that replaces instead of sums.

The interesting one is how "the costliest root is named" is pinned without racing real time: the clock is advanced from inside one root's charged window, which is the same lever the existing slow-query tests use for a request, aimed one level down. No sleeps, no polls.

The branch-group case supplies its own engine through the parameter `evaluateWatchSet` already takes — two groups need a second branch, and no protocol message creates one.

## Validation

- `deno task check` — full workspace, green
- `packages/memory` — 589 passed, 0 failed
- `deno fmt --check`, `deno lint` — clean, repo-wide
- `check-no-waitfor`, `check-conflict-markers`, `check-control-characters` — pass

## Notes for review

- The new cases in `test/v2-query.test.ts` use that file's `Deno.test` / `assert*` form rather than BDD. `docs/development/unit-test-coding-style.md` asks an edit to conform to the area around it and to make a whole-file conversion its own change; the two BDD files are edited in BDD.
- `renderSlow` in `packages/toolshed/routes/health/health.handlers.ts` renders columns (`docsLoaded`, `sqliteReads`, `sqliteMs`, `selectorCount`, `factCount`, `trackerKeys`, `sharedMemoSize`) that no longer exist on `SlowQuery` — they date to #2892 — so those columns have been rendering `-` for a long time. Not fixed here; the JSON is what this PR is aimed at, and reviving that renderer wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)