### PR TITLE
The FLIP: EXPERIMENTAL_SERVER_EXECUTION defaults ON — lane roles swapped, deployed topologies gated

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1177,18 +1177,37 @@ jobs:
       # cf binary ADOPTS the server's published posture
       # (experimentalOptionsForDeployedClient — /api/meta, authority
       # "server"), so every piece/acl/fuse flow below exercises the CLI ON.
-      # This probe pins the server half so the exercise is verified, not
-      # assumed.
-      - name: ✅ Verify the server-execution posture (default posture — server ON)
+      # The probe pins BOTH halves. A serving loop alone is only the
+      # server's: it says nothing about the arm `cf` resolves, and a client
+      # on the other arm is exactly the MIXED posture the P7 independent
+      # review found (finding 7) — which would make this lane's ON exercise
+      # a fiction that reads as a pass. So the probe also resolves the
+      # client arm the way `cf` does — an explicit
+      # EXPERIMENTAL_SERVER_EXECUTION wins, else the published posture —
+      # and refuses a run whose two arms disagree.
+      - name: ✅ Verify the server-execution posture (default posture — server ON, cf adopts ON)
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
         run: |
+          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
           STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
+          echo "$META"
           echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
             echo "::error::the toolshed did not start the serving loop in the CLI lane; the first-party default is ON (the Phase 7 flip) — the CLI would exercise the OFF arm and the deployed-topology gate would be vacuous"
             exit 1
           }
+          SERVER_ARM=$(echo "$META" | jq -r '.experimental.serverExecution // "unpublished"')
+          CLIENT_ARM="${EXPERIMENTAL_SERVER_EXECUTION:-$SERVER_ARM}"
+          if [ "$SERVER_ARM" != "true" ]; then
+            echo "::error::the toolshed is serving but publishes serverExecution=$SERVER_ARM on /api/meta; cf adopts what is published, so this lane would run a MIXED posture (an OFF client against a serving server)"
+            exit 1
+          fi
+          if [ "$CLIENT_ARM" != "$SERVER_ARM" ]; then
+            echo "::error::MIXED posture in the CLI lane: cf resolves serverExecution=$CLIENT_ARM (an explicit EXPERIMENTAL_SERVER_EXECUTION overrides the deployment's posture) while the toolshed publishes $SERVER_ARM; a mixed run is never a valid arm exercise"
+            exit 1
+          fi
+          echo "cf resolves serverExecution=$CLIENT_ARM against a toolshed publishing $SERVER_ARM and serving."
 
       - name: 📦 Install CLI integration dependencies
         uses: ./.github/actions/apt-install

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1394,12 +1394,18 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      # Both kinds of coverage: V8 runtime coverage via DENO_COVERAGE_DIR, and
-      # authored-pattern coverage via CF_PATTERN_COVERAGE_DIR, which the shell
-      # integration harness reads to turn on the browser worker's collector and
-      # to place the LCOV it pulls back at teardown. Absolute, because the
-      # harness resolves it against a working directory that differs between the
-      # two integration jobs. See docs/development/COVERAGE.md.
+      # V8 runtime coverage via DENO_COVERAGE_DIR only. AUTHORED-pattern
+      # coverage (CF_PATTERN_COVERAGE_DIR) moved to the OFF guard lane with
+      # the flip: instrumentation changes the compiled pattern's bytes, so
+      # under the ON default the client's collector compiles a DIFFERENT
+      # content-addressed variant than the serving side — the client's
+      # speculative `computed:` entries can then never be covered by the
+      # served watermark and authored writes over them are refused
+      # (speculation.md §6; the flip board's deterministic sx2-speculation
+      # red). Until serving-side instrumented-variant parity exists (the
+      # register's recorded post-soak obligation), authored coverage is
+      # collected where a single compiler world holds — the OFF lane.
+      # See docs/development/COVERAGE.md.
       # This is the DEFAULT-posture lane (server-execution v2: flag unset =
       # the first-party default, ON since the Phase 7 flip; testing.md §2)
       # — the FULL ON posture at the default resolution; the
@@ -1467,7 +1473,6 @@ jobs:
           API_URL=http://localhost:8000/ \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
-          CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}" \
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
@@ -1638,6 +1643,12 @@ jobs:
           # No skip filter here: tasks/server-execution-on-skips.ts binds to
           # the ON arm (the DEFAULT lanes since the flip); the OFF guard
           # runs the full shard list.
+          # AUTHORED-pattern coverage rides THIS lane since the flip (see
+          # the default lane's note: instrumentation diverges the compiled
+          # variant from what the serving side compiles, so collecting it
+          # under the ON default is unsound until serving-side variant
+          # parity exists — the register's post-soak obligation). The OFF
+          # arm is a single-compiler world, where the collection is sound.
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
@@ -1645,9 +1656,23 @@ jobs:
           EXPERIMENTAL_SERVER_EXECUTION=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
+          CF_PATTERN_COVERAGE_DIR="${{ github.workspace }}/coverage/lcov/pattern-runtime/pattern-integration-${{ matrix.shard }}" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
+
+      # The authored-pattern LCOV the harness wrote under pattern-runtime/
+      # (the collection moved here with the flip — see the run step's note).
+      # coverage-check globs every coverage-profile-* artifact, so these
+      # rows keep reaching the gate from the OFF lane.
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-profile-pattern-integration-off-${{ matrix.shard }}
+          path: coverage/lcov/
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📋 Upload toolshed log on failure
         if: failure()
@@ -1976,6 +2001,11 @@ jobs:
       - package-integration-test
       - cli-integration-test
       - pattern-integration-test
+      # The OFF guard pattern lane carries the authored-pattern coverage
+      # since the flip (variant-divergence note on the lanes); the gate
+      # must wait for its artifacts. The post-soak removal PR re-homes
+      # that collection before deleting the lane.
+      - pattern-integration-test-server-execution-off
       - pattern-reload-integration-test
       - pattern-unit-test
       - generated-patterns-integration-test

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -613,22 +613,23 @@ jobs:
           path: ./dist/toolshed
           if-no-files-found: error
 
-  # The ON-arm toolshed binary (server-execution v2, Phase 7 landed
-  # flip-READY with the first-party default OFF — docs/specs/
+  # The OFF-arm toolshed binary (server-execution v2 — the Phase 7 flip
+  # landed: the first-party default is ON; docs/specs/
   # server-side-execution/testing.md §2): the browser shell's flag is an
   # esbuild define burned in at build time (unset = the first-party default,
-  # OFF today), so the explicit-`true` ON lanes need a binary whose shell was
-  # built with EXPERIMENTAL_SERVER_EXECUTION=true — an ON lane on the default
-  # binary above would run an OFF shell against an ON server, the MIXED
-  # posture Phases 4–6's ON lanes actually ran (which is why two two-browser
-  # gates were "green ON" before Phase 7). Same source, same commit; only
-  # the shell define differs, and the ON lanes VERIFY the posture the binary
-  # carries (/api/meta's `shellServerExecutionDefine`, written by
-  # tasks/build-binaries.ts from this same environment) before they test.
-  # When the flip PR lands the roles invert: this job bakes `false` for the
-  # explicit-false OFF regression-guard lanes and the default binary is ON.
-  build-toolshed-on:
-    name: "Build Binary (toolshed, server-execution ON shell)"
+  # ON since the flip), so the explicit-`false` OFF regression-guard lanes
+  # need a binary whose shell was built with
+  # EXPERIMENTAL_SERVER_EXECUTION=false — an OFF lane on the default binary
+  # above would run an ON shell against an OFF server, the same MIXED
+  # posture the P7 independent review found (finding 7), mirrored. Same
+  # source, same commit; only the shell define differs, and the OFF lanes
+  # VERIFY the posture the binary carries (/api/meta's
+  # `shellServerExecutionDefine`, written by tasks/build-binaries.ts from
+  # this same environment) before they test. Before the flip PR the roles
+  # were inverted: this job baked `true` for the then-explicit-ON lanes.
+  # The post-soak removal PR deletes this job with the OFF path.
+  build-toolshed-off:
+    name: "Build Binary (toolshed, server-execution OFF shell)"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     steps:
@@ -641,17 +642,17 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 🏗️ Build toolshed binary (ON-arm shell)
+      - name: 🏗️ Build toolshed binary (OFF-arm shell)
         timeout-minutes: *work-timeout
         run: deno task build-binaries toolshed
         env:
           COMMIT_SHA: ${{ github.sha }}
-          EXPERIMENTAL_SERVER_EXECUTION: "true"
+          EXPERIMENTAL_SERVER_EXECUTION: "false"
 
-      - name: 📤 Upload toolshed binary (ON-arm shell)
+      - name: 📤 Upload toolshed binary (OFF-arm shell)
         uses: actions/upload-artifact@v7
         with:
-          name: binary-toolshed-on
+          name: binary-toolshed-off
           path: ./dist/toolshed
           if-no-files-found: error
 
@@ -851,6 +852,13 @@ jobs:
           # then returns, so the test steps never race a not-yet-listening
           # server. The server logs to --log-file, which the launcher prints on
           # success and dumps if the server exits before binding.
+          # Flag unset = the first-party default, ON since the Phase 7 flip:
+          # this DEFAULT lane is the ON arm, serving loop and space-root
+          # ensure both at their production defaults (the ensure coverage the
+          # OW45/OW61 rows flagged rides here — `schema-doc-quarantine` log
+          # lines are expected to be ZERO; a live one is contained, not a
+          # process kill, but is evidence of a client absorb/ordering
+          # defect — OW61's residual trigger).
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
@@ -869,13 +877,16 @@ jobs:
           fi
 
       # This is the DEFAULT-posture lane (server-execution v2: flag unset =
-      # the first-party default, OFF while Phase 7 is landed dark;
-      # testing.md §2) — the regression guard for today's behavior. The
-      # explicit-`true` ON arm is the `-server-execution-on` lane below; the
-      # probe here pins that this lane really is OFF (server not serving,
-      # shell define unset), so a silent flip of the default cannot move the
-      # REQUIRED lanes onto the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default posture — server OFF, shell define unset)
+      # the first-party default, ON since the Phase 7 flip; testing.md §2)
+      # — the FULL ON posture at the default resolution: the toolshed
+      # serves, the test processes resolve env-else-default (ON), and the
+      # default-built shell's define fallback is the same constant. The
+      # explicit-`false` OFF regression guard is the `-server-execution-off`
+      # lane below (kept until the post-soak removal PR); the probe here
+      # pins that this lane really is ON (server serving, shell define
+      # unset — the default build), so a silent un-flip of the default
+      # cannot move the REQUIRED lanes off the ON posture unnoticed.
+      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
@@ -884,11 +895,11 @@ jobs:
           STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
           echo "$META"
           echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
-            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell"
+            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell (its define fallback is the first-party constant)"
             exit 1
           }
-          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
-            echo "::error::the toolshed started the serving loop in the DEFAULT lane; the first-party default is OFF (Phase 7 landed dark) — flip the CI lane roles with the flip PR, never silently"
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop in the DEFAULT lane; the first-party default is ON (the Phase 7 flip) — un-flipping the default is reverting the flip PR, never a silent change"
             exit 1
           }
 
@@ -905,8 +916,14 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
+          # The explicit ON-arm skip list rides the DEFAULT lanes since the
+          # flip (testing.md §2: default = ON with the skip list, EMPTY at
+          # the flip); the script prints every skip (or that there are
+          # none) and emits the matching --ignore flag, which binds because
+          # the package `integration` tasks hand deno a QUOTED glob.
+          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
 
       - name: 🧾 Write coverage report
@@ -939,43 +956,44 @@ jobs:
           job: Package Integration Tests (${{ matrix.suite_name }})
           junit: >-
             kind=integration,scope=${{ matrix.suite_name }},prefix=${{ matrix.package_dir }},glob=test-results/${{ matrix.junit_name }}.xml
-  # The server-execution v2 ON arm (docs/specs/server-side-execution/testing.md
-  # §2): the same package integration suites, byte-identical workloads, with
-  # EXPERIMENTAL_SERVER_EXECUTION=true on the toolshed server, on the test
+  # The server-execution v2 OFF regression guard (docs/specs/
+  # server-side-execution/testing.md §2, roles since the Phase 7 flip): the
+  # same package integration suites, byte-identical workloads, with
+  # EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed server, on the test
   # processes (the runner integration harness and the runtime-client worker
-  # declare the posture from the env — the ON lane is UNIFORM, not the mixed
-  # posture the P7 independent review found), AND in the binary's baked
-  # browser shell (build-toolshed-on) — the FULL ON posture, verified by the
-  # probe below before the suite runs. Skips happen only through the explicit
-  # per-phase lists in tasks/server-execution-on-skips.ts, printed by the run
-  # step — never by silent filtering. No coverage collection: the default lane
-  # owns coverage, and this arm exists to prove behavior under the flag. When
-  # the flip PR lands the roles invert (default = ON with the skip list;
-  # explicit-`false` = the OFF regression guard on an OFF-built binary).
-  package-integration-test-server-execution-on:
-    name: "Package Integration Tests / server-execution ON (${{ matrix.suite_name }})"
+  # resolve env-else-default, so the explicit `false` selects the OFF arm —
+  # UNIFORM, not the mixed posture the P7 independent review found), AND in
+  # the binary's baked browser shell (build-toolshed-off) — the FULL OFF
+  # posture, verified by the probe below before the suite runs. The OFF arm
+  # takes no skip list (tasks/server-execution-on-skips.ts binds to the ON
+  # arm — the DEFAULT lanes since the flip). No coverage collection: the
+  # default lane owns coverage, and this arm exists to keep the rollback
+  # lever honest through the soak. The post-soak removal PR deletes this
+  # lane with the OFF path.
+  package-integration-test-server-execution-off:
+    name: "Package Integration Tests / server-execution OFF (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     env:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
-    needs: ["build-toolshed-on"]
+    needs: ["build-toolshed-off"]
     strategy:
       fail-fast: false
       matrix:
         include:
           - suite_name: runner
             package_dir: packages/runner
-            junit_name: runner-server-execution-on
+            junit_name: runner-server-execution-off
             step_name: runner integration tests
             headless: false
           - suite_name: runtime-client
             package_dir: packages/runtime-client
-            junit_name: runtime-client-server-execution-on
+            junit_name: runtime-client-server-execution-off
             step_name: runtime-client integration tests
             headless: false
           - suite_name: shell
             package_dir: packages/shell
-            junit_name: shell-server-execution-on
+            junit_name: shell-server-execution-off
             step_name: shell integration tests
             headless: true
     steps:
@@ -988,13 +1006,13 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
-      - name: 📥 Download toolshed binary (ON-arm shell)
+      - name: 📥 Download toolshed binary (OFF-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed-on
+          name: binary-toolshed-off
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag ON)
+      - name: 🔌 Start Toolshed server for testing (flag OFF)
         env:
           TOOLSHED_PORT: 8000
         run: |
@@ -1003,28 +1021,17 @@ jobs:
           # then returns, so the test steps never race a not-yet-listening
           # server. The server logs to --log-file, which the launcher prints on
           # success and dumps if the server exits before binding.
-          # Space-root ensure ON — the production default (unset knob).
-          # The lanes opted out while OW61's crash class was open (the
-          # ensured root's content-addressed computed cells landed in
-          # fixture spaces' plain subscriptions and the arrival throw
-          # killed the consumers); with the arrival containment (#6223)
-          # and the client absorb fix (#6292) merged the lanes run the
-          # production posture again, and these ON lanes ARE the CI
-          # coverage of the ensure at the true topology (the OW45/OW61
-          # rows' flagged gap). `schema-doc-quarantine` log lines are
-          # expected to be ZERO here; a live one is contained (not a
-          # process kill) but is evidence that another client
-          # absorb/ordering defect remains — OW61's residual trigger.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
       # The posture the binary ACTUALLY carries: the shell define is baked at
-      # build time, so an ON lane on a default-built binary would silently be
-      # the mixed posture; and the server must really be serving.
-      - name: ✅ Verify the server-execution posture (server ON, shell ON-built)
+      # build time, so an OFF lane on a default-built binary would silently be
+      # the mixed posture (ON shell against an OFF server); and the server
+      # must really not be serving.
+      - name: ✅ Verify the server-execution posture (server OFF, shell OFF-built)
         timeout-minutes: *posture-probe-timeout
         env:
           TOOLSHED_PORT: 8000
@@ -1032,12 +1039,12 @@ jobs:
           META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
           STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
           echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == "true"' > /dev/null || {
-            echo "::error::binary-toolshed-on does not carry an ON-built shell (EXPERIMENTAL_SERVER_EXECUTION=true must reach tasks/build-binaries.ts and the shell build); the ON lane would run a MIXED posture"
+          echo "$META" | jq -e '.shellServerExecutionDefine == "false"' > /dev/null || {
+            echo "::error::binary-toolshed-off does not carry an OFF-built shell (EXPERIMENTAL_SERVER_EXECUTION=false must reach tasks/build-binaries.ts and the shell build); the OFF lane would run a MIXED posture"
             exit 1
           }
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop under EXPERIMENTAL_SERVER_EXECUTION=true; the ON lane's server posture is OFF"
+          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
+            echo "::error::the toolshed started the serving loop under EXPERIMENTAL_SERVER_EXECUTION=false; the OFF regression-guard lane's server posture is ON"
             exit 1
           }
 
@@ -1053,7 +1060,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧪 Run ${{ matrix.step_name }} (flag ON)
+      - name: 🧪 Run ${{ matrix.step_name }} (flag OFF)
         timeout-minutes: *work-timeout
         working-directory: ${{ matrix.package_dir }}
         env:
@@ -1065,16 +1072,12 @@ jobs:
           if [ "$HEADLESS_ENABLED" = "true" ]; then
             export HEADLESS=1
           fi
-          # The explicit ON-arm skip list; the script prints every skip (or
-          # that there are none) and emits the matching --ignore flag. The
-          # flag binds because the package `integration` tasks hand deno a
-          # QUOTED glob it expands itself — `deno test --ignore` filters only
-          # files deno discovers and silently ignores nothing when the same
-          # files arrive as explicit arguments (a shell-expanded glob).
-          SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
+          # No skip list here: tasks/server-execution-on-skips.ts binds to
+          # the ON arm (the DEFAULT lanes since the flip); the OFF guard
+          # runs the full suite.
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
           deno task integration
 
       - name: 📤 Upload test timing data
@@ -1090,10 +1093,10 @@ jobs:
         if: always()
         uses: ./.github/actions/test-records-ship
         with:
-          artifact: package-integration-server-execution-on-${{ matrix.suite_name }}
-          variant: server-execution
+          artifact: package-integration-server-execution-off-${{ matrix.suite_name }}
+          variant: server-execution-off
           job: >-
-            Package Integration Tests / server-execution ON
+            Package Integration Tests / server-execution OFF
             (${{ matrix.suite_name }})
           junit: >-
             kind=integration,scope=${{ matrix.suite_name }},prefix=${{ matrix.package_dir }},glob=test-results/${{ matrix.junit_name }}.xml
@@ -1167,6 +1170,25 @@ jobs:
           CFTS_AI_GATEWAY_URL="" MEMORY_URL="$TOOLSHED_URL" API_URL="$TOOLSHED_URL" \
             ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
+
+      # The CLI suites are a deployed-topology gate for `cf` under the
+      # flipped server-execution default (the flip PR's own obligation; P7
+      # review finding 8): the default-built toolshed resolves ON, and the
+      # cf binary ADOPTS the server's published posture
+      # (experimentalOptionsForDeployedClient — /api/meta, authority
+      # "server"), so every piece/acl/fuse flow below exercises the CLI ON.
+      # This probe pins the server half so the exercise is verified, not
+      # assumed.
+      - name: ✅ Verify the server-execution posture (default posture — server ON)
+        timeout-minutes: *posture-probe-timeout
+        env:
+          TOOLSHED_PORT: ${{ matrix.toolshed_port }}
+        run: |
+          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop in the CLI lane; the first-party default is ON (the Phase 7 flip) — the CLI would exercise the OFF arm and the deployed-topology gate would be vacuous"
+            exit 1
+          }
 
       - name: 📦 Install CLI integration dependencies
         uses: ./.github/actions/apt-install
@@ -1379,24 +1401,26 @@ jobs:
       # harness resolves it against a working directory that differs between the
       # two integration jobs. See docs/development/COVERAGE.md.
       # This is the DEFAULT-posture lane (server-execution v2: flag unset =
-      # the first-party default, OFF while Phase 7 is landed dark;
-      # testing.md §2) — the regression guard for today's behavior; the
-      # explicit-`true` ON arm is the `-server-execution-on` lane below. The
-      # probe pins that this lane really is OFF (server not serving, shell
-      # define unset), so a silent flip of the default cannot move the
-      # REQUIRED lanes onto the ON posture unnoticed.
-      - name: ✅ Verify the server-execution posture (default posture — server OFF, shell define unset)
+      # the first-party default, ON since the Phase 7 flip; testing.md §2)
+      # — the FULL ON posture at the default resolution; the
+      # explicit-`false` OFF regression guard is the
+      # `-server-execution-off` lane below (kept until the post-soak
+      # removal PR). The probe pins that this lane really is ON (server
+      # serving, shell define unset — the default build resolves the
+      # constant), so a silent un-flip of the default cannot move the
+      # REQUIRED lanes off the ON posture unnoticed.
+      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
         timeout-minutes: *posture-probe-timeout
         run: |
           META=$(curl -fsS "http://localhost:8000/api/meta")
           STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
           echo "$META"
           echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
-            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell"
+            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the default lane must run the default-built shell (its define fallback is the first-party constant)"
             exit 1
           }
-          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
-            echo "::error::the toolshed started the serving loop in the DEFAULT lane; the first-party default is OFF (Phase 7 landed dark) — flip the CI lane roles with the flip PR, never silently"
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop in the DEFAULT lane; the first-party default is ON (the Phase 7 flip) — un-flipping the default is reverting the flip PR, never a silent change"
             exit 1
           }
 
@@ -1409,15 +1433,33 @@ jobs:
           # empty list that runs ZERO test files and exits green. The
           # selector throws on an empty selection (every shard carries the
           # internally-sharded files), so an empty result here is only ever
-          # a failure — reject it loudly as the backstop.
+          # a failure — reject it loudly as the backstop. The legitimate
+          # empty case lives one stage LATER, after the ON-skip filter,
+          # which rides THIS lane since the flip.
           SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$SELECTED_FILES" ]; then
             echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
             exit 1
           fi
-          mapfile -t TEST_FILES <<< "$SELECTED_FILES"
+          mapfile -t SHARD_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
-          printf '  %s\n' "${TEST_FILES[@]}"
+          printf '  %s\n' "${SHARD_FILES[@]}"
+          # The explicit ON-arm skip list rides the DEFAULT lanes since the
+          # flip (testing.md §2: default = ON with the skip list, EMPTY at
+          # the flip), applied by FILTERING this shard's file list (the
+          # script prints every skip, and which of them it dropped from
+          # THIS list, on stderr): `deno test --ignore` binds only to files
+          # deno discovers itself and silently ignores nothing when the
+          # files arrive as explicit arguments, as they do here. Command
+          # substitution (not a process substitution) so a validation
+          # failure in the script fails this step under `bash -e` instead
+          # of reading as an empty list.
+          FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
+          if [ -z "$FILTERED_FILES" ]; then
+            echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
+            exit 0
+          fi
+          mapfile -t TEST_FILES <<< "$FILTERED_FILES"
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
@@ -1430,6 +1472,18 @@ jobs:
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
+
+      # The default lane is the ON exercise since the flip; its toolshed log
+      # is the first triage artifact for a red shard (the role the old
+      # explicit-ON lane's upload played).
+      - name: 📋 Upload toolshed log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: toolshed-log-pattern-integration-${{ matrix.shard }}
+          path: ${{ runner.temp }}/toolshed.log
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: 🧾 Write coverage report
         if: always()
@@ -1467,31 +1521,26 @@ jobs:
           shard: ${{ matrix.shard }}/${{ matrix.total }}
           junit: >-
             kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-${{ matrix.shard }}.xml
-  # The server-execution v2 ON arm of the end-to-end pattern suite
-  # (docs/specs/server-side-execution/testing.md §2): the same shards,
-  # byte-identical workloads, with EXPERIMENTAL_SERVER_EXECUTION=true on the
-  # toolshed server, on the test processes, AND baked into the binary's
-  # browser shell (build-toolshed-on) — the FULL ON posture, verified by the
-  # probe below before the shard runs. Skips happen only through the explicit
-  # per-phase lists in tasks/server-execution-on-skips.ts, printed by the run
-  # step — never by silent filtering (the lists are EMPTY across ALL suites
-  # since the lunch-poll-vote FILE entry's ruled-3b-close lift, 2026-08-28
-  # — the owner ruled the register's 3b fork, "go with (1) plus the (2-D)
-  # kick": failed replications now park under the WANTED identity and the
-  # matching persist RECORD re-issues them, and served sidecar patterns
-  # kick their closure into the demanding space at page-serve time; this
-  # lane now runs the FULL suite. The flip PR's list-EMPTY precondition
-  # is met; its bar remains a green ON lane, not merely the empty list).
-  # No coverage collection and no cache save-back: the default lane owns
-  # both; the compile byte cache is restored read-only (compiled bytes do not
-  # depend on the flag).
-  pattern-integration-test-server-execution-on:
-    name: "Pattern Integration Tests / server-execution ON (${{ matrix.shard }}/${{ matrix.total }})"
+  # The server-execution v2 OFF regression guard of the end-to-end pattern
+  # suite (docs/specs/server-side-execution/testing.md §2, roles since the
+  # Phase 7 flip): the same shards, byte-identical workloads, with
+  # EXPERIMENTAL_SERVER_EXECUTION=false on the toolshed server, on the test
+  # processes, AND baked into the binary's browser shell
+  # (build-toolshed-off) — the FULL OFF posture, verified by the probe
+  # below before the shard runs. The OFF arm takes no skip list
+  # (tasks/server-execution-on-skips.ts binds to the ON arm — the DEFAULT
+  # lanes since the flip; the lists were EMPTY across ALL suites at the
+  # flip, the ruled-3b-close lift's precondition). No coverage collection
+  # and no cache save-back: the default lane owns both; the compile byte
+  # cache is restored read-only (compiled bytes do not depend on the
+  # flag). The post-soak removal PR deletes this lane with the OFF path.
+  pattern-integration-test-server-execution-off:
+    name: "Pattern Integration Tests / server-execution OFF (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
     env:
       CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
-    needs: ["build-toolshed-on"]
+    needs: ["build-toolshed-off"]
     strategy:
       fail-fast: false
       matrix:
@@ -1520,39 +1569,36 @@ jobs:
           restore-keys: |
             cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/runner/src/harness/**', 'packages/runner/src/pattern-coverage.ts', 'packages/runner/src/sandbox/**', 'packages/schema-generator/**', 'packages/api/**', 'packages/static/assets/types/**', 'deno.jsonc', 'deno.lock') }}-${{ matrix.total }}-${{ matrix.shard }}-
 
-      - name: 📥 Download toolshed binary (ON-arm shell)
+      - name: 📥 Download toolshed binary (OFF-arm shell)
         uses: actions/download-artifact@v8
         with:
-          name: binary-toolshed-on
+          name: binary-toolshed-off
           path: common-binaries
 
-      - name: 🔌 Start Toolshed server for testing (flag ON)
+      - name: 🔌 Start Toolshed server for testing (flag OFF)
         run: |
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
-          # Space-root ensure ON — the production default (see the
-          # package ON lane's note: the opt-out retired with OW61's
-          # arrival containment (#6223) and client absorb fix (#6292)).
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
-      # The posture the binary ACTUALLY carries (see the package ON lane).
-      - name: ✅ Verify the server-execution posture (server ON, shell ON-built)
+      # The posture the binary ACTUALLY carries (see the package OFF lane).
+      - name: ✅ Verify the server-execution posture (server OFF, shell OFF-built)
         timeout-minutes: *posture-probe-timeout
         run: |
           META=$(curl -fsS "http://localhost:8000/api/meta")
           STATS=$(curl -fsS "http://localhost:8000/api/health/stats")
           echo "$META"
-          echo "$META" | jq -e '.shellServerExecutionDefine == "true"' > /dev/null || {
-            echo "::error::binary-toolshed-on does not carry an ON-built shell (EXPERIMENTAL_SERVER_EXECUTION=true must reach tasks/build-binaries.ts and the shell build); the ON lane would run a MIXED posture"
+          echo "$META" | jq -e '.shellServerExecutionDefine == "false"' > /dev/null || {
+            echo "::error::binary-toolshed-off does not carry an OFF-built shell (EXPERIMENTAL_SERVER_EXECUTION=false must reach tasks/build-binaries.ts and the shell build); the OFF lane would run a MIXED posture"
             exit 1
           }
-          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
-            echo "::error::the toolshed did not start the serving loop under EXPERIMENTAL_SERVER_EXECUTION=true; the ON lane's server posture is OFF"
+          echo "$STATS" | jq -e '.servingLoop == null' > /dev/null || {
+            echo "::error::the toolshed started the serving loop under EXPERIMENTAL_SERVER_EXECUTION=false; the OFF regression-guard lane's server posture is ON"
             exit 1
           }
 
@@ -1568,7 +1614,7 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
-      - name: 🧩 Run end-to-end patterns integration tests (flag ON)
+      - name: 🧩 Run end-to-end patterns integration tests (flag OFF)
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
@@ -1577,47 +1623,37 @@ jobs:
           # empty list that runs ZERO test files and exits green. The
           # selector throws on an empty selection (every shard carries the
           # internally-sharded files), so an empty result here is only ever
-          # a failure — reject it loudly as the backstop. The legitimate
-          # empty case lives one stage LATER, after the ON-skip filter.
+          # a failure — reject it loudly as the backstop. This OFF guard
+          # runs the full shard list, so there is no later legitimate
+          # empty stage: the ON-skip filter rides the DEFAULT lane.
           SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$SELECTED_FILES" ]; then
             echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
             exit 1
           fi
-          mapfile -t SHARD_FILES <<< "$SELECTED_FILES"
+          mapfile -t TEST_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
-          printf '  %s\n' "${SHARD_FILES[@]}"
-          # The explicit ON-arm skip list, applied by FILTERING this shard's
-          # file list (the script prints every skip, and which of them it
-          # dropped from THIS list, on stderr): `deno test --ignore` binds
-          # only to files deno discovers itself and silently ignores nothing
-          # when the files arrive as explicit arguments, as they do here.
-          # Command substitution (not a process substitution) so a validation
-          # failure in the script fails this step under `bash -e` instead of
-          # reading as an empty list.
-          FILTERED_FILES=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts patterns --filter "${SHARD_FILES[@]}")
-          if [ -z "$FILTERED_FILES" ]; then
-            echo "Every file of this shard is skip-listed for the ON arm; nothing to run."
-            exit 0
-          fi
-          mapfile -t TEST_FILES <<< "$FILTERED_FILES"
+          printf '  %s\n' "${TEST_FILES[@]}"
           mkdir -p ../../test-results
+          # No skip filter here: tasks/server-execution-on-skips.ts binds to
+          # the ON arm (the DEFAULT lanes since the flip); the OFF guard
+          # runs the full shard list.
           # --no-check: the Check job type-checks packages/patterns/integration
           # (tasks/check.sh).
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
-          EXPERIMENTAL_SERVER_EXECUTION=true \
+          EXPERIMENTAL_SERVER_EXECUTION=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
-            --junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml \
+            --junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
 
       - name: 📋 Upload toolshed log on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}
+          name: toolshed-log-pattern-integration-server-execution-off-${{ matrix.shard }}
           path: ${{ runner.temp }}/toolshed.log
           retention-days: 14
           if-no-files-found: ignore
@@ -1626,7 +1662,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-timing-pattern-integration-server-execution-on-${{ matrix.shard }}
+          name: test-timing-pattern-integration-server-execution-off-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore
@@ -1635,14 +1671,14 @@ jobs:
         if: always()
         uses: ./.github/actions/test-records-ship
         with:
-          artifact: pattern-integration-server-execution-on-${{ matrix.shard }}
-          variant: server-execution
+          artifact: pattern-integration-server-execution-off-${{ matrix.shard }}
+          variant: server-execution-off
           job: >-
-            Pattern Integration Tests / server-execution ON
+            Pattern Integration Tests / server-execution OFF
             (${{ matrix.shard }}/${{ matrix.total }})
           shard: ${{ matrix.shard }}/${{ matrix.total }}
           junit: >-
-            kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-server-execution-on-${{ matrix.shard }}.xml
+            kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-server-execution-off-${{ matrix.shard }}.xml
 
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"
@@ -1799,6 +1835,127 @@ jobs:
           job: Pattern Unit Tests (${{ matrix.chunk }}/${{ matrix.total }})
           shard: ${{ matrix.chunk }}/${{ matrix.total }}
 
+  # The deployed-topology posture gates (server-execution v2 Phase 7's flip
+  # PR — its own recorded obligation; the P7 independent review's finding
+  # 8): the presets flip binaries and hosts that no other lane exercises at
+  # the DEFAULT resolution. Two gates against one default-built (ON)
+  # toolshed: the REAL bg-piece-service binary starts, initializes against
+  # the serving toolshed, reports its resolved posture (its startup log
+  # line — the binary has no HTTP surface), and stops cleanly on SIGTERM;
+  # and cf-harness's production fabric-session factory (PKCS#8 identity
+  # from disk → PiecesController.initialize → deployed-client adoption)
+  # resolves ON with nothing declared and serves one genuine piece flow.
+  # The other two topologies ride existing lanes since the flip: the CLI's
+  # gate is cli-integration-test (cf adopts the server's published posture;
+  # probed there), and PiecesController hosts ride the default
+  # package/pattern lanes (sx2-scale's controllers and the
+  # pieces-controller helper). The post-soak removal PR keeps this job —
+  # it gates the surviving default posture, not the OFF path.
+  deployed-topology-gate:
+    name: "Deployed Topology Posture Gates"
+    runs-on: ubuntu-latest
+    timeout-minutes: *job-timeout
+    env:
+      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
+    needs: ["build-toolshed", "build-bg-piece-service"]
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 📥 Download toolshed binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-toolshed
+          path: common-binaries
+
+      - name: 📥 Download bg-piece-service binary
+        uses: actions/download-artifact@v8
+        with:
+          name: binary-bg-piece-service
+          path: common-binaries
+
+      - name: 🔌 Start Toolshed server for testing
+        env:
+          TOOLSHED_PORT: 8000
+        run: |
+          chmod +x ./common-binaries/toolshed
+          chmod +x ./common-binaries/bg-piece-service
+          # --background waits until the server has bound its port before it
+          # returns. Flag unset = the first-party default (ON since the
+          # flip) — the gates below exercise exactly that resolution.
+          CFTS_AI_GATEWAY_URL="" \
+          CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
+          ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
+            --background --log-file="$RUNNER_TEMP/toolshed.log"
+
+      - name: ✅ Verify the server-execution posture (default posture — server ON, shell define unset)
+        timeout-minutes: *posture-probe-timeout
+        env:
+          TOOLSHED_PORT: 8000
+        run: |
+          META=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/meta")
+          STATS=$(curl -fsS "http://localhost:${TOOLSHED_PORT}/api/health/stats")
+          echo "$META"
+          echo "$META" | jq -e '.shellServerExecutionDefine == null' > /dev/null || {
+            echo "::error::binary-toolshed carries a shell built with an explicit EXPERIMENTAL_SERVER_EXECUTION define; the deployed-topology gates must run against the default build"
+            exit 1
+          }
+          echo "$STATS" | jq -e '.servingLoop != null' > /dev/null || {
+            echo "::error::the toolshed did not start the serving loop at the default resolution; the first-party default is ON (the Phase 7 flip) — the deployed-topology gates would be vacuous"
+            exit 1
+          }
+
+      - name: 🧪 Run bg-piece-service posture gate
+        timeout-minutes: *work-timeout
+        working-directory: packages/background-piece-service
+        env:
+          API_URL: http://localhost:8000
+          BG_PIECE_SERVICE_BIN: ${{ github.workspace }}/common-binaries/bg-piece-service
+        run: |
+          mkdir -p ../../test-results
+          deno test --no-check \
+            --junit-path=../../test-results/bg-piece-service-posture-gate.xml \
+            --allow-env --allow-run --allow-net \
+            integration/posture-gate.test.ts
+
+      - name: 🧪 Run cf-harness posture gate
+        timeout-minutes: *work-timeout
+        working-directory: packages/cf-harness
+        env:
+          API_URL: http://localhost:8000
+        run: |
+          mkdir -p ../../test-results
+          deno test --no-check \
+            --junit-path=../../test-results/cf-harness-posture-gate.xml \
+            -A \
+            integration/fabric-session-posture-gate.test.ts
+
+      - name: 📋 Upload toolshed log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: toolshed-log-deployed-topology-gate
+          path: ${{ runner.temp }}/toolshed.log
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: 📤 Ship test records
+        if: always()
+        uses: ./.github/actions/test-records-ship
+        with:
+          artifact: deployed-topology-gate
+          job: Deployed Topology Posture Gates
+          junit: >-
+            kind=integration,scope=background-piece-service,prefix=packages/background-piece-service,glob=test-results/bg-piece-service-posture-gate.xml
+
+            kind=integration,scope=cf-harness,prefix=packages/cf-harness,glob=test-results/cf-harness-posture-gate.xml
+
   # ---------------------------------------------------------------------------
   # Tier 2 – Post-test gates and deployments
   # ---------------------------------------------------------------------------
@@ -1901,17 +2058,18 @@ jobs:
       - test
       - runner-test
       - build-toolshed
-      - build-toolshed-on
+      - build-toolshed-off
       - build-bg-piece-service
       - build-cf
       - generated-patterns-integration-test
       - package-integration-test
-      - package-integration-test-server-execution-on
+      - package-integration-test-server-execution-off
       - cli-integration-test
       - pattern-integration-test
-      - pattern-integration-test-server-execution-on
+      - pattern-integration-test-server-execution-off
       - pattern-reload-integration-test
       - pattern-unit-test
+      - deployed-topology-gate
       - coverage-check
     permissions: {}
     runs-on: ubuntu-latest
@@ -1940,6 +2098,10 @@ jobs:
     timeout-minutes: *job-timeout
     # A release artifact must not outlive a failed pattern-migration gate.
     # Production deploys consume this artifact without rerunning those gates.
+    # Since the flip, deployed-topology-gate is in the list for the same
+    # reason: it exercises the very binaries this job attests (toolshed
+    # serving at the default posture; bg-piece-service resolving it), and a
+    # binary that fails its posture gate must not reach a deploy.
     needs:
       [
         "test",
@@ -1956,6 +2118,7 @@ jobs:
         "package-integration-test",
         "cli-integration-test",
         "generated-patterns-integration-test",
+        "deployed-topology-gate",
       ]
     environment: ci
     permissions:

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
 | [`readerSchemaPrecedence`](#readerschemaprecedence)                         | `EXPERIMENTAL_READER_SCHEMA_PRECEDENCE` env, or `RuntimeOptions.experimental`                                                                   | on                                                                                   | Robin McCollum (#6338)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
-| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | off (`SERVER_EXECUTION_DEFAULT_ENABLED = false` — the ONE first-party default; Phase 7 landed flip-READY, DARK; explicit `true` = the ON arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | the flip is its OWN one-line PR after the plan's Phase-7 ordered gates; then soak on main, then delete the flag and the OFF path (the split-out post-soak PR) | Phases 1–6 landed; Phase 7 flip-READY landed dark (owner ruling 2026-08-16): OFF by default everywhere, the ON arm fully selectable and CI-tested on an ON-built binary |
+| [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **on** (`SERVER_EXECUTION_DEFAULT_ENABLED = true` — the ONE first-party default, FLIPPED by the flip PR 2026-08-28; explicit `false` = the OFF arm / rollback lever) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | soak on main (started at the flip PR's merge), then delete the flag and the OFF path (the split-out post-soak PR, which also removes the OFF guard lanes) | Phases 1–7 landed; the flip PR made ON the default everywhere the deployed-topology presets reach; OFF stays fully selectable through the soak and is CI-guarded on an OFF-built binary |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -316,9 +316,9 @@ server](#clients-that-are-not-built-alongside-their-server).
   states, no shippable intermediates (spec README §3.4); deliberately named
   unlike v1's `SERVER_PRIMARY_EXECUTION` so the archived v1 documents never
   alias it. Both states, defined:
-  - **OFF (the default today — the first-party default constant is `false`;
-    explicit `false` selects it regardless of the constant): today's
-    behavior, byte-for-byte.** Every client
+  - **OFF (the ROLLBACK arm since the flip — explicit `false` selects it
+    regardless of the constant, which is `true` since the flip PR): the
+    pre-v2 behavior, byte-for-byte.** Every client
     runtime runs and commits derivations exactly as it does today, and every
     client commit is `authored`-class — `derived` is never claimed off the
     flag. The commit `class` metadata is still *written* in this arm (it is
@@ -326,8 +326,8 @@ server](#clients-that-are-not-built-alongside-their-server).
     is enforced from it, and `stream-data` behaves as today. Any OFF-arm
     behavioral diff from a v2 stage is a phase-gate failure by itself
     (testing.md §2).
-  - **ON (explicit `true` — or the first-party default once the flip PR
-    sets the constant `true`): the v2 posture.** With stages A–F landed
+  - **ON (the DEFAULT since the flip PR set the constant `true`; explicit
+    `true` selects it regardless): the v2 posture.** With stages A–F landed
     this means: the per-class admission rows of protocol.md §2 are enforced
     — the `derived` row is the stage-B lease equality check PLUS stage F's
     derived-envelope defense-in-depth (the producing session must BE the
@@ -360,45 +360,65 @@ server](#clients-that-are-not-built-alongside-their-server).
     F10 interim — is DELETED). Later stages add their surfaces under
     this same flag; both halves of any coupled behavior move together
     on it.
-- **Current default and planned end state.** **OFF by default** — the ONE
+- **Current default and planned end state.** **ON by default** — the ONE
   first-party default is `SERVER_EXECUTION_DEFAULT_ENABLED` in
   [`packages/memory/v2/server-execution-default.ts`](../../packages/memory/v2/server-execution-default.ts),
-  value `false` (Phase 7 landed flip-READY, DARK, by owner ruling
-  2026-08-16), read by every deployed-topology entry point — the
-  `productionServer` / `remoteClient` construction presets (toolshed's
-  operator runtime, the background piece service, the CLI, every pieces
-  controller and integration harness against a toolshed), toolshed's
-  serving-host gate and its memory ACL principal lists (the DELEGATING
-  class since OW31's build — the process identity is no longer an
-  implicit-OWNER service principal), and the browser
+  value `true` since the flip PR (2026-08-28, after the plan's Phase-7
+  ordered gates were met: the ON-skip registry EMPTY, OW31's ruled
+  posture built, OW45–OW53 closed, the OW38(ii) benchmark bar ruled met
+  — "topics numbers are fine"; landed flip-READY DARK at `false`
+  2026-08-16 by owner ruling), read by every deployed-topology entry
+  point — the `productionServer` / `remoteClient` construction presets
+  (toolshed's operator runtime, the background piece service, the CLI,
+  every pieces controller and integration harness against a toolshed),
+  toolshed's serving-host gate and its memory ACL principal lists (the
+  DELEGATING class since OW31's build — the process identity is no
+  longer an implicit-OWNER service principal), and the browser
   shell's build define fallback. An UNSET flag resolves to it; an explicit
-  `EXPERIMENTAL_SERVER_EXECUTION=true` (or `experimental.serverExecution:
-  true`, or the shell define `true`) selects the ON arm, an explicit `false`
-  the OFF arm regardless of the constant. Single-process harnesses do not
+  `EXPERIMENTAL_SERVER_EXECUTION=false` (or `experimental.serverExecution:
+  false`, or the shell define `"false"`) selects the OFF arm — THE
+  ROLLBACK LEVER through the soak — and an explicit `true` the ON arm,
+  regardless of the constant. Un-flipping the default is reverting the
+  flip PR (repo convention: a flip is reverted by reverting the PR that
+  only flips — it carries the constant, the absolute pin, the CI lane
+  roles + probes, the deployed-topology gates, and this entry together).
+  Single-process harnesses do not
   read the constant: a bare `new Runtime` and the `patternTest` /
   `localDev` / `unitTest` presets have no serving host, so they resolve the
   ambient baseline (OFF) by construction — the unit suites and `cf test`
-  run the derive-and-commit model; the ON posture's unit coverage sets the
-  flag explicitly (the `executor-*` suites) and its integration coverage is
-  the explicit-`true` CI lanes. In CI (testing.md §2) the DEFAULT lanes are
-  the OFF posture (probed), and the explicit-`true` lanes on an ON-BUILT
-  binary (`build-toolshed-on`; the shell define is baked at build) are the
-  ON arm — the full posture, verified by a probe before each suite, its
-  Deno-side clients declaring the posture from the env — with skips only
-  through `tasks/server-execution-on-skips.ts`, printed loudly (six
-  `phase-7` entries today, all red under the full ON posture, none
-  vacuous). **THE FLIP IS ITS OWN ONE-LINE PR** (the constant → `true`, plus
-  the absolute pin, the CI lane roles + probes, and this entry; repo
-  convention: a flip is reverted by reverting the PR that only flips),
-  landing after the plan's Phase-7 ordered gates: OW32 (the client-side
-  non-settling loop in the two-browser journeys) triaged → OW17 (the
-  serving replica's per-instance re-keying, with OW29) → OW28
-  (`compile-and-run` as an outbox effect kind) → the honest propagation
-  benchmark → the skip list EMPTY and the deployed-topology binaries the
-  presets flip exercised ON by a gate → the flip PR. End state: after a soak
-  on main (which starts at the flip PR's merge) the flag retires and the
-  OFF code path is removed — a separate post-soak PR (the plan's Phase 7
-  task 2, split from the flip because stacked PRs cannot soak).
+  run the derive-and-commit model (which is why the flip does not reach
+  the no-server pattern-tests lane and its `topics/multi-user.test.tsx`,
+  the lane-posture item the topics measurement report recorded for the
+  flip decision); the ON posture's unit coverage sets the
+  flag explicitly (the `executor-*` suites) and its integration coverage
+  is the DEFAULT CI lanes. In CI (testing.md §2) the DEFAULT lanes are
+  the ON posture (probed: serving loop present, shell define unset), the
+  explicit-`false` lanes on an OFF-BUILT binary (`build-toolshed-off`;
+  the shell define is baked at build) are the OFF regression guard, the
+  `deployed-topology-gate` job exercises the real `bg-piece-service`
+  binary and cf-harness's fabric session at the default resolution, and
+  the CLI lanes probe the server their `cf` adopts its posture from —
+  with ON-arm skips only through `tasks/server-execution-on-skips.ts`,
+  printed loudly (EMPTY at the flip, its stated precondition). End
+  state: after a soak on main (which started at the flip PR's merge) the
+  flag retires and the OFF code path is removed — a separate post-soak
+  PR (the plan's Phase 7 task 2, split from the flip because stacked PRs
+  cannot soak; it also removes the OFF guard lanes and
+  `build-toolshed-off`).
+- **Status on 2026-08-28 (the FLIP).** The flip PR set the constant `true`
+  after every ordered gate was met on main (the ON-skip registry EMPTY
+  across all four suites — the ruled-3b-close lift #6528; OW31's ruled
+  write/read-authority posture BUILT; the first-ON-CI gate's owed rows
+  OW45–OW53 CLOSED; the OW38(ii) performance bar RULED met by the owner
+  on the topics measurement). It carried the lane-role swap (default
+  lanes = the ON arm, probed; explicit-`false` lanes = the OFF guard on
+  `build-toolshed-off`), the deployed-topology gates (the
+  `bg-piece-service` binary and cf-harness's fabric session at the
+  default resolution; the CLI lanes probed as `cf`'s gate;
+  `PiecesController` hosts riding the default lanes), and the
+  env-else-default posture resolution for the Deno-side integration
+  clients. The soak on main runs from its merge; the OFF path, the OFF
+  guard lanes, and this flag retire in the post-soak removal PR.
 - **Status on 2026-08-16 (Phase 7 flip-READY, landed DARK).** Phases 1–6
   landed; Phase 7 landed the flip's mechanism — the one constant and its
   readers, OW27 per-stream send pacing in the event-append queue

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -71,8 +71,10 @@ are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
 `contentAddressedSchemas`, `plainResultReceipts`, `computedCellIds`,
 `lazyMaterialization` and `readerSchemaPrecedence` default on;
 `serverExecution` resolves an unset flag to the ONE first-party default
-`SERVER_EXECUTION_DEFAULT_ENABLED` in the deployed-topology presets — `false`
-today, Phase 7 having landed flip-ready DARK (its section); the other flags in
+`SERVER_EXECUTION_DEFAULT_ENABLED` in the deployed-topology presets — `true`
+since the Phase 7 flip (2026-08-28; its section), with an explicit `false`
+selecting the OFF arm, the soak's rollback lever (the single-process presets
+read no default and stay OFF — the section says how); the other flags in
 this category default off unless their section says otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
@@ -1336,7 +1338,8 @@ The background piece service's main and worker processes use the same mapping
 and the same presets, so the server-side wirings agree on how a value parses.
 
 The CLI is not one of them. `cf`, the pieces controller behind it, the agents
-host and `cast-admin` are clients of a deployment rather than part of one, and
+host, the GitHub connector host and `cast-admin` are clients of a deployment
+rather than part of one, and
 they resolve their posture from that deployment first — the environment
 supplies their overrides, not their starting point. Their wiring is
 [Clients that are not built alongside their
@@ -1378,7 +1381,8 @@ The shell disagrees with its server only by explicit define: toolshed bakes
 the defines and serves the bundle, so the two ship one posture per deploy.
 Every other client is installed, deployed, or checked out on its own
 schedule — the `cf` binary, the pieces controller a FUSE mount opens, the
-agents host, the background-piece admin CLI — and the environment they read
+agents host, the GitHub connector host, the background-piece admin CLI — and
+the environment they read
 belongs to whoever launched them, not to the deployment they talk to. Left
 there, the operator has to know a deployment's flags and set them by hand, and
 nothing reports it when they do not.
@@ -1388,7 +1392,7 @@ These clients take the posture from the server instead. Each one calls
 before constructing its `Runtime`:
 
 ```
-cf / pieces controller / agents host / cast-admin
+cf / pieces controller / agents host / github host / cast-admin
   |
   +-- GET <apiUrl>/api/meta  --> { experimental: { <flag>: <boolean>, ... } }
   |     the posture the SERVER runs at

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -19,12 +19,12 @@ A test's identity has three required parts: **kind** (`unit`, `browser`,
 (the owning workspace member, or `repo`), and **name** (whatever the test's
 own runner reports — a bdd describe chain, a pattern file path, a task name,
 a script step). An optional **variant** separates the same test running
-in a non-default configuration. The default configuration is unmarked. The
-server-execution ON jobs use `server-execution` after variant-aware relay
-support is on the default branch. When server execution becomes the default,
-remove that marker from the ON jobs and mark the surviving explicit OFF jobs
-as `server-execution-off`. New default runs then continue the history of
-today's unmarked default jobs. One record is one JSON line; one uploaded
+in a non-default configuration. The default configuration is unmarked. Since
+the server-execution flip (2026-08-28) the default jobs run the ON posture
+unmarked — continuing the history of the previously unmarked default jobs —
+and the surviving explicit OFF regression-guard jobs use
+`server-execution-off`. The pre-flip explicit-ON jobs' `server-execution`
+marker is retired; their history stays queryable under it. One record is one JSON line; one uploaded
 object is a run's
 context line followed by its record lines. The schema, the line codecs, and
 their validators live in `packages/test-support/src/records/`.

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -20,11 +20,15 @@ A test's identity has three required parts: **kind** (`unit`, `browser`,
 own runner reports — a bdd describe chain, a pattern file path, a task name,
 a script step). An optional **variant** separates the same test running
 in a non-default configuration. The default configuration is unmarked. Since
-the server-execution flip (2026-08-28) the default jobs run the ON posture
-unmarked — continuing the history of the previously unmarked default jobs —
-and the surviving explicit OFF regression-guard jobs use
-`server-execution-off`. The pre-flip explicit-ON jobs' `server-execution`
-marker is retired; their history stays queryable under it. One record is one JSON line; one uploaded
+the server-execution flip (2026-08-28) the default deployed-topology lanes
+run the ON posture unmarked — continuing the history of the previously
+unmarked default jobs — and the surviving explicit OFF regression-guard jobs
+use `server-execution-off`. The pre-flip explicit-ON jobs'
+`server-execution` marker is retired; their history stays queryable under
+it. The single-process default jobs (the unit suites, `cf test`, the
+no-server pattern-unit lane) never read that default and stay ambient-OFF,
+so they are unmarked for the older reason: the flip does not reach them
+(`docs/specs/test-records.md`). One record is one JSON line; one uploaded
 object is a run's
 context line followed by its record lines. The schema, the line codecs, and
 their validators live in `packages/test-support/src/records/`.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -301,8 +301,8 @@ because one runner does not imply one scope: `workspace-unit` spans every
 workspace package, and the package integration command spans `runner`,
 `runtime-client`, and `shell`. The optional `variant` is suite-wide because
 the suite declares the configuration in which every one of its items runs.
-Default suites omit it. The two server-execution ON suites set it to
-`server-execution`.
+Default suites omit it. Since the server-execution flip, the two explicit OFF
+suites set it to `server-execution-off`.
 
 `enumerate()` is what makes a new test visible without a workflow edit. It
 reads the working tree — usually a file glob, sometimes a list parsed out
@@ -394,32 +394,34 @@ table is the migration's checklist.
 | `pattern-vintage` | `Pattern Update State and Baseline Integrity` | — | `deno`, `git-history` |
 | `generated-patterns` | `Generated Patterns Integration Tests (1..2)` | — | `deno`, `compile-cache` |
 | `package-integration` | `Package Integration Tests (3 suites)` | — | `deno`, `toolshed`, `browser` |
-| `package-integration-on` | the server-execution ON arm | `server-execution` | `deno`, `toolshed-baked-on`, `browser` |
+| `package-integration-off` | the server-execution OFF arm | `server-execution-off` | `deno`, `toolshed-baked-off`, `browser` |
+| `deployed-topology` | the background-service and cf-harness default-posture gates | — | `deno`, `toolshed`, `bg-piece-service-binary` |
 | `cli-core` | `CLI Integration Tests (3 suites)` | — | `deno`, `toolshed`, `cf`, `jq` |
 | `cli-fuse` | the FUSE steps of the third CLI suite | — | `deno`, `toolshed`, `cf`, `fuse` |
 | `cli-deno` | the Deno-based CLI integration step | — | `deno`, `toolshed`, `cf` |
 | `pattern-integration` | `Pattern Integration Tests (1..10)` | — | `deno`, `toolshed`, `browser`, `compile-cache` |
-| `pattern-integration-on` | the server-execution ON arm | `server-execution` | `deno`, `toolshed-baked-on`, `browser` |
+| `pattern-integration-off` | the server-execution OFF arm | `server-execution-off` | `deno`, `toolshed-baked-off`, `browser` |
 | `pattern-reload` | `Pattern Reload Integration Tests` | — | `deno`, `local-dev-servers`, `browser` |
 | `pattern-unit` | `Pattern Unit Tests (1..4)` | — | `deno`, `cf`, `compile-cache` |
 | `binaries` | the compile inside `Build Binary (toolshed)` and the two beside it | — | `deno` |
-| `binaries-on` | the compile inside `Build Binary (toolshed, server-execution ON shell)` | `server-execution` | `deno` |
+| `binaries-off` | the compile inside `Build Binary (toolshed, server-execution OFF shell)` | `server-execution-off` | `deno` |
 
-When server execution becomes the default, the unmarked
-`package-integration` and `pattern-integration` suites change their commands
-and capabilities to the ON posture without changing their record identity.
-The `*-integration-on` suites disappear. Any surviving explicit OFF suites
-use `server-execution-off`. No identity alias joins these histories: the
-unmarked default continues by construction, and each non-default posture
-has its own marker.
+The server-execution flip moved the unmarked `package-integration` and
+`pattern-integration` suites to the ON posture without changing their record
+identity. Their pre-flip explicit-ON counterparts became explicit-OFF suites
+under `server-execution-off`. No identity alias joins these histories: the
+unmarked default continues by construction, and each non-default posture has
+its own marker.
 
 ### Declared unavailable tests
 
 A configuration-specific skip is neither an unknown test nor evidence that
-the topology missed a surface. The server-execution ON suites therefore
-read `tasks/server-execution-on-skips.ts` as part of their topology. The
-skip registry remains the single source of truth for the phase and reason;
-the selection system does not grow a second list.
+the topology missed a surface. The default suites, which run the
+server-execution ON posture since the flip, therefore read
+`tasks/server-execution-on-skips.ts` as part of their topology. The explicit
+OFF suites run every file. The skip registry remains the single source of
+truth for the phase and reason; the selection system does not grow a second
+list.
 
 A whole-file entry removes that file from the variant suite's enumerated
 items. The manifest reports it as unavailable under that suite and variant,
@@ -444,7 +446,7 @@ servers and its command line from source and compiles nothing, so a
 compile that breaks would be found on `main`, after the change that broke
 it has merged — where today it is caught before it lands. So `binaries`
 makes each shipped binary a unit whose test is that it still compiles,
-and `binaries-on` does the same for the toolshed under the
+and `binaries-off` does the same for the toolshed under the explicit-OFF
 server-execution define, which is the same build in a different
 configuration and therefore a variant of it rather than a second test.
 
@@ -1022,7 +1024,8 @@ batches.
 | `git-history` | Unshallows the checkout | 3–10 seconds |
 | `toolshed` | A Toolshed server listening on an allocated port | see below |
 | `local-dev-servers` | The whole local dev stack, brought up by `deno task integration` on a chosen port offset | 15–20 seconds |
-| `toolshed-baked-on` | The same, from a binary whose shell carries the server-execution define | 42 seconds to build, or 17 to restore |
+| `toolshed-baked-off` | The same, from a binary whose shell carries the explicit-OFF server-execution define | 42 seconds to build, or 17 to restore |
+| `bg-piece-service-binary` | The compiled background service used by its deployed-topology gate | about 30 seconds to build, or under a second to restore |
 | `cf` | The `cf` command-line tool on the path | as above |
 | `compile-cache` | Restores a pattern compile byte cache | 3 seconds |
 
@@ -1039,7 +1042,7 @@ source costs a few seconds. The full run on `main` keeps the
 compiled-binary path, because it needs the binary anyway for attestation
 and deployment.
 
-**`toolshed-baked-on` cannot.** The server-execution ON arm depends on a
+**`toolshed-baked-off` cannot.** The server-execution OFF arm depends on a
 compile-time define baked into the browser shell inside the binary, and a
 source run cannot reproduce that. So that capability has a different
 provider: restore the binary from the Actions cache if the key hits, and
@@ -3333,12 +3336,12 @@ exercised on the branch on its own.
       distinguishes item identities from overlapping suite-level
       measurements, and returns at most one item for an identity that
       several arms or entry points can run. Add `tasks/ci-capabilities.ts`.
-      Twenty suites hold 2,396 units. The repository gates are two
+      Twenty-one suites currently hold 2,396 units. The repository gates are two
       suites rather than one, because `mandatory` belongs to a suite and
       the `always` set has to stay tiny: `repo-gates` holds formatting,
       linting and the drift guard, and `repo-checks` holds the rest of
       what the `Check` job runs, selected on value like anything else.
-- [x] The server-execution variant suites consume
+- [x] The server-execution ON configuration consumes
       `tasks/server-execution-on-skips.ts`: whole-file entries are declared
       unavailable and omitted from enumeration, while step entries exclude
       only the named leaf identity from unknown and coverage rules.

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -2081,7 +2081,17 @@ Tasks:
       [#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN
       (the coordination-state delta above carries its contents; the
       owner reads and merges it personally — the soak starts at that
-      merge, and the OFF path stays the rollback lever through it)**. OW31 (the
+      merge, and the OFF path stays the rollback lever through it).
+      Its first board surfaced ONE owner-court STOP: the verb
+      DECLARED-RESULT surface is absent under ON — receipts are
+      unwritten under the flag by events.md §4/N26's exactly-once
+      subsumption, which replaced only that role and left the
+      receipt's result-carriage (plainResultReceipts; `cf call`'s
+      `.result`) with no substitute — the register's FLIP block item
+      (5) carries the mechanism, and the CLI piece-call lane's
+      umbrella-create assert stays red as the witness until it is
+      ruled (serving-side receipt write vs a new served result
+      channel)**. OW31 (the
       service-principal write-authority posture) was RULED 2026-08-18 —
       the serving identity never writes users' home spaces; genesis
       under the space's own keys, owner := the acting user — and its

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,15 +38,28 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
-**Delta 2026-08-28 (the FLIP PR —
+**Delta 2026-08-28, last updated 2026-08-29 (the FLIP PR —
 [#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN, the
 owner merges it personally; the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
-`true`, with every ordered gate met on main at the base (e16780fca —
-rebased onto it 2026-08-29 from 4e02f75c4, the gate claims re-verified
-at the new base): the
+`true`, with every ordered gate met on main at the base (22c93b540 —
+rebased onto it 2026-08-29, from e16780fca and originally 4e02f75c4;
+the gate claims re-verified at each new base): the
 ON-skip registry EMPTY across all four suites (the ruled-3b-close lift,
 #6528), OW31's ruled posture BUILT, OW45–OW53 CLOSED, and the OW38(ii)
-bar RULED met ("topics numbers are fine", 2026-08-24).** The PR carries,
+bar RULED met ("topics numbers are fine", 2026-08-24).** The 2026-08-29
+updates this block carries, since the events they record post-date its
+2026-08-28 heading: the two rebases above; the DECLARED-RESULT STOP
+RULED (task 6's block — the serving side writes the verb
+receipt/result); and the bot-review AMENDMENT (the deployed-topology
+gates' startup wait made event-driven, their temporary identity no
+longer leaked, the CLI health probes bounded, and the CLI lane's gate
+now cross-checking `cf`'s resolved arm against the server's published
+one). The OFF-world half of those same findings landed separately on
+main as
+[#6545](https://github.com/commontoolsinc/labs/pull/6545) — the GitHub
+connector host adopting the deployment's posture, and the pattern
+shard selectors failing loudly on an empty selection — which is the
+base this branch now sits on. The PR carries,
 beside the one-liner and the absolute pin's re-tense: the LANE-ROLE SWAP
 (default lanes = the ON arm, probed serving-loop-present +
 shell-define-unset, carrying the empty ON skip list; the pre-flip
@@ -2171,13 +2184,20 @@ their protocol and full numbers are in the
 [stage-C closeout](../history/plans/server-execution-v2/stage-c-closeout.md)
 and the reports beside it):**
 
+*Reading the posture column after the flip: every `DEFAULT` row records
+the default AS OF THAT RUN — OFF, by the 2026-08-16 dark-landing ruling
+— not the default today. The flip PR makes the DEFAULT lanes the ON
+arm, so those gates re-run under ON on its own board rather than being
+re-tensed in place here; the `explicit ON` rows are what the ON arm
+exercised at the time.*
+
 | gate | posture | result |
 | --- | --- | --- |
 | `sx2-serving-loop`, `sx2-speculation`, `sx2-events`, `sx2-effect-channel`, `sx2-scale` | explicit `EXPERIMENTAL_SERVER_EXECUTION=true` everywhere (the ON arm — the sx2 arm detection reads env-else-default) | see the PR's bar (fixer re-run, fresh store) |
-| same five | DEFAULT (unset = OFF by ruling) | see the PR's bar (fixer re-run) |
-| runner package integration (14) | DEFAULT (OFF) | 14/14 GREEN |
+| same five | DEFAULT at the run's date (unset = OFF by the dark-landing ruling; the flip makes DEFAULT the ON arm) | see the PR's bar (fixer re-run) |
+| runner package integration (14) | DEFAULT at the run's date (OFF) | 14/14 GREEN |
 | runner package integration | explicit ON, UNIFORM (the 4 tests that talk to the lane's toolshed declare ON; the 8 in-process-app harness tests are OFF by construction) | 13/14 GREEN + `pattern-and-data-persistence` RED → ON-skip-listed (OW33); the pre-fix "14/14 under ON" was a MIXED posture (OFF clients) |
-| runtime-client package integration | DEFAULT (OFF) | 45 steps GREEN |
+| runtime-client package integration | DEFAULT at the run's date (OFF) | 45 steps GREEN |
 | runtime-client package integration | explicit ON, UNIFORM (the worker declares ON) | 43 steps GREEN + 2 STEP entries ignored loudly (CT-1606 PerUser header render 3/3 red; single-navigateTo dispatch 1/3 red — OW33) |
 | `counter` | full ON | 1 red / 3 green in the build's runs (OW30's controller write-destination race — intermittent); green in the review's run; server exhausts 2/5 waves with no client loop |
 | `topics-navigation` | full ON | RED fast (`missing required property myName`, OW30 class) — ON-skip-listed (and, since the fixer, actually skipped) |

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -41,7 +41,9 @@ it in the PR that moves the state.
 **Delta 2026-08-28 (the FLIP PR —
 [#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN, the
 owner merges it personally; the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
-`true`, with every ordered gate met on main at the base (4e02f75c4): the
+`true`, with every ordered gate met on main at the base (e16780fca —
+rebased onto it 2026-08-29 from 4e02f75c4, the gate claims re-verified
+at the new base): the
 ON-skip registry EMPTY across all four suites (the ruled-3b-close lift,
 #6528), OW31's ruled posture BUILT, OW45–OW53 CLOSED, and the OW38(ii)
 bar RULED met ("topics numbers are fine", 2026-08-24).** The PR carries,
@@ -2082,17 +2084,23 @@ Tasks:
       (the coordination-state delta above carries its contents; the
       owner reads and merges it personally — the soak starts at that
       merge, and the OFF path stays the rollback lever through it).
-      Its first board surfaced ONE owner-court STOP: the verb
-      DECLARED-RESULT surface is absent under ON — receipts are
-      unwritten under the flag by events.md §4/N26's exactly-once
-      subsumption, which replaced only that role and left the
-      receipt's result-carriage (plainResultReceipts; `cf call`'s
-      `.result`) with no substitute — the register's FLIP block item
-      (5) carries the mechanism, and the CLI piece-call lane's
-      umbrella-create assert stays red as the witness until it is
-      ruled (serving-side receipt write vs a new served result
-      channel)**. OW31 (the
-      service-principal write-authority posture) was RULED 2026-08-18 —
+      Its first board surfaced ONE owner-court STOP — RULED AND BUILT,
+      no longer standing: the verb DECLARED-RESULT surface was absent
+      under ON, because receipts went unwritten under the flag by
+      events.md §4/N26's exactly-once subsumption, which replaced only
+      that role and left the receipt's result-carriage
+      (plainResultReceipts; `cf call`'s `.result`) with no substitute.
+      The owner RULED it 2026-08-29 — "yes, Serving-side receipt/result
+      write, as that is indeed what i said before" — and the PR's
+      result-carriage commit (its fourth) builds it: the served handler
+      run writes the receipt in its OWN transaction (same wave as the
+      entry's `consequenced` mark) at the same cause-derived address the
+      client-era write used, write-once by CAS with a lost CAS a loud
+      no-op. The register's FLIP block item (5) carries the mechanism
+      and its pins; the CLI piece-call lane's umbrella-create assert —
+      the witness that was red — is GREEN (board 33239003881)**. OW31
+      (the service-principal write-authority posture) was RULED
+      2026-08-18 —
       the serving identity never writes users' home spaces; genesis
       under the space's own keys, owner := the acting user — and its
       build (register OW31's work order) was owed post-merge, BEFORE
@@ -2109,15 +2117,16 @@ Tasks:
 
 Success criteria:
 
-- [ ] The integration suites run ON-only and green. (NOT ticked — untrue
-      today: the default lanes are the OFF posture by ruling. *The rest
-      of this parenthetical was the 2026-08-16 state, since superseded:
-      the explicit-ON lanes were green only WITH the skip list's six
-      `phase-7` entries, which were RED under the full ON posture, not
-      vacuous — table below. The entries were lifted arc-by-arc and the
-      ON-skip registry is EMPTY across all four suites since #6528, the
-      ruled-3b-close lift — the explicit-ON lanes run green with no
-      skips; the Coordination-state delta above carries the lift.*)
+- [ ] The integration suites run ON-only and green. (NOT ticked — but no
+      longer for the old reason, which was the six `phase-7` skip
+      entries the explicit-ON lanes needed. The ON-skip registry has
+      been EMPTY across all four suites since #6528, and the flip PR
+      swaps the lane roles: the DEFAULT lanes ARE the ON arm and run the
+      full suite carrying that empty list. What stays untrue is
+      ON-ONLY — the explicit-`false` OFF regression-guard lanes are the
+      soak's rollback lever and run beside them by design. They retire
+      with the post-soak removal PR, which is when this box can be
+      ticked.)
 - [ ] Cross-user propagation beats the client-computed baseline on the
       byte-identical workloads (the §1 "faster, not tolerably slower"
       requirement). (NOT ticked — UNMEASURED: the measurement leg is

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,8 +38,9 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
-**Delta 2026-08-28 (the FLIP PR — OPEN, the owner merges it personally;
-the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
+**Delta 2026-08-28 (the FLIP PR —
+[#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN, the
+owner merges it personally; the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
 `true`, with every ordered gate met on main at the base (4e02f75c4): the
 ON-skip registry EMPTY across all four suites (the ruled-3b-close lift,
 #6528), OW31's ruled posture BUILT, OW45–OW53 CLOSED, and the OW38(ii)
@@ -2076,10 +2077,11 @@ Tasks:
       via posture adoption; `PiecesController` hosts on the default
       package/pattern lanes)*;
       then (6) the flip PR, and the soak starts at ITS merge — **IN
-      PROGRESS 2026-08-28: the flip PR is OPEN (the coordination-state
-      delta above carries its number and contents; the owner reads and
-      merges it personally — the soak starts at that merge, and the OFF
-      path stays the rollback lever through it)**. OW31 (the
+      PROGRESS 2026-08-28: the flip PR is
+      [#6535](https://github.com/commontoolsinc/labs/pull/6535), OPEN
+      (the coordination-state delta above carries its contents; the
+      owner reads and merges it personally — the soak starts at that
+      merge, and the OFF path stays the rollback lever through it)**. OW31 (the
       service-principal write-authority posture) was RULED 2026-08-18 —
       the serving identity never writes users' home spaces; genesis
       under the space's own keys, owner := the acting user — and its

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,6 +38,41 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
+**Delta 2026-08-28 (the FLIP PR — OPEN, the owner merges it personally;
+the soak starts at ITS merge): `SERVER_EXECUTION_DEFAULT_ENABLED` →
+`true`, with every ordered gate met on main at the base (4e02f75c4): the
+ON-skip registry EMPTY across all four suites (the ruled-3b-close lift,
+#6528), OW31's ruled posture BUILT, OW45–OW53 CLOSED, and the OW38(ii)
+bar RULED met ("topics numbers are fine", 2026-08-24).** The PR carries,
+beside the one-liner and the absolute pin's re-tense: the LANE-ROLE SWAP
+(default lanes = the ON arm, probed serving-loop-present +
+shell-define-unset, carrying the empty ON skip list; the pre-flip
+explicit-`true` lanes become the explicit-`false` OFF regression guard
+on `build-toolshed-off` — the inversion of `build-toolshed-on` — with
+variant `server-execution-off`, per testing.md §2's identity contract);
+the DEPLOYED-TOPOLOGY obligation discharged (the Phase 7 table row):
+a new `deployed-topology-gate` job runs the REAL `bg-piece-service`
+binary (startup posture log line asserted; clean SIGTERM) and
+cf-harness's production fabric-session factory (posture adopted ON; one
+genuine piece flow) against the default toolshed, both red-first against
+forced-OFF; the CLI lanes gain the server posture probe (`cf` adopts the
+published posture — its gate); `PiecesController` hosts ride the default
+lanes (sx2-scale et al.). The Deno-side integration clients (4 runner
+files; the runtime-client host + its step-skip guard) resolve
+env-else-default via the now-exported `withServerExecutionDefault`, so
+the default lanes stay UNIFORM (the P7 finding-7 mixed posture does not
+resurrect). The topics multi-user LANE-POSTURE item (the measurement
+report's §5.1 flip-decision question) is discharged as recorded: the
+no-server pattern-tests lane resolves the AMBIENT baseline (OFF) by
+construction — the `patternTest` preset does not read the constant
+(conformance-golden-pinned) — verified live at the flipped head
+(`topics/multi-user.test.tsx` 7/7 with env unset); "grow the in-process
+serving role" stays the not-taken alternative. testing.md §2,
+EXPERIMENTAL_OPTIONS.md, and the register's FLIP PR block re-tensed
+with it. The OFF path is NOT removed — it is the soak's rollback lever;
+the post-soak removal PR (task 2) deletes it with the OFF lanes. The
+deltas below are the prior PRs' records.**
+
 **Delta 2026-08-28 (the ruled-3b-close PR): THE OWNER RULED THE 3B FORK
 — "go with (1) plus the (2-D) kick" — both mechanisms are LANDED
 red-first, and lunch-poll-vote's FILE entry is LIFTED: the ON-skip
@@ -2033,8 +2068,18 @@ Tasks:
       deployed-topology binaries the presets flip
       (`background-piece-service`, the CLI, cf-harness, every
       `PiecesController`) exercised ON by a gate — the flip PR's own
-      obligation (review finding 8: today nothing exercises them ON);
-      then (6) the flip PR, and the soak starts at ITS merge. OW31 (the
+      obligation (review finding 8: at the flip-ready landing nothing
+      exercised them ON) — *DISCHARGED BY THE FLIP PR (2026-08-28, the
+      four-topology dispositions in its register block and PR body:
+      `deployed-topology-gate` job for the bg-piece-service binary and
+      cf-harness's fabric session; the CLI lanes probed as `cf`'s gate
+      via posture adoption; `PiecesController` hosts on the default
+      package/pattern lanes)*;
+      then (6) the flip PR, and the soak starts at ITS merge — **IN
+      PROGRESS 2026-08-28: the flip PR is OPEN (the coordination-state
+      delta above carries its number and contents; the owner reads and
+      merges it personally — the soak starts at that merge, and the OFF
+      path stays the rollback lever through it)**. OW31 (the
       service-principal write-authority posture) was RULED 2026-08-18 —
       the serving identity never writes users' home spaces; genesis
       under the space's own keys, owner := the acting user — and its
@@ -2043,8 +2088,10 @@ Tasks:
 - [ ] Retire the flag; OFF path removed; `EXPERIMENTAL_OPTIONS.md` entry
       closed out — **SPLIT OUT: the post-soak removal PR** (named here as
       the flip's follow-up; it also removes the OFF regression-guard CI
-      lanes and the OFF-built binary job that the flip PR will introduce
-      by inverting today's `build-toolshed-on`).
+      lanes and the OFF-built binary job — `build-toolshed-off`, which
+      the flip PR introduced by inverting the pre-flip
+      `build-toolshed-on` — while the `deployed-topology-gate` job
+      STAYS: it gates the surviving default posture, not the OFF path).
 - [ ] Archive this plan to `docs/history/plans/` per the lifecycle
       (close-out, after the soak and the removal PR).
 
@@ -2115,7 +2162,7 @@ and the reports beside it):**
 | `topics-navigation` | full ON | RED fast (`missing required property myName`, OW30 class) — ON-skip-listed (and, since the fixer, actually skipped) |
 | `cfc-group-chat-demo-two-browsers` (the Phase-2 gate + the benchmark harness) | full ON — HEAD 2/2 and the unmodified Phase-6 BASE 1/1 (review); **fan-out stage B: 3/3 fresh-store, ON-built binary (2026-08-17)** | Phase 7: RED (300 s stall; the OW32 client loop, 40–56 k action runs / 5 min). **Fan-out stage B: GREEN 3/3 (1m08s / 1m21s / 1m23s), every step in seconds; client action runs 401–586 per browser; zero non-settling; serving loop waves 48–58, derivedCommits = waves, watermarkLag ≤ 12; UN-SKIPPED** |
 | lunch (`lunch-poll-vote`) | full ON — HEAD 2/2 (review); **fan-out stage B: 2 fresh-store runs on the final binary (2026-08-17)** | Phase 7: RED (the identity-less served `#profile` wish + the OW32 loop). **Fan-out stage B: BIMODAL 1/2 — run 4 GREEN 2m28s (login 1.6 s, runtimes idle 1.0 s, joins 12–640 ms, votes and merges in seconds); run 5 RED at "both browsers see 2 love it (merge)" — both vote events consequenced with no error, one vote's served `castVote` no-op'd (`nowTick` null in the actor's run); stays ON-skip-listed with that residual named** |
-| the deployed-topology binaries the presets flip (`background-piece-service`, CLI, cf-harness, `PiecesController` hosts) | ON | NO gate exercises them ON (review finding 8) — recorded as the flip PR's own obligation; with the constant `false` none flips today |
+| the deployed-topology binaries the presets flip (`background-piece-service`, CLI, cf-harness, `PiecesController` hosts) | ON | NO gate exercised them ON at the flip-ready landing (review finding 8) — recorded as the flip PR's own obligation. **DISCHARGED by the flip PR (2026-08-28)**: bg-piece-service + cf-harness get the `deployed-topology-gate` job (the real binary starts/serves and asserts its posture log line; the fabric-session factory resolves ON by adoption and serves one piece flow — both red-first against forced-OFF), the CLI's gate is the probed `cli-integration-test` lanes (`cf` adopts the server's published posture), and `PiecesController` hosts ride the default package/pattern lanes (sx2-scale's controllers; the pieces-controller helper) |
 | OFF-arm neutrality | full runner suite (OFF ambient) + memory + toolshed unit suites + explicit-OFF sx2 | see the PR's bar |
 | **STAGE-C BENCHMARK 1** (2026-08-17, `59b5329ae` ≡ fan-out B runtime; built binaries, posture-verified, fresh store, OFF→ON→OFF, loads 3–9; [report](../history/plans/server-execution-v2/stage-c/stage-c-benchmark-report.md)) — chat two-browsers series n=20 @2 s | OFF ×3 / ON ×3 (+1 at `fadc2efb1b`) | OFF median **227 / 328 / 477 ms** (p95 498–1 069); ON **0 series** — lockdown stall 300 s (t1, smoke0) or lease churn from t≈0 (t2: `lease.lost` 33, load 3.9); per-step ON 3.0–7.2 s vs OFF 4–47 ms where ON reached the step |
 | same benchmark — lunch two-user vote | OFF ×2 / ON ×1 | OFF ✓ 11 s, 16 s; ON **RED** at "both browsers see 2 love it (merge)" 300 s (option A propagates 7 873 ms vs 53/80; both cast green 22 943 ms vs 440/843) |

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -249,6 +249,34 @@ ambient-state one.
   default) is SUBSUMED by `eventWatermark` under the flag; the two
   mechanisms MUST NOT be active for the same event
   (runtime-mapping.md N26).
+- **Result carriage (RULED 2026-08-29 — owner: "yes, Serving-side
+  receipt/result write, as that is indeed what i said before"):** the
+  subsumption above retires the receipt's EXACTLY-ONCE role only — its
+  RESULT-CARRIAGE role (verb contract WS-C/D readback:
+  `tx.handlingReceiptLink`, `plainResultReceipts`, `cf call`'s
+  `.result`/`.receipt`) is replaced by a SERVING-SIDE write. Every
+  served handler completion writes the handling's receipt/result cell —
+  even when the declared value is undefined, so the `{}` existence
+  witness stands — in the handler run's own transaction, so the write
+  seals into the run's wave with the entry's `consequenced` mark (§4's
+  mark/effects atomicity) and rides the same carriage as every other
+  served event-handler write. The cell identity stays the cause-derived
+  address the client-era write used (same event ⇒ same minted cell id),
+  so an unchanged consumer reads served results exactly as it read
+  client-written ones; a flag-ON client's diverted echo publishes that
+  same address on its transaction, and the durable-ack coupling settles
+  the sender's callback only after the handling consequenced — the
+  receipt is durable before the address is ever dereferenced.
+  Exactly-once for the write is the single serving writer plus the
+  store's CAS on the result cell ("all handlers write result cells
+  (even if the value is undefined), and the CAS for that is the
+  write-once guarantee" — the owner's model): a lost CAS means a writer
+  already landed this handling's receipt (a re-served replay converging
+  on the same cause-derived id, or a pre-created cell) and is a LOUD
+  NO-OP — first-writer-wins, the OFF arm's receipt-collision
+  semantics — never a second write, never an error that fails the wave.
+  No create-only mark rides the wave (the invariant above holds); the
+  client's own write stays disabled.
 - **The drain's own re-scan (stage C tuning, 2026-08-18):** the drain
   queues a pending entry into the serving scheduler AT MOST ONCE until
   the store has spoken for it — a re-drain skips an entry whose earlier

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -279,7 +279,13 @@ the verb contract reads a handling's result back by receipt address
 (`tx.handlingReceiptLink`, `runner.ts:4767-4780`,
 `plainResultReceipts`) — events.md is silent on result readback for
 CLI/agent ingress; carry receipts as a value surface or re-spec the
-verb contract. Flag as a Phase 3 decision.
+verb contract. ~~Flag as a Phase 3 decision.~~ **(b) RULED 2026-08-29
+(owner: serving-side receipt/result write): receipts are carried as a
+value surface — the SERVING side writes every handling's receipt (the
+`{}` witness included) in the handler run's own wave, at the same
+cause-derived address, write-once by CAS (lost CAS = loud no-op); the
+readback contract is unchanged. Normative text: events.md §4 "Result
+carriage".**
 
 **N27 (lineage).** Client-side under the flag, lineage's job — drop
 descendants of a failed speculative commit — is absorbed by the

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -50,8 +50,20 @@ processes RESOLVE the posture env-else-default (the runner integration
 tests that talk to the lane's toolshed; the runtime-client worker host —
 never a bare/ambient client, the mixed posture the Phase-7 review found,
 which under default-ON a raw env read would resurrect), and the
-default-built browser shell's define fallback is the same constant; a
-posture PROBE before each suite pins serving-loop PRESENT
+default-built browser shell's define fallback is the same constant. TWO
+files on the default pattern lane deliberately read the RAW env instead,
+and are exceptions rather than drift:
+`packages/patterns/integration/topic-board-child-contract.test.ts` and
+`packages/patterns/integration/convergence-storm.test.ts` key their
+ON-arm STEP-skip guard (`onArmStepSkip`) off it. Neither takes a RUNTIME
+posture from that read — the runtimes there adopt the lane toolshed's
+published posture (and the storm harness resolves env-else-default) — so
+the raw key decides only whether a listed step is skipped. With the
+skip registry EMPTY the guards are inert everywhere; the raw key leaves
+them undefined on the default (ON) lane, so a future entry for either
+file fails LOUD there (the step runs and reds, never a silent skip),
+which is the trigger to convert the key. Each file's own comment carries
+this. A posture PROBE before each suite pins serving-loop PRESENT
 (`/api/health/stats.servingLoop`) and shell define UNSET (`/api/meta`'s
 `shellServerExecutionDefine` null), so a silent un-flip of the default
 cannot move the REQUIRED lanes off ON. The explicit

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -41,45 +41,59 @@ not-yet-implemented phases via explicit skip lists per phase, never via
 silent filtering. (v1's terminal failure mode: the flags-on branch never
 went through CI at all.)
 
-*Phase 7 landed FLIP-READY, DARK (owner ruling 2026-08-16;
-`SERVER_EXECUTION_DEFAULT_ENABLED = false`; the flip is its own later
-one-line PR). The arms today: the DEFAULT lanes (flag unset = the
-first-party default, OFF) are the regression guard — a posture PROBE
-before each suite pins server-not-serving (`/api/health/stats` carries no
-`servingLoop`) and shell define unset (`/api/meta`'s
-`shellServerExecutionDefine` null), so a silent flip of the default
-cannot move the REQUIRED lanes onto ON; the explicit
-`EXPERIMENTAL_SERVER_EXECUTION=true` lanes are the ON arm in the FULL
-posture — the toolshed serves, the test processes DECLARE the posture
-from the env (the runner integration tests that talk to the lane's
-toolshed; the runtime-client worker — never a bare/undeclared client, the
-mixed posture the Phase-7 review found), and the binary's baked browser
-shell is ON-built (`build-toolshed-on`, the define `true`) — VERIFIED
-by the same probe (`shellServerExecutionDefine === "true"`,
-`servingLoop` present) before the suite runs. Skips only via
+*Phase 7 FLIPPED (the flip PR, 2026-08-28, after the plan's ordered
+gates: `SERVER_EXECUTION_DEFAULT_ENABLED = true`; landed FLIP-READY DARK
+2026-08-16 by owner ruling, roles inverted until the flip). The arms
+since the flip: the DEFAULT lanes (flag unset = the first-party default,
+ON) ARE the ON arm in the FULL posture — the toolshed serves, the test
+processes RESOLVE the posture env-else-default (the runner integration
+tests that talk to the lane's toolshed; the runtime-client worker host —
+never a bare/ambient client, the mixed posture the Phase-7 review found,
+which under default-ON a raw env read would resurrect), and the
+default-built browser shell's define fallback is the same constant; a
+posture PROBE before each suite pins serving-loop PRESENT
+(`/api/health/stats.servingLoop`) and shell define UNSET (`/api/meta`'s
+`shellServerExecutionDefine` null), so a silent un-flip of the default
+cannot move the REQUIRED lanes off ON. The explicit
+`EXPERIMENTAL_SERVER_EXECUTION=false` lanes are the OFF regression
+guard — the rollback lever kept honest through the soak — on an
+OFF-built binary (`build-toolshed-off`, the define `"false"`), VERIFIED
+by the same probe (`shellServerExecutionDefine === "false"`,
+`servingLoop` absent) before the suite runs; they retire with the OFF
+path in the post-soak removal PR. Skips only via
 `tasks/server-execution-on-skips.ts` (file entries; STEP entries for a
 one-file suite, guarded in-file and bound to the register), printed
-loudly — and, since 2026-08-16, actually EFFECTIVE: `deno test --ignore`
-binds only to files deno discovers itself, so the package `integration`
-tasks hand deno a quoted glob and the pattern shards filter their file
-list through the script (`--filter`); until then every listed skip ran.
-When the flip PR lands the roles invert (default = ON with the skip list,
-which must be EMPTY by then; explicit `false` = the OFF guard on an
-OFF-built binary), and both lanes stay until the OFF path is removed
-(the post-soak PR). Single-process suites (the unit suites, `cf test`,
-the runner integration files that serve toolshed's `app.ts` in-process)
-are not arms of this contract: they have no serving host and run the
-derive-and-commit model by construction (EXPERIMENTAL_OPTIONS.md).*
+loudly, riding the DEFAULT lanes (the ON arm — the OFF guard never
+skips), EMPTY at the flip (its stated precondition) — and, since
+2026-08-16, actually EFFECTIVE: `deno test --ignore` binds only to
+files deno discovers itself, so the package `integration` tasks hand
+deno a quoted glob and the pattern shards filter their file list
+through the script (`--filter`); until then every listed skip ran. The
+deployed-topology binaries the presets flip carry their own gates since
+the flip PR (its recorded obligation; P7 review finding 8): the
+`deployed-topology-gate` job runs the real `bg-piece-service` binary
+and cf-harness's fabric-session factory against the default (ON)
+toolshed, posture-asserted; the CLI lanes are `cf`'s gate (it adopts
+the server's published posture; the lane probes the server half); and
+`PiecesController` hosts ride the default package/pattern lanes
+(sx2-scale's controllers, the pieces-controller helper). Single-process
+suites (the unit suites, `cf test`, the runner integration files that
+serve toolshed's `app.ts` in-process — the serving loop starts in the
+binary's `index.ts`, not in `app.ts`) are not arms of this contract:
+they have no serving host and run the derive-and-commit model (the
+ambient baseline, OFF) by construction (EXPERIMENTAL_OPTIONS.md) — the
+flip does not reach them.*
 
 Test-record identity follows the [test-run record
-contract](../test-records.md). The current default arm leaves the shipping
-action's `variant` input unset. The explicit ON package and pattern jobs set
-it to `server-execution`, so results from the two configurations keep separate
-histories. Any additional non-default arm uses its own stable variant. The
-workflow tests assert both that non-default arms carry their exact marker and
-that the default arm remains unmarked. When ON becomes the default, remove its
-marker and mark the surviving explicit OFF arm as `server-execution-off`; new
-default runs then continue the existing unmarked history.
+contract](../test-records.md). The current default arm (ON since the flip)
+leaves the shipping action's `variant` input unset, continuing the existing
+unmarked history. The explicit OFF package and pattern jobs set it to
+`server-execution-off`, so the regression guard keeps its own history; the
+pre-flip explicit-ON arm's `server-execution` marker retired with the flip
+(its history stays queryable under that variant). Any additional
+non-default arm uses its own stable variant. The workflow tests assert both
+that non-default arms carry their exact marker and that the default arm
+remains unmarked.
 
 ## 3. The watermark replaces polling
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3243,7 +3243,8 @@ findings; the OWNER RULING — the flip lands DARK):
   OW28 → the honest benchmark → the flip PR (which also flips the
   absolute pin, the CI lane roles and their posture probes, and
   EXPERIMENTAL_OPTIONS.md; and MUST land with the ON skip list EMPTY).
-  **THE FLIP PR (2026-08-28, base 4e02f75c4 — every ordered gate met: the
+  **THE FLIP PR (#6535, 2026-08-28, base 4e02f75c4 — every ordered gate
+  met: the
   ON-skip registry EMPTY across all four suites (#6528, the
   ruled-3b-close lift), OW31's ruled posture BUILT, OW45–OW53 CLOSED,
   OW38(ii) RULED met ("topics numbers are fine"). The owner merges it

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3243,197 +3243,9 @@ findings; the OWNER RULING — the flip lands DARK):
   OW28 → the honest benchmark → the flip PR (which also flips the
   absolute pin, the CI lane roles and their posture probes, and
   EXPERIMENTAL_OPTIONS.md; and MUST land with the ON skip list EMPTY).
-  **THE FLIP PR (#6535, 2026-08-28, base e16780fca — rebased onto it
-  2026-08-29 from the original base 4e02f75c4, with every gate claim
-  re-verified there; every ordered gate met: the
-  ON-skip registry EMPTY across all four suites (#6528, the
-  ruled-3b-close lift), OW31's ruled posture BUILT, OW45–OW53 CLOSED,
-  OW38(ii) RULED met ("topics numbers are fine"). The owner merges it
-  personally; the soak starts at ITS merge.** What it carries:
-  - The one-liner: `SERVER_EXECUTION_DEFAULT_ENABLED = true`
-    (`packages/memory/v2/server-execution-default.ts`), and the absolute
-    pin re-tensed to state the default IS ON
-    (`packages/toolshed/lib/server-execution-flag.test.ts` — watched RED
-    at the flipped constant before the re-tense).
-  - The LANE-ROLE SWAP, old → new (testing.md §2 re-tensed with it):
-    `build-toolshed-on` (bakes `true`) → `build-toolshed-off` (bakes
-    `"false"`); default `package-integration-test` /
-    `pattern-integration-test` lanes: OFF probe → ON probe
-    (serving-loop PRESENT + shell define UNSET) and they now carry the
-    ON skip list (EMPTY; the OFF guard never skips);
-    `package-integration-test-server-execution-on` /
-    `pattern-integration-test-server-execution-on` (explicit `true`,
-    variant `server-execution`) →
-    `...-server-execution-off` (explicit `false` on the OFF-built
-    binary, probe inverted, variant `server-execution-off` — the
-    default arm continues the unmarked history). The old ci-workflow
-    lane pins were watched RED on the swapped workflow, then
-    reconciled, plus a new lane-roles pin test (a partial revert of one
-    half now reds).
-  - The four-topology gate dispositions (the Phase-7 table row's
-    obligation, review finding 8), lane by lane:
-    (1) `background-piece-service` — had NO exercising lane; the new
-    `deployed-topology-gate` job starts the REAL binary against the
-    default (ON, probed) toolshed, asserts its new startup posture log
-    line (`main.ts`; the binary has no HTTP surface) and clean SIGTERM
-    exit — RED-FIRST with a forced-OFF service env (posture line "OFF"
-    vs expected "ON").
-    (2) cf-harness — had NO toolshed-backed lane (its integration suite
-    is CF_HARNESS_INTEGRATION-gated); the same job runs
-    `createHarnessFabricSessionFactory` (PKCS#8 from disk →
-    `PiecesController.initialize` → deployed-client adoption), asserts
-    the session's runtime resolved ON with nothing declared, and serves
-    one genuine flow (compile + create a piece, read the result back) —
-    RED-FIRST against a forced-OFF server.
-    (3) the CLI — `cli-integration-test` (all three suites) becomes the
-    ON exercise: `cf` ADOPTS the server's published posture
-    (`experimentalOptionsForDeployedClient`, authority "server") from
-    the default binary's /api/meta; the job gains the server-side ON
-    posture probe so the exercise is verified, not assumed. (`cf test`
-    / `cf dev` stay deliberately ambient-OFF — patternTest/localDev
-    presets.)
-    (4) `PiecesController` hosts — the default package/pattern lanes
-    are the ON exercise (sx2-scale's N controllers, the
-    pieces-controller helper, every integration file initializing a
-    controller against the lane's toolshed); the agents host
-    (`connectors/agents/host`) shares the same
-    `experimentalOptionsForDeployedClient` + remoteClient seam and is
-    covered at it (no dedicated lane exists for it — recorded).
-  - The UNIFORM-posture reconciliation the swap needs: 4 runner
-    integration files and the runtime-client integration host (worker
-    declaration + `onArmStepSkip` guard) resolve env-else-default via
-    the now-exported `withServerExecutionDefault` — under default-ON a
-    raw env read would resurrect the P7 finding-7 MIXED posture in the
-    default lanes.
-  - The topics multi-user LANE-POSTURE item (the topics measurement
-    report §5.1/§6, 2026-08-24: "the serverless multi-user pattern lane
-    — a lane-posture question the flip decision has to address either
-    way"), discharged as recorded: the pattern-tests lane runs with NO
-    server (`PACKAGES_WITHOUT_SERVER`) through the `patternTest`
-    preset, which deliberately does NOT read the constant — the lane
-    resolves the AMBIENT baseline (OFF) by construction, i.e. the
-    "lane pins OFF" arm realized structurally (pinned by the preset
-    conformance goldens: only productionServer/remoteClient carry the
-    constant). Verified live at the flipped head:
-    `topics/multi-user.test.tsx` 7/7 GREEN with the env unset (the
-    campaign's 5/7 red was under EXPLICIT env ON only). The
-    alternative the report named — the in-process surface growing the
-    serving role — is NOT taken; it would be its own design work if
-    ever wanted.
-  - **THE FIRST FLIP BOARD (run 33232274193) — seven reds, every one
-    classified from its assertion before any fix; the fix round rode
-    the same PR.** (1) `Test (2/8)`: the `startServerExecutionHost OFF
-    witness` unit pins keyed unset=OFF — re-keyed (unset = the
-    first-party default, gate-opens witnessed; OFF witness = the
-    explicit-false arm). (2) `sx2-speculation` in the default pattern
-    lane, DETERMINISTIC: the novel ON×coverage combination —
-    `CF_PATTERN_COVERAGE_DIR` makes the client compile the INSTRUMENTED
-    pattern variant while the serving side compiles uninstrumented, so
-    the client's speculative `computed:` entries (content-addressed by
-    module bytes) can never be covered by the served watermark, and an
-    authored write whose basis touches them is refused per
-    speculation.md §6. Repro: red with coverage, green without, same ON
-    toolshed. Disposition: authored-pattern coverage COLLECTS ON THE
-    OFF GUARD LANE through the soak (single-compiler world — sound;
-    the pre-flip default lane's own posture), the default lane keeps
-    V8 coverage. **OWED (post-soak, before the OFF lanes retire):
-    serving-side instrumented-variant parity — the serving compile
-    honoring the space's coverage variant — or a re-homed authored
-    coverage collection; pattern-reload still collects under its
-    now-ON self-booted toolshed and shares this mechanism (green so
-    far, named here as the residual to watch).** BOARD-READING
-    CONSEQUENCE through the soak: `coverage-check` now `needs` the OFF
-    pattern lane, so ANY red in that lane also SKIPS Coverage Check and
-    reds Status — board 33239003881 shows exactly that shape behind the
-    owned-elsewhere firebreak red. The coupling retires when the OWED
-    re-homing above lands. (3) CLI
-    `core-piece-values`: the "cannot project in a fresh session"
-    refusal DISSOLVES under ON by design (the serving loop
-    materializes the session-derived result; a fresh session projects
-    it) — the step is arm-aware now and under ON asserts the SERVED
-    value. (4) CLI `core-piece-call` dedup: retry left EXACTLY ONE
-    message (the dedupe-horizon skip works) but `deduplicated: true`
-    cannot be reported — verb receipts are deliberately unwritten
-    under ON — the script's ON arm asserts the behavioral witness
-    (same id, exit 0, exactly-one-message). (5) **RULED 2026-08-29 —
-    owner: "yes, Serving-side receipt/result write, as that is indeed
-    what i said before" — LANDED (was STOP-AND-REPORT: the verb
-    DECLARED-RESULT surface was ABSENT under ON; CLI topology, first
-    ON exercise).** The gap's mechanism, as reported to owner court:
-    `runner.ts handleJavaScriptHandlerResult` disabled the whole
-    receipt write under the flag (`receiptsEnabled = … &&
-    serverExecution !== true`) on events.md §4/N26's subsumption,
-    which subsumes only the EXACTLY-ONCE role — the receipt's
-    RESULT-CARRIAGE role (plainResultReceipts, verb contract WS-C/D —
-    `cf call`'s `.result`/`.receipt`) had no replacement sentence and
-    no serving-side writer. The ruling resolves the fork to a
-    SERVING-SIDE receipt/result write, on the owner's stated model:
-    "all handlers write result cells (even if the value is undefined),
-    and that CAS for that is the write-once guarantee." Landed
-    mechanism: the served handler run writes the receipt in its OWN
-    transaction (same wave as the entry's `consequenced` mark —
-    mark/effects atomic; §2b carriage as any served handler write) at
-    the same cause-derived address the client-era write used;
-    write-once by CAS with a lost CAS a LOUD no-op (never a second
-    write, never a wave failure — counter
-    `runner.servedReceiptCasLosses` + warn line); undefined-value
-    handlers write the `{}` witness; the flag-ON client's echo
-    publishes the address (`tx.handlingReceiptLink`) so the unchanged
-    CLI readback works — the durable-ack coupling already orders the
-    readback after the consequence. The client write stays disabled;
-    no create-only mark rides a wave. Spec: events.md §4 "Result
-    carriage" (the replacement sentence) + runtime-mapping.md N26(b)
-    re-tensed RULED. Pins (executor-events-down.test.ts, each
-    red-first at the pre-fix head and mutation-killed independently —
-    M1 drop-the-write kills the declared-value + `{}` pins, M2
-    skip-undefined kills the `{}` pin alone, M3 drop-the-CAS-check and
-    M4 CAS-loss-fails-the-wave each kill the CAS-loss pin alone):
-    declared value written by ONE derived commit whose
-    `consequence_of` names the event (revision-table single-writer
-    proof — the client never wrote); `{}` witness post-serve;
-    CAS-loss loud no-op with the standing value winning, the wave
-    still committing, and the OFF-arm probe's pre-created receipt
-    proving cross-arm address agreement. Witness red→green: CLI
-    three-topic fixture (integration.sh:908 umbrella declared-result
-    assert) RED at a5d5561dc vs a default-ON source toolshed, GREEN
-    with the fix on BOTH arms — including the dropped-response retry
-    and imposter replay now reading the ORIGINAL result back under ON
-    (their `deduplicated`-key asserts went arm-aware like flip-board
-    item (4); the D3 original-result assert_json_eq holds in both
-    arms). (6) `topic-board-pivot-contract` 4≠3
-    crossref rows: intermittent ON-arm convergence transient (~2/22
-    local only under load, 14 straight greens after; single CI
-    observation; clean titles = duplicated ROW). NOT patched — the
-    test's own comment records that the pivot "has been seen to
-    settle a row away … under server execution" and deliberately
-    asserts rather than awaits, so any wait-shape is the surface
-    owner's decision (flag-don't-fill); WATCHED intermittent, this
-    row is its record. (7) `iframe Firebreak Commons` red in BOTH
-    arms: INHERITED — the file (#6526) landed on main after this PR's
-    base and reaches the board only via the merge ref; main's own
-    board at d1eca661f failed the explicit-ON pattern lane on it.
-    The file's owner's, not the flip's.
-  - **The OFF→ON CONTRACT DELTA the first cf-ON exercise surfaced: a
-    THROWN handling durably CONSUMES its invocation id.** Under ON the
-    throw happens SERVER-side, where an error IS the consequence
-    (events.md §5): the errored handling is the event's recorded
-    outcome and the watermark advances past it, so a SAME-id retry
-    never re-executes. Its mechanical shape is a race the spec allows
-    either way — admission refuses the duplicate while the errored
-    entry is still above the dedupe horizon, or admits it and the
-    processing skip passes it (settled, no result; no receipt exists
-    for an errored handling) — and both agree on the semantic: nothing
-    runs, nothing is created. Under OFF the client-side refusal never
-    consumed the id, so the same id then executed. The caller's correct
-    move after an error is therefore a FRESH id. NOT a defect and
-    nothing to fix: a spec-consistent consequence of moving the
-    handling to the serving side, recorded here so the settled delta is
-    not re-litigated post-soak. Asserted arm-aware by
-    `packages/cli/integration/verbs-over-the-cli.sh` step 10 ("A thrown
-    call and its invocation id") — under ON the same-id retry yields no
-    result and leaves the note count unchanged, and a fresh id executes
-    the corrected call; under OFF the same id executes. The step's ON
-    comment points at this row.
+  The PR that discharged it is its own delta below (2026-08-29 —
+  #6535); the rest of THIS delta is the pre-flip world that PR
+  changed, and reads as the history it is.
 - CI lanes (testing.md §2 re-tensed): default lanes = the OFF posture
   (probe: server not serving, shell define unset); explicit-`true` ON
   lanes on `build-toolshed-on` (shell define baked `true`), FULL ON
@@ -3499,6 +3311,204 @@ findings; the OWNER RULING — the flip lands DARK):
   a byte-identical cross-user propagation number for the Deno client
   posture today. Recorded in the plan; the browser number waits for the
   two-user family.
+
+Delta 2026-08-29 — THE FLIP: the first-party default goes ON (the
+separate one-line flip PR the 2026-08-16 ruling above made owed —
+recorded here rather than inside that delta, whose own bullets state
+the pre-flip posture they were written in):
+
+**THE FLIP PR (#6535, 2026-08-28, base e16780fca — rebased onto it
+2026-08-29 from the original base 4e02f75c4, with every gate claim
+re-verified there; every ordered gate met: the
+ON-skip registry EMPTY across all four suites (#6528, the
+ruled-3b-close lift), OW31's ruled posture BUILT, OW45–OW53 CLOSED,
+OW38(ii) RULED met ("topics numbers are fine"). The owner merges it
+personally; the soak starts at ITS merge.** What it carries:
+
+- The one-liner: `SERVER_EXECUTION_DEFAULT_ENABLED = true`
+  (`packages/memory/v2/server-execution-default.ts`), and the absolute
+  pin re-tensed to state the default IS ON
+  (`packages/toolshed/lib/server-execution-flag.test.ts` — watched RED
+  at the flipped constant before the re-tense).
+- The LANE-ROLE SWAP, old → new (testing.md §2 re-tensed with it):
+  `build-toolshed-on` (bakes `true`) → `build-toolshed-off` (bakes
+  `"false"`); default `package-integration-test` /
+  `pattern-integration-test` lanes: OFF probe → ON probe
+  (serving-loop PRESENT + shell define UNSET) and they now carry the
+  ON skip list (EMPTY; the OFF guard never skips);
+  `package-integration-test-server-execution-on` /
+  `pattern-integration-test-server-execution-on` (explicit `true`,
+  variant `server-execution`) →
+  `...-server-execution-off` (explicit `false` on the OFF-built
+  binary, probe inverted, variant `server-execution-off` — the
+  default arm continues the unmarked history). The old ci-workflow
+  lane pins were watched RED on the swapped workflow, then
+  reconciled, plus a new lane-roles pin test (a partial revert of one
+  half now reds).
+- The four-topology gate dispositions (the Phase-7 table row's
+  obligation, review finding 8), lane by lane:
+  (1) `background-piece-service` — had NO exercising lane; the new
+  `deployed-topology-gate` job starts the REAL binary against the
+  default (ON, probed) toolshed, asserts its new startup posture log
+  line (`main.ts`; the binary has no HTTP surface) and clean SIGTERM
+  exit — RED-FIRST with a forced-OFF service env (posture line "OFF"
+  vs expected "ON").
+  (2) cf-harness — had NO toolshed-backed lane (its integration suite
+  is CF_HARNESS_INTEGRATION-gated); the same job runs
+  `createHarnessFabricSessionFactory` (PKCS#8 from disk →
+  `PiecesController.initialize` → deployed-client adoption), asserts
+  the session's runtime resolved ON with nothing declared, and serves
+  one genuine flow (compile + create a piece, read the result back) —
+  RED-FIRST against a forced-OFF server.
+  (3) the CLI — `cli-integration-test` (all three suites) becomes the
+  ON exercise: `cf` ADOPTS the server's published posture
+  (`experimentalOptionsForDeployedClient`, authority "server") from
+  the default binary's /api/meta; the job gains the server-side ON
+  posture probe so the exercise is verified, not assumed. (`cf test`
+  / `cf dev` stay deliberately ambient-OFF — patternTest/localDev
+  presets.)
+  (4) `PiecesController` hosts — the default package/pattern lanes
+  are the ON exercise (sx2-scale's N controllers, the
+  pieces-controller helper, every integration file initializing a
+  controller against the lane's toolshed); the agents host
+  (`connectors/agents/host`) shares the same
+  `experimentalOptionsForDeployedClient` + remoteClient seam and is
+  covered at it (no dedicated lane exists for it — recorded).
+- The UNIFORM-posture reconciliation the swap needs: 4 runner
+  integration files and the runtime-client integration host (worker
+  declaration + `onArmStepSkip` guard) resolve env-else-default via
+  the now-exported `withServerExecutionDefault` — under default-ON a
+  raw env read would resurrect the P7 finding-7 MIXED posture in the
+  default lanes.
+- The topics multi-user LANE-POSTURE item (the topics measurement
+  report §5.1/§6, 2026-08-24: "the serverless multi-user pattern lane
+  — a lane-posture question the flip decision has to address either
+  way"), discharged as recorded: the pattern-tests lane runs with NO
+  server (`PACKAGES_WITHOUT_SERVER`) through the `patternTest`
+  preset, which deliberately does NOT read the constant — the lane
+  resolves the AMBIENT baseline (OFF) by construction, i.e. the
+  "lane pins OFF" arm realized structurally (pinned by the preset
+  conformance goldens: only productionServer/remoteClient carry the
+  constant). Verified live at the flipped head:
+  `topics/multi-user.test.tsx` 7/7 GREEN with the env unset (the
+  campaign's 5/7 red was under EXPLICIT env ON only). The
+  alternative the report named — the in-process surface growing the
+  serving role — is NOT taken; it would be its own design work if
+  ever wanted.
+- **THE FIRST FLIP BOARD (run 33232274193) — seven reds, every one
+  classified from its assertion before any fix; the fix round rode
+  the same PR.** (1) `Test (2/8)`: the `startServerExecutionHost OFF
+  witness` unit pins keyed unset=OFF — re-keyed (unset = the
+  first-party default, gate-opens witnessed; OFF witness = the
+  explicit-false arm). (2) `sx2-speculation` in the default pattern
+  lane, DETERMINISTIC: the novel ON×coverage combination —
+  `CF_PATTERN_COVERAGE_DIR` makes the client compile the INSTRUMENTED
+  pattern variant while the serving side compiles uninstrumented, so
+  the client's speculative `computed:` entries (content-addressed by
+  module bytes) can never be covered by the served watermark, and an
+  authored write whose basis touches them is refused per
+  speculation.md §6. Repro: red with coverage, green without, same ON
+  toolshed. Disposition: authored-pattern coverage COLLECTS ON THE
+  OFF GUARD LANE through the soak (single-compiler world — sound;
+  the pre-flip default lane's own posture), the default lane keeps
+  V8 coverage. **OWED (post-soak, before the OFF lanes retire):
+  serving-side instrumented-variant parity — the serving compile
+  honoring the space's coverage variant — or a re-homed authored
+  coverage collection; pattern-reload still collects under its
+  now-ON self-booted toolshed and shares this mechanism (green so
+  far, named here as the residual to watch).** BOARD-READING
+  CONSEQUENCE through the soak: `coverage-check` now `needs` the OFF
+  pattern lane, so ANY red in that lane also SKIPS Coverage Check and
+  reds Status — board 33239003881 shows exactly that shape behind the
+  owned-elsewhere firebreak red. The coupling retires when the OWED
+  re-homing above lands. (3) CLI
+  `core-piece-values`: the "cannot project in a fresh session"
+  refusal DISSOLVES under ON by design (the serving loop
+  materializes the session-derived result; a fresh session projects
+  it) — the step is arm-aware now and under ON asserts the SERVED
+  value. (4) CLI `core-piece-call` dedup: retry left EXACTLY ONE
+  message (the dedupe-horizon skip works) but `deduplicated: true`
+  cannot be reported — verb receipts are deliberately unwritten
+  under ON — the script's ON arm asserts the behavioral witness
+  (same id, exit 0, exactly-one-message). (5) **RULED 2026-08-29 —
+  owner: "yes, Serving-side receipt/result write, as that is indeed
+  what i said before" — LANDED (was STOP-AND-REPORT: the verb
+  DECLARED-RESULT surface was ABSENT under ON; CLI topology, first
+  ON exercise).** The gap's mechanism, as reported to owner court:
+  `runner.ts handleJavaScriptHandlerResult` disabled the whole
+  receipt write under the flag (`receiptsEnabled = … &&
+  serverExecution !== true`) on events.md §4/N26's subsumption,
+  which subsumes only the EXACTLY-ONCE role — the receipt's
+  RESULT-CARRIAGE role (plainResultReceipts, verb contract WS-C/D —
+  `cf call`'s `.result`/`.receipt`) had no replacement sentence and
+  no serving-side writer. The ruling resolves the fork to a
+  SERVING-SIDE receipt/result write, on the owner's stated model:
+  "all handlers write result cells (even if the value is undefined),
+  and that CAS for that is the write-once guarantee." Landed
+  mechanism: the served handler run writes the receipt in its OWN
+  transaction (same wave as the entry's `consequenced` mark —
+  mark/effects atomic; §2b carriage as any served handler write) at
+  the same cause-derived address the client-era write used;
+  write-once by CAS with a lost CAS a LOUD no-op (never a second
+  write, never a wave failure — counter
+  `runner.servedReceiptCasLosses` + warn line); undefined-value
+  handlers write the `{}` witness; the flag-ON client's echo
+  publishes the address (`tx.handlingReceiptLink`) so the unchanged
+  CLI readback works — the durable-ack coupling already orders the
+  readback after the consequence. The client write stays disabled;
+  no create-only mark rides a wave. Spec: events.md §4 "Result
+  carriage" (the replacement sentence) + runtime-mapping.md N26(b)
+  re-tensed RULED. Pins (executor-events-down.test.ts, each
+  red-first at the pre-fix head and mutation-killed independently —
+  M1 drop-the-write kills the declared-value + `{}` pins, M2
+  skip-undefined kills the `{}` pin alone, M3 drop-the-CAS-check and
+  M4 CAS-loss-fails-the-wave each kill the CAS-loss pin alone):
+  declared value written by ONE derived commit whose
+  `consequence_of` names the event (revision-table single-writer
+  proof — the client never wrote); `{}` witness post-serve;
+  CAS-loss loud no-op with the standing value winning, the wave
+  still committing, and the OFF-arm probe's pre-created receipt
+  proving cross-arm address agreement. Witness red→green: CLI
+  three-topic fixture (integration.sh:908 umbrella declared-result
+  assert) RED at a5d5561dc vs a default-ON source toolshed, GREEN
+  with the fix on BOTH arms — including the dropped-response retry
+  and imposter replay now reading the ORIGINAL result back under ON
+  (their `deduplicated`-key asserts went arm-aware like flip-board
+  item (4); the D3 original-result assert_json_eq holds in both
+  arms). (6) `topic-board-pivot-contract` 4≠3
+  crossref rows: intermittent ON-arm convergence transient (~2/22
+  local only under load, 14 straight greens after; single CI
+  observation; clean titles = duplicated ROW). NOT patched — the
+  test's own comment records that the pivot "has been seen to
+  settle a row away … under server execution" and deliberately
+  asserts rather than awaits, so any wait-shape is the surface
+  owner's decision (flag-don't-fill); WATCHED intermittent, this
+  row is its record. (7) `iframe Firebreak Commons` red in BOTH
+  arms: INHERITED — the file (#6526) landed on main after this PR's
+  base and reaches the board only via the merge ref; main's own
+  board at d1eca661f failed the explicit-ON pattern lane on it.
+  The file's owner's, not the flip's.
+- **The OFF→ON CONTRACT DELTA the first cf-ON exercise surfaced: a
+  THROWN handling durably CONSUMES its invocation id.** Under ON the
+  throw happens SERVER-side, where an error IS the consequence
+  (events.md §5): the errored handling is the event's recorded
+  outcome and the watermark advances past it, so a SAME-id retry
+  never re-executes. Its mechanical shape is a race the spec allows
+  either way — admission refuses the duplicate while the errored
+  entry is still above the dedupe horizon, or admits it and the
+  processing skip passes it (settled, no result; no receipt exists
+  for an errored handling) — and both agree on the semantic: nothing
+  runs, nothing is created. Under OFF the client-side refusal never
+  consumed the id, so the same id then executed. The caller's correct
+  move after an error is therefore a FRESH id. NOT a defect and
+  nothing to fix: a spec-consistent consequence of moving the
+  handling to the serving side, recorded here so the settled delta is
+  not re-litigated post-soak. Asserted arm-aware by
+  `packages/cli/integration/verbs-over-the-cli.sh` step 10 ("A thrown
+  call and its invocation id") — under ON the same-id retry yields no
+  result and leaves the note count unchanged, and a fresh id executes
+  the corrected call; under OFF the same id executes. The step's ON
+  comment points at this row.
 
 Delta 2026-08-16 — fan-out stage A (OW17 leg 1: the instance-keyed
 serving replica + wire; the client arrival gate):

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3243,6 +3243,81 @@ findings; the OWNER RULING — the flip lands DARK):
   OW28 → the honest benchmark → the flip PR (which also flips the
   absolute pin, the CI lane roles and their posture probes, and
   EXPERIMENTAL_OPTIONS.md; and MUST land with the ON skip list EMPTY).
+  **THE FLIP PR (2026-08-28, base 4e02f75c4 — every ordered gate met: the
+  ON-skip registry EMPTY across all four suites (#6528, the
+  ruled-3b-close lift), OW31's ruled posture BUILT, OW45–OW53 CLOSED,
+  OW38(ii) RULED met ("topics numbers are fine"). The owner merges it
+  personally; the soak starts at ITS merge.** What it carries:
+  - The one-liner: `SERVER_EXECUTION_DEFAULT_ENABLED = true`
+    (`packages/memory/v2/server-execution-default.ts`), and the absolute
+    pin re-tensed to state the default IS ON
+    (`packages/toolshed/lib/server-execution-flag.test.ts` — watched RED
+    at the flipped constant before the re-tense).
+  - The LANE-ROLE SWAP, old → new (testing.md §2 re-tensed with it):
+    `build-toolshed-on` (bakes `true`) → `build-toolshed-off` (bakes
+    `"false"`); default `package-integration-test` /
+    `pattern-integration-test` lanes: OFF probe → ON probe
+    (serving-loop PRESENT + shell define UNSET) and they now carry the
+    ON skip list (EMPTY; the OFF guard never skips);
+    `package-integration-test-server-execution-on` /
+    `pattern-integration-test-server-execution-on` (explicit `true`,
+    variant `server-execution`) →
+    `...-server-execution-off` (explicit `false` on the OFF-built
+    binary, probe inverted, variant `server-execution-off` — the
+    default arm continues the unmarked history). The old ci-workflow
+    lane pins were watched RED on the swapped workflow, then
+    reconciled, plus a new lane-roles pin test (a partial revert of one
+    half now reds).
+  - The four-topology gate dispositions (the Phase-7 table row's
+    obligation, review finding 8), lane by lane:
+    (1) `background-piece-service` — had NO exercising lane; the new
+    `deployed-topology-gate` job starts the REAL binary against the
+    default (ON, probed) toolshed, asserts its new startup posture log
+    line (`main.ts`; the binary has no HTTP surface) and clean SIGTERM
+    exit — RED-FIRST with a forced-OFF service env (posture line "OFF"
+    vs expected "ON").
+    (2) cf-harness — had NO toolshed-backed lane (its integration suite
+    is CF_HARNESS_INTEGRATION-gated); the same job runs
+    `createHarnessFabricSessionFactory` (PKCS#8 from disk →
+    `PiecesController.initialize` → deployed-client adoption), asserts
+    the session's runtime resolved ON with nothing declared, and serves
+    one genuine flow (compile + create a piece, read the result back) —
+    RED-FIRST against a forced-OFF server.
+    (3) the CLI — `cli-integration-test` (all three suites) becomes the
+    ON exercise: `cf` ADOPTS the server's published posture
+    (`experimentalOptionsForDeployedClient`, authority "server") from
+    the default binary's /api/meta; the job gains the server-side ON
+    posture probe so the exercise is verified, not assumed. (`cf test`
+    / `cf dev` stay deliberately ambient-OFF — patternTest/localDev
+    presets.)
+    (4) `PiecesController` hosts — the default package/pattern lanes
+    are the ON exercise (sx2-scale's N controllers, the
+    pieces-controller helper, every integration file initializing a
+    controller against the lane's toolshed); the agents host
+    (`connectors/agents/host`) shares the same
+    `experimentalOptionsForDeployedClient` + remoteClient seam and is
+    covered at it (no dedicated lane exists for it — recorded).
+  - The UNIFORM-posture reconciliation the swap needs: 4 runner
+    integration files and the runtime-client integration host (worker
+    declaration + `onArmStepSkip` guard) resolve env-else-default via
+    the now-exported `withServerExecutionDefault` — under default-ON a
+    raw env read would resurrect the P7 finding-7 MIXED posture in the
+    default lanes.
+  - The topics multi-user LANE-POSTURE item (the topics measurement
+    report §5.1/§6, 2026-08-24: "the serverless multi-user pattern lane
+    — a lane-posture question the flip decision has to address either
+    way"), discharged as recorded: the pattern-tests lane runs with NO
+    server (`PACKAGES_WITHOUT_SERVER`) through the `patternTest`
+    preset, which deliberately does NOT read the constant — the lane
+    resolves the AMBIENT baseline (OFF) by construction, i.e. the
+    "lane pins OFF" arm realized structurally (pinned by the preset
+    conformance goldens: only productionServer/remoteClient carry the
+    constant). Verified live at the flipped head:
+    `topics/multi-user.test.tsx` 7/7 GREEN with the env unset (the
+    campaign's 5/7 red was under EXPLICIT env ON only). The
+    alternative the report named — the in-process surface growing the
+    serving role — is NOT taken; it would be its own design work if
+    ever wanted.
 - CI lanes (testing.md §2 re-tensed): default lanes = the OFF posture
   (probe: server not serving, shell define unset); explicit-`true` ON
   lanes on `build-toolshed-on` (shell define baked `true`), FULL ON

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3243,8 +3243,9 @@ findings; the OWNER RULING — the flip lands DARK):
   OW28 → the honest benchmark → the flip PR (which also flips the
   absolute pin, the CI lane roles and their posture probes, and
   EXPERIMENTAL_OPTIONS.md; and MUST land with the ON skip list EMPTY).
-  **THE FLIP PR (#6535, 2026-08-28, base 4e02f75c4 — every ordered gate
-  met: the
+  **THE FLIP PR (#6535, 2026-08-28, base e16780fca — rebased onto it
+  2026-08-29 from the original base 4e02f75c4, with every gate claim
+  re-verified there; every ordered gate met: the
   ON-skip registry EMPTY across all four suites (#6528, the
   ruled-3b-close lift), OW31's ruled posture BUILT, OW45–OW53 CLOSED,
   OW38(ii) RULED met ("topics numbers are fine"). The owner merges it
@@ -3340,7 +3341,12 @@ findings; the OWNER RULING — the flip lands DARK):
     honoring the space's coverage variant — or a re-homed authored
     coverage collection; pattern-reload still collects under its
     now-ON self-booted toolshed and shares this mechanism (green so
-    far, named here as the residual to watch).** (3) CLI
+    far, named here as the residual to watch).** BOARD-READING
+    CONSEQUENCE through the soak: `coverage-check` now `needs` the OFF
+    pattern lane, so ANY red in that lane also SKIPS Coverage Check and
+    reds Status — board 33239003881 shows exactly that shape behind the
+    owned-elsewhere firebreak red. The coupling retires when the OWED
+    re-homing above lands. (3) CLI
     `core-piece-values`: the "cannot project in a fresh session"
     refusal DISSOLVES under ON by design (the serving loop
     materializes the session-derived result; a fresh session projects
@@ -3407,6 +3413,27 @@ findings; the OWNER RULING — the flip lands DARK):
     base and reaches the board only via the merge ref; main's own
     board at d1eca661f failed the explicit-ON pattern lane on it.
     The file's owner's, not the flip's.
+  - **The OFF→ON CONTRACT DELTA the first cf-ON exercise surfaced: a
+    THROWN handling durably CONSUMES its invocation id.** Under ON the
+    throw happens SERVER-side, where an error IS the consequence
+    (events.md §5): the errored handling is the event's recorded
+    outcome and the watermark advances past it, so a SAME-id retry
+    never re-executes. Its mechanical shape is a race the spec allows
+    either way — admission refuses the duplicate while the errored
+    entry is still above the dedupe horizon, or admits it and the
+    processing skip passes it (settled, no result; no receipt exists
+    for an errored handling) — and both agree on the semantic: nothing
+    runs, nothing is created. Under OFF the client-side refusal never
+    consumed the id, so the same id then executed. The caller's correct
+    move after an error is therefore a FRESH id. NOT a defect and
+    nothing to fix: a spec-consistent consequence of moving the
+    handling to the serving side, recorded here so the settled delta is
+    not re-litigated post-soak. Asserted arm-aware by
+    `packages/cli/integration/verbs-over-the-cli.sh` step 10 ("A thrown
+    call and its invocation id") — under ON the same-id retry yields no
+    result and leaves the note count unchanged, and a fresh id executes
+    the corrected call; under OFF the same id executes. The step's ON
+    comment points at this row.
 - CI lanes (testing.md §2 re-tensed): default lanes = the OFF posture
   (probe: server not serving, shell define unset); explicit-`true` ON
   lanes on `build-toolshed-on` (shell define baked `true`), FULL ON

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3319,6 +3319,66 @@ findings; the OWNER RULING — the flip lands DARK):
     alternative the report named — the in-process surface growing the
     serving role — is NOT taken; it would be its own design work if
     ever wanted.
+  - **THE FIRST FLIP BOARD (run 33232274193) — seven reds, every one
+    classified from its assertion before any fix; the fix round rode
+    the same PR.** (1) `Test (2/8)`: the `startServerExecutionHost OFF
+    witness` unit pins keyed unset=OFF — re-keyed (unset = the
+    first-party default, gate-opens witnessed; OFF witness = the
+    explicit-false arm). (2) `sx2-speculation` in the default pattern
+    lane, DETERMINISTIC: the novel ON×coverage combination —
+    `CF_PATTERN_COVERAGE_DIR` makes the client compile the INSTRUMENTED
+    pattern variant while the serving side compiles uninstrumented, so
+    the client's speculative `computed:` entries (content-addressed by
+    module bytes) can never be covered by the served watermark, and an
+    authored write whose basis touches them is refused per
+    speculation.md §6. Repro: red with coverage, green without, same ON
+    toolshed. Disposition: authored-pattern coverage COLLECTS ON THE
+    OFF GUARD LANE through the soak (single-compiler world — sound;
+    the pre-flip default lane's own posture), the default lane keeps
+    V8 coverage. **OWED (post-soak, before the OFF lanes retire):
+    serving-side instrumented-variant parity — the serving compile
+    honoring the space's coverage variant — or a re-homed authored
+    coverage collection; pattern-reload still collects under its
+    now-ON self-booted toolshed and shares this mechanism (green so
+    far, named here as the residual to watch).** (3) CLI
+    `core-piece-values`: the "cannot project in a fresh session"
+    refusal DISSOLVES under ON by design (the serving loop
+    materializes the session-derived result; a fresh session projects
+    it) — the step is arm-aware now and under ON asserts the SERVED
+    value. (4) CLI `core-piece-call` dedup: retry left EXACTLY ONE
+    message (the dedupe-horizon skip works) but `deduplicated: true`
+    cannot be reported — verb receipts are deliberately unwritten
+    under ON — the script's ON arm asserts the behavioral witness
+    (same id, exit 0, exactly-one-message). (5) **STOP-AND-REPORT —
+    the verb DECLARED-RESULT surface is ABSENT under ON (CLI topology,
+    first ON exercise; owner-court).** Mechanism:
+    `runner.ts handleJavaScriptHandlerResult` disables the whole
+    receipt write under the flag (`receiptsEnabled = … &&
+    serverExecution !== true`), on events.md §4/N26's subsumption —
+    which subsumes only the EXACTLY-ONCE role; the receipt's
+    RESULT-CARRIAGE role (plainResultReceipts, verb contract WS-C/D —
+    `cf call`'s `.result`/`.receipt`) has NO replacement sentence
+    anywhere in the spec, and no serving-side writer exists. A
+    `cf call` on a result-declaring verb returns `status: settled`
+    with no result under the flipped default
+    (integration.sh:908's umbrella-create assert is the exact
+    witness; the CLI lane will red there until this is designed —
+    deliberately NOT arm-gated away). The fix needs a ruling: a
+    serving-side receipt write (result-carriage without the
+    create-only precondition role, keeping N26's invariant), or a new
+    served result channel. (6) `topic-board-pivot-contract` 4≠3
+    crossref rows: intermittent ON-arm convergence transient (~2/22
+    local only under load, 14 straight greens after; single CI
+    observation; clean titles = duplicated ROW). NOT patched — the
+    test's own comment records that the pivot "has been seen to
+    settle a row away … under server execution" and deliberately
+    asserts rather than awaits, so any wait-shape is the surface
+    owner's decision (flag-don't-fill); WATCHED intermittent, this
+    row is its record. (7) `iframe Firebreak Commons` red in BOTH
+    arms: INHERITED — the file (#6526) landed on main after this PR's
+    base and reaches the board only via the merge ref; main's own
+    board at d1eca661f failed the explicit-ON pattern lane on it.
+    The file's owner's, not the flip's.
 - CI lanes (testing.md §2 re-tensed): default lanes = the OFF posture
   (probe: server not serving, shell define unset); explicit-`true` ON
   lanes on `build-toolshed-on` (shell define baked `true`), FULL ON

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3349,24 +3349,52 @@ findings; the OWNER RULING — the flip lands DARK):
     message (the dedupe-horizon skip works) but `deduplicated: true`
     cannot be reported — verb receipts are deliberately unwritten
     under ON — the script's ON arm asserts the behavioral witness
-    (same id, exit 0, exactly-one-message). (5) **STOP-AND-REPORT —
-    the verb DECLARED-RESULT surface is ABSENT under ON (CLI topology,
-    first ON exercise; owner-court).** Mechanism:
-    `runner.ts handleJavaScriptHandlerResult` disables the whole
+    (same id, exit 0, exactly-one-message). (5) **RULED 2026-08-29 —
+    owner: "yes, Serving-side receipt/result write, as that is indeed
+    what i said before" — LANDED (was STOP-AND-REPORT: the verb
+    DECLARED-RESULT surface was ABSENT under ON; CLI topology, first
+    ON exercise).** The gap's mechanism, as reported to owner court:
+    `runner.ts handleJavaScriptHandlerResult` disabled the whole
     receipt write under the flag (`receiptsEnabled = … &&
-    serverExecution !== true`), on events.md §4/N26's subsumption —
-    which subsumes only the EXACTLY-ONCE role; the receipt's
+    serverExecution !== true`) on events.md §4/N26's subsumption,
+    which subsumes only the EXACTLY-ONCE role — the receipt's
     RESULT-CARRIAGE role (plainResultReceipts, verb contract WS-C/D —
-    `cf call`'s `.result`/`.receipt`) has NO replacement sentence
-    anywhere in the spec, and no serving-side writer exists. A
-    `cf call` on a result-declaring verb returns `status: settled`
-    with no result under the flipped default
-    (integration.sh:908's umbrella-create assert is the exact
-    witness; the CLI lane will red there until this is designed —
-    deliberately NOT arm-gated away). The fix needs a ruling: a
-    serving-side receipt write (result-carriage without the
-    create-only precondition role, keeping N26's invariant), or a new
-    served result channel. (6) `topic-board-pivot-contract` 4≠3
+    `cf call`'s `.result`/`.receipt`) had no replacement sentence and
+    no serving-side writer. The ruling resolves the fork to a
+    SERVING-SIDE receipt/result write, on the owner's stated model:
+    "all handlers write result cells (even if the value is undefined),
+    and that CAS for that is the write-once guarantee." Landed
+    mechanism: the served handler run writes the receipt in its OWN
+    transaction (same wave as the entry's `consequenced` mark —
+    mark/effects atomic; §2b carriage as any served handler write) at
+    the same cause-derived address the client-era write used;
+    write-once by CAS with a lost CAS a LOUD no-op (never a second
+    write, never a wave failure — counter
+    `runner.servedReceiptCasLosses` + warn line); undefined-value
+    handlers write the `{}` witness; the flag-ON client's echo
+    publishes the address (`tx.handlingReceiptLink`) so the unchanged
+    CLI readback works — the durable-ack coupling already orders the
+    readback after the consequence. The client write stays disabled;
+    no create-only mark rides a wave. Spec: events.md §4 "Result
+    carriage" (the replacement sentence) + runtime-mapping.md N26(b)
+    re-tensed RULED. Pins (executor-events-down.test.ts, each
+    red-first at the pre-fix head and mutation-killed independently —
+    M1 drop-the-write kills the declared-value + `{}` pins, M2
+    skip-undefined kills the `{}` pin alone, M3 drop-the-CAS-check and
+    M4 CAS-loss-fails-the-wave each kill the CAS-loss pin alone):
+    declared value written by ONE derived commit whose
+    `consequence_of` names the event (revision-table single-writer
+    proof — the client never wrote); `{}` witness post-serve;
+    CAS-loss loud no-op with the standing value winning, the wave
+    still committing, and the OFF-arm probe's pre-created receipt
+    proving cross-arm address agreement. Witness red→green: CLI
+    three-topic fixture (integration.sh:908 umbrella declared-result
+    assert) RED at a5d5561dc vs a default-ON source toolshed, GREEN
+    with the fix on BOTH arms — including the dropped-response retry
+    and imposter replay now reading the ORIGINAL result back under ON
+    (their `deduplicated`-key asserts went arm-aware like flip-board
+    item (4); the D3 original-result assert_json_eq holds in both
+    arms). (6) `topic-board-pivot-contract` 4≠3
     crossref rows: intermittent ON-arm convergence transient (~2/22
     local only under load, 14 straight greens after; single CI
     observation; clean titles = duplicated ROW). NOT patched — the

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -26,12 +26,13 @@ A test's identity has three required parts, scoped within a repository:
   piece-values`), or a task-plus-item pair (`cfcheck <file>`,
   `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`).
 - **variant**, when present — a stable name for a non-default configuration
-  that runs the same test. The default configuration has no variant. The
-  server-execution ON jobs use `server-execution` after variant-aware relay
-  support is on the default branch. When server execution becomes the
-  default, the ON jobs omit that marker, so new runs continue the history of
-  today's unmarked default jobs. The surviving explicit OFF jobs use
-  `server-execution-off` so their history remains separate.
+  that runs the same test. The default configuration has no variant. Since
+  the server-execution flip (2026-08-28) the default jobs run the ON
+  posture unmarked, continuing the history of the previously unmarked
+  default jobs; the surviving explicit OFF regression-guard jobs use
+  `server-execution-off` so their history remains separate. The pre-flip
+  explicit-ON jobs' `server-execution` marker is retired; their history
+  stays queryable under it.
 
 Identity survives moving a test between files, splitting or renaming test
 files, reformatting, editing bodies, and resharding — shard and slice

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -27,12 +27,18 @@ A test's identity has three required parts, scoped within a repository:
   `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`).
 - **variant**, when present — a stable name for a non-default configuration
   that runs the same test. The default configuration has no variant. Since
-  the server-execution flip (2026-08-28) the default jobs run the ON
-  posture unmarked, continuing the history of the previously unmarked
-  default jobs; the surviving explicit OFF regression-guard jobs use
-  `server-execution-off` so their history remains separate. The pre-flip
-  explicit-ON jobs' `server-execution` marker is retired; their history
-  stays queryable under it.
+  the server-execution flip (2026-08-28) the default DEPLOYED-TOPOLOGY
+  lanes — the ones that run a test process against a serving toolshed —
+  run the ON posture unmarked, continuing the history of the previously
+  unmarked default jobs; the surviving explicit OFF regression-guard jobs
+  use `server-execution-off` so their history remains separate. The
+  pre-flip explicit-ON jobs' `server-execution` marker is retired; their
+  history stays queryable under it. The claim is deliberately narrow: the
+  single-process default jobs (the unit suites, `cf test`, the no-server
+  pattern-unit lane — the `patternTest` / `unitTest` presets) never read
+  the first-party default and stay ambient-OFF by construction, so they
+  are unmarked because the flip does not reach them, not because they run
+  ON.
 
 Identity survives moving a test between files, splitting or renaming test
 files, reformatting, editing bodies, and resharding — shard and slice

--- a/packages/background-piece-service/integration/posture-gate.test.ts
+++ b/packages/background-piece-service/integration/posture-gate.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Deployed-topology posture gate for the `bg-piece-service` BINARY
+ * (server-execution v2 Phase 7's flip PR — the plan's own obligation, and
+ * the P7 independent review's finding 8: the deployed-topology binaries the
+ * presets flip were built by CI but exercised ON by no gate).
+ *
+ * What it proves, on the real compiled binary against a real serving
+ * toolshed: the binary STARTS, initializes its service (a genuine flow —
+ * identity, session open, and the BG-pieces read/watch against the
+ * toolshed), and RESOLVES the first-party server-execution default ON (the
+ * `productionServer` preset's env-else-`SERVER_EXECUTION_DEFAULT_ENABLED`
+ * resolution — exactly the path the flip changes, which explicit-env lanes
+ * never exercise). The binary has no HTTP surface, so its startup posture
+ * log line is the probe. It then shuts down cleanly on SIGTERM.
+ *
+ * Runs only in the "Deployed Topology Posture Gates" CI job (deno.yml),
+ * which provides the two env inputs; it is in `integration/`, which the
+ * package's `test` task does not match, so the workspace Test job never
+ * runs it. Locally:
+ *   BG_PIECE_SERVICE_BIN=./dist/bg-piece-service \
+ *   API_URL=http://localhost:8000 \
+ *   deno test --allow-env --allow-run --allow-net integration/posture-gate.test.ts
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+const BIN = Deno.env.get("BG_PIECE_SERVICE_BIN");
+const API_URL = Deno.env.get("API_URL");
+
+const STARTED_LINE = "Background Piece Service started successfully";
+const POSTURE_LINE =
+  /Background Piece Service server-execution posture: (ON|OFF)/;
+const STARTUP_TIMEOUT_MS = 120_000;
+const SHUTDOWN_TIMEOUT_MS = 30_000;
+
+/** Collects a stream's lines into `sink`, resolving when the stream ends. */
+const drain = async (
+  stream: ReadableStream<Uint8Array>,
+  sink: string[],
+): Promise<void> => {
+  const decoder = new TextDecoder();
+  let buffered = "";
+  for await (const chunk of stream) {
+    buffered += decoder.decode(chunk, { stream: true });
+    const lines = buffered.split("\n");
+    buffered = lines.pop() ?? "";
+    sink.push(...lines);
+  }
+  if (buffered.length > 0) sink.push(buffered);
+};
+
+describe(
+  "bg-piece-service deployed-topology posture gate",
+  { ignore: !BIN || !API_URL },
+  () => {
+    it("the binary starts against the serving toolshed, resolves the default posture ON, and stops cleanly", async () => {
+      // The gate exercises the DEFAULT resolution (unset flag → the
+      // first-party constant). An inherited explicit value would make it
+      // vacuously test the env path instead — refuse to run that way.
+      expect(Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION")).toBe(undefined);
+
+      const child = new Deno.Command(BIN!, {
+        args: [],
+        env: {
+          API_URL: API_URL!,
+          OPERATOR_PASS: "deployed-topology-posture-gate",
+        },
+        stdout: "piped",
+        stderr: "piped",
+        stdin: "null",
+      }).spawn();
+
+      const lines: string[] = [];
+      const stdoutDone = drain(child.stdout, lines);
+      const stderrDone = drain(child.stderr, lines);
+
+      const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+      let exited: Deno.CommandStatus | undefined;
+      child.status.then((status) => {
+        exited = status;
+      });
+      while (!lines.some((line) => line.includes(STARTED_LINE))) {
+        if (exited !== undefined) {
+          throw new Error(
+            `bg-piece-service exited (code ${exited.code}) before startup ` +
+              `completed. Output:\n${lines.join("\n")}`,
+          );
+        }
+        if (Date.now() > deadline) {
+          child.kill("SIGKILL");
+          await Promise.allSettled([stdoutDone, stderrDone, child.status]);
+          throw new Error(
+            `bg-piece-service did not report startup within ` +
+              `${STARTUP_TIMEOUT_MS} ms. Output:\n${lines.join("\n")}`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      try {
+        const postures = lines
+          .map((line) => POSTURE_LINE.exec(line)?.[1])
+          .filter((arm): arm is string => arm !== undefined);
+        expect(
+          postures,
+          `expected exactly one posture line in:\n${lines.join("\n")}`,
+        ).toEqual(["ON"]);
+      } finally {
+        // Clean shutdown is part of the gate: the SIGTERM handler stops the
+        // service and exits 0.
+        child.kill("SIGTERM");
+        const shutdownTimer = setTimeout(() => {
+          child.kill("SIGKILL");
+        }, SHUTDOWN_TIMEOUT_MS);
+        const status = await child.status;
+        clearTimeout(shutdownTimer);
+        await Promise.allSettled([stdoutDone, stderrDone]);
+        expect(status.code).toBe(0);
+      }
+    });
+  },
+);

--- a/packages/background-piece-service/integration/posture-gate.test.ts
+++ b/packages/background-piece-service/integration/posture-gate.test.ts
@@ -24,6 +24,7 @@
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { defer } from "@commonfabric/utils/defer";
 
 const BIN = Deno.env.get("BG_PIECE_SERVICE_BIN");
 const API_URL = Deno.env.get("API_URL");
@@ -31,23 +32,41 @@ const API_URL = Deno.env.get("API_URL");
 const STARTED_LINE = "Background Piece Service started successfully";
 const POSTURE_LINE =
   /Background Piece Service server-execution posture: (ON|OFF)/;
+/**
+ * A bounded DIAGNOSTIC backstop, never the wait itself: the startup wait
+ * below resolves on the line the stream reader delivers, raced against the
+ * child's own exit, so a slow runner cannot fail a healthy startup. This
+ * bound only exists to report a startup signal that never arrived at all
+ * (docs/development/waiting-in-tests.md: an event where one exists; a bound
+ * only where none does).
+ */
 const STARTUP_TIMEOUT_MS = 120_000;
 const SHUTDOWN_TIMEOUT_MS = 30_000;
 
-/** Collects a stream's lines into `sink`, resolving when the stream ends. */
+/**
+ * Collects a stream's lines into `sink`, resolving when the stream ends, and
+ * hands every line to `onLine` as it arrives — which is what lets the caller
+ * settle a deferred the instant the startup line is delivered, instead of
+ * re-reading the collected lines on a timer.
+ */
 const drain = async (
   stream: ReadableStream<Uint8Array>,
   sink: string[],
+  onLine: (line: string) => void,
 ): Promise<void> => {
   const decoder = new TextDecoder();
   let buffered = "";
+  const take = (line: string) => {
+    sink.push(line);
+    onLine(line);
+  };
   for await (const chunk of stream) {
     buffered += decoder.decode(chunk, { stream: true });
     const lines = buffered.split("\n");
     buffered = lines.pop() ?? "";
-    sink.push(...lines);
+    for (const line of lines) take(line);
   }
-  if (buffered.length > 0) sink.push(buffered);
+  if (buffered.length > 0) take(buffered);
 };
 
 describe(
@@ -72,30 +91,51 @@ describe(
       }).spawn();
 
       const lines: string[] = [];
-      const stdoutDone = drain(child.stdout, lines);
-      const stderrDone = drain(child.stderr, lines);
+      // The startup wait is an EVENT, not a poll: the stream readers settle
+      // this the instant the line is delivered.
+      const started = defer();
+      const noticeStartup = (line: string) => {
+        if (line.includes(STARTED_LINE)) started.resolve();
+      };
+      const stdoutDone = drain(child.stdout, lines, noticeStartup);
+      const stderrDone = drain(child.stderr, lines, noticeStartup);
 
-      const deadline = Date.now() + STARTUP_TIMEOUT_MS;
-      let exited: Deno.CommandStatus | undefined;
-      child.status.then((status) => {
-        exited = status;
+      // Raced against the child's own exit — the other way this wait ends —
+      // with the deadline as the diagnostic backstop only.
+      let backstopTimer: ReturnType<typeof setTimeout> | undefined;
+      const backstopFired = new Promise<"backstop">((resolve) => {
+        backstopTimer = setTimeout(
+          () => resolve("backstop"),
+          STARTUP_TIMEOUT_MS,
+        );
       });
-      while (!lines.some((line) => line.includes(STARTED_LINE))) {
-        if (exited !== undefined) {
-          throw new Error(
-            `bg-piece-service exited (code ${exited.code}) before startup ` +
-              `completed. Output:\n${lines.join("\n")}`,
-          );
-        }
-        if (Date.now() > deadline) {
+      const startup = await Promise.race([
+        started.promise.then(() => "started" as const),
+        child.status.then((status) => ({ exited: status })),
+        backstopFired,
+      ]);
+      clearTimeout(backstopTimer);
+
+      if (startup !== "started") {
+        if (startup === "backstop") {
           child.kill("SIGKILL");
           await Promise.allSettled([stdoutDone, stderrDone, child.status]);
           throw new Error(
-            `bg-piece-service did not report startup within ` +
-              `${STARTUP_TIMEOUT_MS} ms. Output:\n${lines.join("\n")}`,
+            `bg-piece-service never reported its startup signal ` +
+              `("${STARTED_LINE}"); the ${STARTUP_TIMEOUT_MS} ms diagnostic ` +
+              `backstop fired. Output:\n${lines.join("\n")}`,
           );
         }
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        // The child ended the wait by exiting. Flush both streams first, so
+        // the report carries everything it printed on the way down. The
+        // wording covers both shapes this takes — never started, or started
+        // and died — because either way the gate never got to read the
+        // posture of a running service.
+        await Promise.allSettled([stdoutDone, stderrDone]);
+        throw new Error(
+          `bg-piece-service exited (code ${startup.exited.code}) before the ` +
+            `gate could read its posture. Output:\n${lines.join("\n")}`,
+        );
       }
 
       try {

--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -111,6 +111,20 @@ export async function startBackgroundPieceService(
     dependencies.env.OPERATOR_PASS,
   );
   const runtime = dependencies.createRuntime(dependencies.env, identity);
+  // The server-execution v2 posture this service RESOLVED (the
+  // productionServer preset: an explicit EXPERIMENTAL_SERVER_EXECUTION,
+  // else the first-party default — ON since the Phase 7 flip). Logged at
+  // startup so the deployed-topology posture gate, and an operator reading
+  // service logs, can verify the arm the binary actually runs — the role
+  // /api/meta's `experimental` plays for toolshed; this binary has no HTTP
+  // surface, so the log line is its posture probe.
+  // (Optional-chained because the unit suite injects shape-only fake
+  // runtimes; the real construction always carries `experimental`.)
+  dependencies.log(
+    `Background Piece Service server-execution posture: ${
+      runtime.experimental?.serverExecution === true ? "ON" : "OFF"
+    }`,
+  );
   const service = dependencies.createService({
     identity,
     toolshedUrl: dependencies.env.API_URL,

--- a/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
+++ b/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
@@ -49,32 +49,59 @@ describe(
         .json() as { servingLoop?: unknown };
       expect(stats.servingLoop != null).toBe(true);
 
-      const { path } = await writeTempIdentity();
-      const factory = createHarnessFabricSessionFactory({
-        apiUrl: API_URL!,
-        identityKeyPath: path,
-        space: `cf-harness-posture-gate-${Date.now()}`,
-      });
-      const session = await factory();
+      // The keyfile's path is tracked OUTSIDE the session setup: the outer
+      // `finally` below owns it, so it is removed even when session
+      // construction throws before the inner `try` begins.
+      let identityKeyPath: string | undefined;
       try {
-        // The client half: the session's runtime resolved ON from the
-        // deployment with nothing declared locally.
-        expect(session.pieces.runtime.experimental.serverExecution).toBe(true);
+        const { path } = await writeTempIdentity();
+        identityKeyPath = path;
+        const factory = createHarnessFabricSessionFactory({
+          apiUrl: API_URL!,
+          identityKeyPath: path,
+          space: `cf-harness-posture-gate-${Date.now()}`,
+        });
+        const session = await factory();
+        try {
+          // The client half: the session's runtime resolved ON from the
+          // deployment with nothing declared locally.
+          expect(session.pieces.runtime.experimental.serverExecution).toBe(
+            true,
+          );
 
-        // One genuine flow through the session: compile + instantiate a
-        // pattern and read its result back through the serving topology.
-        const piece = await session.pieces.create(GATE_PATTERN);
-        const statusCell = (await piece.result.getCell())
-          .asSchema<{ status?: string }>()
-          .key("status");
-        await statusCell.pull();
-        await waitForCellValue<string>(
-          session.pieces.runtime,
-          statusCell,
-          (value) => value === "serving",
-        );
+          // One genuine flow through the session: compile + instantiate a
+          // pattern and read its result back through the serving topology.
+          const piece = await session.pieces.create(GATE_PATTERN);
+          const statusCell = (await piece.result.getCell())
+            .asSchema<{ status?: string }>()
+            .key("status");
+          await statusCell.pull();
+          await waitForCellValue<string>(
+            session.pieces.runtime,
+            statusCell,
+            (value) => value === "serving",
+          );
+        } finally {
+          await session.pieces.dispose();
+        }
       } finally {
-        await session.pieces.dispose();
+        // `writeTempIdentity`'s own contract: "The caller owns the file and
+        // removes it when done" — otherwise every run leaves a PKCS#8
+        // identity in the system temp dir.
+        const created = identityKeyPath;
+        if (created !== undefined) {
+          await Deno.remove(created).catch((error: unknown) => {
+            // Already gone is the goal state. Anything else is REPORTED,
+            // never thrown: a cleanup throw here would replace the gate's
+            // own failure with a temp-file error.
+            if (!(error instanceof Deno.errors.NotFound)) {
+              console.warn(
+                `cf-harness posture gate: could not remove the temporary ` +
+                  `identity keyfile ${created}: ${error}`,
+              );
+            }
+          });
+        }
       }
     });
   },

--- a/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
+++ b/packages/cf-harness/integration/fabric-session-posture-gate.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Deployed-topology posture gate for cf-harness's FABRIC SESSION
+ * (server-execution v2 Phase 7's flip PR — the plan's own obligation, and
+ * the P7 independent review's finding 8: cf-harness resolves the flag by
+ * the presets, and no gate exercised that resolution ON).
+ *
+ * What it proves, against a real serving toolshed: the harness's OWN
+ * production session path — `createHarnessFabricSessionFactory` (PKCS#8
+ * identity from disk → `PiecesController.initialize` → deployed-client
+ * posture adoption → the remoteClient preset) — resolves the flipped
+ * first-party default ON with NOTHING declared in the environment, and the
+ * session executes one genuine flow (compile + instantiate a pattern,
+ * read a served result back). The explicit-env ON lanes never exercised
+ * this unset-flag path; the flip changes exactly it.
+ *
+ * Runs only in the "Deployed Topology Posture Gates" CI job (deno.yml),
+ * which sets API_URL; it is in `integration/`, which the package's `test`
+ * task does not match, so the workspace Test job never runs it. Locally:
+ *   API_URL=http://localhost:8000 deno test --allow-env --allow-net \
+ *     --allow-read --allow-write --allow-ffi --allow-run \
+ *     integration/fabric-session-posture-gate.test.ts
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+import { createHarnessFabricSessionFactory } from "../src/fabric-session.ts";
+
+const API_URL = Deno.env.get("API_URL");
+
+const GATE_PATTERN = `import { pattern } from "commonfabric";
+export default pattern(() => ({ status: "serving" }));
+`;
+
+describe(
+  "cf-harness deployed-topology posture gate",
+  { ignore: !API_URL },
+  () => {
+    it("the fabric session resolves the flipped default ON and serves one genuine flow", async () => {
+      // The gate exercises the DEFAULT resolution (unset flag → server
+      // adoption → the first-party constant). An inherited explicit value
+      // would make it vacuously test the env path instead.
+      expect(Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION")).toBe(undefined);
+
+      // The server half of the posture, probed from the gate itself: the
+      // lane's toolshed really serves (the default binary since the flip).
+      const stats = await (await fetch(new URL("/api/health/stats", API_URL)))
+        .json() as { servingLoop?: unknown };
+      expect(stats.servingLoop != null).toBe(true);
+
+      const { path } = await writeTempIdentity();
+      const factory = createHarnessFabricSessionFactory({
+        apiUrl: API_URL!,
+        identityKeyPath: path,
+        space: `cf-harness-posture-gate-${Date.now()}`,
+      });
+      const session = await factory();
+      try {
+        // The client half: the session's runtime resolved ON from the
+        // deployment with nothing declared locally.
+        expect(session.pieces.runtime.experimental.serverExecution).toBe(true);
+
+        // One genuine flow through the session: compile + instantiate a
+        // pattern and read its result back through the serving topology.
+        const piece = await session.pieces.create(GATE_PATTERN);
+        const statusCell = (await piece.result.getCell())
+          .asSchema<{ status?: string }>()
+          .key("status");
+        await statusCell.pull();
+        await waitForCellValue<string>(
+          session.pieces.runtime,
+          statusCell,
+          (value) => value === "serving",
+        );
+      } finally {
+        await session.pieces.dispose();
+      }
+    });
+  },
+);

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -96,6 +96,28 @@ new_invocation_id() {
   fi
 }
 
+# The server-execution arm this run's `cf` resolves (server-execution v2,
+# testing.md §2), decided the way the cf binary itself decides: an explicit
+# EXPERIMENTAL_SERVER_EXECUTION wins, else the deployment's own posture —
+# probed off /api/health/stats (`servingLoop` present = the toolshed
+# serves, and cf adopts the published ON posture). ON since the flip in
+# the default CI lane; a pre-flip toolshed, or the explicit-`false`
+# rollback arm, resolves OFF. Verb receipts are DELIBERATELY not written
+# under ON (events.md §4: exactly-once is the stream's eventWatermark, so
+# the receipt create-only mechanism must not coexist with it), which is
+# why the dedup asserts below branch on this: the `deduplicated` key is
+# the OFF arm's receipt-collision witness, and the ON arm's witness is
+# BEHAVIORAL — same invocation echoed, exit 0, and exactly one message
+# (which still fails if --invocation were ignored outright).
+server_execution_on() {
+  case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
+    true) return 0 ;;
+    false) return 1 ;;
+  esac
+  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
+    | jq -e '.servingLoop != null' > /dev/null 2>&1
+}
+
 # The session this run's invocation ids are chosen within. `cf piece call`
 # takes it from CF_INVOCATION_SESSION, and an id addresses an outcome only
 # within its session — so every retry below has to name the session its
@@ -698,7 +720,17 @@ run_piece_call_retry() {
     error "Retrying a killed-after-dispatch call should exit 0, got $RETRY_2_STATUS"
   fi
   echo "killed-after-dispatch: committed before kill = $COMMITTED_BEFORE_KILL"
-  if [ "$COMMITTED_BEFORE_KILL" = "1" ]; then
+  if server_execution_on; then
+    # ON: no receipt is written (events.md §4 subsumption), so there is no
+    # `deduplicated` key to assert either way; the dedupe-horizon skip's
+    # witness is the message count below — with the committed-before-kill
+    # value recorded above, "exactly one" is the strong assert in BOTH
+    # sub-cases (a retry that ignored --invocation would append a second
+    # message; an uncommitted first attempt retried cleanly leaves one).
+    if echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null; then
+      error "No receipt exists under server execution, so the retry cannot claim receipt-level dedup, got: $RETRY_2"
+    fi
+  elif [ "$COMMITTED_BEFORE_KILL" = "1" ]; then
     echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null ||
       error "The killed call had committed, so its retry must deduplicate, got: $RETRY_2"
   elif echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null; then
@@ -725,8 +757,17 @@ run_piece_call_retry() {
   if [ "$REPLAY_STATUS" -ne 0 ]; then
     error "A same-id retry should exit 0, got status $REPLAY_STATUS"
   fi
-  echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null ||
-    error "A same-id retry should report deduplicated, got: $REPLAY"
+  if server_execution_on; then
+    # ON: receipt-level dedup reporting does not exist (no receipt is
+    # written); the behavioral witness is the count assert below plus the
+    # id echo here.
+    if echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null; then
+      error "No receipt exists under server execution, so the replay cannot claim receipt-level dedup, got: $REPLAY"
+    fi
+  else
+    echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null ||
+      error "A same-id retry should report deduplicated, got: $REPLAY"
+  fi
   echo "$REPLAY" | jq -e --arg id "$INVOCATION_3" '.invocation == $id' > /dev/null ||
     error "A same-id retry should echo the caller's invocation id, got: $REPLAY"
   assert_message_count "$RETRY_PIECE_3" 1 \

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -109,13 +109,20 @@ new_invocation_id() {
 # the OFF arm's receipt-collision witness, and the ON arm's witness is
 # BEHAVIORAL — same invocation echoed, exit 0, and exactly one message
 # (which still fails if --invocation were ignored outright).
+#
+# The probe carries connect and total deadlines. A toolshed that ACCEPTS the
+# connection and then stalls would otherwise hold this helper — and with it
+# the whole retry suite, which calls it per assertion — for as long as the
+# server stays silent, with no output and no step-level diagnosis. A stats
+# endpoint that cannot answer within seconds is a dead deployment; the arm
+# then reads OFF and the assertion that follows fails loudly.
 server_execution_on() {
   case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
     true) return 0 ;;
     false) return 1 ;;
   esac
-  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
-    | jq -e '.servingLoop != null' > /dev/null 2>&1
+  curl --connect-timeout 5 --max-time 15 -fsS "$API_URL/api/health/stats" \
+    2>/dev/null | jq -e '.servingLoop != null' > /dev/null 2>&1
 }
 
 # The session this run's invocation ids are chosen within. `cf piece call`

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -721,14 +721,16 @@ run_piece_call_retry() {
   fi
   echo "killed-after-dispatch: committed before kill = $COMMITTED_BEFORE_KILL"
   if server_execution_on; then
-    # ON: no receipt is written (events.md §4 subsumption), so there is no
-    # `deduplicated` key to assert either way; the dedupe-horizon skip's
-    # witness is the message count below — with the committed-before-kill
-    # value recorded above, "exactly one" is the strong assert in BOTH
-    # sub-cases (a retry that ignored --invocation would append a second
-    # message; an uncommitted first attempt retried cleanly leaves one).
+    # ON: no receipt PRECONDITION exists (events.md §4 subsumption — the
+    # SERVING side writes the receipt itself, the ruled result carriage,
+    # 2026-08-29), so there is no `deduplicated` key to assert either
+    # way; the dedupe-horizon skip's witness is the message count below —
+    # with the committed-before-kill value recorded above, "exactly one"
+    # is the strong assert in BOTH sub-cases (a retry that ignored
+    # --invocation would append a second message; an uncommitted first
+    # attempt retried cleanly leaves one).
     if echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null; then
-      error "No receipt exists under server execution, so the retry cannot claim receipt-level dedup, got: $RETRY_2"
+      error "No receipt precondition exists under server execution, so the retry cannot claim receipt-level dedup, got: $RETRY_2"
     fi
   elif [ "$COMMITTED_BEFORE_KILL" = "1" ]; then
     echo "$RETRY_2" | jq -e '.deduplicated == true' > /dev/null ||
@@ -758,11 +760,12 @@ run_piece_call_retry() {
     error "A same-id retry should exit 0, got status $REPLAY_STATUS"
   fi
   if server_execution_on; then
-    # ON: receipt-level dedup reporting does not exist (no receipt is
-    # written); the behavioral witness is the count assert below plus the
-    # id echo here.
+    # ON: receipt-level dedup REPORTING does not exist (the receipt is
+    # written by the SERVING side, without the create-only precondition —
+    # the ruled result carriage, 2026-08-29); the behavioral witness is
+    # the count assert below plus the id echo here.
     if echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null; then
-      error "No receipt exists under server execution, so the replay cannot claim receipt-level dedup, got: $REPLAY"
+      error "No receipt precondition exists under server execution, so the replay cannot claim receipt-level dedup, got: $REPLAY"
     fi
   else
     echo "$REPLAY" | jq -e '.deduplicated == true' > /dev/null ||
@@ -984,10 +987,22 @@ run_three_topic_fixture() {
   if [ "$CHILD_B_STATUS" -ne 0 ]; then
     error "Retrying the dropped create under the same id should exit 0, got $CHILD_B_STATUS"
   fi
-  # The commit provably preceded the kill, so the retry MUST collide on the
-  # create-only receipt and settle as the ORIGINAL handling — every run.
-  echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null ||
-    error "The dropped create had committed, so its retry must deduplicate, got: $CHILD_B_JSON"
+  # The commit provably preceded the kill, so the retry MUST settle as the
+  # ORIGINAL handling — every run. The mechanism is arm-specific: OFF, the
+  # retry collides on the create-only receipt and says so (`deduplicated`);
+  # ON, no receipt precondition exists (events.md §4's subsumption) — the
+  # duplicate is skipped at the dedupe horizon, and the retry's readback
+  # resolves the SAME cause-derived receipt the SERVING side wrote for the
+  # original handling (the ruled result carriage, 2026-08-29). The
+  # original-result readback below is the witness in both arms.
+  if server_execution_on; then
+    if echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null; then
+      error "No receipt precondition exists under server execution, so the retry cannot claim receipt-level dedup, got: $CHILD_B_JSON"
+    fi
+  else
+    echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null ||
+      error "The dropped create had committed, so its retry must deduplicate, got: $CHILD_B_JSON"
+  fi
   # The retry's Invocation JSON carries the settled handling's result — the
   # readback the caller acts on after losing a response.
   CHILD_B_ID=$(echo "$CHILD_B_JSON" | jq -re '.result.topic.id') ||
@@ -1007,8 +1022,20 @@ run_three_topic_fixture() {
   if [ "$REPLAY_STATUS" -ne 0 ]; then
     error "A same-id replay should exit 0, got $REPLAY_STATUS"
   fi
-  echo "$REPLAY_JSON" | jq -e '.deduplicated == true' > /dev/null ||
-    error "A same-id replay should deduplicate, got: $REPLAY_JSON"
+  # Same arm split as step 3: the `deduplicated` key is the OFF arm's
+  # receipt-precondition witness. The D3 semantic itself — the replay hands
+  # back the ORIGINAL result, nothing derived from the imposter payload —
+  # is the assert_json_eq below, and it holds in BOTH arms (ON: the
+  # readback address derives from the invocation id, so the replay reads
+  # the original handling's serving-side receipt).
+  if server_execution_on; then
+    if echo "$REPLAY_JSON" | jq -e '.deduplicated == true' > /dev/null; then
+      error "No receipt precondition exists under server execution, so the replay cannot claim receipt-level dedup, got: $REPLAY_JSON"
+    fi
+  else
+    echo "$REPLAY_JSON" | jq -e '.deduplicated == true' > /dev/null ||
+      error "A same-id replay should deduplicate, got: $REPLAY_JSON"
+  fi
   assert_json_eq \
     "$(echo "$REPLAY_JSON" | jq '.result')" \
     "$(echo "$CHILD_B_JSON" | jq '.result')" \

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -59,14 +59,15 @@ ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 
 # The host's server-execution posture (same probe as integration.sh): the
 # `deduplicated` key is the OFF arm's receipt-precondition witness and is
-# asserted per arm below.
+# asserted per arm below. Deadlines as in integration.sh: an
+# accepted-then-silent server must not hold the suite with no output.
 server_execution_on() {
   case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
     true) return 0 ;;
     false) return 1 ;;
   esac
-  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
-    | jq -e '.servingLoop != null' > /dev/null 2>&1
+  curl --connect-timeout 5 --max-time 15 -fsS "$API_URL/api/health/stats" \
+    2>/dev/null | jq -e '.servingLoop != null' > /dev/null 2>&1
 }
 # An id alone does not name an invocation — the session it was chosen within is
 # the other half, and `--invocation` is refused without one.

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -56,6 +56,18 @@ if [ -z "${CF_IDENTITY:-}" ]; then
   $CF id new >"$CF_IDENTITY" 2>/dev/null
 fi
 ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+
+# The host's server-execution posture (same probe as integration.sh): the
+# `deduplicated` key is the OFF arm's receipt-precondition witness and is
+# asserted per arm below.
+server_execution_on() {
+  case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
+    true) return 0 ;;
+    false) return 1 ;;
+  esac
+  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
+    | jq -e '.servingLoop != null' > /dev/null 2>&1
+}
 # An id alone does not name an invocation — the session it was chosen within is
 # the other half, and `--invocation` is refused without one.
 if [ -z "${CF_INVOCATION_SESSION:-}" ]; then
@@ -335,8 +347,18 @@ check "first attempt" "$(echo "$R2" | jq -r '.result.note.body // empty')" \
   "replaying a settled id hands back the original result, not the new payload"
 check "$(echo "$R1" | jq -r '.receipt // empty')" "$(echo "$R2" | jq -r '.receipt // empty')" \
   "and names the same receipt the first call did"
-check "true" "$(echo "$R2" | jq -r '.deduplicated // false')" \
-  "and says so itself, rather than leaving a caller to infer it"
+if server_execution_on; then
+  # ON: no receipt precondition exists (events.md §4 subsumption) — the
+  # replay is skipped at the dedupe horizon and the two checks above (the
+  # ORIGINAL result and the SAME receipt address, read back from the
+  # serving-side receipt — the ruled result carriage, 2026-08-29) are the
+  # witness; the OFF-arm mechanism key must not be fabricated.
+  check "false" "$(echo "$R2" | jq -r '.deduplicated // false')" \
+    "and does not claim receipt-level dedup under server execution"
+else
+  check "true" "$(echo "$R2" | jq -r '.deduplicated // false')" \
+    "and says so itself, rather than leaving a caller to infer it"
+fi
 check "$LIVE1" "$(notes_len)" \
   "and the piece is unchanged — the replay committed no second note"
 

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -57,14 +57,15 @@ ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 # steps assert arm-specific mechanics — the OFF arm's receipt-precondition
 # `deduplicated` key, the client-env plainResultReceipts authority, and what
 # a same-id retry of a THROWN handling does — and each says which truth it
-# is asserting.
+# is asserting. Deadlines as in integration.sh: an accepted-then-silent
+# server must not hold the walkthrough with no output.
 server_execution_on() {
   case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
     true) return 0 ;;
     false) return 1 ;;
   esac
-  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
-    | jq -e '.servingLoop != null' > /dev/null 2>&1
+  curl --connect-timeout 5 --max-time 15 -fsS "$API_URL/api/health/stats" \
+    2>/dev/null | jq -e '.servingLoop != null' > /dev/null 2>&1
 }
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -52,6 +52,20 @@ if [ -z "${CF_IDENTITY:-}" ]; then
   $CF id new >"$CF_IDENTITY" 2>/dev/null
 fi
 ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+
+# The host's server-execution posture (same probe as integration.sh): a few
+# steps assert arm-specific mechanics — the OFF arm's receipt-precondition
+# `deduplicated` key, the client-env plainResultReceipts authority, and what
+# a same-id retry of a THROWN handling does — and each says which truth it
+# is asserting.
+server_execution_on() {
+  case "${EXPERIMENTAL_SERVER_EXECUTION:-}" in
+    true) return 0 ;;
+    false) return 1 ;;
+  esac
+  curl -fsS "$API_URL/api/health/stats" 2>/dev/null \
+    | jq -e '.servingLoop != null' > /dev/null 2>&1
+}
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
 
@@ -206,8 +220,18 @@ D=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation create-1 \
   createNote '{"title":"IMPOSTER"}' 2>/dev/null)
 check "First note" "$(echo "$D" | jq -r '.result.note["$NAME"] // empty')" \
   "the replay returns the first result, not the imposter's"
-check "true" "$(echo "$D" | jq -r '.deduplicated // false')" \
-  "the call reports itself deduplicated"
+if server_execution_on; then
+  # ON: no receipt precondition exists (events.md §4 subsumption) — the
+  # replay is skipped at the dedupe horizon and reads the ORIGINAL result
+  # back from the serving-side receipt (the ruled result carriage,
+  # 2026-08-29); the two checks around this one are the witness. The
+  # OFF-arm mechanism key must NOT be fabricated.
+  check "false" "$(echo "$D" | jq -r '.deduplicated // false')" \
+    "the replay does not claim receipt-level dedup under server execution"
+else
+  check "true" "$(echo "$D" | jq -r '.deduplicated // false')" \
+    "the call reports itself deduplicated"
+fi
 check "$BEFORE" "$($CF cell get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
   "the replay created no note (count unchanged at $BEFORE)"
 
@@ -237,8 +261,18 @@ check "Flag-off note" "$(echo "$P" | jq -r '.result.note["$NAME"] // empty')" \
 Q=$(EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false $CF piece call --quiet \
   --piece "$BOARD" $ARGS --invocation label-flagoff \
   setLabel '{"label":"Written anyway"}' 2>/dev/null)
-check "null" "$(echo "$Q" | jq -r '.result // "null"')" \
-  "the plain record is absent with the option OFF"
+if server_execution_on; then
+  # ON: the deployed client ADOPTS the server's plainResultReceipts
+  # (runtime-presets.ts, authority "server" — "a client on the other value
+  # reads back a receipt shaped by a rule it does not share"), and the
+  # SERVING side wrote the receipt under the server's posture — so the
+  # client env cannot turn the plain record off; it arrives regardless.
+  check "Written anyway" "$(echo "$Q" | jq -r '.result.label // "null"')" \
+    "the plain record arrives despite the client env: the posture authority is the server's"
+else
+  check "null" "$(echo "$Q" | jq -r '.result // "null"')" \
+    "the plain record is absent with the option OFF"
+fi
 check "Written anyway" \
   "$($CF cell get --quiet --piece "$BOARD" $ARGS label --input 2>/dev/null | jq -r '.')" \
   "but the write landed regardless — an absent result is not a failed mutation"
@@ -249,15 +283,39 @@ V=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation touch-1 \
 check "settled" "$(echo "$V" | jq -r '.status')" "the value-less verb settled"
 check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
 
-step "10. A refused call does not spend its invocation id"
+step "10. A thrown call and its invocation id"
 $CF piece call --quiet --piece "$BOARD" $ARGS --invocation reuse-1 \
   createNote '{"title":""}' >/dev/null 2>&1
 rc=$?
 check "1" "$([ "$rc" -ne 0 ] && echo 1 || echo 0)" "an empty title exits nonzero"
+COUNT_AFTER_THROW=$($CF cell get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)
 C=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation reuse-1 \
   createNote '{"title":"Corrected"}' 2>/dev/null)
-check "Corrected" "$(echo "$C" | jq -r '.result.note["$NAME"] // empty')" \
-  "the SAME id then executes, because the refusal never consumed it"
+if server_execution_on; then
+  # ON: the throw happened SERVER-side and "the error IS the consequence"
+  # (events.md §5) — the errored handling durably CONSUMED the id, so a
+  # same-id retry never re-executes. Its mechanical shape is a race the
+  # spec allows either way: admission refuses the duplicate while the
+  # errored entry is still above the horizon, or admits it and the
+  # processing skip passes it (settled, no result — no receipt exists
+  # for an errored handling). Both agree on the semantic asserted here:
+  # nothing runs, nothing is created. The caller's correct move after an
+  # error is a FRESH id — asserted below. This is a real OFF→ON contract
+  # delta, recorded in the flip register (verification-coverage.md FLIP
+  # block).
+  check "" "$(echo "$C" | jq -r '.result.note["$NAME"] // empty')" \
+    "the same-id retry does not execute: the errored handling consumed the id"
+  check "$COUNT_AFTER_THROW" \
+    "$($CF cell get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
+    "no note was created by the same-id retry"
+  FRESH=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation reuse-1-fresh \
+    createNote '{"title":"Corrected"}' 2>/dev/null)
+  check "Corrected" "$(echo "$FRESH" | jq -r '.result.note["$NAME"] // empty')" \
+    "a FRESH id executes the corrected call"
+else
+  check "Corrected" "$(echo "$C" | jq -r '.result.note["$NAME"] // empty')" \
+    "the SAME id then executes, because the refusal never consumed it"
+fi
 
 step "11. Reading a verb redirects to cf piece call"
 OUT=$($CF cell get --piece "$BOARD" $ARGS createNote 2>&1)

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -12,6 +12,7 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import type { Identity } from "@commonfabric/identity";
+import { experimentalOptionsForDeployedClient } from "@commonfabric/runner";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
 import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
@@ -49,6 +50,13 @@ let sessionScopedPieceId = "";
 let flags = "";
 let identityPath = "";
 let spaceConfig: SpaceConfig;
+// The server-execution arm `cf` itself runs at (server-execution v2,
+// testing.md §2): resolved exactly as the cf binary resolves it — the
+// deployed-client rule (explicit EXPERIMENTAL_* env, else the server's
+// published posture, else the first-party default). ON since the flip in
+// the default CI lane; the explicit-`false` OFF guard lane, and a
+// pre-flip toolshed, resolve OFF.
+let serverExecutionOn = false;
 
 // Resolves once the piece's result/content cell holds `expected`. Uses its
 // own controller, so readiness is judged from a fresh client's view of the
@@ -82,6 +90,10 @@ async function waitForContent(
 
 describe("cf cell get (integration)", { ignore: !API_URL }, () => {
   beforeAll(async () => {
+    serverExecutionOn = (await experimentalOptionsForDeployedClient({
+      apiUrl: new URL(API_URL!),
+      env: Deno.env.get,
+    })).serverExecution === true;
     const { identity, path } = await writeTempIdentity();
     identityPath = path;
     const spaceName = `cf-piece-get-test-${Date.now()}`;
@@ -148,12 +160,24 @@ describe("cf cell get (integration)", { ignore: !API_URL }, () => {
     expect(json.content).toBe(NOTE_CONTENT);
   });
 
-  it("reports present result data that cannot project in a fresh session", async () => {
+  it("reports present result data that cannot project in a fresh session (OFF) — and serves it under the flipped default (ON)", async () => {
     const sessionFlags =
       `--api-url ${API_URL} --identity ${identityPath} --space ${spaceConfig.space} --piece ${sessionResultPieceId}`;
-    const { code, stderr } = await integrationCf(
+    const { code, stdout, stderr } = await integrationCf(
       `cell get ${sessionFlags}`,
     );
+    if (serverExecutionOn) {
+      // Under ON the refusal scenario DISSOLVES by design: the serving
+      // loop materializes the session-derived result server-side
+      // (derived-class commits under the space's lease), so a fresh
+      // session projects the value that OFF could only report as
+      // present-but-unprojectable. The strong assert is the served
+      // value itself, not merely exit 0.
+      expect(code).toBe(0);
+      const json = JSON.parse(stdout.join(""));
+      expect(json.value).toBe("session-ready");
+      return;
+    }
     expect(code).toBe(1);
     expect(stderr.join("\n")).toContain("stored data is present");
     expect(stderr.join("\n")).toContain("--step");

--- a/packages/memory/v2/server-execution-default.ts
+++ b/packages/memory/v2/server-execution-default.ts
@@ -10,23 +10,23 @@
  * an implicit-OWNER service grant),
  * and the browser shell's build-define fallback
  * (`packages/shell/src/lib/env.ts`), so flipping the default is this one
- * value. `false` is the pre-flip behavior byte-for-byte; `true` is the v2
- * posture. An explicit `EXPERIMENTAL_SERVER_EXECUTION=true|false` (or
- * `experimental.serverExecution`) selects an arm regardless of this value.
- *
- * LANDED DARK (owner ruling 2026-08-16, on the Phase 7 independent
- * review): the flip-ready mechanism landed with this constant `false` —
- * the OFF posture stays the default everywhere it reaches, the ON posture
- * stays fully selectable (CI's explicit-`true` lanes run it on an ON-built
- * binary). The flip to `true` is its OWN separate one-line PR (repo
+ * value. `true` is the v2 posture — the first-party default since the
+ * flip PR, which landed after the plan's Phase 7 ordered gates were met
+ * (ON-skip registry EMPTY, OW31's ruled posture built, OW45–OW53 closed,
+ * the OW38(ii) benchmark bar ruled met); `false` is the pre-flip behavior
+ * byte-for-byte. An explicit `EXPERIMENTAL_SERVER_EXECUTION=true|false`
+ * (or `experimental.serverExecution`) selects an arm regardless of this
+ * value: an explicit `false` is the ROLLBACK LEVER (and CI's OFF
+ * regression guard, run on an OFF-built binary) and stays selectable
+ * through the post-flip soak. Un-flipping is reverting the flip PR (repo
  * convention: a flip is reverted by reverting the PR that only flips),
- * owed AFTER the ON posture works and is performant — the plan's Phase 7
- * task 1 records the ordered gates (client non-settling triage → OW17
- * re-keying → OW28 → the honest benchmark → then the flip). The flip PR
- * changes this value AND the absolute pin in
+ * never a hand edit here; the flip PR changes this value AND the absolute
+ * pin in
  * `packages/toolshed/lib/server-execution-flag.test.ts` (which states the
  * current default so a silent flip either way cannot hide behind
  * relative pins), the CI lane roles, and EXPERIMENTAL_OPTIONS.md together.
+ * After the soak, the post-soak removal PR (Phase 7's split-out task)
+ * retires the flag, the OFF path, and the OFF guard lanes.
  *
  * Deliberately a leaf module: the shell's main thread imports it without
  * pulling the wire-shape module (`../v2.ts`, which re-exports it).
@@ -36,4 +36,4 @@
  * serving host, so they resolve the ambient baseline (OFF) by construction
  * (see the ambient flag in `../v2.ts`).
  */
-export const SERVER_EXECUTION_DEFAULT_ENABLED = false;
+export const SERVER_EXECUTION_DEFAULT_ENABLED = true;

--- a/packages/patterns/integration/convergence-storm.test.ts
+++ b/packages/patterns/integration/convergence-storm.test.ts
@@ -27,10 +27,14 @@ import {
 } from "./multi-runtime-harness.ts";
 import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
 
-// The server-execution v2 posture this test process runs (testing.md §2):
-// declared from the environment — the CI ON lane sets
-// EXPERIMENTAL_SERVER_EXECUTION=true; unset = OFF (the first-party default
-// while Phase 7 is landed dark).
+// The RAW env posture, read only to key the skip guard below (testing.md
+// §2): the explicit-`false` OFF regression-guard lane sets
+// EXPERIMENTAL_SERVER_EXECUTION=false; the DEFAULT lanes leave it unset and
+// resolve the first-party default, which is ON since the flip. This value
+// is therefore undefined on the default (ON) lane — NOT the resolved
+// posture. The test's runtime posture is not taken from here:
+// `MultiRuntimeHarness` resolves it env-else-first-party-default and picks
+// its backend accordingly.
 const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
   .serverExecution;
 
@@ -41,6 +45,13 @@ const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
  * the entry exists — the OFF arm and an unlisted step always run. Never a
  * silent filter: the CI step prints every entry, and the validator
  * requires this file to name each listed step and call this guard.
+ *
+ * The registry is EMPTY, so this guard is inert everywhere today. Note the
+ * key: it is the RAW env, while the on-skips module asks callers to resolve
+ * env-else-first-party-default (as runtime-client's host now does). Inert
+ * today for exactly that reason — undefined on the default lane — and a
+ * future entry for this file would fail LOUD there (a red lane, never a
+ * silent skip), which is when the key gets converted.
  */
 function onArmStepSkip(step: string): { ignore: boolean } {
   if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };

--- a/packages/patterns/integration/topic-board-child-contract.test.ts
+++ b/packages/patterns/integration/topic-board-child-contract.test.ts
@@ -33,17 +33,28 @@ import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-sk
 
 const { API_URL, SPACE_NAME } = env;
 
-// The server-execution v2 posture this test process runs (testing.md §2):
-// the CI ON lane sets EXPERIMENTAL_SERVER_EXECUTION=true; unset = OFF.
+// The RAW env posture, read only to key the skip guard below (testing.md
+// §2): the explicit-`false` OFF regression-guard lane sets
+// EXPERIMENTAL_SERVER_EXECUTION=false; the DEFAULT lanes leave it unset and
+// resolve the first-party default, which is ON since the flip. This value
+// is therefore undefined on the default (ON) lane — NOT the resolved
+// posture. The test's runtime posture is not taken from here: it is
+// whatever the lane's toolshed publishes and `PiecesController` adopts.
 const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
   .serverExecution;
 
 // The ON arm's STEP-level skip guard (tasks/server-execution-on-skips.ts):
 // a step listed there for this file is skipped ONLY under the ON posture,
 // loudly (its reason is printed), and only while the entry exists — the OFF
-// arm and an unlisted step always run. No step of this file is listed
-// today; the guard stays wired on the pivot baseline case so a future
-// entry binds without re-plumbing.
+// arm and an unlisted step always run. The registry is EMPTY: no step of
+// any file is listed today, so this guard is inert everywhere and stays
+// wired on the pivot baseline case only so a future entry binds without
+// re-plumbing. Note
+// the key: it is the RAW env, while the on-skips module asks callers to
+// resolve env-else-first-party-default (as runtime-client's host now
+// does). Inert today for exactly that reason — undefined on the default
+// lane — and a future entry for this file would fail LOUD there (a red
+// lane, never a silent skip), which is when the key gets converted.
 function onArmStepSkip(step: string): { ignore: boolean } {
   if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };
   const entry = serverExecutionOnStepSkip(

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -5,6 +5,7 @@ import {
   experimentalOptionsFromEnv,
   type JSONSchema,
   Runtime,
+  withServerExecutionDefault,
 } from "@commonfabric/runner";
 import { Identity, IdentityCreateConfig } from "@commonfabric/identity";
 import { env } from "@commonfabric/integration";
@@ -24,10 +25,16 @@ async function test() {
   const runtime1 = new Runtime({
     apiUrl: new URL(API_URL),
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),
@@ -60,10 +67,16 @@ async function test() {
   const runtime2 = new Runtime({
     apiUrl: new URL(API_URL),
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { Identity, Session } from "@commonfabric/identity";
-import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  withServerExecutionDefault,
+} from "@commonfabric/runner";
 import { env } from "@commonfabric/integration";
 import { PiecesController } from "@commonfabric/piece/ops";
 
@@ -104,10 +107,16 @@ async function runTest() {
   const runtime = new Runtime({
     apiUrl: new URL(API_URL),
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager,
   });
 

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -20,6 +20,7 @@ import {
   type MemorySpace,
   Runtime,
   type RuntimeProgram,
+  withServerExecutionDefault,
 } from "@commonfabric/runner";
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
 import { env } from "@commonfabric/integration";
@@ -105,10 +106,16 @@ function createTestContext(identity: Identity): TestContext {
   const runtime = new Runtime({
     apiUrl: API_URL,
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager,
   });
   return { runtime, storageManager };

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -8,6 +8,7 @@ import {
   type NormalizedLink,
   Runtime,
   type URI,
+  withServerExecutionDefault,
 } from "@commonfabric/runner";
 import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
 import { env } from "@commonfabric/integration";
@@ -46,10 +47,16 @@ async function test() {
   const runtime1 = new Runtime({
     apiUrl: new URL(API_URL),
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),
@@ -123,10 +130,16 @@ async function test() {
   const runtime2 = new Runtime({
     apiUrl: new URL(API_URL),
     // The posture this client runs (server-execution v2, testing.md §2):
-    // declared from the environment so the CI ON lane's test process
-    // really runs the ON client arm (a bare construction resolved OFF and
-    // made the ON lane a MIXED posture — P7 review finding 7); unset = OFF.
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
+    // resolved exactly like a deployed entry point — the canonical env
+    // mapping, else the first-party default (ON since the flip) — so this
+    // process runs the arm the lane's toolshed runs: the DEFAULT lane's
+    // unset flag resolves ON, the OFF regression-guard lane's explicit
+    // `false` the OFF arm. A bare construction resolves the AMBIENT
+    // baseline instead, which post-flip is the P7 review's finding-7
+    // mixed posture.
+    experimental: withServerExecutionDefault(
+      experimentalOptionsFromEnv(Deno.env.get),
+    ),
     storageManager: StorageManager.open({
       as: identity,
       memoryHost: new URL(API_URL),

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -50,6 +50,7 @@ export {
   runtimePresets,
   SERVER_EXPERIMENTAL_PATH,
   type UnitTestPresetParams,
+  withServerExecutionDefault,
 } from "./runtime-presets.ts";
 export type {
   UnsafeHostTrust,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1926,6 +1926,13 @@ export class Runner {
   #locallyCommittedHandlerResultStarts = new Set<
     `${MemorySpace}/${ScopeKey}/${URI}`
   >();
+  // DIAGNOSTIC counter (tests; the loud-no-op pin): served receipt
+  // writes skipped as write-once CAS losses — the handling's result
+  // cell already held a value when the serving run went to write it
+  // (handleJavaScriptHandlerResult's ruled serving-side write,
+  // events.md §4 "Result carriage"). Each skip also logs a warn line;
+  // this is the machine-readable half.
+  servedReceiptCasLosses = 0;
   // Results started in their own right rather than as part of an enclosing
   // pattern, which is what navigating to a nested result does. An enclosing
   // pattern releasing such a result leaves it running; only stopping it
@@ -7820,6 +7827,23 @@ export class Runner {
       // overlay anyway, and a serving run's create-only mark would ride
       // the WAVE commit as a precondition the watermark already covers.
       this.runtime.experimental.serverExecution !== true;
+    // The serving-side receipt/result write (owner-ruled 2026-08-29;
+    // events.md §4 "Result carriage"): N26's subsumption retired the
+    // receipt's EXACTLY-ONCE role, not its RESULT-CARRIAGE role. Under
+    // the flag the SERVING side writes the handling's receipt — every
+    // served handler completion writes its result cell, even when the
+    // declared value is undefined — in the handler run's own transaction,
+    // so the write seals into the run's wave with the entry's
+    // `consequenced` mark (events.md §4 mark/effects atomicity) and
+    // enters the space through the same carriage every served
+    // event-handler write rides. Only a run whose body actually ran
+    // writes (a skipped served dispatch is withdrawn whole — see
+    // `dispatchedHandlerNotRun`); the client's write stays disabled
+    // (`receiptsEnabled` above), so the serving run is the ONE writer.
+    const servedReceiptWrite =
+      this.runtime.experimental.serverExecution === true &&
+      waveRunContextOf(tx)?.kind === "event-handler" &&
+      tx.dispatchedHandlerNotRun === undefined;
     // Expose the handling's receipt address on the transaction, where the
     // sender's commit callback can read it (verb contract WS-D). Stashed
     // before the branches so BOTH outcomes carry it: a committed handling
@@ -7831,7 +7855,17 @@ export class Runner {
     // its address would hand the caller a witness that does not exist and
     // invite a readback against an unwritten cell. Absent beats fabricated —
     // the same fail-closed stance cfc/grants.ts takes when its gate is off.
-    if (receiptsEnabled) {
+    //
+    // Under EXPERIMENTAL_SERVER_EXECUTION the receipt IS being written —
+    // by the SERVING side (the ruled write above). The address is
+    // cause-derived, so the client's diverted ECHO of the same event mints
+    // the same address the serving run writes; publishing it on the echo's
+    // transaction is what hands an unchanged caller (the CLI verb
+    // dispatch, WS-D) a readable handle on the served outcome. The
+    // durable-ack coupling (cell.ts) settles that caller's callback only
+    // after the handling CONSEQUENCED — the serving wave, receipt
+    // included, committed before the address is ever dereferenced.
+    if (receiptsEnabled || this.runtime.experimental.serverExecution === true) {
       tx.handlingReceiptLink = receiptCell.getAsNormalizedFullLink();
     }
     if (!resultHasReactives && frame.reactives.size === 0) {
@@ -7870,6 +7904,53 @@ export class Runner {
           receipt.setMetaRaw("schema", shape, rawMetaWriteAuthorization);
         }
         tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+      } else if (servedReceiptWrite) {
+        // The ruled serving-side receipt write (owner, 2026-08-29): the
+        // value-less/plain shape is EXACTLY the client-era one — `{}` as
+        // the existence witness, the handler's plain return under
+        // `plainResultReceipts` — and the cell identity is the same
+        // cause-derived address, so the verb contract's readback
+        // (WS-C/D; `cf call`'s `.result`) needs no migration.
+        //
+        // Write-once is CAS, not a wire precondition: no markCreateOnly
+        // (N26 — a create-only mark must not ride a wave commit whose
+        // event the watermark already covers), and a receipt that
+        // ALREADY holds a value is a LOUD NO-OP. A lost CAS means a
+        // writer already landed this handling's receipt — a re-served
+        // replay converging on the same cause-derived id, or a
+        // pre-created cell — and first-writer-wins is the OFF arm's
+        // receipt-collision semantics: never a second write, never an
+        // error that fails the wave (the entry's consequenced mark and
+        // the handler's other consequences still commit; the read below
+        // rides the wave's basis for this doc, so a genuinely
+        // concurrent landing rebases the run and the re-run takes this
+        // same no-op arm).
+        const existing = receiptCell.getRaw({ meta: ignoreReadForScheduling });
+        if (existing !== undefined) {
+          this.servedReceiptCasLosses += 1;
+          logger.warn("served-receipt", () => [
+            "served receipt write skipped (write-once CAS loss): the " +
+            "handling's result cell already holds a value — a prior " +
+            "serve/replay or a pre-created cell landed it first, and " +
+            "the standing value wins",
+            {
+              receipt: receiptCell.getAsNormalizedFullLink().id,
+              eventId: waveRunContextOf(tx)?.eventId,
+            },
+          ]);
+        } else {
+          const receiptValue =
+            this.runtime.experimental.plainResultReceipts === true &&
+              result !== undefined
+              ? result
+              : {};
+          const receipt = receiptCell.withTx(tx);
+          receipt.set(receiptValue);
+          const shape = receiptShapeSchema(receiptValue);
+          if (shape !== undefined) {
+            receipt.setMetaRaw("schema", shape, rawMetaWriteAuthorization);
+          }
+        }
       }
       return result;
     }

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -728,8 +728,17 @@ interface CoreParams {
  * has no serving host, so it runs the derive-and-commit model (the
  * ambient baseline, OFF) by construction — see
  * `docs/development/EXPERIMENTAL_OPTIONS.md`.
+ *
+ * Exported for the deployed-topology test clients that construct a bare
+ * `Runtime` against a lane's toolshed (the runner integration tests, the
+ * runtime-client integration host): they resolve the posture with exactly
+ * this rule — the canonical env mapping, else the first-party default —
+ * so the DEFAULT CI lane's test processes run the arm the lane's server
+ * runs (testing.md §2's uniform posture; a raw env read resolves unset to
+ * the AMBIENT baseline instead, which under default-ON is the P7 review's
+ * finding-7 mixed posture, resurrected by the flip).
  */
-function withServerExecutionDefault(
+export function withServerExecutionDefault(
   experimental: ExperimentalOptions,
 ): ExperimentalOptions {
   return {

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -291,6 +291,26 @@ const THROW_PATTERN = [
   ">(({ value }) => ({ value, explode: explode({ value }) }));",
 ].join("\n");
 
+/** Verbs with DECLARED results and no cell writes of their own — the
+ * serving-side receipt/result-write pins (owner-ruled 2026-08-29;
+ * events.md §4 "Result carriage"). `probe` returns a plain value derived
+ * from the event payload; `quiet` returns nothing (the `{}` existence
+ * witness). Both bind `{}` — no context cells — so the handlings'
+ * cause-derived receipt addresses depend on nothing but the pattern and
+ * the invocation id, and their only durable consequence is the receipt
+ * itself. */
+const DECLARED_RESULT_PATTERN = [
+  "import { handler, pattern, Stream, Writable } from 'commonfabric';",
+  "const probe = handler<{ n?: number }, Record<string, never>>(",
+  "  (ev) => ({ token: 'tok-' + (ev?.n ?? 0) }),",
+  ");",
+  "const quiet = handler<unknown, Record<string, never>>(() => {});",
+  "export default pattern<",
+  "  { value: Writable<number> },",
+  "  { value: number; probe: Stream<unknown>; quiet: Stream<unknown> }",
+  ">(({ value }) => ({ value, probe: probe({}), quiet: quiet({}) }));",
+].join("\n");
+
 /** A handler whose `$ctx` requires a plain-number `gate` the argument doc
  * does not hold at fire time: the served dispatch's argument read fails the
  * schema (`isValidArgument === false`, runner.ts's "-- not running" skip)
@@ -2341,6 +2361,280 @@ describe("Phase 3 events-down (serving side)", () => {
       id: argument.getAsNormalizedFullLink().id,
     });
     expect((doc?.value as { value?: number })?.value).toBe(1);
+    cancelDemand();
+  });
+
+  /** The serving-side receipt/result write (owner-ruled 2026-08-29;
+   * events.md §4 "Result carriage"): fire a result-declaring verb, then
+   * a `send` helper the three pins below share. The commit callback is
+   * the durable-ack coupling's — it settles only after the handling
+   * CONSEQUENCED — and hands back the echo's transaction, whose
+   * `handlingReceiptLink` is the cause-derived receipt address. */
+  const fireVerb = (
+    result: Cell<Record<string, unknown>>,
+    verb: string,
+    payload: unknown,
+    eventId: string,
+  ): {
+    ack: () => { status: string; tx: IExtendedStorageTransaction } | undefined;
+  } => {
+    let settled:
+      | { status: string; tx: IExtendedStorageTransaction }
+      | undefined;
+    (result.key(verb) as unknown as {
+      send(
+        value: unknown,
+        onCommit?: (tx: IExtendedStorageTransaction) => void,
+        options?: { eventId?: string; session?: string },
+      ): unknown;
+    }).send(payload, (tx) => {
+      settled = { status: tx.status().status, tx };
+    }, { eventId, session: "receipt-pin-session" });
+    return { ack: () => settled };
+  };
+
+  /** Every commit that ever wrote a doc, from the durable record: the
+   * per-doc `revision` rows joined to their commits. The receipt pins'
+   * single-writer evidence — who wrote the receipt, in which commit
+   * class, carrying which consequenceOf. */
+  const commitsWriting = (
+    engine: Engine.Engine,
+    docId: string,
+  ): Array<{ seq: number; class: string; consequenceOf: string | null }> =>
+    engine.database.prepare(
+      `SELECT DISTINCT r.commit_seq AS seq, c.class AS class,
+              c.consequence_of AS consequenceOf
+         FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+        WHERE r.id = :id ORDER BY r.commit_seq`,
+    ).all({ id: docId }) as Array<
+      { seq: number; class: string; consequenceOf: string | null }
+    >;
+
+  it("the ruled result carriage (owner, 2026-08-29): a served result-declaring handler WRITES its receipt — the declared value, in the handling's OWN consequence commit (mark and result atomic), by the serving side alone; the client's echo publishes the same cause-derived address and never writes (mutation: drop the serving write → no receipt doc; write outside the handler tx → consequenceOf linkage breaks; re-enable the client write → an authored commit appears)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { result } = await standUp(clientRuntime, DECLARED_RESULT_PATTERN, {
+      arg: "result-carriage-arg",
+      result: "result-carriage-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const fired = fireVerb(result, "probe", { n: 7 }, "result-carriage-1");
+    await clientRuntime.idle();
+
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        const entry = value?.entries?.[0];
+        return entry?.consequenced === true &&
+          value?.eventWatermark === entry?.seq;
+      },
+      "the handling to consequence",
+    );
+    // The durable id: the caller pair (id, session) scopes to a hashed
+    // `evt:caller:` id (event-identity.ts) — read it off the entry.
+    const durableId = (Engine.read(engine, { id: sidecarId })
+      ?.value as StreamEventsDocValue).entries![0].eventId;
+    // The durable ack settles non-error only after the consequence — so
+    // the receipt the address names is durable BEFORE any caller could
+    // dereference it (the readback-ordering half of the contract).
+    await waitUntil(() => fired.ack() !== undefined, "the durable ack");
+    expect(fired.ack()!.status).not.toBe("error");
+
+    // WS-D under ON: the echo's transaction publishes the handling's
+    // receipt address — the same cause-derived cell the serving side
+    // wrote. An unchanged caller (the CLI verb dispatch) needs no
+    // migration: address out of the callback, value by ordinary read.
+    const link = fired.ack()!.tx.handlingReceiptLink;
+    expect(link).toBeDefined();
+
+    // The serving side wrote the DECLARED value (plainResultReceipts is
+    // default-on for the serving runtime), durably, server-side.
+    const receiptDoc = Engine.read(engine, { id: link!.id });
+    expect(receiptDoc?.value).toEqual({ token: "tok-7" });
+
+    // One writer, exactly once, atomic with the handling: the receipt
+    // doc's WHOLE write history is one derived commit — the wave commit
+    // that consequences this event (mark + effects + result together).
+    // No authored commit ever touched it: the client never wrote.
+    const writers = commitsWriting(engine, link!.id);
+    expect(writers.length).toBe(1);
+    expect(writers[0].class).toBe("derived");
+    expect(writers[0].consequenceOf ?? "").toContain(durableId);
+    const carryingBatch = observedWaveCommits.find((batch) =>
+      batch.consequenceOf.includes(durableId)
+    );
+    expect(carryingBatch).toBeDefined();
+    expect(JSON.stringify(carryingBatch!.operations)).toContain(link!.id);
+    cancelDemand();
+  });
+
+  it("the ruled result carriage, value-less arm: a served handler that returns undefined STILL writes its receipt — the `{}` existence witness (owner: 'even if the value is undefined'), one derived commit, atomic with the mark", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { result } = await standUp(clientRuntime, DECLARED_RESULT_PATTERN, {
+      arg: "valueless-receipt-arg",
+      result: "valueless-receipt-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const fired = fireVerb(result, "quiet", {}, "valueless-receipt-1");
+    await clientRuntime.idle();
+
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        const entry = value?.entries?.[0];
+        return entry?.consequenced === true &&
+          value?.eventWatermark === entry?.seq;
+      },
+      "the handling to consequence",
+    );
+    await waitUntil(() => fired.ack() !== undefined, "the durable ack");
+    expect(fired.ack()!.status).not.toBe("error");
+    const link = fired.ack()!.tx.handlingReceiptLink;
+    expect(link).toBeDefined();
+
+    // The cell EXISTS post-serve, holding exactly the empty record — the
+    // value-less witness consumers distinguish from "no receipt at all".
+    const receiptDoc = Engine.read(engine, { id: link!.id });
+    expect(receiptDoc?.value).toEqual({});
+    const writers = commitsWriting(engine, link!.id);
+    expect(writers.length).toBe(1);
+    expect(writers[0].class).toBe("derived");
+    cancelDemand();
+  });
+
+  it("the ruled result carriage, CAS-loss arm: a receipt that ALREADY exists when the serving run goes to write is a LOUD NO-OP — the standing value wins, no second write, and the wave still commits (mark + consequences land); the pre-created cell comes from the real OFF-arm client writer under the SAME invocation id, so the pin also proves the cross-arm address agreement (mutation: drop the existence check → the receipt is overwritten and a derived writer appears; make CAS-loss fail the wave → the entry never consequences)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const names = { arg: "cas-loss-arg", result: "cas-loss-result" };
+    const { result } = await standUp(
+      clientRuntime,
+      DECLARED_RESULT_PATTERN,
+      names,
+    );
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    // The pre-created receipt, minted through the CLIENT-ERA writer: an
+    // explicit-OFF probe runtime (commitPreconditions on, the pre-flip
+    // client posture — a mixed-fleet OFF client against this ON server)
+    // dispatches the SAME invocation id locally and commits the receipt
+    // as an ordinary authored write. Explicit `false` does NOT un-claim
+    // the process-global serving flag while the harness's ON enablers
+    // are live (runtime.ts's enabler-count guard).
+    const probeManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    extraManagers.push(probeManager);
+    const probeRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: probeManager,
+      experimental: { serverExecution: false, commitPreconditions: true },
+    });
+    extraRuntimes.push(probeRuntime);
+    const { result: probeResult } = await standUp(
+      probeRuntime,
+      DECLARED_RESULT_PATTERN,
+      names,
+    );
+    const cancelProbeDemand = probeResult.sink(() => {});
+    await probeRuntime.idle();
+    const probeFired = fireVerb(
+      probeResult,
+      "probe",
+      { n: 99 },
+      "cas-loss-1",
+    );
+    await probeRuntime.idle();
+    await probeRuntime.storageManager.synced();
+    await waitUntil(() => probeFired.ack() !== undefined, "the OFF-arm ack");
+    expect(probeFired.ack()!.status).not.toBe("error");
+    const probeLink = probeFired.ack()!.tx.handlingReceiptLink;
+    expect(probeLink).toBeDefined();
+    await waitUntil(
+      () => Engine.read(engine, { id: probeLink!.id })?.value !== undefined,
+      "the pre-created receipt to land durably",
+    );
+    expect(Engine.read(engine, { id: probeLink!.id })?.value).toEqual({
+      token: "tok-99",
+    });
+    cancelProbeDemand();
+
+    // Now the ON client fires the SAME id; the serving run's write finds
+    // the cell taken and must lose the CAS loudly — and harmlessly.
+    host = newHost();
+    const fired = fireVerb(result, "probe", { n: 7 }, "cas-loss-1");
+    await clientRuntime.idle();
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the event append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        const entry = value?.entries?.[0];
+        return entry?.consequenced === true &&
+          value?.eventWatermark === entry?.seq;
+      },
+      "the wave to commit despite the CAS loss (never an error that " +
+        "fails the wave)",
+    );
+    const durableId = (Engine.read(engine, { id: sidecarId })
+      ?.value as StreamEventsDocValue).entries![0].eventId;
+    await waitUntil(() => fired.ack() !== undefined, "the durable ack");
+    expect(fired.ack()!.status).not.toBe("error");
+
+    // Cross-arm address agreement: the ON echo published the SAME
+    // cause-derived address the OFF-arm writer used — the no-migration
+    // property, witnessed through the real machinery on both sides.
+    const link = fired.ack()!.tx.handlingReceiptLink;
+    expect(link).toBeDefined();
+    expect(link!.id).toBe(probeLink!.id);
+
+    // Single write: the standing value won — the served handler's value
+    // (tok-7) never landed. The whole write history stays the ONE
+    // authored commit; the serve added no derived writer, and the
+    // consequence wave carries no operation on the receipt doc.
+    expect(Engine.read(engine, { id: link!.id })?.value).toEqual({
+      token: "tok-99",
+    });
+    const writers = commitsWriting(engine, link!.id);
+    expect(writers.length).toBe(1);
+    expect(writers[0].class).toBe("authored");
+    const carryingBatch = observedWaveCommits.find((batch) =>
+      batch.consequenceOf.includes(durableId)
+    );
+    expect(carryingBatch).toBeDefined();
+    expect(JSON.stringify(carryingBatch!.operations)).not.toContain(link!.id);
+
+    // The LOUD half: the serving runner counted the skip.
+    expect(servingRuntime!.runner.servedReceiptCasLosses).toBe(1);
     cancelDemand();
   });
 

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -25,7 +25,10 @@ import {
   type RuntimeClientOptions,
   type VNode,
 } from "@commonfabric/runtime-client";
-import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import {
+  experimentalOptionsFromEnv,
+  withServerExecutionDefault,
+} from "@commonfabric/runner";
 import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
 import { MessagePortRuntimeTransport } from "@commonfabric/runtime-client/transports/message-port";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
@@ -43,13 +46,15 @@ const keyConfig: IdentityCreateConfig = {
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 // The server-execution v2 posture this test process runs (testing.md §2):
-// declared from the environment — the CI ON lane sets
-// EXPERIMENTAL_SERVER_EXECUTION=true — so the worker below really runs the
-// ON client arm; unset = OFF (the first-party default while Phase 7 is
-// landed dark). An undeclared worker resolves OFF and made the ON lane a
-// MIXED posture (P7 review finding 7).
-const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
-  .serverExecution;
+// resolved exactly like a deployed entry point — the canonical env
+// mapping, else the first-party default (ON since the flip) — so the
+// worker below runs the arm the lane's toolshed runs: the DEFAULT lane's
+// unset flag resolves ON, the explicit-`false` OFF regression-guard
+// lane the OFF arm. An UNDECLARED worker resolves the ambient baseline
+// instead, which post-flip is the P7 review's finding-7 mixed posture.
+const SERVER_EXECUTION_RESOLVED = withServerExecutionDefault(
+  experimentalOptionsFromEnv(Deno.env.get),
+).serverExecution;
 
 /**
  * The ON arm's STEP-level skip guard (tasks/server-execution-on-skips.ts):
@@ -60,7 +65,7 @@ const SERVER_EXECUTION_FROM_ENV = experimentalOptionsFromEnv(Deno.env.get)
  * requires this file to name each listed step and call this guard.
  */
 function onArmStepSkip(step: string): { ignore: boolean } {
-  if (SERVER_EXECUTION_FROM_ENV !== true) return { ignore: false };
+  if (SERVER_EXECUTION_RESOLVED !== true) return { ignore: false };
   const entry = serverExecutionOnStepSkip(
     "runtime-client",
     "integration/client.test.ts",
@@ -1973,10 +1978,11 @@ async function clientOptionsFor(
     // The HOST declares the worker's posture (runtime-client's posture
     // agreement; the worker refuses to initialize on a mismatch). Only the
     // server-execution flag is declared: the other experimental keys keep
-    // the worker's own defaults.
-    experimental: SERVER_EXECUTION_FROM_ENV === undefined
-      ? {}
-      : { serverExecution: SERVER_EXECUTION_FROM_ENV },
+    // the worker's own defaults. Always declared since the flip — the
+    // resolved value is env-else-first-party-default, never the worker's
+    // ambient baseline (which would be the finding-7 mixed posture under
+    // default ON).
+    experimental: { serverExecution: SERVER_EXECUTION_RESOLVED },
     ...extraOptions,
   };
 }

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -77,7 +77,7 @@ export const EXPERIMENTAL = {
   modernCellRep: flagValue(EXPERIMENTAL_MODERN_CELL_REP_DEFINE),
   computedCellIds: flagValue(EXPERIMENTAL_COMPUTED_CELL_IDS_DEFINE),
   // Server-execution v2 (docs/specs/server-side-execution/): the
-  // first-party default (the landed-dark constant, `false` until the flip
+  // first-party default (the constant — `true` since the Phase 7 flip
   // PR), overridable by the build define either way
   // (`EXPERIMENTAL_SERVER_EXECUTION=false` builds the OFF-arm shell — the
   // rollback lever and CI's regression guard). The worker refuses to

--- a/packages/toolshed/lib/server-execution-flag.test.ts
+++ b/packages/toolshed/lib/server-execution-flag.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/server-execution-flag.ts";
 
 // The toolshed process's ONE flag resolution (server-execution v2 Phase 7,
-// flip-ready): unset means the FIRST-PARTY DEFAULT — the value of
+// the flip): unset means the FIRST-PARTY DEFAULT — the value of
 // `SERVER_EXECUTION_DEFAULT_ENABLED`, whichever it is — and an explicit
 // "false" is the OFF arm, an explicit "true" the ON arm. Pinned against
 // the constant, not a literal, so the tests state the contract rather
@@ -16,17 +16,18 @@ import {
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
 
-describe("the landing posture (server-execution v2 Phase 7, landed dark by owner ruling 2026-08-16)", () => {
-  it("the first-party default IS OFF — the flip to ON is its own separate one-line PR (docs/plans/server-execution-v2.md Phase 7 task 1) and must update this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together", () => {
+describe("the flipped posture (server-execution v2 Phase 7, the flip PR — default ON after the plan's ordered gates)", () => {
+  it("the first-party default IS ON — flipped by the flip PR (docs/plans/server-execution-v2.md Phase 7 task 1), which updates this pin, the CI lane roles, and EXPERIMENTAL_OPTIONS.md together; un-flipping is reverting that PR, never an edit here", () => {
     // Every other flip pin in the tree is deliberately RELATIVE to the
     // constant (so the flip PR is one line plus this pin); this is the
     // one ABSOLUTE pin, so a silent flip in EITHER direction cannot hide
-    // behind green relative pins — flipped silently ON, the REQUIRED
-    // default CI lanes would carry the ON posture (the P7 independent
-    // review's blocker: two two-browser gates red under ON); flipped
-    // silently OFF after the flip PR, the "ON arm" default lanes would
-    // run OFF with every test still green.
-    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(false);
+    // behind green relative pins — flipped silently OFF, the default
+    // lanes (the ON arm since the flip) would run OFF with every test
+    // still green while the explicit-`false` OFF guard lanes ran the
+    // same arm twice; flipped silently ON before the flip PR, the
+    // REQUIRED default lanes would have carried an unreviewed posture
+    // change (the P7 independent review's blocker class).
+    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
   });
 });
 

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -13,6 +13,7 @@ import {
   experimentalPosture,
   publishExperimentalPosture,
 } from "@/lib/experimental-posture.ts";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
@@ -106,8 +107,9 @@ describe("serverExecutionPolicyFromEnv", () => {
 describe("startServerExecutionHost OFF witness", () => {
   // The OFF witness for the serving-loop bootstrap (OW45 arm-B
   // server-ensure stage 1's explicit pin; the arc's OFF byte-identity
-  // bar): with the flag OFF — unset (the first-party default is OFF until
-  // the flip PR) or explicitly "false" — `startServerExecutionHost`
+  // bar): with the flag OFF — explicitly "false", the rollback arm (the
+  // first-party default is ON since the Phase 7 flip PR) —
+  // `startServerExecutionHost`
   // returns undefined, so NO ExecutorHost exists, NO SpaceServer is ever
   // built, and the server-side space-root ensure path added by stage 1
   // (the SpaceServer activation owed-step) structurally does not exist
@@ -116,26 +118,42 @@ describe("startServerExecutionHost OFF witness", () => {
   //
   // The options are untouchable fakes on purpose: the flag check is the
   // function's FIRST act, so the OFF arm must touch neither the server
-  // nor the identity — any use throws and fails the pin.
+  // nor the identity — any use throws and fails the pin. The same
+  // untouchables give the UNSET arm its witness in the other direction
+  // since the flip: unset resolves the first-party default (ON), the gate
+  // opens, and the construction's first touch of the identity is the
+  // proof — the full ON construction is exercised by the integration
+  // lanes and the deployed-topology gate, not here.
 
   const untouchable = <T extends object>(label: string): T =>
     new Proxy({} as T, {
       get(_target, property) {
         throw new Error(
-          `${label}.${String(property)} touched on the OFF arm — the ` +
-            "flag check must precede any use",
+          `${label}.${String(property)} touched — on the OFF arm the ` +
+            "flag check must precede any use (the pin's failure); on " +
+            "the unset arm, since the flip, this touch is the " +
+            "gate-opened witness",
         );
       },
     });
 
-  it("is inert with the flag unset (the first-party default: OFF until the flip PR)", () => {
-    const host = startServerExecutionHost({
-      server: untouchable<MemoryServer>("server"),
-      identity: untouchable<Identity>("identity"),
-      apiUrl: new URL("http://toolshed.test"),
-      envGet: () => undefined,
-    });
-    expect(host).toBeUndefined();
+  it("resolves the UNSET flag to the first-party default — ON since the flip PR: the gate opens (witnessed by the identity being touched), never the silent OFF arm", () => {
+    // Relative to the constant on purpose (the one absolute pin lives in
+    // server-execution-flag.test.ts): if the default were OFF this would
+    // return undefined without touching anything; with the flipped
+    // default the bootstrap proceeds past the gate and its first act on
+    // the ON path — logging the serving identity — touches the
+    // untouchable, which is exactly the witness that unset no longer
+    // resolves OFF.
+    expect(SERVER_EXECUTION_DEFAULT_ENABLED).toBe(true);
+    expect(() =>
+      startServerExecutionHost({
+        server: untouchable<MemoryServer>("server"),
+        identity: untouchable<Identity>("identity"),
+        apiUrl: new URL("http://toolshed.test"),
+        envGet: () => undefined,
+      })
+    ).toThrow("identity.did touched");
   });
 
   it("is inert with the flag explicitly false", () => {
@@ -166,11 +184,14 @@ describe("startServerExecutionHost OFF witness", () => {
     it("adds nothing while the serving loop is off", () => {
       publishExperimentalPosture({ modernCellRep: false });
       try {
+        // Explicit "false" — the OFF arm's selector since the flip made
+        // the unset default ON.
         startServerExecutionHost({
           server: untouchable<MemoryServer>("server"),
           identity: untouchable<Identity>("identity"),
           apiUrl: new URL("http://toolshed.test"),
-          envGet: () => undefined,
+          envGet: (name) =>
+            name === "EXPERIMENTAL_SERVER_EXECUTION" ? "false" : undefined,
         });
         expect(experimentalPosture()).toEqual({ modernCellRep: false });
       } finally {

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -6,7 +6,9 @@
 // writes ride the direct engine plane (plane c), and the serving
 // runtimes' storage sessions are in-process loopback connections with the
 // SAME signed session-open production clients present (plane a). OFF (the
-// default), nothing here runs and toolshed is byte-identical to today.
+// explicit-`false` rollback arm; the first-party default is ON since the
+// Phase 7 flip), nothing here runs and toolshed is byte-identical to the
+// pre-v2 behavior.
 
 import {
   type EnvReader,

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -474,11 +474,13 @@ export async function prepareWorkspace(
     // define read from this same environment in packages/shell/felt.config.ts
     // when buildShell runs below): the raw `EXPERIMENTAL_SERVER_EXECUTION`
     // value, or null when unset — the shell then follows the first-party
-    // default. Surfaced on toolshed's /api/meta as `shellServerExecutionDefine`
-    // so CI's explicit-ON lanes can verify the binary they run actually
-    // carries an ON-built shell (docs/specs/server-side-execution/testing.md
-    // §2; the shell define is baked, so an ON lane on a default-built binary
-    // would silently be a mixed posture). Written to both markers because
+    // default (ON since the Phase 7 flip). Surfaced on toolshed's /api/meta
+    // as `shellServerExecutionDefine` so CI's posture probes can verify the
+    // binary they run: the explicit-`false` OFF guard lanes require an
+    // OFF-built shell, and the default lanes require the define UNSET
+    // (docs/specs/server-side-execution/testing.md §2; the shell define is
+    // baked, so a lane on the wrong binary would silently be a mixed
+    // posture). Written to both markers because
     // they are one file written twice; only the toolshed embeds the shell.
     shellServerExecutionDefine: Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") ??
       null,

--- a/tasks/ci-capabilities.test.ts
+++ b/tasks/ci-capabilities.test.ts
@@ -51,6 +51,7 @@ describe("ci capabilities", () => {
     // type and not to the registry, or the other way round, and a suite
     // asking for one that is not there fails the lane before it starts.
     expect([...CAPABILITIES.keys()].toSorted()).toEqual([
+      "bg-piece-service-binary",
       "browser",
       "cf",
       "compile-cache",
@@ -60,7 +61,7 @@ describe("ci capabilities", () => {
       "jq",
       "local-dev-servers",
       "toolshed",
-      "toolshed-baked-on",
+      "toolshed-baked-off",
     ]);
   });
 
@@ -135,6 +136,9 @@ describe("ci capabilities", () => {
     expect(opened.env.API_URL).toBeDefined();
     expect(opened.env.TOOLSHED_PORT).toBeDefined();
     expect(opened.env.CF_LABS_ROOT).toBe(Deno.cwd());
+    expect(opened.env.BG_PIECE_SERVICE_BIN).toBe(
+      `${Deno.cwd()}/${BINARY_CACHE_DIR}/bg-piece-service`,
+    );
     expect(opened.env.PATH?.startsWith(`${Deno.cwd()}/bin`)).toBe(true);
     expect(opened.env.CF_COMPILE_CACHE_FILE).toBe(
       `${Deno.cwd()}/${COMPILE_CACHE_FILE}`,
@@ -355,8 +359,8 @@ describe("opening a capability on a machine that answers", () => {
   });
 
   it("builds the server-execution binary only when none was restored", async () => {
-    const answers = { "toolshed-on": "listening (pid 999999). Logs: x\n" };
-    const openOn = async (restored: boolean) => {
+    const answers = { "toolshed-off": "listening (pid 999999). Logs: x\n" };
+    const openOff = async (restored: boolean) => {
       const m = machine(answers);
       const root = await Deno.makeTempDir({ prefix: "capability-" });
       // What a build leaves behind, so the copy into the cache has
@@ -365,9 +369,12 @@ describe("opening a capability on a machine that answers", () => {
       await Deno.writeTextFile(`${root}/dist/toolshed`, "");
       if (restored) {
         await Deno.mkdir(`${root}/${BINARY_CACHE_DIR}`, { recursive: true });
-        await Deno.writeTextFile(`${root}/${BINARY_CACHE_DIR}/toolshed-on`, "");
+        await Deno.writeTextFile(
+          `${root}/${BINARY_CACHE_DIR}/toolshed-off`,
+          "",
+        );
       }
-      const opened = await openCapabilities(["toolshed-baked-on"], {
+      const opened = await openCapabilities(["toolshed-baked-off"], {
         root,
         dryRun: false,
         workDir: root,
@@ -379,8 +386,37 @@ describe("opening a capability on a machine that answers", () => {
     };
     // A cache miss builds; a restore does not, which is the difference
     // between forty seconds and seventeen on every lane that needs it.
-    expect(await openOn(false)).toBe(true);
-    expect(await openOn(true)).toBe(false);
+    expect(await openOff(false)).toBe(true);
+    expect(await openOff(true)).toBe(false);
+  });
+
+  it("builds the background service binary only when none was restored", async () => {
+    const openBinary = async (restored: boolean) => {
+      const m = machine();
+      const root = await Deno.makeTempDir({ prefix: "capability-" });
+      await Deno.mkdir(`${root}/dist`, { recursive: true });
+      await Deno.writeTextFile(`${root}/dist/bg-piece-service`, "");
+      if (restored) {
+        await Deno.mkdir(`${root}/${BINARY_CACHE_DIR}`, { recursive: true });
+        await Deno.writeTextFile(
+          `${root}/${BINARY_CACHE_DIR}/bg-piece-service`,
+          "",
+        );
+      }
+      const opened = await openCapabilities(["bg-piece-service-binary"], {
+        root,
+        dryRun: false,
+        workDir: root,
+        exec: m.exec,
+      }, CAPABILITIES);
+      await opened.close();
+      await Deno.remove(root, { recursive: true });
+      return m.asked.some((line) =>
+        line.includes("build-binaries bg-piece-service")
+      );
+    };
+    expect(await openBinary(false)).toBe(true);
+    expect(await openBinary(true)).toBe(false);
   });
 });
 

--- a/tasks/ci-capabilities.ts
+++ b/tasks/ci-capabilities.ts
@@ -4,12 +4,12 @@
  *
  * A lane works out the union of what its batches need, opens each one
  * once, and runs the batches inside it. Naming them is what lets two ways
- * of providing the same thing coexist: `toolshed` runs a server from
- * source, which is cheap enough for a pull request, while
- * `toolshed-baked-on` restores or builds a binary because the
- * server-execution ON posture is baked into the browser shell inside it
- * and a source run cannot reproduce that. A suite says which it needs and
- * neither the workflow nor the other suites know the difference.
+ * of providing the same thing coexist: `toolshed` runs the default posture
+ * from source, which is cheap enough for a pull request, while
+ * `toolshed-baked-off` restores or builds a binary because the explicit-OFF
+ * server-execution posture is baked into the browser shell inside it and a
+ * source run cannot reproduce that. A suite says which it needs and neither
+ * the workflow nor the other suites know the difference.
  *
  * Every capability is idempotent: opening one that is already open is the
  * same as not opening it. The lane runner relies on that when a batch it
@@ -26,7 +26,8 @@ export type CapabilityId =
   | "browser"
   | "git-history"
   | "toolshed"
-  | "toolshed-baked-on"
+  | "toolshed-baked-off"
+  | "bg-piece-service-binary"
   | "cf"
   | "local-dev-servers"
   | "compile-cache";
@@ -378,19 +379,18 @@ const toolshed: Capability = {
 };
 
 /**
- * The same server with server execution on, from a compiled binary. The
- * ON posture is a compile-time define baked into the browser shell inside
- * the binary, so a source run cannot reproduce it. The lane's workflow
- * restores the binary from the Actions cache before the runner starts;
+ * The same server with server execution explicitly off, from a compiled
+ * binary. The OFF posture is a compile-time define baked into the browser
+ * shell inside the binary, so a source run cannot reproduce it. The lane's
+ * workflow restores the binary from the Actions cache before the runner starts;
  * building it here is what happens when that cache missed.
  */
-const toolshedBakedOn: Capability = {
-  id: "toolshed-baked-on",
-  description:
-    "a Toolshed server with the server-execution define baked into its shell",
+const toolshedBakedOff: Capability = {
+  id: "toolshed-baked-off",
+  description: "a Toolshed server with server execution OFF in its baked shell",
   needs: ["deno"],
   async open(context) {
-    const binary = path.join(context.root, BINARY_CACHE_DIR, "toolshed-on");
+    const binary = path.join(context.root, BINARY_CACHE_DIR, "toolshed-off");
     if (!context.dryRun) {
       let present = true;
       try {
@@ -410,7 +410,7 @@ const toolshedBakedOn: Capability = {
             cwd: context.root,
             env: {
               ...Deno.env.toObject(),
-              EXPERIMENTAL_SERVER_EXECUTION: "true",
+              EXPERIMENTAL_SERVER_EXECUTION: "false",
             },
           },
         );
@@ -425,8 +425,48 @@ const toolshedBakedOn: Capability = {
     return await startToolshed(context, {
       command: [binary],
       cwd: context.root,
-      env: { EXPERIMENTAL_SERVER_EXECUTION: "true" },
+      env: { EXPERIMENTAL_SERVER_EXECUTION: "false" },
     });
+  },
+};
+
+/**
+ * The compiled background-piece-service binary used by its deployed-topology
+ * gate. That gate deliberately starts the shipped artifact rather than a
+ * source process, so the binary is a capability like the baked Toolshed.
+ */
+const bgPieceServiceBinary: Capability = {
+  id: "bg-piece-service-binary",
+  description: "the compiled background-piece-service binary",
+  needs: ["deno"],
+  async open(context) {
+    const binary = path.join(
+      context.root,
+      BINARY_CACHE_DIR,
+      "bg-piece-service",
+    );
+    if (!context.dryRun) {
+      let present = true;
+      try {
+        await Deno.stat(binary);
+      } catch {
+        present = false;
+      }
+      if (!present) {
+        await execOf(context)(
+          Deno.execPath(),
+          ["task", "build-binaries", "bg-piece-service"],
+          { cwd: context.root },
+        );
+        await Deno.mkdir(path.dirname(binary), { recursive: true });
+        await Deno.copyFile(
+          path.join(context.root, "dist", "bg-piece-service"),
+          binary,
+        );
+      }
+      await Deno.chmod(binary, 0o755);
+    }
+    return exported({ BG_PIECE_SERVICE_BIN: binary });
   },
 };
 
@@ -492,7 +532,8 @@ export const CAPABILITIES: ReadonlyMap<CapabilityId, Capability> = new Map(
     browser,
     gitHistory,
     toolshed,
-    toolshedBakedOn,
+    toolshedBakedOff,
+    bgPieceServiceBinary,
     cf,
     localDevServers,
     compileCache,

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -878,15 +878,21 @@ Deno.test("test-records-ship forwards its optional variant input", async () => {
   assertStringIncludes(action, 'args+=(--variant "$SHIP_VARIANT")');
 });
 
-Deno.test("server-execution ON jobs ship records under their variant", async () => {
+Deno.test("server-execution OFF jobs ship records under their variant; the default (ON since the flip) stays unmarked", async () => {
+  // testing.md §2's test-record identity contract, post-flip: the DEFAULT
+  // configuration (ON since the Phase 7 flip) continues the existing
+  // unmarked history, and the surviving explicit-OFF regression guard is
+  // marked `server-execution-off`. (The pre-flip explicit-ON arm's
+  // `server-execution` marker retired with the flip — its history stays
+  // queryable under that variant.)
   const contents = withoutComments(await workflow("deno.yml"));
   const packageJob = jobBlock(
     contents,
-    "package-integration-test-server-execution-on",
+    "package-integration-test-server-execution-off",
   );
   const patternJob = jobBlock(
     contents,
-    "pattern-integration-test-server-execution-on",
+    "pattern-integration-test-server-execution-off",
   );
   assertStringIncludes(
     packageJob,
@@ -899,11 +905,11 @@ Deno.test("server-execution ON jobs ship records under their variant", async () 
   );
   assertStringIncludes(
     patternJob,
-    "--junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml",
+    "--junit-path=../../test-results/patterns-server-execution-off-${{ matrix.shard }}.xml",
   );
   assertStringIncludes(
     stepBlock(patternJob, "📤 Ship test records"),
-    "glob=test-results/patterns-server-execution-on-${{ matrix.shard }}.xml",
+    "glob=test-results/patterns-server-execution-off-${{ matrix.shard }}.xml",
   );
 
   for (
@@ -918,20 +924,96 @@ Deno.test("server-execution ON jobs ship records under their variant", async () 
 
   for (
     const jobId of [
-      "package-integration-test-server-execution-on",
-      "pattern-integration-test-server-execution-on",
+      "package-integration-test-server-execution-off",
+      "pattern-integration-test-server-execution-off",
     ]
   ) {
     const ship = stepBlock(jobBlock(contents, jobId), "📤 Ship test records");
-    assertStringIncludes(ship, "variant: server-execution");
+    assertStringIncludes(ship, "variant: server-execution-off");
   }
 });
 
-Deno.test("server-execution ON pattern failures upload the toolshed log", async () => {
+Deno.test("server-execution lane roles match the flipped default (testing.md §2)", async () => {
+  // The flip PR's lane-role swap, pinned: the DEFAULT lanes are the ON
+  // exercise (probe: serving loop PRESENT, shell define unset) and carry
+  // the ON-arm skip list; the explicit-`false` lanes are the OFF
+  // regression guard on the OFF-built binary (probe: serving loop ABSENT,
+  // define "false") and take no skip list. A partial revert that swapped
+  // one half back would otherwise leave a lane silently testing the wrong
+  // arm with every test green.
+  const contents = await workflow("deno.yml");
+
+  for (
+    const jobId of ["package-integration-test", "pattern-integration-test"]
+  ) {
+    const job = jobBlock(contents, jobId);
+    assertStringIncludes(
+      job,
+      "✅ Verify the server-execution posture (default posture — server ON, shell define unset)",
+      `${jobId}: the default lane must probe the ON posture`,
+    );
+    assertStringIncludes(
+      job,
+      ".servingLoop != null",
+      `${jobId}: the default lane's probe must require the serving loop`,
+    );
+    assertStringIncludes(
+      job,
+      "server-execution-on-skips.ts",
+      `${jobId}: the ON-arm skip list rides the default lanes since the flip`,
+    );
+  }
+
+  for (
+    const jobId of [
+      "package-integration-test-server-execution-off",
+      "pattern-integration-test-server-execution-off",
+    ]
+  ) {
+    const job = jobBlock(contents, jobId);
+    assertStringIncludes(
+      job,
+      "EXPERIMENTAL_SERVER_EXECUTION=false",
+      `${jobId}: the OFF guard must select the OFF arm explicitly`,
+    );
+    assertStringIncludes(
+      job,
+      ".servingLoop == null",
+      `${jobId}: the OFF guard's probe must require the serving loop absent`,
+    );
+    assertStringIncludes(
+      job,
+      "binary-toolshed-off",
+      `${jobId}: the OFF guard runs the OFF-built binary`,
+    );
+    assert(
+      !withoutComments(job).includes("server-execution-on-skips.ts"),
+      `${jobId}: the OFF arm takes no skip list`,
+    );
+  }
+
+  const buildOff = jobBlock(contents, "build-toolshed-off");
+  assertStringIncludes(
+    buildOff,
+    'EXPERIMENTAL_SERVER_EXECUTION: "false"',
+    "build-toolshed-off must bake the OFF define into the shell",
+  );
+
+  // The deployed-topology gates (the flip PR's own obligation — P7 review
+  // finding 8): the real bg-piece-service binary and cf-harness's fabric
+  // session, exercised at the DEFAULT (ON) resolution.
+  const gate = jobBlock(contents, "deployed-topology-gate");
+  assertStringIncludes(gate, "binary-bg-piece-service");
+  assertStringIncludes(gate, "integration/posture-gate.test.ts");
+  assertStringIncludes(gate, "integration/fabric-session-posture-gate.test.ts");
+  assertStringIncludes(gate, ".servingLoop != null");
+});
+
+Deno.test("server-execution OFF pattern failures upload the toolshed log", async () => {
   const contents = await workflow("deno.yml");
   const patternJob = jobBlock(
     contents,
-    "pattern-integration-test-server-execution-on",
+    "pattern-integration-test-server-execution-off",
   );
   const upload = stepBlock(patternJob, "📋 Upload toolshed log on failure");
 
@@ -939,9 +1021,22 @@ Deno.test("server-execution ON pattern failures upload the toolshed log", async 
   assertStringIncludes(upload, "uses: actions/upload-artifact@v7");
   assertStringIncludes(
     upload,
-    "name: toolshed-log-pattern-integration-server-execution-on-${{ matrix.shard }}",
+    "name: toolshed-log-pattern-integration-server-execution-off-${{ matrix.shard }}",
   );
   assertStringIncludes(upload, "path: ${{ runner.temp }}/toolshed.log");
   assertStringIncludes(upload, "retention-days: 14");
   assertStringIncludes(upload, "if-no-files-found: ignore");
+
+  // The default lane is the ON exercise since the flip; it carries the
+  // same triage affordance.
+  const defaultJob = jobBlock(contents, "pattern-integration-test");
+  const defaultUpload = stepBlock(
+    defaultJob,
+    "📋 Upload toolshed log on failure",
+  );
+  assertStringIncludes(defaultUpload, "if: failure()");
+  assertStringIncludes(
+    defaultUpload,
+    "name: toolshed-log-pattern-integration-${{ matrix.shard }}",
+  );
 });

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -968,18 +968,41 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
     );
   }
 
+  // Each step that SELECTS the arm carries its own assertion: the step
+  // that starts the toolshed, and the step that runs the test processes.
+  // A job-wide substring is satisfied by any single occurrence — the
+  // posture probe's `::error::` prose selects nothing and satisfies it —
+  // so the two selecting steps could disagree, and a lane that starts its
+  // server on one arm while running its tests on the other is a MIXED
+  // posture that every test still passes. The posture probe cannot stand
+  // in for this: it reads the SERVER, so the arm the test processes run
+  // under is unexamined unless asserted here. Comments are stripped on
+  // both, so a note naming an arm never counts as selecting it.
   for (
-    const jobId of [
-      "package-integration-test-server-execution-off",
-      "pattern-integration-test-server-execution-off",
+    const { jobId, runStep } of [
+      {
+        jobId: "package-integration-test-server-execution-off",
+        runStep: "🧪 Run ${{ matrix.step_name }} (flag OFF)",
+      },
+      {
+        jobId: "pattern-integration-test-server-execution-off",
+        runStep: "🧩 Run end-to-end patterns integration tests (flag OFF)",
+      },
     ]
   ) {
     const job = jobBlock(contents, jobId);
-    assertStringIncludes(
-      job,
-      "EXPERIMENTAL_SERVER_EXECUTION=false",
-      `${jobId}: the OFF guard must select the OFF arm explicitly`,
-    );
+    for (
+      const stepName of [
+        "🔌 Start Toolshed server for testing (flag OFF)",
+        runStep,
+      ]
+    ) {
+      assertStringIncludes(
+        withoutComments(stepBlock(job, stepName)),
+        "EXPERIMENTAL_SERVER_EXECUTION=false",
+        `${jobId}: "${stepName}" must select the OFF arm explicitly`,
+      );
+    }
     assertStringIncludes(
       job,
       ".servingLoop == null",

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -517,9 +517,13 @@ Deno.test("pattern shard selection fails loudly instead of running an empty shar
 
   const contents = withoutComments(await workflow("deno.yml"));
   for (
+    // Both pattern shard lanes under their post-flip names: the DEFAULT
+    // lane (the ON arm since the flip) and the explicit-`false` OFF
+    // regression guard — the pre-flip `-server-execution-on` job with its
+    // role inverted, which is where this pin's second job went.
     const jobId of [
       "pattern-integration-test",
-      "pattern-integration-test-server-execution-on",
+      "pattern-integration-test-server-execution-off",
     ]
   ) {
     const job = jobBlock(contents, jobId);
@@ -1007,6 +1011,43 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
   assertStringIncludes(gate, "integration/posture-gate.test.ts");
   assertStringIncludes(gate, "integration/fabric-session-posture-gate.test.ts");
   assertStringIncludes(gate, ".servingLoop != null");
+});
+
+Deno.test("the CLI lane refuses a mixed server-execution posture", async () => {
+  // `cf` is a deployed CLIENT: it ADOPTS the arm the server publishes on
+  // /api/meta (experimentalOptionsForDeployedClient, authority "server")
+  // unless an explicit EXPERIMENTAL_SERVER_EXECUTION overrides it. A
+  // serving loop therefore proves only the SERVER's half — the review's
+  // finding-7 mixed posture (a client on the other arm) would still read
+  // as a passing ON exercise. The probe has to compare both arms and fail
+  // on a disagreement, which is what this pins.
+  const contents = await workflow("deno.yml");
+  const job = jobBlock(contents, "cli-integration-test");
+  const probe = stepBlock(
+    job,
+    "✅ Verify the server-execution posture (default posture — server ON, cf adopts ON)",
+  );
+
+  assertStringIncludes(
+    probe,
+    ".servingLoop != null",
+    "the CLI probe must require the server's serving loop",
+  );
+  assertStringIncludes(
+    probe,
+    ".experimental.serverExecution",
+    "the CLI probe must read the posture the server PUBLISHES, which is what cf adopts",
+  );
+  assertStringIncludes(
+    probe,
+    'CLIENT_ARM="${EXPERIMENTAL_SERVER_EXECUTION:-$SERVER_ARM}"',
+    "the CLI probe must resolve the client arm the way cf does: an explicit env wins, else the published posture",
+  );
+  assertStringIncludes(
+    probe,
+    '[ "$CLIENT_ARM" != "$SERVER_ARM" ]',
+    "the CLI probe must fail on a client/server arm disagreement",
+  );
 });
 
 Deno.test("server-execution OFF pattern failures upload the toolshed log", async () => {

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -3,17 +3,18 @@
 // The EXPLICIT per-phase skip lists of the server-execution v2 ON arm
 // (docs/specs/server-side-execution/testing.md §2): in CI the integration
 // suites run twice — the DEFAULT lanes (flag unset = the first-party
-// default, which is OFF: Phase 7 landed flip-READY with the constant
-// `false` by owner ruling 2026-08-16, the flip being its own later PR) and
-// the explicit-`EXPERIMENTAL_SERVER_EXECUTION=true` ON lanes (the toolshed
-// server ON, the test processes ON, AND the binary's baked browser shell
-// ON-built — `build-toolshed-on`) — and the ON arm may skip a test only by
-// listing it here, with the plan phase whose not-yet-landed surface it
-// exercises and a reason. Never by silent filtering: the CI step prints
-// every skip from this file, and an empty list means the ON arm runs the
-// full suite. When the flip PR lands the lane roles swap (default = ON
-// with this list; explicit-`false` = the OFF regression guard on an
-// OFF-built binary) — the flip PR MUST land with this list EMPTY.
+// default, ON since the Phase 7 flip: these lanes ARE the ON arm and
+// carry this list) and the explicit-`EXPERIMENTAL_SERVER_EXECUTION=false`
+// OFF regression-guard lanes (the toolshed server OFF, the test processes
+// OFF, AND the binary's baked browser shell OFF-built —
+// `build-toolshed-off`; kept until the post-soak removal PR). The ON arm
+// may skip a test only by listing it here, with the plan phase whose
+// not-yet-landed surface it exercises and a reason. Never by silent
+// filtering: the CI step prints every skip from this file, and an empty
+// list means the ON arm runs the full suite — the OFF guard never skips.
+// The flip PR landed with this list EMPTY (its stated precondition);
+// before it the roles were inverted (default = OFF, explicit-`true` = the
+// ON arm on `build-toolshed-on`).
 //
 // An entry retires when its phase lands (docs/plans/server-execution-v2.md);
 // a file listed here that no longer exists fails the run, so the lists
@@ -350,8 +351,8 @@ export const serverExecutionOnIgnoreArg = (
  * The step-level guard a test FILE calls (see `ServerExecutionOnSkip.step`):
  * the entry for `step` in `file`, or undefined when the ON arm runs it.
  * Callers pass `ignore: serverExecutionOnStepSkip(...) !== undefined` only
- * when the process actually runs the ON posture (they read
- * EXPERIMENTAL_SERVER_EXECUTION themselves — the OFF arm never skips), and
+ * when the process actually runs the ON posture (they resolve it
+ * themselves, env-else-first-party-default — the OFF arm never skips), and
  * log the entry's reason when they skip, so the skip is never silent.
  */
 export const serverExecutionOnStepSkip = (

--- a/tasks/test-topology.test.ts
+++ b/tasks/test-topology.test.ts
@@ -35,8 +35,8 @@ describe("the test topology", () => {
   });
 
   it("lets a default suite and a variant suite hold one source file", () => {
-    const on = suites.find((suite) => suite.id === "package-integration-on")!;
-    const off = suites.find((suite) => suite.id === "package-integration")!;
+    const on = suites.find((suite) => suite.id === "package-integration")!;
+    const off = suites.find((suite) => suite.id === "package-integration-off")!;
     // Pinned to a runner-scope file rather than whichever unit sorts
     // first: a record's scope has to match the part that holds the file,
     // and taking the first shared unit would make this fail for the
@@ -58,9 +58,9 @@ describe("the test topology", () => {
       expect(
         claimsFor(suites, {
           ...record,
-          test: { ...record.test, v: "server-execution" },
+          test: { ...record.test, v: "server-execution-off" },
         }).map((claim) => claim.suite.id),
-      ).toEqual(["package-integration-on"]);
+      ).toEqual(["package-integration-off"]);
     }
   });
 

--- a/tasks/test-topology/binaries.test.ts
+++ b/tasks/test-topology/binaries.test.ts
@@ -19,19 +19,21 @@ describe("the binary build suites", () => {
     // The same build under a different compile-time define, which is
     // what a variant is. One configuration's record must never stand in
     // for the other's.
-    const on = byId("binaries-on");
-    expect(on.variant).toBe("server-execution");
-    expect(on.units).toEqual(["toolshed"]);
+    const off = byId("binaries-off");
+    expect(off.variant).toBe("server-execution-off");
+    expect(off.units).toEqual(["toolshed"]);
     expect(
-      on.locate({ test: { k: "gate", s: "repo", n: "build-binary toolshed" } }),
+      off.locate({
+        test: { k: "gate", s: "repo", n: "build-binary toolshed" },
+      }),
     ).toBeUndefined();
     expect(
-      on.locate({
+      off.locate({
         test: {
           k: "gate",
           s: "repo",
           n: "build-binary toolshed",
-          v: "server-execution",
+          v: "server-execution-off",
         },
       }),
     ).toEqual({ level: "unit", unit: "toolshed" });
@@ -62,11 +64,11 @@ describe("the binary build suites", () => {
   });
 
   it("builds the server-execution shell with the define set", () => {
-    return byId("binaries-on").command(
+    return byId("binaries-off").command(
       [{ unit: "toolshed", skip: [] }],
       { root: "/repo", outputDir: "/out" },
     ).then((made) => {
-      expect(made[0]!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("true");
+      expect(made[0]!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("false");
     });
   });
 });

--- a/tasks/test-topology/binaries.ts
+++ b/tasks/test-topology/binaries.ts
@@ -38,7 +38,7 @@ import {
   type Suite,
   type Unit,
 } from "./suite.ts";
-import { SERVER_EXECUTION_VARIANT } from "./patterns.ts";
+import { SERVER_EXECUTION_OFF_VARIANT } from "./patterns.ts";
 
 /** What a unit's record is named for. */
 const PREFIX = "build-binary";
@@ -109,9 +109,9 @@ function binarySuite(
 export function loadBinarySuites(): Suite[] {
   return [
     binarySuite("binaries", BINARY_NAMES),
-    binarySuite("binaries-on", ["toolshed"], {
-      variant: SERVER_EXECUTION_VARIANT,
-      env: { EXPERIMENTAL_SERVER_EXECUTION: "true" },
+    binarySuite("binaries-off", ["toolshed"], {
+      variant: SERVER_EXECUTION_OFF_VARIANT,
+      env: { EXPERIMENTAL_SERVER_EXECUTION: "false" },
     }),
   ];
 }

--- a/tasks/test-topology/package-integration.ts
+++ b/tasks/test-topology/package-integration.ts
@@ -1,7 +1,9 @@
 /**
  * The package integration suites: the runner, the runtime client and the
  * shell, each driving a real Toolshed server, and the same three again
- * with server execution on.
+ * with server execution explicitly off. The deployed-topology suite owns
+ * the background service and cf-harness gates that exercise the default-ON
+ * production construction paths.
  *
  * One runner does not imply one scope here. The three packages share a
  * command shape and a server, and each records under its own scope, so
@@ -19,7 +21,7 @@ import {
   type Suite,
   unavailableFrom,
 } from "./suite.ts";
-import { SERVER_EXECUTION_VARIANT } from "./patterns.ts";
+import { SERVER_EXECUTION_OFF_VARIANT } from "./patterns.ts";
 
 /** The packages the suite spans, and what each one's tests need. */
 const PACKAGES: ReadonlyArray<
@@ -53,32 +55,72 @@ async function integrationFiles(
   return found.sort();
 }
 
-/** Both suites, the default one and the server-execution arm. */
+/** The default-ON suite, its explicit-OFF arm, and the deployed-topology gate. */
 export async function loadPackageIntegrationSuites(
   root: string,
 ): Promise<Suite[]> {
   const defaults: FilePart[] = [];
-  const on: FilePart[] = [];
+  const off: FilePart[] = [];
   for (const { scope, headless } of PACKAGES) {
     const packageDir = `packages/${scope}`;
     const files = await integrationFiles(root, packageDir);
     const junit = { kind: "integration", scope, filePrefix: packageDir };
     const env: Record<string, string> = headless ? { HEADLESS: "1" } : {};
-    defaults.push({ packageDir, flags: ["-A"], env, junit, files });
-
     const { whole, unavailable } = unavailableFrom(
       SERVER_EXECUTION_ON_SKIPS[scope],
       packageDir,
     );
-    on.push({
+    defaults.push({
       packageDir,
       flags: ["-A"],
-      env: { ...env, EXPERIMENTAL_SERVER_EXECUTION: "true" },
+      env,
       junit,
       files: files.filter((file) => !whole.has(file)),
       unavailable,
     });
+    off.push({
+      packageDir,
+      flags: ["-A"],
+      env: { ...env, EXPERIMENTAL_SERVER_EXECUTION: "false" },
+      junit,
+      files,
+    });
   }
+  const backgroundPostureGate =
+    "packages/background-piece-service/integration/posture-gate.test.ts";
+  const harnessPostureGate =
+    "packages/cf-harness/integration/fabric-session-posture-gate.test.ts";
+  const deployedTopology = fileSuite({
+    id: "deployed-topology",
+    needs: ["deno", "toolshed", "bg-piece-service-binary"],
+    parts: [
+      {
+        packageDir: "packages/background-piece-service",
+        flags: ["--no-check", "--allow-env", "--allow-run", "--allow-net"],
+        junit: {
+          kind: "integration",
+          scope: "background-piece-service",
+          filePrefix: "packages/background-piece-service",
+        },
+        files: (await integrationFiles(
+          root,
+          "packages/background-piece-service",
+        )).filter((file) => file === backgroundPostureGate),
+      },
+      {
+        packageDir: "packages/cf-harness",
+        flags: ["--no-check", "-A"],
+        junit: {
+          kind: "integration",
+          scope: "cf-harness",
+          filePrefix: "packages/cf-harness",
+        },
+        files: (await integrationFiles(root, "packages/cf-harness")).filter(
+          (file) => file === harnessPostureGate,
+        ),
+      },
+    ],
+  });
   return [
     fileSuite({
       id: "package-integration",
@@ -86,10 +128,11 @@ export async function loadPackageIntegrationSuites(
       parts: defaults,
     }),
     fileSuite({
-      id: "package-integration-on",
-      variant: SERVER_EXECUTION_VARIANT,
-      needs: ["deno", "toolshed-baked-on", "browser"],
-      parts: on,
+      id: "package-integration-off",
+      variant: SERVER_EXECUTION_OFF_VARIANT,
+      needs: ["deno", "toolshed-baked-off", "browser"],
+      parts: off,
     }),
+    deployedTopology,
   ];
 }

--- a/tasks/test-topology/patterns.test.ts
+++ b/tasks/test-topology/patterns.test.ts
@@ -29,14 +29,14 @@ describe("the pattern and package suites", () => {
     expect(invocation!.junit?.[0]?.scope).toBe("patterns");
   });
 
-  it("runs the server-execution arm with the define set", async () => {
-    const suite = byId("pattern-integration-on");
+  it("runs the server-execution OFF arm with the define set", async () => {
+    const suite = byId("pattern-integration-off");
     const [invocation] = await suite.command(
       [{ unit: suite.units[0]!, skip: [] }],
       { root, outputDir: await outputDir() },
     );
-    expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("true");
-    expect(suite.variant).toBe("server-execution");
+    expect(invocation!.env?.EXPERIMENTAL_SERVER_EXECUTION).toBe("false");
+    expect(suite.variant).toBe("server-execution-off");
   });
 
   it("names a skip list only where a leaf inside a unit is skipped", async () => {
@@ -84,6 +84,24 @@ describe("the pattern and package suites", () => {
     expect(made.length).toBe(2);
     expect(made.map((i) => i.junit?.[0]?.scope).toSorted())
       .toEqual(["runner", "shell"]);
+  });
+
+  it("owns both deployed-topology posture gates", async () => {
+    const suite = byId("deployed-topology");
+    expect(suite.units).toEqual([
+      "packages/background-piece-service/integration/posture-gate.test.ts",
+      "packages/cf-harness/integration/fabric-session-posture-gate.test.ts",
+    ]);
+    expect(suite.needs).toContain("bg-piece-service-binary");
+    expect(suite.needs).toContain("toolshed");
+    const made = await suite.command(
+      suite.units.map((unit) => ({ unit, skip: [] })),
+      { root, outputDir: await outputDir() },
+    );
+    expect(made.map((invocation) => invocation.junit?.[0]?.scope)).toEqual([
+      "background-piece-service",
+      "cf-harness",
+    ]);
   });
 
   it("gives the reload suite its own unit and its own task", async () => {

--- a/tasks/test-topology/patterns.ts
+++ b/tasks/test-topology/patterns.ts
@@ -21,8 +21,8 @@ import {
   unavailableFrom,
 } from "./suite.ts";
 
-/** The variant the server-execution ON arms mark their records with. */
-export const SERVER_EXECUTION_VARIANT = "server-execution";
+/** The variant the explicit server-execution OFF arms mark their records with. */
+export const SERVER_EXECUTION_OFF_VARIANT = "server-execution-off";
 
 /** Test files directly inside a directory, repository-relative and sorted. */
 async function filesIn(
@@ -96,20 +96,20 @@ async function patternIntegrationSuites(root: string): Promise<Suite[]> {
         flags,
         env: { HEADLESS: "1" },
         junit,
-        files,
+        files: files.filter((file) => !on.whole.has(file)),
+        unavailable: on.unavailable,
       }],
     }),
     fileSuite({
-      id: "pattern-integration-on",
-      variant: SERVER_EXECUTION_VARIANT,
-      needs: ["deno", "toolshed-baked-on", "browser", "compile-cache"],
+      id: "pattern-integration-off",
+      variant: SERVER_EXECUTION_OFF_VARIANT,
+      needs: ["deno", "toolshed-baked-off", "browser", "compile-cache"],
       parts: [{
         packageDir,
         flags,
-        env: { HEADLESS: "1", EXPERIMENTAL_SERVER_EXECUTION: "true" },
+        env: { HEADLESS: "1", EXPERIMENTAL_SERVER_EXECUTION: "false" },
         junit,
-        files: files.filter((file) => !on.whole.has(file)),
-        unavailable: on.unavailable,
+        files,
       }],
     }),
   ];


### PR DESCRIPTION
## Why

Server-execution v2 has been building toward one line since Phase 1 landed dark in early August: servers do all the compute that is stored; clients commit nothing but intent. Every stage of that arc — the serving loop, per-instance re-keying (OW17/OW29 via fan-out A/B), events-down, the effect channel, the design-pass demand model (d′), the W4 acceptance benchmark, the first-ON-CI gate's seven write-path defects (OW45–OW53), the ruled write/read-authority posture (OW31), and the skip-lift campaigns that emptied the ON-skip registry three times — existed to make this PR safe and boring: `SERVER_EXECUTION_DEFAULT_ENABLED` flips `false` → `true`.

Every ordered gate of the plan's Phase 7 task 1 is met **on main at this PR's base (e16780fca — rebased onto it from the original base 4e02f75c4; gate claims re-verified at the new base)**:

| gate | evidence |
| --- | --- |
| ON-skip registry EMPTY, all four suites | #6528 (the owner-ruled 3b close; third lift under the ruled local-plus-CI-probe bar, PROBE 6 green at the surface) — after #6484/#6502 closed the lunch supplier geometries 1–3 red-first |
| OW31's ruled posture BUILT | register OW31: the serving identity never writes users' home spaces; delegating principal, ACL-only service reads, `actingAs` binding — built 2026-08-21, pinned |
| OW45–OW53 CLOSED | the register's first-ON-CI-gate rows, each with red-first pins and lift evidence |
| the performance bar (OW38 ii) | RULED met by the owner 2026-08-24 — "topics numbers are fine" — on the topics measurement campaign (settle-to-coverage p50 22 ms, cross-surface arrival 1.51× OFF, board bench 1.4–1.5×) |
| deployed-topology binaries exercised ON | **discharged in this PR** (review finding 8; table below) |

The flip is deliberately its own PR (repo convention: a flip is reverted by reverting the PR that only flips). The OFF path is **not** removed — explicit `EXPERIMENTAL_SERVER_EXECUTION=false` is the rollback lever through the soak, and this PR introduces the CI lanes that keep it honest. The post-soak removal PR deletes the flag, the OFF path, the OFF guard lanes, and `build-toolshed-off`.

## What changed

1. **The one-liner**: `packages/memory/v2/server-execution-default.ts` — `SERVER_EXECUTION_DEFAULT_ENABLED = true` (header re-tensed). The absolute pin (`packages/toolshed/lib/server-execution-flag.test.ts`) was **watched RED** at the flipped constant, then re-tensed to state the default IS ON.
2. **The lane-role swap** (testing.md §2 executed and re-tensed):

| pre-flip | post-flip |
| --- | --- |
| `build-toolshed-on` (bakes `true`) | `build-toolshed-off` (bakes `"false"`) |
| default package/pattern lanes = OFF guard (probe: no serving loop, define unset) | default lanes = **the ON arm** (probe: serving loop present, define unset — the default build resolves the constant); they now carry the ON-arm skip list (EMPTY) |
| `…-server-execution-on` lanes = explicit-`true` ON arm, variant `server-execution` | `…-server-execution-off` lanes = explicit-`false` OFF regression guard on the OFF-built binary, variant `server-execution-off`; no skip list (the OFF arm never skips) |
| CLI lanes: no posture probe | CLI lanes probe the server half (they are `cf`'s deployed-topology gate) |
| — | new `deployed-topology-gate` job (below) |

   Test-record identity follows testing.md's contract: the default arm continues the unmarked history; `server-execution-off` marks the OFF guard; the old `server-execution` marker retires with its arm. The old ci-workflow lane pins were **watched RED** on the swapped workflow, then reconciled — plus a new lane-roles pin test so a partial revert of one half reds.
3. **The four-topology obligation** (the plan's Phase-7 table row, review finding 8 — "NO gate exercises them ON"):

| topology | disposition | gate / lane |
| --- | --- | --- |
| `background-piece-service` | (iii) had NO exercising lane → new minimal gate | `deployed-topology-gate`: the REAL binary starts against the default (ON, probed) toolshed, initializes (session-open + BG-pieces read), asserts its new startup posture log line (`src/main.ts`; the binary has no HTTP surface), exits 0 on SIGTERM. **Red-first**: forced-OFF service env → posture line "OFF" vs expected "ON" |
| cf-harness | (iii) no toolshed-backed lane (its integration suite is env+docker gated) → new minimal gate | same job: `createHarnessFabricSessionFactory` (PKCS#8 from disk → `PiecesController.initialize` → deployed-client adoption) resolves ON with nothing declared and serves one genuine flow (compile + create a piece, read the result back). **Red-first**: forced-OFF server → probe/posture asserts fail |
| CLI (`cf`) | (i) covered post-flip by existing default-posture lanes, made posture-verified | `cli-integration-test` ×3: the default toolshed resolves ON and `cf` ADOPTS the published posture (`experimentalOptionsForDeployedClient`, authority "server"); the new probe pins the server half. (`cf test`/`cf dev` stay deliberately ambient-OFF — patternTest/localDev presets) |
| `PiecesController` hosts | (i) covered post-flip by existing default lanes | default pattern lanes (sx2-scale's N controllers, the pieces-controller helper, every controller-initializing integration file) + the runner package lane, against the probed-ON toolshed. The agents host shares the same adoption seam (no dedicated lane — recorded in the register block) |

4. **Uniform posture for the default lanes' Deno-side clients**: `withServerExecutionDefault` is exported, and the 4 bare-Runtime runner integration files plus the runtime-client integration host (worker declaration + `onArmStepSkip` guard) resolve env-else-default — under default-ON a raw env read would resurrect the P7 review's finding-7 MIXED posture.
5. **The topics multi-user lane-posture item** (the topics measurement report §5.1/§6 recorded it as a question "the flip decision has to address either way"): discharged as recorded — the no-server pattern-tests lane (`PACKAGES_WITHOUT_SERVER`) runs through the `patternTest` preset, which deliberately does NOT read the constant, so the lane resolves the ambient baseline (OFF) by construction; the "lane pins OFF" arm realized structurally, pinned by the preset conformance goldens. **Verified live at this head**: `deno task cf test packages/patterns/topics/multi-user.test.tsx` with the env unset = 7/7 green (the campaign's 5/7 red was explicit-env-ON only). The "grow the in-process serving role" alternative is not taken.
6. **Docs**: the plan's coordination-state delta + Phase-7 flip step IN PROGRESS + topology row discharged; the register's FLIP PR block (the swap table, the dispositions, the topics item); testing.md §2 re-tensed; `EXPERIMENTAL_OPTIONS.md` — default now ON, OFF = rollback lever, removal owed post-soak; both test-records docs' variant vocabulary.

## Test plan

- Red-first, all watched and archived: the absolute pin at the flipped constant; the old ci-workflow lane pins on the swapped workflow; the bg gate under a forced-OFF service (posture "OFF" vs ["ON"]); the cf-harness gate against a forced-OFF server.
- Local: server-execution-flag (3), runtime-options (3), runtime-presets conformance (43 steps — the goldens adapt relatively; patternTest structurally unmoved), shell env (4), on-skips (17), bg-piece-service unit (55 steps — the new log line is fake-safe), ci-workflow (19; the one failure, "CI browser tests use the runner's installed Chrome", reproduces on pristine main locally — environmental), memory-adjacent toolshed suites under the flipped in-process default (24), full runner suite (below), `check-test-aliases`, `check-package-cycles`, fmt/lint/`deno check` on every touched file. A source toolshed with the env unset publishes `serverExecution: true`, define null, serving loop present; both new gates green against it (cf-harness gate: pattern compiled, created, and read back through the serving topology in 2 s).
- **The board at this head is the B4 evidence** — every lane read, lane by lane, with the ON exercise stated explicitly (the register's FLIP block). Lanes that become a genuinely new ON exercise and deserve the closest read: `cli-integration-test` (first-ever `cf` ON), `pattern-reload-integration-test` (its self-booted source toolshed now resolves ON), the default package/pattern lanes (the roles just swapped), and `deployed-topology-gate` (new).

## Not in this PR

The OFF path's removal, the OFF guard lanes' removal, and the plan's archival — all post-soak (the plan's split-out task 2). No new skip entries were added anywhere (the registry stays EMPTY).

Related: #6528 (B1 — the registry emptied), #6502 and #6484 (the lunch supplier-geometry closes that made the third lift stick), #6201 (the flip-readiness dossier + OW38(ii) benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## First board (run 33232274193): 7 reds, all classified from their assertions; one owner-court STOP

| red | class | disposition (this PR's second commit set) |
| --- | --- | --- |
| Test (2/8) — `startServerExecutionHost OFF witness` (unset=OFF-keyed unit pins) | (a) swap-plumbing miss | re-keyed: unset = the first-party default (gate-opens witnessed by the untouchable's throw); OFF witness = explicit-false. 12 steps green |
| Pattern default (10/10) — `sx2-speculation` `SpeculativeBasisError`, deterministic | (c) ON×coverage: instrumented client variant vs uninstrumented served variant → divergent content-addressed `computed:` ids → speculative basis can never retire → authored write refused (speculation.md §6). Red w/ coverage, green w/o, same ON toolshed | authored-pattern coverage moved to the OFF guard pattern lane (single-compiler world — sound; the pre-flip default's own posture); default lane keeps V8 coverage; coverage-check waits on the OFF lane's artifacts. **Register OWED row: serving-side instrumented-variant parity before the OFF lanes retire (pattern-reload named as same-mechanism residual)** |
| CLI core-piece-values — "cannot project in a fresh session" expected exit 1, got 0 | (c) the refusal dissolves under ON by design (served materialization) | arm-aware step: ON asserts the SERVED value (`session-ready`) — stronger than the old exit-code pin; OFF keeps the refusal. 7 steps green vs an ON toolshed |
| CLI core-piece-call — retry lacked `deduplicated: true` | (c) dedup WORKS (repro: exactly one message — the dedupe-horizon skip); the receipt-collision witness structurally can't fire under ON (receipts unwritten) | script's ON arm asserts the behavioral witness (same id + exit 0 + exactly-one-message; a `deduplicated` claim under ON now errors as impossible); OFF arm unchanged |
| **CLI core-piece-call — "The umbrella create's Invocation JSON should carry its declared result" (integration.sh:908; surfaced by the local fix-round run past the dedup step)** | **(c) RULED 2026-08-29 AND FIXED — owner: "yes, Serving-side receipt/result write, as that is indeed what i said before"** | **The verb DECLARED-RESULT surface is back under ON: the SERVING side now writes the handling's receipt/result in the served handler's own wave (mark/effects atomic; same cause-derived address as the client-era write, so the unchanged CLI readback works), write-once by CAS (lost CAS = loud no-op — counter + warn; never a second write, never a wave failure), `{}` witness for undefined returns; the flag-ON client's echo publishes the address and the durable-ack coupling orders the readback after the consequence. Witness red→green locally on BOTH arms at the pre-fix/post-fix heads; three red-first pins in `executor-events-down.test.ts`, each mutation-killed independently (drop-the-write, skip-undefined, drop-the-CAS-check, CAS-loss-fails-the-wave). Spec: events.md §4 "Result carriage" + runtime-mapping.md N26(b) RULED; register FLIP row converted. Newly-reached ON-arm steps behind the witness (verbs walkthrough, verb-session gaps, three-topic dedup keys) went arm-aware per this PR's established pattern — including one recorded OFF→ON contract delta: a THROWN handling durably consumes its invocation id under ON (events.md §5 error-is-the-consequence), so a same-id retry never re-executes; the caller's move is a fresh id** |
| Pattern default (7/10) — topic-board crossrefs 4≠3 | (c) intermittent ON convergence transient (2/22 local under load only; 14 straight greens; single CI observation) | NOT patched — the test's own comment rules out wait-shapes (settle-away trap); recorded as a WATCHED intermittent in the register (flag-don't-fill) |
| Pattern default (1/10) + OFF (1/10) — firebreak `Disabled control: #advance`, both arms | (d) inherited | the file (#6526) landed on main AFTER this base and reaches the board via the merge ref only (not in this tree); main's own board at d1eca661f failed its explicit-ON lane on it. The file owner's |

NO new skip entries anywhere. The declared-result STOP is RULED (2026-08-29) and fixed — the piece-call lane's witness is green locally on both arms. The board at the current head (rebased onto main e16780fca) is expected green except possibly the two known intermittents (topic-board 4≠3 settle transient; the #6526 multiplayer-iframe firebreak test, owned by another agent per owner directive).

## Coverage ratchet

The +5 at head 901a3f819 is `packages/memory/v2/client.ts:1073-1075` and `packages/memory/v2/standalone.ts:83-84` — files this PR does not touch, flagged by the coverage tool itself as "not attributable to this PR's added lines … inconsistently covered on `main`" (the head commit is docs/comments-only). Same flaky-baseline class as #6502's accepted +1. Accepting only those:

ACCEPT_COVERAGE_DEBT: packages/memory +5 lines
