### PR TITLE
Adopt the server posture in the GitHub host; fail empty pattern shards loudly

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1394,7 +1394,18 @@ jobs:
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
-          mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          # Command substitution (not a process substitution) so a selector
+          # failure fails this step under `bash -e` instead of reading as an
+          # empty list that runs ZERO test files and exits green. The
+          # selector throws on an empty selection (every shard carries the
+          # internally-sharded files), so an empty result here is only ever
+          # a failure — reject it loudly as the backstop.
+          SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          if [ -z "$SELECTED_FILES" ]; then
+            echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
+            exit 1
+          fi
+          mapfile -t TEST_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${TEST_FILES[@]}"
           mkdir -p ../../test-results
@@ -1551,7 +1562,19 @@ jobs:
         timeout-minutes: *work-timeout
         working-directory: packages/patterns
         run: |
-          mapfile -t SHARD_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          # Command substitution (not a process substitution) so a selector
+          # failure fails this step under `bash -e` instead of reading as an
+          # empty list that runs ZERO test files and exits green. The
+          # selector throws on an empty selection (every shard carries the
+          # internally-sharded files), so an empty result here is only ever
+          # a failure — reject it loudly as the backstop. The legitimate
+          # empty case lives one stage LATER, after the ON-skip filter.
+          SELECTED_FILES=$(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          if [ -z "$SELECTED_FILES" ]; then
+            echo "::error::select-pattern-integration-files.ts selected no files for shard ${{ matrix.shard }}/${{ matrix.total }}"
+            exit 1
+          fi
+          mapfile -t SHARD_FILES <<< "$SELECTED_FILES"
           printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
           printf '  %s\n' "${SHARD_FILES[@]}"
           # The explicit ON-arm skip list, applied by FILTERING this shard's

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -1970,12 +1970,16 @@ Tasks:
       clients declaring the posture from the env (uniform, not mixed);
       the ON skip list — made EFFECTIVE by the fixer (it had been inert
       since Phase 4: `deno test --ignore` never applied to explicitly
-      listed files) — holds `phase-7` entries: patterns ×3
+      listed files) — held `phase-7` entries at this ruling's date:
+      patterns ×3
       (`topics-navigation`, `cfc-group-chat-demo-two-browsers`,
       `lunch-poll-vote`), runner ×1 (`pattern-and-data-persistence`),
       runtime-client ×2 STEP entries (`tasks/server-execution-on-skips.
       ts`, each with its loud reason; verification-coverage OW30/OW32/
-      OW33). **THE FLIP PR (one line: the constant → `true`, plus the
+      OW33) *— since lifted arc-by-arc: the ON-skip registry is EMPTY
+      across all four suites (#6528, the ruled-3b-close lift — the
+      Coordination-state delta above), so gate (5)'s list-EMPTY half
+      below is MET*. **THE FLIP PR (one line: the constant → `true`, plus the
       absolute pin, the lane roles + probes, EXPERIMENTAL_OPTIONS.md)
       lands only after these ORDERED GATES, in this order:** (1) OW32 —
       the client-side scheduler-non-settling loop TRIAGED and fixed (the
@@ -2033,8 +2037,8 @@ Tasks:
       service-principal write-authority posture) was RULED 2026-08-18 —
       the serving identity never writes users' home spaces; genesis
       under the space's own keys, owner := the acting user — and its
-      build (register OW31's work order) lands post-merge, BEFORE the
-      flip.
+      build (register OW31's work order) was owed post-merge, BEFORE
+      the flip: BUILT 2026-08-21 (the register's OW31 row).
 - [ ] Retire the flag; OFF path removed; `EXPERIMENTAL_OPTIONS.md` entry
       closed out — **SPLIT OUT: the post-soak removal PR** (named here as
       the flip's follow-up; it also removes the OFF regression-guard CI
@@ -2046,10 +2050,14 @@ Tasks:
 Success criteria:
 
 - [ ] The integration suites run ON-only and green. (NOT ticked — untrue
-      today: the default lanes are the OFF posture by ruling; the
-      explicit-ON lanes are green only WITH the skip list's six
-      `phase-7` entries, which are RED under the full ON posture, not
-      vacuous — table below.)
+      today: the default lanes are the OFF posture by ruling. *The rest
+      of this parenthetical was the 2026-08-16 state, since superseded:
+      the explicit-ON lanes were green only WITH the skip list's six
+      `phase-7` entries, which were RED under the full ON posture, not
+      vacuous — table below. The entries were lifted arc-by-arc and the
+      ON-skip registry is EMPTY across all four suites since #6528, the
+      ruled-3b-close lift — the explicit-ON lanes run green with no
+      skips; the Coordination-state delta above carries the lift.*)
 - [ ] Cross-user propagation beats the client-computed baseline on the
       byte-identical workloads (the §1 "faster, not tolerably slower"
       requirement). (NOT ticked — UNMEASURED: the measurement leg is

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -3258,15 +3258,21 @@ findings; the OWNER RULING — the flip lands DARK):
   runner/runtime-client/shell `integration` tasks now hand deno a
   QUOTED glob; the pattern ON shard filters its list through the
   script's `--filter` mode; STEP-level entries exist (in-file guard
-  bound to the register, validated). Entries today (ALL `phase-7`, none
-  of the lists EMPTY — the P7 phase PR's "one entry" and every earlier
-  "EMPTY" wording were about a mechanism that never bit): patterns ×3
+  bound to the register, validated). Entries at this delta's date (ALL
+  `phase-7`, none of the lists EMPTY — the P7 phase PR's "one entry" and
+  every earlier "EMPTY" wording were about a mechanism that never bit):
+  patterns ×3
   (`topics-navigation`, `cfc-group-chat-demo-two-browsers`,
   `lunch-poll-vote` — the last two on OW32's characterized, unattributed
   loop), runner ×1 (`pattern-and-data-persistence` — OW33),
   runtime-client ×2 STEP entries in `client.test.ts` (OW33). Verified
   locally: runner integration 14/14 default posture, 13/14 + 1 skipped
   under ON; runtime-client 45 steps default, 43 + 2 ignored under ON.
+  [State at 2026-08-16, SUPERSEDED: the six entries were lifted
+  arc-by-arc and the ON-skip registry has been EMPTY across all four
+  suites since the ruled-3b-close lift (#6528, 2026-08-28 — the
+  RULED-CLOSE LIFT block below); the INERT-mechanism discovery, the
+  quoted-glob/`--filter` fix, and the register binding remain current.]
 - Rows: OW17 gains the review's CLASS VERDICT and the correction (the
   two-browser red is NOT evidenced as OW17; the lunch "(1)+(2)+(3) →
   join UI" narrative did not reproduce); OW25 DISCHARGED (the ON shell
@@ -3275,7 +3281,8 @@ findings; the OWNER RULING — the flip lands DARK):
   carries the characterization and fix shape (compile as an outbox
   effect kind + completion-class writeback); OW29 folds in the
   demand-root chain's list-builtin gap (fixed) and the wish-sidecar
-  question (flagged); NEW OW31 (write-authority posture — ruled item),
+  question (flagged); NEW OW31 (write-authority posture — ruled item;
+  since RULED 2026-08-18 and BUILT 2026-08-21 — its row above),
   OW32 (the client non-settling loop — first gate), OW33 (the ON-posture
   Deno-client family).
 - protocol.md §2 gains the `capabilityRef` vocabulary sentence (review
@@ -7917,6 +7924,16 @@ supply; OW29/OW32/OW34 closed):
     never a regression. The alternative — re-checking the map on
     re-park — is exactly the immediate-retry spin the guard exists to
     prevent, so the code is right and the RECORD is what was owed.
+    One bound worth stating outright (review-6528 F4): record events
+    include re-issues' OWN re-records — a re-issue that succeeds past
+    the already-stored short-circuit re-verifies and re-RECORDS the
+    entry's module set — so two parks whose wanted identities live in
+    each other's entries can in principle wake each other in a cycle.
+    That cycle is one wake per persist event, paced by real storage
+    I/O, loud at every step, sustainable only while every wanted-read
+    keeps failing as every entry verify-read keeps succeeding
+    (doc-specific persistent read pathology in every candidate space),
+    and it heals outright on the first good read.
     Where truly nothing ever records, the loud one-shot behavior stands
     — the correct floor under the wedge-loudly ruling.
     **RULED-CLOSE LIFT (2026-08-28, this PR — the THIRD lift; the

--- a/packages/connectors/github/host/src/fabric-runtime.ts
+++ b/packages/connectors/github/host/src/fabric-runtime.ts
@@ -1,7 +1,7 @@
 import { GithubFabricTarget } from "@commonfabric/github-connector/fabric";
 import { createSession, Identity, isDID } from "@commonfabric/identity";
 import {
-  experimentalOptionsFromEnv,
+  experimentalOptionsForDeployedClient,
   type MemorySpace,
   Runtime,
   runtimePresets,
@@ -35,6 +35,17 @@ export async function openGithubFabricRuntime(options: {
     await (isDID(options.space)
       ? createSession({ identity, spaceDid: options.space })
       : createSession({ identity, spaceName: options.space }));
+  // The deployment's posture, with this host's explicit EXPERIMENTAL_* still
+  // winning per flag: the GitHub host is installed separately from the
+  // toolshed it talks to (docs/development/EXPERIMENTAL_OPTIONS.md), so an
+  // unset flag must adopt what the server runs rather than fall to this
+  // build's own default — the same resolution the agents host, the pieces
+  // controller, and cast-admin perform. Resolved before anything is
+  // allocated; this startup carries no cancellation signal to thread.
+  const experimental = await experimentalOptionsForDeployedClient({
+    apiUrl,
+    env: (key) => Deno.env.get(key),
+  });
   const storageManager = StorageManager.open({
     as: session.as,
     memoryHost: apiUrl,
@@ -43,7 +54,7 @@ export async function openGithubFabricRuntime(options: {
   const runtime = new Runtime(runtimePresets.remoteClient({
     apiUrl,
     storageManager,
-    experimental: experimentalOptionsFromEnv((key) => Deno.env.get(key)),
+    experimental,
     trustSnapshotProvider: () => ({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),

--- a/packages/connectors/github/host/test/fabric-runtime.test.ts
+++ b/packages/connectors/github/host/test/fabric-runtime.test.ts
@@ -57,4 +57,99 @@ describe("openGithubFabricRuntime", () => {
       githubAccount: "acme",
     })).rejects.toThrow("could not connect to https://fabric.example.test");
   });
+
+  it("resolves the deployment posture before constructing the runtime", async () => {
+    // The GitHub host is installed separately from the toolshed it talks
+    // to, and every experimental flag is server-authoritative
+    // (EXPERIMENTAL_FLAG_AUTHORITY) — so the host must ask the deployment
+    // for its posture rather than fill unset flags with its own build's
+    // defaults. A rebuilt host with an empty environment against a server
+    // held on an explicit posture would otherwise run the two sides on
+    // different arms (the #6535 Codex P1: an ON-client against a
+    // rolled-back OFF-server waits for a serving loop that does not
+    // exist). The posture request must come FIRST: it is what the runtime
+    // is constructed from.
+    const requestPaths: string[] = [];
+    globalThis.fetch = (input) => {
+      const url = new URL(
+        input instanceof Request ? input.url : String(input),
+      );
+      requestPaths.push(url.pathname);
+      if (url.pathname === "/api/meta") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              did: "did:key:z",
+              experimental: { serverExecution: false },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 503 }));
+    };
+
+    await expect(openGithubFabricRuntime({
+      apiUrl: "https://fabric.example.test",
+      identityPath,
+      space: "github-space",
+      githubHost: "github.com",
+      githubAccount: "acme",
+    })).rejects.toThrow("could not connect to https://fabric.example.test");
+    // The FIRST request is the posture read — nothing runtime-owned may
+    // precede it — and startup then went on to its health check.
+    expect(requestPaths[0]).toBe("/api/meta");
+    expect(requestPaths.length).toBeGreaterThan(1);
+  });
+
+  it("honors CF_ADOPT_SERVER_FLAGS=false without losing the request wiring", async () => {
+    // The opt-out keeps a host on its own posture when a deployment
+    // publishes something it cannot run. Both arms in one test, because
+    // each is the other's control: without the opt-out the meta document
+    // is requested (so the quiet arm below is the opt-out working, not
+    // the adoption missing), and with it the request must not happen at
+    // all (so the env reader is genuinely wired through — a host reading
+    // nothing would fetch in both arms).
+    const requestPaths: string[] = [];
+    globalThis.fetch = (input) => {
+      const url = new URL(
+        input instanceof Request ? input.url : String(input),
+      );
+      requestPaths.push(url.pathname);
+      if (url.pathname === "/api/meta") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ did: "did:key:z", experimental: {} }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 503 }));
+    };
+    const open = () =>
+      expect(openGithubFabricRuntime({
+        apiUrl: "https://fabric.example.test",
+        identityPath,
+        space: "github-space",
+        githubHost: "github.com",
+        githubAccount: "acme",
+      })).rejects.toThrow("could not connect to https://fabric.example.test");
+
+    await open();
+    expect(requestPaths).toContain("/api/meta");
+
+    requestPaths.length = 0;
+    const previous = Deno.env.get("CF_ADOPT_SERVER_FLAGS");
+    Deno.env.set("CF_ADOPT_SERVER_FLAGS", "false");
+    try {
+      await open();
+    } finally {
+      if (previous === undefined) Deno.env.delete("CF_ADOPT_SERVER_FLAGS");
+      else Deno.env.set("CF_ADOPT_SERVER_FLAGS", previous);
+    }
+    expect(requestPaths).not.toContain("/api/meta");
+    // The health check still ran: the quiet arm skipped the posture
+    // request specifically, not the startup around it.
+    expect(requestPaths.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -699,6 +699,83 @@ describe("runtimePresets conformance (CT-1814)", () => {
         expect(warnings.length).toBe(1);
         expect(String(warnings[0][0])).toContain(ADOPT_SERVER_FLAGS_ENV);
       });
+
+      it("an adopted server-OFF posture rides the deployed-topology presets explicitly, immune to the first-party default", async () => {
+        // The separately-installed-host shape (the #6535 Codex P1 on the
+        // GitHub host): nothing declared in the environment, talking to a
+        // server held on the explicit-OFF rollback posture. Adoption hands
+        // the preset an EXPLICIT `false`, and the presets' `??` fill then
+        // never consults `SERVER_EXECUTION_DEFAULT_ENABLED` — which is why
+        // the first arm of this pin references no constant: it must hold
+        // under EITHER value (that immunity is the rollback lever working
+        // across a staggered upgrade, not a restatement of the absolute
+        // pin in toolshed's server-execution-flag.test.ts).
+        const adopted = await experimentalOptionsForDeployedClient({
+          apiUrl: new URL("https://deployment.example"),
+          env: () => undefined,
+          fetch: () =>
+            Promise.resolve(metaResponse({
+              did: "did:key:z",
+              experimental: { serverExecution: false },
+            })),
+        });
+        expect(adopted.serverExecution).toBe(false);
+        for (const preset of ["remoteClient", "productionServer"] as const) {
+          expect(
+            runtimePresets[preset]({
+              apiUrl,
+              storageManager,
+              experimental: adopted,
+            })
+              .experimental?.serverExecution,
+          ).toBe(false);
+        }
+        // The arm adoption replaces: an env-only resolution leaves the
+        // unset flag ABSENT, and the preset fills it with the first-party
+        // constant — under a flipped default that is an ON client against
+        // the rolled-back OFF server, the mixed topology the adoption
+        // exists to prevent. Compared against the imported constant, not a
+        // literal, so this documents the exposure without pinning the
+        // constant's value.
+        expect(
+          runtimePresets.remoteClient({
+            apiUrl,
+            storageManager,
+            experimental: experimentalOptionsFromEnv(() => undefined),
+          }).experimental?.serverExecution,
+        ).toBe(SERVER_EXECUTION_DEFAULT_ENABLED);
+      });
+
+      it("an explicit environment outranks the published posture in both directions, through the preset", async () => {
+        // Both arms stay selectable on a deployed client: the env is the
+        // documented rollback lever and CI's way to pin a lane, so it must
+        // survive adoption AND the preset fill in each direction.
+        for (
+          const arm of [
+            { env: "true", server: false, resolved: true },
+            { env: "false", server: true, resolved: false },
+          ] as const
+        ) {
+          const adopted = await experimentalOptionsForDeployedClient({
+            apiUrl: new URL("https://deployment.example"),
+            env: (name) =>
+              name === "EXPERIMENTAL_SERVER_EXECUTION" ? arm.env : undefined,
+            fetch: () =>
+              Promise.resolve(metaResponse({
+                did: "did:key:z",
+                experimental: { serverExecution: arm.server },
+              })),
+          });
+          expect(adopted.serverExecution).toBe(arm.resolved);
+          expect(
+            runtimePresets.remoteClient({
+              apiUrl,
+              storageManager,
+              experimental: adopted,
+            }).experimental?.serverExecution,
+          ).toBe(arm.resolved);
+        }
+      });
     });
   });
 

--- a/packages/runner/test/wish-sidecar-closure-kick.test.ts
+++ b/packages/runner/test/wish-sidecar-closure-kick.test.ts
@@ -1,25 +1,27 @@
-// The (2-D) serve-time closure kick of the ruled 3b close
-// (verification-coverage.md OW45, RULING 2026-08-28): the sidecar pattern
-// cache is process-global while a serving runtime serves MANY spaces, and
-// its compile persists a closure only into the FIRST demanding space — so
-// every later space is served a pattern whose closure was never persisted
-// THERE, and a cross-space child replication out of such a space finds its
-// origin dry (the lunch host-join park's supplier hole, one channel of
-// it). The kick: serving a cached sidecar pattern for a space other than
-// the one it compiled into fires the same fire-and-forget
-// replicate-into-the-demanding-space the content-cache hit fires, so the
-// space's closure supplier is REGISTERED at page-serve time — before any
-// create-profile click can issue the child replication, whose
-// strictly-older-ticket await then covers the race by registration
-// instead of healing after the fact.
-//
-// This file pins the cache-level mechanism (`ensureClosureReplicated` and
-// the fetch-side kick for chained demanders) against real storage: the
-// demanding space ends up holding a loadable closure, exactly once per
-// (cache epoch, space). The wish launch arms wire the same call under
-// `runtime.servingPosture` (see wish.ts); the serving-stack end-to-end
-// coverage is the lunch surface itself (the arc's campaign + direct-CI
-// probe).
+/**
+ * The (2-D) serve-time closure kick of the ruled 3b close
+ * (verification-coverage.md OW45, RULING 2026-08-28): the sidecar pattern
+ * cache is process-global while a serving runtime serves MANY spaces, and
+ * its compile persists a closure only into the FIRST demanding space — so
+ * every later space is served a pattern whose closure was never persisted
+ * THERE, and a cross-space child replication out of such a space finds its
+ * origin dry (the lunch host-join park's supplier hole, one channel of
+ * it). The kick: serving a cached sidecar pattern for a space other than
+ * the one it compiled into fires the same fire-and-forget
+ * replicate-into-the-demanding-space the content-cache hit fires, so the
+ * space's closure supplier is REGISTERED at page-serve time — before any
+ * create-profile click can issue the child replication, whose
+ * strictly-older-ticket await then covers the race by registration
+ * instead of healing after the fact.
+ *
+ * This file pins the cache-level mechanism (`ensureClosureReplicated` and
+ * the fetch-side kick for chained demanders) against real storage: the
+ * demanding space ends up holding a loadable closure, exactly once per
+ * (cache epoch, space). The wish launch arms wire the same call under
+ * `runtime.servingPosture` (see wish.ts); the serving-stack end-to-end
+ * coverage is the lunch surface itself (the arc's campaign + direct-CI
+ * probe).
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -506,6 +506,41 @@ Deno.test("sharded pattern caches follow their shard topology", async () => {
   }
 });
 
+Deno.test("pattern shard selection fails loudly instead of running an empty shard", async () => {
+  // `mapfile -t X < <(deno run … select-pattern-integration-files.ts …)`
+  // discards the selector's exit status: a selector failure leaves the
+  // array empty WITHOUT failing the step, and the step then runs ZERO test
+  // files and exits green — a silently empty shard. The selector itself
+  // throws on an empty selection (every shard carries the
+  // internally-sharded files), so empty output is only ever a failure; the
+  // exit status is the discriminator, and only a plain command
+  // substitution propagates it under `bash -e`.
+  const contents = withoutComments(await workflow("deno.yml"));
+  for (
+    const jobId of [
+      "pattern-integration-test",
+      "pattern-integration-test-server-execution-on",
+    ]
+  ) {
+    const job = jobBlock(contents, jobId);
+    assert(
+      !/mapfile[^\n]*<\s*<\([^\n]*select-pattern-integration-files/.test(job),
+      `${jobId}: the shard selector must not feed mapfile through a ` +
+        `process substitution — that discards its exit status, and a ` +
+        `selector failure then runs an empty shard green`,
+    );
+    assertStringIncludes(
+      job,
+      "SELECTED_FILES=$(deno run --allow-read " +
+        "../../tasks/select-pattern-integration-files.ts",
+    );
+    assertStringIncludes(
+      job,
+      "::error::select-pattern-integration-files.ts selected no files",
+    );
+  }
+});
+
 Deno.test("Dashboard publishes only from main, never from a pull request", async () => {
   const deno = await workflow("deno.yml");
   const dashboard = await workflow("dashboard-image.yml");


### PR DESCRIPTION
## Why

The flip PR (#6535) turns the server-execution default ON on Monday. Two of its bot findings are not about the flip's own diff — they are latent on MAIN, and they matter most in exactly the post-flip situations the flip exists to survive:

- **The rollback lever must reach every deployed client.** The GitHub connector host resolved its experimental posture from env alone, so a rebuilt host with nothing declared would fill unset flags from its OWN build's first-party default. Today that is harmlessly OFF-vs-OFF; the moment the default flips, a host rebuilt during a rollback (explicit-OFF toolshed) runs client-ON against server-OFF and waits for a serving loop that does not exist (Codex P1 on #6535, r3885488810).
- **CI must not be able to run an empty shard green.** Both pattern-integration shard selectors fed `mapfile` through a process substitution, which discards the selector's exit status: a selector failure ran a zero-file shard successfully — a silent green exactly where the flip's soak needs the lanes to be evidence (Cubic on #6535, r3885488105 / r3885611642; pre-existing on main).

Landing both on main BEFORE the flip means Monday's flip lands on a fleet whose rollback lever and CI cannot silently lie. Nothing here changes ON/OFF behavior: the default on main stays OFF, and the posture fix is neutral by construction — the host adopts whatever the server says, and today's all-OFF fleet publishes exactly the value the preset fill already produced (the new pins prove the explicit-adopted value is terminal under either value of the constant).

The PR also settles the paperwork the flip's reviews flagged on the main side: register/plan claims that have been false on main since #6528/OW31's build, and two small ledger leftovers from the #6528 review round.

## What changed

1. **GitHub host adopts the deployment posture** (`packages/connectors/github/host/src/fabric-runtime.ts`): `experimental` now resolves via `experimentalOptionsForDeployedClient` (the `/api/meta` posture, explicit `EXPERIMENTAL_*` winning per flag, `CF_ADOPT_SERVER_FLAGS=false` opt-out) — the same resolution the agents host, pieces controller, CLI, and cast-admin already perform. Discharges Codex P1 r3885488810.
2. **Loud shard selection** (`.github/workflows/deno.yml`, both `pattern-integration-test` jobs): the selector is captured with a plain command substitution (exit status fails the step under `bash -e`) plus a loud `::error::` empty-result backstop. `tasks/select-pattern-integration-files.ts` already throws on an empty selection (every shard carries the internally-sharded files), so empty output is only ever a failure; the ON lane's legitimate empty stays where it was — after the ON-skip filter. Discharges Cubic r3885488105 / r3885611642 for main.
3. **Stale-history reclassification** (`docs/specs/server-side-execution/verification-coverage.md`, `docs/plans/server-execution-v2.md`): the 2026-08-16 delta's six-entry ON-skip inventory and the "ruled item" OW31 note, plus the plan's task/success-criteria copies of the same claims, are bracketed as superseded history (registry EMPTY since #6528; OW31 RULED 2026-08-18, BUILT 2026-08-21) — without rewriting the record's substance. Statements still true on main (constant `false`, default lanes OFF, flip-contingent text) are deliberately untouched: their re-tense rides #6535 itself (its threads r3885488816 / r3885486046 / r3885611646 keep the flip-side half).
4. **Ledger sweep**: the review-6528 F4 storm-bound sentence now lives at the spin-guard residue record (record events include re-issues' own re-records; one wake per persist event, I/O-paced, heals on first good read); the `wish-sidecar-closure-kick.test.ts` preamble becomes the doc-comment file header `docs/development/code-comment-style.md` §File headers prescribes.

## Test plan

Red-first, all watched red at the pre-fix state:

- `packages/connectors/github/host/test/fabric-runtime.test.ts`: "resolves the deployment posture before constructing the runtime" (first request is `/api/meta`, startup proceeds to its health check) and "honors CF_ADOPT_SERVER_FLAGS=false without losing the request wiring" (control arm red pre-fix) — both RED before the host change, green after.
- `tasks/ci-workflow.test.ts`: "pattern shard selection fails loudly instead of running an empty shard" — RED against main's deno.yml, green after; a one-site mutation (ON lane back to process substitution) reds with that job named.
- `packages/runner/test/runtime-presets.test.ts` pins the mechanism the host leans on: an adopted server-OFF posture rides `remoteClient`/`productionServer` as an EXPLICIT `false` (no constant referenced — the pin holds under either value of `SERVER_EXECUTION_DEFAULT_ENABLED`, which is what makes the fix provably inert today and load-bearing post-flip); the env-only arm documents the exposure against the imported constant (symbolic, not a literal — no second absolute pin); explicit env outranks the published posture in both directions through the preset.

Mutations killed: adoption dropped in the host → both host pins red; host env reader severed → exactly the opt-out pin red; `adoptServerExperimentalOptions` ignoring server flags → 9 steps red; `withServerExecutionDefault` trampling explicit values → exactly the new through-the-preset pin red (the pre-existing treatment matrix does not catch trampling). Sources restored byte-identical between mutations.

Suites at the final tree: github host package 19/19; agents host (sibling) 96/96; full `tasks/` suite 647 passed / 1084 steps (ci-workflow 20/20 incl. the parse-all-workflows YAML gate over the edited deno.yml; on-skips 17/17; selector/weighted-shards/workspace tests); `deno task check-test-aliases` clean; full runner suite green — 1322 passed, 7857 steps, 0 failed, 9m43s; fmt/lint/`deno check` clean on every touched TS file; `deno.lock` untouched.

Flip-branch note: #6535's doc hunks overlap the bracketed regions — its next rebase reconciles trivially (the brackets are pure additions; the flip's own re-tense supersedes the neighboring pre-flip prose it already edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

