### PR TITLE
docs(cli): CF_SPACE in the configuration registry, step 8 on main

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -314,6 +314,7 @@ the labs checkout and dispatches to `packages/cli/mod.ts`.
 |---|---|---|
 | `CF_IDENTITY` | _(none)_ | Path to identity keyfile. Required for the server-touching commands — `piece`, the top-level `get`/`set`/`call`, `wish`, `acl`, `exec` — against a remote toolshed. |
 | `CF_API_URL` | _(none)_ | Toolshed URL. Required for the same commands as above. |
+| `CF_SPACE` | _(none)_ | The space a command acts on, when `--space` is absent. Read by `piece`, the top-level `get`/`set`/`call`, `wish`, `acl` and `deps` — `check`, `fuse` and `ingest` take a space and do not read it. `--space` overrides it, and a written `--space` beside `--url` is still refused where an ambient one yields to the space the URL carries. A command that writes names the space it wrote to on stderr, which is what makes an ambient default safe to leave set. |
 | `CF_INVOCATION_SESSION` | _(none)_ | Invocation session `cf call` scopes an invocation id to. Mint one per agent run with `cf invocation-session new`. Carried here rather than as `--invocation-session <id>` because the session is what makes a call's outcome unguessable, and an argument is readable in a process listing. |
 | `CF_LOG_LEVEL` | `error` | `debug` \| `info` \| `warn` \| `error` \| `silent`. Also settable per-invocation with `--log-level`. |
 | `CF_CLI_NAME` | `cf` | Override the displayed CLI name (for branded builds). |

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -29,7 +29,7 @@ have landed.
 
 | step | state |
 | --- | --- |
-| 8 — `CF_SPACE` is ambient, and a write names the space it wrote to | not started |
+| 8 — `CF_SPACE` is ambient, and a write names the space it wrote to | on main |
 | 9 — a reference takes a space by name and a piece by slug, positionally | not started |
 | 10 — the verb opens the callable's section and `--` closes it | not started; `PIECE_DATA_SPELLING_END_DATE` is the thing to check first |
 | 11 — `--url` decomposes into the transport it names and the reference it carries | not started |


### PR DESCRIPTION
## Why

Two obligations #6498 should have carried and did not.

`CF_SPACE` shipped with **no entry in `docs/development/CONFIGURATION.md`**, the table that carries every other `CF_*` variable. The only places naming it were the CLI's own help output and the plan that proposed it — so someone reading the registry to find out what configures `cf` would not learn the variable exists.

And the status block added in #6494 still said step 8 was **not started**, three commits after it landed. That block exists precisely to stop a reader having to reconstruct state from PRs, and it says of itself that the change moving a step updates it. It did not update itself.

## What Changed

- `CF_SPACE` added to the CLI environment-variable table, beside `CF_API_URL`. It names which commands read it (`piece`, the top-level `get`/`set`/`call`, `wish`, `acl`, `deps`), which take a space and deliberately do not (`check`, `fuse`, `ingest`), the precedence against `--space`, the `--url` interaction, and the write receipt — the half that makes an ambient default safe to leave set.
- The tracker moves step 8 to `on main`.

## Test plan

`deno task check-docs` (587 blocks) and `deno task check-docs-history-index` (161 entries over 243 documents). Both prose changes; no code block touched.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

