### PR TITLE
bench(runtime-client): what a whole message costs to cross the connection

### DIFF
--- a/packages/runtime-client/bench/fixtures/ipc-far-side.ts
+++ b/packages/runtime-client/bench/fixtures/ipc-far-side.ts
@@ -1,0 +1,83 @@
+/**
+ * The receiving side of a whole-crossing benchmark: it takes what the worker
+ * posted, does what that side of the connection does with it, and acks.
+ *
+ * Under `fixtures/` rather than beside the benchmark because a file here is
+ * neither a `*.bench.ts` nor a test, and the coverage tooling counts anything
+ * else under `packages/` as source a suite failed to reach.
+ *
+ * The ack carries one boolean. What the benchmark wants to know is what the
+ * send and this side's work cost, and a reply carrying any part of the
+ * received value would put a second clone of it on the return leg and bury
+ * exactly that.
+ */
+
+import type { BenchWorkerAck } from "@commonfabric/test-support/bench-worker";
+
+import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
+import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
+
+import { CellHandle } from "@/cell-handle.ts";
+import { $conn, type RuntimeClient } from "@/runtime-client.ts";
+
+/** What the benchmark asks this side to do with what it sent. */
+export type CrossingRequest =
+  | {
+    /**
+     * The envelope arm: the payload is an encoding, so this side decodes it
+     * before hydrating.
+     */
+    readonly kind: "envelope";
+
+    /** The realm-encoded tree. */
+    readonly payload: RealmEncodedValue;
+  }
+  | {
+    /**
+     * The status-quo arm: the payload arrived unencoded, as a connection
+     * relying on structured cloning alone sends it, so there is nothing to
+     * decode and the hydration runs on what arrived.
+     */
+    readonly kind: "status-quo";
+
+    /** The bare value, as it was handed to `postMessage()`. */
+    readonly payload: unknown;
+  };
+
+/**
+ * A handle for the hydration to walk from. `deserialize()` reads its ref, to
+ * rebase a relative link, and its client, to hand to a hydrated child -- so a
+ * stand-in serves, and building a real `RuntimeClient` here would put a
+ * connection this benchmark does not use behind every iteration.
+ */
+const base = new CellHandle(
+  { [$conn]: () => ({}) } as unknown as RuntimeClient,
+  {
+    id: `of:${"0".repeat(64)}`,
+    space: `did:key:z${"a".repeat(47)}`,
+    scope: "space",
+    path: [],
+  },
+);
+
+self.onmessage = (ev: MessageEvent<CrossingRequest>) => {
+  const request = ev.data;
+
+  try {
+    // No cast on the decode: the discriminant is what says this payload is an
+    // encoding. The result is dropped, but both walks have run in full --
+    // `decode()` is eager and so is the hydration, so there is no lazy
+    // remainder for dropping the result to skip.
+    const received = request.kind === "envelope"
+      ? fabricFromRealmValue(request.payload)
+      : request.payload;
+
+    CellHandle.deserialize(base, received);
+
+    self.postMessage({ ok: true } satisfies BenchWorkerAck);
+  } catch (e) {
+    self.postMessage(
+      { ok: false, error: (e as Error).message } satisfies BenchWorkerAck,
+    );
+  }
+};

--- a/packages/runtime-client/bench/ipc-crossing.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing.bench.ts
@@ -1,0 +1,134 @@
+/**
+ * What a whole message costs to cross the worker connection, against what the
+ * same message cost before the envelope encoding carried it.
+ *
+ * `data-model`'s `bench/ipc-status-quo.bench.ts` measures the encoding's own
+ * contribution: encode, `postMessage()`, decode. This file measures the
+ * crossing that contribution sits inside, which is the larger thing and the
+ * one a reader means by "what does a message cost". The walks around the codec
+ * predate it and are unchanged by it, so a ratio taken across the codec alone
+ * overstates what the connection as a whole pays.
+ *
+ * The subject is a cell update travelling worker to client, which is the
+ * connection's highest-volume message. Both arms run the same four steps and
+ * differ only in the two the envelope added:
+ *
+ * | | status quo | envelope |
+ * | --- | --- | --- |
+ * | worker: convert cells to links | yes | yes |
+ * | worker: redact carried label views | yes | yes |
+ * | worker: encode | -- | yes |
+ * | `postMessage()` | yes | yes |
+ * | client: decode | -- | yes |
+ * | client: hydrate refs into handles | yes | yes |
+ *
+ * Every step is inside the timed region, including both encodes, because both
+ * are what a sender pays. One message is in flight at a time: an iteration is
+ * one round trip, and a pipeline of overlapping sends would report throughput
+ * while the harness is timing latency.
+ *
+ * Payloads are records carrying links, since what these walks cost turns on
+ * containers visited rather than bytes moved, and a link is what a converted
+ * cell becomes. A payload the status quo cannot carry at all is deliberately
+ * absent: timing a crossing that arrives damaged against one that arrives
+ * whole yields a ratio that reads as a regression and says nothing.
+ *
+ * Run with:
+ *
+ *     deno task bench
+ */
+
+import { BenchWorker } from "@commonfabric/test-support/bench-worker";
+
+import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { convertCellsToLinks, KeepAsCell } from "@commonfabric/runner";
+import { redactSigilCfcLabelViewsForDisplay } from "@commonfabric/runner/cfc";
+
+import type { CrossingRequest } from "./fixtures/ipc-far-side.ts";
+
+/** The options the IPC response and notification paths convert under. */
+const CONVERT_OPTIONS = {
+  includeSchema: true,
+  keepAsCell: KeepAsCell.All,
+  doNotConvertCellResults: true,
+  includeCfcLabelView: true,
+} as const;
+
+const farSide = new BenchWorker<CrossingRequest>(
+  import.meta.resolve("./fixtures/ipc-far-side.ts"),
+);
+
+/** Builds the link that a converted cell becomes, distinct per index. */
+function makeLink(index: number): FabricValue {
+  return linkRefFrom({
+    id: `of:${"0".repeat(56)}${index.toString(16).padStart(8, "0")}`,
+    space: `did:key:z${"a".repeat(47)}`,
+    path: ["items", String(index)],
+  }) as unknown as FabricValue;
+}
+
+/** A list of records, each with a few scalars, a nested array, and one link. */
+function makeList(items: number): FabricValue {
+  const list: FabricValue[] = [];
+
+  for (let i = 0; i < items; i++) {
+    list.push({
+      title: `item number ${i}`,
+      count: i,
+      done: (i % 3) === 0,
+      tags: [`tag-${i % 7}`, `tag-${i % 11}`],
+      source: makeLink(i),
+    });
+  }
+
+  return { items: list, total: items, updatedAt: "2026-08-27T00:00:00Z" };
+}
+
+/** A flat object of `count` scalar members: one container, many members. */
+function makeFlat(count: number): FabricValue {
+  const out: Record<string, FabricValue> = {};
+
+  for (let i = 0; i < count; i++) out[`member${i}`] = i;
+
+  return out;
+}
+
+/**
+ * A spread of shapes rather than sizes of one shape: what a crossing costs
+ * turns on how many containers the walks visit, and these differ in that as
+ * well as in total size.
+ */
+const SUBJECTS: readonly (readonly [string, FabricValue])[] = [
+  ["small record", { title: "a note", count: 3, source: makeLink(0) }],
+  ["flat 100 members", makeFlat(100)],
+  ["100 records with links", makeList(100)],
+  ["1000 records with links", makeList(1000)],
+];
+
+for (const [name, value] of SUBJECTS) {
+  /** The two worker-side walks both arms run before anything is sent. */
+  const converted = (): FabricValue =>
+    redactSigilCfcLabelViewsForDisplay(
+      convertCellsToLinks(value as never, CONVERT_OPTIONS),
+    ) as FabricValue;
+
+  Deno.bench({
+    name: `status quo — ${name}`,
+    group: name,
+    baseline: true,
+  }, async () => {
+    await farSide.send({ kind: "status-quo", payload: converted() });
+  });
+
+  Deno.bench({ name: `envelope — ${name}`, group: name }, async () => {
+    // Encoded here, inside the measurement: the send pays for it.
+    await farSide.send({
+      kind: "envelope",
+      payload: realmFromFabricValue(converted()),
+    });
+  });
+}
+
+globalThis.addEventListener("unload", () => farSide.close());

--- a/packages/runtime-client/deno.jsonc
+++ b/packages/runtime-client/deno.jsonc
@@ -8,7 +8,11 @@
   "tasks": {
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check --allow-env --allow-read --allow-ffi test/",
-    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\""
+    "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS \"./integration/*.test.ts\"",
+    // --allow-read so that a benchmark may start a `Worker`, which reads the
+    // worker's module from disk. The crossing benchmark measures a real
+    // `postMessage()`, that being the boundary the connection is.
+    "bench": "deno bench --allow-read --no-check bench/"
   },
   "exports": {
     ".": "./src/mod.ts",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`data-model`'s `ipc-status-quo.bench.ts` measures the envelope encoding's own
contribution — encode, `postMessage()`, decode — which is a slice of what a
message pays rather than the whole of it. The walks around the codec predate it
and are untouched by it, so a ratio taken across the codec alone overstates the
share of a crossing the codec is.

This measures the crossing that slice sits inside:

| | |
| --- | --- |
| worker | `convertCellsToLinks()`, the label redaction, the encode |
| | `postMessage()` |
| client | the decode, `CellHandle.deserialize()` |

Same two-arm shape as the existing benchmark, the arms differing only in the
encode and decode the envelope added, so the ratio between them is a cost rather
than an artifact.

It is a new file rather than a widening of the old one because `data-model`
cannot reach these walks: its import map is `@/` and `@node/crypto`, and both
`runner` and `runtime-client` sit above it. The old benchmark stays where it is,
along with what already cites it.

## What it is for

Deciding which phase of a crossing is worth attention. The conversion turned out
to be the largest single term — larger than the encode, the structured clone and
the decode individually — which is not what the codec-only numbers suggest, and
is the sort of thing this is here to keep visible.

Its near side is the shared `BenchWorker` from #6553, so it adds no harness of
its own.

## Gates

`deno task check`, `deno fmt` and `deno lint` green; the `runtime-client` suite
green; the benchmark runs to completion, exit 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

