### PR TITLE
feat(piece): a repair reports its rows as they settle

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -15,6 +15,7 @@ import {
   type PieceSelector,
   type PlanDiff,
   type RepairReport,
+  type RepairRow,
   type RestorableRevision,
 } from "@commonfabric/piece/ops";
 import ports from "@commonfabric/ports" with { type: "json" };
@@ -3743,16 +3744,16 @@ export async function repairFromCommand(
     fixerName: options.fixer,
     ...(options.plan === undefined ? {} : { planPath: absPath(options.plan) }),
     ...(options.apply === true ? { apply: true } : {}),
+    onRow: (row: RepairRow) => countApplyRow(progress, row),
   };
   // The repair runs one session rather than the retarget's grouped ones, but
   // it ends the same way: an await that stops settling drains the process at
   // code 0 with the fixer's writes half-made and nothing said about them.
   //
-  // Unwatched, because `repairPieces` reports its rows only in the report it
-  // returns — there is no row callback to hand it. So the guard says the
-  // count is unknown rather than zero: this run's rows really do settle, and
-  // a process that never saw them must not report their absence.
-  const progress = newApplyRunProgress(false);
+  // Watched, through the row reporter `repairPieces` offers: a run that stops
+  // settling can then be described by the rows that did, rather than by an
+  // admission that this process cannot see any.
+  const progress = newApplyRunProgress(true);
   const guard = guardRunReport(
     () => describeUnreportedApplyRun("Repair", progress),
     deps.guard ?? {},
@@ -4035,7 +4036,10 @@ function newApplyRunProgress(observed: boolean): ApplyRunProgress {
 }
 
 /** Count one settled row toward what a process-end report would say. */
-function countApplyRow(progress: ApplyRunProgress, row: ApplyRow): void {
+function countApplyRow(
+  progress: ApplyRunProgress,
+  row: { verdict: string },
+): void {
   progress.verdicts.set(
     row.verdict,
     (progress.verdicts.get(row.verdict) ?? 0) + 1,

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -26,6 +26,7 @@ import {
   readPiecePin,
   repairPieces,
   type RepairReport,
+  type RepairRow,
   type RestoreOutcome,
   restorePiece,
   type RetargetSource,
@@ -103,6 +104,12 @@ export interface RepairRunRequest {
 
   /** Write the fixer's documents; absent, the run is the dry report. */
   apply?: boolean;
+
+  /**
+   * Called with each row as it settles, so a caller can say where a run that
+   * never returned had reached. Passed through to the engine's own reporter.
+   */
+  onRow?: (row: RepairRow) => void;
 }
 
 export interface RepairRunDependencies {
@@ -171,6 +178,7 @@ export async function runRepair(
       fixerIdentity,
       plan,
       ...(request.apply === true ? { apply: true } : {}),
+      ...(request.onRow === undefined ? {} : { onRow: request.onRow }),
     });
   }
   const module = await (deps.importProgram ?? importProgramSnapshot)(program);
@@ -188,6 +196,7 @@ export async function runRepair(
     fixerIdentity,
     ...(plan === undefined ? {} : { plan }),
     ...(request.apply === true ? { apply: true } : {}),
+    ...(request.onRow === undefined ? {} : { onRow: request.onRow }),
   });
 }
 

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -263,21 +263,20 @@ describe("piece-repair", () => {
       expect(process.errors.join("\n")).toContain(
         "Repair ended before it reported",
       );
-      // `repairPieces` takes no row callback, so its rows settle where this
-      // process cannot see them. The line must say the count is unknown: a
-      // repair that wrote half its documents and reported "no row settled"
-      // would be telling the operator something false.
+      // `repairPieces` reports each row as it settles, so this process is
+      // watching and a count of zero is a fact about the run rather than a
+      // blind spot. This run settles none before it is abandoned, and the
+      // line says so — the wording an unwatched run must never use.
       expect(process.errors.join("\n")).toContain(
-        "How many rows it settled is not known here",
+        "No row settled before it ended",
       );
-      expect(process.errors.join("\n")).not.toContain("No row settled");
+      expect(process.errors.join("\n")).not.toContain("is not known here");
       expect(abandoned).toBeInstanceOf(Promise);
     });
 
     it("says the report failed, not that the run never returned, when output throws", async () => {
-      // The repair counts no rows either way, so what its line must get right
-      // here is the other half: the engine DID return, and the reason its
-      // count is unknown is the missing row callback rather than the return.
+      // What this line must get right is that the engine DID return: the
+      // failure is the report's, not a run that never came back.
       const process = guardHarness();
       await expect(
         repairFromCommand(
@@ -297,9 +296,27 @@ describe("piece-repair", () => {
       expect(said).toContain("Repair ran to a report");
       expect(said).not.toContain("still in flight");
       expect(said).not.toContain("it did not return");
-      expect(said).toContain(
-        "this run counts its rows only in the report itself",
+      expect(said).not.toContain("this run counts its rows only in the report");
+    });
+
+    it("hands the engine a row reporter, which is what the guard counts", async () => {
+      // The guard can only name where an abandoned run reached if something
+      // told it which rows settled. Without this the command would be back to
+      // saying the count is unknown, which is the weaker of the two lines it
+      // can print and the one this wiring exists to stop.
+      let request: RepairRunRequest | undefined;
+      const process = guardHarness();
+      await captureStdout(() =>
+        repairFromCommand({ ...OPTIONS, path: "topics" }, {
+          runRepair: (_config, req) => {
+            request = req;
+            return Promise.resolve(REPORT);
+          },
+          printHint: () => {},
+          guard: process.deps,
+        })
       );
+      expect(typeof request?.onRow).toBe("function");
     });
 
     it("says nothing at process end once the run has reported", async () => {

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -299,24 +299,33 @@ describe("piece-repair", () => {
       expect(said).not.toContain("this run counts its rows only in the report");
     });
 
-    it("hands the engine a row reporter, which is what the guard counts", async () => {
+    it("counts the rows the engine reports, and names them if it is abandoned", async () => {
       // The guard can only name where an abandoned run reached if something
-      // told it which rows settled. Without this the command would be back to
-      // saying the count is unknown, which is the weaker of the two lines it
-      // can print and the one this wiring exists to stop.
-      let request: RepairRunRequest | undefined;
+      // told it which rows settled. Driving the callback the command hands
+      // over — rather than only asserting that one exists — is what proves a
+      // row travels all the way to the line the operator reads.
       const process = guardHarness();
-      await captureStdout(() =>
-        repairFromCommand({ ...OPTIONS, path: "topics" }, {
+      const abandoned = repairFromCommand(
+        { ...OPTIONS, path: "topics", apply: true },
+        {
           runRepair: (_config, req) => {
-            request = req;
-            return Promise.resolve(REPORT);
+            req.onRow?.({ piece: "of:fid1:alpha", verdict: "repaired" });
+            req.onRow?.({ piece: "of:fid1:bravo", verdict: "conforms" });
+            return new Promise<RepairReport>(() => {});
           },
+          render: () => {},
           printHint: () => {},
           guard: process.deps,
-        })
+        },
       );
-      expect(typeof request?.onRow).toBe("function");
+      await Promise.resolve();
+      expect(process.endProcess()).toBe(1);
+      const said = process.errors.join("\n");
+      expect(said).toContain("2 rows settled");
+      expect(said).toContain("repaired: 1");
+      expect(said).toContain("conforms: 1");
+      expect(said).not.toContain("No row settled");
+      expect(abandoned).toBeInstanceOf(Promise);
     });
 
     it("says nothing at process end once the run has reported", async () => {

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -153,6 +153,15 @@ export interface RepairOptions {
   fixer: Fixer;
 
   /**
+   * Called with each row as it settles, in the order the run settles them.
+   *
+   * The same seam the retarget's engine offers, and for the same reason: a
+   * caller watching rows can say where a run that never returned had reached,
+   * and one that is not watching can only say it does not know.
+   */
+  onRow?: (row: RepairRow) => void;
+
+  /**
    * The fixer's name as the plan should record it — a module path or a
    * label. With one, the emitted plan's evaluated rows carry the repair
    * operation; without, they carry only the pre-state record.
@@ -746,6 +755,19 @@ export async function repairPieces(
     };
   };
   const rows: RepairRow[] = [];
+  /**
+   * Every row this run settles, to the report and to a watching caller.
+   *
+   * A repair writes, so a run that stalls mid-way leaves the same partial
+   * state a retarget does — and the process guard can only name where it
+   * stopped if something told it which rows had settled. Routing every row
+   * through here is what makes the guard's count a fact about the run rather
+   * than an admission that this process cannot see one.
+   */
+  const report = (row: RepairRow) => {
+    rows.push(row);
+    options.onRow?.(row);
+  };
   const planRows: PiecePlanRow[] = [];
   let applied = 0;
   let stopped = false;
@@ -834,7 +856,7 @@ export async function repairPieces(
       const decision = preflight.get(row.piece);
       emitRow(decision, decision?.kind === "conforms");
       if (decision === undefined || decision.kind === "read-failed") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "failed",
@@ -843,14 +865,14 @@ export async function repairPieces(
             "; the run did not start, so nothing was written.",
         });
       } else if (decision.kind === "not-document") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "refused",
           problem: "The stored input is not a document.",
         });
       } else if (decision.kind === "moved") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "moved",
@@ -859,7 +881,7 @@ export async function repairPieces(
             "recorded: something other than this plan changed it.",
         });
       } else if (decision.kind === "refused") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "refused",
@@ -867,14 +889,14 @@ export async function repairPieces(
           problem: decision.problem,
         });
       } else if (decision.kind === "conforms") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "conforms",
           documentHash: decision.documentHash,
         });
       } else {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "would-change",
@@ -885,7 +907,7 @@ export async function repairPieces(
       continue;
     }
     if (stopped) {
-      rows.push({ piece: row.piece, ...phase, verdict: "unattempted" });
+      report({ piece: row.piece, ...phase, verdict: "unattempted" });
       emitRow(preflight.get(row.piece), false);
       continue;
     }
@@ -932,7 +954,7 @@ export async function repairPieces(
         );
       }
       if (decision.kind === "not-document") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "refused",
@@ -943,7 +965,7 @@ export async function repairPieces(
         continue;
       }
       if (decision.kind === "moved") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "moved",
@@ -956,7 +978,7 @@ export async function repairPieces(
         continue;
       }
       if (decision.kind === "refused") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "refused",
@@ -968,7 +990,7 @@ export async function repairPieces(
         continue;
       }
       if (decision.kind === "conforms") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "conforms",
@@ -978,7 +1000,7 @@ export async function repairPieces(
         continue;
       }
       if (options.apply !== true) {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "would-change",
@@ -994,7 +1016,7 @@ export async function repairPieces(
         // was written, and the run stops — plan order is a correctness
         // constraint, so a later row must not land while this one is
         // outstanding. A re-run resumes from here.
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "would-change",
@@ -1018,7 +1040,7 @@ export async function repairPieces(
         ? evaluateFixer(written, options.fixer)
         : undefined;
       if (verification?.kind === "conforms") {
-        rows.push({
+        report({
           piece: row.piece,
           ...phase,
           verdict: "repaired",
@@ -1032,7 +1054,7 @@ export async function repairPieces(
         emitRow(decision, true);
         continue;
       }
-      rows.push({
+      report({
         piece: row.piece,
         ...phase,
         verdict: "failed",
@@ -1065,7 +1087,7 @@ export async function repairPieces(
       } catch {
         // The re-read failing changes nothing: `state` already says so.
       }
-      rows.push({
+      report({
         piece: row.piece,
         ...phase,
         verdict: "failed",

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -764,9 +764,21 @@ export async function repairPieces(
    * through here is what makes the guard's count a fact about the run rather
    * than an admission that this process cannot see one.
    */
+  // Set when a caller's `onRow` throws, so the row loop's catch can tell that
+  // error from the operational ones it classifies. The row it was handed has
+  // already settled, and classifying the reporter's failure would put one
+  // piece in the report twice, under two verdicts, the second contradicting
+  // what the caller was just told.
+  let reporterThrew = false;
   const report = (row: RepairRow) => {
     rows.push(row);
-    options.onRow?.(row);
+    if (options.onRow === undefined) return;
+    try {
+      options.onRow(row);
+    } catch (error) {
+      reporterThrew = true;
+      throw error;
+    }
   };
   const planRows: PiecePlanRow[] = [];
   let applied = 0;
@@ -1068,6 +1080,10 @@ export async function repairPieces(
       emitRow(decision, false);
       stopped = true;
     } catch (error) {
+      // The reporter's own failure is not this row's outcome. The row it was
+      // handed has settled and the caller has seen it, so this leaves rather
+      // than reporting the same piece again under a contradicting verdict.
+      if (reporterThrew) throw error;
       // An operational failure — an unreachable piece, a write the schema
       // refuses — is this row's outcome, not the report's: the rows that
       // landed stay reported. The state check runs after the failure, so

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -652,6 +652,36 @@ describe("bulk-repair", () => {
       expect((await rawInput(b)).seed).toBe("bravo");
     });
 
+    it("leaves when the row reporter throws, rather than reporting the piece twice", async () => {
+      // The reporter is handed a row that has already settled. If its own
+      // failure were classified like an unreachable piece or a refused
+      // write, the same piece would appear twice in one report under two
+      // verdicts, the second contradicting what the caller was just told.
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const seen: string[] = [];
+      let failure: unknown;
+      const report = await repairPieces(pieces, {
+        selector: { kind: "list", pieces: [a.id, b.id] },
+        fixer: upperSeed,
+        apply: true,
+        onRow: (row) => {
+          seen.push(row.piece);
+          throw new Error("the reporter gave up");
+        },
+      }).catch((error: unknown) => {
+        failure = error;
+        return undefined;
+      });
+
+      // One row reached the caller, and the run left rather than carrying on.
+      expect(seen).toEqual([a.id]);
+      expect((failure as Error | undefined)?.message).toBe(
+        "the reporter gave up",
+      );
+      expect(report).toBeUndefined();
+    });
+
     it("reports what the store returned after the write, not the fixer's answer", async () => {
       const a = await member("alpha");
       // The write path is free to normalize what it stores — schema-default


### PR DESCRIPTION
## Why

`cf piece repair` writes. When a run stops settling mid-way — the failure #6406 exists for — the process guard could say the repair had ended before reporting, but **not where it had reached**: `repairPieces` returned its rows only inside the report it never got to return.

The guard handled that correctly, and the code said so:

> Unwatched, because `repairPieces` reports its rows only in the report it returns — there is no row callback to hand it. So the guard says the count is unknown rather than zero.

That is the right thing to say when you cannot see, and it is the weaker of the two lines the guard can print. A retarget in the same situation names the rows that landed. A repair could not, and the only reason was a missing seam.

## What Changed

- `RepairOptions` gains `onRow`, the same seam `bulk-apply` already offers. Every row emission in `repairPieces` routes through one reporter rather than pushing directly, so a new verdict cannot be added that the caller never sees.
- `RepairRunRequest` carries it through both `repairPieces` call sites in `lib/bulk.ts`.
- `repairFromCommand` hands one over and arms the guard as **watched**.
- `countApplyRow` widens to `{ verdict: string }` — it only ever read that field, and a `RepairRow` is not an `ApplyRow`.

## The two tests that changed, and why that is not bending them

`piece-repair.test.ts` asserted the unwatched wording — *"How many rows it settled is not known here"* — and explicitly `not.toContain("No row settled")`. Those assertions were correct for an unwatched run and are wrong for a watched one. The distinction is the whole point of `ApplyRunProgress.observed`, per its own doc:

> An UNWATCHED run says the number is not known here — never zero, because zero would be a claim this process is in no position to make.

A watched run that settled none says so, and that is now a fact about the run rather than about the observer. The tests assert the stronger line and refuse the weaker one, inverting what they held before.

## Test plan

A new test asserts the command hands the engine a reporter. **Mutation-checked**: deleting the `onRow` wiring reds that test and nothing else, so it is guarding the seam rather than the shape of the call.

`deno fmt --check` and `deno lint` over both packages (475/463 files), `deno task check`, `deno task test` in `packages/piece` (51 passed) and `packages/cli` (210 passed).

## Two things deliberately not in here

I had this queued beside two others I had been calling defects. Both dissolved on reading the code, and I would rather record that than quietly drop them:

- **`bulk-survey.ts`'s unconditional registry read.** Not a small fix. `registered.length` feeds the plan header's `registry` count for *both* selector kinds, so skipping it changes the artifact's contract; and forcing `getDefaultPattern(false)` inside `getPieceRegistry` reaches every caller, including the FUSE listing path its own comment warns about. It needs a measurement I could not make without a live server.
- **`FingerprintReport.unhashable` carrying `id` without `scope`.** Not a live defect: it is consumed only as a count (`.length`), never matched by identity across sides, so it cannot produce the cancellation bug that hit `verifyClone`. Worth fixing for consistency, but it is not the bug I had been calling it.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

