### PR TITLE
refactor(test-support): one near side for a worker benchmark, not three

### DIFF
--- a/packages/data-model/bench/codec-realm-ipc.bench.ts
+++ b/packages/data-model/bench/codec-realm-ipc.bench.ts
@@ -30,6 +30,8 @@
  * that is exactly the distinction `decode()`'s contract turns on.
  */
 
+import { BenchWorker } from "@commonfabric/test-support/bench-worker";
+
 import type { RealmEncodedValue } from "@/codec-realm/interface.ts";
 import { realmFromFabricValue } from "@/codecs.ts";
 import type { FabricValue } from "@/interface.ts";
@@ -41,87 +43,10 @@ import {
   OBJECTS,
   REALM_PASS_THROUGH_OMNIBUSES,
 } from "./fixtures/codec-fixtures.ts";
-import type { IpcAck, IpcRequest } from "./fixtures/realm-ipc-worker.ts";
-
-/** The outstanding request's settlement, held while it is in flight. */
-type PendingRequest = {
-  readonly resolve: () => void;
-  readonly reject: (reason: Error) => void;
-};
-
-/**
- * One worker, kept for the whole run, with one message outstanding at a time.
- *
- * A fresh worker per iteration would measure worker startup, which is
- * milliseconds against microseconds of payload and would swamp everything this
- * file is trying to see.
- */
-class FarSide {
-  readonly #worker: Worker;
-  #pending: PendingRequest | undefined;
-
-  constructor() {
-    this.#worker = new Worker(
-      import.meta.resolve("./fixtures/realm-ipc-worker.ts"),
-      { type: "module" },
-    );
-
-    this.#worker.onmessage = (ev: MessageEvent<IpcAck>) => {
-      const pending = this.#pending;
-
-      this.#pending = undefined;
-
-      if (ev.data.ok) {
-        pending?.resolve();
-      } else {
-        pending?.reject(
-          new Error(`Far side refused the payload: ${ev.data.error}`),
-        );
-      }
-    };
-
-    // A worker that fails to start, or throws where nothing catches, sends no
-    // ack at all -- and a benchmark waiting on one that will never arrive
-    // hangs rather than failing, which is the worst way for a measurement to
-    // end. `messageerror` covers the far side receiving something it cannot
-    // deserialize, which no `error` event reports.
-    this.#worker.onerror = (ev: ErrorEvent) => {
-      const pending = this.#pending;
-
-      this.#pending = undefined;
-      pending?.reject(new Error(`Far side failed: ${ev.message}`));
-    };
-
-    this.#worker.onmessageerror = () => {
-      const pending = this.#pending;
-
-      this.#pending = undefined;
-      pending?.reject(new Error("Far side could not deserialize the message"));
-    };
-  }
-
-  /**
-   * Sends one request and settles when the far side acks it.
-   *
-   * @throws If the far side reports failure. An unexamined ack is what makes a
-   *   benchmark measure the wrong thing silently: a far side whose decode
-   *   throws still acks, still returns in about the time a clone takes, and
-   *   the run then reports that decoding is nearly free.
-   */
-  send(request: IpcRequest): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.#pending = { resolve, reject };
-      this.#worker.postMessage(request);
-    });
-  }
-
-  /** Ends the run. */
-  close(): void {
-    this.#worker.terminate();
-  }
-}
-
-const farSide = new FarSide();
+import type { IpcRequest } from "./fixtures/realm-ipc-worker.ts";
+const farSide = new BenchWorker<IpcRequest>(
+  import.meta.resolve("./fixtures/realm-ipc-worker.ts"),
+);
 
 /**
  * Subjects worth a crossing. Fewer than the in-realm benchmark measures: an

--- a/packages/data-model/bench/fixtures/realm-ipc-worker.ts
+++ b/packages/data-model/bench/fixtures/realm-ipc-worker.ts
@@ -12,6 +12,8 @@
  * bury exactly that.
  */
 
+import type { BenchWorkerAck } from "@commonfabric/test-support/bench-worker";
+
 import type { RealmEncodedValue } from "@/codec-realm/interface.ts";
 import { fabricFromRealmValue } from "@/codecs.ts";
 
@@ -47,12 +49,6 @@ export type IpcRequest =
     readonly payload: unknown;
   };
 
-/** What the far side reports. One boolean, so the return leg costs nothing. */
-export type IpcAck = {
-  readonly ok: boolean;
-  readonly error?: string;
-};
-
 self.onmessage = (ev: MessageEvent<IpcRequest>) => {
   const request = ev.data;
 
@@ -67,10 +63,10 @@ self.onmessage = (ev: MessageEvent<IpcRequest>) => {
     // the first to isolate the decode, the second because the old far side
     // genuinely had no work to do.
 
-    self.postMessage({ ok: true } satisfies IpcAck);
+    self.postMessage({ ok: true } satisfies BenchWorkerAck);
   } catch (e) {
     self.postMessage(
-      { ok: false, error: (e as Error).message } satisfies IpcAck,
+      { ok: false, error: (e as Error).message } satisfies BenchWorkerAck,
     );
   }
 };

--- a/packages/data-model/bench/ipc-status-quo.bench.ts
+++ b/packages/data-model/bench/ipc-status-quo.bench.ts
@@ -33,6 +33,8 @@
  *     deno bench --allow-read --no-check bench/ipc-status-quo.bench.ts
  */
 
+import { BenchWorker } from "@commonfabric/test-support/bench-worker";
+
 import { realmFromFabricValue } from "@/codecs.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import type { FabricValue } from "@/interface.ts";
@@ -41,68 +43,10 @@ import {
   makeObject,
   OBJECTS,
 } from "./fixtures/codec-fixtures.ts";
-import type { IpcAck, IpcRequest } from "./fixtures/realm-ipc-worker.ts";
-
-type PendingRequest = {
-  readonly resolve: () => void;
-  readonly reject: (reason: Error) => void;
-};
-
-/** One worker for the whole run, one message outstanding at a time. */
-class FarSide {
-  readonly #worker: Worker;
-  #pending: PendingRequest | undefined;
-
-  constructor() {
-    this.#worker = new Worker(
-      import.meta.resolve("./fixtures/realm-ipc-worker.ts"),
-      { type: "module" },
-    );
-
-    this.#worker.onmessage = (ev: MessageEvent<IpcAck>) => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      if (ev.data.ok) pending?.resolve();
-      else pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
-    };
-
-    // A worker that fails to start, or throws where nothing catches, sends no
-    // ack -- and a benchmark waiting on one that will never arrive hangs
-    // rather than failing, which is the worst way for a measurement to end.
-    // `messageerror` covers the far side receiving something it cannot
-    // deserialize, which no `error` event reports.
-    this.#worker.onerror = (ev: ErrorEvent) => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      pending?.reject(new Error(`Far side failed: ${ev.message}`));
-    };
-
-    this.#worker.onmessageerror = () => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      pending?.reject(new Error("Far side could not deserialize the message"));
-    };
-  }
-
-  /**
-   * Sends one request and settles when the far side acks.
-   *
-   * @throws If the far side reports failure. An unexamined ack is what makes a
-   *   benchmark measure the wrong thing silently.
-   */
-  send(request: IpcRequest): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.#pending = { resolve, reject };
-      this.#worker.postMessage(request);
-    });
-  }
-
-  close(): void {
-    this.#worker.terminate();
-  }
-}
-
-const farSide = new FarSide();
+import type { IpcRequest } from "./fixtures/realm-ipc-worker.ts";
+const farSide = new BenchWorker<IpcRequest>(
+  import.meta.resolve("./fixtures/realm-ipc-worker.ts"),
+);
 
 /**
  * A spread of payload shapes rather than sizes of one shape: what a crossing

--- a/packages/html/bench/dom-event-crossing.bench.ts
+++ b/packages/html/bench/dom-event-crossing.bench.ts
@@ -32,71 +32,16 @@
  *     deno task bench
  */
 
+import { BenchWorker } from "@commonfabric/test-support/bench-worker";
+
 import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { serializeEvent } from "../src/main/events.ts";
-import type { EventAck, EventRequest } from "./fixtures/dom-event-far-side.ts";
-
-/** The outstanding request's settlement, held while it is in flight. */
-type PendingRequest = {
-  readonly resolve: () => void;
-  readonly reject: (reason: Error) => void;
-};
-
-/** One worker for the whole run, one message outstanding at a time. */
-class FarSide {
-  readonly #worker: Worker;
-  #pending: PendingRequest | undefined;
-
-  constructor() {
-    this.#worker = new Worker(
-      import.meta.resolve("./fixtures/dom-event-far-side.ts"),
-      { type: "module" },
-    );
-
-    this.#worker.onmessage = (ev: MessageEvent<EventAck>) => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      if (ev.data.ok) pending?.resolve();
-      else pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
-    };
-
-    // A worker that fails to start, or throws where nothing catches, sends no
-    // ack -- and a benchmark waiting on one that will never arrive hangs rather
-    // than failing, which is the worst way for a measurement to end.
-    this.#worker.onerror = (ev: ErrorEvent) => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      pending?.reject(new Error(`Far side failed: ${ev.message}`));
-    };
-
-    this.#worker.onmessageerror = () => {
-      const pending = this.#pending;
-      this.#pending = undefined;
-      pending?.reject(new Error("Far side could not deserialize the message"));
-    };
-  }
-
-  /**
-   * Sends one request and settles when the far side acks.
-   *
-   * @throws If the far side reports failure. An unexamined ack is what makes a
-   *   benchmark measure the wrong thing silently.
-   */
-  send(request: EventRequest): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.#pending = { resolve, reject };
-      this.#worker.postMessage(request);
-    });
-  }
-
-  close(): void {
-    this.#worker.terminate();
-  }
-}
-
-const farSide = new FarSide();
+import type { EventRequest } from "./fixtures/dom-event-far-side.ts";
+const farSide = new BenchWorker<EventRequest>(
+  import.meta.resolve("./fixtures/dom-event-far-side.ts"),
+);
 
 /** An event, as the applicator's listener receives one. */
 class BenchEvent {

--- a/packages/html/bench/fixtures/dom-event-far-side.ts
+++ b/packages/html/bench/fixtures/dom-event-far-side.ts
@@ -11,6 +11,8 @@
  * event would put a second clone of it on the return leg and bury exactly that.
  */
 
+import type { BenchWorkerAck } from "@commonfabric/test-support/bench-worker";
+
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 import { stripSigilCfcLabelViews } from "@commonfabric/runner/cfc";
@@ -20,9 +22,6 @@ export type EventRequest = {
   /** The `dom-event` message, encoded as the transport encodes it. */
   readonly payload: RealmEncodedValue;
 };
-
-/** What this side reports. One boolean, so the return leg costs nothing. */
-export type EventAck = { readonly ok: boolean; readonly error?: string };
 
 self.onmessage = (ev: MessageEvent<EventRequest>) => {
   try {
@@ -35,10 +34,10 @@ self.onmessage = (ev: MessageEvent<EventRequest>) => {
 
     stripSigilCfcLabelViews(message.event);
 
-    self.postMessage({ ok: true } satisfies EventAck);
+    self.postMessage({ ok: true } satisfies BenchWorkerAck);
   } catch (e) {
     self.postMessage(
-      { ok: false, error: (e as Error).message } satisfies EventAck,
+      { ok: false, error: (e as Error).message } satisfies BenchWorkerAck,
     );
   }
 };

--- a/packages/test-support/deno.jsonc
+++ b/packages/test-support/deno.jsonc
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "exports": {
     ".": "./src/mod.ts",
+    "./bench-worker": "./src/bench-worker.ts",
     "./clock-preload": "./test/clock-preload.ts",
     "./compile-byte-cache": "./src/compile-byte-cache.ts",
     "./fixture-runner": "./src/fixture-runner.ts",

--- a/packages/test-support/src/bench-worker.test.ts
+++ b/packages/test-support/src/bench-worker.test.ts
@@ -75,6 +75,23 @@ describe("BenchWorker", () => {
         worker.close();
       }
     });
+    it("does not latch when a request cannot be cloned", () => {
+      // The request never reaches the far side, so nothing is in flight and the
+      // refusal above must not treat it as though something were. A worker
+      // stuck refusing every later send would end the run, not the request.
+      const worker = new BenchWorker<unknown>(ACKS);
+
+      return (async () => {
+        try {
+          await expect(worker.send(() => {})).rejects.toThrow(
+            "could not be cloned",
+          );
+          await worker.send(1);
+        } finally {
+          worker.close();
+        }
+      })();
+    });
   });
 
   describe("close()", () => {

--- a/packages/test-support/src/bench-worker.test.ts
+++ b/packages/test-support/src/bench-worker.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { BenchWorker } from "./bench-worker.ts";
+
+/** A far side that fails on startup, before any request can be in flight. */
+const DIES_AT_ONCE =
+  `data:application/javascript,throw new Error("dead on arrival");`;
+
+/** A far side that acknowledges whatever it is sent. */
+const ACKS =
+  `data:application/javascript,self.onmessage=()=>self.postMessage({ok:true});`;
+
+/** A far side that refuses whatever it is sent. */
+const REFUSES =
+  `data:application/javascript,self.onmessage=()=>self.postMessage({ok:false,error:"no"});`;
+
+describe("BenchWorker", () => {
+  describe("send()", () => {
+    it("resolves when the far side acknowledges", async () => {
+      const worker = new BenchWorker<number>(ACKS);
+
+      try {
+        await worker.send(1);
+      } finally {
+        worker.close();
+      }
+    });
+
+    it("rejects when the far side refuses", async () => {
+      const worker = new BenchWorker<number>(REFUSES);
+
+      try {
+        await expect(worker.send(1)).rejects.toThrow("Far side refused");
+      } finally {
+        worker.close();
+      }
+    });
+
+    it("rejects rather than hanging when the far side died before the send", async () => {
+      // The case a benchmark cannot survive: a worker that fails during startup
+      // has no request to reject, so a failure not recorded then leaves every
+      // later send waiting on an acknowledgement that cannot come. A hung
+      // benchmark reports nothing at all, where a failed one reports why.
+      const worker = new BenchWorker<number>(DIES_AT_ONCE);
+
+      try {
+        // Give the startup failure a turn to arrive, which is what puts the
+        // send after it rather than in a race with it.
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+        await expect(worker.send(1)).rejects.toThrow("Far side failed");
+      } finally {
+        worker.close();
+      }
+    });
+  });
+});

--- a/packages/test-support/src/bench-worker.test.ts
+++ b/packages/test-support/src/bench-worker.test.ts
@@ -3,10 +3,6 @@ import { expect } from "@std/expect";
 
 import { BenchWorker } from "./bench-worker.ts";
 
-/** A far side that fails on startup, before any request can be in flight. */
-const DIES_AT_ONCE =
-  `data:application/javascript,throw new Error("dead on arrival");`;
-
 /** A far side that acknowledges whatever it is sent. */
 const ACKS =
   `data:application/javascript,self.onmessage=()=>self.postMessage({ok:true});`;
@@ -14,6 +10,13 @@ const ACKS =
 /** A far side that refuses whatever it is sent. */
 const REFUSES =
   `data:application/javascript,self.onmessage=()=>self.postMessage({ok:false,error:"no"});`;
+
+/** A far side that never answers, so a send stays in flight. */
+const SILENT = `data:application/javascript,self.onmessage=()=>{};`;
+
+/** A far side that fails on startup, before any request can be in flight. */
+const DIES_AT_ONCE =
+  `data:application/javascript,throw new Error("dead on arrival");`;
 
 describe("BenchWorker", () => {
   describe("send()", () => {
@@ -37,21 +40,53 @@ describe("BenchWorker", () => {
       }
     });
 
-    it("rejects rather than hanging when the far side died before the send", async () => {
-      // The case a benchmark cannot survive: a worker that fails during startup
-      // has no request to reject, so a failure not recorded then leaves every
-      // later send waiting on an acknowledgement that cannot come. A hung
-      // benchmark reports nothing at all, where a failed one reports why.
-      const worker = new BenchWorker<number>(DIES_AT_ONCE);
+    it("rejects a send made while another is in flight", async () => {
+      // The first send is still outstanding, so the second would take its
+      // acknowledgement and leave it unsettled.
+      const worker = new BenchWorker<number>(SILENT);
 
       try {
-        // Give the startup failure a turn to arrive, which is what puts the
-        // send after it rather than in a race with it.
-        await new Promise<void>((resolve) => setTimeout(resolve, 50));
-        await expect(worker.send(1)).rejects.toThrow("Far side failed");
+        const first = worker.send(1);
+
+        await expect(worker.send(2)).rejects.toThrow("already in flight");
+
+        // `close()` settles the first, which is what lets this end.
+        worker.close();
+        await expect(first).rejects.toThrow("closed");
       } finally {
         worker.close();
       }
+    });
+
+    it("rejects a send made after the far side has already failed", async () => {
+      // The failure that arrives with nothing in flight is the one a benchmark
+      // cannot survive unrecorded: nothing is there to reject, so a later send
+      // would wait for an acknowledgement that cannot come.
+      //
+      // Awaiting the first send is what puts this one after the failure rather
+      // than in a race with it -- the failure is what settles that send, so by
+      // the time it has, the record exists.
+      const worker = new BenchWorker<number>(DIES_AT_ONCE);
+
+      try {
+        await expect(worker.send(1)).rejects.toThrow("Far side failed");
+        await expect(worker.send(2)).rejects.toThrow("Far side failed");
+      } finally {
+        worker.close();
+      }
+    });
+  });
+
+  describe("close()", () => {
+    it("settles a request left in flight", async () => {
+      // Terminating leaves an acknowledgement unable to arrive, so a request
+      // still pending would wait for one forever.
+      const worker = new BenchWorker<number>(SILENT);
+      const pending = worker.send(1);
+
+      worker.close();
+
+      await expect(pending).rejects.toThrow("Far side was closed");
     });
   });
 });

--- a/packages/test-support/src/bench-worker.ts
+++ b/packages/test-support/src/bench-worker.ts
@@ -1,0 +1,126 @@
+/**
+ * The near side of a benchmark that measures a crossing to a worker.
+ *
+ * A benchmark of this shape sends one message, waits for the far side to
+ * acknowledge it, and counts the round trip as one iteration. That is what a
+ * `Deno.bench()` iteration can measure -- a pipeline of overlapping sends would
+ * report throughput while the harness is timing latency -- and it is the shape
+ * the connections these benchmarks stand in for actually use.
+ *
+ * One worker serves a whole run. A fresh one per iteration would measure worker
+ * startup, which is milliseconds against the microseconds of a payload and
+ * would swamp everything such a benchmark is trying to see.
+ *
+ * The far side is a module of the benchmark's own, since what it should do with
+ * a message is the benchmark's question. What this fixes is the near side:
+ * holding one request in flight, settling it against the ack, and failing
+ * rather than hanging when the worker cannot answer.
+ */
+
+/**
+ * What a far side reports. One boolean and, on failure, why.
+ *
+ * Deliberately this small: a reply carrying any part of what was sent would put
+ * a second clone of it on the return leg and bury the cost being measured.
+ */
+export type BenchWorkerAck = {
+  readonly ok: boolean;
+  readonly error?: string;
+};
+
+/** The outstanding request's settlement, held while it is in flight. */
+type PendingRequest = {
+  readonly resolve: () => void;
+  readonly reject: (reason: Error) => void;
+};
+
+/**
+ * A worker held for a whole benchmark run, with one message outstanding at a
+ * time.
+ *
+ * @typeParam Request What the benchmark posts. The far side reads it; nothing
+ *   here does.
+ */
+export class BenchWorker<Request> {
+  readonly #worker: Worker;
+  #pending: PendingRequest | undefined;
+
+  /**
+   * A failure the worker reported with nothing in flight, kept so the next
+   * send reports it instead of waiting for an ack that cannot come.
+   */
+  #terminal: Error | undefined;
+
+  /**
+   * Constructs an instance, starting the worker.
+   *
+   * @param moduleUrl The far side's module, as `import.meta.resolve()` gives
+   *   it.
+   */
+  constructor(moduleUrl: string) {
+    this.#worker = new Worker(moduleUrl, { type: "module" });
+
+    this.#worker.onmessage = (ev: MessageEvent<BenchWorkerAck>) => {
+      const pending = this.#pending;
+
+      this.#pending = undefined;
+
+      if (ev.data.ok) {
+        pending?.resolve();
+      } else {
+        pending?.reject(new Error(`Far side refused: ${ev.data.error}`));
+      }
+    };
+
+    // A worker that fails to start, or throws where nothing catches, sends no
+    // ack -- and a benchmark waiting on one that will never arrive hangs rather
+    // than failing, which is the worst way for a measurement to end. Both
+    // routes below settle a request in flight AND record the failure, because
+    // the first of them can arrive before the first send: a worker that dies
+    // during startup has nothing to reject, and without the record every later
+    // send would wait on it.
+    this.#worker.onerror = (ev: ErrorEvent) => {
+      // Handled here, so it stops here: an error left to its default course
+      // reaches the host as an unhandled worker error and takes the process
+      // with it, which ends the run rather than the measurement.
+      ev.preventDefault();
+      this.#fail(new Error(`Far side failed: ${ev.message}`));
+    };
+
+    // Covers the far side receiving something it cannot deserialize, which no
+    // `error` event reports.
+    this.#worker.onmessageerror = () => {
+      this.#fail(new Error("Far side could not deserialize the message"));
+    };
+  }
+
+  /**
+   * Sends one request and settles when the far side acknowledges it.
+   *
+   * @throws If the far side reports failure, or has already failed. An
+   *   unexamined ack is what makes a benchmark measure the wrong thing
+   *   silently.
+   */
+  send(request: Request): Promise<void> {
+    if (this.#terminal !== undefined) return Promise.reject(this.#terminal);
+
+    return new Promise((resolve, reject) => {
+      this.#pending = { resolve, reject };
+      this.#worker.postMessage(request);
+    });
+  }
+
+  /** Stops the worker. */
+  close(): void {
+    this.#worker.terminate();
+  }
+
+  /** Settles anything in flight with `error`, and records it for later sends. */
+  #fail(error: Error): void {
+    const pending = this.#pending;
+
+    this.#pending = undefined;
+    this.#terminal = error;
+    pending?.reject(error);
+  }
+}

--- a/packages/test-support/src/bench-worker.ts
+++ b/packages/test-support/src/bench-worker.ts
@@ -79,18 +79,17 @@ export class BenchWorker<Request> {
     // the first of them can arrive before the first send: a worker that dies
     // during startup has nothing to reject, and without the record every later
     // send would wait on it.
+    // A far side that posts something uncloneable throws where it posts, which
+    // arrives here as well: `postMessage()` refuses on the sending side rather
+    // than the receiving one, so an acknowledgement that cannot cross is an
+    // error rather than a `messageerror`. The ack this harness defines is a
+    // boolean and a string, so neither can arise from a far side that conforms.
     this.#worker.onerror = (ev: ErrorEvent) => {
       // Handled here, so it stops here: an error left to its default course
       // reaches the host as an unhandled worker error and takes the process
       // with it, which ends the run rather than the measurement.
       ev.preventDefault();
       this.#fail(new Error(`Far side failed: ${ev.message}`));
-    };
-
-    // Covers the far side receiving something it cannot deserialize, which no
-    // `error` event reports.
-    this.#worker.onmessageerror = () => {
-      this.#fail(new Error("Far side could not deserialize the message"));
     };
   }
 
@@ -104,14 +103,34 @@ export class BenchWorker<Request> {
   send(request: Request): Promise<void> {
     if (this.#terminal !== undefined) return Promise.reject(this.#terminal);
 
+    if (this.#pending !== undefined) {
+      // One at a time is what an iteration measures, so a second send would be
+      // measuring something else -- and it would take the first one's
+      // acknowledgement, leaving that request unsettled and this one settled by
+      // an answer to a message it did not send. Refused rather than queued: a
+      // benchmark that overlaps sends has the wrong shape, and hiding that
+      // behind a queue would let it report throughput while timing latency.
+      return Promise.reject(
+        new Error("A request is already in flight; sends do not overlap."),
+      );
+    }
+
     return new Promise((resolve, reject) => {
       this.#pending = { resolve, reject };
       this.#worker.postMessage(request);
     });
   }
 
-  /** Stops the worker. */
+  /**
+   * Stops the worker.
+   *
+   * Anything in flight is settled as failed first. Terminating leaves an
+   * acknowledgement unable to arrive, so a request left pending would wait for
+   * one forever -- and a benchmark closing its worker in a `finally` is exactly
+   * where that would strand a caller.
+   */
   close(): void {
+    this.#fail(new Error("Far side was closed."));
     this.#worker.terminate();
   }
 

--- a/packages/test-support/src/bench-worker.ts
+++ b/packages/test-support/src/bench-worker.ts
@@ -117,7 +117,21 @@ export class BenchWorker<Request> {
 
     return new Promise((resolve, reject) => {
       this.#pending = { resolve, reject };
-      this.#worker.postMessage(request);
+
+      try {
+        this.#worker.postMessage(request);
+      } catch (cause) {
+        // A request that cannot be cloned never reaches the far side, so
+        // nothing will acknowledge it and it is not in flight. Clearing before
+        // rejecting is what keeps the refusal above from latching: the record
+        // exists only for a request the far side has actually been given.
+        //
+        // The worker itself is unharmed -- what failed is this request rather
+        // than the crossing -- so no terminal failure is recorded and the next
+        // send proceeds.
+        this.#pending = undefined;
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
     });
   }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Three benchmarks measure a crossing to a worker, and each carried its own copy
of the near side: `data-model`'s two IPC benchmarks and `html`'s DOM-event one.
The copies differ in the worker module they start and the names of two types.
Nothing else.

## The duplication had already cost something

All three rejected through `pending?.reject` alone, so **each dropped a worker
failure that arrived with nothing in flight**. A benchmark whose worker dies
during startup then waits forever for an acknowledgement that cannot come — and
a benchmark that hangs reports nothing at all, where one that fails reports why.

One defect, three places, written from one shape, and nothing mechanical would
have caught a fix applied to one of them. That is the failure mode duplicated
machinery is expected to produce, and it had already produced it. It is also why
this is an extraction rather than three patches.

A second one surfaced while testing the extraction: none of the three called
`preventDefault()` on the error. Left to its default course a worker error
reaches the host as an unhandled error and takes the process down — ending the
run rather than the measurement. The connection's real transport
(`transport-web-worker.ts`) already does this; the benchmarks had not.

## What is shared and what is not

`BenchWorker` in `test-support` is the near side, once: it holds one request in
flight, settles it against the acknowledgement, records a failure that arrives
with nothing in flight, and reports that from the next send.

The **far side stays each benchmark's own**, since what to do with a message is
the question each benchmark is asking. Only its acknowledgement type is shared,
so the two sides cannot drift apart.

No package gains a dependency declaration: `test-support` is a workspace member,
and workspace siblings resolve without one — `html` already imports
`@commonfabric/runner` with no entry for it.

## Tests

Three, each failing without the piece it covers: an acknowledged send, a refused
one, and a worker that dies before the send is made. Ablating the terminal-
failure record fails the third; ablating `preventDefault()` fails the file.

## Gates

`deno task check`, `deno fmt` and `deno lint` green; full suites green for
`test-support`, `data-model` and `html`. All three migrated benchmarks run to
completion, exit 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

