### PR TITLE
Preserve provider data from normalized stream errors

### DIFF
--- a/packages/toolshed/routes/ai/llm/generateText.ts
+++ b/packages/toolshed/routes/ai/llm/generateText.ts
@@ -192,8 +192,8 @@ function truncateDescription(text: string): string {
 /**
  * Renders a failure the AI SDK recorded as one line of text. An HTTP status
  * separates a request the provider turned down from a rate limit or an
- * outage. The provider's response body is left out: it reaches the log
- * through the cause of the error this description goes into.
+ * outage. A normalized stream error includes the provider data the AI SDK
+ * wrapped; raw response bodies stay in the cause that reaches the log.
  */
 function describeStreamError(error: unknown): string {
   if (typeof error !== "object" || error === null) {
@@ -208,11 +208,23 @@ function describeStreamError(error: unknown): string {
       return truncateDescription(String(error));
     }
   }
-  const { statusCode } = error as { statusCode?: unknown };
+  const { data, statusCode } = error as {
+    data?: unknown;
+    statusCode?: unknown;
+  };
   const status = typeof statusCode === "number"
     ? `; HTTP status ${statusCode}`
     : "";
-  return `${error.name}: ${truncateDescription(error.message)}${status}`;
+  const description = `${error.name}: ${
+    truncateDescription(error.message)
+  }${status}`;
+  const providerData = error.name === "AI_StreamProviderError" &&
+      data !== undefined && data !== error
+    ? `; provider data: ${describeStreamError(data)}`
+    : "";
+  return providerData === ""
+    ? description
+    : truncateDescription(`${description}${providerData}`);
 }
 
 /**


### PR DESCRIPTION
## Why

The `ai` dependency range now resolves `7.0.83`, which wraps plain stream-provider payloads in `AI_StreamProviderError`. Toolshed consequently dropped the provider payload from the client-visible failure and the compatibility gate failed on every fresh dependency resolution.

## What Changed

When that specific SDK wrapper carries provider data, include its bounded description alongside the normalized name, message, and status. Other errors retain their existing formatting.

## Test plan

- Observed the existing plain-object provider failure test fail with a clean `ai@7.0.83` cache
- Focused compatibility suite passes with `ai@7.0.83` and cached `ai@7.0.52`
- Full Toolshed suite: 147 passed / 463 steps
- Repo-wide lint passes
- Focused format and type-check pass
- Repo-wide format check also reports pre-existing UI formatting drift on `main`; the changed file is clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

