### PR TITLE
refactor(data-model): the builtin class lookup becomes its own module

### DIFF
--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -31,7 +31,6 @@ import {
 
 import {
   type FabricConvertibleValue,
-  type FabricNativeObject,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -43,6 +42,7 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeValue } from "./native-type-tags.ts";
+import { isValidFabricNativeObject } from "./type-check.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 
@@ -161,33 +161,6 @@ export function shallowCleanPlainObject(
   }
 
   return result;
-}
-
-/**
- * Returns `true` if the value is a `FabricNativeObject`: one of the
- * "wild-west" native JS instances that the conversion layer wraps into a
- * `FabricNativeWrapper` subclass, a `FabricPrimitive`, or a `FabricInstance`.
- *
- * Arrays, plain objects, and system-defined `FabricPrimitive`s are recognized
- * by `tagFromNativeValue()` but are _not_ `FabricNativeObject`s -- they have
- * their own handling paths in the conversion layer.
- *
- * This function is a TypeScript type guard for `FabricNativeObject`.
- */
-export function isValidFabricNativeObject(
-  value: unknown,
-): value is FabricNativeObject {
-  switch (tagFromNativeValue(value)) {
-    case VALUE_TAGS.Error:
-    case VALUE_TAGS.Map:
-    case VALUE_TAGS.Set:
-    case VALUE_TAGS.Date:
-    case VALUE_TAGS.Uint8Array:
-    case VALUE_TAGS.RegExp:
-      return true;
-    default:
-      return false;
-  }
 }
 
 /** Map from Error subclass name to its constructor. */

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -16,6 +16,7 @@
 import { constructorOfPrototype } from "@commonfabric/utils/objects";
 
 import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
+import { tagFromNativeBuiltinClass } from "./tagFromNativeBuiltinClass.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
@@ -39,44 +40,23 @@ export function isNativeError(value: unknown): value is Error {
 }
 
 /**
- * Maps a constructor to its native-instance tag. Returns the tag string if
- * the constructor is a recognized type (JS builtins or system-defined
- * `FabricPrimitive`s), or `null` otherwise.
+ * Maps a constructor to its tag. Returns the tag string if the constructor is a
+ * recognized type (JS builtins or system-defined `FabricPrimitive`s), or `null`
+ * otherwise.
  *
- * Uses a `switch` on the constructor identity for O(1) dispatch (instead of
- * sequential `instanceof` checks). Falls back to `instanceof Error` on the
- * constructor's prototype to catch exotic `Error` subclasses. (Note:
- * `Error.isError()` doesn't work on prototype objects -- it only recognizes
- * actual `Error` instances, not the prototype chain -- so we use `instanceof`.)
+ * The builtins are asked first, by `tagFromNativeBuiltinClass()`. Order decides
+ * nothing between the two -- a class is in one list or the other, never both --
+ * so what it is chosen for is cost: a `switch` on object identity compares in
+ * order, and plain objects and arrays outnumber everything else this is asked
+ * about by a wide margin.
  */
 export function tagFromNativeClass(
   constructorFn: { prototype: unknown },
 ): ValueTag | null {
-  switch (constructorFn) {
-    // `Error` and standard subclasses all map to the `Error` tag.
-    case Error:
-    case TypeError:
-    case RangeError:
-    case SyntaxError:
-    case ReferenceError:
-    case URIError:
-    case EvalError:
-      return VALUE_TAGS.Error;
+  const builtin = tagFromNativeBuiltinClass(constructorFn);
+  if (builtin !== null) return builtin;
 
-    case Array:
-      return VALUE_TAGS.Array;
-    case Object:
-      return VALUE_TAGS.Object;
-    case Map:
-      return VALUE_TAGS.Map;
-    case Set:
-      return VALUE_TAGS.Set;
-    case Date:
-      return VALUE_TAGS.Date;
-    case Uint8Array:
-      return VALUE_TAGS.Uint8Array;
-    case RegExp:
-      return VALUE_TAGS.RegExp;
+  switch (constructorFn) {
     case FabricBytes:
       return VALUE_TAGS.FabricBytes;
     case FabricEpochNsec:
@@ -89,17 +69,7 @@ export function tagFromNativeClass(
       return VALUE_TAGS.FabricKeyPair;
     case FabricRegExp:
       return VALUE_TAGS.FabricRegExp;
-
     default:
-      // Catch exotic `Error` subclasses (e.g. custom subclasses with
-      // non-standard constructors). Guard against non-function values
-      // (e.g. null-prototype objects where `constructor()` is undefined).
-      if (
-        typeof constructorFn === "function" &&
-        constructorFn.prototype instanceof Error
-      ) {
-        return VALUE_TAGS.Error;
-      }
       return null;
   }
 }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -4,13 +4,20 @@
  * tags a wire format writes, which say what it became.
  *
  * The question is harder than an `instanceof` because the answer must not be
- * forgeable, and must still be reachable for a value that did not come from
- * here. A class is read off the prototype rather than off the value, since an
- * own `constructor` property is ordinary data that would otherwise let a plain
- * record present itself as an `Error`. A value from another realm, or one
- * whose prototype has been severed, has to be recognized regardless, which is
+ * forgeable. A class is read off the prototype rather than off the value,
+ * since an own `constructor` property is ordinary data that would otherwise
+ * let a plain record present itself as an `Error`.
+ *
+ * Two kinds of value are recognized with no reachable class at all, which is
  * why the constructor switch has fallbacks beneath it rather than standing
- * alone.
+ * alone: an array, by `Array.isArray()`, and an error, by `Error.isError()`.
+ * Each tests an internal slot rather than a prototype, so each holds across
+ * realms and through a severed prototype.
+ *
+ * Nothing else does. A `Date`, `Map`, `Set`, `RegExp` or `Uint8Array` is
+ * recognized by constructor identity, which is a per-realm question, and one
+ * of those from another realm is reported as unrecognized. Values from another
+ * realm are outside what this is asked about.
  */
 
 import { constructorOfPrototype } from "@commonfabric/utils/objects";

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -33,20 +33,6 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricInstance } from "./interface.ts";
 
 /**
- * Checks whether a value is a native `Error`.
- *
- * `Error.isError()` recognizes errors from other realms when the engine
- * provides it. Engines without it fall back to `instanceof`, which recognizes
- * errors that share the current realm's prototype hierarchy.
- */
-export function isNativeError(value: unknown): value is Error {
-  const isError = (Error as { isError?: (value: unknown) => boolean }).isError;
-  return typeof isError === "function"
-    ? isError(value)
-    : value instanceof Error;
-}
-
-/**
  * Maps a constructor to its tag. Returns the tag string if the constructor is a
  * recognized type (JS builtins or system-defined `FabricPrimitive`s), or `null`
  * otherwise.
@@ -130,7 +116,7 @@ export function tagFromNativeValue(value: unknown): ValueTag | null {
   // tagged `Object` so the object rule decides it by name, the same way an
   // indirect array is decided by the array rule.
   if (proto === null) {
-    return isNativeError(value) ? VALUE_TAGS.Error : VALUE_TAGS.Object;
+    return Error.isError(value) ? VALUE_TAGS.Error : VALUE_TAGS.Object;
   }
 
   // The class is read from the PROTOTYPE, not from the value. What is being
@@ -151,7 +137,7 @@ export function tagFromNativeValue(value: unknown): ValueTag | null {
   // `Error`s with no reachable constructor -- e.g. one from another realm. An
   // ordinary subclass (including `DOMException`) never gets here:
   // `tagFromNativeClass()` matches it via `prototype instanceof Error`.
-  if (isNativeError(value)) return VALUE_TAGS.Error;
+  if (Error.isError(value)) return VALUE_TAGS.Error;
 
   // `FabricInstance` values (object-like protocol types).
   if (value instanceof FabricInstance) return VALUE_TAGS.FabricInstance;

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -57,20 +57,33 @@ export function tagFromNativeClass(
   if (builtin !== null) return builtin;
 
   switch (constructorFn) {
-    case FabricBytes:
+    case FabricBytes: {
       return VALUE_TAGS.FabricBytes;
-    case FabricEpochNsec:
+    }
+
+    case FabricEpochNsec: {
       return VALUE_TAGS.EpochNsec;
-    case FabricEpochDay:
+    }
+
+    case FabricEpochDay: {
       return VALUE_TAGS.EpochDay;
-    case FabricHash:
+    }
+
+    case FabricHash: {
       return VALUE_TAGS.Hash;
-    case FabricKeyPair:
+    }
+
+    case FabricKeyPair: {
       return VALUE_TAGS.FabricKeyPair;
-    case FabricRegExp:
+    }
+
+    case FabricRegExp: {
       return VALUE_TAGS.FabricRegExp;
-    default:
+    }
+
+    default: {
       return null;
+    }
   }
 }
 

--- a/packages/data-model/src/tagFromNativeBuiltinClass.ts
+++ b/packages/data-model/src/tagFromNativeBuiltinClass.ts
@@ -1,36 +1,20 @@
-/**
- * Recognizing the native JS builtins, which is the part of the dispatch that
- * needs no class this system defines.
- *
- * It is separate for the sake of where its callers sit. Recognizing a
- * `FabricBytes` means holding the `FabricBytes` class, and a concrete fabric
- * class reaches the codecs and, through them, the instance bases -- so a module
- * that asks about the fabric classes is layered above them. `type-check.ts` is
- * layered _below_ them, and still has to be able to tell a `Date` from a `Map`
- * from an ordinary class instance; this is what it asks. `native-type-tags.ts`
- * asks this first and then its own.
- *
- * What this file must not import is any module that knows a fabric class, since
- * that is the whole of what its callers cannot reach. `VALUE_TAGS.ts` is below
- * even this one and is fine; anything else deserves a second look.
- */
-
 import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
 
 /**
  * Maps a constructor to its tag, for the native JS builtins alone. Returns
- * `null` for anything else, a fabric class included -- `tagFromNativeClass()`
- * is what knows those.
+ * `null` for anything else, a fabric class included.
  *
- * Uses a `switch` on the constructor identity for dispatch (instead of
- * sequential `instanceof` checks). Falls back to `instanceof Error` on the
- * constructor's prototype to catch exotic `Error` subclasses. (Note:
- * `Error.isError()` doesn't work on prototype objects -- it only recognizes
- * actual `Error` instances, not the prototype chain -- so we use `instanceof`.)
+ * Answering this needs no class this system defines, which is what lets code
+ * layered below the fabric classes ask it at all: recognizing a `FabricBytes`
+ * would mean holding that class, and a concrete fabric class reaches the
+ * codecs and, through them, the instance bases. Nothing here may import a
+ * module that knows a fabric class, for that reason.
  */
 export function tagFromNativeBuiltinClass(
   constructorFn: { prototype: unknown },
 ): ValueTag | null {
+  // A `switch` on constructor identity, rather than sequential `instanceof`
+  // checks.
   switch (constructorFn) {
     // The two commonest by a distance, and a `switch` on object identity
     // compares in order, so they are asked first.
@@ -62,7 +46,9 @@ export function tagFromNativeBuiltinClass(
 
     default:
       // Catch exotic `Error` subclasses (e.g. custom subclasses with
-      // non-standard constructors). Guard against non-function values
+      // non-standard constructors). `Error.isError()` is no use here: it
+      // recognizes actual `Error` instances, not a prototype chain, and what
+      // is in hand is a constructor. Guard against non-function values too
       // (e.g. null-prototype objects where `constructor()` is undefined).
       if (
         typeof constructorFn === "function" &&

--- a/packages/data-model/src/tagFromNativeBuiltinClass.ts
+++ b/packages/data-model/src/tagFromNativeBuiltinClass.ts
@@ -18,10 +18,13 @@ export function tagFromNativeBuiltinClass(
   switch (constructorFn) {
     // The two commonest by a distance, and a `switch` on object identity
     // compares in order, so they are asked first.
-    case Object:
+    case Object: {
       return VALUE_TAGS.Object;
-    case Array:
+    }
+
+    case Array: {
       return VALUE_TAGS.Array;
+    }
 
     // `Error` and standard subclasses all map to the `Error` tag.
     case Error:
@@ -30,19 +33,29 @@ export function tagFromNativeBuiltinClass(
     case SyntaxError:
     case ReferenceError:
     case URIError:
-    case EvalError:
+    case EvalError: {
       return VALUE_TAGS.Error;
+    }
 
-    case Map:
+    case Map: {
       return VALUE_TAGS.Map;
-    case Set:
+    }
+
+    case Set: {
       return VALUE_TAGS.Set;
-    case Date:
+    }
+
+    case Date: {
       return VALUE_TAGS.Date;
-    case Uint8Array:
+    }
+
+    case Uint8Array: {
       return VALUE_TAGS.Uint8Array;
-    case RegExp:
+    }
+
+    case RegExp: {
       return VALUE_TAGS.RegExp;
+    }
 
     default: {
       // Catch exotic `Error` subclasses (e.g. custom subclasses with

--- a/packages/data-model/src/tagFromNativeBuiltinClass.ts
+++ b/packages/data-model/src/tagFromNativeBuiltinClass.ts
@@ -44,7 +44,7 @@ export function tagFromNativeBuiltinClass(
     case RegExp:
       return VALUE_TAGS.RegExp;
 
-    default:
+    default: {
       // Catch exotic `Error` subclasses (e.g. custom subclasses with
       // non-standard constructors). `Error.isError()` is no use here: it
       // recognizes actual `Error` instances, not a prototype chain, and what
@@ -57,5 +57,6 @@ export function tagFromNativeBuiltinClass(
         return VALUE_TAGS.Error;
       }
       return null;
+    }
   }
 }

--- a/packages/data-model/src/tagFromNativeBuiltinClass.ts
+++ b/packages/data-model/src/tagFromNativeBuiltinClass.ts
@@ -9,6 +9,13 @@ import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
  * would mean holding that class, and a concrete fabric class reaches the
  * codecs and, through them, the instance bases. Nothing here may import a
  * module that knows a fabric class, for that reason.
+ *
+ * Recognition is by constructor identity, which is a per-realm question:
+ * another realm's `Date` is a different `Date`, and is not this one. Values
+ * from another realm are outside what this is asked about, so no brand check
+ * stands behind the identity comparison. A cross-realm value that did arrive
+ * would come back `null` -- unrecognized rather than misidentified, which is
+ * the direction an unhandled case should fail in.
  */
 export function tagFromNativeBuiltinClass(
   constructorFn: { prototype: unknown },

--- a/packages/data-model/src/tagFromNativeBuiltinClass.ts
+++ b/packages/data-model/src/tagFromNativeBuiltinClass.ts
@@ -1,0 +1,75 @@
+/**
+ * Recognizing the native JS builtins, which is the part of the dispatch that
+ * needs no class this system defines.
+ *
+ * It is separate for the sake of where its callers sit. Recognizing a
+ * `FabricBytes` means holding the `FabricBytes` class, and a concrete fabric
+ * class reaches the codecs and, through them, the instance bases -- so a module
+ * that asks about the fabric classes is layered above them. `type-check.ts` is
+ * layered _below_ them, and still has to be able to tell a `Date` from a `Map`
+ * from an ordinary class instance; this is what it asks. `native-type-tags.ts`
+ * asks this first and then its own.
+ *
+ * What this file must not import is any module that knows a fabric class, since
+ * that is the whole of what its callers cannot reach. `VALUE_TAGS.ts` is below
+ * even this one and is fine; anything else deserves a second look.
+ */
+
+import { VALUE_TAGS, type ValueTag } from "./VALUE_TAGS.ts";
+
+/**
+ * Maps a constructor to its tag, for the native JS builtins alone. Returns
+ * `null` for anything else, a fabric class included -- `tagFromNativeClass()`
+ * is what knows those.
+ *
+ * Uses a `switch` on the constructor identity for dispatch (instead of
+ * sequential `instanceof` checks). Falls back to `instanceof Error` on the
+ * constructor's prototype to catch exotic `Error` subclasses. (Note:
+ * `Error.isError()` doesn't work on prototype objects -- it only recognizes
+ * actual `Error` instances, not the prototype chain -- so we use `instanceof`.)
+ */
+export function tagFromNativeBuiltinClass(
+  constructorFn: { prototype: unknown },
+): ValueTag | null {
+  switch (constructorFn) {
+    // The two commonest by a distance, and a `switch` on object identity
+    // compares in order, so they are asked first.
+    case Object:
+      return VALUE_TAGS.Object;
+    case Array:
+      return VALUE_TAGS.Array;
+
+    // `Error` and standard subclasses all map to the `Error` tag.
+    case Error:
+    case TypeError:
+    case RangeError:
+    case SyntaxError:
+    case ReferenceError:
+    case URIError:
+    case EvalError:
+      return VALUE_TAGS.Error;
+
+    case Map:
+      return VALUE_TAGS.Map;
+    case Set:
+      return VALUE_TAGS.Set;
+    case Date:
+      return VALUE_TAGS.Date;
+    case Uint8Array:
+      return VALUE_TAGS.Uint8Array;
+    case RegExp:
+      return VALUE_TAGS.RegExp;
+
+    default:
+      // Catch exotic `Error` subclasses (e.g. custom subclasses with
+      // non-standard constructors). Guard against non-function values
+      // (e.g. null-prototype objects where `constructor()` is undefined).
+      if (
+        typeof constructorFn === "function" &&
+        constructorFn.prototype instanceof Error
+      ) {
+        return VALUE_TAGS.Error;
+      }
+      return null;
+  }
+}

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -15,7 +15,10 @@
  */
 
 import { isInertArray } from "@commonfabric/utils/arrays";
-import { isInertPlainObject } from "@commonfabric/utils/objects";
+import {
+  constructorOfObject,
+  isInertPlainObject,
+} from "@commonfabric/utils/objects";
 import {
   isPlainContainer,
   isPlainObject,
@@ -26,11 +29,14 @@ import {
   type FabricArray,
   type FabricContainerValue,
   FabricInstance,
+  type FabricNativeObject,
   type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
 } from "./interface.ts";
+import { VALUE_TAGS } from "./VALUE_TAGS.ts";
+import { tagFromNativeBuiltinClass } from "./tagFromNativeBuiltinClass.ts";
 import { BaseFabricInstance } from "./fabric-bases/BaseFabricInstance.ts";
 import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
 
@@ -299,4 +305,45 @@ export function isFabricPlainObject(
   value: FabricValue,
 ): value is FabricPlainObject {
   return isPlainObject(value);
+}
+
+/**
+ * Returns `true` if the value is a `FabricNativeObject`: one of the
+ * "wild-west" native JS instances that the conversion layer wraps into a
+ * `FabricNativeWrapper` subclass, a `FabricPrimitive`, or a `FabricInstance`.
+ *
+ * Arrays, plain objects, and system-defined `FabricPrimitive`s are _not_
+ * `FabricNativeObject`s -- they have their own handling paths in the
+ * conversion layer.
+ *
+ * This function is a TypeScript type guard for `FabricNativeObject`.
+ */
+export function isValidFabricNativeObject(
+  value: unknown,
+): value is FabricNativeObject {
+  if (value === null || typeof value !== "object") return false;
+
+  // Arrays first, and unconditionally, exactly as the full dispatch does it.
+  // An array's class is USUALLY `Array`, whose tag is not one of the six
+  // below -- but a prototype can be re-pointed, and an array wearing
+  // `Date.prototype` would otherwise be reported as a convertible `Date`.
+  // `Array.isArray()` sees through that, and through a subclass and a severed
+  // prototype besides, which is why the array rule alone decides what an array
+  // may be.
+  if (Array.isArray(value)) return false;
+
+  const ctor = constructorOfObject(value);
+  const tag = (ctor !== undefined) ? tagFromNativeBuiltinClass(ctor) : null;
+
+  switch (tag ?? (Error.isError(value) ? VALUE_TAGS.Error : null)) {
+    case VALUE_TAGS.Error:
+    case VALUE_TAGS.Map:
+    case VALUE_TAGS.Set:
+    case VALUE_TAGS.Date:
+    case VALUE_TAGS.Uint8Array:
+    case VALUE_TAGS.RegExp:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -325,8 +325,9 @@ export function isValidFabricNativeObject(
 
   // Arrays first, and unconditionally, exactly as the full dispatch does it.
   // An array's class is USUALLY `Array`, whose tag is not one of the six
-  // below -- but a prototype can be re-pointed, and an array wearing
-  // `Date.prototype` would otherwise be reported as a convertible `Date`.
+  // below -- but a prototype can be re-pointed, and an array whose
+  // `prototype` is `Date.prototype` would otherwise be reported as a
+  // convertible `Date`.
   // `Array.isArray()` sees through that, and through a subclass and a severed
   // prototype besides, which is why the array rule alone decides what an array
   // may be.

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -341,9 +341,12 @@ export function isValidFabricNativeObject(
     case VALUE_TAGS.Set:
     case VALUE_TAGS.Date:
     case VALUE_TAGS.Uint8Array:
-    case VALUE_TAGS.RegExp:
+    case VALUE_TAGS.RegExp: {
       return true;
-    default:
+    }
+
+    default: {
       return false;
+    }
   }
 }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -336,12 +336,10 @@ export function isValidFabricNativeObject(
   const ctor = constructorOfObject(value);
   const tag = (ctor !== undefined) ? tagFromNativeBuiltinClass(ctor) : null;
 
-  // `Error.isError()` is called directly rather than through a guarded
-  // wrapper. It is the test that holds across realms, where `instanceof` does
-  // not, and the one environment here that used to lack the method -- SES
-  // lockdown, which rebuilds the `Error` constructor -- has it restored before
-  // any of this runs. A guarded fallback would be unreachable on every runtime
-  // this supports, and wrong on one old enough to need it.
+  // `Error.isError()` is the test that holds across realms, where `instanceof`
+  // does not, and it is what sees an error whose constructor is unreachable.
+  // The one environment here that rebuilds the `Error` constructor -- SES
+  // lockdown -- has the method restored before any of this runs.
   switch (tag ?? (Error.isError(value) ? VALUE_TAGS.Error : null)) {
     case VALUE_TAGS.Error:
     case VALUE_TAGS.Map:

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -336,6 +336,12 @@ export function isValidFabricNativeObject(
   const ctor = constructorOfObject(value);
   const tag = (ctor !== undefined) ? tagFromNativeBuiltinClass(ctor) : null;
 
+  // `Error.isError()` is called directly rather than through a guarded
+  // wrapper. It is the test that holds across realms, where `instanceof` does
+  // not, and the one environment here that used to lack the method -- SES
+  // lockdown, which rebuilds the `Error` constructor -- has it restored before
+  // any of this runs. A guarded fallback would be unreachable on every runtime
+  // this supports, and wrong on one old enough to need it.
   switch (tag ?? (Error.isError(value) ? VALUE_TAGS.Error : null)) {
     case VALUE_TAGS.Error:
     case VALUE_TAGS.Map:

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -29,7 +29,7 @@ import {
   shallowFabricFromNativeValue,
 } from "@/fabric-value.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { isValidFabricNativeObject } from "@/native-conversion.ts";
+import { isValidFabricNativeObject } from "@/type-check.ts";
 import { tagFromNativeClass, tagFromNativeValue } from "@/native-type-tags.ts";
 import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import { hashOf } from "@/value-hash.ts";

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -27,6 +27,22 @@ export class PlainClass {}
 export class ArraySubclass extends Array {}
 
 /**
+ * An `Error` subclass reached by the class lookup's `prototype instanceof
+ * Error` fallback rather than by an identity case.
+ */
+export class WeirdError extends RangeError {}
+
+/**
+ * Returns an `Error` whose prototype has been severed, so that it names no
+ * class and only the internal-slot test still sees it as an error.
+ */
+function severedError(): Error {
+  const error = new Error("severed");
+  Object.setPrototypeOf(error, null);
+  return error;
+}
+
+/**
  * One entry per dispatch arm, labeled. The labels reach test names, so they
  * read as noun phrases.
  */
@@ -66,6 +82,8 @@ export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
   ["a `Uint8Array`", new Uint8Array([1, 2, 3])],
   ["a `RegExp`", /abc/gi],
   ["an `Error`", new Error("boom")],
+  ["a custom `Error` subclass instance", new WeirdError("weird")],
+  ["an `Error` whose prototype was severed", severedError()],
   ["a `Map`", new Map()],
   ["a `Set`", new Set()],
 ];

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -1,0 +1,71 @@
+/**
+ * The shared population the value-dispatch cross-checks run over.
+ *
+ * `tagFromNativeValue()` names what a value already is,
+ * `isValidFabricNativeObject()` decides a subset of that answer by a narrower
+ * route, and `isValidFabricValueLayer()` decides membership -- so each is
+ * worth checking against the others rather than only against a hand-picked
+ * case. This carries one entry per arm of the dispatch those functions make,
+ * plus the shapes each arm accepts and refuses; an entry dropped from here is
+ * an arm the cross-checks stop reaching.
+ */
+
+import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricKeyPair } from "@/fabric-primitives/FabricKeyPair.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+
+/** A class with no fabric representation, wanted here by name. */
+export class PlainClass {}
+
+/**
+ * An `Array` subclass, whose instances are live code rather than inert data.
+ */
+export class ArraySubclass extends Array {}
+
+/**
+ * One entry per dispatch arm, labeled. The labels reach test names, so they
+ * read as noun phrases.
+ */
+export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
+  ["a boolean", true],
+  ["a string", "hello"],
+  ["a number", 42],
+  ["a `bigint`", 42n],
+  ["`null`", null],
+  ["`undefined`", undefined],
+  ["a registry-interned symbol", Symbol.for("fabric-value-corpus")],
+  ["a unique symbol", Symbol("nope")],
+  ["a function", () => {}],
+  ["an inert array", [1, 2, 3]],
+  ["an inert plain object", { a: 1 }],
+  ["an array carrying a named property", Object.assign([1], { z: 1 })],
+  ["an `Array` subclass instance", ArraySubclass.from([1, 2])],
+  ["an object carrying a symbol key", { a: 1, [Symbol.for("k")]: 2 }],
+  ["an object carrying a reserved property name", { ["__proto__"]: 1 }],
+  ["a null-prototype object", Object.assign(Object.create(null), { a: 1 })],
+  ["a class instance", new PlainClass()],
+  ["a `FabricBytes`", new FabricBytes(new Uint8Array([1]))],
+  ["a `FabricEpochNsec`", new FabricEpochNsec(0n)],
+  ["a `FabricEpochDay`", new FabricEpochDay(0n)],
+  ["a `FabricRegExp`", new FabricRegExp(/a/)],
+  ["a `FabricHash`", new FabricHash(new Uint8Array(32), "fid1")],
+  [
+    "a `FabricKeyPair`",
+    new FabricKeyPair(
+      "ExampleAlgorithm",
+      new Uint8Array([1]),
+      new Uint8Array([2]),
+    ),
+  ],
+  ["a `FabricError`", FabricError.fromNativeError(new Error("x"))],
+  ["a `Date`", new Date(1234)],
+  ["a `Uint8Array`", new Uint8Array([1, 2, 3])],
+  ["a `RegExp`", /abc/gi],
+  ["an `Error`", new Error("boom")],
+  ["a `Map`", new Map()],
+  ["a `Set`", new Set()],
+];

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -36,7 +36,7 @@ export class WeirdError extends RangeError {}
  * Returns an array whose prototype has been re-pointed at `Date.prototype`, so
  * that its class reads as `Date` and only the array rule still sees an array.
  */
-function arrayWearingDatePrototype(): unknown {
+function arrayWithDatePrototype(): unknown {
   return Object.setPrototypeOf([1], Date.prototype);
 }
 
@@ -68,7 +68,10 @@ export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
   ["an inert plain object", { a: 1 }],
   ["an array carrying a named property", Object.assign([1], { z: 1 })],
   ["an `Array` subclass instance", ArraySubclass.from([1, 2])],
-  ["an array wearing `Date.prototype`", arrayWearingDatePrototype()],
+  [
+    "an array whose `prototype` is `Date.prototype`",
+    arrayWithDatePrototype(),
+  ],
   ["an object carrying a symbol key", { a: 1, [Symbol.for("k")]: 2 }],
   ["an object carrying a reserved property name", { ["__proto__"]: 1 }],
   ["a null-prototype object", Object.assign(Object.create(null), { a: 1 })],

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -33,6 +33,14 @@ export class ArraySubclass extends Array {}
 export class WeirdError extends RangeError {}
 
 /**
+ * Returns an array whose prototype has been re-pointed at `Date.prototype`, so
+ * that its class reads as `Date` and only the array rule still sees an array.
+ */
+function arrayWearingDatePrototype(): unknown {
+  return Object.setPrototypeOf([1], Date.prototype);
+}
+
+/**
  * Returns an `Error` whose prototype has been severed, so that it names no
  * class and only the internal-slot test still sees it as an error.
  */
@@ -60,6 +68,7 @@ export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
   ["an inert plain object", { a: 1 }],
   ["an array carrying a named property", Object.assign([1], { z: 1 })],
   ["an `Array` subclass instance", ArraySubclass.from([1, 2])],
+  ["an array wearing `Date.prototype`", arrayWearingDatePrototype()],
   ["an object carrying a symbol key", { a: 1, [Symbol.for("k")]: 2 }],
   ["an object carrying a reserved property name", { ["__proto__"]: 1 }],
   ["a null-prototype object", Object.assign(Object.create(null), { a: 1 })],

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -60,7 +60,6 @@ import {
 import {
   fabricFromNativeValue,
   isValidFabricConvertibleValue,
-  isValidFabricNativeObject,
   nativeFromFabricValue,
   shallowCleanArray,
   shallowCleanPlainObject,
@@ -340,44 +339,6 @@ describe("native-conversion", () => {
       expect(Object.isFrozen(result)).toBe(false);
       expect(result.cause).toBeInstanceOf(Error);
       expect(Object.isFrozen(result.cause)).toBe(false);
-    });
-  });
-
-  describe("isValidFabricNativeObject()", () => {
-    it("returns `true` for all convertible types", () => {
-      expect(isValidFabricNativeObject(new Error("e"))).toBe(true);
-      expect(isValidFabricNativeObject(new TypeError("e"))).toBe(true);
-      expect(isValidFabricNativeObject(new Map())).toBe(true);
-      expect(isValidFabricNativeObject(new Set())).toBe(true);
-      expect(isValidFabricNativeObject(new Date())).toBe(true);
-      expect(isValidFabricNativeObject(new Uint8Array())).toBe(true);
-    });
-
-    it("returns `true` for exotic `Error` subclass", () => {
-      class WeirdError extends RangeError {}
-      expect(isValidFabricNativeObject(new WeirdError("weird"))).toBe(true);
-    });
-
-    it("returns `true` for `RegExp`", () => {
-      expect(isValidFabricNativeObject(/abc/)).toBe(true);
-    });
-
-    it("returns `false` for non-convertible types", () => {
-      expect(isValidFabricNativeObject({})).toBe(false);
-      expect(isValidFabricNativeObject([])).toBe(false);
-      expect(isValidFabricNativeObject(new WeakMap())).toBe(false);
-    });
-
-    it("returns `false` for objects with `toJSON()`", () => {
-      expect(isValidFabricNativeObject({ toJSON: () => "x" })).toBe(false);
-    });
-
-    it("returns `false` for a non-object", () => {
-      expect(isValidFabricNativeObject(null)).toBe(false);
-      expect(isValidFabricNativeObject(undefined)).toBe(false);
-      expect(isValidFabricNativeObject(1)).toBe(false);
-      expect(isValidFabricNativeObject("a")).toBe(false);
-      expect(isValidFabricNativeObject(() => {})).toBe(false);
     });
   });
 

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -321,10 +321,10 @@ describe("native-type-tags", () => {
 
   describe("the builtin lookup and the full class lookup", () => {
     // `tagFromNativeClass()` asks `tagFromNativeBuiltinClass()` first and its
-    // own switch second, which is only sound because no class is answered by
-    // both. Were one in both, the delegation order would silently decide its
-    // tag -- and the builtin lookup's own fallback, which claims any `Error`
-    // subclass, would reach a fabric class that happened to be one.
+    // own switch second, so the builtin lookup's `Error` fallback -- which
+    // claims any `Error` subclass -- is reached ahead of the fabric classes.
+    // No fabric class is an `Error` subclass, which is what leaves that
+    // fallback nothing of theirs to claim; the group below holds it so.
     const fabricClasses = [
       FabricBytes,
       FabricEpochDay,

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -28,6 +28,12 @@ import {
 } from "@/native-type-tags.ts";
 import { isValidFabricNativeObject } from "@/type-check.ts";
 import { tagFromNativeBuiltinClass } from "@/tagFromNativeBuiltinClass.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricKeyPair } from "@/fabric-primitives/FabricKeyPair.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { LAYER_CORPUS } from "./fabric-value-corpus.ts";
 
 describe("native-type-tags", () => {
@@ -315,9 +321,19 @@ describe("native-type-tags", () => {
 
   describe("the builtin lookup and the full class lookup", () => {
     // `tagFromNativeClass()` asks `tagFromNativeBuiltinClass()` first and its
-    // own switch second, on the stated grounds that a class is in one list or
-    // the other and never both. Were a class in both, the order would silently
-    // decide its tag, so the corpus is walked to hold that apart.
+    // own switch second, which is only sound because no class is answered by
+    // both. Were one in both, the delegation order would silently decide its
+    // tag -- and the builtin lookup's own fallback, which claims any `Error`
+    // subclass, would reach a fabric class that happened to be one.
+    const fabricClasses = [
+      FabricBytes,
+      FabricEpochDay,
+      FabricEpochNsec,
+      FabricHash,
+      FabricKeyPair,
+      FabricRegExp,
+    ];
+
     const constructors = LAYER_CORPUS
       .filter(([, value]) => (value !== null) && (typeof value === "object"))
       .map(([label, value]) =>
@@ -325,32 +341,31 @@ describe("native-type-tags", () => {
       )
       .filter(([, ctor]) => typeof ctor === "function");
 
-    for (const [label, ctor] of constructors) {
-      it(`gives ${label} one tag, from one of the two`, () => {
-        const builtin = tagFromNativeBuiltinClass(ctor);
-        const full = tagFromNativeClass(ctor);
-        if (builtin !== null) {
-          // A builtin passes through the delegation unchanged.
-          expect(full).toBe(builtin);
-        } else {
-          // Anything else is the fabric switch's to answer, or nobody's.
-          expect(builtin).toBe(null);
-        }
+    // Partitioned here rather than inside a test, so that each assertion below
+    // is unconditional: a test that only asserts on one side of an `if` skips
+    // the case it was written for.
+    const builtinBacked = constructors
+      .filter(([, ctor]) => tagFromNativeBuiltinClass(ctor) !== null);
+
+    for (const [label, ctor] of builtinBacked) {
+      it(`passes ${label} through the delegation unchanged`, () => {
+        expect(tagFromNativeClass(ctor)).toBe(tagFromNativeBuiltinClass(ctor));
       });
     }
 
-    // Both arms have to be populated, or the loop above proves nothing about
-    // the split it is checking.
+    for (const cls of fabricClasses) {
+      it(`leaves \`${cls.name}\` to the fabric switch`, () => {
+        // The disjointness the delegation rests on, asserted against the
+        // fabric classes by name rather than against whatever the builtin
+        // lookup happens to decline.
+        expect(tagFromNativeBuiltinClass(cls)).toBe(null);
+        expect(tagFromNativeClass(cls)).not.toBe(null);
+      });
+    }
+
     it("reaches classes on both sides of the split", () => {
-      const builtins = constructors
-        .filter(([, ctor]) => tagFromNativeBuiltinClass(ctor) !== null);
-      const fabrics = constructors
-        .filter(([, ctor]) =>
-          (tagFromNativeBuiltinClass(ctor) === null) &&
-          (tagFromNativeClass(ctor) !== null)
-        );
-      expect(builtins.length).toBeGreaterThan(0);
-      expect(fabrics.length).toBeGreaterThan(0);
+      expect(builtinBacked.length).toBeGreaterThan(0);
+      expect(fabricClasses.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -26,7 +26,9 @@ import {
   tagFromNativeClass,
   tagFromNativeValue,
 } from "@/native-type-tags.ts";
-import { isValidFabricNativeObject } from "@/native-conversion.ts";
+import { isValidFabricNativeObject } from "@/type-check.ts";
+import { tagFromNativeBuiltinClass } from "@/tagFromNativeBuiltinClass.ts";
+import { LAYER_CORPUS } from "./fabric-value-corpus.ts";
 
 describe("native-type-tags", () => {
   describe("tagFromNativeValue()", () => {
@@ -308,6 +310,47 @@ describe("native-type-tags", () => {
       it("returns `Date` tag for `Date`, whose `toJSON` is not consulted", () => {
         expect(tagFromNativeClass(Date)).toBe(VALUE_TAGS.Date);
       });
+    });
+  });
+
+  describe("the builtin lookup and the full class lookup", () => {
+    // `tagFromNativeClass()` asks `tagFromNativeBuiltinClass()` first and its
+    // own switch second, on the stated grounds that a class is in one list or
+    // the other and never both. Were a class in both, the order would silently
+    // decide its tag, so the corpus is walked to hold that apart.
+    const constructors = LAYER_CORPUS
+      .filter(([, value]) => (value !== null) && (typeof value === "object"))
+      .map(([label, value]) =>
+        [label, Object.getPrototypeOf(value as object)?.constructor] as const
+      )
+      .filter(([, ctor]) => typeof ctor === "function");
+
+    for (const [label, ctor] of constructors) {
+      it(`gives ${label} one tag, from one of the two`, () => {
+        const builtin = tagFromNativeBuiltinClass(ctor);
+        const full = tagFromNativeClass(ctor);
+        if (builtin !== null) {
+          // A builtin passes through the delegation unchanged.
+          expect(full).toBe(builtin);
+        } else {
+          // Anything else is the fabric switch's to answer, or nobody's.
+          expect(builtin).toBe(null);
+        }
+      });
+    }
+
+    // Both arms have to be populated, or the loop above proves nothing about
+    // the split it is checking.
+    it("reaches classes on both sides of the split", () => {
+      const builtins = constructors
+        .filter(([, ctor]) => tagFromNativeBuiltinClass(ctor) !== null);
+      const fabrics = constructors
+        .filter(([, ctor]) =>
+          (tagFromNativeBuiltinClass(ctor) === null) &&
+          (tagFromNativeClass(ctor) !== null)
+        );
+      expect(builtins.length).toBeGreaterThan(0);
+      expect(fabrics.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -21,11 +21,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
-import {
-  isNativeError,
-  tagFromNativeClass,
-  tagFromNativeValue,
-} from "@/native-type-tags.ts";
+import { tagFromNativeClass, tagFromNativeValue } from "@/native-type-tags.ts";
 import { isValidFabricNativeObject } from "@/type-check.ts";
 import { tagFromNativeBuiltinClass } from "@/tagFromNativeBuiltinClass.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
@@ -126,28 +122,6 @@ describe("native-type-tags", () => {
     it("returns `Object` tag for null-prototype objects (no constructor)", () => {
       const obj = Object.create(null);
       expect(tagFromNativeValue(obj)).toBe(VALUE_TAGS.Object);
-    });
-
-    it("classifies values when `Error.isError` is unavailable", () => {
-      const descriptor = Object.getOwnPropertyDescriptor(Error, "isError");
-      Object.defineProperty(Error, "isError", {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      try {
-        expect(isNativeError(new Error("test"))).toBe(true);
-        expect(tagFromNativeValue(Object.create(null))).toBe(
-          VALUE_TAGS.Object,
-        );
-      } finally {
-        if (descriptor) {
-          Object.defineProperty(Error, "isError", descriptor);
-        } else {
-          delete (Error as { isError?: unknown }).isError;
-        }
-      }
     });
 
     it("returns `null` for class instances", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -17,11 +17,15 @@ import { expect } from "@std/expect";
 import {
   isFabricContainerValue,
   isFabricPlainObject,
+  isValidFabricNativeObject,
   isValidFabricPlainObject,
   isValidFabricValue,
   isValidFabricValueLayer,
 } from "@/type-check.ts";
 import type { FabricValue } from "@/interface.ts";
+import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
+import { tagFromNativeValue } from "@/native-type-tags.ts";
+import { LAYER_CORPUS } from "./fabric-value-corpus.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -730,6 +734,78 @@ describe("type-check", () => {
         expect(isFabricPlainObject(/regex/ as unknown as FabricValue))
           .toBe(false);
       });
+    });
+  });
+
+  describe("isValidFabricNativeObject()", () => {
+    it("returns `true` for all convertible types", () => {
+      expect(isValidFabricNativeObject(new Error("e"))).toBe(true);
+      expect(isValidFabricNativeObject(new TypeError("e"))).toBe(true);
+      expect(isValidFabricNativeObject(new Map())).toBe(true);
+      expect(isValidFabricNativeObject(new Set())).toBe(true);
+      expect(isValidFabricNativeObject(new Date())).toBe(true);
+      expect(isValidFabricNativeObject(new Uint8Array())).toBe(true);
+    });
+
+    it("returns `true` for exotic `Error` subclass", () => {
+      class WeirdError extends RangeError {}
+      expect(isValidFabricNativeObject(new WeirdError("weird"))).toBe(true);
+    });
+
+    it("returns `true` for `RegExp`", () => {
+      expect(isValidFabricNativeObject(/abc/)).toBe(true);
+    });
+
+    it("returns `false` for non-convertible types", () => {
+      expect(isValidFabricNativeObject({})).toBe(false);
+      expect(isValidFabricNativeObject([])).toBe(false);
+      expect(isValidFabricNativeObject(new WeakMap())).toBe(false);
+    });
+
+    it("returns `false` for objects with `toJSON()`", () => {
+      expect(isValidFabricNativeObject({ toJSON: () => "x" })).toBe(false);
+    });
+
+    it("returns `false` for a non-object", () => {
+      expect(isValidFabricNativeObject(null)).toBe(false);
+      expect(isValidFabricNativeObject(undefined)).toBe(false);
+      expect(isValidFabricNativeObject(1)).toBe(false);
+      expect(isValidFabricNativeObject("a")).toBe(false);
+      expect(isValidFabricNativeObject(() => {})).toBe(false);
+    });
+  });
+
+  describe("`isValidFabricNativeObject()` over the corpus", () => {
+    // The predicate answers by a narrow route -- the array rule, the builtin
+    // class lookup, and an `Error` test -- while the full dispatch reaches the
+    // same values through the fabric classes as well. Deciding a subset of one
+    // answer by a different road is only correct if the two agree on every arm,
+    // which is what the corpus is for.
+    const nativeObjectTags: ReadonlyArray<string> = [
+      VALUE_TAGS.Error,
+      VALUE_TAGS.Map,
+      VALUE_TAGS.Set,
+      VALUE_TAGS.Date,
+      VALUE_TAGS.Uint8Array,
+      VALUE_TAGS.RegExp,
+    ];
+
+    for (const [label, value] of LAYER_CORPUS) {
+      it(`agrees with the full dispatch about ${label}`, () => {
+        const tag = tagFromNativeValue(value);
+        const viaDispatch = (tag !== null) && nativeObjectTags.includes(tag);
+        expect(isValidFabricNativeObject(value)).toBe(viaDispatch);
+      });
+    }
+
+    // Agreement is free for a predicate that has drifted to one side, so that
+    // the corpus lands on both answers is asserted rather than assumed.
+    it("is checked against both answers", () => {
+      const answers = LAYER_CORPUS.map(([, value]) =>
+        isValidFabricNativeObject(value)
+      );
+      expect(answers).toContain(true);
+      expect(answers).toContain(false);
     });
   });
 });

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -762,8 +762,13 @@ describe("type-check", () => {
       expect(isValidFabricNativeObject(new WeakMap())).toBe(false);
     });
 
-    it("returns `false` for objects with `toJSON()`", () => {
+    it("returns `false` for a plain object carrying `toJSON()`", () => {
+      // `toJSON()` is not consulted, and carrying one decides nothing: what
+      // rejects this value is being a plain object. The `Date` below carries
+      // one too and is accepted, which is what holds the two apart.
       expect(isValidFabricNativeObject({ toJSON: () => "x" })).toBe(false);
+      expect(typeof Date.prototype.toJSON).toBe("function");
+      expect(isValidFabricNativeObject(new Date())).toBe(true);
     });
 
     it("returns `false` for a non-object", () => {

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -8,7 +8,6 @@ import {
   fabricFromNativeValue,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
-import { isNativeError } from "@commonfabric/data-model/native-type-tags";
 
 import { isReactive } from "../builder/types.ts";
 import { hasEncodableForm } from "../encodable-form.ts";
@@ -112,7 +111,7 @@ function normalizeSandboxNativeLeaf(value: unknown): unknown {
     return new FabricBytes(value as Uint8Array);
   }
 
-  if (isNativeError(value)) {
+  if (Error.isError(value)) {
     return FabricError.fromNativeError(value as Error);
   }
 
@@ -146,7 +145,7 @@ function formatActionResultError(
   const actionStr = actionName ? `\n  in action: ${actionName}` : "";
   const hint = hintForActionResult(value);
   const hintStr = hint ? ` ${hint}` : "";
-  const causeIsError = isNativeError(cause);
+  const causeIsError = Error.isError(cause);
   const causeStr = causeIsError ? `\n${(cause as Error).message}` : "";
   return new Error(
     `Action returned a ${typeNameForActionResult(value)}${pathStr}.` +

--- a/packages/runner/test/action-result-validation.test.ts
+++ b/packages/runner/test/action-result-validation.test.ts
@@ -36,37 +36,6 @@ describe("normalizeSandboxResult", () => {
     expect((value.error as FabricError).type).toBe("TypeError");
   });
 
-  it("canonicalizes errors when `Error.isError` is unavailable", async () => {
-    const descriptor = Object.getOwnPropertyDescriptor(Error, "isError");
-    Object.defineProperty(Error, "isError", {
-      value: undefined,
-      writable: true,
-      configurable: true,
-    });
-
-    try {
-      const {
-        normalizeSandboxResult: normalizeWithoutNativeErrorCheck,
-        // The test needs an instance built while Error.isError is absent; the
-        // query string is what makes that instance.
-        // deno-lint-ignore cf-imports/no-inline-module-import
-      } = await import(
-        "../src/sandbox/result-normalization.ts?error-is-error-unavailable"
-      );
-      const normalized = normalizeWithoutNativeErrorCheck(
-        new TypeError("fabric"),
-      );
-      expect(normalized.value).toBeInstanceOf(FabricError);
-      expect((normalized.value as FabricError).type).toBe("TypeError");
-    } finally {
-      if (descriptor) {
-        Object.defineProperty(Error, "isError", descriptor);
-      } else {
-        delete (Error as { isError?: unknown }).isError;
-      }
-    }
-  });
-
   it("preserves opaque leaves while normalizing their siblings", () => {
     const reactive = { [isReactiveMarker]: true };
     const cellLink = linkRefFrom({ id: "of:test" });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Two structural moves in `data-model`, and the shared test corpus that
cross-checks them. This is preparation for #6491, which carries both moves today
alongside changes of a different kind; landing them here lets that branch shrink
to the change it is actually about.

## The builtin class lookup becomes its own module

`tagFromNativeClass()` answered for the native JS builtins and for the fabric
classes in a single switch. That put the whole question above the fabric classes
in the layering: recognizing a `FabricBytes` means holding that class, and a
concrete fabric class reaches the codecs and, through them, the instance bases.

`tagFromNativeBuiltinClass()` now lives in `tagFromNativeBuiltinClass.ts` and
imports nothing but `VALUE_TAGS.ts`. `tagFromNativeClass()` asks it first and its
own switch second. A class is in one list or the other and never both, so the
order buys cost rather than meaning — a `switch` on object identity compares in
order, and plain objects and arrays outnumber everything else this is asked
about by a wide margin.

## `isValidFabricNativeObject()` moves to `type-check.ts`

That is where the question belongs, and it only became reachable once the builtin
lookup stopped dragging the fabric classes behind it: `type-check.ts` sits below
those classes and still has to tell a `Date` from a `Map` from an ordinary class
instance. Callers are repointed rather than given a re-export, and the function's
test group moves with it.

The predicate now decides by a narrower route than before — the array rule, the
builtin class lookup, and an `Error` test — rather than by running the full
`tagFromNativeValue()` dispatch and discarding most of the answer.

## The corpus, and what it is for

`test/fabric-value-corpus.ts` carries one entry per arm of the dispatch, plus the
shapes each arm accepts and refuses. Two groups cross-check over it:

- **the predicate agrees with the full dispatch**, value for value. Deciding a
  subset of one answer by a different road is only correct if the two agree on
  every arm, and that is the claim this change actually makes.
- **the builtin lookup and the fabric switch each answer for their own
  classes** — a builtin passes through the delegation unchanged, and anything
  else is the fabric switch's to answer or nobody's.

Each group also asserts that the corpus lands on both sides of its split, so
neither can pass by having drifted to a single answer.

## Verification

`deno task test` in `data-model` (48 passed, 2598 steps), plus `deno task check`,
`deno lint`, and `deno fmt --check` green repo-wide. Both symbols are
`data-model`-internal — nothing outside the package reaches either.

The new tests were ablated rather than assumed to have grip:

| ablation | result |
| --- | --- |
| drop `RegExp` from the predicate's accepted tags | 2 failed |
| `tagFromNativeClass()` stops delegating to the builtin lookup | 11 failed |
| corpus loses every fabric-class entry | 1 failed (the both-sides guard) |

The third was a dud on its first attempt — a regex that left two entries behind,
which read as a passing control. It is reported above from the version that
verifies the property at runtime (0 fabric entries of 23) before running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FStELffQSLrgyz2VuK8n3e

## Coverage

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines

`packages/runner/src/executor/wave.ts:2306-2307`, a pair inside the
concurrent-write patch guard. This change does not touch `wave.ts`, and the file
is the identical blob at every commit compared below.

Flake was confirmed against the run artifacts rather than assumed from the
label. Merging each run's shards by max hits:

| run | 2306 | 2307 |
| --- | --- | --- |
| baseline, `main` @ `00b23214c` | 1 | 1 |
| this PR, measured on that same base | 0 | 0 |
| `main` @ `d569f3722` | 0 | 0 |
| `main` @ `e5df808ee` | 0 | 0 |

The baseline is the outlier: the same source scores covered in one `main` run
and uncovered in three others, which is flake by construction since no code
differs between them.

That also rules out this change as the cause. The only `runner` test it removes
is one in `action-result-validation.test.ts`, and both `main` runs above still
carried that test while scoring these lines uncovered -- so the test is not what
covers them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


