### PR TITLE
build(api): the type-profiling harness targets `ESNext`

### DIFF
--- a/packages/api/perf/README.md
+++ b/packages/api/perf/README.md
@@ -13,6 +13,9 @@ when rolling it.
 The profiling projects use TypeScript's own module resolver rather than Deno's.
 `tsconfig.base.json` therefore maps the workspace imports reached from the API
 source. Add a path there when the API begins importing another workspace entry.
+Its `target` is `ESNext`, matching the `esnext` lib the workspace's `deno.jsonc`
+names. A narrower target rejects source that type-checks everywhere else in the
+tree.
 
 ## Quick Metrics
 

--- a/packages/api/perf/tsconfig.base.json
+++ b/packages/api/perf/tsconfig.base.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    // What belongs here is `ES2026`, the version that defines
+    // `Error.isError()`. The pinned TypeScript does not recognize that
+    // target, and declares the method only in its `esnext` lib.
+    "target": "ESNext",
     "module": "NodeNext",
     "moduleResolution": "Node16",
     "strict": true,

--- a/packages/api/perf/tsconfig.base.json
+++ b/packages/api/perf/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    // What belongs here is `ES2026`, the version that defines
-    // `Error.isError()`. The pinned TypeScript does not recognize that
-    // target, and declares the method only in its `esnext` lib.
+    // `data-model` requires `Error.isError()`, which is introduced in
+    // ES2026. As of this writing, TypeScript does not recognize `es2026`,
+    // so we use `ESNext` instead.
     "target": "ESNext",
     "module": "NodeNext",
     "moduleResolution": "Node16",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`packages/api/perf/tsconfig.base.json` targeted `ES2022`, whose standard library
does not declare `Error.isError()`. That harness type-checks `data-model` source
through its `@/*` path mapping using real `tsc`, so a `data-model` call to that
method fails the `api` package's own test task with TS2550 even though every
Deno-side check passes. The root `deno.jsonc` already names `esnext` in its
`lib` array; only this harness disagreed, and it is the sole `tsconfig` in the
tree that sets a `target` for workspace source.

## Why `ESNext` and not a numbered version

`ESNext` is the only target the pinned TypeScript recognizes that carries the
method. Measured against a one-line probe calling `Error.isError()`:

| target | result |
| --- | --- |
| `ES2022` - `ES2025` | TS2550, property does not exist |
| `ES2026` | TS6046, not a recognized target |
| `ESNext` | clean |

The ladder stops at `es2025`, and `Error.isError()` is declared in
`lib.esnext.error.d.ts`, which only `lib.esnext.d.ts` references. A comment on
the setting records that `ES2026` is the version that actually defines it, so
the intent survives the next TypeScript roll.

## Cost

The added standard library is a fixed cost rather than a scaling one, and lands
identically on every scenario because all of them extend this file:

| project | files | types | instantiations |
| --- | --- | --- | --- |
| `baseline` | 81 -> 111 | 6476 -> 7676 | 8716 -> 11402 |
| `key` | 81 -> 111 | 94799 -> 95999 | 1161487 -> 1164173 |
| `ikeyable-realistic` | 81 -> 111 | 7803 -> 9003 | 11020 -> 13742 |

The type delta is +1200 in all three and the instantiation delta ~+2700, which
is what makes it fixed. Reading a scenario relative to the baseline, which is
how the harness is meant to be read, is unaffected; the absolute numbers in any
existing notes shift by that constant.

## Verification

- `deno task test` in `packages/api`: green.
- `deno task check`, `deno lint`, `deno fmt --check`: green repo-wide. `deno fmt`
  tolerates the comment in this `.json` file, confirmed by a control that
  mis-indents it and observes `--check` fail on that path.
- Differential on `danfuzz/native-builtin-tags`, which is where the TS2550
  currently fires: that branch's `api` task exits 2 with this file as it stands
  on `main`, and exits 0 with the version in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FStELffQSLrgyz2VuK8n3e


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

