### PR TITLE
docs(development): a comment about a test block goes inside the block

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -45,8 +45,8 @@ authority, and a new test file is a reason to open it rather than to copy a
 neighbor. Not every file in the tree follows it, so what sits beside you in
 the same directory is not evidence of what to write.
 
-The five its readers most often get wrong by defaulting to the surrounding
-code:
+The five rules its readers most often get wrong by defaulting to the
+surrounding code:
 
 - BDD only — `describe()` / `it()` / `beforeEach()` from `@std/testing/bdd`,
   never `Deno.test()`.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -45,7 +45,7 @@ authority, and a new test file is a reason to open it rather than to copy a
 neighbor. Not every file in the tree follows it, so what sits beside you in
 the same directory is not evidence of what to write.
 
-The four its readers most often get wrong by defaulting to the surrounding
+The five its readers most often get wrong by defaulting to the surrounding
 code:
 
 - BDD only — `describe()` / `it()` / `beforeEach()` from `@std/testing/bdd`,
@@ -57,6 +57,10 @@ code:
   function", not "rejects a bare function".
 - `expect()` over `assert*()`, always for structured values. Plain `assert(x)`
   only where truthiness itself is the assertion.
+- A comment about a test or a group of tests goes inside the block, as the
+  first thing in the callback and followed by a blank line. Above the
+  `describe()` or `it()` line, the next block inserted there lands between the
+  comment and what it describes.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -242,7 +242,10 @@ we were not looking."
 Section markers separate major portions of a file or class. They are not
 headers for individual functions and their helpers — doc comments already
 carry that structure, and a reader navigating by rendered documentation never
-sees the marker at all.
+sees the marker at all. They are not headers for individual test blocks
+either;
+[`unit-test-coding-style.md`](unit-test-coding-style.md#commenting-a-block)
+says where a comment about one of those goes.
 
 Where `//` comments can be used, mark a section of a file or a class with a
 `//` comment block that opens and closes with a line holding nothing but `//`.

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -191,8 +191,9 @@ declare class DonutWeight {
 }
 
 describe("instance members", () => {
-  // Each member reads through the snapshot the constructor froze, so a
-  // mutation to the source object after construction is invisible here.
+  // Comparing two `DonutWeight`s would rest on whatever equality the class
+  // gives. Each case reads `grams` off the result instead, so what the
+  // assertion turns on is the arithmetic alone.
 
   describe("plus()", () => {
     it("returns the sum of the two weights", () => {
@@ -225,8 +226,9 @@ Two nearby shapes are not this one:
 - A [section marker](code-comment-style.md#section-markers) titles a region of
   the file holding several blocks. Reach is what tells the two apart, not
   length or subject matter. A marker covering a single block is not marking a
-  region: either it says something about that block, and goes inside it in the
-  form above, or it restates the block's own description, and goes.
+  region. Where it says something about that block, it becomes a block comment
+  in the form above. Where it only restates the block's own description, it is
+  deleted.
 
 ## Assertions
 

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -175,6 +175,59 @@ Description strings may run past the 80-column line width the rest of the
 repository holds to. A description that reads well is worth more than a
 description that wraps well.
 
+### Commenting a block
+
+A comment about a test, or about a group of tests, goes inside the block it
+describes, as the first thing in the callback, followed by a blank line:
+
+```ts
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+declare class DonutWeight {
+  constructor(grams: number);
+  readonly grams: number;
+  plus(other: DonutWeight): DonutWeight;
+}
+
+describe("instance members", () => {
+  // Each member reads through the snapshot the constructor froze, so a
+  // mutation to the source object after construction is invisible here.
+
+  describe("plus()", () => {
+    it("returns the sum of the two weights", () => {
+      expect(new DonutWeight(3).plus(new DonutWeight(4)).grams).toBe(7);
+    });
+  });
+});
+```
+
+Above the call, such a comment is held in place by adjacency and nothing else.
+A block inserted at that line lands between the two, and the comment then heads
+a group it was not written for while the group it describes has none. Inside
+the callback there is nothing to insert between them, and the indentation says
+how far the comment reaches.
+
+The blank line under it separates the two jobs a `//` comment does here. With
+one, the comment is about the block. Without one, it is about the statement
+directly beneath it, which is the ordinary use and is untouched by any of this.
+
+Every block that takes a body works this way: `describe()`, `it()`, the
+`beforeEach()` family, and `Deno.test()`, `Deno.bench()` and `t.step()` where a
+file uses them.
+
+Two nearby shapes are not this one:
+
+- A comment describing the **file** rather than any block in it is a file
+  header. It goes at the top of the file as a doc comment, per
+  [File headers](code-comment-style.md#file-headers), and not above the
+  top-level `describe()`.
+- A [section marker](code-comment-style.md#section-markers) titles a region of
+  the file holding several blocks. Reach is what tells the two apart, not
+  length or subject matter. A marker covering a single block is not marking a
+  region: either it says something about that block, and goes inside it in the
+  form above, or it restates the block's own description, and goes.
+
 ## Assertions
 
 Default to `expect()`-style assertions — `expect(...).toBe(...)`,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A `//` comment describing a test or a group of tests sits above the
`describe()` or `it()` line in most of the tree, held there by adjacency and
nothing else. Inserting a block at that line lands it between the comment and
what the comment describes, so the comment heads a group it was not written for
and the group it was written for has none. Nothing catches that: it formats,
lints, and passes.

This states the placement in `unit-test-coding-style.md` as a new "Commenting a
block" subsection: inside the callback, as its first content, followed by a
blank line. The blank line separates a comment about the block from a comment
about the first statement under it, which is the ordinary use and is
unaffected. It covers every block that takes a body -- `describe()`, `it()`,
the hooks, and `Deno.test()`, `Deno.bench()` and `t.step()` where a file uses
them.

Two neighboring shapes get their dispositions named in the same section. A
comment describing the file is a file header and belongs at the top of the file
in doc-comment form. A section marker titles a region of several blocks, so one
covering a single block is either a block comment or a restatement of that
block's own description.

`code-comment-style.md` gains the cross-reference from its section-marker rule,
and `.claude/rules/tests.md` the bullet.

## Conformance today

Across 2278 `*.test.ts` / `*.test.tsx` / `*.bench.ts` files, counting a `//`
block directly above a test-block opener with no blank line between (which
excludes section markers, since those take a blank line after):

| | count |
|---|---|
| Above the opener | 818, in 239 files |
| Inside the block, blank line after | 163 |

So about 17%. Conforming the tree is separate work, one package group at a
time; this change is documentation only and touches no test file.

## Gates

`deno task check-docs` passes, including the new TypeScript block.
`deno task check-skill-facts` passes. `docs/` and `.claude/` are excluded from
`deno fmt`, so the added prose is hand-wrapped at 80 columns; no added line
exceeds it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

