### PR TITLE
docs(data-model): the format decides what an accepted value encodes to

### DIFF
--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -298,9 +298,11 @@ export function assertValidFabricValueLayer(
  * *convertible* to fabric form).
  *
  * This is the admission test the encoding path's input contract is written
- * against: a value this accepts encodes, and one it does not gets whatever
- * best-effort handling costs correct input nothing. See
- * `BaseCodecEngine.encode()`.
+ * against: a value this accepts is one that path takes, and one it does not
+ * gets whatever best-effort handling costs correct input nothing. What an
+ * accepted value encodes to is `BaseCodecEngine.encode()`'s to say -- given
+ * one, a format writes its serialized form or throws for a reason it names,
+ * a cycle among them.
  */
 export function isValidFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive returns without


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`isValidFabricValue()`'s doc comment closed by saying that a value it accepts
encodes. That is one claim too strong. The predicate is a membership check, and
membership admits a cycle -- deliberately, and the space-model formal spec says
so in as many words: "membership admits a cycle -- `isValidFabricValue()`
handles one and returns `true` -- while this entry point declines to construct
one."

Measured on the branch's base: `isValidFabricValue()` returns `true` for a plain
object holding a reference to itself, and `realmFromFabricValue()` on the same
value throws `Circular reference detected during encoding`.

The two places that already state the contract correctly are
`BaseCodecEngine.encode()` -- "given one, this encodes, or throws for one of the
reasons below", the reasons naming a cycle among them -- and section 2.10 of
the space-model formal spec. This change says the same thing at the predicate,
and hands the question of what an accepted value becomes to the engine that
answers it.

Comment text only; no code path changes. `deno task check` and the `data-model`
suite pass (48 tests, 2747 steps), as do `deno fmt --check` and `deno lint` on
the file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

