### PR TITLE
docs(cli): steps 9 and 11 land together, and the question under them

### DIFF
--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -30,9 +30,9 @@ have landed.
 | step | state |
 | --- | --- |
 | 8 — `CF_SPACE` is ambient, and a write names the space it wrote to | on main |
-| 9 — a reference takes a space by name and a piece by slug, positionally | not started |
+| 9 — a reference takes a space by name and a piece by slug, positionally | not started; lands with 11, not alone |
 | 10 — the verb opens the callable's section and `--` closes it | not started; `PIECE_DATA_SPELLING_END_DATE` is the thing to check first |
-| 11 — `--url` decomposes into the transport it names and the reference it carries | not started |
+| 11 — `--url` decomposes into the transport it names and the reference it carries | not started; lands with 9 |
 
 ## What the surface is for
 
@@ -643,6 +643,27 @@ thing to check before starting step
 Steps 8, 9 and 11 add. Step 10 is the one that changes what a written line
 means, and it is the one the rest of the surface reads against — a projection
 cannot be written after the verb until it lands.
+
+**9 and 11 land together, as one change.** Step 9 on its own gives the
+canonical reference a vocabulary two other spellings already have and retires
+neither, so the surface it leaves is the same four spellings with more overlap
+between them — capability added to the accretion this document exists to
+reduce. What makes 9 worth doing is 11: the reference earns the human
+vocabulary so that `--url` can decompose to it and stop being the only spelling
+that carries a whole target. Landed as a pair, the surface ends with one fewer
+way to name a thing; landed alone, 9 ends with one more.
+
+Their ergonomics compound the same way, and mostly outside 9. Naming the space
+ambiently is step 8's, and the slug is what saves the hundred characters — so
+the increment 9 adds over 8 is that a slug also works in the canonical
+position, not the whole distance between the long form and the short one.
+
+**The prior question, which this document does not answer.** Whether a
+reference grammar is the right home for this at all, or whether it stands in
+for a naming and resolution layer that does not exist. Everything above assumes
+the canonical reference's structure is right and only its vocabulary is
+missing. That assumption is worth testing before 9 and 11 are built, because a
+resolution layer would make both of them smaller — or unnecessary.
 
 The sweep is bounded and enumerable: twelve files across `docs/`, `skills/`,
 `packages/cli/README.md`, and the CLI's own tests and integration scripts teach

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -645,7 +645,7 @@ means, and it is the one the rest of the surface reads against — a projection
 cannot be written after the verb until it lands.
 
 **9 and 11 land together, as one change.** Step 9 on its own gives the
-canonical reference a vocabulary two other spellings already have and retires
+canonical reference a vocabulary another spelling already has and retires
 neither, so the surface it leaves is the same four spellings with more overlap
 between them — capability added to the accretion this document exists to
 reduce. What makes 9 worth doing is 11: the reference earns the human


### PR DESCRIPTION
## Why

Anyone picking up arc two reads the steps in order and builds 9 next, because it is additive and ungated. That is the wrong read, and nothing in the plan says so.

**Step 9 on its own makes the surface worse by the measure this document exists to improve.** It gives the canonical reference a vocabulary that `--space`/`--piece` and `--url` already have, and retires neither — leaving the same four spellings for a target with more overlap between them, and adding a positional form on top. Capability added to the accretion, rather than accretion reduced.

What makes 9 worth doing is 11. The reference earns the human vocabulary precisely so `--url` can decompose to it and stop being the only spelling that carries a whole target. **Landed as a pair the surface ends with one fewer way to name a thing; landed alone, 9 ends with one more.**

The ergonomics point the same way. The plan sells the target grammar with a 110-to-7 character comparison, but says itself that the slug saves the hundred and the ambient space saves the rest — and the ambient space is step 8, already on main. So 9's real increment is "a slug also works in the canonical position", not the distance between the long form and the short one.

## What Changed

Prose only.

- A paragraph after the step list: 9 and 11 land together, why, and how their ergonomics actually divide.
- The tracker rows say `lands with 11, not alone` and `lands with 9`, so the pairing is visible without reading to the bottom.
- A note of the prior question the sequence assumes away — whether a reference grammar is the right home at all, or stands in for a naming and resolution layer that does not exist. Everything in "Naming the target" assumes the canonical reference's structure is right and only its vocabulary is missing. That assumption is worth testing before either step is built, because such a layer would make both smaller or unnecessary.

## Test plan

`deno task check-docs` — 587 blocks pass. Prose only; no code block touched.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

