### PR TITLE
refactor: `#` private members in `runner`'s scheduler and tests

### DIFF
--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -265,84 +265,88 @@ export {
 };
 
 export class Scheduler {
+  // A member below declared `private` rather than `#` is one the scheduler
+  // suites reach and drive directly; a `#` name would put it out of their
+  // reach.
+
   private eventQueue: QueuedEvent[] = [];
-  private eventHandlers: [NormalizedFullLink, EventHandler][] = [];
+  #eventHandlers: [NormalizedFullLink, EventHandler][] = [];
   readonly lineage = new SpeculationLineage({
-    dropQueuedEvent: (event, reason) => this.dropEvent(event, reason),
+    dropQueuedEvent: (event, reason) => this.#dropEvent(event, reason),
     queueExecution: () => this.queueExecution(),
     onError: (error) => logger.error("lineage", () => [error]),
   });
 
   private pending = new Set<Action>();
-  private dependencies = new WeakMap<Action, ReactivityLog>();
+  #dependencies = new WeakMap<Action, ReactivityLog>();
   private cancels = new WeakMap<Action, Cancel>();
   // Thunk, not a captured value: keys must always resolve against the
   // runtime's CURRENT authenticated session (one source of truth), and a
   // field initializer runs before constructor parameter properties assign.
-  private triggerIndex = new SchedulerTriggerIndex(
+  #triggerIndex = new SchedulerTriggerIndex(
     () => this.runtime.scopeKeyIdentity,
   );
-  private actionChangeGroups = new WeakMap<Action, ChangeGroup>();
+  #actionChangeGroups = new WeakMap<Action, ChangeGroup>();
   private retries = new WeakMap<Action, number>();
-  private offBudgetRetries = new WeakMap<Action, number>();
+  #offBudgetRetries = new WeakMap<Action, number>();
 
   // Effect/computation tracking for pull-based scheduling
   private nodes = new NodeRegistry();
-  private dependents = new WeakMap<Action, Set<Action>>();
-  private reverseDependencies = new WeakMap<Action, Set<Action>>();
-  private passCounter = 0;
-  private activePassId: number | undefined;
-  private provisionalDemandThisPass = new Set<SchedulerNode>();
+  #dependents = new WeakMap<Action, Set<Action>>();
+  #reverseDependencies = new WeakMap<Action, Set<Action>>();
+  #passCounter = 0;
+  #activePassId: number | undefined;
+  #provisionalDemandThisPass = new Set<SchedulerNode>();
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
-  private breakpoints = new Set<string>();
+  #breakpoints = new Set<string>();
 
   // Compute time tracking for auto-debounce and diagnostics
   // Keyed by action ID (source location) to persist stats across action recreation
   private actionStats = new BoundedKeyMap<string, ActionStats>(
     MAX_ACTION_STATS,
   );
-  private actionTimingState: ActionTimingState = {
+  #actionTimingState: ActionTimingState = {
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
   };
-  private actionIdentityState: SchedulerActionIdentityState = {
+  #actionIdentityState: SchedulerActionIdentityState = {
     anonymousActionIds: new WeakMap<Action | EventHandler, string>(),
     anonymousActionCounter: 0,
   };
-  private eventPreflightTraceContext?: EventPreflightTraceContext;
+  #eventPreflightTraceContext?: EventPreflightTraceContext;
 
-  private rerunAfterCurrentExecute = false;
+  #rerunAfterCurrentExecute = false;
 
   // Non-settling heuristic (Phase 1): detects when the system is churning
   private settlingTracker: SettlingTracker = createSettlingTracker();
-  private autoTriggerDiagnosis = false;
+  #autoTriggerDiagnosis = false;
 
   // Idempotency diagnosis (Phase 2): captures read/write values per action run
   private diagnosisEnabled = false;
-  private diagnosisTimeout: ReturnType<typeof setTimeout> | null = null;
-  private diagnosisStartTime = 0;
-  private diagnosisBusyTime = 0;
-  private diagnosisResolve:
+  #diagnosisTimeout: ReturnType<typeof setTimeout> | null = null;
+  #diagnosisStartTime = 0;
+  #diagnosisBusyTime = 0;
+  #diagnosisResolve:
     | ((result: SchedulerDiagnosisResult) => void)
     | null = null;
-  private diagnosisHistory = new Map<string, DiagnosisRecord[]>();
-  private diagnosisNonIdempotent: NonIdempotentReport[] = [];
+  #diagnosisHistory = new Map<string, DiagnosisRecord[]>();
+  #diagnosisNonIdempotent: NonIdempotentReport[] = [];
 
   // Inline idempotency check mode: when enabled, every computation re-run
   // in run() is followed by a second synchronous run for comparison.
-  private idempotencyCheckMode = false;
-  private idempotencyViolations: NonIdempotentReport[] = [];
+  #idempotencyCheckMode = false;
+  #idempotencyViolations: NonIdempotentReport[] = [];
 
   // Cycle detection (Phase 3): tracks causal edges between actions
-  private causalEdges: {
+  #causalEdges: {
     writer: string;
     cell: string;
     triggered: string;
     timestamp: number;
   }[] = [];
-  private changeGroupToActionId = new Map<ChangeGroup, string>();
-  private diagnosisControlState!: SchedulerDiagnosisControlState;
+  #changeGroupToActionId = new Map<ChangeGroup, string>();
+  #diagnosisControlState!: SchedulerDiagnosisControlState;
 
   // Debounce infrastructure for throttling slow actions
   private pendingQueueTaskTimer: ReturnType<typeof setTimeout> | null = null;
@@ -352,51 +356,50 @@ export class Scheduler {
     nodes: this.nodes,
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
-    isDisposed: () => this.disposed,
+    isDisposed: () => this.#disposed,
     queueExecution: () => this.queueExecution(),
   });
-  private writeIndex!: SchedulerWriteIndex;
+  #writeIndex!: SchedulerWriteIndex;
   private materializers = new SchedulerMaterializers(
     this.nodes.effects,
     () => this.runtime.scopeKeyIdentity,
   );
-  private eventPreflightDependencyState!: EventPreflightDependencyState;
+  #eventPreflightDependencyState!: EventPreflightDependencyState;
   // Filter stats for diagnostics
-  private filterStats: FilterStatsState = { filtered: 0, executed: 0 };
+  #filterStats: FilterStatsState = { filtered: 0, executed: 0 };
 
   // Settle stats for performance analysis (opt-in via enableSettleStats())
-  private collectSettleStats = false;
-  private lastSettleStats: SettleStats | null = null;
-  private settleStatsHistory: SettleStatsHistoryEntry[] = [];
-  private collectActionRunTrace = false;
-  private actionRunTrace: ActionRunTraceEntry[] = [];
-  private collectTriggerTrace = false;
-  private triggerTrace: TriggerTraceEntry[] = [];
-  private eventPreflightTelemetryEnabled = false;
-  private eventPassDemandRefresh?: (demand: Set<Action>) => void;
-  private storageNotificationState!: StorageNotificationState;
+  #collectSettleStats = false;
+  #lastSettleStats: SettleStats | null = null;
+  #settleStatsHistory: SettleStatsHistoryEntry[] = [];
+  #collectActionRunTrace = false;
+  #actionRunTrace: ActionRunTraceEntry[] = [];
+  #collectTriggerTrace = false;
+  #triggerTrace: TriggerTraceEntry[] = [];
+  #eventPreflightTelemetryEnabled = false;
+  #eventPassDemandRefresh?: (demand: Set<Action>) => void;
+  #storageNotificationState!: StorageNotificationState;
   // Parent-child action tracking for proper execution ordering
   // When a child action is created during parent execution, parent must run first
-  private executingAction: Action | null = null;
+  #executingAction: Action | null = null;
   currentActionId?: string;
-  private dependencyGraphState!: DependencyGraphState;
+  #dependencyGraphState!: DependencyGraphState;
   private dependencyUpdateState!: DependencyUpdateState;
-  private triggerSubscriptionState!: TriggerSubscriptionState;
-  private pendingPullRunnableState!: PendingPullRunnableState;
-  private dirtyPullRunnableState!: DirtyPullRunnableState;
-  private dirtyPullRunnableStateWithDebounce!:
-    DirtyPullRunnableStateWithDebounce;
-  private pullSchedulingState!: PullSchedulingState;
-  private subscriptionState!: SchedulerSubscriptionState;
-  private subscribeActionState!: SchedulerSubscribeActionState;
-  private unsubscribeState!: SchedulerUnsubscribeActionState;
+  #triggerSubscriptionState!: TriggerSubscriptionState;
+  #pendingPullRunnableState!: PendingPullRunnableState;
+  #dirtyPullRunnableState!: DirtyPullRunnableState;
+  #dirtyPullRunnableStateWithDebounce!: DirtyPullRunnableStateWithDebounce;
+  #pullSchedulingState!: PullSchedulingState;
+  #subscriptionState!: SchedulerSubscriptionState;
+  #subscribeActionState!: SchedulerSubscribeActionState;
+  #unsubscribeState!: SchedulerUnsubscribeActionState;
 
   /** The storage subscriber registered in the constructor, kept so `dispose`
    * can hand it back. */
   readonly #storageSubscription: IStorageSubscription;
 
-  private idlePromises: (() => void)[] = [];
-  private backgroundTasks = new Set<Promise<unknown>>();
+  #idlePromises: (() => void)[] = [];
+  #backgroundTasks = new Set<Promise<unknown>>();
   // The single wake-shaping choke point (plan C): holds renderer-originated
   // input events out of the event queue (W3) and shapable cell-flip wakes out
   // of the reactive-notification path (plan B), coarsening the cadence a
@@ -404,11 +407,11 @@ export class Scheduler {
   // holdShapedCellNotification() from the invalidation.ts routing of renderer
   // $value writes and server pushes. See
   // docs/specs/sandboxing/TIMING_SIDE_CHANNELS.md.
-  private wakeShaper = new WakeShaper();
+  #wakeShaper = new WakeShaper();
   // Head event parked on in-flight document loads (CT-1795). Keyed by event
   // id; released by loadsSettled, which either re-queues execution on success
   // or drops the at-most-once event on an explicit load failure.
-  private headEventLoadPark: {
+  #headEventLoadPark: {
     eventId: string;
     keys: readonly string[];
     generations: ReadonlyMap<string, number>;
@@ -419,29 +422,29 @@ export class Scheduler {
   // park re-arms per pass and the event never dispatches. Once a key settled
   // for this event its replica is warm — a refresh is an ordinary concurrent
   // update, not a provisional snapshot.
-  private headEventLoadParkHistory: {
+  #headEventLoadParkHistory: {
     eventId: string;
     generations: Map<string, number>;
   } | null = null;
   // Generations already pending before the current event preflight. Used to
   // distinguish a genuine concurrent refresh from a load kicked by preflight
   // itself (the latter must not re-arm the same event forever).
-  private preflightPendingLoadGenerations = new Map<string, number>();
+  #preflightPendingLoadGenerations = new Map<string, number>();
   private errorHandlers = new Set<ErrorHandler>();
-  private consoleHandler: ConsoleHandler;
-  private _running: Promise<unknown> | undefined = undefined;
+  #consoleHandler: ConsoleHandler;
+  #running: Promise<unknown> | undefined = undefined;
   private scheduled = false;
-  private disposed = false;
-  private actionRunState!: SchedulerActionRunState;
-  private graphSnapshotState!: SchedulerGraphSnapshotState;
-  private settleLoopState!: SchedulerSettleLoopState;
-  private executeContinuationState!: ExecuteContinuationState;
+  #disposed = false;
+  #actionRunState!: SchedulerActionRunState;
+  #graphSnapshotState!: SchedulerGraphSnapshotState;
+  #settleLoopState!: SchedulerSettleLoopState;
+  #executeContinuationState!: ExecuteContinuationState;
   // The serving posture's cooperative macrotask yield (server-execution
   // v2 stage C tuning T3, cooperative-yield.ts): constructed ONLY for a
   // serving runtime, so the OFF arm and flag-ON clients keep their
   // settle loops' exact microtask shape. Its observer is the runtime's
   // `servingYieldObserver` seam — the SpaceServer's mid-wave lease renew.
-  private readonly cooperativeYield: CooperativeYield | undefined;
+  readonly #cooperativeYield: CooperativeYield | undefined;
 
   //
   // Public API
@@ -455,11 +458,11 @@ export class Scheduler {
     if (runtime.servingPosture) {
       const yielder = new CooperativeYield();
       yielder.onYield = () => runtime.servingYieldObserver?.();
-      this.cooperativeYield = yielder;
+      this.#cooperativeYield = yielder;
     }
-    this.initializeSchedulerState();
+    this.#initializeSchedulerState();
 
-    this.consoleHandler = consoleHandler ||
+    this.#consoleHandler = consoleHandler ||
       function (data) {
         // Default console handler returns arguments unaffected.
         return data.args;
@@ -472,7 +475,7 @@ export class Scheduler {
     // Subscribe to storage notifications. The subscriber is retained because
     // `subscribe` returns nothing — the argument is the only handle disposal
     // will ever have to hand back, and one built inline is unreachable.
-    this.#storageSubscription = this.createStorageSubscription();
+    this.#storageSubscription = this.#createStorageSubscription();
     this.runtime.storageManager.subscribe(this.#storageSubscription);
 
     // Set up harness event listeners
@@ -481,7 +484,7 @@ export class Scheduler {
       // called within the runtime.
       const { method, args } = e as ConsoleEvent;
       const metadata = getPieceMetadataFromFrame();
-      const result = this.consoleHandler({ metadata, method, args });
+      const result = this.#consoleHandler({ metadata, method, args });
       const output = Array.isArray(result) ? { method, args: result } : result;
       const target = output.target ?? console;
       target[output.method].apply(target, output.args);
@@ -489,18 +492,18 @@ export class Scheduler {
   }
 
   get runningPromise(): Promise<unknown> | undefined {
-    return this._running;
+    return this.#running;
   }
 
   set runningPromise(promise: Promise<unknown> | undefined) {
-    if (this._running !== undefined) {
+    if (this.#running !== undefined) {
       throw new Error(
         "Cannot set running while another promise is in progress",
       );
     }
     if (promise !== undefined) {
-      this._running = promise.finally(() => {
-        this._running = undefined;
+      this.#running = promise.finally(() => {
+        this.#running = undefined;
       });
     }
   }
@@ -511,12 +514,12 @@ export class Scheduler {
    * executing action afterwards (stack-like nesting).
    */
   withExecutingAction<T>(action: Action, fn: () => T): T {
-    const prev = this.executingAction;
-    this.executingAction = action;
+    const prev = this.#executingAction;
+    this.#executingAction = action;
     try {
       return fn();
     } finally {
-      this.executingAction = prev;
+      this.#executingAction = prev;
     }
   }
 
@@ -549,7 +552,7 @@ export class Scheduler {
     // instance and to distinguish pattern readers from internal machinery —
     // plan B).
     if (options.observationIdentity) {
-      this.setActionObservationIdentity(action, options.observationIdentity);
+      this.#setActionObservationIdentity(action, options.observationIdentity);
     }
     const subscribeOptions = {
       isEffect: options.isEffect,
@@ -558,15 +561,18 @@ export class Scheduler {
       throttle: options.throttle,
       changeGroup: options.changeGroup,
     };
-    this.updateMaterializerRegistration(action);
+    this.#updateMaterializerRegistration(action);
     const cancel = subscribePullSchedulerAction(
-      this.subscribeActionState,
+      this.#subscribeActionState,
       action,
       dependencies,
       subscribeOptions,
     );
     if (options.awaitSyncBeforeInitialRun) {
-      this.holdInitialRunUntilSynced(action, options.awaitSyncBeforeInitialRun);
+      this.#holdInitialRunUntilSynced(
+        action,
+        options.awaitSyncBeforeInitialRun,
+      );
     }
     return cancel;
   }
@@ -575,7 +581,7 @@ export class Scheduler {
   // hold is a bounded time gate (worst case the timeout releases it); the sync
   // completing releases it early. The awaiting task joins backgroundTasks so
   // idle() waits for the release decision.
-  private holdInitialRunUntilSynced(
+  #holdInitialRunUntilSynced(
     action: Action,
     options: { space: MemorySpace; timeoutMs?: number },
   ): void {
@@ -654,10 +660,10 @@ export class Scheduler {
   ): void {
     const record = this.nodes.get(action);
     const wasLiveBeforeRootRegistration = record !== undefined &&
-      isLive(this.dependencyGraphState, record);
-    this.updateMaterializerRegistration(action);
+      isLive(this.#dependencyGraphState, record);
+    this.#updateMaterializerRegistration(action);
     resubscribePullSchedulerAction(
-      this.subscribeActionState,
+      this.#subscribeActionState,
       action,
       log,
       options,
@@ -665,7 +671,7 @@ export class Scheduler {
     );
   }
 
-  private setActionObservationIdentity(
+  #setActionObservationIdentity(
     action: Action,
     identity: SchedulerObservationIdentity & { space?: MemorySpace },
   ): void {
@@ -691,12 +697,12 @@ export class Scheduler {
     action: Action,
     options: { preserveChangeGroup?: boolean } = {},
   ): void {
-    unsubscribeSchedulerAction(this.unsubscribeState, action, options);
+    unsubscribeSchedulerAction(this.#unsubscribeState, action, options);
     this.materializers.clearAction(action);
   }
 
   async run(action: Action): Promise<any> {
-    return await runSchedulerAction(this.actionRunState, action);
+    return await runSchedulerAction(this.#actionRunState, action);
   }
 
   /**
@@ -731,14 +737,14 @@ export class Scheduler {
         error,
       ]);
     });
-    this.backgroundTasks.add(task);
+    this.#backgroundTasks.add(task);
     task.finally(() => {
-      this.backgroundTasks.delete(task);
+      this.#backgroundTasks.delete(task);
     });
   }
 
   idle(): Promise<void> {
-    return this.waitForQuiescence(false);
+    return this.#waitForQuiescence(false);
   }
 
   // Client-facing quiescence: reactive quiescence AND durability of in-flight
@@ -755,7 +761,7 @@ export class Scheduler {
   // convergence idle() uses (no separate retry loop, no round cap) and, like
   // idle(), never resolves for a system that genuinely never settles.
   idleWithPendingCommits(): Promise<void> {
-    return this.waitForQuiescence(true);
+    return this.#waitForQuiescence(true);
   }
 
   /**
@@ -768,11 +774,11 @@ export class Scheduler {
    */
   isIdle(): boolean {
     return !this.runningPromise &&
-      this.backgroundTasks.size === 0 &&
-      !this.wakeShaper.hasPending() &&
+      this.#backgroundTasks.size === 0 &&
+      !this.#wakeShaper.hasPending() &&
       this.eventQueue.length === 0 &&
       !this.scheduled &&
-      !this.hasRunnablePullWork();
+      !this.#hasRunnablePullWork();
   }
 
   /**
@@ -785,12 +791,12 @@ export class Scheduler {
     return this.gates.hasWakeTimer();
   }
 
-  private waitForQuiescence(awaitPendingCommits: boolean): Promise<void> {
+  #waitForQuiescence(awaitPendingCommits: boolean): Promise<void> {
     return new Promise<void>((resolve) => {
       // Re-evaluate every condition from scratch once the thing we are waiting
       // on settles.
       const recheck = () =>
-        this.waitForQuiescence(awaitPendingCommits).then(resolve);
+        this.#waitForQuiescence(awaitPendingCommits).then(resolve);
       // A parked waiter (idlePromises) is released when the scheduler drains,
       // and draining settles only the conditions the execute loop owns. Two
       // things can still be outstanding at that moment: a commit in flight,
@@ -806,23 +812,23 @@ export class Scheduler {
       // into unbounded growth rather than a slow path (measured: the
       // non-converging cycle in scheduler-convergence.test.ts exhausts the heap).
       const park = awaitPendingCommits ? () => queueMicrotask(recheck) : () => {
-        if (this.backgroundTasks.size === 0) resolve();
+        if (this.#backgroundTasks.size === 0) resolve();
         else queueMicrotask(recheck);
       };
       if (this.runningPromise) {
         // Something is currently running - wait for it then check again
         this.runningPromise.then(recheck);
-      } else if (this.backgroundTasks.size > 0) {
+      } else if (this.#backgroundTasks.size > 0) {
         // Async scheduler work, such as event-triggered auto-start, is still in
         // flight. Wait for it to settle and then re-check the scheduler state.
-        Promise.allSettled([...this.backgroundTasks]).then(recheck);
-      } else if (this.wakeShaper.hasPending()) {
+        Promise.allSettled([...this.#backgroundTasks]).then(recheck);
+      } else if (this.#wakeShaper.hasPending()) {
         // Input events (W3) or cell-flip notifications (plan B) are being held
         // for wake shaping. Wait for them to release (which re-queues the
         // events and delivers the notifications) and then re-check. Draining
         // before the pending-commit branch means idleWithPendingCommits()
         // releases the held wakes first, then awaits the commits they produce.
-        this.wakeShaper.whenDrained().then(recheck);
+        this.#wakeShaper.whenDrained().then(recheck);
       } else if (
         awaitPendingCommits && this.runtime.storageManager.hasPendingCommits()
       ) {
@@ -851,8 +857,8 @@ export class Scheduler {
         // (the serving loop's settle probes must not chase client
         // persistence).
         this.runtime.patternManager.pendingPatternWorkSettled().then(recheck);
-      } else if (this.disposed) {
-        // Every branch below parks on `idlePromises`, which only the execute
+      } else if (this.#disposed) {
+        // Every branch below parks on `#idlePromises`, which only the execute
         // loop drains — and `execute()` returns immediately once disposed. So
         // parking here would park FOREVER, which is how a caller that disposed
         // the scheduler by hand made `Runtime.dispose()` hang: its teardown
@@ -868,7 +874,7 @@ export class Scheduler {
         // Note this covers the parking branches WHOLESALE rather than fixing
         // the reachable one. Clearing `scheduled` in dispose() would let the
         // "nothing scheduled" branch resolve most of these, but only while
-        // `hasRunnablePullWork()` is false — that branch re-queues execution
+        // `#hasRunnablePullWork()` is false — that branch re-queues execution
         // and parks when it is true, so the hang would come back for a
         // scheduler disposed with pull work outstanding.
         resolve();
@@ -876,33 +882,33 @@ export class Scheduler {
         this.gates.hasWakeTimer() &&
         ((this.eventQueue.length > 0 &&
           isHeadEventParkedState({ eventQueue: this.eventQueue })) ||
-          this.hasIdleBlockingDeferredPullWork())
+          this.#hasIdleBlockingDeferredPullWork())
       ) {
         // A queued event or idle-blocking pull node is parked behind a time
         // gate. Wait for the wake timer to re-schedule the queue and re-check.
-        this.idlePromises.push(park);
+        this.#idlePromises.push(park);
       } else if (
-        this.hasPendingLineageHeadEvent() || this.hasLoadParkedHeadEvent()
+        this.#hasPendingLineageHeadEvent() || this.#hasLoadParkedHeadEvent()
       ) {
         // A cross-space lineage head has no timer — its origin commit callback
         // is the wake source; a load-parked head wakes on load completion or
         // drops on an explicit load failure. Either way idle must stay open
         // until the callback re-queues execution.
-        this.idlePromises.push(park);
+        this.#idlePromises.push(park);
       } else if (!this.scheduled) {
-        if (this.hasRunnablePullWork()) {
+        if (this.#hasRunnablePullWork()) {
           this.queueExecution();
-          this.idlePromises.push(park);
+          this.#idlePromises.push(park);
           return;
         }
         // Nothing is scheduled to run - we're idle.
         // In pull mode, pending computations won't run without an effect to pull them,
         // so we don't wait for them.
-        this.resetConvergenceHoldPasses();
+        this.#resetConvergenceHoldPasses();
         resolve();
       } else {
         // Execution is scheduled - wait for it to complete
-        this.idlePromises.push(park);
+        this.#idlePromises.push(park);
       }
     });
   }
@@ -945,7 +951,7 @@ export class Scheduler {
           : undefined);
       if (demandRootIds === undefined) continue;
       if (!demandRootIds.some((id) => roots.has(id))) continue;
-      this.markActionInvalid(record.action, undefined, {
+      this.#markActionInvalid(record.action, undefined, {
         fanOutInstances: "keep",
       });
       this.pending.add(record.action);
@@ -1001,7 +1007,7 @@ export class Scheduler {
    * CURRENT — never run at the node's ratchet for that principal. B7 made
    * cleanliness per instance, so a node the watchers made node-level
    * clean can still be missing the actor's instance entirely; the
-   * node-level preflight (`collectInvalidUpstreamForLog`) asks only
+   * node-level preflight (`#collectInvalidUpstreamForLog`) asks only
    * whether the NODE is invalid, so the actor's own per-user derivation
    * was never materialized and her handler read an empty instance —
    * refused as a schema mismatch and, until the mark/effects-atomicity
@@ -1037,10 +1043,10 @@ export class Scheduler {
   ): Action[] {
     const directWriters = collectDirectWritersForLog({
       scopeKeyIdentity: () => this.runtime.scopeKeyIdentity,
-      writersByEntity: this.writeIndex.writersByEntity,
+      writersByEntity: this.#writeIndex.writersByEntity,
       effects: this.nodes.effects,
       getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
+        this.#writeIndex.getSchedulingWrites(action),
     }, deps);
     const rearmed: Action[] = [];
     for (const writer of directWriters) {
@@ -1051,7 +1057,7 @@ export class Scheduler {
       // Current for the actor: her instance ran at the ratchet and no
       // cause dirtied it — nothing to materialize.
       if (record.fanOut.clean.has(actorKey)) continue;
-      this.markActionInvalid(writer, undefined, { fanOutInstances: "keep" });
+      this.#markActionInvalid(writer, undefined, { fanOutInstances: "keep" });
       this.pending.add(writer);
       rearmed.push(writer);
     }
@@ -1070,51 +1076,51 @@ export class Scheduler {
    * the writer index's vocabulary: two instances of one doc, `user:alice`
    * and `user:bob`, name ONE entity whose one node writes both). The
    * count is the number of registry instance keys naming the entity. */
-  private readonly demandedEntityRefs = new Map<SpaceScopeAndURI, number>();
+  readonly #demandedEntityRefs = new Map<SpaceScopeAndURI, number>();
 
   /** Per-runtime enter/leave/re-arm tallies. The SpaceServer reads the
    * enter/leave DELTA per pass and folds it into its space-lived
    * `stats.demand` accumulators (these reset with the runtime on a
    * reactivation, so they are a per-tenure source, not the total). */
   readonly demandRootCounters = { enters: 0, leaves: 0, notCurrentRearms: 0 };
-  private demandedWriterHookInstalled = false;
+  #demandedWriterHookInstalled = false;
 
-  private installDemandedWriterHook(): void {
-    if (this.demandedWriterHookInstalled) return;
-    this.demandedWriterHookInstalled = true;
+  #installDemandedWriterHook(): void {
+    if (this.#demandedWriterHookInstalled) return;
+    this.#demandedWriterHookInstalled = true;
     // The REGISTRATION / UNREGISTRATION bracket (§2.4): a writer whose
     // surface gains a demanded entity enters the root set; one that loses
     // its last demanded entity leaves it. Bracketed like every other root
     // flip (serving-loop.md §8: capture wasLive → flip → notify).
-    this.writeIndex.onWriterEntitiesChanged = (action, added, removed) => {
+    this.#writeIndex.onWriterEntitiesChanged = (action, added, removed) => {
       let touchesDemand = false;
       for (const entity of added) {
-        if ((this.demandedEntityRefs.get(entity) ?? 0) > 0) {
+        if ((this.#demandedEntityRefs.get(entity) ?? 0) > 0) {
           touchesDemand = true;
           break;
         }
       }
       if (!touchesDemand) {
         for (const entity of removed) {
-          if ((this.demandedEntityRefs.get(entity) ?? 0) > 0) {
+          if ((this.#demandedEntityRefs.get(entity) ?? 0) > 0) {
             touchesDemand = true;
             break;
           }
         }
       }
       if (!touchesDemand) return;
-      this.reconcileDemandedWriter(action);
+      this.#reconcileDemandedWriter(action);
     };
   }
 
   /** Recompute whether `action` is a demanded writer from its CURRENT
    * write entities and the demanded entity refs; bracket the flip. */
-  private reconcileDemandedWriter(action: Action): void {
-    const entities = this.writeIndex.actionWriteEntities.get(action);
+  #reconcileDemandedWriter(action: Action): void {
+    const entities = this.#writeIndex.actionWriteEntities.get(action);
     let shouldBeRoot = false;
     if (entities !== undefined) {
       for (const entity of entities) {
-        if ((this.demandedEntityRefs.get(entity) ?? 0) > 0) {
+        if ((this.#demandedEntityRefs.get(entity) ?? 0) > 0) {
           shouldBeRoot = true;
           break;
         }
@@ -1124,7 +1130,7 @@ export class Scheduler {
     if (shouldBeRoot === isRoot) return;
     const record = this.nodes.get(action);
     const wasLive = record !== undefined &&
-      isLive(this.dependencyGraphState, record);
+      isLive(this.#dependencyGraphState, record);
     if (shouldBeRoot) {
       this.nodes.demandedWriters.add(action);
       this.demandRootCounters.enters += 1;
@@ -1133,9 +1139,10 @@ export class Scheduler {
       this.demandRootCounters.leaves += 1;
     }
     if (record === undefined) return;
-    notifyNodeLivenessChange(this.dependencyGraphState, action, wasLive);
+    notifyNodeLivenessChange(this.#dependencyGraphState, action, wasLive);
     if (
-      shouldBeRoot && this.isLiveAction(action) && this.isInvalidAction(action)
+      shouldBeRoot && this.#isLiveAction(action) &&
+      this.#isInvalidAction(action)
     ) {
       // A dirty / never-ran node that just became live is a runnable seed
       // (work-oracle: dirty ∧ live); make sure the loop wakes for it.
@@ -1151,13 +1158,13 @@ export class Scheduler {
   enterDemandedEntity(
     address: { space: MemorySpace; id: string; scope: CellScope },
   ): Action[] {
-    this.installDemandedWriterHook();
+    this.#installDemandedWriterHook();
     const entity = entityNameKey(address as never);
-    const before = this.demandedEntityRefs.get(entity) ?? 0;
-    this.demandedEntityRefs.set(entity, before + 1);
-    const writers = [...(this.writeIndex.writersByEntity.get(entity) ?? [])];
+    const before = this.#demandedEntityRefs.get(entity) ?? 0;
+    this.#demandedEntityRefs.set(entity, before + 1);
+    const writers = [...(this.#writeIndex.writersByEntity.get(entity) ?? [])];
     if (before === 0) {
-      for (const writer of writers) this.reconcileDemandedWriter(writer);
+      for (const writer of writers) this.#reconcileDemandedWriter(writer);
     }
     return writers;
   }
@@ -1170,14 +1177,14 @@ export class Scheduler {
     address: { space: MemorySpace; id: string; scope: CellScope },
   ): void {
     const entity = entityNameKey(address as never);
-    const before = this.demandedEntityRefs.get(entity) ?? 0;
+    const before = this.#demandedEntityRefs.get(entity) ?? 0;
     if (before <= 1) {
-      this.demandedEntityRefs.delete(entity);
-      for (const writer of this.writeIndex.writersByEntity.get(entity) ?? []) {
-        this.reconcileDemandedWriter(writer);
+      this.#demandedEntityRefs.delete(entity);
+      for (const writer of this.#writeIndex.writersByEntity.get(entity) ?? []) {
+        this.#reconcileDemandedWriter(writer);
       }
     } else {
-      this.demandedEntityRefs.set(entity, before - 1);
+      this.#demandedEntityRefs.set(entity, before - 1);
     }
   }
 
@@ -1196,7 +1203,7 @@ export class Scheduler {
     demander: ScopeKeyIdentity,
   ): number {
     const entity = entityNameKey(address as never);
-    const writers = this.writeIndex.writersByEntity.get(entity);
+    const writers = this.#writeIndex.writersByEntity.get(entity);
     if (writers === undefined || writers.size === 0) return 0;
     let rearmed = 0;
     for (const writer of writers) {
@@ -1206,7 +1213,7 @@ export class Scheduler {
       const pairKey = keyAtRatchet(record.fanOut, demander);
       if (pairKey === undefined) continue;
       if (record.fanOut.clean.has(pairKey)) continue;
-      this.markActionInvalid(writer, undefined, { fanOutInstances: "keep" });
+      this.#markActionInvalid(writer, undefined, { fanOutInstances: "keep" });
       this.pending.add(writer);
       rearmed += 1;
     }
@@ -1225,7 +1232,7 @@ export class Scheduler {
 
   /** DIAGNOSTIC: the demanded entity refcount map's size. */
   get demandedEntityCount(): number {
-    return this.demandedEntityRefs.size;
+    return this.#demandedEntityRefs.size;
   }
 
   /** DIAGNOSTIC (tests): a node's fan-out record — the known-scope
@@ -1254,22 +1261,22 @@ export class Scheduler {
 
   /** The bound yield hook handed to the settle loop (stage C tuning T3):
    * a promise to await when the slice is spent, else undefined. Defined
-   * only when `cooperativeYield` exists. */
-  private readonly cooperativeYieldBetweenRuns = ():
+   * only when `#cooperativeYield` exists. */
+  readonly #cooperativeYieldBetweenRuns = ():
     | Promise<void>
-    | undefined => this.cooperativeYield?.maybeYield();
+    | undefined => this.#cooperativeYield?.maybeYield();
 
   /** DIAGNOSTIC (tests): the serving posture's cooperative yielder, if
    * this scheduler has one. */
   get servingYield(): CooperativeYield | undefined {
-    return this.cooperativeYield;
+    return this.#cooperativeYield;
   }
 
   queueExecution(): void {
-    if (this.disposed) return;
+    if (this.#disposed) return;
     if (this.scheduled) {
       if (this.pendingQueueTaskTimer === null) {
-        this.rerunAfterCurrentExecute = true;
+        this.#rerunAfterCurrentExecute = true;
       }
       return;
     }
@@ -1340,9 +1347,9 @@ export class Scheduler {
     // input, so it is never reshaped.
     if (!doNotLoadPieceIfNotRunning && shouldShapeDelivery(event)) {
       holdShapedEvent(
-        this.wakeShaper,
-        this.shapedEventDeliver,
-        this.pieceIdForEventLink(eventLink),
+        this.#wakeShaper,
+        this.#shapedEventDeliver,
+        this.#pieceIdForEventLink(eventLink),
         eventLink,
         this.runtime.scopeKeyIdentity,
         event,
@@ -1376,7 +1383,7 @@ export class Scheduler {
 
   // A released shaped event re-enters the ordinary queue path; the shaper reads
   // eventQueueState at release time, so it stays correct across state re-init.
-  private shapedEventDeliver: DeliverFn = (
+  #shapedEventDeliver: DeliverFn = (
     eventLink,
     event,
     retries,
@@ -1405,10 +1412,10 @@ export class Scheduler {
   // includes the owning space so two instances of one pattern in different spaces
   // (same content-addressed pieceId) do not share a bucket (see
   // shaperInstanceGroupKey).
-  private pieceIdForEventLink(
+  #pieceIdForEventLink(
     eventLink: NormalizedFullLink,
   ): string | undefined {
-    for (const [link, handler] of this.eventHandlers) {
+    for (const [link, handler] of this.#eventHandlers) {
       if (areNormalizedLinksSame(link, eventLink)) {
         return shaperInstanceGroupKey(
           (handler as {
@@ -1456,14 +1463,14 @@ export class Scheduler {
     chargeKey: object,
     deliver: () => void,
   ): void {
-    holdShapedCell(this.wakeShaper, groupKey, itemKey, chargeKey, deliver);
+    holdShapedCell(this.#wakeShaper, groupKey, itemKey, chargeKey, deliver);
   }
 
   // Whether any shapable cell-flip wake is currently held out of the scheduler
   // (plan B). Exposed for tests that need to observe that a change was routed
   // through the wake shaper's cell path before idle() drains it.
   hasPendingShapedCellNotifications(): boolean {
-    return this.wakeShaper.hasPending(CELL_GROUP_PREFIX);
+    return this.#wakeShaper.hasPending(CELL_GROUP_PREFIX);
   }
 
   addEventHandler(
@@ -1475,7 +1482,7 @@ export class Scheduler {
     ) => void,
   ): Cancel {
     return addSchedulerEventHandler({
-      eventHandlers: this.eventHandlers,
+      eventHandlers: this.#eventHandlers,
     }, {
       handler,
       ref,
@@ -1484,7 +1491,7 @@ export class Scheduler {
   }
 
   onConsole(fn: ConsoleHandler): void {
-    this.consoleHandler = fn;
+    this.#consoleHandler = fn;
   }
 
   onError(fn: ErrorHandler): void {
@@ -1492,11 +1499,11 @@ export class Scheduler {
   }
 
   setEventPreflightTelemetryEnabled(enabled: boolean): void {
-    this.eventPreflightTelemetryEnabled = enabled;
+    this.#eventPreflightTelemetryEnabled = enabled;
   }
 
   isEventPreflightTelemetryEnabled(): boolean {
-    return this.eventPreflightTelemetryEnabled;
+    return this.#eventPreflightTelemetryEnabled;
   }
 
   //
@@ -1515,12 +1522,12 @@ export class Scheduler {
     // (arming is otherwise the invalidation path's job; queries stay pure).
     const record = this.nodes.get(action);
     if (
-      ms > 0 && record?.kind === "computation" && this.isInvalidAction(action)
+      ms > 0 && record?.kind === "computation" && this.#isInvalidAction(action)
     ) {
       this.gates.onInvalidated(
         record,
         performance.now(),
-        this.createDebouncedComputationContext(),
+        this.#createDebouncedComputationContext(),
       );
     }
   }
@@ -1581,9 +1588,9 @@ export class Scheduler {
    * Set action IDs that should trigger a debugger breakpoint before execution.
    */
   setBreakpoints(actionIds: readonly string[]): void {
-    this.breakpoints.clear();
+    this.#breakpoints.clear();
     for (const id of actionIds) {
-      this.breakpoints.add(id);
+      this.#breakpoints.add(id);
     }
   }
 
@@ -1591,14 +1598,14 @@ export class Scheduler {
    * Get currently set breakpoint action IDs.
    */
   getBreakpoints(): string[] {
-    return Array.from(this.breakpoints);
+    return Array.from(this.#breakpoints);
   }
 
   /**
    * Check if an action ID has a breakpoint set.
    */
   hasBreakpoint(actionId: string): boolean {
-    return this.breakpoints.has(actionId);
+    return this.#breakpoints.has(actionId);
   }
 
   /**
@@ -1631,14 +1638,14 @@ export class Scheduler {
    * Returns whether an action is marked as dirty.
    */
   isDirty(action: Action): boolean {
-    return this.isInvalidAction(action);
+    return this.#isInvalidAction(action);
   }
 
   /**
    * Returns the set of actions that depend on this action's output.
    */
   getDependents(action: Action): Set<Action> {
-    return this.dependents.get(action) ?? new Set();
+    return this.#dependents.get(action) ?? new Set();
   }
 
   /**
@@ -1646,7 +1653,7 @@ export class Scheduler {
    * Uses getActionId for the identifier (includes code location).
    */
   getGraphSnapshot(): SchedulerGraphSnapshot {
-    return buildSchedulerGraphSnapshot(this.graphSnapshotState);
+    return buildSchedulerGraphSnapshot(this.#graphSnapshotState);
   }
 
   //
@@ -1657,7 +1664,7 @@ export class Scheduler {
    * Returns the action's static write surface.
    */
   getMightWrite(action: Action): IMemorySpaceAddress[] | undefined {
-    return this.writeIndex.getSchedulingWrites(action);
+    return this.#writeIndex.getSchedulingWrites(action);
   }
 
   //
@@ -1670,22 +1677,22 @@ export class Scheduler {
    * Accepts either an Action or an action ID string.
    */
   getActionStats(action: Action | string): ActionStats | undefined {
-    return getActionStatsFromState(this.actionTimingState, action);
+    return getActionStatsFromState(this.#actionTimingState, action);
   }
 
   /**
    * Returns filter statistics for the current/last execution cycle.
    */
   getFilterStats(): { filtered: number; executed: number } {
-    return { ...this.filterStats };
+    return { ...this.#filterStats };
   }
 
   /**
    * Resets filter statistics.
    */
   resetFilterStats(): void {
-    this.filterStats.filtered = 0;
-    this.filterStats.executed = 0;
+    this.#filterStats.filtered = 0;
+    this.#filterStats.executed = 0;
   }
 
   /**
@@ -1701,10 +1708,10 @@ export class Scheduler {
    * Disabling also clears the last collected stats to avoid outdated reads.
    */
   setSettleStatsEnabled(enabled: boolean): void {
-    this.collectSettleStats = enabled;
+    this.#collectSettleStats = enabled;
     if (!enabled) {
-      this.lastSettleStats = null;
-      this.settleStatsHistory = [];
+      this.#lastSettleStats = null;
+      this.#settleStatsHistory = [];
     }
   }
 
@@ -1712,14 +1719,14 @@ export class Scheduler {
    * Returns settle stats from the last execute() call, or null if not enabled/collected.
    */
   getSettleStats(): SettleStats | null {
-    return this.lastSettleStats;
+    return this.#lastSettleStats;
   }
 
   /**
    * Returns recent settle stats history from execute() calls, oldest first.
    */
   getSettleStatsHistory(): SettleStatsHistoryEntry[] {
-    return [...this.settleStatsHistory];
+    return [...this.#settleStatsHistory];
   }
 
   /**
@@ -1727,9 +1734,9 @@ export class Scheduler {
    * Disabling clears the current ring buffer to avoid outdated reads.
    */
   setActionRunTraceEnabled(enabled: boolean): void {
-    this.collectActionRunTrace = enabled;
+    this.#collectActionRunTrace = enabled;
     if (!enabled) {
-      this.actionRunTrace.length = 0;
+      this.#actionRunTrace.length = 0;
     }
   }
 
@@ -1737,7 +1744,7 @@ export class Scheduler {
    * Returns recent exact action-run history, oldest first.
    */
   getActionRunTrace(): ActionRunTraceEntry[] {
-    return [...this.actionRunTrace];
+    return [...this.#actionRunTrace];
   }
 
   /**
@@ -1745,9 +1752,9 @@ export class Scheduler {
    * Disabling clears the current ring buffer to avoid outdated reads.
    */
   setTriggerTraceEnabled(enabled: boolean): void {
-    this.collectTriggerTrace = enabled;
+    this.#collectTriggerTrace = enabled;
     if (!enabled) {
-      this.triggerTrace = [];
+      this.#triggerTrace = [];
     }
   }
 
@@ -1755,7 +1762,7 @@ export class Scheduler {
    * Returns recent structured trigger-trace entries, oldest first.
    */
   getTriggerTrace(): TriggerTraceEntry[] {
-    return [...this.triggerTrace];
+    return [...this.#triggerTrace];
   }
 
   //
@@ -1776,7 +1783,7 @@ export class Scheduler {
    * is detected. Off by default.
    */
   setAutoTriggerDiagnosis(enabled: boolean): void {
-    this.autoTriggerDiagnosis = enabled;
+    this.#autoTriggerDiagnosis = enabled;
   }
 
   /**
@@ -1784,7 +1791,7 @@ export class Scheduler {
    * This is the main entry point for external callers (IPC, console).
    */
   runDiagnosis(durationMs = 5000): Promise<SchedulerDiagnosisResult> {
-    return runSchedulerDiagnosis(this.diagnosisControlState, durationMs);
+    return runSchedulerDiagnosis(this.#diagnosisControlState, durationMs);
   }
 
   //
@@ -1792,17 +1799,17 @@ export class Scheduler {
   //
 
   enableIdempotencyCheck(): void {
-    this.idempotencyCheckMode = true;
-    this.idempotencyViolations.length = 0;
+    this.#idempotencyCheckMode = true;
+    this.#idempotencyViolations.length = 0;
     this.queueExecution();
   }
 
   disableIdempotencyCheck(): void {
-    this.idempotencyCheckMode = false;
+    this.#idempotencyCheckMode = false;
   }
 
   getIdempotencyViolations(): NonIdempotentReport[] {
-    return [...this.idempotencyViolations];
+    return [...this.#idempotencyViolations];
   }
 
   /**
@@ -1811,7 +1818,7 @@ export class Scheduler {
    * automatically gets a second synchronous run for comparison.
    */
   async runIdempotencyCheck(): Promise<SchedulerDiagnosisResult> {
-    return await runSchedulerIdempotencyCheck(this.diagnosisControlState);
+    return await runSchedulerIdempotencyCheck(this.#diagnosisControlState);
   }
 
   /**
@@ -1826,16 +1833,16 @@ export class Scheduler {
     // `unsubscribe` is optional on the capability, so a manager without one is
     // left as it was rather than crashing a disposal.
     this.runtime.storageManager.unsubscribe?.(this.#storageSubscription);
-    this.headEventLoadPark = null;
-    this.headEventLoadParkHistory = null;
-    this.disposed = true;
+    this.#headEventLoadPark = null;
+    this.#headEventLoadParkHistory = null;
+    this.#disposed = true;
     this.gates.cancelWake();
     if (this.pendingQueueTaskTimer !== null) {
       clearTimeout(this.pendingQueueTaskTimer);
       this.pendingQueueTaskTimer = null;
     }
-    this.triggerIndex.clear();
-    this.wakeShaper.dispose();
+    this.#triggerIndex.clear();
+    this.#wakeShaper.dispose();
     // Release waiters already parked when dispose arrived. The branch in
     // waitForQuiescence covers idle() calls made AFTER this point; it cannot
     // reach these, and nothing else will — `execute()` is the only other drain
@@ -1847,23 +1854,23 @@ export class Scheduler {
     //
     // Routed back through waitForQuiescence rather than resolved here, because
     // dispose does NOT cancel a run already under way — `execute()` tests
-    // `disposed` only on entry. Every parking branch is reached with
+    // `#disposed` only on entry. Every parking branch is reached with
     // `runningPromise` unset, so a waiter parked while execution was merely
     // SCHEDULED is still parked once the run begins; resolving it directly
     // would report quiescence with an action, and its commit, still going. The
     // re-check waits on that promise and only then takes the disposed branch,
     // which is exactly the guarantee the branch documents. It cannot re-park:
     // the disposed branch sits above every push to this list.
-    const parked = this.idlePromises.splice(0);
+    const parked = this.#idlePromises.splice(0);
     if (parked.length > 0) {
-      this.waitForQuiescence(false).then(() => {
+      this.#waitForQuiescence(false).then(() => {
         for (const resolve of parked) resolve();
       });
     }
     // Clean up diagnosis state
-    if (this.diagnosisTimeout) {
-      clearTimeout(this.diagnosisTimeout);
-      this.diagnosisTimeout = null;
+    if (this.#diagnosisTimeout) {
+      clearTimeout(this.#diagnosisTimeout);
+      this.#diagnosisTimeout = null;
     }
     this.diagnosisEnabled = false;
   }
@@ -1872,7 +1879,7 @@ export class Scheduler {
   // Execution orchestration
   //
 
-  private handleError(error: Error, action: any) {
+  #handleError(error: Error, action: any) {
     handleSchedulerError(
       {
         errorHandlers: this.errorHandlers,
@@ -1884,30 +1891,30 @@ export class Scheduler {
   }
 
   private async execute(): Promise<void> {
-    if (this.disposed) return;
+    if (this.#disposed) return;
     logger.timeStart("scheduler", "execute");
     // Each execute pass starts in a fresh macrotask (queueTask): restart
     // the serving posture's yield slice so idle time between passes never
     // reads as spent work (stage C tuning T3).
-    this.cooperativeYield?.noteMacrotaskBoundary();
+    this.#cooperativeYield?.noteMacrotaskBoundary();
 
     // In case a directly invoked `run` is still running, wait for it to finish.
     if (this.runningPromise) await this.runningPromise;
 
-    this.beginExecuteCycle();
-    const eventBlockingDeps = await this.processExecuteEventPhase();
-    const initialSeeds = this.buildInitialExecuteSeeds(eventBlockingDeps);
+    this.#beginExecuteCycle();
+    const eventBlockingDeps = await this.#processExecuteEventPhase();
+    const initialSeeds = this.#buildInitialExecuteSeeds(eventBlockingDeps);
 
-    const settleResult = await this.runSettleLoop(initialSeeds);
+    const settleResult = await this.#runSettleLoop(initialSeeds);
     this.recordBudgetBackoffTelemetry(settleResult);
     this.recordExecuteEndTelemetry();
-    this.applyExecuteContinuation();
+    this.#applyExecuteContinuation();
     logger.timeEnd("scheduler", "execute");
   }
 
-  private beginExecuteCycle(): void {
-    this.activePassId = ++this.passCounter;
-    this.provisionalDemandThisPass.clear();
+  #beginExecuteCycle(): void {
+    this.#activePassId = ++this.#passCounter;
+    this.#provisionalDemandThisPass.clear();
     for (const record of this.nodes.nodes()) {
       record.passRuns = 0;
     }
@@ -1916,10 +1923,10 @@ export class Scheduler {
     markExecuteStart(this.settlingTracker);
   }
 
-  private async processExecuteEventPhase(): Promise<Set<Action>> {
+  async #processExecuteEventPhase(): Promise<Set<Action>> {
     // Track dirty dependencies that block events - these must be added to workSet
     const eventBlockingDeps = new Set<Action>();
-    this.eventPassDemandRefresh = undefined;
+    this.#eventPassDemandRefresh = undefined;
 
     logger.timeStart("scheduler", "execute", "event");
     try {
@@ -1933,7 +1940,7 @@ export class Scheduler {
     }
   }
 
-  private buildInitialExecuteSeeds(
+  #buildInitialExecuteSeeds(
     eventBlockingDeps: Iterable<Action>,
   ): Set<Action> {
     // Capture the head event's transient demand roots for this settle pass.
@@ -1942,18 +1949,18 @@ export class Scheduler {
     });
   }
 
-  private async runSettleLoop(
+  async #runSettleLoop(
     initialSeeds: ReadonlySet<Action>,
   ): Promise<SchedulerSettleResult> {
     const settleResult = await runPullSchedulerSettleLoop(
-      this.settleLoopState,
+      this.#settleLoopState,
       initialSeeds,
     );
 
     if (settleResult.settleStats) {
-      this.lastSettleStats = settleResult.settleStats;
+      this.#lastSettleStats = settleResult.settleStats;
       pushBoundedHistory(
-        this.settleStatsHistory,
+        this.#settleStatsHistory,
         { recordedAt: performance.now(), stats: settleResult.settleStats },
         MAX_SETTLE_STATS_HISTORY,
       );
@@ -1968,15 +1975,15 @@ export class Scheduler {
       workSetSize: settleResult.workSetSize,
     });
 
-    this.clearProvisionalDemandAtPassEnd();
+    this.#clearProvisionalDemandAtPassEnd();
     this.clearBackoffForCleanNodes();
-    this.activePassId = undefined;
+    this.#activePassId = undefined;
 
     return settleResult;
   }
 
-  private applyExecuteContinuation(): void {
-    applyPullExecuteContinuation(this.executeContinuationState);
+  #applyExecuteContinuation(): void {
+    applyPullExecuteContinuation(this.#executeContinuationState);
   }
 
   private recordBudgetBackoffTelemetry(
@@ -1984,7 +1991,7 @@ export class Scheduler {
   ): void {
     if (!settleResult.backoffApplied) return;
 
-    const deferredActions = this.describeDeferredActions(
+    const deferredActions = this.#describeDeferredActions(
       settleResult.backoffActions,
     );
     this.runtime.telemetry.submit({
@@ -1997,7 +2004,10 @@ export class Scheduler {
     // The marker carries every episode; the warning is a latched
     // summary so a permanently non-converging graph does not flood the log.
     if (markNonSettlingEpisode(this.settlingTracker)) {
-      this.warnNonSettlingActions(settleResult.backoffActions, deferredActions);
+      this.#warnNonSettlingActions(
+        settleResult.backoffActions,
+        deferredActions,
+      );
     }
   }
 
@@ -2008,7 +2018,7 @@ export class Scheduler {
    * pieceId is `<scope>:<id>` of the piece's result cell; the marker carries
    * the id alone, the form consumers compare against.
    */
-  private describeDeferredActions(
+  #describeDeferredActions(
     actions: readonly Action[],
   ): NonSettlingDeferredAction[] {
     const maxListedActions = 10;
@@ -2036,7 +2046,7 @@ export class Scheduler {
     });
   }
 
-  private warnNonSettlingActions(
+  #warnNonSettlingActions(
     actions: readonly Action[],
     deferredActions: readonly NonSettlingDeferredAction[],
   ): void {
@@ -2059,7 +2069,7 @@ export class Scheduler {
     // Non-settling heuristic: accumulate busy time at end of execute()
     const executeEnd = recordExecuteEnd(this.settlingTracker);
     if (this.diagnosisEnabled) {
-      this.diagnosisBusyTime += executeEnd.diagnosisBusyTimeMs;
+      this.#diagnosisBusyTime += executeEnd.diagnosisBusyTimeMs;
     }
     if (executeEnd.nonSettlingTelemetry) {
       this.runtime.telemetry.submit({
@@ -2067,8 +2077,8 @@ export class Scheduler {
         ...executeEnd.nonSettlingTelemetry,
       });
       // Auto-trigger diagnosis if enabled
-      if (this.autoTriggerDiagnosis && !this.diagnosisEnabled) {
-        this.startDiagnosis();
+      if (this.#autoTriggerDiagnosis && !this.diagnosisEnabled) {
+        this.#startDiagnosis();
       }
     }
   }
@@ -2081,15 +2091,15 @@ export class Scheduler {
    * Starts diagnosis mode: captures read/write values and causal edges.
    * Automatically stops after durationMs.
    */
-  private startDiagnosis(durationMs = 5000): void {
-    startSchedulerDiagnosis(this.diagnosisControlState, durationMs);
+  #startDiagnosis(durationMs = 5000): void {
+    startSchedulerDiagnosis(this.#diagnosisControlState, durationMs);
   }
 
   /**
    * Stops diagnosis mode and finalizes results.
    */
-  private stopDiagnosis(): void {
-    stopSchedulerDiagnosis(this.diagnosisControlState);
+  #stopDiagnosis(): void {
+    stopSchedulerDiagnosis(this.#diagnosisControlState);
   }
 
   /**
@@ -2098,7 +2108,7 @@ export class Scheduler {
    */
   private updateDependents(action: Action, log: ReactivityLog): void {
     const actionId = this.getActionId(action);
-    updateDependentEdgesForLog(this.dependencyGraphState, action, log);
+    updateDependentEdgesForLog(this.#dependencyGraphState, action, log);
 
     // Emit telemetry for dependency updates
     this.runtime.telemetry.submit({
@@ -2117,113 +2127,113 @@ export class Scheduler {
 
   // Keep state-bundle wiring explicit without making the field declarations
   // read like one large object graph.
-  private initializeSchedulerState(): void {
-    this.diagnosisControlState = this.createDiagnosisControlState();
-    this.writeIndex = this.createWriteIndex();
-    this.eventPreflightDependencyState = this
-      .createEventPreflightDependencyState();
-    this.dependencyGraphState = this.createDependencyGraphState();
-    this.dependencyUpdateState = this.createDependencyUpdateState();
-    this.triggerSubscriptionState = this.createTriggerSubscriptionState();
-    this.storageNotificationState = this.createStorageNotificationState();
-    this.pendingPullRunnableState = this.createPendingPullRunnableState();
-    this.dirtyPullRunnableState = this.createDirtyPullRunnableState();
-    this.dirtyPullRunnableStateWithDebounce = this
-      .createDirtyPullRunnableStateWithDebounce();
-    this.pullSchedulingState = this.createPullSchedulingState();
-    this.subscriptionState = this.createSubscriptionState();
-    this.subscribeActionState = this.createSubscribeActionState();
-    this.unsubscribeState = this.createUnsubscribeState();
-    this.settleLoopState = this.createSettleLoopState();
-    this.executeContinuationState = this.createExecuteContinuationState();
-    this.eventQueueState = this.createEventQueueState();
-    this.eventExecutionState = this.createEventExecutionState();
-    this.actionRunState = this.createActionRunState();
-    this.graphSnapshotState = this.createGraphSnapshotState();
+  #initializeSchedulerState(): void {
+    this.#diagnosisControlState = this.#createDiagnosisControlState();
+    this.#writeIndex = this.#createWriteIndex();
+    this.#eventPreflightDependencyState = this
+      .#createEventPreflightDependencyState();
+    this.#dependencyGraphState = this.#createDependencyGraphState();
+    this.dependencyUpdateState = this.#createDependencyUpdateState();
+    this.#triggerSubscriptionState = this.#createTriggerSubscriptionState();
+    this.#storageNotificationState = this.#createStorageNotificationState();
+    this.#pendingPullRunnableState = this.#createPendingPullRunnableState();
+    this.#dirtyPullRunnableState = this.#createDirtyPullRunnableState();
+    this.#dirtyPullRunnableStateWithDebounce = this
+      .#createDirtyPullRunnableStateWithDebounce();
+    this.#pullSchedulingState = this.#createPullSchedulingState();
+    this.#subscriptionState = this.#createSubscriptionState();
+    this.#subscribeActionState = this.#createSubscribeActionState();
+    this.#unsubscribeState = this.#createUnsubscribeState();
+    this.#settleLoopState = this.#createSettleLoopState();
+    this.#executeContinuationState = this.#createExecuteContinuationState();
+    this.eventQueueState = this.#createEventQueueState();
+    this.eventExecutionState = this.#createEventExecutionState();
+    this.#actionRunState = this.#createActionRunState();
+    this.#graphSnapshotState = this.#createGraphSnapshotState();
   }
 
-  private createDiagnosisControlState(): SchedulerDiagnosisControlState {
+  #createDiagnosisControlState(): SchedulerDiagnosisControlState {
     return {
       getDiagnosisEnabled: () => this.diagnosisEnabled,
       setDiagnosisEnabled: (enabled) => {
         this.diagnosisEnabled = enabled;
       },
-      getDiagnosisTimeout: () => this.diagnosisTimeout,
+      getDiagnosisTimeout: () => this.#diagnosisTimeout,
       setDiagnosisTimeout: (timeout) => {
-        this.diagnosisTimeout = timeout;
+        this.#diagnosisTimeout = timeout;
       },
-      getDiagnosisStartTime: () => this.diagnosisStartTime,
+      getDiagnosisStartTime: () => this.#diagnosisStartTime,
       setDiagnosisStartTime: (time) => {
-        this.diagnosisStartTime = time;
+        this.#diagnosisStartTime = time;
       },
-      getDiagnosisBusyTime: () => this.diagnosisBusyTime,
+      getDiagnosisBusyTime: () => this.#diagnosisBusyTime,
       setDiagnosisBusyTime: (time) => {
-        this.diagnosisBusyTime = time;
+        this.#diagnosisBusyTime = time;
       },
-      getDiagnosisResolve: () => this.diagnosisResolve,
+      getDiagnosisResolve: () => this.#diagnosisResolve,
       setDiagnosisResolve: (resolve) => {
-        this.diagnosisResolve = resolve;
+        this.#diagnosisResolve = resolve;
       },
-      diagnosisHistory: this.diagnosisHistory,
-      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
-      causalEdges: this.causalEdges,
-      idempotencyViolations: this.idempotencyViolations,
+      diagnosisHistory: this.#diagnosisHistory,
+      diagnosisNonIdempotent: this.#diagnosisNonIdempotent,
+      causalEdges: this.#causalEdges,
+      idempotencyViolations: this.#idempotencyViolations,
       computations: this.nodes.computations,
       setIdempotencyCheckMode: (enabled) => {
-        this.idempotencyCheckMode = enabled;
+        this.#idempotencyCheckMode = enabled;
       },
       runAction: (action) => this.run(action),
     };
   }
 
-  private createWriteIndex(): SchedulerWriteIndex {
+  #createWriteIndex(): SchedulerWriteIndex {
     return new SchedulerWriteIndex(() => this.runtime.scopeKeyIdentity);
   }
 
-  private createEventPreflightDependencyState(): EventPreflightDependencyState {
+  #createEventPreflightDependencyState(): EventPreflightDependencyState {
     return {
       scopeKeyIdentity: () => this.runtime.scopeKeyIdentity,
-      getTrace: () => this.eventPreflightTraceContext,
+      getTrace: () => this.#eventPreflightTraceContext,
       nodes: this.nodes,
       pending: this.pending,
-      reverseDependencies: this.reverseDependencies,
-      dependents: this.dependents,
-      dependencies: this.dependencies,
-      writersByEntity: this.writeIndex.writersByEntity,
+      reverseDependencies: this.#reverseDependencies,
+      dependents: this.#dependents,
+      dependencies: this.#dependencies,
+      writersByEntity: this.#writeIndex.writersByEntity,
       effects: this.nodes.effects,
       materializerIndex: this.materializers,
-      triggerIndex: this.triggerIndex,
+      triggerIndex: this.#triggerIndex,
       getSchedulingWrites: (target) =>
-        this.writeIndex.getSchedulingWrites(target),
+        this.#writeIndex.getSchedulingWrites(target),
       getActionId: (target) => this.getActionId(target),
     };
   }
 
-  private createDependencyGraphState(): DependencyGraphState {
+  #createDependencyGraphState(): DependencyGraphState {
     return {
       scopeKeyIdentity: () => this.runtime.scopeKeyIdentity,
-      triggerIndex: this.triggerIndex,
-      writersByEntity: this.writeIndex.writersByEntity,
-      dependencies: this.dependencies,
-      dependents: this.dependents,
-      reverseDependencies: this.reverseDependencies,
+      triggerIndex: this.#triggerIndex,
+      writersByEntity: this.#writeIndex.writersByEntity,
+      dependencies: this.#dependencies,
+      dependents: this.#dependents,
+      reverseDependencies: this.#reverseDependencies,
       nodes: this.nodes,
       materializerIndex: this.materializers,
       getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
+        this.#writeIndex.getSchedulingWrites(action),
     };
   }
 
-  private createDependencyUpdateState(): DependencyUpdateState {
+  #createDependencyUpdateState(): DependencyUpdateState {
     return {
-      writeIndex: this.writeIndex,
-      dependencies: this.dependencies,
+      writeIndex: this.#writeIndex,
+      dependencies: this.#dependencies,
     };
   }
 
-  private createTriggerSubscriptionState(): TriggerSubscriptionState {
+  #createTriggerSubscriptionState(): TriggerSubscriptionState {
     return new SchedulerTriggerSubscriptions({
-      triggerIndex: this.triggerIndex,
+      triggerIndex: this.#triggerIndex,
       cancels: this.cancels,
       getActionId: (action) => this.getActionId(action),
       onTriggerUnsubscribe: (actionId, entityCount) => {
@@ -2235,17 +2245,17 @@ export class Scheduler {
     });
   }
 
-  private createStorageNotificationState(): StorageNotificationState {
+  #createStorageNotificationState(): StorageNotificationState {
     return {
-      triggerIndex: this.triggerIndex,
+      triggerIndex: this.#triggerIndex,
       nodes: this.nodes,
       getDiagnosisEnabled: () => this.diagnosisEnabled,
-      getCollectTriggerTrace: () => this.collectTriggerTrace,
-      changeGroupToActionId: this.changeGroupToActionId,
+      getCollectTriggerTrace: () => this.#collectTriggerTrace,
+      changeGroupToActionId: this.#changeGroupToActionId,
       recordCausalEdge: (edge) => {
-        this.causalEdges.push(edge);
+        this.#causalEdges.push(edge);
       },
-      actionChangeGroups: this.actionChangeGroups,
+      actionChangeGroups: this.#actionChangeGroups,
       effects: this.nodes.effects,
       pending: this.pending,
       getActionId: (target) => this.getActionId(target),
@@ -2255,11 +2265,11 @@ export class Scheduler {
           change,
         }),
       recordTriggerTrace: (entry) =>
-        recordTriggerTraceState({ triggerTrace: this.triggerTrace }, entry),
-      scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
+        recordTriggerTraceState({ triggerTrace: this.#triggerTrace }, entry),
+      scheduleWithDebounce: (target) => this.#scheduleWithDebounce(target),
       markInvalid: (target, cause) =>
         this.markAndScheduleInvalidAction(target, cause),
-      isInvalid: (target) => this.isInvalidAction(target),
+      isInvalid: (target) => this.#isInvalidAction(target),
       materializerIndex: this.materializers,
       queueExecution: () => this.queueExecution(),
       isRendererInputSource: (source) =>
@@ -2269,33 +2279,33 @@ export class Scheduler {
     };
   }
 
-  private createStorageSubscription(): IStorageSubscription {
+  #createStorageSubscription(): IStorageSubscription {
     return {
       next: (notification: StorageNotification) => {
-        this.processStorageNotification(notification);
+        this.#processStorageNotification(notification);
         return { done: false };
       },
     };
   }
 
-  private processStorageNotification(notification: StorageNotification): void {
+  #processStorageNotification(notification: StorageNotification): void {
     processStorageNotification(
-      this.storageNotificationState,
+      this.#storageNotificationState,
       notification,
     );
   }
 
-  private createPendingPullRunnableState(): PendingPullRunnableState {
+  #createPendingPullRunnableState(): PendingPullRunnableState {
     return {
       effects: this.nodes.effects,
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
       shouldRunFirstPullComputationInDemandContext: (action) =>
-        this.shouldRunFirstPullComputationInDemandContext(action),
+        this.#shouldRunFirstPullComputationInDemandContext(action),
     };
   }
 
-  private createDirtyPullRunnableState(): DirtyPullRunnableState {
+  #createDirtyPullRunnableState(): DirtyPullRunnableState {
     return {
       effects: this.nodes.effects,
       isDemandedPullComputation: (action) =>
@@ -2304,46 +2314,47 @@ export class Scheduler {
     };
   }
 
-  private createDirtyPullRunnableStateWithDebounce(): DirtyPullRunnableStateWithDebounce {
+  #createDirtyPullRunnableStateWithDebounce(): DirtyPullRunnableStateWithDebounce {
     return {
-      ...this.dirtyPullRunnableState,
+      ...this.#dirtyPullRunnableState,
       isDebouncedComputationWaiting: (action) =>
-        this.isDebouncedComputationWaiting(action),
+        this.#isDebouncedComputationWaiting(action),
     };
   }
 
-  private createPullSchedulingState(): PullSchedulingState {
+  #createPullSchedulingState(): PullSchedulingState {
     return {
       nodes: this.nodes,
       pending: this.pending,
       effects: this.nodes.effects,
       materializerIndex: this.materializers,
-      pendingPullRunnableState: this.pendingPullRunnableState,
-      dirtyPullRunnableState: this.dirtyPullRunnableState,
+      pendingPullRunnableState: this.#pendingPullRunnableState,
+      dirtyPullRunnableState: this.#dirtyPullRunnableState,
       dirtyPullRunnableStateWithDebounce: this
-        .dirtyPullRunnableStateWithDebounce,
-      isLiveAction: (action) => this.isLiveAction(action),
+        .#dirtyPullRunnableStateWithDebounce,
+      isLiveAction: (action) => this.#isLiveAction(action),
       hasActiveDebounceTimer: (action) =>
         this.gates.hasActiveDebounceTimer(action),
-      getNextEligibleRunTime: (action) => this.getNextEligibleRunTime(action),
+      getNextEligibleRunTime: (action) => this.#getNextEligibleRunTime(action),
       // Engaged only while an initial rehydration is being applied (synchronous
       // post-phase-7). MUST NOT read backgroundTasks: that set holds work such
       // as an event-driven piece start (events.ts) or a sidecar pattern launch,
       // so gating on it would pause all pull scheduling on every one of them.
       // Per-node convergence episode state prevents one exhausted subgraph
       // from releasing idle for unrelated work.
-      isConvergenceHoldActive: (action) => this.isConvergenceHoldActive(action),
+      isConvergenceHoldActive: (action) =>
+        this.#isConvergenceHoldActive(action),
       isConvergenceBackoffDeferred: (action) =>
-        this.isConvergenceBackoffDeferred(action),
+        this.#isConvergenceBackoffDeferred(action),
     };
   }
 
-  private isConvergenceHoldActive(action: Action): boolean {
+  #isConvergenceHoldActive(action: Action): boolean {
     return (this.nodes.get(action)?.gate.convergenceHoldPasses ?? 0) <
       CONVERGENCE_IDLE_HOLD_MAX_BACKOFF_PASSES;
   }
 
-  private resetConvergenceHoldPasses(): void {
+  #resetConvergenceHoldPasses(): void {
     for (const record of this.nodes.nodes()) {
       record.gate.convergenceHoldPasses = 0;
     }
@@ -2354,47 +2365,47 @@ export class Scheduler {
   // the settle-cap backoff (planBudgetBackoff); the resume initial-run hold that
   // also rides `backoffUntil` only applies to never-ran nodes. Throttle and
   // debounce use their own gate fields, so this cleanly excludes them.
-  private isConvergenceBackoffDeferred(action: Action): boolean {
+  #isConvergenceBackoffDeferred(action: Action): boolean {
     const backoffUntil = this.nodes.get(action)?.gate.backoffUntil;
     return backoffUntil !== undefined && backoffUntil > performance.now();
   }
 
-  private createSubscriptionState(): SchedulerSubscriptionState {
+  #createSubscriptionState(): SchedulerSubscriptionState {
     return {
-      actionChangeGroups: this.actionChangeGroups,
-      changeGroupToActionId: this.changeGroupToActionId,
+      actionChangeGroups: this.#actionChangeGroups,
+      changeGroupToActionId: this.#changeGroupToActionId,
       nodes: this.nodes,
-      dependencyGraphState: this.dependencyGraphState,
-      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
+      dependencyGraphState: this.#dependencyGraphState,
+      getIdempotencyCheckMode: () => this.#idempotencyCheckMode,
       queueExecution: () => this.queueExecution(),
       getActionId: (target) => this.getActionId(target),
-      getExecutingAction: () => this.executingAction,
+      getExecutingAction: () => this.#executingAction,
     };
   }
 
-  private createSubscribeActionState(): SchedulerSubscribeActionState {
+  #createSubscribeActionState(): SchedulerSubscribeActionState {
     return {
-      subscriptionState: this.subscriptionState,
+      subscriptionState: this.#subscriptionState,
       dependencyUpdateState: this.dependencyUpdateState,
-      triggerSubscriptionState: this.triggerSubscriptionState,
-      markProvisionalDemand: (record) => this.markProvisionalDemand(record),
+      triggerSubscriptionState: this.#triggerSubscriptionState,
+      markProvisionalDemand: (record) => this.#markProvisionalDemand(record),
       pending: this.pending,
       effects: this.nodes.effects,
-      writeIndex: this.writeIndex,
+      writeIndex: this.#writeIndex,
       adoptGateConfig: (action) => this.gates.adopt(action),
       setDebounce: (action, ms) => this.setDebounce(action, ms),
       setNoDebounce: (action, optOut) => this.setNoDebounce(action, optOut),
       setThrottle: (action, ms) => this.setThrottle(action, ms),
       getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
+        this.#writeIndex.getSchedulingWrites(action),
       isThrottled: (action) => this.gates.isThrottled(action),
       isDebouncedComputationWaiting: (action) =>
-        this.isDebouncedComputationWaiting(action),
+        this.#isDebouncedComputationWaiting(action),
       markInvalid: (action) => this.markAndScheduleInvalidAction(action),
       updateDependents: (action, log) => this.updateDependents(action, log),
       registerWriterDependents: (action, writes) =>
         registerDependentsForWriterSurface(
-          this.dependencyGraphState,
+          this.#dependencyGraphState,
           action,
           writes,
         ),
@@ -2407,20 +2418,20 @@ export class Scheduler {
     };
   }
 
-  private createUnsubscribeState(): SchedulerUnsubscribeActionState {
+  #createUnsubscribeState(): SchedulerUnsubscribeActionState {
     return {
       cancels: this.cancels,
-      dependencies: this.dependencies,
-      actionChangeGroups: this.actionChangeGroups,
-      changeGroupToActionId: this.changeGroupToActionId,
+      dependencies: this.#dependencies,
+      actionChangeGroups: this.#actionChangeGroups,
+      changeGroupToActionId: this.#changeGroupToActionId,
       pending: this.pending,
-      reverseDependencies: this.reverseDependencies,
-      dependents: this.dependents,
-      dependencyGraphState: this.dependencyGraphState,
+      reverseDependencies: this.#reverseDependencies,
+      dependents: this.#dependents,
+      dependencyGraphState: this.#dependencyGraphState,
       nodes: this.nodes,
-      writeIndex: this.writeIndex,
+      writeIndex: this.#writeIndex,
       getActionId: (target) => this.getActionId(target),
-      clearInvalid: (target) => this.clearInvalidAction(target),
+      clearInvalid: (target) => this.#clearInvalidAction(target),
       cancelDebounceTimer: (target) => this.gates.cancelDebounceTimer(target),
       clearComputationDebounceState: (target, targetOptions) =>
         this.gates.clearComputationDebounceState(target, targetOptions),
@@ -2428,55 +2439,55 @@ export class Scheduler {
     };
   }
 
-  private createSettleLoopState(): SchedulerSettleLoopState {
+  #createSettleLoopState(): SchedulerSettleLoopState {
     return {
       scopeKeyIdentity: () => this.runtime.scopeKeyIdentity,
-      getCollectSettleStats: () => this.collectSettleStats,
+      getCollectSettleStats: () => this.#collectSettleStats,
       effects: this.nodes.effects,
       computations: this.nodes.computations,
       pending: this.pending,
-      dependencies: this.dependencies,
+      dependencies: this.#dependencies,
       nodes: this.nodes,
-      dependents: this.dependents,
-      filterStats: this.filterStats,
+      dependents: this.#dependents,
+      filterStats: this.#filterStats,
       materializerIndex: this.materializers,
-      writersByEntity: this.writeIndex.writersByEntity,
+      writersByEntity: this.#writeIndex.writersByEntity,
       getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
-      getSchedulingWritesMap: () => this.writeIndex.getSchedulingWritesMap(),
+        this.#writeIndex.getSchedulingWrites(action),
+      getSchedulingWritesMap: () => this.#writeIndex.getSchedulingWritesMap(),
       collectPullIterationSeeds: (seeds) =>
-        this.collectPullIterationSeeds(seeds),
+        this.#collectPullIterationSeeds(seeds),
       refreshPassScopedDemand: (demand) => {
-        this.eventPassDemandRefresh?.(demand);
+        this.#eventPassDemandRefresh?.(demand);
       },
       getActionId: (action) => this.getActionId(action),
       isThrottled: (action) => this.gates.isThrottled(action),
-      getNextEligibleRunTime: (action) => this.getNextEligibleRunTime(action),
+      getNextEligibleRunTime: (action) => this.#getNextEligibleRunTime(action),
       isDebouncedComputationWaiting: (action) =>
-        this.isDebouncedComputationWaiting(action),
+        this.#isDebouncedComputationWaiting(action),
       clearComputationDebounceState: (action) =>
         this.gates.clearComputationDebounceState(action),
-      isLiveAction: (action) => this.isLiveAction(action),
+      isLiveAction: (action) => this.#isLiveAction(action),
       runAction: (action) => this.run(action),
       // Stage C tuning T3: only a serving runtime yields between runs.
-      ...(this.cooperativeYield !== undefined
-        ? { yieldBetweenRuns: this.cooperativeYieldBetweenRuns }
+      ...(this.#cooperativeYield !== undefined
+        ? { yieldBetweenRuns: this.#cooperativeYieldBetweenRuns }
         : {}),
     };
   }
 
-  private createExecuteContinuationState(): ExecuteContinuationState {
+  #createExecuteContinuationState(): ExecuteContinuationState {
     return {
-      pullScheduling: this.pullSchedulingState,
+      pullScheduling: this.#pullSchedulingState,
       eventQueue: this.eventQueue,
-      idlePromises: this.idlePromises,
+      idlePromises: this.#idlePromises,
       consumeRerunAfterCurrentExecute: () => {
-        const shouldRerun = this.rerunAfterCurrentExecute;
-        this.rerunAfterCurrentExecute = false;
+        const shouldRerun = this.#rerunAfterCurrentExecute;
+        this.#rerunAfterCurrentExecute = false;
         return shouldRerun;
       },
-      hasPendingLineageHeadEvent: () => this.hasPendingLineageHeadEvent(),
-      hasLoadParkedHeadEvent: () => this.hasLoadParkedHeadEvent(),
+      hasPendingLineageHeadEvent: () => this.#hasPendingLineageHeadEvent(),
+      hasLoadParkedHeadEvent: () => this.#hasLoadParkedHeadEvent(),
       scheduleWake: (at) => this.gates.scheduleWake(at),
       hasWakeTimer: () => this.gates.hasWakeTimer(),
       setScheduled: (scheduled) => {
@@ -2486,7 +2497,7 @@ export class Scheduler {
         this.settlingTracker = createSettlingTracker();
       },
       resetConvergenceHoldPasses: () => {
-        this.resetConvergenceHoldPasses();
+        this.#resetConvergenceHoldPasses();
       },
       setPendingQueueTaskTimer: (timer) => {
         this.pendingQueueTaskTimer = timer;
@@ -2495,12 +2506,12 @@ export class Scheduler {
     };
   }
 
-  private createEventQueueState(): SchedulerEventQueueState {
+  #createEventQueueState(): SchedulerEventQueueState {
     return {
       runtime: this.runtime,
-      eventHandlers: this.eventHandlers,
+      eventHandlers: this.#eventHandlers,
       eventQueue: this.eventQueue,
-      backgroundTasks: this.backgroundTasks,
+      backgroundTasks: this.#backgroundTasks,
       queueExecution: () => this.queueExecution(),
       recordLineageEvent: (originTx, queuedEvent) => {
         this.lineage.recordEvent(originTx, queuedEvent);
@@ -2511,19 +2522,20 @@ export class Scheduler {
     };
   }
 
-  private createEventExecutionState(): SchedulerEventExecutionState {
+  #createEventExecutionState(): SchedulerEventExecutionState {
     const getEventPreflightTelemetryEnabled = () =>
-      this.eventPreflightTelemetryEnabled;
+      this.#eventPreflightTelemetryEnabled;
     return {
       runtime: this.runtime,
       eventQueue: this.eventQueue,
       backpressure: this.runtime.commitBackpressure,
       collectPendingLoadParkKeys: (event, deps) =>
-        this.collectPendingLoadParkKeys(event, deps),
-      capturePendingLoadGenerations: () => this.capturePendingLoadGenerations(),
+        this.#collectPendingLoadParkKeys(event, deps),
+      capturePendingLoadGenerations: () =>
+        this.#capturePendingLoadGenerations(),
       parkHeadEventForLoads: (event, keys) =>
-        this.parkHeadEventForLoads(event, keys),
-      isHeadEventLoadParked: (event) => this.isHeadEventLoadParked(event),
+        this.#parkHeadEventForLoads(event, keys),
+      isHeadEventLoadParked: (event) => this.#isHeadEventLoadParked(event),
       nodes: this.nodes,
       pending: this.pending,
       get eventPreflightTelemetryEnabled() {
@@ -2535,13 +2547,13 @@ export class Scheduler {
       getActionId: (target) => this.getActionId(target),
       getActionTelemetryInfo: (target) =>
         getSchedulerActionTelemetryInfo(target),
-      handleError: (error, target) => this.handleError(error, target),
+      handleError: (error, target) => this.#handleError(error, target),
       queueExecution: () => this.queueExecution(),
       setEventPreflightTraceContext: (trace) => {
-        this.eventPreflightTraceContext = trace;
+        this.#eventPreflightTraceContext = trace;
       },
       collectInvalidUpstreamForLog: (deps, invalidDeps) =>
-        this.collectInvalidUpstreamForLog(
+        this.#collectInvalidUpstreamForLog(
           deps,
           invalidDeps,
         ),
@@ -2557,19 +2569,19 @@ export class Scheduler {
         }
         : {}),
       setEventPassDemandRefresh: (refresh) => {
-        this.eventPassDemandRefresh = refresh;
+        this.#eventPassDemandRefresh = refresh;
       },
       isDebouncedComputationWaiting: (target) =>
-        this.isDebouncedComputationWaiting(target),
-      getNextDebounceRunTime: (target) => this.getNextDebounceRunTime(target),
-      getNextEligibleRunTime: (target) => this.getNextEligibleRunTime(target),
+        this.#isDebouncedComputationWaiting(target),
+      getNextDebounceRunTime: (target) => this.#getNextDebounceRunTime(target),
+      getNextEligibleRunTime: (target) => this.#getNextEligibleRunTime(target),
       scheduleWake: (notBefore) => this.gates.scheduleWake(notBefore),
       lineageStatus: (originTx) => this.lineage.originStatus(originTx),
       releaseLineageEvent: (originTx, queuedEvent) => {
         this.lineage.release(originTx, queuedEvent);
       },
       dropEvent: (queuedEvent, reason) => {
-        this.dropEvent(queuedEvent, reason);
+        this.#dropEvent(queuedEvent, reason);
       },
       recordLineageEvent: (originTx, queuedEvent) => {
         this.lineage.recordEvent(originTx, queuedEvent);
@@ -2578,37 +2590,37 @@ export class Scheduler {
         getCommitLocalSeq(originTx.tx, targetSpace),
       snapshotEventPreflightTraceContext: (trace) =>
         snapshotEventPreflightTraceContext(
-          this.eventPreflightDependencyState,
+          this.#eventPreflightDependencyState,
           trace,
         ),
     };
   }
 
-  private createActionRunState(): SchedulerActionRunState {
+  #createActionRunState(): SchedulerActionRunState {
     return {
       runtime: this.runtime,
-      actionChangeGroups: this.actionChangeGroups,
-      actionTimingState: this.actionTimingState,
+      actionChangeGroups: this.#actionChangeGroups,
+      actionTimingState: this.#actionTimingState,
       retries: this.retries,
-      offBudgetRetries: this.offBudgetRetries,
+      offBudgetRetries: this.#offBudgetRetries,
       pending: this.pending,
-      actionRunTrace: this.actionRunTrace,
+      actionRunTrace: this.#actionRunTrace,
       nodes: this.nodes,
-      diagnosisHistory: this.diagnosisHistory,
-      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
-      idempotencyViolations: this.idempotencyViolations,
+      diagnosisHistory: this.#diagnosisHistory,
+      diagnosisNonIdempotent: this.#diagnosisNonIdempotent,
+      idempotencyViolations: this.#idempotencyViolations,
       getRunningPromise: () => this.runningPromise,
       setRunningPromise: (promise) => {
         this.runningPromise = promise;
       },
-      getCollectActionRunTrace: () => this.collectActionRunTrace,
+      getCollectActionRunTrace: () => this.#collectActionRunTrace,
       getDiagnosisEnabled: () => this.diagnosisEnabled,
-      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
+      getIdempotencyCheckMode: () => this.#idempotencyCheckMode,
       getActionId: (target) => this.getActionId(target),
       getActionTelemetryInfo: (target) =>
         getSchedulerActionTelemetryInfo(target),
       getSchedulingWrites: (target) =>
-        this.writeIndex.getSchedulingWrites(target),
+        this.#writeIndex.getSchedulingWrites(target),
       getMaterializerWriteEnvelopes: (target) =>
         this.materializers.getMaterializerWriteEnvelopes(target),
       getDebounce: (target) => this.gates.getDebounce(target),
@@ -2616,31 +2628,31 @@ export class Scheduler {
       getThrottle: (target) => this.gates.getThrottle(target),
       maybeAutoDebounce: (target) => this.maybeAutoDebounce(target),
       markActionHasRun: (target) => this.gates.markActionHasRun(target),
-      markNodeHasRun: (target) => this.markNodeHasRun(target),
-      handleError: (error, target) => this.handleError(error, target),
+      markNodeHasRun: (target) => this.#markNodeHasRun(target),
+      handleError: (error, target) => this.#handleError(error, target),
       resubscribe: (target, log) => this.resubscribe(target, log),
       markInvalid: (target, options) =>
-        this.markActionInvalid(target, undefined, options),
+        this.#markActionInvalid(target, undefined, options),
       queueExecution: () => this.queueExecution(),
       setExecutingAction: (target, targetActionId) => {
-        this.executingAction = target;
+        this.#executingAction = target;
         this.currentActionId = targetActionId;
       },
       clearExecutingAction: () => {
-        this.executingAction = null;
+        this.#executingAction = null;
         this.currentActionId = undefined;
       },
     };
   }
 
-  private createGraphSnapshotState(): SchedulerGraphSnapshotState {
+  #createGraphSnapshotState(): SchedulerGraphSnapshotState {
     return {
       scopeKeyIdentity: () => this.runtime.scopeKeyIdentity,
       effects: this.nodes.effects,
       computations: this.nodes.computations,
       pending: this.pending,
-      dependencies: this.dependencies,
-      dependents: this.dependents,
+      dependencies: this.#dependencies,
+      dependents: this.#dependents,
       nodes: this.nodes,
       actionStats: this.actionStats,
       getDebounce: (action) => this.gates.getDebounce(action),
@@ -2649,13 +2661,13 @@ export class Scheduler {
         this.gates.hasActiveDebounceTimer(action),
       getActionId: (action) => this.getActionId(action),
       getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
-      getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
-      getNextEligibleRunTime: (action) => this.getNextEligibleRunTime(action),
+        this.#writeIndex.getSchedulingWrites(action),
+      getNextDebounceRunTime: (action) => this.#getNextDebounceRunTime(action),
+      getNextEligibleRunTime: (action) => this.#getNextEligibleRunTime(action),
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
-      isLiveEffect: (action) => this.isLiveEffect(action),
-      isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+      isLiveEffect: (action) => this.#isLiveEffect(action),
+      isPullDemandRootEffect: (action) => this.#isPullDemandRootEffect(action),
       getPatternIdentity: (action) => {
         const annotated = action as Partial<TelemetryAnnotations>;
         return annotated.pattern
@@ -2675,16 +2687,16 @@ export class Scheduler {
    * This ID is used for stats tracking to persist across action recreation.
    */
   private getActionId(action: Action | EventHandler): string {
-    return getSchedulerActionId(this.actionIdentityState, action);
+    return getSchedulerActionId(this.#actionIdentityState, action);
   }
 
   private isDemandedPullComputation(action: Action): boolean {
     const record = this.nodes.get(action);
     return record?.kind === "computation" &&
-      isLive(this.dependencyGraphState, record);
+      isLive(this.#dependencyGraphState, record);
   }
 
-  private shouldRunFirstPullComputationInDemandContext(
+  #shouldRunFirstPullComputationInDemandContext(
     action: Action,
   ): boolean {
     const record = this.nodes.get(action);
@@ -2693,31 +2705,31 @@ export class Scheduler {
       record.provisionalDemand;
   }
 
-  private isLiveEffect(action: Action): boolean {
+  #isLiveEffect(action: Action): boolean {
     return this.nodes.get(action)?.kind === "effect";
   }
 
-  private isLiveAction(action: Action): boolean {
+  #isLiveAction(action: Action): boolean {
     const record = this.nodes.get(action);
-    return record !== undefined && isLive(this.dependencyGraphState, record);
+    return record !== undefined && isLive(this.#dependencyGraphState, record);
   }
 
-  private isPullDemandRootEffect(action: Action): boolean {
+  #isPullDemandRootEffect(action: Action): boolean {
     const record = this.nodes.get(action);
     return record?.kind === "effect" &&
-      (this.writeIndex.getSchedulingWrites(action)?.length ?? 0) === 0;
+      (this.#writeIndex.getSchedulingWrites(action)?.length ?? 0) === 0;
   }
 
-  private isInvalidAction(action: Action): boolean {
+  #isInvalidAction(action: Action): boolean {
     const record = this.nodes.get(action);
     return record?.status === "invalid" || record?.status === "never-ran";
   }
 
-  private getNextEligibleRunTime(action: Action): number | undefined {
+  #getNextEligibleRunTime(action: Action): number | undefined {
     return this.gates.getNextEligibleRunTime(action);
   }
 
-  private markActionInvalid(
+  #markActionInvalid(
     action: Action,
     cause?: IMemorySpaceAddress,
     options?: MarkInvalidOptions,
@@ -2733,12 +2745,12 @@ export class Scheduler {
       this.gates.onInvalidated(
         record,
         performance.now(),
-        this.createDebouncedComputationContext(),
+        this.#createDebouncedComputationContext(),
       );
     }
   }
 
-  private clearInvalidAction(action: Action): void {
+  #clearInvalidAction(action: Action): void {
     const record = this.nodes.get(action);
     if (!record) return;
     if (record.status === "invalid") {
@@ -2751,14 +2763,14 @@ export class Scheduler {
     action: Action,
     cause?: IMemorySpaceAddress,
   ): void {
-    this.markActionInvalid(action, cause);
+    this.#markActionInvalid(action, cause);
 
     if (this.nodes.effects.has(action) && this.gates.getDebounce(action)) {
-      this.scheduleWithDebounce(action);
+      this.#scheduleWithDebounce(action);
       return;
     }
     if (
-      this.isLiveAction(action) ||
+      this.#isLiveAction(action) ||
       this.materializers.isMaterializer(action) ||
       this.pending.has(action)
     ) {
@@ -2766,30 +2778,30 @@ export class Scheduler {
     }
   }
 
-  private collectInvalidUpstreamForLog(
+  #collectInvalidUpstreamForLog(
     log: ReactivityLog,
     workSet: Set<Action>,
   ): boolean {
     return collectInvalidUpstreamForLogState(
-      this.eventPreflightDependencyState,
+      this.#eventPreflightDependencyState,
       log,
       workSet,
     );
   }
 
-  private collectPendingLoadParkKeys(
+  #collectPendingLoadParkKeys(
     event: QueuedEvent,
     log: ReactivityLog,
   ): string[] {
     const pendingLoadAddresses =
       this.runtime.storageManager.pendingLoadAddresses?.() ?? [];
     const keys = collectPendingLoadParkKeysState(
-      this.eventPreflightDependencyState,
+      this.#eventPreflightDependencyState,
       pendingLoadAddresses,
       log,
     );
     if (keys.length === 0) return keys;
-    const history = this.headEventLoadParkHistory;
+    const history = this.#headEventLoadParkHistory;
     if (!history || history.eventId !== event.id) return keys;
     return keys.filter((key) => {
       const currentGeneration =
@@ -2797,54 +2809,54 @@ export class Scheduler {
       const settledGeneration = history.generations.get(key);
       if (settledGeneration === undefined) return true;
       if (settledGeneration === currentGeneration) return false;
-      return this.preflightPendingLoadGenerations.get(key) ===
+      return this.#preflightPendingLoadGenerations.get(key) ===
         currentGeneration;
     });
   }
 
-  private capturePendingLoadGenerations(): void {
-    this.preflightPendingLoadGenerations.clear();
+  #capturePendingLoadGenerations(): void {
+    this.#preflightPendingLoadGenerations.clear();
     for (
       const address of this.runtime.storageManager.pendingLoadAddresses?.() ??
         []
     ) {
       const key = entityKey(address, this.runtime.scopeKeyIdentity);
-      this.preflightPendingLoadGenerations.set(
+      this.#preflightPendingLoadGenerations.set(
         key,
         this.runtime.storageManager.pendingLoadGeneration?.(key) ?? 0,
       );
     }
   }
 
-  private parkHeadEventForLoads(
+  #parkHeadEventForLoads(
     event: QueuedEvent,
     keys: readonly string[],
   ): void {
-    if (this.headEventLoadPark?.eventId === event.id) return;
+    if (this.#headEventLoadPark?.eventId === event.id) return;
     const generations = new Map(
       keys.map((key) => [
         key,
         this.runtime.storageManager.pendingLoadGeneration?.(key) ?? 0,
       ]),
     );
-    this.headEventLoadPark = { eventId: event.id, keys, generations };
+    this.#headEventLoadPark = { eventId: event.id, keys, generations };
     const settled = this.runtime.storageManager.loadsSettled?.(keys) ??
       Promise.resolve();
     settled.then(
-      () => this.releaseHeadEventLoadPark(event.id),
-      (error) => this.failHeadEventLoadPark(event, error),
+      () => this.#releaseHeadEventLoadPark(event.id),
+      (error) => this.#failHeadEventLoadPark(event, error),
     );
   }
 
-  private releaseHeadEventLoadPark(eventId: string): void {
-    if (this.headEventLoadPark?.eventId !== eventId) return;
-    if (this.headEventLoadParkHistory?.eventId !== eventId) {
-      this.headEventLoadParkHistory = { eventId, generations: new Map() };
+  #releaseHeadEventLoadPark(eventId: string): void {
+    if (this.#headEventLoadPark?.eventId !== eventId) return;
+    if (this.#headEventLoadParkHistory?.eventId !== eventId) {
+      this.#headEventLoadParkHistory = { eventId, generations: new Map() };
     }
-    for (const [key, generation] of this.headEventLoadPark.generations) {
-      this.headEventLoadParkHistory.generations.set(key, generation);
+    for (const [key, generation] of this.#headEventLoadPark.generations) {
+      this.#headEventLoadParkHistory.generations.set(key, generation);
     }
-    this.headEventLoadPark = null;
+    this.#headEventLoadPark = null;
     this.queueExecution();
   }
 
@@ -2892,11 +2904,11 @@ export class Scheduler {
    * the drop keeps today's shape — the same split events.ts makes for a
    * piece-load failure.
    */
-  private failHeadEventLoadPark(event: QueuedEvent, error: unknown): void {
-    if (this.headEventLoadPark?.eventId !== event.id) return;
-    const keys = this.headEventLoadPark.keys.join(", ");
-    this.headEventLoadPark = null;
-    this.headEventLoadParkHistory = null;
+  #failHeadEventLoadPark(event: QueuedEvent, error: unknown): void {
+    if (this.#headEventLoadPark?.eventId !== event.id) return;
+    const keys = this.#headEventLoadPark.keys.join(", ");
+    this.#headEventLoadPark = null;
+    this.#headEventLoadParkHistory = null;
     const detail = error instanceof Error ? error.message : String(error);
     const failure = error instanceof ReplicaLoadFailureError ? error.failure : {
       failureClass: "unknown" as const,
@@ -2904,7 +2916,7 @@ export class Scheduler {
       permanentEvidence: false,
     };
     if (event.served === undefined) {
-      this.dropEvent(
+      this.#dropEvent(
         event,
         `Event dropped: required replica load failed before dispatch (${detail})`,
       );
@@ -2914,7 +2926,7 @@ export class Scheduler {
     // The head's debug record names the failing doc keys and error;
     // `events.loadParkDeferrals` counts every head and barrier deferral, while
     // the durable checkpoint and terminal attention surface persistent failure.
-    this.dropEvent(
+    this.#dropEvent(
       event,
       `Event deferred: required replica load failed before dispatch ` +
         `(${keys}: ${detail}); the entry stays pending and a later drain ` +
@@ -2933,7 +2945,7 @@ export class Scheduler {
     for (const later of [...this.eventQueue]) {
       if (later.eventLink.space !== event.eventLink.space) continue;
       if (later.served?.streamEntry === undefined) continue;
-      this.dropEvent(
+      this.#dropEvent(
         later,
         `Event deferred: held behind ${event.id}, whose required replica ` +
           `load failed before dispatch (${keys}); later-arrived events wait ` +
@@ -2952,7 +2964,7 @@ export class Scheduler {
     this.queueExecution();
   }
 
-  private dropEvent(
+  #dropEvent(
     event: QueuedEvent,
     reason: string,
     options: {
@@ -2964,11 +2976,11 @@ export class Scheduler {
       servedOutcome?: ServedEventFailureOutcome;
     } = {},
   ): void {
-    if (this.headEventLoadPark?.eventId === event.id) {
-      this.headEventLoadPark = null;
+    if (this.#headEventLoadPark?.eventId === event.id) {
+      this.#headEventLoadPark = null;
     }
-    if (this.headEventLoadParkHistory?.eventId === event.id) {
-      this.headEventLoadParkHistory = null;
+    if (this.#headEventLoadParkHistory?.eventId === event.id) {
+      this.#headEventLoadParkHistory = null;
     }
     dropQueuedEvent(
       {
@@ -3007,53 +3019,53 @@ export class Scheduler {
   ): number {
     const matches = this.eventQueue.filter(predicate);
     for (const event of matches) {
-      this.dropEvent(event, reason, { quiet: true });
+      this.#dropEvent(event, reason, { quiet: true });
     }
     return matches.length;
   }
 
-  private isHeadEventLoadParked(event: QueuedEvent): boolean {
-    return this.headEventLoadPark?.eventId === event.id;
+  #isHeadEventLoadParked(event: QueuedEvent): boolean {
+    return this.#headEventLoadPark?.eventId === event.id;
   }
 
-  private hasLoadParkedHeadEvent(): boolean {
+  #hasLoadParkedHeadEvent(): boolean {
     const head = this.eventQueue[0];
-    return head !== undefined && this.headEventLoadPark?.eventId === head.id;
+    return head !== undefined && this.#headEventLoadPark?.eventId === head.id;
   }
 
-  private canAutomaticallyDebounce(action: Action): boolean {
+  #canAutomaticallyDebounce(action: Action): boolean {
     return this.gates.canAutomaticallyDebounce(action, {
       effects: this.nodes.effects,
     });
   }
 
-  private collectPullIterationSeeds(workSet: Set<Action>): void {
-    collectPullIterationSeedsState(this.pullSchedulingState, workSet);
+  #collectPullIterationSeeds(workSet: Set<Action>): void {
+    collectPullIterationSeedsState(this.#pullSchedulingState, workSet);
   }
 
-  private hasRunnablePullWork(): boolean {
-    return hasRunnablePullWorkState(this.pullSchedulingState);
+  #hasRunnablePullWork(): boolean {
+    return hasRunnablePullWorkState(this.#pullSchedulingState);
   }
 
-  private hasIdleBlockingDeferredPullWork(): boolean {
-    return hasIdleBlockingDeferredPullWorkState(this.pullSchedulingState);
+  #hasIdleBlockingDeferredPullWork(): boolean {
+    return hasIdleBlockingDeferredPullWorkState(this.#pullSchedulingState);
   }
 
   private clearBackoffForCleanNodes(): void {
     let clearedDeadline = false;
     for (const record of this.nodes.nodes()) {
       if (record.status === "clean") {
-        clearedDeadline = this.clearNodeBackoff(record) || clearedDeadline;
+        clearedDeadline = this.#clearNodeBackoff(record) || clearedDeadline;
       }
     }
     if (clearedDeadline) this.gates.recomputeWakeAfterClear();
   }
 
-  private clearNodeBackoff(record: SchedulerNode): boolean {
+  #clearNodeBackoff(record: SchedulerNode): boolean {
     return this.gates.clearBackoff(record);
   }
 
-  private hasPendingLineageHeadEvent(): boolean {
+  #hasPendingLineageHeadEvent(): boolean {
     const head = this.eventQueue[0];
     if (head?.originTx === undefined) return false;
     if (this.lineage.originStatus(head.originTx) !== "pending") return false;
@@ -3061,29 +3073,29 @@ export class Scheduler {
       undefined;
   }
 
-  private updateMaterializerRegistration(action: Action): void {
+  #updateMaterializerRegistration(action: Action): void {
     const record = this.nodes.get(action);
-    const wasLive = record ? isLive(this.dependencyGraphState, record) : false;
+    const wasLive = record ? isLive(this.#dependencyGraphState, record) : false;
     this.materializers.register(
       action,
       (action as Partial<TelemetryAnnotations>).materializerWriteEnvelopes,
     );
-    notifyNodeLivenessChange(this.dependencyGraphState, action, wasLive);
+    notifyNodeLivenessChange(this.#dependencyGraphState, action, wasLive);
   }
 
-  private markProvisionalDemand(record: SchedulerNode): void {
+  #markProvisionalDemand(record: SchedulerNode): void {
     setNodeProvisionalDemand(
-      this.dependencyGraphState,
+      this.#dependencyGraphState,
       record,
       true,
-      this.activePassId,
+      this.#activePassId,
     );
-    if (this.activePassId !== undefined) {
-      this.provisionalDemandThisPass.add(record);
+    if (this.#activePassId !== undefined) {
+      this.#provisionalDemandThisPass.add(record);
     }
   }
 
-  private markNodeHasRun(action: Action): void {
+  #markNodeHasRun(action: Action): void {
     const record = this.nodes.get(action);
     if (!record) return;
 
@@ -3094,42 +3106,42 @@ export class Scheduler {
     if (
       record.provisionalDemand &&
       (record.provisionalDemandPass === undefined ||
-        this.passCounter > record.provisionalDemandPass)
+        this.#passCounter > record.provisionalDemandPass)
     ) {
-      setNodeProvisionalDemand(this.dependencyGraphState, record, false);
+      setNodeProvisionalDemand(this.#dependencyGraphState, record, false);
     }
   }
 
-  private clearProvisionalDemandAtPassEnd(): void {
-    const passId = this.activePassId;
+  #clearProvisionalDemandAtPassEnd(): void {
+    const passId = this.#activePassId;
     if (passId === undefined) return;
 
-    for (const record of this.provisionalDemandThisPass) {
+    for (const record of this.#provisionalDemandThisPass) {
       if (
         record.provisionalDemand &&
         record.provisionalDemandPass === passId &&
         record.status !== "never-ran"
       ) {
-        setNodeProvisionalDemand(this.dependencyGraphState, record, false);
+        setNodeProvisionalDemand(this.#dependencyGraphState, record, false);
       }
     }
-    this.provisionalDemandThisPass.clear();
+    this.#provisionalDemandThisPass.clear();
   }
 
-  private getNextDebounceRunTime(action: Action): number | undefined {
+  #getNextDebounceRunTime(action: Action): number | undefined {
     // Same context as the waiting/schedule paths — the planner must agree
     // with them on the first-run debounce gate (shouldDebounceFirstRun), or a
     // scheduled debounce has no wake time.
     return this.gates.getNextDebounceRunTime(
       action,
-      this.createDebouncedComputationContext(),
+      this.#createDebouncedComputationContext(),
     );
   }
 
-  private isDebouncedComputationWaiting(action: Action): boolean {
+  #isDebouncedComputationWaiting(action: Action): boolean {
     return this.gates.isDebouncedComputationWaiting(
       action,
-      this.createDebouncedComputationContext(),
+      this.#createDebouncedComputationContext(),
     );
   }
 
@@ -3138,7 +3150,7 @@ export class Scheduler {
    * If the action has a debounce delay, it will wait before being added to pending.
    * Otherwise, it's added immediately.
    */
-  private scheduleWithDebounce(action: Action): void {
+  #scheduleWithDebounce(action: Action): void {
     this.gates.scheduleWithDebounce(action, {
       pending: this.pending,
       queueExecution: () => this.queueExecution(),
@@ -3155,7 +3167,7 @@ export class Scheduler {
   private maybeAutoDebounce(action: Action): void {
     const update = this.gates.maybeAutoDebounce(action, {
       canAutomaticallyDebounce: (candidate) =>
-        this.canAutomaticallyDebounce(candidate),
+        this.#canAutomaticallyDebounce(candidate),
     });
     if (update) {
       logger.debug("schedule-debounce", () => [
@@ -3167,11 +3179,11 @@ export class Scheduler {
     }
   }
 
-  private createDebouncedComputationContext() {
+  #createDebouncedComputationContext() {
     return {
       computations: this.nodes.computations,
       effects: this.nodes.effects,
-      isInvalid: (target: Action) => this.isInvalidAction(target),
+      isInvalid: (target: Action) => this.#isInvalidAction(target),
       pending: this.pending,
       queueExecution: () => this.queueExecution(),
       logDebounce: (message: string) =>

--- a/packages/runner/src/scheduler/gates.ts
+++ b/packages/runner/src/scheduler/gates.ts
@@ -22,19 +22,29 @@ interface DebouncedComputationContext {
 }
 
 export class SchedulerGates {
-  private readonly stagedGates = new WeakMap<Action, SchedulerGateState>();
-  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
-  private wakeAt: number | null = null;
+  readonly #stagedGates = new WeakMap<Action, SchedulerGateState>();
+  #wakeTimer: ReturnType<typeof setTimeout> | null = null;
+  #wakeAt: number | null = null;
+
+  readonly #state: {
+    readonly nodes: NodeRegistry;
+    readonly actionStats: ReadonlyMap<string, ActionStats>;
+    readonly getActionId: (action: Action) => string;
+    readonly isDisposed: () => boolean;
+    readonly queueExecution: () => void;
+  };
 
   constructor(
-    private readonly state: {
+    state: {
       readonly nodes: NodeRegistry;
       readonly actionStats: ReadonlyMap<string, ActionStats>;
       readonly getActionId: (action: Action) => string;
       readonly isDisposed: () => boolean;
       readonly queueExecution: () => void;
     },
-  ) {}
+  ) {
+    this.#state = state;
+  }
 
   /**
    * Hold a just-registered action's initial run until `notBefore` (used for
@@ -44,28 +54,28 @@ export class SchedulerGates {
    * is released early via releaseInitialRunHold when the space sync completes.
    */
   holdInitialRun(action: Action, notBefore: number): void {
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     gate.backoffUntil = Math.max(gate.backoffUntil ?? 0, notBefore);
     this.scheduleWake(notBefore);
   }
 
   releaseInitialRunHold(action: Action): void {
-    const record = this.state.nodes.get(action);
+    const record = this.#state.nodes.get(action);
     if (!record?.gate?.backoffUntil) return;
     record.gate.backoffUntil = 0;
     this.recomputeWakeAfterClear();
   }
 
   adopt(action: Action): void {
-    const record = this.state.nodes.get(action);
-    const staged = this.stagedGates.get(action);
+    const record = this.#state.nodes.get(action);
+    const staged = this.#stagedGates.get(action);
     if (!record || !staged) return;
     record.gate = { ...record.gate, ...staged };
-    this.stagedGates.delete(action);
+    this.#stagedGates.delete(action);
   }
 
   setDebounce(action: Action, ms: number): void {
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     if (ms <= 0) {
       delete gate.debounceMs;
       this.clearComputationDebounceState(action);
@@ -98,7 +108,7 @@ export class SchedulerGates {
   }
 
   setNoDebounce(action: Action, optOut: boolean): void {
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     if (optOut) {
       gate.noAutoDebounce = true;
     } else {
@@ -135,11 +145,11 @@ export class SchedulerGates {
     | undefined {
     if (!context.canAutomaticallyDebounce(action)) return undefined;
 
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     if (gate.debounceMs !== undefined) return undefined;
 
-    const actionId = this.state.getActionId(action);
-    const stats = this.state.actionStats.get(actionId);
+    const actionId = this.#state.getActionId(action);
+    const stats = this.#state.actionStats.get(actionId);
     if (!stats) return undefined;
     if (stats.runCount < AUTO_DEBOUNCE_MIN_RUNS) return undefined;
     if (stats.averageTime < AUTO_DEBOUNCE_THRESHOLD_MS) return undefined;
@@ -156,7 +166,7 @@ export class SchedulerGates {
   markActionHasRun(action: Action): void {
     const gate = this.gate(action);
     if (gate) delete gate.debounceReadyAt;
-    this.armThrottleFromStats(action);
+    this.#armThrottleFromStats(action);
   }
 
   onInvalidated(
@@ -164,10 +174,12 @@ export class SchedulerGates {
     now = performance.now(),
     context?: DebouncedComputationContext,
   ): void {
-    if (!context || !this.shouldDebouncePullComputation(node.action, context)) {
+    if (
+      !context || !this.#shouldDebouncePullComputation(node.action, context)
+    ) {
       return;
     }
-    this.armComputationDebounce(node.action, context, now);
+    this.#armComputationDebounce(node.action, context, now);
   }
 
   onRunCompleted(
@@ -184,7 +196,7 @@ export class SchedulerGates {
       thresholdMs: number;
     }
     | undefined {
-    this.armThrottleFromStats(node.action);
+    this.#armThrottleFromStats(node.action);
     return this.maybeAutoDebounce(node.action, context);
   }
 
@@ -212,7 +224,7 @@ export class SchedulerGates {
       readonly isInvalid: (action: Action) => boolean;
     },
   ): number | undefined {
-    if (!this.shouldDebouncePullComputation(action, context)) {
+    if (!this.#shouldDebouncePullComputation(action, context)) {
       return undefined;
     }
     if (!context.isInvalid(action)) return undefined;
@@ -250,19 +262,19 @@ export class SchedulerGates {
 
     this.cancelDebounceTimer(action);
 
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     const readyAt = performance.now() + debounceMs;
     gate.debounceReadyAt = readyAt;
     this.scheduleWake(readyAt);
 
     context.logDebounce(
-      `[DEBOUNCE] Action ${this.state.getActionId(action)} ` +
+      `[DEBOUNCE] Action ${this.#state.getActionId(action)} ` +
         `debounced for ${debounceMs}ms`,
     );
   }
 
   setThrottle(action: Action, ms: number): void {
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     const previousReadyAt = gate.throttleReadyAt;
     if (ms <= 0) {
       delete gate.throttleMs;
@@ -270,7 +282,7 @@ export class SchedulerGates {
       this.recomputeWakeAfterClear();
     } else {
       gate.throttleMs = ms;
-      this.armThrottleFromStats(action);
+      this.#armThrottleFromStats(action);
       if (
         previousReadyAt !== undefined &&
         (gate.throttleReadyAt ?? 0) < previousReadyAt
@@ -293,7 +305,7 @@ export class SchedulerGates {
   }
 
   isThrottled(action: Action, now = performance.now()): boolean {
-    const record = this.state.nodes.get(action);
+    const record = this.#state.nodes.get(action);
     if (!record) return false;
     return (record.gate.throttleReadyAt ?? 0) > now;
   }
@@ -314,7 +326,7 @@ export class SchedulerGates {
     action: Action,
     now = performance.now(),
   ): number | undefined {
-    const record = this.state.nodes.get(action);
+    const record = this.#state.nodes.get(action);
     if (!record) return undefined;
     const eligibleAt = this.eligibleAt(record);
     return eligibleAt > now ? eligibleAt : undefined;
@@ -339,32 +351,34 @@ export class SchedulerGates {
   }
 
   scheduleWake(at: number): void {
-    if (this.state.isDisposed()) return;
-    if (this.wakeAt !== null && this.wakeAt <= at && this.wakeTimer !== null) {
+    if (this.#state.isDisposed()) return;
+    if (
+      this.#wakeAt !== null && this.#wakeAt <= at && this.#wakeTimer !== null
+    ) {
       return;
     }
 
     this.cancelWake();
 
     const delay = Math.max(0, at - performance.now());
-    this.wakeAt = at;
-    this.wakeTimer = setTimeout(() => {
-      this.wakeTimer = null;
-      this.wakeAt = null;
-      this.state.queueExecution();
+    this.#wakeAt = at;
+    this.#wakeTimer = setTimeout(() => {
+      this.#wakeTimer = null;
+      this.#wakeAt = null;
+      this.#state.queueExecution();
     }, delay);
   }
 
   cancelWake(): void {
-    if (this.wakeTimer !== null) {
-      clearTimeout(this.wakeTimer);
-      this.wakeTimer = null;
+    if (this.#wakeTimer !== null) {
+      clearTimeout(this.#wakeTimer);
+      this.#wakeTimer = null;
     }
-    this.wakeAt = null;
+    this.#wakeAt = null;
   }
 
   hasWakeTimer(): boolean {
-    return this.wakeTimer !== null;
+    return this.#wakeTimer !== null;
   }
 
   /**
@@ -378,9 +392,9 @@ export class SchedulerGates {
    * idle() can resolve promptly).
    */
   recomputeWakeAfterClear(): void {
-    if (this.state.isDisposed()) return;
+    if (this.#state.isDisposed()) return;
     this.cancelWake();
-    this.state.queueExecution();
+    this.#state.queueExecution();
   }
 
   clearBackoff(node: SchedulerNode): boolean {
@@ -391,7 +405,7 @@ export class SchedulerGates {
     return clearedDeadline;
   }
 
-  private armComputationDebounce(
+  #armComputationDebounce(
     action: Action,
     context: DebouncedComputationContext,
     now: number,
@@ -401,18 +415,18 @@ export class SchedulerGates {
 
     this.cancelDebounceTimer(action);
 
-    const gate = this.mutableGate(action);
+    const gate = this.#mutableGate(action);
     const readyAt = now + debounceMs;
     gate.debounceReadyAt = readyAt;
     this.scheduleWake(readyAt);
 
     context.logDebounce(
-      `[DEBOUNCE] Computation ${this.state.getActionId(action)} ` +
+      `[DEBOUNCE] Computation ${this.#state.getActionId(action)} ` +
         `trailing flush scheduled for ${debounceMs}ms`,
     );
   }
 
-  private shouldDebouncePullComputation(
+  #shouldDebouncePullComputation(
     action: Action,
     context: {
       readonly computations: ReadonlySet<Action>;
@@ -422,7 +436,7 @@ export class SchedulerGates {
   ): boolean {
     const gate = this.gate(action);
     const debounceMs = gate?.debounceMs;
-    const hasRun = this.state.nodes.get(action)?.status !== "never-ran";
+    const hasRun = this.#state.nodes.get(action)?.status !== "never-ran";
     return context.computations.has(action) &&
       !context.effects.has(action) &&
       (hasRun || context.shouldDebounceFirstRun?.(action) === true) &&
@@ -430,7 +444,7 @@ export class SchedulerGates {
       debounceMs > 0;
   }
 
-  private armThrottleFromStats(action: Action): void {
+  #armThrottleFromStats(action: Action): void {
     const gate = this.gate(action);
     const throttleMs = gate?.throttleMs;
     if (!gate || !throttleMs || throttleMs <= 0) {
@@ -438,7 +452,7 @@ export class SchedulerGates {
       return;
     }
 
-    const stats = this.state.actionStats.get(this.state.getActionId(action));
+    const stats = this.#state.actionStats.get(this.#state.getActionId(action));
     if (!stats) {
       delete gate.throttleReadyAt;
       return;
@@ -447,17 +461,17 @@ export class SchedulerGates {
   }
 
   private gate(action: Action): SchedulerGateState | undefined {
-    return this.state.nodes.get(action)?.gate ?? this.stagedGates.get(action);
+    return this.#state.nodes.get(action)?.gate ?? this.#stagedGates.get(action);
   }
 
-  private mutableGate(action: Action): SchedulerGateState {
-    const record = this.state.nodes.get(action);
+  #mutableGate(action: Action): SchedulerGateState {
+    const record = this.#state.nodes.get(action);
     if (record) return record.gate;
 
-    let gate = this.stagedGates.get(action);
+    let gate = this.#stagedGates.get(action);
     if (!gate) {
       gate = { backoffStreak: 0, convergenceHoldPasses: 0 };
-      this.stagedGates.set(action, gate);
+      this.#stagedGates.set(action, gate);
     }
     return gate;
   }

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -16,10 +16,19 @@ interface OriginRecord {
  * origin settles and its launches are flushed.
  */
 export class SpeculationLineage {
-  private byOrigin = new Map<IExtendedStorageTransaction, OriginRecord>();
+  #byOrigin = new Map<IExtendedStorageTransaction, OriginRecord>();
+
+  readonly #hooks: {
+    /** Drop and settle a not-yet-dispatched event from the queue. */
+    dropQueuedEvent: (event: QueuedEvent, reason: string) => void;
+
+    /** Wake the scheduler (parked cross-space events become ready). */
+    queueExecution: () => void;
+    onError: (error: unknown) => void;
+  };
 
   constructor(
-    private readonly hooks: {
+    hooks: {
       /** Drop and settle a not-yet-dispatched event from the queue. */
       dropQueuedEvent: (event: QueuedEvent, reason: string) => void;
 
@@ -27,10 +36,12 @@ export class SpeculationLineage {
       queueExecution: () => void;
       onError: (error: unknown) => void;
     },
-  ) {}
+  ) {
+    this.#hooks = hooks;
+  }
 
-  private recordFor(origin: IExtendedStorageTransaction): OriginRecord {
-    let record = this.byOrigin.get(origin);
+  #recordFor(origin: IExtendedStorageTransaction): OriginRecord {
+    let record = this.#byOrigin.get(origin);
     if (!record) {
       // A read-only transaction (cell.send() forwards its tx as the origin,
       // which in read contexts is runtime.readTx()) never commits: it is not
@@ -48,22 +59,22 @@ export class SpeculationLineage {
         events: new Set(),
         pieceStops: [],
       };
-      this.byOrigin.set(origin, record);
+      this.#byOrigin.set(origin, record);
       if (record.status !== "pending") return record;
 
       origin.addCommitCallback((_tx, result) => {
-        const settled = this.byOrigin.get(origin);
+        const settled = this.#byOrigin.get(origin);
         if (!settled) return;
         settled.status = result.error ? "failed" : "confirmed";
         if (result.error) {
           for (const event of settled.events) {
             try {
-              this.hooks.dropQueuedEvent(
+              this.#hooks.dropQueuedEvent(
                 event,
                 `Event dropped: speculative origin failed before ${event.id} dispatched`,
               );
             } catch (error) {
-              this.hooks.onError(error);
+              this.#hooks.onError(error);
             }
           }
           settled.events.clear();
@@ -71,11 +82,11 @@ export class SpeculationLineage {
             try {
               stop();
             } catch (error) {
-              this.hooks.onError(error);
+              this.#hooks.onError(error);
             }
           }
           settled.pieceStops.length = 0;
-          this.byOrigin.delete(origin);
+          this.#byOrigin.delete(origin);
         } else {
           // Success: compensation is moot, but the EVENTS must stay
           // registered — still-queued descendants (e.g. cross-space parked
@@ -84,38 +95,38 @@ export class SpeculationLineage {
           // delete the record and strand the rest.
           settled.pieceStops.length = 0;
           if (settled.events.size === 0) {
-            this.byOrigin.delete(origin);
+            this.#byOrigin.delete(origin);
           }
         }
-        this.hooks.queueExecution();
+        this.#hooks.queueExecution();
       });
     }
     return record;
   }
 
   recordEvent(origin: IExtendedStorageTransaction, event: QueuedEvent): void {
-    this.recordFor(origin).events.add(event);
+    this.#recordFor(origin).events.add(event);
   }
 
   recordPieceStop(origin: IExtendedStorageTransaction, stop: () => void): void {
-    this.recordFor(origin).pieceStops.push(stop);
+    this.#recordFor(origin).pieceStops.push(stop);
   }
 
   /** Called when an event is dispatched or dropped. */
   release(origin: IExtendedStorageTransaction, event: QueuedEvent): void {
-    const record = this.byOrigin.get(origin);
+    const record = this.#byOrigin.get(origin);
     if (!record) return;
     record.events.delete(event);
     if (
       record.status !== "pending" && record.events.size === 0 &&
       record.pieceStops.length === 0
     ) {
-      this.byOrigin.delete(origin);
+      this.#byOrigin.delete(origin);
     }
   }
 
   originStatus(origin: IExtendedStorageTransaction): OriginStatus {
-    return this.byOrigin.get(origin)?.status ??
+    return this.#byOrigin.get(origin)?.status ??
       // Unknown origin ⇒ no active lineage record remains. A still-queued
       // event with an already-failed origin creates a failed record and is
       // dropped before release; successful origins keep the record until

--- a/packages/runner/src/scheduler/materializers.ts
+++ b/packages/runner/src/scheduler/materializers.ts
@@ -21,11 +21,11 @@ export interface MaterializerIndexState {
 export class SchedulerMaterializers implements MaterializerIndexState {
   readonly materializers = new Set<Action>();
   readonly materializersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
-  private readonly writeEnvelopes = new WeakMap<
+  readonly #writeEnvelopes = new WeakMap<
     Action,
     IMemorySpaceAddress[]
   >();
-  private readonly actionEntities = new WeakMap<
+  readonly #actionEntities = new WeakMap<
     Action,
     Set<SpaceScopeAndURI>
   >();
@@ -57,7 +57,7 @@ export class SchedulerMaterializers implements MaterializerIndexState {
     if (writes.length === 0) return;
 
     this.materializers.add(action);
-    this.writeEnvelopes.set(action, writes);
+    this.#writeEnvelopes.set(action, writes);
 
     const entities = new Set<SpaceScopeAndURI>();
     // Reader→writer TOPOLOGY, keyed by scope NAME (server-execution v2
@@ -75,13 +75,13 @@ export class SchedulerMaterializers implements MaterializerIndexState {
       }
       materializers.add(action);
     }
-    this.actionEntities.set(action, entities);
+    this.#actionEntities.set(action, entities);
   }
 
   clearAction(action: Action): void {
     this.materializers.delete(action);
-    this.writeEnvelopes.delete(action);
-    const entities = this.actionEntities.get(action);
+    this.#writeEnvelopes.delete(action);
+    const entities = this.#actionEntities.get(action);
     if (!entities) return;
 
     for (const entity of entities) {
@@ -91,7 +91,7 @@ export class SchedulerMaterializers implements MaterializerIndexState {
         this.materializersByEntity.delete(entity);
       }
     }
-    this.actionEntities.delete(action);
+    this.#actionEntities.delete(action);
   }
 
   isMaterializer(action: Action): boolean {
@@ -101,7 +101,7 @@ export class SchedulerMaterializers implements MaterializerIndexState {
   getMaterializerWriteEnvelopes(
     action: Action,
   ): readonly IMemorySpaceAddress[] | undefined {
-    return this.writeEnvelopes.get(action);
+    return this.#writeEnvelopes.get(action);
   }
 }
 

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -51,23 +51,23 @@ export interface SchedulerNode {
 }
 
 export class NodeRegistry {
-  private records = new WeakMap<Action, SchedulerNode>();
-  private childActionsByParent = new WeakMap<Action, Set<Action>>();
-  private all = new Set<SchedulerNode>();
-  private activeEffects = new Set<Action>();
-  private activeComputations = new Set<Action>();
+  #records = new WeakMap<Action, SchedulerNode>();
+  #childActionsByParent = new WeakMap<Action, Set<Action>>();
+  #all = new Set<SchedulerNode>();
+  #activeEffects = new Set<Action>();
+  #activeComputations = new Set<Action>();
   // Active nodes whose status is `invalid` or `never-ran` — i.e. the nodes
   // `isInvalidOrNeverRan` would match. Maintained incrementally through
   // setStatus/activate/remove so the event-preflight gate (decision 15) and
   // the pull seed scans can iterate the (small) invalid set instead of every
   // registered node. Membership tracks both status AND active membership:
-  // a removed node drops out even though its record persists in `records`.
-  private invalidNodes = new Set<Action>();
+  // a removed node drops out even though its record persists in `#records`.
+  #invalidNodes = new Set<Action>();
   // Source of monotonic registration ordinals (see SchedulerNode.ordinal).
-  private nextOrdinal = 0;
+  #nextOrdinal = 0;
 
-  readonly effects: ReadonlySet<Action> = this.activeEffects;
-  readonly computations: ReadonlySet<Action> = this.activeComputations;
+  readonly effects: ReadonlySet<Action> = this.#activeEffects;
+  readonly computations: ReadonlySet<Action> = this.#activeComputations;
 
   /** (d′) — the STANDING, refcounted `demandedWriters` root
    * kind (design §2.4; serving-loop.md §1's "a demanded instance's
@@ -91,7 +91,7 @@ export class NodeRegistry {
     kind: NodeKind,
     parentAction?: Action,
   ): SchedulerNode {
-    const existing = this.records.get(action);
+    const existing = this.#records.get(action);
     if (existing) {
       if (existing.kind !== kind) {
         // v1 parity: a computation re-subscribed with `isEffect: true` is
@@ -105,13 +105,13 @@ export class NodeRegistry {
           );
         }
       }
-      this.activate(existing);
+      this.#activate(existing);
       return existing;
     }
 
     const record: SchedulerNode = {
       action,
-      ordinal: this.nextOrdinal++,
+      ordinal: this.#nextOrdinal++,
       kind,
       status: "never-ran",
       declaredReads: [],
@@ -121,25 +121,25 @@ export class NodeRegistry {
       gate: { backoffStreak: 0, convergenceHoldPasses: 0 },
       passRuns: 0,
     };
-    this.records.set(action, record);
-    const children = this.childActionsByParent.get(action);
+    this.#records.set(action, record);
+    const children = this.#childActionsByParent.get(action);
     if (children) {
       record.children = children;
     }
-    this.activate(record);
+    this.#activate(record);
     if (parentAction !== undefined) {
-      this.captureParentAction(record, parentAction);
+      this.#captureParentAction(record, parentAction);
     }
     return record;
   }
 
   remove(action: Action): SchedulerNode | undefined {
-    const record = this.records.get(action);
+    const record = this.#records.get(action);
     if (!record) return undefined;
-    this.all.delete(record);
-    this.activeEffects.delete(action);
-    this.activeComputations.delete(action);
-    this.invalidNodes.delete(action);
+    this.#all.delete(record);
+    this.#activeEffects.delete(action);
+    this.#activeComputations.delete(action);
+    this.#invalidNodes.delete(action);
     // Drop the child from its parent's index. The index holds actions
     // strongly, so a child left in it is retained by the parent — along with
     // the frame of the child's last run, that run's storage transaction, and
@@ -149,37 +149,37 @@ export class NodeRegistry {
     // The record keeps `parentAction`, so the parent stays known across a
     // re-registration window, and re-subscribing re-enters the index.
     if (record.parentAction !== undefined) {
-      this.childActionsByParent.get(record.parentAction)?.delete(action);
+      this.#childActionsByParent.get(record.parentAction)?.delete(action);
     }
     return record;
   }
 
   get(action: Action): SchedulerNode | undefined {
-    return this.records.get(action);
+    return this.#records.get(action);
   }
 
   /**
    * The stable registration ordinal for `action`, or `undefined` if it was
    * never registered. Assigned once at first registration and preserved
-   * across re-subscribe/re-registration (the record persists in `records`
+   * across re-subscribe/re-registration (the record persists in `#records`
    * even after `remove`), so it is a stable, arrival-order-independent
    * tie-break key for `topologicalSort` (spec §7.4 rule 3).
    */
   getRegistrationOrdinal(action: Action): number | undefined {
-    return this.records.get(action)?.ordinal;
+    return this.#records.get(action)?.ordinal;
   }
 
   /**
    * The only sanctioned status mutator. Routing every status write here keeps
-   * the `invalidNodes` index in lockstep with `record.status` (the index is a
+   * the `#invalidNodes` index in lockstep with `record.status` (the index is a
    * derived view, never authoritative). Callers keep their own transition
    * guards (e.g. clean→invalid only); this just assigns and re-indexes.
    */
   setStatus(action: Action, status: NodeStatus): void {
-    const record = this.records.get(action);
+    const record = this.#records.get(action);
     if (!record) return;
     record.status = status;
-    this.syncInvalidIndex(record);
+    this.#syncInvalidIndex(record);
   }
 
   /**
@@ -187,17 +187,17 @@ export class NodeRegistry {
    * event-preflight walk (decision 15) and the pull scheduling scans.
    */
   getInvalidNodes(): ReadonlySet<Action> {
-    return this.invalidNodes;
+    return this.#invalidNodes;
   }
 
-  private syncInvalidIndex(record: SchedulerNode): void {
+  #syncInvalidIndex(record: SchedulerNode): void {
     if (
-      this.all.has(record) &&
+      this.#all.has(record) &&
       (record.status === "invalid" || record.status === "never-ran")
     ) {
-      this.invalidNodes.add(record.action);
+      this.#invalidNodes.add(record.action);
     } else {
-      this.invalidNodes.delete(record.action);
+      this.#invalidNodes.delete(record.action);
     }
   }
 
@@ -209,22 +209,22 @@ export class NodeRegistry {
     const { allowExisting = true } = options;
     if (!parentAction || parentAction === childAction) return undefined;
 
-    const child = this.records.get(childAction);
+    const child = this.#records.get(childAction);
     if (!child) return undefined;
     if (!allowExisting && child.parentAction) {
       return this.parentOf(childAction);
     }
 
     if (child.parentAction && child.parentAction !== parentAction) {
-      this.childActionsByParent.get(child.parentAction)?.delete(child.action);
+      this.#childActionsByParent.get(child.parentAction)?.delete(child.action);
     }
-    this.captureParentAction(child, parentAction);
+    this.#captureParentAction(child, parentAction);
     return this.parentOf(childAction);
   }
 
   parentOf(action: Action): SchedulerNode | undefined {
-    const parentAction = this.records.get(action)?.parentAction;
-    return parentAction ? this.records.get(parentAction) : undefined;
+    const parentAction = this.#records.get(action)?.parentAction;
+    return parentAction ? this.#records.get(parentAction) : undefined;
   }
 
   /**
@@ -234,39 +234,39 @@ export class NodeRegistry {
    * parent through registration churn windows where parentOf() is undefined.
    */
   parentActionOf(action: Action): Action | undefined {
-    return this.records.get(action)?.parentAction;
+    return this.#records.get(action)?.parentAction;
   }
 
   childrenOf(action: Action): ReadonlySet<SchedulerNode> | undefined {
-    const childActions = this.childActionsByParent.get(action);
+    const childActions = this.#childActionsByParent.get(action);
     if (!childActions) return undefined;
 
     const children = new Set<SchedulerNode>();
     for (const childAction of childActions) {
-      const child = this.records.get(childAction);
+      const child = this.#records.get(childAction);
       if (child) children.add(child);
     }
     return children;
   }
 
   isEffect(action: Action): boolean {
-    return this.activeEffects.has(action);
+    return this.#activeEffects.has(action);
   }
 
   isComputation(action: Action): boolean {
-    return this.activeComputations.has(action);
+    return this.#activeComputations.has(action);
   }
 
   isKnownEffect(action: Action): boolean {
-    return this.records.get(action)?.kind === "effect";
+    return this.#records.get(action)?.kind === "effect";
   }
 
   isKnownComputation(action: Action): boolean {
-    return this.records.get(action)?.kind === "computation";
+    return this.#records.get(action)?.kind === "computation";
   }
 
   *nodes(kind?: NodeKind): IterableIterator<SchedulerNode> {
-    for (const record of this.all) {
+    for (const record of this.#all) {
       if (kind === undefined || record.kind === kind) {
         yield record;
       }
@@ -275,54 +275,54 @@ export class NodeRegistry {
 
   size(kind: NodeKind): number {
     return kind === "effect"
-      ? this.activeEffects.size
-      : this.activeComputations.size;
+      ? this.#activeEffects.size
+      : this.#activeComputations.size;
   }
 
   isAncestor(
     sourceAction: Action,
     candidateAncestor: Action,
   ): boolean {
-    let parentAction = this.records.get(sourceAction)?.parentAction;
+    let parentAction = this.#records.get(sourceAction)?.parentAction;
     while (parentAction) {
       if (parentAction === candidateAncestor) {
         return true;
       }
-      parentAction = this.records.get(parentAction)?.parentAction;
+      parentAction = this.#records.get(parentAction)?.parentAction;
     }
     return false;
   }
 
-  private captureParentAction(
+  #captureParentAction(
     child: SchedulerNode,
     parentAction: Action,
   ): void {
     child.parentAction = parentAction;
 
-    let children = this.childActionsByParent.get(parentAction);
+    let children = this.#childActionsByParent.get(parentAction);
     if (!children) {
       children = new Set();
-      this.childActionsByParent.set(parentAction, children);
+      this.#childActionsByParent.set(parentAction, children);
     }
     children.add(child.action);
 
-    const parent = this.records.get(parentAction);
+    const parent = this.#records.get(parentAction);
     if (parent) {
       parent.children = children;
     }
   }
 
-  private activate(record: SchedulerNode): void {
-    this.all.add(record);
+  #activate(record: SchedulerNode): void {
+    this.#all.add(record);
     if (record.kind === "effect") {
-      this.activeEffects.add(record.action);
-      this.activeComputations.delete(record.action);
+      this.#activeEffects.add(record.action);
+      this.#activeComputations.delete(record.action);
     } else {
-      this.activeComputations.add(record.action);
-      this.activeEffects.delete(record.action);
+      this.#activeComputations.add(record.action);
+      this.#activeEffects.delete(record.action);
     }
     // A freshly registered node is born `never-ran`; a reactivated record
     // re-enters the index iff its (preserved) status still qualifies.
-    this.syncInvalidIndex(record);
+    this.#syncInvalidIndex(record);
   }
 }

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -88,8 +88,18 @@ function removeTriggerMapSpace(
 }
 
 export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
+  readonly #state: {
+    readonly triggerIndex: TriggerIndexState;
+    readonly cancels: WeakMap<Action, Cancel>;
+    readonly getActionId: (action: Action) => string;
+    readonly onTriggerUnsubscribe?: (
+      actionId: string,
+      entityCount: number,
+    ) => void;
+  };
+
   constructor(
-    private readonly state: {
+    state: {
       readonly triggerIndex: TriggerIndexState;
       readonly cancels: WeakMap<Action, Cancel>;
       readonly getActionId: (action: Action) => string;
@@ -98,36 +108,38 @@ export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
         entityCount: number,
       ) => void;
     },
-  ) {}
+  ) {
+    this.#state = state;
+  }
 
   get scopeKeyIdentity(): TriggerIndexState["scopeKeyIdentity"] {
-    return this.state.triggerIndex.scopeKeyIdentity;
+    return this.#state.triggerIndex.scopeKeyIdentity;
   }
 
   get triggers(): TriggerIndexState["triggers"] {
-    return this.state.triggerIndex.triggers;
+    return this.#state.triggerIndex.triggers;
   }
 
   get nonRecursiveTriggers(): TriggerIndexState["nonRecursiveTriggers"] {
-    return this.state.triggerIndex.nonRecursiveTriggers;
+    return this.#state.triggerIndex.nonRecursiveTriggers;
   }
 
   get actionTriggerEntities(): TriggerIndexState["actionTriggerEntities"] {
-    return this.state.triggerIndex.actionTriggerEntities;
+    return this.#state.triggerIndex.actionTriggerEntities;
   }
 
   get cancels(): WeakMap<Action, Cancel> {
-    return this.state.cancels;
+    return this.#state.cancels;
   }
 
   get getActionId(): (action: Action) => string {
-    return this.state.getActionId;
+    return this.#state.getActionId;
   }
 
   get onTriggerUnsubscribe():
     | ((actionId: string, entityCount: number) => void)
     | undefined {
-    return this.state.onTriggerUnsubscribe;
+    return this.#state.onTriggerUnsubscribe;
   }
 
   addActionReads(
@@ -138,30 +150,30 @@ export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
     entities: Set<SpaceScopeAndURI>;
     triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
   } {
-    return this.state.triggerIndex.addActionReads(action, reads, shallowReads);
+    return this.#state.triggerIndex.addActionReads(action, reads, shallowReads);
   }
 
   removeActionFromEntities(
     action: Action,
     entities: Iterable<SpaceScopeAndURI>,
   ): void {
-    this.state.triggerIndex.removeActionFromEntities(action, entities);
+    this.#state.triggerIndex.removeActionFromEntities(action, entities);
   }
 
   removeSpace(space: MemorySpace): void {
-    this.state.triggerIndex.removeSpace(space);
+    this.#state.triggerIndex.removeSpace(space);
   }
 
   collectReadersForWrite(write: IMemorySpaceAddress): Set<Action> {
-    return this.state.triggerIndex.collectReadersForWrite(write);
+    return this.#state.triggerIndex.collectReadersForWrite(write);
   }
 
   hasRegisteredTriggers(): boolean {
-    return this.state.triggerIndex.hasRegisteredTriggers();
+    return this.#state.triggerIndex.hasRegisteredTriggers();
   }
 
   clear(): void {
-    this.state.triggerIndex.clear();
+    this.#state.triggerIndex.clear();
   }
 
   collectTriggeredActionsForChange(
@@ -172,7 +184,7 @@ export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
     hasMatchingTriggerPaths: boolean;
     triggeredActions: Action[];
   } {
-    return this.state.triggerIndex.collectTriggeredActionsForChange(
+    return this.#state.triggerIndex.collectTriggeredActionsForChange(
       space,
       change,
     );

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -77,11 +77,15 @@ const seedPrivilegedCfc = (
 };
 
 class SharedV2SessionFactory implements V2Storage.SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   async create(space: MemorySpace) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(space, {}, testSessionOpenAuthFactory);
     return { client, session };

--- a/packages/runner/test/compile-cache-storage-served-values.test.ts
+++ b/packages/runner/test/compile-cache-storage-served-values.test.ts
@@ -27,14 +27,14 @@ const runtimeVersion = resolvedRuntimeVersion;
 // module-byte-cache.test.ts): stores artifact references as handed over, the
 // way the shared integration singleton does.
 class FakeByteCache implements ModuleByteCache {
-  private readonly m = new Map<string, CompiledModuleArtifact>();
+  readonly #m = new Map<string, CompiledModuleArtifact>();
   getCompleteSet(
     rt: string,
     ids: readonly string[],
   ): Map<string, CompiledModuleArtifact> | undefined {
     const out = new Map<string, CompiledModuleArtifact>();
     for (const id of ids) {
-      const a = this.m.get(`${rt}\0${id}`);
+      const a = this.#m.get(`${rt}\0${id}`);
       if (a === undefined) return undefined;
       out.set(id, a);
     }
@@ -45,7 +45,7 @@ class FakeByteCache implements ModuleByteCache {
     mods: readonly ({ identity: string } & CompiledModuleArtifact)[],
   ): void {
     for (const x of mods) {
-      this.m.set(`${rt}\0${x.identity}`, {
+      this.#m.set(`${rt}\0${x.identity}`, {
         js: x.js,
         ...(x.sourceMap === undefined ? {} : { sourceMap: x.sourceMap }),
         ...(x.patternCoverageSpans === undefined

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -253,10 +253,13 @@ class CountingLoopbackSessionFactory implements SessionFactory {
   aclCommits = 0;
   #aclDocId: string;
 
+  readonly #server: MemoryV2Server.Server;
+
   constructor(
-    private readonly server: MemoryV2Server.Server,
+    server: MemoryV2Server.Server,
     space: MemorySpace,
   ) {
+    this.#server = server;
     this.#aclDocId = `of:${space}`;
   }
 
@@ -266,7 +269,7 @@ class CountingLoopbackSessionFactory implements SessionFactory {
     requested: MemoryV2Client.MountOptions = {},
   ) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,
@@ -408,7 +411,11 @@ class SessionErrorSessionFactory implements SessionFactory {
   commits = 0;
   #armed = false;
 
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   arm(): void {
     this.#armed = true;
@@ -421,7 +428,7 @@ class SessionErrorSessionFactory implements SessionFactory {
   ) {
     this.sessions++;
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,

--- a/packages/runner/test/executor-wave.test.ts
+++ b/packages/runner/test/executor-wave.test.ts
@@ -2495,7 +2495,11 @@ describe("stage D seal-into-wave", () => {
     class BootstrapLoopbackFactory implements SessionFactory {
       readonly supportsAclBootstrap = true;
       readonly principals: string[] = [];
-      constructor(private readonly server: MemoryV2Server.Server) {}
+      readonly #server: MemoryV2Server.Server;
+
+      constructor(server: MemoryV2Server.Server) {
+        this.#server = server;
+      }
       async create(
         targetSpace: MemorySpace,
         sessionSigner?: Signer,
@@ -2503,7 +2507,7 @@ describe("stage D seal-into-wave", () => {
       ) {
         this.principals.push(sessionSigner?.did() ?? "<anonymous>");
         const client = await MemoryV2Client.connect({
-          transport: MemoryV2Client.loopback(this.server),
+          transport: MemoryV2Client.loopback(this.#server),
         });
         const session = await client.mount(
           targetSpace,

--- a/packages/runner/test/graph-query.test.ts
+++ b/packages/runner/test/graph-query.test.ts
@@ -38,7 +38,11 @@ const keyFor = (id: string) =>
 class StubObjectManager implements ObjectStorageManager {
   readonly requested: string[] = [];
 
-  constructor(private readonly documents: Map<string, FabricValue>) {}
+  readonly #documents: Map<string, FabricValue>;
+
+  constructor(documents: Map<string, FabricValue>) {
+    this.#documents = documents;
+  }
 
   load(address: BaseMemoryAddress): IAttestation | null {
     const key = schemaTrackerKey(
@@ -48,7 +52,7 @@ class StubObjectManager implements ObjectStorageManager {
       TEST_SCOPE_IDENTITY,
     );
     this.requested.push(key);
-    const value = this.documents.get(key);
+    const value = this.#documents.get(key);
     if (value === undefined) {
       return null;
     }

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -337,10 +337,14 @@ function plainLoopback(
 }
 
 class LoopbackSessionFactory implements SessionFactory {
-  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  readonly #getServer: () => MemoryV2Server.Server;
+
+  constructor(getServer: () => MemoryV2Server.Server) {
+    this.#getServer = getServer;
+  }
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: plainLoopback(this.getServer()),
+      transport: plainLoopback(this.#getServer()),
     });
     const session = await client.mount(
       spaceId,

--- a/packages/runner/test/list-container-link-reissue.test.ts
+++ b/packages/runner/test/list-container-link-reissue.test.ts
@@ -64,10 +64,14 @@ const signer = await Identity.fromPassphrase("list container link reissue");
 const space = signer.did();
 
 class SharedSessionFactory implements SessionFactory {
-  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  readonly #getServer: () => MemoryV2Server.Server;
+
+  constructor(getServer: () => MemoryV2Server.Server) {
+    this.#getServer = getServer;
+  }
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.getServer()),
+      transport: MemoryV2Client.loopback(this.#getServer()),
     });
     const session = await client.mount(
       spaceId,

--- a/packages/runner/test/list-fresh-init.test.ts
+++ b/packages/runner/test/list-fresh-init.test.ts
@@ -36,9 +36,13 @@ function lb(s: MemoryV2Server.Server) {
   return MemoryV2Client.loopback(s);
 }
 class F implements SessionFactory {
-  constructor(private gs: () => MemoryV2Server.Server) {}
+  #gs: () => MemoryV2Server.Server;
+
+  constructor(gs: () => MemoryV2Server.Server) {
+    this.#gs = gs;
+  }
   async create(spaceId: string, sgnr?: Signer) {
-    const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
+    const client = await MemoryV2Client.connect({ transport: lb(this.#gs()) });
     const session = await client.mount(
       spaceId,
       {},

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -265,28 +265,47 @@ function rewritingLoopback(
 }
 
 class RewritingSessionFactory implements SessionFactory {
+  readonly #getServer: () => MemoryV2Server.Server;
+  readonly #redirectSends: boolean;
+  readonly #onWithheldCommitOp: (n: number) => void;
+  readonly #onWithheldUpsert: (n: number) => void;
+  readonly #onFrame?: (
+    direction: "send" | "receive",
+    payload: string,
+  ) => void;
+  readonly #holdReceive?: (payload: string) => boolean;
+  readonly #onHeldReceive?: (deliver: () => void) => void;
+
   constructor(
-    private readonly getServer: () => MemoryV2Server.Server,
-    private readonly redirectSends: boolean,
-    private readonly onWithheldCommitOp: (n: number) => void,
-    private readonly onWithheldUpsert: (n: number) => void,
-    private readonly onFrame?: (
+    getServer: () => MemoryV2Server.Server,
+    redirectSends: boolean,
+    onWithheldCommitOp: (n: number) => void,
+    onWithheldUpsert: (n: number) => void,
+    onFrame?: (
       direction: "send" | "receive",
       payload: string,
     ) => void,
-    private readonly holdReceive?: (payload: string) => boolean,
-    private readonly onHeldReceive?: (deliver: () => void) => void,
-  ) {}
+    holdReceive?: (payload: string) => boolean,
+    onHeldReceive?: (deliver: () => void) => void,
+  ) {
+    this.#getServer = getServer;
+    this.#redirectSends = redirectSends;
+    this.#onWithheldCommitOp = onWithheldCommitOp;
+    this.#onWithheldUpsert = onWithheldUpsert;
+    this.#onFrame = onFrame;
+    this.#holdReceive = holdReceive;
+    this.#onHeldReceive = onHeldReceive;
+  }
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({
       transport: rewritingLoopback(
-        this.getServer(),
-        this.redirectSends,
-        this.onWithheldCommitOp,
-        this.onWithheldUpsert,
-        this.onFrame,
-        this.holdReceive,
-        this.onHeldReceive,
+        this.#getServer(),
+        this.#redirectSends,
+        this.#onWithheldCommitOp,
+        this.#onWithheldUpsert,
+        this.#onFrame,
+        this.#holdReceive,
+        this.#onHeldReceive,
       ),
     });
     const session = await client.mount(

--- a/packages/runner/test/list-resume-input-settle.test.ts
+++ b/packages/runner/test/list-resume-input-settle.test.ts
@@ -38,10 +38,14 @@ function loopback(s: MemoryV2Server.Server) {
   return MemoryV2Client.loopback(s);
 }
 class F implements SessionFactory {
-  constructor(private gs: () => MemoryV2Server.Server) {}
+  #gs: () => MemoryV2Server.Server;
+
+  constructor(gs: () => MemoryV2Server.Server) {
+    this.#gs = gs;
+  }
   async create(id: string, s?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: loopback(this.gs()),
+      transport: loopback(this.#gs()),
     });
     const session = await client.mount(
       id,

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -125,14 +125,20 @@ class ResumeBatchGate {
 }
 
 class GatedSessionFactory implements SessionFactory {
+  readonly #getServer: () => MemoryV2Server.Server;
+  readonly #gate?: ResumeBatchGate;
+
   constructor(
-    private readonly getServer: () => MemoryV2Server.Server,
-    private readonly gate?: ResumeBatchGate,
-  ) {}
+    getServer: () => MemoryV2Server.Server,
+    gate?: ResumeBatchGate,
+  ) {
+    this.#getServer = getServer;
+    this.#gate = gate;
+  }
   async create(spaceId: string, sgnr?: Signer) {
-    const base = MemoryV2Client.loopback(this.getServer());
+    const base = MemoryV2Client.loopback(this.#getServer());
     const client = await MemoryV2Client.connect({
-      transport: this.gate ? this.gate.wrap(base) : base,
+      transport: this.#gate ? this.#gate.wrap(base) : base,
     });
     const session = await client.mount(
       spaceId,

--- a/packages/runner/test/list-shrink-converge.test.ts
+++ b/packages/runner/test/list-shrink-converge.test.ts
@@ -35,9 +35,13 @@ function lb(s: MemoryV2Server.Server) {
   return MemoryV2Client.loopback(s);
 }
 class F implements SessionFactory {
-  constructor(private gs: () => MemoryV2Server.Server) {}
+  #gs: () => MemoryV2Server.Server;
+
+  constructor(gs: () => MemoryV2Server.Server) {
+    this.#gs = gs;
+  }
   async create(spaceId: string, sgnr?: Signer) {
-    const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
+    const client = await MemoryV2Client.connect({ transport: lb(this.#gs()) });
     const session = await client.mount(
       spaceId,
       {},

--- a/packages/runner/test/map-conflict-element-setup.test.ts
+++ b/packages/runner/test/map-conflict-element-setup.test.ts
@@ -106,14 +106,18 @@ const gatedLoopback = (
 class GatedSessionFactory implements SessionFactory {
   gate: FrameGate | undefined;
 
-  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  readonly #getServer: () => MemoryV2Server.Server;
+
+  constructor(getServer: () => MemoryV2Server.Server) {
+    this.#getServer = getServer;
+  }
 
   async create(
     space: MemorySpace,
     signer?: Signer,
     mountOptions: MemoryV2Client.MountOptions = {},
   ) {
-    const { transport, gate } = gatedLoopback(this.getServer());
+    const { transport, gate } = gatedLoopback(this.#getServer());
     this.gate = gate;
     const client = await MemoryV2Client.connect({ transport });
     const session = await client.mount(

--- a/packages/runner/test/memory-v2-acl-bootstrap.test.ts
+++ b/packages/runner/test/memory-v2-acl-bootstrap.test.ts
@@ -22,7 +22,11 @@ class RecordingLoopbackSessionFactory implements SessionFactory {
     actualSessionId: string;
   }> = [];
 
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   async create(
     space: MemorySpace,
@@ -31,7 +35,7 @@ class RecordingLoopbackSessionFactory implements SessionFactory {
   ) {
     this.principals.push(signer?.did() ?? "<anonymous>");
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,

--- a/packages/runner/test/memory-v2-acl-mutation.test.ts
+++ b/packages/runner/test/memory-v2-acl-mutation.test.ts
@@ -45,8 +45,10 @@ class RecordingLoopbackSessionFactory implements SessionFactory {
   readonly aclOperations: RecordedOperation[] = [];
   #aclDocId: string;
 
+  readonly #server: MemoryV2Server.Server;
+
   constructor(
-    private readonly server: MemoryV2Server.Server,
+    server: MemoryV2Server.Server,
     space: MemorySpace,
     // `false` suppresses the storage manager's ACL genesis at session open
     // (storage/v2.ts returns early when the factory does not advertise
@@ -54,6 +56,7 @@ class RecordingLoopbackSessionFactory implements SessionFactory {
     // whose ACL document does not exist yet.
     supportsAclBootstrap = true,
   ) {
+    this.#server = server;
     this.#aclDocId = `of:${space}`;
     this.supportsAclBootstrap = supportsAclBootstrap;
   }
@@ -73,7 +76,7 @@ class RecordingLoopbackSessionFactory implements SessionFactory {
     requested: MemoryV2Client.MountOptions = {},
   ) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       space,

--- a/packages/runner/test/memory-v2-pre-watch-effect.test.ts
+++ b/packages/runner/test/memory-v2-pre-watch-effect.test.ts
@@ -57,17 +57,24 @@ class PreWatchEffectTransport extends ScriptedSessionTransport {
   watchResponseSent = false;
   effectSentBeforeWatchResponse = false;
 
+  readonly #schemaId: URI;
+  readonly #schema: JSONSchemaObj;
+  readonly #referrerId: URI;
+
   constructor(
     space: MemorySpace,
-    private readonly schemaId: URI,
-    private readonly schema: JSONSchemaObj,
-    private readonly referrerId: URI,
+    schemaId: URI,
+    schema: JSONSchemaObj,
+    referrerId: URI,
   ) {
     super({
       name: "pre-watch-effect",
       sessionId: "session:pre-watch-effect",
       space,
     });
+    this.#schemaId = schemaId;
+    this.#schema = schema;
+    this.#referrerId = referrerId;
   }
 
   protected override ackServerSeq(): number {
@@ -81,7 +88,7 @@ class PreWatchEffectTransport extends ScriptedSessionTransport {
 
     this.effectSentBeforeWatchResponse = !this.watchResponseSent;
     this.emitSync(sync(0, 1, [
-      upsert(this.schemaId, 1, { value: this.schema }),
+      upsert(this.#schemaId, 1, { value: this.#schema }),
     ]));
 
     this.watchResponseSent = true;
@@ -91,14 +98,14 @@ class PreWatchEffectTransport extends ScriptedSessionTransport {
       ok: {
         serverSeq: 2,
         sync: sync(1, 2, [
-          upsert(this.referrerId, 2, {
+          upsert(this.#referrerId, 2, {
             value: {
               carried: {
                 "/": {
                   "link@1": {
                     id: "of:pre-watch-effect-target",
                     path: [],
-                    schema: { $ref: this.schemaId },
+                    schema: { $ref: this.#schemaId },
                   },
                 },
               },
@@ -113,16 +120,21 @@ class PreWatchEffectTransport extends ScriptedSessionTransport {
 class ReplacingPreWatchEffectTransport extends ScriptedSessionTransport {
   watchAddCount = 0;
 
+  readonly #schemaId: URI;
+  readonly #schema: JSONSchemaObj;
+
   constructor(
     space: MemorySpace,
-    private readonly schemaId: URI,
-    private readonly schema: JSONSchemaObj,
+    schemaId: URI,
+    schema: JSONSchemaObj,
   ) {
     super({
       name: "replacing-pre-watch-effect",
       sessionId: "session:replacing-pre-watch-effect",
       space,
     });
+    this.#schemaId = schemaId;
+    this.#schema = schema;
   }
 
   protected override ackServerSeq(): number {
@@ -137,7 +149,7 @@ class ReplacingPreWatchEffectTransport extends ScriptedSessionTransport {
     this.watchAddCount += 1;
     if (this.watchAddCount === 1) {
       this.emitSync(sync(0, 1, [
-        upsert(this.schemaId, 1, { value: this.schema }),
+        upsert(this.#schemaId, 1, { value: this.#schema }),
       ]));
       this.disconnect(new Error("scripted session replacement"));
       return;

--- a/packages/runner/test/memory-v2-reconnect-holdings.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-holdings.test.ts
@@ -73,7 +73,11 @@ class DroppableTransport implements MemoryV2Client.Transport {
   #sessionId: string | null = null;
   #serverSeq = 0;
 
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
 
   /** Hands the client a crafted fan-out frame, as though the server had
    * pushed it: the way a test reaches frame shapes — a foreign branch, an
@@ -125,7 +129,7 @@ class DroppableTransport implements MemoryV2Client.Transport {
   }
 
   close(): Promise<void> {
-    this.drop();
+    this.#drop();
     return Promise.resolve();
   }
 
@@ -144,11 +148,11 @@ class DroppableTransport implements MemoryV2Client.Transport {
     const waiting = defer<SessionHolding[]>();
     this.#waiting = waiting;
     this.dropEffects = false;
-    this.drop();
+    this.#drop();
     return waiting.promise;
   }
 
-  private drop(): void {
+  #drop(): void {
     this.#connection?.close();
     this.#connection = null;
     queueMicrotask(() => this.#closeReceiver(new Error("disconnect")));
@@ -156,7 +160,7 @@ class DroppableTransport implements MemoryV2Client.Transport {
 
   private connection(): ReturnType<MemoryV2Server.Server["connect"]> {
     if (this.#connection === null) {
-      this.#connection = this.server.connect((message) => {
+      this.#connection = this.#server.connect((message) => {
         const framed = message as {
           type?: string;
           requestId?: string;

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -55,10 +55,16 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
   #dropResponses = false;
   #dropped = new Set<number>();
 
+  readonly #server: MemoryV2Server.Server;
+  readonly #dropOnFirstLocalSeqs: number[];
+
   constructor(
-    private readonly server: MemoryV2Server.Server,
-    private readonly dropOnFirstLocalSeqs: number[] = [],
-  ) {}
+    server: MemoryV2Server.Server,
+    dropOnFirstLocalSeqs: number[] = [],
+  ) {
+    this.#server = server;
+    this.#dropOnFirstLocalSeqs = dropOnFirstLocalSeqs;
+  }
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -78,7 +84,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
     if (
       message.type === "transact" &&
       typeof localSeq === "number" &&
-      this.dropOnFirstLocalSeqs.includes(localSeq) &&
+      this.#dropOnFirstLocalSeqs.includes(localSeq) &&
       !this.#dropped.has(localSeq)
     ) {
       this.#dropped.add(localSeq);
@@ -111,7 +117,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
     if (this.#connection === null) {
       this.connectionCount++;
       this.onConnectionCount?.(this.connectionCount);
-      this.#connection = this.server.connect((message) => {
+      this.#connection = this.#server.connect((message) => {
         if (!this.#dropResponses) {
           this.#receiver(encodeMemoryBoundary(message));
         }

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -203,14 +203,14 @@ class ScriptedServerModel {
   }
 
   seed(id: URI, value: RootValue): DocState {
-    return this.applyRootCommit({
+    return this.#applyRootCommit({
       label: "seed",
       operations: [{ op: value === undefined ? "delete" : "set", id, value }],
     }).states.get(id)!;
   }
 
   injectRemote(remote: RemoteCommit): void {
-    this.applyRootCommit(remote);
+    this.#applyRootCommit(remote);
   }
 
   transact(
@@ -230,7 +230,7 @@ class ScriptedServerModel {
 
     const scripted = this.scripted.get(commit.localSeq) ?? { kind: "accept" };
     if (scripted.remoteInterleave) {
-      this.applyRootCommit(scripted.remoteInterleave);
+      this.#applyRootCommit(scripted.remoteInterleave);
     }
 
     // A scripted retryAfterSeq marks whichever ConflictError this commit
@@ -243,9 +243,9 @@ class ScriptedServerModel {
     const readError =
       scripted.kind === "accept" && scripted.skipReadValidation === true
         ? null
-        : this.validateReads(commit);
+        : this.#validateReads(commit);
     if (readError) {
-      return this.reject(
+      return this.#reject(
         commit,
         retryAfterSeq === undefined
           ? readError
@@ -259,7 +259,7 @@ class ScriptedServerModel {
       scripted.kind === "dropThenReplayReject";
 
     if (shouldReject) {
-      const rejected = this.reject(commit, {
+      const rejected = this.#reject(commit, {
         name: "ConflictError",
         message: scripted.message ?? "synthetic conflict",
         ...(retryAfterSeq !== undefined ? { retryAfterSeq } : {}),
@@ -271,7 +271,7 @@ class ScriptedServerModel {
       return rejected;
     }
 
-    const applied = this.accept(commit);
+    const applied = this.#accept(commit);
     if (shouldDrop && !this.dropped.has(commit.localSeq)) {
       this.dropped.add(commit.localSeq);
       return { type: "drop" };
@@ -279,7 +279,7 @@ class ScriptedServerModel {
     return applied;
   }
 
-  private validateReads(
+  #validateReads(
     commit: ClientCommit,
   ): RejectionError | null {
     for (const read of commit.reads.pending) {
@@ -344,7 +344,7 @@ class ScriptedServerModel {
     return null;
   }
 
-  private reject(
+  #reject(
     commit: ClientCommit,
     error: RejectionError,
   ) {
@@ -356,7 +356,7 @@ class ScriptedServerModel {
     return { type: "reject" as const, error };
   }
 
-  private accept(commit: ClientCommit) {
+  #accept(commit: ClientCommit) {
     const touched = commit.operations.flatMap((operation) =>
       touchedWritesForOperation(operation)
     );
@@ -398,7 +398,7 @@ class ScriptedServerModel {
     return { type: "accept" as const, applied };
   }
 
-  private applyRootCommit(
+  #applyRootCommit(
     remote: RemoteCommit,
   ): { states: Map<URI, DocState> } {
     const seq = ++this.serverSeq;

--- a/packages/runner/test/memory-v2-sync-under-pending.test.ts
+++ b/packages/runner/test/memory-v2-sync-under-pending.test.ts
@@ -91,14 +91,17 @@ class HeldTransactTransport extends ScriptedSessionTransport {
   #held: HeldTransact | null = null;
   #transactSent = Promise.withResolvers<void>();
 
+  readonly #docs: Map<URI, SessionSyncUpsert["doc"]>;
+
   constructor(
-    private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
+    docs: Map<URI, SessionSyncUpsert["doc"]>,
   ) {
     super({
       name: "sync-under-pending",
       sessionId: "session:sync-under-pending",
       space,
     });
+    this.#docs = docs;
   }
 
   protected override ackServerSeq(): number {
@@ -130,7 +133,7 @@ class HeldTransactTransport extends ScriptedSessionTransport {
             serverSeq: roots.length,
             sync: fullSync(
               roots.length,
-              roots.map((id) => doc(id, 1, this.docs.get(id))),
+              roots.map((id) => doc(id, 1, this.#docs.get(id))),
             ),
           },
         });

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -145,8 +145,19 @@ export abstract class ScriptedSessionTransport
   #sessionOpenCount = 0;
   #helloCount = 0;
 
+  readonly #script: {
+    /** Challenge-id prefix; keep unique per transport class. */
+    name: string;
+
+    /** sessionId confirmed on session.open and stamped on effect frames. */
+    sessionId: string;
+
+    /** The space effect frames (emitSync) are addressed to. */
+    space: MemorySpace;
+  };
+
   constructor(
-    private readonly script: {
+    script: {
       /** Challenge-id prefix; keep unique per transport class. */
       name: string;
 
@@ -156,7 +167,9 @@ export abstract class ScriptedSessionTransport
       /** The space effect frames (emitSync) are addressed to. */
       space: MemorySpace;
     },
-  ) {}
+  ) {
+    this.#script = script;
+  }
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -210,7 +223,7 @@ export abstract class ScriptedSessionTransport
       case "hello":
         this.onHello(++this.#helloCount);
         this.#sessionOpen = testSessionOpenAuthMetadata(
-          `${this.script.name}-hello-${this.#helloCount}`,
+          `${this.#script.name}-hello-${this.#helloCount}`,
         );
         this.respond({
           type: "hello.ok",
@@ -226,13 +239,13 @@ export abstract class ScriptedSessionTransport
           this.#sessionOpen.challenge.value,
         );
         this.#sessionOpen = testSessionOpenAuthMetadata(
-          `${this.script.name}-open-${++this.#sessionOpenCount}`,
+          `${this.#script.name}-open-${++this.#sessionOpenCount}`,
         );
         this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
-            sessionId: message.session?.sessionId ?? this.script.sessionId,
+            sessionId: message.session?.sessionId ?? this.#script.sessionId,
             serverSeq: this.openServerSeq(),
             sessionOpen: this.#sessionOpen,
           },
@@ -279,8 +292,8 @@ export abstract class ScriptedSessionTransport
   emitSync(sync: SessionSync): void {
     this.respond({
       type: "session/effect",
-      space: this.script.space,
-      sessionId: this.script.sessionId,
+      space: this.#script.space,
+      sessionId: this.#script.sessionId,
       effect: sync,
     });
   }
@@ -290,8 +303,8 @@ export abstract class ScriptedSessionTransport
   emitRevoked(reason: "taken-over" | "unauthorized" = "taken-over"): void {
     this.respond({
       type: "session/revoked",
-      space: this.script.space,
-      sessionId: this.script.sessionId,
+      space: this.#script.space,
+      sessionId: this.#script.sessionId,
       reason,
     });
   }
@@ -301,14 +314,18 @@ export class SingleSessionFactory implements SessionFactory {
   client: MemoryV2Client.Client | null = null;
   session: MemoryV2Client.SpaceSession | null = null;
 
-  constructor(private readonly transport: MemoryV2Client.Transport) {}
+  readonly #transport: MemoryV2Client.Transport;
+
+  constructor(transport: MemoryV2Client.Transport) {
+    this.#transport = transport;
+  }
 
   async create(space: MemorySpace) {
     if (this.client !== null) {
       throw new Error(`Session already created for ${space}`);
     }
     const client = await MemoryV2Client.connect({
-      transport: this.transport,
+      transport: this.#transport,
     });
     const session = await client.mount(space, {}, testSessionOpenAuthFactory);
     this.client = client;

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -147,14 +147,17 @@ class DelayedWatchAddTransport extends ScriptedSessionTransport {
 }
 
 class IncrementalEffectTransport extends ScriptedSessionTransport {
+  readonly #docs: Map<URI, SessionSyncUpsert["doc"]>;
+
   constructor(
-    private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
+    docs: Map<URI, SessionSyncUpsert["doc"]>,
   ) {
     super({
       name: "incremental-effect",
       sessionId: "session:incremental-effect",
       space,
     });
+    this.#docs = docs;
   }
 
   protected override ackServerSeq(): number {
@@ -175,7 +178,7 @@ class IncrementalEffectTransport extends ScriptedSessionTransport {
             serverSeq: roots.length,
             sync: fullSync(
               roots.length,
-              roots.map((id, index) => doc(id, index + 1, this.docs.get(id))),
+              roots.map((id, index) => doc(id, index + 1, this.#docs.get(id))),
             ),
           },
         });

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -57,12 +57,15 @@ const getObjectValue = (
 // removes `removedId` in the same batch, simulating a watched doc deleted
 // upstream as the watch is established.
 class WatchAddRemoveTransport extends ScriptedSessionTransport {
-  constructor(private readonly removedId: URI) {
+  readonly #removedId: URI;
+
+  constructor(removedId: URI) {
     super({
       name: "watch-remove-coverage",
       sessionId: "session:watch-remove-coverage",
       space,
     });
+    this.#removedId = removedId;
   }
 
   protected override ackServerSeq(): number {
@@ -89,7 +92,7 @@ class WatchAddRemoveTransport extends ScriptedSessionTransport {
               upserts: roots.map((id, index) =>
                 doc(id, index + 1, { value: { label: id } })
               ),
-              removes: [{ branch: "", id: this.removedId }],
+              removes: [{ branch: "", id: this.#removedId }],
             } satisfies SessionSync,
           },
         });

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -33,7 +33,7 @@ const runtimeVersion = resolvedRuntimeVersion;
 class FakeByteCache implements ModuleByteCache {
   gets = 0;
   puts = 0;
-  private readonly m = new Map<string, CompiledModuleArtifact>();
+  readonly #m = new Map<string, CompiledModuleArtifact>();
   getCompleteSet(
     rt: string,
     ids: readonly string[],
@@ -41,7 +41,7 @@ class FakeByteCache implements ModuleByteCache {
     this.gets++;
     const out = new Map<string, CompiledModuleArtifact>();
     for (const id of ids) {
-      const a = this.m.get(`${rt}\0${id}`);
+      const a = this.#m.get(`${rt}\0${id}`);
       if (a === undefined) return undefined;
       out.set(id, a);
     }
@@ -53,7 +53,7 @@ class FakeByteCache implements ModuleByteCache {
   ): void {
     this.puts++;
     for (const x of mods) {
-      this.m.set(`${rt}\0${x.identity}`, {
+      this.#m.set(`${rt}\0${x.identity}`, {
         js: x.js,
         ...(x.sourceMap === undefined ? {} : { sourceMap: x.sourceMap }),
         ...(x.patternCoverageSpans === undefined

--- a/packages/runner/test/resume-append-scenario.ts
+++ b/packages/runner/test/resume-append-scenario.ts
@@ -51,7 +51,10 @@ class Gate {
    * the per-element result documents). The test awaits this instead of polling.
    */
   readonly firstHeld: Promise<void>;
-  constructor(private readonly match: RegExp) {
+  readonly #match: RegExp;
+
+  constructor(match: RegExp) {
+    this.#match = match;
     this.firstHeld = new Promise((resolve) => {
       this.#firstHeldResolve = resolve;
     });
@@ -63,7 +66,7 @@ class Gate {
       setReceiver: (receive: (payload: string) => void) => {
         this.#deliver = receive;
         inner.setReceiver((payload: string) => {
-          if (!this.#open && this.match.test(payload)) {
+          if (!this.#open && this.#match.test(payload)) {
             this.#held.push(payload);
             this.#firstHeldResolve?.();
             this.#firstHeldResolve = undefined;
@@ -88,13 +91,19 @@ class Gate {
 }
 
 class GatedSessionFactory implements SessionFactory {
+  #getServer: () => MemoryV2Server.Server;
+  #gate?: Gate;
+
   constructor(
-    private getServer: () => MemoryV2Server.Server,
-    private gate?: Gate,
-  ) {}
+    getServer: () => MemoryV2Server.Server,
+    gate?: Gate,
+  ) {
+    this.#getServer = getServer;
+    this.#gate = gate;
+  }
   async create(id: string, signer?: Signer) {
-    const base = MemoryV2Client.loopback(this.getServer());
-    const transport = this.gate ? this.gate.wrap(base) : base;
+    const base = MemoryV2Client.loopback(this.#getServer());
+    const transport = this.#gate ? this.#gate.wrap(base) : base;
     const client = await MemoryV2Client.connect({ transport });
     const session = await client.mount(
       id,

--- a/packages/runner/test/resume-owned-cells.test.ts
+++ b/packages/runner/test/resume-owned-cells.test.ts
@@ -43,10 +43,14 @@ function plainLoopback(
 }
 
 class LoopbackSessionFactory implements SessionFactory {
-  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  readonly #getServer: () => MemoryV2Server.Server;
+
+  constructor(getServer: () => MemoryV2Server.Server) {
+    this.#getServer = getServer;
+  }
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: plainLoopback(this.getServer()),
+      transport: plainLoopback(this.#getServer()),
     });
     const session = await client.mount(
       spaceId,

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -46,12 +46,15 @@ interface FakeLink {
 // implemented.
 class FakeCell {
   setValues: unknown[] = [];
+  readonly #syncResult: () => Promise<unknown>;
+
   constructor(
     readonly id: string,
     public value: unknown,
-    private readonly syncResult: () => Promise<unknown> = () =>
-      Promise.resolve(),
-  ) {}
+    syncResult: () => Promise<unknown> = () => Promise.resolve(),
+  ) {
+    this.#syncResult = syncResult;
+  }
   getAsNormalizedFullLink(): FakeLink {
     return { space: "space", id: this.id, path: [], scope: "space" };
   }
@@ -68,7 +71,7 @@ class FakeCell {
     this.setValues.push(v);
   }
   sync(): Promise<unknown> {
-    return this.syncResult();
+    return this.#syncResult();
   }
   asCell(): this {
     return this;
@@ -78,7 +81,11 @@ class FakeCell {
 // An input-list cell: get() returns `{ list }`. The list is whatever the test
 // supplies (a real array, a sparse array, or a non-array to drive the guard).
 class FakeInputsCell {
-  constructor(private readonly listValue: unknown) {}
+  readonly #listValue: unknown;
+
+  constructor(listValue: unknown) {
+    this.#listValue = listValue;
+  }
   asSchema(): this {
     return this;
   }
@@ -86,7 +93,7 @@ class FakeInputsCell {
     return this;
   }
   get(): { list?: unknown } {
-    return { list: this.listValue };
+    return { list: this.#listValue };
   }
 }
 

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -54,10 +54,14 @@ const SCHEMA = {
 } as const;
 
 class LoopbackSessionFactory implements SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
   async create(id: string, signer?: Signer) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
+      transport: MemoryV2Client.loopback(this.#server),
     });
     const session = await client.mount(
       id as MemorySpace,

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -19,9 +19,13 @@ import {
 // promise never settles on its own.
 class WithheldCommitSessionFactory implements SessionFactory {
   withhold = false;
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
   async create(id: string, signer?: Signer) {
-    const base = MemoryV2Client.loopback(this.server);
+    const base = MemoryV2Client.loopback(this.#server);
     const transport: MemoryV2Client.Transport = {
       send: (payload: string) =>
         this.withhold && payload.includes('"transact"')

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -24,11 +24,17 @@ import {
 } from "@commonfabric/memory/v2";
 
 class LoopbackSessionFactory implements SessionFactory {
+  readonly #serverForSpace: (
+    space: MemorySpace,
+  ) => MemoryV2Server.Server;
+
   constructor(
-    private readonly serverForSpace: (
+    serverForSpace: (
       space: MemorySpace,
     ) => MemoryV2Server.Server,
-  ) {}
+  ) {
+    this.#serverForSpace = serverForSpace;
+  }
 
   async create(
     space: MemorySpace,
@@ -37,7 +43,7 @@ class LoopbackSessionFactory implements SessionFactory {
     _signal?: AbortSignal,
   ) {
     const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.serverForSpace(space)),
+      transport: MemoryV2Client.loopback(this.#serverForSpace(space)),
     });
     const session = await client.mount(
       space,

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -41,9 +41,13 @@ function makeServer(): MemoryV2Server.Server {
 // so the storage layer is left with an open watch whose long-poll never
 // settles on its own.
 class WithheldWatchSessionFactory implements SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
+  readonly #server: MemoryV2Server.Server;
+
+  constructor(server: MemoryV2Server.Server) {
+    this.#server = server;
+  }
   async create(id: string, signer?: Signer) {
-    const base = MemoryV2Client.loopback(this.server);
+    const base = MemoryV2Client.loopback(this.#server);
     const transport: MemoryV2Client.Transport = {
       send: (payload: string) =>
         payload.includes("session.watch.add")

--- a/packages/runner/test/storage-synced-authorization.test.ts
+++ b/packages/runner/test/storage-synced-authorization.test.ts
@@ -38,13 +38,19 @@ function makeServer(): MemoryV2Server.Server {
  * pull, and thus the sync) fails authorization.
  */
 class DenyingWatchSessionFactory implements SessionFactory {
+  readonly #server: MemoryV2Server.Server;
+  readonly #retriable: boolean;
+
   constructor(
-    private readonly server: MemoryV2Server.Server,
-    private readonly retriable: boolean,
-  ) {}
+    server: MemoryV2Server.Server,
+    retriable: boolean,
+  ) {
+    this.#server = server;
+    this.#retriable = retriable;
+  }
 
   async create(id: string, signer?: Signer) {
-    const base = MemoryV2Client.loopback(this.server);
+    const base = MemoryV2Client.loopback(this.#server);
     let receive: (payload: string) => void = () => {};
     const transport: MemoryV2Client.Transport = {
       send: (payload: string) => {
@@ -59,7 +65,7 @@ class DenyingWatchSessionFactory implements SessionFactory {
             error: {
               name: "AuthorizationError",
               message: "Principal lacks READ on space",
-              ...(this.retriable ? { retriable: true } : {}),
+              ...(this.#retriable ? { retriable: true } : {}),
             },
           }));
           return Promise.resolve();

--- a/packages/runner/test/transaction-summary.test.ts
+++ b/packages/runner/test/transaction-summary.test.ts
@@ -14,22 +14,30 @@ import type {
 
 // Simple test transaction journal
 class TestJournal implements ITransactionJournal {
+  #noveltyData: IAttestation[];
+  #historyData: IAttestation[];
+  #activityData: any[];
+
   constructor(
-    private noveltyData: IAttestation[] = [],
-    private historyData: IAttestation[] = [],
-    private activityData: any[] = [],
-  ) {}
+    noveltyData: IAttestation[] = [],
+    historyData: IAttestation[] = [],
+    activityData: any[] = [],
+  ) {
+    this.#noveltyData = noveltyData;
+    this.#historyData = historyData;
+    this.#activityData = activityData;
+  }
 
   activity(): Iterable<any> {
-    return this.activityData;
+    return this.#activityData;
   }
 
   novelty(_space: any): Iterable<IAttestation> {
-    return this.noveltyData;
+    return this.#noveltyData;
   }
 
   history(_space: any): Iterable<IAttestation> {
-    return this.historyData;
+    return this.#historyData;
   }
 }
 

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -155,9 +155,13 @@ function buildLatencyReport(
  * the corpus, exactly as live storage does.
  */
 export class FixtureObjectManager implements ObjectStorageManager {
-  private attestations = new Map<string, IAttestation>();
+  #attestations = new Map<string, IAttestation>();
 
-  constructor(private docs: Record<string, FabricValue>) {}
+  #docs: Record<string, FabricValue>;
+
+  constructor(docs: Record<string, FabricValue>) {
+    this.#docs = docs;
+  }
 
   load(address: BaseMemoryAddress): IAttestation | null {
     if (hasDataUriScheme(address.id)) {
@@ -169,9 +173,9 @@ export class FixtureObjectManager implements ObjectStorageManager {
     const key = fixtureDocKey(
       address as BaseMemoryAddress & { space: string },
     );
-    const cached = this.attestations.get(key);
+    const cached = this.#attestations.get(key);
     if (cached !== undefined) return cached;
-    const value = this.docs[key];
+    const value = this.#docs[key];
     if (value === undefined) return null;
     const attestation: IAttestation = {
       address: { ...address, path: [] },
@@ -181,7 +185,7 @@ export class FixtureObjectManager implements ObjectStorageManager {
       // can never engage during replay even though they do in production.
       value: deepFreeze(value),
     };
-    this.attestations.set(key, attestation);
+    this.#attestations.set(key, attestation);
     return attestation;
   }
 }

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -4370,13 +4370,16 @@ describe("SchemaObjectTraverser slow-traverse reporting", () => {
   // what `readStore` is asserted on.
   class ClockAdvancingStore extends Map<string, Revision<State>> {
     advanced = false;
-    constructor(private readonly onFirstRead: () => void) {
+    readonly #onFirstRead: () => void;
+
+    constructor(onFirstRead: () => void) {
       super();
+      this.#onFirstRead = onFirstRead;
     }
     override get(key: string): Revision<State> | undefined {
       if (!this.advanced) {
         this.advanced = true;
-        this.onFirstRead();
+        this.#onFirstRead();
       }
       return super.get(key);
     }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

First of three covering `runner`. The three are split so that each carries the
prose for the members it renames: no commit leaves `main` with a comment naming
a member that no longer exists, and a file appearing in more than one of them
is the price of that.

This one takes `src/scheduler/` and `test/` — 249 members converted, per
`docs/development/DEVELOPMENT.md` § Classes. A `#` field is not an own
property, whereas a field declared `private` is, the modifier being erased.

## What stays TypeScript-private

`Scheduler` keeps 24 members, under one `//` note at the top of its body rather
than a copy on each. The scheduler suites drive those directly — through
`scheduler as any`, and through `getStaleSchedulerInternals` in
`test/scheduler-test-utils.ts`, which casts the scheduler to a shape naming
them.

Four of the 24 were found by the suite rather than by the scan, and
deliberately so. `pending`, `actionStats`, `getActionId`, and
`maybeAutoDebounce` are names generic enough that a scan cannot say which class
a test means, so they were left converted and the suite asked instead. It named
these four and nothing else.

## Prose

Eight comments named a renamed member and now name the `#` one. Three more sit
in `docs/history/`, which is a point-in-time record and stays as it is.

## Verification

`deno fmt --check`, `deno lint`, and `deno task check` pass. The `runner` suite
is green at 1321 passed, 0 failed — the same as `main`. Sweeps report none for
a doc comment missing its blank line above, a `//` comment stranded beside one,
and a comment naming a renamed member by its bare name.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

