### PR TITLE
test(patterns): stabilize iframe browser regressions

### DIFF
--- a/packages/patterns/iframe-impossible-machine/interaction.browser.test.ts
+++ b/packages/patterns/iframe-impossible-machine/interaction.browser.test.ts
@@ -2,42 +2,15 @@
 
 // @deno-types="npm:@types/react@19.2.18"
 // deno-lint-ignore no-external-import
-import React, { act } from "npm:react@19.2.8";
+import React from "npm:react@19.2.8";
 // @deno-types="npm:@types/react-dom@19.2.5/client.d.ts"
 // deno-lint-ignore no-external-import
 import { createRoot } from "npm:react-dom@19.2.8/client";
+// deno-lint-ignore no-external-import
+import { flushSync } from "npm:react-dom@19.2.8";
 import { expect } from "@std/expect";
 
-import {
-  createSelectionRequestTracker,
-  nodeControlBoundaryProps,
-} from "./interaction.ts";
-
-function SelectionHarness(
-  { writeSelection }: Readonly<{
-    writeSelection: (nodeId: string) => Promise<unknown>;
-  }>,
-) {
-  const tracker = React.useRef(createSelectionRequestTracker("node-a"));
-  return React.createElement(
-    React.Fragment,
-    null,
-    React.createElement(
-      "button",
-      {
-        onClick: () => void tracker.current.request("node-a", writeSelection),
-      },
-      "Select A",
-    ),
-    React.createElement(
-      "button",
-      {
-        onClick: () => void tracker.current.request("node-b", writeSelection),
-      },
-      "Select B",
-    ),
-  );
-}
+import { nodeControlBoundaryProps } from "./interaction.ts";
 
 function NodeControlHarness(
   { onNodeSelection }: Readonly<{ onNodeSelection: () => void }>,
@@ -68,13 +41,8 @@ function NodeControlHarness(
   );
 }
 
-Deno.test("embedded controls do not select their React Flow node", async () => {
+Deno.test("embedded controls do not select their React Flow node", () => {
   if (typeof document === "undefined") return;
-  const environment = globalThis as typeof globalThis & {
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
-  };
-  const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
-  environment.IS_REACT_ACT_ENVIRONMENT = true;
 
   const container = document.createElement("div");
   document.body.append(container);
@@ -82,7 +50,7 @@ Deno.test("embedded controls do not select their React Flow node", async () => {
   let nodeSelections = 0;
 
   try {
-    await act(() => {
+    flushSync(() => {
       root.render(
         React.createElement(NodeControlHarness, {
           onNodeSelection: () => nodeSelections++,
@@ -92,54 +60,14 @@ Deno.test("embedded controls do not select their React Flow node", async () => {
 
     const select = container.querySelector("select");
     expect(select).not.toBeNull();
-    await act(() => select!.click());
+    select!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
 
     expect(nodeSelections).toBe(0);
     expect(select!.disabled).toBe(false);
   } finally {
-    await act(() => root.unmount());
+    flushSync(() => root.unmount());
     container.remove();
-    environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
-  }
-});
-
-Deno.test("rapid node selections retain the latest requested node", async () => {
-  if (typeof document === "undefined") return;
-  const environment = globalThis as typeof globalThis & {
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
-  };
-  const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
-  environment.IS_REACT_ACT_ENVIRONMENT = true;
-
-  const container = document.createElement("div");
-  document.body.append(container);
-  const root = createRoot(container);
-  const writes: string[] = [];
-  let releaseNodeB!: () => void;
-  const nodeBGate = new Promise<void>((resolve) => releaseNodeB = resolve);
-  const writeSelection = (nodeId: string) => {
-    writes.push(nodeId);
-    return nodeId === "node-b" ? nodeBGate : Promise.resolve();
-  };
-
-  try {
-    await act(() => {
-      root.render(React.createElement(SelectionHarness, { writeSelection }));
-    });
-    const [selectA, selectB] = container.querySelectorAll("button");
-
-    selectA.click();
-    selectB.click();
-    selectA.click();
-
-    expect(writes).toEqual(["node-b", "node-a"]);
-  } finally {
-    releaseNodeB();
-    await act(async () => {
-      await nodeBGate;
-      root.unmount();
-    });
-    container.remove();
-    environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
   }
 });

--- a/packages/patterns/integration/iframe-firebreak-commons.test.ts
+++ b/packages/patterns/integration/iframe-firebreak-commons.test.ts
@@ -363,6 +363,16 @@ function waitForTurn(
   );
 }
 
+function waitForEnabledButton(
+  driver: GuestDomDriver,
+  selector: string,
+): Promise<boolean> {
+  return driver.waitFor<boolean>(`() => {
+    const control = document.querySelector(${JSON.stringify(selector)});
+    return control instanceof HTMLButtonElement && !control.disabled;
+  }`);
+}
+
 describe("iframe Firebreak Commons", () => {
   const aliceShell = new ShellIntegration();
   const bobShell = new ShellIntegration();
@@ -484,6 +494,7 @@ describe("iframe Firebreak Commons", () => {
       }
 
       await alice.setValue("#crew-name", "Unsaved lookout");
+      await waitForEnabledButton(bob, "#advance");
       await bob.click("#advance");
       const advanced = await Promise.all([
         waitForTurn(alice, 2),


### PR DESCRIPTION
## Why

Two new browser regressions had avoidable timing surface:

- Impossible Machine mixed the irreducible React synthetic-event boundary with an asynchronous rapid-selection harness that is already covered deterministically in Deno.
- Firebreak observed shared action rows before the guest mutation queue had finished and re-enabled the Advance button.

## What

- Keep one synchronous real-Chrome React boundary using `flushSync` and an explicit bubbling `MouseEvent`.
- Remove the duplicate asynchronous rapid-selection browser case.
- Wait for the actual Firebreak `disabled` attribute transition through the existing MutationObserver-based guest wait before clicking Advance.

## Verification

- Impossible Machine browser boundary: 50/50 fresh Chrome launches
- Patterns package: 71 tests / 240 steps, source coverage, 1 browser test
- Firebreak focused integration: OFF and server-execution ON
- `deno task check-no-waitfor`
- `deno fmt --check`
- `deno lint`
- `deno task check`
- `git diff --check`