### PR TITLE
docs(patterns): say how the write-trace stack filters go quiet

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1470,9 +1470,11 @@ async function collectWriteTraceOrderSummary(page: Page): Promise<unknown> {
     //
     // A member converted to a `#` private name changes its own frame text.
     // Chrome writes `at #member`, Deno writes `at Class.#member`, and a
-    // public member keeps its class in both. Neither form is promised, and
-    // two engines agreeing says nothing about a third. Match the bare
-    // `#member`, a substring of both, rather than either whole form.
+    // public member keeps its class in both. The split does not follow the V8
+    // version -- for one example, the two were a single V8 minor apart on the
+    // machine this was tested on, as of this writing -- so it says nothing
+    // about a third engine, or a later Chrome. Match the bare `#member`, a
+    // substring of both, rather than either whole form.
     function classifyStack(stack?: string): string {
       if (!stack) return "unknown";
       if (

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1468,12 +1468,12 @@ async function collectWriteTraceOrderSummary(page: Page): Promise<unknown> {
     // The `_CellImpl` names are the bundler's, not the source's. Renaming
     // `CellImpl` or changing how the shell is bundled breaks every one of them.
     //
-    // A member converted to a `#` private name changes its own frame text, and
-    // the two V8 builds this repo runs disagree on the new form: Chromium 125
-    // writes `at #member`, Deno 2.9.4 writes `at Class.#member`, and a public
-    // member keeps its class in both. Both are V8, so the difference is an
-    // engine-build detail and not a browser-versus-Deno one. Match the bare
-    // `#member`, which is a substring of either form.
+    // A member converted to a `#` private name changes its own frame text.
+    // Chrome writes `at #member`, Deno writes `at Class.#member`, and a
+    // public member keeps its class in both. That split does not track the V8
+    // version -- these two are one minor apart -- so it says nothing about
+    // what a third engine, or a later Chrome, will write. Match the bare
+    // `#member`, which is a substring of both forms.
     function classifyStack(stack?: string): string {
       if (!stack) return "unknown";
       if (

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1470,10 +1470,9 @@ async function collectWriteTraceOrderSummary(page: Page): Promise<unknown> {
     //
     // A member converted to a `#` private name changes its own frame text.
     // Chrome writes `at #member`, Deno writes `at Class.#member`, and a
-    // public member keeps its class in both. That split does not track the V8
-    // version -- these two are one minor apart -- so it says nothing about
-    // what a third engine, or a later Chrome, will write. Match the bare
-    // `#member`, which is a substring of both forms.
+    // public member keeps its class in both. Neither form is promised, and
+    // two engines agreeing says nothing about a third. Match the bare
+    // `#member`, a substring of both, rather than either whole form.
     function classifyStack(stack?: string): string {
       if (!stack) return "unknown";
       if (

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1460,6 +1460,20 @@ async function collectWriteTraceOrderSummary(page: Page): Promise<unknown> {
       .filter((entry) => entry.path.length === 0)
       .sort((a, b) => a.recordedAt - b.recordedAt);
 
+    // The `stack.includes(...)` tests in `classifyStack` and
+    // `interestingCallPath` match frame text, which no engine promises to keep
+    // stable, and a filter that matches nothing looks exactly like a run with
+    // nothing to report. Two ways they go quiet:
+    //
+    // The `_CellImpl` names are the bundler's, not the source's. Renaming
+    // `CellImpl` or changing how the shell is bundled breaks every one of them.
+    //
+    // A member converted to a `#` private name changes its own frame text, and
+    // the two V8 builds this repo runs disagree on the new form: Chromium 125
+    // writes `at #member`, Deno 2.9.4 writes `at Class.#member`, and a public
+    // member keeps its class in both. Both are V8, so the difference is an
+    // engine-build detail and not a browser-versus-Deno one. Match the bare
+    // `#member`, which is a substring of either form.
     function classifyStack(stack?: string): string {
       if (!stack) return "unknown";
       if (


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`collectWriteTraceOrderSummary` in the default-app integration test
classifies and filters write-trace entries by matching substrings of stack
frame text. Nothing about that text is a contract, and the failure is
silent in the worst way: a filter that matches nothing produces the same
output as a run that had nothing to report.

This adds a comment at the site naming the two ways the filters stop
matching.

The `_CellImpl` names are the bundler's, not the source's, so renaming
`CellImpl` or changing how the shell is bundled breaks all of them at once.

A member converted to a `#` private name changes its own frame text, and
Chrome and Deno render the result differently. Measured on a class carrying
a sync private method, a private arrow-function field, an async private
method, and a public method:

| runtime | V8 | private method | private field | async private | public method |
| --- | --- | --- | --- | --- | --- |
| Chrome 151.0.7922.174 | 15.1.206.23 | `at #sync` | `at #asField` | `at #asyncOne` | `at Runner.publicOne` |
| Chromium 125.0.6400.0 | 12.5 | `at #sync` | `at #asField` | -- | `at Runner.publicOne` |
| Deno 2.9.4 | 15.0.245.2-rusty | `at Runner.#sync` | `at Runner.#asField` | `at Runner.#asyncOne` | `at Runner.publicOne` |

Chrome 151 and Deno 2.9.4 are one V8 minor apart and disagree, while
Chromium 125 is three years older than either and agrees with Chrome 151.
So the split does not follow from the V8 version, and it equally does not
license a guess about Firefox, Safari, or a later Chrome. Two controls rule
out the obvious confound: in Deno a class defined inside `eval()` still
renders `at Runner.#sync`, and in Chrome a real `<script type="module">`
rather than a CDP evaluation still renders `at #sync`.

The bare `#member` is a substring of both measured forms, which is what the
comment tells a future editor to match. The comment states the two runtimes
by name and claims nothing beyond them; the version numbers stay here,
where they can be dated, rather than in the source.

Which browser matters, because it is easy to measure the wrong one:
`astralBinaryPath()` in `packages/integration/astral-adapter.ts` prefers an
installed Chrome or Chromium over astral's own download, and
`.github/workflows/deno.yml` sets `ASTRAL_BIN_PATH: /usr/bin/google-chrome`
for CI. The Chrome 151 row is the one that reflects what runs here; the
Chromium 125 row is astral's fallback, included because it is what a probe
gets by default and because it is the older bound on the Chrome side.

Comment only: 14 added lines, all `//`, nothing removed, and no change to
any matched string. `packages/patterns/integration/` is excluded from
pattern source by `NON_PATTERN_PREFIXES` in `tasks/pattern-files.ts`, and
`.test.ts` is excluded ahead of that, so no pattern contract is in reach.

`deno fmt --check`, `deno lint`, and `deno task check` are green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

