### PR TITLE
feat(data-model): `assertValidFabricValueLayer()`, the vet beside the predicate

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -45,6 +45,7 @@ export {
   isFabricObjectOrArray,
   isFabricPlainContainer,
   isFabricPlainObject,
+  isValidFabricNativeObject,
   isValidFabricPlainObject,
   isValidFabricValue,
   isValidFabricValueLayer,
@@ -58,7 +59,5 @@ export {
   shallowCleanPlainObject,
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
-
-export { isValidFabricNativeObject } from "./type-check.ts";
 
 export { valueEqual } from "./valueEqual.ts";

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -40,6 +40,7 @@ export {
 } from "./value-clone.ts";
 
 export {
+  assertValidFabricValueLayer,
   isFabricContainerValue,
   isFabricObjectOrArray,
   isFabricPlainContainer,
@@ -57,5 +58,7 @@ export {
   shallowCleanPlainObject,
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
+
+export { isValidFabricNativeObject } from "./type-check.ts";
 
 export { valueEqual } from "./valueEqual.ts";

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -42,7 +42,7 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { VALUE_TAGS } from "./VALUE_TAGS.ts";
 import { tagFromNativeValue } from "./native-type-tags.ts";
-import { isValidFabricNativeObject } from "./type-check.ts";
+import { isValidFabricNativeObject, refusedClassNameOf } from "./type-check.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 
@@ -360,7 +360,7 @@ export function shallowFabricFromNativeValue(
       // not valid `FabricValue`. Death before confusion!
       throw new Error(
         `Not representable as a \`FabricValue\`: ${
-          backtickQuote((value as object).constructor?.name ?? typeof value)
+          backtickQuote(refusedClassNameOf(value as object))
         } (not a recognized fabric type)`,
       );
   }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,6 +1,8 @@
 /**
  * The predicates deciding whether a value belongs to the `FabricValue` type,
  * and the narrowings that ask a shape question about one that already does.
+ * The single-level predicate has a throwing form beside it, which decides
+ * exactly what the predicate decides and exists to say why the answer was no.
  *
  * Membership turns on inertness: a `FabricValue` is data, so anything that is
  * live code is refused -- a function, an accessor-backed property, the
@@ -14,6 +16,7 @@
  * refuses, the difference is stated on that narrowing rather than here.
  */
 
+import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isInertArray } from "@commonfabric/utils/arrays";
 import {
   constructorOfObject,
@@ -135,6 +138,99 @@ export function isValidFabricValueLayer(
  * best-effort handling costs correct input nothing. See
  * `BaseCodecEngine.encode()`.
  */
+/**
+ * Throws unless the value is usable as a `FabricValueLayer`, naming what is
+ * wrong with it when it is not. This is `isValidFabricValueLayer()` asked so
+ * that the answer carries a reason: that predicate decides the outcome and
+ * this adds nothing to it, everything past the decision existing to say why it
+ * went the way it did.
+ *
+ * A `FabricNativeObject` gets a reason of its own: a `Date` and a `Map` alike
+ * are values conversion has a say over, which is a different position from a
+ * class instance that has no fabric form at all. The message says which, and
+ * sends the caller to ask.
+ *
+ * @param value The value to check.
+ */
+export function assertValidFabricValueLayer(
+  value: unknown,
+): asserts value is FabricValueLayer {
+  if (isValidFabricValueLayer(value)) {
+    return;
+  }
+
+  // Past here the value is refused, and all that is left is to say why. Each
+  // test below distinguishes two reasons from each other; none of them decides
+  // the outcome, which the call above already did.
+
+  if (Array.isArray(value)) {
+    // An array in this system is _inert_: a direct `Array` instance, which may
+    // only carry numeric index properties, each a data property. A named or
+    // symbol-keyed property has no fabric representation, and an
+    // accessor-backed index is live code rather than inert data -- as is the
+    // prototype of an `Array` subclass instance, which can make iteration
+    // yield differently than the indices say.
+    throw new Error(
+      "Not representable as a `FabricValue`: array that is not an inert array",
+    );
+  }
+
+  switch (typeof value) {
+    case "function": {
+      throw new Error("Not representable as a `FabricValue`: function");
+    }
+    case "symbol": {
+      // Registry-interned symbols are valid `FabricValue`s; unique ones have
+      // no portable representation.
+      throw new Error(
+        "Not representable as a `FabricValue`: unique (uninterned) symbol",
+      );
+    }
+  }
+
+  if (isValidFabricNativeObject(value)) {
+    throw new Error(
+      `Not already a \`FabricValue\`: ${
+        backtickQuote((value as object).constructor?.name ?? typeof value)
+      } (a \`FabricNativeObject\`, so conversion is what decides it)`,
+    );
+  }
+
+  if (isPlainObject(value)) {
+    // A reserved property name is a restriction of this implementation rather
+    // than of the model, so it says so rather than blaming inertness: such an
+    // object _is_ inert, and a runtime that does not route property assignment
+    // through a prototype chain reserves no names at all.
+    const unsafeKey = isInertPlainObject(value)
+      ? unsafeObjectKeyIn(value)
+      : undefined;
+    if (unsafeKey !== undefined) {
+      throw new Error(
+        "Not representable as a `FabricValue`: object with a property name " +
+          `this runtime reserves (\`${unsafeKey}\`)`,
+      );
+    }
+    // A plain object is _inert_ for the same reasons an array is:
+    // `FabricPlainObject` is keyed by `string`, so a symbol key has no fabric
+    // representation, and neither does a non-enumerable string key; an
+    // accessor-backed property is live code rather than inert data. A
+    // null-prototype object is refused here too: a record has one shape in
+    // this system, and a prototype is not part of what a value says as data.
+    throw new Error(
+      "Not representable as a `FabricValue`: object that is not an inert " +
+        "plain object",
+    );
+  }
+
+  // No recognized shape at all -- an ordinary class instance, most commonly.
+  // Death before confusion!
+  throw new Error(
+    `Not representable as a \`FabricValue\`: ${
+      backtickQuote((value as object).constructor?.name ?? typeof value)
+    } (not a recognized fabric type)`,
+  );
+}
+
 export function isValidFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive returns without
   // allocating the cycle-tracking set or the recursion closure below.
@@ -315,6 +411,9 @@ export function isFabricPlainObject(
  * Arrays, plain objects, and system-defined `FabricPrimitive`s are _not_
  * `FabricNativeObject`s -- they have their own handling paths in the
  * conversion layer.
+ *
+ * Membership is not convertibility: a `Map` and a `Set` are members whose
+ * fabric form has yet to be built.
  *
  * This function is a TypeScript type guard for `FabricNativeObject`.
  */

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -104,18 +104,26 @@ export function isValidFabricValueLayer(
 }
 
 /**
- * Helper for `assertValidFabricValueLayer()`, which names the class of a value
- * it is refusing.
+ * Names the class of a value being refused, for a refusal message.
  *
  * The class is read from the prototype rather than from the value, for the
  * reason the dispatch reads it there: an own `constructor` property is
  * ordinary data, so a value could otherwise choose the name it is refused
- * under. A name that is not a string is treated as no name at all, since the
- * message is built from it and a diagnostic must not fail while reporting.
+ * under.
+ *
+ * Nothing here is allowed to throw, because every caller is already on its way
+ * to reporting a different problem and an error raised here would replace it.
+ * Two ways that can happen, both reachable: a `constructor` accessor on the
+ * prototype that throws, and a `name` that is not a string. Either is treated
+ * as no name at all.
  */
-function refusedClassNameOf(value: object): string {
-  const name = (constructorOfObject(value) as { name?: unknown } | undefined)
-    ?.name;
+export function refusedClassNameOf(value: object): string {
+  let name: unknown;
+  try {
+    name = (constructorOfObject(value) as { name?: unknown } | undefined)?.name;
+  } catch {
+    return typeof value;
+  }
   return (typeof name === "string" && name !== "") ? name : typeof value;
 }
 

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -177,7 +177,18 @@ export function assertValidFabricValueLayer(
     }
   }
 
-  if (isValidFabricNativeObject(value)) {
+  // The outcome is already settled; this only picks which reason to give, so a
+  // value that makes the probe fail gets the generic reason rather than the
+  // probe's error in place of a refusal. A `constructor` accessor on the
+  // prototype that throws is the reachable way that happens.
+  let isNativeObject: boolean;
+  try {
+    isNativeObject = isValidFabricNativeObject(value);
+  } catch {
+    isNativeObject = false;
+  }
+
+  if (isNativeObject) {
     throw new Error(
       `Not already a \`FabricValue\`: ${
         backtickQuote(refusedClassNameOf(value as object))

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -104,40 +104,21 @@ export function isValidFabricValueLayer(
 }
 
 /**
- * Indicates whether the value is a `FabricValue` -- a recursive check of exact
- * structural membership in the `FabricValue` type, independent of frozen-ness.
+ * Helper for `assertValidFabricValueLayer()`, which names the class of a value
+ * it is refusing.
  *
- * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number` --
- * including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
- * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
- * `FabricPrimitive`, a direct `Array` instance holding `FabricValue`s with no
- * named or symbol-keyed properties, `length` aside (sparse holes allowed), or a
- * plain object whose values are all `FabricValue`s. Returns `false` for a
- * `function` or a unique (uninterned) symbol -- whether the value itself or
- * reached anywhere within it -- for an accessor-backed (getter/setter) property
- * anywhere, plain-object keyed or array-indexed alike, which makes its
- * container non-inert, for an `Array` subclass instance or other
- * indirectly-rooted array, whose prototype is live code the same way an
- * accessor is, and for any other class instance (`Date`, `Map`, ...) not
- * representable as a `FabricValue`. Handles circular references.
- *
- * This is a *membership* check, not a frozen-ness check: a structurally-valid
- * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
- * question, see `isValidDeepFrozenFabricValue()`. A `FabricInstance` is a
- * member by type (it is a `FabricSpecialObject`); this does not recurse into
- * its private interior, whose contents are `FabricValue`s by the instance's
- * construction contract and are reachable only via frozen-semantic protocols
- * that a membership check must not invoke.
- *
- * Contrast the shallow, single-level sibling `isValidFabricValueLayer()` and
- * `isValidFabricConvertibleValue()` (which additionally accepts native values
- * *convertible* to fabric form).
- *
- * This is the admission test the encoding path's input contract is written
- * against: a value this accepts encodes, and one it does not gets whatever
- * best-effort handling costs correct input nothing. See
- * `BaseCodecEngine.encode()`.
+ * The class is read from the prototype rather than from the value, for the
+ * reason the dispatch reads it there: an own `constructor` property is
+ * ordinary data, so a value could otherwise choose the name it is refused
+ * under. A name that is not a string is treated as no name at all, since the
+ * message is built from it and a diagnostic must not fail while reporting.
  */
+function refusedClassNameOf(value: object): string {
+  const name = (constructorOfObject(value) as { name?: unknown } | undefined)
+    ?.name;
+  return (typeof name === "string" && name !== "") ? name : typeof value;
+}
+
 /**
  * Throws unless the value is usable as a `FabricValueLayer`, naming what is
  * wrong with it when it is not. This is `isValidFabricValueLayer()` asked so
@@ -191,7 +172,7 @@ export function assertValidFabricValueLayer(
   if (isValidFabricNativeObject(value)) {
     throw new Error(
       `Not already a \`FabricValue\`: ${
-        backtickQuote((value as object).constructor?.name ?? typeof value)
+        backtickQuote(refusedClassNameOf(value as object))
       } (a \`FabricNativeObject\`, so conversion is what decides it)`,
     );
   }
@@ -226,11 +207,46 @@ export function assertValidFabricValueLayer(
   // Death before confusion!
   throw new Error(
     `Not representable as a \`FabricValue\`: ${
-      backtickQuote((value as object).constructor?.name ?? typeof value)
+      backtickQuote(refusedClassNameOf(value as object))
     } (not a recognized fabric type)`,
   );
 }
 
+/**
+ * Indicates whether the value is a `FabricValue` -- a recursive check of exact
+ * structural membership in the `FabricValue` type, independent of frozen-ness.
+ *
+ * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number` --
+ * including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
+ * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
+ * `FabricPrimitive`, a direct `Array` instance holding `FabricValue`s with no
+ * named or symbol-keyed properties, `length` aside (sparse holes allowed), or a
+ * plain object whose values are all `FabricValue`s. Returns `false` for a
+ * `function` or a unique (uninterned) symbol -- whether the value itself or
+ * reached anywhere within it -- for an accessor-backed (getter/setter) property
+ * anywhere, plain-object keyed or array-indexed alike, which makes its
+ * container non-inert, for an `Array` subclass instance or other
+ * indirectly-rooted array, whose prototype is live code the same way an
+ * accessor is, and for any other class instance (`Date`, `Map`, ...) not
+ * representable as a `FabricValue`. Handles circular references.
+ *
+ * This is a *membership* check, not a frozen-ness check: a structurally-valid
+ * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
+ * question, see `isValidDeepFrozenFabricValue()`. A `FabricInstance` is a
+ * member by type (it is a `FabricSpecialObject`); this does not recurse into
+ * its private interior, whose contents are `FabricValue`s by the instance's
+ * construction contract and are reachable only via frozen-semantic protocols
+ * that a membership check must not invoke.
+ *
+ * Contrast the shallow, single-level sibling `isValidFabricValueLayer()` and
+ * `isValidFabricConvertibleValue()` (which additionally accepts native values
+ * *convertible* to fabric form).
+ *
+ * This is the admission test the encoding path's input contract is written
+ * against: a value this accepts encodes, and one it does not gets whatever
+ * best-effort handling costs correct input nothing. See
+ * `BaseCodecEngine.encode()`.
+ */
 export function isValidFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive returns without
   // allocating the cycle-tracking set or the recursion closure below.

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -24,6 +24,17 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 export class PlainClass {}
 
 /**
+ * Returns a `PlainClass` instance carrying an own `constructor` property that
+ * names a different class, so that reading the class off the value and reading
+ * it off the prototype give different answers.
+ */
+function forgedConstructorInstance(): unknown {
+  const instance = new PlainClass();
+  Object.defineProperty(instance, "constructor", { value: Date });
+  return instance;
+}
+
+/**
  * An `Array` subclass, whose instances are live code rather than inert data.
  */
 export class ArraySubclass extends Array {}
@@ -78,6 +89,7 @@ export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
   ["an object carrying a reserved property name", { ["__proto__"]: 1 }],
   ["a null-prototype object", Object.assign(Object.create(null), { a: 1 })],
   ["a class instance", new PlainClass()],
+  ["a class instance with a forged `constructor`", forgedConstructorInstance()],
   ["a `FabricBytes`", new FabricBytes(new Uint8Array([1]))],
   ["a `FabricEpochNsec`", new FabricEpochNsec(0n)],
   ["a `FabricEpochDay`", new FabricEpochDay(0n)],

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -3,9 +3,11 @@
  *
  * `tagFromNativeValue()` names what a value already is,
  * `isValidFabricNativeObject()` decides a subset of that answer by a narrower
- * route, and `isValidFabricValueLayer()` decides membership -- so each is
- * worth checking against the others rather than only against a hand-picked
- * case. This carries one entry per arm of the dispatch those functions make,
+ * route, `isValidFabricValueLayer()` decides membership, and
+ * `assertValidFabricValueLayer()` answers that last question in the form that
+ * carries a reason, which `shallowFabricFromNativeValue()` is held against
+ * word for word -- so each is worth checking against the others rather than
+ * only against a hand-picked case. This carries one entry per arm of the dispatch those functions make,
  * plus the shapes each arm accepts and refuses; an entry dropped from here is
  * an arm the cross-checks stop reaching.
  */

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -5,9 +5,7 @@
  * A prototype can be severed, an `Error` can arrive from another realm or from
  * a subclass nobody here knows, an array can be an `Array` subclass, and an
  * object can have no prototype at all. Each still has a right answer, so these
- * cases are mostly the awkward shapes rather than the ordinary ones --
- * including a run with `Error.isError` removed, to reach the fallback beneath
- * it.
+ * cases are mostly the awkward shapes rather than the ordinary ones.
  *
  * One group pins where the class is read FROM: a value's own `constructor`
  * property is data, and must not be able to present a plain record as an
@@ -164,6 +162,39 @@ describe("native-type-tags", () => {
         expect(tagFromNativeValue(new Map())).toBe(VALUE_TAGS.Map);
         expect(isValidFabricNativeObject(new Map())).toBe(true);
       });
+    });
+
+    describe("an array is decided by the array rule, whatever its prototype", () => {
+      // A prototype can be re-pointed, so "an array's class is `Array`" is only
+      // usually true. `Array.isArray()` is what is actually true of every array,
+      // and it is why the array rule runs before any class is consulted -- in
+      // both dispatches, since either one reporting an array as a convertible
+      // `Date` would be a walk rebuilding it as one.
+      for (
+        const [label, value] of [
+          ["an ordinary array", [1, 2]],
+          [
+            "an array whose `prototype` is `Date.prototype`",
+            Object.setPrototypeOf([1, 2], Date.prototype),
+          ],
+          [
+            "an array whose `prototype` is `Map.prototype`",
+            Object.setPrototypeOf([1, 2], Map.prototype),
+          ],
+          [
+            "an array whose prototype was severed",
+            Object.setPrototypeOf([1, 2], null),
+          ],
+        ] as ReadonlyArray<[string, unknown]>
+      ) {
+        it(`tags ${label} \`Array\``, () => {
+          expect(tagFromNativeValue(value)).toBe(VALUE_TAGS.Array);
+        });
+
+        it(`reports ${label} as no \`FabricNativeObject\``, () => {
+          expect(isValidFabricNativeObject(value)).toBe(false);
+        });
+      }
     });
 
     describe("`toJSON()` is intentionally not supported", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -1,7 +1,11 @@
 /**
  * Membership in the `FabricValue` type, asked one level deep and asked all the
  * way down, plus the plain-record question asked as membership and as a
- * narrowing.
+ * narrowing. The one-level question also has a throwing form, whose group is
+ * mostly about the reasons it gives, what it accepts being what the predicate
+ * accepts -- and which is cross-checked, value for value, against the refusal
+ * `shallowFabricFromNativeValue()` performs today, that being the refusal it
+ * is there to stand in for.
  *
  * The two depths ask the same question at different scopes, and the cases are
  * arranged around where that difference tells.
@@ -15,6 +19,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  assertValidFabricValueLayer,
   isFabricContainerValue,
   isFabricPlainObject,
   isValidFabricNativeObject,
@@ -25,7 +30,9 @@ import {
 import type { FabricValue } from "@/interface.ts";
 import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import { tagFromNativeValue } from "@/native-type-tags.ts";
-import { LAYER_CORPUS } from "./fabric-value-corpus.ts";
+import { codecClasses } from "@/fabric-primitives/index.ts";
+import { shallowFabricFromNativeValue } from "@/native-conversion.ts";
+import { LAYER_CORPUS, PlainClass } from "./fabric-value-corpus.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -811,6 +818,164 @@ describe("type-check", () => {
       );
       expect(answers).toContain(true);
       expect(answers).toContain(false);
+    });
+  });
+
+  describe("assertValidFabricValueLayer()", () => {
+    /** Whether the vet refuses the given value. */
+    function refuses(value: unknown): boolean {
+      try {
+        assertValidFabricValueLayer(value);
+        return false;
+      } catch {
+        return true;
+      }
+    }
+
+    /** The message the vet refuses the given value with, or `null`. */
+    function refusalOf(value: unknown): string | null {
+      try {
+        assertValidFabricValueLayer(value);
+        return null;
+      } catch (e) {
+        return (e as Error).message;
+      }
+    }
+
+    /** The message the shallow conversion refuses the value with, or `null`. */
+    function conversionRefusalOf(value: unknown): string | null {
+      try {
+        shallowFabricFromNativeValue(value);
+        return null;
+      } catch (e) {
+        return (e as Error).message;
+      }
+    }
+
+    describe("agrees with `isValidFabricValueLayer()`", () => {
+      // The vet decides exactly what the predicate decides. That the corpus
+      // lands on both answers is asserted rather than assumed, agreement being
+      // free for one that has drifted to a side.
+      const accepted: string[] = [];
+      const refused: string[] = [];
+
+      for (const [label, value] of LAYER_CORPUS) {
+        (isValidFabricValueLayer(value) ? accepted : refused).push(label);
+        it(`treats ${label} the same way`, () => {
+          expect(refuses(value)).toBe(!isValidFabricValueLayer(value));
+        });
+      }
+
+      it("is checked against both answers", () => {
+        expect(accepted.length).toBeGreaterThan(0);
+        expect(refused.length).toBeGreaterThan(0);
+      });
+
+      // The predicate's accepting side is a chain of shape tests, so a class
+      // the corpus never carries is a branch no cross-check above reaches.
+      it("carries every registered primitive class", () => {
+        const carried = new Set(
+          LAYER_CORPUS.map(([, value]) =>
+            (value as object)?.constructor as unknown
+          ),
+        );
+        for (const cls of codecClasses()) {
+          expect([cls.name, carried.has(cls)]).toEqual([cls.name, true]);
+        }
+      });
+    });
+
+    describe("says what the shallow conversion says", () => {
+      // What this vet is FOR: standing in for the refusal that
+      // `shallowFabricFromNativeValue()` performs today, so that a caller can
+      // vet without converting. Its verdict and its wording therefore have to be
+      // that function's, value for value -- which is what this pins, over the
+      // whole corpus rather than over a chosen case.
+      //
+      // The exception is a `FabricNativeObject`, and it is the whole of the
+      // exception: conversion has a say over one, and either mints its fabric
+      // form or refuses it there. The vet has no say and does not pretend to,
+      // which its own group below covers.
+      for (const [label, value] of LAYER_CORPUS) {
+        if (isValidFabricNativeObject(value)) continue;
+        it(`gives ${label} the same verdict, in the same words`, () => {
+          expect(refusalOf(value)).toBe(conversionRefusalOf(value));
+        });
+      }
+
+      it("is checked against both verdicts", () => {
+        const outcomes = LAYER_CORPUS
+          .filter(([, value]) => !isValidFabricNativeObject(value))
+          .map(([, value]) => refusalOf(value) === null);
+        expect(outcomes).toContain(true);
+        expect(outcomes).toContain(false);
+      });
+    });
+
+    describe("refusals", () => {
+      it("names an array that is not inert", () => {
+        expect(() => assertValidFabricValueLayer(Object.assign([1], { z: 1 })))
+          .toThrow(
+            "Not representable as a `FabricValue`: array that is not an " +
+              "inert array",
+          );
+      });
+
+      it("names an object that is not an inert plain object", () => {
+        expect(() =>
+          assertValidFabricValueLayer({ a: 1, [Symbol.for("k")]: 2 })
+        ).toThrow(
+          "Not representable as a `FabricValue`: object that is not an " +
+            "inert plain object",
+        );
+      });
+
+      it("names the property name this runtime reserves", () => {
+        expect(() => assertValidFabricValueLayer({ ["__proto__"]: 1 })).toThrow(
+          "Not representable as a `FabricValue`: object with a property " +
+            "name this runtime reserves (`__proto__`)",
+        );
+      });
+
+      it("names a function", () => {
+        expect(() => assertValidFabricValueLayer(() => {})).toThrow(
+          "Not representable as a `FabricValue`: function",
+        );
+      });
+
+      it("names a unique symbol", () => {
+        expect(() => assertValidFabricValueLayer(Symbol("nope"))).toThrow(
+          "Not representable as a `FabricValue`: unique (uninterned) symbol",
+        );
+      });
+
+      it("names a class instance as an unrecognized type", () => {
+        expect(() => assertValidFabricValueLayer(new PlainClass())).toThrow(
+          "Not representable as a `FabricValue`: `PlainClass` (not a " +
+            "recognized fabric type)",
+        );
+      });
+
+      // A `FabricNativeObject` is in a different position from a value with no
+      // fabric form at all: conversion is what settles it, and settles it
+      // either way -- a `Date` gets a fabric form, a `Map` is refused there
+      // too, its form not being built. Both are told to go and ask.
+      for (
+        const [label, value] of [
+          ["a `Date`", new Date(0)],
+          ["a `Uint8Array`", new Uint8Array([1])],
+          ["a `RegExp`", /x/],
+          ["an `Error`", new Error("x")],
+          ["a `Map`", new Map()],
+          ["a `Set`", new Set()],
+        ] as ReadonlyArray<[string, unknown]>
+      ) {
+        it(`sends ${label} to the conversion`, () => {
+          expect(() => assertValidFabricValueLayer(value)).toThrow(
+            "(a `FabricNativeObject`, so conversion is what decides it)",
+          );
+        });
+      }
     });
   });
 });

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -892,6 +892,12 @@ describe("type-check", () => {
       // that function's, value for value -- which is what this pins, over the
       // whole corpus rather than over a chosen case.
       //
+      // The agreement is bounded to values whose class can be read at all. A
+      // value whose prototype has a throwing `constructor` accessor cannot be
+      // classified, so conversion fails on it outright, while the vet still
+      // names a reason -- its outcome having been settled before the probe
+      // that fails. The corpus carries no such value, and that bound is why.
+      //
       // The exception is a `FabricNativeObject`, and it is the whole of the
       // exception: conversion has a say over one, and either mints its fabric
       // form or refuses it there. The vet has no say and does not pretend to,

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -949,6 +949,50 @@ describe("type-check", () => {
         );
       });
 
+      describe("names the class from the prototype, not from the value", () => {
+        // The refusal message is built from the class name, and an own
+        // `constructor` property is ordinary data -- so reading it off the
+        // value would let a value choose the name it is refused under, and
+        // would let it make the refusal fail instead of report. Each case
+        // below is refused as `Widget`, which is what its prototype says.
+        class Widget {}
+
+        function widgetWith(descriptor: PropertyDescriptor): unknown {
+          const widget = new Widget();
+          Object.defineProperty(widget, "constructor", descriptor);
+          return widget;
+        }
+
+        for (
+          const [label, value] of [
+            [
+              "an own `constructor` naming another class",
+              widgetWith({ value: Date }),
+            ],
+            [
+              "a `constructor.name` that is not a string",
+              widgetWith({ value: { name: 123 } }),
+            ],
+            [
+              "a `constructor` whose getter throws",
+              widgetWith({
+                get() {
+                  throw new Error("the diagnostic must not propagate this");
+                },
+              }),
+            ],
+            ["a `constructor` of `null`", widgetWith({ value: null })],
+          ] as ReadonlyArray<[string, unknown]>
+        ) {
+          it(`refuses ${label} as \`Widget\``, () => {
+            expect(() => assertValidFabricValueLayer(value)).toThrow(
+              "Not representable as a `FabricValue`: `Widget` (not a " +
+                "recognized fabric type)",
+            );
+          });
+        }
+      });
+
       it("names a class instance as an unrecognized type", () => {
         expect(() => assertValidFabricValueLayer(new PlainClass())).toThrow(
           "Not representable as a `FabricValue`: `PlainClass` (not a " +

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -997,6 +997,24 @@ describe("type-check", () => {
             );
           });
         }
+
+        it("refuses a value whose class cannot be read, without propagating", () => {
+          // The one shape that defeats the prototype read as well. Both the
+          // reason-picking probe and the name lookup fail on it, and the
+          // refusal has to survive each: an error raised while explaining a
+          // refusal would arrive in place of the refusal.
+          class Unreadable {}
+          Object.defineProperty(Unreadable.prototype, "constructor", {
+            get() {
+              throw new Error("this must not reach the caller");
+            },
+          });
+
+          expect(() => assertValidFabricValueLayer(new Unreadable())).toThrow(
+            "Not representable as a `FabricValue`: `object` (not a " +
+              "recognized fabric type)",
+          );
+        });
       });
 
       it("names a class instance as an unrecognized type", () => {

--- a/packages/runner/src/sandbox/error-taming.ts
+++ b/packages/runner/src/sandbox/error-taming.ts
@@ -38,8 +38,12 @@
 /**
  * The real `Error.isError`, captured before lockdown can replace the
  * constructor holding it. `undefined` on a runtime that predates the method,
- * in which case there is nothing to restore. Error classification falls back
- * to the shared prototype hierarchy on those runtimes.
+ * in which case there is nothing to restore -- and error classification, which
+ * calls `Error.isError` directly, throws there rather than answering a weaker
+ * way. That is the intended shape: `instanceof` is not a substitute here, it
+ * is the very test SES's two `Error` constructors defeat, so answering with it
+ * would be answering wrongly. Every runtime this project supports has the
+ * method.
  */
 const FERAL_IS_ERROR: unknown = (Error as { isError?: unknown }).isError;
 

--- a/packages/runner/test/error-taming.test.ts
+++ b/packages/runner/test/error-taming.test.ts
@@ -58,8 +58,11 @@ describe("Error.isError under SES lockdown", () => {
     });
 
     it("installs nothing when handed a non-function", () => {
-      // How a runtime without `Error.isError` declines. The pinned browser
-      // integration runtime takes this path. The shim defines nothing because
+      // How a runtime without `Error.isError` declines. Nothing this project
+      // runs on takes this path any more: a browser test drives a system
+      // Chrome, and astral's own download -- the one browser old enough to
+      // lack the method -- is reached only on a machine that has no browser
+      // installed at all. The shim defines nothing because
       // an `undefined` property fails SES's `isError: fn` permit and gets
       // stripped back out with an unpermitted-intrinsic report.
       //


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`isValidFabricValueLayer()` decides membership in `FabricValueLayer`. This adds
`assertValidFabricValueLayer()`, which asks the same question in the form that
carries a reason: the predicate decides the outcome, and everything past that
decision exists to say why it went the way it did.

A `FabricNativeObject` gets a reason of its own. A `Date` and a `Map` alike are
values conversion has a say over, which is a different position from a class
instance with no fabric form at all, so the message says which and sends the
caller to ask.

This supersedes #6491, whose other content landed in #6527. What remained there
was this function and its tests, so the branch was rebuilt on `main` rather than
rebased -- the rebase conflicted on the first of sixteen commits, trying to
re-add a module `main` now carries under a different name.

## What it carries

- `assertValidFabricValueLayer()`, and its export from the package barrel.
- Three corpus-driven cross-checks: the vet accepts exactly what the predicate
  accepts, its refusals match `shallowFabricFromNativeValue()`'s word for word
  (that being the refusal it stands in for), and every registered primitive
  class is carried by the corpus. Each asserts the corpus lands on both sides,
  so none can pass by having drifted to one answer.
- The array-rule group: an array is decided by `Array.isArray()` whatever its
  prototype -- `Date.prototype`, `Map.prototype`, or severed -- in both
  dispatches, since either one reporting an array as a convertible `Date` would
  be a walk rebuilding it as one.
- Three comment corrections. Each described behavior that no longer exists:
  error classification has no prototype-hierarchy fallback, no runtime this
  project targets declines `Error.isError`, and no test run removes it. The
  first and third were falsified by #6527 and missed there.

## Nothing lost from #6491

A rebuild can silently drop work, so this was audited mechanically rather than
by reading. Every non-blank line #6491 added over its merge-base was checked for
presence in `main` or in this branch:

| stage | unaccounted lines |
| --- | --- |
| against `main` alone | 206 |
| against `main` + this branch, first pass | 55 |
| after closing the five gaps that pass found | 45 |

All 45 remaining are supersessions, each verified individually: the file header
#6527 removed by design, a module renamed to `tagFromNativeBuiltinClass.ts`,
`case X:` lines that are now `case X: {`, two labels reworded away from
`wearing`, a test renamed after review, and doc clauses trimmed for surveying a
neighbouring module. The content survives in a different form in every case.

The five gaps the audit caught were all documentation the rebuild had dropped:
two doc paragraphs describing the throwing form, a line distinguishing
membership from convertibility, the corpus header's account of what it serves,
and a now-false clause about a test run that no longer exists.

## Verification

`deno task test` in `data-model`: 48 passed, 2685 steps. `deno task check`,
`deno lint`, `deno fmt --check` green repo-wide. The `runner` changes are
comment-only.

Ablated rather than assumed:

| ablation | result |
| --- | --- |
| the vet accepts every value | 43 failed steps |
| the array rule stops running first in `tagFromNativeValue()` | 4 failed tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FStELffQSLrgyz2VuK8n3e


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

