### PR TITLE
docs(pattern-iframe): harden React lifecycle guidance

### DIFF
--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -34,9 +34,10 @@ select a React version for applications.
 Pattern discovery treats an ordinary non-test `.ts` or `.tsx` file under an
 `iframe-*` pattern as another pattern entry. Keep browser-only code in the root
 `guest.tsx`, or give an extracted browser helper the basename `guest.ts` or
-`guest.tsx`, as in `editor/guest.ts` above. This keeps the helper in the guest
-bundle without asking the pattern compiler to evaluate React or browser-only
-dependencies.
+`guest.tsx`, as in `editor/guest.ts` above. Import that helper from the root
+guest so the wrapper includes it in the bundle; the basename prevents pattern
+discovery from separately asking the pattern compiler to evaluate its React or
+browser-only dependencies.
 
 ## Describe input, state, and output
 

--- a/docs/common/ai/iframe-pattern-react-guide.md
+++ b/docs/common/ai/iframe-pattern-react-guide.md
@@ -14,10 +14,12 @@ you are migrating an existing guest and need to compare the two source styles.
 Keep these authored files beside the generated wrapper:
 
 ```text
-packages/patterns/react-quick-notes/
+packages/patterns/iframe-react-quick-notes/
 ├── contract.ts  # input, durable state, output, scopes, optional databases
 ├── guest.tsx    # React application and Fabric bridge client
 ├── guest.html   # optional document shell
+├── editor/
+│   └── guest.ts  # optional browser-only helper; see below
 └── main.tsx     # generated wrapper; do not hand-edit
 ```
 
@@ -28,6 +30,13 @@ application. It does not need a module server at runtime. Keep `contract.ts` and
 React is owned by the guest bundle. The iframe sandbox adapter accepts the
 exact React instance the guest imports; `@commonfabric/iframe-sandbox` does not
 select a React version for applications.
+
+Pattern discovery treats an ordinary non-test `.ts` or `.tsx` file under an
+`iframe-*` pattern as another pattern entry. Keep browser-only code in the root
+`guest.tsx`, or give an extracted browser helper the basename `guest.ts` or
+`guest.tsx`, as in `editor/guest.ts` above. This keeps the helper in the guest
+bundle without asking the pattern compiler to evaluate React or browser-only
+dependencies.
 
 ## Describe input, state, and output
 
@@ -318,6 +327,129 @@ async function appendNote(text: string): Promise<void> {
 `push()` is a mergeable append. Replacing the whole array from a React setter
 has a wider conflict domain.
 
+## Give every state layer one owner
+
+Fabric updates can rerender a React tree at any time, including while a pointer
+gesture, native popup, text edit, animation, or third-party component update is
+in progress. Divide state by the lifecycle that owns it:
+
+| State | Owner | Examples |
+| --- | --- | --- |
+| Durable collaborative data | Fabric Cell or SQLite | records, committed positions, shared edges |
+| Local user intent not yet committed | React state or refs | a text draft, open menu, active drag, pending selection |
+| Third-party interaction state | The library's local component state | `dragging`, measured bounds, viewport, focus, selection handles |
+| Pure presentation | Derived during render | labels, colors, filtered rows |
+
+Fabric is authoritative for durable values, but it is not a frame-by-frame
+controller for a stateful React library. If a diagram, grid, editor, or canvas
+emits change objects, keep its working value in a dedicated child component and
+apply changes with the library's own reducer. Commit only at a semantic
+boundary such as drag stop, edit confirmation, or row commit. Persisting every
+pointer move adds worker traffic and lets authoritative rerenders interrupt the
+gesture.
+
+Reconcile the local library value in `useLayoutEffect` only when its
+authoritative projection changes. Memoize that projection from the durable
+snapshot so an unrelated parent render does not manufacture a new dependency.
+During reconciliation, merge new durable data by stable ID while preserving:
+
+- the library's transient fields, such as `dragging`, measured dimensions, and
+  viewport state;
+- the active local draft for the item being edited;
+- a pending local selection until its write succeeds and the matching
+  authoritative sink update arrives.
+
+Do not replace the library value with a fresh Fabric projection on every
+render. That turns each pointer event or Cell acknowledgement into a visual
+remount: native popups close, focus moves, selections flash, and dragged items
+snap between local and durable positions. Keep component types, React keys, and
+the library root stable for the same reason. The full loading view belongs only
+to initial hydration; an ordinary mutation must not remount the application.
+
+### Reconcile asynchronous gestures by identity
+
+Serialized writes still complete later than the browser gesture that created
+them. Track each draft with a monotonically increasing token, not only its
+value. Two different drags can end at the same coordinates, and an older
+completion must not clear the newer draft merely because their values compare
+equal.
+
+On completion, settle only the matching token. A successful write can retain
+the draft until the same value arrives through the authoritative subscription.
+A failed current write can roll back to the latest authoritative value; a
+failed older write must not move or clear a newer gesture. Apply the same rule
+to selection and other optimistic UI. Repeated requests for the same pending
+selection should share that request's eventual result rather than reporting an
+early success.
+
+Capture event-owned values synchronously. If an action instead derives a new
+value from shared state, pull that value when the serialized action begins, not
+when it is enqueued. This keeps two rapid updater actions from deriving the same
+replacement from one stale render.
+
+### Scope pending state to the affected interaction
+
+A single global `pending` flag makes a narrow worker round trip look like a
+page refresh. Use the smallest pending boundary that matches the operation:
+
+- global pending for an action that genuinely changes the whole application;
+- per-item pending for a parameter or row edit;
+- no global visual lock for quiet persistence such as a drag position or
+  personal selection.
+
+The application may keep one serializer for ordering while exposing these
+different pending indicators. Preserve the latest visible error until the user
+acts on it; a later queued success must not erase an earlier rejection before
+it can be read.
+
+### Isolate controls embedded in interactive components
+
+Interactive libraries often treat any descendant pointer or click as a canvas,
+row, or node gesture. A native `select`, text field, or button inside that
+surface therefore needs both the library's gesture opt-out and a React event
+boundary. For React Flow, use `nodrag nopan` and stop the bubbling click at one
+ancestor:
+
+```tsx
+// Shown at module scope.
+/** @jsxRuntime classic */
+/** @jsx React.createElement */
+// @deno-types="npm:@types/react@19.2.18"
+import React from "npm:react@19.2.8";
+
+function NodeControls({ children }: React.PropsWithChildren) {
+  return React.createElement(
+    "div",
+    {
+      className: "nodrag nopan",
+      onClick: (event: React.MouseEvent<HTMLDivElement>) =>
+        event.stopPropagation(),
+    },
+    children,
+  );
+}
+```
+
+Use the equivalent gesture opt-out for another library. Keep editable control
+values in local React drafts while focused, and adopt authoritative values only
+when that local edit is settled. A Cell rerender must not close the popup or
+replace the text under the user's cursor.
+
+### Include the library's structural CSS
+
+The generated wrapper bundles JavaScript imports, but a React library can also
+depend on stylesheet rules that give its viewport, measurement wrappers,
+overlays, portals, and controls their geometry. Theme colors alone are not
+enough. Put the required structural rules in `guest.html` so the document stays
+self-contained under the iframe CSP. Give `html`, `body`, `#root`, and every
+intermediate layout container an explicit height, and give custom measured
+items a stable width or size when the library expects one.
+
+Exercise built-in layout actions such as fit-to-view and inspect the rendered
+bounds. A component that mounts without an exception can still be unusable when
+its measurement layer is zero-sized or an overlay is positioned outside the
+viewport.
+
 ## Fine-grained paths and stable array items
 
 The React adapter intentionally covers named root resources. Use the direct
@@ -326,8 +458,13 @@ rerender for the entire root. `sink()` calls its listener synchronously with the
 current cached sample, then again for later values; call `pull()` when the
 component requires current data before mutation.
 
-An array index is a position rather than an identity. Resolve the item first,
-then keep the resolved handle in the effect:
+An array index is a position rather than an identity. `resolve()` gives a stable
+handle only when that value is backed by a stored entity document. Do not assume
+that a seeded inline object is such an entity: resolving an inline value can
+produce a detached value capability rather than the durable array address.
+
+When the contract guarantees entity-backed items, resolve the item and keep the
+host-minted handle in the effect:
 
 ```tsx
 /** @jsxRuntime classic */
@@ -373,6 +510,13 @@ move. Its `.identity.id` names the entity document. Its
 sessions for one PerUser Cell, different across users, and different for every
 PerSession Cell. The guest cannot turn an arbitrary ID into authority; writes
 go through the resolved handle.
+
+For inline objects in an append-only array, use an application-level stable ID.
+Pull the array when the queued action begins, locate the current index by ID,
+derive the path handle, pull it, and recheck its ID before the narrow write. This
+is safe only while existing entries never reorder or disappear. If entries can
+move or be deleted, store them as independently addressable entities or use a
+record keyed by stable ID instead of retaining an array path.
 
 ## Add SQLite without querying before hydration
 
@@ -463,6 +607,8 @@ An authoritative sink or hook rerender can arrive while the user edits a text
 field. Keep the draft in `useState`; copy authoritative data into it only when
 there is no pending local edit. Disable the action while its write is pending,
 and surface rejected writes. Do not clear the draft before a successful write.
+Use a form-level edit generation when several fields form one submission: a
+change to any field means an older completion owns none of the new draft.
 
 Use `button type="button"` for every bridge action. The sandbox does not grant
 native form submission or navigation, so do not wrap bridge controls in a
@@ -481,9 +627,9 @@ settings target the Common Fabric host runtime instead.
 
 ```bash
 deno run -A tools/write-iframe-wrapper.ts \
-  --contract packages/patterns/react-quick-notes/contract.ts \
-  --guest packages/patterns/react-quick-notes/guest.tsx \
-  --out packages/patterns/react-quick-notes/main.tsx \
+  --contract packages/patterns/iframe-react-quick-notes/contract.ts \
+  --guest packages/patterns/iframe-react-quick-notes/guest.tsx \
+  --out packages/patterns/iframe-react-quick-notes/main.tsx \
   --react
 ```
 
@@ -496,9 +642,9 @@ must contain `<!-- PATTERN_IFRAME_SCRIPT -->` exactly once.
 Format and compile both realms:
 
 ```bash
-deno fmt packages/patterns/react-quick-notes
-deno check packages/patterns/react-quick-notes/guest.tsx
-deno task cf check packages/patterns/react-quick-notes/main.tsx --no-run
+deno fmt packages/patterns/iframe-react-quick-notes
+deno check packages/patterns/iframe-react-quick-notes/guest.tsx
+deno task cf check packages/patterns/iframe-react-quick-notes/main.tsx --no-run
 ```
 
 Launch against local servers:
@@ -507,10 +653,10 @@ Launch against local servers:
 ./scripts/start-local-dev.sh
 mkdir -p .cf
 test -e .cf/iframe-pattern.key || \
-  deno task cf id new > .cf/iframe-pattern.key
+deno task cf id new > .cf/iframe-pattern.key
 CF_API_URL=http://localhost:8000 \
 CF_IDENTITY=.cf/iframe-pattern.key \
-deno task cf piece new packages/patterns/react-quick-notes/main.tsx \
+deno task cf piece new packages/patterns/iframe-react-quick-notes/main.tsx \
   --root . --space iframe-react-notes --slug react-notes
 ```
 
@@ -528,7 +674,40 @@ Verify at least these behaviors:
 - a SQLite mutation causes the active query to rerender;
 - a rejected write or query renders an error rather than silently clearing a
   draft;
+- a high-frequency third-party interaction stays mounted across several
+  painted frames and persists only at its commit boundary;
+- native controls embedded in an interactive node or row keep focus and do not
+  trigger the parent library's selection or drag behavior;
+- a narrow mutation does not return the whole application to loading or disable
+  unrelated controls;
 - cleanup disconnects the bridge when the iframe document is replaced.
+
+Put deterministic reconciliation, gesture-token, and write-ordering logic in
+plain modules and cover the failure and out-of-order cases with Deno tests. If
+you test a hook boundary with a small injected harness, model React dependency
+arrays with `Object.is`; a harness that runs every layout effect on every render
+cannot detect accidental reconciliation during local state updates.
+
+Use a real browser test for DOM event propagation, native controls, focus, and
+third-party lifecycle behavior. Exercise the rendered descendant and make the
+parent handler change observable state so the assertion would fail without the
+event boundary. Run `*.browser.test.ts` through the package's browser task and
+exclude it from plain Deno discovery; a DOM guard that turns the same file into
+a no-op unit test is false coverage. Prefer this focused component boundary
+when the regression does not require the running shell. Reserve a full pattern
+integration test for behavior that genuinely crosses the wrapper, runtime,
+scope, or reload boundary. Do not add an application-specific `postMessage`
+command or snapshot backdoor only to automate the guest.
+
+A source-token assertion can guard that a tested helper remains wired into the
+guest, but it is not behavioral proof on its own. Keep it insensitive to
+formatting and attribute order, and pair it with the unit or browser test that
+executes the behavior.
+
+Wait for rendered state or an explicit completion event. Do not use sleeps to
+make gestures line up with worker acknowledgements. A final Computer Use pass
+should drag through multiple visible frames, operate every embedded native
+control, and confirm that the browser console stays clean.
 
 For multi-user state, cover two sessions of one identity, a second identity,
 and a reload. PerSpace data agrees everywhere, PerUser data agrees only between

--- a/skills/pattern-iframe/SKILL.md
+++ b/skills/pattern-iframe/SKILL.md
@@ -14,8 +14,11 @@ primary rendering owner, in this order:
   `docs/common/ai/iframe-pattern-phaser-guide.md` in full.
 - For a data visualization whose DOM or SVG is owned by D3, read
   `docs/common/ai/iframe-pattern-d3-guide.md` in full.
-- For a React component tree, hooks, or an explicitly requested React guest,
-  read `docs/common/ai/iframe-pattern-react-guide.md` in full.
+- For a React component tree, hooks, an explicitly requested React guest, or a
+  stateful React-only editor, diagram, grid, or canvas library, read
+  `docs/common/ai/iframe-pattern-react-guide.md` in full. It owns the boundary
+  between durable Fabric data, React drafts, and library-managed interaction
+  state.
 - Otherwise read `docs/common/ai/iframe-pattern-guide.md` in full for a plain
   DOM guest.
 
@@ -27,6 +30,9 @@ extends beyond the generated wrapper.
 
 Keep the authored surface small:
 
+- Put the files under `packages/patterns/iframe-<name>/`. The `iframe-` prefix
+  is load-bearing: pattern discovery uses it to recognize `guest.ts` and
+  `guest.tsx` as browser sources rather than additional pattern entries.
 - `contract.ts` names the input, durable state, and output data shapes and their
   defaults.
 - `guest.ts` or `guest.tsx` owns the application. It may use plain DOM code or
@@ -40,24 +46,24 @@ Generate the wrapper with:
 
 ```bash
 deno run -A tools/write-iframe-wrapper.ts \
-  --contract packages/patterns/<name>/contract.ts \
-  --guest packages/patterns/<name>/guest.ts \
-  --out packages/patterns/<name>/main.tsx
+  --contract packages/patterns/iframe-<name>/contract.ts \
+  --guest packages/patterns/iframe-<name>/guest.ts \
+  --out packages/patterns/iframe-<name>/main.tsx
 ```
 
 Add `--react` when the authored guest is React TSX, as required by the React
 guide.
 
-Add `--html packages/patterns/<name>/guest.html` when the guest needs a custom
-document shell, and `--force` only when regenerating the named output. The HTML
-shell must contain `<!-- PATTERN_IFRAME_SCRIPT -->` exactly once.
+Add `--html packages/patterns/iframe-<name>/guest.html` when the guest needs a
+custom document shell, and `--force` only when regenerating the named output.
+The HTML shell must contain `<!-- PATTERN_IFRAME_SCRIPT -->` exactly once.
 
 Validate the generated pattern with:
 
 ```bash
-deno fmt packages/patterns/<name>
-deno check packages/patterns/<name>/<guest-file>
-deno task cf check packages/patterns/<name>/main.tsx --no-run
+deno fmt packages/patterns/iframe-<name>
+deno check packages/patterns/iframe-<name>/<guest-file>
+deno task cf check packages/patterns/iframe-<name>/main.tsx --no-run
 ```
 
 Replace `<guest-file>` with the authored `guest.ts` or `guest.tsx` filename.


### PR DESCRIPTION
## Why

React iframe guests need an explicit ownership boundary between durable Fabric state, local user drafts, and third-party component interaction state. Without that boundary, ordinary Cell acknowledgements can remount or visually reset a controlled widget, dismiss native controls, and make narrow writes look like page refreshes.

The existing guide also used a non-`iframe-*` sample directory even though that prefix is load-bearing for guest-source discovery.

## What changed

- document local ownership and authoritative reconciliation for stateful React libraries
- cover gesture tokens, pending-scope boundaries, embedded controls, structural CSS, and event-time versus queue-time reads
- clarify stable entity handles versus seeded inline array objects
- add focused browser-test guidance that avoids no-op DOM tests and app-specific `postMessage` backdoors
- make the skill route React-only editors, diagrams, grids, and canvas libraries to the React guide
- use the required `iframe-` directory prefix throughout the skill and React example

## Verification

- `deno task check`
- `deno task check-docs` (588 code blocks)
- `deno task check-skill-facts` (47 documents)
- `deno fmt --check`
- `deno lint`
- `quick_validate.py skills/pattern-iframe`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

