### PR TITLE
The lane-role pin asserts the arm at BOTH selection sites, not once per job

### DIFF
--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -967,18 +967,41 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
     );
   }
 
+  // The explicit arm is asserted at EACH site that SELECTS it — the step
+  // that starts the server, and the step that runs the test processes —
+  // never once over the whole job. A job-wide substring is satisfied by
+  // any single occurrence, including the posture probe's `::error::`
+  // prose, which selects nothing at all; both real sites could point at
+  // the ON arm with this pin still green. A lane that starts its server
+  // on one arm and runs its tests on the other is the P7 review's
+  // finding-7 MIXED posture, and the server-side probe below cannot see
+  // it: the probe reads the SERVER, so the test processes' arm is
+  // unexamined unless asserted here.
   for (
-    const jobId of [
-      "package-integration-test-server-execution-off",
-      "pattern-integration-test-server-execution-off",
+    const { jobId, runStep } of [
+      {
+        jobId: "package-integration-test-server-execution-off",
+        runStep: "🧪 Run ${{ matrix.step_name }} (flag OFF)",
+      },
+      {
+        jobId: "pattern-integration-test-server-execution-off",
+        runStep: "🧩 Run end-to-end patterns integration tests (flag OFF)",
+      },
     ]
   ) {
     const job = jobBlock(contents, jobId);
-    assertStringIncludes(
-      job,
-      "EXPERIMENTAL_SERVER_EXECUTION=false",
-      `${jobId}: the OFF guard must select the OFF arm explicitly`,
-    );
+    for (
+      const stepName of [
+        "🔌 Start Toolshed server for testing (flag OFF)",
+        runStep,
+      ]
+    ) {
+      assertStringIncludes(
+        stepBlock(job, stepName),
+        "EXPERIMENTAL_SERVER_EXECUTION=false",
+        `${jobId}: "${stepName}" must select the OFF arm explicitly`,
+      );
+    }
     assertStringIncludes(
       job,
       ".servingLoop == null",

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -967,16 +967,16 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
     );
   }
 
-  // The explicit arm is asserted at EACH site that SELECTS it — the step
-  // that starts the server, and the step that runs the test processes —
-  // never once over the whole job. A job-wide substring is satisfied by
-  // any single occurrence, including the posture probe's `::error::`
-  // prose, which selects nothing at all; both real sites could point at
-  // the ON arm with this pin still green. A lane that starts its server
-  // on one arm and runs its tests on the other is the P7 review's
-  // finding-7 MIXED posture, and the server-side probe below cannot see
-  // it: the probe reads the SERVER, so the test processes' arm is
-  // unexamined unless asserted here.
+  // Each step that SELECTS the arm carries its own assertion: the step
+  // that starts the toolshed, and the step that runs the test processes.
+  // A job-wide substring is satisfied by any single occurrence — the
+  // posture probe's `::error::` prose selects nothing and satisfies it —
+  // so the two selecting steps could disagree, and a lane that starts its
+  // server on one arm while running its tests on the other is a MIXED
+  // posture that every test still passes. The posture probe cannot stand
+  // in for this: it reads the SERVER, so the arm the test processes run
+  // under is unexamined unless asserted here. Comments are stripped on
+  // both, so a note naming an arm never counts as selecting it.
   for (
     const { jobId, runStep } of [
       {
@@ -997,7 +997,7 @@ Deno.test("server-execution lane roles match the flipped default (testing.md §2
       ]
     ) {
       assertStringIncludes(
-        stepBlock(job, stepName),
+        withoutComments(stepBlock(job, stepName)),
         "EXPERIMENTAL_SERVER_EXECUTION=false",
         `${jobId}: "${stepName}" must select the OFF arm explicitly`,
       );


### PR DESCRIPTION
## Why

Stacked on #6535 (the flip). Gap found while building #6552 (the rollback lever); mirrored back into it as `f49a1f9`.

The **guard half** of `server-execution lane roles match the flipped default (testing.md §2)` is what stands between a partial revert and a lane that silently tests the wrong arm with every test green. It asserted the explicit arm **once over the whole job block**:

```ts
assertStringIncludes(job, "EXPERIMENTAL_SERVER_EXECUTION=false", ...)
```

But a guard job selects that arm at **two independent sites** — the step that starts the toolshed, and the step that runs the test processes. A substring over the whole job is satisfied by either one alone. So a lane that started its server on one arm and ran its test processes on the other passed this assertion — and that is exactly the P7 independent review's **finding-7 MIXED posture**, the thing this pin family exists to prevent.

The server-side posture probe cannot cover for it: it reads `/api/meta` on the **server**, so the test processes' arm is unexamined unless the pin asserts it. (This is the same hole #6535 already closed for the CLI lane, where `cf` is a deployed client — the guard lanes still had it.)

It is worse than "either site alone". The posture-probe step carries `EXPERIMENTAL_SERVER_EXECUTION=false` inside two `::error::` **message strings**, which select nothing at all — so **both** real sites could be pointed at the ON arm with the pin still green.

The gap is pre-existing and symmetric: the same shape was in the pin before the lever inverted it, with `=true`. It was deliberately left out of scope for a minimal rollback lever; this PR is that follow-up.

## What Changed

`tasks/ci-workflow.test.ts` only — 31 insertions, 8 deletions. No workflow change, no behavior change. The pin gets stricter; nothing it should accept is now rejected.

Each guard job's two **selecting** steps are extracted with the file's existing `stepBlock(job, ...)` helper and asserted separately, through the file's existing `withoutComments()` so a stale note naming an arm never counts as selecting it. The run step is named per lane — the package lane's is `🧪 Run ${{ matrix.step_name }} (flag OFF)`, the pattern lane's is `🧩 Run end-to-end patterns integration tests (flag OFF)` — so the loop carries the `{jobId, runStep}` pair rather than a bare job id. The failure message names the offending step, so a red says which half drifted.

Comment-stripping was checked safe before it was applied: the four selecting steps carry 3–23 comment lines each, and the assignment survives the strip in all four.

## Test plan

Red-first, mutation-probed against this branch's own tree. Every row was run; "before" is the assertion as it stood.

| mutation | before | after |
|---|---|---|
| package guard, **start** step → `=true` | green | **red** — names `🔌 Start Toolshed server for testing (flag OFF)` |
| package guard, **run** step → `=true` | green | **red** — names `🧪 Run ${{ matrix.step_name }} (flag OFF)` |
| pattern guard, **start** step → `=true` | green | **red** — names `🔌 Start Toolshed server for testing (flag OFF)` |
| pattern guard, **run** step → `=true` | green | **red** — names `🧩 Run end-to-end patterns integration tests (flag OFF)` |
| **both** package sites → `=true` (only `::error::` prose left) | green | **red** |
| stale `# EXPERIMENTAL_SERVER_EXECUTION=false` comment beside a flipped assignment | green | **red** |
| rename a selecting step | green | **red** — `step not found` |

So the pin cannot be defeated quietly: not by drift on one side, not by a stale comment, not by a rename.

Unmutated tree: full `tasks/ci-workflow.test.ts` **22 passed, 0 failed**; `deno fmt --check` and `deno lint` clean; no lockfile churn.

## CI

This PR targets `claude/server-exec-v2-flip-pr`, and the CI workflow triggers only on pull requests into `main` — so no lanes run here, same as #6552. The full board comes from #6535 once this merges into it.

## Review

Both bot findings (cubic P2 and Codex P2, the same comment-stripping hole; plus Codex P2 on comment style) are addressed in `9b227b5`. Self-review, including two residual gaps deliberately flagged rather than filled, is in [this comment](https://github.com/commontoolsinc/labs/pull/6554#issuecomment-5464948309).
