### PR TITLE
cf-harness: the interactive lane honors CF_HARNESS_SANDBOX_DOCKER_RUNTIME like batch (loom#5168)

### DIFF
--- a/packages/cf-harness/src/host-mounts.ts
+++ b/packages/cf-harness/src/host-mounts.ts
@@ -166,7 +166,12 @@ export const parseHostMountSpecs = async (
  * Loom-local host — so neither can advertise a flag it then drops. The first
  * version of this change wired only the Loom host, and the standalone
  * entrypoint accepted `--host-mount`, printed it in its usage text, and ignored
- * it: the same "second entrypoint, no provisioning" defect one layer in.
+ * it: the same "second entrypoint, no provisioning" defect one layer in. The
+ * sandbox Docker runtime pin was a third instance of that class —
+ * `CF_HARNESS_SANDBOX_DOCKER_RUNTIME` reached the batch CLI only, so on a host
+ * whose gVisor runtime is unusable an interactive session had no way to select
+ * a working one and every sandboxed tool call died — and so it is resolved
+ * here too.
  */
 export const resolveInteractiveProvisioning = async (
   parsed: {
@@ -174,17 +179,23 @@ export const resolveInteractiveProvisioning = async (
     maxModelTurns?: number;
   },
   cwd: string,
+  env: Readonly<Record<string, string | undefined>> = Deno.env.toObject(),
 ): Promise<{
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   maxModelTurns?: number;
+  sandboxDockerRuntime?: string;
 }> => {
   const mounts = hostMountsToAdditionalMounts(
     await parseHostMountSpecs(parsed.hostMountSpecs, cwd),
   );
+  const sandboxDockerRuntime = env.CF_HARNESS_SANDBOX_DOCKER_RUNTIME?.trim();
   return {
     ...(mounts.length > 0 ? { additionalMounts: mounts } : {}),
     ...(parsed.maxModelTurns !== undefined
       ? { maxModelTurns: parsed.maxModelTurns }
+      : {}),
+    ...(sandboxDockerRuntime !== undefined && sandboxDockerRuntime !== ""
+      ? { sandboxDockerRuntime }
       : {}),
   };
 };

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -650,6 +650,10 @@ export const runHarnessInteractiveChatStdioCli = async (
   );
   await run({
     ...options,
+    // Assignment rather than a merge is safe only because
+    // HarnessInteractiveChatStdioCliOptions has no basePromptLoopOptions of
+    // its own — `options` is the parsed argv, so there is never a caller value
+    // here to overwrite. If that type ever gains one, this becomes a merge.
     ...(Object.keys(provisioning).length > 0
       ? { basePromptLoopOptions: provisioning }
       : {}),

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -571,6 +571,9 @@ export const createLoomLocalCfHarnessHost = async (
         // Same base the batch path resolves relative sources against, so a
         // spec means the same thing on either entrypoint.
         options.cliDependencies?.cwd ?? Deno.cwd(),
+        // The sanitized host environment, so the sandbox runtime pin is read
+        // from the same place every other binding field is.
+        processEnv,
       );
       const provider = await configuredProvider();
       const binding: LoomLocalHostBinding = {

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1329,7 +1329,7 @@ Deno.test("no provisioning flags leaves the run options untouched", async () => 
   // The other half of the standalone-entrypoint contract: adding these flags
   // must not change what happens when nobody passes them, or every existing
   // embedder gets a behaviour change for free.
-  assertEquals(await resolveInteractiveProvisioning({}, Deno.cwd()), {});
+  assertEquals(await resolveInteractiveProvisioning({}, Deno.cwd(), {}), {});
 
   const seen: RunHarnessInteractiveChatStdioOptions[] = [];
   await runHarnessInteractiveChatStdioCli(
@@ -1347,7 +1347,64 @@ Deno.test("no provisioning flags leaves the run options untouched", async () => 
 
 Deno.test("resolveInteractiveProvisioning carries a turn budget without mounts", async () => {
   assertEquals(
-    await resolveInteractiveProvisioning({ maxModelTurns: 32 }, Deno.cwd()),
+    await resolveInteractiveProvisioning({ maxModelTurns: 32 }, Deno.cwd(), {}),
     { maxModelTurns: 32 },
   );
+});
+
+Deno.test("resolveInteractiveProvisioning pins the sandbox docker runtime from the environment", async () => {
+  // CF_HARNESS_SANDBOX_DOCKER_RUNTIME reached the batch CLI only, so an
+  // interactive session on a host whose gVisor runtime is unusable had no way
+  // to select a working one: every sandboxed tool call died, and no flag or
+  // variable could change it.
+  assertEquals(
+    await resolveInteractiveProvisioning({}, Deno.cwd(), {
+      CF_HARNESS_SANDBOX_DOCKER_RUNTIME: "runc",
+    }),
+    { sandboxDockerRuntime: "runc" },
+  );
+
+  assertEquals(
+    await resolveInteractiveProvisioning({ maxModelTurns: 8 }, Deno.cwd(), {
+      CF_HARNESS_SANDBOX_DOCKER_RUNTIME: " runc ",
+    }),
+    { maxModelTurns: 8, sandboxDockerRuntime: "runc" },
+  );
+
+  // A blank value is absence, not a runtime named "" — the same reading the
+  // batch CLI gives it. Anything else hands docker an empty `--runtime` and
+  // fails the run over a variable someone exported empty.
+  assertEquals(
+    await resolveInteractiveProvisioning({}, Deno.cwd(), {
+      CF_HARNESS_SANDBOX_DOCKER_RUNTIME: "   ",
+    }),
+    {},
+  );
+  assertEquals(await resolveInteractiveProvisioning({}, Deno.cwd(), {}), {});
+});
+
+Deno.test("the standalone stdio entrypoint carries an environment runtime pin", async () => {
+  // The standalone entrypoint takes the helper's default env, so the pin has
+  // to survive that path too and not just a directly-passed env.
+  const previous = Deno.env.get("CF_HARNESS_SANDBOX_DOCKER_RUNTIME");
+  Deno.env.set("CF_HARNESS_SANDBOX_DOCKER_RUNTIME", "runc");
+  try {
+    const seen: RunHarnessInteractiveChatStdioOptions[] = [];
+    await runHarnessInteractiveChatStdioCli(
+      [],
+      Deno.cwd(),
+      (options) => {
+        seen.push(options);
+        return Promise.resolve();
+      },
+    );
+    assertEquals(seen.length, 1);
+    assertEquals(seen[0].basePromptLoopOptions?.sandboxDockerRuntime, "runc");
+  } finally {
+    if (previous === undefined) {
+      Deno.env.delete("CF_HARNESS_SANDBOX_DOCKER_RUNTIME");
+    } else {
+      Deno.env.set("CF_HARNESS_SANDBOX_DOCKER_RUNTIME", previous);
+    }
+  }
 });

--- a/packages/cf-harness/test/loom-local-host-interactive.test.ts
+++ b/packages/cf-harness/test/loom-local-host-interactive.test.ts
@@ -573,3 +573,41 @@ Deno.test("local Loom interactive help does not require provider configuration o
   assertEquals(stderr.includes("provider-configuration-required"), false);
   assertEquals(stderr.includes("provider-auth-required"), false);
 });
+
+Deno.test("local Loom interactive carries the sandbox docker runtime pin into every turn", async () => {
+  // Loom starts chat sessions through this host, not the standalone
+  // entrypoint, and pins the runtime by environment variable. The batch lane
+  // honoured CF_HARNESS_SANDBOX_DOCKER_RUNTIME and this one dropped it, so on
+  // a host with an unusable gVisor build every sandboxed tool call in a chat
+  // session exited 159 while the same work succeeded from the CLI.
+  const home = await Deno.makeTempDir();
+  const credentials = new InMemoryHarnessCredentialStore();
+  await credentials.set("local", "openai-codex", {
+    type: "oauth",
+    providerId: "openai-codex",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    expiresAt: Date.now() + 60 * 60_000,
+    accountId: "account-secret",
+  });
+  const seen: RunHarnessInteractiveChatStdioOptions[] = [];
+  const host = await createLoomLocalCfHarnessHost({
+    harnessHome: home,
+    env: { CF_HARNESS_SANDBOX_DOCKER_RUNTIME: "runc" },
+    credentialStore: credentials,
+    providerSettingsStore: configured("openai-codex"),
+    fetchFn: () => Promise.reject(new Error("must not request")),
+    interactiveStdioRunner: (options) => {
+      seen.push(options);
+      return Promise.resolve();
+    },
+  });
+
+  await host.runInteractive([]);
+
+  assertEquals(seen.length, 1);
+  assertEquals(
+    seen[0].basePromptLoopOptions?.sandboxDockerRuntime,
+    "runc",
+  );
+});


### PR DESCRIPTION
## Why

The sandbox Docker runtime pin reached the batch CLI only. On a host whose gVisor build is unusable (commontoolsinc/gvisor#37), `cf-harness run` can select a working runtime — `--sandbox-docker-runtime`, or `CF_HARNESS_SANDBOX_DOCKER_RUNTIME` — while an interactive chat session over the same engine cannot. `resolveInteractiveProvisioning` returned only mounts and a turn budget, so the loop built an engine with `sandboxDockerRuntime === undefined`, `resolveSandboxConfig` saw no runtime name, and `docker-runsc.ts` fell back to its `runsc-cfc` default. Every sandboxed bash and file tool call in a chat session then exits 159, with no flag or variable able to change it — while the same work succeeds from the CLI on the same machine.

That asymmetry is the third instance of the class this module's own doc comment already records. #4125 wired the runtime override into the batch CLI only. #6130 gave the interactive entrypoints mounts and a turn budget and stopped short of the runtime; its comment describes the first version of *that* change wiring only the Loom host while the standalone entrypoint advertised `--host-mount` and ignored it. Each time, a second entrypoint over the same engine was left without a provisioning surface the first one had.

So the fix goes in the shared helper rather than inline in either host: both interactive entrypoints resolve through it, which is what keeps them from drifting apart again.

## What Changed

- `packages/cf-harness/src/host-mounts.ts` — `resolveInteractiveProvisioning` takes an `env` argument (defaulting to the process environment) and returns `sandboxDockerRuntime` when `CF_HARNESS_SANDBOX_DOCKER_RUNTIME` is non-blank after trimming. A blank value is absence, not a runtime named `""` — the same reading the batch CLI gives it, and the one that avoids handing docker an empty `--runtime`. The doc comment names this third instance of the class.
- `packages/cf-harness/src/loom-local-host.ts` — passes its already-sanitized `processEnv` (this is the entrypoint Loom's chat lane actually runs; it spreads `provisioning` into `basePromptLoopOptions`, which the interactive service spreads into every turn).
- `packages/cf-harness/src/interactive-chat-stdio.ts` — takes the helper's default env. The nearby `basePromptLoopOptions` assignment is left as an assignment, with a comment recording why it is safe: `options` there is the parsed argv, and `HarnessInteractiveChatStdioCliOptions` has no `basePromptLoopOptions` of its own, so there is no caller value to overwrite. (I tried merging first; the type checker showed the field does not exist, which is the proof.) If that type ever gains one, the comment says to make it a merge.

No new dependencies, no refactors beyond the above.

## Test plan

Red first, both new tests, against the unmodified sources (`--no-check`, since the new `env` argument does not exist yet):

```
the standalone stdio entrypoint carries an environment runtime pin => interactive-chat-stdio.test.ts:1386
error: AssertionError: Values are not equal.   - undefined  / + "runc"

local Loom interactive carries the sandbox docker runtime pin into every turn => loom-local-host-interactive.test.ts:577
error: AssertionError: Values are not equal.   - undefined  / + "runc"

FAILED | 0 passed | 2 failed | 38 filtered out
```

Green after:

- `deno test --no-lock -A packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/loom-local-host-interactive.test.ts` → **ok | 40 passed | 0 failed**
- `deno test --no-lock -A packages/cf-harness/test/cli.test.ts packages/cf-harness/test/loom-local-host.test.ts packages/cf-harness/test/loom-local-host-controls.test.ts packages/cf-harness/test/interactive-chat-service.test.ts` → **ok | 240 passed | 0 failed**
- `deno check --no-lock` on all five touched files → clean; `deno fmt --check` and `deno lint` → clean.

New coverage: the helper pins from an explicit env, trims, drops a whitespace-only value, and returns `{}` for an empty env; the standalone entrypoint carries a pin taken from the ambient environment; and the Loom-local host carries `sandboxDockerRuntime: "runc"` into the `basePromptLoopOptions` every turn is built from. One pre-existing assertion (`resolveInteractiveProvisioning({}, cwd)` returning `{}`) now passes an explicit empty env, so it tests the flag contract rather than whatever the runner's environment happens to hold.

Fixes the labs half of commontoolsinc/loom#5168; loom's chat lane still needs to consult its own probe verdict (loom-side follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHv32HdAs6unx5iNRi78kw


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

