### PR TITLE
refactor: `#` private members in `cli` and `schema-generator`

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -882,7 +882,7 @@ canonical; update prose from it, not the other way around. Paths relative to
 
 | Spec content | Canonical source | Guard / note |
 | --- | --- | --- |
-| Formatter chain + order (§3) | `SchemaGenerator.formatters` (`src/schema-generator.ts`) | array literal is the order; routing tests in `test/schema-generator.test.ts` |
+| Formatter chain + order (§3) | `SchemaGenerator.#formatters` (`src/schema-generator.ts`) | array literal is the order; routing tests in `test/schema-generator.test.ts` |
 | Core keyword mappings (§4) | `PrimitiveFormatter.getSchemaType` (`src/formatters/primitive-formatter.ts`); node table `analyzeTypeNodeStructure` (`src/schema-generator.ts`) | void-type / array-special-types tests |
 | Hoisting exclusion rule (§5.1) | `getNamedTypeKey` (`src/type-utils.ts`) | recursion/shared-type/alias fixtures |
 | Native leaf table + guard (§5.2) | `NATIVE_TYPE_SCHEMAS` / `LIB_DECLARED_NATIVE_TYPES` (`src/formatters/native-type-formatter.ts`) | `test/native-type-parameters.test.ts` |

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -274,17 +274,23 @@ function tokenizePredicate(source: string): Token[] {
 class PredicateParser {
   #index = 0;
 
+  readonly #source: string;
+  readonly #tokens: Token[];
+
   constructor(
-    private readonly source: string,
-    private readonly tokens: Token[],
-  ) {}
+    source: string,
+    tokens: Token[],
+  ) {
+    this.#source = source;
+    this.#tokens = tokens;
+  }
 
   parse(): SelectionPredicate {
     const result = this.#parseOr();
     const trailing = this.#peek();
     if (trailing.kind !== "eof") {
       throw expressionError(
-        this.source,
+        this.#source,
         trailing.position,
         "unexpected trailing input",
       );
@@ -293,17 +299,17 @@ class PredicateParser {
   }
 
   #peek(): Token {
-    return this.tokens[this.#index];
+    return this.#tokens[this.#index];
   }
 
   #take(): Token {
-    return this.tokens[this.#index++];
+    return this.#tokens[this.#index++];
   }
 
   #takeKind(kind: TokenKind, message: string): Token {
     const token = this.#peek();
     if (token.kind !== kind) {
-      throw expressionError(this.source, token.position, message);
+      throw expressionError(this.#source, token.position, message);
     }
     return this.#take();
   }
@@ -393,7 +399,7 @@ class PredicateParser {
       }
     }
     throw expressionError(
-      this.source,
+      this.#source,
       token.position,
       "expected a path, literal, or parenthesized expression",
     );
@@ -426,7 +432,7 @@ class PredicateParser {
         const segment = this.#peek();
         if (segment.kind !== "string" && segment.kind !== "number") {
           throw expressionError(
-            this.source,
+            this.#source,
             segment.position,
             "expected a string or number inside brackets",
           );

--- a/packages/cli/lib/view/editbuffer.ts
+++ b/packages/cli/lib/view/editbuffer.ts
@@ -30,7 +30,7 @@ export class EditBuffer {
 
   /** The "goal" column for vertical motion, so up/down keep the column over
    * short lines (Emacs/most editors). -1 means "track the current column". */
-  private goalCol = -1;
+  #goalCol = -1;
 
   /** Mark for region operations (C-Space … C-w), or null. */
   mark: { row: number; col: number } | null = null;
@@ -39,25 +39,25 @@ export class EditBuffer {
   killRing: string[] = [];
 
   /** Index of the entry the next yank-pop will use; -1 when not yank-popping. */
-  private yankIndex = -1;
+  #yankIndex = -1;
 
   /** [row, col] span the last yank inserted, for yank-pop to replace. */
-  private lastYank:
+  #lastYank:
     | { row: number; col: number; endRow: number; endCol: number }
     | null = null;
-  private lastKill: LastKill = "none";
+  #lastKill: LastKill = "none";
 
-  private original: string;
-  private lineEndings: Array<LineEndingProvenance | undefined>;
+  #original: string;
+  #lineEndings: Array<LineEndingProvenance | undefined>;
 
   constructor(
     text: string,
     lineEndings: readonly (LineEndingProvenance | undefined)[] = [],
   ) {
-    this.original = text;
+    this.#original = text;
     // split("\n") always yields at least one element (`""` for an empty string).
     this.lines = text.split("\n");
-    this.lineEndings = this.lines.map((_, index) => lineEndings[index]);
+    this.#lineEndings = this.lines.map((_, index) => lineEndings[index]);
   }
 
   //
@@ -69,37 +69,37 @@ export class EditBuffer {
   }
 
   dirty(): boolean {
-    return this.text() !== this.original;
+    return this.text() !== this.#original;
   }
 
   /** Make the current text the clean baseline (after a successful save). */
   commitSaved(): void {
-    this.original = this.text();
+    this.#original = this.text();
   }
 
   /** Replace the clean baseline without touching the cursor or current text.
    * Used when revealing diff context, which is applied to both sides so it does
    * not read as an edit. */
   setBaseline(text: string): void {
-    this.original = text;
+    this.#original = text;
   }
 
   /** The clean baseline — the text this buffer was created with (or last saved
    * to). Edits are measured against it. */
   baseline(): string {
-    return this.original;
+    return this.#original;
   }
 
   /** File-ending information attached to the current physical rows. */
   lineEndingProvenance(): readonly (LineEndingProvenance | undefined)[] {
-    return this.lineEndings;
+    return this.#lineEndings;
   }
 
   /** Replace file-ending information after the backing source is saved. */
   setLineEndingProvenance(
     lineEndings: readonly (LineEndingProvenance | undefined)[] = [],
   ): void {
-    this.lineEndings = this.lines.map((_, index) => lineEndings[index]);
+    this.#lineEndings = this.lines.map((_, index) => lineEndings[index]);
   }
 
   /** Replace the whole text and place the cursor, keeping the clean baseline —
@@ -111,15 +111,15 @@ export class EditBuffer {
     col = 0,
     lineEndings: readonly (LineEndingProvenance | undefined)[] = [],
   ): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     this.mark = null;
     // split("\n") always yields at least one element.
     this.lines = text.split("\n");
-    this.lineEndings = this.lines.map((_, index) => lineEndings[index]);
+    this.#lineEndings = this.lines.map((_, index) => lineEndings[index]);
     this.row = clamp(row, 0, this.lines.length - 1);
-    this.col = clamp(col, 0, this.lineLen(this.row));
+    this.col = clamp(col, 0, this.#lineLen(this.row));
   }
 
   /** Replace `count` lines starting at `row` with `replacement`, leaving the
@@ -133,10 +133,10 @@ export class EditBuffer {
     cursorRow: number,
     cursorCol: number,
   ): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    const removedEndings = this.lineEndings.slice(row, row + count);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    const removedEndings = this.#lineEndings.slice(row, row + count);
     let replacementEndings: Array<LineEndingProvenance | undefined>;
     if (count === replacement.length) {
       replacementEndings = replacement.map((_, index) => removedEndings[index]);
@@ -153,49 +153,49 @@ export class EditBuffer {
       replacementEndings = replacement.map(() => inherited);
     }
     this.lines.splice(row, count, ...replacement);
-    this.lineEndings.splice(row, count, ...replacementEndings);
+    this.#lineEndings.splice(row, count, ...replacementEndings);
     if (this.lines.length === 0) {
       this.lines = [""];
-      this.lineEndings = [undefined];
+      this.#lineEndings = [undefined];
     }
     this.row = clamp(row + cursorRow, 0, this.lines.length - 1);
-    this.col = clamp(cursorCol, 0, this.lineLen(this.row));
+    this.col = clamp(cursorCol, 0, this.#lineLen(this.row));
   }
 
-  private chars(row: number): string[] {
+  #chars(row: number): string[] {
     return [...(this.lines[row] ?? "")];
   }
 
-  private lineLen(row: number): number {
-    return this.chars(row).length;
+  #lineLen(row: number): number {
+    return this.#chars(row).length;
   }
 
   /** Code-point length of the cursor's current line. */
   currentLineLength(): number {
-    return this.lineLen(this.row);
+    return this.#lineLen(this.row);
   }
 
   /** Place the cursor, clamped into range; resets motion/kill/yank state. */
   place(row: number, col: number): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     this.row = clamp(row, 0, this.lines.length - 1);
-    this.col = clamp(col, 0, this.lineLen(this.row));
+    this.col = clamp(col, 0, this.#lineLen(this.row));
   }
 
   /** Call before a non-vertical action so it does not inherit a stale goal. */
-  private resetGoal(): void {
-    this.goalCol = -1;
+  #resetGoal(): void {
+    this.#goalCol = -1;
   }
 
-  private endKill(): void {
-    this.lastKill = "none";
+  #endKill(): void {
+    this.#lastKill = "none";
   }
 
-  private endYank(): void {
-    this.yankIndex = -1;
-    this.lastYank = null;
+  #endYank(): void {
+    this.#yankIndex = -1;
+    this.#lastYank = null;
   }
 
   //
@@ -203,21 +203,21 @@ export class EditBuffer {
   //
 
   moveLeft(): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     if (this.col > 0) this.col -= 1;
     else if (this.row > 0) {
       this.row -= 1;
-      this.col = this.lineLen(this.row);
+      this.col = this.#lineLen(this.row);
     }
   }
 
   moveRight(): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    if (this.col < this.lineLen(this.row)) this.col += 1;
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    if (this.col < this.#lineLen(this.row)) this.col += 1;
     else if (this.row < this.lines.length - 1) {
       this.row += 1;
       this.col = 0;
@@ -225,81 +225,81 @@ export class EditBuffer {
   }
 
   moveUp(): void {
-    this.endKill();
-    this.endYank();
-    if (this.goalCol < 0) this.goalCol = this.col;
+    this.#endKill();
+    this.#endYank();
+    if (this.#goalCol < 0) this.#goalCol = this.col;
     if (this.row > 0) {
       this.row -= 1;
-      this.col = Math.min(this.goalCol, this.lineLen(this.row));
+      this.col = Math.min(this.#goalCol, this.#lineLen(this.row));
     }
   }
 
   moveDown(): void {
-    this.endKill();
-    this.endYank();
-    if (this.goalCol < 0) this.goalCol = this.col;
+    this.#endKill();
+    this.#endYank();
+    if (this.#goalCol < 0) this.#goalCol = this.col;
     if (this.row < this.lines.length - 1) {
       this.row += 1;
-      this.col = Math.min(this.goalCol, this.lineLen(this.row));
+      this.col = Math.min(this.#goalCol, this.#lineLen(this.row));
     }
   }
 
   moveLineStart(): void { // C-a
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     this.col = 0;
   }
 
   moveLineEnd(): void { // C-e
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    this.col = this.lineLen(this.row);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    this.col = this.#lineLen(this.row);
   }
 
   moveBufferStart(): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     this.row = 0;
     this.col = 0;
   }
 
   moveBufferEnd(): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     this.row = this.lines.length - 1;
-    this.col = this.lineLen(this.row);
+    this.col = this.#lineLen(this.row);
   }
 
   moveWordForward(): void { // M-f
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    const pos = this.nextWordEnd(this.row, this.col);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    const pos = this.#nextWordEnd(this.row, this.col);
     this.row = pos.row;
     this.col = pos.col;
   }
 
   moveWordBackward(): void { // M-b
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    const pos = this.prevWordStart(this.row, this.col);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    const pos = this.#prevWordStart(this.row, this.col);
     this.row = pos.row;
     this.col = pos.col;
   }
 
   /** Destination of a forward word operation without moving the cursor. */
   wordEndForward(): { row: number; col: number } {
-    return this.nextWordEnd(this.row, this.col);
+    return this.#nextWordEnd(this.row, this.col);
   }
 
   /** Destination of a backward word operation without moving the cursor. */
   wordStartBackward(): { row: number; col: number } {
-    return this.prevWordStart(this.row, this.col);
+    return this.#prevWordStart(this.row, this.col);
   }
 
   setMark(): void { // C-Space
@@ -311,13 +311,13 @@ export class EditBuffer {
   //
 
   insert(s: string): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     if (s.length === 0) return;
     if (s.includes("\n")) {
       for (const ch of s) {
-        if (ch === "\n") this.splitLine();
+        if (ch === "\n") this.#splitLine();
         else this.insertChar(ch);
       }
       return;
@@ -326,31 +326,31 @@ export class EditBuffer {
   }
 
   insertChar(ch: string): void { // a single code point
-    const cps = this.chars(this.row);
+    const cps = this.#chars(this.row);
     cps.splice(this.col, 0, ch);
     this.lines[this.row] = cps.join("");
     this.col += 1;
   }
 
   insertNewline(endColumn?: number, newBoundarySuffix = ""): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    this.splitLine(endColumn, newBoundarySuffix);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    this.#splitLine(endColumn, newBoundarySuffix);
   }
 
   /** Split before source-owned characters that terminate the physical row. */
-  private splitLine(endColumn?: number, newBoundarySuffix = ""): void {
-    const cps = this.chars(this.row);
+  #splitLine(endColumn?: number, newBoundarySuffix = ""): void {
+    const cps = this.#chars(this.row);
     const end = clamp(endColumn ?? cps.length, 0, cps.length);
     const split = Math.min(this.col, end);
     const suffix = cps.slice(end);
     const boundarySuffix = suffix.length > 0 ? suffix : [...newBoundarySuffix];
     const before = [...cps.slice(0, split), ...boundarySuffix].join("");
     const after = [...cps.slice(split, end), ...suffix].join("");
-    const ending = this.lineEndings[this.row];
+    const ending = this.#lineEndings[this.row];
     this.lines.splice(this.row, 1, before, after);
-    this.lineEndings.splice(this.row, 1, ending, ending);
+    this.#lineEndings.splice(this.row, 1, ending, ending);
     this.row += 1;
     this.col = 0;
   }
@@ -360,16 +360,16 @@ export class EditBuffer {
   //
 
   deleteBackward(previousEndColumn?: number): void { // Backspace
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
     if (this.col > 0) {
-      const cps = this.chars(this.row);
+      const cps = this.#chars(this.row);
       cps.splice(this.col - 1, 1);
       this.lines[this.row] = cps.join("");
       this.col -= 1;
     } else if (this.row > 0) {
-      const previous = this.chars(this.row - 1);
+      const previous = this.#chars(this.row - 1);
       const previousEnd = clamp(
         previousEndColumn ?? previous.length,
         0,
@@ -377,19 +377,19 @@ export class EditBuffer {
       );
       this.lines[this.row - 1] = previous.slice(0, previousEnd).join("") +
         this.lines[this.row];
-      this.lineEndings[this.row - 1] = this.lineEndings[this.row];
+      this.#lineEndings[this.row - 1] = this.#lineEndings[this.row];
       this.lines.splice(this.row, 1);
-      this.lineEndings.splice(this.row, 1);
+      this.#lineEndings.splice(this.row, 1);
       this.row -= 1;
       this.col = previousEnd;
     }
   }
 
   deleteForward(endColumn?: number): void { // Delete / C-d
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    const cps = this.chars(this.row);
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    const cps = this.#chars(this.row);
     const end = clamp(endColumn ?? cps.length, 0, cps.length);
     if (this.col < end) {
       cps.splice(this.col, 1);
@@ -397,9 +397,9 @@ export class EditBuffer {
     } else if (this.col === end && this.row < this.lines.length - 1) {
       this.lines[this.row] = cps.slice(0, end).join("") +
         this.lines[this.row + 1];
-      this.lineEndings[this.row] = this.lineEndings[this.row + 1];
+      this.#lineEndings[this.row] = this.#lineEndings[this.row + 1];
       this.lines.splice(this.row + 1, 1);
-      this.lineEndings.splice(this.row + 1, 1);
+      this.#lineEndings.splice(this.row + 1, 1);
     }
   }
 
@@ -410,9 +410,9 @@ export class EditBuffer {
   /** C-k: kill to end of line; at end of line, kill the newline (join next).
    * `endColumn` can keep source-owned transport after the editable text. */
   killLine(endColumn?: number): void {
-    this.resetGoal();
-    this.endYank();
-    const cps = this.chars(this.row);
+    this.#resetGoal();
+    this.#endYank();
+    const cps = this.#chars(this.row);
     const end = clamp(endColumn ?? cps.length, 0, cps.length);
     if (this.col < end) {
       const killed = cps.slice(this.col, end).join("");
@@ -420,22 +420,22 @@ export class EditBuffer {
         ...cps.slice(0, this.col),
         ...cps.slice(end),
       ].join("");
-      this.pushKill(killed, "append");
+      this.#pushKill(killed, "append");
     } else if (this.col === end && this.row < this.lines.length - 1) {
       const transport = cps.slice(end).join("");
       this.lines[this.row] = cps.slice(0, end).join("") +
         this.lines[this.row + 1];
-      this.lineEndings[this.row] = this.lineEndings[this.row + 1];
+      this.#lineEndings[this.row] = this.#lineEndings[this.row + 1];
       this.lines.splice(this.row + 1, 1);
-      this.lineEndings.splice(this.row + 1, 1);
-      this.pushKill(`${transport}\n`, "append");
+      this.#lineEndings.splice(this.row + 1, 1);
+      this.#pushKill(`${transport}\n`, "append");
     }
   }
 
   /** Kill the whole current line (its text and its newline). */
   killWholeLine(): void {
-    this.resetGoal();
-    this.endYank();
+    this.#resetGoal();
+    this.#endYank();
     // The killed line has a terminating newline only when it is not the last
     // line; killing the last line (no newline after it) must not add one, or a
     // later yank would insert a spurious trailing newline.
@@ -445,75 +445,75 @@ export class EditBuffer {
       this.lines[0] = "";
     } else {
       if (this.row === this.lines.length - 1) {
-        this.lineEndings[this.row - 1] = this.lineEndings[this.row];
+        this.#lineEndings[this.row - 1] = this.#lineEndings[this.row];
       }
       this.lines.splice(this.row, 1);
-      this.lineEndings.splice(this.row, 1);
+      this.#lineEndings.splice(this.row, 1);
       if (this.row >= this.lines.length) this.row = this.lines.length - 1;
     }
     this.col = 0;
-    this.pushKill(text, "append");
+    this.#pushKill(text, "append");
   }
 
   killWordForward(): void { // M-d
-    this.resetGoal();
-    this.endYank();
-    const end = this.nextWordEnd(this.row, this.col);
-    const killed = this.cut(this.row, this.col, end.row, end.col);
-    this.pushKill(killed, "append");
+    this.#resetGoal();
+    this.#endYank();
+    const end = this.#nextWordEnd(this.row, this.col);
+    const killed = this.#cut(this.row, this.col, end.row, end.col);
+    this.#pushKill(killed, "append");
   }
 
   killWordBackward(): void { // M-Backspace
-    this.resetGoal();
-    this.endYank();
-    const start = this.prevWordStart(this.row, this.col);
-    const killed = this.cut(start.row, start.col, this.row, this.col);
+    this.#resetGoal();
+    this.#endYank();
+    const start = this.#prevWordStart(this.row, this.col);
+    const killed = this.#cut(start.row, start.col, this.row, this.col);
     this.row = start.row;
     this.col = start.col;
-    this.pushKill(killed, "prepend");
+    this.#pushKill(killed, "prepend");
   }
 
   /** C-w: kill the region between the mark and the cursor. */
   killRegion(): void {
-    this.resetGoal();
-    this.endYank();
+    this.#resetGoal();
+    this.#endYank();
     if (!this.mark) return;
     const [a, b] = orderPoints(this.mark, { row: this.row, col: this.col });
-    const killed = this.cut(a.row, a.col, b.row, b.col);
+    const killed = this.#cut(a.row, a.col, b.row, b.col);
     this.row = a.row;
     this.col = a.col;
     this.mark = null;
-    this.pushKill(killed, "append");
+    this.#pushKill(killed, "append");
   }
 
   yank(): void { // C-y
-    this.resetGoal();
-    this.endKill();
+    this.#resetGoal();
+    this.#endKill();
     if (this.killRing.length === 0) return;
-    this.yankIndex = 0;
-    this.insertYank(this.killRing[0]);
+    this.#yankIndex = 0;
+    this.#insertYank(this.killRing[0]);
   }
 
   yankPop(): void { // M-y — only valid right after a yank/yank-pop
-    this.resetGoal();
-    this.endKill();
-    if (this.yankIndex < 0 || !this.lastYank || this.killRing.length === 0) {
+    this.#resetGoal();
+    this.#endKill();
+    if (this.#yankIndex < 0 || !this.#lastYank || this.killRing.length === 0) {
       return;
     }
     // Remove the previously-yanked text, then insert the next ring entry.
-    const { row, col, endRow, endCol } = this.lastYank;
-    this.cut(row, col, endRow, endCol);
+    const { row, col, endRow, endCol } = this.#lastYank;
+    this.#cut(row, col, endRow, endCol);
     this.row = row;
     this.col = col;
-    this.yankIndex = (this.yankIndex + 1) % this.killRing.length;
-    this.insertYank(this.killRing[this.yankIndex]);
+    this.#yankIndex = (this.#yankIndex + 1) % this.killRing.length;
+    this.#insertYank(this.killRing[this.#yankIndex]);
   }
 
-  private insertYank(s: string): void {
+  #insertYank(s: string): void {
     const startRow = this.row;
     const startCol = this.col;
-    this.insertRaw(s);
-    this.lastYank = {
+    this.#insertRaw(s);
+    this.#lastYank = {
       row: startRow,
       col: startCol,
       endRow: this.row,
@@ -522,16 +522,16 @@ export class EditBuffer {
   }
 
   /** Insert without disturbing the yank/kill bookkeeping. */
-  private insertRaw(s: string): void {
+  #insertRaw(s: string): void {
     for (const ch of s) {
-      if (ch === "\n") this.splitLine();
+      if (ch === "\n") this.#splitLine();
       else this.insertChar(ch);
     }
   }
 
-  private pushKill(text: string, mode: "append" | "prepend"): void {
+  #pushKill(text: string, mode: "append" | "prepend"): void {
     if (text.length === 0) return;
-    if (this.lastKill !== "none" && this.killRing.length > 0) {
+    if (this.#lastKill !== "none" && this.killRing.length > 0) {
       // Accrete consecutive kills into one ring entry, like Emacs.
       this.killRing[0] = mode === "prepend"
         ? text + this.killRing[0]
@@ -539,9 +539,9 @@ export class EditBuffer {
     } else {
       this.killRing.unshift(text);
     }
-    this.lastKill = mode;
-    this.yankIndex = -1;
-    this.lastYank = null;
+    this.#lastKill = mode;
+    this.#yankIndex = -1;
+    this.#lastYank = null;
   }
 
   //
@@ -549,15 +549,15 @@ export class EditBuffer {
   //
 
   lowercaseWord(): void { // M-l
-    this.transformWord((s) => s.toLowerCase());
+    this.#transformWord((s) => s.toLowerCase());
   }
 
   uppercaseWord(): void { // M-u
-    this.transformWord((s) => s.toUpperCase());
+    this.#transformWord((s) => s.toUpperCase());
   }
 
   capitalizeWord(): void { // M-c
-    this.transformWord((s) => {
+    this.#transformWord((s) => {
       const m = s.match(/[\p{L}\p{N}]/u);
       if (!m || m.index === undefined) return s;
       const i = m.index;
@@ -565,17 +565,17 @@ export class EditBuffer {
     });
   }
 
-  private transformWord(fn: (s: string) => string): void {
-    this.resetGoal();
-    this.endKill();
-    this.endYank();
-    const end = this.nextWordEnd(this.row, this.col);
+  #transformWord(fn: (s: string) => string): void {
+    this.#resetGoal();
+    this.#endKill();
+    this.#endYank();
+    const end = this.#nextWordEnd(this.row, this.col);
     if (end.row !== this.row) {
       // Word ops stay on the current line for simplicity; move to its end.
-      this.col = this.lineLen(this.row);
+      this.col = this.#lineLen(this.row);
       return;
     }
-    const cps = this.chars(this.row);
+    const cps = this.#chars(this.row);
     const seg = cps.slice(this.col, end.col).join("");
     const replaced = [...fn(seg)];
     cps.splice(this.col, end.col - this.col, ...replaced);
@@ -589,43 +589,43 @@ export class EditBuffer {
 
   /** Cut text between two ordered points and return it; cursor left at a-side
    * is the caller's responsibility. */
-  private cut(
+  #cut(
     aRow: number,
     aCol: number,
     bRow: number,
     bCol: number,
   ): string {
     if (aRow === bRow) {
-      const cps = this.chars(aRow);
+      const cps = this.#chars(aRow);
       const out = cps.slice(aCol, bCol).join("");
       cps.splice(aCol, bCol - aCol);
       this.lines[aRow] = cps.join("");
       return out;
     }
-    const first = this.chars(aRow);
-    const last = this.chars(bRow);
+    const first = this.#chars(aRow);
+    const last = this.#chars(bRow);
     const parts: string[] = [first.slice(aCol).join("")];
     for (let r = aRow + 1; r < bRow; r++) parts.push(this.lines[r]);
     parts.push(last.slice(0, bCol).join(""));
     const head = first.slice(0, aCol).join("");
     const tail = last.slice(bCol).join("");
-    this.lineEndings[aRow] = this.lineEndings[bRow];
+    this.#lineEndings[aRow] = this.#lineEndings[bRow];
     this.lines.splice(aRow, bRow - aRow + 1, head + tail);
-    this.lineEndings.splice(aRow + 1, bRow - aRow);
+    this.#lineEndings.splice(aRow + 1, bRow - aRow);
     return parts.join("\n");
   }
 
-  private isWordChar(ch: string | undefined): boolean {
+  #isWordChar(ch: string | undefined): boolean {
     return ch !== undefined && /[\p{L}\p{N}_]/u.test(ch);
   }
 
   /** End of the word at/after (row,col): skip non-word chars, then word chars. */
-  private nextWordEnd(row: number, col: number): { row: number; col: number } {
+  #nextWordEnd(row: number, col: number): { row: number; col: number } {
     let r = row;
     let c = col;
     // Skip non-word characters (crossing line ends).
     for (;;) {
-      const cps = this.chars(r);
+      const cps = this.#chars(r);
       if (c >= cps.length) {
         if (r < this.lines.length - 1) {
           r += 1;
@@ -634,16 +634,16 @@ export class EditBuffer {
         }
         return { row: r, col: c };
       }
-      if (this.isWordChar(cps[c])) break;
+      if (this.#isWordChar(cps[c])) break;
       c += 1;
     }
-    const cps = this.chars(r);
-    while (c < cps.length && this.isWordChar(cps[c])) c += 1;
+    const cps = this.#chars(r);
+    while (c < cps.length && this.#isWordChar(cps[c])) c += 1;
     return { row: r, col: c };
   }
 
   /** Start of the word at/before (row,col). */
-  private prevWordStart(
+  #prevWordStart(
     row: number,
     col: number,
   ): { row: number; col: number } {
@@ -653,15 +653,15 @@ export class EditBuffer {
       if (c <= 0) {
         if (r > 0) {
           r -= 1;
-          c = this.lineLen(r);
+          c = this.#lineLen(r);
           continue;
         }
         return { row: r, col: c };
       }
-      if (this.isWordChar(this.chars(r)[c - 1])) break;
+      if (this.#isWordChar(this.#chars(r)[c - 1])) break;
       c -= 1;
     }
-    while (c > 0 && this.isWordChar(this.chars(r)[c - 1])) c -= 1;
+    while (c > 0 && this.#isWordChar(this.#chars(r)[c - 1])) c -= 1;
     return { row: r, col: c };
   }
 }

--- a/packages/cli/lib/view/languages/markdown/markdown.ts
+++ b/packages/cli/lib/view/languages/markdown/markdown.ts
@@ -123,7 +123,7 @@ interface RichStyle {
 class RichLine {
   text = "";
   readonly spans: Span[] = [];
-  private sourceHidden = false;
+  #sourceHidden = false;
 
   append(value: string, style: RichStyle): void {
     if (value.length === 0) return;
@@ -149,7 +149,7 @@ class RichLine {
   }
 
   appendLine(line: Line, extra: Partial<RichStyle> = {}): void {
-    if (line.renderedSourceHidden) this.sourceHidden = true;
+    if (line.renderedSourceHidden) this.#sourceHidden = true;
     if (line.spans.length === 0 && line.text.length > 0) {
       this.append(line.text, { ...extra, cls: extra.cls ?? "plain" });
       return;
@@ -166,14 +166,14 @@ class RichLine {
   }
 
   hideSource(): void {
-    this.sourceHidden = true;
+    this.#sourceHidden = true;
   }
 
   line(): Line {
     return {
       text: this.text,
       spans: this.spans,
-      ...(this.sourceHidden ? { renderedSourceHidden: true } : {}),
+      ...(this.#sourceHidden ? { renderedSourceHidden: true } : {}),
     };
   }
 }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -212,29 +212,33 @@ interface JumpEntry {
 }
 
 export class Session {
+  // A member below declared `private` rather than `#` is one the view tests
+  // reach and drive directly, `test/view-session-gate2.test.ts` chief among
+  // them; a `#` name would put it out of their reach.
+
   /** The parsed source document used for editing, offsets, and source cards. */
-  private sourceDoc: Document;
-  private currentDoc: Document;
-  private viewMode: ViewMode = "source";
-  private color: boolean;
-  private lineNumberMode: LineNumberMode = "off";
+  #sourceDoc: Document;
+  #currentDoc: Document;
+  #viewMode: ViewMode = "source";
+  #color: boolean;
+  #lineNumberMode: LineNumberMode = "off";
 
   /** How long logical lines continue on later screen rows. */
-  private wrapMode: WrapMode = "off";
+  #wrapMode: WrapMode = "off";
 
   /** How non-printable characters are shown; edit mode forces the first mode. */
-  private displayMode: DisplayMode = DISPLAY_MODES[0];
+  #displayMode: DisplayMode = DISPLAY_MODES[0];
 
   /** Indices (document order) of the diff files collapsed to a summary line.
    * Cleared when the text cursor is revealed, since hidden lines cannot be
    * edited. `this.top` is a display row while any file is collapsed. */
-  private collapsed = new Set<number>();
+  #collapsed = new Set<number>();
 
   /** Bumped whenever `collapsed` changes, to invalidate the fold-plan cache. */
-  private foldVersion = 0;
-  private foldFileCache?: { doc: Document; files: DiffFileRange[] };
-  private foldPlanCache?: { doc: Document; version: number; plan: FoldPlan };
-  private wrapPlanCache?: {
+  #foldVersion = 0;
+  #foldFileCache?: { doc: Document; files: DiffFileRange[] };
+  #foldPlanCache?: { doc: Document; version: number; plan: FoldPlan };
+  #wrapPlanCache?: {
     lines: readonly Line[];
     mode: DisplayMode;
     wrapMode: ActiveWrapMode;
@@ -242,64 +246,64 @@ export class Session {
     decorations: string;
     plan: WrapPlan;
   };
-  private baseWrapPlanCache?: {
+  #baseWrapPlanCache?: {
     lines: readonly Line[];
     mode: DisplayMode;
     wrapMode: ActiveWrapMode;
     width: number;
     plan: WrapPlan;
   };
-  private expansionLayoutCache?: ExpansionLayoutCache;
-  private wrapDecorations = new Map<number, WrapDecoration>();
-  private wrapDecorationKey = "";
-  private displayColumnCache?: {
+  #expansionLayoutCache?: ExpansionLayoutCache;
+  #wrapDecorations = new Map<number, WrapDecoration>();
+  #wrapDecorationKey = "";
+  #displayColumnCache?: {
     doc: Document;
     mode: DisplayMode;
     columns: Map<number, Uint32Array>;
   };
 
-  private get wrapLines(): boolean {
-    return this.wrapMode !== "off";
+  get #wrapLines(): boolean {
+    return this.#wrapMode !== "off";
   }
 
-  private get activeWrapMode(): ActiveWrapMode {
-    return this.wrapMode === "word" ? "word" : "hard";
+  get #activeWrapMode(): ActiveWrapMode {
+    return this.#wrapMode === "word" ? "word" : "hard";
   }
-  private maxDisplayWidthCache?: {
+  #maxDisplayWidthCache?: {
     lines: readonly Line[];
     mode: DisplayMode;
     width: number;
   };
-  private nonPrintCache?: { doc: Document; value: boolean };
-  private fileLineCache?: { doc: Document; value: (number | null)[] | null };
+  #nonPrintCache?: { doc: Document; value: boolean };
+  #fileLineCache?: { doc: Document; value: (number | null)[] | null };
 
   /** Diff metadata lines, cached against the parsed document. */
-  private diffMetadataCache?: { doc: Document; lines: readonly number[] };
+  #diffMetadataCache?: { doc: Document; lines: readonly number[] };
 
   width: number;
   height: number;
   top = 0;
   left = 0;
-  private selectedIndex: number | null = null;
-  private query = "";
-  private matches: Match[] = [];
-  private currentMatch = 0;
+  #selectedIndex: number | null = null;
+  #query = "";
+  #matches: Match[] = [];
+  #currentMatch = 0;
 
   /** Where an edit-mode search (Ctrl-S) began, so its focused match is the
    * first at or after the cursor and Enter lands the cursor there. Null for a
    * normal-mode `/` search. */
-  private searchAnchor: { row: number; col: number } | null = null;
-  private message = "";
-  private mode: Mode = "normal";
-  private input = "";
-  private overlay: PeekOverlay | null = null;
-  private overlayScroll = 0;
+  #searchAnchor: { row: number; col: number } | null = null;
+  #message = "";
+  #mode: Mode = "normal";
+  #input = "";
+  #overlay: PeekOverlay | null = null;
+  #overlayScroll = 0;
 
   /** The overlays followed to reach the current one, so Esc walks back through
    * the chain of cards and file peeks. Empty when the current overlay is the
    * first one opened from the main view. */
-  private overlayStack: Array<{ overlay: PeekOverlay; scroll: number }> = [];
-  private semantics?: Semantics;
+  #overlayStack: Array<{ overlay: PeekOverlay; scroll: number }> = [];
+  #semantics?: Semantics;
   quit = false;
 
   /** An edit patched only the changed lines for speed; a full re-parse (for
@@ -327,50 +331,50 @@ export class Session {
   transientMessage = false;
 
   /** How much context each hunk can reveal, cached against the document. */
-  private roomCache?: { doc: Document; room: ReadonlyMap<number, HunkRoom> };
+  #roomCache?: { doc: Document; room: ReadonlyMap<number, HunkRoom> };
 
   //
   // editing
   //
 
-  private source?: EditableSource;
+  #source?: EditableSource;
   private buffer?: EditBuffer;
 
   /** Incremental highlighter for the current buffer, created lazily on the first
    * edit and discarded (re-baselined) on each deferred re-parse and file swap. */
-  private highlighter?: Highlighter;
+  #highlighter?: Highlighter;
 
   /** Row of the added line a context-line split produced, so undoing that edit
    * collapses the pair back — even after moving the cursor away and back — while
    * editing an author-written -/+ pair to match does not. Overwritten by the
    * next split, cleared on a collapse or when the buffer text is replaced. */
-  private splitRow: number | null = null;
-  private cursorOn = false;
+  #splitRow: number | null = null;
+  #cursorOn = false;
 
   /** Pending C-x prefix (Emacs chord), reset by the next key. */
-  private chord: "ctrl-x" | null = null;
+  #chord: "ctrl-x" | null = null;
 
   /** Which button the active prompt's Tab focus rests on — an index into its
    * button row. Space and Enter activate it; it is reset to the default button
    * each time a prompt opens. */
-  private dialogFocus = 0;
+  #dialogFocus = 0;
 
   /** What the active save prompt does on confirm. */
-  private savePromptThen: "quit" | null = null;
+  #savePromptThen: "quit" | null = null;
 
   /** Filenames a save would write, computed when the quit prompt opens and
    * listed above it. */
-  private editedFiles: string[] = [];
+  #editedFiles: string[] = [];
 
   //
   // file picker (C-x C-f)
   //
 
-  private readonly files?: FileGateway;
-  private pickerDir = "";
-  private pickerFilter = "";
-  private pickerEntries: DirEntry[] = [];
-  private pickerSel = 0;
+  readonly #files?: FileGateway;
+  #pickerDir = "";
+  #pickerFilter = "";
+  #pickerEntries: DirEntry[] = [];
+  #pickerSel = 0;
 
   //
   // jump list (i)
@@ -378,10 +382,10 @@ export class Session {
 
   /** Every file and commit in the diff, in document order; the filter narrows
    * this into the shown {@link jumpEntries}. */
-  private jumpAll: JumpEntry[] = [];
-  private jumpEntries: JumpEntry[] = [];
-  private jumpFilter = "";
-  private jumpSel = 0;
+  #jumpAll: JumpEntry[] = [];
+  #jumpEntries: JumpEntry[] = [];
+  #jumpFilter = "";
+  #jumpSel = 0;
 
   constructor(
     doc: Document,
@@ -391,15 +395,15 @@ export class Session {
     source?: EditableSource,
     files?: FileGateway,
   ) {
-    this.sourceDoc = doc;
-    this.currentDoc = doc;
-    this.color = options.color;
-    this.lineNumberMode = options.showLineNumbers ? "input" : "off";
+    this.#sourceDoc = doc;
+    this.#currentDoc = doc;
+    this.#color = options.color;
+    this.#lineNumberMode = options.showLineNumbers ? "input" : "off";
     this.width = size.width;
     this.height = size.height;
-    this.semantics = semantics;
-    this.source = source;
-    this.files = files;
+    this.#semantics = semantics;
+    this.#source = source;
+    this.#files = files;
     // The edit buffer mirrors the document text; for an editable file the two
     // stay in lock-step (the document is a re-parse of the buffer).
     if (source) {
@@ -410,65 +414,65 @@ export class Session {
     }
     const initialViewMode = options.viewMode ?? source?.defaultViewMode;
     if (initialViewMode === "rendered" && source?.render) {
-      this.viewMode = "rendered";
-      this.setSourceDocument(doc);
+      this.#viewMode = "rendered";
+      this.#setSourceDocument(doc);
     }
   }
 
   get doc(): Document {
-    return this.currentDoc;
+    return this.#currentDoc;
   }
 
   /** Install a newly parsed source document in the active representation. */
-  private setSourceDocument(doc: Document): void {
-    this.sourceDoc = doc;
-    if (this.viewMode === "rendered" && this.source?.render) {
-      const rendered = this.source.render(doc);
-      this.currentDoc = { ...doc, lines: rendered.lines };
+  #setSourceDocument(doc: Document): void {
+    this.#sourceDoc = doc;
+    if (this.#viewMode === "rendered" && this.#source?.render) {
+      const rendered = this.#source.render(doc);
+      this.#currentDoc = { ...doc, lines: rendered.lines };
     } else {
-      this.viewMode = "source";
-      this.currentDoc = doc;
+      this.#viewMode = "source";
+      this.#currentDoc = doc;
     }
   }
 
   /** Change representation while keeping the same source line at the top. */
-  private setViewMode(mode: ViewMode, announce = true): boolean {
-    if (mode === this.viewMode) return false;
-    if (mode === "rendered" && !this.source?.render) return false;
-    const anchor = this.viewportAnchor();
-    this.viewMode = mode;
-    this.setSourceDocument(this.sourceDoc);
-    if (this.wrapLines) {
-      this.restoreWrappedAnchor({ ...anchor, displayCol: 0 });
+  #setViewMode(mode: ViewMode, announce = true): boolean {
+    if (mode === this.#viewMode) return false;
+    if (mode === "rendered" && !this.#source?.render) return false;
+    const anchor = this.#viewportAnchor();
+    this.#viewMode = mode;
+    this.#setSourceDocument(this.#sourceDoc);
+    if (this.#wrapLines) {
+      this.#restoreWrappedAnchor({ ...anchor, displayCol: 0 });
     } else {
       this.top = anchor.foldedLine;
       this.left = 0;
-      this.clampScroll();
+      this.#clampScroll();
     }
-    if (this.query.length > 0) {
-      this.matches = findMatches(this.currentDoc, this.query);
-      this.currentMatch = clamp(
-        this.currentMatch,
+    if (this.#query.length > 0) {
+      this.#matches = findMatches(this.#currentDoc, this.#query);
+      this.#currentMatch = clamp(
+        this.#currentMatch,
         0,
-        Math.max(0, this.matches.length - 1),
+        Math.max(0, this.#matches.length - 1),
       );
     }
     if (announce) {
-      this.message = `View: ${this.viewMode}`;
+      this.#message = `View: ${this.#viewMode}`;
     }
     return true;
   }
 
-  private toggleViewMode(): void {
-    if (this.source?.renderLineTopology === "independent") {
-      this.message = "This rendered view has no line-aligned source view.";
+  #toggleViewMode(): void {
+    if (this.#source?.renderLineTopology === "independent") {
+      this.#message = "This rendered view has no line-aligned source view.";
       return;
     }
-    const changed = this.setViewMode(
-      this.viewMode === "source" ? "rendered" : "source",
+    const changed = this.#setViewMode(
+      this.#viewMode === "source" ? "rendered" : "source",
     );
-    if (!changed && this.viewMode === "source") {
-      this.message = "Rendered view isn't available here.";
+    if (!changed && this.#viewMode === "source") {
+      this.#message = "Rendered view isn't available here.";
     }
   }
 
@@ -478,24 +482,24 @@ export class Session {
 
   /** The diff's files (with collapsed summaries), or [] for a non-diff view.
    * Cached against the current document. */
-  private foldFiles(): DiffFileRange[] {
-    if (!this.source?.isDiff) return []; // only a diff has foldable files
-    if (this.foldFileCache?.doc !== this.currentDoc) {
-      this.foldFileCache = {
-        doc: this.currentDoc,
-        files: diffFiles(this.currentDoc.text),
+  #foldFiles(): DiffFileRange[] {
+    if (!this.#source?.isDiff) return []; // only a diff has foldable files
+    if (this.#foldFileCache?.doc !== this.#currentDoc) {
+      this.#foldFileCache = {
+        doc: this.#currentDoc,
+        files: diffFiles(this.#currentDoc.text),
       };
     }
-    return this.foldFileCache.files;
+    return this.#foldFileCache.files;
   }
 
   /** Whole-diff totals for the corner label on the first line, summed over the
    * diff's files. Null when the source is not a diff, when the text parses to
    * no diff files, or while the text cursor is active (edit mode reflows the
    * content the label would cover). */
-  private activeDiffTotals(): DiffTotals | null {
-    if (this.cursorOn || this.source?.isDiff !== true) return null;
-    const files = this.foldFiles();
+  #activeDiffTotals(): DiffTotals | null {
+    if (this.#cursorOn || this.#source?.isDiff !== true) return null;
+    const files = this.#foldFiles();
     if (files.length === 0) return null;
     let adds = 0;
     let dels = 0;
@@ -507,112 +511,112 @@ export class Session {
   }
 
   /** Columns the whole-diff totals label occupies, 0 when hidden. */
-  private cornerTotalsWidth(): number {
-    const totals = this.activeDiffTotals();
+  #cornerTotalsWidth(): number {
+    const totals = this.#activeDiffTotals();
     return totals ? diffTotalsWidth(totals) : 0;
   }
 
   /** Whether the document holds any non-printable character, so cycling the
    * display mode would change what is shown. Cached against the document. */
-  private hasNonPrintables(): boolean {
-    if (this.nonPrintCache?.doc !== this.currentDoc) {
-      this.nonPrintCache = {
-        doc: this.currentDoc,
-        value: this.currentDoc.lines.some((l) => hasNonPrintable(l.text)),
+  #hasNonPrintables(): boolean {
+    if (this.#nonPrintCache?.doc !== this.#currentDoc) {
+      this.#nonPrintCache = {
+        doc: this.#currentDoc,
+        value: this.#currentDoc.lines.some((l) => hasNonPrintable(l.text)),
       };
     }
-    return this.nonPrintCache.value;
+    return this.#nonPrintCache.value;
   }
 
   /** The current collapse plan: the display line list and the maps between
    * document lines and display rows. The identity plan when nothing is hidden. */
-  private foldPlan(): FoldPlan {
-    if (this.collapsed.size === 0) return identityFold(this.currentDoc.lines);
+  #foldPlan(): FoldPlan {
+    if (this.#collapsed.size === 0) return identityFold(this.#currentDoc.lines);
     if (
-      this.foldPlanCache?.doc !== this.currentDoc ||
-      this.foldPlanCache.version !== this.foldVersion
+      this.#foldPlanCache?.doc !== this.#currentDoc ||
+      this.#foldPlanCache.version !== this.#foldVersion
     ) {
-      this.foldPlanCache = {
-        doc: this.currentDoc,
-        version: this.foldVersion,
+      this.#foldPlanCache = {
+        doc: this.#currentDoc,
+        version: this.#foldVersion,
         plan: buildFoldPlan(
-          this.currentDoc.lines,
-          this.foldFiles(),
-          this.collapsed,
+          this.#currentDoc.lines,
+          this.#foldFiles(),
+          this.#collapsed,
         ),
       };
     }
-    return this.foldPlanCache.plan;
+    return this.#foldPlanCache.plan;
   }
 
   /** The document as rendered: full lines, with each collapsed file replaced by
    * its one-line summary. The renderer and cursor placement use this. */
   displayDoc(): Document {
-    if (this.collapsed.size === 0) return this.currentDoc;
-    return { ...this.currentDoc, lines: this.foldPlan().displayLines };
+    if (this.#collapsed.size === 0) return this.#currentDoc;
+    return { ...this.#currentDoc, lines: this.#foldPlan().displayLines };
   }
 
   /** The screen-row layout while wrapping is on. */
-  private wrapPlan(): WrapPlan {
-    const lines = this.foldPlan().displayLines;
-    const width = this.contentWidth();
+  #wrapPlan(): WrapPlan {
+    const lines = this.#foldPlan().displayLines;
+    const width = this.#contentWidth();
     if (
-      this.wrapPlanCache?.lines !== lines ||
-      this.wrapPlanCache.mode !== this.displayMode ||
-      this.wrapPlanCache.wrapMode !== this.activeWrapMode ||
-      this.wrapPlanCache.width !== width ||
-      this.wrapPlanCache.decorations !== this.wrapDecorationKey
+      this.#wrapPlanCache?.lines !== lines ||
+      this.#wrapPlanCache.mode !== this.#displayMode ||
+      this.#wrapPlanCache.wrapMode !== this.#activeWrapMode ||
+      this.#wrapPlanCache.width !== width ||
+      this.#wrapPlanCache.decorations !== this.#wrapDecorationKey
     ) {
-      this.wrapPlanCache = {
+      this.#wrapPlanCache = {
         lines,
-        mode: this.displayMode,
-        wrapMode: this.activeWrapMode,
+        mode: this.#displayMode,
+        wrapMode: this.#activeWrapMode,
         width,
-        decorations: this.wrapDecorationKey,
+        decorations: this.#wrapDecorationKey,
         plan: buildWrapPlan(
           lines,
-          this.displayMode,
+          this.#displayMode,
           width,
-          this.wrapDecorations,
-          this.activeWrapMode,
+          this.#wrapDecorations,
+          this.#activeWrapMode,
         ),
       };
     }
-    return this.wrapPlanCache.plan;
+    return this.#wrapPlanCache.plan;
   }
 
   /** Wrapped text layout without transient right-edge annotations. */
-  private baseWrapPlan(): WrapPlan {
-    const lines = this.foldPlan().displayLines;
-    const width = this.contentWidth();
+  #baseWrapPlan(): WrapPlan {
+    const lines = this.#foldPlan().displayLines;
+    const width = this.#contentWidth();
     if (
-      this.baseWrapPlanCache?.lines !== lines ||
-      this.baseWrapPlanCache.mode !== this.displayMode ||
-      this.baseWrapPlanCache.wrapMode !== this.activeWrapMode ||
-      this.baseWrapPlanCache.width !== width
+      this.#baseWrapPlanCache?.lines !== lines ||
+      this.#baseWrapPlanCache.mode !== this.#displayMode ||
+      this.#baseWrapPlanCache.wrapMode !== this.#activeWrapMode ||
+      this.#baseWrapPlanCache.width !== width
     ) {
-      this.baseWrapPlanCache = {
+      this.#baseWrapPlanCache = {
         lines,
-        mode: this.displayMode,
-        wrapMode: this.activeWrapMode,
+        mode: this.#displayMode,
+        wrapMode: this.#activeWrapMode,
         width,
         plan: buildWrapPlan(
           lines,
-          this.displayMode,
+          this.#displayMode,
           width,
           new Map(),
-          this.activeWrapMode,
+          this.#activeWrapMode,
         ),
       };
     }
-    return this.baseWrapPlanCache.plan;
+    return this.#baseWrapPlanCache.plan;
   }
 
   /** Number of screen rows after file folding and optional line wrapping. */
-  private displayCount(): number {
-    return this.wrapLines
-      ? this.wrapPlan().rowCount
-      : this.foldPlan().displayLines.length;
+  #displayCount(): number {
+    return this.#wrapLines
+      ? this.#wrapPlan().rowCount
+      : this.#foldPlan().displayLines.length;
   }
 
   /** A frame part way through the last reveal: the finished document with only
@@ -622,7 +626,7 @@ export class Session {
    * key revealed nothing. */
   revealFrame(shown: number): { doc: Document; view: ViewState } | null {
     const rev = this.pendingReveal;
-    if (!rev || this.wrapLines) return null;
+    if (!rev || this.#wrapLines) return null;
     const waiting = rev.count - clamp(shown, 0, rev.count);
     // The lines still to come are the ones furthest from the hunk, so what is on
     // screen is always a run of the file that meets the hunk's edge rather than
@@ -701,45 +705,45 @@ export class Session {
   }
 
   /** A document line to its logical row after collapsed files are replaced. */
-  private toFolded(docLine: number): number {
-    return this.foldPlan().docToDisplay(docLine);
+  #toFolded(docLine: number): number {
+    return this.#foldPlan().docToDisplay(docLine);
   }
 
   /** A document position to its screen row. A hidden line maps to its file's
    * summary, and a wrapped line maps to the segment containing `displayCol`. */
-  private toDisplay(docLine: number, displayCol = 0): number {
-    return this.toDisplayWithPlan(
+  #toDisplay(docLine: number, displayCol = 0): number {
+    return this.#toDisplayWithPlan(
       docLine,
       displayCol,
-      this.wrapLines ? this.wrapPlan() : null,
+      this.#wrapLines ? this.#wrapPlan() : null,
     );
   }
 
   /** Map a document position through a specific wrapped layout. */
-  private toDisplayWithPlan(
+  #toDisplayWithPlan(
     docLine: number,
     displayCol: number,
     plan: WrapPlan | null,
   ): number {
-    const fold = this.foldPlan();
+    const fold = this.#foldPlan();
     const folded = fold.docToDisplay(docLine);
-    const col = fold.displayLines[folded] === this.currentDoc.lines[docLine]
+    const col = fold.displayLines[folded] === this.#currentDoc.lines[docLine]
       ? displayCol
       : 0;
-    return this.foldedPositionToDisplayWithPlan(folded, col, plan);
+    return this.#foldedPositionToDisplayWithPlan(folded, col, plan);
   }
 
   /** A folded logical line and display column to its screen row. */
-  private foldedPositionToDisplay(folded: number, displayCol = 0): number {
-    return this.foldedPositionToDisplayWithPlan(
+  #foldedPositionToDisplay(folded: number, displayCol = 0): number {
+    return this.#foldedPositionToDisplayWithPlan(
       folded,
       displayCol,
-      this.wrapLines ? this.wrapPlan() : null,
+      this.#wrapLines ? this.#wrapPlan() : null,
     );
   }
 
   /** Map a folded position through a specific wrapped layout. */
-  private foldedPositionToDisplayWithPlan(
+  #foldedPositionToDisplayWithPlan(
     folded: number,
     displayCol: number,
     plan: WrapPlan | null,
@@ -750,62 +754,62 @@ export class Session {
   }
 
   /** The last screen row occupied by a document line. */
-  private toDisplayEnd(docLine: number): number {
-    return this.toDisplayEndWithPlan(
+  #toDisplayEnd(docLine: number): number {
+    return this.#toDisplayEndWithPlan(
       docLine,
-      this.wrapLines ? this.wrapPlan() : null,
+      this.#wrapLines ? this.#wrapPlan() : null,
     );
   }
 
   /** Last screen row for a document line in a specific wrapped layout. */
-  private toDisplayEndWithPlan(
+  #toDisplayEndWithPlan(
     docLine: number,
     plan: WrapPlan | null,
   ): number {
-    const folded = this.toFolded(docLine);
+    const folded = this.#toFolded(docLine);
     return plan ? plan.lastRow[folded] ?? 0 : folded;
   }
 
   /** A screen row to the document line it stands for. */
-  private toDoc(displayRow: number): number {
+  #toDoc(displayRow: number): number {
     let folded = displayRow;
-    if (this.wrapLines) {
-      const plan = this.wrapPlan();
+    if (this.#wrapLines) {
+      const plan = this.#wrapPlan();
       const row = wrappedRowAt(
         plan,
         clamp(displayRow, 0, Math.max(0, plan.rowCount - 1)),
       );
       folded = row?.line ?? 0;
     }
-    return this.foldPlan().displayToDoc(folded);
+    return this.#foldPlan().displayToDoc(folded);
   }
 
   /** The selected node with its line range mapped into display rows (a node in a
    * collapsed file collapses onto that file's summary row). */
-  private displaySelected(): StructureNode | null {
-    const selected = this.selectedNode();
+  #displaySelected(): StructureNode | null {
+    const selected = this.#selectedNode();
     if (!selected) return null;
-    const node = this.viewMode === "rendered"
+    const node = this.#viewMode === "rendered"
       ? {
         ...selected,
-        startCol: this.renderedLineChangesColumns(selected.startLine)
+        startCol: this.#renderedLineChangesColumns(selected.startLine)
           ? 0
           : selected.startCol,
-        endCol: this.renderedLineChangesColumns(selected.endLine)
+        endCol: this.#renderedLineChangesColumns(selected.endLine)
           ? codePointLength(
-            this.currentDoc.lines[selected.endLine]?.text ?? "",
+            this.#currentDoc.lines[selected.endLine]?.text ?? "",
           )
           : selected.endCol,
       }
       : selected;
-    if (this.collapsed.size === 0) return node;
-    const fold = this.foldPlan();
+    if (this.#collapsed.size === 0) return node;
+    const fold = this.#foldPlan();
     const startLine = fold.docToDisplay(node.startLine);
     const endLine = fold.docToDisplay(node.endLine);
     const startSynthetic = fold.displayLines[startLine] !==
-      this.currentDoc.lines[node.startLine];
+      this.#currentDoc.lines[node.startLine];
     const endSynthetic = fold.displayLines[endLine] !==
-      this.currentDoc.lines[node.endLine];
+      this.#currentDoc.lines[node.endLine];
     return {
       ...node,
       startLine,
@@ -818,12 +822,12 @@ export class Session {
   }
 
   /** The search matches with their line mapped into display rows. */
-  private displayMatches(): Match[] {
-    if (this.collapsed.size === 0) return this.matches;
-    const fold = this.foldPlan();
-    return this.matches.map((match) => {
+  #displayMatches(): Match[] {
+    if (this.#collapsed.size === 0) return this.#matches;
+    const fold = this.#foldPlan();
+    return this.#matches.map((match) => {
       const line = fold.docToDisplay(match.line);
-      if (fold.displayLines[line] === this.currentDoc.lines[match.line]) {
+      if (fold.displayLines[line] === this.#currentDoc.lines[match.line]) {
         return { ...match, line };
       }
       return {
@@ -838,10 +842,10 @@ export class Session {
   /** The file currently in view: the diff file or transformed-output section
    * under the viewport (or the cursor, when editing), else the single file the
    * view is of, else null (a bare pipe). */
-  private currentFile(): string | null {
-    const line = this.cursorOn && this.buffer
+  #currentFile(): string | null {
+    const line = this.#cursorOn && this.buffer
       ? this.buffer.row
-      : this.toDoc(this.top);
+      : this.#toDoc(this.top);
     // The innermost file/section node whose range holds the line (diff file
     // nodes and `// transformed:` blocks are both `section` kind).
     let section: StructureNode | null = null;
@@ -851,26 +855,26 @@ export class Session {
       }
     }
     if (section) return section.name ?? section.label.replace(/^[▸▾]\s*/, "");
-    return this.source?.label ?? null;
+    return this.#source?.label ?? null;
   }
 
-  private get maxLineLen(): number {
+  get #maxLineLen(): number {
     let m = 0;
-    for (const l of this.currentDoc.lines) m = Math.max(m, l.text.length);
+    for (const l of this.#currentDoc.lines) m = Math.max(m, l.text.length);
     return m;
   }
 
   /** The folded line and display column at the viewport's top-left content. */
-  private viewportAnchor(): ViewportAnchor {
-    const fold = this.foldPlan();
+  #viewportAnchor(): ViewportAnchor {
+    const fold = this.#foldPlan();
     let foldedLine = clamp(
       this.top,
       0,
       Math.max(0, fold.displayLines.length - 1),
     );
     let displayCol = this.left;
-    if (this.wrapLines) {
-      const plan = this.wrapPlan();
+    if (this.#wrapLines) {
+      const plan = this.#wrapPlan();
       const row = wrappedRowAt(
         plan,
         clamp(this.top, 0, Math.max(0, plan.rowCount - 1)),
@@ -886,60 +890,62 @@ export class Session {
   }
 
   /** Restore an anchor after the width or display layout changes. */
-  private restoreWrappedAnchor(anchor: ViewportAnchor): void {
-    const plan = this.wrapPlan();
+  #restoreWrappedAnchor(anchor: ViewportAnchor): void {
+    const plan = this.#wrapPlan();
     const line = clamp(
       anchor.foldedLine,
       0,
       Math.max(0, plan.firstRow.length - 1),
     );
     this.top = wrappedRowForPosition(plan, line, anchor.displayCol)?.row ?? 0;
-    this.clampScroll();
+    this.#clampScroll();
   }
 
   /** Source column at an anchor under the current non-printable display mode. */
-  private anchorSourceCol(anchor: ViewportAnchor): number {
-    const line = this.foldPlan().displayLines[anchor.foldedLine];
-    return line ? sourceColumnOf(line, this.displayMode, anchor.displayCol) : 0;
+  #anchorSourceCol(anchor: ViewportAnchor): number {
+    const line = this.#foldPlan().displayLines[anchor.foldedLine];
+    return line
+      ? sourceColumnOf(line, this.#displayMode, anchor.displayCol)
+      : 0;
   }
 
   resize(width: number, height: number): void {
-    const anchor = this.wrapLines ? this.viewportAnchor() : null;
+    const anchor = this.#wrapLines ? this.#viewportAnchor() : null;
     this.width = width;
     this.height = height;
-    if (anchor) this.restoreWrappedAnchor(anchor);
-    else this.clampScroll();
+    if (anchor) this.#restoreWrappedAnchor(anchor);
+    else this.#clampScroll();
   }
 
   view(): ViewState {
-    const o = this.overlay;
-    const expand = this.mode === "normal" && !this.overlay &&
-        !this.cursorOn && this.chord === null && this.source?.expandContext
-      ? this.expandOffer()
+    const o = this.#overlay;
+    const expand = this.#mode === "normal" && !this.#overlay &&
+        !this.#cursorOn && this.#chord === null && this.#source?.expandContext
+      ? this.#expandOffer()
       : null;
     const offeredExpand = expand && !("blocked" in expand) ? expand : null;
-    const diffMargin = this.hasDiffMargin();
+    const diffMargin = this.#hasDiffMargin();
     let diffAnnotations = diffMargin
       ? this.displayDiffAnnotations(offeredExpand)
       : [];
-    diffAnnotations = this.syncWrapDecorations(diffAnnotations);
-    if (!this.wrapLines) {
-      this.left = clamp(this.left, 0, this.maxLeft(diffAnnotations));
+    diffAnnotations = this.#syncWrapDecorations(diffAnnotations);
+    if (!this.#wrapLines) {
+      this.left = clamp(this.left, 0, this.#maxLeft(diffAnnotations));
     }
     const expandRow = offeredExpand?.markerLine === null ||
         offeredExpand?.markerLine === undefined
       ? null
-      : this.toDisplay(offeredExpand.markerLine);
-    const ov: OverlayState | null = this.mode === "filePicker"
-      ? this.pickerOverlay()
-      : this.mode === "jumpList"
-      ? this.jumpOverlay()
+      : this.#toDisplay(offeredExpand.markerLine);
+    const ov: OverlayState | null = this.#mode === "filePicker"
+      ? this.#pickerOverlay()
+      : this.#mode === "jumpList"
+      ? this.#jumpOverlay()
       : o
       ? {
         title: o.title,
-        lines: this.activeOverlayLines(o),
-        scroll: this.overlayScroll,
-        footer: this.overlayFooter(o),
+        lines: this.#activeOverlayLines(o),
+        scroll: this.#overlayScroll,
+        footer: this.#overlayFooter(o),
         selectedLine: o.mode === "info" && o.cardSel >= 0
           ? o.targets[o.cardSel]?.cardLine
           : undefined,
@@ -954,78 +960,80 @@ export class Session {
       left: this.left,
       width: this.width,
       height: this.height,
-      color: this.color,
-      isDiff: this.source?.isDiff === true,
-      showLineNumbers: this.lineNumberMode !== "off",
-      wrapMode: this.wrapMode,
-      wrapPlan: this.wrapLines ? this.wrapPlan() : null,
-      lineNumbers: this.lineNumberMode === "off" ? null : this.gutterNumbers(),
-      displayMode: this.displayMode,
-      selected: this.displaySelected(),
-      matches: this.query.length > 0 ? this.displayMatches() : null,
-      currentMatch: this.currentMatch,
-      message: this.message,
-      inputLine: this.mode === "search"
-        ? `/${this.input}`
-        : this.mode === "deflookup"
-        ? `definition: ${this.input}`
-        : this.mode === "filePicker"
-        ? `find file: ${this.files?.join(this.pickerDir, this.pickerFilter)}`
-        : this.mode === "jumpList"
-        ? `jump to: ${this.jumpFilter}`
+      color: this.#color,
+      isDiff: this.#source?.isDiff === true,
+      showLineNumbers: this.#lineNumberMode !== "off",
+      wrapMode: this.#wrapMode,
+      wrapPlan: this.#wrapLines ? this.#wrapPlan() : null,
+      lineNumbers: this.#lineNumberMode === "off"
+        ? null
+        : this.#gutterNumbers(),
+      displayMode: this.#displayMode,
+      selected: this.#displaySelected(),
+      matches: this.#query.length > 0 ? this.#displayMatches() : null,
+      currentMatch: this.#currentMatch,
+      message: this.#message,
+      inputLine: this.#mode === "search"
+        ? `/${this.#input}`
+        : this.#mode === "deflookup"
+        ? `definition: ${this.#input}`
+        : this.#mode === "filePicker"
+        ? `find file: ${this.#files?.join(this.#pickerDir, this.#pickerFilter)}`
+        : this.#mode === "jumpList"
+        ? `jump to: ${this.#jumpFilter}`
         : null,
-      dialog: this.promptDialog(),
+      dialog: this.#promptDialog(),
       overlay: ov,
-      cursor: this.cursorOn && this.buffer
-        ? { line: this.toFolded(this.buffer.row), col: this.buffer.col }
+      cursor: this.#cursorOn && this.buffer
+        ? { line: this.#toFolded(this.buffer.row), col: this.buffer.col }
         : null,
-      editHint: this.cursorOn ? this.editHint() : null,
+      editHint: this.#cursorOn ? this.#editHint() : null,
       canExpand: offeredExpand !== null,
       expandMargin: diffMargin,
       diffAnnotations,
-      diffTotals: this.activeDiffTotals(),
+      diffTotals: this.#activeDiffTotals(),
       expandRow,
       expandUp: offeredExpand?.up ?? null,
       diffMetadataRows: diffMargin
         ? this.displayAdjacentDiffMetadataRows(offeredExpand)
         : [],
-      canEdit: !this.cursorOn && !!this.source?.editable,
-      canRender: !!this.source?.render &&
-        this.source.renderLineTopology !== "independent",
-      viewMode: this.viewMode,
-      hasNonPrintables: this.hasNonPrintables(),
+      canEdit: !this.#cursorOn && !!this.#source?.editable,
+      canRender: !!this.#source?.render &&
+        this.#source.renderLineTopology !== "independent",
+      viewMode: this.#viewMode,
+      hasNonPrintables: this.#hasNonPrintables(),
       notice: null,
-      currentFile: this.currentFile(),
+      currentFile: this.#currentFile(),
     };
   }
 
   /** The edit-mode key hints for the status line. */
-  private editHint(): KeyHint[] {
+  #editHint(): KeyHint[] {
     const hints: KeyHint[] = [
       { key: "Esc", label: "Done" },
       { key: "^S", label: "Search" },
       { key: "^R", label: "Revert" },
     ];
-    if (this.canResurrectRemovedLine()) {
+    if (this.#canResurrectRemovedLine()) {
       hints.splice(1, 0, { key: "R", label: "Resurrect" });
     }
-    if (this.source?.policy) hints.push({ key: "^L", label: "Expand" });
+    if (this.#source?.policy) hints.push({ key: "^L", label: "Expand" });
     hints.push({ key: "^X^S", label: "Save" }, { key: "^X^F", label: "Open" });
     return hints;
   }
 
   /** The modal dialog for whichever confirmation prompt is open, or null when no
    * prompt is up. Rebuilt each frame from the current buffer and source. */
-  private promptDialog(): DialogState | null {
+  #promptDialog(): DialogState | null {
     let dialog: DialogState | null = null;
-    if (this.mode === "savePrompt") dialog = this.saveDialog();
-    else if (this.mode === "amendPrompt") dialog = this.amendDialog();
-    else if (this.mode === "revertPrompt") dialog = this.revertDialog();
+    if (this.#mode === "savePrompt") dialog = this.#saveDialog();
+    else if (this.#mode === "amendPrompt") dialog = this.#amendDialog();
+    else if (this.#mode === "revertPrompt") dialog = this.#revertDialog();
     if (!dialog) return null;
     // -1 means no button is focused (a prompt with no default, before Tab).
-    const focus = this.dialogFocus < 0
+    const focus = this.#dialogFocus < 0
       ? -1
-      : clamp(this.dialogFocus, 0, Math.max(0, dialog.buttons.length - 1));
+      : clamp(this.#dialogFocus, 0, Math.max(0, dialog.buttons.length - 1));
     return { ...dialog, focus };
   }
 
@@ -1033,18 +1041,18 @@ export class Session {
    * prompt opens. A prompt with no default button (the diff revert) starts with
    * no focus — an index of -1 — so Space and Enter do nothing until Tab picks a
    * button, keeping a stray Enter from reverting. */
-  private focusDefaultButton(): void {
-    const buttons = this.promptDialog()?.buttons ?? [];
-    this.dialogFocus = buttons.findIndex((b) => b.kind === "default");
+  #focusDefaultButton(): void {
+    const buttons = this.#promptDialog()?.buttons ?? [];
+    this.#dialogFocus = buttons.findIndex((b) => b.kind === "default");
   }
 
   /** The save-changes confirmation: names what a save writes, lists the files
    * when there is more than one, and offers save / discard / cancel. */
-  private saveDialog(): DialogState {
-    const files = this.editedFiles;
+  #saveDialog(): DialogState {
+    const files = this.#editedFiles;
     const n = files.length;
-    const amend = this.source && this.buffer
-      ? this.source.pendingAmend?.(this.buffer.baseline(), this.buffer.text())
+    const amend = this.#source && this.buffer
+      ? this.#source.pendingAmend?.(this.buffer.baseline(), this.buffer.text())
       : null;
     const what = n === 0
       ? (amend ? "the commit message" : "your edits")
@@ -1070,9 +1078,9 @@ export class Session {
   }
 
   /** The amend-commit confirmation, naming the commit and its subject. */
-  private amendDialog(): DialogState {
-    const amend = this.source && this.buffer
-      ? this.source.pendingAmend?.(this.buffer.baseline(), this.buffer.text())
+  #amendDialog(): DialogState {
+    const amend = this.#source && this.buffer
+      ? this.#source.pendingAmend?.(this.buffer.baseline(), this.buffer.text())
       : null;
     const sha = amend?.sha.slice(0, 9) ?? "";
     const full = amend?.subject ?? "";
@@ -1091,8 +1099,8 @@ export class Session {
   /** The revert confirmation. A diff offers only the scopes that apply where the
    * cursor sits — the hunk and/or file it is in, or the commit message — plus
    * all; a plain file reverts wholesale. */
-  private revertDialog(): DialogState {
-    if (!this.source?.policy) {
+  #revertDialog(): DialogState {
+    if (!this.#source?.policy) {
       return {
         title: "Revert",
         body: ["Revert all edits?"],
@@ -1102,7 +1110,7 @@ export class Session {
         ],
       };
     }
-    const s = this.revertScopesAt();
+    const s = this.#revertScopesAt();
     const buttons: DialogButton[] = [];
     if (s.chunk) buttons.push({ label: "Hunk", hotkey: "h" });
     if (s.file) buttons.push({ label: "File", hotkey: "f" });
@@ -1121,60 +1129,60 @@ export class Session {
     this.pendingPush = null;
     this.expireMessage();
     if (
-      this.mode === "savePrompt" || this.mode === "amendPrompt" ||
-      this.mode === "revertPrompt"
+      this.#mode === "savePrompt" || this.#mode === "amendPrompt" ||
+      this.#mode === "revertPrompt"
     ) {
-      this.handleDialogKey(key, beforeButtonAction);
+      this.#handleDialogKey(key, beforeButtonAction);
       return;
     }
-    if (this.mode === "filePicker") {
-      this.handleFilePicker(key);
+    if (this.#mode === "filePicker") {
+      this.#handleFilePicker(key);
       return;
     }
-    if (this.mode === "jumpList") {
-      this.handleJumpList(key);
+    if (this.#mode === "jumpList") {
+      this.#handleJumpList(key);
       return;
     }
-    if (this.mode === "search" || this.mode === "deflookup") {
-      this.handleInputKey(key);
+    if (this.#mode === "search" || this.#mode === "deflookup") {
+      this.#handleInputKey(key);
       return;
     }
-    if (this.chord === "ctrl-x") {
-      this.handleChord(key);
+    if (this.#chord === "ctrl-x") {
+      this.#handleChord(key);
       return;
     }
-    if (this.overlay) {
+    if (this.#overlay) {
       this.handleOverlayKey(key);
       return;
     }
-    this.handleNormalKey(key);
+    this.#handleNormalKey(key);
   }
 
   //
   // internals
   //
 
-  private contentRows(): number {
+  #contentRows(): number {
     return Math.max(1, this.height - 1);
   }
 
-  private clampScroll(): void {
-    this.top = clamp(this.top, 0, this.lastTop());
-    this.left = this.wrapLines ? 0 : clamp(this.left, 0, this.maxLeft());
+  #clampScroll(): void {
+    this.top = clamp(this.top, 0, this.#lastTop());
+    this.left = this.#wrapLines ? 0 : clamp(this.left, 0, this.#maxLeft());
   }
 
   /** Furthest vertical position for the current pager or editor mode. */
-  private lastTop(): number {
-    return this.cursorOn
+  #lastTop(): number {
+    return this.#cursorOn
       ? maxTop(this.doc.lines.length, this.height)
-      : this.pagerLastTop(this.displayCount());
+      : this.#pagerLastTop(this.#displayCount());
   }
 
   /** Furthest vertical position for a pager layout with `rowCount` rows. */
-  private pagerLastTop(rowCount: number): number {
-    const isDiff = this.source?.isDiff === true;
+  #pagerLastTop(rowCount: number): number {
+    const isDiff = this.#source?.isDiff === true;
     const hasTrailingEmptyLine = isDiff &&
-      this.foldPlan().displayLines.at(-1)?.text.length === 0;
+      this.#foldPlan().displayLines.at(-1)?.text.length === 0;
     return isDiff
       ? maxPagerTop(
         diffContentRowCount(rowCount, hasTrailingEmptyLine),
@@ -1183,112 +1191,117 @@ export class Session {
       : maxTop(rowCount, this.height);
   }
 
-  private selectedNode(): StructureNode | null {
-    return this.selectedIndex !== null
-      ? this.doc.flatStructure[this.selectedIndex] ?? null
+  #selectedNode(): StructureNode | null {
+    return this.#selectedIndex !== null
+      ? this.doc.flatStructure[this.#selectedIndex] ?? null
       : null;
   }
 
-  private renderedLineChangesColumns(line: number): boolean {
-    return this.viewMode === "rendered" &&
-      this.sourceDoc.lines[line]?.text !== this.currentDoc.lines[line]?.text;
+  #renderedLineChangesColumns(line: number): boolean {
+    return this.#viewMode === "rendered" &&
+      this.#sourceDoc.lines[line]?.text !== this.#currentDoc.lines[line]?.text;
   }
 
   /** Screen row containing the first character of a structure node. */
-  private nodeStartRow(node: StructureNode): number {
-    return this.nodeStartRowWithPlan(
+  #nodeStartRow(node: StructureNode): number {
+    return this.#nodeStartRowWithPlan(
       node,
-      this.wrapLines ? this.wrapPlan() : null,
+      this.#wrapLines ? this.#wrapPlan() : null,
     );
   }
 
   /** First row of a structure node in a specific wrapped layout. */
-  private nodeStartRowWithPlan(
+  #nodeStartRowWithPlan(
     node: StructureNode,
     plan: WrapPlan | null,
   ): number {
-    const col = this.renderedLineChangesColumns(node.startLine)
+    const col = this.#renderedLineChangesColumns(node.startLine)
       ? 0
       : node.startCol;
-    return this.toDisplayWithPlan(
+    return this.#toDisplayWithPlan(
       node.startLine,
-      this.displayCol(node.startLine, col),
+      this.#displayCol(node.startLine, col),
       plan,
     );
   }
 
   /** Screen row containing the last character of a structure node. */
-  private nodeEndRow(node: StructureNode): number {
-    return this.nodeEndRowWithPlan(
+  #nodeEndRow(node: StructureNode): number {
+    return this.#nodeEndRowWithPlan(
       node,
-      this.wrapLines ? this.wrapPlan() : null,
+      this.#wrapLines ? this.#wrapPlan() : null,
     );
   }
 
   /** Last row of a structure node in a specific wrapped layout. */
-  private nodeEndRowWithPlan(
+  #nodeEndRowWithPlan(
     node: StructureNode,
     plan: WrapPlan | null,
   ): number {
-    const fold = this.foldPlan();
+    const fold = this.#foldPlan();
     const folded = fold.docToDisplay(node.endLine);
-    if (fold.displayLines[folded] !== this.currentDoc.lines[node.endLine]) {
+    if (fold.displayLines[folded] !== this.#currentDoc.lines[node.endLine]) {
       return plan ? plan.lastRow[folded] ?? 0 : folded;
     }
-    const endCol = this.renderedLineChangesColumns(node.endLine)
-      ? codePointLength(this.currentDoc.lines[node.endLine]?.text ?? "")
+    const endCol = this.#renderedLineChangesColumns(node.endLine)
+      ? codePointLength(this.#currentDoc.lines[node.endLine]?.text ?? "")
       : node.endCol;
-    return this.toDisplayWithPlan(
+    return this.#toDisplayWithPlan(
       node.endLine,
-      this.displayCol(node.endLine, Math.max(0, endCol - 1)),
+      this.#displayCol(node.endLine, Math.max(0, endCol - 1)),
       plan,
     );
   }
 
   private selectNode(idx: number): void {
     if (idx < 0 || idx >= this.doc.flatStructure.length) return;
-    const viewport = this.wrapLines ? this.viewportAnchor() : null;
-    this.selectedIndex = idx;
+    const viewport = this.#wrapLines ? this.#viewportAnchor() : null;
+    this.#selectedIndex = idx;
     const node = this.doc.flatStructure[idx];
-    if (viewport) this.restoreWrappedAnchor(viewport);
+    if (viewport) this.#restoreWrappedAnchor(viewport);
     // Keep the viewport stable: only scroll if the selection's anchor (its first
     // line, where the block opens) would otherwise be off screen. Horizontal
     // scroll is left untouched for the same reason. Anchors are in display rows,
     // since a collapsed file's lines share its summary row.
     this.top = clamp(
       scrollToAnchor(
-        this.nodeStartRow(node),
+        this.#nodeStartRow(node),
         this.top,
         this.height,
-        this.displayCount(),
+        this.#displayCount(),
       ),
       0,
-      this.lastTop(),
+      this.#lastTop(),
     );
-    this.message = "";
+    this.#message = "";
   }
 
   /** Remember the current overlay so a later Esc returns to it, before a link
    * opens a new one over the top. */
-  private pushOverlay(): void {
-    if (this.overlay) {
-      this.overlayStack.push({
-        overlay: this.overlay,
-        scroll: this.overlayScroll,
+  #pushOverlay(): void {
+    if (this.#overlay) {
+      this.#overlayStack.push({
+        overlay: this.#overlay,
+        scroll: this.#overlayScroll,
       });
     }
   }
 
   /** Close the overlay and discard the whole navigation stack. */
-  private closeOverlay(): void {
-    this.overlay = null;
-    this.overlayScroll = 0;
-    this.overlayStack = [];
+  #closeOverlay(): void {
+    this.#overlay = null;
+    this.#overlayScroll = 0;
+    this.#overlayStack = [];
   }
 
-  private openPeek(node: StructureNode, expanded = false): void {
-    const card = buildPeekCard(this.sourceDoc, node, this.semantics, expanded);
-    this.overlay = {
+  #openPeek(node: StructureNode, expanded = false): void {
+    const card = buildPeekCard(
+      this.#sourceDoc,
+      node,
+      this.#semantics,
+      expanded,
+    );
+    this.#overlay = {
       title: card.title,
       info: card.info,
       source: card.source,
@@ -1297,28 +1310,28 @@ export class Session {
       cardSel: -1,
       node,
     };
-    this.overlayScroll = 0;
+    this.#overlayScroll = 0;
   }
 
   /** Rebuild the open card with every truncated list shown in full, keeping the
    * scroll position so the newly revealed entries appear where "… N more" was. */
-  private expandCard(node: StructureNode): void {
-    const scroll = this.overlayScroll;
-    const card = buildPeekCard(this.sourceDoc, node, this.semantics, true);
-    this.overlay = {
-      ...this.overlay!,
+  #expandCard(node: StructureNode): void {
+    const scroll = this.#overlayScroll;
+    const card = buildPeekCard(this.#sourceDoc, node, this.#semantics, true);
+    this.#overlay = {
+      ...this.#overlay!,
       info: card.info,
       source: card.source,
       targets: card.targets,
       cardSel: -1,
     };
-    this.overlayScroll = scroll;
+    this.#overlayScroll = scroll;
   }
 
-  private lookupDefinition(name: string): void {
+  #lookupDefinition(name: string): void {
     const defs = this.doc.definitions.get(name);
     if (!defs || defs.length === 0) {
-      this.message = `No definition found for "${name}"`;
+      this.#message = `No definition found for "${name}"`;
       return;
     }
     const def = defs[defs.length - 1];
@@ -1327,8 +1340,8 @@ export class Session {
       n.startOffset === def.startOffset && n.endOffset === def.endOffset
     );
     if (node) {
-      const card = buildPeekCard(this.sourceDoc, node, this.semantics);
-      this.overlay = {
+      const card = buildPeekCard(this.#sourceDoc, node, this.#semantics);
+      this.#overlay = {
         title: `definition: ${card.title}`,
         info: card.info,
         source: card.source,
@@ -1338,9 +1351,9 @@ export class Session {
         node,
       };
     } else {
-      this.overlay = {
+      this.#overlay = {
         title: `definition: ${name}  (${def.kind})`,
-        info: this.sourceDoc.lines.slice(def.startLine, def.endLine + 1),
+        info: this.#sourceDoc.lines.slice(def.startLine, def.endLine + 1),
         mode: "info",
         targets: [],
         cardSel: -1,
@@ -1348,16 +1361,16 @@ export class Session {
         infoIsSource: true,
       };
     }
-    this.overlayScroll = 0;
+    this.#overlayScroll = 0;
   }
 
-  private activeOverlayLines(overlay: PeekOverlay): readonly Line[] {
+  #activeOverlayLines(overlay: PeekOverlay): readonly Line[] {
     return overlay.mode === "source" && overlay.source
       ? overlay.source
       : overlay.info;
   }
 
-  private overlayFooter(overlay: PeekOverlay): string {
+  #overlayFooter(overlay: PeekOverlay): string {
     if (overlay.staticFooter) return overlay.staticFooter;
     const parts: string[] = [];
     if (overlay.mode === "info" && overlay.targets.length > 0) {
@@ -1370,46 +1383,46 @@ export class Session {
       parts.push(overlay.mode === "info" ? "tab source" : "tab card");
     }
     // Esc walks back through followed links; only closes at the bottom.
-    if (this.overlayStack.length > 0) parts.push("esc back", "q close");
+    if (this.#overlayStack.length > 0) parts.push("esc back", "q close");
     else parts.push("esc close");
     return parts.join(" · ");
   }
 
   /** Move the card's reference selection and keep it visible. */
   private moveCardSelection(delta: number): void {
-    const o = this.overlay;
+    const o = this.#overlay;
     if (!o || o.mode !== "info" || o.targets.length === 0) return;
     if (delta > 0) {
       o.cardSel = Math.min(o.cardSel + 1, o.targets.length - 1);
     } else {
       if (o.cardSel <= 0) {
         o.cardSel = -1;
-        this.overlayScroll = 0;
+        this.#overlayScroll = 0;
         return;
       }
       o.cardSel -= 1;
     }
     const line = o.targets[o.cardSel].cardLine;
     const innerH = overlayBox(this.width, this.height).innerH;
-    if (line < this.overlayScroll) this.overlayScroll = line;
-    else if (line >= this.overlayScroll + innerH) {
-      this.overlayScroll = line - innerH + 1;
+    if (line < this.#overlayScroll) this.#overlayScroll = line;
+    else if (line >= this.#overlayScroll + innerH) {
+      this.#overlayScroll = line - innerH + 1;
     }
   }
 
   /** Open an external definition file in a read-only overlay, framed at the
    * definition line. */
-  private openExternalFile(target: CardTarget): void {
-    const lines = this.semantics?.fileLines(target.filePath!);
+  #openExternalFile(target: CardTarget): void {
+    const lines = this.#semantics?.fileLines(target.filePath!);
     if (!lines) {
-      this.message = `Cannot open ${target.filePath}`;
+      this.#message = `Cannot open ${target.filePath}`;
       return;
     }
     // Lead the title with the filename and line: the overlay centers and
     // left-truncates titles, so a raw absolute path would keep only its shared
     // workspace prefix and drop the identifying part.
     const name = target.filePath!.split(/[\\/]/).pop() ?? target.filePath!;
-    this.overlay = {
+    this.#overlay = {
       title: `${name}  ·  line ${target.destLine + 1}, column ${
         target.destCol + 1
       }`,
@@ -1419,7 +1432,7 @@ export class Session {
       cardSel: -1,
       infoIsSource: true,
     };
-    this.overlayScroll = clamp(
+    this.#overlayScroll = clamp(
       target.destLine - 2,
       0,
       Math.max(0, lines.length - 1),
@@ -1428,7 +1441,7 @@ export class Session {
 
   /** Index of the node a definition target denotes. Nested nodes can share a
    * start offset (diff views clamp them), so a matching end offset wins. */
-  private findTargetIndex(target: CardTarget): number {
+  #findTargetIndex(target: CardTarget): number {
     if (target.defOffset === undefined) return -1;
     if (target.defEndOffset !== undefined) {
       const exact = this.doc.flatStructure.findIndex((n) =>
@@ -1445,26 +1458,26 @@ export class Session {
   /** Jump the main view to a card target, selecting the relevant node. This
    * leaves the overlay for the main view, so the whole navigation stack goes. */
   private jumpToTarget(target: CardTarget): void {
-    this.overlay = null;
-    this.overlayScroll = 0;
-    this.overlayStack = [];
-    let idx = this.findTargetIndex(target);
+    this.#overlay = null;
+    this.#overlayScroll = 0;
+    this.#overlayStack = [];
+    let idx = this.#findTargetIndex(target);
     if (idx < 0) idx = nodeAtLine(this.doc.flatStructure, target.destLine);
-    this.selectedIndex = idx >= 0 ? idx : null;
+    this.#selectedIndex = idx >= 0 ? idx : null;
     const node = idx >= 0 ? this.doc.flatStructure[idx] : null;
-    const sourceCol = this.renderedLineChangesColumns(target.destLine)
+    const sourceCol = this.#renderedLineChangesColumns(target.destLine)
       ? 0
       : target.destCol;
-    const destCol = this.displayCol(target.destLine, sourceCol);
-    const destRow = this.toDisplay(target.destLine, destCol);
+    const destCol = this.#displayCol(target.destLine, sourceCol);
+    const destRow = this.#toDisplay(target.destLine, destCol);
     // Frame the resolved node and destination together when they fit. Otherwise
     // center the destination row so the referenced text is visible.
     let start = destRow;
     let end = destRow;
     if (node) {
-      start = Math.min(this.nodeStartRow(node), destRow);
-      end = Math.max(this.nodeEndRow(node), destRow);
-      if (end - start + 1 > this.contentRows()) {
+      start = Math.min(this.#nodeStartRow(node), destRow);
+      end = Math.max(this.#nodeEndRow(node), destRow);
+      if (end - start + 1 > this.#contentRows()) {
         start = destRow;
         end = destRow;
       }
@@ -1474,25 +1487,25 @@ export class Session {
         start,
         end,
         this.height,
-        this.displayCount(),
+        this.#displayCount(),
       ),
       0,
-      this.lastTop(),
+      this.#lastTop(),
     );
-    this.revealColumn(target.destLine, destCol);
-    this.message = `→ line ${target.destLine + 1}`;
+    this.#revealColumn(target.destLine, destCol);
+    this.#message = `→ line ${target.destLine + 1}`;
   }
 
   /** The structure node a card target points at, if any. */
-  private resolveTargetNode(target: CardTarget): StructureNode | null {
-    const idx = this.findTargetIndex(target);
+  #resolveTargetNode(target: CardTarget): StructureNode | null {
+    const idx = this.#findTargetIndex(target);
     if (idx >= 0) return this.doc.flatStructure[idx];
     const at = nodeAtLine(this.doc.flatStructure, target.destLine);
     return at >= 0 ? this.doc.flatStructure[at] : null;
   }
 
   /** What `z` reveals: the selected reference, else the card's own subject. */
-  private overlayRevealTarget(overlay: PeekOverlay): CardTarget | null {
+  #overlayRevealTarget(overlay: PeekOverlay): CardTarget | null {
     if (overlay.cardSel >= 0) return overlay.targets[overlay.cardSel] ?? null;
     const node = overlay.node;
     if (!node) return null;
@@ -1505,30 +1518,30 @@ export class Session {
     };
   }
 
-  private runSearch(jumpForward: boolean): void {
-    this.matches = findMatches(this.doc, this.query);
-    if (this.matches.length === 0) {
-      this.currentMatch = 0;
-      this.message = this.query ? `Pattern not found: ${this.query}` : "";
+  #runSearch(jumpForward: boolean): void {
+    this.#matches = findMatches(this.doc, this.#query);
+    if (this.#matches.length === 0) {
+      this.#currentMatch = 0;
+      this.#message = this.#query ? `Pattern not found: ${this.#query}` : "";
       return;
     }
     // The viewport anchor is a display row; match lines are document lines.
-    const anchor = this.toDoc(this.top) - 1;
-    const idx = nextMatchIndex(this.matches, anchor, -1, jumpForward);
-    this.currentMatch = idx < 0 ? 0 : idx;
+    const anchor = this.#toDoc(this.top) - 1;
+    const idx = nextMatchIndex(this.#matches, anchor, -1, jumpForward);
+    this.#currentMatch = idx < 0 ? 0 : idx;
     this.revealMatch();
   }
 
   /** Begin a search from edit mode (Ctrl-S): anchor it at the cursor so the
    * focused match is the next one at or after the cursor, and seed the input
    * with the last query so a bare Ctrl-S then Enter repeats it. */
-  private enterEditSearch(): void {
-    this.searchAnchor = this.buffer
+  #enterEditSearch(): void {
+    this.#searchAnchor = this.buffer
       ? { row: this.buffer.row, col: this.buffer.col }
       : null;
-    this.mode = "search";
-    this.input = this.query;
-    this.refreshSearchMatches();
+    this.#mode = "search";
+    this.#input = this.#query;
+    this.#refreshSearchMatches();
   }
 
   /** Recompute the full match set for the current query and focus one: for an
@@ -1536,16 +1549,16 @@ export class Session {
    * cursor lands somewhere it can type); for a normal search, the first in the
    * document. `this.matches` stays the full set, so leaving the search does not
    * leave normal-mode n/N stepping a filtered subset. */
-  private refreshSearchMatches(): void {
-    this.matches = findMatches(this.doc, this.query);
-    if (this.matches.length === 0) {
-      this.currentMatch = 0;
+  #refreshSearchMatches(): void {
+    this.#matches = findMatches(this.doc, this.#query);
+    if (this.#matches.length === 0) {
+      this.#currentMatch = 0;
       return;
     }
-    const a = this.searchAnchor;
-    this.currentMatch = a
-      ? this.firstEditableMatch(
-        nextMatchIndex(this.matches, a.row, a.col - 1, true),
+    const a = this.#searchAnchor;
+    this.#currentMatch = a
+      ? this.#firstEditableMatch(
+        nextMatchIndex(this.#matches, a.row, a.col - 1, true),
       )
       : 0;
     this.revealMatch();
@@ -1553,84 +1566,84 @@ export class Session {
 
   /** The first editable match at or after index `from` (wrapping), for an
    * edit-mode search; `from` itself when none is editable. */
-  private firstEditableMatch(from: number): number {
+  #firstEditableMatch(from: number): number {
     const start = from < 0 ? 0 : from;
-    for (let n = 0; n < this.matches.length; n++) {
-      const i = (start + n) % this.matches.length;
-      if (this.isEditableLine(this.matches[i].line)) return i;
+    for (let n = 0; n < this.#matches.length; n++) {
+      const i = (start + n) % this.#matches.length;
+      if (this.#isEditableLine(this.#matches[i].line)) return i;
     }
     return start;
   }
 
   /** Whether the cursor may edit `line` under the source's policy (a diff). A
    * file (no policy) is editable everywhere. */
-  private isEditableLine(line: number): boolean {
-    const pol = this.source?.policy;
+  #isEditableLine(line: number): boolean {
+    const pol = this.#source?.policy;
     if (!pol) return true;
     const lines = this.buffer?.lines ?? this.doc.lines.map((l) => l.text);
     return pol.editStart(lines, line) !== null;
   }
 
   /** Land the edit cursor on the focused match (edit-mode search commit). */
-  private placeCursorAtMatch(): void {
-    const m = this.matches[this.currentMatch];
-    if (!m || !this.cursorOn || !this.buffer) return;
+  #placeCursorAtMatch(): void {
+    const m = this.#matches[this.#currentMatch];
+    if (!m || !this.#cursorOn || !this.buffer) return;
     this.buffer.place(m.line, m.start);
     this.ensureCursorVisible();
   }
 
-  private stepMatch(forward: boolean): void {
-    if (this.matches.length === 0) {
-      this.message = "No matches";
+  #stepMatch(forward: boolean): void {
+    if (this.#matches.length === 0) {
+      this.#message = "No matches";
       return;
     }
-    const cur = this.matches[this.currentMatch];
-    let idx = nextMatchIndex(this.matches, cur.line, cur.start, forward);
+    const cur = this.#matches[this.#currentMatch];
+    let idx = nextMatchIndex(this.#matches, cur.line, cur.start, forward);
     // An edit-mode search (Ctrl-S) steps only between editable matches.
-    if (this.searchAnchor) idx = this.firstEditableMatch(idx);
-    this.currentMatch = idx;
+    if (this.#searchAnchor) idx = this.#firstEditableMatch(idx);
+    this.#currentMatch = idx;
     this.revealMatch();
   }
 
   private revealMatch(): void {
-    const m = this.matches[this.currentMatch];
+    const m = this.#matches[this.#currentMatch];
     if (!m) return;
-    const col = this.displayCol(m.line, m.start);
-    const row = this.toDisplay(m.line, col);
-    if (row < this.top || row >= this.top + this.contentRows()) {
+    const col = this.#displayCol(m.line, m.start);
+    const row = this.#toDisplay(m.line, col);
+    if (row < this.top || row >= this.top + this.#contentRows()) {
       this.top = clamp(
-        row - Math.floor(this.contentRows() / 2),
+        row - Math.floor(this.#contentRows() / 2),
         0,
-        this.lastTop(),
+        this.#lastTop(),
       );
     }
-    this.revealColumn(m.line, col);
-    this.message = "";
+    this.#revealColumn(m.line, col);
+    this.#message = "";
   }
 
   /** The display column a source column maps to on `line` under the current
    * mode — what horizontal scrolling counts in, since a compacting mode draws
    * fewer columns than the line has source code points. */
-  private displayCol(line: number, sourceCol: number): number {
+  #displayCol(line: number, sourceCol: number): number {
     const l = this.doc.lines[line];
-    if (!l || this.displayMode === "pictures") return sourceCol;
+    if (!l || this.#displayMode === "pictures") return sourceCol;
     if (
-      this.displayColumnCache?.doc !== this.currentDoc ||
-      this.displayColumnCache.mode !== this.displayMode
+      this.#displayColumnCache?.doc !== this.#currentDoc ||
+      this.#displayColumnCache.mode !== this.#displayMode
     ) {
-      this.displayColumnCache = {
-        doc: this.currentDoc,
-        mode: this.displayMode,
+      this.#displayColumnCache = {
+        doc: this.#currentDoc,
+        mode: this.#displayMode,
         columns: new Map(),
       };
     }
-    let columns = this.displayColumnCache.columns.get(line);
+    let columns = this.#displayColumnCache.columns.get(line);
     if (!columns) {
       columns = Uint32Array.from(
-        displayLine(l, this.displayMode),
+        displayLine(l, this.#displayMode),
         (cell) => cell.col,
       );
-      this.displayColumnCache.columns.set(line, columns);
+      this.#displayColumnCache.columns.set(line, columns);
     }
     let lo = 0;
     let hi = columns.length;
@@ -1642,56 +1655,56 @@ export class Session {
     return lo;
   }
 
-  private handleInputKey(key: Key): void {
+  #handleInputKey(key: Key): void {
     if (key.name === "escape") {
-      this.mode = "normal";
-      this.input = "";
-      this.searchAnchor = null;
-      if (this.query.length === 0) this.matches = [];
+      this.#mode = "normal";
+      this.#input = "";
+      this.#searchAnchor = null;
+      if (this.#query.length === 0) this.#matches = [];
       // An edit-mode search scrolled to matches while the cursor stayed put;
       // bring the viewport back so the text cursor is on screen.
-      if (this.cursorOn) this.ensureCursorVisible();
+      if (this.#cursorOn) this.ensureCursorVisible();
       return;
     }
     // Ctrl-S inside a search steps to the next match (Emacs-style repeat).
     if (key.name === "ctrl-s") {
-      if (this.mode === "search") this.stepMatch(true);
+      if (this.#mode === "search") this.#stepMatch(true);
       return;
     }
     if (key.name === "enter") {
-      if (this.mode === "search") {
-        this.query = this.input;
+      if (this.#mode === "search") {
+        this.#query = this.#input;
         // An edit-mode search lands the cursor on the focused match; a
         // normal-mode search jumps the viewport to it.
-        if (this.searchAnchor || this.cursorOn) this.placeCursorAtMatch();
-        else this.runSearch(true);
+        if (this.#searchAnchor || this.#cursorOn) this.#placeCursorAtMatch();
+        else this.#runSearch(true);
       } else {
-        this.lookupDefinition(this.input.trim());
+        this.#lookupDefinition(this.#input.trim());
       }
-      this.mode = "normal";
-      this.input = "";
-      this.searchAnchor = null;
+      this.#mode = "normal";
+      this.#input = "";
+      this.#searchAnchor = null;
       return;
     }
     if (key.name === "backspace") {
-      this.input = this.input.slice(0, -1);
-      if (this.mode === "search") {
-        this.query = this.input;
-        this.refreshSearchMatches();
+      this.#input = this.#input.slice(0, -1);
+      if (this.#mode === "search") {
+        this.#query = this.#input;
+        this.#refreshSearchMatches();
       }
       return;
     }
     if (key.char && key.char >= " ") {
-      this.input += key.char;
-      if (this.mode === "search") {
-        this.query = this.input;
-        this.refreshSearchMatches();
+      this.#input += key.char;
+      if (this.#mode === "search") {
+        this.#query = this.#input;
+        this.#refreshSearchMatches();
       }
     }
   }
 
   private handleOverlayKey(key: Key): void {
-    const overlay = this.overlay;
+    const overlay = this.#overlay;
     if (!overlay) return;
     // Stop scrolling once the last line reaches the bottom of the box, so the
     // final line does not drift up past the frame — the same clamp the main
@@ -1699,31 +1712,31 @@ export class Session {
     const innerH = overlayBox(this.width, this.height).innerH;
     const maxScroll = Math.max(
       0,
-      this.activeOverlayLines(overlay).length - innerH,
+      this.#activeOverlayLines(overlay).length - innerH,
     );
     const hasTargets = overlay.mode === "info" && overlay.targets.length > 0;
     switch (key.name) {
       case "escape":
         // Walk back through the stack of followed links; the last Esc, with an
         // empty stack, closes the overlay.
-        if (this.overlayStack.length > 0) {
-          const prev = this.overlayStack.pop()!;
-          this.overlay = prev.overlay;
-          this.overlayScroll = prev.scroll;
+        if (this.#overlayStack.length > 0) {
+          const prev = this.#overlayStack.pop()!;
+          this.#overlay = prev.overlay;
+          this.#overlayScroll = prev.scroll;
         } else {
-          this.overlay = null;
-          this.overlayScroll = 0;
+          this.#overlay = null;
+          this.#overlayScroll = 0;
         }
         break;
       case "q":
-        this.closeOverlay();
+        this.#closeOverlay();
         break;
       case "Q":
-        this.requestQuit();
+        this.#requestQuit();
         break;
       case "t":
-        this.mode = "deflookup";
-        this.input = overlay.node?.name ?? this.selectedNode()?.name ?? "";
+        this.#mode = "deflookup";
+        this.#input = overlay.node?.name ?? this.#selectedNode()?.name ?? "";
         break;
       case "enter":
         // Follow the selected reference, pushing this card so Esc returns to it:
@@ -1732,19 +1745,19 @@ export class Session {
         if (hasTargets && overlay.cardSel >= 0) {
           const target = overlay.targets[overlay.cardSel];
           if (target.expand) {
-            this.expandCard(overlay.node!);
+            this.#expandCard(overlay.node!);
           } else if (target.filePath) {
-            this.pushOverlay();
-            this.openExternalFile(target);
+            this.#pushOverlay();
+            this.#openExternalFile(target);
           } else {
-            const node = this.resolveTargetNode(target);
+            const node = this.#resolveTargetNode(target);
             if (node) {
-              this.pushOverlay();
-              this.openPeek(node);
-            } else this.message = "Nothing to open for this reference";
+              this.#pushOverlay();
+              this.#openPeek(node);
+            } else this.#message = "Nothing to open for this reference";
           }
         } else {
-          this.closeOverlay();
+          this.#closeOverlay();
         }
         break;
       case "z":
@@ -1752,12 +1765,12 @@ export class Session {
         // Reveal the target: an external file opens in place; an in-blob target
         // closes the card and centers the main view on it. A "… N more" line has
         // no destination to reveal.
-        const reveal = this.overlayRevealTarget(overlay);
+        const reveal = this.#overlayRevealTarget(overlay);
         if (reveal?.expand) break;
         if (reveal?.filePath) {
           // Opening the file over the card: Esc returns to the card.
-          this.pushOverlay();
-          this.openExternalFile(reveal);
+          this.#pushOverlay();
+          this.#openExternalFile(reveal);
         } else if (reveal) {
           this.jumpToTarget(reveal); // exits the card viewer entirely
         }
@@ -1767,94 +1780,94 @@ export class Session {
         if (overlay.source) {
           overlay.mode = overlay.mode === "info" ? "source" : "info";
           overlay.cardSel = -1;
-          this.overlayScroll = 0;
+          this.#overlayScroll = 0;
         }
         break;
       case "down":
       case "j":
       case "J":
         if (hasTargets) this.moveCardSelection(1);
-        else this.overlayScroll = clamp(this.overlayScroll + 1, 0, maxScroll);
+        else this.#overlayScroll = clamp(this.#overlayScroll + 1, 0, maxScroll);
         break;
       case "up":
       case "k":
       case "K":
         if (hasTargets) this.moveCardSelection(-1);
-        else this.overlayScroll = clamp(this.overlayScroll - 1, 0, maxScroll);
+        else this.#overlayScroll = clamp(this.#overlayScroll - 1, 0, maxScroll);
         break;
       case "pagedown":
       case "space":
-        this.overlayScroll = clamp(this.overlayScroll + 10, 0, maxScroll);
+        this.#overlayScroll = clamp(this.#overlayScroll + 10, 0, maxScroll);
         break;
       case "b":
       case "B":
       case "pageup":
-        this.overlayScroll = clamp(this.overlayScroll - 10, 0, maxScroll);
+        this.#overlayScroll = clamp(this.#overlayScroll - 10, 0, maxScroll);
         break;
     }
   }
 
-  private handleNormalKey(key: Key): void {
-    this.message = "";
+  #handleNormalKey(key: Key): void {
+    this.#message = "";
 
     // Editor chords / save, available in both cursor and pager modes.
-    if (key.name === "ctrl-x" && this.source) {
-      this.chord = "ctrl-x";
+    if (key.name === "ctrl-x" && this.#source) {
+      this.#chord = "ctrl-x";
       return;
     }
     if (key.name === "f3") {
-      this.requestSave();
+      this.#requestSave();
       return;
     }
     // Alt+arrows scroll/pan — "do what the cursor keys used to do".
     if (key.alt && isArrowName(key.name)) {
-      this.scrollOrPan(key.name);
+      this.#scrollOrPan(key.name);
       return;
     }
-    if (this.cursorOn) {
-      this.handleEditKey(key);
+    if (this.#cursorOn) {
+      this.#handleEditKey(key);
       return;
     }
     // Cursor off: a bare arrow scrolls or pans the view, like the vi keys.
     if (!key.alt && isArrowName(key.name)) {
-      this.scrollOrPan(key.name);
+      this.#scrollOrPan(key.name);
       return;
     }
 
-    const rows = this.contentRows();
-    const lastTop = this.lastTop();
+    const rows = this.#contentRows();
+    const lastTop = this.#lastTop();
     switch (key.name) {
       case "q":
       case "Q":
       case "ctrl-c":
-        this.requestQuit();
+        this.#requestQuit();
         return;
       case "?":
-        this.overlay = helpOverlay();
-        this.overlayScroll = 0;
+        this.#overlay = helpOverlay();
+        this.#overlayScroll = 0;
         return;
       case "/":
-        this.mode = "search";
-        this.input = "";
-        this.searchAnchor = null;
+        this.#mode = "search";
+        this.#input = "";
+        this.#searchAnchor = null;
         return;
       case "v":
       case "V":
-        this.toggleViewMode();
+        this.#toggleViewMode();
         return;
       case "e":
         // Enter edit mode: reveal the text cursor at the top of the view.
-        this.revealCursor();
+        this.#revealCursor();
         return;
       case "t":
-        this.mode = "deflookup";
-        this.input = this.selectedNode()?.name ?? "";
+        this.#mode = "deflookup";
+        this.#input = this.#selectedNode()?.name ?? "";
         return;
       case "n":
-        this.stepMatch(true);
+        this.#stepMatch(true);
         return;
       case "N":
-        this.stepMatch(false);
+        this.#stepMatch(false);
         return;
       case "j":
       case "J":
@@ -1866,15 +1879,15 @@ export class Session {
         return;
       case "h":
       case "H":
-        this.left = this.wrapLines
+        this.left = this.#wrapLines
           ? 0
-          : clamp(this.left - this.horizontalStep(), 0, this.maxLeft());
+          : clamp(this.left - this.#horizontalStep(), 0, this.#maxLeft());
         return;
       case "l":
       case "L":
-        this.left = this.wrapLines
+        this.left = this.#wrapLines
           ? 0
-          : clamp(this.left + this.horizontalStep(), 0, this.maxLeft());
+          : clamp(this.left + this.#horizontalStep(), 0, this.#maxLeft());
         return;
       case "space":
       case "pagedown":
@@ -1903,160 +1916,160 @@ export class Session {
         this.top = lastTop;
         return;
       case "ctrl-l":
-        this.performExpand();
+        this.#performExpand();
         return;
       case "w":
       case "W":
-        this.navigateTree(treePrevSibling);
+        this.#navigateTree(treePrevSibling);
         return;
       case "s":
       case "S":
-        this.navigateTree(treeNextSibling);
+        this.#navigateTree(treeNextSibling);
         return;
       case "a":
       case "A":
-        this.navigateTree(treeParent);
+        this.#navigateTree(treeParent);
         return;
       case "d":
       case "D":
-        this.navigateTree(treeChild);
+        this.#navigateTree(treeChild);
         return;
       case "tab":
-        this.navigateTree(treePreOrderNext);
+        this.#navigateTree(treePreOrderNext);
         return;
       case "shift-tab":
-        this.navigateTree(treePreOrderPrev);
+        this.#navigateTree(treePreOrderPrev);
         return;
       case "enter": {
-        const node = this.selectedNode();
-        if (node) this.openPeek(node);
+        const node = this.#selectedNode();
+        if (node) this.#openPeek(node);
         else {
-          this.message =
+          this.#message =
             "Select a node first (wasd / tab), then Enter for its info card";
         }
         return;
       }
       case "z":
       case "Z": {
-        const node = this.selectedNode();
+        const node = this.#selectedNode();
         if (node) {
           this.top = clamp(
             frameTop(
-              this.nodeStartRow(node),
-              this.nodeEndRow(node),
+              this.#nodeStartRow(node),
+              this.#nodeEndRow(node),
               this.height,
-              this.displayCount(),
+              this.#displayCount(),
             ),
             0,
-            this.lastTop(),
+            this.#lastTop(),
           );
         }
         return;
       }
       case "\\":
-        this.cycleLineWrapping();
+        this.#cycleLineWrapping();
         return;
       case "#":
-        this.cycleLineNumbers();
+        this.#cycleLineNumbers();
         return;
       case "c":
       case "C":
-        this.cycleDisplayMode();
+        this.#cycleDisplayMode();
         return;
       case "f":
-        this.toggleCurrentFile();
+        this.#toggleCurrentFile();
         return;
       case "i":
-        this.openJumpList();
+        this.#openJumpList();
         return;
       case "F":
-        this.collapseAllFiles();
+        this.#collapseAllFiles();
         return;
       case "E":
-        this.expandAllFiles();
+        this.#expandAllFiles();
         return;
       case "T":
-        this.toggleFileCategory((file) => file.isTest, "test");
+        this.#toggleFileCategory((file) => file.isTest, "test");
         return;
       case "M":
-        this.toggleFileCategory((file) => file.isMarkdown, "Markdown");
+        this.#toggleFileCategory((file) => file.isMarkdown, "Markdown");
         return;
       case "escape": {
-        const anchor = this.wrapLines ? this.viewportAnchor() : null;
-        this.selectedIndex = null;
-        this.query = "";
-        this.matches = [];
-        this.message = "";
-        if (anchor) this.restoreWrappedAnchor(anchor);
-        else this.clampScroll();
+        const anchor = this.#wrapLines ? this.#viewportAnchor() : null;
+        this.#selectedIndex = null;
+        this.#query = "";
+        this.#matches = [];
+        this.#message = "";
+        if (anchor) this.#restoreWrappedAnchor(anchor);
+        else this.#clampScroll();
         return;
       }
     }
   }
 
   /** Step to the next non-printable display mode and report it. */
-  private cycleDisplayMode(): void {
-    const anchor = this.viewportAnchor();
-    const sourceCol = this.anchorSourceCol(anchor);
-    const i = DISPLAY_MODES.indexOf(this.displayMode);
-    this.displayMode = DISPLAY_MODES[(i + 1) % DISPLAY_MODES.length];
-    const line = this.foldPlan().displayLines[anchor.foldedLine];
+  #cycleDisplayMode(): void {
+    const anchor = this.#viewportAnchor();
+    const sourceCol = this.#anchorSourceCol(anchor);
+    const i = DISPLAY_MODES.indexOf(this.#displayMode);
+    this.#displayMode = DISPLAY_MODES[(i + 1) % DISPLAY_MODES.length];
+    const line = this.#foldPlan().displayLines[anchor.foldedLine];
     const displayCol = line
-      ? displayColumnOf(line, this.displayMode, sourceCol)
+      ? displayColumnOf(line, this.#displayMode, sourceCol)
       : 0;
-    if (this.wrapLines) {
-      this.restoreWrappedAnchor({ ...anchor, displayCol });
+    if (this.#wrapLines) {
+      this.#restoreWrappedAnchor({ ...anchor, displayCol });
     } else {
       this.left = displayCol;
-      this.clampScroll();
+      this.#clampScroll();
     }
-    this.message = `Non-printables: ${displayModeLabel(this.displayMode)}`;
+    this.#message = `Non-printables: ${displayModeLabel(this.#displayMode)}`;
   }
 
   /** Step through wrapping modes while keeping the top-left content in view. */
-  private cycleLineWrapping(): void {
-    const anchor = this.viewportAnchor();
-    this.wrapMode = this.wrapMode === "off"
+  #cycleLineWrapping(): void {
+    const anchor = this.#viewportAnchor();
+    this.#wrapMode = this.#wrapMode === "off"
       ? "hard"
-      : this.wrapMode === "hard"
+      : this.#wrapMode === "hard"
       ? "word"
       : "off";
-    this.expansionLayoutCache = undefined;
-    if (this.wrapLines) {
+    this.#expansionLayoutCache = undefined;
+    if (this.#wrapLines) {
       this.left = 0;
-      this.restoreWrappedAnchor(anchor);
+      this.#restoreWrappedAnchor(anchor);
     } else {
       this.top = anchor.foldedLine;
       this.left = anchor.displayCol;
-      this.clampScroll();
+      this.#clampScroll();
     }
-    this.message = `Line wrapping: ${this.wrapMode}`;
+    this.#message = `Line wrapping: ${this.#wrapMode}`;
   }
 
   //
   // file-fold commands
   //
 
-  private ensureDiffForFolding(): boolean {
-    if (this.foldFiles().length === 0) {
-      this.message = "Hiding files is only available in a diff view.";
+  #ensureDiffForFolding(): boolean {
+    if (this.#foldFiles().length === 0) {
+      this.#message = "Hiding files is only available in a diff view.";
       return false;
     }
     return true;
   }
 
   /** The document position the fold commands keep at the top of the viewport. */
-  private foldAnchor(): FoldAnchor {
-    const node = this.selectedNode();
-    const anchor = this.viewportAnchor();
-    const fold = this.foldPlan();
+  #foldAnchor(): FoldAnchor {
+    const node = this.#selectedNode();
+    const anchor = this.#viewportAnchor();
+    const fold = this.#foldPlan();
     if (node) {
       const folded = fold.docToDisplay(node.startLine);
       const synthetic = fold.displayLines[folded] !==
-        this.currentDoc.lines[node.startLine];
+        this.#currentDoc.lines[node.startLine];
       return {
         docLine: node.startLine,
-        sourceCol: this.renderedLineChangesColumns(node.startLine)
+        sourceCol: this.#renderedLineChangesColumns(node.startLine)
           ? 0
           : node.startCol,
         syntheticDisplayCol: synthetic && folded === anchor.foldedLine
@@ -2066,7 +2079,7 @@ export class Session {
     }
     if (
       fold.displayLines[anchor.foldedLine] !==
-        this.currentDoc.lines[anchor.docLine]
+        this.#currentDoc.lines[anchor.docLine]
     ) {
       return {
         docLine: anchor.docLine,
@@ -2076,99 +2089,99 @@ export class Session {
     }
     return {
       docLine: anchor.docLine,
-      sourceCol: this.anchorSourceCol(anchor),
+      sourceCol: this.#anchorSourceCol(anchor),
     };
   }
 
   /** Refresh the layout after a fold changes and restore its viewport anchor. */
-  private applyFoldChange(anchor: FoldAnchor): void {
-    this.markFoldChanged();
-    const fold = this.foldPlan();
+  #applyFoldChange(anchor: FoldAnchor): void {
+    this.#markFoldChanged();
+    const fold = this.#foldPlan();
     const folded = fold.docToDisplay(anchor.docLine);
     const stillSynthetic = fold.displayLines[folded] !==
-      this.currentDoc.lines[anchor.docLine];
+      this.#currentDoc.lines[anchor.docLine];
     const row = stillSynthetic && anchor.syntheticDisplayCol !== undefined
-      ? this.foldedPositionToDisplay(folded, anchor.syntheticDisplayCol)
-      : this.toDisplay(
+      ? this.#foldedPositionToDisplay(folded, anchor.syntheticDisplayCol)
+      : this.#toDisplay(
         anchor.docLine,
-        this.displayCol(anchor.docLine, anchor.sourceCol),
+        this.#displayCol(anchor.docLine, anchor.sourceCol),
       );
     this.top = clamp(
       row,
       0,
-      this.lastTop(),
+      this.#lastTop(),
     );
-    this.clampScroll();
+    this.#clampScroll();
   }
 
   /** Toggle the file the viewport (or selection) is on between shown and hidden. */
-  private toggleCurrentFile(): void {
-    if (!this.ensureDiffForFolding()) return;
-    const files = this.foldFiles();
-    const line = this.foldAnchor().docLine;
+  #toggleCurrentFile(): void {
+    if (!this.#ensureDiffForFolding()) return;
+    const files = this.#foldFiles();
+    const line = this.#foldAnchor().docLine;
     const file = files.find((f) => line >= f.headerLine && line <= f.endLine) ??
       files.find((f) => f.headerLine >= line) ?? files[files.length - 1];
-    if (this.collapsed.has(file.index)) {
-      this.collapsed.delete(file.index);
-      this.message = `Showing ${file.path}`;
+    if (this.#collapsed.has(file.index)) {
+      this.#collapsed.delete(file.index);
+      this.#message = `Showing ${file.path}`;
     } else {
-      this.collapsed.add(file.index);
-      this.message = `Hiding ${file.path}`;
+      this.#collapsed.add(file.index);
+      this.#message = `Hiding ${file.path}`;
     }
-    this.applyFoldChange({ docLine: file.headerLine, sourceCol: 0 });
+    this.#applyFoldChange({ docLine: file.headerLine, sourceCol: 0 });
   }
 
   /** Hide every file (collapse all to summary lines). */
-  private collapseAllFiles(): void {
-    if (!this.ensureDiffForFolding()) return;
-    const anchor = this.foldAnchor();
+  #collapseAllFiles(): void {
+    if (!this.#ensureDiffForFolding()) return;
+    const anchor = this.#foldAnchor();
     let changed = false;
-    for (const f of this.foldFiles()) {
-      if (!this.collapsed.has(f.index)) {
-        this.collapsed.add(f.index);
+    for (const f of this.#foldFiles()) {
+      if (!this.#collapsed.has(f.index)) {
+        this.#collapsed.add(f.index);
         changed = true;
       }
     }
-    if (changed) this.applyFoldChange(anchor);
-    this.message = "Hid all files.";
+    if (changed) this.#applyFoldChange(anchor);
+    this.#message = "Hid all files.";
   }
 
   /** Show every file (expand all). */
-  private expandAllFiles(): void {
-    if (!this.ensureDiffForFolding()) return;
-    const anchor = this.foldAnchor();
-    if (this.collapsed.size > 0) {
-      this.collapsed.clear();
-      this.applyFoldChange(anchor);
+  #expandAllFiles(): void {
+    if (!this.#ensureDiffForFolding()) return;
+    const anchor = this.#foldAnchor();
+    if (this.#collapsed.size > 0) {
+      this.#collapsed.clear();
+      this.#applyFoldChange(anchor);
     }
-    this.message = "Showing all files.";
+    this.#message = "Showing all files.";
   }
 
   /** Toggle one kind of file as a group. A mixed group is made fully hidden. */
-  private toggleFileCategory(
+  #toggleFileCategory(
     matches: (file: DiffFileRange) => boolean,
     label: string,
   ): void {
-    if (!this.ensureDiffForFolding()) return;
-    const files = this.foldFiles().filter(matches);
+    if (!this.#ensureDiffForFolding()) return;
+    const files = this.#foldFiles().filter(matches);
     if (files.length === 0) {
-      this.message = `No ${label} files.`;
+      this.#message = `No ${label} files.`;
       return;
     }
-    const anchor = this.foldAnchor();
-    const expand = files.every((file) => this.collapsed.has(file.index));
+    const anchor = this.#foldAnchor();
+    const expand = files.every((file) => this.#collapsed.has(file.index));
     let changed = 0;
     for (const f of files) {
       if (expand) {
-        this.collapsed.delete(f.index);
+        this.#collapsed.delete(f.index);
         changed++;
-      } else if (!this.collapsed.has(f.index)) {
-        this.collapsed.add(f.index);
+      } else if (!this.#collapsed.has(f.index)) {
+        this.#collapsed.add(f.index);
         changed++;
       }
     }
-    this.applyFoldChange(anchor);
-    this.message = `${expand ? "Showing" : "Hid"} ${changed} ${label} file${
+    this.#applyFoldChange(anchor);
+    this.#message = `${expand ? "Showing" : "Hid"} ${changed} ${label} file${
       changed === 1 ? "" : "s"
     }.`;
   }
@@ -2177,70 +2190,70 @@ export class Session {
   // editing
   //
 
-  private scrollOrPan(name: string): void {
-    const lastTop = this.lastTop();
+  #scrollOrPan(name: string): void {
+    const lastTop = this.#lastTop();
     if (name === "up") this.top = clamp(this.top - 1, 0, lastTop);
     else if (name === "down") this.top = clamp(this.top + 1, 0, lastTop);
     else if (name === "left") {
-      this.left = this.wrapLines
+      this.left = this.#wrapLines
         ? 0
-        : clamp(this.left - this.horizontalStep(), 0, this.maxLeft());
+        : clamp(this.left - this.#horizontalStep(), 0, this.#maxLeft());
     } else if (name === "right") {
-      this.left = this.wrapLines
+      this.left = this.#wrapLines
         ? 0
-        : clamp(this.left + this.horizontalStep(), 0, this.maxLeft());
+        : clamp(this.left + this.#horizontalStep(), 0, this.#maxLeft());
     }
   }
 
   /** Show the text cursor at the top of the viewport, if the view is editable. */
-  private revealCursor(): void {
-    if (!this.source?.editable || !this.buffer) {
-      this.message = this.source?.reason ??
+  #revealCursor(): void {
+    if (!this.#source?.editable || !this.buffer) {
+      this.#message = this.#source?.reason ??
         "This view has no underlying file to edit.";
       return;
     }
-    const leftRenderedView = this.setViewMode("source", false);
-    const wasWrapped = this.wrapLines;
-    const anchor = wasWrapped ? this.viewportAnchor() : null;
-    const topDoc = anchor?.docLine ?? this.toDoc(this.top);
+    const leftRenderedView = this.#setViewMode("source", false);
+    const wasWrapped = this.#wrapLines;
+    const anchor = wasWrapped ? this.#viewportAnchor() : null;
+    const topDoc = anchor?.docLine ?? this.#toDoc(this.top);
     const displayedLine = anchor
-      ? this.foldPlan().displayLines[anchor.foldedLine]
+      ? this.#foldPlan().displayLines[anchor.foldedLine]
       : undefined;
-    const cursorCol = anchor && displayedLine === this.currentDoc.lines[topDoc]
-      ? this.anchorSourceCol(anchor)
+    const cursorCol = anchor && displayedLine === this.#currentDoc.lines[topDoc]
+      ? this.#anchorSourceCol(anchor)
       : 0;
-    this.wrapMode = "off";
-    this.cursorOn = true;
-    this.selectedIndex = null;
+    this.#wrapMode = "off";
+    this.#cursorOn = true;
+    this.#selectedIndex = null;
     // Editing relies on every source column mapping to one display column, which
     // only the first mode guarantees (it hides nothing and collapses nothing).
-    this.displayMode = DISPLAY_MODES[0];
+    this.#displayMode = DISPLAY_MODES[0];
     if (anchor) this.left = cursorCol;
     // Editing works on the full text, so expand every folded file; the top
     // display row becomes its document line.
-    this.clearFolds();
+    this.#clearFolds();
     this.top = topDoc;
     this.buffer.place(topDoc, cursorCol);
-    this.seedHighlighter();
+    this.#seedHighlighter();
     this.ensureCursorVisible();
     if (leftRenderedView && wasWrapped) {
-      this.message = "Source view; line wrapping turned off for editing.";
+      this.#message = "Source view; line wrapping turned off for editing.";
     } else if (leftRenderedView) {
-      this.message = "Source view for editing.";
+      this.#message = "Source view for editing.";
     } else if (wasWrapped) {
-      this.message = "Line wrapping turned off for editing.";
+      this.#message = "Line wrapping turned off for editing.";
     }
   }
 
-  private markFoldChanged(): void {
-    this.foldVersion++;
-    this.foldPlanCache = undefined;
+  #markFoldChanged(): void {
+    this.#foldVersion++;
+    this.#foldPlanCache = undefined;
   }
 
-  private clearFolds(): void {
-    if (this.collapsed.size === 0) return;
-    this.collapsed.clear();
-    this.markFoldChanged();
+  #clearFolds(): void {
+    if (this.#collapsed.size === 0) return;
+    this.#collapsed.clear();
+    this.#markFoldChanged();
   }
 
   /** Create (or re-baseline) the incremental highlighter, seeded with the
@@ -2248,72 +2261,72 @@ export class Session {
    * starts and after the deferred re-parse — the two moments the document's
    * lines and the buffer text are known to agree — so a diff's live highlighter
    * can reuse the workspace-colored lines for everything an edit doesn't touch. */
-  private seedHighlighter(): void {
-    this.highlighter = this.source?.createHighlighter?.(
+  #seedHighlighter(): void {
+    this.#highlighter = this.#source?.createHighlighter?.(
       this.buffer!.text(),
-      this.currentDoc.lines,
+      this.#currentDoc.lines,
       this.buffer!.lineEndingProvenance(),
     );
   }
 
-  private handleEditKey(key: Key): void {
+  #handleEditKey(key: Key): void {
     const b = this.buffer!;
     if (key.alt) {
       switch (key.name) {
         case "f":
         case "F":
           b.moveWordForward();
-          return this.afterMove();
+          return this.#afterMove();
         case "b":
         case "B":
           b.moveWordBackward();
-          return this.afterMove();
+          return this.#afterMove();
         case "v":
-          return this.cursorPage(-1);
+          return this.#cursorPage(-1);
         case "<":
           b.moveBufferStart();
-          return this.afterMove();
+          return this.#afterMove();
         case ">":
           b.moveBufferEnd();
-          return this.afterMove();
+          return this.#afterMove();
         case "d":
-          if (this.guardForwardWordEdit()) {
+          if (this.#guardForwardWordEdit()) {
             b.killWordForward();
-            this.afterEdit();
+            this.#afterEdit();
           }
           return;
         case "y":
-          if (this.source?.policy) {
-            this.message = "Yank-pop isn't available while editing a diff.";
+          if (this.#source?.policy) {
+            this.#message = "Yank-pop isn't available while editing a diff.";
             return;
           }
           b.yankPop();
-          return this.afterEdit();
+          return this.#afterEdit();
         case "l":
         case "L":
-          if (this.allowEdit(false)) {
+          if (this.#allowEdit(false)) {
             b.lowercaseWord();
-            this.afterEdit();
+            this.#afterEdit();
           }
           return;
         case "u":
         case "U":
-          if (this.allowEdit(false)) {
+          if (this.#allowEdit(false)) {
             b.uppercaseWord();
-            this.afterEdit();
+            this.#afterEdit();
           }
           return;
         case "c":
         case "C":
-          if (this.allowEdit(false)) {
+          if (this.#allowEdit(false)) {
             b.capitalizeWord();
-            this.afterEdit();
+            this.#afterEdit();
           }
           return;
         case "backspace":
-          if (this.guardBackwardEdit()) {
+          if (this.#guardBackwardEdit()) {
             b.killWordBackward();
-            this.afterEdit();
+            this.#afterEdit();
           }
           return;
       }
@@ -2322,90 +2335,90 @@ export class Session {
     switch (key.name) {
       case "left":
         b.moveLeft();
-        return this.afterMove();
+        return this.#afterMove();
       case "right":
-        this.moveRightAcrossTransport();
-        return this.afterMove();
+        this.#moveRightAcrossTransport();
+        return this.#afterMove();
       case "up":
         b.moveUp();
-        return this.afterMove();
+        return this.#afterMove();
       case "down":
         b.moveDown();
-        return this.afterMove();
+        return this.#afterMove();
       case "home":
       case "ctrl-a":
         b.moveLineStart();
-        return this.afterMove();
+        return this.#afterMove();
       case "end":
       case "ctrl-e":
         b.moveLineEnd();
-        return this.afterMove();
+        return this.#afterMove();
       case "ctrl-b":
         b.moveLeft();
-        return this.afterMove();
+        return this.#afterMove();
       case "ctrl-f":
-        this.moveRightAcrossTransport();
-        return this.afterMove();
+        this.#moveRightAcrossTransport();
+        return this.#afterMove();
       case "ctrl-p":
         b.moveUp();
-        return this.afterMove();
+        return this.#afterMove();
       case "ctrl-n":
         b.moveDown();
-        return this.afterMove();
+        return this.#afterMove();
       case "pageup":
-        return this.cursorPage(-1);
+        return this.#cursorPage(-1);
       case "pagedown":
       case "ctrl-v":
-        return this.cursorPage(1);
+        return this.#cursorPage(1);
       case "escape":
-        this.cursorOn = false;
+        this.#cursorOn = false;
         this.reparse(); // refresh structure before returning to navigation
         this.ensureCursorVisible();
         return;
       case "ctrl-s":
-        this.enterEditSearch();
+        this.#enterEditSearch();
         return;
       case "ctrl-r":
-        this.openRevertPrompt();
+        this.#openRevertPrompt();
         return;
       case "ctrl-l":
-        this.performExpand();
+        this.#performExpand();
         return;
       case "ctrl-c":
-        this.requestQuit();
+        this.#requestQuit();
         return;
       case "r":
       case "R":
-        if (this.resurrectRemovedLine()) return;
+        if (this.#resurrectRemovedLine()) return;
         break;
       case "delete":
       case "ctrl-d":
-        if (this.guardForwardEdit()) {
-          b.deleteForward(this.logicalLineEnd());
-          this.afterEdit();
+        if (this.#guardForwardEdit()) {
+          b.deleteForward(this.#logicalLineEnd());
+          this.#afterEdit();
         }
         return;
       case "backspace":
-        this.handleBackspace();
+        this.#handleBackspace();
         return;
       case "enter": {
         // A commit-message line splits into two indented message lines, plain
         // text — no diff pairing, no hunk-count bookkeeping.
-        if (this.inMessageRow()) {
-          if (this.allowEdit(false, false)) {
-            b.insert(`\n${this.source!.policy!.messageIndent}`);
-            this.afterEdit();
+        if (this.#inMessageRow()) {
+          if (this.#allowEdit(false, false)) {
+            b.insert(`\n${this.#source!.policy!.messageIndent}`);
+            this.#afterEdit();
           }
           return;
         }
-        const prefix = this.source?.policy?.insertPrefix;
+        const prefix = this.#source?.policy?.insertPrefix;
         if (prefix !== undefined) {
-          if (this.allowEdit(false, false)) {
-            const hunkHeader = this.hunkHeaderAt(b.row);
+          if (this.#allowEdit(false, false)) {
+            const hunkHeader = this.#hunkHeaderAt(b.row);
             const start = this.editStart() ?? 1;
             const line = b.lines[b.row] ?? "";
             const onContext = line[0] === " ";
-            const logicalEnd = this.logicalLineEnd();
+            const logicalEnd = this.#logicalLineEnd();
             const transport = logicalEnd < b.currentLineLength() ? "\r" : "";
             // Enter splits the line at the cursor. On a context line the result
             // is shown minimally: an empty half just adds a blank line and the
@@ -2442,10 +2455,10 @@ export class Session {
                   start,
                 );
               }
-              this.splitRow = null;
+              this.#splitRow = null;
             } else if (onContext && b.col < logicalEnd) {
               this.prepareContextEdit();
-              this.splitDiffLine(prefix);
+              this.#splitDiffLine(prefix);
             } else if (onContext) {
               b.spliceLines(
                 b.row + 1,
@@ -2455,64 +2468,64 @@ export class Session {
                 [...prefix].length,
               );
             } else {
-              this.splitDiffLine(prefix);
+              this.#splitDiffLine(prefix);
             }
             this.adjustHunkCounts(0, 1, hunkHeader);
-            this.afterEdit();
+            this.#afterEdit();
           }
         } else {
           b.insertNewline(
-            this.logicalLineEnd(),
-            this.plainNewlineSuffix(),
+            this.#logicalLineEnd(),
+            this.#plainNewlineSuffix(),
           );
-          this.afterEdit();
+          this.#afterEdit();
         }
         return;
       }
       case "tab":
-        if (this.allowEdit(false)) {
+        if (this.#allowEdit(false)) {
           b.insert("  ");
-          this.afterEdit();
+          this.#afterEdit();
         }
         return;
       case "ctrl-k":
-        if (this.guardForwardEdit()) {
-          b.killLine(this.logicalLineEnd());
-          this.afterEdit();
+        if (this.#guardForwardEdit()) {
+          b.killLine(this.#logicalLineEnd());
+          this.#afterEdit();
         }
         return;
       case "ctrl-y": {
         const top = b.killRing[0] ?? "";
-        if (this.allowEdit(top.includes("\n"))) {
+        if (this.#allowEdit(top.includes("\n"))) {
           b.yank();
-          this.afterEdit();
+          this.#afterEdit();
         }
         return;
       }
       case "ctrl-w":
-        if (this.guardRegionEdit()) {
+        if (this.#guardRegionEdit()) {
           b.killRegion();
-          this.afterEdit();
+          this.#afterEdit();
         }
         return;
       case "ctrl-`": // C-Space (NUL) — set the mark
       case "ctrl-space":
         b.setMark();
-        this.message = "Mark set";
+        this.#message = "Mark set";
         return;
       case "space":
-        if (this.allowEdit(false)) {
+        if (this.#allowEdit(false)) {
           b.insert(" ");
-          this.afterEdit();
+          this.#afterEdit();
         }
         return;
     }
     if (key.char && key.char >= " " && !key.ctrl) {
       // A key.char carrying a newline (e.g. a future bracketed-paste handler)
       // would add lines; treat it as a line change so a diff refuses it.
-      if (this.allowEdit(key.char.includes("\n"))) {
+      if (this.#allowEdit(key.char.includes("\n"))) {
         b.insert(key.char);
-        this.afterEdit();
+        this.#afterEdit();
       }
     }
   }
@@ -2527,10 +2540,10 @@ export class Session {
    * (no diff policy).
    */
   private prepareContextEdit(): void {
-    if (!this.source?.policy || !this.buffer) return;
+    if (!this.#source?.policy || !this.buffer) return;
     // A commit-message line is plain indented text, not a diff line: editing it
     // must not split it into a removed/added pair.
-    if (this.inMessageRow()) return;
+    if (this.#inMessageRow()) return;
     const b = this.buffer;
     const line = b.lines[b.row];
     if (line === undefined || line[0] !== " ") return;
@@ -2541,14 +2554,14 @@ export class Session {
       b.mark = { row: b.row + 1, col: b.mark.col };
     }
     b.spliceLines(b.row, 1, [`-${content}`, `+${content}`], 1, col);
-    this.splitRow = b.row; // the added line, so undoing the edit can collapse it
+    this.#splitRow = b.row; // the added line, so undoing the edit can collapse it
   }
 
   /** Split an added diff line while retaining its newline transport. */
-  private splitDiffLine(prefix: string): void {
+  #splitDiffLine(prefix: string): void {
     const b = this.buffer!;
     const chars = [...b.lines[b.row]];
-    const logicalEnd = this.logicalLineEnd();
+    const logicalEnd = this.#logicalLineEnd();
     const transport = logicalEnd < chars.length ? "\r" : "";
     const split = Math.min(b.col, logicalEnd);
     const before = chars.slice(0, split).join("");
@@ -2564,8 +2577,8 @@ export class Session {
 
   /** Whether the cursor is on a removed line in a hunk whose new side can be
    * saved back to disk. */
-  private canResurrectRemovedLine(): boolean {
-    const pol = this.source?.policy;
+  #canResurrectRemovedLine(): boolean {
+    const pol = this.#source?.policy;
     const b = this.buffer;
     return !!pol && !!b && b.lines[b.row]?.[0] === "-" &&
       pol.regionKind(b.lines, b.row) === "removed";
@@ -2573,26 +2586,26 @@ export class Session {
 
   /** Carry a removed line back onto the diff's new side. Lines whose old and
    * new encoding markers differ remain a removed/added pair. */
-  private resurrectRemovedLine(): boolean {
-    if (!this.canResurrectRemovedLine()) return false;
+  #resurrectRemovedLine(): boolean {
+    if (!this.#canResurrectRemovedLine()) return false;
     const b = this.buffer!;
     const targetRow = b.row;
-    const parsed = this.parsedHunkAt(b.row);
+    const parsed = this.#parsedHunkAt(b.row);
     const hunkHeader = parsed?.hunk.headerLine ?? null;
     const line = b.lines[b.row];
     const oldHasUtf8Bom = parsed?.model.lines[b.row]?.oldLine === 0 &&
       line[1] === "\uFEFF";
-    const newHasUtf8Bom = this.source?.policy?.hasUtf8Bom?.(
+    const newHasUtf8Bom = this.#source?.policy?.hasUtf8Bom?.(
       b.lines,
       b.row,
     ) === true;
     const carriesNewUtf8Bom = newHasUtf8Bom && parsed !== null &&
-      this.newSideInsertionLine(parsed.model, parsed.hunk, b.row) === 0;
+      this.#newSideInsertionLine(parsed.model, parsed.hunk, b.row) === 0;
     const newSideBom = carriesNewUtf8Bom && parsed
-      ? this.newSideBomCarrier(parsed.model, parsed.hunk)
+      ? this.#newSideBomCarrier(parsed.model, parsed.hunk)
       : null;
     if (!this.adjustHunkCounts(0, 1, hunkHeader)) {
-      this.message = "This hunk could not be updated.";
+      this.#message = "This hunk could not be updated.";
       return true;
     }
     const decodedContent = [...line].slice(oldHasUtf8Bom ? 2 : 1).join("");
@@ -2627,8 +2640,8 @@ export class Session {
         );
       }
     }
-    this.afterEdit();
-    this.message = "Resurrected the removed line.";
+    this.#afterEdit();
+    this.#message = "Resurrected the removed line.";
     return true;
   }
 
@@ -2637,10 +2650,10 @@ export class Session {
    * — you undid the change. Scoped to the row {@link prepareContextEdit} created
    * (`splitRow`), so editing an author-written `-`/`+` pair to match does not
    * silently drop their removed line. Count-neutral, the inverse of the split. */
-  private collapseUnchangedPair(): void {
-    if (!this.source?.policy || !this.buffer) return;
+  #collapseUnchangedPair(): void {
+    if (!this.#source?.policy || !this.buffer) return;
     const b = this.buffer;
-    if (b.row !== this.splitRow) return;
+    if (b.row !== this.#splitRow) return;
     const cur = b.lines[b.row];
     const above = b.lines[b.row - 1];
     if (
@@ -2648,22 +2661,22 @@ export class Session {
       cur.slice(1) === above.slice(1)
     ) {
       b.spliceLines(b.row - 1, 2, [` ${cur.slice(1)}`], 0, b.col);
-      this.splitRow = null;
+      this.#splitRow = null;
     }
   }
 
   /** The parsed hunk containing a body row. Structural lookup keeps body text
    * such as `--- prior` and `+++ next` from being mistaken for file headers. */
-  private hunkHeaderAt(row: number): number | null {
-    return this.parsedHunkAt(row)?.hunk.headerLine ?? null;
+  #hunkHeaderAt(row: number): number | null {
+    return this.#parsedHunkAt(row)?.hunk.headerLine ?? null;
   }
 
   /** The parsed hunk containing a body row. */
-  private parsedHunkAt(
+  #parsedHunkAt(
     row: number,
   ): { model: DiffModel; hunk: DiffHunk } | null {
     if (!this.buffer) return null;
-    const policyLookup = this.source?.policy?.hunkAt;
+    const policyLookup = this.#source?.policy?.hunkAt;
     if (policyLookup) return policyLookup(this.buffer.lines, row);
     const model = parseDiff(this.buffer.text());
     if (!model) return null;
@@ -2678,7 +2691,7 @@ export class Session {
   }
 
   /** The first new-side line carrying the file's decoded UTF-8 BOM. */
-  private newSideBomCarrier(model: DiffModel, hunk: DiffHunk): number | null {
+  #newSideBomCarrier(model: DiffModel, hunk: DiffHunk): number | null {
     for (let row = hunk.headerLine + 1; row <= hunk.endLine; row++) {
       const kind = model.lines[row]?.kind;
       if (
@@ -2693,7 +2706,7 @@ export class Session {
   }
 
   /** The new-file line where a removed row would be inserted. */
-  private newSideInsertionLine(
+  #newSideInsertionLine(
     model: DiffModel,
     hunk: DiffHunk,
     row: number,
@@ -2712,10 +2725,11 @@ export class Session {
   private adjustHunkCounts(
     oldDelta: number,
     newDelta: number,
-    hunkHeader = this.hunkHeaderAt(this.buffer?.row ?? -1),
+    hunkHeader = this.#hunkHeaderAt(this.buffer?.row ?? -1),
   ): boolean {
     if (
-      !this.source?.policy || !this.buffer || (oldDelta === 0 && newDelta === 0)
+      !this.#source?.policy || !this.buffer ||
+      (oldDelta === 0 && newDelta === 0)
     ) {
       return false;
     }
@@ -2749,25 +2763,25 @@ export class Session {
   /** The first editable column on the cursor's line under the source's policy
    * (a diff), or null when the line cannot be edited. No policy → column 0. */
   private editStart(): number | null {
-    const pol = this.source?.policy;
+    const pol = this.#source?.policy;
     if (!pol) return 0;
     return pol.editStart(this.buffer!.lines, this.buffer!.row);
   }
 
   /** The current line's last editable column, before source-owned transport. */
-  private logicalLineEnd(row = this.buffer!.row): number {
+  #logicalLineEnd(row = this.buffer!.row): number {
     const b = this.buffer!;
     const line = b.lines[row] ?? "";
     const physicalEnd = [...line].length;
     const ordinaryEnd = line.endsWith("\r") && row < b.lines.length - 1
       ? physicalEnd - 1
       : physicalEnd;
-    const end = this.source?.logicalEnd?.(b.lines, row) ?? ordinaryEnd;
+    const end = this.#source?.logicalEnd?.(b.lines, row) ?? ordinaryEnd;
     return clamp(end, 0, physicalEnd);
   }
 
   /** The character before LF in the nearest newline of an ordinary file. */
-  private plainNewlineSuffix(): string {
+  #plainNewlineSuffix(): string {
     const b = this.buffer!;
     if (b.row < b.lines.length - 1) {
       const line = b.lines[b.row] ?? "";
@@ -2781,9 +2795,9 @@ export class Session {
   }
 
   /** Keep a right-arrow motion able to cross a protected CRLF boundary. */
-  private moveRightAcrossTransport(): void {
+  #moveRightAcrossTransport(): void {
     const b = this.buffer!;
-    const logicalEnd = this.logicalLineEnd();
+    const logicalEnd = this.#logicalLineEnd();
     if (
       b.col >= logicalEnd && logicalEnd < b.currentLineLength() &&
       b.row < b.lines.length - 1
@@ -2795,17 +2809,17 @@ export class Session {
   }
 
   /** Keep source-owned transport outside the text cursor. */
-  private clampToLogicalLine(): void {
+  #clampToLogicalLine(): void {
     const b = this.buffer;
     if (!b) return;
-    const end = this.logicalLineEnd();
+    const end = this.#logicalLineEnd();
     if (b.col > end) b.place(b.row, end);
   }
 
   /** Whether the cursor sits in an editable commit-message line — plain indented
    * text, edited without the diff's removed/added pairing. */
-  private inMessageRow(): boolean {
-    const pol = this.source?.policy;
+  #inMessageRow(): boolean {
+    const pol = this.#source?.policy;
     return !!pol && !!this.buffer &&
       pol.regionKind(this.buffer.lines, this.buffer.row) === "message";
   }
@@ -2816,19 +2830,19 @@ export class Session {
    * editable; otherwise nudges the cursor past the diff marker and allows it. A
    * plain file (no policy) always passes.
    */
-  private allowEdit(multiline: boolean, split = true): boolean {
-    if (!this.source?.policy) return true;
+  #allowEdit(multiline: boolean, split = true): boolean {
+    if (!this.#source?.policy) return true;
     if (multiline) {
-      this.message = MULTILINE_MSG;
+      this.#message = MULTILINE_MSG;
       return false;
     }
     const b = this.buffer!;
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return false;
     }
-    this.clampToLogicalLine();
+    this.#clampToLogicalLine();
     if (b.col < start) b.place(b.row, start);
     if (split) this.prepareContextEdit();
     return true;
@@ -2837,18 +2851,18 @@ export class Session {
   /** Gate a delete-forward edit (delete, C-k): refuse the diff marker and
    * a delete at end of line, which would join the next line — removing a line
    * is Backspace at its start instead. */
-  private guardForwardEdit(): boolean {
-    if (!this.source?.policy) return true;
+  #guardForwardEdit(): boolean {
+    if (!this.#source?.policy) return true;
     const b = this.buffer!;
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return false;
     }
-    this.clampToLogicalLine();
+    this.#clampToLogicalLine();
     if (b.col < start) b.place(b.row, start);
-    if (b.col >= this.logicalLineEnd()) {
-      this.message = JOIN_MSG;
+    if (b.col >= this.#logicalLineEnd()) {
+      this.#message = JOIN_MSG;
       return false;
     }
     this.prepareContextEdit();
@@ -2856,17 +2870,17 @@ export class Session {
   }
 
   /** Gate a forward word kill that would consume a diff line boundary. */
-  private guardForwardWordEdit(): boolean {
-    if (!this.source?.policy) return true;
+  #guardForwardWordEdit(): boolean {
+    if (!this.#source?.policy) return true;
     const b = this.buffer!;
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return false;
     }
     if (b.col < start) b.place(b.row, start);
     if (b.wordEndForward().row !== b.row) {
-      this.message = JOIN_MSG;
+      this.#message = JOIN_MSG;
       return false;
     }
     this.prepareContextEdit();
@@ -2876,43 +2890,43 @@ export class Session {
   /** Backspace under the source's policy: delete a character past the marker,
    * remove the whole line when its content is empty (an added line taken back),
    * else protect the marker. A plain file just deletes backward. */
-  private handleBackspace(): void {
+  #handleBackspace(): void {
     const b = this.buffer!;
-    if (!this.source?.policy) {
+    if (!this.#source?.policy) {
       b.deleteBackward(
-        b.row > 0 ? this.logicalLineEnd(b.row - 1) : undefined,
+        b.row > 0 ? this.#logicalLineEnd(b.row - 1) : undefined,
       );
-      return this.afterEdit();
+      return this.#afterEdit();
     }
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return;
     }
-    this.clampToLogicalLine();
+    this.#clampToLogicalLine();
     if (b.col > start) {
       this.prepareContextEdit();
       b.deleteBackward();
-      return this.afterEdit();
+      return this.#afterEdit();
     }
-    if (this.logicalLineEnd() <= start && b.row > 0) {
-      this.removeDiffLine(start);
-      return this.afterEdit();
+    if (this.#logicalLineEnd() <= start && b.row > 0) {
+      this.#removeDiffLine(start);
+      return this.#afterEdit();
     }
-    this.message = MARKER_MSG;
+    this.#message = MARKER_MSG;
   }
 
   /** Remove an empty added line. An empty context line becomes a removal so its
    * original old-side coordinate and content provenance remain represented. */
-  private removeDiffLine(markerLen: number): void {
+  #removeDiffLine(markerLen: number): void {
     const b = this.buffer!;
     const marker = b.lines[b.row][0] ?? "";
     const context = marker === " " &&
-      this.source?.policy?.regionKind(b.lines, b.row) === "hunk";
-    const parsed = this.parsedHunkAt(b.row);
+      this.#source?.policy?.regionKind(b.lines, b.row) === "hunk";
+    const parsed = this.#parsedHunkAt(b.row);
     const hunkHeader = parsed?.hunk.headerLine ?? null;
-    const transportWidth = b.currentLineLength() - this.logicalLineEnd();
-    this.transferProtectedPrefix(markerLen, parsed);
+    const transportWidth = b.currentLineLength() - this.#logicalLineEnd();
+    this.#transferProtectedPrefix(markerLen, parsed);
     if (context) {
       b.lines[b.row] = `-${b.lines[b.row].slice(1)}`;
       b.place(b.row, 1);
@@ -2935,7 +2949,7 @@ export class Session {
 
   /** Move an encoding prefix from a removed first new-side line to its
    * successor. A context successor becomes a removed/added pair. */
-  private transferProtectedPrefix(
+  #transferProtectedPrefix(
     markerLen: number,
     parsed: { model: DiffModel; hunk: DiffHunk } | null,
   ): void {
@@ -2961,22 +2975,22 @@ export class Session {
   }
 
   /** Gate a backward word kill (M-Backspace): refuse reaching the marker. */
-  private guardBackwardEdit(): boolean {
-    if (!this.source?.policy) return true;
+  #guardBackwardEdit(): boolean {
+    if (!this.#source?.policy) return true;
     const b = this.buffer!;
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return false;
     }
-    this.clampToLogicalLine();
+    this.#clampToLogicalLine();
     if (b.col <= start) {
-      this.message = MARKER_MSG;
+      this.#message = MARKER_MSG;
       return false;
     }
     const destination = b.wordStartBackward();
     if (destination.row !== b.row || destination.col < start) {
-      this.message = MARKER_MSG;
+      this.#message = MARKER_MSG;
       return false;
     }
     this.prepareContextEdit();
@@ -2985,73 +2999,73 @@ export class Session {
 
   /** Gate a region kill (C-w): refuse a multi-line region or one that reaches
    * into the diff marker. */
-  private guardRegionEdit(): boolean {
-    if (!this.source?.policy) return true;
+  #guardRegionEdit(): boolean {
+    if (!this.#source?.policy) return true;
     const b = this.buffer!;
     const mark = b.mark;
     if (!mark) {
-      this.message = "Set the mark first (Ctrl-Space).";
+      this.#message = "Set the mark first (Ctrl-Space).";
       return false;
     }
     if (mark.row !== b.row) {
-      this.message = MULTILINE_MSG;
+      this.#message = MULTILINE_MSG;
       return false;
     }
     const start = this.editStart();
     if (start === null) {
-      this.message = this.notEditableMessage();
+      this.#message = this.#notEditableMessage();
       return false;
     }
     if (Math.min(b.col, mark.col) < start) {
-      this.message = MARKER_MSG;
+      this.#message = MARKER_MSG;
       return false;
     }
-    if (Math.max(b.col, mark.col) > this.logicalLineEnd()) {
-      this.message = JOIN_MSG;
+    if (Math.max(b.col, mark.col) > this.#logicalLineEnd()) {
+      this.#message = JOIN_MSG;
       return false;
     }
     this.prepareContextEdit();
     return true;
   }
 
-  private notEditableMessage(): string {
-    if (this.canResurrectRemovedLine()) {
+  #notEditableMessage(): string {
+    if (this.#canResurrectRemovedLine()) {
       return "This removed line isn't editable; press R to resurrect it.";
     }
     const b = this.buffer;
-    const policy = this.source?.policy;
+    const policy = this.#source?.policy;
     return (b ? policy?.notEditableMessage?.(b.lines, b.row) : null) ??
       NOT_EDITABLE_MSG;
   }
 
-  private afterMove(): void {
-    this.clampToLogicalLine();
+  #afterMove(): void {
+    this.#clampToLogicalLine();
     this.ensureCursorVisible();
   }
 
-  private afterEdit(): void {
-    this.selectedIndex = null;
-    this.collapseUnchangedPair();
-    this.clampToLogicalLine();
-    if (this.source && this.buffer) {
+  #afterEdit(): void {
+    this.#selectedIndex = null;
+    this.#collapseUnchangedPair();
+    this.#clampToLogicalLine();
+    if (this.#source && this.buffer) {
       const text = this.buffer.text();
-      const lines = this.liveHighlight(text);
+      const lines = this.#liveHighlight(text);
       if (lines) {
         // Re-highlight on every keystroke — correct for multi-line tokens, and a
         // fraction of a full parse because it skips the structure tree. The
         // structure (navigation, cross-references) is refreshed on the deferred
         // re-parse.
-        this.sourceDoc = { ...this.sourceDoc, text, lines };
-        this.currentDoc = this.sourceDoc;
+        this.#sourceDoc = { ...this.#sourceDoc, text, lines };
+        this.#currentDoc = this.#sourceDoc;
         this.needsReparse = true;
       } else {
-        this.setSourceDocument(
-          this.source.parse(text, this.buffer.lineEndingProvenance()),
+        this.#setSourceDocument(
+          this.#source.parse(text, this.buffer.lineEndingProvenance()),
         );
         this.needsReparse = false;
       }
     }
-    this.clampScroll();
+    this.#clampScroll();
     this.ensureCursorVisible();
   }
 
@@ -3061,21 +3075,21 @@ export class Session {
   expireMessage(): void {
     if (!this.transientMessage) return;
     this.transientMessage = false;
-    this.message = "";
+    this.#message = "";
   }
 
   /** Live re-highlight `text` into rendered lines, or null when the source has
    * no live highlighter (then the caller does a full parse). Prefers the
    * incremental highlighter, created lazily and seeded with the current text so
    * the first keystroke is a full highlight and each later one is incremental. */
-  private liveHighlight(text: string): readonly Line[] | null {
-    if (this.highlighter) {
-      return this.highlighter.update(
+  #liveHighlight(text: string): readonly Line[] | null {
+    if (this.#highlighter) {
+      return this.#highlighter.update(
         text,
         this.buffer?.lineEndingProvenance(),
       );
     }
-    return this.source?.highlight?.(text) ?? null;
+    return this.#source?.highlight?.(text) ?? null;
   }
 
   /** Run the deferred full re-parse, refreshing the structure tree and
@@ -3083,9 +3097,9 @@ export class Session {
    * current but not the structure). The incremental highlighter is discarded so
    * the next edit re-seeds it from this authoritative parse. */
   reparse(): void {
-    if (!this.source || !this.buffer || !this.needsReparse) return;
-    this.setSourceDocument(
-      this.source.parse(
+    if (!this.#source || !this.buffer || !this.needsReparse) return;
+    this.#setSourceDocument(
+      this.#source.parse(
         this.buffer.text(),
         this.buffer.lineEndingProvenance(),
       ),
@@ -3093,15 +3107,15 @@ export class Session {
     this.needsReparse = false;
     // Re-baseline the live highlighter from this authoritative parse while still
     // editing; drop it when leaving edit mode.
-    if (this.cursorOn) this.seedHighlighter();
-    else this.highlighter = undefined;
-    this.clampScroll();
+    if (this.#cursorOn) this.#seedHighlighter();
+    else this.#highlighter = undefined;
+    this.#clampScroll();
     this.ensureCursorVisible();
   }
 
-  private cursorPage(dir: number): void {
+  #cursorPage(dir: number): void {
     const b = this.buffer!;
-    const step = Math.max(1, this.contentRows() - 1);
+    const step = Math.max(1, this.#contentRows() - 1);
     b.place(b.row + dir * step, b.col);
     this.top = clamp(
       this.top + dir * step,
@@ -3114,146 +3128,146 @@ export class Session {
   private ensureCursorVisible(): void {
     if (!this.buffer) return;
     const b = this.buffer;
-    const rows = this.contentRows();
+    const rows = this.#contentRows();
     if (b.row < this.top) this.top = b.row;
     else if (b.row >= this.top + rows) this.top = b.row - rows + 1;
     this.top = clamp(this.top, 0, maxTop(this.doc.lines.length, this.height));
-    const cw = this.contentWidth();
+    const cw = this.#contentWidth();
     if (b.col < this.left) this.left = b.col;
     else if (b.col >= this.left + cw) this.left = b.col - cw + 1;
-    this.left = clamp(this.left, 0, this.maxLeft());
+    this.left = clamp(this.left, 0, this.#maxLeft());
   }
 
-  private contentWidth(): number {
+  #contentWidth(): number {
     const fitted = fitViewLayout(
       this.width,
-      this.gutterWidth(),
-      this.selectedNode() ? 1 : 0,
-      this.hasDiffMargin() ? DIFF_MARGIN_WIDTH : 0,
-      this.wrapLines,
+      this.#gutterWidth(),
+      this.#selectedNode() ? 1 : 0,
+      this.#hasDiffMargin() ? DIFF_MARGIN_WIDTH : 0,
+      this.#wrapLines,
     );
     return fitted.contentWidth + fitted.marginWidth;
   }
 
   /** Pager annotations currently visible beside logical document lines. */
-  private activeDiffAnnotations(): readonly DiffAnnotation[] {
+  #activeDiffAnnotations(): readonly DiffAnnotation[] {
     if (
-      this.mode !== "normal" || this.overlay || this.cursorOn ||
-      this.chord !== null || !this.source?.expandContext
+      this.#mode !== "normal" || this.#overlay || this.#cursorOn ||
+      this.#chord !== null || !this.#source?.expandContext
     ) {
       return [];
     }
-    const expand = this.expandOffer();
+    const expand = this.#expandOffer();
     return expand && !("blocked" in expand)
       ? this.displayDiffAnnotations(expand)
       : [];
   }
 
   /** Widest folded line under the active non-printable display mode. */
-  private maxDisplayWidth(): number {
-    const lines = this.foldPlan().displayLines;
+  #maxDisplayWidth(): number {
+    const lines = this.#foldPlan().displayLines;
     if (
-      this.maxDisplayWidthCache?.lines !== lines ||
-      this.maxDisplayWidthCache.mode !== this.displayMode
+      this.#maxDisplayWidthCache?.lines !== lines ||
+      this.#maxDisplayWidthCache.mode !== this.#displayMode
     ) {
       let width = 0;
       for (const line of lines) {
-        width = Math.max(width, displayWidth(line, this.displayMode));
+        width = Math.max(width, displayWidth(line, this.#displayMode));
       }
-      this.maxDisplayWidthCache = { lines, mode: this.displayMode, width };
+      this.#maxDisplayWidthCache = { lines, mode: this.#displayMode, width };
     }
-    return this.maxDisplayWidthCache.width;
+    return this.#maxDisplayWidthCache.width;
   }
 
   /** Source cells available on one folded line after its annotation and, on
    * the first line, the whole-diff totals label. */
-  private lineContentWidth(
+  #lineContentWidth(
     foldedLine: number,
-    annotations = this.activeDiffAnnotations(),
-    contentWidth = this.contentWidth(),
+    annotations = this.#activeDiffAnnotations(),
+    contentWidth = this.#contentWidth(),
   ): number {
     const annotation = annotations.find((item) => item.line === foldedLine);
     const annotationWidth = annotation
       ? diffAnnotationDecoration(annotation.kind, contentWidth).firstWidth
       : 0;
-    const totalsWidth = foldedLine === 0 ? this.cornerTotalsWidth() : 0;
+    const totalsWidth = foldedLine === 0 ? this.#cornerTotalsWidth() : 0;
     return Math.max(1, contentWidth - annotationWidth - totalsWidth);
   }
 
   /** Furthest horizontal offset needed by any line under its own annotation
    * or, on the first line, the whole-diff totals label. */
-  private maxLeft(
-    annotations: readonly DiffAnnotation[] = this.activeDiffAnnotations(),
+  #maxLeft(
+    annotations: readonly DiffAnnotation[] = this.#activeDiffAnnotations(),
   ): number {
-    if (!this.hasDiffMargin()) return this.maxLineLen;
-    const contentWidth = this.contentWidth();
-    let width = this.maxDisplayWidth() - contentWidth;
-    const lines = this.foldPlan().displayLines;
+    if (!this.#hasDiffMargin()) return this.#maxLineLen;
+    const contentWidth = this.#contentWidth();
+    let width = this.#maxDisplayWidth() - contentWidth;
+    const lines = this.#foldPlan().displayLines;
     const constrained = new Set(
       annotations.map((annotation) => annotation.line),
     );
-    if (this.cornerTotalsWidth() > 0) constrained.add(0);
+    if (this.#cornerTotalsWidth() > 0) constrained.add(0);
     for (const lineIdx of constrained) {
       const line = lines[lineIdx];
       if (!line) continue;
       width = Math.max(
         width,
-        displayWidth(line, this.displayMode) -
-          this.lineContentWidth(lineIdx, annotations, contentWidth),
+        displayWidth(line, this.#displayMode) -
+          this.#lineContentWidth(lineIdx, annotations, contentWidth),
       );
     }
     return Math.max(0, width);
   }
 
   /** Horizontal pan distance for the current content width. */
-  private horizontalStep(): number {
-    if (!this.hasDiffMargin()) return HORIZONTAL_STEP;
-    const annotations = this.activeDiffAnnotations();
-    let width = this.lineContentWidth(0, annotations);
+  #horizontalStep(): number {
+    if (!this.#hasDiffMargin()) return HORIZONTAL_STEP;
+    const annotations = this.#activeDiffAnnotations();
+    let width = this.#lineContentWidth(0, annotations);
     for (const annotation of annotations) {
       width = Math.min(
         width,
-        this.lineContentWidth(annotation.line, annotations),
+        this.#lineContentWidth(annotation.line, annotations),
       );
     }
     return Math.max(1, Math.min(HORIZONTAL_STEP, width));
   }
 
   /** Bring one display column into an unwrapped viewport. */
-  private revealColumn(docLine: number, col: number): void {
-    if (this.wrapLines) return;
-    const width = this.lineContentWidth(this.toFolded(docLine));
+  #revealColumn(docLine: number, col: number): void {
+    if (this.#wrapLines) return;
+    const width = this.#lineContentWidth(this.#toFolded(docLine));
     if (col >= this.left && col < this.left + width) return;
     const leading = Math.min(4, width - 1);
-    this.left = clamp(col - leading, 0, this.maxLeft());
+    this.left = clamp(col - leading, 0, this.#maxLeft());
   }
 
   /** Whether this pager can draw diff annotations. */
-  private hasDiffMargin(): boolean {
-    return !this.cursorOn && !!this.source?.expandContext;
+  #hasDiffMargin(): boolean {
+    return !this.#cursorOn && !!this.#source?.expandContext;
   }
 
   /** Cycle the line-number gutter: off → input position → file/message line. */
-  private cycleLineNumbers(): void {
-    const anchor = this.wrapLines ? this.viewportAnchor() : null;
+  #cycleLineNumbers(): void {
+    const anchor = this.#wrapLines ? this.#viewportAnchor() : null;
     const order: LineNumberMode[] = ["off", "input", "file"];
-    this.lineNumberMode =
-      order[(order.indexOf(this.lineNumberMode) + 1) % order.length];
-    if (anchor) this.restoreWrappedAnchor(anchor);
-    else this.clampScroll();
-    const label = this.lineNumberMode === "off"
+    this.#lineNumberMode =
+      order[(order.indexOf(this.#lineNumberMode) + 1) % order.length];
+    if (anchor) this.#restoreWrappedAnchor(anchor);
+    else this.#clampScroll();
+    const label = this.#lineNumberMode === "off"
       ? "off"
-      : this.lineNumberMode === "input"
+      : this.#lineNumberMode === "input"
       ? "input position"
       : "file / message line";
-    this.message = `Line numbers: ${label}`;
+    this.#message = `Line numbers: ${label}`;
   }
 
   /** The gutter width for the current mode: wide enough for the largest number
    * it shows (file lines can exceed the number of lines the diff spans). */
-  private gutterWidth(): number {
-    if (this.lineNumberMode === "off") return 0;
-    const max = this.gutterNumbers().reduce<number>(
+  #gutterWidth(): number {
+    if (this.#lineNumberMode === "off") return 0;
+    const max = this.#gutterNumbers().reduce<number>(
       (m, n) => n !== null && n > m ? n : m,
       0,
     );
@@ -3263,11 +3277,11 @@ export class Session {
   /** The number the gutter shows on each display row, or null for a blank
    * gutter there (a removed or structural diff line in file mode, or an
    * unmapped row). */
-  private gutterNumbers(): (number | null)[] {
-    const plan = this.foldPlan();
+  #gutterNumbers(): (number | null)[] {
+    const plan = this.#foldPlan();
     const rows = plan.displayLines.length;
-    const fileNums = this.lineNumberMode === "file"
-      ? this.fileLineNumbers()
+    const fileNums = this.#lineNumberMode === "file"
+      ? this.#fileLineNumbers()
       : null;
     const out: (number | null)[] = new Array(rows);
     for (let r = 0; r < rows; r++) {
@@ -3284,21 +3298,21 @@ export class Session {
    * null. Null for a non-diff view (no distinct underlying file). Cached against
    * the document, since every frame draws the gutter and the map costs a parse
    * of the whole diff. */
-  private fileLineNumbers(): (number | null)[] | null {
-    if (this.fileLineCache?.doc !== this.currentDoc) {
-      this.fileLineCache = {
-        doc: this.currentDoc,
-        value: this.computeFileLineNumbers(),
+  #fileLineNumbers(): (number | null)[] | null {
+    if (this.#fileLineCache?.doc !== this.#currentDoc) {
+      this.#fileLineCache = {
+        doc: this.#currentDoc,
+        value: this.#computeFileLineNumbers(),
       };
     }
-    return this.fileLineCache.value;
+    return this.#fileLineCache.value;
   }
 
-  private computeFileLineNumbers(): (number | null)[] | null {
-    if (!this.source?.isDiff) return null;
-    const texts = this.currentDoc.lines.map((l) => l.text);
+  #computeFileLineNumbers(): (number | null)[] | null {
+    if (!this.#source?.isDiff) return null;
+    const texts = this.#currentDoc.lines.map((l) => l.text);
     const out: (number | null)[] = new Array(texts.length).fill(null);
-    const model = parseDiff(this.currentDoc.text);
+    const model = parseDiff(this.#currentDoc.text);
     if (model) {
       for (let i = 0; i < model.lines.length && i < out.length; i++) {
         const nl = model.lines[i].newLine;
@@ -3313,59 +3327,59 @@ export class Session {
     return out;
   }
 
-  private handleChord(key: Key): void {
-    this.chord = null;
-    this.message = "";
-    if (key.name === "ctrl-s") this.requestSave();
-    else if (key.name === "ctrl-c") this.requestQuit();
-    else if (key.name === "ctrl-f") this.openFilePicker();
-    else this.message = `C-x ${key.name}: unbound`;
+  #handleChord(key: Key): void {
+    this.#chord = null;
+    this.#message = "";
+    if (key.name === "ctrl-s") this.#requestSave();
+    else if (key.name === "ctrl-c") this.#requestQuit();
+    else if (key.name === "ctrl-f") this.#openFilePicker();
+    else this.#message = `C-x ${key.name}: unbound`;
   }
 
-  private requestSave(target?: "amend" | "workspace"): boolean {
-    if (!this.source || !this.buffer) {
-      this.message = "Nothing to save.";
+  #requestSave(target?: "amend" | "workspace"): boolean {
+    if (!this.#source || !this.buffer) {
+      this.#message = "Nothing to save.";
       return false;
     }
-    if (!this.source.editable) {
-      this.message = this.source.reason ?? "This view is read-only.";
+    if (!this.#source.editable) {
+      this.#message = this.#source.reason ?? "This view is read-only.";
       return false;
     }
     const baseline = this.buffer.baseline();
     const current = this.buffer.text();
     if (!this.buffer.dirty()) {
-      this.message = "Saved 0 files";
+      this.#message = "Saved 0 files";
       return true;
     }
     // Saving changed commit output rewrites git history, so confirm first.
-    const amend = this.source.pendingAmend?.(baseline, current) ?? null;
+    const amend = this.#source.pendingAmend?.(baseline, current) ?? null;
     if (amend && target === undefined) {
-      this.mode = "amendPrompt";
-      this.focusDefaultButton();
-      this.message = "";
+      this.#mode = "amendPrompt";
+      this.#focusDefaultButton();
+      this.#message = "";
       return false;
     }
     if (amend && target === "amend" && amend.subject.trim() === "") {
-      this.message = "Refusing to amend: the commit message would be empty.";
+      this.#message = "Refusing to amend: the commit message would be empty.";
       return false;
     }
     const options: SaveOptions | undefined = target === "workspace"
       ? { amendCommit: false }
       : undefined;
     try {
-      this.message = this.source.save(
+      this.#message = this.#source.save(
         current,
         this.buffer.lineEndingProvenance(),
         baseline,
         options,
       );
-      const savedBaseline = this.source.baselineAfterSave?.(
+      const savedBaseline = this.#source.baselineAfterSave?.(
         baseline,
         current,
         options,
       ) ?? current;
       this.buffer.setBaseline(savedBaseline);
-      const refreshedLineEndings = this.source.lineEndingProvenance?.(current);
+      const refreshedLineEndings = this.#source.lineEndingProvenance?.(current);
       if (refreshedLineEndings) {
         const retainedLineEndings = this.buffer.lineEndingProvenance();
         this.buffer.setLineEndingProvenance(
@@ -3375,48 +3389,48 @@ export class Session {
         );
       }
       if (target === "workspace" && this.buffer.dirty()) {
-        this.message += "; commit message remains unsaved";
+        this.#message += "; commit message remains unsaved";
       }
       return true;
     } catch (e) {
-      this.message = `Save failed: ${e instanceof Error ? e.message : e}`;
+      this.#message = `Save failed: ${e instanceof Error ? e.message : e}`;
       return false;
     }
   }
 
-  private applyAmendButton(button: DialogButton): void {
+  #applyAmendButton(button: DialogButton): void {
     if (button.hotkey === "a" || button.hotkey === "s") {
-      const ok = this.requestSave(
+      const ok = this.#requestSave(
         button.hotkey === "a" ? "amend" : "workspace",
       );
-      this.mode = "normal";
-      this.editedFiles = [];
+      this.#mode = "normal";
+      this.#editedFiles = [];
       if (
-        ok && this.savePromptThen === "quit" && !this.buffer?.dirty()
+        ok && this.#savePromptThen === "quit" && !this.buffer?.dirty()
       ) {
         this.quit = true;
       }
-      this.savePromptThen = null;
+      this.#savePromptThen = null;
     } else if (button.kind === "cancel") {
-      this.mode = "normal";
-      this.savePromptThen = null;
-      this.editedFiles = [];
-      this.message = "Save cancelled.";
+      this.#mode = "normal";
+      this.#savePromptThen = null;
+      this.#editedFiles = [];
+      this.#message = "Save cancelled.";
     }
   }
 
-  private requestQuit(): void {
+  #requestQuit(): void {
     if (this.buffer?.dirty()) {
       // A quit signal can arrive with a peek overlay still open; the modal save
       // prompt replaces it rather than drawing over it.
-      this.overlay = null;
-      this.overlayScroll = 0;
-      this.overlayStack = [];
-      this.mode = "savePrompt";
-      this.savePromptThen = "quit";
-      this.editedFiles = this.computeEditedFiles();
-      this.focusDefaultButton();
-      this.message = "";
+      this.#overlay = null;
+      this.#overlayScroll = 0;
+      this.#overlayStack = [];
+      this.#mode = "savePrompt";
+      this.#savePromptThen = "quit";
+      this.#editedFiles = this.computeEditedFiles();
+      this.#focusDefaultButton();
+      this.#message = "";
     } else {
       this.quit = true;
     }
@@ -3427,13 +3441,13 @@ export class Session {
    * when only the commit message changed); a plain file falls back to its one
    * label. */
   private computeEditedFiles(): string[] {
-    if (!this.source || !this.buffer) return [];
-    const labels = this.source.dirtyLabels?.(
+    if (!this.#source || !this.buffer) return [];
+    const labels = this.#source.dirtyLabels?.(
       this.buffer.baseline(),
       this.buffer.text(),
     );
     if (labels !== undefined) return labels;
-    return this.source.label ? [this.source.label] : [];
+    return this.#source.label ? [this.#source.label] : [];
   }
 
   /**
@@ -3443,9 +3457,9 @@ export class Session {
    * interrupt during the prompt, so the driver should terminate.
    */
   requestQuitFromSignal(): boolean {
-    if (this.mode === "savePrompt") return false;
+    if (this.#mode === "savePrompt") return false;
     const willPrompt = this.buffer?.dirty() ?? false;
-    this.requestQuit();
+    this.#requestQuit();
     return willPrompt;
   }
 
@@ -3453,26 +3467,28 @@ export class Session {
    * move the focus ring between buttons, wrapping around; Space and Enter
    * activate the focused button; Esc activates the cancel button; a button's
    * shortcut letter activates it directly. Any other key leaves the prompt up. */
-  private handleDialogKey(
+  #handleDialogKey(
     key: Key,
     beforeButtonAction?: () => void,
   ): void {
     // Reached only from the prompt modes, each of which builds a dialog with at
     // least two buttons, so the dialog is present and its row is non-empty.
-    const dialog = this.promptDialog()!;
+    const dialog = this.#promptDialog()!;
     const buttons = dialog.buttons;
     const n = buttons.length;
 
     // Tab moves the ring forward, Shift-Tab back, both wrapping around. From no
     // focus (-1) Tab lands on the first button and Shift-Tab on the last.
     if (key.name === "tab") {
-      this.dialogFocus = this.dialogFocus < 0 ? 0 : (this.dialogFocus + 1) % n;
+      this.#dialogFocus = this.#dialogFocus < 0
+        ? 0
+        : (this.#dialogFocus + 1) % n;
       return;
     }
     if (key.name === "shift-tab") {
-      this.dialogFocus = this.dialogFocus < 0
+      this.#dialogFocus = this.#dialogFocus < 0
         ? n - 1
-        : (this.dialogFocus - 1 + n) % n;
+        : (this.#dialogFocus - 1 + n) % n;
       return;
     }
 
@@ -3488,19 +3504,19 @@ export class Session {
       index = buttons.findIndex((b) => b.hotkey.toLowerCase() === k);
     }
     if (index < 0 || index >= n) return; // an unbound key leaves the prompt up
-    this.activateButton(dialog, index, beforeButtonAction);
+    this.#activateButton(dialog, index, beforeButtonAction);
   }
 
   /** Capture a prompt button's pushed frame, let the driver paint it, then run
    * the button's action. The pressed button is drawn focused as well, so a
    * shortcut-key press shows it highlighted rather than leaving the highlight
    * on whatever Tab last chose. */
-  private activateButton(
+  #activateButton(
     dialog: DialogState,
     index: number,
     beforeButtonAction?: () => void,
   ): void {
-    this.dialogFocus = index;
+    this.#dialogFocus = index;
     this.pendingPush = {
       doc: this.displayDoc(),
       view: {
@@ -3510,57 +3526,57 @@ export class Session {
     };
     beforeButtonAction?.();
     const button = dialog.buttons[index];
-    if (this.mode === "savePrompt") this.applySaveButton(button);
-    else if (this.mode === "amendPrompt") this.applyAmendButton(button);
-    else if (this.mode === "revertPrompt") this.applyRevertButton(button);
+    if (this.#mode === "savePrompt") this.#applySaveButton(button);
+    else if (this.#mode === "amendPrompt") this.#applyAmendButton(button);
+    else if (this.#mode === "revertPrompt") this.#applyRevertButton(button);
   }
 
-  private applySaveButton(button: DialogButton): void {
+  #applySaveButton(button: DialogButton): void {
     if (button.hotkey === "s") {
-      const ok = this.requestSave();
+      const ok = this.#requestSave();
       // The save may need to confirm a commit amend first; leave that prompt up
       // (keeping the quit intent) instead of forcing back to normal mode.
-      if (this.mode === "amendPrompt") return;
-      this.mode = "normal";
-      this.editedFiles = [];
-      if (ok && this.savePromptThen === "quit") this.quit = true;
-      this.savePromptThen = null;
+      if (this.#mode === "amendPrompt") return;
+      this.#mode = "normal";
+      this.#editedFiles = [];
+      if (ok && this.#savePromptThen === "quit") this.quit = true;
+      this.#savePromptThen = null;
     } else if (button.hotkey === "d") {
-      this.mode = "normal";
-      this.editedFiles = [];
-      if (this.savePromptThen === "quit") this.quit = true;
-      this.savePromptThen = null;
+      this.#mode = "normal";
+      this.#editedFiles = [];
+      if (this.#savePromptThen === "quit") this.quit = true;
+      this.#savePromptThen = null;
     } else if (button.kind === "cancel") {
-      this.mode = "normal";
-      this.savePromptThen = null;
-      this.editedFiles = [];
-      this.message = "Cancelled";
+      this.#mode = "normal";
+      this.#savePromptThen = null;
+      this.#editedFiles = [];
+      this.#message = "Cancelled";
     }
   }
 
   /** Open the revert prompt (Ctrl-R while editing). A diff offers only the
    * scopes that apply where the cursor is — the hunk and/or file it is in, or
    * the commit message it is in — plus all; a plain file reverts wholesale. */
-  private openRevertPrompt(): void {
+  #openRevertPrompt(): void {
     if (!this.buffer?.dirty()) {
-      this.message = "Nothing to revert.";
+      this.#message = "Nothing to revert.";
       return;
     }
-    this.mode = "revertPrompt";
-    this.focusDefaultButton();
-    this.message = "";
+    this.#mode = "revertPrompt";
+    this.#focusDefaultButton();
+    this.#message = "";
   }
 
   /** Which revert scopes apply at the cursor: whether it sits in a hunk, in a
    * file, and in an editable commit message. Derived from the current buffer
    * text so it matches what the revert itself finds. */
-  private revertScopesAt(): {
+  #revertScopesAt(): {
     chunk: boolean;
     file: boolean;
     message: boolean;
   } {
     const row = this.buffer!.row;
-    const message = this.inMessageRow();
+    const message = this.#inMessageRow();
     let file = false;
     let chunk = false;
     const model = parseDiff(this.buffer!.text());
@@ -3572,7 +3588,7 @@ export class Session {
     return { chunk, file, message };
   }
 
-  private applyRevertButton(button: DialogButton): void {
+  #applyRevertButton(button: DialogButton): void {
     // The dialog only offers the scopes that apply where the cursor sits, so a
     // scope button that reached here is always valid.
     let scope: RevertScope | null = null;
@@ -3592,22 +3608,22 @@ export class Session {
         break;
     }
     if (scope) {
-      this.performRevert(scope);
-      this.mode = "normal";
+      this.#performRevert(scope);
+      this.#mode = "normal";
     } else if (button.kind === "cancel") {
-      this.message = "Cancelled";
-      this.mode = "normal";
+      this.#message = "Cancelled";
+      this.#mode = "normal";
     }
   }
 
   /** Restore the chosen scope to its original form, keeping the dirty baseline
    * so any remaining edits still count. */
-  private performRevert(scope: RevertScope): void {
-    if (!this.source?.revert || !this.buffer) {
-      this.message = "Revert isn't available here.";
+  #performRevert(scope: RevertScope): void {
+    if (!this.#source?.revert || !this.buffer) {
+      this.#message = "Revert isn't available here.";
       return;
     }
-    const result = this.source.revert(
+    const result = this.#source.revert(
       this.buffer.baseline(),
       this.buffer.text(),
       this.buffer.row,
@@ -3615,34 +3631,34 @@ export class Session {
       this.buffer.lineEndingProvenance(),
     );
     if (!result) {
-      this.message = "Nothing to revert there.";
+      this.#message = "Nothing to revert there.";
       return;
     }
     this.buffer.setText(
       result.text,
       result.cursorLine,
       0,
-      result.lineEndings ?? this.source.lineEndingProvenance?.(result.text),
+      result.lineEndings ?? this.#source.lineEndingProvenance?.(result.text),
     );
-    this.splitRow = null;
-    this.snapCursorToEditable();
-    this.setSourceDocument(
-      this.source.parse(result.text, this.buffer.lineEndingProvenance()),
+    this.#splitRow = null;
+    this.#snapCursorToEditable();
+    this.#setSourceDocument(
+      this.#source.parse(result.text, this.buffer.lineEndingProvenance()),
     );
     this.needsReparse = false;
-    if (this.cursorOn) this.seedHighlighter();
-    this.clampScroll();
+    if (this.#cursorOn) this.#seedHighlighter();
+    this.#clampScroll();
     this.ensureCursorVisible();
-    this.message = `Reverted ${
+    this.#message = `Reverted ${
       scope === "all" ? "all edits" : "the " + scope
     }.`;
   }
 
   /** Move the cursor down to the first editable line at or after it, so it does
    * not sit on a non-editable header after a revert restores a hunk or file. */
-  private snapCursorToEditable(): void {
+  #snapCursorToEditable(): void {
     const b = this.buffer;
-    const pol = this.source?.policy;
+    const pol = this.#source?.policy;
     if (!b || !pol) return;
     while (
       b.row < b.lines.length - 1 && pol.editStart(b.lines, b.row) === null
@@ -3657,27 +3673,27 @@ export class Session {
    * content, and the view holds the far edge of that hunk still so the revealed
    * lines open a gap in front of the user. The extra context is applied to the
    * baseline too, so it does not count as an unsaved edit. */
-  private performExpand(): void {
-    if (!this.source?.expandContext || !this.buffer) {
-      this.message = "Expanding context isn't available here.";
+  #performExpand(): void {
+    if (!this.#source?.expandContext || !this.buffer) {
+      this.#message = "Expanding context isn't available here.";
       return;
     }
     let refLine: number;
     let up: boolean | undefined;
-    if (this.cursorOn) {
+    if (this.#cursorOn) {
       refLine = this.buffer.row; // the cursor names a point, not an edge
     } else {
-      const offer = this.expandOffer();
+      const offer = this.#expandOffer();
       // Ctrl-L is not offered in any of these, so it changes nothing and there
       // is nothing to leave the reason standing next to: say why, and take it
       // away again once it has been read.
       if (offer === null) {
-        this.message = "Move to a hunk's edge, then Ctrl-L to expand it.";
+        this.#message = "Move to a hunk's edge, then Ctrl-L to expand it.";
         this.transientMessage = true;
         return;
       }
       if ("blocked" in offer) {
-        this.message = offer.blocked === "top"
+        this.#message = offer.blocked === "top"
           ? "Top of file."
           : offer.blocked === "bottom"
           ? "Bottom of file."
@@ -3687,24 +3703,24 @@ export class Session {
       }
       refLine = offer.line;
       up = offer.up;
-      if (this.wrapLines) {
-        this.syncWrapDecorations(this.displayDiffAnnotations(offer));
+      if (this.#wrapLines) {
+        this.#syncWrapDecorations(this.displayDiffAnnotations(offer));
       }
     }
-    const r = this.source.expandContext(
+    const r = this.#source.expandContext(
       this.buffer.text(),
       this.buffer.baseline(),
       refLine,
       up,
     );
     if (!r) {
-      this.message = "No more context to show.";
+      this.#message = "No more context to show.";
       return;
     }
     // The node the selection denotes, captured before the reparse renumbers the
     // structure tree under it. The pinned line's row is captured too, before the
     // fold plan (which the reparse invalidates) changes.
-    const selected = this.cursorOn ? null : this.selectedNode();
+    const selected = this.#cursorOn ? null : this.#selectedNode();
     // Where a line of the old text lands in the new one.
     const moved = (n: number) =>
       n + (n >= r.insertedAt ? r.inserted : 0) -
@@ -3735,8 +3751,8 @@ export class Session {
     const pinDoc = r.removedAt !== null
       ? (r.up ? r.removedAt - 1 : r.removedAt + 1)
       : (r.up ? r.insertedAt - 1 : r.insertedAt);
-    const pinRow = this.toDisplay(pinDoc) - this.top;
-    const col = this.cursorOn ? this.buffer.col : 0;
+    const pinRow = this.#toDisplay(pinDoc) - this.top;
+    const col = this.#cursorOn ? this.buffer.col : 0;
     this.buffer.setBaseline(r.baseline);
     this.buffer.setText(
       r.text,
@@ -3744,88 +3760,88 @@ export class Session {
       col,
       lineEndings,
     );
-    this.splitRow = null;
-    this.setSourceDocument(
-      this.source.parse(r.text, this.buffer.lineEndingProvenance()),
+    this.#splitRow = null;
+    this.#setSourceDocument(
+      this.#source.parse(r.text, this.buffer.lineEndingProvenance()),
     );
     this.needsReparse = false;
-    this.wrapDecorations = new Map();
-    this.wrapDecorationKey = "";
-    this.wrapPlanCache = undefined;
-    this.expansionLayoutCache = undefined;
-    if (this.cursorOn) {
-      this.seedHighlighter();
-      this.clampScroll();
+    this.#wrapDecorations = new Map();
+    this.#wrapDecorationKey = "";
+    this.#wrapPlanCache = undefined;
+    this.#expansionLayoutCache = undefined;
+    if (this.#cursorOn) {
+      this.#seedHighlighter();
+      this.#clampScroll();
       this.ensureCursorVisible();
-      this.reportReveal(r);
+      this.#reportReveal(r);
       return;
     }
     // Pager mode: re-point the selection at the same node (its line moved), and
     // put the pinned line back on the row it was on.
-    this.reselectAfterExpand(selected, moved);
+    this.#reselectAfterExpand(selected, moved);
     const movedPin = moved(pinDoc);
-    if (this.wrapLines) {
-      const basePlan = this.baseWrapPlan();
-      const basePin = this.toDisplayWithPlan(movedPin, 0, basePlan);
+    if (this.#wrapLines) {
+      const basePlan = this.#baseWrapPlan();
+      const basePin = this.#toDisplayWithPlan(movedPin, 0, basePlan);
       const baseTop = clamp(
         basePin - pinRow,
         0,
-        this.pagerLastTop(basePlan.rowCount),
+        this.#pagerLastTop(basePlan.rowCount),
       );
       this.top = baseTop;
-      const next = this.expandOffer();
+      const next = this.#expandOffer();
       const nextOffer = next && !("blocked" in next) ? next : null;
       let nextAnnotations = this.displayDiffAnnotations(nextOffer);
-      let state = this.wrapDecorationState(nextAnnotations);
-      this.wrapDecorations = state.decorations;
-      this.wrapDecorationKey = state.key;
-      this.wrapPlanCache = undefined;
-      let decoratedPlan = this.wrapPlan();
+      let state = this.#wrapDecorationState(nextAnnotations);
+      this.#wrapDecorations = state.decorations;
+      this.#wrapDecorationKey = state.key;
+      this.#wrapPlanCache = undefined;
+      let decoratedPlan = this.#wrapPlan();
       let decoratedTop = clamp(
-        this.toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
+        this.#toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
         0,
-        this.pagerLastTop(decoratedPlan.rowCount),
+        this.#pagerLastTop(decoratedPlan.rowCount),
       );
-      const visible = this.metadataWithVisibleTriangle(
+      const visible = this.#metadataWithVisibleTriangle(
         nextAnnotations,
         decoratedPlan,
         decoratedTop,
       );
       if (visible.length !== nextAnnotations.length) {
         nextAnnotations = visible;
-        state = this.wrapDecorationState(nextAnnotations);
-        this.wrapDecorations = state.decorations;
-        this.wrapDecorationKey = state.key;
-        this.wrapPlanCache = undefined;
-        decoratedPlan = this.wrapPlan();
+        state = this.#wrapDecorationState(nextAnnotations);
+        this.#wrapDecorations = state.decorations;
+        this.#wrapDecorationKey = state.key;
+        this.#wrapPlanCache = undefined;
+        decoratedPlan = this.#wrapPlan();
         decoratedTop = clamp(
-          this.toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
+          this.#toDisplayWithPlan(movedPin, 0, decoratedPlan) - pinRow,
           0,
-          this.pagerLastTop(decoratedPlan.rowCount),
+          this.#pagerLastTop(decoratedPlan.rowCount),
         );
       }
       this.top = decoratedTop;
-      this.expansionLayoutCache = {
+      this.#expansionLayoutCache = {
         decoratedPlan,
         decoratedTop: this.top,
         basePlan,
         baseTop,
       };
     } else {
-      this.top = this.toDisplay(movedPin) - pinRow;
+      this.top = this.#toDisplay(movedPin) - pinRow;
     }
-    this.clampScroll();
+    this.#clampScroll();
     // The revealed lines fill the gap the insertion point opened, so the driver
     // can walk them in from the held edge. A join is drawn in one step instead:
     // its frames would stand the two hunks' bodies next to each other before the
     // lines that join them had arrived, showing a file that reads nothing like
     // the one on disk.
-    this.pendingReveal = r.removedAt !== null || this.wrapLines ? null : {
-      row: this.toDisplay(r.insertedAt),
+    this.pendingReveal = r.removedAt !== null || this.#wrapLines ? null : {
+      row: this.#toDisplay(r.insertedAt),
       count: r.inserted,
       up: r.up,
     };
-    this.reportReveal(r);
+    this.#reportReveal(r);
   }
 
   /** Say what a reveal showed: which way it reached, and which lines of the file
@@ -3833,11 +3849,11 @@ export class Session {
    * like any other, and the file's own numbers are what tie them to it. A reveal
    * that closed the last gap between two hunks says so too, since a header
    * disappearing is otherwise left to be puzzled over. */
-  private reportReveal(r: ExpandResult): void {
+  #reportReveal(r: ExpandResult): void {
     const { from, to } = r.revealed;
     const lines = from === to ? `line ${from}` : `lines ${from}-${to}`;
     const where = r.up ? "above" : "below";
-    this.message = r.removedAt !== null
+    this.#message = r.removedAt !== null
       ? `Showing ${lines} ${where} — the two hunks are now one.`
       : `Showing ${lines} ${where} the hunk.`;
     this.transientMessage = true;
@@ -3850,7 +3866,7 @@ export class Session {
    * hunk starts at a given header line, and its label (the `@@` counts) changes
    * as the hunk grows; other kinds keep the label, which is stable and tells
    * apart nodes sharing a start line. */
-  private reselectAfterExpand(
+  #reselectAfterExpand(
     node: StructureNode | null,
     moved: (line: number) => number,
   ): void {
@@ -3860,42 +3876,42 @@ export class Session {
       n.startLine === startLine && n.kind === node.kind &&
       (node.kind === "hunk" || n.label === node.label)
     );
-    this.selectedIndex = idx >= 0 ? idx : null;
+    this.#selectedIndex = idx >= 0 ? idx : null;
   }
 
   /** Whether a node overlaps one viewport under a specific wrapped layout.
    * Nodes inside a collapsed file are excluded because their hidden lines map
    * to the visible file summary. */
-  private nodeOnScreenWithLayout(
+  #nodeOnScreenWithLayout(
     node: StructureNode,
     plan: WrapPlan | null,
     top: number,
   ): boolean {
-    const inHiddenFile = this.foldFiles().some((f) =>
-      this.collapsed.has(f.index) &&
+    const inHiddenFile = this.#foldFiles().some((f) =>
+      this.#collapsed.has(f.index) &&
       node.startLine > f.headerLine && node.startLine <= f.endLine
     );
     if (inHiddenFile) return false;
-    return this.nodeEndRowWithPlan(node, plan) >= top &&
-      this.nodeStartRowWithPlan(node, plan) < top + this.contentRows();
+    return this.#nodeEndRowWithPlan(node, plan) >= top &&
+      this.#nodeStartRowWithPlan(node, plan) < top + this.#contentRows();
   }
 
   /** The row one quarter down the screen's content area. */
-  private expansionTargetRow(top: number): number {
-    return top + Math.floor((this.contentRows() - 1) / 4);
+  #expansionTargetRow(top: number): number {
+    return top + Math.floor((this.#contentRows() - 1) / 4);
   }
 
   /** Expansion layout without the annotations that the chosen edge produces. */
-  private expansionLayout(): { plan: WrapPlan | null; top: number } {
-    if (!this.wrapLines) return { plan: null, top: this.top };
-    const decorated = this.wrapPlan();
-    const base = this.baseWrapPlan();
+  #expansionLayout(): { plan: WrapPlan | null; top: number } {
+    if (!this.#wrapLines) return { plan: null, top: this.top };
+    const decorated = this.#wrapPlan();
+    const base = this.#baseWrapPlan();
     if (
-      this.expansionLayoutCache?.decoratedPlan === decorated &&
-      this.expansionLayoutCache.basePlan === base &&
-      this.expansionLayoutCache.decoratedTop === this.top
+      this.#expansionLayoutCache?.decoratedPlan === decorated &&
+      this.#expansionLayoutCache.basePlan === base &&
+      this.#expansionLayoutCache.decoratedTop === this.top
     ) {
-      return { plan: base, top: this.expansionLayoutCache.baseTop };
+      return { plan: base, top: this.#expansionLayoutCache.baseTop };
     }
     const topRow = wrappedRowAt(
       decorated,
@@ -3904,7 +3920,7 @@ export class Session {
     const baseTop = topRow
       ? wrappedRowForPosition(base, topRow.line, topRow.offset)?.row ?? 0
       : 0;
-    this.expansionLayoutCache = {
+    this.#expansionLayoutCache = {
       decoratedPlan: decorated,
       decoratedTop: this.top,
       basePlan: base,
@@ -3915,23 +3931,23 @@ export class Session {
 
   /** How much context each hunk can still reveal, keyed by its header line.
    * Cached against the document, which the source rebuilds on every expand. */
-  private expandRoom(): ReadonlyMap<number, HunkRoom> {
-    if (this.roomCache?.doc !== this.currentDoc) {
-      this.roomCache = {
-        doc: this.currentDoc,
-        room: this.source?.expandRoom?.(this.currentDoc.text) ?? new Map(),
+  #expandRoom(): ReadonlyMap<number, HunkRoom> {
+    if (this.#roomCache?.doc !== this.#currentDoc) {
+      this.#roomCache = {
+        doc: this.#currentDoc,
+        room: this.#source?.expandRoom?.(this.#currentDoc.text) ?? new Map(),
       };
     }
-    return this.roomCache.room;
+    return this.#roomCache.room;
   }
 
   /** Lines classified as file or hunk metadata by the diff parser. */
-  private diffMetadataLines(): readonly number[] {
-    if (this.diffMetadataCache?.doc === this.currentDoc) {
-      return this.diffMetadataCache.lines;
+  #diffMetadataLines(): readonly number[] {
+    if (this.#diffMetadataCache?.doc === this.#currentDoc) {
+      return this.#diffMetadataCache.lines;
     }
     const lines: number[] = [];
-    const model = parseDiff(this.currentDoc.text);
+    const model = parseDiff(this.#currentDoc.text);
     if (model) {
       for (let line = 0; line < model.lines.length; line++) {
         const kind = model.lines[line].kind;
@@ -3940,28 +3956,28 @@ export class Session {
         }
       }
     }
-    this.diffMetadataCache = { doc: this.currentDoc, lines };
+    this.#diffMetadataCache = { doc: this.#currentDoc, lines };
     return lines;
   }
 
   /** Metadata line directly beyond the marked expansion edge. */
-  private adjacentDiffMetadataLine(expand: ExpandOffer | null): number | null {
+  #adjacentDiffMetadataLine(expand: ExpandOffer | null): number | null {
     if (!expand || expand.markerLine === null) return null;
     const line = expand.up ? expand.line : expand.line + 1;
-    return this.diffMetadataLines().includes(line) ? line : null;
+    return this.#diffMetadataLines().includes(line) ? line : null;
   }
 
   /** Screen rows of metadata directly beyond the marked expansion edge. */
   private displayAdjacentDiffMetadataRows(
     expand: ExpandOffer | null,
   ): readonly number[] {
-    const line = this.adjacentDiffMetadataLine(expand);
+    const line = this.#adjacentDiffMetadataLine(expand);
     if (line === null) return [];
-    const fold = this.foldPlan();
+    const fold = this.#foldPlan();
     const folded = fold.docToDisplay(line);
-    if (fold.displayLines[folded] !== this.currentDoc.lines[line]) return [];
-    const first = this.toDisplay(line);
-    const last = this.toDisplayEnd(line);
+    if (fold.displayLines[folded] !== this.#currentDoc.lines[line]) return [];
+    const first = this.#toDisplay(line);
+    const last = this.#toDisplayEnd(line);
     const rows: number[] = [];
     for (let row = first; row <= last; row++) rows.push(row);
     return rows;
@@ -3971,17 +3987,17 @@ export class Session {
   private displayDiffAnnotations(
     expand: ExpandOffer | null,
   ): DiffAnnotation[] {
-    const { top } = this.expansionLayout();
+    const { top } = this.#expansionLayout();
     if (
       !expand || expand.markerLine === null || expand.row === null ||
-      expand.row < top || expand.row >= top + this.contentRows()
+      expand.row < top || expand.row >= top + this.#contentRows()
     ) {
       return [];
     }
-    const fold = this.foldPlan();
+    const fold = this.#foldPlan();
     const marker = fold.docToDisplay(expand.markerLine);
     if (
-      fold.displayLines[marker] !== this.currentDoc.lines[expand.markerLine]
+      fold.displayLines[marker] !== this.#currentDoc.lines[expand.markerLine]
     ) {
       return [];
     }
@@ -3989,11 +4005,11 @@ export class Session {
       line: marker,
       kind: expand.up ? "expandUp" : "expandDown",
     }];
-    const metadataLine = this.adjacentDiffMetadataLine(expand);
+    const metadataLine = this.#adjacentDiffMetadataLine(expand);
     if (metadataLine !== null) {
       const metadata = fold.docToDisplay(metadataLine);
       if (
-        fold.displayLines[metadata] === this.currentDoc.lines[metadataLine]
+        fold.displayLines[metadata] === this.#currentDoc.lines[metadataLine]
       ) {
         annotations.push({ line: metadata, kind: "diffMetadata" });
       }
@@ -4003,35 +4019,35 @@ export class Session {
 
   /** Apply line-specific wrap widths while keeping the viewport's source
    * position fixed. */
-  private syncWrapDecorations(
+  #syncWrapDecorations(
     annotations: readonly DiffAnnotation[],
   ): DiffAnnotation[] {
     let visible = [...annotations];
-    const baseTop = this.wrapLines ? this.expansionLayout().top : 0;
-    const anchor = this.wrapLines ? this.viewportAnchor() : null;
+    const baseTop = this.#wrapLines ? this.#expansionLayout().top : 0;
+    const anchor = this.#wrapLines ? this.#viewportAnchor() : null;
     if (anchor) {
-      const tentative = this.wrapDecorationState(visible);
+      const tentative = this.#wrapDecorationState(visible);
       const plan = buildWrapPlan(
-        this.foldPlan().displayLines,
-        this.displayMode,
-        this.contentWidth(),
+        this.#foldPlan().displayLines,
+        this.#displayMode,
+        this.#contentWidth(),
         tentative.decorations,
-        this.activeWrapMode,
+        this.#activeWrapMode,
       );
-      const top = this.wrappedTopForAnchor(anchor, plan);
-      visible = this.metadataWithVisibleTriangle(visible, plan, top);
+      const top = this.#wrappedTopForAnchor(anchor, plan);
+      visible = this.#metadataWithVisibleTriangle(visible, plan, top);
     }
-    const state = this.wrapDecorationState(visible);
-    if (state.key === this.wrapDecorationKey) return visible;
-    this.wrapDecorations = state.decorations;
-    this.wrapDecorationKey = state.key;
-    this.wrapPlanCache = undefined;
+    const state = this.#wrapDecorationState(visible);
+    if (state.key === this.#wrapDecorationKey) return visible;
+    this.#wrapDecorations = state.decorations;
+    this.#wrapDecorationKey = state.key;
+    this.#wrapPlanCache = undefined;
     if (anchor) {
-      this.restoreWrappedAnchor(anchor);
-      this.expansionLayoutCache = {
-        decoratedPlan: this.wrapPlan(),
+      this.#restoreWrappedAnchor(anchor);
+      this.#expansionLayoutCache = {
+        decoratedPlan: this.#wrapPlan(),
         decoratedTop: this.top,
-        basePlan: this.baseWrapPlan(),
+        basePlan: this.#baseWrapPlan(),
         baseTop,
       };
     }
@@ -4039,18 +4055,18 @@ export class Session {
   }
 
   /** Top row produced by restoring one source position in a wrapped plan. */
-  private wrappedTopForAnchor(anchor: ViewportAnchor, plan: WrapPlan): number {
+  #wrappedTopForAnchor(anchor: ViewportAnchor, plan: WrapPlan): number {
     const line = clamp(
       anchor.foldedLine,
       0,
       Math.max(0, plan.firstRow.length - 1),
     );
     const row = wrappedRowForPosition(plan, line, anchor.displayCol)?.row ?? 0;
-    return clamp(row, 0, this.pagerLastTop(plan.rowCount));
+    return clamp(row, 0, this.#pagerLastTop(plan.rowCount));
   }
 
   /** Hide a metadata label when its reflow pushes the triangle off-screen. */
-  private metadataWithVisibleTriangle(
+  #metadataWithVisibleTriangle(
     annotations: readonly DiffAnnotation[],
     plan: WrapPlan,
     top: number,
@@ -4065,7 +4081,7 @@ export class Session {
       return [...annotations];
     }
     const row = plan.firstRow[triangle.line];
-    if (row >= top && row < top + this.contentRows()) {
+    if (row >= top && row < top + this.#contentRows()) {
       return [...annotations];
     }
     return annotations.filter((annotation) =>
@@ -4074,22 +4090,22 @@ export class Session {
   }
 
   /** Wrap widths and cache identity for one set of diff annotations. */
-  private wrapDecorationState(
+  #wrapDecorationState(
     annotations: readonly DiffAnnotation[],
   ): { decorations: Map<number, WrapDecoration>; key: string } {
     const decorations = new Map<number, WrapDecoration>();
-    const contentWidth = this.contentWidth();
-    const totalsWidth = this.wrapLines ? this.cornerTotalsWidth() : 0;
-    const metadataLabelLine = this.wrapLines
+    const contentWidth = this.#contentWidth();
+    const totalsWidth = this.#wrapLines ? this.#cornerTotalsWidth() : 0;
+    const metadataLabelLine = this.#wrapLines
       ? labeledDiffMetadataLine(
-        this.foldPlan().displayLines,
-        this.displayMode,
+        this.#foldPlan().displayLines,
+        this.#displayMode,
         contentWidth,
         annotations,
         totalsWidth,
       )
       : null;
-    if (this.wrapLines) {
+    if (this.#wrapLines) {
       for (const annotation of annotations) {
         decorations.set(
           annotation.line,
@@ -4108,8 +4124,8 @@ export class Session {
         );
       }
     }
-    const key = this.wrapLines
-      ? `${contentWidth}|${this.displayMode}|${
+    const key = this.#wrapLines
+      ? `${contentWidth}|${this.#displayMode}|${
         metadataLabelLine ?? "-"
       }|${totalsWidth}|${
         annotations.map((annotation) => `${annotation.line}:${annotation.kind}`)
@@ -4121,17 +4137,17 @@ export class Session {
 
   /** Every hunk boundary visible at its expansion row. `markerLine` names the
    * first or last body line and is null when the hunk has no body. */
-  private visibleEdges(
+  #visibleEdges(
     plan: WrapPlan | null,
     top: number,
   ): ExpandEdge[] {
-    const room = this.expandRoom();
-    const rows = this.contentRows();
+    const room = this.#expandRoom();
+    const rows = this.#contentRows();
     const onScreen = (row: number) => row >= top && row < top + rows;
     const out: ExpandEdge[] = [];
     for (const h of this.doc.flatStructure) {
       if (
-        h.kind !== "hunk" || !this.nodeOnScreenWithLayout(h, plan, top)
+        h.kind !== "hunk" || !this.#nodeOnScreenWithLayout(h, plan, top)
       ) {
         continue;
       }
@@ -4147,10 +4163,10 @@ export class Session {
           [h.endLine, hasBody ? h.endLine : null, false],
         ] as const
       ) {
-        const aimRow = this.toDisplayEndWithPlan(line, plan);
+        const aimRow = this.#toDisplayEndWithPlan(line, plan);
         const row = markerLine === null
           ? null
-          : this.toDisplayWithPlan(markerLine, 0, plan);
+          : this.#toDisplayWithPlan(markerLine, 0, plan);
         if (onScreen(aimRow)) {
           out.push({ row, markerLine, aimRow, line, up, room: r });
         }
@@ -4164,14 +4180,14 @@ export class Session {
    * one sits in a hunk. Null when no edge is on screen. The edge is returned
    * whether or not it has room, so that the offer of Ctrl-L and what Ctrl-L
    * does agree. */
-  private expandEdge(): ExpandEdge | null {
-    const { plan, top } = this.expansionLayout();
-    const edges = this.visibleEdges(plan, top);
+  #expandEdge(): ExpandEdge | null {
+    const { plan, top } = this.#expansionLayout();
+    const edges = this.#visibleEdges(plan, top);
     if (edges.length === 0) return null;
     // A selected node sitting in a hunk aims at that hunk, and its own row is
     // what the edges are measured from: the user picked a place to look.
-    const sel = this.selectedNode();
-    const own = sel && this.nodeOnScreenWithLayout(sel, plan, top)
+    const sel = this.#selectedNode();
+    const own = sel && this.#nodeOnScreenWithLayout(sel, plan, top)
       ? edges.filter((e) =>
         this.doc.flatStructure.some((h) =>
           h.kind === "hunk" && h.startLine <= e.line && e.line <= h.endLine &&
@@ -4180,8 +4196,8 @@ export class Session {
       )
       : [];
     const from = own.length > 0
-      ? this.nodeStartRowWithPlan(sel!, plan)
-      : this.expansionTargetRow(top);
+      ? this.#nodeStartRowWithPlan(sel!, plan)
+      : this.#expansionTargetRow(top);
     const pool = own.length > 0 ? own : edges;
     // Distance in display rows: a collapsed file stands on one row, and the
     // lines it hides are not distance the eye travels.
@@ -4206,11 +4222,11 @@ export class Session {
   /** Whether Ctrl-L would reveal anything, and what stops it when it would not.
    * Drives the edge marker, the status bar's offer of Ctrl-L, and the key
    * itself. */
-  private expandOffer():
+  #expandOffer():
     | ExpandOffer
     | { blocked: "top" | "bottom" | "hunk" }
     | null {
-    const edge = this.expandEdge();
+    const edge = this.#expandEdge();
     if (!edge) return null;
     if ((edge.up ? edge.room.up : edge.room.down) > 0) {
       return {
@@ -4228,100 +4244,100 @@ export class Session {
   // file picker (C-x C-f)
   //
 
-  private openFilePicker(): void {
-    if (!this.files) {
-      this.message = "Opening files isn't available here.";
+  #openFilePicker(): void {
+    if (!this.#files) {
+      this.#message = "Opening files isn't available here.";
       return;
     }
-    const wasCursorOn = this.cursorOn;
-    this.cursorOn = false;
+    const wasCursorOn = this.#cursorOn;
+    this.#cursorOn = false;
     // Opening the picker drops the text cursor, and cancelling it returns to
     // navigation, which reads the structure tree. Refresh it here as leaving
     // edit mode by Esc does, so that return lands on a current tree.
     this.reparse();
     if (wasCursorOn) this.ensureCursorVisible();
-    else this.clampScroll();
-    this.overlay = null;
-    this.overlayStack = [];
-    this.pickerDir = this.pickerStartDir();
-    this.pickerFilter = "";
-    this.pickerSel = 0;
-    this.overlayScroll = 0;
-    this.mode = "filePicker";
+    else this.#clampScroll();
+    this.#overlay = null;
+    this.#overlayStack = [];
+    this.#pickerDir = this.#pickerStartDir();
+    this.#pickerFilter = "";
+    this.#pickerSel = 0;
+    this.#overlayScroll = 0;
+    this.#mode = "filePicker";
     this.refreshPicker();
   }
 
   /** Open at the current file's directory, else the gateway's cwd. */
-  private pickerStartDir(): string {
-    const path = this.source?.path;
-    if (path && this.files) return this.files.parent(path);
-    return this.files!.cwd();
+  #pickerStartDir(): string {
+    const path = this.#source?.path;
+    if (path && this.#files) return this.#files.parent(path);
+    return this.#files!.cwd();
   }
 
   /** Re-list the current directory, filtered by what has been typed. */
   private refreshPicker(): void {
-    if (!this.files) return;
-    const all = this.files.list(this.pickerDir) ?? [];
-    const f = this.pickerFilter.toLowerCase();
+    if (!this.#files) return;
+    const all = this.#files.list(this.#pickerDir) ?? [];
+    const f = this.#pickerFilter.toLowerCase();
     const matched = all.filter((e) => e.name.toLowerCase().includes(f));
     matched.sort((a, b) =>
       a.isDir === b.isDir ? a.name.localeCompare(b.name) : a.isDir ? -1 : 1
     );
     // A ".." entry to step up, offered when not narrowing by a filter.
-    this.pickerEntries = this.pickerFilter.length === 0
+    this.#pickerEntries = this.#pickerFilter.length === 0
       ? [{ name: "..", isDir: true }, ...matched]
       : matched;
-    this.pickerSel = clamp(
-      this.pickerSel,
+    this.#pickerSel = clamp(
+      this.#pickerSel,
       0,
-      Math.max(0, this.pickerEntries.length - 1),
+      Math.max(0, this.#pickerEntries.length - 1),
     );
-    this.ensurePickerVisible();
+    this.#ensurePickerVisible();
   }
 
-  private ensurePickerVisible(): void {
-    this.scrollListToSelection(this.pickerSel);
+  #ensurePickerVisible(): void {
+    this.#scrollListToSelection(this.#pickerSel);
   }
 
   /** Scroll the overlay list so row `sel` sits inside the box. Shared by the
    * file picker and the jump list, which both project a selectable list into an
    * {@link OverlayState} scrolled by `overlayScroll`. */
-  private scrollListToSelection(sel: number): void {
+  #scrollListToSelection(sel: number): void {
     const innerH = overlayBox(this.width, this.height).innerH;
-    if (sel < this.overlayScroll) {
-      this.overlayScroll = sel;
-    } else if (sel >= this.overlayScroll + innerH) {
-      this.overlayScroll = sel - innerH + 1;
+    if (sel < this.#overlayScroll) {
+      this.#overlayScroll = sel;
+    } else if (sel >= this.#overlayScroll + innerH) {
+      this.#overlayScroll = sel - innerH + 1;
     }
   }
 
-  private handleFilePicker(key: Key): void {
-    this.message = "";
-    const last = Math.max(0, this.pickerEntries.length - 1);
+  #handleFilePicker(key: Key): void {
+    this.#message = "";
+    const last = Math.max(0, this.#pickerEntries.length - 1);
     switch (key.name) {
       case "escape":
-        this.mode = "normal";
-        this.overlayScroll = 0;
-        this.message = "Cancelled";
+        this.#mode = "normal";
+        this.#overlayScroll = 0;
+        this.#message = "Cancelled";
         return;
       case "down":
       case "ctrl-n":
-        this.pickerSel = clamp(this.pickerSel + 1, 0, last);
-        return this.ensurePickerVisible();
+        this.#pickerSel = clamp(this.#pickerSel + 1, 0, last);
+        return this.#ensurePickerVisible();
       case "up":
       case "ctrl-p":
-        this.pickerSel = clamp(this.pickerSel - 1, 0, last);
-        return this.ensurePickerVisible();
+        this.#pickerSel = clamp(this.#pickerSel - 1, 0, last);
+        return this.#ensurePickerVisible();
       case "pagedown":
-        this.pickerSel = clamp(this.pickerSel + 10, 0, last);
-        return this.ensurePickerVisible();
+        this.#pickerSel = clamp(this.#pickerSel + 10, 0, last);
+        return this.#ensurePickerVisible();
       case "pageup":
-        this.pickerSel = clamp(this.pickerSel - 10, 0, last);
-        return this.ensurePickerVisible();
+        this.#pickerSel = clamp(this.#pickerSel - 10, 0, last);
+        return this.#ensurePickerVisible();
       case "backspace":
-        if (this.pickerFilter.length > 0) {
-          this.pickerFilter = this.pickerFilter.slice(0, -1);
-          this.pickerSel = 0;
+        if (this.#pickerFilter.length > 0) {
+          this.#pickerFilter = this.#pickerFilter.slice(0, -1);
+          this.#pickerSel = 0;
           this.refreshPicker();
         } else {
           this.pickerUp();
@@ -4333,29 +4349,31 @@ export class Session {
         return;
     }
     if (key.char && key.char >= " " && !key.ctrl) {
-      this.pickerFilter += key.char;
-      this.pickerSel = 0;
+      this.#pickerFilter += key.char;
+      this.#pickerSel = 0;
       this.refreshPicker();
     }
   }
 
   private pickerUp(): void {
-    if (!this.files) return;
-    this.pickerDir = this.files.parent(this.pickerDir);
-    this.pickerFilter = "";
-    this.pickerSel = 0;
-    this.overlayScroll = 0;
+    if (!this.#files) return;
+    this.#pickerDir = this.#files.parent(this.#pickerDir);
+    this.#pickerFilter = "";
+    this.#pickerSel = 0;
+    this.#overlayScroll = 0;
     this.refreshPicker();
   }
 
   /** Act on the highlighted entry: step up, descend a directory, or open a
    * file. With nothing highlighted, treat the typed text as a filename. */
   private activatePicked(): void {
-    if (!this.files) return;
-    const entry = this.pickerEntries[this.pickerSel];
+    if (!this.#files) return;
+    const entry = this.#pickerEntries[this.#pickerSel];
     if (!entry) {
-      if (this.pickerFilter.length > 0) {
-        this.openPickedFile(this.files.join(this.pickerDir, this.pickerFilter));
+      if (this.#pickerFilter.length > 0) {
+        this.openPickedFile(
+          this.#files.join(this.#pickerDir, this.#pickerFilter),
+        );
       }
       return;
     }
@@ -4363,12 +4381,12 @@ export class Session {
       this.pickerUp();
       return;
     }
-    const target = this.files.join(this.pickerDir, entry.name);
+    const target = this.#files.join(this.#pickerDir, entry.name);
     if (entry.isDir) {
-      this.pickerDir = target;
-      this.pickerFilter = "";
-      this.pickerSel = 0;
-      this.overlayScroll = 0;
+      this.#pickerDir = target;
+      this.#pickerFilter = "";
+      this.#pickerSel = 0;
+      this.#overlayScroll = 0;
       this.refreshPicker();
     } else {
       this.openPickedFile(target);
@@ -4378,53 +4396,53 @@ export class Session {
   /** Replace the session's buffer/source/document with the chosen file. Refuses
    * when the current buffer has unsaved edits, to avoid losing them. */
   private openPickedFile(absPath: string): void {
-    if (!this.files) return;
+    if (!this.#files) return;
     if (this.buffer?.dirty()) {
-      this.mode = "normal";
-      this.message =
+      this.#mode = "normal";
+      this.#message =
         "Save or discard your changes before opening another file.";
       return;
     }
-    const opened = this.files.open(absPath);
+    const opened = this.#files.open(absPath);
     if (!opened) {
-      this.mode = "normal";
-      this.message = `Cannot open ${absPath}`;
+      this.#mode = "normal";
+      this.#message = `Cannot open ${absPath}`;
       return;
     }
-    this.source = opened.source;
+    this.#source = opened.source;
     if (opened.source.defaultViewMode === "rendered") {
-      this.viewMode = "rendered";
+      this.#viewMode = "rendered";
     }
     this.buffer = new EditBuffer(
       opened.text,
       opened.source.lineEndingProvenance?.(opened.text),
     );
-    this.splitRow = null;
-    this.highlighter = undefined; // the old highlighter was for the previous file
-    this.clearFolds(); // the previous file's fold indices do not carry over
-    this.setSourceDocument(
+    this.#splitRow = null;
+    this.#highlighter = undefined; // the old highlighter was for the previous file
+    this.#clearFolds(); // the previous file's fold indices do not carry over
+    this.#setSourceDocument(
       opened.source.parse(
         opened.text,
         this.buffer.lineEndingProvenance(),
       ),
     );
-    this.semantics = undefined; // the old service was for the previous file
-    this.mode = "normal";
-    this.cursorOn = false;
-    this.overlay = null;
-    this.overlayScroll = 0;
-    this.overlayStack = [];
-    this.selectedIndex = null;
-    this.query = "";
-    this.matches = [];
-    this.currentMatch = 0;
+    this.#semantics = undefined; // the old service was for the previous file
+    this.#mode = "normal";
+    this.#cursorOn = false;
+    this.#overlay = null;
+    this.#overlayScroll = 0;
+    this.#overlayStack = [];
+    this.#selectedIndex = null;
+    this.#query = "";
+    this.#matches = [];
+    this.#currentMatch = 0;
     this.top = 0;
     this.left = 0;
-    this.message = `Opened ${opened.source.label ?? absPath}`;
+    this.#message = `Opened ${opened.source.label ?? absPath}`;
   }
 
-  private pickerOverlay(): OverlayState {
-    const lines: Line[] = this.pickerEntries.map((e) => {
+  #pickerOverlay(): OverlayState {
+    const lines: Line[] = this.#pickerEntries.map((e) => {
       const text = e.isDir ? `${e.name}/` : e.name;
       const cls: TokenClass = e.isDir ? "builderCall" : "plain";
       return { text, spans: [{ col: 0, text, cls }] };
@@ -4433,13 +4451,15 @@ export class Session {
       const text = "(no matching files)";
       lines.push({ text, spans: [{ col: 0, text, cls: "comment" }] });
     }
-    const name = this.files?.base(this.pickerDir) || this.pickerDir;
+    const name = this.#files?.base(this.#pickerDir) || this.#pickerDir;
     return {
       title: `Open file — ${name}`,
       lines,
-      scroll: this.overlayScroll,
+      scroll: this.#overlayScroll,
       footer: "↑/↓ select · enter open · ⌫ up · esc cancel",
-      selectedLine: this.pickerEntries.length > 0 ? this.pickerSel : undefined,
+      selectedLine: this.#pickerEntries.length > 0
+        ? this.#pickerSel
+        : undefined,
     };
   }
 
@@ -4450,28 +4470,28 @@ export class Session {
   /** Open the list of the diff's files and commit messages, so Enter jumps the
    * view to the one chosen. Only a diff has this list; a plain source view says
    * so and stays put. */
-  private openJumpList(): void {
-    const entries = this.buildJumpEntries();
+  #openJumpList(): void {
+    const entries = this.#buildJumpEntries();
     if (entries.length === 0) {
-      this.message = "The jump list is only available in a diff view.";
+      this.#message = "The jump list is only available in a diff view.";
       return;
     }
-    this.jumpAll = entries;
-    this.jumpFilter = "";
-    this.overlayScroll = 0;
-    this.mode = "jumpList";
-    this.refreshJump();
+    this.#jumpAll = entries;
+    this.#jumpFilter = "";
+    this.#overlayScroll = 0;
+    this.#mode = "jumpList";
+    this.#refreshJump();
     // Open focused on the file the viewport is already reading, so the list
     // starts where the eye is.
-    this.jumpSel = this.jumpEntryAtViewport();
-    this.scrollListToSelection(this.jumpSel);
+    this.#jumpSel = this.#jumpEntryAtViewport();
+    this.#scrollListToSelection(this.#jumpSel);
   }
 
   /** Every file the diff touches and every commit whose message it carries, in
    * document order. Empty for a non-diff view. */
-  private buildJumpEntries(): JumpEntry[] {
-    if (!this.source?.isDiff) return [];
-    const texts = this.currentDoc.lines.map((l) => l.text);
+  #buildJumpEntries(): JumpEntry[] {
+    if (!this.#source?.isDiff) return [];
+    const texts = this.#currentDoc.lines.map((l) => l.text);
     const subjects = commitSubjects(texts);
     const entries: JumpEntry[] = [];
     for (const header of findCommitHeaders(texts)) {
@@ -4484,10 +4504,10 @@ export class Session {
         name: `commit ${short}`,
       });
     }
-    for (const file of this.foldFiles()) {
+    for (const file of this.#foldFiles()) {
       entries.push({
         line: file.headerLine,
-        display: fileJumpLine(file, this.collapsed.has(file.index)),
+        display: fileJumpLine(file, this.#collapsed.has(file.index)),
         filterText: file.path.toLowerCase(),
         name: file.path,
       });
@@ -4497,98 +4517,98 @@ export class Session {
   }
 
   /** Re-derive the shown rows from the filter, keeping the selection in range. */
-  private refreshJump(): void {
-    const f = this.jumpFilter.toLowerCase();
-    this.jumpEntries = f.length === 0
-      ? this.jumpAll
-      : this.jumpAll.filter((e) => e.filterText.includes(f));
-    this.jumpSel = clamp(
-      this.jumpSel,
+  #refreshJump(): void {
+    const f = this.#jumpFilter.toLowerCase();
+    this.#jumpEntries = f.length === 0
+      ? this.#jumpAll
+      : this.#jumpAll.filter((e) => e.filterText.includes(f));
+    this.#jumpSel = clamp(
+      this.#jumpSel,
       0,
-      Math.max(0, this.jumpEntries.length - 1),
+      Math.max(0, this.#jumpEntries.length - 1),
     );
-    this.scrollListToSelection(this.jumpSel);
+    this.#scrollListToSelection(this.#jumpSel);
   }
 
   /** The index of the entry the viewport currently sits on: the last one whose
    * jump line is at or above the top document line. */
-  private jumpEntryAtViewport(): number {
-    const line = this.toDoc(this.top);
+  #jumpEntryAtViewport(): number {
+    const line = this.#toDoc(this.top);
     let idx = 0;
-    for (let i = 0; i < this.jumpEntries.length; i++) {
-      if (this.jumpEntries[i].line <= line) idx = i;
+    for (let i = 0; i < this.#jumpEntries.length; i++) {
+      if (this.#jumpEntries[i].line <= line) idx = i;
       else break;
     }
     return idx;
   }
 
-  private handleJumpList(key: Key): void {
-    this.message = "";
-    const last = Math.max(0, this.jumpEntries.length - 1);
+  #handleJumpList(key: Key): void {
+    this.#message = "";
+    const last = Math.max(0, this.#jumpEntries.length - 1);
     switch (key.name) {
       case "escape":
-        this.mode = "normal";
-        this.overlayScroll = 0;
-        this.message = "Cancelled";
+        this.#mode = "normal";
+        this.#overlayScroll = 0;
+        this.#message = "Cancelled";
         return;
       case "down":
       case "ctrl-n":
-        this.jumpSel = clamp(this.jumpSel + 1, 0, last);
-        return this.scrollListToSelection(this.jumpSel);
+        this.#jumpSel = clamp(this.#jumpSel + 1, 0, last);
+        return this.#scrollListToSelection(this.#jumpSel);
       case "up":
       case "ctrl-p":
-        this.jumpSel = clamp(this.jumpSel - 1, 0, last);
-        return this.scrollListToSelection(this.jumpSel);
+        this.#jumpSel = clamp(this.#jumpSel - 1, 0, last);
+        return this.#scrollListToSelection(this.#jumpSel);
       case "pagedown":
-        this.jumpSel = clamp(this.jumpSel + 10, 0, last);
-        return this.scrollListToSelection(this.jumpSel);
+        this.#jumpSel = clamp(this.#jumpSel + 10, 0, last);
+        return this.#scrollListToSelection(this.#jumpSel);
       case "pageup":
-        this.jumpSel = clamp(this.jumpSel - 10, 0, last);
-        return this.scrollListToSelection(this.jumpSel);
+        this.#jumpSel = clamp(this.#jumpSel - 10, 0, last);
+        return this.#scrollListToSelection(this.#jumpSel);
       case "backspace":
-        if (this.jumpFilter.length > 0) {
-          this.jumpFilter = this.jumpFilter.slice(0, -1);
-          this.jumpSel = 0;
-          this.refreshJump();
+        if (this.#jumpFilter.length > 0) {
+          this.#jumpFilter = this.#jumpFilter.slice(0, -1);
+          this.#jumpSel = 0;
+          this.#refreshJump();
         }
         return;
       case "tab":
       case "enter":
-        this.activateJump();
+        this.#activateJump();
         return;
     }
     if (key.char && key.char >= " " && !key.ctrl) {
-      this.jumpFilter += key.char;
-      this.jumpSel = 0;
-      this.refreshJump();
+      this.#jumpFilter += key.char;
+      this.#jumpSel = 0;
+      this.#refreshJump();
     }
   }
 
   /** Jump to the highlighted entry and close the list. A filter that matches
    * nothing leaves the list open so it can be edited. */
-  private activateJump(): void {
-    const entry = this.jumpEntries[this.jumpSel];
+  #activateJump(): void {
+    const entry = this.#jumpEntries[this.#jumpSel];
     if (!entry) return;
-    this.mode = "normal";
-    this.overlayScroll = 0;
-    this.jumpToLine(entry.line);
-    this.message = `Jumped to ${entry.name}`;
+    this.#mode = "normal";
+    this.#overlayScroll = 0;
+    this.#jumpToLine(entry.line);
+    this.#message = `Jumped to ${entry.name}`;
   }
 
   /** Land document line `docLine` at the top of the viewport, dropping any node
    * selection so tree navigation resumes from where the jump landed. */
-  private jumpToLine(docLine: number): void {
-    this.selectedIndex = null;
+  #jumpToLine(docLine: number): void {
+    this.#selectedIndex = null;
     this.top = clamp(
-      this.toDisplay(docLine),
+      this.#toDisplay(docLine),
       0,
-      this.lastTop(),
+      this.#lastTop(),
     );
     this.left = 0;
   }
 
-  private jumpOverlay(): OverlayState {
-    const lines: Line[] = this.jumpEntries.map((e) => e.display);
+  #jumpOverlay(): OverlayState {
+    const lines: Line[] = this.#jumpEntries.map((e) => e.display);
     if (lines.length === 0) {
       const text = "(no matches)";
       lines.push({ text, spans: [{ col: 0, text, cls: "comment" }] });
@@ -4596,39 +4616,41 @@ export class Session {
     return {
       title: "Jump to file or commit",
       lines,
-      scroll: this.overlayScroll,
+      scroll: this.#overlayScroll,
       footer: "↑/↓ select · enter jump · esc cancel",
-      selectedLine: this.jumpEntries.length > 0 ? this.jumpSel : undefined,
+      selectedLine: this.#jumpEntries.length > 0 ? this.#jumpSel : undefined,
     };
   }
 
-  private navigateTree(
+  #navigateTree(
     step: (flat: readonly StructureNode[], idx: number) => number,
   ): void {
     if (this.doc.flatStructure.length === 0) {
-      this.message = "No structure detected";
+      this.#message = "No structure detected";
       return;
     }
     // Navigation walks only the nodes that are on screen: a collapsed file's
     // interior (its hunks and code) is skipped, leaving just the file itself.
-    const nav = this.navigableIndices();
+    const nav = this.#navigableIndices();
     const navNodes = nav.map((i) => this.doc.flatStructure[i]);
-    if (this.selectedIndex === null) {
-      this.selectNode(nav[this.viewportNodeIndex(navNodes)]);
+    if (this.#selectedIndex === null) {
+      this.selectNode(nav[this.#viewportNodeIndex(navNodes)]);
       return;
     }
-    let cur = nav.indexOf(this.selectedIndex);
-    if (cur < 0) cur = this.reselectAfterCollapse(navNodes); // hidden by a fold
+    let cur = nav.indexOf(this.#selectedIndex);
+    if (cur < 0) cur = this.#reselectAfterCollapse(navNodes); // hidden by a fold
     this.selectNode(nav[step(navNodes, cur)]);
   }
 
   /** The full-flatStructure indices navigation may land on: every node except
    * the interior of a collapsed file — its `section` node stays (it represents
    * the collapsed file), its descendants are dropped. */
-  private navigableIndices(): number[] {
+  #navigableIndices(): number[] {
     const flat = this.doc.flatStructure;
-    if (this.collapsed.size === 0) return flat.map((_, i) => i);
-    const hidden = this.foldFiles().filter((f) => this.collapsed.has(f.index));
+    if (this.#collapsed.size === 0) return flat.map((_, i) => i);
+    const hidden = this.#foldFiles().filter((f) =>
+      this.#collapsed.has(f.index)
+    );
     const out: number[] = [];
     for (let i = 0; i < flat.length; i++) {
       const n = flat[i];
@@ -4646,30 +4668,30 @@ export class Session {
 
   /** Where to resume navigation when the selected node was folded away: the
    * navigable `section` node whose range contains the old selection. */
-  private reselectAfterCollapse(navNodes: readonly StructureNode[]): number {
-    const sel = this.doc.flatStructure[this.selectedIndex!];
+  #reselectAfterCollapse(navNodes: readonly StructureNode[]): number {
+    const sel = this.doc.flatStructure[this.#selectedIndex!];
     const idx = navNodes.findIndex((n) =>
       n.kind === "section" && sel.startLine >= n.startLine &&
       sel.startLine <= n.endLine
     );
-    return idx >= 0 ? idx : this.viewportNodeIndex(navNodes);
+    return idx >= 0 ? idx : this.#viewportNodeIndex(navNodes);
   }
 
   /** The node to select when navigation starts with none selected: the first
    * node whose start sits on screen, else the node enclosing the viewport top,
    * else the first. Works in display rows, since a collapsed file's document
    * lines are not a contiguous on-screen span. */
-  private viewportNodeIndex(nodes: readonly StructureNode[]): number {
-    const bottom = this.top + this.contentRows() - 1;
+  #viewportNodeIndex(nodes: readonly StructureNode[]): number {
+    const bottom = this.top + this.#contentRows() - 1;
     for (let i = 0; i < nodes.length; i++) {
-      const row = this.nodeStartRow(nodes[i]);
+      const row = this.#nodeStartRow(nodes[i]);
       if (row >= this.top && row <= bottom) return i;
     }
     let enclosing = -1;
     let enclosingSpan = Infinity;
     for (let i = 0; i < nodes.length; i++) {
-      const start = this.nodeStartRow(nodes[i]);
-      const end = this.nodeEndRow(nodes[i]);
+      const start = this.#nodeStartRow(nodes[i]);
+      const end = this.#nodeEndRow(nodes[i]);
       const span = end - start;
       if (start <= this.top && end >= this.top && span <= enclosingSpan) {
         enclosing = i;
@@ -4677,7 +4699,7 @@ export class Session {
       }
     }
     if (enclosing >= 0) return enclosing;
-    const onLine = nodeAtLine(nodes, this.toDoc(this.top));
+    const onLine = nodeAtLine(nodes, this.#toDoc(this.top));
     return onLine >= 0 ? onLine : 0;
   }
 }

--- a/packages/cli/support/profiling/inspector-protocol-client.ts
+++ b/packages/cli/support/profiling/inspector-protocol-client.ts
@@ -35,24 +35,24 @@ type PendingCommand = {
 
 export class InspectorProtocolClient extends EventTarget {
   readonly Console = {
-    enable: () => this.command("Console.enable"),
+    enable: () => this.#command("Console.enable"),
   };
 
   readonly Debugger = {
     enable: (params: Record<string, unknown>) =>
-      this.command("Debugger.enable", params),
+      this.#command("Debugger.enable", params),
   };
 
   readonly Profiler = {
-    enable: () => this.command("Profiler.enable"),
+    enable: () => this.#command("Profiler.enable"),
     setSamplingInterval: (params: { interval: number }) =>
-      this.command("Profiler.setSamplingInterval", params),
-    start: () => this.command<void>("Profiler.start"),
-    stop: () => this.command<{ profile: unknown }>("Profiler.stop"),
+      this.#command("Profiler.setSamplingInterval", params),
+    start: () => this.#command<void>("Profiler.start"),
+    stop: () => this.#command<{ profile: unknown }>("Profiler.stop"),
   };
 
   readonly Runtime = {
-    enable: () => this.command("Runtime.enable"),
+    enable: () => this.#command("Runtime.enable"),
   };
 
   readonly #socket: WebSocket;
@@ -94,7 +94,7 @@ export class InspectorProtocolClient extends EventTarget {
     await closed.promise;
   }
 
-  private command<T = unknown>(
+  #command<T = unknown>(
     method: string,
     params: Record<string, unknown> = {},
   ): Promise<T> {

--- a/packages/schema-generator/src/formatters/array-formatter.ts
+++ b/packages/schema-generator/src/formatters/array-formatter.ts
@@ -8,7 +8,11 @@ import type { SchemaGenerator } from "../schema-generator.ts";
 import { getArrayElementInfo } from "../type-utils.ts";
 
 export class ArrayFormatter implements TypeFormatter {
-  constructor(private schemaGenerator: SchemaGenerator) {}
+  #schemaGenerator: SchemaGenerator;
+
+  constructor(schemaGenerator: SchemaGenerator) {
+    this.#schemaGenerator = schemaGenerator;
+  }
 
   supportsType(type: ts.Type, context: GenerationContext): boolean {
     return !!getArrayElementInfo(type, context.typeChecker, context.typeNode);
@@ -63,7 +67,7 @@ export class ArrayFormatter implements TypeFormatter {
 
     // Use formatChildType - it will auto-detect whether to use type-based
     // or node-based analysis based on whether the type is reliable
-    const items = this.schemaGenerator.formatChildType(
+    const items = this.#schemaGenerator.formatChildType(
       info.elementType,
       context,
       info.elementNode,

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -121,7 +121,10 @@ const applyScopeToAsCellEntry = (
  * manually traverse alias chains.
  */
 export class CommonFabricFormatter implements TypeFormatter {
-  constructor(private schemaGenerator: SchemaGenerator) {
+  #schemaGenerator: SchemaGenerator;
+
+  constructor(schemaGenerator: SchemaGenerator) {
+    this.#schemaGenerator = schemaGenerator;
     if (!schemaGenerator) {
       throw new Error(
         "CommonFabricFormatter requires a SchemaGenerator instance",
@@ -143,7 +146,9 @@ export class CommonFabricFormatter implements TypeFormatter {
       return true;
     }
 
-    if (this.resolveCfcAliasInstantiation(type as TypeWithInternals, context)) {
+    if (
+      this.#resolveCfcAliasInstantiation(type as TypeWithInternals, context)
+    ) {
       return true;
     }
 
@@ -164,14 +169,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // Check if this is FactoryInput<T>.
-    if (this.getFactoryInputBase(type)) {
+    if (this.#getFactoryInputBase(type)) {
       return true;
     }
 
     // Check if union contains wrapper types via node inspection
     // This must come before the blanket union rejection to handle
     // cases like Reactive<T> | undefined without expanding conditionals
-    if (this.isWrapperUnion(type, context)) {
+    if (this.#isWrapperUnion(type, context)) {
       return true; // Take ownership of wrapper unions
     }
 
@@ -191,7 +196,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     const n = context.typeNode;
     const resolvedScopeWrapper = resolveScopeWrapperNode(n);
     if (resolvedScopeWrapper) {
-      return this.formatScopeWrapperTypeFromNode(
+      return this.#formatScopeWrapperTypeFromNode(
         resolvedScopeWrapper.node,
         context,
         resolvedScopeWrapper.scope,
@@ -207,20 +212,20 @@ export class CommonFabricFormatter implements TypeFormatter {
           `${aliasType.aliasSymbol?.name}<T> requires type argument`,
         );
       }
-      const innerSchema = this.schemaGenerator.formatChildType(
+      const innerSchema = this.#schemaGenerator.formatChildType(
         innerType,
         context,
         undefined,
       );
-      return this.applyScopeWrapperSemantics(innerSchema, aliasScope);
+      return this.#applyScopeWrapperSemantics(innerSchema, aliasScope);
     }
 
-    const resolvedCfcAlias = this.resolveCfcAliasInstantiation(
+    const resolvedCfcAlias = this.#resolveCfcAliasInstantiation(
       aliasType,
       context,
     );
     if (resolvedCfcAlias) {
-      return this.formatResolvedCfcAlias(resolvedCfcAlias, context);
+      return this.#formatResolvedCfcAlias(resolvedCfcAlias, context);
     }
 
     // Handle wrapper unions first (before FactoryInput<T> union check)
@@ -228,22 +233,22 @@ export class CommonFabricFormatter implements TypeFormatter {
     // via node inspection to avoid conditional type expansion
     if (
       (type.flags & ts.TypeFlags.Union) !== 0 &&
-      this.isWrapperUnion(type, context)
+      this.#isWrapperUnion(type, context)
     ) {
-      return this.formatWrapperUnion(type as ts.UnionType, context);
+      return this.#formatWrapperUnion(type as ts.UnionType, context);
     }
 
     // Check if this is FactoryInput<T> and handle it first
     // This prevents the UnionFormatter from creating an anyOf
-    const factoryInputBase = this.getFactoryInputBase(type);
+    const factoryInputBase = this.#getFactoryInputBase(type);
     if (factoryInputBase) {
-      const innerSchema = this.schemaGenerator.formatChildType(
+      const innerSchema = this.#schemaGenerator.formatChildType(
         factoryInputBase,
         context,
         undefined, // Don't pass typeNode since we're working with the unwrapped type
       );
 
-      return this.applyWrapperSemantics(innerSchema, "OpaqueCell");
+      return this.#applyWrapperSemantics(innerSchema, "OpaqueCell");
     }
 
     // Check via typeNode for all wrapper types (handles both direct usage and aliases)
@@ -261,7 +266,7 @@ export class CommonFabricFormatter implements TypeFormatter {
         : resolvedWrapper.node; // Direct reference or fallback
 
       if (nodeForDefault && ts.isTypeReferenceNode(nodeForDefault)) {
-        return this.formatDefaultType(nodeForDefault, context, type);
+        return this.#formatDefaultType(nodeForDefault, context, type);
       }
     }
 
@@ -276,7 +281,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       typeWithAlias.aliasTypeArguments.length >= 1
     ) {
       const innerType = typeWithAlias.aliasTypeArguments[0]!;
-      const valueSchema = this.schemaGenerator.formatChildType(
+      const valueSchema = this.#schemaGenerator.formatChildType(
         innerType,
         context,
         undefined,
@@ -284,7 +289,7 @@ export class CommonFabricFormatter implements TypeFormatter {
 
       if (typeWithAlias.aliasTypeArguments.length >= 2) {
         const defaultType = typeWithAlias.aliasTypeArguments[1]!;
-        const defaultValue = this.extractDefaultValue(defaultType, context);
+        const defaultValue = this.#extractDefaultValue(defaultType, context);
         // TODO(danfuzz): A default for a fabric-backed native disagrees with
         // the value its type actually stores. `Date`, `RegExp`, and
         // `Uint8Array` map to `{ type: "object" }` because they are stored as
@@ -317,9 +322,9 @@ export class CommonFabricFormatter implements TypeFormatter {
       resolvedWrapper.kind !== "Default" &&
       wrapperInfo &&
       wrapperInfo.kind !== resolvedWrapper.kind &&
-      this.isSyntheticWrapperNode(resolvedWrapper.node)
+      this.#isSyntheticWrapperNode(resolvedWrapper.node)
     ) {
-      return this.formatWrapperTypeFromNode(
+      return this.#formatWrapperTypeFromNode(
         resolvedWrapper.node,
         context,
         resolvedWrapper.kind,
@@ -335,12 +340,12 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     if (wrapperInfo && !(type.flags & ts.TypeFlags.Union)) {
-      const nodeToPass = this.selectWrapperTypeNode(
+      const nodeToPass = this.#selectWrapperTypeNode(
         n,
         resolvedWrapper,
         wrapperInfo.kind,
       );
-      return this.formatWrapperType(
+      return this.#formatWrapperType(
         wrapperInfo.typeRef,
         nodeToPass,
         context,
@@ -356,7 +361,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       resolvedWrapper.kind !== "Default" &&
       !wrapperInfo
     ) {
-      return this.formatWrapperTypeFromNode(
+      return this.#formatWrapperTypeFromNode(
         resolvedWrapper.node,
         context,
         resolvedWrapper.kind,
@@ -376,18 +381,18 @@ export class CommonFabricFormatter implements TypeFormatter {
       "ComparableCell",
     ];
     for (const kind of wrapperKinds) {
-      const unwrappedType = this.recursivelyUnwrapOpaqueCell(
+      const unwrappedType = this.#recursivelyUnwrapOpaqueCell(
         type,
         kind,
         context.typeChecker,
       );
       if (unwrappedType) {
-        const nodeToPass = this.selectWrapperTypeNode(
+        const nodeToPass = this.#selectWrapperTypeNode(
           n,
           resolvedWrapper,
           unwrappedType.kind,
         );
-        return this.formatWrapperType(
+        return this.#formatWrapperType(
           unwrappedType.typeRef,
           nodeToPass,
           context,
@@ -396,13 +401,13 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    const nodeName = this.getTypeRefIdentifierName(n);
+    const nodeName = this.#getTypeRefIdentifierName(n);
     throw new Error(
       `Unexpected Common Fabric type: ${nodeName}`,
     );
   }
 
-  private formatWrapperTypeFromNode(
+  #formatWrapperTypeFromNode(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
     wrapperKind: WrapperKind,
@@ -442,11 +447,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     // synthetic position, so the node-driven result must win there (e.g. a
     // `string | undefined` inner whose `| undefined` lives only on the node).
     if (
-      this.isUnusableInnerType(innerType) && fallbackInnerTypeRef &&
+      this.#isUnusableInnerType(innerType) && fallbackInnerTypeRef &&
       ts.isTypeReferenceNode(innerTypeNode)
     ) {
       const fallbackInner = fallbackInnerTypeRef.typeArguments?.[0];
-      if (fallbackInner && !this.isUnusableInnerType(fallbackInner)) {
+      if (fallbackInner && !this.#isUnusableInnerType(fallbackInner)) {
         innerType = fallbackInner;
       }
     }
@@ -456,7 +461,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
-        const itemsOverride = this.createArrayItemsOverride(
+        const itemsOverride = this.#createArrayItemsOverride(
           innerType,
           innerTypeNode,
           context,
@@ -465,7 +470,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    const innerSchema = this.schemaGenerator.formatChildType(
+    const innerSchema = this.#schemaGenerator.formatChildType(
       innerType,
       childContext,
       innerTypeNode,
@@ -473,9 +478,9 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     if (wrapperKind === "Stream") {
       if (typeof innerSchema === "boolean") {
-        return this.applyWrapperSemantics(innerSchema, "Stream");
+        return this.#applyWrapperSemantics(innerSchema, "Stream");
       }
-      return this.applyWrapperSemantics(
+      return this.#applyWrapperSemantics(
         innerSchema as MutableJSONSchemaObj,
         "Stream",
       );
@@ -487,7 +492,7 @@ export class CommonFabricFormatter implements TypeFormatter {
         context.typeChecker,
       );
       if (
-        this.isStreamType(innerType, context.typeChecker) ||
+        this.#isStreamType(innerType, context.typeChecker) ||
         innerWrapper?.kind === "Stream"
       ) {
         throw new Error(
@@ -496,10 +501,10 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    return this.applyWrapperSemantics(innerSchema, wrapperKind);
+    return this.#applyWrapperSemantics(innerSchema, wrapperKind);
   }
 
-  private formatScopeWrapperTypeFromNode(
+  #formatScopeWrapperTypeFromNode(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
     scope: SchemaScope,
@@ -517,16 +522,16 @@ export class CommonFabricFormatter implements TypeFormatter {
       innerType = context.typeChecker.getAnyType();
     }
 
-    const innerSchema = this.schemaGenerator.formatChildType(
+    const innerSchema = this.#schemaGenerator.formatChildType(
       innerType,
       context,
       innerTypeNode,
     );
 
-    return this.applyScopeWrapperSemantics(innerSchema, scope);
+    return this.#applyScopeWrapperSemantics(innerSchema, scope);
   }
 
-  private applyScopeWrapperSemantics(
+  #applyScopeWrapperSemantics(
     schema: MutableJSONSchema,
     scope: SchemaScope,
   ): MutableJSONSchema {
@@ -551,7 +556,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return { ...schema, scope };
   }
 
-  private formatWrapperType(
+  #formatWrapperType(
     typeRef: ts.TypeReference,
     typeRefNode: ts.TypeNode | undefined,
     context: GenerationContext,
@@ -586,13 +591,13 @@ export class CommonFabricFormatter implements TypeFormatter {
     // when wrapper references degrade to unknown/any/type-parameter.
     let innerType: ts.Type | undefined = innerTypeFromType;
     if (
-      (!innerType || this.isUnusableInnerType(innerType)) &&
+      (!innerType || this.#isUnusableInnerType(innerType)) &&
       innerTypeNode
     ) {
       try {
         const fromNode = context.typeRegistry?.get(innerTypeNode) ??
           context.typeChecker.getTypeFromTypeNode(innerTypeNode);
-        if (fromNode && !this.isUnusableInnerType(fromNode)) {
+        if (fromNode && !this.#isUnusableInnerType(fromNode)) {
           innerType = fromNode;
         }
       } catch {
@@ -618,7 +623,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       innerTypeNode.end === -1;
 
     const syntheticNodeNeedsHelp = !!innerTypeNode && !!isSyntheticNode &&
-      this.innerTypeNeedsNodeAssistance(innerType, context.typeChecker);
+      this.#innerTypeNeedsNodeAssistance(innerType, context.typeChecker);
 
     // Prefer real source nodes, but allow synthetic nodes when the resolved type
     // is widened/unusable and the node still carries useful structure.
@@ -638,7 +643,7 @@ export class CommonFabricFormatter implements TypeFormatter {
         // element's `comparable` capability lives ONLY on the synthetic node
         // (the resolved union type can't express it), so the node is required to
         // recover it. (CT-1639 Gap B)
-        const itemsOverride = this.createArrayItemsOverride(
+        const itemsOverride = this.#createArrayItemsOverride(
           innerType,
           innerTypeNode,
           context,
@@ -647,7 +652,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    const innerSchema = this.schemaGenerator.formatChildType(
+    const innerSchema = this.#schemaGenerator.formatChildType(
       innerType,
       childContext,
       shouldPassTypeNode ? innerTypeNode : undefined,
@@ -656,9 +661,9 @@ export class CommonFabricFormatter implements TypeFormatter {
     // Stream<T>: can also reflect inner Cell-ness
     if (wrapperKind === "Stream") {
       if (typeof innerSchema === "boolean") {
-        return this.applyWrapperSemantics(innerSchema, "Stream");
+        return this.#applyWrapperSemantics(innerSchema, "Stream");
       }
-      return this.applyWrapperSemantics(
+      return this.#applyWrapperSemantics(
         innerSchema as MutableJSONSchemaObj,
         "Stream",
       );
@@ -667,7 +672,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     // Cell<T>: disallow Cell<Stream<T>> to avoid ambiguous semantics
     if (
       wrapperKind === "Cell" &&
-      this.isStreamType(innerType, context.typeChecker)
+      this.#isStreamType(innerType, context.typeChecker)
     ) {
       throw new Error(
         "Cell<Stream<T>> is unsupported. Wrap the stream: Cell<{ stream: Stream<T> }>.",
@@ -675,10 +680,10 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // Apply wrapper semantics (asCell/asOpaque) to the inner schema
-    return this.applyWrapperSemantics(innerSchema, wrapperKind);
+    return this.#applyWrapperSemantics(innerSchema, wrapperKind);
   }
 
-  private createArrayItemsOverride(
+  #createArrayItemsOverride(
     arrayType: ts.Type,
     arrayTypeNode: ts.TypeNode | undefined,
     context: GenerationContext,
@@ -702,7 +707,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       // The real array member's element capability (e.g. `comparable`) lives on
       // the synthetic NODE, not the resolved union type, so recover it from the
       // node by descending to the real array member's element. (CT-1639 Gap B)
-      resolvedElementWrapperKind = this.elementWrapperFromUnionNode(
+      resolvedElementWrapperKind = this.#elementWrapperFromUnionNode(
         arrayTypeNode,
         context.typeChecker,
       );
@@ -712,7 +717,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       ? undefined
       : resolvedElementWrapperKind;
     return elementWrapperKind
-      ? this.applyWrapperSemantics(base, elementWrapperKind)
+      ? this.#applyWrapperSemantics(base, elementWrapperKind)
       : base;
   }
 
@@ -723,14 +728,14 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Empty-array / `Default<...>` members are skipped. Returns undefined when the
    * node is not a union, has no real array member, or the element is unwrapped.
    */
-  private elementWrapperFromUnionNode(
+  #elementWrapperFromUnionNode(
     node: ts.TypeNode | undefined,
     checker: ts.TypeChecker,
   ): "Default" | WrapperKind | undefined {
     if (!node || !ts.isUnionTypeNode(node)) return undefined;
     let elementNode: ts.TypeNode | undefined;
     for (const member of node.types) {
-      const arrayElement = this.arrayElementNode(member);
+      const arrayElement = this.#arrayElementNode(member);
       if (!arrayElement) continue; // non-array member (e.g. Default<[]>) — skip
       // Skip degenerate empty-array members (`never[]`) — they're the unbranded
       // arm of an expanded `Default<[]>` and carry no real element. (The branded
@@ -745,7 +750,7 @@ export class CommonFabricFormatter implements TypeFormatter {
   }
 
   /** The element TypeNode of `T[]` or `Array<T>`/`ReadonlyArray<T>`, else undefined. */
-  private arrayElementNode(node: ts.TypeNode): ts.TypeNode | undefined {
+  #arrayElementNode(node: ts.TypeNode): ts.TypeNode | undefined {
     if (ts.isArrayTypeNode(node)) return node.elementType;
     if (
       ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) &&
@@ -758,25 +763,25 @@ export class CommonFabricFormatter implements TypeFormatter {
     return undefined;
   }
 
-  private isUnusableInnerType(type: ts.Type): boolean {
+  #isUnusableInnerType(type: ts.Type): boolean {
     return (type.flags &
       (ts.TypeFlags.Any | ts.TypeFlags.Unknown |
         ts.TypeFlags.TypeParameter)) !==
       0;
   }
 
-  private innerTypeNeedsNodeAssistance(
+  #innerTypeNeedsNodeAssistance(
     type: ts.Type,
     checker: ts.TypeChecker,
   ): boolean {
-    if (this.isUnusableInnerType(type)) {
+    if (this.#isUnusableInnerType(type)) {
       return true;
     }
     const numericIndex = checker.getIndexTypeOfType(type, ts.IndexKind.Number);
     if (!numericIndex) {
       return false;
     }
-    return this.isUnusableInnerType(numericIndex);
+    return this.#isUnusableInnerType(numericIndex);
   }
 
   /**
@@ -786,7 +791,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * opaque-branded layers due to the recursive definition of the FactoryInput
    * type.
    */
-  private recursivelyUnwrapOpaqueCell(
+  #recursivelyUnwrapOpaqueCell(
     type: ts.Type,
     targetWrapperKind: WrapperKind,
     checker: ts.TypeChecker,
@@ -812,7 +817,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       const unionType = type as ts.UnionType;
       for (const member of unionType.types) {
         // Try to unwrap this member
-        const result = this.recursivelyUnwrapOpaqueCell(
+        const result = this.#recursivelyUnwrapOpaqueCell(
           member,
           targetWrapperKind,
           checker,
@@ -823,10 +828,10 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // If this is an opaque-branded cell, extract its type argument and recurse
-    if (this.isOpaqueCellType(type, checker)) {
-      const innerType = this.extractOpaqueCellTypeArgument(type, checker);
+    if (this.#isOpaqueCellType(type, checker)) {
+      const innerType = this.#extractOpaqueCellTypeArgument(type, checker);
       if (innerType) {
-        return this.recursivelyUnwrapOpaqueCell(
+        return this.#recursivelyUnwrapOpaqueCell(
           innerType,
           targetWrapperKind,
           checker,
@@ -841,7 +846,7 @@ export class CommonFabricFormatter implements TypeFormatter {
   /**
    * Extract the base type from FactoryInput<T>.
    */
-  private getFactoryInputBase(type: ts.Type): ts.Type | undefined {
+  #getFactoryInputBase(type: ts.Type): ts.Type | undefined {
     const aliasType = type as TypeWithInternals;
     return aliasType.aliasSymbol?.name === "FactoryInput"
       ? aliasType.aliasTypeArguments?.[0]
@@ -852,14 +857,14 @@ export class CommonFabricFormatter implements TypeFormatter {
   // brand it matches, not the `Reactive` annotation spelling: that is an
   // identity alias for T (no runtime wrapper, no brand), so it cannot be
   // detected structurally here — only OpaqueCell can.
-  private isOpaqueCellType(type: ts.Type, checker: ts.TypeChecker): boolean {
+  #isOpaqueCellType(type: ts.Type, checker: ts.TypeChecker): boolean {
     return isCellBrand(type, checker, "opaque");
   }
 
   /**
    * Extract the type argument T from an opaque-branded cell (OpaqueCell<T>).
    */
-  private extractOpaqueCellTypeArgument(
+  #extractOpaqueCellTypeArgument(
     type: ts.Type,
     checker: ts.TypeChecker,
   ): ts.Type | undefined {
@@ -876,7 +881,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return typeArgs && typeArgs.length > 0 ? typeArgs[0] : undefined;
   }
 
-  private selectWrapperTypeNode(
+  #selectWrapperTypeNode(
     originalNode: ts.TypeNode | undefined,
     resolvedWrapper:
       | {
@@ -899,11 +904,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     return undefined;
   }
 
-  private isSyntheticWrapperNode(node: ts.Node): boolean {
+  #isSyntheticWrapperNode(node: ts.Node): boolean {
     return node.pos < 0 || node.end < 0;
   }
 
-  private getTypeRefIdentifierName(
+  #getTypeRefIdentifierName(
     node?: ts.TypeNode,
   ): string | undefined {
     if (!node || !ts.isTypeReferenceNode(node)) return undefined;
@@ -911,11 +916,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     return ts.isIdentifier(tn) ? tn.text : undefined;
   }
 
-  private isStreamType(type: ts.Type, checker: ts.TypeChecker): boolean {
+  #isStreamType(type: ts.Type, checker: ts.TypeChecker): boolean {
     return getCellBrand(type, checker) === "stream";
   }
 
-  private formatDefaultType(
+  #formatDefaultType(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
     pairedType?: ts.Type,
@@ -934,21 +939,21 @@ export class CommonFabricFormatter implements TypeFormatter {
     // Get the value type from the type nodes
     const valueType = context.typeRegistry?.get(valueTypeNode) ??
       context.typeChecker.getTypeFromTypeNode(valueTypeNode);
-    if (typeArgs.length === 1 && this.isUndefinedType(valueType)) {
+    if (typeArgs.length === 1 && this.#isUndefinedType(valueType)) {
       throw new Error(
         "Default<undefined> is unsupported; use an optional field or a JSON value default.",
       );
     }
 
     // Generate schema for the value type
-    const valueSchema = this.schemaGenerator.formatChildType(
+    const valueSchema = this.#schemaGenerator.formatChildType(
       valueType,
       context,
       valueTypeNode,
     );
 
     // Extract default value from the default type node (this can handle complex literals)
-    let defaultValue = this.extractDefaultValueFromNode(
+    let defaultValue = this.#extractDefaultValueFromNode(
       defaultTypeNode,
       context,
     );
@@ -987,7 +992,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return valueSchema;
   }
 
-  private formatCfcAlias(
+  #formatCfcAlias(
     typeWithAlias: TypeWithInternals,
     context: GenerationContext,
     aliasName: string,
@@ -998,14 +1003,14 @@ export class CommonFabricFormatter implements TypeFormatter {
       throw new Error(`${aliasName}<T> requires type argument`);
     }
 
-    const baseTypeNode = this.getAliasTypeArgumentNode(context.typeNode, 0);
-    const baseSchema = this.schemaGenerator.formatChildType(
+    const baseTypeNode = this.#getAliasTypeArgumentNode(context.typeNode, 0);
+    const baseSchema = this.#schemaGenerator.formatChildType(
       baseType,
       context,
       baseTypeNode,
     );
 
-    const ifc = this.buildIfcMetadataForAlias(
+    const ifc = this.#buildIfcMetadataForAlias(
       aliasName,
       aliasArgs,
       context,
@@ -1014,10 +1019,10 @@ export class CommonFabricFormatter implements TypeFormatter {
       return baseSchema;
     }
 
-    return this.mergeIfcMetadata(baseSchema, ifc);
+    return this.#mergeIfcMetadata(baseSchema, ifc);
   }
 
-  private formatResolvedCfcAlias(
+  #formatResolvedCfcAlias(
     resolved: ResolvedCfcAlias,
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -1028,11 +1033,11 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     const baseTypeNode = resolved.aliasArgNodes?.[0];
     const baseSchema = baseTypeNode
-      ? this.formatCfcAliasTypeNode(baseTypeNode, context) ??
-        this.schemaGenerator.formatChildType(baseType, context, baseTypeNode)
-      : this.schemaGenerator.formatChildType(baseType, context, undefined);
+      ? this.#formatCfcAliasTypeNode(baseTypeNode, context) ??
+        this.#schemaGenerator.formatChildType(baseType, context, baseTypeNode)
+      : this.#schemaGenerator.formatChildType(baseType, context, undefined);
 
-    const ifc = this.buildIfcMetadataForAlias(
+    const ifc = this.#buildIfcMetadataForAlias(
       resolved.aliasName,
       resolved.aliasArgs,
       context,
@@ -1042,17 +1047,17 @@ export class CommonFabricFormatter implements TypeFormatter {
       return baseSchema;
     }
 
-    return this.mergeIfcMetadata(baseSchema, ifc);
+    return this.#mergeIfcMetadata(baseSchema, ifc);
   }
 
-  private formatCfcAliasTypeNode(
+  #formatCfcAliasTypeNode(
     typeNode: ts.TypeNode,
     context: GenerationContext,
   ): MutableJSONSchema | undefined {
     if (
       ts.isParenthesizedTypeNode(typeNode) || ts.isTypeOperatorNode(typeNode)
     ) {
-      return this.formatCfcAliasTypeNode(typeNode.type, context);
+      return this.#formatCfcAliasTypeNode(typeNode.type, context);
     }
     if (
       !ts.isTypeReferenceNode(typeNode) || !ts.isIdentifier(typeNode.typeName)
@@ -1060,7 +1065,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const aliasDeclaration = this.getTypeAliasDeclarationForSymbol(
+    const aliasDeclaration = this.#getTypeAliasDeclarationForSymbol(
       context.typeChecker.getSymbolAtLocation(typeNode.typeName),
       context,
     );
@@ -1072,9 +1077,9 @@ export class CommonFabricFormatter implements TypeFormatter {
       ? [...typeNode.typeArguments]
       : undefined;
     const aliasArgs = (aliasArgNodes ?? []).map((argNode) =>
-      this.resolveTypeNodeToType(argNode, context, new Map())
+      this.#resolveTypeNodeToType(argNode, context, new Map())
     );
-    const resolved = this.resolveCfcAliasFromDeclaration(
+    const resolved = this.#resolveCfcAliasFromDeclaration(
       aliasDeclaration,
       aliasArgs,
       aliasArgNodes,
@@ -1082,11 +1087,11 @@ export class CommonFabricFormatter implements TypeFormatter {
       new Set([aliasDeclaration.name.text]),
     );
     return resolved
-      ? this.formatResolvedCfcAlias(resolved, context)
+      ? this.#formatResolvedCfcAlias(resolved, context)
       : undefined;
   }
 
-  private resolveCfcAliasInstantiation(
+  #resolveCfcAliasInstantiation(
     typeWithAlias: TypeWithInternals,
     context: GenerationContext,
   ): ResolvedCfcAlias | undefined {
@@ -1100,7 +1105,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     const aliasSymbol = typeWithAlias.aliasSymbol;
-    const aliasDeclaration = this.getTypeAliasDeclarationForSymbol(
+    const aliasDeclaration = this.#getTypeAliasDeclarationForSymbol(
       aliasSymbol,
       context,
     );
@@ -1108,16 +1113,16 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
-    return this.resolveCfcAliasFromDeclaration(
+    return this.#resolveCfcAliasFromDeclaration(
       aliasDeclaration,
       aliasArgs,
-      this.getAliasTypeArgumentNodes(context.typeNode),
+      this.#getAliasTypeArgumentNodes(context.typeNode),
       context,
       new Set([aliasName]),
     );
   }
 
-  private resolveCfcAliasFromDeclaration(
+  #resolveCfcAliasFromDeclaration(
     aliasDeclaration: ts.TypeAliasDeclaration,
     aliasArgs: readonly ts.Type[],
     aliasArgNodes: readonly ts.TypeNode[] | undefined,
@@ -1145,7 +1150,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const targetDeclaration = this.getTypeAliasDeclarationForSymbol(
+    const targetDeclaration = this.#getTypeAliasDeclarationForSymbol(
       context.typeChecker.getSymbolAtLocation(aliased.typeName),
       context,
     );
@@ -1170,15 +1175,15 @@ export class CommonFabricFormatter implements TypeFormatter {
     const resolvedArgs: ts.Type[] = [];
     const resolvedArgNodes: ts.TypeNode[] = [];
     for (const argNode of aliased.typeArguments ?? []) {
-      const resolvedArgNode = this.substituteTypeNode(argNode, paramNodeMap);
+      const resolvedArgNode = this.#substituteTypeNode(argNode, paramNodeMap);
       resolvedArgs.push(
-        this.resolveTypeNodeToType(resolvedArgNode, context, new Map()),
+        this.#resolveTypeNodeToType(resolvedArgNode, context, new Map()),
       );
       resolvedArgNodes.push(resolvedArgNode);
     }
 
     visited.add(aliasName);
-    return this.resolveCfcAliasFromDeclaration(
+    return this.#resolveCfcAliasFromDeclaration(
       targetDeclaration,
       resolvedArgs,
       resolvedArgNodes,
@@ -1187,7 +1192,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     );
   }
 
-  private resolveTypeNodeToType(
+  #resolveTypeNodeToType(
     typeNode: ts.TypeNode,
     context: GenerationContext,
     paramMap: ReadonlyMap<string, ts.Type>,
@@ -1213,7 +1218,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
   }
 
-  private getTypeAliasDeclarationForSymbol(
+  #getTypeAliasDeclarationForSymbol(
     symbol: ts.Symbol | undefined,
     context: GenerationContext,
   ): ts.TypeAliasDeclaration | undefined {
@@ -1225,7 +1230,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     );
   }
 
-  private substituteTypeNode(
+  #substituteTypeNode(
     typeNode: ts.TypeNode,
     paramMap: ReadonlyMap<string, ts.TypeNode>,
   ): ts.TypeNode {
@@ -1246,7 +1251,7 @@ export class CommonFabricFormatter implements TypeFormatter {
           typeNode.typeName,
           ts.factory.createNodeArray(
             typeNode.typeArguments.map((arg) =>
-              this.substituteTypeNode(arg, paramMap)
+              this.#substituteTypeNode(arg, paramMap)
             ),
           ),
         );
@@ -1265,7 +1270,7 @@ export class CommonFabricFormatter implements TypeFormatter {
                 member.modifiers,
                 member.name,
                 member.questionToken,
-                this.substituteTypeNode(member.type, paramMap),
+                this.#substituteTypeNode(member.type, paramMap),
               );
             }
             return member;
@@ -1278,7 +1283,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       return ts.factory.updateTupleTypeNode(
         typeNode,
         typeNode.elements.map((element) =>
-          this.substituteTypeNode(element, paramMap) as ts.TypeNode
+          this.#substituteTypeNode(element, paramMap) as ts.TypeNode
         ),
       );
     }
@@ -1286,38 +1291,38 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (ts.isArrayTypeNode(typeNode)) {
       return ts.factory.updateArrayTypeNode(
         typeNode,
-        this.substituteTypeNode(typeNode.elementType, paramMap),
+        this.#substituteTypeNode(typeNode.elementType, paramMap),
       );
     }
 
     if (ts.isTypeOperatorNode(typeNode)) {
       return ts.factory.updateTypeOperatorNode(
         typeNode,
-        this.substituteTypeNode(typeNode.type, paramMap),
+        this.#substituteTypeNode(typeNode.type, paramMap),
       );
     }
 
     if (ts.isParenthesizedTypeNode(typeNode)) {
       return ts.factory.updateParenthesizedType(
         typeNode,
-        this.substituteTypeNode(typeNode.type, paramMap),
+        this.#substituteTypeNode(typeNode.type, paramMap),
       );
     }
 
     return typeNode;
   }
 
-  private buildIfcMetadataForAlias(
+  #buildIfcMetadataForAlias(
     aliasName: string,
     aliasArgs: readonly ts.Type[],
     context: GenerationContext,
     aliasArgNodes?: readonly ts.TypeNode[],
   ): Record<string, unknown> | undefined {
     const readValue = (index: number): unknown => {
-      return this.extractLiteralLikeValue(
+      return this.#extractLiteralLikeValue(
         aliasArgs[index],
         aliasArgNodes?.[index] ??
-          this.getAliasTypeArgumentNode(context.typeNode, index),
+          this.#getAliasTypeArgumentNode(context.typeNode, index),
         context,
       );
     };
@@ -1354,9 +1359,9 @@ export class CommonFabricFormatter implements TypeFormatter {
       case "ExactCopy":
         return { exactCopyOf: readValue(1) };
       case "WriteAuthorizedBy":
-        return this.buildWriteAuthorizedByMetadata(context, aliasArgNodes);
+        return this.#buildWriteAuthorizedByMetadata(context, aliasArgNodes);
       case "TrustedActionWriteWithIntegrity":
-        return this.buildTrustedActionWriteMetadata({
+        return this.#buildTrustedActionWriteMetadata({
           context,
           aliasArgNodes,
           action: readValue(2),
@@ -1365,7 +1370,7 @@ export class CommonFabricFormatter implements TypeFormatter {
         });
       case "TrustedActionWrite": {
         const trustedPattern = readValue(3);
-        return this.buildTrustedActionWriteMetadata({
+        return this.#buildTrustedActionWriteMetadata({
           context,
           aliasArgNodes,
           action: readValue(2),
@@ -1387,19 +1392,19 @@ export class CommonFabricFormatter implements TypeFormatter {
         };
       }
       case "ProjectionPath":
-        return this.buildProjectionMetadata(aliasArgs, context, {
+        return this.#buildProjectionMetadata(aliasArgs, context, {
           fromIndex: 1,
           pathIndex: 2,
           defaultFrom: undefined,
         });
       case "ProjectionOf":
-        return this.buildProjectionMetadata(aliasArgs, context, {
+        return this.#buildProjectionMetadata(aliasArgs, context, {
           fromIndex: 1,
           pathIndex: 1,
           defaultFrom: "/",
         });
       case "Projection":
-        return this.buildProjectionMetadata(aliasArgs, context, {
+        return this.#buildProjectionMetadata(aliasArgs, context, {
           fromIndex: 1,
           pathIndex: 1,
           defaultFrom: "/",
@@ -1409,7 +1414,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
   }
 
-  private buildProjectionMetadata(
+  #buildProjectionMetadata(
     aliasArgs: readonly ts.Type[],
     context: GenerationContext,
     options: {
@@ -1419,15 +1424,17 @@ export class CommonFabricFormatter implements TypeFormatter {
     },
   ): Record<string, unknown> | undefined {
     const readValue = (index: number): unknown => {
-      return this.extractLiteralLikeValue(
+      return this.#extractLiteralLikeValue(
         aliasArgs[index],
-        this.getAliasTypeArgumentNode(context.typeNode, index),
+        this.#getAliasTypeArgumentNode(context.typeNode, index),
         context,
       );
     };
 
     const from = options.defaultFrom ?? readValue(options.fromIndex);
-    const directPath = this.encodeJsonPointerPath(readValue(options.pathIndex));
+    const directPath = this.#encodeJsonPointerPath(
+      readValue(options.pathIndex),
+    );
     if (directPath !== undefined) {
       return {
         projection: {
@@ -1438,14 +1445,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     const sourceRefType = aliasArgs[0] as TypeWithInternals | undefined;
-    const sourceRefNode = this.getAliasTypeArgumentNode(context.typeNode, 0);
+    const sourceRefNode = this.#getAliasTypeArgumentNode(context.typeNode, 0);
     const nestedPathType = sourceRefType?.aliasTypeArguments?.[1];
     const nestedPathNode =
       sourceRefNode && ts.isTypeReferenceNode(sourceRefNode)
         ? sourceRefNode.typeArguments?.[1]
         : undefined;
-    const nestedPath = this.encodeJsonPointerPath(
-      this.extractLiteralLikeValue(nestedPathType, nestedPathNode, context),
+    const nestedPath = this.#encodeJsonPointerPath(
+      this.#extractLiteralLikeValue(nestedPathType, nestedPathNode, context),
     );
     if (nestedPath === undefined) {
       return undefined;
@@ -1459,18 +1466,18 @@ export class CommonFabricFormatter implements TypeFormatter {
     };
   }
 
-  private buildWriteAuthorizedByMetadata(
+  #buildWriteAuthorizedByMetadata(
     context: GenerationContext,
     aliasArgNodes?: readonly ts.TypeNode[],
   ): Record<string, unknown> | undefined {
-    return this.buildWriteAuthorizedByMetadataForArg(
+    return this.#buildWriteAuthorizedByMetadataForArg(
       context,
       aliasArgNodes,
       1,
     );
   }
 
-  private buildTrustedActionWriteMetadata(
+  #buildTrustedActionWriteMetadata(
     options: {
       context: GenerationContext;
       aliasArgNodes: readonly ts.TypeNode[] | undefined;
@@ -1479,7 +1486,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       requiredEventIntegrity: unknown;
     },
   ): Record<string, unknown> | undefined {
-    const writeMetadata = this.buildWriteAuthorizedByMetadataForArg(
+    const writeMetadata = this.#buildWriteAuthorizedByMetadataForArg(
       options.context,
       options.aliasArgNodes,
       1,
@@ -1495,13 +1502,13 @@ export class CommonFabricFormatter implements TypeFormatter {
     };
   }
 
-  private buildWriteAuthorizedByMetadataForArg(
+  #buildWriteAuthorizedByMetadataForArg(
     context: GenerationContext,
     aliasArgNodes: readonly ts.TypeNode[] | undefined,
     bindingIndex: number,
   ): Record<string, unknown> | undefined {
     const bindingNode = aliasArgNodes?.[bindingIndex] ??
-      this.getAliasTypeArgumentNode(context.typeNode, bindingIndex);
+      this.#getAliasTypeArgumentNode(context.typeNode, bindingIndex);
     if (!bindingNode || !ts.isTypeQueryNode(bindingNode)) {
       return undefined;
     }
@@ -1511,7 +1518,7 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     return {
       writeAuthorizedBy: {
-        __ctWriterIdentityOf: this.writeAuthorizedByIdentityForBinding(
+        __ctWriterIdentityOf: this.#writeAuthorizedByIdentityForBinding(
           context,
           bindingNode.exprName,
         ),
@@ -1519,7 +1526,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     };
   }
 
-  private writeAuthorizedByIdentityForBinding(
+  #writeAuthorizedByIdentityForBinding(
     context: GenerationContext,
     bindingName: ts.Identifier,
     normalizeFile = true,
@@ -1560,7 +1567,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     };
   }
 
-  private getAliasTypeArgumentNode(
+  #getAliasTypeArgumentNode(
     typeNode: ts.TypeNode | undefined,
     index: number,
   ): ts.TypeNode | undefined {
@@ -1570,7 +1577,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return typeNode.typeArguments?.[index];
   }
 
-  private getAliasTypeArgumentNodes(
+  #getAliasTypeArgumentNodes(
     typeNode: ts.TypeNode | undefined,
   ): readonly ts.TypeNode[] | undefined {
     if (!typeNode || !ts.isTypeReferenceNode(typeNode)) {
@@ -1579,7 +1586,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return typeNode.typeArguments ? [...typeNode.typeArguments] : undefined;
   }
 
-  private mergeIfcMetadata(
+  #mergeIfcMetadata(
     schema: MutableJSONSchema,
     ifc: Record<string, unknown>,
   ): MutableJSONSchema {
@@ -1597,7 +1604,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     };
   }
 
-  private encodeJsonPointerPath(value: unknown): string | undefined {
+  #encodeJsonPointerPath(value: unknown): string | undefined {
     if (typeof value === "string") {
       return value;
     }
@@ -1617,7 +1624,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return undefined;
   }
 
-  private extractLiteralLikeValue(
+  #extractLiteralLikeValue(
     type: ts.Type | undefined,
     typeNode: ts.TypeNode | undefined,
     context: GenerationContext,
@@ -1628,13 +1635,13 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     if (typeNode) {
       if (ts.isParenthesizedTypeNode(typeNode)) {
-        return this.extractLiteralLikeValue(type, typeNode.type, context);
+        return this.#extractLiteralLikeValue(type, typeNode.type, context);
       }
       if (ts.isTypeOperatorNode(typeNode)) {
-        return this.extractLiteralLikeValue(type, typeNode.type, context);
+        return this.#extractLiteralLikeValue(type, typeNode.type, context);
       }
       if (ts.isTypeQueryNode(typeNode)) {
-        return this.extractValueFromTypeQuery(typeNode, context);
+        return this.#extractValueFromTypeQuery(typeNode, context);
       }
       if (ts.isLiteralTypeNode(typeNode)) {
         const literal = typeNode.literal;
@@ -1646,19 +1653,19 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
       if (ts.isTupleTypeNode(typeNode)) {
         return typeNode.elements.map((element) =>
-          this.extractLiteralLikeValue(undefined, element, context)
+          this.#extractLiteralLikeValue(undefined, element, context)
         );
       }
       if (
         ts.isTypeReferenceNode(typeNode) && ts.isIdentifier(typeNode.typeName)
       ) {
-        const referencedName = this.resolveTypeReferenceName(
+        const referencedName = this.#resolveTypeReferenceName(
           typeNode.typeName,
           context,
         );
         if (referencedName === "AnyOf") {
           const alternativesNode = typeNode.typeArguments?.[0];
-          const alternatives = this.extractLiteralLikeValue(
+          const alternatives = this.#extractLiteralLikeValue(
             undefined,
             alternativesNode,
             context,
@@ -1676,7 +1683,7 @@ export class CommonFabricFormatter implements TypeFormatter {
             return {
               type: CFC_ATOM_TYPE.Policy,
               policyRefKind: "module",
-              __ctPolicyIdentityOf: this.writeAuthorizedByIdentityForBinding(
+              __ctPolicyIdentityOf: this.#writeAuthorizedByIdentityForBinding(
                 context,
                 bindingNode.exprName,
                 false,
@@ -1686,7 +1693,7 @@ export class CommonFabricFormatter implements TypeFormatter {
           }
           return undefined;
         }
-        const aliasDeclaration = this.getTypeAliasDeclarationForSymbol(
+        const aliasDeclaration = this.#getTypeAliasDeclarationForSymbol(
           context.typeChecker.getSymbolAtLocation(typeNode.typeName),
           context,
         );
@@ -1703,9 +1710,9 @@ export class CommonFabricFormatter implements TypeFormatter {
               paramMap.set(paramName, actualArgNode);
             }
           }
-          return this.extractLiteralLikeValue(
+          return this.#extractLiteralLikeValue(
             undefined,
-            this.substituteTypeNode(aliasDeclaration.type, paramMap),
+            this.#substituteTypeNode(aliasDeclaration.type, paramMap),
             context,
           );
         }
@@ -1716,7 +1723,7 @@ export class CommonFabricFormatter implements TypeFormatter {
           if (ts.isPropertySignature(member) && member.name && member.type) {
             const propName = getPropertyNameText(member.name);
             if (!propName) continue;
-            obj[propName] = this.extractLiteralLikeValue(
+            obj[propName] = this.#extractLiteralLikeValue(
               undefined,
               member.type,
               context,
@@ -1765,7 +1772,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       const elements = context.typeChecker.getTypeArguments(tupleType);
       if (elements.length > 0) {
         return elements.map((element) =>
-          this.extractLiteralLikeValue(element, undefined, context)
+          this.#extractLiteralLikeValue(element, undefined, context)
         );
       }
     }
@@ -1778,7 +1785,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       const elements = context.typeChecker.getTypeArguments(tupleType);
       if (elements.length > 0) {
         return elements.map((element) =>
-          this.extractLiteralLikeValue(element, undefined, context)
+          this.#extractLiteralLikeValue(element, undefined, context)
         );
       }
     }
@@ -1793,7 +1800,7 @@ export class CommonFabricFormatter implements TypeFormatter {
             property.valueDeclaration ?? property.declarations?.[0] ??
               context.typeNode ?? ({} as ts.Node),
           );
-          obj[property.getName()] = this.extractLiteralLikeValue(
+          obj[property.getName()] = this.#extractLiteralLikeValue(
             propType,
             undefined,
             context,
@@ -1806,7 +1813,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     return undefined;
   }
 
-  private resolveTypeReferenceName(
+  #resolveTypeReferenceName(
     typeName: ts.Identifier,
     context: GenerationContext,
   ): string {
@@ -1817,14 +1824,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     return resolved?.name ?? typeName.text;
   }
 
-  private extractDefaultValueFromNode(
+  #extractDefaultValueFromNode(
     typeNode: ts.TypeNode,
     context: GenerationContext,
   ): unknown {
     // Handle typeof expressions (TypeQuery nodes)
     // These reference a variable's value, like: typeof defaultRoutes
     if (ts.isTypeQueryNode(typeNode)) {
-      return this.extractValueFromTypeQuery(typeNode, context);
+      return this.#extractValueFromTypeQuery(typeNode, context);
     }
 
     // Handle type references that represent empty objects
@@ -1857,7 +1864,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     // Handle array literals (tuples) like [1, 2] or ["item1", "item2"]
     if (ts.isTupleTypeNode(typeNode)) {
       return typeNode.elements.map((element) =>
-        this.extractDefaultValueFromNode(element, context)
+        this.#extractDefaultValueFromNode(element, context)
       );
     }
 
@@ -1873,7 +1880,7 @@ export class CommonFabricFormatter implements TypeFormatter {
           if (!propName) {
             continue;
           }
-          obj[propName] = this.extractDefaultValueFromNode(
+          obj[propName] = this.#extractDefaultValueFromNode(
             member.type,
             context,
           );
@@ -1889,10 +1896,10 @@ export class CommonFabricFormatter implements TypeFormatter {
     // Fallback: try to get the type and extract from it
     const type = context.typeRegistry?.get(typeNode) ??
       context.typeChecker.getTypeFromTypeNode(typeNode);
-    return this.extractDefaultValue(type, context);
+    return this.#extractDefaultValue(type, context);
   }
 
-  private extractDefaultValue(
+  #extractDefaultValue(
     type: ts.Type,
     context: GenerationContext,
   ): unknown {
@@ -1917,13 +1924,13 @@ export class CommonFabricFormatter implements TypeFormatter {
     // This is a simplified approach that works for many cases
     const symbol = type.getSymbol();
     if (symbol && symbol.valueDeclaration) {
-      return this.extractComplexDefaultFromTypeSymbol(type, symbol, context);
+      return this.#extractComplexDefaultFromTypeSymbol(type, symbol, context);
     }
 
     return undefined;
   }
 
-  private extractValueFromTypeQuery(
+  #extractValueFromTypeQuery(
     typeQueryNode: ts.TypeQueryNode,
     context: GenerationContext,
   ): unknown {
@@ -1936,27 +1943,27 @@ export class CommonFabricFormatter implements TypeFormatter {
       return undefined;
     }
 
-    return this.extractValueFromSymbol(symbol, context);
+    return this.#extractValueFromSymbol(symbol, context);
   }
 
   /**
    * Extract a runtime value from a symbol's value declaration.
    * Works for variables with initializers like: const foo = [1, 2, 3]
    */
-  private extractValueFromSymbol(
+  #extractValueFromSymbol(
     symbol: ts.Symbol,
     context: GenerationContext,
   ): unknown {
     return extractLiteralValueOfSymbol(symbol, context.typeChecker)?.value;
   }
 
-  private extractComplexDefaultFromTypeSymbol(
+  #extractComplexDefaultFromTypeSymbol(
     type: ts.Type,
     symbol: ts.Symbol,
     context: GenerationContext,
   ): unknown {
     // Try to extract from the symbol's value declaration initializer (AST-based)
-    const extracted = this.extractValueFromSymbol(symbol, context);
+    const extracted = this.#extractValueFromSymbol(symbol, context);
     if (extracted !== undefined) {
       return extracted;
     }
@@ -1977,7 +1984,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Check if a type is the undefined type.
    * Extracted for clarity and consistency with UnionFormatter.
    */
-  private isUndefinedType(type: ts.Type): boolean {
+  #isUndefinedType(type: ts.Type): boolean {
     return (type.flags & ts.TypeFlags.Undefined) !== 0;
   }
 
@@ -1985,7 +1992,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Apply wrapper semantics to a schema, handling boolean schemas correctly.
    * Boolean schemas (true/false) can't have properties spread into them.
    */
-  private applyWrapperSemantics(
+  #applyWrapperSemantics(
     schema: MutableJSONSchema,
     wrapperKind: WrapperKind,
   ): MutableJSONSchema {
@@ -2011,7 +2018,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Handles empty array by returning true (any value is valid).
    * Deduplicates identical schemas before wrapping.
    */
-  private maybeWrapInAnyOf(
+  #maybeWrapInAnyOf(
     schemas: MutableJSONSchema[],
   ): MutableJSONSchema {
     if (schemas.length === 0) {
@@ -2036,7 +2043,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Handles cases like: Reactive<T> | undefined, Cell<T> | null, etc.
    * Uses nodes when available to preserve named type hoisting.
    */
-  private formatWrapperUnion(
+  #formatWrapperUnion(
     unionType: ts.UnionType,
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -2068,7 +2075,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
 
       // Include undefined as an explicit type in the schema
-      if (this.isUndefinedType(memberType)) {
+      if (this.#isUndefinedType(memberType)) {
         schemas.push({ type: "undefined" });
         continue;
       }
@@ -2100,7 +2107,7 @@ export class CommonFabricFormatter implements TypeFormatter {
           ? resolveWrapperNode(memberNode, context.typeChecker)
           : undefined;
 
-        const schema = this.formatWrapperType(
+        const schema = this.#formatWrapperType(
           wrapperInfo.typeRef,
           wrapperNodeInfo?.node, // Pass node if available for proper name hoisting
           context,
@@ -2110,7 +2117,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       } else {
         // Not a wrapper - use standard formatting
         // Pass the member node if available to preserve named type hoisting
-        const schema = this.schemaGenerator.formatChildType(
+        const schema = this.#schemaGenerator.formatChildType(
           memberType,
           context,
           memberNode, // Pass node to preserve named type information
@@ -2119,7 +2126,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    return this.maybeWrapInAnyOf(schemas);
+    return this.#maybeWrapInAnyOf(schemas);
   }
 
   /**
@@ -2130,7 +2137,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Examples that return true: Reactive<T> | undefined, Cell<T> | null, Stream<T> | null | undefined
    * Examples that return false: string | Cell | null (mixed union, should use UnionFormatter)
    */
-  private isWrapperUnion(type: ts.Type, context: GenerationContext): boolean {
+  #isWrapperUnion(type: ts.Type, context: GenerationContext): boolean {
     // Must be a union type
     if ((type.flags & ts.TypeFlags.Union) === 0) {
       return false;
@@ -2146,7 +2153,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     for (const memberType of unionType.types) {
       // Skip undefined and null - they're modifiers, not members
       if (
-        this.isUndefinedType(memberType) ||
+        this.#isUndefinedType(memberType) ||
         (memberType.flags & ts.TypeFlags.Null) !== 0
       ) {
         continue;

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -17,7 +17,11 @@ const DOC_CONFLICT_COMMENT =
   "Conflicting docs across intersection constituents; using first";
 
 export class IntersectionFormatter implements TypeFormatter {
-  constructor(private schemaGenerator: SchemaGenerator) {}
+  #schemaGenerator: SchemaGenerator;
+
+  constructor(schemaGenerator: SchemaGenerator) {
+    this.#schemaGenerator = schemaGenerator;
+  }
 
   supportsType(type: ts.Type, context: GenerationContext): boolean {
     // Don't handle cell types - they are intersection types but should be handled by CommonFabricFormatter
@@ -52,7 +56,7 @@ export class IntersectionFormatter implements TypeFormatter {
     // Brand-only parts are object types with no string-keyed properties and no
     // index signatures — they carry only symbol-keyed brand markers.
     const effectiveParts = parts.filter(
-      (p) => !this.isBrandOnlyOrEmpty(p, checker),
+      (p) => !this.#isBrandOnlyOrEmpty(p, checker),
     );
 
     // If all parts were brand markers / empty, fall back to the full set
@@ -61,10 +65,10 @@ export class IntersectionFormatter implements TypeFormatter {
 
     // If filtering reduced us to a single substantive part, delegate directly.
     if (partsToProcess.length === 1) {
-      return this.schemaGenerator.formatChildType(partsToProcess[0]!, context);
+      return this.#schemaGenerator.formatChildType(partsToProcess[0]!, context);
     }
 
-    const failureReason = this.validateIntersectionParts(
+    const failureReason = this.#validateIntersectionParts(
       partsToProcess,
       checker,
     );
@@ -76,8 +80,8 @@ export class IntersectionFormatter implements TypeFormatter {
       };
     }
 
-    const merged = this.mergeIntersectionParts(partsToProcess, context);
-    return this.applyIntersectionDocs(merged);
+    const merged = this.#mergeIntersectionParts(partsToProcess, context);
+    return this.#applyIntersectionDocs(merged);
   }
 
   /**
@@ -88,7 +92,7 @@ export class IntersectionFormatter implements TypeFormatter {
    *   - `{}` (empty object) — e.g. the second part of RequireDefaults<number[]>
    *   - `{ readonly [DEFAULT_MARKER]: T }` — the brand object inside Default<T,V>
    */
-  private isBrandOnlyOrEmpty(part: ts.Type, checker: ts.TypeChecker): boolean {
+  #isBrandOnlyOrEmpty(part: ts.Type, checker: ts.TypeChecker): boolean {
     if ((part.flags & ts.TypeFlags.Object) === 0) return false;
 
     try {
@@ -122,7 +126,7 @@ export class IntersectionFormatter implements TypeFormatter {
     return true;
   }
 
-  private validateIntersectionParts(
+  #validateIntersectionParts(
     parts: readonly ts.Type[],
     checker: ts.TypeChecker,
   ): string | null {
@@ -151,7 +155,7 @@ export class IntersectionFormatter implements TypeFormatter {
     return null;
   }
 
-  private mergeIntersectionParts(
+  #mergeIntersectionParts(
     parts: readonly ts.Type[],
     context: GenerationContext,
   ): {
@@ -176,8 +180,8 @@ export class IntersectionFormatter implements TypeFormatter {
         missingSources.push(docInfo.typeName);
       }
 
-      const schema = this.schemaGenerator.formatChildType(part, context);
-      const objSchema = this.resolveObjectSchema(schema, context);
+      const schema = this.#schemaGenerator.formatChildType(part, context);
+      const objSchema = this.#resolveObjectSchema(schema, context);
       if (!objSchema) continue;
 
       if (objSchema.properties) {
@@ -232,7 +236,7 @@ export class IntersectionFormatter implements TypeFormatter {
     return { schema: result, docTexts, documentedSources, missingSources };
   }
 
-  private isObjectSchema(
+  #isObjectSchema(
     schema: MutableJSONSchema,
   ): schema is MutableJSONSchemaObj & { type: "object" } {
     return (
@@ -242,11 +246,11 @@ export class IntersectionFormatter implements TypeFormatter {
     );
   }
 
-  private resolveObjectSchema(
+  #resolveObjectSchema(
     schema: MutableJSONSchema,
     context: GenerationContext,
   ): (MutableJSONSchemaObj & { type: "object" }) | undefined {
-    if (this.isObjectSchema(schema)) return schema;
+    if (this.#isObjectSchema(schema)) return schema;
     if (
       typeof schema === "object" &&
       schema !== null &&
@@ -257,13 +261,13 @@ export class IntersectionFormatter implements TypeFormatter {
       if (ref.startsWith(prefix)) {
         const name = ref.slice(prefix.length);
         const def = context.definitions[name];
-        if (def && this.isObjectSchema(def)) return def;
+        if (def && this.#isObjectSchema(def)) return def;
       }
     }
     return undefined;
   }
 
-  private applyIntersectionDocs(
+  #applyIntersectionDocs(
     data: {
       schema: MutableJSONSchemaObj;
       docTexts: string[];

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -87,14 +87,14 @@ const LIB_DECLARED_NATIVE_TYPES = new Set([
  */
 export class NativeTypeFormatter implements TypeFormatter {
   supportsType(type: ts.Type, context: GenerationContext): boolean {
-    const typeName = NativeTypeFormatter.getTypeName(type);
+    const typeName = NativeTypeFormatter.#getTypeName(type);
     if (!NativeTypeFormatter.isNativeType(typeName)) {
       return false;
     }
     if (
       typeName !== undefined && LIB_DECLARED_NATIVE_TYPES.has(typeName)
     ) {
-      return NativeTypeFormatter.hasLibraryDeclaration(type, context);
+      return NativeTypeFormatter.#hasLibraryDeclaration(type, context);
     }
     if (NativeTypeFormatter.isFabricPrimitiveTypeName(typeName)) {
       return NativeTypeFormatter.declaresFabricSpecialObjectBrand(type);
@@ -106,7 +106,7 @@ export class NativeTypeFormatter implements TypeFormatter {
     type: ts.Type,
     _context: GenerationContext,
   ): MutableJSONSchema {
-    const typeName = NativeTypeFormatter.getTypeName(type);
+    const typeName = NativeTypeFormatter.#getTypeName(type);
     const schema = NATIVE_TYPE_SCHEMAS[typeName!];
     // TODO(danfuzz): `structuredClone()` mangles non-JSON `FabricValue`s —
     // harmless while `NATIVE_TYPE_SCHEMAS` are plain JSON, but a problem once
@@ -116,7 +116,7 @@ export class NativeTypeFormatter implements TypeFormatter {
     return (typeof schema === "boolean" ? schema : structuredClone(schema!));
   }
 
-  private static getTypeName(type: ts.Type): string | undefined {
+  static #getTypeName(type: ts.Type): string | undefined {
     // Prefer direct symbol name; fall back to target symbol for TypeReference
     const symbol = type.symbol;
     let name = symbol?.name;
@@ -156,7 +156,7 @@ export class NativeTypeFormatter implements TypeFormatter {
     return name;
   }
 
-  private static getTypeSymbol(type: ts.Type): ts.Symbol | undefined {
+  static #getTypeSymbol(type: ts.Type): ts.Symbol | undefined {
     if (type.symbol) return type.symbol;
 
     const objectFlags = (type as ts.ObjectType).objectFlags ?? 0;
@@ -190,11 +190,11 @@ export class NativeTypeFormatter implements TypeFormatter {
     return type.getProperty(FABRIC_SPECIAL_OBJECT_BRAND) !== undefined;
   }
 
-  private static hasLibraryDeclaration(
+  static #hasLibraryDeclaration(
     type: ts.Type,
     context: GenerationContext,
   ): boolean {
-    const symbol = NativeTypeFormatter.getTypeSymbol(type);
+    const symbol = NativeTypeFormatter.#getTypeSymbol(type);
     return symbol?.declarations?.some((declaration) => {
       const sourceFile = declaration.getSourceFile();
       const program = (

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -246,7 +246,11 @@ function hasFabricExecPlainObjectBase(
  * Formatter for object types (interfaces, type literals, etc.)
  */
 export class ObjectFormatter implements TypeFormatter {
-  constructor(private schemaGenerator: SchemaGenerator) {}
+  #schemaGenerator: SchemaGenerator;
+
+  constructor(schemaGenerator: SchemaGenerator) {
+    this.#schemaGenerator = schemaGenerator;
+  }
 
   supportsType(type: ts.Type, context: GenerationContext): boolean {
     // Handle object types (interfaces, type literals, classes)
@@ -270,7 +274,7 @@ export class ObjectFormatter implements TypeFormatter {
       return { type: "object", additionalProperties: true };
     }
 
-    const builtin = this.lookupBuiltInSchema(type, checker);
+    const builtin = this.#lookupBuiltInSchema(type, checker);
     if (builtin) return builtin;
 
     // Do not early-return for empty object types. Instead, try to enumerate
@@ -365,7 +369,7 @@ export class ObjectFormatter implements TypeFormatter {
       }
 
       // Delegate to the main generator (specific formatters handle wrappers/defaults)
-      const generated = this.schemaGenerator.formatChildType(
+      const generated = this.#schemaGenerator.formatChildType(
         resolvedPropType,
         context,
         propTypeNode,
@@ -405,7 +409,7 @@ export class ObjectFormatter implements TypeFormatter {
       ? undefined
       : stringIndex ?? numberIndex;
     if (chosenIndex) {
-      const apSchema = this.schemaGenerator.formatChildType(
+      const apSchema = this.#schemaGenerator.formatChildType(
         chosenIndex,
         context,
         undefined,
@@ -451,7 +455,7 @@ export class ObjectFormatter implements TypeFormatter {
     return schema;
   }
 
-  private lookupBuiltInSchema(
+  #lookupBuiltInSchema(
     type: ts.Type,
     checker: ts.TypeChecker,
   ): MutableJSONSchema | undefined {

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -85,7 +85,11 @@ function orderMemberNodesBySemanticType(
 }
 
 export class UnionFormatter implements TypeFormatter {
-  constructor(private schemaGenerator: SchemaGenerator) {}
+  #schemaGenerator: SchemaGenerator;
+
+  constructor(schemaGenerator: SchemaGenerator) {
+    this.#schemaGenerator = schemaGenerator;
+  }
 
   supportsType(type: ts.Type, _context: GenerationContext): boolean {
     return (type.flags & ts.TypeFlags.Union) !== 0;
@@ -97,7 +101,7 @@ export class UnionFormatter implements TypeFormatter {
   ): MutableJSONSchema {
     const union = type as ts.UnionType;
     const members = union.types ?? [];
-    const unionNode = this.getUnionTypeNode(
+    const unionNode = this.#getUnionTypeNode(
       context.typeNode,
       context.typeChecker,
     );
@@ -115,7 +119,7 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     const defaultUnionSchema = memberNodes
-      ? this.tryFormatDefaultUnion(memberNodes, context)
+      ? this.#tryFormatDefaultUnion(memberNodes, context)
       : undefined;
     if (defaultUnionSchema !== undefined) {
       return defaultUnionSchema;
@@ -126,7 +130,7 @@ export class UnionFormatter implements TypeFormatter {
     // the union is `T | (T & DefaultMarker<V>)` and the brand payload
     // carries V. Format the unbranded members and attach the extracted
     // default — no authored AST required.
-    const expandedDefault = this.tryFormatExpandedDefaultViaBrandPayload(
+    const expandedDefault = this.#tryFormatExpandedDefaultViaBrandPayload(
       members,
       orderedMemberNodes,
       context,
@@ -157,7 +161,7 @@ export class UnionFormatter implements TypeFormatter {
       if (native !== undefined) {
         return cloneSchemaDefinition(native);
       }
-      return this.schemaGenerator.formatChildType(
+      return this.#schemaGenerator.formatChildType(
         t,
         context,
         memberNode,
@@ -228,12 +232,12 @@ export class UnionFormatter implements TypeFormatter {
     // When widenLiterals is true, try to merge structurally identical schemas
     // that only differ in literal enum values
     if (context.widenLiterals && unionOptions.length > 1) {
-      unionOptions = this.mergeIdenticalSchemas(unionOptions);
+      unionOptions = this.#mergeIdenticalSchemas(unionOptions);
     }
     const anyOf: MutableJSONSchemaObj[] = [];
     for (const option of unionOptions) {
       // mergePrimitiveSchemaIntoAnyOf mutates anyOf in place; returns true to short-circuit
-      if (this.mergePrimitiveSchemaIntoAnyOf(anyOf, option)) {
+      if (this.#mergePrimitiveSchemaIntoAnyOf(anyOf, option)) {
         return true;
       }
     }
@@ -262,7 +266,7 @@ export class UnionFormatter implements TypeFormatter {
    * brand, more than one brand, or a payload that is not literal-shaped —
    * preserving prior behavior exactly in those cases.
    */
-  private tryFormatExpandedDefaultViaBrandPayload(
+  #tryFormatExpandedDefaultViaBrandPayload(
     members: readonly ts.Type[],
     orderedMemberNodes: ReadonlyArray<ts.TypeNode | undefined> | undefined,
     context: GenerationContext,
@@ -295,10 +299,10 @@ export class UnionFormatter implements TypeFormatter {
     // the expanded-empty-default shape before relying on it.
     const hasRealArray = rest.some((m) =>
       (checker.isArrayType(m) || checker.isTupleType(m)) &&
-      !this.isEmptyArrayType(m, checker)
+      !this.#isEmptyArrayType(m, checker)
     );
     if (hasRealArray) {
-      rest = rest.filter((m) => !this.isEmptyArrayType(m, checker));
+      rest = rest.filter((m) => !this.#isEmptyArrayType(m, checker));
     }
     if (rest.length === 0) return undefined;
     const schemas = rest.map((m) => {
@@ -310,15 +314,15 @@ export class UnionFormatter implements TypeFormatter {
       if (native !== undefined) {
         return cloneSchemaDefinition(native) as MutableJSONSchema;
       }
-      return this.schemaGenerator.formatChildType(m, context, memberNode);
+      return this.#schemaGenerator.formatChildType(m, context, memberNode);
     });
-    return this.applySchemaDefault(
-      this.combineUnionSchemas(schemas, context),
+    return this.#applySchemaDefault(
+      this.#combineUnionSchemas(schemas, context),
       extracted.value,
     );
   }
 
-  private tryFormatDefaultUnion(
+  #tryFormatDefaultUnion(
     memberNodes: readonly ts.TypeNode[],
     context: GenerationContext,
   ): MutableJSONSchema | undefined {
@@ -326,7 +330,7 @@ export class UnionFormatter implements TypeFormatter {
       .map((node, index) => ({
         index,
         node,
-        entry: this.getDefaultUnionEntry(node, context),
+        entry: this.#getDefaultUnionEntry(node, context),
       }))
       .filter((item): item is {
         index: number;
@@ -350,28 +354,28 @@ export class UnionFormatter implements TypeFormatter {
 
     const schemas: MutableJSONSchema[] = [];
     for (const node of nonDefaultNodes) {
-      schemas.push(this.formatTypeNodeMember(node, context));
+      schemas.push(this.#formatTypeNodeMember(node, context));
     }
 
     if (defaultEntry.entry.kind === "DeepDefault") {
-      this.assertDeepDefaultHasObjectTarget(
+      this.#assertDeepDefaultHasObjectTarget(
         defaultEntry.entry,
         nonDefaultNodes,
         context.typeChecker,
       );
-      return this.applyDeepDefaultToSchema(
-        this.combineUnionSchemas(schemas, context),
+      return this.#applyDeepDefaultToSchema(
+        this.#combineUnionSchemas(schemas, context),
         defaultEntry.entry.defaultValue,
         context.definitions,
       );
     }
 
-    const isCovered = this.isDefaultCoveredByUnion(
+    const isCovered = this.#isDefaultCoveredByUnion(
       defaultEntry.entry,
       nonDefaultNodes,
       context.typeChecker,
     );
-    this.assertDefaultObjectDoesNotWidenExistingObject(
+    this.#assertDefaultObjectDoesNotWidenExistingObject(
       defaultEntry.entry,
       nonDefaultNodes,
       isCovered,
@@ -380,18 +384,18 @@ export class UnionFormatter implements TypeFormatter {
 
     if (!isCovered) {
       schemas.push(
-        this.formatTypeNodeMember(defaultEntry.entry.valueTypeNode, context),
+        this.#formatTypeNodeMember(defaultEntry.entry.valueTypeNode, context),
       );
     }
 
-    return this.applySchemaDefault(
-      this.combineUnionSchemas(schemas, context),
+    return this.#applySchemaDefault(
+      this.#combineUnionSchemas(schemas, context),
       defaultEntry.entry.defaultValue,
     );
   }
 
   /** Empty tuple `[]`, or `never[]`. */
-  private isEmptyArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
+  #isEmptyArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
     if (checker.isTupleType(type)) {
       return checker.getTypeArguments(type as ts.TypeReference).length === 0;
     }
@@ -404,7 +408,7 @@ export class UnionFormatter implements TypeFormatter {
     return false;
   }
 
-  private getUnionTypeNode(
+  #getUnionTypeNode(
     typeNode: ts.TypeNode | undefined,
     checker: ts.TypeChecker,
     visited = new Set<string>(),
@@ -438,24 +442,24 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const aliasKey = this.getTypeAliasDeclarationKey(aliasDeclaration);
+    const aliasKey = this.#getTypeAliasDeclarationKey(aliasDeclaration);
     if (visited.has(aliasKey)) {
       throw new Error(
         `Circular type alias detected: ${aliasDeclaration.name.text}`,
       );
     }
     visited.add(aliasKey);
-    return this.getUnionTypeNode(aliasDeclaration.type, checker, visited);
+    return this.#getUnionTypeNode(aliasDeclaration.type, checker, visited);
   }
 
-  private getTypeAliasDeclarationKey(
+  #getTypeAliasDeclarationKey(
     declaration: ts.TypeAliasDeclaration,
   ): string {
     const sourceFile = declaration.getSourceFile();
     return `${sourceFile.fileName}:${declaration.pos}:${declaration.end}`;
   }
 
-  private getDefaultUnionEntry(
+  #getDefaultUnionEntry(
     memberNode: ts.TypeNode,
     context: GenerationContext,
   ): DefaultUnionEntry | undefined {
@@ -463,7 +467,7 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const directName = this.getTypeReferenceName(memberNode);
+    const directName = this.#getTypeReferenceName(memberNode);
     if (directName === "DeepDefault") {
       const typeArgs = memberNode.typeArguments;
       if (!typeArgs || typeArgs.length !== 1 || !typeArgs[0]) {
@@ -476,7 +480,7 @@ export class UnionFormatter implements TypeFormatter {
         defaultTypeNode: valueTypeNode,
         valueType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
         defaultType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
-        defaultValue: this.extractDefaultValueFromNode(
+        defaultValue: this.#extractDefaultValueFromNode(
           valueTypeNode,
           context,
         ),
@@ -502,7 +506,7 @@ export class UnionFormatter implements TypeFormatter {
     const defaultType = context.typeChecker.getTypeFromTypeNode(
       defaultTypeNode,
     );
-    if (typeArgs.length === 1 && this.isUndefinedType(valueType)) {
+    if (typeArgs.length === 1 && this.#isUndefinedType(valueType)) {
       throw new Error(
         "Default<undefined> is unsupported; use an optional field or a JSON value default.",
       );
@@ -514,16 +518,16 @@ export class UnionFormatter implements TypeFormatter {
       defaultTypeNode,
       valueType,
       defaultType,
-      defaultValue: this.extractDefaultValueFromNode(defaultTypeNode, context),
+      defaultValue: this.#extractDefaultValueFromNode(defaultTypeNode, context),
     };
   }
 
-  private getTypeReferenceName(typeNode: ts.TypeReferenceNode): string {
+  #getTypeReferenceName(typeNode: ts.TypeReferenceNode): string {
     const typeName = typeNode.typeName;
     return ts.isIdentifier(typeName) ? typeName.text : typeName.right.text;
   }
 
-  private isDefaultCoveredByUnion(
+  #isDefaultCoveredByUnion(
     defaultEntry: DefaultUnionEntry,
     nonDefaultNodes: readonly ts.TypeNode[],
     checker: ts.TypeChecker,
@@ -537,20 +541,20 @@ export class UnionFormatter implements TypeFormatter {
     });
   }
 
-  private assertDefaultObjectDoesNotWidenExistingObject(
+  #assertDefaultObjectDoesNotWidenExistingObject(
     defaultEntry: DefaultUnionEntry,
     nonDefaultNodes: readonly ts.TypeNode[],
     isCovered: boolean,
     checker: ts.TypeChecker,
   ): void {
     if (
-      isCovered || !this.isPlainObjectType(defaultEntry.defaultType, checker)
+      isCovered || !this.#isPlainObjectType(defaultEntry.defaultType, checker)
     ) {
       return;
     }
 
     const hasObjectTarget = nonDefaultNodes.some((node) =>
-      this.isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
+      this.#isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
     );
     if (!hasObjectTarget) {
       return;
@@ -561,17 +565,17 @@ export class UnionFormatter implements TypeFormatter {
     );
   }
 
-  private assertDeepDefaultHasObjectTarget(
+  #assertDeepDefaultHasObjectTarget(
     defaultEntry: DefaultUnionEntry,
     nonDefaultNodes: readonly ts.TypeNode[],
     checker: ts.TypeChecker,
   ): void {
     const hasObjectTarget = nonDefaultNodes.some((node) =>
-      this.isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
+      this.#isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
     );
     if (
       hasObjectTarget &&
-      this.isPlainObjectType(defaultEntry.defaultType, checker)
+      this.#isPlainObjectType(defaultEntry.defaultType, checker)
     ) {
       return;
     }
@@ -581,7 +585,7 @@ export class UnionFormatter implements TypeFormatter {
     );
   }
 
-  private isPlainObjectType(
+  #isPlainObjectType(
     type: ts.Type,
     checker: ts.TypeChecker,
   ): boolean {
@@ -595,7 +599,7 @@ export class UnionFormatter implements TypeFormatter {
     return symbolName !== "Array" && symbolName !== "ReadonlyArray";
   }
 
-  private formatTypeNodeMember(
+  #formatTypeNodeMember(
     typeNode: ts.TypeNode,
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -607,10 +611,10 @@ export class UnionFormatter implements TypeFormatter {
     if (native !== undefined) {
       return cloneSchemaDefinition(native);
     }
-    return this.schemaGenerator.formatChildType(type, context, typeNode);
+    return this.#schemaGenerator.formatChildType(type, context, typeNode);
   }
 
-  private combineUnionSchemas(
+  #combineUnionSchemas(
     schemas: MutableJSONSchema[],
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -630,12 +634,12 @@ export class UnionFormatter implements TypeFormatter {
 
     let unionOptions = schemas;
     if (context.widenLiterals && unionOptions.length > 1) {
-      unionOptions = this.mergeIdenticalSchemas(unionOptions);
+      unionOptions = this.#mergeIdenticalSchemas(unionOptions);
     }
 
     const anyOf: MutableJSONSchemaObj[] = [];
     for (const option of unionOptions) {
-      if (this.mergePrimitiveSchemaIntoAnyOf(anyOf, option)) {
+      if (this.#mergePrimitiveSchemaIntoAnyOf(anyOf, option)) {
         return true;
       }
     }
@@ -650,7 +654,7 @@ export class UnionFormatter implements TypeFormatter {
     return { anyOf };
   }
 
-  private applySchemaDefault(
+  #applySchemaDefault(
     schema: MutableJSONSchema,
     defaultValue: unknown,
   ): MutableJSONSchema {
@@ -671,25 +675,25 @@ export class UnionFormatter implements TypeFormatter {
     };
   }
 
-  private applyDeepDefaultToSchema(
+  #applyDeepDefaultToSchema(
     schema: MutableJSONSchema,
     defaultValue: unknown,
     rootDefs?: Record<string, unknown>,
   ): MutableJSONSchema {
-    const withDefault = this.applySchemaDefault(schema, defaultValue);
-    if (!this.isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
+    const withDefault = this.#applySchemaDefault(schema, defaultValue);
+    if (!this.#isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
       return withDefault;
     }
 
-    return this.applyObjectPropertyDefaults(
+    return this.#applyObjectPropertyDefaults(
       withDefault,
       defaultValue,
       [],
-      this.getSchemaDefs(withDefault) ?? rootDefs,
+      this.#getSchemaDefs(withDefault) ?? rootDefs,
     );
   }
 
-  private applyObjectPropertyDefaults(
+  #applyObjectPropertyDefaults(
     schema: MutableJSONSchemaObj,
     defaults: Record<string, unknown>,
     path: string[] = [],
@@ -699,7 +703,7 @@ export class UnionFormatter implements TypeFormatter {
     const properties = isObjectOrArray(schema.properties)
       ? { ...schema.properties }
       : {};
-    const targetProperties = this.getObjectTargetProperties(
+    const targetProperties = this.#getObjectTargetProperties(
       isObjectOrArray(targetSchema) ? targetSchema : schema,
       rootDefs,
     );
@@ -715,7 +719,7 @@ export class UnionFormatter implements TypeFormatter {
           }" does not exist on the target object type.`,
         );
       }
-      properties[name] = this.applyDeepDefaultToProperty(
+      properties[name] = this.#applyDeepDefaultToProperty(
         properties[name] as MutableJSONSchema | undefined,
         value,
         fullPath,
@@ -730,19 +734,19 @@ export class UnionFormatter implements TypeFormatter {
     };
   }
 
-  private applyDeepDefaultToProperty(
+  #applyDeepDefaultToProperty(
     schema: MutableJSONSchema | undefined,
     defaultValue: unknown,
     path: string[] = [],
     rootDefs?: Record<string, unknown>,
     targetSchema?: MutableJSONSchema,
   ): MutableJSONSchema {
-    const withDefault = this.applySchemaDefault(schema ?? true, defaultValue);
-    if (!this.isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
+    const withDefault = this.#applySchemaDefault(schema ?? true, defaultValue);
+    if (!this.#isDefaultObject(defaultValue) || !isObjectOrArray(withDefault)) {
       return withDefault;
     }
 
-    return this.applyObjectPropertyDefaults(
+    return this.#applyObjectPropertyDefaults(
       withDefault,
       defaultValue,
       path,
@@ -751,7 +755,7 @@ export class UnionFormatter implements TypeFormatter {
     );
   }
 
-  private getObjectTargetProperties(
+  #getObjectTargetProperties(
     schema: MutableJSONSchemaObj,
     rootDefs?: Record<string, unknown>,
     seen = new Set<MutableJSONSchemaObj>(),
@@ -765,16 +769,16 @@ export class UnionFormatter implements TypeFormatter {
       return schema.properties;
     }
 
-    const refSchema = this.resolveLocalRefSchema(schema, rootDefs);
+    const refSchema = this.#resolveLocalRefSchema(schema, rootDefs);
     if (refSchema) {
-      return this.getObjectTargetProperties(refSchema, rootDefs, seen);
+      return this.#getObjectTargetProperties(refSchema, rootDefs, seen);
     }
 
     if (Array.isArray(schema.anyOf)) {
       const candidates = schema.anyOf
         .map((option) =>
           isObjectOrArray(option)
-            ? this.getObjectTargetProperties(
+            ? this.#getObjectTargetProperties(
               option as MutableJSONSchemaObj,
               rootDefs,
               new Set(seen),
@@ -793,7 +797,7 @@ export class UnionFormatter implements TypeFormatter {
     return undefined;
   }
 
-  private resolveLocalRefSchema(
+  #resolveLocalRefSchema(
     schema: MutableJSONSchemaObj,
     rootDefs?: Record<string, unknown>,
   ): MutableJSONSchemaObj | undefined {
@@ -805,14 +809,14 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const defs = this.getSchemaDefs(schema) ?? rootDefs;
+    const defs = this.#getSchemaDefs(schema) ?? rootDefs;
     const resolved = defs?.[schema.$ref.slice(prefix.length)];
     return isObjectOrArray(resolved)
       ? resolved as MutableJSONSchemaObj
       : undefined;
   }
 
-  private getSchemaDefs(
+  #getSchemaDefs(
     schema: MutableJSONSchemaObj,
   ): Record<string, unknown> | undefined {
     if (isObjectOrArray(schema.$defs)) {
@@ -821,16 +825,16 @@ export class UnionFormatter implements TypeFormatter {
     return isObjectOrArray(schema.definitions) ? schema.definitions : undefined;
   }
 
-  private isDefaultObject(value: unknown): value is Record<string, unknown> {
+  #isDefaultObject(value: unknown): value is Record<string, unknown> {
     return isObjectNotArray(value);
   }
 
-  private extractDefaultValueFromNode(
+  #extractDefaultValueFromNode(
     typeNode: ts.TypeNode,
     context: GenerationContext,
   ): unknown {
     if (ts.isTypeQueryNode(typeNode)) {
-      return this.extractValueFromTypeQuery(typeNode, context);
+      return this.#extractValueFromTypeQuery(typeNode, context);
     }
 
     if (ts.isLiteralTypeNode(typeNode)) {
@@ -844,7 +848,7 @@ export class UnionFormatter implements TypeFormatter {
 
     if (ts.isTupleTypeNode(typeNode)) {
       return typeNode.elements.map((element) =>
-        this.extractDefaultValueFromNode(element, context)
+        this.#extractDefaultValueFromNode(element, context)
       );
     }
 
@@ -858,7 +862,7 @@ export class UnionFormatter implements TypeFormatter {
         if (!propName) {
           continue;
         }
-        obj[propName] = this.extractDefaultValueFromNode(
+        obj[propName] = this.#extractDefaultValueFromNode(
           member.type,
           context,
         );
@@ -869,13 +873,13 @@ export class UnionFormatter implements TypeFormatter {
     if (typeNode.kind === ts.SyntaxKind.NullKeyword) return null;
     if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) return undefined;
 
-    return this.extractDefaultValue(
+    return this.#extractDefaultValue(
       context.typeChecker.getTypeFromTypeNode(typeNode),
       context,
     );
   }
 
-  private extractDefaultValue(
+  #extractDefaultValue(
     type: ts.Type,
     context: GenerationContext,
   ): unknown {
@@ -897,30 +901,30 @@ export class UnionFormatter implements TypeFormatter {
 
     const symbol = type.getSymbol();
     if (symbol?.valueDeclaration) {
-      return this.extractValueFromSymbol(symbol, context);
+      return this.#extractValueFromSymbol(symbol, context);
     }
 
     return undefined;
   }
 
-  private extractValueFromTypeQuery(
+  #extractValueFromTypeQuery(
     typeQueryNode: ts.TypeQueryNode,
     context: GenerationContext,
   ): unknown {
     const symbol = context.typeChecker.getSymbolAtLocation(
       typeQueryNode.exprName,
     );
-    return symbol ? this.extractValueFromSymbol(symbol, context) : undefined;
+    return symbol ? this.#extractValueFromSymbol(symbol, context) : undefined;
   }
 
-  private extractValueFromSymbol(
+  #extractValueFromSymbol(
     symbol: ts.Symbol,
     context: GenerationContext,
   ): unknown {
     return extractLiteralValueOfSymbol(symbol, context.typeChecker)?.value;
   }
 
-  private isUndefinedType(type: ts.Type): boolean {
+  #isUndefinedType(type: ts.Type): boolean {
     return (type.flags & ts.TypeFlags.Undefined) !== 0;
   }
 
@@ -929,7 +933,7 @@ export class UnionFormatter implements TypeFormatter {
    * Used when widenLiterals is true to collapse unions like
    * {x: {enum: [10]}} | {x: {enum: [20]}} into {x: {type: "number"}}
    */
-  private mergeIdenticalSchemas(
+  #mergeIdenticalSchemas(
     schemas: MutableJSONSchema[],
   ): MutableJSONSchema[] {
     if (schemas.length <= 1) return schemas;
@@ -938,7 +942,7 @@ export class UnionFormatter implements TypeFormatter {
     const groups = new Map<string, MutableJSONSchema[]>();
 
     for (const schema of schemas) {
-      const normalized = this.normalizeSchemaForComparison(schema);
+      const normalized = this.#normalizeSchemaForComparison(schema);
       const key = JSON.stringify(normalized);
       const group = groups.get(key) ?? [];
       group.push(schema);
@@ -952,7 +956,7 @@ export class UnionFormatter implements TypeFormatter {
         result.push(group[0]!);
       } else {
         // Multiple schemas with same structure - merge them
-        result.push(this.mergeSchemaGroup(group));
+        result.push(this.#mergeSchemaGroup(group));
       }
     }
 
@@ -963,7 +967,7 @@ export class UnionFormatter implements TypeFormatter {
    * Merge `cur` into the `anyOf` accumulator array in place.
    * Returns true if the result is the permissive schema (short-circuit the caller).
    */
-  private mergePrimitiveSchemaIntoAnyOf(
+  #mergePrimitiveSchemaIntoAnyOf(
     anyOf: MutableJSONSchemaObj[],
     cur: MutableJSONSchema,
   ): boolean {
@@ -1060,7 +1064,7 @@ export class UnionFormatter implements TypeFormatter {
    * Normalize a schema for structural comparison by removing enum values
    * and converting them to base types
    */
-  private normalizeSchemaForComparison(
+  #normalizeSchemaForComparison(
     schema: MutableJSONSchema,
   ): Record<string, unknown> {
     if (typeof schema === "boolean") return { _bool: schema };
@@ -1085,7 +1089,7 @@ export class UnionFormatter implements TypeFormatter {
     if ("properties" in schema && isObjectOrArray(schema.properties)) {
       const props: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(schema.properties)) {
-        props[key] = this.normalizeSchemaForComparison(
+        props[key] = this.#normalizeSchemaForComparison(
           value as MutableJSONSchema,
         );
       }
@@ -1094,7 +1098,7 @@ export class UnionFormatter implements TypeFormatter {
 
     // Recursively normalize items
     if ("items" in schema && schema.items) {
-      result.items = this.normalizeSchemaForComparison(
+      result.items = this.#normalizeSchemaForComparison(
         schema.items as MutableJSONSchema,
       );
     }
@@ -1111,7 +1115,7 @@ export class UnionFormatter implements TypeFormatter {
   /**
    * Merge a group of structurally identical schemas by widening their enums
    */
-  private mergeSchemaGroup(
+  #mergeSchemaGroup(
     schemas: MutableJSONSchema[],
   ): MutableJSONSchema {
     if (schemas.length === 0) {
@@ -1150,7 +1154,7 @@ export class UnionFormatter implements TypeFormatter {
           .filter((p): p is MutableJSONSchema => p !== undefined);
 
         if (propSchemas.length > 0) {
-          props[key] = this.mergeSchemaGroup(propSchemas);
+          props[key] = this.#mergeSchemaGroup(propSchemas);
         }
       }
       result.properties = props;
@@ -1167,7 +1171,7 @@ export class UnionFormatter implements TypeFormatter {
         .filter((i): i is MutableJSONSchema => i !== undefined);
 
       if (itemSchemas.length > 0) {
-        result.items = this.mergeSchemaGroup(itemSchemas);
+        result.items = this.#mergeSchemaGroup(itemSchemas);
       }
     }
 

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -35,7 +35,7 @@ import { assertScopeDeclarationsAreReachable } from "./scope-placement.ts";
  * Main schema generator that uses a chain of formatters
  */
 export class SchemaGenerator {
-  private formatters: TypeFormatter[] = [
+  #formatters: TypeFormatter[] = [
     new CommonFabricFormatter(this),
     new NativeTypeFormatter(),
     new UnionFormatter(this),
@@ -47,10 +47,10 @@ export class SchemaGenerator {
   ];
 
   /** Synthetic names for anonymous recursive types */
-  private anonymousNames: WeakMap<ts.Type, string> = new WeakMap();
+  #anonymousNames: WeakMap<ts.Type, string> = new WeakMap();
 
   /** Counter to generate stable synthetic identifiers */
-  private anonymousNameCounter: number = 0;
+  #anonymousNameCounter: number = 0;
 
   /**
    * Generate JSON Schema for a TypeScript type.
@@ -64,7 +64,7 @@ export class SchemaGenerator {
     schemaHints?: SchemaHints,
     sourceFile?: ts.SourceFile,
   ): MutableJSONSchema {
-    return this.generateSchemaInternal(
+    return this.#generateSchemaInternal(
       type,
       checker,
       typeNode,
@@ -92,7 +92,7 @@ export class SchemaGenerator {
   ): MutableJSONSchema {
     // Pass 'any' type with the typeNode - auto-detection will choose node-based analysis
     const anyType = checker.getAnyType();
-    return this.generateSchemaInternal(
+    return this.#generateSchemaInternal(
       anyType,
       checker,
       typeNode,
@@ -107,7 +107,7 @@ export class SchemaGenerator {
    * Internal unified implementation for schema generation.
    * Handles both normal and synthetic type node cases, with optional typeRegistry.
    */
-  private generateSchemaInternal(
+  #generateSchemaInternal(
     type: ts.Type,
     checker: ts.TypeChecker,
     typeNode?: ts.TypeNode,
@@ -117,7 +117,7 @@ export class SchemaGenerator {
     sourceFile?: ts.SourceFile,
   ): MutableJSONSchema {
     // Create unified context with all state
-    const cycles = this.getCycles(type, checker);
+    const cycles = this.#getCycles(type, checker);
     const context: GenerationContext = {
       // Immutable context
       typeChecker: checker,
@@ -152,26 +152,26 @@ export class SchemaGenerator {
     // Auto-detect: Should we use node-based or type-based analysis?
     let schema: MutableJSONSchema;
     let result: MutableJSONSchema;
-    if (this.shouldUseNodeBasedAnalysis(type, typeNode, checker)) {
+    if (this.#shouldUseNodeBasedAnalysis(type, typeNode, checker)) {
       // Use node-based analysis (for synthetic nodes or when type is unreliable)
-      schema = this.analyzeTypeNodeStructure(
+      schema = this.#analyzeTypeNodeStructure(
         typeNode!,
         checker,
         context,
       );
-      schema = this.applyNodeSchemaHints(schema, context);
+      schema = this.#applyNodeSchemaHints(schema, context);
       // Build final schema with $schema and $defs
-      result = this.buildFinalSchemaForSynthetic(schema, context);
+      result = this.#buildFinalSchemaForSynthetic(schema, context);
     } else {
       // Use type-based analysis (normal path)
-      schema = this.formatType(type, context, true);
-      schema = this.applyNodeSchemaHints(schema, context);
+      schema = this.#formatType(type, context, true);
+      schema = this.#applyNodeSchemaHints(schema, context);
 
       // Attach root-level description from JSDoc if available
-      schema = this.attachRootDescription(schema, type, context);
+      schema = this.#attachRootDescription(schema, type, context);
 
       // Build final schema with definitions if needed
-      result = this.buildFinalSchema(schema, type, context, typeNode);
+      result = this.#buildFinalSchema(schema, type, context, typeNode);
     }
 
     assertScopeDeclarationsAreReachable(result);
@@ -189,7 +189,7 @@ export class SchemaGenerator {
    * which may appear as 'any', but they should use type-based analysis because
    * CommonFabricFormatter handles them specially via typeNode context.
    */
-  private shouldUseNodeBasedAnalysis(
+  #shouldUseNodeBasedAnalysis(
     type: ts.Type,
     typeNode: ts.TypeNode | undefined,
     checker: ts.TypeChecker,
@@ -226,15 +226,15 @@ export class SchemaGenerator {
     const childContext = typeNode ? { ...context, typeNode } : baseContext;
 
     // Auto-detect: Should we use node-based or type-based analysis?
-    const useNodeBased = this.shouldUseNodeBasedAnalysis(
+    const useNodeBased = this.#shouldUseNodeBasedAnalysis(
       type,
       typeNode,
       context.typeChecker,
     );
     if (useNodeBased) {
       // Use node-based analysis (for synthetic nodes or when type is unreliable)
-      return this.applyNodeSchemaHints(
-        this.analyzeTypeNodeStructure(
+      return this.#applyNodeSchemaHints(
+        this.#analyzeTypeNodeStructure(
           typeNode!,
           context.typeChecker,
           childContext,
@@ -244,8 +244,8 @@ export class SchemaGenerator {
     }
 
     // Use type-based analysis (normal path)
-    return this.applyNodeSchemaHints(
-      this.formatType(type, childContext, false),
+    return this.#applyNodeSchemaHints(
+      this.#formatType(type, childContext, false),
       childContext,
     );
   }
@@ -254,7 +254,7 @@ export class SchemaGenerator {
    * Create a stack key that distinguishes erased wrapper types from their
    * inner types
    */
-  private createStackKey(
+  #createStackKey(
     type: ts.Type,
     typeNode?: ts.TypeNode,
     checker?: ts.TypeChecker,
@@ -301,20 +301,20 @@ export class SchemaGenerator {
     return type;
   }
 
-  private ensureSyntheticName(
+  #ensureSyntheticName(
     type: ts.Type,
   ): string {
-    const existing = this.anonymousNames.get(type);
+    const existing = this.#anonymousNames.get(type);
     if (existing) return existing;
-    const synthetic = `AnonymousType_${++this.anonymousNameCounter}`;
-    this.anonymousNames.set(type, synthetic);
+    const synthetic = `AnonymousType_${++this.#anonymousNameCounter}`;
+    this.#anonymousNames.set(type, synthetic);
     return synthetic;
   }
 
   /**
    * Format a type using the appropriate formatter
    */
-  private formatType(
+  #formatType(
     type: ts.Type,
     context: GenerationContext,
     isRootType: boolean = false,
@@ -323,11 +323,11 @@ export class SchemaGenerator {
       const checker = context.typeChecker;
       const baseConstraint = checker.getBaseConstraintOfType(type);
       if (baseConstraint && baseConstraint !== type) {
-        return this.formatType(baseConstraint, context, isRootType);
+        return this.#formatType(baseConstraint, context, isRootType);
       }
       const defaultConstraint = checker.getDefaultFromTypeParameter?.(type);
       if (defaultConstraint && defaultConstraint !== type) {
-        return this.formatType(defaultConstraint, context, isRootType);
+        return this.#formatType(defaultConstraint, context, isRootType);
       }
       return {};
     }
@@ -360,7 +360,7 @@ export class SchemaGenerator {
 
     if (!namedKey && !isWrapperContext) {
       // Only use synthetic names if we're not processing a wrapper type
-      const synthetic = this.anonymousNames.get(type);
+      const synthetic = this.#anonymousNames.get(type);
       if (synthetic) namedKey = synthetic;
     }
 
@@ -378,7 +378,7 @@ export class SchemaGenerator {
     }
 
     // Cycle detection: if we see the same type again by identity, emit a $ref
-    const stackKey = this.createStackKey(
+    const stackKey = this.#createStackKey(
       type,
       context.typeNode,
       context.typeChecker,
@@ -388,7 +388,7 @@ export class SchemaGenerator {
         context.emittedRefs.add(namedKey);
         return { "$ref": `#/$defs/${namedKey}` };
       }
-      const syntheticKey = this.ensureSyntheticName(type);
+      const syntheticKey = this.#ensureSyntheticName(type);
       context.inProgressNames.add(syntheticKey);
       context.emittedRefs.add(syntheticKey);
       return { "$ref": `#/$defs/${syntheticKey}` };
@@ -396,11 +396,11 @@ export class SchemaGenerator {
 
     // Push current type onto the stack
     context.definitionStack.add(
-      this.createStackKey(type, context.typeNode, context.typeChecker),
+      this.#createStackKey(type, context.typeNode, context.typeChecker),
     );
 
     // Try to find a formatter that supports this type
-    for (const formatter of this.formatters) {
+    for (const formatter of this.#formatters) {
       if (formatter.supportsType(type, context)) {
         const result = formatter.formatType(type, context);
 
@@ -409,12 +409,12 @@ export class SchemaGenerator {
         // Only look up synthetic names if namedKey wasn't already set and we're
         // not in a wrapper context (to avoid storing wrapper results).
         const keyForDef = namedKey ??
-          (isWrapperContext ? undefined : this.anonymousNames.get(type));
+          (isWrapperContext ? undefined : this.#anonymousNames.get(type));
         if (keyForDef) {
           context.definitions[keyForDef] = result;
           context.inProgressNames.delete(keyForDef);
           context.definitionStack.delete(
-            this.createStackKey(type, context.typeNode, context.typeChecker),
+            this.#createStackKey(type, context.typeNode, context.typeChecker),
           );
           if (!isRootType) {
             context.emittedRefs.add(keyForDef);
@@ -424,7 +424,7 @@ export class SchemaGenerator {
         }
         // Pop after formatting
         context.definitionStack.delete(
-          this.createStackKey(type, context.typeNode, context.typeChecker),
+          this.#createStackKey(type, context.typeNode, context.typeChecker),
         );
         return result;
       }
@@ -433,7 +433,7 @@ export class SchemaGenerator {
     // If no formatter supports this type, this is an error - we should have
     // complete coverage
     context.definitionStack.delete(
-      this.createStackKey(type, context.typeNode, context.typeChecker),
+      this.#createStackKey(type, context.typeNode, context.typeChecker),
     );
 
     const typeName = context.typeChecker.typeToString(type);
@@ -448,7 +448,7 @@ export class SchemaGenerator {
   /**
    * Build the final schema with definitions if needed
    */
-  private buildFinalSchema(
+  #buildFinalSchema(
     schema: MutableJSONSchema,
     type: ts.Type,
     context: GenerationContext,
@@ -462,8 +462,8 @@ export class SchemaGenerator {
     }
 
     // Decide if we promote root to a $ref
-    const namedKey = getNamedTypeKey(type) ?? this.anonymousNames.get(type);
-    const shouldPromoteRoot = this.shouldPromoteToRef(namedKey, context);
+    const namedKey = getNamedTypeKey(type) ?? this.#anonymousNames.get(type);
+    const shouldPromoteRoot = this.#shouldPromoteToRef(namedKey, context);
 
     let base: MutableJSONSchema;
 
@@ -484,7 +484,7 @@ export class SchemaGenerator {
 
     // Object schema: attach only the definitions actually referenced by the
     // final output
-    const filtered = this.collectReferencedDefinitions(base, definitions);
+    const filtered = this.#collectReferencedDefinitions(base, definitions);
     const out: Record<string, unknown> = {
       ...(base as Record<string, unknown>),
     };
@@ -495,7 +495,7 @@ export class SchemaGenerator {
   /**
    * Determine if root schema should be promoted to a $ref
    */
-  private shouldPromoteToRef(
+  #shouldPromoteToRef(
     namedKey: string | undefined,
     context: GenerationContext,
   ): boolean {
@@ -508,7 +508,7 @@ export class SchemaGenerator {
     return !!(definitions[namedKey] && emittedRefs.has(namedKey));
   }
 
-  private applyNodeSchemaHints(
+  #applyNodeSchemaHints(
     schema: MutableJSONSchema,
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -519,7 +519,7 @@ export class SchemaGenerator {
   /**
    * Detect cycles in the type graph
    */
-  private getCycles(
+  #getCycles(
     type: ts.Type,
     checker?: ts.TypeChecker,
   ): { types: Set<ts.Type>; names: Set<string> } {
@@ -595,7 +595,7 @@ export class SchemaGenerator {
    * Attach a root-level description from JSDoc when the root schema does not
    * already supply one.
    */
-  private attachRootDescription(
+  #attachRootDescription(
     schema: MutableJSONSchema,
     type: ts.Type,
     context: GenerationContext,
@@ -619,7 +619,7 @@ export class SchemaGenerator {
    * and return the minimal subset of definitions required to resolve them,
    * including transitive dependencies.
    */
-  private collectReferencedDefinitions(
+  #collectReferencedDefinitions(
     fragment: MutableJSONSchema,
     allDefs: Record<string, MutableJSONSchema>,
   ): Record<string, MutableJSONSchema> {
@@ -684,7 +684,7 @@ export class SchemaGenerator {
    * Uses formatChildType for properties to share context properly.
    * Gets typeRegistry from context.typeRegistry if available.
    */
-  private analyzeTypeNodeStructure(
+  #analyzeTypeNodeStructure(
     typeNode: ts.TypeNode,
     checker: ts.TypeChecker,
     context: GenerationContext,
@@ -796,7 +796,7 @@ export class SchemaGenerator {
     // resolved directly by the switch below, so they never cause widening.
     if (ts.isUnionTypeNode(typeNode)) {
       const memberSchemas = typeNode.types.map((member) =>
-        this.analyzeTypeNodeStructure(member, checker, context)
+        this.#analyzeTypeNodeStructure(member, checker, context)
       );
       if (memberSchemas.some((schema) => schema === true)) {
         return true;
@@ -841,7 +841,7 @@ export class SchemaGenerator {
         return this.formatChildType(wrapperType, context, typeNode);
       }
 
-      const resolved = this.resolveTypeReferenceFromScope(
+      const resolved = this.#resolveTypeReferenceFromScope(
         typeNode,
         checker,
         context,
@@ -894,7 +894,7 @@ export class SchemaGenerator {
     return true;
   }
 
-  private resolveTypeReferenceFromScope(
+  #resolveTypeReferenceFromScope(
     typeNode: ts.TypeReferenceNode,
     checker: ts.TypeChecker,
     context: GenerationContext,
@@ -941,7 +941,7 @@ export class SchemaGenerator {
   /**
    * Build final schema for synthetic TypeNode with $schema and $defs
    */
-  private buildFinalSchemaForSynthetic(
+  #buildFinalSchemaForSynthetic(
     schema: MutableJSONSchema,
     context: GenerationContext,
   ): MutableJSONSchema {
@@ -958,7 +958,7 @@ export class SchemaGenerator {
     }
 
     // Object schema: attach only the definitions actually referenced
-    const filtered = this.collectReferencedDefinitions(schema, definitions);
+    const filtered = this.#collectReferencedDefinitions(schema, definitions);
     const out: Record<string, unknown> = {
       ...(schema as Record<string, unknown>),
     };


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`schema-generator` goes from 110 TypeScript-`private` members to none, `cli`
from 257 to 17, per `docs/development/DEVELOPMENT.md` § Classes. The two
spellings differ at runtime: a `#` field is not an own property, whereas a
field declared `private` is, the modifier being erased. `private` constructor
parameter properties become the field declaration and the assignment they stand
for.

## What stays TypeScript-private

Seventeen `Session` members, all driven directly by the view tests. The class
carries one `//` note at the top of its body saying so, rather than seventeen
copies of the same sentence — the shape used for `CellBridge` and
`RuntimeProcessor`.

## Documentation

`docs/specs/schema-generator/ts_to_json_schema_mapping.md` names
`SchemaGenerator.formatters` in its sources-of-truth table for the formatter
chain. It now names the `#` member.

## Verification

The tool's count was reconciled against an independent census before the
apply — 367 `private` members across the two packages, 367 converted, no
residue.

`schema-generator`'s own guide warns that its emission is pinned by
`ts-transformers` goldens as well as its own suite, since the transformer
constructs the generator at compile time. Both suites pass, so nothing the
generator emits moved. `cli`'s suite passes too, and those three are every
package that imports either of the two changed here.

Which members a test reaches was settled by running the suites. One was missed
by the syntactic scan first: `displayAdjacentDiffMetadataRows` is named in a
cast whose type literal nests braces in a parameter type, which a regex
terminates early on. Reading casts from the AST rather than by pattern finds
it, and the suite found it regardless.

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, and
`deno task check-command-docs` all pass. Sweeps for prose still naming a
member that became `#`-private, for a doc comment missing its blank line above,
and for a `//` comment stranded beside one all report none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

