### PR TITLE
refactor: `#` private members in `shell`

### DIFF
--- a/packages/shell/src/components/Button.ts
+++ b/packages/shell/src/components/Button.ts
@@ -57,7 +57,7 @@ export class XButtonElement extends LitElement {
   @property({ attribute: true })
   accessor variant: VariantType = "none";
 
-  private onClick(e: Event) {
+  #onClick(e: Event) {
     // If this is a "submit" button, then we need
     // to handle execution as the shadow DOM prevents
     // default mapping of the button to a parent form.
@@ -81,7 +81,7 @@ export class XButtonElement extends LitElement {
   override render() {
     return html`
       <button
-        @click="${this.onClick}"
+        @click="${this.#onClick}"
         type="${this.type}"
         ?disabled="${this.disabled}"
         x-variant="${this.variant}"

--- a/packages/shell/src/components/OmniLayout.ts
+++ b/packages/shell/src/components/OmniLayout.ts
@@ -135,8 +135,8 @@ export class XOmniLayout extends LitElement {
   @state()
   private accessor isResizing = false;
 
-  private resizeStartX = 0;
-  private resizeStartWidth = 0;
+  #resizeStartX = 0;
+  #resizeStartWidth = 0;
 
   override firstUpdated() {
     const slot = this.shadowRoot?.querySelector(
@@ -182,33 +182,33 @@ export class XOmniLayout extends LitElement {
     this.hasSidebarContent = hasContent;
   }
 
-  private handleResizeStart = (e: PointerEvent) => {
+  #handleResizeStart = (e: PointerEvent) => {
     e.preventDefault();
     this.isResizing = true;
-    this.resizeStartX = e.clientX;
-    this.resizeStartWidth = this.sidebarWidth;
+    this.#resizeStartX = e.clientX;
+    this.#resizeStartWidth = this.sidebarWidth;
 
     const handle = e.target as HTMLElement;
     handle.setPointerCapture(e.pointerId);
     handle.classList.add("dragging");
 
-    document.addEventListener("pointermove", this.handleResizeMove);
-    document.addEventListener("pointerup", this.handleResizeEnd);
+    document.addEventListener("pointermove", this.#handleResizeMove);
+    document.addEventListener("pointerup", this.#handleResizeEnd);
   };
 
-  private handleResizeMove = (e: PointerEvent) => {
+  #handleResizeMove = (e: PointerEvent) => {
     if (!this.isResizing) return;
 
-    const delta = this.resizeStartX - e.clientX;
+    const delta = this.#resizeStartX - e.clientX;
     const newWidth = Math.min(
       MAX_SIDEBAR_WIDTH,
-      Math.max(MIN_SIDEBAR_WIDTH, this.resizeStartWidth + delta),
+      Math.max(MIN_SIDEBAR_WIDTH, this.#resizeStartWidth + delta),
     );
 
     this.sidebarWidth = newWidth;
   };
 
-  private handleResizeEnd = (_e: PointerEvent) => {
+  #handleResizeEnd = (_e: PointerEvent) => {
     if (!this.isResizing) return;
 
     this.isResizing = false;
@@ -219,8 +219,8 @@ export class XOmniLayout extends LitElement {
       handle.classList.remove("dragging");
     }
 
-    document.removeEventListener("pointermove", this.handleResizeMove);
-    document.removeEventListener("pointerup", this.handleResizeEnd);
+    document.removeEventListener("pointermove", this.#handleResizeMove);
+    document.removeEventListener("pointerup", this.#handleResizeEnd);
   };
 
   override render() {
@@ -234,7 +234,7 @@ export class XOmniLayout extends LitElement {
         <div class="sidebar">
           <div
             class="resize-handle"
-            @pointerdown="${this.handleResizeStart}"
+            @pointerdown="${this.#handleResizeStart}"
           ></div>
           <div class="sidebar-content">
             <slot name="sidebar"></slot>

--- a/packages/shell/src/components/PieceList.ts
+++ b/packages/shell/src/components/PieceList.ts
@@ -85,7 +85,7 @@ export class XPieceList extends LitElement {
   @property({ attribute: false })
   accessor activePieceId: string | undefined = undefined;
 
-  private _handleClick(e: Event) {
+  #handleClick(e: Event) {
     const target = (e.target as HTMLElement).closest<HTMLElement>(
       "[data-piece-id]",
     );
@@ -120,7 +120,7 @@ export class XPieceList extends LitElement {
                 ? "active"
                 : ""}"
               data-piece-id="${piece.id}"
-              @click="${this._handleClick}"
+              @click="${this.#handleClick}"
             >
               ${piece.name}
             </button>

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -39,93 +39,96 @@ export interface GraphWithHistory {
  * - Memory management by limiting event history
  */
 export class DebuggerController implements ReactiveController {
-  private host: ReactiveControllerHost & HTMLElement;
-  private runtime?: RuntimeInternals;
-  private visible = false;
-  private telemetryEnabled = false; // Manual telemetry on/off
-  private telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
-  private updateVersion = 0;
+  #host: ReactiveControllerHost & HTMLElement;
+  #runtime?: RuntimeInternals;
+  #visible = false;
+  #telemetryEnabled = false; // Manual telemetry on/off
+  #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
+  #updateVersion = 0;
 
   // Scheduler graph tracking with historical edges
-  private currentSnapshot?: SchedulerGraphSnapshot;
-  private historicalEdges = new Set<string>(); // "from->to" format
-  private graphUpdateVersion = 0;
-  private isProcessingTelemetry = false; // Guard against re-entrant updates
+  #currentSnapshot?: SchedulerGraphSnapshot;
+  #historicalEdges = new Set<string>(); // "from->to" format
+  #graphUpdateVersion = 0;
+  #isProcessingTelemetry = false; // Guard against re-entrant updates
 
   // Diagnosis state for non-idempotent detection
-  private diagnosisResult: SchedulerDiagnosisResult | null = null;
-  private isDiagnosing = false;
-  private diagnosisVersion = 0;
+  #diagnosisResult: SchedulerDiagnosisResult | null = null;
+  #isDiagnosing = false;
+  #diagnosisVersion = 0;
 
   // Logger flags from worker (e.g. "action invalid input" flags)
-  private activeFlags: LoggerFlagsData = {};
-  private flagsVersion = 0;
+  #activeFlags: LoggerFlagsData = {};
+  #flagsVersion = 0;
 
   // Baseline stats for scheduler graph delta calculations
   // Persists across tab switches (stored here instead of in SchedulerGraphView component)
-  private schedulerBaselineStats = new Map<
+  #schedulerBaselineStats = new Map<
     string,
     { runCount: number; totalTime: number }
   >();
-  private schedulerBaselineVersion = 0;
+  #schedulerBaselineVersion = 0;
 
   // Pattern source files for source browser
-  private patternSources: readonly PatternSourceInfo[] = [];
-  private patternSourcesVersion = 0;
+  #patternSources: readonly PatternSourceInfo[] = [];
+  #patternSourcesVersion = 0;
 
   // Debugger breakpoints: action IDs
-  private breakpointIds = new Set<string>();
-  private breakpointsVersion = 0;
+  #breakpointIds = new Set<string>();
+  #breakpointsVersion = 0;
 
   constructor(host: ReactiveControllerHost & HTMLElement) {
-    this.host = host;
-    this.host.addController(this);
+    this.#host = host;
+    this.#host.addController(this);
   }
 
   hostConnected() {
     // Load visibility from localStorage
     const savedVisible = localStorage.getItem(STORAGE_KEY);
     if (savedVisible !== null) {
-      this.visible = savedVisible === "true";
+      this.#visible = savedVisible === "true";
     }
 
     // Load telemetry enabled state from localStorage (default to false)
     const savedTelemetryEnabled = localStorage.getItem(TELEMETRY_ENABLED_KEY);
     if (savedTelemetryEnabled !== null) {
-      this.telemetryEnabled = savedTelemetryEnabled === "true";
+      this.#telemetryEnabled = savedTelemetryEnabled === "true";
     }
 
-    globalThis.addEventListener("storage", this.handleStorageChange);
-    this.host.addEventListener("clear-telemetry", this.handleClearTelemetry);
+    globalThis.addEventListener("storage", this.#handleStorageChange);
+    this.#host.addEventListener("clear-telemetry", this.#handleClearTelemetry);
   }
 
   hostDisconnected() {
-    globalThis.removeEventListener("storage", this.handleStorageChange);
-    this.host.removeEventListener("clear-telemetry", this.handleClearTelemetry);
+    globalThis.removeEventListener("storage", this.#handleStorageChange);
+    this.#host.removeEventListener(
+      "clear-telemetry",
+      this.#handleClearTelemetry,
+    );
   }
 
   /**
    * Set the runtime and start listening to telemetry events
    */
   setRuntime(runtime: RuntimeInternals) {
-    if (this.runtime) {
-      this.runtime.removeEventListener(
+    if (this.#runtime) {
+      this.#runtime.removeEventListener(
         "telemetryupdate",
-        this.handleTelemetryUpdate,
+        this.#handleTelemetryUpdate,
       );
     }
 
-    this.runtime = runtime;
+    this.#runtime = runtime;
 
-    if (this.runtime) {
-      this.runtime.addEventListener(
+    if (this.#runtime) {
+      this.#runtime.addEventListener(
         "telemetryupdate",
-        this.handleTelemetryUpdate,
+        this.#handleTelemetryUpdate,
       );
 
       // Set telemetry enabled state based on saved preference
-      const rt = this.runtime.runtime();
-      rt.setTelemetryEnabled(this.telemetryEnabled).catch((e) => {
+      const rt = this.#runtime.runtime();
+      rt.setTelemetryEnabled(this.#telemetryEnabled).catch((e) => {
         console.error(
           "[DebuggerController] Failed to set telemetry enabled:",
           e,
@@ -133,18 +136,18 @@ export class DebuggerController implements ReactiveController {
       });
 
       // Clear stale pattern sources from previous runtime
-      this.patternSources = [];
-      this.patternSourcesVersion++;
+      this.#patternSources = [];
+      this.#patternSourcesVersion++;
 
       // Re-sync breakpoints to new runtime
-      this.syncBreakpoints().catch(() => {});
+      this.#syncBreakpoints().catch(() => {});
 
       // Load existing telemetry markers
-      this.telemetryMarkers = this.runtime.telemetry().slice(
+      this.#telemetryMarkers = this.#runtime.telemetry().slice(
         -MAX_TELEMETRY_EVENTS,
       );
-      this.updateVersion++;
-      this.host.requestUpdate();
+      this.#updateVersion++;
+      this.#host.requestUpdate();
     }
   }
 
@@ -152,75 +155,75 @@ export class DebuggerController implements ReactiveController {
    * Get the current telemetry markers
    */
   getTelemetryMarkers(): RuntimeTelemetryMarkerResult[] {
-    return this.telemetryMarkers;
+    return this.#telemetryMarkers;
   }
 
   /**
    * Get the update version for change detection
    */
   getUpdateVersion(): number {
-    return this.updateVersion;
+    return this.#updateVersion;
   }
 
   /**
    * Check if the debugger is visible
    */
   isVisible(): boolean {
-    return this.visible;
+    return this.#visible;
   }
 
   /**
    * Toggle debugger visibility
    */
   toggleVisibility() {
-    this.setVisibility(!this.visible);
+    this.setVisibility(!this.#visible);
   }
 
   /**
    * Set debugger visibility
    */
   setVisibility(visible: boolean) {
-    if (this.visible === visible) return;
+    if (this.#visible === visible) return;
 
-    this.visible = visible;
+    this.#visible = visible;
     localStorage.setItem(STORAGE_KEY, String(visible));
-    this.host.requestUpdate();
+    this.#host.requestUpdate();
   }
 
   /**
    * Clear all telemetry events
    */
   clearTelemetry() {
-    this.telemetryMarkers = [];
-    this.updateVersion++;
-    this.host.requestUpdate();
+    this.#telemetryMarkers = [];
+    this.#updateVersion++;
+    this.#host.requestUpdate();
   }
 
   /**
    * Check if telemetry is enabled
    */
   isTelemetryEnabled(): boolean {
-    return this.telemetryEnabled;
+    return this.#telemetryEnabled;
   }
 
   /**
    * Toggle telemetry collection on/off
    */
   toggleTelemetry() {
-    this.setTelemetryEnabled(!this.telemetryEnabled);
+    this.setTelemetryEnabled(!this.#telemetryEnabled);
   }
 
   /**
    * Set telemetry enabled state
    */
   setTelemetryEnabled(enabled: boolean) {
-    if (this.telemetryEnabled === enabled) return;
+    if (this.#telemetryEnabled === enabled) return;
 
-    this.telemetryEnabled = enabled;
+    this.#telemetryEnabled = enabled;
     localStorage.setItem(TELEMETRY_ENABLED_KEY, String(enabled));
 
     // Update telemetry collection in the worker
-    const rt = this.runtime?.runtime();
+    const rt = this.#runtime?.runtime();
     if (rt) {
       rt.setTelemetryEnabled(enabled).catch((e) => {
         console.error(
@@ -230,30 +233,30 @@ export class DebuggerController implements ReactiveController {
       });
     }
 
-    this.host.requestUpdate();
+    this.#host.requestUpdate();
   }
 
   /**
    * Handle telemetry updates from the runtime
    */
-  private handleTelemetryUpdate = () => {
+  #handleTelemetryUpdate = () => {
     // Guard against re-entrant updates (telemetry -> UI update -> sink -> telemetry)
-    if (this.isProcessingTelemetry) return;
+    if (this.#isProcessingTelemetry) return;
 
-    if (this.runtime) {
-      this.isProcessingTelemetry = true;
+    if (this.#runtime) {
+      this.#isProcessingTelemetry = true;
       try {
         // Get all telemetry markers from runtime
-        const allMarkers = this.runtime.telemetry();
+        const allMarkers = this.#runtime.telemetry();
 
         // Limit to maximum number of events to prevent memory issues
-        this.telemetryMarkers = allMarkers.slice(-MAX_TELEMETRY_EVENTS);
-        this.updateVersion++;
+        this.#telemetryMarkers = allMarkers.slice(-MAX_TELEMETRY_EVENTS);
+        this.#updateVersion++;
 
         // Check for graph snapshot events in recent markers
         const latestMarker = allMarkers[allMarkers.length - 1];
         if (latestMarker?.type === "scheduler.graph.snapshot") {
-          this.processGraphSnapshot(
+          this.#processGraphSnapshot(
             (latestMarker as { graph: SchedulerGraphSnapshot }).graph,
           );
         }
@@ -277,7 +280,7 @@ export class DebuggerController implements ReactiveController {
         // Request update to refresh the UI
         //this.host.requestUpdate();
       } finally {
-        this.isProcessingTelemetry = false;
+        this.#isProcessingTelemetry = false;
       }
     }
   };
@@ -285,35 +288,35 @@ export class DebuggerController implements ReactiveController {
   /**
    * Process a new graph snapshot and track historical edges
    */
-  private processGraphSnapshot(newSnapshot: SchedulerGraphSnapshot): void {
-    if (this.currentSnapshot) {
+  #processGraphSnapshot(newSnapshot: SchedulerGraphSnapshot): void {
+    if (this.#currentSnapshot) {
       // Build set of current edges in the new snapshot
       const newEdgeSet = new Set(
         newSnapshot.edges.map((e) => `${e.from}->${e.to}`),
       );
 
       // Any edges in the old snapshot but not in the new one become historical
-      for (const edge of this.currentSnapshot.edges) {
+      for (const edge of this.#currentSnapshot.edges) {
         const edgeKey = `${edge.from}->${edge.to}`;
         if (!newEdgeSet.has(edgeKey)) {
-          this.historicalEdges.add(edgeKey);
+          this.#historicalEdges.add(edgeKey);
         }
       }
     }
 
-    this.currentSnapshot = newSnapshot;
-    this.graphUpdateVersion++;
+    this.#currentSnapshot = newSnapshot;
+    this.#graphUpdateVersion++;
   }
 
   /**
    * Handle storage change events for cross-tab synchronization
    */
-  private handleStorageChange = (event: StorageEvent) => {
+  #handleStorageChange = (event: StorageEvent) => {
     if (event.key === STORAGE_KEY && event.newValue !== null) {
       const newVisible = event.newValue === "true";
-      if (this.visible !== newVisible) {
-        this.visible = newVisible;
-        this.host.requestUpdate();
+      if (this.#visible !== newVisible) {
+        this.#visible = newVisible;
+        this.#host.requestUpdate();
       }
     }
   };
@@ -324,16 +327,16 @@ export class DebuggerController implements ReactiveController {
   getStatistics() {
     const eventTypes = new Map<string, number>();
 
-    for (const marker of this.telemetryMarkers) {
+    for (const marker of this.#telemetryMarkers) {
       const type = marker.type.split(".")[0]; // Get the main category
       eventTypes.set(type, (eventTypes.get(type) || 0) + 1);
     }
 
     return {
-      totalEvents: this.telemetryMarkers.length,
+      totalEvents: this.#telemetryMarkers.length,
       eventTypes: Object.fromEntries(eventTypes),
-      oldestEvent: this.telemetryMarkers[0]?.timeStamp,
-      newestEvent: this.telemetryMarkers[this.telemetryMarkers.length - 1]
+      oldestEvent: this.#telemetryMarkers[0]?.timeStamp,
+      newestEvent: this.#telemetryMarkers[this.#telemetryMarkers.length - 1]
         ?.timeStamp,
     };
   }
@@ -342,15 +345,15 @@ export class DebuggerController implements ReactiveController {
    * Get the current graph snapshot with historical edge tracking
    */
   getGraphWithHistory(): GraphWithHistory | undefined {
-    if (!this.currentSnapshot) return undefined;
+    if (!this.#currentSnapshot) return undefined;
 
     // Build set of current edge keys
     const currentEdgeSet = new Set(
-      this.currentSnapshot.edges.map((e) => `${e.from}->${e.to}`),
+      this.#currentSnapshot.edges.map((e) => `${e.from}->${e.to}`),
     );
 
     // Combine current edges with historical flag
-    const edges: GraphEdgeWithHistory[] = this.currentSnapshot.edges.map(
+    const edges: GraphEdgeWithHistory[] = this.#currentSnapshot.edges.map(
       (e) => ({
         ...e,
         isHistorical: false,
@@ -358,7 +361,7 @@ export class DebuggerController implements ReactiveController {
     );
 
     // Add historical edges that are not in current snapshot
-    for (const edgeKey of this.historicalEdges) {
+    for (const edgeKey of this.#historicalEdges) {
       if (!currentEdgeSet.has(edgeKey)) {
         const [from, to] = edgeKey.split("->");
         edges.push({
@@ -371,9 +374,9 @@ export class DebuggerController implements ReactiveController {
     }
 
     return {
-      nodes: this.currentSnapshot.nodes,
+      nodes: this.#currentSnapshot.nodes,
       edges,
-      timestamp: this.currentSnapshot.timestamp,
+      timestamp: this.#currentSnapshot.timestamp,
     };
   }
 
@@ -381,20 +384,20 @@ export class DebuggerController implements ReactiveController {
    * Get the graph update version for change detection
    */
   getGraphUpdateVersion(): number {
-    return this.graphUpdateVersion;
+    return this.#graphUpdateVersion;
   }
 
   /**
    * Request a fresh graph snapshot from the scheduler
    */
   async requestGraphSnapshot(): Promise<void> {
-    if (!this.runtime) return;
+    if (!this.#runtime) return;
 
-    const rt = this.runtime.runtime();
+    const rt = this.#runtime.runtime();
     if (!rt) return;
     const snapshot = await rt.getGraphSnapshot();
-    this.processGraphSnapshot(snapshot);
-    this.host.requestUpdate();
+    this.#processGraphSnapshot(snapshot);
+    this.#host.requestUpdate();
 
     // Also refresh flags alongside the graph
     this.requestFlags().catch(() => {});
@@ -404,16 +407,16 @@ export class DebuggerController implements ReactiveController {
    * Get the current runtime internals
    */
   getRuntime(): RuntimeInternals | undefined {
-    return this.runtime;
+    return this.#runtime;
   }
 
   /**
    * Clear historical edges
    */
   clearHistoricalEdges(): void {
-    this.historicalEdges.clear();
-    this.graphUpdateVersion++;
-    this.host.requestUpdate();
+    this.#historicalEdges.clear();
+    this.#graphUpdateVersion++;
+    this.#host.requestUpdate();
   }
 
   /**
@@ -423,7 +426,7 @@ export class DebuggerController implements ReactiveController {
     string,
     { runCount: number; totalTime: number }
   > {
-    return this.schedulerBaselineStats;
+    return this.#schedulerBaselineStats;
   }
 
   /**
@@ -432,39 +435,39 @@ export class DebuggerController implements ReactiveController {
   setSchedulerBaselineStats(
     stats: Map<string, { runCount: number; totalTime: number }>,
   ): void {
-    this.schedulerBaselineStats = stats;
-    this.schedulerBaselineVersion++;
-    this.host.requestUpdate();
+    this.#schedulerBaselineStats = stats;
+    this.#schedulerBaselineVersion++;
+    this.#host.requestUpdate();
   }
 
   /**
    * Clear the scheduler baseline stats
    */
   clearSchedulerBaselineStats(): void {
-    this.schedulerBaselineStats.clear();
-    this.schedulerBaselineVersion++;
-    this.host.requestUpdate();
+    this.#schedulerBaselineStats.clear();
+    this.#schedulerBaselineVersion++;
+    this.#host.requestUpdate();
   }
 
   /**
    * Get the scheduler baseline version for change detection
    */
   getSchedulerBaselineVersion(): number {
-    return this.schedulerBaselineVersion;
+    return this.#schedulerBaselineVersion;
   }
 
   /**
    * Request pattern source files for the source browser
    */
   async requestPatternSources(): Promise<void> {
-    if (!this.runtime) return;
-    const rt = this.runtime.runtime();
+    if (!this.#runtime) return;
+    const rt = this.#runtime.runtime();
     if (!rt) return;
     try {
       const response = await rt.getPatternSources();
-      this.patternSources = response.patterns;
-      this.patternSourcesVersion++;
-      this.host.requestUpdate();
+      this.#patternSources = response.patterns;
+      this.#patternSourcesVersion++;
+      this.#host.requestUpdate();
     } catch (e) {
       console.error(
         "[DebuggerController] Failed to request pattern sources:",
@@ -477,28 +480,28 @@ export class DebuggerController implements ReactiveController {
    * Get cached pattern sources
    */
   getPatternSources(): readonly PatternSourceInfo[] {
-    return this.patternSources;
+    return this.#patternSources;
   }
 
   /**
    * Get pattern sources version for change detection
    */
   getPatternSourcesVersion(): number {
-    return this.patternSourcesVersion;
+    return this.#patternSourcesVersion;
   }
 
   /**
    * Toggle a breakpoint for an action ID. Sends updated set to worker.
    */
   async toggleBreakpoint(actionId: string): Promise<void> {
-    if (this.breakpointIds.has(actionId)) {
-      this.breakpointIds.delete(actionId);
+    if (this.#breakpointIds.has(actionId)) {
+      this.#breakpointIds.delete(actionId);
     } else {
-      this.breakpointIds.add(actionId);
+      this.#breakpointIds.add(actionId);
     }
-    this.breakpointsVersion++;
-    this.host.requestUpdate();
-    await this.syncBreakpoints();
+    this.#breakpointsVersion++;
+    this.#host.requestUpdate();
+    await this.#syncBreakpoints();
   }
 
   /**
@@ -510,24 +513,24 @@ export class DebuggerController implements ReactiveController {
   ): Promise<void> {
     for (const id of actionIds) {
       if (enabled) {
-        this.breakpointIds.add(id);
+        this.#breakpointIds.add(id);
       } else {
-        this.breakpointIds.delete(id);
+        this.#breakpointIds.delete(id);
       }
     }
-    this.breakpointsVersion++;
-    this.host.requestUpdate();
-    await this.syncBreakpoints();
+    this.#breakpointsVersion++;
+    this.#host.requestUpdate();
+    await this.#syncBreakpoints();
   }
 
   /**
    * Send current breakpoints to the worker.
    */
-  private async syncBreakpoints(): Promise<void> {
-    const rt = this.runtime?.runtime();
+  async #syncBreakpoints(): Promise<void> {
+    const rt = this.#runtime?.runtime();
     if (!rt) return;
     try {
-      await rt.setBreakpoints(Array.from(this.breakpointIds));
+      await rt.setBreakpoints(Array.from(this.#breakpointIds));
     } catch (e) {
       console.error(
         "[DebuggerController] Failed to set breakpoints:",
@@ -540,58 +543,58 @@ export class DebuggerController implements ReactiveController {
    * Check if an action ID has a breakpoint set.
    */
   hasBreakpoint(actionId: string): boolean {
-    return this.breakpointIds.has(actionId);
+    return this.#breakpointIds.has(actionId);
   }
 
   /**
    * Get all breakpoint action IDs.
    */
   getBreakpoints(): Set<string> {
-    return new Set(this.breakpointIds);
+    return new Set(this.#breakpointIds);
   }
 
   /**
    * Get breakpoints version for change detection.
    */
   getBreakpointsVersion(): number {
-    return this.breakpointsVersion;
+    return this.#breakpointsVersion;
   }
 
   /**
    * Get active logger flags from the worker
    */
   getActiveFlags(): LoggerFlagsData {
-    return this.activeFlags;
+    return this.#activeFlags;
   }
 
   /**
    * Get the flags version for change detection
    */
   getFlagsVersion(): number {
-    return this.flagsVersion;
+    return this.#flagsVersion;
   }
 
   /**
    * Update active flags directly (e.g. from an existing IPC response)
    */
   updateFlags(flags: LoggerFlagsData): void {
-    this.activeFlags = flags;
-    this.flagsVersion++;
+    this.#activeFlags = flags;
+    this.#flagsVersion++;
   }
 
   /**
    * Request fresh flags from the worker via getLoggerCounts
    */
   async requestFlags(): Promise<void> {
-    if (!this.runtime) return;
+    if (!this.#runtime) return;
 
-    const rt = this.runtime.runtime();
+    const rt = this.#runtime.runtime();
     if (!rt) return;
     try {
       const result = await rt.getLoggerCounts();
-      this.activeFlags = result.flags;
-      this.flagsVersion++;
-      this.host.requestUpdate();
+      this.#activeFlags = result.flags;
+      this.#flagsVersion++;
+      this.#host.requestUpdate();
     } catch (e) {
       console.error("[DebuggerController] Failed to request flags:", e);
     }
@@ -605,7 +608,7 @@ export class DebuggerController implements ReactiveController {
     flagName: string,
     id: string,
   ): Record<string, unknown> | null {
-    return this.activeFlags?.["runner"]?.[flagName]?.[id] ?? null;
+    return this.#activeFlags?.["runner"]?.[flagName]?.[id] ?? null;
   }
 
   //
@@ -616,24 +619,24 @@ export class DebuggerController implements ReactiveController {
    * Run diagnosis and store the result.
    */
   async runDiagnosis(durationMs = 5000): Promise<void> {
-    if (!this.runtime || this.isDiagnosing) return;
+    if (!this.#runtime || this.#isDiagnosing) return;
 
-    const rt = this.runtime.runtime();
+    const rt = this.#runtime.runtime();
     if (!rt) return;
 
-    this.isDiagnosing = true;
-    this.host.requestUpdate();
+    this.#isDiagnosing = true;
+    this.#host.requestUpdate();
 
     try {
       const result = await rt.detectNonIdempotent(durationMs);
-      this.diagnosisResult = result;
-      this.diagnosisVersion++;
+      this.#diagnosisResult = result;
+      this.#diagnosisVersion++;
     } catch (e) {
       console.error("[DebuggerController] Diagnosis failed:", e);
-      this.diagnosisResult = null;
+      this.#diagnosisResult = null;
     } finally {
-      this.isDiagnosing = false;
-      this.host.requestUpdate();
+      this.#isDiagnosing = false;
+      this.#host.requestUpdate();
     }
   }
 
@@ -641,28 +644,28 @@ export class DebuggerController implements ReactiveController {
    * Get the current diagnosis result.
    */
   getDiagnosisResult(): SchedulerDiagnosisResult | null {
-    return this.diagnosisResult;
+    return this.#diagnosisResult;
   }
 
   /**
    * Check if diagnosis is currently running.
    */
   getIsDiagnosing(): boolean {
-    return this.isDiagnosing;
+    return this.#isDiagnosing;
   }
 
   /**
    * Get the diagnosis version for change detection.
    */
   getDiagnosisVersion(): number {
-    return this.diagnosisVersion;
+    return this.#diagnosisVersion;
   }
 
   /**
    * Export telemetry data as JSON
    */
   exportTelemetry(): string {
-    return JSON.stringify(this.telemetryMarkers, null, 2);
+    return JSON.stringify(this.#telemetryMarkers, null, 2);
   }
 
   /**
@@ -681,7 +684,7 @@ export class DebuggerController implements ReactiveController {
     URL.revokeObjectURL(url);
   }
 
-  private handleClearTelemetry = () => {
+  #handleClearTelemetry = () => {
     this.clearTelemetry();
   };
 }

--- a/packages/shell/src/lib/global-shortcuts-controller.ts
+++ b/packages/shell/src/lib/global-shortcuts-controller.ts
@@ -18,7 +18,7 @@ type ReactiveAppHost = ReactiveControllerHost & BaseView & { app: AppState };
  * `preventDefault()`.
  */
 export class GlobalShortcutsController implements ReactiveController {
-  private host: ReactiveAppHost;
+  #host: ReactiveAppHost;
 
   // Whether the platform's primary shortcut modifier is Command rather than
   // Control. Read when the host connects, since it depends on `navigator`.
@@ -26,8 +26,8 @@ export class GlobalShortcutsController implements ReactiveController {
   #usesCommandKey = false;
 
   constructor(host: ReactiveAppHost) {
-    this.host = host;
-    this.host.addController(this);
+    this.#host = host;
+    this.#host.addController(this);
   }
 
   hostConnected() {
@@ -48,7 +48,7 @@ export class GlobalShortcutsController implements ReactiveController {
       e.code === "KeyW" && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey
     ) {
       e.preventDefault();
-      navigate(spaceOf(this.host.app));
+      navigate(spaceOf(this.#host.app));
     }
   };
 }

--- a/packages/shell/src/lib/navigation.ts
+++ b/packages/shell/src/lib/navigation.ts
@@ -28,42 +28,42 @@ export class Navigation {
   constructor(app: ShellApp) {
     this.#app = app;
 
-    globalThis.addEventListener(NAVIGATE_EVENT, this.onNavigate);
+    globalThis.addEventListener(NAVIGATE_EVENT, this.#onNavigate);
     globalThis.addEventListener(
       REPLACE_NAVIGATION_EVENT,
-      this.onReplaceNavigate,
+      this.#onReplaceNavigate,
     );
     globalThis.addEventListener(
       UPDATE_PAGE_TITLE_EVENT,
-      this.onUpdatePageTitle,
+      this.#onUpdatePageTitle,
     );
-    globalThis.addEventListener("popstate", this.onPopState);
+    globalThis.addEventListener("popstate", this.#onPopState);
 
     const thisUrl = new URL(globalThis.location.href);
     const init = urlToAppView(thisUrl);
     // Initial state is `null` -- reflect the state given
     // from the current URL.
-    this.replace(init);
-    this.apply(init);
+    this.#replace(init);
+    this.#apply(init);
   }
 
   // Stop listening. The shell's own `Navigation` lives as long as the page, so
   // nothing in the application calls this; a caller that builds one around a
   // fixture needs the four global listeners back.
   dispose() {
-    globalThis.removeEventListener(NAVIGATE_EVENT, this.onNavigate);
+    globalThis.removeEventListener(NAVIGATE_EVENT, this.#onNavigate);
     globalThis.removeEventListener(
       REPLACE_NAVIGATION_EVENT,
-      this.onReplaceNavigate,
+      this.#onReplaceNavigate,
     );
     globalThis.removeEventListener(
       UPDATE_PAGE_TITLE_EVENT,
-      this.onUpdatePageTitle,
+      this.#onUpdatePageTitle,
     );
-    globalThis.removeEventListener("popstate", this.onPopState);
+    globalThis.removeEventListener("popstate", this.#onPopState);
   }
 
-  private onUpdatePageTitle = (e: Event) => {
+  #onUpdatePageTitle = (e: Event) => {
     const title = (e as CustomEvent<string>).detail;
     logger.log("SetTitle", title);
     // Thought this needed to interact with the history.
@@ -71,40 +71,40 @@ export class Navigation {
     document.title = title;
   };
 
-  private onPopState = (e: Event) => {
+  #onPopState = (e: Event) => {
     const state = (e as PopStateEvent).state as NavigationCommand | null;
     logger.log("Pop", state);
     if (!state) {
       console.warn("No state from history!");
       return;
     }
-    this.apply(state);
+    this.#apply(state);
   };
 
-  private onNavigate = (e: Event) => {
+  #onNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("Navigate", command);
     command = mapNavigationView(this.#app, command);
-    this.push(command);
-    this.apply(command);
+    this.#push(command);
+    this.#apply(command);
   };
 
-  private onReplaceNavigate = (e: Event) => {
+  #onReplaceNavigate = (e: Event) => {
     let command = (e as CustomEvent<NavigationCommand>).detail;
     logger.log("ReplaceNavigate", command);
     command = mapNavigationView(this.#app, command);
-    this.replace(command);
-    this.apply(command);
+    this.#replace(command);
+    this.#apply(command);
   };
 
   // Push a new command state to the browser's history.
-  private push(command: NavigationCommand) {
+  #push(command: NavigationCommand) {
     logger.log("Push", command);
     globalThis.history.pushState(command, "", appViewToUrlPath(command));
   }
 
   // Updates the current browser history state and page with a new title.
-  private replace(command: NavigationCommand, title?: string) {
+  #replace(command: NavigationCommand, title?: string) {
     logger.log("Replace", command, title);
     globalThis.history.replaceState(
       command,
@@ -114,7 +114,7 @@ export class Navigation {
   }
 
   // Propagates the command state into the App.
-  private apply(command: NavigationCommand) {
+  #apply(command: NavigationCommand) {
     logger.log("Apply", command);
     this.#app.setView(command);
   }

--- a/packages/shell/src/lib/resizable-drawer-controller.ts
+++ b/packages/shell/src/lib/resizable-drawer-controller.ts
@@ -18,23 +18,23 @@ export interface ResizableDrawerConfig {
  * - Configurable resize direction
  */
 export class ResizableDrawerController implements ReactiveController {
-  private host: ReactiveControllerHost;
-  private config: Required<ResizableDrawerConfig>;
+  #host: ReactiveControllerHost;
+  #config: Required<ResizableDrawerConfig>;
 
-  private _drawerHeight: number;
-  private _isResizing = false;
-  private resizeStartY: number | null = null;
-  private startHeight: number | null = null;
-  private overlayElement: HTMLDivElement | null = null;
+  #drawerHeight: number;
+  #isResizing = false;
+  #resizeStartY: number | null = null;
+  #startHeight: number | null = null;
+  #overlayElement: HTMLDivElement | null = null;
 
   constructor(
     host: ReactiveControllerHost,
     config: ResizableDrawerConfig = {},
   ) {
-    this.host = host;
-    this.host.addController(this);
+    this.#host = host;
+    this.#host.addController(this);
 
-    this.config = {
+    this.#config = {
       initialHeight: config.initialHeight ?? 240,
       minHeight: config.minHeight ?? 150,
       maxHeightFactor: config.maxHeightFactor ?? 0.8,
@@ -42,60 +42,60 @@ export class ResizableDrawerController implements ReactiveController {
       storageKey: config.storageKey ?? "drawerHeight",
     };
 
-    this._drawerHeight = this.config.initialHeight;
+    this.#drawerHeight = this.#config.initialHeight;
   }
 
   hostConnected() {
     // Load saved height from localStorage
-    const savedHeight = localStorage.getItem(this.config.storageKey);
+    const savedHeight = localStorage.getItem(this.#config.storageKey);
     if (savedHeight) {
       const height = parseInt(savedHeight, 10);
-      if (!isNaN(height) && height >= this.config.minHeight) {
-        this._drawerHeight = height;
+      if (!isNaN(height) && height >= this.#config.minHeight) {
+        this.#drawerHeight = height;
       }
     }
   }
 
   hostDisconnected() {
-    this.cleanup();
+    this.#cleanup();
   }
 
   get drawerHeight(): number {
-    return this._drawerHeight;
+    return this.#drawerHeight;
   }
 
   get isResizing(): boolean {
-    return this._isResizing;
+    return this.#isResizing;
   }
 
   handleResizeStart = (e: MouseEvent) => {
     e.preventDefault();
-    this.startResize(e.clientY);
+    this.#startResize(e.clientY);
 
-    document.addEventListener("mousemove", this.handleResizeMove);
-    document.addEventListener("mouseup", this.handleResizeEnd);
+    document.addEventListener("mousemove", this.#handleResizeMove);
+    document.addEventListener("mouseup", this.#handleResizeEnd);
   };
 
   handleTouchResizeStart = (e: TouchEvent) => {
     e.preventDefault();
     if (e.touches.length === 1) {
-      this.startResize(e.touches[0].clientY);
+      this.#startResize(e.touches[0].clientY);
 
-      document.addEventListener("touchmove", this.handleTouchMove, {
+      document.addEventListener("touchmove", this.#handleTouchMove, {
         passive: false,
       });
-      document.addEventListener("touchend", this.handleTouchEnd);
+      document.addEventListener("touchend", this.#handleTouchEnd);
     }
   };
 
-  private startResize(clientY: number) {
-    this.resizeStartY = clientY;
-    this.startHeight = this._drawerHeight;
-    this._isResizing = true;
+  #startResize(clientY: number) {
+    this.#resizeStartY = clientY;
+    this.#startHeight = this.#drawerHeight;
+    this.#isResizing = true;
 
     // Create overlay to capture all mouse events
-    this.overlayElement = document.createElement("div");
-    this.overlayElement.style.cssText = `
+    this.#overlayElement = document.createElement("div");
+    this.#overlayElement.style.cssText = `
       position: fixed;
       top: 0;
       left: 0;
@@ -104,70 +104,70 @@ export class ResizableDrawerController implements ReactiveController {
       z-index: 9999;
       cursor: ns-resize;
     `;
-    document.body.appendChild(this.overlayElement);
+    document.body.appendChild(this.#overlayElement);
 
-    this.host.requestUpdate();
+    this.#host.requestUpdate();
   }
 
-  private handleResizeMove = (e: MouseEvent) => {
-    this.updateHeight(e.clientY);
+  #handleResizeMove = (e: MouseEvent) => {
+    this.#updateHeight(e.clientY);
   };
 
-  private handleTouchMove = (e: TouchEvent) => {
+  #handleTouchMove = (e: TouchEvent) => {
     if (e.touches.length === 1) {
-      this.updateHeight(e.touches[0].clientY);
+      this.#updateHeight(e.touches[0].clientY);
     }
   };
 
-  private updateHeight(clientY: number) {
-    if (this.resizeStartY !== null && this.startHeight !== null) {
+  #updateHeight(clientY: number) {
+    if (this.#resizeStartY !== null && this.#startHeight !== null) {
       // Calculate the difference based on resize direction
-      const diff = this.config.resizeDirection === "up"
-        ? this.resizeStartY - clientY // Moving up increases height
-        : clientY - this.resizeStartY; // Moving down increases height
+      const diff = this.#config.resizeDirection === "up"
+        ? this.#resizeStartY - clientY // Moving up increases height
+        : clientY - this.#resizeStartY; // Moving down increases height
 
       const newHeight = Math.max(
-        this.config.minHeight,
+        this.#config.minHeight,
         Math.min(
-          globalThis.innerHeight * this.config.maxHeightFactor,
-          this.startHeight + diff,
+          globalThis.innerHeight * this.#config.maxHeightFactor,
+          this.#startHeight + diff,
         ),
       );
 
-      this._drawerHeight = newHeight;
+      this.#drawerHeight = newHeight;
 
       // Save to localStorage
-      localStorage.setItem(this.config.storageKey, String(newHeight));
+      localStorage.setItem(this.#config.storageKey, String(newHeight));
 
-      this.host.requestUpdate();
+      this.#host.requestUpdate();
     }
   }
 
-  private handleResizeEnd = () => {
-    this.cleanup();
+  #handleResizeEnd = () => {
+    this.#cleanup();
   };
 
-  private handleTouchEnd = () => {
-    this.cleanup();
+  #handleTouchEnd = () => {
+    this.#cleanup();
   };
 
-  private cleanup() {
-    this.resizeStartY = null;
-    this.startHeight = null;
-    this._isResizing = false;
+  #cleanup() {
+    this.#resizeStartY = null;
+    this.#startHeight = null;
+    this.#isResizing = false;
 
     // Remove overlay
-    if (this.overlayElement) {
-      document.body.removeChild(this.overlayElement);
-      this.overlayElement = null;
+    if (this.#overlayElement) {
+      document.body.removeChild(this.#overlayElement);
+      this.#overlayElement = null;
     }
 
     // Remove event listeners
-    document.removeEventListener("mousemove", this.handleResizeMove);
-    document.removeEventListener("mouseup", this.handleResizeEnd);
-    document.removeEventListener("touchmove", this.handleTouchMove);
-    document.removeEventListener("touchend", this.handleTouchEnd);
+    document.removeEventListener("mousemove", this.#handleResizeMove);
+    document.removeEventListener("mouseup", this.#handleResizeEnd);
+    document.removeEventListener("touchmove", this.#handleTouchMove);
+    document.removeEventListener("touchend", this.#handleTouchEnd);
 
-    this.host.requestUpdate();
+    this.#host.requestUpdate();
   }
 }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -85,16 +85,15 @@ export class XAppView extends BaseView {
   @state()
   private accessor _slugRevision = 0;
 
-  private slugCancel: Cancel | undefined = undefined;
-  private slugPollInterval: ReturnType<typeof setInterval> | undefined =
-    undefined;
-  private slugSubscriptionKey: string | undefined = undefined;
-  private slugSubscriptionToken = 0;
-  private slugTargetKey: string | undefined = undefined;
-  private selectedPatternTargetId: string | undefined = undefined;
+  #slugCancel: Cancel | undefined = undefined;
+  #slugPollInterval: ReturnType<typeof setInterval> | undefined = undefined;
+  #slugSubscriptionKey: string | undefined = undefined;
+  #slugSubscriptionToken = 0;
+  #slugTargetKey: string | undefined = undefined;
+  #selectedPatternTargetId: string | undefined = undefined;
 
-  private debuggerController = new DebuggerController(this);
-  private _keyboard = new GlobalShortcutsController(this);
+  #debuggerController = new DebuggerController(this);
+  #keyboard = new GlobalShortcutsController(this);
 
   _spaceRootPattern = new Task(this, {
     task: async (
@@ -151,14 +150,14 @@ export class XAppView extends BaseView {
       | undefined
     > => {
       if (!rt || !space) return;
-      this.selectedPatternTargetId = undefined;
+      this.#selectedPatternTargetId = undefined;
       try {
         await prepareNamedSpace(app, rt, space);
         if ("pieceSlug" in app.view && app.view.pieceSlug) {
           const pieceId = slugIdForSpace(space, app.view.pieceSlug);
           const target = await rt.getPattern(space, pieceId, { start: false });
           if (signal.aborted) return;
-          this.selectedPatternTargetId = target.id();
+          this.#selectedPatternTargetId = target.id();
           const pattern = await rt.getPattern(space, pieceId);
           if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
@@ -168,7 +167,7 @@ export class XAppView extends BaseView {
             start: false,
           });
           if (signal.aborted) return;
-          this.selectedPatternTargetId = target.id();
+          this.#selectedPatternTargetId = target.id();
           const pattern = await rt.getPattern(space, app.view.pieceId);
           const slug = await rt.getSlug(space, app.view.pieceId);
           if (!signal.aborted && slug) {
@@ -242,34 +241,34 @@ export class XAppView extends BaseView {
       : undefined;
     const key = rt && space && slug ? `${space}:${slug}` : undefined;
 
-    if (key === this.slugSubscriptionKey) return;
+    if (key === this.#slugSubscriptionKey) return;
     this.#clearSlugSubscription();
     if (!rt || !space || !slug || !key) return;
 
-    this.slugSubscriptionKey = key;
-    const token = ++this.slugSubscriptionToken;
+    this.#slugSubscriptionKey = key;
+    const token = ++this.#slugSubscriptionToken;
     rt.getSlugCell(space, slug).then(async (cell) => {
       if (
-        this.slugSubscriptionToken !== token ||
-        this.slugSubscriptionKey !== key
+        this.#slugSubscriptionToken !== token ||
+        this.#slugSubscriptionKey !== key
       ) {
         return;
       }
 
       await this.#refreshSlugTarget(rt, space, slug, token, key, false);
       if (
-        this.slugSubscriptionToken !== token ||
-        this.slugSubscriptionKey !== key
+        this.#slugSubscriptionToken !== token ||
+        this.#slugSubscriptionKey !== key
       ) {
         return;
       }
 
-      this.slugPollInterval = globalThis.setInterval(() => {
+      this.#slugPollInterval = globalThis.setInterval(() => {
         void this.#refreshSlugTarget(rt, space, slug, token, key, true);
       }, 1000);
 
       let sawInitialCallback = false;
-      this.slugCancel = cell.subscribe(() => {
+      this.#slugCancel = cell.subscribe(() => {
         if (!sawInitialCallback) {
           sawInitialCallback = true;
           return;
@@ -277,7 +276,7 @@ export class XAppView extends BaseView {
         void this.#refreshSlugTarget(rt, space, slug, token, key, true);
       });
     }).catch((error) => {
-      if (this.slugSubscriptionToken !== token) return;
+      if (this.#slugSubscriptionToken !== token) return;
       if (rt.signal.aborted) {
         // Reset the subscription key so a replacement runtime for the
         // same space/slug re-subscribes instead of matching the stale key.
@@ -289,15 +288,15 @@ export class XAppView extends BaseView {
   }
 
   #clearSlugSubscription() {
-    this.slugSubscriptionToken++;
-    this.slugCancel?.();
-    if (this.slugPollInterval !== undefined) {
-      globalThis.clearInterval(this.slugPollInterval);
+    this.#slugSubscriptionToken++;
+    this.#slugCancel?.();
+    if (this.#slugPollInterval !== undefined) {
+      globalThis.clearInterval(this.#slugPollInterval);
     }
-    this.slugCancel = undefined;
-    this.slugPollInterval = undefined;
-    this.slugSubscriptionKey = undefined;
-    this.slugTargetKey = undefined;
+    this.#slugCancel = undefined;
+    this.#slugPollInterval = undefined;
+    this.#slugSubscriptionKey = undefined;
+    this.#slugTargetKey = undefined;
   }
 
   async #refreshSlugTarget(
@@ -309,8 +308,8 @@ export class XAppView extends BaseView {
     notify: boolean,
   ) {
     if (
-      this.slugSubscriptionToken !== token ||
-      this.slugSubscriptionKey !== key
+      this.#slugSubscriptionToken !== token ||
+      this.#slugSubscriptionKey !== key
     ) {
       return;
     }
@@ -327,8 +326,8 @@ export class XAppView extends BaseView {
         // teardown, worker replacement) — stop polling it; a new runtime
         // re-subscribes via #syncSlugSubscription.
         if (
-          this.slugSubscriptionToken === token &&
-          this.slugSubscriptionKey === key
+          this.#slugSubscriptionToken === token &&
+          this.#slugSubscriptionKey === key
         ) {
           this.#clearSlugSubscription();
         }
@@ -339,8 +338,8 @@ export class XAppView extends BaseView {
       }
       return;
     }
-    if (targetKey === this.slugTargetKey) return;
-    this.slugTargetKey = targetKey;
+    if (targetKey === this.#slugTargetKey) return;
+    this.#slugTargetKey = targetKey;
     if (notify) {
       this.#handleSlugCellUpdate(rt, space, slug);
     }
@@ -465,12 +464,12 @@ export class XAppView extends BaseView {
 
     // Update debugger controller with runtime
     if (changedProperties.has("rt") && this.rt) {
-      this.debuggerController.setRuntime(this.rt);
+      this.#debuggerController.setRuntime(this.rt);
     }
 
     // Update debugger visibility from app state
     if (changedProperties.has("app")) {
-      this.debuggerController.setVisibility(
+      this.#debuggerController.setVisibility(
         this.app.config.showDebuggerView ?? false,
       );
     }
@@ -485,7 +484,7 @@ export class XAppView extends BaseView {
 
   // Always defer to the loaded active pattern for the ID,
   // but until that loads, use an ID in the view if available.
-  private getActivePatternId(): string | undefined {
+  #getActivePatternId(): string | undefined {
     const activePattern = this._patterns.value?.activePattern;
     if (activePattern) return activePattern.id();
     if ("pieceId" in this.app.view && this.app.view.pieceId) {
@@ -498,9 +497,9 @@ export class XAppView extends BaseView {
     }
   }
 
-  private getRuntimeLoadError(): LoadError | undefined {
+  #getRuntimeLoadError(): LoadError | undefined {
     const event = this.runtimeLoadErrors.findLast((candidate) =>
-      this.runtimeErrorMatchesView(candidate)
+      this.#runtimeErrorMatchesView(candidate)
     );
     if (!event) return;
 
@@ -512,7 +511,7 @@ export class XAppView extends BaseView {
     };
   }
 
-  private runtimeErrorMatchesView(event: ErrorNotification): boolean {
+  #runtimeErrorMatchesView(event: ErrorNotification): boolean {
     if (!event.space || event.space !== this.space) return false;
 
     const isDefaultView = isViewingDefaultPatternView(this.app.view);
@@ -522,7 +521,7 @@ export class XAppView extends BaseView {
         ? [this._spaceRootPattern.value?.id()]
         : "pieceSlug" in this.app.view
         ? [
-          this.slugTargetKey ?? this.selectedPatternTargetId ??
+          this.#slugTargetKey ?? this.#selectedPatternTargetId ??
             (this._selectedPattern.status === TaskStatus.COMPLETE
               ? this._selectedPattern.value?.id()
               : undefined),
@@ -531,7 +530,7 @@ export class XAppView extends BaseView {
           this._selectedPattern.status === TaskStatus.COMPLETE
             ? this._selectedPattern.value?.id()
             : undefined,
-          this.selectedPatternTargetId,
+          this.#selectedPatternTargetId,
           "pieceId" in this.app.view ? this.app.view.pieceId : undefined,
         ];
       const knownPieceIds = addressedPieceIds.filter((id) => id !== undefined);
@@ -564,7 +563,9 @@ export class XAppView extends BaseView {
       ? { kind: "piece", error: this._selectedPattern.error }
       : undefined;
     const loadError = this.spaceLoadError ?? patternLoadError;
-    const runtimeLoadError = loadError ? undefined : this.getRuntimeLoadError();
+    const runtimeLoadError = loadError
+      ? undefined
+      : this.#getRuntimeLoadError();
     this.#setTitleSubscription(activePattern);
 
     const authenticated = html`
@@ -583,7 +584,7 @@ export class XAppView extends BaseView {
       <x-login-view .keyStore="${this.keyStore}"></x-login-view>
     `;
 
-    const pieceId = this.getActivePatternId();
+    const pieceId = this.#getActivePatternId();
     const spaceName = this.app && "spaceName" in this.app.view
       ? this.app.view.spaceName
       : this.app && "builtin" in this.app.view &&
@@ -617,9 +618,10 @@ export class XAppView extends BaseView {
       ${this.app.identity && !embedded
         ? html`
           <x-debugger-view
-            .visible="${this.debuggerController.isVisible()}"
-            .telemetryMarkers="${this.debuggerController.getTelemetryMarkers()}"
-            .debuggerController="${this.debuggerController}"
+            .visible="${this.#debuggerController.isVisible()}"
+            .telemetryMarkers="${this.#debuggerController
+              .getTelemetryMarkers()}"
+            .debuggerController="${this.#debuggerController}"
           ></x-debugger-view>
         `
         : ""}

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -157,7 +157,7 @@ export class XBodyView extends BaseView {
   @property({ type: Boolean })
   accessor embedded = false;
 
-  private _subPages = new Task(this, {
+  #subPages = new Task(this, {
     task: async ([activePattern, spaceRootPattern, embedded]) => {
       if (embedded) {
         return {
@@ -215,8 +215,8 @@ export class XBodyView extends BaseView {
 
     const sidebar = this.embedded
       ? undefined
-      : this._subPages?.value?.sidebarUI;
-    const fab = this.embedded ? undefined : this._subPages?.value?.fabUI;
+      : this.#subPages?.value?.sidebarUI;
+    const fab = this.embedded ? undefined : this.#subPages?.value?.fabUI;
     const runtimeError = this.runtimeError
       ? html`
         <cf-alert class="runtime-error" status="error">

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -64,6 +64,14 @@ export type SubtopicKey<T extends TopicKey> =
  * Presented as a resizable drawer.
  */
 export class XDebuggerView extends LitElement {
+  // The members below stay TypeScript-private rather than becoming `#` names,
+  // which is the convention elsewhere. `test/disposal-handling.test.ts` calls
+  // this view's handlers off `XDebuggerView.prototype` against a stand-in
+  // receiver: a plain object supplying `getLoggerRegistry`,
+  // `debuggerController`, and the rest as ordinary properties. A `#` name is
+  // scoped to real instances, so each of those calls would throw. Converting
+  // the class means rewriting that suite to build real views.
+
   static override styles = css`
     :host {
       position: fixed;

--- a/packages/shell/src/views/DeviceLinkView.ts
+++ b/packages/shell/src/views/DeviceLinkView.ts
@@ -191,6 +191,10 @@ export class XDeviceLinkView extends LitElement {
     super.disconnectedCallback();
   }
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/device-link.test.ts`
+   * drives this member directly.
+   */
   private finish(accepted: boolean) {
     // Exactly one answer, ever: a double-tap must not dispatch twice.
     if (this.#answered) return;

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -548,11 +548,11 @@ export class XHeaderView extends BaseView {
    * demand when the user actually favorites something.
    *
    * Idempotent while a subscription is live. After teardown — a disconnect or
-   * a runtime swap clears `_unsubscribeFavorites` — the next call re-subscribes,
+   * a runtime swap clears `#unsubscribeFavorites` — the next call re-subscribes,
    * so a reconnected header is not left without favorites.
    *
-   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
-   * this member directly.
+   * TypeScript-private rather than a `#` name:
+   * `test/header-view-favorites.test.ts` drives this member directly.
    */
   private _ensureFavoritesSubscription(): void {
     if (this.#unsubscribeFavorites) return;
@@ -759,8 +759,8 @@ export class XHeaderView extends BaseView {
   /**
    * Open the main dropdown menu and move focus to the close button.
    *
-   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
-   * this member directly.
+   * TypeScript-private rather than a `#` name:
+   * `test/header-view-favorites.test.ts` drives this member directly.
    */
   private handleLogoClick(e: Event) {
     e.preventDefault();
@@ -894,24 +894,27 @@ export class XHeaderView extends BaseView {
    * updates local state immediately, then syncs with the server.
    * Rolls back local state on error. Guarded against double-clicks
    * with _isFavoriteLoading to prevent conflicting requests.
+   *
+   * TypeScript-private rather than a `#` name:
+   * `test/header-view-favorites.test.ts` drives this member directly.
    */
-  #isFavoriteLoading = false;
+  private _isFavoriteLoading = false;
 
   /**
-   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
-   * this member directly.
+   * TypeScript-private rather than a `#` name:
+   * `test/header-view-favorites.test.ts` drives this member directly.
    */
   private async handleToggleFavorite(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     const space = this.space;
-    if (!this.rt || !space || !this.pieceId || this.#isFavoriteLoading) {
+    if (!this.rt || !space || !this.pieceId || this._isFavoriteLoading) {
       return;
     }
 
     const currentlyFavorite = this.#isFavorite();
     this._localIsFavorite = !currentlyFavorite;
-    this.#isFavoriteLoading = true;
+    this._isFavoriteLoading = true;
     // Favoriting touches the home pattern anyway; start reflecting server
     // state from here on if the menu was never opened.
     this._ensureFavoritesSubscription();
@@ -931,7 +934,7 @@ export class XHeaderView extends BaseView {
       console.error("[HeaderView] Error toggling favorite:", err);
       this._localIsFavorite = undefined;
     } finally {
-      this.#isFavoriteLoading = false;
+      this._isFavoriteLoading = false;
     }
   }
 

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -523,13 +523,13 @@ export class XHeaderView extends BaseView {
   @state()
   private accessor _localIsFavorite: boolean | undefined = undefined;
 
-  private _unsubscribeFavorites: (() => void) | undefined;
+  #unsubscribeFavorites: (() => void) | undefined;
 
   /** Subscribe to the favorites list so the menu reflects current state. */
-  private _setupFavoritesSubscription(): void {
-    this._cleanupFavoritesSubscription();
+  #setupFavoritesSubscription(): void {
+    this.#cleanupFavoritesSubscription();
     if (!this.rt) return;
-    this._unsubscribeFavorites = this.rt
+    this.#unsubscribeFavorites = this.rt
       .favorites()
       .subscribeFavorites((favorites) => {
         this._serverFavorites = favorites;
@@ -550,17 +550,20 @@ export class XHeaderView extends BaseView {
    * Idempotent while a subscription is live. After teardown — a disconnect or
    * a runtime swap clears `_unsubscribeFavorites` — the next call re-subscribes,
    * so a reconnected header is not left without favorites.
+   *
+   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
+   * this member directly.
    */
   private _ensureFavoritesSubscription(): void {
-    if (this._unsubscribeFavorites) return;
-    this._setupFavoritesSubscription();
+    if (this.#unsubscribeFavorites) return;
+    this.#setupFavoritesSubscription();
   }
 
   /** Unsubscribe from favorites when component disconnects or runtime changes. */
-  private _cleanupFavoritesSubscription(): void {
-    if (this._unsubscribeFavorites) {
-      this._unsubscribeFavorites();
-      this._unsubscribeFavorites = undefined;
+  #cleanupFavoritesSubscription(): void {
+    if (this.#unsubscribeFavorites) {
+      this.#unsubscribeFavorites();
+      this.#unsubscribeFavorites = undefined;
     }
   }
 
@@ -568,7 +571,7 @@ export class XHeaderView extends BaseView {
    * Derive whether the current piece is favorited. Prefers optimistic
    * local state (set immediately on click) over server state.
    */
-  private _isFavorite(): boolean {
+  #isFavorite(): boolean {
     if (this._localIsFavorite !== undefined) {
       return this._localIsFavorite;
     }
@@ -583,22 +586,22 @@ export class XHeaderView extends BaseView {
     );
   }
 
-  private _resizeTimer?: ReturnType<typeof setTimeout>;
+  #resizeTimer?: ReturnType<typeof setTimeout>;
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener("keydown", this._handleKeyDown);
-    globalThis.addEventListener("resize", this._handleResize);
-    globalThis.addEventListener("click", this._closeHeaderPieceDropdown);
+    this.addEventListener("keydown", this.#handleKeyDown);
+    globalThis.addEventListener("resize", this.#handleResize);
+    globalThis.addEventListener("click", this.#closeHeaderPieceDropdown);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._cleanupFavoritesSubscription();
-    this.removeEventListener("keydown", this._handleKeyDown);
-    globalThis.removeEventListener("resize", this._handleResize);
-    globalThis.removeEventListener("click", this._closeHeaderPieceDropdown);
-    if (this._resizeTimer) clearTimeout(this._resizeTimer);
+    this.#cleanupFavoritesSubscription();
+    this.removeEventListener("keydown", this.#handleKeyDown);
+    globalThis.removeEventListener("resize", this.#handleResize);
+    globalThis.removeEventListener("click", this.#closeHeaderPieceDropdown);
+    if (this.#resizeTimer) clearTimeout(this.#resizeTimer);
   }
 
   /**
@@ -606,17 +609,17 @@ export class XHeaderView extends BaseView {
    * prevent the menu from flashing when crossing the mobile/desktop
    * breakpoint in DevTools.
    */
-  private _handleResize = () => {
+  #handleResize = () => {
     this.classList.add("resizing");
-    if (this._resizeTimer) clearTimeout(this._resizeTimer);
-    this._resizeTimer = setTimeout(() => {
+    if (this.#resizeTimer) clearTimeout(this.#resizeTimer);
+    this.#resizeTimer = setTimeout(() => {
       this.classList.remove("resizing");
     }, 150);
   };
 
   /** Close the innermost open dropdown on Escape, prioritizing the piece
    *  switcher over the main menu. Returns focus to the trigger on menu close. */
-  private _handleKeyDown = (e: KeyboardEvent) => {
+  #handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
       if (this.headerPieceDropdownOpen) {
         e.preventDefault();
@@ -627,7 +630,7 @@ export class XHeaderView extends BaseView {
         e.preventDefault();
         this.menuOpen = false;
         this.pieceListExpanded = false;
-        this._focusTrigger();
+        this.#focusTrigger();
       }
     }
   };
@@ -636,8 +639,8 @@ export class XHeaderView extends BaseView {
     if (changedProperties.has("rt")) {
       this._serverFavorites = [];
       this._localIsFavorite = undefined;
-      this._piecesCache = undefined;
-      this._cleanupFavoritesSubscription();
+      this.#piecesCache = undefined;
+      this.#cleanupFavoritesSubscription();
       // If the menu is already open when a runtime arrives, the favorites
       // surface is showing, so subscribe now; otherwise wait for the first open.
       if (this.menuOpen) this._ensureFavoritesSubscription();
@@ -646,7 +649,7 @@ export class XHeaderView extends BaseView {
     // replaces rt — the per-space pieces cache must invalidate on the
     // space itself.
     if (changedProperties.has("space")) {
-      this._piecesCache = undefined;
+      this.#piecesCache = undefined;
     }
     if (changedProperties.has("pieceId")) {
       this._localIsFavorite = undefined;
@@ -661,15 +664,15 @@ export class XHeaderView extends BaseView {
    * Fetches are parallelized with Promise.allSettled; pieces that fail
    * to resolve are silently skipped.
    */
-  private _piecesCache: PieceItem[] | undefined;
+  #piecesCache: PieceItem[] | undefined;
 
-  private _pieces = new Task(this, {
+  #pieces = new Task(this, {
     task: async ([rt, space]): Promise<PieceItem[]> => {
       if (!rt || !space) {
-        this._piecesCache = undefined;
+        this.#piecesCache = undefined;
         return [];
       }
-      if (this._piecesCache) return this._piecesCache;
+      if (this.#piecesCache) return this.#piecesCache;
 
       await rt.synced(space);
       const piecesListCell = await rt.getPiecesListCell(space);
@@ -697,19 +700,19 @@ export class XHeaderView extends BaseView {
         }),
       );
 
-      this._piecesCache = results
+      this.#piecesCache = results
         .filter(
           (r): r is PromiseFulfilledResult<PieceItem> =>
             r.status === "fulfilled",
         )
         .map((r) => r.value);
-      return this._piecesCache;
+      return this.#piecesCache;
     },
     args: () => [this.rt, this.space] as const,
   });
 
   /** Clear the keystore and identity, logging the user out. */
-  private handleAuthClick(e: Event) {
+  #handleAuthClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     if (!this.keyStore) {
@@ -722,7 +725,7 @@ export class XHeaderView extends BaseView {
   }
 
   /** Toggle the debugger panel visibility via app state command. */
-  private handleDebuggerToggleClick(e: Event) {
+  #handleDebuggerToggleClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.command({
@@ -734,7 +737,7 @@ export class XHeaderView extends BaseView {
   }
 
   /** Toggle between light and dark mode. */
-  private handleThemeToggle(e: Event) {
+  #handleThemeToggle(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     toggleTheme();
@@ -743,7 +746,7 @@ export class XHeaderView extends BaseView {
   }
 
   /** Navigate to the current space root when the breadcrumb is clicked. */
-  private _handleSpaceClick(e: Event) {
+  #handleSpaceClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     if (this.spaceName) {
@@ -753,7 +756,12 @@ export class XHeaderView extends BaseView {
     }
   }
 
-  /** Open the main dropdown menu and move focus to the close button. */
+  /**
+   * Open the main dropdown menu and move focus to the close button.
+   *
+   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
+   * this member directly.
+   */
   private handleLogoClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
@@ -765,44 +773,44 @@ export class XHeaderView extends BaseView {
   }
 
   /** Return focus to the logo trigger button after the menu closes. */
-  private _focusTrigger() {
+  #focusTrigger() {
     this.updateComplete.then(() => {
       this.renderRoot.querySelector<HTMLElement>(".nav-picker")?.focus();
     });
   }
 
   /** Close the main menu via the X button. */
-  private handleCloseMenu(e: Event) {
+  #handleCloseMenu(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.menuOpen = false;
     this.pieceListExpanded = false;
-    this._focusTrigger();
+    this.#focusTrigger();
   }
 
   /** Close the main menu when the dark backdrop overlay is clicked. */
-  private handleBackdropClick() {
+  #handleBackdropClick() {
     this.menuOpen = false;
     this.pieceListExpanded = false;
-    this._focusTrigger();
+    this.#focusTrigger();
   }
 
   /** Toggle the piece list inside the mobile menu. */
-  private handleTogglePieceList(e: Event) {
+  #handleTogglePieceList(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.pieceListExpanded = !this.pieceListExpanded;
   }
 
   /** Toggle the piece switcher dropdown in the desktop header breadcrumb. */
-  private handleToggleHeaderPieceDropdown(e: Event) {
+  #handleToggleHeaderPieceDropdown(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.headerPieceDropdownOpen = !this.headerPieceDropdownOpen;
   }
 
   /** Close the desktop piece switcher when clicking outside of it. */
-  private _closeHeaderPieceDropdown = (e: Event) => {
+  #closeHeaderPieceDropdown = (e: Event) => {
     const path = e.composedPath();
     const wrapper = this.renderRoot.querySelector(".header-piece-wrapper");
     if (wrapper && !path.includes(wrapper)) {
@@ -811,7 +819,7 @@ export class XHeaderView extends BaseView {
   };
 
   /** Handle piece selection from either the mobile or desktop piece list. */
-  private handlePieceSelected(e: Event) {
+  #handlePieceSelected(e: Event) {
     const { id: pieceId } = (e as CustomEvent<PieceItem>).detail;
     this.menuOpen = false;
     this.pieceListExpanded = false;
@@ -827,11 +835,11 @@ export class XHeaderView extends BaseView {
    * Contextual navigation: when viewing a piece, go back to the space
    * root. When already at the space root, go to the user's home (/).
    */
-  private handleNavigateUp(e: Event) {
+  #handleNavigateUp(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.menuOpen = false;
-    if (this._isViewingPiece) {
+    if (this.#isViewingPiece) {
       // Viewing a piece — go back to the space
       if (this.spaceName) {
         navigate({ spaceName: this.spaceName });
@@ -845,32 +853,32 @@ export class XHeaderView extends BaseView {
   }
 
   /** Whether we have a space identifier (name or DID) to navigate with. */
-  private get _hasSpace(): boolean {
+  get #hasSpace(): boolean {
     return !!(this.spaceName || this.spaceDid);
   }
 
   /** Human-readable space name, falling back to a truncated DID. */
-  private get _spaceDisplayName(): string {
+  get #spaceDisplayName(): string {
     if (this.spaceName) return this.spaceName;
     if (this.spaceDid) return this.spaceDid.slice(0, 20) + "...";
     return "";
   }
 
   /** True when viewing a specific piece (not the space's default pattern). */
-  private get _isViewingPiece(): boolean {
-    return !!(this.pieceId && this._hasSpace && !this.isViewingDefaultPattern);
+  get #isViewingPiece(): boolean {
+    return !!(this.pieceId && this.#hasSpace && !this.isViewingDefaultPattern);
   }
 
   /** Label for the navigate-up button: "Back to <space>" or "Go Home". */
-  private get _navigateUpLabel(): string {
-    if (this._isViewingPiece) {
-      return `Back to ${this._spaceDisplayName}`;
+  get #navigateUpLabel(): string {
+    if (this.#isViewingPiece) {
+      return `Back to ${this.#spaceDisplayName}`;
     }
     return "Go Home";
   }
 
   /** Copy the current page URL to the clipboard. */
-  private async handleCopyLink(e: Event) {
+  async #handleCopyLink(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     try {
@@ -887,19 +895,23 @@ export class XHeaderView extends BaseView {
    * Rolls back local state on error. Guarded against double-clicks
    * with _isFavoriteLoading to prevent conflicting requests.
    */
-  private _isFavoriteLoading = false;
+  #isFavoriteLoading = false;
 
+  /**
+   * TypeScript-private rather than a `#` name: `test/root-view.test.ts` drives
+   * this member directly.
+   */
   private async handleToggleFavorite(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     const space = this.space;
-    if (!this.rt || !space || !this.pieceId || this._isFavoriteLoading) {
+    if (!this.rt || !space || !this.pieceId || this.#isFavoriteLoading) {
       return;
     }
 
-    const currentlyFavorite = this._isFavorite();
+    const currentlyFavorite = this.#isFavorite();
     this._localIsFavorite = !currentlyFavorite;
-    this._isFavoriteLoading = true;
+    this.#isFavoriteLoading = true;
     // Favoriting touches the home pattern anyway; start reflecting server
     // state from here on if the menu was never opened.
     this._ensureFavoritesSubscription();
@@ -919,19 +931,19 @@ export class XHeaderView extends BaseView {
       console.error("[HeaderView] Error toggling favorite:", err);
       this._localIsFavorite = undefined;
     } finally {
-      this._isFavoriteLoading = false;
+      this.#isFavoriteLoading = false;
     }
   }
 
   /** Derive connection status from runtime availability. */
-  private getConnectionStatus(): ConnectionStatus {
+  #getConnectionStatus(): ConnectionStatus {
     return this.rt ? "connected" : "disconnected";
   }
 
   override render() {
-    const connectionStatus = this.getConnectionStatus();
+    const connectionStatus = this.#getConnectionStatus();
     const connectionColor = getConnectionColor(connectionStatus);
-    const isFavorite = this._isFavorite();
+    const isFavorite = this.#isFavorite();
 
     return html`
       <div class="header">
@@ -953,22 +965,22 @@ export class XHeaderView extends BaseView {
             </span>
           </button>
           <div class="header-breadcrumbs">
-            ${this._hasSpace
+            ${this.#hasSpace
               ? html`
                 <a
                   class="header-space"
                   href="${this.spaceName
                     ? `/${this.spaceName}`
                     : `/${this.spaceDid ?? ""}`}"
-                  @click="${this._handleSpaceClick}"
-                >${this._spaceDisplayName}</a>
+                  @click="${this.#handleSpaceClick}"
+                >${this.#spaceDisplayName}</a>
                 ${this.pieceTitle
                   ? html`
                     <span class="header-separator">/</span>
                     <span class="header-piece-wrapper">
                       <button
                         class="header-piece-trigger"
-                        @click="${this.handleToggleHeaderPieceDropdown}"
+                        @click="${this.#handleToggleHeaderPieceDropdown}"
                         aria-haspopup="true"
                         aria-expanded="${this.headerPieceDropdownOpen}"
                       >
@@ -986,10 +998,10 @@ export class XHeaderView extends BaseView {
                         ? html`
                           <div class="header-piece-dropdown">
                             <x-piece-list
-                              .pieces="${this._pieces.value ?? []}"
+                              .pieces="${this.#pieces.value ?? []}"
                               .activePieceId="${this.pieceId}"
                               @piece-selected="${this
-                                .handlePieceSelected}"
+                                .#handlePieceSelected}"
                             ></x-piece-list>
                           </div>
                         `
@@ -1004,23 +1016,23 @@ export class XHeaderView extends BaseView {
       </div>
 
       <div class="menu-container ${this.menuOpen ? "open" : ""}">
-        <div class="menu-backdrop" @click="${this.handleBackdropClick}"></div>
+        <div class="menu-backdrop" @click="${this.#handleBackdropClick}"></div>
         <div class="menu-panel" role="menu">
           <div class="menu-inner">
             <button
               class="menu-close"
-              @click="${this.handleCloseMenu}"
+              @click="${this.#handleCloseMenu}"
               aria-label="Close menu"
             >
               <span class="menu-close-icon">${iconClose()}</span>
             </button>
             <div class="menu-title">
-              ${this._hasSpace
+              ${this.#hasSpace
                 ? html`
                   <div class="breadcrumb">
                     <span class="breadcrumb-icon">${iconFolder()}</span>
                     <span class="breadcrumb-text">${this
-                      ._spaceDisplayName}</span>
+                      .#spaceDisplayName}</span>
                     <span class="breadcrumb-chevron">
                       ${iconChevronRight()}
                     </span>
@@ -1029,7 +1041,7 @@ export class XHeaderView extends BaseView {
                 : nothing}
               <button
                 class="piece-title-row"
-                @click="${this.handleTogglePieceList}"
+                @click="${this.#handleTogglePieceList}"
                 aria-expanded="${this.pieceListExpanded}"
               >
                 <span class="piece-title-text">
@@ -1046,9 +1058,9 @@ export class XHeaderView extends BaseView {
               ${this.pieceListExpanded
                 ? html`
                   <x-piece-list
-                    .pieces="${this._pieces.value ?? []}"
+                    .pieces="${this.#pieces.value ?? []}"
                     .activePieceId="${this.pieceId}"
-                    @piece-selected="${this.handlePieceSelected}"
+                    @piece-selected="${this.#handlePieceSelected}"
                   ></x-piece-list>
                 `
                 : nothing}
@@ -1058,10 +1070,10 @@ export class XHeaderView extends BaseView {
               <button
                 class="menu-item"
                 role="menuitem"
-                @click="${this.handleNavigateUp}"
+                @click="${this.#handleNavigateUp}"
               >
                 <span class="menu-item-icon">${iconArrowLeft()}</span>
-                <span class="menu-item-label">${this._navigateUpLabel}</span>
+                <span class="menu-item-label">${this.#navigateUpLabel}</span>
               </button>
 
               <div class="divider"><div class="divider-line"></div></div>
@@ -1084,7 +1096,7 @@ export class XHeaderView extends BaseView {
               <button
                 class="menu-item"
                 role="menuitem"
-                @click="${this.handleCopyLink}"
+                @click="${this.#handleCopyLink}"
               >
                 <span class="menu-item-icon">${iconLink()}</span>
                 <span class="menu-item-label">Copy link</span>
@@ -1093,7 +1105,7 @@ export class XHeaderView extends BaseView {
               <button
                 class="menu-item"
                 role="menuitem"
-                @click="${this.handleDebuggerToggleClick}"
+                @click="${this.#handleDebuggerToggleClick}"
               >
                 <span class="menu-item-icon">${iconBug()}</span>
                 <span class="menu-item-label">Toggle debug mode</span>
@@ -1102,7 +1114,7 @@ export class XHeaderView extends BaseView {
               <button
                 class="menu-item"
                 role="menuitem"
-                @click="${this.handleThemeToggle}"
+                @click="${this.#handleThemeToggle}"
               >
                 <span class="menu-item-icon">${iconThemeToggle(
                   getEffectiveTheme() === "dark",
@@ -1117,7 +1129,7 @@ export class XHeaderView extends BaseView {
               <button
                 class="menu-item"
                 role="menuitem"
-                @click="${this.handleAuthClick}"
+                @click="${this.#handleAuthClick}"
               >
                 <span class="menu-item-icon">${iconLogOut()}</span>
                 <span class="menu-item-label">Sign out</span>

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -217,20 +217,20 @@ export class XLoginView extends BaseView {
   @property({ attribute: false })
   private accessor keyStore: KeyStore | undefined = undefined;
 
-  private availableMethods: AuthMethod[] = [];
+  #availableMethods: AuthMethod[] = [];
 
   override connectedCallback() {
     super.connectedCallback();
-    this.checkAvailableMethods();
-    this.addEventListener(AUTH_EVENT, this.onAuthEvent as EventListener);
+    this.#checkAvailableMethods();
+    this.addEventListener(AUTH_EVENT, this.#onAuthEvent as EventListener);
   }
 
   override disconnectedCallback() {
-    this.removeEventListener(AUTH_EVENT, this.onAuthEvent as EventListener);
+    this.removeEventListener(AUTH_EVENT, this.#onAuthEvent as EventListener);
     super.disconnectedCallback();
   }
 
-  private checkAvailableMethods() {
+  #checkAvailableMethods() {
     const methods: AuthMethod[] = [];
 
     // Check if passkeys are available (not on localhost, WebAuthn available)
@@ -245,7 +245,7 @@ export class XLoginView extends BaseView {
     methods.push(AUTH_METHOD_PASSPHRASE);
     methods.push(AUTH_METHOD_KEYFILE);
 
-    this.availableMethods = methods;
+    this.#availableMethods = methods;
 
     // If only one method available, pre-select it
     if (methods.length === 1) {
@@ -253,14 +253,14 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private getKeyStore(): KeyStore {
+  #getKeyStore(): KeyStore {
     if (this.keyStore) {
       return this.keyStore;
     }
     throw new Error("Keystore not set.");
   }
 
-  private dispatchAuthEvent(
+  #dispatchAuthEvent(
     type: AuthEventType,
     data?: { mnemonic?: string } | {
       descriptor?: PublicKeyCredentialDescriptor;
@@ -275,7 +275,7 @@ export class XLoginView extends BaseView {
     );
   }
 
-  private onAuthEvent = async (event: Event) => {
+  #onAuthEvent = async (event: Event) => {
     const e = event as CustomEvent<AuthEventDetail>;
     e.stopPropagation(); // Ensure event doesn't bubble up
 
@@ -286,22 +286,22 @@ export class XLoginView extends BaseView {
     try {
       switch (type) {
         case "passkey-register":
-          await this.handlePasskeyRegister();
+          await this.#handlePasskeyRegister();
           break;
         case "passkey-authenticate":
-          await this.handlePasskeyAuthenticate(descriptor);
+          await this.#handlePasskeyAuthenticate(descriptor);
           break;
         case "passphrase-generate":
-          await this.handlePassphraseGenerate();
+          await this.#handlePassphraseGenerate();
           break;
         case "passphrase-authenticate":
           if (!data || !("mnemonic" in data) || !data.mnemonic) {
             throw new Error("Invalid mnemonic.");
           }
-          await this.handlePassphraseAuthenticate(data.mnemonic);
+          await this.#handlePassphraseAuthenticate(data.mnemonic);
           break;
         case "clear-stored-credential":
-          this.handleClearStoredCredential();
+          this.#handleClearStoredCredential();
           break;
       }
     } catch (error) {
@@ -316,7 +316,7 @@ export class XLoginView extends BaseView {
   // Auth event handlers
   //
 
-  private async handlePasskeyRegister() {
+  async #handlePasskeyRegister() {
     this.isProcessing = true;
     this.error = null;
 
@@ -328,7 +328,7 @@ export class XLoginView extends BaseView {
       const identity = await passkey.createRootKey();
 
       // Save identity to keyStore
-      const keyStore = this.getKeyStore();
+      const keyStore = this.#getKeyStore();
       if (keyStore) {
         await keyStore.set(ROOT_KEY, identity);
       }
@@ -348,7 +348,7 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private async handlePasskeyAuthenticate(
+  async #handlePasskeyAuthenticate(
     descriptor?: PublicKeyCredentialDescriptor,
   ) {
     this.isProcessing = true;
@@ -361,7 +361,7 @@ export class XLoginView extends BaseView {
       const identity = await passkey.createRootKey();
 
       // Save identity to keyStore
-      const keyStore = this.getKeyStore();
+      const keyStore = this.#getKeyStore();
       if (keyStore) {
         await keyStore.set(ROOT_KEY, identity);
       }
@@ -383,7 +383,7 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private async handlePassphraseGenerate() {
+  async #handlePassphraseGenerate() {
     this.isProcessing = true;
     this.error = null;
 
@@ -400,7 +400,7 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private async handlePassphraseAuthenticate(mnemonic: string) {
+  async #handlePassphraseAuthenticate(mnemonic: string) {
     this.isProcessing = true;
     this.error = null;
 
@@ -408,7 +408,7 @@ export class XLoginView extends BaseView {
       const identity = await Identity.fromMnemonic(mnemonic);
 
       // Save identity to keyStore
-      const keyStore = this.getKeyStore();
+      const keyStore = this.#getKeyStore();
       if (keyStore) {
         await keyStore.set(ROOT_KEY, identity);
       }
@@ -430,7 +430,7 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private async handleKeyFileImport(file: File) {
+  async #handleKeyFileImport(file: File) {
     this.isProcessing = true;
     this.error = null;
 
@@ -439,7 +439,7 @@ export class XLoginView extends BaseView {
         new Uint8Array(await file.arrayBuffer()),
       );
 
-      const keyStore = this.getKeyStore();
+      const keyStore = this.#getKeyStore();
       if (keyStore) {
         await keyStore.set(ROOT_KEY, identity);
       }
@@ -457,20 +457,20 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private handleClearStoredCredential() {
+  #handleClearStoredCredential() {
     clearStoredCredential();
     this.storedCredential = null;
   }
 
-  private handleRegister() {
+  #handleRegister() {
     if (this.method === AUTH_METHOD_PASSKEY) {
-      this.dispatchAuthEvent("passkey-register");
+      this.#dispatchAuthEvent("passkey-register");
     } else if (this.method === AUTH_METHOD_PASSPHRASE) {
-      this.dispatchAuthEvent("passphrase-generate");
+      this.#dispatchAuthEvent("passphrase-generate");
     }
   }
 
-  private handleLogin(passphrase?: string) {
+  #handleLogin(passphrase?: string) {
     console.log("[LoginView] Handling login:", {
       method: this.method,
       hasPassphrase: !!passphrase,
@@ -481,15 +481,15 @@ export class XLoginView extends BaseView {
       const descriptor = getPublicKeyCredentialDescriptor(
         this.storedCredential,
       );
-      this.dispatchAuthEvent("passkey-authenticate", { descriptor });
+      this.#dispatchAuthEvent("passkey-authenticate", { descriptor });
     } else if (passphrase) {
-      this.dispatchAuthEvent("passphrase-authenticate", {
+      this.#dispatchAuthEvent("passphrase-authenticate", {
         mnemonic: passphrase,
       });
     }
   }
 
-  private async copyToClipboard() {
+  async #copyToClipboard() {
     if (this.mnemonic) {
       await navigator.clipboard.writeText(this.mnemonic);
       this.copied = true;
@@ -497,12 +497,12 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private renderInitial() {
+  #renderInitial() {
     if (this.storedCredential) {
       const isPassphrase =
         this.storedCredential.method === AUTH_METHOD_PASSPHRASE;
       const isKeyFile = this.storedCredential.method === AUTH_METHOD_KEYFILE;
-      const isPasskeyAvailable = this.availableMethods.includes(
+      const isPasskeyAvailable = this.#availableMethods.includes(
         AUTH_METHOD_PASSKEY,
       );
       const storedLabel = isPassphrase
@@ -517,14 +517,14 @@ export class XLoginView extends BaseView {
             <div class="login-row">
               <x-button
                 variant="primary"
-                @click="${() => this.handleQuickUnlock()}"
+                @click="${() => this.#handleQuickUnlock()}"
               >
                 🔒 Login with ${storedLabel}
               </x-button>
               <x-button
                 class="delete-button"
                 @click="${() => {
-                  this.dispatchAuthEvent("clear-stored-credential");
+                  this.#dispatchAuthEvent("clear-stored-credential");
                 }}"
                 title="Remove saved credential"
               >
@@ -535,7 +535,7 @@ export class XLoginView extends BaseView {
           : html`
             <x-button
               variant="primary"
-              @click="${() => this.handleQuickUnlock()}"
+              @click="${() => this.#handleQuickUnlock()}"
             >
               🔒 Login with ${storedLabel}
             </x-button>
@@ -544,7 +544,7 @@ export class XLoginView extends BaseView {
             <x-button @click="${() => {
               this.flow = "login";
               this.method = AUTH_METHOD_PASSKEY;
-              this.handleLogin();
+              this.#handleLogin();
             }}">
               🔑 Login w/ Passkey
             </x-button>
@@ -578,22 +578,22 @@ export class XLoginView extends BaseView {
     `;
   }
 
-  private async handleQuickUnlock() {
+  async #handleQuickUnlock() {
     if (!this.storedCredential) return;
 
     this.method = this.storedCredential.method;
     this.flow = "login";
 
     if (this.storedCredential.method === AUTH_METHOD_PASSKEY) {
-      this.handleLogin();
+      this.#handleLogin();
     } else if (this.storedCredential.method === AUTH_METHOD_KEYFILE) {
       this.isProcessing = true;
       this.error = null;
 
       try {
-        const identity = await this.getKeyStore().get(ROOT_KEY);
+        const identity = await this.#getKeyStore().get(ROOT_KEY);
         if (!identity) {
-          this.handleClearStoredCredential();
+          this.#handleClearStoredCredential();
           this.flow = null;
           this.method = null;
           this.error =
@@ -613,11 +613,11 @@ export class XLoginView extends BaseView {
     }
   }
 
-  private renderMethodSelection() {
+  #renderMethodSelection() {
     return html`
       <h2>${this.flow === "login" ? "Login with" : "Register with"}</h2>
       <div class="method-list">
-        ${this.availableMethods.map((method) =>
+        ${this.#availableMethods.map((method) =>
           html`
             <x-button
               test-id="${method === AUTH_METHOD_PASSKEY
@@ -625,7 +625,7 @@ export class XLoginView extends BaseView {
                 : method === AUTH_METHOD_PASSPHRASE
                 ? "use-passphrase"
                 : "import-cli-key"}"
-              @click="${() => this.handleMethodSelect(method)}"
+              @click="${() => this.#handleMethodSelect(method)}"
             >
               ${method === AUTH_METHOD_PASSKEY
                 ? "🔑 Use Passkey"
@@ -645,26 +645,26 @@ export class XLoginView extends BaseView {
     `;
   }
 
-  private handleMethodSelect(method: AuthMethod) {
+  #handleMethodSelect(method: AuthMethod) {
     this.method = method;
     if (method === AUTH_METHOD_KEYFILE) {
       return;
     }
     if (this.flow === "register" && method === AUTH_METHOD_PASSKEY) {
-      this.handleRegister();
+      this.#handleRegister();
     } else if (this.flow === "login" && method === AUTH_METHOD_PASSKEY) {
-      this.handleLogin();
+      this.#handleLogin();
     }
   }
 
-  private renderPassphraseAuth() {
+  #renderPassphraseAuth() {
     if (this.flow === "register") {
       if (this.mnemonic) {
-        return this.renderMnemonicDisplay();
+        return this.#renderMnemonicDisplay();
       }
       return html`
         <x-button variant="primary" test-id="generate-passphrase" @click="${() =>
-          this.handleRegister()}">
+          this.#handleRegister()}">
           🔑 Generate Passphrase
         </x-button>
         <x-button @click="${() => {
@@ -677,7 +677,7 @@ export class XLoginView extends BaseView {
     }
 
     return html`
-      <form @submit="${this.handlePassphraseLogin}">
+      <form @submit="${this.#handlePassphraseLogin}">
         <input
           type="password"
           name="passphrase"
@@ -698,17 +698,17 @@ export class XLoginView extends BaseView {
     `;
   }
 
-  private handlePassphraseLogin = (e: Event) => {
+  #handlePassphraseLogin = (e: Event) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
     const formData = new FormData(form);
     const passphrase = formData.get("passphrase") as string;
-    this.handleLogin(passphrase);
+    this.#handleLogin(passphrase);
   };
 
-  private renderKeyFileImport() {
+  #renderKeyFileImport() {
     return html`
-      <form @submit="${this.handleKeyFileSubmit}">
+      <form @submit="${this.#handleKeyFileSubmit}">
         <input
           type="file"
           name="keyfile"
@@ -732,7 +732,7 @@ export class XLoginView extends BaseView {
     `;
   }
 
-  private handleKeyFileSubmit = (e: Event) => {
+  #handleKeyFileSubmit = (e: Event) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
     const file = new FormData(form).get("keyfile");
@@ -740,10 +740,10 @@ export class XLoginView extends BaseView {
       this.error = "Select a key file to import.";
       return;
     }
-    void this.handleKeyFileImport(file);
+    void this.#handleKeyFileImport(file);
   };
 
-  private renderMnemonicDisplay() {
+  #renderMnemonicDisplay() {
     return html`
       <div class="message success">
         <p>Your Secret Recovery Phrase:</p>
@@ -754,7 +754,7 @@ export class XLoginView extends BaseView {
             ""}</textarea>
           <x-button
             class="copy-button"
-            @click="${this.copyToClipboard}"
+            @click="${this.#copyToClipboard}"
           >
             ${this.copied ? "✓ Copied" : "📋 Copy"}
           </x-button>
@@ -769,7 +769,7 @@ export class XLoginView extends BaseView {
         @click="${() => {
           // User has saved the mnemonic, now authenticate with it
           if (this.mnemonic) {
-            this.handleLogin(this.mnemonic);
+            this.#handleLogin(this.mnemonic);
           }
           this.mnemonic = null;
         }}"
@@ -779,7 +779,7 @@ export class XLoginView extends BaseView {
     `;
   }
 
-  private renderSuccess() {
+  #renderSuccess() {
     return html`
       <div class="success">
         <p>✓ ${this.method === AUTH_METHOD_PASSKEY
@@ -820,17 +820,17 @@ export class XLoginView extends BaseView {
         </div>
       `
       : this.mnemonic
-      ? this.renderMnemonicDisplay()
+      ? this.#renderMnemonicDisplay()
       : this.registrationSuccess
-      ? this.renderSuccess()
+      ? this.#renderSuccess()
       : this.flow === null
-      ? this.renderInitial()
+      ? this.#renderInitial()
       : this.method === null
-      ? this.renderMethodSelection()
+      ? this.#renderMethodSelection()
       : this.method === AUTH_METHOD_PASSPHRASE
-      ? this.renderPassphraseAuth()
+      ? this.#renderPassphraseAuth()
       : this.method === AUTH_METHOD_KEYFILE
-      ? this.renderKeyFileImport()
+      ? this.#renderKeyFileImport()
       : this.method === AUTH_METHOD_PASSKEY
       ? html`
         <div class="loading">

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -151,21 +151,23 @@ export class XRootView extends BaseView implements ShellApp {
   @state()
   private accessor _resolvingAttention = new Map<string, symbol>();
 
-  private _eventAttentionMutation = 0;
-  private _eventAttentionMutationVersions = new Map<
+  #eventAttentionMutation = 0;
+  #eventAttentionMutationVersions = new Map<
     DID,
     Map<string, number>
   >();
-  private _eventAttentionRefreshOwners = new Map<DID, symbol>();
+  #eventAttentionRefreshOwners = new Map<DID, symbol>();
 
   // Invalidates callbacks from replaced workers. A coded compiler-load error
   // can arrive through either a request reply or an asynchronous runtime error;
   // only the currently-owned worker may trigger one replacement.
+  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
+  // drives this member directly.
   private _runtimeGeneration = 0;
-  private _preserveRuntimeErrorsForNextViewChange = false;
+  #preserveRuntimeErrorsForNextViewChange = false;
 
   readonly preserveRuntimeErrorsForNextViewChange = (): void => {
-    this._preserveRuntimeErrorsForNextViewChange = true;
+    this.#preserveRuntimeErrorsForNextViewChange = true;
   };
 
   readonly _handleRuntimeError = (
@@ -216,12 +218,13 @@ export class XRootView extends BaseView implements ShellApp {
   @state()
   private accessor presenceUrl: string | undefined = PRESENCE_URL?.href;
 
-  // The runtime task runs when AppState changes, and determines if a
-  // new RuntimeInternals must be created — only when identity or host
-  // (apiUrl) change; one runtime serves every space. This is manually
-  // run in `updated()` because we want to compare to previous values,
-  // leaving this function responsible for cleaning up previous
-  // runtimes, and creating a new one.
+  // The runtime task runs when AppState changes, and determines if a new
+  // RuntimeInternals must be created — only when identity or host (apiUrl)
+  // change; one runtime serves every space. This is manually run in `updated()`
+  // because we want to compare to previous values, leaving this function
+  // responsible for cleaning up previous runtimes, and creating a new one.
+  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
+  // drives this member directly.
   private _rt = new Task<[AppState | undefined], RuntimeInternals | undefined>(
     this,
     {
@@ -242,8 +245,8 @@ export class XRootView extends BaseView implements ShellApp {
           previous.dispose().catch(console.error);
         }
         this._eventAttention = [];
-        this._eventAttentionMutationVersions.clear();
-        this._eventAttentionRefreshOwners.clear();
+        this.#eventAttentionMutationVersions.clear();
+        this.#eventAttentionRefreshOwners.clear();
 
         if (!app || !app.identity) {
           // Clear the runtime when no app state. The space belongs to the
@@ -339,7 +342,7 @@ export class XRootView extends BaseView implements ShellApp {
     this.addEventListener(SHELL_COMMAND, this.onCommand);
     document.addEventListener(
       "theme-preference-changed",
-      this._onThemeChanged,
+      this.#onThemeChanged,
     );
     globalThis.addEventListener("beforeunload", this._onBeforeUnload);
   }
@@ -349,7 +352,7 @@ export class XRootView extends BaseView implements ShellApp {
     this.removeEventListener(SHELL_COMMAND, this.onCommand);
     document.removeEventListener(
       "theme-preference-changed",
-      this._onThemeChanged,
+      this.#onThemeChanged,
     );
     globalThis.removeEventListener("beforeunload", this._onBeforeUnload);
     super.disconnectedCallback();
@@ -362,6 +365,8 @@ export class XRootView extends BaseView implements ShellApp {
   // unconfirmed, ask the browser to confirm leaving instead of silently losing
   // them. Commits confirm quickly (typically well under a second), so the
   // prompt only appears in the narrow window a reload would actually lose data.
+  // TypeScript-private rather than a `#` name, because `test/root-view.test.ts`
+  // drives this member directly.
   private _onBeforeUnload = (event: BeforeUnloadEvent): void => {
     if (this.runtime?.hasPendingWrites()) {
       event.preventDefault();
@@ -376,10 +381,10 @@ export class XRootView extends BaseView implements ShellApp {
     if (changedProperties.has("app")) {
       const previous = changedProperties.get("app");
       if (JSON.stringify(previous?.view) !== JSON.stringify(this.app?.view)) {
-        if (!this._preserveRuntimeErrorsForNextViewChange) {
+        if (!this.#preserveRuntimeErrorsForNextViewChange) {
           this._runtimeLoadErrors = [];
         }
-        this._preserveRuntimeErrorsForNextViewChange = false;
+        this.#preserveRuntimeErrorsForNextViewChange = false;
       }
       this.#syncViewSpace(this.app);
     }
@@ -480,8 +485,8 @@ export class XRootView extends BaseView implements ShellApp {
     this.space = space;
     this._eventAttention = [];
     if (previousSpace !== undefined) {
-      this._eventAttentionMutationVersions.delete(previousSpace);
-      this._eventAttentionRefreshOwners.delete(previousSpace);
+      this.#eventAttentionMutationVersions.delete(previousSpace);
+      this.#eventAttentionRefreshOwners.delete(previousSpace);
     }
     // Keep browser OTel span attribution in sync with the resolved space —
     // the telemetry sink lives across navigations.
@@ -506,24 +511,24 @@ export class XRootView extends BaseView implements ShellApp {
   };
 
   #noteEventAttentionMutation(space: DID, key: string): void {
-    const versions = this._eventAttentionMutationVersions.get(space) ??
+    const versions = this.#eventAttentionMutationVersions.get(space) ??
       new Map<string, number>();
-    versions.set(key, ++this._eventAttentionMutation);
-    this._eventAttentionMutationVersions.set(space, versions);
+    versions.set(key, ++this.#eventAttentionMutation);
+    this.#eventAttentionMutationVersions.set(space, versions);
   }
 
   async #refreshEventAttention(space: DID, generation: number): Promise<void> {
     const runtime = this.runtime;
     if (runtime === undefined) return;
     const owner = Symbol(space);
-    const startedAt = this._eventAttentionMutation;
-    this._eventAttentionRefreshOwners.set(space, owner);
+    const startedAt = this.#eventAttentionMutation;
+    this.#eventAttentionRefreshOwners.set(space, owner);
     try {
       const notices = await runtime.listEventAttention(space);
       if (
         generation !== this._runtimeGeneration || runtime !== this.runtime ||
         space !== this.space ||
-        this._eventAttentionRefreshOwners.get(space) !== owner
+        this.#eventAttentionRefreshOwners.get(space) !== owner
       ) return;
       const currentByKey = new Map(
         this._eventAttention.filter((notice) => notice.space === space).map(
@@ -537,7 +542,7 @@ export class XRootView extends BaseView implements ShellApp {
       );
       for (
         const [key, version]
-          of this._eventAttentionMutationVersions.get(space) ?? []
+          of this.#eventAttentionMutationVersions.get(space) ?? []
       ) {
         if (version <= startedAt) continue;
         const current = currentByKey.get(key);
@@ -552,14 +557,14 @@ export class XRootView extends BaseView implements ShellApp {
       if (
         generation === this._runtimeGeneration && runtime === this.runtime &&
         space === this.space &&
-        this._eventAttentionRefreshOwners.get(space) === owner
+        this.#eventAttentionRefreshOwners.get(space) === owner
       ) {
         console.error("[RootView] Failed to load event attention:", error);
       }
     } finally {
-      if (this._eventAttentionRefreshOwners.get(space) === owner) {
-        this._eventAttentionRefreshOwners.delete(space);
-        this._eventAttentionMutationVersions.delete(space);
+      if (this.#eventAttentionRefreshOwners.get(space) === owner) {
+        this.#eventAttentionRefreshOwners.delete(space);
+        this.#eventAttentionMutationVersions.delete(space);
       }
     }
   }
@@ -594,7 +599,7 @@ export class XRootView extends BaseView implements ShellApp {
     }
   };
 
-  private _onThemeChanged = (e: Event) => {
+  #onThemeChanged = (e: Event) => {
     this._themePreference = (e as CustomEvent).detail;
   };
 

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -1133,14 +1133,14 @@ export class XSchedulerGraph extends LitElement {
   @query(".graph-container")
   private accessor graphContainer: HTMLElement | null = null;
 
-  private lastGraphVersion = -1;
-  private lastPatternSourcesVersion = -1;
-  private hasInitialZoom = false;
+  #lastGraphVersion = -1;
+  #lastPatternSourcesVersion = -1;
+  #hasInitialZoom = false;
 
   /**
    * Get baseline stats from the controller (persists across tab switches)
    */
-  private get baselineStats(): Map<
+  get #baselineStats(): Map<
     string,
     { runCount: number; totalTime: number }
   > {
@@ -1151,11 +1151,11 @@ export class XSchedulerGraph extends LitElement {
   }
 
   // Minimum effective node size before we boost triggered nodes
-  private static readonly READABLE_THRESHOLD = 50;
+  static readonly #READABLE_THRESHOLD = 50;
 
   override connectedCallback() {
     super.connectedCallback();
-    this.updateLayout();
+    this.#updateLayout();
   }
 
   override updated(changedProperties: Map<string, unknown>) {
@@ -1164,27 +1164,27 @@ export class XSchedulerGraph extends LitElement {
     // Check if we need to update the graph
     if (this.debuggerController) {
       const currentVersion = this.debuggerController.getGraphUpdateVersion();
-      if (currentVersion !== this.lastGraphVersion) {
-        this.lastGraphVersion = currentVersion;
-        this.updateLayout();
+      if (currentVersion !== this.#lastGraphVersion) {
+        this.#lastGraphVersion = currentVersion;
+        this.#updateLayout();
 
         // Zoom to fit on first load
-        if (!this.hasInitialZoom && this.layoutNodes.size > 0) {
-          this.hasInitialZoom = true;
-          requestAnimationFrame(() => this.zoomToFit());
+        if (!this.#hasInitialZoom && this.layoutNodes.size > 0) {
+          this.#hasInitialZoom = true;
+          requestAnimationFrame(() => this.#zoomToFit());
         }
       }
 
       // Re-render when pattern sources arrive (for source view)
       const sourcesVersion = this.debuggerController.getPatternSourcesVersion();
-      if (sourcesVersion !== this.lastPatternSourcesVersion) {
-        this.lastPatternSourcesVersion = sourcesVersion;
+      if (sourcesVersion !== this.#lastPatternSourcesVersion) {
+        this.#lastPatternSourcesVersion = sourcesVersion;
         this.requestUpdate();
       }
     }
   }
 
-  private updateLayout(): void {
+  #updateLayout(): void {
     if (!this.debuggerController) return;
 
     const graphData = this.debuggerController.getGraphWithHistory();
@@ -1200,7 +1200,7 @@ export class XSchedulerGraph extends LitElement {
     // Infer parent relationships for sinks without parents by matching entity IDs
     // This handles the case where sinks are created outside of action execution
     // but logically belong to a pattern/module action
-    const inferredParents = this.inferParentsByEntity(graphData.nodes);
+    const inferredParents = this.#inferParentsByEntity(graphData.nodes);
 
     // Create a combined view with both explicit and inferred parents
     const effectiveParentId = (node: SchedulerGraphNode): string | undefined =>
@@ -1352,6 +1352,9 @@ export class XSchedulerGraph extends LitElement {
    * Examples:
    * - "sink:did:key:z6Mkk.../of:fid1:abc.../value" → "sink:...c.../value"
    * - "parentAction" → "parentAction"
+   *
+   * TypeScript-private rather than a `#` name:
+   * `test/entity-id-scheme-parsing.test.ts` drives this member directly.
    */
   private truncateLabel(label: string, maxLen = 20): string {
     // Simple case - short enough already
@@ -1432,6 +1435,9 @@ export class XSchedulerGraph extends LitElement {
    * Handles formats like:
    * - sink:did:key:.../of:entityId/path
    * - action:pattern:did:key:.../computed:entityId/path
+   *
+   * TypeScript-private rather than a `#` name:
+   * `test/entity-id-scheme-parsing.test.ts` drives this member directly.
    */
   private extractEntityId(actionId: string): string | undefined {
     const entityUri = entityUriFromActionId(actionId);
@@ -1455,7 +1461,7 @@ export class XSchedulerGraph extends LitElement {
    * Infer parent relationships for sinks that don't have explicit parents.
    * Groups sinks with non-sink actions that share the same entity ID.
    */
-  private inferParentsByEntity(
+  #inferParentsByEntity(
     nodes: SchedulerGraphNode[],
   ): Map<string, string> {
     const inferredParents = new Map<string, string>();
@@ -1496,12 +1502,12 @@ export class XSchedulerGraph extends LitElement {
     return inferredParents;
   }
 
-  private async handleSnapshot(): Promise<void> {
+  async #handleSnapshot(): Promise<void> {
     await this.debuggerController?.requestGraphSnapshot();
     this.requestUpdate();
   }
 
-  private handleResetBaseline(): void {
+  #handleResetBaseline(): void {
     // Capture current stats as the baseline
     const newBaseline = new Map<
       string,
@@ -1519,7 +1525,7 @@ export class XSchedulerGraph extends LitElement {
     this.debuggerController?.setSchedulerBaselineStats(newBaseline);
   }
 
-  private handleEdgeClick(e: MouseEvent, edge: LayoutEdge): void {
+  #handleEdgeClick(e: MouseEvent, edge: LayoutEdge): void {
     e.stopPropagation();
 
     this.selectedNode = null; // Clear node selection
@@ -1531,7 +1537,7 @@ export class XSchedulerGraph extends LitElement {
     }
   }
 
-  private handleNodeClick(e: MouseEvent, node: LayoutNode): void {
+  #handleNodeClick(e: MouseEvent, node: LayoutNode): void {
     e.stopPropagation();
 
     this.selectedEdge = null; // Clear edge selection
@@ -1542,12 +1548,12 @@ export class XSchedulerGraph extends LitElement {
     }
   }
 
-  private handleContainerClick(): void {
+  #handleContainerClick(): void {
     this.selectedEdge = null;
     this.selectedNode = null;
   }
 
-  private selectNodeById(nodeId: string): void {
+  #selectNodeById(nodeId: string): void {
     const node = this.layoutNodes.get(nodeId);
     if (node) {
       this.selectedEdge = null;
@@ -1555,7 +1561,7 @@ export class XSchedulerGraph extends LitElement {
     }
   }
 
-  private getInboundNodes(nodeId: string): LayoutNode[] {
+  #getInboundNodes(nodeId: string): LayoutNode[] {
     // Find edges where this node is the target (other nodes depend on this)
     const inboundEdges = this.layoutEdges.filter(
       (e) => e.to === nodeId && e.edgeType !== "parent",
@@ -1566,7 +1572,7 @@ export class XSchedulerGraph extends LitElement {
       .filter((n): n is LayoutNode => n !== undefined);
   }
 
-  private getOutboundNodes(nodeId: string): LayoutNode[] {
+  #getOutboundNodes(nodeId: string): LayoutNode[] {
     // Find edges where this node is the source (this node depends on others)
     const outboundEdges = this.layoutEdges.filter(
       (e) => e.from === nodeId && e.edgeType !== "parent",
@@ -1577,19 +1583,19 @@ export class XSchedulerGraph extends LitElement {
       .filter((n): n is LayoutNode => n !== undefined);
   }
 
-  private handleZoomIn(): void {
-    this.zoomAroundCenter(this.zoomLevel * 1.25);
+  #handleZoomIn(): void {
+    this.#zoomAroundCenter(this.zoomLevel * 1.25);
   }
 
-  private handleZoomOut(): void {
-    this.zoomAroundCenter(this.zoomLevel / 1.25);
+  #handleZoomOut(): void {
+    this.#zoomAroundCenter(this.zoomLevel / 1.25);
   }
 
-  private handleZoomReset(): void {
-    this.zoomToFit();
+  #handleZoomReset(): void {
+    this.#zoomToFit();
   }
 
-  private centerOnNode(nodeId: string): void {
+  #centerOnNode(nodeId: string): void {
     const node = this.layoutNodes.get(nodeId);
     if (!node) return;
 
@@ -1617,7 +1623,7 @@ export class XSchedulerGraph extends LitElement {
     });
   }
 
-  private switchToGraphView(): void {
+  #switchToGraphView(): void {
     const hadSelection = this.selectedNode !== null;
     const selectedId = this.selectedNode?.id;
 
@@ -1628,13 +1634,13 @@ export class XSchedulerGraph extends LitElement {
       // Wait for layout to complete before centering
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          this.centerOnNode(selectedId);
+          this.#centerOnNode(selectedId);
         });
       });
     }
   }
 
-  private handleWheel(e: WheelEvent): void {
+  #handleWheel(e: WheelEvent): void {
     // Only zoom if ctrl/cmd is held, otherwise allow normal scroll
     if (!e.ctrlKey && !e.metaKey) return;
 
@@ -1652,10 +1658,10 @@ export class XSchedulerGraph extends LitElement {
     const mouseX = e.clientX - rect.left + container.scrollLeft;
     const mouseY = e.clientY - rect.top + container.scrollTop;
 
-    this.zoomAroundPoint(newZoom, mouseX, mouseY);
+    this.#zoomAroundPoint(newZoom, mouseX, mouseY);
   }
 
-  private zoomAroundPoint(
+  #zoomAroundPoint(
     newZoom: number,
     pointX: number,
     pointY: number,
@@ -1686,7 +1692,7 @@ export class XSchedulerGraph extends LitElement {
     });
   }
 
-  private zoomAroundCenter(newZoom: number): void {
+  #zoomAroundCenter(newZoom: number): void {
     const container = this.graphContainer;
     if (!container) {
       this.zoomLevel = newZoom;
@@ -1718,7 +1724,7 @@ export class XSchedulerGraph extends LitElement {
     });
   }
 
-  private zoomToFit(): void {
+  #zoomToFit(): void {
     const container = this.graphContainer;
     if (!container) return;
 
@@ -1734,15 +1740,15 @@ export class XSchedulerGraph extends LitElement {
     this.zoomLevel = Math.max(0.1, fitZoom);
   }
 
-  private get effectiveNodeWidth(): number {
+  get #effectiveNodeWidth(): number {
     return NODE_WIDTH * this.zoomLevel;
   }
 
-  private get shouldBoostTriggeredNodes(): boolean {
-    return this.effectiveNodeWidth < XSchedulerGraph.READABLE_THRESHOLD;
+  get #shouldBoostTriggeredNodes(): boolean {
+    return this.#effectiveNodeWidth < XSchedulerGraph.#READABLE_THRESHOLD;
   }
 
-  private handleToggleCollapse(nodeId: string, e: Event): void {
+  #handleToggleCollapse(nodeId: string, e: Event): void {
     e.stopPropagation();
     const newCollapsed = new Set(this.collapsedParents);
     if (newCollapsed.has(nodeId)) {
@@ -1751,10 +1757,10 @@ export class XSchedulerGraph extends LitElement {
       newCollapsed.add(nodeId);
     }
     this.collapsedParents = newCollapsed;
-    this.updateLayout();
+    this.#updateLayout();
   }
 
-  private renderToolbar(): TemplateResult {
+  #renderToolbar(): TemplateResult {
     const nodeCount = this.layoutNodes.size;
     const edgeCount = this.layoutEdges.filter((e) => !e.isHistorical).length;
     const historicalCount = this.layoutEdges.filter((e) => e.isHistorical)
@@ -1771,14 +1777,14 @@ export class XSchedulerGraph extends LitElement {
     }
 
     // Calculate delta since baseline (if baseline exists)
-    const hasBaseline = this.baselineStats.size > 0;
+    const hasBaseline = this.#baselineStats.size > 0;
     let totalRunsSinceBaseline = 0;
     let totalTimeSinceBaseline = 0;
 
     if (hasBaseline) {
       for (const node of this.layoutNodes.values()) {
         if (node.stats) {
-          const baseline = this.baselineStats.get(node.id);
+          const baseline = this.#baselineStats.get(node.id);
           totalRunsSinceBaseline += node.stats.runCount -
             (baseline?.runCount ?? 0);
           totalTimeSinceBaseline += node.stats.totalTime -
@@ -1800,7 +1806,7 @@ export class XSchedulerGraph extends LitElement {
           <button
             type="button"
             class="toggle-button ${this.viewMode === "graph" ? "active" : ""}"
-            @click="${() => this.switchToGraphView()}"
+            @click="${() => this.#switchToGraphView()}"
             title="Graph view"
           >
             Graph
@@ -1841,7 +1847,7 @@ export class XSchedulerGraph extends LitElement {
         <button
           type="button"
           class="action-button"
-          @click="${this.handleResetBaseline}"
+          @click="${this.#handleResetBaseline}"
           title="Reset baseline to current stats (for delta tracking)"
         >
           Reset Baseline
@@ -1850,7 +1856,7 @@ export class XSchedulerGraph extends LitElement {
         <button
           type="button"
           class="action-button"
-          @click="${this.handleSnapshot}"
+          @click="${this.#handleSnapshot}"
           title="Capture current scheduler state"
         >
           Snapshot
@@ -1862,7 +1868,7 @@ export class XSchedulerGraph extends LitElement {
               <button
                 type="button"
                 class="zoom-button"
-                @click="${this.handleZoomOut}"
+                @click="${this.#handleZoomOut}"
                 title="Zoom out"
               >
                 -
@@ -1870,7 +1876,7 @@ export class XSchedulerGraph extends LitElement {
               <button
                 type="button"
                 class="zoom-level"
-                @click="${this.handleZoomReset}"
+                @click="${this.#handleZoomReset}"
                 title="Reset zoom"
               >
                 ${Math.round(this.zoomLevel * 100)}%
@@ -1878,7 +1884,7 @@ export class XSchedulerGraph extends LitElement {
               <button
                 type="button"
                 class="zoom-button"
-                @click="${this.handleZoomIn}"
+                @click="${this.#handleZoomIn}"
                 title="Zoom in"
               >
                 +
@@ -1898,7 +1904,7 @@ export class XSchedulerGraph extends LitElement {
           <span>Total: <span class="stat-value">${totalRuns} runs</span>
             <span class="stat-value">${formatTime(totalTime)}</span></span>
           ${hasBaseline
-            ? this.renderBaselineStats(
+            ? this.#renderBaselineStats(
               totalRunsSinceBaseline,
               totalTimeSinceBaseline,
               formatTime,
@@ -1914,7 +1920,7 @@ export class XSchedulerGraph extends LitElement {
    * The crash occurs with deeply nested ternaries in class attributes
    * combined with multiline function calls in adjacent template expressions.
    */
-  private renderBaselineStats(
+  #renderBaselineStats(
     runsDelta: number,
     timeDelta: number,
     formatTime: (ms: number) => string,
@@ -1937,12 +1943,12 @@ export class XSchedulerGraph extends LitElement {
     `;
   }
 
-  private renderNode(node: LayoutNode): TemplateResult {
+  #renderNode(node: LayoutNode): TemplateResult {
     const isTriggered = this.triggeredNodes.has(node.id) &&
       Date.now() - (this.triggeredNodes.get(node.id) ?? 0) < 2000;
 
     // Boost triggered nodes when zoomed out below readable threshold
-    const shouldBoost = isTriggered && this.shouldBoostTriggeredNodes;
+    const shouldBoost = isTriggered && this.#shouldBoostTriggeredNodes;
 
     const isSelected = this.selectedNode?.id === node.id;
 
@@ -1984,7 +1990,7 @@ export class XSchedulerGraph extends LitElement {
       <g
         class="${nodeClass}"
         transform="translate(${x}, ${y})"
-        @click="${(e: MouseEvent) => this.handleNodeClick(e, node)}"
+        @click="${(e: MouseEvent) => this.#handleNodeClick(e, node)}"
         style="cursor: pointer;"
       >
         <title>${tooltip}</title>
@@ -2022,13 +2028,13 @@ export class XSchedulerGraph extends LitElement {
         `
         : ""
     }
-        ${this.renderCollapseToggle(node)}
-        ${this.renderChildCountBadge(node)}
+        ${this.#renderCollapseToggle(node)}
+        ${this.#renderChildCountBadge(node)}
       </g>
     `;
   }
 
-  private renderCollapseToggle(node: LayoutNode): TemplateResult | null {
+  #renderCollapseToggle(node: LayoutNode): TemplateResult | null {
     // Only show toggle if node has children
     if (!node.childCount || node.childCount === 0) return null;
 
@@ -2041,14 +2047,14 @@ export class XSchedulerGraph extends LitElement {
         x="${node.width - 8}"
         y="12"
         text-anchor="middle"
-        @click="${(e: Event) => this.handleToggleCollapse(node.id, e)}"
+        @click="${(e: Event) => this.#handleToggleCollapse(node.id, e)}"
       >
         ${symbol}
       </text>
     `;
   }
 
-  private renderChildCountBadge(node: LayoutNode): TemplateResult | null {
+  #renderChildCountBadge(node: LayoutNode): TemplateResult | null {
     // Only show badge if this node has collapsed children
     if (!node.collapsedChildCount || node.collapsedChildCount === 0) {
       return null;
@@ -2066,7 +2072,7 @@ export class XSchedulerGraph extends LitElement {
     `;
   }
 
-  private computeParentGroups(): Map<
+  #computeParentGroups(): Map<
     string,
     { parent: LayoutNode; children: LayoutNode[]; bounds: DOMRect }
   > {
@@ -2125,8 +2131,8 @@ export class XSchedulerGraph extends LitElement {
     return groups;
   }
 
-  private renderParentGroups(): TemplateResult[] {
-    const groups = this.computeParentGroups();
+  #renderParentGroups(): TemplateResult[] {
+    const groups = this.#computeParentGroups();
     const results: TemplateResult[] = [];
 
     for (const group of groups.values()) {
@@ -2159,7 +2165,7 @@ export class XSchedulerGraph extends LitElement {
     return results;
   }
 
-  private renderEdge(edge: LayoutEdge): TemplateResult | null {
+  #renderEdge(edge: LayoutEdge): TemplateResult | null {
     const source = this.layoutNodes.get(edge.from);
     const target = this.layoutNodes.get(edge.to);
     if (!source || !target) return null;
@@ -2184,12 +2190,12 @@ export class XSchedulerGraph extends LitElement {
         class="${edgeClasses}"
         d="${path}"
         marker-end="url(#arrowhead)"
-        @click="${(e: MouseEvent) => this.handleEdgeClick(e, edge)}"
+        @click="${(e: MouseEvent) => this.#handleEdgeClick(e, edge)}"
       />
     `;
   }
 
-  private renderGraph(): TemplateResult {
+  #renderGraph(): TemplateResult {
     if (this.layoutNodes.size === 0) {
       return html`
         <div class="empty-state">
@@ -2197,7 +2203,7 @@ export class XSchedulerGraph extends LitElement {
           <button
             type="button"
             class="action-button"
-            @click="${this.handleSnapshot}"
+            @click="${this.#handleSnapshot}"
           >
             Load Graph
           </button>
@@ -2229,21 +2235,23 @@ export class XSchedulerGraph extends LitElement {
         </defs>
 
         <g class="parent-groups">
-          ${this.renderParentGroups()}
+          ${this.#renderParentGroups()}
         </g>
 
         <g class="edges">
-          ${this.layoutEdges.map((edge) => this.renderEdge(edge))}
+          ${this.layoutEdges.map((edge) => this.#renderEdge(edge))}
         </g>
 
         <g class="nodes">
-          ${[...this.layoutNodes.values()].map((node) => this.renderNode(node))}
+          ${[...this.layoutNodes.values()].map((node) =>
+            this.#renderNode(node)
+          )}
         </g>
       </svg>
     `;
   }
 
-  private renderTooltip(): TemplateResult | null {
+  #renderTooltip(): TemplateResult | null {
     if (!this.selectedEdge) return null;
 
     const fromNode = this.layoutNodes.get(this.selectedEdge.from);
@@ -2282,7 +2290,7 @@ export class XSchedulerGraph extends LitElement {
     `;
   }
 
-  private renderDetailPane(): TemplateResult | null {
+  #renderDetailPane(): TemplateResult | null {
     if (!this.selectedNode && !this.selectedEdge) return null;
 
     const formatTime = (ms: number) => {
@@ -2305,8 +2313,8 @@ export class XSchedulerGraph extends LitElement {
 
     if (this.selectedNode) {
       const node = this.selectedNode;
-      const baseline = this.baselineStats.get(node.id);
-      const hasBaseline = this.baselineStats.size > 0;
+      const baseline = this.#baselineStats.get(node.id);
+      const hasBaseline = this.#baselineStats.size > 0;
 
       const renderStatWithDelta = (
         label: string,
@@ -2383,7 +2391,7 @@ export class XSchedulerGraph extends LitElement {
                 </div>
               </div>
             `
-            : ""} ${node.preview || this.hasSourceLocation(node.id)
+            : ""} ${node.preview || this.#hasSourceLocation(node.id)
             ? html`
               <div class="detail-section">
                 ${node.preview
@@ -2391,7 +2399,7 @@ export class XSchedulerGraph extends LitElement {
                     <div class="detail-section-title">Code Preview</div>
                     <div class="detail-preview">${node.preview}</div>
                   `
-                  : ""} ${this.hasSourceLocation(node.id)
+                  : ""} ${this.#hasSourceLocation(node.id)
                   ? html`
                     <button
                       type="button"
@@ -2443,7 +2451,7 @@ export class XSchedulerGraph extends LitElement {
               </div>
             `
             : ""} ${(() => {
-              const inbound = this.getInboundNodes(node.id);
+              const inbound = this.#getInboundNodes(node.id);
               return inbound.length > 0
                 ? html`
                   <div class="detail-section">
@@ -2456,7 +2464,7 @@ export class XSchedulerGraph extends LitElement {
                           html`
                             <div
                               class="adjacent-node"
-                              @click="${() => this.selectNodeById(n.id)}"
+                              @click="${() => this.#selectNodeById(n.id)}"
                               title="${n.fullId}"
                             >
                               <span class="type-badge ${n.type}">${n
@@ -2471,7 +2479,7 @@ export class XSchedulerGraph extends LitElement {
                 `
                 : "";
             })()} ${(() => {
-              const outbound = this.getOutboundNodes(node.id);
+              const outbound = this.#getOutboundNodes(node.id);
               return outbound.length > 0
                 ? html`
                   <div class="detail-section">
@@ -2484,7 +2492,7 @@ export class XSchedulerGraph extends LitElement {
                           html`
                             <div
                               class="adjacent-node"
-                              @click="${() => this.selectNodeById(n.id)}"
+                              @click="${() => this.#selectNodeById(n.id)}"
                               title="${n.fullId}"
                             >
                               <span class="type-badge ${n.type}">${n
@@ -2623,7 +2631,7 @@ export class XSchedulerGraph extends LitElement {
     return null;
   }
 
-  private renderLegend(): TemplateResult {
+  #renderLegend(): TemplateResult {
     return html`
       <div class="legend">
         <div class="legend-item">
@@ -2652,33 +2660,33 @@ export class XSchedulerGraph extends LitElement {
 
   override render(): TemplateResult {
     return html`
-      ${this.renderToolbar()} ${this.viewMode === "graph"
+      ${this.#renderToolbar()} ${this.viewMode === "graph"
         ? html`
           <div class="graph-wrapper">
             <div
               class="graph-container"
-              @click="${this.handleContainerClick}"
-              @wheel="${this.handleWheel}"
+              @click="${this.#handleContainerClick}"
+              @wheel="${this.#handleWheel}"
             >
-              ${this.renderGraph()} ${this.renderTooltip()} ${this
-                .renderLegend()}
+              ${this.#renderGraph()} ${this.#renderTooltip()} ${this
+                .#renderLegend()}
             </div>
-            ${this.renderDetailPane()}
+            ${this.#renderDetailPane()}
           </div>
         `
         : this.viewMode === "flags"
-        ? this.renderFlagsView()
+        ? this.#renderFlagsView()
         : this.viewMode === "source"
-        ? this.renderSourceView()
-        : this.renderTable()}
+        ? this.#renderSourceView()
+        : this.#renderTable()}
     `;
   }
 
-  private hasSourceLocation(nodeId: string): boolean {
+  #hasSourceLocation(nodeId: string): boolean {
     return parseActionLocation(nodeId) !== null;
   }
 
-  private renderSourceView(): TemplateResult {
+  #renderSourceView(): TemplateResult {
     const sources = this.debuggerController?.getPatternSources() ?? [];
     // Build SourceViewNode map from layoutNodes
     const sourceNodes = new Map<string, SourceViewNode>();
@@ -2703,7 +2711,7 @@ export class XSchedulerGraph extends LitElement {
           .patternSources="${sources}"
           .nodes="${sourceNodes}"
           .selectedNodeId="${this.selectedNode?.id ?? null}"
-          .baselineStats="${this.baselineStats}"
+          .baselineStats="${this.#baselineStats}"
           .breakpoints="${this.debuggerController?.getBreakpoints() ??
             new Set()}"
           @node-selected="${(e: CustomEvent) => {
@@ -2722,12 +2730,12 @@ export class XSchedulerGraph extends LitElement {
             this.requestUpdate();
           }}"
         ></x-scheduler-source>
-        ${this.renderDetailPane()}
+        ${this.#renderDetailPane()}
       </div>
     `;
   }
 
-  private renderFlagsView(): TemplateResult {
+  #renderFlagsView(): TemplateResult {
     const flags = this.debuggerController?.getActiveFlags() ?? {};
     const invalidInputMap = flags["runner"]?.["action invalid input"] ?? {};
     const invalidInputIds = Object.keys(invalidInputMap);
@@ -2809,12 +2817,12 @@ export class XSchedulerGraph extends LitElement {
             `
             : ""}
         </div>
-        ${this.renderDetailPane()}
+        ${this.#renderDetailPane()}
       </div>
     `;
   }
 
-  private renderTable(): TemplateResult {
+  #renderTable(): TemplateResult {
     // Get all nodes with stats
     const allNodesWithStats = Array.from(this.layoutNodes.values())
       .filter((n) => n.type !== "input" && n.stats)
@@ -2855,7 +2863,7 @@ export class XSchedulerGraph extends LitElement {
 
     // Helper to get delta for a node
     const getNodeDelta = (id: string, runCount: number, totalTime: number) => {
-      const baseline = this.baselineStats.get(id);
+      const baseline = this.#baselineStats.get(id);
       return {
         deltaRunCount: runCount - (baseline?.runCount ?? 0),
         deltaTotalTime: totalTime - (baseline?.totalTime ?? 0),
@@ -2916,7 +2924,7 @@ export class XSchedulerGraph extends LitElement {
     }
 
     // Sort based on current column (and whether we're sorting by delta)
-    const useDelta = this.sortByDelta && this.baselineStats.size > 0;
+    const useDelta = this.sortByDelta && this.#baselineStats.size > 0;
     const sortNodes = (nodes: GroupedNode[]) => {
       nodes.sort((a, b) => {
         let cmp = 0;
@@ -2967,9 +2975,9 @@ export class XSchedulerGraph extends LitElement {
       return `${(ms / 1000).toFixed(2)}s`;
     };
 
-    const hasBaseline = this.baselineStats.size > 0;
+    const hasBaseline = this.#baselineStats.size > 0;
 
-    const getBaseline = (id: string) => this.baselineStats.get(id);
+    const getBaseline = (id: string) => this.#baselineStats.get(id);
 
     const getDelta = (
       current: number,
@@ -3279,7 +3287,7 @@ export class XSchedulerGraph extends LitElement {
             </tbody>
           </table>
         </div>
-        ${this.renderDetailPane()}
+        ${this.#renderDetailPane()}
       </div>
     `;
   }

--- a/packages/shell/src/views/SchedulerSourceView.ts
+++ b/packages/shell/src/views/SchedulerSourceView.ts
@@ -322,7 +322,7 @@ export class XSchedulerSource extends LitElement {
   private accessor selectedEntryIdx = 0;
 
   /** Build lookup: file -> line -> LineAnnotation */
-  private buildAnnotations(): Map<string, Map<number, LineAnnotation>> {
+  #buildAnnotations(): Map<string, Map<number, LineAnnotation>> {
     const result = new Map<string, Map<number, LineAnnotation>>();
 
     for (const [nodeId, node] of this.nodes) {
@@ -394,7 +394,7 @@ export class XSchedulerSource extends LitElement {
   }
 
   /** Compute heat color based on totalTime relative to max */
-  private heatColor(
+  #heatColor(
     totalTime: number,
     maxTime: number,
     types: Set<string>,
@@ -412,18 +412,18 @@ export class XSchedulerSource extends LitElement {
     return `rgba(59, 130, 246, ${alpha})`;
   }
 
-  private formatTime(ms: number): string {
+  #formatTime(ms: number): string {
     if (ms === 0) return "";
     if (ms < 1) return `${(ms * 1000).toFixed(0)}us`;
     if (ms < 1000) return `${ms.toFixed(1)}ms`;
     return `${(ms / 1000).toFixed(2)}s`;
   }
 
-  private hasAnyBreakpoint(entries: ActionEntry[]): boolean {
+  #hasAnyBreakpoint(entries: ActionEntry[]): boolean {
     return entries.some((e) => this.breakpoints.has(e.nodeId));
   }
 
-  private handleBreakpointToggle(entries: ActionEntry[]) {
+  #handleBreakpointToggle(entries: ActionEntry[]) {
     // If all are set, disable all; otherwise enable all
     const allSet = entries.every((e) => this.breakpoints.has(e.nodeId));
     const actionIds = entries.map((e) => e.nodeId);
@@ -438,7 +438,7 @@ export class XSchedulerSource extends LitElement {
     this.requestUpdate();
   }
 
-  private handleLineClick(entries: ActionEntry[]) {
+  #handleLineClick(entries: ActionEntry[]) {
     // Caller must pass a non-empty entries array.
     if (entries.length === 0) {
       throw new Error("handleLineClick requires a non-empty entries array");
@@ -463,7 +463,7 @@ export class XSchedulerSource extends LitElement {
   }
 
   /** Navigate to the correct pattern, file, and line for the selected node */
-  private navigateToSelectedNode() {
+  #navigateToSelectedNode() {
     if (!this.selectedNodeId || this.patternSources.length === 0) return;
 
     const loc = parseActionLocation(this.selectedNodeId);
@@ -507,7 +507,7 @@ export class XSchedulerSource extends LitElement {
       changedProperties.has("selectedNodeId") ||
       changedProperties.has("patternSources")
     ) {
-      this.navigateToSelectedNode();
+      this.#navigateToSelectedNode();
     }
   }
 
@@ -537,7 +537,7 @@ export class XSchedulerSource extends LitElement {
     const lines = file.contents.split("\n");
 
     // Build annotations for current file
-    const annotations = this.buildAnnotations();
+    const annotations = this.#buildAnnotations();
     const fileAnnotations = annotations.get(file.name) ?? new Map();
 
     // Use delta time for heat scaling when baseline exists, else total
@@ -614,22 +614,22 @@ export class XSchedulerSource extends LitElement {
                 ? (hasBaseline ? ann.deltaTime : ann.totalTime)
                 : 0;
               const bgColor = ann
-                ? this.heatColor(heatTime, maxTime, ann.types)
+                ? this.#heatColor(heatTime, maxTime, ann.types)
                 : "transparent";
 
               const bpToggle = hasAction
-                ? () => this.handleBreakpointToggle(ann!.entries)
+                ? () => this.#handleBreakpointToggle(ann!.entries)
                 : undefined;
               const nodeSelect = hasAction
-                ? () => this.handleLineClick(ann!.entries)
+                ? () => this.#handleLineClick(ann!.entries)
                 : undefined;
 
-              const bpClass = ann && this.hasAnyBreakpoint(ann.entries)
+              const bpClass = ann && this.#hasAnyBreakpoint(ann.entries)
                 ? "active"
                 : "";
 
               // deno-fmt-ignore
-              return html`<tr class="source-line ${hasAction ? "has-action" : ""} ${isSelected ? "selected" : ""}" data-line="${lineNum}" style="background-color: ${bgColor}"><td class="line-bp" @click=${bpToggle}><span class="bp-indicator ${bpClass}"></span></td><td class="line-gutter" @click=${bpToggle}>${lineNum}</td><td class="line-markers" @click=${nodeSelect}>${ann ? ann.entries.map((entry: ActionEntry) => html`<span class="marker-dot ${entry.type} ${entry.nodeId === this.selectedNodeId ? "selected-entry" : ""}" title="col ${entry.col}: ${entry.type} ${this.formatTime(entry.totalTime)}"></span>`) : ""}</td><td class="line-code" @click=${nodeSelect}>${lineText}</td><td class="line-stats" @click=${nodeSelect}>${ann ? this.renderLineStats(ann, hasBaseline) : ""}</td></tr>`;
+              return html`<tr class="source-line ${hasAction ? "has-action" : ""} ${isSelected ? "selected" : ""}" data-line="${lineNum}" style="background-color: ${bgColor}"><td class="line-bp" @click=${bpToggle}><span class="bp-indicator ${bpClass}"></span></td><td class="line-gutter" @click=${bpToggle}>${lineNum}</td><td class="line-markers" @click=${nodeSelect}>${ann ? ann.entries.map((entry: ActionEntry) => html`<span class="marker-dot ${entry.type} ${entry.nodeId === this.selectedNodeId ? "selected-entry" : ""}" title="col ${entry.col}: ${entry.type} ${this.#formatTime(entry.totalTime)}"></span>`) : ""}</td><td class="line-code" @click=${nodeSelect}>${lineText}</td><td class="line-stats" @click=${nodeSelect}>${ann ? this.#renderLineStats(ann, hasBaseline) : ""}</td></tr>`;
             })}
           </tbody>
         </table>
@@ -637,7 +637,7 @@ export class XSchedulerSource extends LitElement {
     `;
   }
 
-  private renderLineStats(
+  #renderLineStats(
     ann: LineAnnotation,
     hasBaseline: boolean,
   ): TemplateResult {
@@ -649,7 +649,7 @@ export class XSchedulerSource extends LitElement {
         `;
       }
       return html`
-        <span class="delta-time">+${this.formatTime(ann.deltaTime)}</span>
+        <span class="delta-time">+${this.#formatTime(ann.deltaTime)}</span>
         (${ann.deltaRuns}x)${ann.entries.length > 1
           ? html`
             <span class="entry-count">[${ann.entries.length}]</span>
@@ -659,7 +659,7 @@ export class XSchedulerSource extends LitElement {
     }
     // No baseline — show totals
     return html`
-      ${this.formatTime(ann.totalTime)} ${ann.runCount > 0
+      ${this.#formatTime(ann.totalTime)} ${ann.runCount > 0
         ? `(${ann.runCount}x)`
         : ""}${ann.entries.length > 1
         ? html`

--- a/packages/shell/test/credentials.test.ts
+++ b/packages/shell/test/credentials.test.ts
@@ -10,30 +10,30 @@ import {
 } from "../src/lib/credentials.ts";
 
 class MemoryStorage implements Storage {
-  private values = new Map<string, string>();
+  #values = new Map<string, string>();
 
   get length(): number {
-    return this.values.size;
+    return this.#values.size;
   }
 
   clear(): void {
-    this.values.clear();
+    this.#values.clear();
   }
 
   getItem(key: string): string | null {
-    return this.values.get(key) ?? null;
+    return this.#values.get(key) ?? null;
   }
 
   key(index: number): string | null {
-    return Array.from(this.values.keys())[index] ?? null;
+    return Array.from(this.#values.keys())[index] ?? null;
   }
 
   removeItem(key: string): void {
-    this.values.delete(key);
+    this.#values.delete(key);
   }
 
   setItem(key: string, value: string): void {
-    this.values.set(key, value);
+    this.#values.set(key, value);
   }
 }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts 232 of `shell`'s 298 TypeScript-`private` members to JavaScript `#`
private names, per `docs/development/DEVELOPMENT.md` § Classes. A `#` field is
not an own property, whereas a field declared `private` is, the modifier being
erased — which is also exactly why a suite reaching through `private` stops
working, and that governs everything left alone below.

## Lit reactive properties: 66

Members carrying `@state` or `@property`. Lit builds its accessor over a
declared class field and has no `#` form it can see, so these stay as they are
— the same exemption the exposed Lit fields already carry. The conversion tool
refuses a decorated member rather than guessing.

## `XDebuggerView`, left whole

The reason sits on the class rather than on each of its members.
`test/disposal-handling.test.ts` calls this view's handlers off
`XDebuggerView.prototype` against a stand-in receiver — a plain object
supplying `getLoggerRegistry`, `debuggerController`, `workerLoggerMetadata` and
the rest as ordinary properties. A `#` name is scoped to real instances, so
each of those calls would throw.

## Seven members driven by the view tests

Across `XRootView`, `XHeaderView`, `XDeviceLinkView`, and `XSchedulerGraph`,
each saying so on its declaration. Four keep a leading `_` this convention
otherwise drops, because the tests name them that way.

## How the exempt set was found

By running the suite; the syntactic scan only narrowed where to look, and one
member was outside what it can see at all. `test/disposal-handling.test.ts`
indexes the prototype dynamically —
`(XDebuggerView.prototype as Record<string, fn>)[name]`, with the names coming
from a data table — so no cast names the members and no scan of casts can find
them. The suite named them immediately.

## Verification

The tool's count was reconciled against an independent census before the
apply: 298 `private` members, 232 converted and 66 refused as decorated, no
residue.

`deno fmt --check`, `deno lint`, and `deno task check` pass. `shell`'s suite is
green, as is `integration`'s — the only other package importing `shell`.
Sweeps for prose still naming a member that became `#`-private, for a doc
comment missing its blank line above, and for a `//` comment stranded beside
one all report none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

