### PR TITLE
test(data-model): a block's comment moves inside the block it describes

### DIFF
--- a/packages/content-hash/test/createHasher.test.ts
+++ b/packages/content-hash/test/createHasher.test.ts
@@ -53,9 +53,10 @@ for (const createFunc of createFuncs) {
     let testId = -1;
     let oneLength = 10; // For multi-byte variety; updated pseudorandomly.
 
-    // A caller-supplied encoding name reaches the message, so a name holding
-    // a backtick must not break the span around it.
     it("quotes an unknown encoding name safely, backticks and all", () => {
+      // A caller-supplied encoding name reaches the message, so a name holding
+      // a backtick must not break the span around it.
+
       const hasher = createFunc();
       hasher.update(new Uint8Array([1, 2, 3]));
       expect(() => hasher.digest("a`b" as "base64url"))
@@ -65,9 +66,11 @@ for (const createFunc of createFuncs) {
     describe("after `digest()`", () => {
       const alreadyDone = /`digest\(\)` already done/;
 
-      // A small update is the interesting case: implementations that buffer
-      // small writes can satisfy one without consulting the underlying hasher.
       it("throws given a small `update()`", () => {
+        // A small update is the interesting case: implementations that buffer
+        // small writes can satisfy one without consulting the underlying
+        // hasher.
+
         const hasher = createFunc();
         hasher.update(new Uint8Array([1, 2, 3]));
         hasher.digest();

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -567,6 +567,7 @@ describe("CodecRegistry", () => {
   describe("frozen instances", () => {
     // `Object.freeze()` cannot reach a private `Map` or `Set`, so each mutator
     // has to refuse on its own; these cases pin that each one does.
+
     describe("register()", () => {
       it("throws", () => {
         const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -25,9 +25,10 @@ import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "../fabric-instances/fixtures.ts";
 
 describe("ProblematicValue", () => {
-  // Subclass-checking-superclass identity: lives directly under the class
-  // describe (the rule's cross-cutting carve-out).
   it("is an instance of `BaseFabricInstance`", () => {
+    // Subclass-checking-superclass identity: lives directly under the class
+    // describe (the rule's cross-cutting carve-out).
+
     const value = new ProblematicValue("Test@1", "state", "oops");
     expect(value instanceof BaseFabricInstance).toBe(true);
   });

--- a/packages/data-model/test/codec-common/UnknownValue.test.ts
+++ b/packages/data-model/test/codec-common/UnknownValue.test.ts
@@ -24,9 +24,10 @@ import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "../fabric-instances/fixtures.ts";
 
 describe("UnknownValue", () => {
-  // Subclass-checking-superclass identity: lives directly under the class
-  // describe (the rule's cross-cutting carve-out).
   it("is an instance of `BaseFabricInstance`", () => {
+    // Subclass-checking-superclass identity: lives directly under the class
+    // describe (the rule's cross-cutting carve-out).
+
     const value = new UnknownValue("Test@1", "state");
     expect(value instanceof BaseFabricInstance).toBe(true);
   });

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -2046,6 +2046,7 @@ describe("JsonCodecEngine", () => {
     // JSON that happens to look similar does not. One case feeds it real
     // encoder output, so the shape recognized here cannot drift from the shape
     // produced.
+
     it("recognizes a string with the encoding prefix", () => {
       expect(JsonCodecEngine.seemsLikeEncoded('fvj1:{"a":1}')).toBe(true);
       expect(JsonCodecEngine.seemsLikeEncoded("fvj1:null")).toBe(true);

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -132,6 +132,7 @@ describe("codecs", () => {
     // by a codec in the registry, and that codec refuses this instance's
     // state. Asserted through the engine rather than the codec, because the
     // contract the spec states is the engine's.
+
     it(
       "throws through the engine, where the format has no form for it",
       async () => {

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -75,11 +75,12 @@ describe("data-uri-codec", () => {
       expect(JsonCodecEngine.seemsLikeEncoded(payload)).toBe(true);
     });
 
-    // The payload is base64url of the UTF-8 form of the encoded text. The id
-    // is that payload, so however the bytes are arrived at, the answer has to
-    // be the one stated here. The cases cover text that is entirely
-    // ASCII, text that is not, and text too long to take any short cut.
     it("mints a payload that is base64url of the encoded text", () => {
+      // The payload is base64url of the UTF-8 form of the encoded text. The id
+      // is that payload, so however the bytes are arrived at, the answer has to
+      // be the one stated here. The cases cover text that is entirely
+      // ASCII, text that is not, and text too long to take any short cut.
+
       const textEncoder = new TextEncoder();
       const values = [
         { x: 1 },
@@ -95,18 +96,20 @@ describe("data-uri-codec", () => {
       }
     });
 
-    // The standard encoding canonicalizes key order, so the minted id is a
-    // function of content alone.
     it("mints the same URI regardless of key insertion order", () => {
+      // The standard encoding canonicalizes key order, so the minted id is a
+      // function of content alone.
+
       const inOrder = { alpha: 1, beta: [2, 3], gamma: { delta: 4 } };
       const scrambled = { gamma: { delta: 4 }, beta: [2, 3], alpha: 1 };
       expect(dataUriFromValue(scrambled)).toBe(dataUriFromValue(inOrder));
     });
 
-    // Canonical order is UTF-8 byte order, which differs from the order a
-    // plain JavaScript string comparison gives whenever a key carries a
-    // surrogate pair.
     it("mints the same URI for keys that a UTF-16 sort would order differently", () => {
+      // Canonical order is UTF-8 byte order, which differs from the order a
+      // plain JavaScript string comparison gives whenever a key carries a
+      // surrogate pair.
+
       const oneWay = { "￿": 1, "\u{10000}": 2 };
       const other = { "\u{10000}": 2, "￿": 1 };
       expect(dataUriFromValue(other)).toBe(dataUriFromValue(oneWay));
@@ -129,11 +132,12 @@ describe("data-uri-codec", () => {
       expect(Object.is(parsed.i, -Infinity)).toBe(true);
     });
 
-    // Distinctness is a separate property from round-tripping, and the more
-    // important one here: these URIs are content addresses, so two values that
-    // are not equal must not mint the same identifier. A codec could round-trip
-    // every value faithfully and still collide.
     it("mints distinct URIs for `-0` and `+0`", () => {
+      // Distinctness is a separate property from round-tripping, and the more
+      // important one here: these URIs are content addresses, so two values
+      // that are not equal must not mint the same identifier. A codec could
+      // round-trip every value faithfully and still collide.
+
       expect(dataUriFromValue(-0)).not.toBe(dataUriFromValue(0));
       expect(dataUriFromValue({ z: -0 })).not.toBe(dataUriFromValue({ z: 0 }));
     });
@@ -149,11 +153,12 @@ describe("data-uri-codec", () => {
       expect(dataUriFromValue(NaN)).not.toBe(dataUriFromValue(-Infinity));
     });
 
-    // Arithmetic only ever yields one `NaN` bit pattern, so `NaN` and `0 / 0`
-    // are the same value and comparing them proves only determinism. A
-    // distinct payload has to be built through a typed-array view, which is
-    // also how one reaches a caller in practice.
     it("mints one URI for every `NaN`, whatever its payload", () => {
+      // Arithmetic only ever yields one `NaN` bit pattern, so `NaN` and `0 / 0`
+      // are the same value and comparing them proves only determinism. A
+      // distinct payload has to be built through a typed-array view, which is
+      // also how one reaches a caller in practice.
+
       const buffer = new ArrayBuffer(8);
       const bytes = new Uint8Array(buffer);
       const doubles = new Float64Array(buffer);
@@ -233,9 +238,10 @@ describe("data-uri-codec", () => {
       );
     });
 
-    // Exactly one media type is accepted; the historical `application/json`
-    // form is not.
     it("throws given the `application/json` media type", () => {
+      // Exactly one media type is accepted; the historical `application/json`
+      // form is not.
+
       const payload = toUnpaddedBase64url(
         new TextEncoder().encode(jsonFromFabricValue({ a: 1 })),
       );
@@ -243,9 +249,10 @@ describe("data-uri-codec", () => {
         .toThrow(/Invalid URI/);
     });
 
-    // There are no header parameters in this format; a header carrying any
-    // fails the media-type check.
     it("throws given header parameters (charset, base64)", () => {
+      // There are no header parameters in this format; a header carrying any
+      // fails the media-type check.
+
       const payload = toUnpaddedBase64url(
         new TextEncoder().encode(jsonFromFabricValue({})),
       );
@@ -277,9 +284,10 @@ describe("data-uri-codec", () => {
       ).toThrow(/not base64url/);
     });
 
-    // Both `data:` URI payload readers (this one and attestation `load()`)
-    // reject an empty payload uniformly; see `valueFromDataUriPayloadText()`.
     it("throws given an empty payload", () => {
+      // Both `data:` URI payload readers (this one and attestation `load()`)
+      // reject an empty payload uniformly; see `valueFromDataUriPayloadText()`.
+
       expect(() => valueFromDataUri(`data:${DATA_URI_MEDIA_TYPE},`))
         .toThrow();
     });
@@ -320,10 +328,12 @@ describe("data-uri-codec", () => {
         expect(Object.is(result.value[2], Infinity)).toBe(true);
       });
 
-      // Sigil links are plain objects with a `/`-prefixed key, which the codec
-      // escapes on encode (spec section 5.6); they must come back as the same
-      // plain objects, since link recognition downstream depends on that shape.
       it("round-trips a plain object with a `/`-prefixed key", () => {
+        // Sigil links are plain objects with a `/`-prefixed key, which the
+        // codec escapes on encode (spec section 5.6); they must come back as
+        // the same plain objects, since link recognition downstream depends on
+        // that shape.
+
         const value = {
           value: { "/": { "link@1": { id: "of:xyz", path: ["a"] } } },
         };

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -132,12 +132,11 @@ describe("data-uri-codec", () => {
       expect(Object.is(parsed.i, -Infinity)).toBe(true);
     });
 
+    // Distinctness is a separate property from round-tripping, and the more
+    // important one here: these URIs are content addresses, so two values that
+    // are not equal must not mint the same identifier. A codec could round-trip
+    // every value faithfully and still collide.
     it("mints distinct URIs for `-0` and `+0`", () => {
-      // Distinctness is a separate property from round-tripping, and the more
-      // important one here: these URIs are content addresses, so two values
-      // that are not equal must not mint the same identifier. A codec could
-      // round-trip every value faithfully and still collide.
-
       expect(dataUriFromValue(-0)).not.toBe(dataUriFromValue(0));
       expect(dataUriFromValue({ z: -0 })).not.toBe(dataUriFromValue({ z: 0 }));
     });

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -65,6 +65,7 @@ describe("deep-freeze", () => {
       // that freeze objects-with-methods keep working. A function's internal
       // `prototype` and closure state stays mutable, which the opacity does not
       // and cannot cover.
+
       it("returns `true` for a function", () => {
         expect(isDeepFrozen(() => {})).toBe(true);
         expect(isDeepFrozen(function () {})).toBe(true);
@@ -247,18 +248,19 @@ describe("deep-freeze", () => {
       });
     });
 
-    // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
-    // inputs, including a `FabricInstance` participating in a circular
-    // reference. `isDeepFrozen`'s recursion threads an
-    // `inProgress: Set<object>` for cycle-safety and resolves a
-    // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member --
-    // inspecting its logical contents, not its enumerable own-props -- so
-    // values held in non-enumerable slots (such as
-    // `FabricError`'s private extras `Map`) are checked too.
-    // (`isValidDeepFrozenFabricValue` uses the same protocol dispatch but
-    // additionally type-guards the value as a `FabricValue`; it has its own
-    // coverage in the sibling describe below.)
     describe("`FabricInstance` and `FabricPrimitive`", () => {
+      // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
+      // inputs, including a `FabricInstance` participating in a circular
+      // reference. `isDeepFrozen`'s recursion threads an
+      // `inProgress: Set<object>` for cycle-safety and resolves a
+      // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member --
+      // inspecting its logical contents, not its enumerable own-props -- so
+      // values held in non-enumerable slots (such as
+      // `FabricError`'s private extras `Map`) are checked too.
+      // (`isValidDeepFrozenFabricValue` uses the same protocol dispatch but
+      // additionally type-guards the value as a `FabricValue`; it has its own
+      // coverage in the sibling describe below.)
+
       it("returns `true` for a `FabricPrimitive` (self-frozen at construction)", () => {
         const epoch = new FabricEpochNsec(1234567890n);
         expect(isDeepFrozen(epoch)).toBe(true);
@@ -472,6 +474,7 @@ describe("deep-freeze", () => {
     // Only registry-interned symbols are `FabricValue`s; unique (uninterned)
     // symbols are not portable across realms and are rejected, consistent with
     // `isValidFabricValue()` / `isValidFabricValueLayer()`.
+
     it("returns `true` for an interned symbol", () => {
       expect(isValidDeepFrozenFabricValue(Symbol.for("k"))).toBe(true);
     });
@@ -512,16 +515,17 @@ describe("deep-freeze", () => {
     });
   });
 
-  // Cycle coverage for `deepFreeze()`'s arms (per the function's doc-comment
-  // 4-arm dispatch) and for `isValidDeepFrozenFabricValue()`, which composes
-  // `isValidFabricValue()` and `isDeepFrozen()` -- each threading its own
-  // cycle-tracking set (`seen` / `inProgress`) through its recursion.
-  //
-  // Termination assertion: a cycle without such threading would manifest as
-  // `RangeError: Maximum call stack size exceeded` (a clean fast throw, not a
-  // hang). `.not.toThrow()` is the discriminating assertion for "this call
-  // terminates."
   describe("cycle behavior", () => {
+    // Cycle coverage for `deepFreeze()`'s arms (per the function's doc-comment
+    // 4-arm dispatch) and for `isValidDeepFrozenFabricValue()`, which composes
+    // `isValidFabricValue()` and `isDeepFrozen()` -- each threading its own
+    // cycle-tracking set (`seen` / `inProgress`) through its recursion.
+    //
+    // Termination assertion: a cycle without such threading would manifest as
+    // `RangeError: Maximum call stack size exceeded` (a clean fast throw, not a
+    // hang). `.not.toThrow()` is the discriminating assertion for "this call
+    // terminates."
+
     describe("`deepFreeze()` (plain object / array)", () => {
       it("terminates on a self-referential plain object", () => {
         const a: Record<string, unknown> = { x: 1 };
@@ -562,6 +566,7 @@ describe("deep-freeze", () => {
       // `isDeepFrozen()`, each of which threads its own cycle-tracking set
       // through its recursion, so the composition is cycle-safe. These tests
       // pin that property so a future change does not regress it.
+
       it("terminates on a deep-frozen self-referential plain object", () => {
         const a: Record<string, unknown> = { x: 1 };
         a.self = a;

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -43,6 +43,7 @@ describe("FabricError", () => {
   // Pure type-identity / supertype checks: they don't fit a single member and
   // aren't about construction mechanics, so they live directly under the class
   // `describe()` (the rule's cross-cutting carve-out).
+
   it("implements `FabricInstance`", () => {
     const se = FabricError.fromNativeError(new Error("test"));
     expect(se instanceof FabricInstance).toBe(true);
@@ -69,6 +70,7 @@ describe("FabricError", () => {
     // decides which class a value comes back as. An own `constructor` property
     // is ordinary data, and reading it there would let a value pick that class
     // for itself.
+
     it("ignores an own `constructor` naming another class", () => {
       const error = new Error("boom");
       Object.defineProperty(error, "constructor", {
@@ -407,10 +409,11 @@ describe("FabricError", () => {
         expect(fe.extraSize).toBe(1);
       });
 
-      // The constructor filters its `extras` input independently of the codec,
-      // which filters again on the way in. Both layers matter: extras carry
-      // whatever the wire supplied, and the constructor is public.
       it("drops unsafe and reserved keys supplied to the constructor", () => {
+        // The constructor filters its `extras` input independently of the
+        // codec, which filters again on the way in. Both layers matter: extras
+        // carry whatever the wire supplied, and the constructor is public.
+
         const fe = new FabricError({
           type: "Error",
           name: "Error",
@@ -555,11 +558,12 @@ describe("FabricError", () => {
       });
     });
 
-    // `FabricError` inherits the `deepClone()` template from
-    // `BaseFabricInstance` and supplies only its `[DEEP_CLONE_CORE]` (a codec
-    // round-trip). These cases pin the template contract for this concrete
-    // implementor.
     describe("deepClone()", () => {
+      // `FabricError` inherits the `deepClone()` template from
+      // `BaseFabricInstance` and supplies only its `[DEEP_CLONE_CORE]` (a codec
+      // round-trip). These cases pin the template contract for this concrete
+      // implementor.
+
       it("returns a deep-frozen clone with equal state", () => {
         const fe = FabricError.fromNativeError(
           new Error("boom", { cause: { detail: 1 } }),
@@ -602,13 +606,14 @@ describe("FabricError", () => {
         expect(fe.message).toBe("outer");
       });
 
-      // KNOWN GAP (pre-existing): the clone core round-trips through
-      // `[CODEC]`, whose `encode()` passes `cause` (and extras) through by
-      // reference, so an *unfrozen* deep clone still shares its nested
-      // `cause` with the original -- contrary to the `deepClone(false)`
-      // contract on `FabricInstance`. Pinned to record the actual behavior,
-      // not to bless it.
       it("returns a mutable clone that currently SHARES the nested `cause` reference (known gap)", () => {
+        // KNOWN GAP (pre-existing): the clone core round-trips through
+        // `[CODEC]`, whose `encode()` passes `cause` (and extras) through by
+        // reference, so an *unfrozen* deep clone still shares its nested
+        // `cause` with the original -- contrary to the `deepClone(false)`
+        // contract on `FabricInstance`. Pinned to record the actual behavior,
+        // not to bless it.
+
         const cause = { detail: 1 };
         const fe = FabricError.fromNativeError(new Error("outer", { cause }));
         const clone = fe.deepClone(false) as FabricError;
@@ -666,9 +671,10 @@ describe("FabricError", () => {
         });
       });
 
-      // Decoding hand-built state (not via `encode()`): exercises name/type
-      // handling and back-compat that the round-trip tests don't.
       describe("canDecode()", () => {
+        // Decoding hand-built state (not via `encode()`): exercises name/type
+        // handling and back-compat that the round-trip tests don't.
+
         it("returns `true` for a record", () => {
           expect(codec.canDecode({ type: "Error", message: "boop" }))
             .toBe(true);
@@ -685,10 +691,12 @@ describe("FabricError", () => {
       });
 
       describe("decode()", () => {
-        // `JSON.parse` creates an own `__proto__` property where an object
-        // literal instead invokes the setter, so parsed wire state is the one
-        // place a prototype-sensitive key genuinely arrives as decodable input.
         it("drops a `__proto__` key arriving from parsed wire state", () => {
+          // `JSON.parse` creates an own `__proto__` property where an object
+          // literal instead invokes the setter, so parsed wire state is the one
+          // place a prototype-sensitive key genuinely arrives as decodable
+          // input.
+
           const state = JSON.parse(
             '{"type":"Error","message":"x","__proto__":"bad","code":7}',
           );

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -38,9 +38,10 @@ import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricLink", () => {
-  // Pure type-identity / supertype check: cross-cutting carve-out per the
-  // rule (doesn't fit a single member, isn't construction mechanics).
   it("extends `FabricInstance` (not `FabricPrimitive`)", () => {
+    // Pure type-identity / supertype check: cross-cutting carve-out per the
+    // rule (doesn't fit a single member, isn't construction mechanics).
+
     const link = new FabricLink({ id: "fid1:abc" });
     expect(link instanceof FabricInstance).toBe(true);
     expect(link instanceof FabricPrimitive).toBe(false);
@@ -257,9 +258,10 @@ describe("FabricLink", () => {
     });
   });
 
-  // Free functions exercising `FabricLink` rather than members of the class
-  // itself, so they live directly under the class `describe()`.
   describe("round-trip via `jsonFromFabricValue()` / `fabricFromJsonValue()`", () => {
+    // Free functions exercising `FabricLink` rather than members of the class
+    // itself, so they live directly under the class `describe()`.
+
     it("round-trips a `FabricLink`, including a nested schema", () => {
       const original = new FabricLink({
         id: "fid1:abc",
@@ -294,9 +296,10 @@ describe("FabricLink", () => {
     });
   });
 
-  // A `FabricLink` nested in a container must clone through the generic
-  // `FabricInstance` clone path (no dedicated dispatch case anymore).
   describe("generic clone dispatch (nested in a container)", () => {
+    // A `FabricLink` nested in a container must clone through the generic
+    // `FabricInstance` clone path (no dedicated dispatch case anymore).
+
     it("deep-clones a container holding one without throwing", () => {
       const link = new FabricLink({ id: "fid1:abc" });
       const cloned = cloneIfNecessary({ link }, { frozen: true });

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -30,6 +30,7 @@ import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 describe("FabricMap", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
   // rule (they don't fit a single member, aren't construction mechanics).
+
   it("implements `FabricInstance`", () => {
     const sm = new FabricMap(new Map());
     expect(sm instanceof FabricInstance).toBe(true);
@@ -77,9 +78,10 @@ describe("FabricMap", () => {
       });
     });
 
-    // The protocol methods are unimplemented stubs that throw, which these
-    // cases pin at both entry points: dispatch and direct invocation.
     describe("[DEEP_FREEZE]", () => {
+      // The protocol methods are unimplemented stubs that throw, which these
+      // cases pin at both entry points: dispatch and direct invocation.
+
       describe("via dispatch", () => {
         it("throws not-yet-implemented", () => {
           const fm = new FabricMap(
@@ -131,10 +133,11 @@ describe("FabricMap", () => {
   });
 
   describe("static members", () => {
-    // Nominal coverage: the codec exists and reports its wire tag and claims
-    // its instances, but `encode()` / `decode()` are throwing stubs until
-    // `Map` support is implemented.
     describe("[CODEC]", () => {
+      // Nominal coverage: the codec exists and reports its wire tag and claims
+      // its instances, but `encode()` / `decode()` are throwing stubs until
+      // `Map` support is implemented.
+
       const codec = FabricMap[CODEC];
       const expectedTag = CODEC_TYPE_TAGS.Map;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -27,9 +27,10 @@ import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 
 describe("FabricSet", () => {
-  // Pure type-identity / supertype check: cross-cutting carve-out per the
-  // rule (doesn't fit a single member, isn't construction mechanics).
   it("implements `FabricInstance`", () => {
+    // Pure type-identity / supertype check: cross-cutting carve-out per the
+    // rule (doesn't fit a single member, isn't construction mechanics).
+
     const ss = new FabricSet(new Set());
     expect(ss instanceof FabricInstance).toBe(true);
   });
@@ -115,10 +116,11 @@ describe("FabricSet", () => {
   });
 
   describe("static members", () => {
-    // Nominal coverage: the codec exists and reports its wire tag and claims
-    // its instances, but `encode()` / `decode()` are throwing stubs until
-    // `Set` support is implemented.
     describe("[CODEC]", () => {
+      // Nominal coverage: the codec exists and reports its wire tag and claims
+      // its instances, but `encode()` / `decode()` are throwing stubs until
+      // `Set` support is implemented.
+
       const codec = FabricSet[CODEC];
       const expectedTag = CODEC_TYPE_TAGS.Set;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -22,9 +22,10 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 
 describe("FabricBytes", () => {
-  // Pure type-identity / supertype check: cross-cutting carve-out per the
-  // rule (doesn't fit a single member, isn't construction mechanics).
   it("extends `FabricPrimitive` (not `FabricInstance`)", () => {
+    // Pure type-identity / supertype check: cross-cutting carve-out per the
+    // rule (doesn't fit a single member, isn't construction mechanics).
+
     const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
     expect(fb instanceof FabricPrimitive).toBe(true);
     expect(fb instanceof FabricInstance).toBe(false);

--- a/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
@@ -25,6 +25,7 @@ import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 describe("FabricEpochDay", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
   // rule (don't fit a single member, aren't construction mechanics).
+
   it("is an instance of `FabricPrimitive`", () => {
     expect(new FabricEpochDay(0n) instanceof FabricPrimitive).toBe(
       true,
@@ -158,9 +159,10 @@ describe("FabricEpochDay", () => {
     });
   });
 
-  // Exercises the free `shallowFabricFromNativeValue()` rather than a member
-  // of the class, so it lives directly under the class `describe()`.
   describe("`shallowFabricFromNativeValue()` integration", () => {
+    // Exercises the free `shallowFabricFromNativeValue()` rather than a member
+    // of the class, so it lives directly under the class `describe()`.
+
     it("passes through unchanged even with `freeze=false`", () => {
       const days = new FabricEpochDay(456n);
       // freeze=false should still return the same instance (not a copy).

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -25,6 +25,7 @@ import { FabricInstance, FabricPrimitive } from "@/interface.ts";
 describe("FabricEpochNsec", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
   // rule (don't fit a single member, aren't construction mechanics).
+
   it("is an instance of `FabricPrimitive`", () => {
     expect(new FabricEpochNsec(0n) instanceof FabricPrimitive).toBe(
       true,
@@ -178,9 +179,10 @@ describe("FabricEpochNsec", () => {
     });
   });
 
-  // Exercises the free `shallowFabricFromNativeValue()` rather than a member
-  // of the class, so it lives directly under the class `describe()`.
   describe("`shallowFabricFromNativeValue()` integration", () => {
+    // Exercises the free `shallowFabricFromNativeValue()` rather than a member
+    // of the class, so it lives directly under the class `describe()`.
+
     it("passes through unchanged even with `freeze=false`", () => {
       const nsec = new FabricEpochNsec(123n);
       // freeze=false should still return the same instance (not a copy).

--- a/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
@@ -497,11 +497,12 @@ describe("FabricKeyPair", () => {
   });
 
   describe("as a `FabricValue`", () => {
-    // An instance in either state has to pass the vetting boundary. The
-    // realm encoding does not vet what it passes through, so a value that
-    // fails here can still cross and still work, right up until something
-    // checks it.
     it("returns `true` from `isValidFabricValue()` in either state", async () => {
+      // An instance in either state has to pass the vetting boundary. The
+      // realm encoding does not vet what it passes through, so a value that
+      // fails here can still cross and still work, right up until something
+      // checks it.
+
       expect(isValidFabricValue(materialPair())).toBe(true);
       expect(isValidFabricValue(new FabricKeyPair(await generatePair())))
         .toBe(true);

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -35,9 +35,10 @@ import { VALUE_TAGS } from "@/VALUE_TAGS.ts";
 import { hashOf } from "@/value-hash.ts";
 
 describe("FabricRegExp", () => {
-  // Pure type-identity / supertype check: cross-cutting carve-out per the
-  // rule (doesn't fit a single member, isn't construction mechanics).
   it("extends `FabricPrimitive` (not `FabricInstance`)", () => {
+    // Pure type-identity / supertype check: cross-cutting carve-out per the
+    // rule (doesn't fit a single member, isn't construction mechanics).
+
     const re = new FabricRegExp(/abc/gi);
     expect(re instanceof FabricPrimitive).toBe(true);
     expect(re instanceof FabricInstance).toBe(false);
@@ -283,10 +284,11 @@ describe("FabricRegExp", () => {
     });
   });
 
-  // The following exercise free functions' handling of `FabricRegExp` /
-  // `RegExp` rather than members of the class itself, so they live directly
-  // under the class `describe()` (the cross-cutting carve-out).
   describe("round-trip via `jsonFromFabricValue()` / `fabricFromJsonValue()`", () => {
+    // The following exercise free functions' handling of `FabricRegExp` /
+    // `RegExp` rather than members of the class itself, so they live directly
+    // under the class `describe()` (the cross-cutting carve-out).
+
     it("round-trips a `FabricRegExp`", () => {
       const original = new FabricRegExp(/hello\s+world/gim);
       const restored = fabricFromJsonValue(

--- a/packages/data-model/test/frozen-builtins.test.ts
+++ b/packages/data-model/test/frozen-builtins.test.ts
@@ -155,12 +155,13 @@ describe("frozen-builtins", () => {
       expect([...fm.entries()]).toEqual([["a", 1]]);
     });
 
-    // Keys go through `Map.prototype.set`, which carries the same signed-zero
-    // normalization as `Set.prototype.add`. This is a separate construction
-    // site from `FrozenSet`'s, so the equivalent `FrozenSet` cases below do
-    // not reach it -- see the rationale on that block for why the behavior is
-    // deliberate rather than a defect.
     describe("non-finite and signed-zero keys", () => {
+      // Keys go through `Map.prototype.set`, which carries the same signed-zero
+      // normalization as `Set.prototype.add`. This is a separate construction
+      // site from `FrozenSet`'s, so the equivalent `FrozenSet` cases below do
+      // not reach it -- see the rationale on that block for why the behavior is
+      // deliberate rather than a defect.
+
       it("normalizes a `-0` key to `+0`, as `Map` does", () => {
         const fm = new FrozenMap<number, string>([[-0, "a"]]);
 
@@ -355,10 +356,11 @@ describe("frozen-builtins", () => {
         expect(empty.isDisjointFrom(new Set([1]))).toBe(true);
       });
 
-      // `Set.prototype.intersection` iterates whichever operand is smaller,
-      // so the result's iteration order follows that operand rather than
-      // always following the receiver.
       it("takes `intersection()` order from the smaller operand", () => {
+        // `Set.prototype.intersection` iterates whichever operand is smaller,
+        // so the result's iteration order follows that operand rather than
+        // always following the receiver.
+
         const fs = new FrozenSet<number>([1, 2, 3, 4, 5]);
         expect([...fs.intersection(new Set([5, 1]))]).toEqual([5, 1]);
       });
@@ -368,12 +370,13 @@ describe("frozen-builtins", () => {
         expect([...fs.intersection(new Set([1, 2, 3, 4, 5]))]).toEqual([5, 1]);
       });
 
-      // Equal sizes are the boundary between the two branches, and the
-      // intrinsic iterates the receiver there. The operands below share their
-      // elements but not their order, so the result distinguishes which side
-      // was iterated -- which an equal-size case with coinciding orders
-      // cannot.
       it("takes `intersection()` order from itself on equal sizes", () => {
+        // Equal sizes are the boundary between the two branches, and the
+        // intrinsic iterates the receiver there. The operands below share their
+        // elements but not their order, so the result distinguishes which side
+        // was iterated -- which an equal-size case with coinciding orders
+        // cannot.
+
         const fs = new FrozenSet<number>([1, 2]);
         expect([...fs.intersection(new Set([2, 1]))]).toEqual([1, 2]);
       });
@@ -399,6 +402,7 @@ describe("frozen-builtins", () => {
       //
       // `toBe()` compares with `Object.is()`, which tells `-0` from `+0`.
       // `toEqual()` does not, and would make these assertions vacuous.
+
       it("normalizes `-0` to `+0` on insertion, as `Set` does", () => {
         const fs = new FrozenSet<number>([-0]);
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -472,15 +472,16 @@ describe("native-conversion", () => {
     });
   });
 
-  // Cycle-capable wired impls: `FabricError` (recurses through `error.cause`
-  // + custom enumerable own properties), `ProblematicValue` (recurses through
-  // `state`), `UnknownValue` (recurses through `state`).
-  //
-  // Termination assertion: a cycle without shared-`inProgress` threading
-  // would manifest as `RangeError: Maximum call stack size exceeded` (a
-  // clean fast throw, not a hang); `.not.toThrow()` is the discriminating
-  // assertion.
   describe("cycle behavior via `[DEEP_FREEZE]`", () => {
+    // Cycle-capable wired impls: `FabricError` (recurses through `error.cause`
+    // + custom enumerable own properties), `ProblematicValue` (recurses through
+    // `state`), `UnknownValue` (recurses through `state`).
+    //
+    // Termination assertion: a cycle without shared-`inProgress` threading
+    // would manifest as `RangeError: Maximum call stack size exceeded` (a
+    // clean fast throw, not a hang); `.not.toThrow()` is the discriminating
+    // assertion.
+
     describe("FabricError", () => {
       it("terminates on a cycle through `error.cause`", () => {
         // Build a cycle: a plain-object wrapper holds the FabricError, and the
@@ -596,13 +597,14 @@ describe("native-conversion", () => {
       }
     });
 
-    // The `undefined` is not a verdict on the value: it reports that there was
-    // nothing to mint, which is as true of a `Map` -- a `FabricNativeObject`
-    // whose fabric form has yet to be built -- as of a function. What protects
-    // a caller is the pair, so this pins the pair rather than either half. A
-    // `Map` that reached a walk would be rebuilt from its (empty) entries as
-    // a bare `{}`.
     it("leaves a `Map` and a `Set` to the vet, which refuses them", () => {
+      // The `undefined` is not a verdict on the value: it reports that there
+      // was nothing to mint, which is as true of a `Map` -- a
+      // `FabricNativeObject` whose fabric form has yet to be built -- as of a
+      // function. What protects a caller is the pair, so this pins the pair
+      // rather than either half. A `Map` that reached a walk would be rebuilt
+      // from its (empty) entries as a bare `{}`.
+
       for (const value of [new Map(), new Set()]) {
         expect(shallowFabricFromNativeObjectElseUndefined(value)).toBe(
           undefined,
@@ -810,11 +812,12 @@ describe("native-conversion", () => {
           expect(shallowFabricFromNativeValue(value)).toBe(value);
         });
 
-        // `freeze: false` skips the deep-frozen identity shortcut in
-        // `fabricFromNativeValue()`, which is what the sandbox boundary
-        // passes for an action result, so it reaches the `switch` that
-        // `shallowFabricFromNativeValue()` shares.
         it(`carries a \`${name}\` nested in an object, unfrozen`, () => {
+          // `freeze: false` skips the deep-frozen identity shortcut in
+          // `fabricFromNativeValue()`, which is what the sandbox boundary
+          // passes for an action result, so it reaches the `switch` that
+          // `shallowFabricFromNativeValue()` shares.
+
           const result = fabricFromNativeValue({ v: value }, false) as {
             v: unknown;
           };
@@ -831,10 +834,11 @@ describe("native-conversion", () => {
       });
     });
 
-    // "Death before confusion": a native type with a dedicated fabric
-    // representation carries no room for extra state, so silently dropping it
-    // would lose data on a round trip.
     describe("rejects extra enumerable properties", () => {
+      // "Death before confusion": a native type with a dedicated fabric
+      // representation carries no room for extra state, so silently dropping it
+      // would lose data on a round trip.
+
       it("throws for a `Date` carrying an extra property", () => {
         const date = new Date(0) as Date & { extra?: number };
         date.extra = 1;
@@ -870,10 +874,11 @@ describe("native-conversion", () => {
       });
     });
 
-    // A value that has no fabric representation of its own does not acquire
-    // one by naming the JSON protocol's method, and a record that happens to
-    // carry that name is read as the record it is.
     describe("`toJSON()` is intentionally not supported", () => {
+      // A value that has no fabric representation of its own does not acquire
+      // one by naming the JSON protocol's method, and a record that happens to
+      // carry that name is read as the record it is.
+
       it("throws for a function carrying `toJSON()`", () => {
         const fn = Object.assign(() => {}, {
           toJSON: () => "converted function",
@@ -913,14 +918,13 @@ describe("native-conversion", () => {
       });
     });
 
-    // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
-    // members and pass through unchanged.
     describe("property names this runtime reserves", () => {
       // A restriction of this runtime rather than of the data model: such an
       // object is perfectly inert, and its keys are strings like any other.
       // `__proto__` is refused because the assignment that rebuilds records
       // cannot create it, `constructor` because other boundaries here already
       // drop or refuse it.
+
       it("throws for `__proto__`, naming it as the cause", () => {
         expect(() => fabricFromNativeValue({ ["__proto__"]: 1, a: 2 })).toThrow(
           "Not representable as a `FabricValue`: object with a property name " +
@@ -951,6 +955,9 @@ describe("native-conversion", () => {
     });
 
     describe("special numbers", () => {
+      // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
+      // members and pass through unchanged.
+
       it("passes `NaN` through", () => {
         expect(Number.isNaN(shallowFabricFromNativeValue(NaN))).toBe(true);
       });
@@ -965,9 +972,10 @@ describe("native-conversion", () => {
       });
     });
 
-    // Registry-interned symbols (`Symbol.for(key)`) are `FabricValue`s and
-    // pass through; unique symbols (`Symbol(desc)`) are rejected.
     describe("interned symbols", () => {
+      // Registry-interned symbols (`Symbol.for(key)`) are `FabricValue`s and
+      // pass through; unique symbols (`Symbol(desc)`) are rejected.
+
       it("passes an interned symbol through", () => {
         const sym = Symbol.for("k");
         // Interned symbols are primitives -- pass-through, no wrapping.
@@ -1412,9 +1420,10 @@ describe("native-conversion", () => {
       });
     });
 
-    // Cause and custom properties must be recursively converted to
-    // `FabricValue` before wrapping in `FabricError`.
     describe("converts `Error` internals (cause and custom properties)", () => {
+      // Cause and custom properties must be recursively converted to
+      // `FabricValue` before wrapping in `FabricError`.
+
       it("converts `Error` with raw `Error` cause into nested `FabricError`", () => {
         const inner = new Error("inner");
         const outer = new Error("outer", { cause: inner });
@@ -1823,9 +1832,10 @@ describe("native-conversion", () => {
       });
     });
 
-    // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
-    // members and pass through unchanged.
     describe("special numbers", () => {
+      // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
+      // members and pass through unchanged.
+
       it("passes special numbers through", () => {
         expect(Number.isNaN(fabricFromNativeValue(NaN))).toBe(true);
         expect(fabricFromNativeValue(Infinity)).toBe(Infinity);
@@ -1859,9 +1869,10 @@ describe("native-conversion", () => {
       });
     });
 
-    // Registry-interned symbols (`Symbol.for(key)`) are `FabricValue`s and
-    // pass through; unique symbols (`Symbol(desc)`) are rejected.
     describe("interned symbols", () => {
+      // Registry-interned symbols (`Symbol.for(key)`) are `FabricValue`s and
+      // pass through; unique symbols (`Symbol(desc)`) are rejected.
+
       it("passes an interned symbol through", () => {
         const sym = Symbol.for("top-level");
         expect(fabricFromNativeValue(sym)).toBe(sym);

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -203,6 +203,7 @@ describe("native-type-tags", () => {
       // classifier that consulted it would let one assignment --
       // `Array.prototype.toJSON`, an own key on a record -- redirect values
       // wholesale.
+
       it("returns `Object` tag for a plain object carrying `toJSON()`", () => {
         expect(tagFromNativeValue({ toJSON: () => "converted" })).toBe(
           VALUE_TAGS.Object,

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -663,11 +663,12 @@ describe("type-check", () => {
     });
 
     describe("given a non-container `FabricValue`", () => {
-      // The whole of the difference from `isFabricObjectOrArray()`, which
-      // accepts these: a `FabricPrimitive` self-freezes at construction and
-      // exposes no `FabricValue` for a walk to descend into, whatever it holds
-      // privately.
       it("returns `false` for a `FabricPrimitive`", () => {
+        // The whole of the difference from `isFabricObjectOrArray()`, which
+        // accepts these: a `FabricPrimitive` self-freezes at construction and
+        // exposes no `FabricValue` for a walk to descend into, whatever it
+        // holds privately.
+
         expect(isFabricContainerValue(new FabricBytes(new Uint8Array([1]))))
           .toBe(false);
         expect(isFabricContainerValue(new FabricEpochNsec(1n))).toBe(false);
@@ -810,9 +811,10 @@ describe("type-check", () => {
       });
     }
 
-    // Agreement is free for a predicate that has drifted to one side, so that
-    // the corpus lands on both answers is asserted rather than assumed.
     it("is checked against both answers", () => {
+      // Agreement is free for a predicate that has drifted to one side, so that
+      // the corpus lands on both answers is asserted rather than assumed.
+
       const answers = LAYER_CORPUS.map(([, value]) =>
         isValidFabricNativeObject(value)
       );
@@ -871,9 +873,10 @@ describe("type-check", () => {
         expect(refused.length).toBeGreaterThan(0);
       });
 
-      // The predicate's accepting side is a chain of shape tests, so a class
-      // the corpus never carries is a branch no cross-check above reaches.
       it("carries every registered primitive class", () => {
+        // The predicate's accepting side is a chain of shape tests, so a class
+        // the corpus never carries is a branch no cross-check above reaches.
+
         const carried = new Set(
           LAYER_CORPUS.map(([, value]) =>
             (value as object)?.constructor as unknown

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -121,10 +121,11 @@ describe("toStructuredDebugValue()", () => {
     });
   });
 
-  // Every case here holds at least one value that does not survive conversion
-  // unchanged, so that a walk which returned its input untouched would be
-  // caught. A container of scalars alone cannot tell the two apart.
   describe("containers", () => {
+    // Every case here holds at least one value that does not survive conversion
+    // unchanged, so that a walk which returned its input untouched would be
+    // caught. A container of scalars alone cannot tell the two apart.
+
     it("returns a plain object with its values converted", () => {
       expect(
         toStructuredDebugValue({ a: 1, fn: function foo() {}, m: new Map() }),
@@ -544,9 +545,10 @@ describe("toStructuredDebugValue()", () => {
       expect(result.z).toBe(2);
     });
 
-    // What lands in the `/unconvertible` payload depends on what was thrown,
-    // and anything at all can be thrown.
     describe("the `/unconvertible` message", () => {
+      // What lands in the `/unconvertible` payload depends on what was thrown,
+      // and anything at all can be thrown.
+
       /** Converts a value whose sole property throws `thrown` when read. */
       function messageFor(thrown: unknown): unknown {
         const value = {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -509,6 +509,7 @@ describe("value-debug", () => {
     // fields, which have no enumerable own properties for an inspector to find.
     // The elided `(...)` is the debug renderer's own current limitation, marked
     // by a TODO there; delegating means this surface inherits the fix.
+
     it("renders a FabricPrimitive as its debug string, not `{}`", () => {
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
       expect(Deno.inspect(bytes)).toBe("/Bytes(...)");

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1373,11 +1373,12 @@ describe("value-hash", () => {
     });
   });
 
-  // Registry-interned symbols: hashed via TAG_SYMBOL (0x2a) followed by a
-  // self-tagged string-rep of `Symbol.keyFor(s)` (i.e., the same byte stream
-  // that a plain string of that key would feed). Unique (uninterned) symbols
-  // have no portable key and throw.
   describe("`hashOf()` interned symbols", () => {
+    // Registry-interned symbols: hashed via TAG_SYMBOL (0x2a) followed by a
+    // self-tagged string-rep of `Symbol.keyFor(s)` (i.e., the same byte stream
+    // that a plain string of that key would feed). Unique (uninterned) symbols
+    // have no portable key and throw.
+
     it("takes the inline TAG_STRING path for a short key", () => {
       // utf8Length(3) <= MAX_DIRECT_STRING_LENGTH(64), so the key is fed as
       // [TAG_STRING][len][utf8].

--- a/packages/data-model/test/valueEqual.test.ts
+++ b/packages/data-model/test/valueEqual.test.ts
@@ -119,19 +119,20 @@ describe("valueEqual()", () => {
     expect(valueEqual([1, , 3], [1, , 3])).toBe(true);
   });
 
-  // Value equality follows `Object.is()`: `-0` and `+0` are distinct, all
-  // `NaN`s are equal, and the two infinities are distinct (spec §6.7).
-  //
-  // Two different mechanisms produce that, and they need separate tests. A
-  // top-level primitive is settled by the `Object.is()` fast path; a primitive
-  // nested in a container never reaches that path, and is settled by the
-  // canonical content hash instead. Testing only the top level would leave the
-  // nested behavior resting on an untested second implementation.
-  //
-  // Each assertion below is on a boolean, so the matcher never has to tell
-  // `-0` from `+0` itself -- the weird number is always an input, and it is
-  // the implementation's comparison that decides the result.
   describe("non-finite and signed-zero values", () => {
+    // Value equality follows `Object.is()`: `-0` and `+0` are distinct, all
+    // `NaN`s are equal, and the two infinities are distinct (spec §6.7).
+    //
+    // Two different mechanisms produce that, and they need separate tests. A
+    // top-level primitive is settled by the `Object.is()` fast path; a
+    // primitive nested in a container never reaches that path, and is settled
+    // by the canonical content hash instead. Testing only the top level would
+    // leave the nested behavior resting on an untested second implementation.
+    //
+    // Each assertion below is on a boolean, so the matcher never has to tell
+    // `-0` from `+0` itself -- the weird number is always an input, and it is
+    // the implementation's comparison that decides the result.
+
     it("holds `-0` distinct from `+0` at the top level", () => {
       expect(valueEqual(-0, 0)).toBe(false);
       expect(valueEqual(0, -0)).toBe(false);
@@ -173,13 +174,14 @@ describe("valueEqual()", () => {
       expect(valueEqual({ a: { b: [NaN] } }, { a: { b: [NaN] } })).toBe(true);
     });
 
-    // Every case above uses the literal `NaN` on both sides, which pins that a
-    // `NaN` equals itself through the hash path but not that distinct `NaN`
-    // payloads unify. That unification is a deliberate step -- the hash feeds a
-    // canonical byte sequence for any `NaN` rather than the value's own bits --
-    // and arithmetic never produces a second payload, so reaching one takes a
-    // typed-array view.
     it("holds distinct `NaN` payloads equal inside a container", () => {
+      // Every case above uses the literal `NaN` on both sides, which pins that
+      // a `NaN` equals itself through the hash path but not that distinct `NaN`
+      // payloads unify. That unification is a deliberate step -- the hash feeds
+      // a canonical byte sequence for any `NaN` rather than the value's own
+      // bits -- and arithmetic never produces a second payload, so reaching one
+      // takes a typed-array view.
+
       const buffer = new ArrayBuffer(8);
       const bytes = new Uint8Array(buffer);
       const doubles = new Float64Array(buffer);
@@ -205,10 +207,11 @@ describe("valueEqual()", () => {
     });
   });
 
-  // CT-1770: FabricPrimitives keep their state in private fields, so a
-  // generic enumerable-own-prop comparison (`deepEqual`) conflates every
-  // distinct same-class instance. `valueEqual` compares them by content.
   describe("FabricSpecialObject values (CT-1770)", () => {
+    // CT-1770: FabricPrimitives keep their state in private fields, so a
+    // generic enumerable-own-prop comparison (`deepEqual`) conflates every
+    // distinct same-class instance. `valueEqual` compares them by content.
+
     it("distinguishes FabricBytes by content", () => {
       const a = new FabricBytes(new Uint8Array([1, 2, 3, 4]));
       const b = new FabricBytes(new Uint8Array([9, 8, 7, 6]));
@@ -255,16 +258,17 @@ describe("valueEqual()", () => {
     });
   });
 
-  // Content equality is independent of frozen-state. The three states differ
-  // only in which internal path decides them:
-  //   DF (deep-frozen)            -> the both-deep-frozen early-hash fast-path
-  //                                  (only when BOTH sides are DF).
-  //   F  (frozen, NOT deep-frozen) -> shallow `Object.freeze` with a non-frozen
-  //                                  nested value fails `isDeepFrozen()`, so it
-  //                                  takes the general subtype + hash path.
-  //   U  (unfrozen)                -> likewise the general subtype + hash path.
-  // Every pairing must agree on the result regardless of state.
   describe("frozen-state matrix", () => {
+    // Content equality is independent of frozen-state. The three states differ
+    // only in which internal path decides them:
+    // DF (deep-frozen)            -> the both-deep-frozen early-hash fast-path
+    //                                (only when BOTH sides are DF).
+    // F  (frozen, NOT deep-frozen) -> shallow `Object.freeze` with a non-frozen
+    //                                nested value fails `isDeepFrozen()`, so it
+    //                                takes the general subtype + hash path.
+    // U  (unfrozen)                -> likewise the general subtype + hash path.
+    // Every pairing must agree on the result regardless of state.
+
     // The nested array keeps the shallow-frozen `F` build genuinely
     // not-deep-frozen (an all-primitive shallow freeze reads as deep-frozen).
     const equalShape = () => ({ a: 1, b: [2, 3] });
@@ -299,9 +303,10 @@ describe("valueEqual()", () => {
     }
   });
 
-  // The cheap subtype short-circuits that resolve an object comparison
-  // without computing a hash (taken when the sides are not both deep-frozen).
   describe("object-subtype-check branch", () => {
+    // The cheap subtype short-circuits that resolve an object comparison
+    // without computing a hash (taken when the sides are not both deep-frozen).
+
     describe("given a plain object and an array", () => {
       it("returns `false`", () => {
         expect(valueEqual({ 0: 1, 1: 2 }, [1, 2])).toBe(false);

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -342,6 +342,7 @@ describe("arrays", () => {
     describe("subsumes the index-only check", () => {
       // `isInertArray()` includes everything
       // `isArrayWithOnlyIndexProperties()` checks; callers never need both.
+
       it("rejects a named property", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";

--- a/packages/utils/test/base64url.test.ts
+++ b/packages/utils/test/base64url.test.ts
@@ -35,10 +35,6 @@ function arrayString(arr: readonly number[]): string {
   return result.join("");
 }
 
-//
-// `toUnpaddedBase64url()` and polyfill
-//
-
 for (const toBase64 of [toUnpaddedBase64url, toBase64Polyfill]) {
   describe(`${toBase64.name}()`, () => {
     for (const { arr, b64 } of TEST_PAIRS) {
@@ -49,10 +45,6 @@ for (const toBase64 of [toUnpaddedBase64url, toBase64Polyfill]) {
     }
   });
 }
-
-//
-// `fromBase64url()` and polyfill
-//
 
 for (const fromBase64 of [fromBase64url, fromBase64Polyfill]) {
   describe(`${fromBase64.name}()`, () => {
@@ -71,10 +63,6 @@ for (const fromBase64 of [fromBase64url, fromBase64Polyfill]) {
     }
   });
 }
-
-//
-// `toUnpaddedBase64urlFromText()`
-//
 
 describe("toUnpaddedBase64urlFromText()", () => {
   const textEncoder = new TextEncoder();
@@ -111,10 +99,6 @@ describe("toUnpaddedBase64urlFromText()", () => {
     expect(long).toBe(toUnpaddedBase64url(textEncoder.encode("z".repeat(400))));
   });
 });
-
-//
-// Base64url round-trip
-//
 
 describe("base64url round-trip", () => {
   it("round-trips various byte arrays", () => {

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -224,10 +224,6 @@ const referenceFixtures: readonly Fixture[] = [
   ),
 ];
 
-//
-// Tests to validate reference encoder
-//
-
 describe("`referenceEncode()` (test oracle)", () => {
   it("encodes all reference fixtures as expected", () => {
     // A small set of explicit byte-level assertions that pin `referenceEncode`

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -229,10 +229,11 @@ const referenceFixtures: readonly Fixture[] = [
 //
 
 describe("`referenceEncode()` (test oracle)", () => {
-  // A small set of explicit byte-level assertions that pin `referenceEncode`
-  // against the spec. The rest of the suite trusts it as an oracle, so it
-  // matters that these can't both be wrong in the same way.
   it("encodes all reference fixtures as expected", () => {
+    // A small set of explicit byte-level assertions that pin `referenceEncode`
+    // against the spec. The rest of the suite trusts it as an oracle, so it
+    // matters that these can't both be wrong in the same way.
+
     for (const { value, encoded, label } of referenceFixtures) {
       try {
         expect(referenceEncode(value)).toEqual(new Uint8Array(encoded));

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -247,6 +247,7 @@ describe("objects", () => {
     // dispatch is: it needs the prototype for its own null test, so asking it
     // to hand the object over and have the prototype read again would be one
     // read too many and a second answer to disagree with.
+
     it("returns the constructor a prototype names", () => {
       expect(constructorOfPrototype(Object.prototype)).toBe(Object);
       expect(constructorOfPrototype(Map.prototype)).toBe(Map);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`unit-test-coding-style.md` places a comment about a test or a group of tests
inside the block's callback, as its first content, followed by a blank line.
Above the call, adjacency is the only thing holding it there, and the next
block inserted at that line lands between the comment and its subject.

This conforms the first five packages: `data-model`, `utils`, `content-hash`,
`leb128` and `pure-json`. The last two carry no such comment; the other three
carry 75 between them, in 28 files.

- **57 move** into the block they describe.
- **17 stay** and take only the blank line: each already sits at the top of the
  block whose whole content it describes, so the comment is already in the
  right place and only the separation from the first statement was missing.
- **1 was the failure the rule names, found in place.** In
  `native-conversion.test.ts` a comment reading "`-0`, `NaN`, `+Infinity`, and
  `-Infinity` are valid `FabricValue` members and pass through unchanged" sat
  above `describe("property names this runtime reserves")`, two blocks above
  the `describe("special numbers")` it describes, which had none. The same
  comment heads the corresponding `special numbers` block further down the
  file, so what it belongs to is not in doubt. It moves to its subject rather
  than into the block it happened to sit above.

Re-indenting pushed nineteen lines past 80 columns. The prose among them is
rewrapped; the state-matrix table in `valueEqual.test.ts` shifts left by two
so its alignment survives the extra indent.

## What the diff is, as a property

Across the 28 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0).
- Per file, the multiset of comment words is unchanged.
- Per file, the multiset of non-comment lines is unchanged.

Both halves of that check were controlled: altering one comment word, and
altering one `expect()` line, each turn it red, naming the file and the token.

## Five section markers that only name the block below them

A marker earns its place by titling a region; one that restates the block
beneath it adds nothing the code does not already state. Five in `utils` are
that: four in `base64url.test.ts` naming the function each region tests, and
one in `bigint.test.ts` reading "Tests to validate reference encoder" over
`describe("`referenceEncode()` (test oracle)")`. They go. The words removed
across the two files are exactly those five titles, and no word is added.

The markers left standing in these packages title a region descriptively --
"Same-object benchmarks (measures cache effectiveness)", "Per-function fixture
loops" -- and are not restatements. One is a judgment call left alone:
`hashing.bench.ts` has `// sparse arrays //` over a fixture and the single
bench that uses it, which is nominal but does group two things.

## Gates

`deno task check` passes over the workspace. `deno fmt --check` and `deno lint`
pass over the three packages. Suites: `data-model` 48 passed / 0 failed (2747
steps), `utils` 99 passed / 0 failed (711 steps), `content-hash` 2 passed / 0
failed (725 steps). A re-run of the census over these packages finds no
remaining comment above a test-block opener, and the diff adds no comment line
over 80 columns.

Depends on nothing; the rule it conforms to is in #6559, which touches no test
file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


