### PR TITLE
fix(data-model): a native error's class is read from its prototype

### DIFF
--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -509,7 +509,16 @@ export class FabricError extends FabricNativeWrapper<Error>
    * conversion path is responsible for converting them when needed.
    */
   static fromNativeError(error: Error): FabricError {
-    const type = error.constructor.name;
+    // The class is read from the prototype, not from the value. An own
+    // `constructor` property is ordinary data, and this name is stored and
+    // used to rebuild the error on the way back, so reading it off the value
+    // would let a value choose the class it comes back as. A severed prototype
+    // names no class, and `Error` is what such a value still is.
+    const ctor = (Object.getPrototypeOf(error) as { constructor?: unknown })
+      ?.constructor as { name?: unknown } | undefined;
+    const type = (typeof ctor?.name === "string") && (ctor.name !== "")
+      ? ctor.name
+      : "Error";
     const name = error.name === type ? null : error.name;
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -543,7 +543,10 @@ export class FabricError extends FabricNativeWrapper<Error>
     return new FabricError({
       type,
       name,
-      message: error.message,
+      // `message` is normally inherited from `Error.prototype`, so a severed
+      // prototype leaves a message-less error without one at all. `FabricError`
+      // declares a `string`, and the empty string is what such an error means.
+      message: (typeof error.message === "string") ? error.message : "",
       stack: error.stack,
       cause: error.cause as FabricValue | undefined,
       extras,

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -515,9 +515,19 @@ export class FabricError extends FabricNativeWrapper<Error>
     // used to rebuild the error on the way back, so reading it off the value
     // would let a value choose the class it comes back as. A severed prototype
     // names no class, and `Error` is what such a value still is.
-    const ctor = constructorOfObject(error) as { name?: unknown } | undefined;
-    const type = (typeof ctor?.name === "string") && (ctor.name !== "")
-      ? ctor.name
+    let className: unknown;
+    try {
+      className = (constructorOfObject(error) as { name?: unknown } | undefined)
+        ?.name;
+    } catch {
+      // A `constructor` accessor on the prototype that throws. Reading it is
+      // this conversion's business and failing it is not: the value is an
+      // error, and the conversion owes a result rather than the accessor's
+      // exception.
+      className = undefined;
+    }
+    const type = (typeof className === "string") && (className !== "")
+      ? className
       : "Error";
     const name = error.name === type ? null : error.name;
     const extras: Array<[string, FabricValue]> = [];

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -17,6 +17,7 @@ import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,
 } from "@/api.ts";
+import { constructorOfObject } from "@commonfabric/utils/objects";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
@@ -514,8 +515,7 @@ export class FabricError extends FabricNativeWrapper<Error>
     // used to rebuild the error on the way back, so reading it off the value
     // would let a value choose the class it comes back as. A severed prototype
     // names no class, and `Error` is what such a value still is.
-    const ctor = (Object.getPrototypeOf(error) as { constructor?: unknown })
-      ?.constructor as { name?: unknown } | undefined;
+    const ctor = constructorOfObject(error) as { name?: unknown } | undefined;
     const type = (typeof ctor?.name === "string") && (ctor.name !== "")
       ? ctor.name
       : "Error";

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -107,6 +107,16 @@ describe("FabricError", () => {
       expect(FabricError.fromNativeError(new Hostile("x")).type).toBe("Error");
     });
 
+    it("gives a message-less severed-prototype error an empty message", () => {
+      // `message` is inherited from `Error.prototype` unless the constructor
+      // was given one, so severing the prototype takes it away entirely.
+      // `FabricError` declares a `string`.
+      const bare = Object.setPrototypeOf(new Error(), null) as Error;
+      const converted = FabricError.fromNativeError(bare);
+      expect(typeof converted.message).toBe("string");
+      expect(converted.message).toBe("");
+    });
+
     it("names a severed-prototype error `Error`", () => {
       // Such a value names no class at all. It is still an error --
       // `Error.isError()` sees it, and the dispatch tags it so -- and the

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -83,6 +83,17 @@ describe("FabricError", () => {
       );
     });
 
+    it("ignores a prototype whose `constructor` is not callable", () => {
+      // The name has to come from something that could have constructed the
+      // value. A `constructor` that is not callable did not, so it names no
+      // class, and the value is recorded as the `Error` it still is.
+      class Sneaky extends Error {}
+      Object.defineProperty(Sneaky.prototype, "constructor", {
+        value: { name: "RangeError" },
+      });
+      expect(FabricError.fromNativeError(new Sneaky("x")).type).toBe("Error");
+    });
+
     it("names a severed-prototype error `Error`", () => {
       // Such a value names no class at all. It is still an error --
       // `Error.isError()` sees it, and the dispatch tags it so -- and the

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -63,6 +63,35 @@ describe("FabricError", () => {
     expect({ ...se }).toEqual({});
   });
 
+  describe("`fromNativeError()` reads the class from the prototype", () => {
+    // The `type` this records is stored, and `errorClassFromType()` rebuilds
+    // the error from it on the way back -- so where the name is read from
+    // decides which class a value comes back as. An own `constructor` property
+    // is ordinary data, and reading it there would let a value pick that class
+    // for itself.
+    it("ignores an own `constructor` naming another class", () => {
+      const error = new Error("boom");
+      Object.defineProperty(error, "constructor", {
+        value: { name: "RangeError" },
+      });
+      expect(FabricError.fromNativeError(error).type).toBe("Error");
+    });
+
+    it("keeps the real class of a subclass instance", () => {
+      expect(FabricError.fromNativeError(new RangeError("r")).type).toBe(
+        "RangeError",
+      );
+    });
+
+    it("names a severed-prototype error `Error`", () => {
+      // Such a value names no class at all. It is still an error --
+      // `Error.isError()` sees it, and the dispatch tags it so -- and the
+      // conversion has to produce something rather than fail reading a name.
+      const severed = Object.setPrototypeOf(new Error("severed"), null);
+      expect(FabricError.fromNativeError(severed).type).toBe("Error");
+    });
+  });
+
   describe("constructor()", () => {
     it("wraps the `Error`'s `FabricValue`-shaped state", () => {
       const err = new TypeError("bad");

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -94,6 +94,19 @@ describe("FabricError", () => {
       expect(FabricError.fromNativeError(new Sneaky("x")).type).toBe("Error");
     });
 
+    it("ignores a prototype whose `constructor` accessor throws", () => {
+      // Reading the class is this conversion's business; failing to read it is
+      // not the caller's problem, and the accessor's error must not arrive in
+      // place of a converted value.
+      class Hostile extends Error {}
+      Object.defineProperty(Hostile.prototype, "constructor", {
+        get() {
+          throw new Error("this must not reach the caller");
+        },
+      });
+      expect(FabricError.fromNativeError(new Hostile("x")).type).toBe("Error");
+    });
+
     it("names a severed-prototype error `Error`", () => {
       // Such a value names no class at all. It is still an error --
       // `Error.isError()` sees it, and the dispatch tags it so -- and the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`FabricError.fromNativeError()` took its `type` from `error.constructor.name`,
which reads the class off the value rather than off the prototype. This
codebase reads a class from the prototype everywhere else, for the reason this
bug demonstrates twice.

Found while bringing #6489 up to date: a corpus entry added in #6527 -- an
`Error` whose prototype has been severed -- reaches this on the conversion path
and crashes it.

## An own `constructor` picks the class a value comes back as

The `type` recorded here is stored, and `errorClassFromType()` rebuilds the
error from it on the way back. So a value could choose what it is restored as:

```ts
const error = new Error("boom");
Object.defineProperty(error, "constructor", { value: { name: "RangeError" } });
FabricError.fromNativeError(error).type;  // "RangeError", on `main`
```

That is the same forgery the dispatch already guards against by reading the
prototype, arriving through a different door.

## A severed prototype names no class, so the read threw

```
TypeError: Cannot read properties of undefined (reading 'name')
```

out of `shallowFabricFromNativeValue()` and `fabricFromNativeValue()` alike,
rather than converting or refusing. Such a value is still an error --
`Error.isError()` sees it and `tagFromNativeValue()` tags it `Error` -- so the
conversion has a job to do and now does it, recording the class as `Error`.

## Verification

`deno task test` in `data-model`: 48 passed, 2698 steps. `deno task check`,
`deno lint`, `deno fmt --check` green repo-wide.

Three tests cover it: an own `constructor` naming another class is ignored, a
real subclass still records its own class, and a severed-prototype error
records `Error`. Ablated by restoring the value read: 3 failing steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FStELffQSLrgyz2VuK8n3e


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

