### PR TITLE
fix(cli): cf piece step emits the space receipt its writes owe

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4456,12 +4456,19 @@ export async function callPieceHandler<T = any>(
   );
 }
 
-export async function stepPiece(config: PieceConfig): Promise<void> {
+export async function stepPiece(
+  config: PieceConfig,
+  deps: PieceResolutionDeps = {},
+): Promise<void> {
   const pieces = await timeCliPhase(
     "stepPiece.loadPieces",
-    () => loadPieces(config),
+    () => (deps.loadPieces ?? loadPieces)(config),
   );
-  const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
   const piece = await timeCliPhase(
     "stepPiece.getPiece",
     () =>
@@ -4474,6 +4481,9 @@ export async function stepPiece(config: PieceConfig): Promise<void> {
   );
   await timeCliPhase("stepPiece.pull", () => piece.getCell().pull());
   await timeCliPhase("stepPiece.synced", () => pieces.synced());
+  // A step exists to run the pattern and commit what recomputation
+  // produced, so the synced state above is the write the receipt follows.
+  noteWroteTo(config.space);
   await timeCliPhase(
     "stepPiece.stop",
     () => pieces.stopPiece(resolvedConfig.piece),

--- a/packages/cli/test/piece-step.test.ts
+++ b/packages/cli/test/piece-step.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { PiecesController } from "@commonfabric/piece/ops";
+
+import { type PieceConfig, stepPiece } from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+
+const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+
+const config: PieceConfig = {
+  apiUrl: "http://localhost:8000",
+  space: SPACE,
+  identity: "/nonexistent/keyfile",
+  piece: "fid1:step-receipt-piece",
+};
+
+// A controller stub covering exactly what stepPiece touches: get the piece
+// running, pull its cell, sync, stop.
+function stubController(calls: string[]): PiecesController {
+  return {
+    get: (id: string) => {
+      calls.push(`get ${id}`);
+      return Promise.resolve({
+        getCell: () => ({ pull: () => Promise.resolve() }),
+      });
+    },
+    synced: () => {
+      calls.push("synced");
+      return Promise.resolve();
+    },
+    stopPiece: (id: string) => {
+      calls.push(`stop ${id}`);
+      return Promise.resolve();
+    },
+  } as unknown as PiecesController;
+}
+
+// Collects what a receipt writes, and restores the console afterwards.
+async function captureStderr(body: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await body();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
+describe("stepPiece", () => {
+  it("emits the write receipt for the space it stepped in", async () => {
+    // A step exists to run the pattern and commit what recomputation
+    // produced, so it is a write path and owes the space receipt like any
+    // other (docs/plans/cli-surface-shape.md, step 8).
+    resetWriteReceipts();
+    const calls: string[] = [];
+    const lines = await captureStderr(() =>
+      stepPiece(config, {
+        loadPieces: () => Promise.resolve(stubController(calls)),
+        resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+      })
+    );
+    expect(lines).toContain(`wrote to space ${SPACE}`);
+    expect(calls).toEqual([
+      `get ${config.piece}`,
+      "synced",
+      `stop ${config.piece}`,
+    ]);
+  });
+});

--- a/packages/cli/test/piece-step.test.ts
+++ b/packages/cli/test/piece-step.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for `stepPiece`'s write receipt. A step runs the pattern and
+ * commits what recomputation produced, so it names the space it wrote to
+ * like every other write path (docs/plans/cli-surface-shape.md, step 8);
+ * the injected controller stub is what lets the receipt be asserted
+ * without a live space.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 


### PR DESCRIPTION
## Why

Step 8's contract (#6498) is that a write against an ambient `CF_SPACE` names the space it landed in. `stepPiece` runs the pattern and commits what recomputation produced — the write `cf set`'s own hint directs users to — but it was the one write path in `packages/cli/lib/piece.ts` with no `noteWroteTo`, so `cf piece step` against an ambient space wrote without naming where. Surfaced by a review pass over #6537's design docs; `callPieceHandler` was suspected too but is covered transitively (`executeResolvedCallable` carries both the handler and tool receipts).

## What Changed

- `stepPiece` emits the receipt after `synced()`, and gains the `deps.loadPieces` / `resolvePieceAddress` seam its siblings use (the shape `recreateSpaceRootPattern` and `resolvePieceConfig` already carry), which is what makes the receipt provable from a unit test.
- `packages/cli/test/piece-step.test.ts` — a controller stub covering exactly what `stepPiece` touches, asserting the receipt line and the get/sync/stop order.

**Open question for the step-8 author:** `cf get --step` runs the same recomputation and can commit the same way, but receipting a read command is a call I didn't want to make unilaterally — it would print `wrote to space …` on what the caller typed as a read. Left alone here; say the word and it gets the same treatment.

## Test plan

`deno task test` in `packages/cli` (210 passed), repo-wide `deno fmt --check`, `deno lint`, and `deno task check` all green. The new test fails if the receipt line is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pUbgG5j3sDqRR6Ph91JUB


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

