### PR TITLE
fix(data-model): the vet names a non-array whose class is `Array`

### DIFF
--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -104,7 +104,7 @@ export function isValidFabricValueLayer(
 }
 
 /**
- * Names the class of a value being refused, for a refusal message.
+ * Reads a value's constructor, or `undefined` where there is none to read.
  *
  * The class is read from the prototype rather than from the value, for the
  * reason the dispatch reads it there: an own `constructor` property is
@@ -113,36 +113,35 @@ export function isValidFabricValueLayer(
  *
  * Nothing here is allowed to throw, because every caller is already on its way
  * to reporting a different problem and an error raised here would replace it.
- * Two ways that can happen, both reachable: a `constructor` accessor on the
- * prototype that throws, and a `name` that is not a string. Either is treated
- * as no name at all.
+ * A `constructor` accessor on the prototype that throws is the reachable way
+ * that happens.
  */
-export function refusedClassNameOf(value: object): string {
-  let name: unknown;
+function constructorElseUndefined(
+  value: object,
+): { name?: unknown } | undefined {
   try {
-    name = (constructorOfObject(value) as { name?: unknown } | undefined)?.name;
+    return constructorOfObject(value) as { name?: unknown } | undefined;
   } catch {
-    return typeof value;
+    return undefined;
   }
-  return (typeof name === "string" && name !== "") ? name : typeof value;
 }
 
 /**
- * Helper for `assertValidFabricValueLayer()`, which reports whether a value's
- * class is `Array` -- true of an array, and of a non-array whose prototype
- * chain says otherwise.
+ * Helper for `assertValidFabricValueLayer()`, which names the class of a value
+ * being refused, given the constructor already read from it. A `name` that is
+ * not a string is treated as no name at all.
  */
-function classIsArray(value: unknown): boolean {
-  if ((value === null) || (typeof value !== "object")) return false;
-  try {
-    const ctor = constructorOfObject(value);
-    return (ctor !== undefined) &&
-      (tagFromNativeBuiltinClass(ctor) === VALUE_TAGS.Array);
-  } catch {
-    // A value whose class cannot be read is not claiming to be an `Array`,
-    // and this runs while a refusal is being explained, so it must not throw.
-    return false;
-  }
+function classNameOf(
+  ctor: { name?: unknown } | undefined,
+  value: unknown,
+): string {
+  const name = ctor?.name;
+  return (typeof name === "string" && name !== "") ? name : typeof value;
+}
+
+/** Names the class of a value being refused, for a refusal message. */
+export function refusedClassNameOf(value: object): string {
+  return classNameOf(constructorElseUndefined(value), value);
 }
 
 /**
@@ -170,7 +169,17 @@ export function assertValidFabricValueLayer(
   // test below distinguishes two reasons from each other; none of them decides
   // the outcome, which the call above already did.
 
-  if (Array.isArray(value) || classIsArray(value)) {
+  // Read once, and let every arm below share it. A `constructor` accessor is
+  // ordinary code and may answer differently each time it is asked, so asking
+  // it repeatedly would let one refusal name two different classes.
+  const ctor = ((value !== null) && (typeof value === "object"))
+    ? constructorElseUndefined(value)
+    : undefined;
+  const classIsArray = (ctor !== undefined) &&
+    (tagFromNativeBuiltinClass(ctor as { prototype: unknown }) ===
+      VALUE_TAGS.Array);
+
+  if (Array.isArray(value) || classIsArray) {
     // An array in this system is _inert_: a direct `Array` instance, which may
     // only carry numeric index properties, each a data property. A named or
     // symbol-keyed property has no fabric representation, and an
@@ -214,7 +223,7 @@ export function assertValidFabricValueLayer(
   if (isNativeObject) {
     throw new Error(
       `Not already a \`FabricValue\`: ${
-        backtickQuote(refusedClassNameOf(value as object))
+        backtickQuote(classNameOf(ctor, value))
       } (a \`FabricNativeObject\`, so conversion is what decides it)`,
     );
   }
@@ -249,7 +258,7 @@ export function assertValidFabricValueLayer(
   // Death before confusion!
   throw new Error(
     `Not representable as a \`FabricValue\`: ${
-      backtickQuote(refusedClassNameOf(value as object))
+      backtickQuote(classNameOf(ctor, value))
     } (not a recognized fabric type)`,
   );
 }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -135,7 +135,14 @@ function classNameOf(
   ctor: { name?: unknown } | undefined,
   value: unknown,
 ): string {
-  const name = ctor?.name;
+  let name: unknown;
+  try {
+    name = ctor?.name;
+  } catch {
+    // `name` can be an accessor too, and this runs while a refusal is being
+    // explained. A class that will not say what it is called has no name here.
+    return typeof value;
+  }
   return (typeof name === "string" && name !== "") ? name : typeof value;
 }
 
@@ -175,9 +182,11 @@ export function assertValidFabricValueLayer(
   const ctor = ((value !== null) && (typeof value === "object"))
     ? constructorElseUndefined(value)
     : undefined;
-  const classIsArray = (ctor !== undefined) &&
-    (tagFromNativeBuiltinClass(ctor as { prototype: unknown }) ===
-      VALUE_TAGS.Array);
+  // Compared with `Array` itself rather than asked of the tag lookup, which
+  // reads `.prototype` -- a read a callable `Proxy` can trap, and this is the
+  // refusal path. `Array` is the only constructor that lookup calls an array,
+  // so the two ask the same question.
+  const classIsArray = ctor === Array;
 
   if (Array.isArray(value) || classIsArray) {
     // An array in this system is _inert_: a direct `Array` instance, which may

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -128,6 +128,24 @@ export function refusedClassNameOf(value: object): string {
 }
 
 /**
+ * Helper for `assertValidFabricValueLayer()`, which reports whether a value's
+ * class is `Array` -- true of an array, and of a non-array whose prototype
+ * chain says otherwise.
+ */
+function classIsArray(value: unknown): boolean {
+  if ((value === null) || (typeof value !== "object")) return false;
+  try {
+    const ctor = constructorOfObject(value);
+    return (ctor !== undefined) &&
+      (tagFromNativeBuiltinClass(ctor) === VALUE_TAGS.Array);
+  } catch {
+    // A value whose class cannot be read is not claiming to be an `Array`,
+    // and this runs while a refusal is being explained, so it must not throw.
+    return false;
+  }
+}
+
+/**
  * Throws unless the value is usable as a `FabricValueLayer`, naming what is
  * wrong with it when it is not. This is `isValidFabricValueLayer()` asked so
  * that the answer carries a reason: that predicate decides the outcome and
@@ -152,13 +170,18 @@ export function assertValidFabricValueLayer(
   // test below distinguishes two reasons from each other; none of them decides
   // the outcome, which the call above already did.
 
-  if (Array.isArray(value)) {
+  if (Array.isArray(value) || classIsArray(value)) {
     // An array in this system is _inert_: a direct `Array` instance, which may
     // only carry numeric index properties, each a data property. A named or
     // symbol-keyed property has no fabric representation, and an
     // accessor-backed index is live code rather than inert data -- as is the
     // prototype of an `Array` subclass instance, which can make iteration
     // yield differently than the indices say.
+    //
+    // A value whose class is `Array` without being one gets this reason too.
+    // It is not an array, so the rule that decides arrays never reached it,
+    // but `Array` is what it presents itself as and so what a reader is owed
+    // an answer about -- and it is the reason the conversion gives.
     throw new Error(
       "Not representable as a `FabricValue`: array that is not an inert array",
     );

--- a/packages/data-model/test/fabric-value-corpus.ts
+++ b/packages/data-model/test/fabric-value-corpus.ts
@@ -46,6 +46,17 @@ export class ArraySubclass extends Array {}
 export class WeirdError extends RangeError {}
 
 /**
+ * Returns a non-array whose prototype is `Array.prototype`, so that its class
+ * reads as `Array` while `Array.isArray()` says otherwise.
+ */
+function nonArrayWithArrayPrototype(): unknown {
+  const value = Object.create(Array.prototype) as Record<string, unknown>;
+  value[0] = "a";
+  value.length = 1;
+  return value;
+}
+
+/**
  * Returns an array whose prototype has been re-pointed at `Date.prototype`, so
  * that its class reads as `Date` and only the array rule still sees an array.
  */
@@ -81,6 +92,10 @@ export const LAYER_CORPUS: ReadonlyArray<[string, unknown]> = [
   ["an inert plain object", { a: 1 }],
   ["an array carrying a named property", Object.assign([1], { z: 1 })],
   ["an `Array` subclass instance", ArraySubclass.from([1, 2])],
+  [
+    "a non-array whose `prototype` is `Array.prototype`",
+    nonArrayWithArrayPrototype(),
+  ],
   [
     "an array whose `prototype` is `Date.prototype`",
     arrayWithDatePrototype(),

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -898,6 +898,13 @@ describe("type-check", () => {
       // names a reason -- its outcome having been settled before the probe
       // that fails. The corpus carries no such value, and that bound is why.
       //
+      // Bounded the same way to a class that reads the SAME each time. Each of
+      // these two reads the constructor for itself, so a `constructor`
+      // accessor answering differently on successive reads can be named
+      // differently by each. Neither contradicts itself -- one refusal reads
+      // once -- and a value that answers differently each time it is asked is
+      // not one this agreement is for.
+      //
       // The exception is a `FabricNativeObject`, and it is the whole of the
       // exception: conversion has a say over one, and either mints its fabric
       // form or refuses it there. The vet has no say and does not pretend to,

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -1005,6 +1005,46 @@ describe("type-check", () => {
           });
         }
 
+        it("refuses a value whose class will not say its name", () => {
+          // `name` is an accessor too, so guarding the constructor read alone
+          // leaves the next read out in the open.
+          class NameThrows {}
+          Object.defineProperty(NameThrows.prototype, "constructor", {
+            value: Object.defineProperty(function () {}, "name", {
+              get() {
+                throw new Error("this must not reach the caller");
+              },
+            }),
+          });
+
+          expect(() => assertValidFabricValueLayer(new NameThrows())).toThrow(
+            "Not representable as a `FabricValue`: `object` (not a " +
+              "recognized fabric type)",
+          );
+        });
+
+        it("refuses a value whose constructor traps `prototype`", () => {
+          // A callable `Proxy` can throw from any read, `.prototype` included,
+          // which is what the class lookup would otherwise ask it for.
+          const trapped = new Proxy(function () {}, {
+            get(target, key) {
+              if (key === "prototype") {
+                throw new Error("this must not reach the caller");
+              }
+              return Reflect.get(target, key);
+            },
+          });
+          class ProxyCtor {}
+          Object.defineProperty(ProxyCtor.prototype, "constructor", {
+            value: trapped,
+          });
+
+          expect(() => assertValidFabricValueLayer(new ProxyCtor())).toThrow(
+            "Not representable as a `FabricValue`: `object` (not a " +
+              "recognized fabric type)",
+          );
+        });
+
         it("refuses a value whose class cannot be read, without propagating", () => {
           // The one shape that defeats the prototype read as well. Both the
           // reason-picking probe and the name lookup fail on it, and the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`assertValidFabricValueLayer()` decides arrays by `Array.isArray()`. A value
whose prototype is `Array.prototype` without being an array misses that rule and
falls through to the unrecognized-type reason, while
`shallowFabricFromNativeValue()` reaches the same value through the tag dispatch
and gives the array reason.

So the two disagree today:

```
vet:         Not representable as a `FabricValue`: `Array` (not a recognized fabric type)
conversion:  Not representable as a `FabricValue`: array that is not an inert array
```

The group that cross-checks their wording says they agree value for value. It
never met this, because the corpus carried no such value.

## What changes

The vet asks the class as well as the shape, and the corpus gains a non-array
whose prototype is `Array.prototype` -- which is what makes the existing
cross-check reach the disagreement rather than a new test asserting it
separately.

The class read is guarded. It runs while a refusal is being explained, so a
value whose class cannot be read is treated as not claiming to be an `Array`
rather than allowed to throw in place of the refusal.

## Scope

Extracted from #6489, which needs this because its conversion delegates all
refusals to the vet -- at which point the vet's wording becomes the only
wording. It stands on its own ahead of that: the disagreement above is on `main`
now, and no caller outside this package reaches either function.

Deliberately left behind: #6489 also makes `refusedClassNameOf()` private. That
cannot land here, because `native-conversion.ts` imports it on `main` and stops
only when the conversion gives up building its own refusal message.

## Verification

`deno task test` in `data-model`: 48 passed, 2705 steps. `deno task check`,
`deno lint`, `deno fmt --check` green repo-wide.

Ablated by reverting the vet to its `main` behavior with the corpus entry in
place: 1 failing test, `gives a non-array whose \`prototype\` is
\`Array.prototype\` the same verdict, in the same words`. Without the corpus
entry that same revert is green, which is the point of adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FStELffQSLrgyz2VuK8n3e


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


