### PR TITLE
docs(plans): shuttle — place-aware fabric shell design

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -148,6 +148,12 @@ a record: archive it to `docs/history/plans/` following the procedure in
   do one job under two names. Separate from the read-layer plan because it
   renames rather than adds, so its risk is what breaks for a caller who already
   learned the current spelling.
+- [Shuttle — a place-aware fabric shell](shuttle.md) is the working design
+  state for an interactive terminal tool: a REPL whose prompt carries a
+  mutable current place — the context that fills in the omitted levels of the
+  fabric's right-anchored references — plus full-screen live views, for
+  inspecting and editing space and piece state. Decisions so far and open
+  questions; nothing is built yet.
 - [Shell completion coverage](cli-completion-coverage.md) sequences the work
   that makes `cf completion` answer correctly across the surface it claims and
   reach the verb surface it does not: the slots that offer a wrong candidate,

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -148,7 +148,7 @@ a record: archive it to `docs/history/plans/` following the procedure in
   do one job under two names. Separate from the read-layer plan because it
   renames rather than adds, so its risk is what breaks for a caller who already
   learned the current spelling.
-- [Shuttle — a place-aware fabric shell](shuttle.md) is the working design
+- [Shuttle — a place-aware fabric shell](shuttle/README.md) is the working design
   state for an interactive terminal tool: a REPL whose prompt carries a
   mutable current place — the context that fills in the omitted levels of the
   fabric's right-anchored references — plus full-screen live views, for

--- a/docs/plans/shuttle.md
+++ b/docs/plans/shuttle.md
@@ -142,11 +142,14 @@ The live-view half exists to make reactivity visible.
     the pair (position, scope): both stick across navigation, both render
     in the prompt, and `pwd` prints both. `cd` is the door to both —
     `cd board@session` moves both, `cd @session` scope alone, `cd @space`
-    back to the base (all verified in the canonical grammar) — there is no
-    separate scope verb, and an explicit suffix on an operand overrides
-    the ambient scope for that operand. A suffix names only the reading
-    identity's own overlays; standing in another identity's overlay is a
-    canonical-grammar extension, out of v1.
+    back to the base — there is no separate scope verb, and an explicit
+    suffix on an operand overrides the ambient scope for that operand. All
+    three scope words are canonical, and a suffix on a reference is
+    verified against the canonical parser; a scope-only `@scope` is
+    shuttle navigation syntax that only `cd` and `where` accept, alongside
+    `..` and `-`. A suffix names the base scope or the reading identity's own
+    overlays, never another identity's; standing in another identity's
+    overlay is a canonical-grammar extension, out of v1.
 21. **The native tool set v0** is `jq`, `grep`, `wc`, `head`, `tail`,
     `sort`, `uniq`, `cut` — grown by ruling. `cat` is deliberately absent:
     `get` prints, `< file:…` feeds, and concatenation waits for a demand.
@@ -220,7 +223,7 @@ several) stay reachable later.
 | Canonical + alias reference grammar | `packages/cli/lib/llm-friendly-ref.ts` (doc comment), runner's `parseLLMFriendlyLink` | The address syntax; shuttle consumes it and must not fork it |
 | Target option surface | `targetOptions` in `packages/cli/commands/piece.ts` | The enumeration of exactly what a place must supply |
 | Live-state completion | `packages/cli/lib/completion/providers.ts` (`cellPathCandidates`, `childKeys`, verb candidates with doc comments) | The `ls` primitive and tab completion, already written against live state |
-| Pager/TUI substrate | `packages/cli/lib/view/` — `pager.ts` is the only module touching the TTY; `keys.ts`, `ansi.ts`, `render.ts`; `session.ts` holds state as pure logic | The full-screen half: raw mode, frames, key decoding, testable without a terminal; already follows references and edits buffers |
+| Pager/TUI substrate | `packages/cli/lib/view/` — `pager.ts` is the only module doing raw-mode full-screen TTY handling; `mod.ts` and `loadinput.ts` touch stdio for the one-shot path (capability probes, plain-output writes, piped input); `keys.ts`, `ansi.ts`, `render.ts`, `session.ts` hold state and decoding as pure logic | The full-screen half: raw mode, frames, key decoding, testable without a terminal; already follows references and edits buffers |
 | FUSE mount | `packages/fuse` | The same addressing as a POSIX filesystem; prior art for layout (arrays as numeric directories, handlers as executables, links as symlinks). Shuttle is its interactive, live sibling, not a replacement |
 | Offline inspector | `packages/state-inspector`, `cf inspect` | The forensic counterpart (snapshots, scopes, history); its HTML explorer is prior art for tree-plus-detail browsing |
 | Entry-point resolution | `cf wish` | Headless resolution of `#favorites`-style targets — the mounts of decision 5 |

--- a/docs/plans/shuttle.md
+++ b/docs/plans/shuttle.md
@@ -12,44 +12,57 @@ The codename is the loom's shuttle — the part that travels back and forth
 through the warp carrying the weft — beside the user-facing shell's "weaver".
 
 ```text
-shuttle estuary/board> ls
-  topics/ (16)   members/ (11)   settings
 shuttle estuary/board> watch topics/3
 ┌ topics/3 ──────────────────── ● live ┐
 │ title    "verb contracts"            │
-│ replies  14 → 15                     │
-│ updated  just now                    │
-└── q: back to prompt ─────────────────┘
+│ replies  14                          │
+└── q: back (watch stays armed) ───────┘
 shuttle estuary/board> call topics/3/add-reply --body "hi"
+watch topics/3: replies 14 → 15
+shuttle estuary/board>
 ```
 
 ## Why
 
-Every `cf` invocation names the whole world. The target surface — api-url,
-identity, space, piece — has a single definition (`targetOptions` in
-`packages/cli/commands/piece.ts`) and recurs across nearly every command;
-`CF_API_URL` and `CF_IDENTITY` absorb two of its members and the rest are
-retyped per command. Composition between commands is copying an address one
-command printed into the next (the composition axis of
+Weaver is where a person stands inside the woven fabric: rendered pieces,
+live interfaces, the product. Shuttle is the same sense of presence one
+layer down — standing in the substrate itself, where cells, links, scopes,
+and reactions are visible as themselves. When the rendered surface
+misbehaves, this is the layer a person needs to see: what a cell actually
+holds, when it settled, which overlay a read went through, what a verb call
+wrote.
+
+The substrate is reactive, and no tool shows it moving at this layer. `cf`
+prints snapshots; the FUSE mount is bounded by cache staleness; `cf
+inspect` is offline forensics; weaver shows the rendered product, not the
+mechanism. Shuttle's watches and live views make the mechanism observable:
+arm a watch, issue the cause, see the reaction arrive — cause and effect
+interleaved in one transcript that doubles as a record.
+
+The moving half of context has no home. `CF_API_URL`, `CF_IDENTITY`, and
+`CF_SPACE` absorb the constant half, and
+[`cli-surface-shape.md`](cli-surface-shape.md) step 8's rationale — "a
+parameter that is required everywhere and identical across a working
+session is one a caller should state once" — caps out exactly there,
+because piece, path, and scope are not identical across a session: they
+change with every step, because they are the work. The fabric's reference
+grammar is right-anchored —
+`/[@did:key:…/]of:fid1:<id>[@scope][/path…][#argument]`, documented at the
+top of `packages/cli/lib/llm-friendly-ref.ts` — with omitted levels
+supplied by context, and shuttle makes that context a position you
+navigate: **a place is the context that fills in the omitted levels of a
+reference**, moved by `cd`, relative references, and handles instead of by
+copying printed addresses between commands (the composition axis of
 [`../common/verbs/session-walkthrough.md`](../common/verbs/session-walkthrough.md)).
 
-The fabric's canonical reference grammar already treats context as
-first-class. A reference is right-anchored —
-`/[@did:key:…/]of:fid1:<id>[@scope][/path…][#argument]`, documented at the
-top of `packages/cli/lib/llm-friendly-ref.ts` — and omitted levels are
-supplied by context. Today that context is flags and two environment
-variables. Shuttle makes it a mutable, navigable value: **a place is the
-context that fills in the omitted levels of a reference.**
-
-[`cli-surface-shape.md`](cli-surface-shape.md) step 8 records the same
-observation for the space alone: "a parameter that is required everywhere and
-identical across a working session is one a caller should state once."
-Shuttle generalizes that from the space to the whole prefix, inside one
-interactive process.
-
-Reading state today is one-shot prints, the FUSE mount, or the offline
-inspector. The substrate is reactive; none of those show a value changing.
-The live-view half exists to make reactivity visible.
+Underneath both, a persistent runtime session is a capability one-shot
+commands cannot have at any flag cost: warm pieces serving live computed
+values without a per-command `--step`, subscriptions feeding watches and
+views, pagination cursors, the handle table, invocation-session
+continuity. And where an environment variable makes context ambient and
+invisible, the prompt renders the whole ambient record — place, scope,
+warm or cold — so what every command is about to touch is visible before
+it runs.
 
 ## Settled decisions
 
@@ -188,6 +201,13 @@ The live-view half exists to make reactivity visible.
     form: calling what a listing showed must not need a reference split by
     hand. No new reference syntax — the path is already canonical; the
     sugar is in the verb.
+28. **Watches are session objects.** `watch` arms a subscription that
+    outlives its view: leaving the view keeps it armed, each settled
+    change appends one event line at the prompt, and a pinned strip above
+    the prompt renders armed watches' values live while scrollback flows
+    past. `watches` lists what is armed, `unwatch` disarms, and scrollback
+    stays append-only — liveness lives in the strip and the event lines,
+    never in mutated history.
 
 The line grammar itself — resolution rules, facets, listings, run-state and
 write surfaces, and the redirection/pipe proposals — is drafted in
@@ -234,8 +254,10 @@ several) stay reachable later.
 Shuttle rides the addressing decisions of
 [`cli-surface-shape.md`](cli-surface-shape.md) rather than making its own:
 
-- Step 8 (`CF_SPACE` ambient) is the one-shot cousin of decision 6; the
-  serializable place is the shared seam.
+- Step 8's `CF_SPACE` is on main: the constant half of the context is
+  ambient for one-shot `cf` too, which is what isolates the moving half —
+  piece, path, scope — as shuttle's ground. The serializable ambient
+  record stays the shared seam for any further convergence.
 - Step 9 (space by name, piece by slug, positionally) is what `cd` and the
   prompt want — names, not hashes. Shuttle should consume that work, not
   duplicate it.

--- a/docs/plans/shuttle.md
+++ b/docs/plans/shuttle.md
@@ -20,7 +20,7 @@ shuttle estuary/board> watch topics/3
 │ replies  14 → 15                     │
 │ updated  just now                    │
 └── q: back to prompt ─────────────────┘
-shuttle estuary/board> call topics/3 add-reply --body "hi"
+shuttle estuary/board> call topics/3/add-reply --body "hi"
 ```
 
 ## Why
@@ -176,6 +176,15 @@ The live-view half exists to make reactivity visible.
 26. **The piece overview ships structured, not live.** One frame —
     arguments, result summary, callables, pattern identity — rendered as a
     refreshable snapshot in B3; the live piece watch is deferred.
+27. **A callable is invocable by its path.** `call` keeps `cf`'s
+    address-plus-name form, and adds the one-reference form —
+    `call topics/3/add-reply`, `call %4` — that invokes the callable cell
+    the path names; arity disambiguates. A callable is a cell like
+    everything else (FUSE already invokes one as an executable file), and
+    inline callables in listings plus numbered handles require the path
+    form: calling what a listing showed must not need a reference split by
+    hand. No new reference syntax — the path is already canonical; the
+    sugar is in the verb.
 
 The line grammar itself — resolution rules, facets, listings, run-state and
 write surfaces, and the redirection/pipe proposals — is drafted in

--- a/docs/plans/shuttle.md
+++ b/docs/plans/shuttle.md
@@ -214,7 +214,10 @@ write surfaces, and the redirection/pipe proposals — is drafted in
 [`shuttle/grammar.md`](shuttle/grammar.md). The full-screen views are
 designed in [`shuttle/views.md`](shuttle/views.md). The order of
 construction — the `cli` seam PRs and the shuttle milestones they gate — is
-[`shuttle/build-sequence.md`](shuttle/build-sequence.md).
+[`shuttle/build-sequence.md`](shuttle/build-sequence.md). The trajectory
+past v1 — configuration in the fabric, the session scope as the variable
+store, the scripting layers, and the ranked candidates behind them — is
+[`shuttle/futures.md`](shuttle/futures.md).
 
 ## The ambient model
 

--- a/docs/plans/shuttle.md
+++ b/docs/plans/shuttle.md
@@ -1,0 +1,258 @@
+# Shuttle — a place-aware fabric shell
+
+Status: v1 design settled — the decisions below are ruled, and nothing
+blocks construction. Nothing here is built yet; the order of construction is
+[`shuttle/build-sequence.md`](shuttle/build-sequence.md). This document
+stays the working design state: new decisions land here as they are made.
+
+Shuttle is an interactive terminal tool for exploring and editing fabric
+state: a line-oriented REPL whose prompt carries a mutable **current place**,
+plus full-screen live views that open on demand and drop back to the prompt.
+The codename is the loom's shuttle — the part that travels back and forth
+through the warp carrying the weft — beside the user-facing shell's "weaver".
+
+```text
+shuttle estuary/board> ls
+  topics/ (16)   members/ (11)   settings
+shuttle estuary/board> watch topics/3
+┌ topics/3 ──────────────────── ● live ┐
+│ title    "verb contracts"            │
+│ replies  14 → 15                     │
+│ updated  just now                    │
+└── q: back to prompt ─────────────────┘
+shuttle estuary/board> call topics/3 add-reply --body "hi"
+```
+
+## Why
+
+Every `cf` invocation names the whole world. The target surface — api-url,
+identity, space, piece — has a single definition (`targetOptions` in
+`packages/cli/commands/piece.ts`) and recurs across nearly every command;
+`CF_API_URL` and `CF_IDENTITY` absorb two of its members and the rest are
+retyped per command. Composition between commands is copying an address one
+command printed into the next (the composition axis of
+[`../common/verbs/session-walkthrough.md`](../common/verbs/session-walkthrough.md)).
+
+The fabric's canonical reference grammar already treats context as
+first-class. A reference is right-anchored —
+`/[@did:key:…/]of:fid1:<id>[@scope][/path…][#argument]`, documented at the
+top of `packages/cli/lib/llm-friendly-ref.ts` — and omitted levels are
+supplied by context. Today that context is flags and two environment
+variables. Shuttle makes it a mutable, navigable value: **a place is the
+context that fills in the omitted levels of a reference.**
+
+[`cli-surface-shape.md`](cli-surface-shape.md) step 8 records the same
+observation for the space alone: "a parameter that is required everywhere and
+identical across a working session is one a caller should state once."
+Shuttle generalizes that from the space to the whole prefix, inside one
+interactive process.
+
+Reading state today is one-shot prints, the FUSE mount, or the offline
+inspector. The substrate is reactive; none of those show a value changing.
+The live-view half exists to make reactivity visible.
+
+## Settled decisions
+
+1. **Shape: hybrid.** A REPL is the spine — a prompt showing the place, line
+   commands that print and return. Full-screen live-updating views (`watch` a
+   cell, browse a collection) open on demand and return to the prompt. The
+   prompt serves composition and muscle memory; the views serve the
+   browse-and-observe loop a reactive substrate deserves.
+2. **Home: a new workspace package** (working name `packages/shuttle`),
+   importing `cli` and `runner` plumbing as libraries. Not a `cf` subcommand.
+3. **Audience: the operator at the keyboard.** Power use first; teammates
+   second, served by completion, help, and forgiving defaults. Agents and
+   demo audiences are not v1 targets, and no decision may preclude them.
+4. **First workflows: inspecting live state, and browsing + editing data**
+   (navigate, read, set, call, wish). The pattern-development inner loop and
+   bulk operations are possible futures the design must leave open, not v1
+   targets.
+5. **Place model: reference prefixes plus named entry points.** A place is a
+   prefix of the canonical reference — a space, a piece, a path under a piece
+   — and named entry points (wish targets such as `#favorites`, slugs, space
+   names) are navigable: `cd #favorites` works, and `cf wish` already
+   resolves those targets headlessly. Virtual places — standing inside a
+   search result, a survey's holders, a filtered collection — are a designed
+   extension: the place abstraction must not assume a place is only a
+   prefix.
+6. **Ambience: shell-private, passed explicitly.** The place lives in the
+   shell process. One-shot `cf` outside the shell is untouched. A `cf`
+   command run from inside the shell receives the place explicitly — context
+   injected into that invocation — never by mutating environment variables.
+   The ambient record is one serializable value with one owner module, so
+   a later ambient adoption (step 8's `CF_SPACE`, or a fuller `CF_PLACE`)
+   can reuse the representation without redesign.
+7. **Vocabulary: navigation verbs plus `cf` verbs.** Navigation is
+   shell-native (`cd`, `ls`, `pwd`, `watch`, …). Data verbs are exactly the
+   `cf` ones (`get`, `set`, `call`, `wish`, `verbs`, `describe`, …) with the
+   place filling in target options, so knowledge transfers in both
+   directions between the shell and one-shot `cf`.
+8. **Codename: shuttle.**
+9. **Execution model: in-process, with a `!cf` escape.** The shell's own
+   verbs call the same library seams `cf`'s commands do, over one persistent
+   runtime connection that the live views share for their subscriptions. A
+   `!cf …` escape spawns the real binary with place-derived flags injected,
+   covering the rest of the surface. The known risk is drift where `cli`
+   code is not yet factored as callable seams; the answer is to factor the
+   seam in `cli`, not to reimplement the verb in shuttle.
+   [`shuttle/runtime-integration.md`](shuttle/runtime-integration.md) grounds
+   this decision: the connection and watch mechanics that exist, the
+   lifecycle discipline a long-lived process adds, and the prerequisite seam
+   work in `packages/cli`.
+10. **Run state: entering warms.** `cd` into a piece (or `watch`) starts the
+    pattern in-process and reads inside it are live; pieces merely listed
+    stay cold. A cold-browse mode — unmistakably visible in prompt and views
+    — walks the space with no computation, serving labeled stored state.
+11. **A space root lists facets, never pieces directly** — `slugs/`,
+    `pieces/`, and `fuse/` (the FUSE layout mirrored, leveraging
+    `packages/fuse` rather than reinventing it). Facet names are reserved at
+    the space root only.
+12. **A view is not necessarily a place.** Pagination and search produce
+    views to look at and pick from; they need no path-shaped address unless
+    one earns it (the virtual-places extension of decision 5).
+13. **Prompt and naming: checked names only, fabric's mechanisms only.**
+    Space names and slugs are shown when an index confirms them, shortened
+    unique ids otherwise; shuttle introduces no naming layer of its own.
+14. **Writes: inline value, editor, explicit links.** `set` takes a JSON
+    value on the line (stdin via `-`); `edit` opens `$EDITOR` on the current
+    value; `link` is the only spelling that creates a reference rather than
+    copying a value.
+15. **Externals are schemed; nothing outside the fabric is a default.**
+    Redirection targets fabric paths; a local file is always spelled
+    `file:…`, and `file:` is one member of an open scheme family (`https:`
+    sources work; external writes wait for a use). Beside the place shuttle
+    tracks one **external working location**, schemed like its operands:
+    `xcd` sets or relative-moves it, `xpwd` prints it.
+16. **Pipelines: a published native tool set, and escaped locals.** Names
+    in the native set (`jq`, `grep`, `wc` among the first) work bare and
+    are guaranteed wherever shuttle runs — a native tool may start as a
+    forward to a local binary, but that is implementation, not contract.
+    Arbitrary local programs need an explicit escape, so leaving the
+    portable surface is always visible on the line.
+17. **Numbered handles.** Listings number their rows and `%n` is a
+    reference until the next listing — the mechanism by which a view
+    (decision 12) feeds the next command without being a place.
+18. **`!` means local, everywhere.** Line-initial `! <cmd>` runs a local
+    program, `|!` is the same escape inside a pipeline, `!cf` the special
+    case that injects place-derived flags.
+19. **The binary is `shuttle`.** The codename is the name; aliases and
+    completion absorb the length.
+20. **Scope is the cwd's second dimension.** Per-identity overlays
+    (`@user`, `@session`) are a way of seeing every place, so the cwd is
+    the pair (position, scope): both stick across navigation, both render
+    in the prompt, and `pwd` prints both. `cd` is the door to both —
+    `cd board@session` moves both, `cd @session` scope alone, `cd @space`
+    back to the base (all verified in the canonical grammar) — there is no
+    separate scope verb, and an explicit suffix on an operand overrides
+    the ambient scope for that operand. A suffix names only the reading
+    identity's own overlays; standing in another identity's overlay is a
+    canonical-grammar extension, out of v1.
+21. **The native tool set v0** is `jq`, `grep`, `wc`, `head`, `tail`,
+    `sort`, `uniq`, `cut` — grown by ruling. `cat` is deliberately absent:
+    `get` prints, `< file:…` feeds, and concatenation waits for a demand.
+22. **`where` is the ambient context's one surface.** Every dimension —
+    connection, cwd pair, external location, browse mode, invocation
+    session — prints in `where`, and `where <dimension> <value>` sets any
+    of them; the heavyweight ones rebuild the connection and say so.
+    `cd`/`xcd` are conveniences over the hottest dimensions; launch flags
+    seed the initial record.
+23. **A scheme is legal only on an absolute complete path.** Relative
+    external operands are rooted with the `x:` base (`> x:../out.json`) —
+    a base name, not a scheme — and a bare relative operand is always
+    fabric, so no operand ever changes plane by position.
+24. **Pagination: height-fit pages, and `more` continues.** `ls` prints
+    one terminal-height page plus a status line and never escalates to a
+    view uninvited; `more` continues the listing and its handle numbering,
+    so a run's handles stay valid until a new listing resets them.
+25. **List views watch membership raw, elements deep, window only.**
+    Reader schemas cannot express a membership-only subscription (verified
+    — shapes that look shallow to a reader do not bound what the server
+    syncs), so membership comes from a raw-document subscription on the
+    collection doc and only visible rows sink deeply — cost bounded by
+    page size, never collection size. The seam and solution lanes are
+    issue [#6534](https://github.com/commontoolsinc/labs/issues/6534); B3
+    opens by proving the seam, and falls back to a capped deep sink with
+    an honest label if it disappoints.
+26. **The piece overview ships structured, not live.** One frame —
+    arguments, result summary, callables, pattern identity — rendered as a
+    refreshable snapshot in B3; the live piece watch is deferred.
+
+The line grammar itself — resolution rules, facets, listings, run-state and
+write surfaces, and the redirection/pipe proposals — is drafted in
+[`shuttle/grammar.md`](shuttle/grammar.md). The full-screen views are
+designed in [`shuttle/views.md`](shuttle/views.md). The order of
+construction — the `cli` seam PRs and the shuttle milestones they gate — is
+[`shuttle/build-sequence.md`](shuttle/build-sequence.md).
+
+## The ambient model
+
+The ambient context is one record:
+
+- **Connection**: api endpoint, identity.
+- **The cwd pair**: position (space, optionally a piece, optionally a path
+  inside it) and scope.
+- **External working location**, **browse mode**, **invocation session**.
+
+`cd` accepts relative path segments, `..`, absolute canonical references,
+slugs, space names, wish targets, and scope suffixes. Every reference a
+command takes resolves against the cwd; an absolute reference always works
+and never depends on it. The prompt renders position and scope compactly
+(an elided alias is checked against the target's declared name, never
+guessed).
+
+One place at a time in v1, but no global singleton: the implementation keeps
+place-per-instance so multiple places (tabs, split views, an agent holding
+several) stay reachable later.
+
+## What exists to build on
+
+| Component | Where | What it gives shuttle |
+| --- | --- | --- |
+| Canonical + alias reference grammar | `packages/cli/lib/llm-friendly-ref.ts` (doc comment), runner's `parseLLMFriendlyLink` | The address syntax; shuttle consumes it and must not fork it |
+| Target option surface | `targetOptions` in `packages/cli/commands/piece.ts` | The enumeration of exactly what a place must supply |
+| Live-state completion | `packages/cli/lib/completion/providers.ts` (`cellPathCandidates`, `childKeys`, verb candidates with doc comments) | The `ls` primitive and tab completion, already written against live state |
+| Pager/TUI substrate | `packages/cli/lib/view/` — `pager.ts` is the only module touching the TTY; `keys.ts`, `ansi.ts`, `render.ts`; `session.ts` holds state as pure logic | The full-screen half: raw mode, frames, key decoding, testable without a terminal; already follows references and edits buffers |
+| FUSE mount | `packages/fuse` | The same addressing as a POSIX filesystem; prior art for layout (arrays as numeric directories, handlers as executables, links as symlinks). Shuttle is its interactive, live sibling, not a replacement |
+| Offline inspector | `packages/state-inspector`, `cf inspect` | The forensic counterpart (snapshots, scopes, history); its HTML explorer is prior art for tree-plus-detail browsing |
+| Entry-point resolution | `cf wish` | Headless resolution of `#favorites`-style targets — the mounts of decision 5 |
+| Web shell route grammar | `packages/shell` routes `/<space>/<piece>` | Another spelling of place; keep them mutually translatable |
+
+## Relationship to the CLI surface arc
+
+Shuttle rides the addressing decisions of
+[`cli-surface-shape.md`](cli-surface-shape.md) rather than making its own:
+
+- Step 8 (`CF_SPACE` ambient) is the one-shot cousin of decision 6; the
+  serializable place is the shared seam.
+- Step 9 (space by name, piece by slug, positionally) is what `cd` and the
+  prompt want — names, not hashes. Shuttle should consume that work, not
+  duplicate it.
+- The duplicated nouns that plan records (two `inspect`s, two `view`s) are
+  words shuttle must not add a third meaning to.
+
+Word hazards, so shuttle does not add to them: "shell" names the web
+frontend; "session" already carries three meanings (invocation session,
+process connection, `@session` cell scope) — shuttle says **place** and
+**connection**; "collection" means an array path inside a holder piece
+(`cf piece survey`), and shuttle uses it only that way.
+
+## Open questions
+
+None blocking v1. The B3 seam-proving gate and its two preparatory
+experiments are recorded in decision 25 and issue
+[#6534](https://github.com/commontoolsinc/labs/issues/6534); the piece
+overview's liveness is deferred with the live piece watch
+([`shuttle/views.md`](shuttle/views.md)).
+
+## Non-goals for v1
+
+- Not an agent surface (stable machine-readable output, one-shot scripting)
+  — leave the door open.
+- Not a bulk-operations or migration driver — leave the door open.
+- Not a replacement for `packages/fuse`, `cf view`, or `cf inspect`.
+- No persisted cross-process ambient place, and no environment-variable
+  mutation, ever.
+- Not a hosted or remote terminal — but shuttle must not assume a local
+  execution environment exists, so it can become reachable from one later.
+  The native-versus-escaped pipeline split (decision 16) is that
+  constraint's first tooth.

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -279,8 +279,14 @@ Shuttle rides the addressing decisions of
   piece, path, scope — as shuttle's ground. The serializable ambient
   record stays the shared seam for any further convergence.
 - Step 9 (space by name, piece by slug, positionally) is what `cd` and the
-  prompt want — names, not hashes. Shuttle should consume that work, not
-  duplicate it.
+  prompt want — names, not hashes — and it now lands paired with step 11,
+  under the recorded prior question of whether the reference grammar is
+  the right home for naming at all, or stands in for a resolution layer
+  that does not exist. Shuttle consumes that work rather than duplicating
+  it, and bears on the question from the consumer side: `cd`, completion,
+  and the prompt are exactly a naming-and-resolution layer exercised
+  against live state, so building them produces the evidence the question
+  needs.
 - The duplicated nouns that plan records (two `inspect`s, two `view`s) are
   words shuttle must not add a third meaning to.
 

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -17,7 +17,7 @@ shuttle estuary/board> watch topics/3
 │ title    "verb contracts"            │
 │ replies  14                          │
 └── q: back (watch stays armed) ───────┘
-shuttle estuary/board> call topics/3 add-reply -- --body "hi"
+shuttle estuary/board> call topics/3 add-reply --body "hi"
 watch topics/3: replies 14 → 15
 shuttle estuary/board>
 ```

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -120,9 +120,12 @@ invisible, the prompt renders the whole ambient record — place and scope
    this decision: the connection and watch mechanics that exist, the
    lifecycle discipline a long-lived process adds, and the prerequisite seam
    work in `packages/cli`.
-10. **Run state: entering warms.** `cd` into a piece (or `watch`) starts the
-    pattern in-process and reads inside it are live; pieces merely listed
-    stay cold — which is v1's whole run-state story. A cold-browse mode is
+10. **Run state: reaching in warms.** `cd` into a piece, `watch` on
+    anything inside it, or any read aimed into it — `get topics/3/title`
+    from outside warms `topics/3` exactly as `cd` would — starts the
+    pattern in-process, so every read shuttle serves is live and v1 has no
+    unlabeled stored-state path; pieces merely listed stay cold — which is
+    v1's whole run-state story. A cold-browse mode is
     designed and deferred past v1 ([`futures.md`](futures.md)).
 11. **A space root lists facets, never pieces directly** — `slugs/` and
     `pieces/` in v1; the `fuse/` facet (the FUSE layout mirrored,

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -86,8 +86,12 @@ invisible, the prompt renders the whole ambient record — place and scope
 5. **Place model: reference prefixes plus named entry points.** A place is a
    prefix of the canonical reference — a space, a piece, a path under a piece
    — and named entry points (wish targets such as `#favorites`, slugs, space
-   names) are navigable: `cd #favorites` works, and `cf wish` already
-   resolves those targets headlessly. Virtual places — standing inside a
+   names) are navigable: `cd #favorites` works when the target resolves
+   within the connected space, and `cf wish` already resolves those
+   targets headlessly. A target anchored elsewhere — profile and
+   favorites resolve against the reading identity's home space — is
+   refused with the reason in v1, which serves one space per process
+   (decision 22). Virtual places — standing inside a
    search result, a survey's holders, a filtered collection — are a designed
    extension: the place abstraction must not assume a place is only a
    prefix.
@@ -176,7 +180,10 @@ invisible, the prompt renders the whole ambient record — place and scope
     connection, cwd pair, external location, invocation session — prints
     in `where`, and `where <dimension> <value>` sets the light ones (scope,
     the external location). The heavyweight dimensions — api endpoint,
-    identity — are fixed at launch in v1, and restarting is the switch;
+    identity, and the space — are fixed at launch in v1, and restarting is
+    the switch: one shuttle process serves one space, so `cd` moves within
+    it (multi-space sessions are a named candidate in
+    [`futures.md`](futures.md));
     editing them live is designed and deferred ([`futures.md`](futures.md)),
     which also honors the one-connection-per-process limit the seam work
     records. `cd`/`xcd` are conveniences over the hottest dimensions;
@@ -194,7 +201,9 @@ invisible, the prompt renders the whole ambient record — place and scope
     — shapes that look shallow to a reader do not bound what the server
     syncs), so membership comes from a raw-document subscription on the
     collection doc and only visible rows sink deeply — cost bounded by
-    page size, never collection size. The seam and solution lanes are
+    the visible page in element documents; membership is one document whose
+    size grows with the collection's link array — linear in links, not in
+    element closures. The seam and solution lanes are
     issue [#6534](https://github.com/commontoolsinc/labs/issues/6534); B3
     opens by proving the seam, and falls back to a capped deep sink with
     an honest label if it disappoints. The raw subscription serves the
@@ -249,7 +258,8 @@ The ambient context is one record:
 - **External working location**, **invocation session**.
 
 `cd` accepts relative path segments, `..`, rooted and complete canonical
-references, slugs, space names, wish targets, and scope suffixes. Every
+references, slugs, wish targets, and scope suffixes (space names join
+when multi-space sessions do). Every
 reference a command takes resolves against the cwd, and how much of the
 cwd it needs varies: a rooted `/of:…` fixes the piece and path but still
 draws its space from the place, so only a complete
@@ -269,7 +279,7 @@ several) stay reachable later.
 | --- | --- | --- |
 | Canonical + alias reference grammar | `packages/cli/lib/llm-friendly-ref.ts` (doc comment), runner's `parseLLMFriendlyLink` | The address syntax; shuttle consumes it and must not fork it |
 | Target option surface | `targetOptions` in `packages/cli/commands/piece.ts` | The enumeration of exactly what a place must supply |
-| Live-state completion | `packages/cli/lib/completion/providers.ts` (`cellPathCandidates`, `childKeys`, verb candidates with doc comments) | The `ls` primitive and tab completion, already written against live state |
+| Live-state completion | `packages/cli/lib/completion/providers.ts` — the listing logic is module-private (`cellPathCandidates`, `childKeys`) beside the exported `keysOf`, and opens its own runtime through the default `getCellValue` path | The `ls` primitive and tab completion; A1 factors the listing behind an injectable connection and exports it |
 | Pager/TUI substrate | `packages/cli/lib/view/` — `pager.ts` is the only module doing raw-mode full-screen TTY handling; `mod.ts` and `loadinput.ts` touch stdio for the one-shot path (capability probes, plain-output writes, piped input); `keys.ts`, `ansi.ts`, `render.ts`, `session.ts` hold state and decoding as pure logic | The full-screen half: raw mode, frames, key decoding, testable without a terminal; already follows references and edits buffers |
 | FUSE mount | `packages/fuse` | The same addressing as a POSIX filesystem; prior art for layout (arrays as numeric directories, handlers as executables, links as symlinks). Shuttle is its interactive, live sibling, not a replacement |
 | Offline inspector | `packages/state-inspector`, `cf inspect` | The forensic counterpart (snapshots, scopes, history); its HTML explorer is prior art for tree-plus-detail browsing |

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -17,7 +17,7 @@ shuttle estuary/board> watch topics/3
 │ title    "verb contracts"            │
 │ replies  14                          │
 └── q: back (watch stays armed) ───────┘
-shuttle estuary/board> call topics/3 add-reply --body "hi"
+shuttle estuary/board> call topics/3 add-reply -- --body "hi"
 watch topics/3: replies 14 → 15
 shuttle estuary/board>
 ```
@@ -209,9 +209,9 @@ it runs.
     next positional is the verb name. That delivers the ergonomic the
     listing demands, calling what was shown without splitting a reference
     by hand, and delivers it without a typed path grammar: `call` keeps
-    `cf`'s two-positional form (`call topics/3 add-reply`) as the typed
-    spelling, and a typed path ending in a callable is refused. This is
-    also how a verb is named everywhere else — a verb name is interface
+    `cf`'s receiver-plus-name form (`call topics/3 add-reply`) as the
+    typed spelling, and a typed path ending in a callable is refused. This
+    is also how a verb is named everywhere else — a verb name is interface
     vocabulary rather than a data path, and the receiver is the
     addressable thing.
 28. **Watches are session objects.** `watch` arms a subscription that

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -93,8 +93,9 @@ it runs.
    command run from inside the shell receives the place explicitly — context
    injected into that invocation — never by mutating environment variables.
    The ambient record is one serializable value with one owner module, so
-   a later ambient adoption (step 8's `CF_SPACE`, or a fuller `CF_PLACE`)
-   can reuse the representation without redesign.
+   an ambient adoption fuller than step 8's `CF_SPACE` — a `CF_PLACE`
+   carrying the moving half — can reuse the representation without
+   redesign.
 7. **Vocabulary: navigation verbs plus `cf` verbs.** Navigation is
    shell-native (`cd`, `ls`, `pwd`, `watch`, …). Data verbs are exactly the
    `cf` ones (`get`, `set`, `call`, `wish`, `verbs`, `describe`, …) with the

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -1,8 +1,11 @@
 # Shuttle — a place-aware fabric shell
 
 Status: v1 design settled — the decisions below are ruled, and nothing
-blocks construction. Nothing here is built yet; the order of construction is
-[`build-sequence.md`](build-sequence.md). This document
+blocks construction. The v1 cutline is drawn: a handful of settled designs
+are deferred past v1 and preserved in [`futures.md`](futures.md), so they
+are re-scheduled later rather than re-litigated, and the decisions below
+say so where they defer. Nothing here is built yet; the order of
+construction is [`build-sequence.md`](build-sequence.md). This document
 stays the working design state: new decisions land here as they are made.
 
 Shuttle is an interactive terminal tool for exploring and editing fabric
@@ -61,9 +64,8 @@ commands cannot have at any flag cost: warm pieces serving live computed
 values without a per-command `--step`, subscriptions feeding watches and
 views, pagination cursors, the handle table, invocation-session
 continuity. And where an environment variable makes context ambient and
-invisible, the prompt renders the whole ambient record — place, scope,
-warm or cold — so what every command is about to touch is visible before
-it runs.
+invisible, the prompt renders the whole ambient record — place and scope
+— so what every command is about to touch is visible before it runs.
 
 ## Settled decisions
 
@@ -116,11 +118,12 @@ it runs.
    work in `packages/cli`.
 10. **Run state: entering warms.** `cd` into a piece (or `watch`) starts the
     pattern in-process and reads inside it are live; pieces merely listed
-    stay cold. A cold-browse mode — unmistakably visible in prompt and views
-    — walks the space with no computation, serving labeled stored state.
-11. **A space root lists facets, never pieces directly** — `slugs/`,
-    `pieces/`, and `fuse/` (the FUSE layout mirrored, leveraging
-    `packages/fuse` rather than reinventing it). Facet names are reserved at
+    stay cold — which is v1's whole run-state story. A cold-browse mode is
+    designed and deferred past v1 ([`futures.md`](futures.md)).
+11. **A space root lists facets, never pieces directly** — `slugs/` and
+    `pieces/` in v1; the `fuse/` facet (the FUSE layout mirrored,
+    leveraging `packages/fuse` rather than reinventing it) is designed and
+    deferred ([`futures.md`](futures.md)). Facet names are reserved at
     the space root only.
 12. **A view is not necessarily a place.** Pagination and search produce
     views to look at and pick from; they need no path-shaped address unless
@@ -135,15 +138,16 @@ it runs.
 15. **Externals are schemed; nothing outside the fabric is a default.**
     Redirection targets fabric paths; a local file is always spelled
     `file:…`, and `file:` is one member of an open scheme family (`https:`
-    sources work; external writes wait for a use). Beside the place shuttle
-    tracks one **external working location**, schemed like its operands:
-    `xcd` sets or relative-moves it, `xpwd` prints it.
-16. **Pipelines: a published native tool set, and escaped locals.** Names
-    in the native set (`jq`, `grep`, `wc` among the first) work bare and
-    are guaranteed wherever shuttle runs — a native tool may start as a
-    forward to a local binary, but that is implementation, not contract.
+    sources are designed and deferred; external writes wait for a use).
+    Beside the place shuttle tracks one **external working location**,
+    schemed like its operands: `xcd` sets or relative-moves it, `xpwd`
+    prints it.
+16. **Pipelines: escaped locals now, a published native tool set later.**
     Arbitrary local programs need an explicit escape, so leaving the
-    portable surface is always visible on the line.
+    portable surface is always visible on the line; bare `|` is reserved,
+    and its error names `|!`. The native set — names that work bare and
+    are guaranteed wherever shuttle runs, contract not implementation —
+    is designed and deferred ([`futures.md`](futures.md)).
 17. **Numbered handles.** Listings number their rows and `%n` is a
     reference until the next listing — the mechanism by which a view
     (decision 12) feeds the next command without being a place.
@@ -165,15 +169,18 @@ it runs.
     `..` and `-`. A suffix names the base scope or the reading identity's own
     overlays, never another identity's; standing in another identity's
     overlay is a canonical-grammar extension, out of v1.
-21. **The native tool set v0** is `jq`, `grep`, `wc`, `head`, `tail`,
-    `sort`, `uniq`, `cut` — grown by ruling. `cat` is deliberately absent:
-    `get` prints, `< file:…` feeds, and concatenation waits for a demand.
+21. **The native tool set v0 is ruled and deferred** with decision 16's
+    contract: the list, and `cat`'s deliberate absence, are preserved in
+    [`futures.md`](futures.md).
 22. **`where` is the ambient context's one surface.** Every dimension —
-    connection, cwd pair, external location, browse mode, invocation
-    session — prints in `where`, and `where <dimension> <value>` sets any
-    of them; the heavyweight ones rebuild the connection and say so.
-    `cd`/`xcd` are conveniences over the hottest dimensions; launch flags
-    seed the initial record.
+    connection, cwd pair, external location, invocation session — prints
+    in `where`, and `where <dimension> <value>` sets the light ones (scope,
+    the external location). The heavyweight dimensions — api endpoint,
+    identity — are fixed at launch in v1, and restarting is the switch;
+    editing them live is designed and deferred ([`futures.md`](futures.md)),
+    which also honors the one-connection-per-process limit the seam work
+    records. `cd`/`xcd` are conveniences over the hottest dimensions;
+    launch flags seed the initial record.
 23. **A scheme is legal only on an absolute complete path.** Relative
     external operands are rooted with the `x:` base (`> x:../out.json`) —
     a base name, not a scheme — and a bare relative operand is always
@@ -215,12 +222,12 @@ it runs.
     vocabulary rather than a data path, and the receiver is the
     addressable thing.
 28. **Watches are session objects.** `watch` arms a subscription that
-    outlives its view: leaving the view keeps it armed, each settled
-    change appends one event line at the prompt, and a pinned strip above
-    the prompt renders armed watches' values live while scrollback flows
-    past. `watches` lists what is armed, `unwatch` disarms, and scrollback
-    stays append-only — liveness lives in the strip and the event lines,
-    never in mutated history.
+    outlives its view: leaving the view keeps it armed, and each settled
+    change appends one event line at the prompt. `watches` lists what is
+    armed, `unwatch` disarms, and scrollback stays append-only — liveness
+    lives in the event lines, never in mutated history. The pinned strip
+    (a live region above the prompt) is designed and deferred
+    ([`futures.md`](futures.md)).
 
 The line grammar itself — resolution rules, facets, listings, run-state and
 write surfaces, and the redirection/pipe proposals — is drafted in
@@ -239,7 +246,7 @@ The ambient context is one record:
 - **Connection**: api endpoint, identity.
 - **The cwd pair**: position (space, optionally a piece, optionally a path
   inside it) and scope.
-- **External working location**, **browse mode**, **invocation session**.
+- **External working location**, **invocation session**.
 
 `cd` accepts relative path segments, `..`, rooted and complete canonical
 references, slugs, space names, wish targets, and scope suffixes. Every

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -17,7 +17,7 @@ shuttle estuary/board> watch topics/3
 │ title    "verb contracts"            │
 │ replies  14                          │
 └── q: back (watch stays armed) ───────┘
-shuttle estuary/board> call topics/3/add-reply --body "hi"
+shuttle estuary/board> call topics/3 add-reply --body "hi"
 watch topics/3: replies 14 → 15
 shuttle estuary/board>
 ```
@@ -47,8 +47,9 @@ session is one a caller should state once" — caps out exactly there,
 because piece, path, and scope are not identical across a session: they
 change with every step, because they are the work. The fabric's reference
 grammar is right-anchored —
-`/[@did:key:…/]of:fid1:<id>[@scope][/path…][#argument]`, documented at the
-top of `packages/cli/lib/llm-friendly-ref.ts` — with omitted levels
+`/[@did:key:…/]of:fid1:<id>[@scope][/path…]`, documented at the top of
+`packages/cli/lib/llm-friendly-ref.ts`, which adds the `#argument` suffix
+at the CLI's intake seams — with omitted levels
 supplied by context, and shuttle makes that context a position you
 navigate: **a place is the context that fills in the omitted levels of a
 reference**, moved by `cd`, relative references, and handles instead of by
@@ -189,19 +190,30 @@ it runs.
     page size, never collection size. The seam and solution lanes are
     issue [#6534](https://github.com/commontoolsinc/labs/issues/6534); B3
     opens by proving the seam, and falls back to a capped deep sink with
-    an honest label if it disappoints.
+    an honest label if it disappoints. The raw subscription serves the
+    base scope only — `SpaceReplica.sinkDocument` keys on the base
+    instance and takes no scope — so a list read under `@user` or
+    `@session` takes the capped deep sink, which reads through the scope
+    its cells carry. Making that seam scope-aware end to end is part of
+    #6534, not a shuttle workaround.
 26. **The piece overview ships structured, not live.** One frame —
     arguments, result summary, callables, pattern identity — rendered as a
     refreshable snapshot in B3; the live piece watch is deferred.
-27. **A callable is invocable by its path.** `call` keeps `cf`'s
-    address-plus-name form, and adds the one-reference form —
-    `call topics/3/add-reply`, `call %4` — that invokes the callable cell
-    the path names; arity disambiguates. A callable is a cell like
-    everything else (FUSE already invokes one as an executable file), and
-    inline callables in listings plus numbered handles require the path
-    form: calling what a listing showed must not need a reference split by
-    hand. No new reference syntax — the path is already canonical; the
-    sugar is in the verb.
+27. **Handles are structured.** A handle is a bound reference with
+    structure, not a string: a listing records each row's kind as it mints
+    the handle, and for a callable row it records the receiver and the
+    verb name. So `call %4` invokes what the listing showed through the
+    same root-level name resolution `cf` already performs, and arity
+    resolves against a kind known locally at mint time — a callable handle
+    means the positionals after it are input, a piece handle means the
+    next positional is the verb name. That delivers the ergonomic the
+    listing demands, calling what was shown without splitting a reference
+    by hand, and delivers it without a typed path grammar: `call` keeps
+    `cf`'s two-positional form (`call topics/3 add-reply`) as the typed
+    spelling, and a typed path ending in a callable is refused. This is
+    also how a verb is named everywhere else — a verb name is interface
+    vocabulary rather than a data path, and the receiver is the
+    addressable thing.
 28. **Watches are session objects.** `watch` arms a subscription that
     outlives its view: leaving the view keeps it armed, each settled
     change appends one event line at the prompt, and a pinned strip above
@@ -229,12 +241,16 @@ The ambient context is one record:
   inside it) and scope.
 - **External working location**, **browse mode**, **invocation session**.
 
-`cd` accepts relative path segments, `..`, absolute canonical references,
-slugs, space names, wish targets, and scope suffixes. Every reference a
-command takes resolves against the cwd; an absolute reference always works
-and never depends on it. The prompt renders position and scope compactly
-(an elided alias is checked against the target's declared name, never
-guessed).
+`cd` accepts relative path segments, `..`, rooted and complete canonical
+references, slugs, space names, wish targets, and scope suffixes. Every
+reference a command takes resolves against the cwd, and how much of the
+cwd it needs varies: a rooted `/of:…` fixes the piece and path but still
+draws its space from the place, so only a complete
+`/@did:key:…/of:…` names its cell from anywhere
+([`grammar.md`](grammar.md)). The place is result-rooted — `cd` refuses a
+reference carrying `#argument`, and arguments are reached per operand. The
+prompt renders position and scope compactly (an elided alias is checked
+against the target's declared name, never guessed).
 
 One place at a time in v1, but no global singleton: the implementation keeps
 place-per-instance so multiple places (tabs, split views, an agent holding

--- a/docs/plans/shuttle/README.md
+++ b/docs/plans/shuttle/README.md
@@ -2,7 +2,7 @@
 
 Status: v1 design settled — the decisions below are ruled, and nothing
 blocks construction. Nothing here is built yet; the order of construction is
-[`shuttle/build-sequence.md`](shuttle/build-sequence.md). This document
+[`build-sequence.md`](build-sequence.md). This document
 stays the working design state: new decisions land here as they are made.
 
 Shuttle is an interactive terminal tool for exploring and editing fabric
@@ -41,7 +41,7 @@ interleaved in one transcript that doubles as a record.
 
 The moving half of context has no home. `CF_API_URL`, `CF_IDENTITY`, and
 `CF_SPACE` absorb the constant half, and
-[`cli-surface-shape.md`](cli-surface-shape.md) step 8's rationale — "a
+[`cli-surface-shape.md`](../cli-surface-shape.md) step 8's rationale — "a
 parameter that is required everywhere and identical across a working
 session is one a caller should state once" — caps out exactly there,
 because piece, path, and scope are not identical across a session: they
@@ -53,7 +53,7 @@ supplied by context, and shuttle makes that context a position you
 navigate: **a place is the context that fills in the omitted levels of a
 reference**, moved by `cd`, relative references, and handles instead of by
 copying printed addresses between commands (the composition axis of
-[`../common/verbs/session-walkthrough.md`](../common/verbs/session-walkthrough.md)).
+[`../common/verbs/session-walkthrough.md`](../../common/verbs/session-walkthrough.md)).
 
 Underneath both, a persistent runtime session is a capability one-shot
 commands cannot have at any flag cost: warm pieces serving live computed
@@ -108,7 +108,7 @@ it runs.
    covering the rest of the surface. The known risk is drift where `cli`
    code is not yet factored as callable seams; the answer is to factor the
    seam in `cli`, not to reimplement the verb in shuttle.
-   [`shuttle/runtime-integration.md`](shuttle/runtime-integration.md) grounds
+   [`runtime-integration.md`](runtime-integration.md) grounds
    this decision: the connection and watch mechanics that exist, the
    lifecycle discipline a long-lived process adds, and the prerequisite seam
    work in `packages/cli`.
@@ -211,13 +211,13 @@ it runs.
 
 The line grammar itself — resolution rules, facets, listings, run-state and
 write surfaces, and the redirection/pipe proposals — is drafted in
-[`shuttle/grammar.md`](shuttle/grammar.md). The full-screen views are
-designed in [`shuttle/views.md`](shuttle/views.md). The order of
+[`grammar.md`](grammar.md). The full-screen views are
+designed in [`views.md`](views.md). The order of
 construction — the `cli` seam PRs and the shuttle milestones they gate — is
-[`shuttle/build-sequence.md`](shuttle/build-sequence.md). The trajectory
+[`build-sequence.md`](build-sequence.md). The trajectory
 past v1 — configuration in the fabric, the session scope as the variable
 store, the scripting layers, and the ranked candidates behind them — is
-[`shuttle/futures.md`](shuttle/futures.md).
+[`futures.md`](futures.md).
 
 ## The ambient model
 
@@ -255,7 +255,7 @@ several) stay reachable later.
 ## Relationship to the CLI surface arc
 
 Shuttle rides the addressing decisions of
-[`cli-surface-shape.md`](cli-surface-shape.md) rather than making its own:
+[`cli-surface-shape.md`](../cli-surface-shape.md) rather than making its own:
 
 - Step 8's `CF_SPACE` is on main: the constant half of the context is
   ambient for one-shot `cf` too, which is what isolates the moving half —
@@ -279,7 +279,7 @@ None blocking v1. The B3 seam-proving gate and its two preparatory
 experiments are recorded in decision 25 and issue
 [#6534](https://github.com/commontoolsinc/labs/issues/6534); the piece
 overview's liveness is deferred with the live piece watch
-([`shuttle/views.md`](shuttle/views.md)).
+([`views.md`](views.md)).
 
 ## Non-goals for v1
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -20,7 +20,10 @@ entry: `cellPathCandidates` and `childKeys` in
 `lib/completion/providers.ts` are module-private and open a fresh runtime
 through the default `getCellValue` path, so A1 factors the listing logic
 behind an injectable connection and exports that, beside the
-already-public `keysOf`. Keep the
+already-public `keysOf`. The providers are designed to fail silently and
+empty — right for tab completion, wrong for `ls` — so the factored
+listing surfaces its errors, and completion keeps swallowing them at its
+own call site. Keep the
 list to what shuttle names — an export entry is a contract, and the short
 list is the record of which internals have a second caller. (The view
 substrate's entries wait for B3, which is when they earn their place on
@@ -36,7 +39,9 @@ the fix is a threaded parameter. The genuine conversions — the functions
 that call `loadPieces(config)` directly — are `setCellValue` first (a v1
 verb), then `removePiece`, `renderPiece`, and the `lib/acl.ts` loaders.
 Each change carries the unit test the seam makes possible; that is the
-PR's standalone value.
+PR's standalone value. Re-verify this inventory against the tree when A2
+starts: it churned three times during the design, once against its own
+prerequisite landing (#6556).
 
 **A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
 and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are
@@ -111,7 +116,7 @@ is what `call %n` resolves against (decision 27). The invocation session is
 minted once at startup and passed explicitly. The step-10 call section
 is shuttle's own line grammar, parsed locally and fed to the
 schema-derived flag machinery `cf` already exports (`pieceCallRawArgs`,
-`pieceCallInvocation`), so no arc step gates it either. Warm-on-enter
+`pieceCallInvocation`), so no arc step gates it either. Reaching-in-warms
 lands here, since `set` is what makes stale computed state visible.
 
 **B3 — watch and views** (after A4; view-substrate export entries added

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -15,7 +15,12 @@ prerequisites land.
 **A1 — export entries.** `@commonfabric/cli` exports only `.` → `mod.ts`,
 whose import runs CLI startup. Add workspace-internal export entries for
 the modules a sibling calls: `./lib/piece`, `./commands/piece`,
-`./lib/wish`, `./lib/piece-render`, `./lib/completion/providers`. Keep the
+`./lib/wish`, `./lib/piece-render`. The completion listing is not a plain
+entry: `cellPathCandidates` and `childKeys` in
+`lib/completion/providers.ts` are module-private and open a fresh runtime
+through the default `getCellValue` path, so A1 factors the listing logic
+behind an injectable connection and exports that, beside the
+already-public `keysOf`. Keep the
 list to what shuttle names — an export entry is a contract, and the short
 list is the record of which internals have a second caller. (The view
 substrate's entries wait for B3, which is when they earn their place on
@@ -65,8 +70,12 @@ is half of what a place is (decision 20): `cd @user` and `cd @space` move
 it, the prompt renders it, and `pwd` prints both halves. The prompt, a
 readline loop, and `cd` / `ls` / `pwd` / `get` over one held
 `PiecesController`, with `cd -` for the previous place and `#name` wish
-targets navigable (`cd #favorites`, and the `wish` verb, over the
-`./lib/wish` export entry A1 adds). `where` lands here as the printing
+targets navigable within the connected space (`cd #favorites`, and the
+`wish` verb, over the `./lib/wish` export entry A1 adds; a home-anchored
+target from elsewhere is refused with the reason — decision 5). Slug and
+name resolution rides the machinery `--piece` already uses
+(`resolveStoredPieceAddress`, `listSpaceSlugs`), so no CLI-surface arc
+step gates B1. `where` lands here as the printing
 surface for the ambient record; later milestones add their dimensions to it
 as they add the dimensions themselves. Facets `slugs/` and `pieces/` only.
 
@@ -82,7 +91,9 @@ permanently failed, because no such surface exists today and both the
 prompt and the view markers consume it. No retry loop in shuttle on either
 half.
 
-**B2 — writes, calls, handles** (after A2, A3). `set` with inline values,
+**B2 — writes, calls, handles** (after A2, A3, and A4 — a failed call or
+write must surface as a value, never reach `Deno.exit`). `set` with
+inline values,
 `edit` over `$EDITOR`, and `link` — the one spelling that writes a
 reference instead of copying a value (decision 14), and the only write of
 the three that has no `cf` equivalent to lean on. `call` through
@@ -93,8 +104,11 @@ continues a listing *and its handle numbering* (decision 24), so it needs
 the handle table, not merely a page cursor. Handles are structured at mint
 — each row's kind, plus receiver and verb name for a callable row — which
 is what `call %n` resolves against (decision 27). The invocation session is
-minted once at startup and passed explicitly. Warm-on-enter lands here,
-since `set` is what makes stale computed state visible.
+minted once at startup and passed explicitly. The step-10 call section
+is shuttle's own line grammar, parsed locally and fed to the
+schema-derived flag machinery `cf` already exports (`pieceCallRawArgs`,
+`pieceCallInvocation`), so no arc step gates it either. Warm-on-enter
+lands here, since `set` is what makes stale computed state visible.
 
 **B3 — watch and views** (after A4; view-substrate export entries added
 here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -1,6 +1,6 @@
 # Shuttle — build sequence
 
-Satellite of [`../shuttle.md`](../shuttle.md): the order of construction,
+Satellite of [`README.md`](README.md): the order of construction,
 as small landable pull requests. Stage A is seam work inside `packages/cli`
 — each PR stands on its own merits there, shuttle or no shuttle, because a
 seam that lets a sibling inject a connection is the same seam that lets a

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -26,13 +26,17 @@ list is the record of which internals have a second caller. (The view
 substrate's entries wait for B3, which is when they earn their place on
 that record.)
 
-**A2 — connection injection for the write path.** Thread
-`deps.loadPieces` (the existing `PieceResolutionDeps` seam) through the
-functions that hardcode `await loadPieces(config)` today, in order of
-shuttle's need: `setCellValue` and `callPieceHandler` and `stepPiece`
-first (v1 verbs), then `removePiece`, `getPieceView`, `renderPiece`, the
-`lib/acl.ts` loaders. Each conversion carries the unit test the seam
-makes possible; that is the PR's standalone value.
+**A2 — connection injection for the write path.** Three shapes of work,
+not one. `stepPiece` is already done — it gained the
+`PieceResolutionDeps` seam with its write receipt (#6556), and its unit
+test is the template. `callPieceHandler` and `getPieceView` are
+forwarding gaps: each delegates to an already-injectable function
+(`resolvePieceCallable`, `inspectPiece`) without passing deps through, so
+the fix is a threaded parameter. The genuine conversions — the functions
+that call `loadPieces(config)` directly — are `setCellValue` first (a v1
+verb), then `removePiece`, `renderPiece`, and the `lib/acl.ts` loaders.
+Each change carries the unit test the seam makes possible; that is the
+PR's standalone value.
 
 **A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
 and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -1,0 +1,100 @@
+# Shuttle — build sequence
+
+Satellite of [`../shuttle.md`](../shuttle.md): the order of construction,
+as small landable pull requests. Stage A is seam work inside `packages/cli`
+— each PR stands on its own merits there, shuttle or no shuttle, because a
+seam that lets a sibling inject a connection is the same seam that lets a
+unit test run the action body (the documented rationale of the
+`*FromCommand` family). Stage B is the shuttle package itself, in vertical
+slices. A-PRs go first in line because they gate everything and review
+latency is the scarce resource; B milestones start as soon as their named
+prerequisites land.
+
+## Stage A — seams in `packages/cli`
+
+**A1 — export entries.** `@commonfabric/cli` exports only `.` → `mod.ts`,
+whose import runs CLI startup. Add workspace-internal export entries for
+the modules a sibling calls: `./lib/piece`, `./commands/piece`,
+`./lib/wish`, `./lib/piece-render`, `./lib/completion/providers`. Keep the
+list to what shuttle names — an export entry is a contract, and the short
+list is the record of which internals have a second caller. (The view
+substrate's entries wait for B3, which is when they earn their place on
+that record.)
+
+**A2 — connection injection for the write path.** Thread
+`deps.loadPieces` (the existing `PieceResolutionDeps` seam) through the
+functions that hardcode `await loadPieces(config)` today, in order of
+shuttle's need: `setCellValue` and `callPieceHandler` and `stepPiece`
+first (v1 verbs), then `removePiece`, `getPieceView`, `renderPiece`, the
+`lib/acl.ts` loaders. Each conversion carries the unit test the seam
+makes possible; that is the PR's standalone value.
+
+**A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
+and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are
+already exported. The extraction makes the literal-args array a parameter
+and gives `call` the same named-export shape as its siblings. Independent
+value: an inline action body is uncoverable and everything registered
+after it sits in coverage shadow, so extraction retires debt in the
+package where coverage debt is a standing cost.
+
+**A4 — exit and output seams audit.** Every seam shuttle calls must accept
+an exit override (`exitWithDataError` / `exitPieceCallFailure` call
+`Deno.exit(1)` by default — a data error must not kill the shell) and
+route output through the `render`/`hint` deps rather than stray
+`console.error`. One audit PR that threads what is missing, with the test
+that proves a data error surfaces as a value.
+
+**A5 — module-global state.** `quietMode` is a file-level `let`;
+`setLLMUrl` is written by both `loadPieces` and
+`PiecesController.initialize`. Either scope them per connection, or land a
+recorded limit: one connection per process for shuttle v1, revisited when
+multiple places arrive. The cheap honest move is the recorded limit; the
+PR is whichever the review rules.
+
+## Stage B — the shuttle package
+
+**B0 — scaffold** (after A1). `packages/shuttle` with its path in the root
+`deno.jsonc` workspace array and its own `tasks.test` entry — the two
+edits a new package needs, the second one load-bearing. Dependencies
+follow `docs/development/DEPENDENCIES.md`. No behavior; the package
+compiles and its empty test task runs.
+
+**B1 — walking skeleton** (after A1; A2 for nothing yet). The place value
+and its owner module, the prompt, a readline loop, and `cd` / `ls` /
+`pwd` / `get` over one held `PiecesController` built cf-harness-style
+(memoized factory, cache cleared on rejected construction). Facets
+`slugs/` and `pieces/` only; `fuse/` waits. Liveness: this milestone is
+where the reconnect story is proven, because everything after leans on it.
+
+**B2 — writes, calls, handles** (after A2, A3). `set` with inline values,
+`edit` over `$EDITOR`, `call` through `callFromCommand`, numbered handles
+from listings, and the invocation session minted once at startup and
+passed explicitly. Warm-on-enter lands here, since `set` is what makes
+stale computed state visible.
+
+**B3 — watch and views** (after A4; view-substrate export entries added
+here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the
+value, list, and structured piece-overview views on the `cf view` pager
+substrate; cold-browse mode. Governed by [`views.md`](views.md); it opens
+with the two experiments and the raw-document-subscription proving test
+from issue [#6534](https://github.com/commontoolsinc/labs/issues/6534),
+falling back to the capped deep sink if the seam disappoints.
+
+**B4 — redirection, schemes, pipes.** `>` and `<` over fabric paths,
+`file:` and `https:` read ends, the native tool set v0 and the local
+escape. The external working location (`xcd`/`xpwd`, the `x:` base) and
+the full `where` surface land here.
+
+**B5 — search, pagination polish, `!cf` escape.** `search` at any place,
+cursoring over large listings, and the subprocess escape with
+place-derived flags injected.
+
+## Working rules
+
+- Every stage-A PR carries the unit tests its seam enables; a seam PR
+  without tests is the shape the `FromCommand` rationale exists to
+  prevent.
+- `packages/cli` coverage gates apply to stage A; the extraction PRs are
+  coverage-positive by construction, which is the order's second reason.
+- Shuttle stays out of `deno task check`'s path list until B1 gives it
+  real code, and registers there in the same PR that does.

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -100,26 +100,24 @@ since `set` is what makes stale computed state visible.
 here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the
 value, list, and structured piece-overview views on the `cf view` pager
 substrate; session watches (`watch`, `watches`, `unwatch`) with prompt
-event lines and the pinned strip; cold-browse mode and the `where mode`
-dimension that toggles it. Governed by [`views.md`](views.md); it opens
-with the two experiments and the raw-document-subscription proving test
-from issue [#6534](https://github.com/commontoolsinc/labs/issues/6534),
-falling back to the capped deep sink if the seam disappoints.
+event lines. Governed by [`views.md`](views.md); it opens with the two
+experiments and the raw-document-subscription proving test from issue
+[#6534](https://github.com/commontoolsinc/labs/issues/6534), falling back
+to the capped deep sink if the seam disappoints.
 
-**B4 — redirection, schemes, pipes.** `>` and `<` over fabric paths,
-`file:` and `https:` read ends, the native tool set v0 and the local
-escape. The external working location (`xcd`/`xpwd`, the `x:` base) lands
-here, and with it `where` reaches its full surface: every dimension
-settable, the heavyweight ones rebuilding the connection and saying so
+**B4 — externals and escapes.** `>` and `<` to and from `file:` externals
+under the scheme-absolute rule; the external working location
+(`xcd`/`xpwd`, the `x:` base); the `!` escape family — line-initial `!`,
+`|!` in a pipeline (bare `|` reserved, its error naming `|!`), and `!cf`
+with place-derived flags injected. With the external location, `where`
+reaches its v1 surface: every dimension printed, the light ones settable
 (decision 22).
 
-**B5 — search, the `fuse/` facet, `!cf` escape.** `search` at any place,
-cursoring over large listings, and the subprocess escape with
-place-derived flags injected. The `fuse/` facet (decision 11) lands here
-too: mirroring `packages/fuse`'s tree is a self-contained slice whose only
-prerequisite is B1's facet machinery, so it sits at the tail by scheduling
-rather than by dependency, and can move earlier if the mirror proves
-cheap.
+B4 closes v1. The deferred set — the pinned strip, cold-browse mode, the
+native tool set, heavyweight `where` edits, the `fuse/` facet,
+fabric-to-fabric redirection, `https:` read ends, and `search` — is
+designed and preserved in [`futures.md`](futures.md), each returning as
+its own slice when scheduled.
 
 ## Working rules
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -60,35 +60,66 @@ follow `docs/development/DEPENDENCIES.md`. No behavior; the package
 compiles and its empty test task runs.
 
 **B1 — walking skeleton** (after A1; A2 for nothing yet). The place value
-and its owner module, the prompt, a readline loop, and `cd` / `ls` /
-`pwd` / `get` over one held `PiecesController` built cf-harness-style
-(memoized factory, cache cleared on rejected construction). Facets
-`slugs/` and `pieces/` only; `fuse/` waits. Liveness: this milestone is
-where the reconnect story is proven, because everything after leans on it.
+and its owner module — the whole pair, position *and* scope, because scope
+is half of what a place is (decision 20): `cd @user` and `cd @space` move
+it, the prompt renders it, and `pwd` prints both halves. The prompt, a
+readline loop, and `cd` / `ls` / `pwd` / `get` over one held
+`PiecesController`, with `cd -` for the previous place and `#name` wish
+targets navigable (`cd #favorites`, and the `wish` verb, over the
+`./lib/wish` export entry A1 adds). `where` lands here as the printing
+surface for the ambient record; later milestones add their dimensions to it
+as they add the dimensions themselves. Facets `slugs/` and `pieces/` only.
+
+Liveness, in two halves. The held controller is memoized cf-harness-style,
+which covers the construction that never succeeds — the case that cache
+actually addresses. Recovery of an *established* connection needs nothing
+from shuttle: the memory client reconnects and re-arms its watches by
+itself ([`runtime-integration.md`](runtime-integration.md)), so B1 proves
+that rather than rebuilding it — a test that drops the transport under a
+standing watch and shows the subscription still delivering afterwards. What
+B1 does build is the observation seam, reporting live, reconnecting, and
+permanently failed, because no such surface exists today and both the
+prompt and the view markers consume it. No retry loop in shuttle on either
+half.
 
 **B2 — writes, calls, handles** (after A2, A3). `set` with inline values,
-`edit` over `$EDITOR`, `call` through `callFromCommand`, numbered handles
-from listings, and the invocation session minted once at startup and
-passed explicitly. Warm-on-enter lands here, since `set` is what makes
-stale computed state visible.
+`edit` over `$EDITOR`, and `link` — the one spelling that writes a
+reference instead of copying a value (decision 14), and the only write of
+the three that has no `cf` equivalent to lean on. `call` through
+`callFromCommand`, with `verbs` and `describe` beside it, since listing a
+piece's callables is what makes `call` usable without leaving the shell.
+Numbered handles from listings land here, and `more` with them: `more`
+continues a listing *and its handle numbering* (decision 24), so it needs
+the handle table, not merely a page cursor. Handles are structured at mint
+— each row's kind, plus receiver and verb name for a callable row — which
+is what `call %n` resolves against (decision 27). The invocation session is
+minted once at startup and passed explicitly. Warm-on-enter lands here,
+since `set` is what makes stale computed state visible.
 
 **B3 — watch and views** (after A4; view-substrate export entries added
 here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the
 value, list, and structured piece-overview views on the `cf view` pager
-substrate; session watches with prompt event lines and the pinned strip;
-cold-browse mode. Governed by [`views.md`](views.md); it opens
+substrate; session watches (`watch`, `watches`, `unwatch`) with prompt
+event lines and the pinned strip; cold-browse mode and the `where mode`
+dimension that toggles it. Governed by [`views.md`](views.md); it opens
 with the two experiments and the raw-document-subscription proving test
 from issue [#6534](https://github.com/commontoolsinc/labs/issues/6534),
 falling back to the capped deep sink if the seam disappoints.
 
 **B4 — redirection, schemes, pipes.** `>` and `<` over fabric paths,
 `file:` and `https:` read ends, the native tool set v0 and the local
-escape. The external working location (`xcd`/`xpwd`, the `x:` base) and
-the full `where` surface land here.
+escape. The external working location (`xcd`/`xpwd`, the `x:` base) lands
+here, and with it `where` reaches its full surface: every dimension
+settable, the heavyweight ones rebuilding the connection and saying so
+(decision 22).
 
-**B5 — search, pagination polish, `!cf` escape.** `search` at any place,
+**B5 — search, the `fuse/` facet, `!cf` escape.** `search` at any place,
 cursoring over large listings, and the subprocess escape with
-place-derived flags injected.
+place-derived flags injected. The `fuse/` facet (decision 11) lands here
+too: mirroring `packages/fuse`'s tree is a self-contained slice whose only
+prerequisite is B1's facet machinery, so it sits at the tail by scheduling
+rather than by dependency, and can move earlier if the mirror proves
+cheap.
 
 ## Working rules
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -75,7 +75,8 @@ stale computed state visible.
 **B3 — watch and views** (after A4; view-substrate export entries added
 here). `Cell.sink` with the guard-plus-`idle()` settling discipline; the
 value, list, and structured piece-overview views on the `cf view` pager
-substrate; cold-browse mode. Governed by [`views.md`](views.md); it opens
+substrate; session watches with prompt event lines and the pinned strip;
+cold-browse mode. Governed by [`views.md`](views.md); it opens
 with the two experiments and the raw-document-subscription proving test
 from issue [#6534](https://github.com/commontoolsinc/labs/issues/6534),
 falling back to the capped deep sink if the seam disappoints.

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -74,8 +74,9 @@ decisions point here where they defer.
   habit v1 would have to unteach.
 - **`where` editing the heavyweight dimensions.** Switching api endpoint
   or identity mid-session, rebuilding the connection and saying so. v1
-  fixes both at launch — restarting is the switch — which also honors the
-  one-connection-per-process limit the seam work records.
+  fixes them at launch, the space too (decision 22) — restarting is the
+  switch — which also honors the one-connection-per-process limit the
+  seam work records.
 - **The `fuse/` facet.** The FUSE layout mirrored at the space root, for
   mutual legibility between the two tools. Shuttle reuses `packages/fuse`
   naming and hydration work regardless; the facet is the presentation
@@ -100,15 +101,22 @@ decisions point here where they defer.
    `where writes off` dimension, and per-space protection — shuttle
    refuses writes to a marked space until explicitly armed — encode the
    local, rehearsal, production discipline into the tool.
-3. **History and records.** Persistent, searchable command history; a
+3. **Multi-space sessions.** Per-space controllers behind one prompt, so
+   `cd` can cross spaces and home-anchored wish targets can be followed.
+   Not yet designed: it needs the per-process module globals the seam
+   work records scoped per connection, and a controller lifecycle per
+   space. Until it lands, one shuttle process serves one space,
+   restarting is the space switch, and cross-space references are
+   refused with the reason.
+4. **History and records.** Persistent, searchable command history; a
    `record` verb writing the transcript to a `file:` target or into the
    fabric. The event-line design already makes transcripts evidence;
    this makes them saveable.
-4. **Time and diff.** `history <ref>` and `diff` across time or between
+5. **Time and diff.** `history <ref>` and `diff` across time or between
    references — the state inspector's reconstruction machinery is the
    offline prior art — plus a modest `undo` that writes back what the
    session last saw, honest about concurrent writes.
-5. **Small muscle memory.** `pushd`/`popd` on the place stack;
+6. **Small muscle memory.** `pushd`/`popd` on the place stack;
    `watch --bell` and `--notify` (local side effects, marked as such); an
    opt-in `--resume` restoring the user's own last ambient record — which
    is not the persisted cross-process ambience the non-goals rule out,

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -1,6 +1,6 @@
 # Shuttle — futures
 
-Satellite of [`../shuttle.md`](../shuttle.md): the trajectory past v1.
+Satellite of [`README.md`](README.md): the trajectory past v1.
 Nothing here is v1 scope and nothing is a commitment to build order. The
 positions are taken now so that later features land coherently with the
 settled decisions; the candidates are ranked leads, to be ruled when their

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -47,6 +47,48 @@ The scripting bundle is also the agent door the non-goals hold open:
 stable machine-readable output, exit-code discipline, and deterministic
 non-TTY behavior (no views, no strip) arrive with it, not before.
 
+## Deferred from v1, design settled
+
+Each of these was ruled during the v1 design and then deferred past v1 to
+keep the first build small. The designs are settled — recorded here so
+they are re-scheduled later, never re-litigated — and the main document's
+decisions point here where they defer.
+
+- **The pinned strip.** A reserved region above the prompt renders armed
+  watches' current values live while scrollback flows past. Event lines
+  carry the arm-then-act loop in v1; the strip returns when watch density
+  demands it. Open: its height, and what it shows when more watches are
+  armed than fit.
+- **Cold-browse mode.** Walking around with no computation: reads serve
+  stored state, labeled as such, with the mode unmistakable in the prompt
+  and every view, toggled as a `where` mode dimension. It insures against
+  a warming cost not yet observed; warm-on-enter already leaves merely
+  listed pieces cold, which is v1's whole run-state story.
+- **The native tool set.** Published names that work bare in a pipeline
+  and are guaranteed wherever shuttle runs — a native tool may start as a
+  forward to a local binary; that is implementation, not contract. The
+  v0 list: `jq`, `grep`, `wc`, `head`, `tail`, `sort`, `uniq`, `cut`,
+  with `cat` deliberately absent (`get` prints, `< file:…` feeds, and
+  concatenation waits for a demand). Until the set ships, bare `|` is
+  reserved and its error names `|!`, so nobody learns an invisible local
+  habit v1 would have to unteach.
+- **`where` editing the heavyweight dimensions.** Switching api endpoint
+  or identity mid-session, rebuilding the connection and saying so. v1
+  fixes both at launch — restarting is the switch — which also honors the
+  one-connection-per-process limit the seam work records.
+- **The `fuse/` facet.** The FUSE layout mirrored at the space root, for
+  mutual legibility between the two tools. Shuttle reuses `packages/fuse`
+  naming and hydration work regardless; the facet is the presentation
+  half, and it waits.
+- **Fabric-to-fabric redirection.** `get topics/3 > drafts/copy` as a
+  value copy, with `link` remaining the only reference-writer. The plane
+  grammar — bare relative operands are fabric, schemes are explicit — is
+  settled and v1 grammar; the copy itself waits for a demand.
+- **`https:` read ends.** The scheme family is open by design; `file:` is
+  its v1 member, and `set x - < https://…` joins when a use rules it in.
+- **`search`.** A `search <query>` verb at any place, over what stands
+  below it. Pipes over `ls` cover the interim.
+
 ## Candidates, ranked
 
 1. **The weaver bridge.** `cd <weaver-URL>` lands in that piece one layer

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -62,7 +62,7 @@ decisions point here where they defer.
 - **Cold-browse mode.** Walking around with no computation: reads serve
   stored state, labeled as such, with the mode unmistakable in the prompt
   and every view, toggled as a `where` mode dimension. It insures against
-  a warming cost not yet observed; warm-on-enter already leaves merely
+  a warming cost not yet observed; reaching-in-warms already leaves merely
   listed pieces cold, which is v1's whole run-state story.
 - **The native tool set.** Published names that work bare in a pipeline
   and are guaranteed wherever shuttle runs — a native tool may start as a

--- a/docs/plans/shuttle/futures.md
+++ b/docs/plans/shuttle/futures.md
@@ -1,0 +1,74 @@
+# Shuttle — futures
+
+Satellite of [`../shuttle.md`](../shuttle.md): the trajectory past v1.
+Nothing here is v1 scope and nothing is a commitment to build order. The
+positions are taken now so that later features land coherently with the
+settled decisions; the candidates are ranked leads, to be ruled when their
+turn comes.
+
+## Positions
+
+**Configuration lives in the fabric.** Command aliases and shuttle
+preferences belong in a piece under the user's profile, not in a dotfile:
+they then follow the user to any terminal, including the eventual hosted
+one with no local disk — the same portability constraint the
+native-versus-escaped pipeline split already serves. How the first
+connection bootstraps before configuration loads is the open detail.
+
+**Bookmarks are favorites.** A local bookmark file would be a
+shuttle-private naming layer, which decision 13 forbids — and the fabric
+already has named entry points. A `bookmark` verb writes through the wish
+machinery to the user's favorites, and `cd #<name>` is already the
+spelling that reaches them. Bookmarking is a fabric feature shuttle uses,
+not a shuttle feature.
+
+**The session scope is the variable store.** `@session` scoped cells are
+per-user, per-session, durable, inspectable, and reactive — and redirects
+already write values into the fabric, so
+`get big --filter … > scratch/result@session` is assignment. A `$name`
+spelling can be pure sugar over a session-scoped scratch area. Shuttle
+adds spelling, never a private interpreter heap: script state is then
+debuggable by the same acts as any other state. Where the scratch area's
+home piece lives is the open detail.
+
+**Scripting comes in three layers, and stops there.**
+
+1. Linear command files: `shuttle -c '…'` and `#!/usr/bin/env shuttle`
+   scripts (the `cf exec` shebang is the precedent). No control flow.
+2. Real programs: the seams shuttle calls are importable libraries, so
+   control flow means a TypeScript file using the same API — perhaps
+   `run script.ts` handing it the ambient record. Shuttle never grows a
+   script language of its own.
+3. The stance underneath: recurring automation that lives with the data
+   belongs inside the fabric as a pattern or verb — reactive, durable,
+   shareable. Scripting is for driving the fabric from outside.
+
+The scripting bundle is also the agent door the non-goals hold open:
+stable machine-readable output, exit-code discipline, and deterministic
+non-TTY behavior (no views, no strip) arrive with it, not before.
+
+## Candidates, ranked
+
+1. **The weaver bridge.** `cd <weaver-URL>` lands in that piece one layer
+   down; a `weaver` verb emits the URL for the current place (or a
+   handle: `weaver %3`) to jump a layer up. The route grammar is already
+   in the prior-art table as mutually translatable; this makes the
+   two-layer story concrete in both directions.
+2. **Write guards.** Cold-browse mode is compute-cold, not write-safe. A
+   `where writes off` dimension, and per-space protection — shuttle
+   refuses writes to a marked space until explicitly armed — encode the
+   local, rehearsal, production discipline into the tool.
+3. **History and records.** Persistent, searchable command history; a
+   `record` verb writing the transcript to a `file:` target or into the
+   fabric. The event-line design already makes transcripts evidence;
+   this makes them saveable.
+4. **Time and diff.** `history <ref>` and `diff` across time or between
+   references — the state inspector's reconstruction machinery is the
+   offline prior art — plus a modest `undo` that writes back what the
+   session last saw, honest about concurrent writes.
+5. **Small muscle memory.** `pushd`/`popd` on the place stack;
+   `watch --bell` and `--notify` (local side effects, marked as such); an
+   opt-in `--resume` restoring the user's own last ambient record — which
+   is not the persisted cross-process ambience the non-goals rule out,
+   and the line between the two is drawn here on purpose: resume hands
+   one shuttle its own past, never another tool the session's present.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -26,12 +26,46 @@ case that also injects place-derived flags.
 A reference on the line resolves against the place, right-anchored, exactly
 as the canonical grammar's context rule already works:
 
-- `/…` — absolute canonical reference; never depends on the place.
+- `/of:…` — a **rooted** reference: it names the piece and path from the
+  root, so no part of the position is read from the place — but it omits
+  the space, which the place still supplies. Rooted is not
+  place-independent.
+- `/@did:key:…/of:…` — a **complete** reference: it carries its own space,
+  so it denotes the same cell read from anywhere. Only this form is
+  place-independent, and it is what a printed address or a shared link
+  should be. Denoting is not reaching, though: a connection serves one
+  space, so a complete reference naming a different space than the place's
+  is refused rather than followed — `validateEmbeddedSpaces`
+  (`packages/cli/lib/llm-friendly-ref.ts`) already holds `cf` to that, and
+  shuttle v1 holds one connection.
 - `#…` — a wish target (entry point), resolvable from anywhere.
 - `..` — up one level; `cd -` — the previous place.
 - Anything else — relative: resolved as a child of the current position
   (a facet at a space root, a key or index inside a piece, a slug inside
   `slugs/`).
+
+The distinction is the parser's, not shuttle's: `parseLLMFriendlyLink`
+(`packages/runner/src/link-types.ts`) takes the space as a separate
+argument and uses it whenever the reference carries no `@did:key:…`
+prefix, overriding it with the embedded space when one is present. A
+rooted reference is therefore exactly as space-dependent as a relative
+one; it is the piece and path it fixes, not the space.
+
+Two spellings share the `#` character and nothing else. A lone `#name`
+token is a wish target, as above. `#argument` is a suffix on a reference
+and only that — it selects the piece's arguments cell, the same selection
+`--input` spells as a flag (`normalizeLLMFriendlyRef` in
+`packages/cli/lib/llm-friendly-ref.ts`, which strips it before the runner
+grammar sees the string, and refuses every other fragment).
+
+A place is **result-rooted**, and holds exactly space, piece, path, and
+scope. `cd` refuses a reference carrying `#argument` rather than dropping
+the suffix silently: a place that could root at the arguments cell would
+leave every later relative read ambiguous about which side of the piece it
+addressed, and the prompt would have to carry the distinction for as long
+as you stood there. Arguments are reached per operand instead —
+`get topics/3#argument`, and `--input` on the `cf` verbs that take it — so
+the choice is one visible token at each use.
 
 ## The space root and facets
 
@@ -72,6 +106,12 @@ continues the current one), so `cd %3` and `get %1/title` act on what a
 view showed without retyping anything. Handles are how a view feeds the
 next command without the view being a place; an interactive picker can
 layer on later and produce the same handles.
+
+A handle carries structure rather than a string. The listing records each
+row's kind as it mints one, and for a callable row the receiver and the
+verb name it stands for — which is what lets `call %4` invoke without a
+hand-split reference, and lets arity resolve locally (the "Calling a verb"
+section below).
 
 **A view is not necessarily a place.** A page of results, a search hit
 list, a filtered projection — these are things to look at and pick from,
@@ -173,20 +213,35 @@ legible space names arrive when the fabric grows them.
 
 ## Calling a verb
 
-`call` keeps `cf`'s two-positional form — `call topics/3 add-reply` — so
-knowledge transfers, and adds the one-reference form:
-`call topics/3/add-reply` invokes the callable cell the path names,
-resolving with the same defaulting as `get`. Arity disambiguates: one
-reference argument invokes what the path names; a second positional is the
-callable name, `cf`-style.
+Two forms, and no third:
 
-The path form exists because a callable is a cell like everything else —
-FUSE already mounts a handler as an executable file and `cf exec` runs it
-by path — and because listings surface callables inline and hand out
-handles: when `%4` is a callable row, `call %4` must work without
-splitting a reference by hand. This adds no reference-syntax capability;
-the path is already spellable in the canonical form, and the sugar is in
-the verb.
+- `call <ref> <name>` — the typed spelling, `cf`'s two-positional form
+  (`call topics/3 add-reply`), so knowledge transfers both ways.
+- `call <callable-handle> [input…]` — `call %4`, where the listing minted
+  `%4` from a callable row. The handle carries its receiver and verb name
+  (the listings section above), so it invokes through the same root-level
+  name resolution the typed form uses.
+
+A typed path ending in a callable — `call topics/3/add-reply` — is
+refused, and the error names the two-positional form to use instead.
+
+Both forms land on the resolution that exists. `resolvePieceCallable`
+(`packages/cli/lib/piece.ts`) takes a receiver and a callable *name*,
+resolving it against the piece's result cell, then its input cell, then
+its handlers. A handle that carries the name rather than a path is what
+keeps both forms on that one resolution, so neither needs a full-path
+callable resolver built first.
+
+Arity never has to guess, because a handle's kind is known locally the
+moment the listing mints it: a callable handle means the positionals after
+it are input, a piece handle means the next positional is the verb name.
+Nothing about parsing a line waits on what a reference turns out to
+resolve to.
+
+The split is the one the fabric already draws. A verb name is interface
+vocabulary, not a data path — the receiver is the addressable thing, and
+the name selects from what its interface offers. Two positional slots keep
+that visible on every line.
 
 ## Redirection and schemes
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -213,35 +213,44 @@ legible space names arrive when the fabric grows them.
 
 ## Calling a verb
 
-Two forms, and no third:
+Three spellings, and no fourth:
 
-- `call <ref> <name>` — the typed spelling, `cf`'s two-positional form
-  (`call topics/3 add-reply`), so knowledge transfers both ways.
+- `call <ref> <name> [input]` — the typed form, matching `cf`'s
+  (`call topics/3 add-reply '{"body":"hi"}'`), so knowledge transfers both
+  ways. The input positional takes an inline JSON value or `-` to read the
+  payload from stdin, and `--` opens the callable's schema-derived flags
+  (`call topics/3 search -- --query milk`) — the same spellings
+  `cf piece call` documents.
+- `call <piece-handle> <name> [input]` — a piece handle stands wherever a
+  typed reference stands, so this is the typed form with the receiver
+  already in hand: `call %3 add-reply -- --body "shipped"` off a listing
+  whose rows are pieces.
 - `call <callable-handle> [input…]` — `call %4`, where the listing minted
-  `%4` from a callable row. The handle carries its receiver and verb name
-  (the listings section above), so it invokes through the same root-level
-  name resolution the typed form uses.
+  `%4` from a callable row. That handle carries receiver *and* name, so
+  the name is not spelled again.
 
 A typed path ending in a callable — `call topics/3/add-reply` — is
-refused, and the error names the two-positional form to use instead.
+refused, and the error names the `<ref> <name>` form to use instead.
 
-Both forms land on the resolution that exists. `resolvePieceCallable`
+All three land on the resolution that exists. `resolvePieceCallable`
 (`packages/cli/lib/piece.ts`) takes a receiver and a callable *name*,
 resolving it against the piece's result cell, then its input cell, then
 its handlers. A handle that carries the name rather than a path is what
-keeps both forms on that one resolution, so neither needs a full-path
-callable resolver built first.
+keeps every form on that one resolution, so none of them needs a
+full-path callable resolver built first.
 
-Arity never has to guess, because a handle's kind is known locally the
-moment the listing mints it: a callable handle means the positionals after
-it are input, a piece handle means the next positional is the verb name.
-Nothing about parsing a line waits on what a reference turns out to
-resolve to.
+One arity rule covers all three, and it never consults the fabric. The
+typed form has a fixed shape — reference, name, optional input — and a
+handle's kind is fixed when the listing mints it: a piece handle takes the
+verb name in the next positional, a callable handle takes input. So
+whether a positional is a name or a payload is known from the line and the
+handle table alone, and nothing about parsing waits on what a reference
+turns out to resolve to.
 
 The split is the one the fabric already draws. A verb name is interface
 vocabulary, not a data path — the receiver is the addressable thing, and
-the name selects from what its interface offers. Two positional slots keep
-that visible on every line.
+the name selects from what its interface offers. Keeping receiver and name
+in separate slots keeps that visible on every line.
 
 ## Redirection and schemes
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -126,9 +126,11 @@ document holds open — the abstraction allows it; nothing requires it.
 
 ## Run state
 
-Entering warms: `cd` into a piece (or `watch` on anything inside it) starts
-the pattern in this process, and reads inside it are live from then on.
-Pieces merely listed from outside stay cold.
+Reaching in warms: `cd` into a piece, `watch` on anything inside it, or
+any read aimed into it — `get topics/3/title` from the space root warms
+`topics/3` exactly as `cd` would — starts the pattern in this process, and
+reads are live from then on. A piece is cold only while it is merely
+listed, so there is no unlabeled stored-state read path.
 
 That is v1's whole run-state story. A **cold-browse mode** — walking with
 no computation, stored reads labeled — is designed and deferred past v1

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -218,12 +218,16 @@ Three spellings, and no fourth:
 - `call <ref> <name> [input]` — the typed form, matching `cf`'s
   (`call topics/3 add-reply '{"body":"hi"}'`), so knowledge transfers both
   ways. The input positional takes an inline JSON value or `-` to read the
-  payload from stdin, and `--` opens the callable's schema-derived flags
-  (`call topics/3 search -- --query milk`) — the same spellings
-  `cf piece call` documents.
+  payload from stdin. The verb name opens the callable's section, so its
+  schema-derived flags follow bare — `call topics/3 search --query milk` —
+  and `--` closes the section. That is
+  [`../cli-surface-shape.md`](../cli-surface-shape.md) step 10's form;
+  `cf` today still spells it with `--` opening the section, and shuttle
+  speaks step 10 from the start rather than teaching a spelling the arc
+  retires.
 - `call <piece-handle> <name> [input]` — a piece handle stands wherever a
   typed reference stands, so this is the typed form with the receiver
-  already in hand: `call %3 add-reply -- --body "shipped"` off a listing
+  already in hand: `call %3 add-reply --body "shipped"` off a listing
   whose rows are pieces.
 - `call <callable-handle> [input…]` — `call %4`, where the listing minted
   `%4` from a callable row. That handle carries receiver *and* name, so

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -12,9 +12,9 @@ redirection surface. Ruled points are stated plainly; anything marked
 ```
 
 Navigation verbs are shuttle-native: `cd`, `ls`, `pwd`, `watch`,
-`unwatch`, `watches`, `back` (`cd -` returns to the previous place). Data
-verbs are `cf`'s own — `get`,
-`set`, `call`, `wish`, `verbs`, `describe`, … — accepting their existing
+`unwatch`, `watches` (`cd -` returns to the previous place). Data verbs
+are `cf`'s own — `get`, `set`, `call`, `wish`, `verbs`, `describe`, … —
+accepting their existing
 read and projection options (`--filter`, `--select`, `--schema`, `--json`),
 with the place supplying target options. `!` marks "this runs on the local
 machine" everywhere it appears: line-initial `! <cmd>` runs any local
@@ -137,7 +137,7 @@ no computation, stored reads labeled — is designed and deferred past v1
 ## Scope is the cwd's second dimension
 
 A cell can carry per-identity overlays — `@user`, `@session` — so the same
-piece reads differently per identity (`cf inspect scopes` shows that
+piece reads differently per identity (`cf inspect scopes <space>` shows that
 ground truth offline). Scope is a way of seeing every place, not a
 location, so the cwd is a **pair**: position and scope. Both stick while
 you navigate, both render in the prompt, and `pwd` prints both.
@@ -182,7 +182,7 @@ The canonical grammar bounds what a suffix on a reference can say
   spelling) is not in the grammar and is out of v1. It is a
   canonical-grammar extension first — "the alias must not grow a
   capability the canonical form lacks" (`packages/cli/lib/llm-friendly-ref.ts`)
-  — and a permission question besides; `cf inspect scopes` remains the
+  — and a permission question besides; `cf inspect scopes <space>` remains the
   offline way to see other identities' overlays.
 
 ## The ambient context and `where`

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -98,25 +98,39 @@ ground truth offline). Scope is a way of seeing every place, not a
 location, so the cwd is a **pair**: position and scope. Both stick while
 you navigate, both render in the prompt, and `pwd` prints both.
 
-`cd` is the door to both dimensions, applying whatever components a
-reference carries: `cd board@session` moves position and scope in one
-step, and `cd @session` moves scope alone, exactly as `cd topics/3` moves
-position alone. There is no separate scope verb; the general door is
+`cd` is the door to both dimensions, applying whatever components its
+operand carries: `cd board@session` is a full reference and moves position
+and scope in one step, `cd topics/3` moves position alone, and `cd @session`
+moves scope alone. There is no separate scope verb; the general door is
 `where scope …`, like any other ambient dimension. The active scope fills
 the omitted `@scope` of every reference as the place fills omitted
 position levels, and an explicit suffix on an operand overrides it for
 that operand alone.
 
-The canonical grammar bounds what a suffix can say (verified against
-`parseScopedIdSegment` in `packages/runner/src/link-types.ts`):
+A scope-only `@scope` is shuttle **navigation syntax**, not a reference. It
+sits with `..` and `-`: spellings that `cd` and `where` accept to move the
+cwd, and that the canonical grammar does not parse. `parseScopedIdSegment`
+(`packages/runner/src/link-types.ts`) requires an id in front of the
+suffix and throws without one, so `@session` alone addresses nothing. The
+no-growth rule holds because the spelling never leaves those two verbs: an
+operand and a full reference always carry an id, no link endpoint can hold
+a scope-only suffix, and nothing serializes one. Setting the ambient scope
+is all `cd @session` does, and ordinary references pick it up from there.
 
-- The suffix is a bare `CellScope` word — `@space`, `@user`, `@session` —
-  and identity components are never spelled in a reference. `@session`
+The canonical grammar bounds what a suffix on a reference can say
+(verified against `parseScopedIdSegment` in
+`packages/runner/src/link-types.ts`):
+
+- The suffix is a `CellScope` word — `@space`, `@user`, `@session` — with
+  no identity component; those are never spelled in a reference. `@session`
   and `@user` therefore mean the **reading identity's own** overlays,
   composed with the caller's identity at resolution.
-- `@space` is accepted and explicit: the parser returns `scope: "space"`,
-  distinct from an omitted suffix — so `cd @space` returns to the base
-  overlay inside today's grammar.
+- `@space` is a canonical scope value, not shuttle's addition:
+  `CELL_SCOPE_VALUES` holds it beside `user` and `session`, the parser's
+  rejection text names all three, and `piece1@space/path` parses to
+  `scope: "space"` distinct from an omitted suffix
+  (`packages/cli/test/piece.test.ts`). The base is therefore nameable, and
+  `cd @space` sets the ambient scope back to it.
 - The serializer never emits `@space` (the base renders as a bare id), so
   the prompt and `pwd` render the scope dimension themselves rather than
   round-tripping through the reference serializer.

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -38,7 +38,11 @@ as the canonical grammar's context rule already works:
   is refused rather than followed — `validateEmbeddedSpaces`
   (`packages/cli/lib/llm-friendly-ref.ts`) already holds `cf` to that, and
   shuttle v1 holds one connection.
-- `#…` — a wish target (entry point), resolvable from anywhere.
+- `#…` — a wish target (entry point), resolvable from anywhere within
+  the connected space. A target anchored elsewhere — profile and
+  favorites resolve against the reading identity's home space regardless
+  of the connected space (`packages/cli/lib/wish.ts`) — is refused with
+  the reason in v1, which holds one connection to one space.
 - `..` — up one level; `cd -` — the previous place.
 - Anything else — relative: resolved as a child of the current position
   (a facet at a space root, a key or index inside a piece, a slug inside

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -74,11 +74,10 @@ too large for a flat root. The starting facet set:
 
 - `slugs/` — the slug index: named pieces, the primary human view.
 - `pieces/` — pieces by id.
-- `fuse/` — the FUSE layout mirrored as-is (`packages/fuse`'s tree:
-  `pieces/<slug>/result/…`, entities, exploded JSON). Shuttle leverages that
-  package's naming and hydration work rather than reinventing it, and the
-  mirror keeps the two tools mutually legible. Where shuttle has a clearly
-  better presentation it lives in shuttle's own facets, outside `fuse/`.
+
+A `fuse/` facet mirroring the FUSE layout is designed and deferred past v1
+([`futures.md`](futures.md)); shuttle leverages `packages/fuse`'s naming
+and hydration work regardless of when that facet lands.
 
 Facet names are reserved segments at the space root only; inside a piece,
 every segment is data — always. A piece's callables need no reserved name:
@@ -98,7 +97,8 @@ minus chrome, `--limit` overriding — plus a status line
 uninvited, so piped output stays clean by construction. `more` continues
 the same listing and its numbering (`%39`…`%76`); backward at the prompt
 is scrollback's job, and real two-way navigation is `browse`'s.
-`search <query>` works at any place, over what stands below it.
+A `search <query>` verb at any place is designed and deferred past v1
+([`futures.md`](futures.md)); pipes over `ls` cover the interim.
 
 Listings number their rows, and numbered handles are references: `%1`,
 `%2`, … stay valid until the next new listing resets them (`more`
@@ -126,10 +126,9 @@ Entering warms: `cd` into a piece (or `watch` on anything inside it) starts
 the pattern in this process, and reads inside it are live from then on.
 Pieces merely listed from outside stay cold.
 
-A **cold-browse mode** turns warming off: walking around triggers no
-computation, reads serve stored state, and the mode is unmistakably visible
-in the prompt and in every view (stored values labeled as such). Toggling is
-`where mode cold` and `where mode warm` (the ambient-context section below).
+That is v1's whole run-state story. A **cold-browse mode** — walking with
+no computation, stored reads labeled — is designed and deferred past v1
+([`futures.md`](futures.md)).
 
 ## Scope is the cwd's second dimension
 
@@ -185,12 +184,15 @@ The canonical grammar bounds what a suffix on a reference can say
 ## The ambient context and `where`
 
 Everything ambient is one record: the connection (api endpoint, identity),
-the cwd pair (position, scope), the external working location, the browse
-mode, and the invocation session. `where` prints the whole record, and
-`where <dimension> <value>` sets any dimension — the heavyweight ones
-(`where api …`, `where identity …`) rebuild the connection and say so.
-`cd`/`pwd` and `xcd`/`xpwd` are conveniences over the hottest dimensions,
-not separate mechanisms, and launch flags merely seed the initial record.
+the cwd pair (position, scope), the external working location, and the
+invocation session. `where` prints the whole record, and
+`where <dimension> <value>` sets the light dimensions — scope, the
+external location. The heavyweight dimensions are fixed at launch in v1
+and restarting is the switch; editing them live (`where api …`,
+`where identity …`, rebuilding the connection) is designed and deferred
+([`futures.md`](futures.md)). `cd`/`pwd` and `xcd`/`xpwd` are conveniences
+over the hottest dimensions, not separate mechanisms, and launch flags
+merely seed the initial record.
 
 ## Prompt
 
@@ -261,17 +263,18 @@ in separate slots keeps that visible on every line.
 The ambient data plane is the fabric: redirection targets fabric paths, and
 anything outside the fabric is named by an explicit scheme.
 
-- `get topics/3 > drafts/copy` — reads one place, writes the value to
-  another. Fabric-to-fabric, a value copy (`link` is how one makes a
-  reference instead).
+- Fabric-to-fabric redirection — `get topics/3 > drafts/copy` as a value
+  copy, `link` remaining the reference-writer — is designed and deferred
+  past v1 ([`futures.md`](futures.md)); the plane rules below are settled
+  v1 grammar either way.
 - `file:` names a local file, the only spelling that touches disk — and a
   scheme is legal only on an absolute complete path:
   `get topics --json > file:/tmp/topics.json` is fine, `file:out.json` is
   refused (`file:~/…` counts as absolute).
 - `file:` is one member of an open scheme family: a schemed operand names
-  something outside the fabric. `https:`/`http:` sources work as read ends
-  (`set x - < https://…`); writing to an external scheme stays out of scope
-  until a use rules it in.
+  something outside the fabric. `file:` is the v1 member; `https:` read
+  ends are designed and deferred ([`futures.md`](futures.md)), and writing
+  to an external scheme stays out of scope until a use rules it in.
 - Shuttle maintains two working positions: the fabric cwd and one
   **external working location**. `xcd` sets it — `xcd file:~/data`,
   `xcd https://foo.com/a/b/` — and, its argument being already on the
@@ -282,23 +285,16 @@ anything outside the fabric is named by an explicit scheme.
   whatever that location's scheme, so no operand ever changes plane by
   position. A bare relative operand is always fabric.
 
-## Pipes: native tools and escaped locals
+## Pipes: escaped locals
 
-Shuttle publishes a **native tool set**: names that work bare in a pipeline
-— `get topics --json | jq '.[].title'` — and are guaranteed present
-wherever shuttle runs, including an eventual terminal with no local
-execution environment behind it. A native tool may begin as a forward to a
-local binary; that is implementation, not contract. The initial set:
-`jq`, `grep`, `wc`, `head`, `tail`, `sort`, `uniq`, `cut`. `cat` is
-deliberately absent — printing a value is `get`, feeding a local file is
-`< file:…`, and concatenation, its one irreplaceable job, waits for a
-demand (`! cat` reaches the local one meanwhile).
-
-Arbitrary local programs run only behind the explicit escape — `|!` in a
-pipeline, line-initial `!` for a whole command — so stepping outside the
-portable surface is always visible on the line. The split is deliberate:
-the basics stay covered naturally, and nobody gets used to running local
-tools invisibly.
+Local programs run behind the explicit escape — `|!` in a pipeline
+(`get topics --json |! jq '.[].title'`), line-initial `!` for a whole
+command — so stepping outside the portable surface is always visible on
+the line. Bare `|` is reserved, and its error names `|!`: the **native
+tool set** — names that work bare and are guaranteed wherever shuttle
+runs — is designed and deferred past v1 ([`futures.md`](futures.md)),
+and reserving the spelling now means v1 teaches no invisible-local habit
+the set would have to unteach.
 
 ## Open questions
 

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -1,6 +1,6 @@
 # Shuttle — line grammar and place resolution
 
-Satellite of [`../shuttle.md`](../shuttle.md): the command line's shape, how
+Satellite of [`README.md`](README.md): the command line's shape, how
 references resolve against the place, what listings show, and the write and
 redirection surface. Ruled points are stated plainly; anything marked
 *proposed* awaits a ruling.
@@ -12,7 +12,8 @@ redirection surface. Ruled points are stated plainly; anything marked
 ```
 
 Navigation verbs are shuttle-native: `cd`, `ls`, `pwd`, `watch`,
-`unwatch`, `watches`, `back` (`cd -` returns to the previous place). Data verbs are `cf`'s own — `get`,
+`unwatch`, `watches`, `back` (`cd -` returns to the previous place). Data
+verbs are `cf`'s own — `get`,
 `set`, `call`, `wish`, `verbs`, `describe`, … — accepting their existing
 read and projection options (`--filter`, `--select`, `--schema`, `--json`),
 with the place supplying target options. `!` marks "this runs on the local

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -11,8 +11,8 @@ redirection surface. Ruled points are stated plainly; anything marked
 <verb> [reference] [arguments…] [options…]
 ```
 
-Navigation verbs are shuttle-native: `cd`, `ls`, `pwd`, `watch`, `back`
-(`cd -` returns to the previous place). Data verbs are `cf`'s own — `get`,
+Navigation verbs are shuttle-native: `cd`, `ls`, `pwd`, `watch`,
+`unwatch`, `watches`, `back` (`cd -` returns to the previous place). Data verbs are `cf`'s own — `get`,
 `set`, `call`, `wish`, `verbs`, `describe`, … — accepting their existing
 read and projection options (`--filter`, `--select`, `--schema`, `--json`),
 with the place supplying target options. `!` marks "this runs on the local

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -1,0 +1,207 @@
+# Shuttle — line grammar and place resolution
+
+Satellite of [`../shuttle.md`](../shuttle.md): the command line's shape, how
+references resolve against the place, what listings show, and the write and
+redirection surface. Ruled points are stated plainly; anything marked
+*proposed* awaits a ruling.
+
+## The line
+
+```text
+<verb> [reference] [arguments…] [options…]
+```
+
+Navigation verbs are shuttle-native: `cd`, `ls`, `pwd`, `watch`, `back`
+(`cd -` returns to the previous place). Data verbs are `cf`'s own — `get`,
+`set`, `call`, `wish`, `verbs`, `describe`, … — accepting their existing
+read and projection options (`--filter`, `--select`, `--schema`, `--json`),
+with the place supplying target options. `!` marks "this runs on the local
+machine" everywhere it appears: line-initial `! <cmd>` runs any local
+program, `|!` is the same escape in a pipeline, and `!cf …` is the special
+case that also injects place-derived flags.
+
+## Place resolution
+
+A reference on the line resolves against the place, right-anchored, exactly
+as the canonical grammar's context rule already works:
+
+- `/…` — absolute canonical reference; never depends on the place.
+- `#…` — a wish target (entry point), resolvable from anywhere.
+- `..` — up one level; `cd -` — the previous place.
+- Anything else — relative: resolved as a child of the current position
+  (a facet at a space root, a key or index inside a piece, a slug inside
+  `slugs/`).
+
+## The space root and facets
+
+A space root lists **facets**, never pieces directly — a populated space is
+too large for a flat root. The starting facet set:
+
+- `slugs/` — the slug index: named pieces, the primary human view.
+- `pieces/` — pieces by id.
+- `fuse/` — the FUSE layout mirrored as-is (`packages/fuse`'s tree:
+  `pieces/<slug>/result/…`, entities, exploded JSON). Shuttle leverages that
+  package's naming and hydration work rather than reinventing it, and the
+  mirror keeps the two tools mutually legible. Where shuttle has a clearly
+  better presentation it lives in shuttle's own facets, outside `fuse/`.
+
+Facet names are reserved segments at the space root only; inside a piece,
+every segment is data — always. A piece's callables need no reserved name:
+they surface inline in listings, annotated as callable, exactly as the
+FUSE layout marks a handler an executable file inside the piece's tree
+(and the `verbs` verb lists them on demand).
+
+The facet set stays deliberately small; growing it is a design decision,
+not a convenience.
+
+## Listings, pagination, search
+
+Large collections appear everywhere (a space's pieces, an array of
+thousands). `ls` prints one height-fit page — what the terminal shows
+minus chrome, `--limit` overriding — plus a status line
+(`412 items — more, or browse`), and never takes the screen over
+uninvited, so piped output stays clean by construction. `more` continues
+the same listing and its numbering (`%39`…`%76`); backward at the prompt
+is scrollback's job, and real two-way navigation is `browse`'s.
+`search <query>` works at any place, over what stands below it.
+
+Listings number their rows, and numbered handles are references: `%1`,
+`%2`, … stay valid until the next new listing resets them (`more`
+continues the current one), so `cd %3` and `get %1/title` act on what a
+view showed without retyping anything. Handles are how a view feeds the
+next command without the view being a place; an interactive picker can
+layer on later and produce the same handles.
+
+**A view is not necessarily a place.** A page of results, a search hit
+list, a filtered projection — these are things to look at and pick from,
+and they need no path-shaped address of their own. Requiring every viewable
+thing to be a place would constrain the interface for no gain. When a
+derived set earns an address, that is the virtual-places extension the main
+document holds open — the abstraction allows it; nothing requires it.
+
+## Run state
+
+Entering warms: `cd` into a piece (or `watch` on anything inside it) starts
+the pattern in this process, and reads inside it are live from then on.
+Pieces merely listed from outside stay cold.
+
+A **cold-browse mode** turns warming off: walking around triggers no
+computation, reads serve stored state, and the mode is unmistakably visible
+in the prompt and in every view (stored values labeled as such). Toggling is
+`where mode cold` and `where mode warm` (the ambient-context section below).
+
+## Scope is the cwd's second dimension
+
+A cell can carry per-identity overlays — `@user`, `@session` — so the same
+piece reads differently per identity (`cf inspect scopes` shows that
+ground truth offline). Scope is a way of seeing every place, not a
+location, so the cwd is a **pair**: position and scope. Both stick while
+you navigate, both render in the prompt, and `pwd` prints both.
+
+`cd` is the door to both dimensions, applying whatever components a
+reference carries: `cd board@session` moves position and scope in one
+step, and `cd @session` moves scope alone, exactly as `cd topics/3` moves
+position alone. There is no separate scope verb; the general door is
+`where scope …`, like any other ambient dimension. The active scope fills
+the omitted `@scope` of every reference as the place fills omitted
+position levels, and an explicit suffix on an operand overrides it for
+that operand alone.
+
+The canonical grammar bounds what a suffix can say (verified against
+`parseScopedIdSegment` in `packages/runner/src/link-types.ts`):
+
+- The suffix is a bare `CellScope` word — `@space`, `@user`, `@session` —
+  and identity components are never spelled in a reference. `@session`
+  and `@user` therefore mean the **reading identity's own** overlays,
+  composed with the caller's identity at resolution.
+- `@space` is accepted and explicit: the parser returns `scope: "space"`,
+  distinct from an omitted suffix — so `cd @space` returns to the base
+  overlay inside today's grammar.
+- The serializer never emits `@space` (the base renders as a bare id), so
+  the prompt and `pwd` render the scope dimension themselves rather than
+  round-tripping through the reference serializer.
+- Standing in **another** identity's overlay (an `@session:<sid>`-shaped
+  spelling) is not in the grammar and is out of v1. It is a
+  canonical-grammar extension first — "the alias must not grow a
+  capability the canonical form lacks" (`packages/cli/lib/llm-friendly-ref.ts`)
+  — and a permission question besides; `cf inspect scopes` remains the
+  offline way to see other identities' overlays.
+
+## The ambient context and `where`
+
+Everything ambient is one record: the connection (api endpoint, identity),
+the cwd pair (position, scope), the external working location, the browse
+mode, and the invocation session. `where` prints the whole record, and
+`where <dimension> <value>` sets any dimension — the heavyweight ones
+(`where api …`, `where identity …`) rebuild the connection and say so.
+`cd`/`pwd` and `xcd`/`xpwd` are conveniences over the hottest dimensions,
+not separate mechanisms, and launch flags merely seed the initial record.
+
+## Prompt
+
+The prompt shows the position with checked names only: a space by the name
+fabric knows it by, a piece by its slug when the slug index confirms it, a
+shortened unique id otherwise, then the path. Shuttle uses the naming
+mechanisms the fabric supports and introduces none of its own; user-managed
+legible space names arrive when the fabric grows them.
+
+## Writes
+
+- `set <path> <value>` — the value parses as JSON; a bare word is a string
+  where that is unambiguous. `set <path> -` reads stdin.
+- `edit <path>` — opens `$EDITOR` on the current value, writes back on save
+  (the view substrate's editing buffers already do the hard part).
+- `link <target> <path>` — writes a cell reference, the fabric's link
+  semantics (what FUSE spells `ln -s`). A redirect copies values; `link`
+  is the only spelling that creates references, so the distinction is
+  always visible on the line.
+
+## Redirection and schemes
+
+The ambient data plane is the fabric: redirection targets fabric paths, and
+anything outside the fabric is named by an explicit scheme.
+
+- `get topics/3 > drafts/copy` — reads one place, writes the value to
+  another. Fabric-to-fabric, a value copy (`link` is how one makes a
+  reference instead).
+- `file:` names a local file, the only spelling that touches disk — and a
+  scheme is legal only on an absolute complete path:
+  `get topics --json > file:/tmp/topics.json` is fine, `file:out.json` is
+  refused (`file:~/…` counts as absolute).
+- `file:` is one member of an open scheme family: a schemed operand names
+  something outside the fabric. `https:`/`http:` sources work as read ends
+  (`set x - < https://…`); writing to an external scheme stays out of scope
+  until a use rules it in.
+- Shuttle maintains two working positions: the fabric cwd and one
+  **external working location**. `xcd` sets it — `xcd file:~/data`,
+  `xcd https://foo.com/a/b/` — and, its argument being already on the
+  external plane, moves it with a plain relative path: `xcd ../foo`.
+  `xpwd` prints it. In operands, a relative external path is rooted with
+  the `x:` base — `> x:../out.json`, `< x:data.json`. `x:` is a base name
+  rather than a scheme: it roots a relative path at the external location
+  whatever that location's scheme, so no operand ever changes plane by
+  position. A bare relative operand is always fabric.
+
+## Pipes: native tools and escaped locals
+
+Shuttle publishes a **native tool set**: names that work bare in a pipeline
+— `get topics --json | jq '.[].title'` — and are guaranteed present
+wherever shuttle runs, including an eventual terminal with no local
+execution environment behind it. A native tool may begin as a forward to a
+local binary; that is implementation, not contract. The initial set:
+`jq`, `grep`, `wc`, `head`, `tail`, `sort`, `uniq`, `cut`. `cat` is
+deliberately absent — printing a value is `get`, feeding a local file is
+`< file:…`, and concatenation, its one irreplaceable job, waits for a
+demand (`! cat` reaches the local one meanwhile).
+
+Arbitrary local programs run only behind the explicit escape — `|!` in a
+pipeline, line-initial `!` for a whole command — so stepping outside the
+portable surface is always visible on the line. The split is deliberate:
+the basics stay covered naturally, and nobody gets used to running local
+tools invisibly.
+
+## Open questions
+
+None here — the base-overlay spelling is settled above. The remaining
+open item for shuttle overall (shallow-sink expressibility) lives in
+[`views.md`](views.md).

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -156,6 +156,23 @@ legible space names arrive when the fabric grows them.
   is the only spelling that creates references, so the distinction is
   always visible on the line.
 
+## Calling a verb
+
+`call` keeps `cf`'s two-positional form — `call topics/3 add-reply` — so
+knowledge transfers, and adds the one-reference form:
+`call topics/3/add-reply` invokes the callable cell the path names,
+resolving with the same defaulting as `get`. Arity disambiguates: one
+reference argument invokes what the path names; a second positional is the
+callable name, `cf`-style.
+
+The path form exists because a callable is a cell like everything else —
+FUSE already mounts a handler as an executable file and `cf exec` runs it
+by path — and because listings surface callables inline and hand out
+handles: when `%4` is a callable row, `call %4` must work without
+splitting a reference by hand. This adds no reference-syntax capability;
+the path is already spellable in the canonical form, and the sugar is in
+the verb.
+
 ## Redirection and schemes
 
 The ambient data plane is the fabric: redirection targets fabric paths, and

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -9,10 +9,14 @@ today, the discipline a long-lived process must add, and the seam work in
 ## The connection
 
 One persistent `PiecesController` serves a place. `PiecesController.initialize`
-(`packages/piece/src/ops/pieces-controller.ts`) is the lean constructor;
-`loadPieces` (`packages/cli/lib/piece.ts`) is the CLI's wrapper, adding a
-version check, an experimental-options fetch, and a health check per call —
-preamble a shell pays once, not per verb.
+(`packages/piece/src/ops/pieces-controller.ts`) is the lean constructor: it
+opens the session and its storage manager, builds the `remoteClient` runtime
+over the deployment's experimental options, health-checks the server before
+reading any of the space, and settles the space session. `loadPieces`
+(`packages/cli/lib/piece.ts`) wraps that same sequence for the CLI, adding a
+version check against the server's git sha, embedded-space validation, and the
+error-log, navigate, and JSON-console wiring a one-shot verb wants. A shell
+pays the sequence once at connect; `cf` pays it per invocation.
 
 The connection pushes. The `remoteClient` runtime preset opens a persistent
 `WebSocketTransport` (`packages/runner/src/storage/v2-remote-session.ts`), so
@@ -29,8 +33,11 @@ Two existing long-lived holders show the lifecycle discipline:
 - `packages/fuse`: `CellBridge` takes an injectable `PiecesLoader` plus a
   separate `reconnectPiecesLoader` for recovery.
 
-Skipping `loadPieces`'s per-call preamble also skips its health check, so
-shuttle owns its own liveness story; the cf-harness policy is the leaner fit.
+`initialize` health-checks the server before it returns, so the first
+connection is proven live on the way up. What a long-lived process gives up is
+the repetition: `loadPieces` re-proves liveness on every verb, and a shell
+asks once. Liveness after that first connection is shuttle's to own, and the
+cf-harness reconnect-on-failure policy is the leaner fit.
 
 ## Watch mechanics
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -148,10 +148,17 @@ injection point that lets a lib function reuse a held controller:
 
 - **Accept it:** `getCellValue`, `listPieces`, `listSpaceSlugs`,
   `searchPieces`, `inspectPiece`, `executePieceCallable` (via
-  `PieceCallableDependencies`), `readWish`, `runExec`, all of `lib/bulk.ts`.
-- **Hardcode `loadPieces` instead:** `setCellValue`, `callPieceHandler`,
-  `stepPiece`, `removePiece`, `getPieceView`, `renderPiece`, the
-  `lib/acl.ts` loaders. Each opens a fresh runtime and WebSocket per call.
+  `PieceCallableDependencies`), `readWish`, `runExec`, all of
+  `lib/bulk.ts` — and `stepPiece`, seamed when it gained its write receipt
+  (#6556), whose unit test is the template the rest of this list follows.
+- **Forwarding gaps:** `callPieceHandler` and `getPieceView` hardcode
+  nothing themselves — each delegates to an already-injectable function
+  (`resolvePieceCallable` via `PieceCallableDependencies`; `inspectPiece`)
+  without forwarding a deps argument. The fix is a parameter threaded
+  through, not a conversion.
+- **Hardcode `loadPieces`:** `setCellValue`, `removePiece`, `renderPiece`,
+  the `lib/acl.ts` loaders. Each opens a fresh runtime and WebSocket per
+  call; these are the genuine conversions.
 
 `call` is the one verb with no seam at all: `buildCallCommand`'s action is
 inline and bound to Cliffy's `this` (`getLiteralArgs`). Its constituents are

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -1,6 +1,6 @@
 # Shuttle — runtime integration
 
-Satellite of [`../shuttle.md`](../shuttle.md), grounding decision 9 (one
+Satellite of [`README.md`](README.md), grounding decision 9 (one
 in-process connection, `cf` verbs through shared library seams, a `!cf`
 subprocess escape). This records what the runtime and `packages/cli` offer
 today, the discipline a long-lived process must add, and the seam work in

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -26,18 +26,79 @@ re-fires their sinks. `watch` needs no polling.
 Two existing long-lived holders show the lifecycle discipline:
 
 - `packages/cf-harness`: `createHarnessFabricSessionFactory` builds one
-  controller, `cacheHarnessFabricSessionFactory` memoizes it so every
-  invocation of a run shares it, and a rejected construction clears the cache
-  so a transient failure is not replayed forever. That
-  reconnect-on-failure policy is the model to copy.
+  controller and `cacheHarnessFabricSessionFactory` memoizes it so every
+  invocation of a run shares it. Its cache clears on a **rejected
+  construction** and nothing else — the `session === attempt` test guards
+  against evicting a newer attempt, and is not a health probe — so it
+  covers the connection that never opened, not one that later drops.
 - `packages/fuse`: `CellBridge` takes an injectable `PiecesLoader` plus a
   separate `reconnectPiecesLoader` for recovery.
 
 `initialize` health-checks the server before it returns, so the first
 connection is proven live on the way up. What a long-lived process gives up is
 the repetition: `loadPieces` re-proves liveness on every verb, and a shell
-asks once. Liveness after that first connection is shuttle's to own, and the
-cf-harness reconnect-on-failure policy is the leaner fit.
+asks once.
+
+## Recovery already exists
+
+An established connection heals below shuttle, in the memory client
+(`packages/memory/v2/client.ts`) rather than the storage layer above it:
+
+- `Client.#onClose` marks the client disconnected, calls
+  `handleDisconnect()` on every `SpaceSession`, rejects in-flight requests
+  as `ConnectionError`, and starts `Client.#reconnect()` — a
+  single-flighted loop that re-runs `#hello()` and then `restore()`s each
+  session, backing off through `reconnectDelayMs` (25 ms base, 30 s cap,
+  jittered).
+- Standing watches survive it. `SpaceSession` remembers its selectors in
+  `#watchSpecs`; `restore()` applies the server's `sync` when the server
+  resumed the session and re-arms through `watchSetSync(#watchSpecs, …)`
+  when it did not. Both paths reuse the same `WatchView` instance, which is
+  what keeps `SpaceReplica.#consumeWatchView`'s standing loop delivering.
+  Outstanding commits replay through `#outstandingCommits`.
+- `SpaceReplica` deliberately does nothing on a drop, and says so:
+  `#consumeOwedSessionRemount` records that a transport drop is already
+  healed by the client's own `reconnect()`/`restore()` and must be left
+  alone.
+
+Two gaps around it. **Initial** construction is not retried —
+`SpaceReplica.sessionHandle()` clears its memo on failure and re-attempts
+only when a caller next asks for a session, which is the case cf-harness's
+cache exists for. And a **permanent** failure stops the loop rather than
+retrying: `isPermanentConnectionFailure` (a protocol-flag mismatch) sets
+`Client.#fatalError`, while `isPermanentAuthorizationError` routes a
+non-retriable denial to `#terminateSession` for that one space, leaving the
+client's other spaces alive.
+
+Shuttle therefore adds no recovery of its own. The repo's rule against retry
+loops applies with particular force here: the loop that belongs in this
+system already exists one layer down, and a second one would fight it.
+
+## Observing connection state
+
+What shuttle does need is unavailable today. The prompt's live marker and
+the views' reconnecting marker both want connection state, and nothing in
+the storage layer reports it:
+
+- `Client.isConnected()` exists but reaches no consumer — `SpaceReplica`
+  holds the client in a private field and surfaces nothing from it.
+- The notification channel carries no connection variant.
+  `IStorageNotificationCapability.subscribe` delivers commit, revert, load,
+  pull, integrate, and reset notifications only.
+- `IStorageManager.authorizationError(space)` is the one connection-adjacent
+  state a consumer can read, and it is a per-space poll for permanent
+  denial. Its own documentation records a hole: a denial that arrives during
+  reconnect is visible only as the session's `closeError`.
+- Nothing exposes "reconnecting" at all. `Client.#reconnecting`,
+  `#connected`, and `#fatalError` are private with no accessor, and
+  `#onClose` swallows the reconnect promise, so a consumer cannot tell quiet
+  because nothing changed from quiet because the socket is down and backoff
+  has reached its thirty-second cap.
+
+So the liveness work is an **observation seam**, added where the state
+already lives, reporting live, reconnecting, and permanently failed. That is
+what B1 owes, and the three states are what the prompt and the view markers
+render.
 
 ## Watch mechanics
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -1,0 +1,131 @@
+# Shuttle — runtime integration
+
+Satellite of [`../shuttle.md`](../shuttle.md), grounding decision 9 (one
+in-process connection, `cf` verbs through shared library seams, a `!cf`
+subprocess escape). This records what the runtime and `packages/cli` offer
+today, the discipline a long-lived process must add, and the seam work in
+`cli` that is prerequisite to building anything.
+
+## The connection
+
+One persistent `PiecesController` serves a place. `PiecesController.initialize`
+(`packages/piece/src/ops/pieces-controller.ts`) is the lean constructor;
+`loadPieces` (`packages/cli/lib/piece.ts`) is the CLI's wrapper, adding a
+version check, an experimental-options fetch, and a health check per call —
+preamble a shell pays once, not per verb.
+
+The connection pushes. The `remoteClient` runtime preset opens a persistent
+`WebSocketTransport` (`packages/runner/src/storage/v2-remote-session.ts`), so
+a write landing on the server from anywhere reaches this process's cells and
+re-fires their sinks. `watch` needs no polling.
+
+Two existing long-lived holders show the lifecycle discipline:
+
+- `packages/cf-harness`: `createHarnessFabricSessionFactory` builds one
+  controller, `cacheHarnessFabricSessionFactory` memoizes it so every
+  invocation of a run shares it, and a rejected construction clears the cache
+  so a transient failure is not replayed forever. That
+  reconnect-on-failure policy is the model to copy.
+- `packages/fuse`: `CellBridge` takes an injectable `PiecesLoader` plus a
+  separate `reconnectPiecesLoader` for recovery.
+
+Skipping `loadPieces`'s per-call preamble also skips its health check, so
+shuttle owns its own liveness story; the cf-harness policy is the leaner fit.
+
+## Watch mechanics
+
+`Cell.sink(callback, options)` (`IAnyCell.sink`,
+`packages/runner/src/cell.ts`) is the substrate: it fires immediately with
+the current value and re-fires on every committed change, and it works
+outside a browser — `packages/fuse/cell-bridge.ts`,
+`packages/cli/lib/callable.ts`, and the agents connector all sink from Deno
+processes. (`packages/runtime-client` is not a candidate: its only transport
+is browser-main-thread-to-Web-Worker.)
+
+Two disciplines every existing sink consumer rediscovered:
+
+- **Settling.** One logical change fires several sink callbacks before the
+  reactive graph quiets. FUSE debounces on a timer; `renderVDomToHtml`
+  (`packages/cli/lib/piece-render.ts`) uses a reentrancy guard plus
+  `runtime.idle()` so several batches produce exactly one report per quiet
+  runtime. The guard-plus-`idle()` form is the one to adopt — no timer.
+- **Freshness requires running.** A piece that is not started serves stored
+  state; computed values are only fresh when the pattern runs in this
+  process. That is what `cf get --step` does per invocation
+  (`getCellValue` in `packages/cli/lib/piece.ts`: get with `runIt`, then
+  pull, `idle`, `synced`). In a persistent shell that dance collapses to a
+  one-time start per piece. When shuttle starts a piece is a policy question
+  the main document carries.
+
+`renderPiece(config, { watch, onUpdate })` in
+`packages/cli/lib/piece-render.ts` is the closest prior art: it returns a
+cancel function and drives `onUpdate` per settled change. Its command action
+keeps the process alive with a SIGINT listener and a never-resolving promise
+— the shape a shell must not copy.
+
+## Seam inventory in `packages/cli`
+
+The CLI already factors many command actions as named exports with
+dependency seams — the `*FromCommand` family in
+`packages/cli/commands/piece.ts` (`getCellValueFromCommand`,
+`setCellValueFromCommand`, `listPiecesFromCommand`,
+`describePieceFromCommand`, the survey/repair/retarget/rollback/restore set,
+and more), each shaped `(options, ...positionals, deps)`. `cf wish` goes
+further: `wishAction` over `readWish` (`packages/cli/lib/wish.ts`), which
+abstracts its connection behind `WishRuntimeHost` — the cleanest seam and
+the model to generalize.
+
+Connection injection is uneven. `PieceResolutionDeps.loadPieces` is the
+injection point that lets a lib function reuse a held controller:
+
+- **Accept it:** `getCellValue`, `listPieces`, `listSpaceSlugs`,
+  `searchPieces`, `inspectPiece`, `executePieceCallable` (via
+  `PieceCallableDependencies`), `readWish`, `runExec`, all of `lib/bulk.ts`.
+- **Hardcode `loadPieces` instead:** `setCellValue`, `callPieceHandler`,
+  `stepPiece`, `removePiece`, `getPieceView`, `renderPiece`, the
+  `lib/acl.ts` loaders. Each opens a fresh runtime and WebSocket per call.
+
+`call` is the one verb with no seam at all: `buildCallCommand`'s action is
+inline and bound to Cliffy's `this` (`getLiteralArgs`). Its constituents are
+already exported and library-grade (`executePieceCallable`,
+`pieceCallRawArgs`, `pieceCallInvocation`, `resolveInvocationIdentity`,
+`pieceCallPhaseObserver`, `resolveWaitControl`, `parsePieceCallSelection`,
+`boundedSettlement`, `renderPieceCallOutcome`), so extraction is mechanical:
+the literal-args array becomes a parameter.
+
+## Prerequisite work in `packages/cli`
+
+Each of these is small and lands on its own; together they are what decision
+9's "factor the seam in `cli`, not reimplement in shuttle" means concretely.
+
+1. **Export entries.** `@commonfabric/cli` exports only `.` → `mod.ts`. A
+   sibling package needs real entries for the lib modules it calls.
+2. **Thread `deps.loadPieces` through the hardcoded functions** —
+   `setCellValue` first; `set` is a v1 verb and today cannot share a
+   connection.
+3. **Extract `callFromCommand`** from `buildCallCommand`'s inline action.
+4. **Exit discipline.** `exitWithDataError` and `exitPieceCallFailure` call
+   `Deno.exit(1)` (typed `never`); `getCellValueFromCommand` reaches the
+   former on a data error, which would kill the shell. Both take a `deps`
+   override — shuttle threads an exit shim through every seam it calls, and
+   catches the `ValidationError` that `exitPieceCallFailure` rethrows for
+   Cliffy's usage rendering.
+5. **Output capture.** The `FromCommand` seams accept `render`/`hint` deps;
+   stray `console.error` calls in `lib/piece.ts` do not. Sweep as views
+   need them captured.
+6. **Module-global state.** `quietMode` is a file-level `let` set on every
+   `FromCommand` entry; `setLLMUrl` is a global written by both `loadPieces`
+   and `PiecesController.initialize`, so two connections on different API
+   URLs would fight. Scope them, or accept one-connection-per-process for
+   v1 and record the limit.
+7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
+   success path relies on process exit. In a long-lived shell every
+   un-injected call leaks a runtime, a storage manager, and a WebSocket —
+   injection is correctness, not merely speed. `groupSessions` in
+   `lib/bulk.ts` (open, `synced`, `dispose` per group) names the cost.
+8. **Invocation session.** `newSessionId`'s contract is one per agent run,
+   shared by every call of the run. A shuttle instance is a run: mint one at
+   startup and pass it explicitly into every `call` (decision 6 forbids
+   env-var mutation; `resolveInvocationIdentity` throws on `--invocation`
+   without a session). Replay via `--invocation` then works within a
+   shuttle session for free.

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -18,6 +18,14 @@ version check against the server's git sha, embedded-space validation, and the
 error-log, navigate, and JSON-console wiring a one-shot verb wants. A shell
 pays the sequence once at connect; `cf` pays it per invocation.
 
+The ambient record maps onto the config shapes those functions already
+take: `SpaceConfig` (`apiUrl`, `space`, `identity`, …) and `PieceConfig`
+(adding `piece`, `pieceScope`, `piecePath`, `pieceInput`) in
+`packages/cli/lib/piece.ts`. `cf` builds them from flags through
+`parseSpaceOptions`, `parsePieceOptions`, and `readTargetPositionals`
+(`packages/cli/commands/piece.ts`); shuttle constructs them from the
+ambient record directly and skips the flag parsing.
+
 The connection pushes. The `remoteClient` runtime preset opens a persistent
 `WebSocketTransport` (`packages/runner/src/storage/v2-remote-session.ts`), so
 a write landing on the server from anywhere reaches this process's cells and
@@ -60,6 +68,10 @@ An established connection heals below shuttle, in the memory client
   `#consumeOwedSessionRemount` records that a transport drop is already
   healed by the client's own `reconnect()`/`restore()` and must be left
   alone.
+
+One near-miss worth pinning: `Provider.#syncRequests` and `#replaySync`
+(`packages/runner/src/storage/v2.ts`) look like this replay but fire only
+on route replacement — the reconnect replay is `SpaceSession`'s, above.
 
 Two gaps around it. **Initial** construction is not retried —
 `SpaceReplica.sessionHandle()` clears its memo on failure and re-attempts

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -16,8 +16,9 @@ disciplines it leans on are in
   sits in one module, and state and key handling are pure and testable
   without a terminal.
 - **Everything live obeys the settle discipline**: one repaint per quiet
-  runtime (guard plus `idle()`), never a timer. Sinks are canceled on view
-  exit.
+  runtime (guard plus `idle()`), never a timer. A view's own sinks are
+  canceled on exit; a watch's sink belongs to the watch, which outlives
+  the view (see "Watches are session objects").
 - **Cold-browse mode reaches into views**: an unmistakable banner, stored
   values labeled as stored, no sinks, no warming; `r` re-pulls stored state
   (a storage read, not a pattern run).
@@ -50,6 +51,24 @@ summary, callables with their doc annotations, and pattern identity in one
 frame. It renders as a snapshot with refresh on demand rather than live —
 the live piece watch is deferred — so it costs no sink and ships beside
 the other two.
+
+## Watches are session objects
+
+`watch <ref>` arms a watch — a session-level subscription with its own
+handle — and opens the value view as one lens onto it. `q` closes the lens
+and leaves the watch armed. While the prompt is up, an armed watch shows
+its changes two ways:
+
+- **Event lines.** Each settled change appends one line —
+  `watch topics/3: replies 14 → 15` — and the prompt is redrawn beneath
+  it, so cause and effect interleave in one transcript that doubles as a
+  record.
+- **The pinned strip.** A reserved region above the prompt renders armed
+  watches' current values live while scrollback flows past it.
+
+`watches` lists what is armed (`where` shows it too); `unwatch <handle>`
+disarms. Terminal output that has scrolled off is never mutated: liveness
+lives in the strip and the event lines, and history stays append-only.
 
 ## Keys
 
@@ -104,3 +123,5 @@ first work item, made in `packages/cli` where the substrate lives.
    watch. (The shallow-sink question is settled above: not expressible
    through `Cell.sink`; the raw-document seam and its proving gate are
    issue [#6534](https://github.com/commontoolsinc/labs/issues/6534).)
+2. The pinned strip's layout: its height, and what it shows when more
+   watches are armed than fit.

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -42,7 +42,7 @@ drills in place; leaving restores the parent's scroll and selection.
 │ %2  migration rehearsal   replies  3        │
 │▸%3  co-presence rollout   replies  8    +   │
 │ …                              14 of 16     │
-│ : call %3/add-reply --body "shipped"        │
+│ : call %3 add-reply --body "shipped"        │
 └ q back · enter drill · / filter · : command ┘
 ```
 
@@ -113,9 +113,26 @@ first work item, made in `packages/cli` where the substrate lives.
   problem and the solution lanes. B3 opens by proving that seam on the
   remote path; if it disappoints, the fallback is a capped deep sink with
   an honest "watching first N" label.
+- **The raw subscription serves the base scope only.**
+  `SpaceReplica.sinkDocument` (`packages/runner/src/storage/v2.ts`) accepts
+  no scope and keys its subscriber set with `docKey(uri, "space")` — the
+  base instance — so under `@user` or `@session` it would watch base
+  membership while the frame claimed to show an overlay. A list view
+  therefore takes the raw subscription only when the ambient scope is the
+  base, and the capped deep sink with its "watching first N" label under an
+  overlay, where `Cell.sink` reads through the scope the cell carries. The
+  keying vocabulary for the scope-aware version is already there — `docKey`
+  takes an instance, and the load path passes
+  `instance ?? normalizeCellScope(scope)` — so what has to grow a scope
+  parameter is that one signature, not the storage model. #6534's seam must
+  be scope-aware end to end before the raw path can serve an overlay.
 - Guard-plus-`idle()` settling, per `renderVDomToHtml`'s form.
 - The connection's state is visible in the frame (`● live`, cold banner,
-  or a reconnecting marker); on reconnect the view resyncs and repaints.
+  or a reconnecting marker), read from the observation seam B1 builds —
+  the storage layer publishes no connection state today
+  ([`runtime-integration.md`](runtime-integration.md)). On reconnect the
+  memory client re-arms the watch itself, so the view resyncs and repaints
+  without re-subscribing.
 
 ## Open questions
 

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -12,8 +12,9 @@ disciplines it leans on are in
   `q` returns to the prompt exactly where it was. Moving is always an
   explicit act (a `cd` from inside the view's command line).
 - **Views are pure logic plus injected terminal deps**, the architecture
-  `packages/cli/lib/view` already proves out: one module touches the TTY,
-  state and key handling are pure and testable without a terminal.
+  `packages/cli/lib/view` already proves out: raw-mode terminal handling
+  sits in one module, and state and key handling are pure and testable
+  without a terminal.
 - **Everything live obeys the settle discipline**: one repaint per quiet
   runtime (guard plus `idle()`), never a timer. Sinks are canceled on view
   exit.
@@ -35,7 +36,7 @@ inserts and removals are reflected live and marked briefly. Entering a row
 drills in place; leaving restores the parent's scroll and selection.
 
 ```text
-┌ ~estuary/board/topics ────────────── ● live ┐
+┌ estuary/board/topics ─────────────── ● live ┐
 │ %1  verb contracts        replies 14        │
 │ %2  migration rehearsal   replies  3        │
 │▸%3  co-presence rollout   replies  8    +   │
@@ -68,7 +69,11 @@ prompt (decision 17), so "look, leave, act" needs no retyping.
 `pager.ts` (raw mode, frame rendering, restore-on-every-exit), `keys.ts`,
 and `ansi.ts` are the terminal layer to build on; `session.ts` is the
 pattern to follow rather than import — shuttle views hold different state.
-The export entries for these modules land with B3.
+`pager.ts` is where the raw-mode coupling lives, and it is the piece
+shuttle wants; `mod.ts` and `loadinput.ts` own the rest of `cf view`'s
+stdio — probing whether stdout and stdin are terminals, writing plain
+output, reading a piped document — which is one-shot-command concern a
+shell drives for itself. The export entries for these modules land with B3.
 
 One adaptation to verify early in B3: `cf view` pages a static document,
 so its frame loop may be key-driven only. Shuttle views repaint on two

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -42,7 +42,7 @@ drills in place; leaving restores the parent's scroll and selection.
 │ %2  migration rehearsal   replies  3        │
 │▸%3  co-presence rollout   replies  8    +   │
 │ …                              14 of 16     │
-│ : call %3 add-reply --body "shipped"        │
+│ : call %3 add-reply -- --body "shipped"     │
 └ q back · enter drill · / filter · : command ┘
 ```
 

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -19,7 +19,7 @@ disciplines it leans on are in
   runtime (guard plus `idle()`), never a timer. A view's own sinks are
   canceled on exit; a watch's sink belongs to the watch, which outlives
   the view (see "Watches are session objects").
-- **Views are live because entering warms** (the run-state rule). The
+- **Views are live because reaching in warms** (the run-state rule). The
   deferred cold-browse mode ([`futures.md`](futures.md)) will reach into
   views when it lands — banner, labeled stored values, no sinks.
 

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -101,8 +101,10 @@ first work item, made in `packages/cli` where the substrate lives.
 
 - A list view observes membership through a **raw-document subscription**:
   the collection doc under the rejecting selector, links parsed from the
-  raw value — and sinks deeply only the rows on screen, so cost is bounded
-  by page size rather than collection size. Schema shapes that look
+  raw value — and sinks deeply only the rows on screen. Element cost is
+  bounded by the visible page; membership is one document whose size
+  grows with the collection's link array — the linear-in-links frame
+  that replaces the element-closure shape behind the 89MB sync. Schema shapes that look
   shallow to a reader do not bound what the server syncs, so this is the
   one place shuttle reads below `Cell.sink`; the seam
   (`SpaceReplica.sinkDocument`) exists but is unexercised. Issue

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -19,9 +19,9 @@ disciplines it leans on are in
   runtime (guard plus `idle()`), never a timer. A view's own sinks are
   canceled on exit; a watch's sink belongs to the watch, which outlives
   the view (see "Watches are session objects").
-- **Cold-browse mode reaches into views**: an unmistakable banner, stored
-  values labeled as stored, no sinks, no warming; `r` re-pulls stored state
-  (a storage read, not a pattern run).
+- **Views are live because entering warms** (the run-state rule). The
+  deferred cold-browse mode ([`futures.md`](futures.md)) will reach into
+  views when it lands — banner, labeled stored values, no sinks.
 
 ## The v1 views
 
@@ -57,18 +57,15 @@ the other two.
 `watch <ref>` arms a watch — a session-level subscription with its own
 handle — and opens the value view as one lens onto it. `q` closes the lens
 and leaves the watch armed. While the prompt is up, an armed watch shows
-its changes two ways:
-
-- **Event lines.** Each settled change appends one line —
-  `watch topics/3: replies 14 → 15` — and the prompt is redrawn beneath
-  it, so cause and effect interleave in one transcript that doubles as a
-  record.
-- **The pinned strip.** A reserved region above the prompt renders armed
-  watches' current values live while scrollback flows past it.
+its changes as **event lines**: each settled change appends one line —
+`watch topics/3: replies 14 → 15` — and the prompt is redrawn beneath it,
+so cause and effect interleave in one transcript that doubles as a
+record. (A pinned strip rendering armed watches live above the prompt is
+designed and deferred: [`futures.md`](futures.md).)
 
 `watches` lists what is armed (`where` shows it too); `unwatch <handle>`
 disarms. Terminal output that has scrolled off is never mutated: liveness
-lives in the strip and the event lines, and history stays append-only.
+lives in the event lines, and history stays append-only.
 
 ## Keys
 
@@ -140,5 +137,5 @@ first work item, made in `packages/cli` where the substrate lives.
    watch. (The shallow-sink question is settled above: not expressible
    through `Cell.sink`; the raw-document seam and its proving gate are
    issue [#6534](https://github.com/commontoolsinc/labs/issues/6534).)
-2. The pinned strip's layout: its height, and what it shows when more
-   watches are armed than fit.
+2. The pinned strip's layout — deferred with the strip itself
+   ([`futures.md`](futures.md)).

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -1,6 +1,6 @@
 # Shuttle — live views
 
-Satellite of [`../shuttle.md`](../shuttle.md): the full-screen half of the
+Satellite of [`README.md`](README.md): the full-screen half of the
 hybrid — what opens, how it behaves, and what it reuses. Governs milestone
 B3 of [`build-sequence.md`](build-sequence.md); the settle and lifecycle
 disciplines it leans on are in

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -40,7 +40,7 @@ drills in place; leaving restores the parent's scroll and selection.
 │ %2  migration rehearsal   replies  3        │
 │▸%3  co-presence rollout   replies  8    +   │
 │ …                              14 of 16     │
-│ : call %3 add-reply --body "shipped"        │
+│ : call %3/add-reply --body "shipped"        │
 └ q back · enter drill · / filter · : command ┘
 ```
 

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -1,0 +1,101 @@
+# Shuttle — live views
+
+Satellite of [`../shuttle.md`](../shuttle.md): the full-screen half of the
+hybrid — what opens, how it behaves, and what it reuses. Governs milestone
+B3 of [`build-sequence.md`](build-sequence.md); the settle and lifecycle
+disciplines it leans on are in
+[`runtime-integration.md`](runtime-integration.md).
+
+## Principles
+
+- **A view is a lens, not a move.** Opening a view never changes the place;
+  `q` returns to the prompt exactly where it was. Moving is always an
+  explicit act (a `cd` from inside the view's command line).
+- **Views are pure logic plus injected terminal deps**, the architecture
+  `packages/cli/lib/view` already proves out: one module touches the TTY,
+  state and key handling are pure and testable without a terminal.
+- **Everything live obeys the settle discipline**: one repaint per quiet
+  runtime (guard plus `idle()`), never a timer. Sinks are canceled on view
+  exit.
+- **Cold-browse mode reaches into views**: an unmistakable banner, stored
+  values labeled as stored, no sinks, no warming; `r` re-pulls stored state
+  (a storage read, not a pattern run).
+
+## The v1 views
+
+**Value view** — `watch <ref>`. One cell or subtree, rendered as structured
+JSON: scrollable, references followable, and live — a changed value briefly
+shows its transition (`14 → 15`) before settling, so a change is seen
+rather than inferred.
+
+**List view** — `browse [<ref>]`. A paged listing of whatever stands below
+the reference — a facet, a collection, search results. Rows carry the same
+`%n` handles the prompt uses; selection moves with arrows or `j`/`k`;
+inserts and removals are reflected live and marked briefly. Entering a row
+drills in place; leaving restores the parent's scroll and selection.
+
+```text
+┌ ~estuary/board/topics ────────────── ● live ┐
+│ %1  verb contracts        replies 14        │
+│ %2  migration rehearsal   replies  3        │
+│▸%3  co-presence rollout   replies  8    +   │
+│ …                              14 of 16     │
+│ : call %3 add-reply --body "shipped"        │
+└ q back · enter drill · / filter · : command ┘
+```
+
+**Piece overview** — the structured piece viewer: arguments, a result
+summary, callables with their doc annotations, and pattern identity in one
+frame. It renders as a snapshot with refresh on demand rather than live —
+the live piece watch is deferred — so it costs no sink and ships beside
+the other two.
+
+## Keys
+
+Small, vim-flavored, and stable: `q` back to prompt; `j`/`k`/arrows
+selection; `g`/`G` ends; `enter` drill, `backspace` up; `/` filter within
+the view, `n`/`N` next; `e` edit the selection in `$EDITOR` (the substrate
+already suspends and restores the terminal for this); `:` opens the
+command line.
+
+`:` is the general mechanism instead of a key per verb: any shuttle
+command runs with the view's `%n` handles bound to its rows, and the view
+repaints on the result. On `q`, the last view's handles stay valid at the
+prompt (decision 17), so "look, leave, act" needs no retyping.
+
+## Reuse of the `cf view` substrate
+
+`pager.ts` (raw mode, frame rendering, restore-on-every-exit), `keys.ts`,
+and `ansi.ts` are the terminal layer to build on; `session.ts` is the
+pattern to follow rather than import — shuttle views hold different state.
+The export entries for these modules land with B3.
+
+One adaptation to verify early in B3: `cf view` pages a static document,
+so its frame loop may be key-driven only. Shuttle views repaint on two
+event sources — keys and settled runtime changes — and the loop must
+multiplex them. If the substrate's loop cannot, that generalization is B3's
+first work item, made in `packages/cli` where the substrate lives.
+
+## Live discipline
+
+- A list view observes membership through a **raw-document subscription**:
+  the collection doc under the rejecting selector, links parsed from the
+  raw value — and sinks deeply only the rows on screen, so cost is bounded
+  by page size rather than collection size. Schema shapes that look
+  shallow to a reader do not bound what the server syncs, so this is the
+  one place shuttle reads below `Cell.sink`; the seam
+  (`SpaceReplica.sinkDocument`) exists but is unexercised. Issue
+  [#6534](https://github.com/commontoolsinc/labs/issues/6534) carries the
+  problem and the solution lanes. B3 opens by proving that seam on the
+  remote path; if it disappoints, the fallback is a capped deep sink with
+  an honest "watching first N" label.
+- Guard-plus-`idle()` settling, per `renderVDomToHtml`'s form.
+- The connection's state is visible in the frame (`● live`, cold banner,
+  or a reconnecting marker); on reconnect the view resyncs and repaints.
+
+## Open questions
+
+1. When the piece overview gains liveness — deferred with the live piece
+   watch. (The shallow-sink question is settled above: not expressible
+   through `Cell.sink`; the raw-document seam and its proving gate are
+   issue [#6534](https://github.com/commontoolsinc/labs/issues/6534).)

--- a/docs/plans/shuttle/views.md
+++ b/docs/plans/shuttle/views.md
@@ -42,7 +42,7 @@ drills in place; leaving restores the parent's scroll and selection.
 │ %2  migration rehearsal   replies  3        │
 │▸%3  co-presence rollout   replies  8    +   │
 │ …                              14 of 16     │
-│ : call %3 add-reply -- --body "shipped"     │
+│ : call %3 add-reply --body "shipped"        │
 └ q back · enter drill · / filter · : command ┘
 ```
 


### PR DESCRIPTION
## Why

Weaver is where a person stands inside the woven fabric — rendered pieces, live interfaces, the product. Shuttle is the same sense of presence one layer down: standing in the substrate itself, where cells, links, scopes, and reactions are visible as themselves. When the rendered surface misbehaves, this is the layer a person needs to see, and no tool shows it moving: `cf` prints snapshots, the FUSE mount is bounded by cache staleness, `cf inspect` is offline. Shuttle's watches and live views make the mechanism observable — arm a watch, issue the cause, see the reaction arrive in one transcript.

The constant half of the context now has its ambient home (`CF_API_URL`, `CF_IDENTITY`, and — since #6498 — `CF_SPACE`), and step 8's rationale caps out exactly there: piece, path, and scope are not identical across a session, they change with every step, because they are the work. Shuttle gives the moving half a position you navigate — a cwd that fills the omitted levels of the fabric's right-anchored references, moved by `cd`, relative references, and listing handles instead of by copying printed addresses between commands. Underneath both, a persistent runtime session is a capability one-shots cannot have at any flag cost: warm pieces, subscriptions, pagination cursors, the handle table, invocation-session continuity — and a prompt that renders the ambient record, so what a command is about to touch is visible before it runs.

This PR lands the design as live documentation before any code exists, so the decisions (twenty-eight, each with its reasoning) are reviewable and durable rather than living in one conversation, and so the build order — including the `packages/cli` seam work that stands on its own merits — is agreed before stage A starts.

The investigation behind the design also surfaced one platform gap, filed separately as #6534 (no way to subscribe to a collection's membership without syncing every element); decision 25 and the build sequence gate on it.

## What Changed

- `docs/plans/shuttle/README.md` — the design state (the directory's index, per the tree-wide README convention): motivation, twenty-eight settled decisions, the ambient model, the prior-art table, the relationship to the CLI surface arc, and non-goals.
- `docs/plans/shuttle/grammar.md` — the line grammar and resolution rules: the cwd pair (position + scope, with scope-only `@scope` as navigation syntax), space-root facets, listings/handles/pagination, run state, the ambient context and `where`, writes, calling a verb by name or by path, schemes and the `x:` base, native pipe tools and the `!` local escape.
- `docs/plans/shuttle/runtime-integration.md` — what the runtime and `packages/cli` offer a long-lived process (verified against the code, including what `PiecesController.initialize` does once versus what `loadPieces` repeats per call), and the prerequisite seam work.
- `docs/plans/shuttle/views.md` — the full-screen half: the lens principle, the three v1 views, session watches (event lines at the prompt plus a pinned strip), keys, `cf view` substrate reuse, and the live discipline (raw membership subscription per #6534).
- `docs/plans/shuttle/build-sequence.md` — stage A (five `cli` seam PRs, each with standalone value) and stage B (vertical slices) with their gates.
- `docs/plans/shuttle/futures.md` — the trajectory past v1: positions (configuration and bookmarks in the fabric, the session scope as the variable store, the three scripting layers) and ranked candidates (the weaver bridge, write guards, multi-space sessions, history and records, time and diff).
- `docs/plans/README.md` — index entry.

All four review threads from the first push are addressed in follow-up commits — three by doc fixes (health-check accuracy, scope-only `@scope` reframed, the TTY claim narrowed to raw-mode handling), one rebutted on the thread with parser and test evidence (`@space` is canonical grammar).

## Test plan

Docs-only; no package code changes, so no new tests. Repo-wide `deno fmt --check` and `deno lint` pass; `deno task check-docs`, `check-docs-history-index`, `check-conflict-markers`, `check-control-characters`, and `docs-links --orphan` all pass locally after rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pUbgG5j3sDqRR6Ph91JUB
