### PR TITLE
refactor: `#` private members the sweep did not reach

### DIFF
--- a/packages/memory/test/v2-client-holdings.test.ts
+++ b/packages/memory/test/v2-client-holdings.test.ts
@@ -40,14 +40,17 @@ class DroppableTransport implements Transport {
   #closeReceiver: (error?: Error) => void = () => {};
   #connection: ReturnType<Server["connect"]> | null = null;
 
-  constructor(
-    private server: Server,
-    private readonly stripSessionHoldings = false,
-  ) {}
+  #server: Server;
+  readonly #stripSessionHoldings: boolean;
+
+  constructor(server: Server, stripSessionHoldings = false) {
+    this.#server = server;
+    this.#stripSessionHoldings = stripSessionHoldings;
+  }
 
   async send(payload: string): Promise<void> {
     this.sent.push(decodeMemoryBoundary(payload) as Sent);
-    await this.connection().receive(payload);
+    await this.#openConnection().receive(payload);
   }
 
   close(): Promise<void> {
@@ -70,20 +73,20 @@ class DroppableTransport implements Transport {
   }
 
   retarget(server: Server): void {
-    this.server = server;
+    this.#server = server;
   }
 
-  private connection(): ReturnType<Server["connect"]> {
+  #openConnection(): ReturnType<Server["connect"]> {
     if (this.#connection === null) {
-      this.#connection = this.server.connect((message) => {
-        this.#receiver(encodeMemoryBoundary(this.project(message)));
+      this.#connection = this.#server.connect((message) => {
+        this.#receiver(encodeMemoryBoundary(this.#project(message)));
       });
     }
     return this.#connection;
   }
 
-  private project<T>(message: T): T {
-    if (this.stripSessionHoldings) {
+  #project<T>(message: T): T {
+    if (this.#stripSessionHoldings) {
       const framed = message as { type?: string; flags?: object };
       if (framed.type === "hello.ok" && framed.flags !== undefined) {
         return {

--- a/packages/runner/src/scheduler/gates.ts
+++ b/packages/runner/src/scheduler/gates.ts
@@ -96,11 +96,11 @@ export class SchedulerGates {
   }
 
   getDebounce(action: Action): number | undefined {
-    return this.gate(action)?.debounceMs;
+    return this.#gate(action)?.debounceMs;
   }
 
   clearDebounce(action: Action): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     if (gate) delete gate.debounceMs;
     this.cancelDebounceTimer(action);
     this.clearComputationDebounceState(action, { cancelTimer: false });
@@ -117,7 +117,7 @@ export class SchedulerGates {
   }
 
   getNoDebounce(action: Action): boolean | undefined {
-    return this.gate(action)?.noAutoDebounce ? true : undefined;
+    return this.#gate(action)?.noAutoDebounce ? true : undefined;
   }
 
   canAutomaticallyDebounce(
@@ -126,7 +126,7 @@ export class SchedulerGates {
       readonly effects: ReadonlySet<Action>;
     },
   ): boolean {
-    if (this.gate(action)?.noAutoDebounce) return false;
+    if (this.#gate(action)?.noAutoDebounce) return false;
     return context.effects.has(action);
   }
 
@@ -164,7 +164,7 @@ export class SchedulerGates {
   }
 
   markActionHasRun(action: Action): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     if (gate) delete gate.debounceReadyAt;
     this.#armThrottleFromStats(action);
   }
@@ -204,7 +204,7 @@ export class SchedulerGates {
     action: Action,
     options: { cancelTimer?: boolean } = {},
   ): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     if (gate) delete gate.debounceReadyAt;
     if (options.cancelTimer ?? true) {
       this.cancelDebounceTimer(action);
@@ -212,7 +212,7 @@ export class SchedulerGates {
   }
 
   cancelDebounceTimer(action: Action): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     if (gate) delete gate.debounceReadyAt;
   }
 
@@ -228,7 +228,7 @@ export class SchedulerGates {
       return undefined;
     }
     if (!context.isInvalid(action)) return undefined;
-    const readyAt = this.gate(action)?.debounceReadyAt;
+    const readyAt = this.#gate(action)?.debounceReadyAt;
     return readyAt !== undefined && readyAt > performance.now()
       ? readyAt
       : undefined;
@@ -252,7 +252,7 @@ export class SchedulerGates {
       readonly logDebounce: (message: string) => void;
     },
   ): void {
-    const debounceMs = this.gate(action)?.debounceMs;
+    const debounceMs = this.#gate(action)?.debounceMs;
 
     if (!debounceMs || debounceMs <= 0) {
       context.pending.add(action);
@@ -293,11 +293,11 @@ export class SchedulerGates {
   }
 
   getThrottle(action: Action): number | undefined {
-    return this.gate(action)?.throttleMs;
+    return this.#gate(action)?.throttleMs;
   }
 
   clearThrottle(action: Action): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     if (!gate) return;
     delete gate.throttleMs;
     delete gate.throttleReadyAt;
@@ -346,7 +346,7 @@ export class SchedulerGates {
   }
 
   hasActiveDebounceTimer(action: Action): boolean {
-    const readyAt = this.gate(action)?.debounceReadyAt;
+    const readyAt = this.#gate(action)?.debounceReadyAt;
     return readyAt !== undefined && readyAt > performance.now();
   }
 
@@ -410,7 +410,7 @@ export class SchedulerGates {
     context: DebouncedComputationContext,
     now: number,
   ): void {
-    const debounceMs = this.gate(action)?.debounceMs;
+    const debounceMs = this.#gate(action)?.debounceMs;
     if (!debounceMs || debounceMs <= 0) return;
 
     this.cancelDebounceTimer(action);
@@ -434,7 +434,7 @@ export class SchedulerGates {
       readonly shouldDebounceFirstRun?: (action: Action) => boolean;
     },
   ): boolean {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     const debounceMs = gate?.debounceMs;
     const hasRun = this.#state.nodes.get(action)?.status !== "never-ran";
     return context.computations.has(action) &&
@@ -445,7 +445,7 @@ export class SchedulerGates {
   }
 
   #armThrottleFromStats(action: Action): void {
-    const gate = this.gate(action);
+    const gate = this.#gate(action);
     const throttleMs = gate?.throttleMs;
     if (!gate || !throttleMs || throttleMs <= 0) {
       if (gate) delete gate.throttleReadyAt;
@@ -460,7 +460,7 @@ export class SchedulerGates {
     gate.throttleReadyAt = stats.lastRunTimestamp + throttleMs;
   }
 
-  private gate(action: Action): SchedulerGateState | undefined {
+  #gate(action: Action): SchedulerGateState | undefined {
     return this.#state.nodes.get(action)?.gate ?? this.#stagedGates.get(action);
   }
 

--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -12,8 +12,8 @@ import {
  * The keys for the store map are of the form: `${address.id}/application/json`
  */
 export class StoreObjectManager implements ObjectStorageManager {
-  #readValues = new Map<string, IAttestation>();
   #store: Map<string, Revision<State>>;
+  #readValues = new Map<string, IAttestation>();
   // Cache our read labels, and any docs we can't read
   public missingDocs = new Map<string, BaseMemoryAddress>();
 

--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -13,10 +13,12 @@ import {
  */
 export class StoreObjectManager implements ObjectStorageManager {
   #readValues = new Map<string, IAttestation>();
+  #store: Map<string, Revision<State>>;
   // Cache our read labels, and any docs we can't read
   public missingDocs = new Map<string, BaseMemoryAddress>();
 
-  constructor(private store = new Map<string, Revision<State>>()) {
+  constructor(store = new Map<string, Revision<State>>()) {
+    this.#store = store;
   }
 
   getReadDocs(): Iterable<IAttestation> {
@@ -34,8 +36,8 @@ export class StoreObjectManager implements ObjectStorageManager {
       return this.#readValues.get(key)!;
     }
     // we should only have one match
-    if (this.store.has(key)) {
-      const storeValue = this.store.get(key);
+    if (this.#store.has(key)) {
+      const storeValue = this.#store.get(key);
       const rv = { address: { ...address, path: [] }, value: storeValue?.is };
       this.#readValues.set(key, rv);
       return rv;

--- a/packages/runner/test/memory-v2-reconnect-holdings.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-holdings.test.ts
@@ -125,7 +125,7 @@ class DroppableTransport implements MemoryV2Client.Transport {
     if (message.type === "transact" && this.#verdictWaiting !== null) {
       this.#transactRequestId = message.requestId ?? null;
     }
-    await this.connection().receive(payload);
+    await this.#openConnection().receive(payload);
   }
 
   close(): Promise<void> {
@@ -158,7 +158,7 @@ class DroppableTransport implements MemoryV2Client.Transport {
     queueMicrotask(() => this.#closeReceiver(new Error("disconnect")));
   }
 
-  private connection(): ReturnType<MemoryV2Server.Server["connect"]> {
+  #openConnection(): ReturnType<MemoryV2Server.Server["connect"]> {
     if (this.#connection === null) {
       this.#connection = this.#server.connect((message) => {
         const framed = message as {

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -91,7 +91,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
       this.droppedLocalSeqs.push(localSeq);
       this.#dropResponses = true;
       try {
-        await this.connection().receive(payload);
+        await this.#openConnection().receive(payload);
       } finally {
         this.#dropResponses = false;
         this.disconnect();
@@ -99,7 +99,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
       return;
     }
 
-    await this.connection().receive(payload);
+    await this.#openConnection().receive(payload);
   }
 
   close(): Promise<void> {
@@ -113,7 +113,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
     this.#closeReceiver(new Error("disconnect"));
   }
 
-  private connection(): ReturnType<MemoryV2Server.Server["connect"]> {
+  #openConnection(): ReturnType<MemoryV2Server.Server["connect"]> {
     if (this.#connection === null) {
       this.connectionCount++;
       this.onConnectionCount?.(this.connectionCount);

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -526,14 +526,17 @@ describe("WebSocketTransport failure signaling", () => {
     readonly started = Promise.withResolvers<void>();
     readonly released = Promise.withResolvers<void>();
 
-    constructor(private readonly contents = new Uint8Array([0]).buffer) {
+    readonly #contents: ArrayBuffer;
+
+    constructor(contents = new Uint8Array([0]).buffer) {
       super();
+      this.#contents = contents;
     }
 
     override async arrayBuffer(): Promise<ArrayBuffer> {
       this.started.resolve();
       await this.released.promise;
-      return this.contents;
+      return this.#contents;
     }
   }
 

--- a/skills/deno-memory-profiler/scripts/memory.ts
+++ b/skills/deno-memory-profiler/scripts/memory.ts
@@ -41,14 +41,14 @@ function parseGlobalOpts(args: string[]): { opts: GlobalOpts; rest: string[] } {
 type CDPEventHandler = (params: Record<string, unknown>) => void;
 
 class CDPClient {
-  private ws!: WebSocket;
-  private nextId = 1;
-  private pending = new Map<
+  #ws!: WebSocket;
+  #nextId = 1;
+  #pending = new Map<
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
-  private eventHandlers = new Map<string, CDPEventHandler[]>();
-  private openPromise!: Promise<void>;
+  #eventHandlers = new Map<string, CDPEventHandler[]>();
+  #openPromise!: Promise<void>;
 
   static async connect(host: string, port: number): Promise<CDPClient> {
     // Discover websocket URL
@@ -69,24 +69,24 @@ class CDPClient {
     }
     const wsUrl = targets[0].webSocketDebuggerUrl;
     const client = new CDPClient();
-    await client._connect(wsUrl);
+    await client.#connect(wsUrl);
     return client;
   }
 
-  private _connect(wsUrl: string): Promise<void> {
-    this.ws = new WebSocket(wsUrl);
-    this.openPromise = new Promise<void>((resolve, reject) => {
-      this.ws.onopen = () => resolve();
-      this.ws.onerror = (e) =>
+  #connect(wsUrl: string): Promise<void> {
+    this.#ws = new WebSocket(wsUrl);
+    this.#openPromise = new Promise<void>((resolve, reject) => {
+      this.#ws.onopen = () => resolve();
+      this.#ws.onerror = (e) =>
         reject(new Error("WebSocket error: " + String(e)));
     });
 
-    this.ws.onmessage = (evt) => {
+    this.#ws.onmessage = (evt) => {
       const msg = JSON.parse(String(evt.data));
       if (msg.id !== undefined) {
-        const p = this.pending.get(msg.id);
+        const p = this.#pending.get(msg.id);
         if (p) {
-          this.pending.delete(msg.id);
+          this.#pending.delete(msg.id);
           if (msg.error) {
             p.reject(
               new Error(`CDP error: ${msg.error.message} (${msg.error.code})`),
@@ -97,33 +97,33 @@ class CDPClient {
         }
       } else if (msg.method) {
         // CDP event
-        const handlers = this.eventHandlers.get(msg.method);
+        const handlers = this.#eventHandlers.get(msg.method);
         if (handlers) {
           for (const h of handlers) h(msg.params ?? {});
         }
       }
     };
 
-    return this.openPromise;
+    return this.#openPromise;
   }
 
   on(method: string, handler: CDPEventHandler): void {
-    const list = this.eventHandlers.get(method) ?? [];
+    const list = this.#eventHandlers.get(method) ?? [];
     list.push(handler);
-    this.eventHandlers.set(method, list);
+    this.#eventHandlers.set(method, list);
   }
 
   send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
-    const id = this.nextId++;
+    const id = this.#nextId++;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.ws.send(JSON.stringify({ id, method, params }));
+      this.#pending.set(id, { resolve, reject });
+      this.#ws.send(JSON.stringify({ id, method, params }));
     });
   }
 
   disconnect(): void {
     try {
-      this.ws.close();
+      this.#ws.close();
     } catch {
       // ignore
     }

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -41,8 +41,8 @@ export class BuildConfig {
   readonly toolshedFlags: string[];
   readonly binaries: readonly BinaryName[];
   readonly cliOnly: boolean;
-  private _manifestOriginal: string;
-  private _compileCacheVersionOriginal: string;
+  #manifestOriginal: string;
+  #compileCacheVersionOriginal: string;
 
   constructor(options: BuildConfigInitializer) {
     this.root = options.root;
@@ -57,15 +57,15 @@ export class BuildConfig {
       ? ["cf"]
       : requestedBinaries(options.binaries ?? []);
     this.cliOnly = this.binaries.length === 1 && this.binaries[0] === "cf";
-    this._manifestOriginal = Deno.readTextFileSync(
+    this.#manifestOriginal = Deno.readTextFileSync(
       this.workspaceManifestPath(),
     );
-    this._compileCacheVersionOriginal = Deno.readTextFileSync(
+    this.#compileCacheVersionOriginal = Deno.readTextFileSync(
       this.compileCacheVersionPath(),
     );
   }
 
-  private path(...args: string[]): string {
+  #path(...args: string[]): string {
     return path.join(this.root, ...args);
   }
 
@@ -73,23 +73,23 @@ export class BuildConfig {
   // bytes. The build mutates this copy; the original bytes stay untouched so
   // the revert can restore the file exactly.
   manifest(): Record<string, any> {
-    return parseJsonc(this._manifestOriginal) as Record<string, any>;
+    return parseJsonc(this.#manifestOriginal) as Record<string, any>;
   }
 
   manifestOriginal() {
-    return this._manifestOriginal;
+    return this.#manifestOriginal;
   }
 
   compileCacheVersionOriginal() {
-    return this._compileCacheVersionOriginal;
+    return this.#compileCacheVersionOriginal;
   }
 
   workspaceManifestPath() {
-    return this.path("deno.jsonc");
+    return this.#path("deno.jsonc");
   }
 
   compileCacheVersionPath() {
-    return this.path(
+    return this.#path(
       "packages",
       "runner",
       "src",
@@ -99,39 +99,39 @@ export class BuildConfig {
   }
 
   workspaceLockPath() {
-    return this.path("deno.lock");
+    return this.#path("deno.lock");
   }
 
   shellProjectPath() {
-    return this.path("packages", "shell");
+    return this.#path("packages", "shell");
   }
 
   shellOutPath() {
-    return this.path("packages", "shell", "dist");
+    return this.#path("packages", "shell", "dist");
   }
 
   toolshedProjectPath() {
-    return this.path("packages", "toolshed");
+    return this.#path("packages", "toolshed");
   }
 
   toolshedShellFrontendPath() {
-    return this.path("packages", "toolshed", "shell-frontend");
+    return this.#path("packages", "toolshed", "shell-frontend");
   }
 
   toolshedShellFrontendPathDev() {
-    return this.path("packages", "toolshed", "shell-frontend-dev");
+    return this.#path("packages", "toolshed", "shell-frontend-dev");
   }
 
   toolshedEntryPath() {
-    return this.path("packages", "toolshed", "index.ts");
+    return this.#path("packages", "toolshed", "index.ts");
   }
 
   bgPieceServiceEntryPath() {
-    return this.path("packages", "background-piece-service", "src", "main.ts");
+    return this.#path("packages", "background-piece-service", "src", "main.ts");
   }
 
   bgPieceServiceWorkerPath() {
-    return this.path(
+    return this.#path(
       "packages",
       "background-piece-service",
       "src",
@@ -140,52 +140,52 @@ export class BuildConfig {
   }
 
   toolshedEnvPath() {
-    return this.path("packages", "toolshed", "COMPILED");
+    return this.#path("packages", "toolshed", "COMPILED");
   }
 
   cliEnvPath() {
-    return this.path("packages", "cli", "COMPILED");
+    return this.#path("packages", "cli", "COMPILED");
   }
 
   staticAssetsPath() {
-    return this.path("packages", "static", "assets");
+    return this.#path("packages", "static", "assets");
   }
 
   patternPaths() {
     return [
-      this.path("packages", "patterns"),
+      this.#path("packages", "patterns"),
       ...CONNECTOR_PATTERN_SOURCES.map((source) =>
-        this.path(...source.directory.split("/"))
+        this.#path(...source.directory.split("/"))
       ),
     ];
   }
 
   staticTypesPath() {
-    return this.path("packages", "static", "assets", "types");
+    return this.#path("packages", "static", "assets", "types");
   }
 
   docsCommonPath() {
-    return this.path("docs", "common");
+    return this.#path("docs", "common");
   }
 
   cliEntryPath() {
-    return this.path("packages", "cli", "mod.ts");
+    return this.#path("packages", "cli", "mod.ts");
   }
 
   cliMultiUserTestWorkerPath() {
-    return this.path("packages", "cli", "lib", "multi-user-test-worker.ts");
+    return this.#path("packages", "cli", "lib", "multi-user-test-worker.ts");
   }
 
   fusePackagePath() {
-    return this.path("packages", "fuse");
+    return this.#path("packages", "fuse");
   }
 
   distDir() {
-    return this.path("dist");
+    return this.#path("dist");
   }
 
   distPath(binary: string) {
-    return this.path("dist", binary);
+    return this.#path("dist", binary);
   }
 
   builds(binary: BinaryName): boolean {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A census of every class member still declared with a TypeScript `private`,
outside `ui`, taken from the TypeScript AST rather than a regex so a
`private` inside a string or a comment cannot be counted. 332 members, in
four groups:

| group | count | disposition |
| --- | --- | --- |
| `private constructor` | 30 | no `#` form exists |
| carries a decorator | 66 | see below |
| carries a written exemption above it in-class | 215 | left as it stands |
| everything else | 21 | 18 converted here, 3 out of reach |

## What is converted

Eighteen members across eight files. Two are product code:

- `SchedulerGates.gate` in `packages/runner/src/scheduler/gates.ts`, which
  sits between `#state` and `#mutableGate` in the same class and is called
  fifteen times, all from inside that file.
- `StoreObjectManager`'s `constructor(private store …)` in
  `packages/runner/src/storage/query.ts`. A constructor parameter property
  is a field declaration in disguise, which is the form the class rule in
  `docs/development/DEVELOPMENT.md` names explicitly.

The rest are `tasks/build-binaries.ts`, `skills/deno-memory-profiler/scripts/memory.ts`,
and four test-helper classes under `packages/memory` and `packages/runner`.

## Three that needed more than the modifier struck

**A name already taken.** `DroppableTransport` in
`packages/memory/test/v2-client-holdings.test.ts`, and the two transports
in `packages/runner/test/memory-v2-reconnect-{holdings,race}.test.ts`, each
declare `private connection()` in a class that already holds a
`#connection` field. There is no `#connection` for the method to become, so
it becomes `#openConnection()`, which is also what it does: return the
connection, opening one when the field is null.

**A sibling-instance call.** `CDPClient.connect()` is a static factory that
calls `_connect` on a freshly constructed instance rather than through
`this`. `client.#connect(…)` is legal from inside the class body and is
easy to miss by eye; `deno task check` named it.

**A widened type.** `DeferredBlob.contents` inferred `ArrayBuffer` as a
parameter property. Writing the field out by hand as `ArrayBufferLike`
broke `arrayBuffer()`'s return, and `deno task check` named that too.

## What is left, and why

`private constructor` has no private-name form at all.

The three remaining candidates are in
`packages/patterns/google/core/experimental/`, which is pattern source:
`isPatternSource()` in `tasks/pattern-files.ts` collects it, so any byte
there can move a `moduleIdentity` hash.

The 66 decorated members are Lit reactive properties in `shell`, written
`@state() private accessor`. They are not converted, and one measurement
argues against ever converting them mechanically: `@state() accessor #hidden`
**type-checks clean**, so `deno task check` — the gate that caught two of
the three problems above — would not object. Reading
`@lit/reactive-element@2.1.1`'s `property.js`, the decorator stores
`context.name` as the reactive-property key and hands it to
`requestUpdate`, so a `#` name would key the property system on a string
that reaches no field. That last step is reading rather than a run, which
is reason enough to leave them where they are.

## Verification

No member is stubbed by assignment anywhere in the tree: a scan for
`.<member> =` outside each owning class comes back empty for all eighteen,
which is the failure a passing suite cannot show, because the write makes a
new public property and the real member keeps running.

`deno fmt --check`, `deno lint`, `deno task check`, `check-skill-facts`,
`check-conflict-markers` and `check-control-characters` are green.
`packages/runner` 1322 passed / 0 failed; `packages/memory` 592 passed / 0
failed; `tasks/build-binaries.test.ts` 14 passed / 0 failed;
`skills/deno-memory-profiler/scripts/memory.ts` type-checks on its own,
which is the only gate that reaches it.

Re-running the census against this branch leaves the three pattern-source
members and nothing else.


## Coverage

The coverage gate reports three regressed lines, and neither group's
regression follows from this change.

`packages/runner` +2 is `packages/runner/src/executor/wave.ts` lines 2306 and
2307, a file this pull request does not touch. The gate names them itself and
reports that the baseline run covered them, which makes it two measurements of
identical source disagreeing: the baseline measured commit b2f36d02a and this
run measured that same commit with a diff reaching no part of that file.

`tasks` +1 does not reproduce. Running every `tasks/*.test.ts` under coverage
on this branch and on `main` gives an identical group total, 1562 uncovered
lines on each side, with no file differing. For the one file this change does
touch, `tasks/build-binaries.ts`, the branch has one uncovered line fewer than
`main`, and no line is uncovered on the branch that is not also uncovered on
`main`. A stale baseline does not explain it either: the `tasks` baseline run
measured 5f8257d0c, and the only commit between that and this pull request's
base touches neither `tasks/` nor `wave.ts`, so the source under both
measurements is byte-identical.

Accepted rather than tested against, because a test would be pinned to a line
whose coverage does not depend on anything here:

ACCEPT_COVERAGE_DEBT: tasks +1 line
ACCEPT_COVERAGE_DEBT: packages/runner +2 lines


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


