### PR TITLE
test(runner): drop a write the resume-path gate stopped reading

### DIFF
--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -3323,7 +3323,6 @@ describe("runner utils", () => {
       // dependencies before registering handlers, which is where this race
       // used to allow duplicate starts for the same result cell.
       (runtime.runner as any).locallyPreparedResults.clear();
-      (resultCell as any).synced = true;
 
       const runner = runtime.runner as any;
       let dependencySyncRuns = 0;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

One line goes away from the `runner` test
`does not register duplicate handlers while resumed dependencies sync`:

```ts
(resultCell as any).synced = true;
```

The line decides nothing today. What follows is why it once did, when that
stopped, and the measurements that show removing it is safe.

## What the line was for

The test drives the path a persisted piece takes when it is resumed: `start()`
syncs the piece's dependencies before it registers handlers, and two concurrent
starts on one result cell used to each run that expensive pre-sync. The test
asserts the pair now dedupes into one, via `expect(dependencySyncRuns).toBe(1)`.

To reach that path at all, the test has to convince `start()` that the piece was
not assembled locally. When the line was written, `#doStart` decided that from
the cell's own `synced` flag, so setting the flag was how the test chose the
branch.

## When it stopped deciding anything

`#doStart` no longer gates on that flag. It reads:

```ts
const wasSyncedAtEntry =
  (resultCell as Cell<any> & { synced?: boolean }).synced === true;
```

and then, at the branch itself, discards it:

```ts
void wasSyncedAtEntry;
if (wasPreparedLocally || wasStoppedLocally) {
```

The comment above that branch says why: a fresh-runtime resume arrives past
Step 3 with `getRaw()` populated, so the locally-assembled signals are the
reliable discriminator, and the `synced` flag "is no longer reliably set for a
storage-loaded cell". `wasSyncedAtEntry` is kept for diagnostics and read by
nothing else.

So the branch the test wants is selected entirely by its other setup line,
`(runtime.runner as any).locallyPreparedResults.clear()`, which is what makes
`wasPreparedLocally` false.

## The write was already a no-op before it was unreadable

Worth stating precisely, because the obvious guess is wrong. `CellImpl` reads
its `synced` field in roughly twenty places, most of them
`if (!this.synced) this.sync()`, so a write that lands on the real field could
plausibly suppress sync work. It does not, for a simpler reason: at that point
in the test the flag is already set.

Probing the value on either side of the write, at the commit before the field
became a `#` name:

| | before the write | after the write |
| --- | --- | --- |
| pre-`#`-conversion | `true` | `true` |
| current `main` | absent | `true` |

Pre-conversion the test assigned `true` over `true`. On `main` the field is
`#synced`, so the assignment instead creates a public own property that nothing
reads, and `#synced` keeps its own value. Both are no-ops, by different
mechanisms. Counting `sync()` calls on the cell across the test gives 1 on both
sides, so nothing observable turns on any of this.

## That the rest of the test still grips

Two ablations, each a full run of `packages/runner/test/runner.test.ts`:

- Remove the `synced` write: `4 passed (92 steps)`, exit 0. Nothing depends on
  it.
- Remove `locallyPreparedResults.clear()` instead: the test **fails**, with
  `dependencySyncRuns` actual `0` against expected `1`.

The second is the one that matters. Without that clear, `start()` takes the
local fast path and never reaches the dependency pre-sync, so the headline
assertion drops to zero rather than passing vacuously. The assertion grips a
real value, and the line being removed is not what makes it do so.

## Gates

`deno task test` in `packages/runner` on this branch:
`ok | 1323 passed (7880 steps) | 0 failed`, exit 0 — the same counts a run on
unmodified `main` produces. `deno fmt --check` and `deno lint` clean on the
changed file.

The comment above the remaining setup line still describes what that line does,
and stays as it is.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

