### PR TITLE
test(integration): a local browser run drives the browser CI drives

### DIFF
--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -101,8 +101,14 @@ export const extractAstralConfig = (config: Config): LaunchOptions => {
   // is a constant inside astral rather than anything decided here. A system
   // browser is preferred so that a local run drives what CI drives; when there
   // is none, this stays unset and astral decides as before.
-  const path = astralBinaryPath();
-  if (path !== undefined) astralConfig.path = path;
+  //
+  // Only for Chrome, which is what the search knows how to find. A config that
+  // asked for another product gets no `path` at all, which leaves astral to
+  // resolve that product exactly as it did before this existed.
+  if ((astralConfig.product ?? "chrome") === "chrome") {
+    const path = astralBinaryPath();
+    if (path !== undefined) astralConfig.path = path;
+  }
 
   return astralConfig;
 };

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -2,6 +2,7 @@ import { exists } from "@std/fs/exists";
 import * as path from "@std/path";
 
 import { LaunchOptions } from "@astral/astral";
+import { astralBinaryPath } from "@commonfabric/integration/astral-adapter";
 import { build } from "@commonfabric/felt";
 
 // These configurations can be applied
@@ -95,6 +96,14 @@ export const extractAstralConfig = (config: Config): LaunchOptions => {
   if ("headless" in config) astralConfig.headless = config.headless;
   if ("product" in config) astralConfig.product = config.product;
   if ("args" in config) astralConfig.args = config.args;
+
+  // Left unset, astral downloads a browser of its own choosing, whose version
+  // is a constant inside astral rather than anything decided here. A system
+  // browser is preferred so that a local run drives what CI drives; when there
+  // is none, this stays unset and astral decides as before.
+  const path = astralBinaryPath();
+  if (path !== undefined) astralConfig.path = path;
+
   return astralConfig;
 };
 

--- a/packages/deno-web-test/test/astral-config.test.ts
+++ b/packages/deno-web-test/test/astral-config.test.ts
@@ -1,0 +1,43 @@
+/**
+ * What `extractAstralConfig()` hands a launch, and the one decision in it: a
+ * `path` is supplied only for the product the search knows how to find.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { extractAstralConfig } from "../config.ts";
+
+describe("extractAstralConfig()", () => {
+  it("carries the settings it is given", () => {
+    const config = extractAstralConfig({
+      headless: false,
+      args: ["--flag"],
+    });
+
+    expect(config.headless).toBe(false);
+    expect(config.args).toEqual(["--flag"]);
+  });
+
+  describe("the browser binary", () => {
+    it("supplies one for an unstated product, which astral takes as Chrome", () => {
+      // Only meaningful where a browser is actually installed; where none is,
+      // no path is the right answer and astral downloads as before.
+      const path = extractAstralConfig({}).path;
+      if (path !== undefined) expect(Deno.statSync(path).isFile).toBe(true);
+    });
+
+    it('supplies one for `product: "chrome"`', () => {
+      const path = extractAstralConfig({ product: "chrome" }).path;
+      if (path !== undefined) expect(Deno.statSync(path).isFile).toBe(true);
+    });
+
+    it('supplies none for `product: "firefox"`', () => {
+      // The search finds Chrome and Chromium, so handing its answer to a
+      // Firefox launch would name the wrong browser outright. Leaving `path`
+      // unset gives the whole question back to astral, which resolves Firefox
+      // the way it did before any of this existed.
+      expect(extractAstralConfig({ product: "firefox" }).path).toBe(undefined);
+    });
+  });
+});

--- a/packages/deno-web-test/test/astral-config.test.ts
+++ b/packages/deno-web-test/test/astral-config.test.ts
@@ -1,12 +1,39 @@
 /**
  * What `extractAstralConfig()` hands a launch, and the one decision in it: a
  * `path` is supplied only for the product the search knows how to find.
+ *
+ * Every case here pins `ASTRAL_BIN_PATH` to a file that certainly exists, so
+ * that what the search would have found on the machine running the tests never
+ * enters into it. An assertion conditional on the answer would pass on a
+ * machine with no browser, which is to say it would pass for the regression.
  */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { extractAstralConfig } from "../config.ts";
+
+/** A path that exists, whatever machine this runs on: this file. */
+const EXISTING_FILE = new URL(import.meta.url).pathname;
+
+/** Runs the body with `ASTRAL_BIN_PATH` set as given, then puts it back. */
+function withBinaryOverride(value: string | undefined, body: () => void) {
+  const previous = Deno.env.get("ASTRAL_BIN_PATH");
+  if (value === undefined) {
+    Deno.env.delete("ASTRAL_BIN_PATH");
+  } else {
+    Deno.env.set("ASTRAL_BIN_PATH", value);
+  }
+  try {
+    body();
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("ASTRAL_BIN_PATH");
+    } else {
+      Deno.env.set("ASTRAL_BIN_PATH", previous);
+    }
+  }
+}
 
 describe("extractAstralConfig()", () => {
   it("carries the settings it is given", () => {
@@ -21,23 +48,29 @@ describe("extractAstralConfig()", () => {
 
   describe("the browser binary", () => {
     it("supplies one for an unstated product, which astral takes as Chrome", () => {
-      // Only meaningful where a browser is actually installed; where none is,
-      // no path is the right answer and astral downloads as before.
-      const path = extractAstralConfig({}).path;
-      if (path !== undefined) expect(Deno.statSync(path).isFile).toBe(true);
+      withBinaryOverride(EXISTING_FILE, () => {
+        expect(extractAstralConfig({}).path).toBe(EXISTING_FILE);
+      });
     });
 
     it('supplies one for `product: "chrome"`', () => {
-      const path = extractAstralConfig({ product: "chrome" }).path;
-      if (path !== undefined) expect(Deno.statSync(path).isFile).toBe(true);
+      withBinaryOverride(EXISTING_FILE, () => {
+        expect(extractAstralConfig({ product: "chrome" }).path)
+          .toBe(EXISTING_FILE);
+      });
     });
 
     it('supplies none for `product: "firefox"`', () => {
       // The search finds Chrome and Chromium, so handing its answer to a
       // Firefox launch would name the wrong browser outright. Leaving `path`
       // unset gives the whole question back to astral, which resolves Firefox
-      // the way it did before any of this existed.
-      expect(extractAstralConfig({ product: "firefox" }).path).toBe(undefined);
+      // the way it did before any of this existed -- including reading
+      // `ASTRAL_BIN_PATH` itself, which is why one being set here must still
+      // produce no `path`.
+      withBinaryOverride(EXISTING_FILE, () => {
+        expect(extractAstralConfig({ product: "firefox" }).path)
+          .toBe(undefined);
+      });
     });
   });
 });

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -56,8 +56,11 @@ function isExecutableFile(path: string): boolean {
 }
 
 /**
- * Returns the browser binary an astral launch should be given, or `undefined`
- * to leave the choice to astral.
+ * Returns the browser binary a **Chrome** astral launch should be given, or
+ * `undefined` to leave the choice to astral. The paths searched are Chrome's
+ * and Chromium's, so a caller launching anything else must not ask -- leaving
+ * `path` unset is what hands the whole question back to astral, including its
+ * own reading of `ASTRAL_BIN_PATH` for that product.
  *
  * This answers the same question astral's own `getBinary()` answers, and
  * differs from it in one way: where astral falls straight through to

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -6,6 +6,95 @@ import {
 } from "@astral/astral";
 
 /**
+ * Where a system browser lives, per platform, in preference order. Chrome
+ * before Chromium because it is the one a developer is more likely to have
+ * kept current, and the one CI runs. This project does not target Windows, so
+ * neither does this.
+ */
+const SYSTEM_BROWSERS: Readonly<Record<string, readonly string[]>> = Object
+  .freeze({
+    darwin: Object.freeze([
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ]),
+    linux: Object.freeze([
+      "/usr/bin/google-chrome",
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser",
+    ]),
+  });
+
+/**
+ * Helper for `astralBinaryPath()`, which reports the `ASTRAL_BIN_PATH`
+ * override, or `undefined` where it is unset or unreadable.
+ *
+ * The permission is asked exactly the way astral asks it, so that a caller
+ * which has not granted it gets the same answer from both rather than a throw
+ * from this one.
+ */
+function pathFromEnvironment(): string | undefined {
+  const permission = Deno.permissions.querySync({
+    name: "env",
+    variable: "ASTRAL_BIN_PATH",
+  });
+
+  return (permission.state === "granted")
+    ? (Deno.env.get("ASTRAL_BIN_PATH") || undefined)
+    : undefined;
+}
+
+/** Helper for `astralBinaryPath()`, which reports whether a path is a file. */
+function isExecutableFile(path: string): boolean {
+  try {
+    return Deno.statSync(path).isFile;
+  } catch {
+    // Absent, or unreadable under the permissions this process was given.
+    // Either way it is not a binary to hand a launch.
+    return false;
+  }
+}
+
+/**
+ * Returns the browser binary an astral launch should be given, or `undefined`
+ * to leave the choice to astral.
+ *
+ * This answers the same question astral's own `getBinary()` answers, and
+ * differs from it in one way: where astral falls straight through to
+ * downloading a browser, this looks for one already installed. Which browser
+ * astral downloads is a constant inside astral rather than anything this
+ * repository sets, and its latest release still names Chromium 125. CI never
+ * meets that constant, because the workflow points `ASTRAL_BIN_PATH` at the
+ * runner's own Chrome; a developer's machine meets it every time, so a local
+ * browser run and a CI browser run have been exercising engines years apart,
+ * the local one older.
+ *
+ * `ASTRAL_BIN_PATH` still wins outright, which is what keeps CI's
+ * configuration authoritative and leaves anyone a way to name a specific
+ * binary -- astral's downloaded one included, if a system browser ever
+ * misbehaves. `undefined` comes back when no system browser is installed, so
+ * astral's download stays the last resort rather than being taken away.
+ *
+ * @param candidates The paths to search, in preference order. Defaults to the
+ *   ones this platform installs a browser at, and is a parameter so that the
+ *   search can be asked about a list whose answers are known: on a machine
+ *   where the first default happens to exist, a search that skipped the
+ *   existence check entirely would return the same thing as one that made it.
+ */
+export function astralBinaryPath(
+  candidates: readonly string[] = SYSTEM_BROWSERS[Deno.build.os] ?? [],
+): string | undefined {
+  const fromEnvironment = pathFromEnvironment();
+  if (fromEnvironment !== undefined) return fromEnvironment;
+
+  for (const candidate of candidates) {
+    if (isExecutableFile(candidate)) return candidate;
+  }
+
+  return undefined;
+}
+
+/**
  * How `$`, `$$`, and `waitForSelector` resolve a selector.
  *
  * `native` hands the selector to the page's own `querySelector`, which stops at

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -5,7 +5,7 @@ import {
   UserAgentOptions,
   WaitForOptions,
 } from "@astral/astral";
-import { closeAstralBrowser } from "./astral-adapter.ts";
+import { astralBinaryPath, closeAstralBrowser } from "./astral-adapter.ts";
 import { Page } from "./page.ts";
 
 const DEFAULT_ASTRAL_TIMEOUT = 60_000;
@@ -33,6 +33,9 @@ export class Browser {
     const browser = await launch({
       args,
       headless,
+      // `undefined` leaves the choice to astral, which is the answer when no
+      // system browser is installed.
+      path: astralBinaryPath(),
     });
     return new Browser(browser, { timeout });
   }

--- a/packages/integration/test/astral-binary-path.test.ts
+++ b/packages/integration/test/astral-binary-path.test.ts
@@ -79,16 +79,5 @@ describe("astralBinaryPath()", () => {
           .toBe(undefined);
       });
     });
-
-    it("prefers a system browser to astral's download", () => {
-      // Astral's download lives under its own cache; an answer from there
-      // would mean the search found nothing and fell through, which on a
-      // machine with a browser installed is the bug this exists to prevent.
-      withEnvironmentOverride(undefined, () => {
-        const path = astralBinaryPath();
-        if (path === undefined) return;
-        expect(path.includes("Caches/astral")).toBe(false);
-      });
-    });
   });
 });

--- a/packages/integration/test/astral-binary-path.test.ts
+++ b/packages/integration/test/astral-binary-path.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Which binary an astral launch is given, and the order the answer is decided
+ * in.
+ *
+ * The order is the whole of what this is: an explicit `ASTRAL_BIN_PATH` is
+ * what CI sets and must win, a system browser is what a developer's machine
+ * has and beats astral's download, and `undefined` is what leaves that
+ * download in place for a machine with neither.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { astralBinaryPath } from "../astral-adapter.ts";
+
+/** Runs the body with `ASTRAL_BIN_PATH` set as given, then puts it back. */
+function withEnvironmentOverride(value: string | undefined, body: () => void) {
+  const previous = Deno.env.get("ASTRAL_BIN_PATH");
+  if (value === undefined) {
+    Deno.env.delete("ASTRAL_BIN_PATH");
+  } else {
+    Deno.env.set("ASTRAL_BIN_PATH", value);
+  }
+  try {
+    body();
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("ASTRAL_BIN_PATH");
+    } else {
+      Deno.env.set("ASTRAL_BIN_PATH", previous);
+    }
+  }
+}
+
+describe("astralBinaryPath()", () => {
+  it("returns the `ASTRAL_BIN_PATH` override when one is set", () => {
+    // Deliberately a path that does not exist: the override is taken on the
+    // caller's word, so that naming a binary this code would not have found
+    // works -- astral's own downloaded one, say.
+    withEnvironmentOverride("/nonexistent/named-by-hand", () => {
+      expect(astralBinaryPath()).toBe("/nonexistent/named-by-hand");
+    });
+  });
+
+  it("ignores an override set to the empty string", () => {
+    // An empty variable is how a shell says "unset" by accident, and taking it
+    // literally would hand a launch an empty path.
+    withEnvironmentOverride("", () => {
+      expect(astralBinaryPath()).not.toBe("");
+    });
+  });
+
+  describe("with no override", () => {
+    it("returns an existing file, or nothing at all", () => {
+      // What it must never do is name a path that is not there, since astral
+      // takes the answer as final and would fail to spawn it. Either answer is
+      // correct depending on the machine; naming an absent file is not.
+      withEnvironmentOverride(undefined, () => {
+        const path = astralBinaryPath();
+        if (path === undefined) return;
+        expect(Deno.statSync(path).isFile).toBe(true);
+      });
+    });
+
+    it("skips a candidate that is not there, and takes the next that is", () => {
+      // The existence check, asked where the answer is known. Without it the
+      // first candidate comes back whether or not it exists, and astral takes
+      // that answer as final and fails to spawn it.
+      const real = new URL(import.meta.url).pathname;
+      withEnvironmentOverride(undefined, () => {
+        expect(astralBinaryPath(["/nonexistent/one", "/nonexistent/two", real]))
+          .toBe(real);
+      });
+    });
+
+    it("returns nothing when no candidate is there", () => {
+      withEnvironmentOverride(undefined, () => {
+        expect(astralBinaryPath(["/nonexistent/one", "/nonexistent/two"]))
+          .toBe(undefined);
+      });
+    });
+
+    it("prefers a system browser to astral's download", () => {
+      // Astral's download lives under its own cache; an answer from there
+      // would mean the search found nothing and fell through, which on a
+      // machine with a browser installed is the bug this exists to prevent.
+      withEnvironmentOverride(undefined, () => {
+        const path = astralBinaryPath();
+        if (path === undefined) return;
+        expect(path.includes("Caches/astral")).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

A local browser test run and a CI browser test run have been driving different
engines, and only CI's is current. This closes that from the side we control.

## What was actually happening

Astral downloads a browser of its own when nothing names one, and **which one is
a constant inside astral, not anything this repository sets**:

```ts
/** The automatically downloaded browser versions that are known to work. */
export const SUPPORTED_VERSIONS = { chrome: "125.0.6400.0", ... }
```

`0.5.6` is astral's latest release, and that constant has not moved since
`0.4.5` — so there is nothing to bump and no line here to edit:

```
astral 0.4.0  -> chrome 121.0.6130.0
astral 0.4.5  -> chrome 125.0.6400.0
   ...
astral 0.5.6  -> chrome 125.0.6400.0   <- latest, and what we depend on
```

CI never meets it: `deno.yml` sets `ASTRAL_BIN_PATH: /usr/bin/google-chrome` at
workflow level, and its own comment says why. A developer's machine meets it on
every browser run.

## The change

`astralBinaryPath()` in `astral-adapter.ts`, and both launch sites hand its
answer to astral. Precedence, in order:

1. **`ASTRAL_BIN_PATH`**, taken on the caller's word — this is what CI sets, and
   what lets anyone name a specific binary including astral's downloaded one.
2. **An installed browser**, Chrome before Chromium, macOS and Linux only.
3. **`undefined`**, leaving astral to download exactly as today, which is the
   answer on a machine with no browser installed.

## That it does what it says

Same command, same environment, astral asked to print what it spawns:

```
before   Launching: ~/Library/Caches/astral/125.0.6400.0/.../Google Chrome
after    Launching: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```

125 → 151, from a change with no version number in it. And with
`ASTRAL_BIN_PATH` pointed back at the cached 125 build, that is what launches —
CI's configuration still wins.

Every browser suite passes on the new path, with the override unset:
`identity` 26, `iframe-sandbox` 50, `ui` 52, `dashboard` 6, zero failed.

## Controls

| ablation | reddens |
| --- | --- |
| the `ASTRAL_BIN_PATH` branch goes | the override test |
| an empty override is taken literally rather than as unset | the empty-string test |
| the existence check goes | both candidate-search tests |

The third is why the candidate list is a parameter. Without one that test was
**vacuous**: this machine's first default exists, so a search that skipped the
existence check returned the same path as one that made it, and the ablation
stayed green. The parameter is documented as being there for that reason.

## Two judgement calls worth a look

**It makes a local run depend on whatever Chrome a developer has.** That is the
point — it is what CI does — but two developers can now be on different engines.
The alternative is pinning a browser we download ourselves, which is more
machinery than this deserves.

**Windows is left out**, since we do not support it.

## Gates

`deno task check`, `deno lint`, `deno fmt --check`, `deno task check-docs`, the
`integration` suite (52 passed), and the four browser suites above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

