### PR TITLE
refactor: `#` private members in `ts-transformers`

### DIFF
--- a/packages/ts-transformers/docs/array-method-callback-pipeline.md
+++ b/packages/ts-transformers/docs/array-method-callback-pipeline.md
@@ -185,7 +185,7 @@ recursing into the body. But the analyzer maintains a per-expression cache, and
 `JsxExpressionSiteRouterTransformer` / `LiftLoweringTransformer` can analyze
 expressions in the body before `ClosureTransformer` marks the callback.
 
-`TransformationContext.invalidateReactiveAnalysisCaches()` is called by each
+`TransformationContext.#invalidateReactiveAnalysisCaches()` is called by each
 `mark*` method on the context. It drops three things:
 
 - `#reactiveContextCache`

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -131,8 +131,9 @@ export function createDataFlowAnalyzer(
   hooks: DataFlowAnalyzerHooks = {},
 ): (expression: ts.Expression) => DataFlowAnalysis {
   // Per-expression memoization for `analyze()`. Lives inside this closure;
-  // invalidated as a unit when `TransformationContext.invalidateReactiveAnalysisCaches`
-  // drops the analyzer instance (see core/mod.ts cache-invalidation contract).
+  // invalidated as a unit when
+  // `TransformationContext.#invalidateReactiveAnalysisCaches` drops the
+  // analyzer instance (see core/mod.ts cache-invalidation contract).
   const analysisCache = new WeakMap<ts.Expression, DataFlowAnalysis>();
   const resolvingConstAliases = new Set<ts.Symbol>();
   const isArrayMethodElementBindingReference =

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -86,9 +86,9 @@ export const CFC_TRANSFORMER_STAGE_NAMES: readonly string[] =
   CFC_TRANSFORMER_STAGES.map((stage) => stage.name);
 
 export class CommonFabricTransformerPipeline {
-  private readonly transformers: Transformer[];
-  private readonly diagnosticsCollector: TransformationDiagnostic[];
-  private readonly state: CrossStageState;
+  readonly #transformers: Transformer[];
+  readonly #diagnosticsCollector: TransformationDiagnostic[];
+  readonly #state: CrossStageState;
 
   constructor(options: TransformationOptions = {}) {
     const state = options.state ?? new CrossStageState();
@@ -101,18 +101,18 @@ export class CommonFabricTransformerPipeline {
       ...ops,
       diagnosticsCollector: [],
     };
-    this.transformers = CFC_TRANSFORMER_STAGES.map(
+    this.#transformers = CFC_TRANSFORMER_STAGES.map(
       (Stage) => new Stage(sharedOps),
     );
 
     // Store reference to shared collector
     // Note: We need to access it after construction, so we store the array reference
-    this.diagnosticsCollector = sharedOps.diagnosticsCollector!;
-    this.state = state;
+    this.#diagnosticsCollector = sharedOps.diagnosticsCollector!;
+    this.#state = state;
   }
 
   toFactories(program: ts.Program): ts.TransformerFactory<ts.SourceFile>[] {
-    return this.transformers.map((t) => t.toFactory(program));
+    return this.#transformers.map((t) => t.toFactory(program));
   }
 
   /**
@@ -120,7 +120,7 @@ export class CommonFabricTransformerPipeline {
    * Call this after running the pipeline to get errors and warnings.
    */
   getDiagnostics(): readonly TransformationDiagnostic[] {
-    return this.diagnosticsCollector;
+    return this.#diagnosticsCollector;
   }
 
   /**
@@ -128,17 +128,17 @@ export class CommonFabricTransformerPipeline {
    * Call this if reusing the pipeline for multiple files.
    */
   clearDiagnostics(): void {
-    this.diagnosticsCollector.length = 0;
+    this.#diagnosticsCollector.length = 0;
   }
 
   getBuilderSourceSites(): ReadonlyMap<string, BuilderSourceSitesV1> {
-    return this.state.getBuilderSourceSites();
+    return this.#state.getBuilderSourceSites();
   }
 
   getPolicyManifests(): ReadonlyMap<
     string,
     readonly CfcPolicyCompilerManifestV1[]
   > {
-    return this.state.getPolicyManifests();
+    return this.#state.getPolicyManifests();
   }
 }

--- a/packages/ts-transformers/src/closures/capture-collector.ts
+++ b/packages/ts-transformers/src/closures/capture-collector.ts
@@ -25,13 +25,19 @@ export interface CaptureCollectorOptions {
 }
 
 export class CaptureCollector {
+  readonly #checker: ts.TypeChecker;
+  readonly #options: CaptureCollectorOptions;
+
   constructor(
-    private readonly checker: ts.TypeChecker,
-    private readonly options: CaptureCollectorOptions = {},
-  ) {}
+    checker: ts.TypeChecker,
+    options: CaptureCollectorOptions = {},
+  ) {
+    this.#checker = checker;
+    this.#options = options;
+  }
 
   analyze(func: ts.FunctionLikeDeclaration): CaptureAnalysis {
-    const captures = this.collectCaptures(func);
+    const captures = this.#collectCaptures(func);
     const captureTree = groupCapturesByRoot(captures);
     return { captures, captureTree };
   }
@@ -42,7 +48,7 @@ export class CaptureCollector {
     const current = this.analyze(func);
     const original = ts.getOriginalNode(func);
     if (
-      !this.isFunctionLikeDeclaration(original) ||
+      !this.#isFunctionLikeDeclaration(original) ||
       original === func
     ) {
       return current;
@@ -72,7 +78,7 @@ export class CaptureCollector {
    * Detects captured variables in a function using TypeScript's symbol table.
    * Returns all captured expressions (both reactive and non-reactive).
    */
-  private collectCaptures(
+  #collectCaptures(
     func: ts.FunctionLikeDeclaration,
   ): Set<ts.Expression> {
     const captures = new Set<ts.Expression>();
@@ -82,8 +88,8 @@ export class CaptureCollector {
       // Even though they have their own scope for parameters, they still
       // close over variables from outer scopes, and we need to know about
       // all such captures for the lift-applied/handler transformation
-      if (node !== func && this.isFunctionLikeDeclaration(node)) {
-        const nestedCaptures = this.collectCaptures(node);
+      if (node !== func && this.#isFunctionLikeDeclaration(node)) {
+        const nestedCaptures = this.#collectCaptures(node);
         // Filter out captures that are parameters of the current function
         //
         // CRITICAL: We must filter based on root identifiers for property accesses.
@@ -98,7 +104,7 @@ export class CaptureCollector {
         );
 
         for (const capture of nestedCaptures) {
-          if (this.shouldAddNestedCapture(capture, func, funcParams)) {
+          if (this.#shouldAddNestedCapture(capture, func, funcParams)) {
             captures.add(capture);
           }
         }
@@ -115,7 +121,7 @@ export class CaptureCollector {
         const methodTarget = getMethodCallTarget(node);
         if (methodTarget) {
           // Method call on a property access (e.g., state.counter.set())
-          const captured = this.shouldCapturePropertyAccess(
+          const captured = this.#shouldCapturePropertyAccess(
             methodTarget,
             func,
           );
@@ -126,7 +132,7 @@ export class CaptureCollector {
           }
         } else if (!isMethodCall(node)) {
           // Not a method call, capture the property access normally
-          const captured = this.shouldCapturePropertyAccess(node, func);
+          const captured = this.#shouldCapturePropertyAccess(node, func);
           if (captured) {
             captures.add(captured);
             // Don't visit children - we've captured the whole property access chain
@@ -142,7 +148,7 @@ export class CaptureCollector {
 
       // For plain identifiers
       if (ts.isIdentifier(node)) {
-        const captured = this.shouldCaptureIdentifier(node, func);
+        const captured = this.#shouldCaptureIdentifier(node, func);
         if (captured) {
           captures.add(captured);
         }
@@ -170,7 +176,7 @@ export class CaptureCollector {
    * Check if a property access expression should be captured.
    * Returns the expression to capture, or undefined if it shouldn't be captured.
    */
-  private shouldCapturePropertyAccess(
+  #shouldCapturePropertyAccess(
     node: ts.PropertyAccessExpression,
     func: ts.FunctionLikeDeclaration,
   ): ts.PropertyAccessExpression | undefined {
@@ -184,7 +190,7 @@ export class CaptureCollector {
       return undefined;
     }
 
-    const symbol = this.checker.getSymbolAtLocation(root);
+    const symbol = this.#checker.getSymbolAtLocation(root);
     if (!symbol) return undefined;
 
     const declarations = symbol.getDeclarations();
@@ -213,7 +219,7 @@ export class CaptureCollector {
     // Skip function declarations
     if (
       declarations.some((decl: ts.Declaration) =>
-        isFunctionDeclaration(decl, this.checker)
+        isFunctionDeclaration(decl, this.#checker)
       )
     ) {
       return undefined;
@@ -226,7 +232,7 @@ export class CaptureCollector {
     });
 
     if (hasExternalDeclaration) {
-      if (this.options.captureNonModuleExternalPropertyAccesses === false) {
+      if (this.#options.captureNonModuleExternalPropertyAccesses === false) {
         return undefined;
       }
       // Capture the whole property access expression
@@ -240,7 +246,7 @@ export class CaptureCollector {
    * Check if an identifier should be captured.
    * Returns the identifier to capture, or undefined if it shouldn't be captured.
    */
-  private shouldCaptureIdentifier(
+  #shouldCaptureIdentifier(
     node: ts.Identifier,
     func: ts.FunctionLikeDeclaration,
   ): ts.Identifier | undefined {
@@ -276,7 +282,7 @@ export class CaptureCollector {
     if (ts.isShorthandPropertyAssignment(node.parent)) {
       // For shorthand properties, we need to resolve to the actual variable/value being referenced
       // Use the type checker to get the actual symbol of the referenced value
-      const propSymbol = this.checker.getShorthandAssignmentValueSymbol(
+      const propSymbol = this.#checker.getShorthandAssignmentValueSymbol(
         node.parent,
       );
       if (propSymbol) {
@@ -287,7 +293,7 @@ export class CaptureCollector {
         if (allDeclaredInside) {
           return undefined;
         }
-        return this.shouldCaptureExternalIdentifier(node, propDeclarations)
+        return this.#shouldCaptureExternalIdentifier(node, propDeclarations)
           ? node
           : undefined;
       }
@@ -303,7 +309,7 @@ export class CaptureCollector {
       return undefined;
     }
 
-    const symbol = this.checker.getSymbolAtLocation(node);
+    const symbol = this.#checker.getSymbolAtLocation(node);
     if (!symbol) {
       return undefined;
     }
@@ -363,7 +369,7 @@ export class CaptureCollector {
       return undefined;
     }
 
-    if (!this.shouldCaptureExternalIdentifier(node, declarations)) {
+    if (!this.#shouldCaptureExternalIdentifier(node, declarations)) {
       return undefined;
     }
 
@@ -372,13 +378,13 @@ export class CaptureCollector {
     return node;
   }
 
-  private shouldCaptureExternalIdentifier(
+  #shouldCaptureExternalIdentifier(
     node: ts.Identifier,
     declarations: readonly ts.Declaration[],
   ): boolean {
     // Skip function declarations (can't serialize functions)
     const isFunction = declarations.some((decl: ts.Declaration) =>
-      isFunctionDeclaration(decl, this.checker)
+      isFunctionDeclaration(decl, this.#checker)
     );
     if (isFunction) {
       return false;
@@ -398,22 +404,22 @@ export class CaptureCollector {
       isModuleScopedDeclaration(decl)
     );
     if (isModuleScoped) {
-      const predicate = this.options.captureModuleScopedIdentifierWhen;
+      const predicate = this.#options.captureModuleScopedIdentifierWhen;
       if (!predicate) {
         return false;
       }
-      const type = this.checker.getTypeAtLocation(node);
-      return predicate(node, type, this.checker);
+      const type = this.#checker.getTypeAtLocation(node);
+      return predicate(node, type, this.#checker);
     }
 
-    return this.options.captureNonModuleExternalIdentifiers !== false;
+    return this.#options.captureNonModuleExternalIdentifiers !== false;
   }
 
   /**
    * Type guard for function-like declarations (excludes signature declarations).
    * Used to identify nested functions that can have their own captures.
    */
-  private isFunctionLikeDeclaration(
+  #isFunctionLikeDeclaration(
     node: ts.Node,
   ): node is ts.FunctionLikeDeclaration {
     return ts.isArrowFunction(node) || ts.isFunctionExpression(node) ||
@@ -422,7 +428,7 @@ export class CaptureCollector {
       ts.isConstructorDeclaration(node);
   }
 
-  private isParameterOrLocalVariable(
+  #isParameterOrLocalVariable(
     identifier: ts.Identifier,
     func: ts.FunctionLikeDeclaration,
     funcParams: Set<string>,
@@ -433,7 +439,7 @@ export class CaptureCollector {
     }
 
     // Check if it's a local variable declared within the function
-    const symbol = this.checker.getSymbolAtLocation(identifier);
+    const symbol = this.#checker.getSymbolAtLocation(identifier);
     if (symbol) {
       const declarations = symbol.getDeclarations() || [];
       for (const decl of declarations) {
@@ -450,13 +456,13 @@ export class CaptureCollector {
    * Determines if a capture from a nested function should be added to the outer function's captures.
    * Filters out captures that are parameters or local variables of the outer function.
    */
-  private shouldAddNestedCapture(
+  #shouldAddNestedCapture(
     capture: ts.Expression,
     outerFunc: ts.FunctionLikeDeclaration,
     funcParams: Set<string>,
   ): boolean {
     if (ts.isIdentifier(capture)) {
-      return !this.isParameterOrLocalVariable(
+      return !this.#isParameterOrLocalVariable(
         capture,
         outerFunc,
         funcParams,
@@ -471,7 +477,7 @@ export class CaptureCollector {
         rootExpr = rootExpr.expression;
       }
       if (ts.isIdentifier(rootExpr)) {
-        return !this.isParameterOrLocalVariable(
+        return !this.#isParameterOrLocalVariable(
           rootExpr,
           outerFunc,
           funcParams,

--- a/packages/ts-transformers/src/closures/utils/pattern-builder.ts
+++ b/packages/ts-transformers/src/closures/utils/pattern-builder.ts
@@ -18,16 +18,22 @@ export interface PatternParameter {
 }
 
 export class PatternBuilder {
-  private parameters: PatternParameter[] = [];
-  private captureTree: Map<string, CaptureTreeNode> = new Map();
-  private usedBindingNames = new Set<string>();
+  #parameters: PatternParameter[] = [];
+  #captureTree: Map<string, CaptureTreeNode> = new Map();
+  #usedBindingNames = new Set<string>();
 
-  private captureRenames: Map<string, string> = new Map();
+  #captureRenames: Map<string, string> = new Map();
+
+  #context: TransformationContext;
+  #factory: ts.NodeFactory;
 
   constructor(
-    private context: TransformationContext,
-    private factory: ts.NodeFactory = context.factory,
-  ) {}
+    context: TransformationContext,
+    factory: ts.NodeFactory = context.factory,
+  ) {
+    this.#context = context;
+    this.#factory = factory;
+  }
 
   /**
    * Add a parameter to the destructured input object.
@@ -38,7 +44,7 @@ export class PatternBuilder {
     propertyName?: string,
     initializer?: ts.Expression,
   ): this {
-    this.parameters.push({ name, bindingName, propertyName, initializer });
+    this.#parameters.push({ name, bindingName, propertyName, initializer });
     return this;
   }
 
@@ -46,7 +52,7 @@ export class PatternBuilder {
    * Set the capture tree to generate the 'params' object or merged captures.
    */
   setCaptureTree(tree: Map<string, CaptureTreeNode>): this {
-    this.captureTree = tree;
+    this.#captureTree = tree;
     return this;
   }
 
@@ -55,7 +61,7 @@ export class PatternBuilder {
    */
   registerUsedNames(names: Set<string> | string[]): this {
     for (const name of names) {
-      this.usedBindingNames.add(name);
+      this.#usedBindingNames.add(name);
     }
     return this;
   }
@@ -66,7 +72,7 @@ export class PatternBuilder {
    * Value: new property name in the destructured object
    */
   setCaptureRenames(renames: Map<string, string>): this {
-    this.captureRenames = renames;
+    this.#captureRenames = renames;
     return this;
   }
 
@@ -87,17 +93,17 @@ export class PatternBuilder {
     const bindingElements: ts.BindingElement[] = [];
 
     // 1. Add explicitly registered parameters
-    for (const param of this.parameters) {
+    for (const param of this.#parameters) {
       const bindingName = param.bindingName ||
-        this.factory.createIdentifier(param.name);
+        this.#factory.createIdentifier(param.name);
       const propertyName = param.propertyName
-        ? this.factory.createIdentifier(param.propertyName)
+        ? this.#factory.createIdentifier(param.propertyName)
         : (param.name !== (bindingName as any)?.text
-          ? this.factory.createIdentifier(param.name)
+          ? this.#factory.createIdentifier(param.name)
           : undefined);
 
       bindingElements.push(
-        this.factory.createBindingElement(
+        this.#factory.createBindingElement(
           undefined,
           propertyName,
           bindingName,
@@ -105,27 +111,28 @@ export class PatternBuilder {
         ),
       );
       for (const name of extractBindingNames(bindingName)) {
-        this.usedBindingNames.add(name);
+        this.#usedBindingNames.add(name);
       }
     }
 
     // 2. Add captures
     const createBindingIdentifier = (name: string): ts.Identifier => {
-      return reserveIdentifier(name, this.usedBindingNames, this.factory);
+      return reserveIdentifier(name, this.#usedBindingNames, this.#factory);
     };
 
     // If we have renames, we need to handle them
     const captureBindings: ts.BindingElement[] = [];
-    for (const originalName of this.captureTree.keys()) {
-      const renamedName = this.captureRenames.get(originalName) ?? originalName;
+    for (const originalName of this.#captureTree.keys()) {
+      const renamedName = this.#captureRenames.get(originalName) ??
+        originalName;
 
       const bindingName = createBindingIdentifier(renamedName);
       const propertyName = renamedName !== bindingName.text
-        ? this.factory.createIdentifier(renamedName)
+        ? this.#factory.createIdentifier(renamedName)
         : undefined;
 
       captureBindings.push(
-        this.factory.createBindingElement(
+        this.#factory.createBindingElement(
           undefined,
           propertyName,
           bindingName,
@@ -137,13 +144,13 @@ export class PatternBuilder {
     if (paramsPropertyName) {
       // Group captures under a 'params' property (for map/handler)
       // Always add params property to match existing behavior (e.g. params: {})
-      const paramsPattern = this.factory.createObjectBindingPattern(
+      const paramsPattern = this.#factory.createObjectBindingPattern(
         captureBindings,
       );
       bindingElements.push(
-        this.factory.createBindingElement(
+        this.#factory.createBindingElement(
           undefined,
-          this.factory.createIdentifier(paramsPropertyName),
+          this.#factory.createIdentifier(paramsPropertyName),
           paramsPattern,
           undefined,
         ),
@@ -156,7 +163,7 @@ export class PatternBuilder {
     // 3. Create the destructured parameter
     const destructuredParam = createParameterFromBindings(
       bindingElements,
-      this.factory,
+      this.#factory,
     );
 
     // 4. Create the function
@@ -175,7 +182,7 @@ export class PatternBuilder {
     // derivation, so textRange/original would perturb emit. See
     // preserveSourceMapRange / CT-1868.
     const built = ts.isArrowFunction(originalCallback)
-      ? this.factory.createArrowFunction(
+      ? this.#factory.createArrowFunction(
         originalCallback.modifiers,
         originalCallback.typeParameters,
         [destructuredParam],
@@ -183,7 +190,7 @@ export class PatternBuilder {
         originalCallback.equalsGreaterThanToken,
         body,
       )
-      : this.factory.createFunctionExpression(
+      : this.#factory.createFunctionExpression(
         originalCallback.modifiers,
         originalCallback.asteriskToken,
         originalCallback.name,
@@ -211,9 +218,9 @@ export class PatternBuilder {
 
     // 1. Create event parameter
     // Ensure event parameter doesn't collide with captures
-    const conflicts = new Set(this.usedBindingNames);
-    for (const key of this.captureTree.keys()) {
-      const renamed = this.captureRenames.get(key) ?? key;
+    const conflicts = new Set(this.#usedBindingNames);
+    for (const key of this.#captureTree.keys()) {
+      const renamed = this.#captureRenames.get(key) ?? key;
       conflicts.add(renamed);
     }
 
@@ -222,16 +229,16 @@ export class PatternBuilder {
       // Use original parameter name if possible
       const bindingName = normalizeBindingName(
         eventParam.name,
-        this.factory,
+        this.#factory,
         conflicts,
       );
 
       // Register the chosen name as used
       if (ts.isIdentifier(bindingName)) {
-        this.usedBindingNames.add(bindingName.text);
+        this.#usedBindingNames.add(bindingName.text);
       }
 
-      eventParameter = this.factory.createParameterDeclaration(
+      eventParameter = this.#factory.createParameterDeclaration(
         undefined,
         undefined,
         bindingName,
@@ -244,11 +251,11 @@ export class PatternBuilder {
       const name = reserveIdentifier(
         eventParamName,
         conflicts,
-        this.factory,
+        this.#factory,
       );
-      this.usedBindingNames.add(name.text);
+      this.#usedBindingNames.add(name.text);
 
-      eventParameter = this.factory.createParameterDeclaration(
+      eventParameter = this.#factory.createParameterDeclaration(
         undefined,
         undefined,
         name,
@@ -260,12 +267,12 @@ export class PatternBuilder {
 
     // 2. Create params parameter (destructured captures)
     const createBindingIdentifier = (name: string): ts.Identifier => {
-      return reserveIdentifier(name, this.usedBindingNames, this.factory);
+      return reserveIdentifier(name, this.#usedBindingNames, this.#factory);
     };
 
     const captureBindings = createBindingElementsFromNames(
-      this.captureTree.keys(),
-      this.factory,
+      this.#captureTree.keys(),
+      this.#factory,
       createBindingIdentifier,
     );
 
@@ -273,22 +280,22 @@ export class PatternBuilder {
     if (stateParam) {
       paramsBindingName = normalizeBindingName(
         stateParam.name,
-        this.factory,
-        this.usedBindingNames,
+        this.#factory,
+        this.#usedBindingNames,
       );
     } else if (captureBindings.length > 0) {
-      paramsBindingName = this.factory.createObjectBindingPattern(
+      paramsBindingName = this.#factory.createObjectBindingPattern(
         captureBindings,
       );
     } else {
       paramsBindingName = reserveIdentifier(
         paramsParamName,
-        this.usedBindingNames,
-        this.factory,
+        this.#usedBindingNames,
+        this.#factory,
       );
     }
 
-    const paramsParameter = this.factory.createParameterDeclaration(
+    const paramsParameter = this.#factory.createParameterDeclaration(
       undefined,
       undefined,
       paramsBindingName,
@@ -302,10 +309,10 @@ export class PatternBuilder {
       (param: ts.ParameterDeclaration) => {
         const bindingName = normalizeBindingName(
           param.name,
-          this.factory,
-          this.usedBindingNames,
+          this.#factory,
+          this.#usedBindingNames,
         );
-        return this.factory.createParameterDeclaration(
+        return this.#factory.createParameterDeclaration(
           undefined,
           undefined,
           bindingName,
@@ -321,7 +328,7 @@ export class PatternBuilder {
       : (returnType || originalCallback.type);
 
     return preserveSourceMapRange(
-      this.factory.createArrowFunction(
+      this.#factory.createArrowFunction(
         originalCallback.modifiers,
         originalCallback.typeParameters,
         [eventParameter, paramsParameter, ...additionalParameters],

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -71,7 +71,7 @@ export class TransformationContext {
   }
 
   reportDiagnostic(input: DiagnosticInput): void {
-    const { start, length } = this.resolveDiagnosticRange(input.node);
+    const { start, length } = this.#resolveDiagnosticRange(input.node);
     const location = this.sourceFile.getLineAndCharacterOfPosition(start);
     const diagnostic: TransformationDiagnostic = {
       severity: input.severity ?? "error",
@@ -102,7 +102,7 @@ export class TransformationContext {
    * collide between files.
    */
   reportDiagnosticOnce(input: DiagnosticInput): void {
-    const { start, length } = this.resolveDiagnosticRange(input.node);
+    const { start, length } = this.#resolveDiagnosticRange(input.node);
     const key = `${this.sourceFile.fileName}:${input.type}:${start}:${length}`;
     if (!this.state.markDiagnosticReported(key)) {
       return;
@@ -110,7 +110,7 @@ export class TransformationContext {
     this.reportDiagnostic(input);
   }
 
-  private resolveDiagnosticRange(
+  #resolveDiagnosticRange(
     node: ts.Node,
   ): { start: number; length: number } {
     let current: ts.Node | undefined = node;
@@ -158,7 +158,7 @@ export class TransformationContext {
    */
   markAsArrayMethodCallback(node: ts.Node): void {
     this.state.markArrayMethodCallback(node);
-    this.invalidateReactiveAnalysisCaches();
+    this.#invalidateReactiveAnalysisCaches();
   }
 
   /**
@@ -180,7 +180,7 @@ export class TransformationContext {
    */
   markAsSyntheticComputeCallback(node: ts.Node): void {
     this.state.markSyntheticComputeCallback(node);
-    this.invalidateReactiveAnalysisCaches();
+    this.#invalidateReactiveAnalysisCaches();
   }
 
   /**
@@ -192,7 +192,7 @@ export class TransformationContext {
 
   markSyntheticComputeOwnedSubtree(node: ts.Node): void {
     this.state.markSyntheticComputeOwnedSubtree(node);
-    this.invalidateReactiveAnalysisCaches();
+    this.#invalidateReactiveAnalysisCaches();
   }
 
   isSyntheticComputeOwnedNode(node: ts.Node): boolean {
@@ -270,7 +270,7 @@ export class TransformationContext {
       return;
     }
     this.state.markSyntheticReactiveCollection(symbol);
-    this.invalidateReactiveAnalysisCaches();
+    this.#invalidateReactiveAnalysisCaches();
   }
 
   /**
@@ -363,7 +363,7 @@ export class TransformationContext {
     return info;
   }
 
-  private invalidateReactiveAnalysisCaches(): void {
+  #invalidateReactiveAnalysisCaches(): void {
     this.#reactiveContextCache = new WeakMap<ts.Node, ReactiveContextInfo>();
     this.#relevantDataFlowCache = new WeakMap<
       DataFlowAnalysis,

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -62,9 +62,9 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     const visit = (node: ts.Node): ts.Node => {
       // Check for type assertions (both `as X` and `<X>` syntax)
       if (ts.isAsExpression(node)) {
-        this.validateAsExpression(node, context);
+        this.#validateAsExpression(node, context);
       } else if (ts.isTypeAssertionExpression(node)) {
-        this.validateTypeAssertion(node, context);
+        this.#validateTypeAssertion(node, context);
       }
 
       return ts.visitEachChild(node, visit, context.tsContext);
@@ -73,12 +73,12 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     return ts.visitNode(context.sourceFile, visit) as ts.SourceFile;
   }
 
-  private validateAsExpression(
+  #validateAsExpression(
     node: ts.AsExpression,
     context: TransformationContext,
   ): void {
     // Check for double-cast pattern: `as unknown as X`
-    if (this.isDoubleUnknownCast(node)) {
+    if (this.#isDoubleUnknownCast(node)) {
       context.reportDiagnostic({
         severity: "error",
         type: "cast-validation:double-unknown",
@@ -90,15 +90,15 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     }
 
     // Check the target type of the cast
-    this.validateCastTargetType(node.type, node, context);
+    this.#validateCastTargetType(node.type, node, context);
   }
 
-  private validateTypeAssertion(
+  #validateTypeAssertion(
     node: ts.TypeAssertion,
     context: TransformationContext,
   ): void {
     // Check for double-cast pattern with angle bracket syntax: `<X><unknown>expr`
-    if (this.isDoubleUnknownTypeAssertion(node)) {
+    if (this.#isDoubleUnknownTypeAssertion(node)) {
       context.reportDiagnostic({
         severity: "error",
         type: "cast-validation:double-unknown",
@@ -110,32 +110,32 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     }
 
     // Check the target type of the cast
-    this.validateCastTargetType(node.type, node, context);
+    this.#validateCastTargetType(node.type, node, context);
   }
 
   /**
    * Checks if this is a double-cast pattern: `expr as unknown as X`
    * Also handles mixed syntax: `(<unknown>expr) as X`
    */
-  private isDoubleUnknownCast(node: ts.AsExpression): boolean {
+  #isDoubleUnknownCast(node: ts.AsExpression): boolean {
     // Check if inner expression is an `as` expression casting to `unknown`
     if (ts.isAsExpression(node.expression)) {
       const innerType = node.expression.type;
-      return this.isUnknownType(innerType);
+      return this.#isUnknownType(innerType);
     }
     // Check for mixed syntax: `(<unknown>expr) as X`
     if (ts.isTypeAssertionExpression(node.expression)) {
       const innerType = node.expression.type;
-      return this.isUnknownType(innerType);
+      return this.#isUnknownType(innerType);
     }
     // Check for parenthesized expressions: `(expr as unknown) as X`
     if (ts.isParenthesizedExpression(node.expression)) {
       const inner = node.expression.expression;
-      if (ts.isAsExpression(inner) && this.isUnknownType(inner.type)) {
+      if (ts.isAsExpression(inner) && this.#isUnknownType(inner.type)) {
         return true;
       }
       if (
-        ts.isTypeAssertionExpression(inner) && this.isUnknownType(inner.type)
+        ts.isTypeAssertionExpression(inner) && this.#isUnknownType(inner.type)
       ) {
         return true;
       }
@@ -147,27 +147,27 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
    * Checks if this is a double-cast with angle bracket syntax: `<X><unknown>expr`
    * Also handles mixed syntax: `<X>(expr as unknown)`
    */
-  private isDoubleUnknownTypeAssertion(
+  #isDoubleUnknownTypeAssertion(
     node: ts.TypeAssertion,
   ): boolean {
     // Check for angle bracket inner: `<X><unknown>expr`
     if (ts.isTypeAssertionExpression(node.expression)) {
       const innerType = node.expression.type;
-      return this.isUnknownType(innerType);
+      return this.#isUnknownType(innerType);
     }
     // Check for mixed syntax: `<X>(expr as unknown)`
     if (ts.isAsExpression(node.expression)) {
       const innerType = node.expression.type;
-      return this.isUnknownType(innerType);
+      return this.#isUnknownType(innerType);
     }
     // Check for parenthesized expressions
     if (ts.isParenthesizedExpression(node.expression)) {
       const inner = node.expression.expression;
-      if (ts.isAsExpression(inner) && this.isUnknownType(inner.type)) {
+      if (ts.isAsExpression(inner) && this.#isUnknownType(inner.type)) {
         return true;
       }
       if (
-        ts.isTypeAssertionExpression(inner) && this.isUnknownType(inner.type)
+        ts.isTypeAssertionExpression(inner) && this.#isUnknownType(inner.type)
       ) {
         return true;
       }
@@ -178,7 +178,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
   /**
    * Checks if a type node represents the `unknown` type
    */
-  private isUnknownType(typeNode: ts.TypeNode): boolean {
+  #isUnknownType(typeNode: ts.TypeNode): boolean {
     return (
       typeNode.kind === ts.SyntaxKind.UnknownKeyword ||
       (ts.isTypeReferenceNode(typeNode) &&
@@ -190,13 +190,13 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
   /**
    * Validates the target type of a cast and reports appropriate diagnostics
    */
-  private validateCastTargetType(
+  #validateCastTargetType(
     typeNode: ts.TypeNode,
     castNode: ts.Node,
     context: TransformationContext,
   ): void {
-    const typeNames = this.extractTypeNames(typeNode, context);
-    const classification = this.classifyCastTarget(typeNames);
+    const typeNames = this.#extractTypeNames(typeNode, context);
+    const classification = this.#classifyCastTarget(typeNames);
     if (!classification) return;
 
     if (classification.kind === "forbidden") {
@@ -219,7 +219,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     });
   }
 
-  private classifyCastTarget(
+  #classifyCastTarget(
     typeNames: readonly string[],
   ): CastTargetClassification | undefined {
     const forbiddenTypeName = typeNames.find((typeName) =>
@@ -244,7 +244,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
    * For example, `Cell<number>` returns "Cell".
    * A nested type like `Cell<number> | undefined` returns "Cell".
    */
-  private extractTypeNames(
+  #extractTypeNames(
     typeNode: ts.TypeNode,
     context: TransformationContext,
     seenSymbols = new Set<ts.Symbol>(),
@@ -260,7 +260,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
         for (const child of node.types) visit(child);
         return;
       }
-      const name = this.extractTypeReferenceName(
+      const name = this.#extractTypeReferenceName(
         node,
         context,
         seenSymbols,
@@ -272,25 +272,25 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     return [...names];
   }
 
-  private extractTypeReferenceName(
+  #extractTypeReferenceName(
     typeNode: ts.TypeNode,
     context: TransformationContext,
     seenSymbols: Set<ts.Symbol>,
   ): string | undefined {
     if (ts.isTypeReferenceNode(typeNode)) {
-      return this.resolveWrapperTypeName(
+      return this.#resolveWrapperTypeName(
         typeNode.typeName,
         context,
         seenSymbols,
       );
     }
     if (ts.isImportTypeNode(typeNode)) {
-      return this.resolveImportTypeName(typeNode);
+      return this.#resolveImportTypeName(typeNode);
     }
     return undefined;
   }
 
-  private resolveImportTypeName(
+  #resolveImportTypeName(
     typeNode: ts.ImportTypeNode,
   ): string | undefined {
     const qualifier = typeNode.qualifier;
@@ -305,20 +305,20 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     const typeName = ts.isIdentifier(qualifier)
       ? qualifier.text
       : qualifier.right.text;
-    return this.isWrapperTypeName(typeName) ? typeName : undefined;
+    return this.#isWrapperTypeName(typeName) ? typeName : undefined;
   }
 
-  private resolveWrapperTypeName(
+  #resolveWrapperTypeName(
     typeName: ts.EntityName,
     context: TransformationContext,
     seenSymbols: Set<ts.Symbol>,
   ): string | undefined {
     const symbol = context.checker.getSymbolAtLocation(typeName);
     return symbol &&
-      this.resolveWrapperSymbolName(symbol, context, seenSymbols);
+      this.#resolveWrapperSymbolName(symbol, context, seenSymbols);
   }
 
-  private resolveWrapperSymbolName(
+  #resolveWrapperSymbolName(
     symbol: ts.Symbol,
     context: TransformationContext,
     seenSymbols: Set<ts.Symbol>,
@@ -328,7 +328,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
 
     if (symbol.flags & ts.SymbolFlags.Alias) {
       const aliasedSymbol = context.checker.getAliasedSymbol(symbol);
-      const aliasedName = this.resolveWrapperSymbolName(
+      const aliasedName = this.#resolveWrapperSymbolName(
         aliasedSymbol,
         context,
         seenSymbols,
@@ -338,27 +338,27 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
 
     const symbolName = symbol.getName();
     if (
-      this.isWrapperTypeName(symbolName) &&
-      this.hasCommonFabricDeclaration(symbol)
+      this.#isWrapperTypeName(symbolName) &&
+      this.#hasCommonFabricDeclaration(symbol)
     ) {
       return symbolName;
     }
 
     for (const declaration of symbol.declarations ?? []) {
       if (ts.isTypeAliasDeclaration(declaration)) {
-        const typeNames = this.extractTypeNames(
+        const typeNames = this.#extractTypeNames(
           declaration.type,
           context,
           seenSymbols,
         );
         const wrapperName = typeNames.find((name) =>
-          this.isWrapperTypeName(name)
+          this.#isWrapperTypeName(name)
         );
         if (wrapperName) return wrapperName;
       }
 
       if (ts.isInterfaceDeclaration(declaration)) {
-        const wrapperName = this.resolveInterfaceHeritageWrapperName(
+        const wrapperName = this.#resolveInterfaceHeritageWrapperName(
           declaration,
           context,
           seenSymbols,
@@ -370,7 +370,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     return undefined;
   }
 
-  private resolveInterfaceHeritageWrapperName(
+  #resolveInterfaceHeritageWrapperName(
     declaration: ts.InterfaceDeclaration,
     context: TransformationContext,
     seenSymbols: Set<ts.Symbol>,
@@ -381,7 +381,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
           heritageType.expression,
         );
         if (!symbol) continue;
-        const wrapperName = this.resolveWrapperSymbolName(
+        const wrapperName = this.#resolveWrapperSymbolName(
           symbol,
           context,
           seenSymbols,
@@ -393,12 +393,12 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     return undefined;
   }
 
-  private isWrapperTypeName(typeName: string): boolean {
+  #isWrapperTypeName(typeName: string): boolean {
     return FORBIDDEN_CAST_TYPE_NAMES.has(typeName) ||
       CELL_LIKE_TYPE_NAMES.has(typeName);
   }
 
-  private hasCommonFabricDeclaration(symbol: ts.Symbol): boolean {
+  #hasCommonFabricDeclaration(symbol: ts.Symbol): boolean {
     return (symbol.declarations ?? []).some((declaration) =>
       isCommonFabricDeclaration(declaration)
     );

--- a/packages/ts-transformers/src/transformers/empty-array-of-validation.ts
+++ b/packages/ts-transformers/src/transformers/empty-array-of-validation.ts
@@ -21,13 +21,13 @@ export class EmptyArrayOfValidationTransformer extends HelpersOnlyTransformer {
       if (ts.isCallExpression(node)) {
         const callKind = detectCallKind(node, checker);
         if (callKind?.kind === "cell-factory") {
-          this.validateNotEmptyArray(node, callKind.factoryName, context);
+          this.#validateNotEmptyArray(node, callKind.factoryName, context);
         }
       }
       if (ts.isNewExpression(node)) {
         const callKind = detectNewExpressionKind(node, checker);
         if (callKind?.kind === "cell-factory") {
-          this.validateNotEmptyArray(node, callKind.factoryName, context);
+          this.#validateNotEmptyArray(node, callKind.factoryName, context);
         }
       }
 
@@ -37,7 +37,7 @@ export class EmptyArrayOfValidationTransformer extends HelpersOnlyTransformer {
     return ts.visitNode(context.sourceFile, visit) as ts.SourceFile;
   }
 
-  private validateNotEmptyArray(
+  #validateNotEmptyArray(
     call: ts.CallExpression | ts.NewExpression,
     factoryName: string,
     context: TransformationContext,

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -77,7 +77,7 @@ export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
         );
         if (callback && !checked.has(callback)) {
           checked.add(callback);
-          this.checkCallback(callback, context);
+          this.#checkCallback(callback, context);
         }
       }
       ts.forEachChild(node, visit);
@@ -87,7 +87,7 @@ export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
     return context.sourceFile;
   }
 
-  private checkCallback(
+  #checkCallback(
     callback: ts.ArrowFunction | ts.FunctionExpression,
     context: TransformationContext,
   ): void {

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -24,7 +24,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
     const visit = (node: ts.Node): ts.Node => {
       // Check for .get() calls
       if (ts.isCallExpression(node)) {
-        this.validateGetCall(node, context, checker);
+        this.#validateGetCall(node, context, checker);
       }
 
       return ts.visitEachChild(node, visit, context.tsContext);
@@ -37,7 +37,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
    * Checks if a call expression is a .get() call on a Reactive type
    * and reports a helpful error if so.
    */
-  private validateGetCall(
+  #validateGetCall(
     node: ts.CallExpression,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -74,7 +74,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
 
     // Determine if the receiver is a reactive value (type-based or structural)
     const isReactive = cellKind === "opaque" ||
-      this.isReactiveExpression(receiverExpr, checker);
+      this.#isReactiveExpression(receiverExpr, checker);
 
     if (isReactive) {
       // Get the receiver text for the error message
@@ -103,7 +103,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
    * Lift/handler/action callback parameters keep their declared cell
    * semantics and must not be inferred as opaque from structure alone.
    */
-  private isReactiveExpression(
+  #isReactiveExpression(
     expr: ts.Expression,
     checker: ts.TypeChecker,
   ): boolean {
@@ -113,21 +113,22 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
 
       for (const decl of symbol.declarations ?? []) {
         if (
-          ts.isParameter(decl) && this.isPatternCallbackParameter(decl, checker)
+          ts.isParameter(decl) &&
+          this.#isPatternCallbackParameter(decl, checker)
         ) {
           return true;
         }
 
         if (ts.isVariableDeclaration(decl) && decl.initializer) {
-          if (this.isReactiveInitializer(decl.initializer, checker)) {
+          if (this.#isReactiveInitializer(decl.initializer, checker)) {
             return true;
           }
         }
 
         if (ts.isBindingElement(decl)) {
-          const parameter = this.getOwningParameter(decl);
+          const parameter = this.#getOwningParameter(decl);
           if (
-            parameter && this.isPatternCallbackParameter(parameter, checker)
+            parameter && this.#isPatternCallbackParameter(parameter, checker)
           ) {
             return true;
           }
@@ -141,7 +142,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
             parent = parent.parent;
           }
           if (ts.isVariableDeclaration(parent) && parent.initializer) {
-            if (this.isReactiveInitializer(parent.initializer, checker)) {
+            if (this.#isReactiveInitializer(parent.initializer, checker)) {
               return true;
             }
           }
@@ -152,13 +153,13 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
     if (
       ts.isPropertyAccessExpression(expr) || ts.isElementAccessExpression(expr)
     ) {
-      return this.isReactiveExpression(expr.expression, checker);
+      return this.#isReactiveExpression(expr.expression, checker);
     }
 
     return false;
   }
 
-  private getOwningParameter(
+  #getOwningParameter(
     node: ts.BindingElement,
   ): ts.ParameterDeclaration | undefined {
     let current: ts.Node = node;
@@ -172,7 +173,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
     return ts.isParameter(current) ? current : undefined;
   }
 
-  private isPatternCallbackParameter(
+  #isPatternCallbackParameter(
     param: ts.ParameterDeclaration,
     checker: ts.TypeChecker,
   ): boolean {
@@ -193,7 +194,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
       (callKind.builderName === "pattern" || callKind.builderName === "render");
   }
 
-  private isReactiveInitializer(
+  #isReactiveInitializer(
     expr: ts.Expression,
     checker: ts.TypeChecker,
   ): boolean {

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -173,11 +173,11 @@ export class PatternContextValidationTransformer
         ts.isFunctionExpression(node) ||
         ts.isFunctionDeclaration(node)
       ) {
-        this.validateFunctionCreation(node, context, checker);
+        this.#validateFunctionCreation(node, context, checker);
 
         // Check for reactive operations in standalone functions
         if (isStandaloneFunctionDefinition(node)) {
-          this.validateStandaloneFunction(node, context, checker);
+          this.#validateStandaloneFunction(node, context, checker);
         }
 
         if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
@@ -187,17 +187,17 @@ export class PatternContextValidationTransformer
             context,
           );
           if (boundarySemantics.establishesLocalReactiveAliasScope) {
-            this.validateLocalReactiveAliasUsage(node, context);
+            this.#validateLocalReactiveAliasUsage(node, context);
           }
 
-          this.validateCallbackSelfContainment(
+          this.#validateCallbackSelfContainment(
             node,
             boundarySemantics,
             context,
             checker,
           );
 
-          this.validateSupportedPatternStatements(node, context, checker);
+          this.#validateSupportedPatternStatements(node, context, checker);
         }
       }
 
@@ -207,7 +207,7 @@ export class PatternContextValidationTransformer
       // later, outside the reactive graph. Flag the class once and stop
       // descending so its members don't produce cascading diagnostics.
       if (ts.isClassExpression(node) || ts.isClassDeclaration(node)) {
-        if (this.validateClassCreation(node, context, checker)) {
+        if (this.#validateClassCreation(node, context, checker)) {
           return node;
         }
       }
@@ -220,7 +220,7 @@ export class PatternContextValidationTransformer
         ts.isGetAccessorDeclaration(node) ||
         ts.isSetAccessorDeclaration(node)
       ) {
-        this.validateObjectMemberCreation(node, context, checker);
+        this.#validateObjectMemberCreation(node, context, checker);
       }
 
       // Check for optional navigation in reactive context. Optional property /
@@ -262,10 +262,10 @@ export class PatternContextValidationTransformer
       // Check for .get() calls and lift/handler placement in reactive context
       if (ts.isCallExpression(node)) {
         // Check for lift/handler inside pattern
-        this.validateBuilderPlacement(node, context, checker);
+        this.#validateBuilderPlacement(node, context, checker);
 
         // patternTool's first argument must be a pattern() (CT-1655)
-        this.validatePatternToolFirstArgument(node, context, checker);
+        this.#validatePatternToolFirstArgument(node, context, checker);
 
         const unsupportedCallRoot = classifyUnsupportedExpressionSiteCallRoot(
           node,
@@ -298,8 +298,8 @@ export class PatternContextValidationTransformer
 
       // Check for property access used in computation (not just pass-through)
       // This applies to expressions in binary operators, conditionals, etc.
-      if (this.isComputationExpression(node)) {
-        this.validateComputationExpression(node, context, analyze);
+      if (this.#isComputationExpression(node)) {
+        this.#validateComputationExpression(node, context, analyze);
       }
 
       return ts.visitEachChild(node, visit, context.tsContext);
@@ -312,7 +312,7 @@ export class PatternContextValidationTransformer
    * Checks if this node is an expression that performs computation
    * (binary expression, unary expression, conditional, etc.)
    */
-  private isComputationExpression(node: ts.Node): boolean {
+  #isComputationExpression(node: ts.Node): boolean {
     return (
       ts.isBinaryExpression(node) ||
       ts.isPrefixUnaryExpression(node) ||
@@ -324,7 +324,7 @@ export class PatternContextValidationTransformer
   /**
    * Validates that a computation expression doesn't improperly use reactive values
    */
-  private validateComputationExpression(
+  #validateComputationExpression(
     node: ts.Node,
     context: TransformationContext,
     analyze: ReturnType<TransformationContext["getDataFlowAnalyzer"]>,
@@ -339,7 +339,7 @@ export class PatternContextValidationTransformer
       return;
     }
 
-    const problemAccess = this.findProblematicAccess(node);
+    const problemAccess = this.#findProblematicAccess(node);
     const accessText = problemAccess
       ? `'${getNodeText(problemAccess)}'`
       : "property access";
@@ -357,7 +357,7 @@ export class PatternContextValidationTransformer
   /**
    * Checks if a node is inside a JSX element
    */
-  private isInsideJsx(node: ts.Node): boolean {
+  #isInsideJsx(node: ts.Node): boolean {
     let current: ts.Node | undefined = node.parent;
     while (current) {
       if (
@@ -375,7 +375,7 @@ export class PatternContextValidationTransformer
   /**
    * Finds the first property access expression in the computation
    */
-  private findProblematicAccess(
+  #findProblematicAccess(
     node: ts.Node,
   ): ts.PropertyAccessExpression | undefined {
     let result: ts.PropertyAccessExpression | undefined;
@@ -393,7 +393,7 @@ export class PatternContextValidationTransformer
     return result;
   }
 
-  private validateLocalReactiveAliasUsage(
+  #validateLocalReactiveAliasUsage(
     func: ts.ArrowFunction | ts.FunctionExpression,
     context: TransformationContext,
   ): void {
@@ -446,7 +446,7 @@ export class PatternContextValidationTransformer
 
         if (
           ts.isIdentifier(node) &&
-          !this.isMemberAccessBase(node) &&
+          !this.#isMemberAccessBase(node) &&
           isOpaqueSourceExpression(
             node,
             EMPTY_OPAQUE_ROOTS,
@@ -503,7 +503,7 @@ export class PatternContextValidationTransformer
         checkExpression(node.condition);
       } else if (ts.isSwitchStatement(node)) {
         checkExpression(node.expression);
-      } else if (this.isComputationExpression(node)) {
+      } else if (this.#isComputationExpression(node)) {
         checkExpression(node as ts.Expression);
       }
 
@@ -513,7 +513,7 @@ export class PatternContextValidationTransformer
     visitBody(func.body);
   }
 
-  private isMemberAccessBase(node: ts.Identifier): boolean {
+  #isMemberAccessBase(node: ts.Identifier): boolean {
     const parent = node.parent;
     return !!parent &&
       (
@@ -536,7 +536,7 @@ export class PatternContextValidationTransformer
    * at validation time, which intentionally includes pattern-owned array method
    * callbacks while excluding compute-owned wrappers like computed()/lift().
    */
-  private validateSupportedPatternStatements(
+  #validateSupportedPatternStatements(
     func: ts.ArrowFunction | ts.FunctionExpression,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -657,7 +657,7 @@ export class PatternContextValidationTransformer
    * Functions inside safe wrappers (computed, action, lift, handler)
    * and inside JSX expressions are allowed since they get transformed.
    */
-  private validateFunctionCreation(
+  #validateFunctionCreation(
     node: ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -680,12 +680,12 @@ export class PatternContextValidationTransformer
     // that data object, not an event handler or array-method callback. It is
     // rejected even inside JSX, where the expression-site lowering does not
     // descend into it either.
-    if (this.isObjectLiteralPropertyValueFunction(node)) {
-      this.reportObjectMember(node, "function-property", context);
+    if (this.#isObjectLiteralPropertyValueFunction(node)) {
+      this.#reportObjectMember(node, "function-property", context);
       return;
     }
 
-    if (this.isInsideJsx(node)) {
+    if (this.#isInsideJsx(node)) {
       if (boundarySemantics?.decision.kind === "supported") {
         return;
       }
@@ -726,7 +726,7 @@ export class PatternContextValidationTransformer
    * Returns true when the class was rejected, so the caller can stop descending
    * into its members and avoid cascading per-member diagnostics.
    */
-  private validateClassCreation(
+  #validateClassCreation(
     node: ts.ClassExpression | ts.ClassDeclaration,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -767,7 +767,7 @@ export class PatternContextValidationTransformer
    * rather than written inline (`{ read: makeReader() }`, `{ read: someFn }`) is
    * not caught here.
    */
-  private validateObjectMemberCreation(
+  #validateObjectMemberCreation(
     node:
       | ts.MethodDeclaration
       | ts.GetAccessorDeclaration
@@ -779,10 +779,10 @@ export class PatternContextValidationTransformer
     if (isInsideSafeCallbackWrapper(node, checker, context)) return;
     if (!isInsideRestrictedContext(node, checker, context)) return;
 
-    this.reportObjectMember(node.name, this.objectMemberKind(node), context);
+    this.#reportObjectMember(node.name, this.#objectMemberKind(node), context);
   }
 
-  private objectMemberKind(
+  #objectMemberKind(
     node:
       | ts.MethodDeclaration
       | ts.GetAccessorDeclaration
@@ -793,7 +793,7 @@ export class PatternContextValidationTransformer
     return "method";
   }
 
-  private getStaticMemberName(name: ts.PropertyName): string | undefined {
+  #getStaticMemberName(name: ts.PropertyName): string | undefined {
     if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) {
       return name.text;
     }
@@ -816,10 +816,10 @@ export class PatternContextValidationTransformer
    * The function may be wrapped in transparent expressions (parentheses, `as`,
    * `satisfies`, `!`, `<T>`) before the property assignment.
    */
-  private isObjectLiteralPropertyValueFunction(
+  #isObjectLiteralPropertyValueFunction(
     node: ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration,
   ): boolean {
-    return !!this.getObjectLiteralFunctionPropertyAssignment(node);
+    return !!this.#getObjectLiteralFunctionPropertyAssignment(node);
   }
 
   /**
@@ -828,7 +828,7 @@ export class PatternContextValidationTransformer
    * (possibly-wrapped) function is that property's value. A bare function
    * declaration is never a property value.
    */
-  private getObjectLiteralFunctionPropertyAssignment(
+  #getObjectLiteralFunctionPropertyAssignment(
     node: ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration,
   ): ts.PropertyAssignment | undefined {
     if (ts.isFunctionDeclaration(node)) return undefined;
@@ -849,7 +849,7 @@ export class PatternContextValidationTransformer
     return undefined;
   }
 
-  private reportObjectMember(
+  #reportObjectMember(
     reportNode: ts.Node,
     kind: ObjectMemberKind,
     context: TransformationContext,
@@ -866,7 +866,7 @@ export class PatternContextValidationTransformer
    * Validates that lift() and handler() are at module scope, not inside patterns.
    * These builders create reusable functions and should be defined outside the pattern body.
    */
-  private validateBuilderPlacement(
+  #validateBuilderPlacement(
     node: ts.CallExpression,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -921,7 +921,7 @@ export class PatternContextValidationTransformer
    * both were removed in favor of an explicit, addressable pattern. Authors now
    * wrap the callback themselves: `patternTool(pattern(fn), extraParams?)`.
    */
-  private validatePatternToolFirstArgument(
+  #validatePatternToolFirstArgument(
     node: ts.CallExpression,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -948,7 +948,7 @@ export class PatternContextValidationTransformer
     });
   }
 
-  private validateCallbackSelfContainment(
+  #validateCallbackSelfContainment(
     func: ts.ArrowFunction | ts.FunctionExpression,
     boundarySemantics: CallbackBoundarySemantics,
     context: TransformationContext,
@@ -984,17 +984,17 @@ export class PatternContextValidationTransformer
         return;
       }
 
-      if (ts.isIdentifier(node) && !this.shouldIgnoreReferenceSite(node)) {
-        const symbol = this.getReferenceSymbol(node, checker);
+      if (ts.isIdentifier(node) && !this.#shouldIgnoreReferenceSite(node)) {
+        const symbol = this.#getReferenceSymbol(node, checker);
         const declarations = (symbol?.getDeclarations() ?? []).filter((decl) =>
           !ts.isShorthandPropertyAssignment(decl)
         );
         if (
           declarations.length > 0 &&
           declarations.some((decl) =>
-            this.isEnclosingFunctionScopedDeclaration(decl, func)
+            this.#isEnclosingFunctionScopedDeclaration(decl, func)
           ) &&
-          this.isCallableReference(node, declarations, checker)
+          this.#isCallableReference(node, declarations, checker)
         ) {
           report(node);
         }
@@ -1034,7 +1034,7 @@ export class PatternContextValidationTransformer
    * see that it ends up as a patternTool argument. The workaround is to inline
    * the function into the patternTool() call.
    */
-  private validateStandaloneFunction(
+  #validateStandaloneFunction(
     func: ts.ArrowFunction | ts.FunctionExpression | ts.FunctionDeclaration,
     context: TransformationContext,
     checker: ts.TypeChecker,
@@ -1126,8 +1126,8 @@ export class PatternContextValidationTransformer
     }
   }
 
-  private shouldIgnoreReferenceSite(node: ts.Identifier): boolean {
-    if (!node.parent || this.isInsideTypeNode(node)) {
+  #shouldIgnoreReferenceSite(node: ts.Identifier): boolean {
+    if (!node.parent || this.#isInsideTypeNode(node)) {
       return true;
     }
 
@@ -1179,10 +1179,10 @@ export class PatternContextValidationTransformer
     return false;
   }
 
-  private isInsideTypeNode(node: ts.Node): boolean {
+  #isInsideTypeNode(node: ts.Node): boolean {
     let current: ts.Node | undefined = node.parent;
     while (current) {
-      if (this.isTypeNode(current)) {
+      if (this.#isTypeNode(current)) {
         return true;
       }
       if (ts.isExpression(current)) {
@@ -1193,12 +1193,12 @@ export class PatternContextValidationTransformer
     return false;
   }
 
-  private isTypeNode(node: ts.Node): boolean {
+  #isTypeNode(node: ts.Node): boolean {
     return node.kind >= ts.SyntaxKind.FirstTypeNode &&
       node.kind <= ts.SyntaxKind.LastTypeNode;
   }
 
-  private getReferenceSymbol(
+  #getReferenceSymbol(
     node: ts.Identifier,
     checker: ts.TypeChecker,
   ): ts.Symbol | undefined {
@@ -1212,7 +1212,7 @@ export class PatternContextValidationTransformer
       checker.getSymbolAtLocation(ts.getOriginalNode(node));
   }
 
-  private isEnclosingFunctionScopedDeclaration(
+  #isEnclosingFunctionScopedDeclaration(
     declaration: ts.Declaration,
     func: ts.FunctionLikeDeclaration,
   ): boolean {
@@ -1243,21 +1243,21 @@ export class PatternContextValidationTransformer
     return false;
   }
 
-  private isCallableReference(
+  #isCallableReference(
     node: ts.Identifier,
     declarations: readonly ts.Declaration[],
     checker: ts.TypeChecker,
   ): boolean {
     if (
-      declarations.some((declaration) => this.isSyntacticCallable(declaration))
+      declarations.some((declaration) => this.#isSyntacticCallable(declaration))
     ) {
       return true;
     }
 
     if (
-      !this.isCallableUseSite(node) &&
+      !this.#isCallableUseSite(node) &&
       !declarations.some((declaration) =>
-        this.shouldCheckInferredCallabilityForCapture(declaration)
+        this.#shouldCheckInferredCallabilityForCapture(declaration)
       )
     ) {
       return false;
@@ -1273,7 +1273,7 @@ export class PatternContextValidationTransformer
       type.getConstructSignatures().length > 0;
   }
 
-  private shouldCheckInferredCallabilityForCapture(
+  #shouldCheckInferredCallabilityForCapture(
     declaration: ts.Declaration,
   ): boolean {
     return (
@@ -1284,7 +1284,7 @@ export class PatternContextValidationTransformer
     );
   }
 
-  private isSyntacticCallable(declaration: ts.Declaration): boolean {
+  #isSyntacticCallable(declaration: ts.Declaration): boolean {
     if (
       ts.isFunctionDeclaration(declaration) ||
       ts.isFunctionExpression(declaration) ||
@@ -1306,27 +1306,27 @@ export class PatternContextValidationTransformer
         }
       }
       return !!declaration.type &&
-        this.isCallableTypeNode(declaration.type);
+        this.#isCallableTypeNode(declaration.type);
     }
 
     if (ts.isParameter(declaration)) {
-      return !!declaration.type && this.isCallableTypeNode(declaration.type);
+      return !!declaration.type && this.#isCallableTypeNode(declaration.type);
     }
 
     return false;
   }
 
-  private isCallableTypeNode(type: ts.TypeNode): boolean {
+  #isCallableTypeNode(type: ts.TypeNode): boolean {
     if (ts.isFunctionTypeNode(type) || ts.isConstructorTypeNode(type)) {
       return true;
     }
 
     if (ts.isParenthesizedTypeNode(type)) {
-      return this.isCallableTypeNode(type.type);
+      return this.#isCallableTypeNode(type.type);
     }
 
     if (ts.isUnionTypeNode(type) || ts.isIntersectionTypeNode(type)) {
-      return type.types.some((member) => this.isCallableTypeNode(member));
+      return type.types.some((member) => this.#isCallableTypeNode(member));
     }
 
     if (
@@ -1340,7 +1340,7 @@ export class PatternContextValidationTransformer
     return false;
   }
 
-  private isCallableUseSite(node: ts.Identifier): boolean {
+  #isCallableUseSite(node: ts.Identifier): boolean {
     const parent = node.parent;
     return !!parent &&
       (

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -65,7 +65,7 @@ export class VerbReturnValidationTransformer extends HelpersOnlyTransformer {
           (callKind.builderName === "action" ||
             callKind.builderName === "handler")
         ) {
-          this.validateVoidDeclaredBody(node, callKind.builderName, context);
+          this.#validateVoidDeclaredBody(node, callKind.builderName, context);
         }
       }
       // JSX-aware: the stock visitor skips `JsxExpression.expression`, which
@@ -76,7 +76,7 @@ export class VerbReturnValidationTransformer extends HelpersOnlyTransformer {
     return ts.visitNode(context.sourceFile, visit) as ts.SourceFile;
   }
 
-  private validateVoidDeclaredBody(
+  #validateVoidDeclaredBody(
     call: ts.CallExpression,
     builderName: VerbBuilderName,
     context: TransformationContext,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Converts all 72 of `ts-transformers`'s TypeScript-`private` class members to
JavaScript `#` private names, per `docs/development/DEVELOPMENT.md` § Classes.
Nothing is held back: no member is reached by a test, and none is decorated —
the first package in this series where the count goes to zero with no
exemptions at all.

All 72 are in `src`. The fixture inputs under `test/fixtures/` are transformer
source rather than transformer code, and are untouched.

## Documentation

Two comments named `TransformationContext.invalidateReactiveAnalysisCaches`,
one of them in `docs/array-method-callback-pipeline.md`. Both now name the `#`
member. The comment in `ast/dataflow.ts` was reflowed to fit, and checked to
hold the same words afterward rather than merely to fit.

## Verification

The tool's count was reconciled against an independent census before the
apply: 72 `private` members, 72 converted, no residue.

Behavior here is pinned from two directions — this package's own goldens, and
`schema-generator`'s emission, which these goldens also fix. Both suites pass.
So do `js-compiler`, `cli`, `piece`, and `runner` (1321 passed, 0 failed),
which together with `schema-generator` are every package importing this one.

`deno fmt --check`, `deno lint`, `deno task check`, and `deno task check-docs`
pass. Sweeps report none for: prose naming a member as `Class.member`, a doc
comment missing its blank line above, and a `//` comment stranded beside one.

A fourth sweep is new here, for a comment naming a renamed member by its bare
name — the shape a `Class.member` search cannot see. It is scoped to the file
that declares the member and to comment spans, and it requires a backticked
reference so that an ordinary English word matching a member name (`state`,
`parameters`) is not swept in. Checked in both directions before being trusted:
it flags a bare `` `_unsubscribeFavorites` `` in a comment, and ignores
`state` used as prose.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

