### PR TITLE
perf: a piece view stops running the space app, and the FAB is removed

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -440,9 +440,11 @@ error at the pattern.
 
 See `packages/patterns/examples/ui-variants-demo.tsx` for a full example.
 
-> Note: `sidebarUI`/`fabUI`/`settingsUI` are shell composition **slots**, a
-> separate concept — not size variants. A vended `uiVariant()` helper for
-> render paths outside `cf-render` is a planned follow-up and does not exist yet.
+> Note: `sidebarUI` is a shell composition **slot**, a separate concept from
+> size variants. Other exported subviews such as `settingsUI` are
+> application-level conventions; the shell does not consume `fabUI`. A vended
+> `uiVariant()` helper for render paths outside `cf-render` is a planned
+> follow-up and does not exist yet.
 
 ### The piece context menu
 

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -310,7 +310,14 @@ export class RuntimeInternals extends EventTarget {
   #disposed = false;
   #favorites: FavoritesManager;
   #callbacks: RuntimeInternalsCallbacks;
-  #spaceRootPatterns: Map<DID, Promise<PageHandle<NameSchema>>> = new Map();
+  /** Cached space roots, with whether the cached one was STARTED: a
+   * started root also answers a caller that only reads its exports, while
+   * one resolved without starting does not answer a caller that needs it
+   * running. */
+  #spaceRootPatterns: Map<
+    DID,
+    { pattern: Promise<PageHandle<NameSchema>>; started: boolean }
+  > = new Map();
   #patternCache: Map<
     string,
     { promise: Promise<PageHandle<NameSchema>>; started: boolean }
@@ -380,16 +387,26 @@ export class RuntimeInternals extends EventTarget {
     return this.#client.getPiecesListCell<T>(space);
   }
 
-  getSpaceRootPattern(space: DID): Promise<PageHandle<NameSchema>> {
+  /**
+   * The space's root pattern. `start` defaults to true, which a view that
+   * renders the root needs; pass false to read its exports without running
+   * it.
+   */
+  getSpaceRootPattern(
+    space: DID,
+    options: { start?: boolean } = {},
+  ): Promise<PageHandle<NameSchema>> {
     this.#check();
+    const start = options.start ?? true;
     const cached = this.#spaceRootPatterns.get(space);
-    if (cached) return cached;
-    const pattern = this.#client.getSpaceRootPattern(space);
-    this.#spaceRootPatterns.set(space, pattern);
+    if (cached && (cached.started || !start)) return cached.pattern;
+    const pattern = this.#client.getSpaceRootPattern(space, { start });
+    const entry = { pattern, started: start };
+    this.#spaceRootPatterns.set(space, entry);
     // Evict on rejection: a transient failure (unreachable host, authz)
     // must not poison the space for the runtime's lifetime.
     pattern.catch(() => {
-      if (this.#spaceRootPatterns.get(space) === pattern) {
+      if (this.#spaceRootPatterns.get(space) === entry) {
         this.#spaceRootPatterns.delete(space);
       }
     });
@@ -406,7 +423,10 @@ export class RuntimeInternals extends EventTarget {
     // Clear cached pattern since we're recreating it
     this.#spaceRootPatterns.delete(space);
     const pattern = await this.#client.recreateSpaceRootPattern(space);
-    this.#spaceRootPatterns.set(space, Promise.resolve(pattern));
+    this.#spaceRootPatterns.set(space, {
+      pattern: Promise.resolve(pattern),
+      started: true,
+    });
     return pattern;
   }
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -179,6 +179,44 @@ describe("RuntimeInternals", () => {
       }
     });
 
+    it("caches a recreated root as started", async () => {
+      const client = new MockRuntimeClient();
+      const recreated = { id: "recreated-root" };
+      const starts: Array<boolean | undefined> = [];
+      client.getSpaceRootPattern = (
+        space: DID,
+        options?: { start?: boolean },
+      ) => {
+        client.spaceRootCalls.push(space);
+        starts.push(options?.start);
+        return Promise.resolve({ id: "fetched-root" } as never);
+      };
+      (client as unknown as {
+        recreateSpaceRootPattern: (space: DID) => Promise<unknown>;
+      }).recreateSpaceRootPattern = () => Promise.resolve(recreated);
+      const runtime = new RuntimeInternals(client as any);
+      const space = "did:key:z6Mk-root-recreate" as DID;
+
+      try {
+        await runtime.getSpaceRootPattern(space, { start: false });
+        expect(starts).toEqual([false]);
+
+        // Recreating replaces whatever was cached, and what it caches IS
+        // started — so neither kind of caller refetches afterwards.
+        await expect(runtime.recreateSpaceRootPattern(space)).resolves.toBe(
+          recreated,
+        );
+        await expect(runtime.getSpaceRootPattern(space)).resolves.toBe(
+          recreated,
+        );
+        await expect(runtime.getSpaceRootPattern(space, { start: false }))
+          .resolves.toBe(recreated);
+        expect(starts).toEqual([false]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
     it("retries a root-pattern lookup after rejection", async () => {
       const client = new MockRuntimeClient();
       const runtime = new RuntimeInternals(client as any);

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -149,6 +149,36 @@ describe("RuntimeInternals", () => {
       }
     });
 
+    it("starts the root for a caller that needs it running, after one that did not", async () => {
+      const client = new MockRuntimeClient();
+      const starts: Array<boolean | undefined> = [];
+      client.getSpaceRootPattern = (
+        space: DID,
+        options?: { start?: boolean },
+      ) => {
+        client.spaceRootCalls.push(space);
+        starts.push(options?.start);
+        return Promise.resolve({ id: `root-${options?.start}` } as never);
+      };
+      const runtime = new RuntimeInternals(client as any);
+      const space = "did:key:z6Mk-root-start" as DID;
+
+      try {
+        // A root resolved without starting cannot answer a caller that
+        // renders it, so the cache must not hand the unstarted one back.
+        await runtime.getSpaceRootPattern(space, { start: false });
+        await runtime.getSpaceRootPattern(space);
+        expect(starts).toEqual([false, true]);
+
+        // The reverse direction shares: a started root already answers a
+        // caller that only reads its exports.
+        await runtime.getSpaceRootPattern(space, { start: false });
+        expect(starts).toEqual([false, true]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
     it("retries a root-pattern lookup after rejection", async () => {
       const client = new MockRuntimeClient();
       const runtime = new RuntimeInternals(client as any);

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -640,6 +640,10 @@ export class PiecesController<T = unknown> {
       });
     } catch (error) {
       passiveError = error;
+      pieceUpdateLogger.warn("passive-registry-open-failed", () => [
+        "getPieceRegistry: passive default-root open failed; retrying with start",
+        error,
+      ]);
     }
     if (passiveRoot) {
       const exported = this.#pieceRegistryExport(passiveRoot);

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -103,9 +103,9 @@ const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
 /**
  * What opening a piece does beyond resolving its cell.
  *
- * `reconcile` rolls a stored source forward to the origin it follows — the
- * healing every caller that opens a root has always relied on. `start` runs
- * the pattern, which materializes everything its result reaches.
+ * `reconcile` rolls a stored source forward to the origin it follows, keeping
+ * a followed root current. `start` runs the pattern, which materializes
+ * everything its result reaches.
  *
  * They are separable because they are wanted separately: a caller that
  * RENDERS a piece needs both, while a caller that reads what a piece
@@ -621,20 +621,26 @@ export class PiecesController<T = unknown> {
    * what it writes, so the stored value is current at every quiescent
    * moment, and a listing can be served from it.
    *
-   * The root is still RECONCILED, so a listing keeps healing a stale root
-   * the way it always has; only `runtime.start()` is skipped, which is the
-   * dominant phase of opening a space whose root reaches a large piece.
+   * The root is reconciled before the registry is read, so a listing heals a
+   * stale root without calling `runtime.start()`, the dominant phase of
+   * opening a space whose root reaches a large piece.
    * Running is kept for the cases that cannot be served from what is stored:
    * a root that has never exported a registry here, one whose passive open
    * fails, and `add()`.
    */
   async getPieceRegistry(): Promise<Cell<Cell<unknown>[]>> {
-    // Reconciled but not started: healing is a correctness contract this
-    // path has always carried, and it costs a fraction of the start.
-    const passiveRoot = await this.getDefaultPattern({
-      reconcile: true,
-      start: false,
-    }).catch(() => undefined);
+    // Reconcile without starting so the registry is read from current stored
+    // exports without materializing the root's result graph.
+    let passiveError: unknown;
+    let passiveRoot: Cell<NameSchema> | undefined;
+    try {
+      passiveRoot = await this.getDefaultPattern({
+        reconcile: true,
+        start: false,
+      });
+    } catch (error) {
+      passiveError = error;
+    }
     if (passiveRoot) {
       const exported = this.#pieceRegistryExport(passiveRoot);
       await this.syncPieces(exported);
@@ -647,11 +653,23 @@ export class PiecesController<T = unknown> {
       }
     }
 
-    // The running path is the backstop, and it keeps its own rescue: a
-    // passive open that threw reaches it rather than surfacing, so a root
-    // this listing could previously heal is still healed here.
-    const defaultPattern = await this.getDefaultPattern(true);
+    // The running path supplies a registry when no stored export is available.
+    // If both opens fail, retain both causes so the passive failure is not
+    // hidden by the fallback.
+    let defaultPattern: Cell<NameSchema> | undefined;
+    try {
+      defaultPattern = await this.getDefaultPattern(true);
+    } catch (error) {
+      if (passiveError !== undefined) {
+        throw new AggregateError(
+          [passiveError, error],
+          `Could not open the piece registry for space ${this.#space}`,
+        );
+      }
+      throw error;
+    }
     if (!defaultPattern) {
+      if (passiveError !== undefined) throw passiveError;
       // Return empty array cell if no default pattern. Loud on purpose: any
       // subscription made against this placeholder never fires again, so a
       // cold-cache miss here silently freezes piece listings (e.g. FUSE).

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -581,12 +581,44 @@ export class PiecesController<T = unknown> {
       origin === deriveSystemPatternSource(this.#space, this.runtime);
   }
 
+  /** The root's `pieceRegistry` export, addressed but not yet synced. */
+  #pieceRegistryExport(root: Cell<NameSchema>): Cell<Cell<unknown>[]> {
+    const cell = root.asSchema({
+      type: "object",
+      properties: {
+        pieceRegistry: pieceListSchema,
+      },
+    });
+    return cell.key("pieceRegistry") as Cell<Cell<unknown>[]>;
+  }
+
   /**
    * Get the cell containing the registered pieces in this space.
    * This is the discovery root, not a list of every stored piece root. Reads
    * the default pattern's pieceRegistry export.
+   *
+   * A listing is a read, and a read does not need the root running. The
+   * export's only writer is {@link add}, which runs the root itself, so the
+   * persisted value is current at every quiescent moment — and resolving the
+   * root passively skips `runtime.start()`, which is the dominant phase of
+   * opening a space whose root reaches a large piece. Running is kept for the
+   * two cases that cannot be served from what is stored: a root that has
+   * never exported a registry here, and `add()`.
    */
   async getPieceRegistry(): Promise<Cell<Cell<unknown>[]>> {
+    const passiveRoot = await this.getDefaultPattern(false);
+    if (passiveRoot) {
+      const exported = this.#pieceRegistryExport(passiveRoot);
+      await this.syncPieces(exported);
+      // `pieceListSchema` carries `default: []`, so a root that never
+      // exported a registry and a root whose registry is empty read the same
+      // way through the schema. The raw value is what separates them, and
+      // only the first needs the root run.
+      if (exported.getRaw() !== undefined) {
+        return exported;
+      }
+    }
+
     const defaultPattern = await this.getDefaultPattern(true);
     if (!defaultPattern) {
       // Return empty array cell if no default pattern. Loud on purpose: any
@@ -599,13 +631,7 @@ export class PiecesController<T = unknown> {
       return this.runtime.getCell(this.#space, "empty-pieces", pieceListSchema);
     }
 
-    const cell = defaultPattern.asSchema({
-      type: "object",
-      properties: {
-        pieceRegistry: pieceListSchema,
-      },
-    });
-    const pieceRegistry = cell.key("pieceRegistry") as Cell<Cell<unknown>[]>;
+    const pieceRegistry = this.#pieceRegistryExport(defaultPattern);
     await this.syncPieces(pieceRegistry);
     return pieceRegistry;
   }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -100,6 +100,23 @@ ensureNotRenderThread();
 const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
   Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
 
+/**
+ * What opening a piece does beyond resolving its cell.
+ *
+ * `reconcile` rolls a stored source forward to the origin it follows — the
+ * healing every caller that opens a root has always relied on. `start` runs
+ * the pattern, which materializes everything its result reaches.
+ *
+ * They are separable because they are wanted separately: a caller that
+ * RENDERS a piece needs both, while a caller that reads what a piece
+ * exported needs the value it reads to be current without paying to run it.
+ * A boolean asks for both or neither.
+ */
+export type PieceOpen = { reconcile: boolean; start: boolean };
+
+const normalizePieceOpen = (open: boolean | PieceOpen): PieceOpen =>
+  typeof open === "boolean" ? { reconcile: open, start: open } : open;
+
 const PRIVILEGED_PIECE_LIST_SCHEMA = internSchema({
   type: "array",
   items: { type: "unknown", asCell: ["cell"] },
@@ -473,8 +490,9 @@ export class PiecesController<T = unknown> {
    * @returns The default pattern cell, or undefined if not set
    */
   async getDefaultPattern(
-    runIt: boolean = true,
+    open: boolean | PieceOpen = true,
   ): Promise<Cell<NameSchema> | undefined> {
+    const { reconcile, start } = normalizePieceOpen(open);
     const cell = await timePiecePhase(
       "getDefaultPattern.spaceCell.sync",
       () => this.#spaceCell.key("defaultPattern").sync(),
@@ -496,11 +514,11 @@ export class PiecesController<T = unknown> {
     }
     try {
       return await timePiecePhase(
-        `getDefaultPattern.get(runIt=${runIt})`,
+        `getDefaultPattern.get(reconcile=${reconcile},start=${start})`,
         () =>
           this.getPieceCell(
             defaultPattern,
-            runIt,
+            { reconcile, start },
             nameSchema,
           ),
       );
@@ -513,7 +531,7 @@ export class PiecesController<T = unknown> {
       // this runtime cannot load. Roll that one forward to the space's
       // official system root and retry the start ONCE. Every other failure
       // rethrows untouched.
-      if (!runIt) throw error;
+      if (!start) throw error;
       let healed: Cell<NameSchema>;
       try {
         const root = await this.getPieceCell(defaultPattern, false, nameSchema);
@@ -545,7 +563,7 @@ export class PiecesController<T = unknown> {
         await this.runtime.idle();
         return await timePiecePhase(
           "getDefaultPattern.get(retry-after-heal)",
-          () => this.getPieceCell(healed, runIt, nameSchema),
+          () => this.getPieceCell(healed, { reconcile, start }, nameSchema),
         );
       } catch (retryError) {
         pieceUpdateLogger.warn("default-root-heal-retry-failed", () => [
@@ -597,16 +615,26 @@ export class PiecesController<T = unknown> {
    * This is the discovery root, not a list of every stored piece root. Reads
    * the default pattern's pieceRegistry export.
    *
-   * A listing is a read, and a read does not need the root running. The
-   * export's only writer is {@link add}, which runs the root itself, so the
-   * persisted value is current at every quiescent moment — and resolving the
-   * root passively skips `runtime.start()`, which is the dominant phase of
-   * opening a space whose root reaches a large piece. Running is kept for the
-   * two cases that cannot be served from what is stored: a root that has
-   * never exported a registry here, and `add()`.
+   * A listing is a read, and a read does not need the root running. Every
+   * writer of this export — {@link add}, {@link remove}, the root's own
+   * remove handler, and patterns that reach it through `wish()` — persists
+   * what it writes, so the stored value is current at every quiescent
+   * moment, and a listing can be served from it.
+   *
+   * The root is still RECONCILED, so a listing keeps healing a stale root
+   * the way it always has; only `runtime.start()` is skipped, which is the
+   * dominant phase of opening a space whose root reaches a large piece.
+   * Running is kept for the cases that cannot be served from what is stored:
+   * a root that has never exported a registry here, one whose passive open
+   * fails, and `add()`.
    */
   async getPieceRegistry(): Promise<Cell<Cell<unknown>[]>> {
-    const passiveRoot = await this.getDefaultPattern(false);
+    // Reconciled but not started: healing is a correctness contract this
+    // path has always carried, and it costs a fraction of the start.
+    const passiveRoot = await this.getDefaultPattern({
+      reconcile: true,
+      start: false,
+    }).catch(() => undefined);
     if (passiveRoot) {
       const exported = this.#pieceRegistryExport(passiveRoot);
       await this.syncPieces(exported);
@@ -619,6 +647,9 @@ export class PiecesController<T = unknown> {
       }
     }
 
+    // The running path is the backstop, and it keeps its own rescue: a
+    // passive open that threw reaches it rather than surfacing, so a root
+    // this listing could previously heal is still healed here.
     const defaultPattern = await this.getDefaultPattern(true);
     if (!defaultPattern) {
       // Return empty array cell if no default pattern. Loud on purpose: any
@@ -715,22 +746,23 @@ export class PiecesController<T = unknown> {
    */
   async getPieceCell<S extends JSONSchema = JSONSchema>(
     id: string | Cell<unknown>,
-    runIt: boolean,
+    open: boolean | PieceOpen,
     asSchema: S,
     scope?: CellScope,
   ): Promise<Cell<Schema<S>>>;
   async getPieceCell<T = unknown>(
     id: string | Cell<unknown>,
-    runIt?: boolean,
+    open?: boolean | PieceOpen,
     asSchema?: JSONSchema,
     scope?: CellScope,
   ): Promise<Cell<T>>;
   async getPieceCell<T = unknown>(
     id: string | Cell<unknown>,
-    runIt: boolean = false,
+    open: boolean | PieceOpen = false,
     asSchema?: JSONSchema,
     scope?: CellScope,
   ): Promise<Cell<T>> {
+    const { reconcile, start } = normalizePieceOpen(open);
     // Get the piece cell
     const addressed: Cell<unknown> = isCell(id)
       ? id
@@ -761,7 +793,7 @@ export class PiecesController<T = unknown> {
     // further sync. Idempotent for a normal top-level piece.
     let piece = addressed.resolveAsCell();
 
-    if (runIt) {
+    if (reconcile) {
       const outcome = await timePiecePhase(
         "get.reconcileSource",
         () => reconcilePieceSource(this.runtime, piece),
@@ -769,10 +801,12 @@ export class PiecesController<T = unknown> {
       if (outcome === "updated") {
         // The transition committed through a transaction view, and the caller
         // may have handed us a cell bound to a read transaction older than it.
-        // Detach and resync, or the start below loads the identity the origin
+        // Detach and resync, or a start below loads the identity the origin
         // just replaced — and reads through the returned cell describe it.
         piece = await piece.withTx().sync();
       }
+    }
+    if (start) {
       // start() handles pattern loading and running. It's idempotent - no
       // effect if already running.
       await timePiecePhase(

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -26,6 +26,7 @@ import {
   reconcilePieceSource,
 } from "../src/ops/piece-origin.ts";
 import { rawMetaWriteAuthorization } from "@commonfabric/runner/meta-seam";
+import { getLogger } from "@commonfabric/utils/logger";
 
 // The routes those refs resolve to. A system pattern is still SERVED at, and
 // its modules still NAMED by, the route path; the `system:` ref is what a
@@ -908,6 +909,31 @@ describe("opening a space root", () => {
       passiveFailure,
       runningFailure,
     ]);
+  });
+
+  it("records a passive failure when the running registry fallback succeeds", async () => {
+    await setup();
+    await controller.ensureDefaultPattern();
+    const passiveFailure = new Error("passive registry open failed");
+    const original = controller.getDefaultPattern.bind(controller);
+    controller.getDefaultPattern =
+      ((open = true) =>
+        typeof open === "object"
+          ? Promise.reject(passiveFailure)
+          : original(open)) as typeof controller.getDefaultPattern;
+    const logger = getLogger("piece.update");
+    const warningsBefore =
+      logger.countsByKey["passive-registry-open-failed"]?.warn ?? 0;
+
+    try {
+      expect(await controller.getPieceRegistry()).toBeDefined();
+    } finally {
+      controller.getDefaultPattern = original;
+    }
+
+    expect(
+      logger.countsByKey["passive-registry-open-failed"]?.warn ?? 0,
+    ).toBe(warningsBefore + 1);
   });
 
   it("preserves a passive failure when the running fallback finds no root", async () => {

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -884,6 +884,48 @@ describe("opening a space root", () => {
     expect(getPatternIdentityRef(healed)?.symbol).toBe("default");
   });
 
+  it("heals a stale root whose registry export is already persisted", async () => {
+    await setup();
+    const piece = await controller.ensureDefaultPattern();
+    const root = piece.getCell();
+
+    // The registry path serves a persisted export without running the root.
+    // A root that has ALREADY exported one therefore takes that path — so
+    // the healing has to happen there too, not only on the arm that runs.
+    // `pieceListSchema` defaults an absent export to `[]`, so an export
+    // persisted as empty is exactly the case that reads as present.
+    const { error: seeded } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).asSchema({
+        type: "object",
+        properties: { pieceRegistry: { type: "array" } },
+      }).key("pieceRegistry").set([]);
+    });
+    expect(seeded).toBeUndefined();
+
+    const staleIdentity = await identityForSource(
+      patternSource("unloadable-root-with-persisted-registry"),
+    );
+    await controller.stopPiece(root);
+    const { error } = await runtime.editWithRetry((tx) => {
+      root.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: staleIdentity,
+        symbol: "default",
+      });
+    });
+    expect(error).toBeUndefined();
+
+    stub.setSource(SOURCE_V2);
+
+    const registry = await controller.getPieceRegistry();
+    await runtime.idle();
+
+    expect(registry).toBeDefined();
+    const healed = (await controller.getDefaultPattern(false))!;
+    expect(getPatternIdentityRef(healed)?.identity).toBe(
+      await identityForSource(SOURCE_V2),
+    );
+  });
+
   it("returns the started replacement when the rescue's retry succeeds", async () => {
     await setup();
     // The rescue's whole point is that the caller gets a root it can use. A

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -936,7 +936,7 @@ describe("opening a space root", () => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
         identity: staleIdentity,
         symbol: "default",
-      });
+      }, rawMetaWriteAuthorization);
     });
     expect(error).toBeUndefined();
 

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -910,6 +910,28 @@ describe("opening a space root", () => {
     ]);
   });
 
+  it("preserves a passive failure when the running fallback finds no root", async () => {
+    await setup();
+    const passiveFailure = new Error("passive registry open failed");
+    const original = controller.getDefaultPattern.bind(controller);
+    controller.getDefaultPattern =
+      ((open = true) =>
+        typeof open === "object"
+          ? Promise.reject(passiveFailure)
+          : Promise.resolve(undefined)) as typeof controller.getDefaultPattern;
+
+    let failure: unknown;
+    try {
+      await controller.getPieceRegistry();
+    } catch (error) {
+      failure = error;
+    } finally {
+      controller.getDefaultPattern = original;
+    }
+
+    expect(failure).toBe(passiveFailure);
+  });
+
   it("heals a stale root whose registry export is already persisted", async () => {
     await setup();
     const piece = await controller.ensureDefaultPattern();

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -884,6 +884,32 @@ describe("opening a space root", () => {
     expect(getPatternIdentityRef(healed)?.symbol).toBe("default");
   });
 
+  it("preserves both failures when passive and running registry opens fail", async () => {
+    await setup();
+    const passiveFailure = new Error("passive registry open failed");
+    const runningFailure = new Error("running registry open failed");
+    const original = controller.getDefaultPattern.bind(controller);
+    controller.getDefaultPattern = ((open = true) =>
+      Promise.reject(
+        typeof open === "object" ? passiveFailure : runningFailure,
+      )) as typeof controller.getDefaultPattern;
+
+    let failure: unknown;
+    try {
+      await controller.getPieceRegistry();
+    } catch (error) {
+      failure = error;
+    } finally {
+      controller.getDefaultPattern = original;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      passiveFailure,
+      runningFailure,
+    ]);
+  });
+
   it("heals a stale root whose registry export is already persisted", async () => {
     await setup();
     const piece = await controller.ensureDefaultPattern();

--- a/packages/piece/test/default-pattern-persistence.test.ts
+++ b/packages/piece/test/default-pattern-persistence.test.ts
@@ -170,10 +170,29 @@ describe("PiecesController default pattern persistence", () => {
     await pieces.add([persistedPiece]);
     await pieces.stopPiece(defaultPatternPiece);
 
-    const piecesCell = await pieces.getPieceRegistry();
-    const ids = piecesCell.get().map((piece) => pieceId(piece)).filter(Boolean);
+    // What this test is named for, pinned rather than assumed. `start()` is
+    // idempotent and a restarted root serves the same listing, so a restart
+    // is invisible in the rows and has to be observed at the call.
+    type Startable = { start: (piece: Cell<unknown>) => unknown };
+    const startable = runtime as unknown as Startable;
+    const realStart = startable.start.bind(runtime);
+    const started: Cell<unknown>[] = [];
+    startable.start = (piece: Cell<unknown>) => {
+      started.push(piece);
+      return realStart(piece);
+    };
 
-    expect(ids).toContain(pieceId(persistedPiece));
+    try {
+      const piecesCell = await pieces.getPieceRegistry();
+      const ids = piecesCell.get().map((piece) => pieceId(piece)).filter(
+        Boolean,
+      );
+
+      expect(ids).toContain(pieceId(persistedPiece));
+      expect(started).toEqual([]);
+    } finally {
+      startable.start = realStart;
+    }
   });
 
   it("adds a persisted piece from a fresh runtime", async () => {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1944,10 +1944,14 @@ export class RuntimeProcessor {
     const cc = this.getSpaceCtx(request.space);
     if (request.start === false) {
       // The caller reads the root's exports rather than rendering it, so
-      // resolving what is stored answers it. Only a space with no root yet
-      // falls through — a root has to exist before it can have exported
+      // resolving what is stored answers it — reconciled, so what it reads
+      // is still healed against the root's origin. Only a space with no root
+      // yet falls through: a root has to exist before it can have exported
       // anything, and creating one is not the cost this avoids.
-      const stored = await cc.getDefaultPattern(false);
+      const stored = await cc.getDefaultPattern({
+        reconcile: true,
+        start: false,
+      });
       if (stored) return { page: createPageRef(stored) };
     }
     const piece = await cc.ensureDefaultPattern();

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -1942,6 +1942,14 @@ export class RuntimeProcessor {
     request: PatternGetSpaceRoot,
   ): Promise<PageResponse> {
     const cc = this.getSpaceCtx(request.space);
+    if (request.start === false) {
+      // The caller reads the root's exports rather than rendering it, so
+      // resolving what is stored answers it. Only a space with no root yet
+      // falls through — a root has to exist before it can have exported
+      // anything, and creating one is not the cost this avoids.
+      const stored = await cc.getDefaultPattern(false);
+      if (stored) return { page: createPageRef(stored) };
+    }
     const piece = await cc.ensureDefaultPattern();
     return {
       page: createPageRef(piece.getCell()),

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -1955,6 +1955,19 @@ export type PageGetSpaceDefault = BaseRequest & {
    * The space whose root pattern to read.
    */
   space: DID;
+
+  /**
+   * Whether the root is wanted RUNNING. Defaults to true, which is what a
+   * view that renders the root needs — the space home, where running the
+   * root is the page.
+   *
+   * A caller that only reads what the root exported passes false. Starting
+   * a root materializes everything its result reaches, which on a space
+   * whose root reaches a large piece is the dominant cost of opening
+   * anything; a stored export costs a read. Either way an absent root is
+   * still created, since a space needs one before it can have exports.
+   */
+  start?: boolean;
 };
 
 /** The {@link RequestType.RecreateSpaceRootPattern} request. */

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -454,12 +454,24 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   // operation against that space's piece context over the same
   // connection.
 
-  async getSpaceRootPattern(space: DID): Promise<PageHandle<NameSchema>> {
+  /**
+   * The space's root pattern.
+   *
+   * `start` defaults to true, which is what a view that renders the root
+   * needs. Pass false to read what the root exported without running it —
+   * far cheaper on a space whose root reaches a large piece, and enough for
+   * a caller that only wants an exported sub-page or listing.
+   */
+  async getSpaceRootPattern(
+    space: DID,
+    options: { start?: boolean } = {},
+  ): Promise<PageHandle<NameSchema>> {
     const response = await this.#conn.request<
       RequestType.GetSpaceRootPattern
     >({
       type: RequestType.GetSpaceRootPattern,
       space,
+      ...(options.start === undefined ? {} : { start: options.start }),
     });
     return new PageHandle<NameSchema>(this, response.page);
   }

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -2144,6 +2144,83 @@ describe("runtime-processor", () => {
           });
         expect(result.page.cell).toEqual(ref);
       });
+
+      it("resolves the stored root without starting it when start is false", async () => {
+        const ref: CellRef = {
+          id: "of:stored-root" as CellRef["id"],
+          space: "did:key:test-space" as CellRef["space"],
+          scope: "space",
+          path: [],
+        };
+        const calls: string[] = [];
+        const cc = {
+          getDefaultPattern: (open: unknown) => {
+            calls.push(`getDefaultPattern:${JSON.stringify(open)}`);
+            return Promise.resolve({
+              getAsLink: () => cellRefToSigilLink(ref),
+            });
+          },
+          ensureDefaultPattern: () => {
+            calls.push("ensureDefaultPattern");
+            return Promise.reject(new Error("must not run the root"));
+          },
+        };
+        const processor = {
+          getSpaceCtx: () => cc,
+        } as unknown as RuntimeProcessor;
+
+        const result = await RuntimeProcessor.prototype
+          .handleGetSpaceRootPattern
+          .call(processor, {
+            type: RequestType.GetSpaceRootPattern,
+            space: "did:key:test-space",
+            start: false,
+          });
+
+        expect(result.page.cell).toEqual(ref);
+        // Reconciled but not started: a read of what the root exported still
+        // heals a stale root, and never boots it.
+        expect(calls).toEqual([
+          'getDefaultPattern:{"reconcile":true,"start":false}',
+        ]);
+      });
+
+      it("creates the root for a space that has none, even when start is false", async () => {
+        const ref: CellRef = {
+          id: "of:created-root" as CellRef["id"],
+          space: "did:key:test-space" as CellRef["space"],
+          scope: "space",
+          path: [],
+        };
+        const calls: string[] = [];
+        const cc = {
+          // A space whose root has never existed has nothing stored to read.
+          getDefaultPattern: () => {
+            calls.push("getDefaultPattern");
+            return Promise.resolve(undefined);
+          },
+          ensureDefaultPattern: () => {
+            calls.push("ensureDefaultPattern");
+            return Promise.resolve({
+              getCell: () => ({ getAsLink: () => cellRefToSigilLink(ref) }),
+            });
+          },
+        };
+        const processor = {
+          getSpaceCtx: () => cc,
+        } as unknown as RuntimeProcessor;
+
+        const result = await RuntimeProcessor.prototype
+          .handleGetSpaceRootPattern
+          .call(processor, {
+            type: RequestType.GetSpaceRootPattern,
+            space: "did:key:test-space",
+            start: false,
+          });
+
+        expect(result.page.cell).toEqual(ref);
+        expect(calls).toEqual(["getDefaultPattern", "ensureDefaultPattern"]);
+      });
     });
   });
 

--- a/packages/shell/integration/blob-upload.test.ts
+++ b/packages/shell/integration/blob-upload.test.ts
@@ -27,9 +27,9 @@ describe("shell blob upload", () => {
     await waitForCondition(shell.page(), () => {
       const rootView = document.querySelector("x-root-view");
       const appView = rootView?.shadowRoot?.querySelector("x-app-view") as
-        | { _patterns?: { value?: { spaceRootPattern?: unknown } } }
+        | { _spaceRootPattern?: { value?: unknown } }
         | null;
-      return Boolean(appView?._patterns?.value?.spaceRootPattern);
+      return Boolean(appView?._spaceRootPattern?.value);
     });
 
     const result = await shell.page().evaluate(async () => {

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -94,16 +94,14 @@ async function waitForSpaceRootPattern(
     const rootView = document.querySelector("x-root-view");
     const appView = rootView?.shadowRoot?.querySelector("x-app-view") as
       | {
-        _patterns?: {
+        _spaceRootPattern?: {
           value?: {
-            spaceRootPattern?: {
-              id(): string;
-            };
+            id(): string;
           };
         };
       }
       | null;
-    return !!appView?._patterns?.value?.spaceRootPattern?.id?.();
+    return !!appView?._spaceRootPattern?.value?.id?.();
   });
 }
 

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -194,10 +194,8 @@ export class XAppView extends BaseView {
     args: () => [this.app, this.rt, this.space, this._slugRevision],
   });
 
-  // This derives a space root pattern as well as an "active" (main)
-  // pattern for use in child views.
-  // This hybrid task intentionally only uses completed/fresh
-  // source patterns to avoid unsyncing state.
+  // Derive the active pattern from completed task values so child views never
+  // receive an in-flight or stale selection.
   _patterns = new Task(this, {
     task: function (
       [
@@ -209,7 +207,6 @@ export class XAppView extends BaseView {
       ],
     ): {
       activePattern: PageHandle<NameSchema> | undefined;
-      spaceRootPattern: PageHandle<NameSchema> | undefined;
     } {
       const spaceRootPattern = spaceRootPatternStatus === TaskStatus.COMPLETE
         ? spaceRootPatternValue
@@ -225,10 +222,7 @@ export class XAppView extends BaseView {
         : selectedPatternStatus === TaskStatus.COMPLETE
         ? selectedPatternValue
         : undefined;
-      return {
-        activePattern,
-        spaceRootPattern,
-      };
+      return { activePattern };
     },
     args: () => [
       this.app,
@@ -558,7 +552,7 @@ export class XAppView extends BaseView {
 
   override render() {
     const config = this.app.config ?? {};
-    const { activePattern, spaceRootPattern } = this._patterns.value ?? {};
+    const { activePattern } = this._patterns.value ?? {};
     const embedded = isEmbeddedView(this.app.view);
     const isViewingDefaultPattern = isViewingDefaultPatternView(this.app.view);
     const patternLoadError: LoadError | undefined = isViewingDefaultPattern
@@ -578,7 +572,6 @@ export class XAppView extends BaseView {
       <x-body-view
         .rt="${this.rt}"
         .activePattern="${activePattern}"
-        .spaceRootPattern="${spaceRootPattern}"
         .loadError="${loadError}"
         .runtimeError="${runtimeLoadError}"
         .showShellPieceListView="${config.showShellPieceListView ?? false}"

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -106,13 +106,12 @@ export class XAppView extends BaseView {
       try {
         await prepareNamedSpace(app, rt, space);
         // The space home renders the root, so there it has to run. A
-        // piece-focused view reads exactly one thing from it — the `fabUI`
-        // sub-page BodyView renders — and reading an export does not need
-        // the root running. Starting it materializes everything the root's
-        // result reaches, which on a space whose root reaches a large piece
-        // is the dominant cost of opening any piece in that space.
-        const start = isViewingDefaultPatternView(app.view);
-        return await rt.getSpaceRootPattern(space, { start });
+        // piece-focused view reads NOTHING from it — so it is not fetched
+        // at all, and none of what the root's result reaches is demanded.
+        // On a space whose root reaches a large piece, that demand is the
+        // dominant cost of opening any piece in the space.
+        if (!isViewingDefaultPatternView(app.view)) return;
+        return await rt.getSpaceRootPattern(space);
       } catch (err) {
         if (!rt.signal.aborted) {
           console.error("[AppView] Failed to load space root pattern:", err);

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -105,7 +105,14 @@ export class XAppView extends BaseView {
       if (!rt || !space) return;
       try {
         await prepareNamedSpace(app, rt, space);
-        return await rt.getSpaceRootPattern(space);
+        // The space home renders the root, so there it has to run. A
+        // piece-focused view reads exactly one thing from it — the `fabUI`
+        // sub-page BodyView renders — and reading an export does not need
+        // the root running. Starting it materializes everything the root's
+        // result reaches, which on a space whose root reaches a large piece
+        // is the dominant cost of opening any piece in that space.
+        const start = isViewingDefaultPatternView(app.view);
+        return await rt.getSpaceRootPattern(space, { start });
       } catch (err) {
         if (!rt.signal.aborted) {
           console.error("[AppView] Failed to load space root pattern:", err);

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -13,7 +13,6 @@ import { CellHandle, PageHandle, VNode } from "@commonfabric/runtime-client";
 
 type SubPages = {
   sidebarUI?: VNode;
-  fabUI?: VNode;
 };
 
 export type LoadError = {
@@ -25,7 +24,6 @@ const SubPagesSchema = {
   type: "object",
   properties: {
     sidebarUI: { $ref: "#/$defs/vdomNode" },
-    fabUI: { $ref: "#/$defs/vdomNode" },
   },
   $defs: {
     ...rendererVDOMSchema.$defs,
@@ -139,9 +137,6 @@ export class XBodyView extends BaseView {
   @property({ attribute: false })
   accessor activePattern: PageHandle | undefined = undefined;
 
-  @property({ attribute: false })
-  accessor spaceRootPattern: PageHandle | undefined = undefined;
-
   @property()
   accessor showShellPieceListView = false;
 
@@ -164,9 +159,8 @@ export class XBodyView extends BaseView {
           sidebarUI: undefined,
         };
       }
-      const sidebarUI = await getSubPageCell(
+      const sidebarUI = await getSidebarCell(
         activePattern?.cell() as CellHandle<SubPages> | undefined,
-        "sidebarUI",
       );
       return {
         sidebarUI,
@@ -264,9 +258,8 @@ function loadErrorMessage(error: unknown): string {
 
 globalThis.customElements.define("x-body-view", XBodyView);
 
-async function getSubPageCell(
+async function getSidebarCell(
   cell: CellHandle<SubPages> | undefined,
-  key: "fabUI" | "sidebarUI",
 ): Promise<CellHandle<VNode> | undefined> {
   if (!cell) return undefined;
   const typedCell = cell.asSchema<SubPages>(SubPagesSchema);
@@ -278,7 +271,7 @@ async function getSubPageCell(
       return;
     }
   }
-  if (key in value && value[key]) {
-    return typedCell.key(key).asSchema<VNode>(rendererVDOMSchema);
+  if (value.sidebarUI) {
+    return typedCell.key("sidebarUI").asSchema<VNode>(rendererVDOMSchema);
   }
 }

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -158,29 +158,21 @@ export class XBodyView extends BaseView {
   accessor embedded = false;
 
   #subPages = new Task(this, {
-    task: async ([activePattern, spaceRootPattern, embedded]) => {
+    task: async ([activePattern, embedded]) => {
       if (embedded) {
         return {
           sidebarUI: undefined,
-          fabUI: undefined,
         };
       }
-      const [sidebarUI, fabUI] = await Promise.all([
-        getSubPageCell(
-          activePattern?.cell() as CellHandle<SubPages> | undefined,
-          "sidebarUI",
-        ),
-        getSubPageCell(
-          spaceRootPattern?.cell() as CellHandle<SubPages> | undefined,
-          "fabUI",
-        ),
-      ]);
+      const sidebarUI = await getSubPageCell(
+        activePattern?.cell() as CellHandle<SubPages> | undefined,
+        "sidebarUI",
+      );
       return {
         sidebarUI,
-        fabUI,
       };
     },
-    args: () => [this.activePattern, this.spaceRootPattern, this.embedded],
+    args: () => [this.activePattern, this.embedded],
   });
 
   override render() {
@@ -216,7 +208,6 @@ export class XBodyView extends BaseView {
     const sidebar = this.embedded
       ? undefined
       : this.#subPages?.value?.sidebarUI;
-    const fab = this.embedded ? undefined : this.#subPages?.value?.fabUI;
     const runtimeError = this.runtimeError
       ? html`
         <cf-alert class="runtime-error" status="error">
@@ -243,10 +234,6 @@ export class XBodyView extends BaseView {
           ${mainContent} ${sidebar
             ? html`
               <cf-render slot="sidebar" .cell="${sidebar}"></cf-render>
-            `
-            : null} ${fab
-            ? html`
-              <cf-render slot="fab" .cell="${fab}"></cf-render>
             `
             : null}
         </x-omni-layout>

--- a/packages/shell/test/app-view-named-space.test.ts
+++ b/packages/shell/test/app-view-named-space.test.ts
@@ -139,6 +139,36 @@ describe("XAppView named-space preparation", () => {
     }
   });
 
+  it("does not request the space root for a piece-focused view", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XAppView } = await import("../src/views/AppView.ts");
+      const space = "did:key:z6Mk-shell-piece-without-root" as DID;
+      let rootRequests = 0;
+      const view = new XAppView();
+      view.app = {
+        view: { spaceName: "notebook", pieceId: "of:piece" },
+      } as never;
+      view.space = space;
+      view.rt = {
+        signal: new AbortController().signal,
+        resolveSpaceName: () => Promise.resolve(space),
+        getSpaceRootPattern: () => {
+          rootRequests++;
+          return Promise.reject(new Error("space root must stay untouched"));
+        },
+      } as never;
+
+      view._spaceRootPattern.run();
+      await view._spaceRootPattern.taskComplete;
+
+      expect(view._spaceRootPattern.value).toBeUndefined();
+      expect(rootRequests).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
   it("reports a name that resolves to a space other than the one given", async () => {
     const { prepareNamedSpace } = await import("../src/lib/named-space.ts");
     const atlas = "did:key:z6Mk-shell-named-space-atlas" as DID;


### PR DESCRIPTION
Opening any piece in a space started that space's whole root app, for reads that never needed it running. This removes all three reasons it was started.

## What was happening

- **`getPieceRegistry`** resolved the root with `runIt=true`, so every listing — the shell's menu prefetch, `getRegisteredPieces`, FUSE, `cf piece ls`, background-piece-service — booted the default app to read one exported array.
- **`pattern:getSpaceRoot`** called `ensureDefaultPattern()`, which starts the root whatever the view asking.
- On a piece-focused view the shell read exactly one thing from that root: the `fabUI` sub-page. **A board screen was starting the whole space app to render a floating action button.**

From a live estuary board load:

```
piece/phase/get.runtime.start                  n=2   avg 10,991 ms
piece/phase/getDefaultPattern.get(runIt=true)  n=1        11,298 ms
```

## What this does

1. **`getPieceRegistry` reads the persisted export** instead of running the root. Every writer of that export — `add()`, `remove()`, the root's own remove handler, patterns reaching it via `wish()` — persists what it writes, so the stored value is current at any quiescent moment.
2. **`pattern:getSpaceRoot` carries `start`**, defaulting to true because a view that *renders* the root needs it running.
3. **The FAB is removed** (product decision), which was the piece view's last read of the root — so a piece view now does not fetch it at all, passively or otherwise.

`add()` and `ensureDefaultPattern` are unchanged, so the space home still runs the root — rendering it is the page. A space with no root yet still gets one created; a root must exist before it can have exports, and creating one is not the cost being avoided.

Two subtleties worth review attention:

- `pieceListSchema` carries `default: []`, so a root that never exported a registry and one whose registry is empty read identically through the schema. The raw value separates them, and only the first needs the root run.
- The runtime's per-space root cache had to learn `start`, and **it is not symmetric**: a started root also answers a caller that only reads exports; an unstarted one does not answer a caller that needs it running.

## Measured

**`cf piece ls` against the production board** (exercises the registry path directly):

| | wall clock | rows |
| --- | --- | --- |
| `main` | 5:10, and 2:53 on a repeat | 40 |
| this branch | **0:36** | 40 |

Rows are byte-for-byte identical — same 40 fids, same titles. That is the correctness half: the passive read returns exactly what the running read returned, on production data. Bounds: n=1 branch / n=2 baseline, and baseline varied 2:53→5:10, so the defensible claim is "roughly 5–9x", not a point estimate.

**A board load in the browser**, branch shell against production estuary:

| | main | this branch |
| --- | --- | --- |
| largest single inbound frame | 13.55 MB | **3.96 MB** |
| `get.runtime.start` phases | 2 × ~11 s | 1 |
| distinct watch subscriptions | 8,814 | 8,975 |
| time to content | ~13–19 s | ~13–19 s |

Stated plainly because it matters for expectations: **this does not move time-to-content on a board load.** It removes a demand whose *closure* is large, not a large number of subscriptions, and the remaining wall clock is dominated by the serving shard's stall behavior. The wins here are the piece-start work, the delivered payload, and listing latency.

## Tests

- **piece** — the test that already *named* this property, `reads the persisted registry without restarting the default pattern`, never checked it: it stopped the root and asserted the listing still worked, which held either way because `start()` is idempotent. The restart is only observable at the call, so it is observed there now.
- **piece** — a stale root whose registry export is already persisted still heals (see the review round below).
- **lib-shell** — the asymmetric root cache, pinned in both directions.

All three mutation-verified.

## Review round

Both findings were valid and are fixed:

- **P1 — passive opens stopped healing.** `getPieceCell` gated `reconcilePieceSource()` and `runtime.start()` on one flag, so resolving a root without running it also stopped rolling a stale source forward — and a root that has *already* exported a registry is exactly the one taking the passive path. `reconcile` and `start` are now separable; a boolean still means both or neither, so all 15 existing call sites are unchanged. Reconciliation measured ~319 ms against the start's ~11,000 ms. The passive open also falls back to the running path on a throw, which keeps its own rescue.
- **P3 — the stated invariant was false.** `add()` is not the only writer. Restated on the true, weaker claim: every writer persists what it writes.

## Not in scope

The design's item 5 — the detached empty-cell arm on a space with no default pattern, which silently never fires. That is a behavior change with its own blast radius across FUSE, `cf piece ls`, and the shell menu.

## Validation

- `deno task check` — full workspace, green
- `packages/piece` 51, `packages/lib-shell` 5, `packages/runtime-client` 16, `packages/shell` 57 — all passed, 0 failed
- `deno fmt --check`, `deno lint` — clean, repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
