### PR TITLE
test(cli): a block's comment moves inside the block it describes

### DIFF
--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -3160,11 +3160,12 @@ describe("mounted callable resolution and execution", () => {
     expect(harness.tracker.handlerWrites).toEqual([]);
   });
 
-  // A mounted handler whose event schema sits behind a top-level local $ref
-  // is refused at the flag door, which reads the definition's fields and can
-  // name the type the caller must supply. Nothing dispatches, so an
-  // invocation id is never spent.
   it("refuses an absent payload for a mounted handler that cannot run without one", async () => {
+    // A mounted handler whose event schema sits behind a top-level local $ref
+    // is refused at the flag door, which reads the definition's fields and can
+    // name the type the caller must supply. Nothing dispatches, so an
+    // invocation id is never spent.
+
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
       relativePath: "home/pieces/notes-2/result/add.handler",

--- a/packages/cli/test/ingest-channels.test.ts
+++ b/packages/cli/test/ingest-channels.test.ts
@@ -120,11 +120,12 @@ afterAll(async () => {
 
 describe("resolveSpaceDid", () => {
   describe("control-plane URL construction", () => {
-    // A root-absolute path resolved against a base URL discards the base's own
-    // path, so a deployment served under a prefix had every command addressed at
-    // the origin — failing as a 404 from somewhere else rather than as a
-    // configuration error.
     it("keeps the configured base path", () => {
+      // A root-absolute path resolved against a base URL discards the base's
+      // own path, so a deployment served under a prefix had every command
+      // addressed at the origin — failing as a 404 from somewhere else rather
+      // than as a configuration error.
+
       expect(
         controlPlaneUrl(new URL("https://host.example/fabric"), "mint").href,
       )
@@ -154,9 +155,10 @@ describe("resolveSpaceDid", () => {
       expect(base.href).toBe("https://host.example/fabric");
     });
 
-    // The proof commits to the URL, so signing one path and sending another is
-    // not merely a wrong endpoint — it would fail to verify.
     it("signs the same pathful URL it sends to", async () => {
+      // The proof commits to the URL, so signing one path and sending another
+      // is not merely a wrong endpoint — it would fail to verify.
+
       await withStubbedFetch(
         { body: { channels: [] } },
         async (calls) => {

--- a/packages/cli/test/ingest-channels.test.ts
+++ b/packages/cli/test/ingest-channels.test.ts
@@ -120,12 +120,12 @@ afterAll(async () => {
 
 describe("resolveSpaceDid", () => {
   describe("control-plane URL construction", () => {
-    it("keeps the configured base path", () => {
-      // A root-absolute path resolved against a base URL discards the base's
-      // own path, so a deployment served under a prefix had every command
-      // addressed at the origin — failing as a 404 from somewhere else rather
-      // than as a configuration error.
+    // A root-absolute path resolved against a base URL discards the base's own
+    // path, so a deployment served under a prefix had every command addressed at
+    // the origin — failing as a 404 from somewhere else rather than as a
+    // configuration error.
 
+    it("keeps the configured base path", () => {
       expect(
         controlPlaneUrl(new URL("https://host.example/fabric"), "mint").href,
       )

--- a/packages/cli/test/ingest-command.test.ts
+++ b/packages/cli/test/ingest-command.test.ts
@@ -235,9 +235,10 @@ describe("cf ingest mint", () => {
     expect(output).toContain("tok-secret");
   });
 
-  // Every self-serve credential is finite-lived, so the expiry line is always
-  // present: the server applies a default when no --ttl-days is given.
   it("forwards a did:key space verbatim and always shows an expiry", async () => {
+    // Every self-serve credential is finite-lived, so the expiry line is always
+    // present: the server applies a default when no --ttl-days is given.
+
     const { output, calls } = await run([
       "mint",
       "--identity",
@@ -260,11 +261,12 @@ describe("cf ingest mint", () => {
     expect(output).toContain("expires:     2026-11-02T00:00:00.000Z");
   });
 
-  // The server always sets an expiry, so a response without one means the two
-  // sides disagree about the contract. Printing a bare blank there would hide
-  // that behind something that reads like "never expires" — the opposite of
-  // the truth.
   it("says so loudly when a mint response carries no expiry", async () => {
+    // The server always sets an expiry, so a response without one means the two
+    // sides disagree about the contract. Printing a bare blank there would hide
+    // that behind something that reads like "never expires" — the opposite of
+    // the truth.
+
     const { expiresAt: _dropped, ...noExpiry } = minted;
     const { output } = await run([
       "mint",
@@ -402,11 +404,12 @@ describe("cf ingest revoke", () => {
     expect(output).toContain("retained as an audit record");
   });
 
-  // The whole point of revocation-by-current-owner is a channel minted by
-  // someone whose access has since been removed. That channel has a different
-  // owner, so it is NOT in the caller's own list — looking the revision up
-  // there would make the one case this exists for unreachable.
   it("looks a foreign channel up in the space when --space is given", async () => {
+    // The whole point of revocation-by-current-owner is a channel minted by
+    // someone whose access has since been removed. That channel has a different
+    // owner, so it is NOT in the caller's own list — looking the revision up
+    // there would make the one case this exists for unreachable.
+
     const { calls } = await run([
       "revoke",
       "chan-1",
@@ -426,10 +429,11 @@ describe("cf ingest revoke", () => {
     expect(calls[1].body.expectedRevision).toBe(3);
   });
 
-  // Revoking an already-revoked channel is a legitimate confirm, not an error —
-  // and the CLI has to say which it is, or "it worked" and "it was already
-  // dead" are indistinguishable.
   it("says a channel was already revoked before re-issuing", async () => {
+    // Revoking an already-revoked channel is a legitimate confirm, not an error
+    // — and the CLI has to say which it is, or "it worked" and "it was already
+    // dead" are indistinguishable.
+
     const { output, calls } = await run([
       "revoke",
       "chan-1",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4714,12 +4714,12 @@ describe("runtimeErrorLog", () => {
 });
 
 describe("schemaIsObjectShaped", () => {
-  it("rejects boolean schemas and accepts object shapes", () => {
-    // Pinned directly: the gate's caller pre-filters non-object roots, so the
-    // defensive boolean-target guard is unreachable through it, and the
-    // combinator boundary this function encodes (allOf conjunctions count,
-    // disjunctions never) deserves its own record.
+  // Pinned directly: the gate's caller pre-filters non-object roots, so the
+  // defensive boolean-target guard is unreachable through it, and the
+  // combinator boundary this function encodes (allOf conjunctions count,
+  // disjunctions never) deserves its own record.
 
+  it("rejects boolean schemas and accepts object shapes", () => {
     expect(schemaIsObjectShaped(true, true)).toBe(false);
     expect(schemaIsObjectShaped(false, false)).toBe(false);
     expect(schemaIsObjectShaped({ type: "object" }, {})).toBe(true);

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -299,14 +299,15 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.sendOptions).toEqual([]);
   });
 
-  // The schema below is the deployed shape a stream's event is routinely
-  // written in: a top-level local $ref with the stream marker. The arg
-  // parser reads the definition's fields, so absence is refused where the
-  // caller can act on it — naming the type to supply — rather than deeper in
-  // at the payload gate. Either way nothing dispatches; what this pins is
-  // that the id survives a refusal, so the retry that does send a payload
-  // can still use it.
   it("refuses an absent payload against a verb that provably cannot run without one", async () => {
+    // The schema below is the deployed shape a stream's event is routinely
+    // written in: a top-level local $ref with the stream marker. The arg
+    // parser reads the definition's fields, so absence is refused where the
+    // caller can act on it — naming the type to supply — rather than deeper in
+    // at the payload gate. Either way nothing dispatches; what this pins is
+    // that the id survives a refusal, so the retry that does send a payload
+    // can still use it.
+
     const harness = createPieceCallableHarness({
       callableKind: "handler",
       cellKey: "recordMessage",
@@ -352,13 +353,14 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.sendOptions).toEqual([]);
   });
 
-  // A $ref-carrying stream shape declares its fields in the definition, and
-  // the arg parser reads them there — so a bare call takes the same
-  // implicit-pipe path as the identical verb written without the
-  // indirection ("infers piped stdin for object handlers", below). Piped
-  // bytes reach a verb through this shape; how the schema spells its event
-  // is not something a caller should have to know to pipe into it.
   it("infers piped stdin for a bare $ref-stream verb call", async () => {
+    // A $ref-carrying stream shape declares its fields in the definition, and
+    // the arg parser reads them there — so a bare call takes the same
+    // implicit-pipe path as the identical verb written without the
+    // indirection ("infers piped stdin for object handlers", below). Piped
+    // bytes reach a verb through this shape; how the schema spells its event
+    // is not something a caller should have to know to pipe into it.
+
     const harness = createPieceCallableHarness({
       callableKind: "handler",
       cellKey: "recordMessage",
@@ -4379,11 +4381,12 @@ describe("verbInputSchemaError", () => {
       .toBeUndefined();
   });
 
-  // `{}` rather than a misspelling, so this reaches the schema validation
-  // rather than the undeclared-field refusal that now precedes it — a
-  // misspelled required property is BOTH, and it is refused as the undeclared
-  // field it is (verb-undeclared-field.test.ts).
   it("rejects a missing required property", () => {
+    // `{}` rather than a misspelling, so this reaches the schema validation
+    // rather than the undeclared-field refusal that now precedes it — a
+    // misspelled required property is BOTH, and it is refused as the undeclared
+    // field it is (verb-undeclared-field.test.ts).
+
     expect(verbInputSchemaError({}, objectSchema)).toMatch(/message/);
   });
 
@@ -4401,13 +4404,14 @@ describe("verbInputSchemaError", () => {
     expect(verbInputSchemaError({ anything: 1 }, true)).toBeUndefined();
   });
 
-  // The runtime injects a property's default when the payload omits it, so
-  // requiring it here would refuse a call the verb would have accepted. This
-  // pins that the gate APPLIES the relaxation; the relaxation's own semantics
-  // ($ref chains, combinators, cycles, the `definitions` refusal) are pinned
-  // where the helpers live (runner `cfc-defaulted-required-relaxation.test.ts`
-  // — verb contract D6).
   it("treats a defaulted property as satisfied when omitted", () => {
+    // The runtime injects a property's default when the payload omits it, so
+    // requiring it here would refuse a call the verb would have accepted. This
+    // pins that the gate APPLIES the relaxation; the relaxation's own semantics
+    // ($ref chains, combinators, cycles, the `definitions` refusal) are pinned
+    // where the helpers live (runner
+    // `cfc-defaulted-required-relaxation.test.ts` — verb contract D6).
+
     expect(verbInputSchemaError({}, {
       type: "object",
       properties: { mode: { type: "string", default: "fast" } },
@@ -4476,10 +4480,11 @@ describe("normalizeAbsentVerbPayload", () => {
     expect(normalizeAbsentVerbPayload(undefined, true)).toBeUndefined();
   });
 
-  // An absent payload must keep passing a `false` schema — a supplied one is
-  // already refused by the validator ("schema rejects all values"), and
-  // normalizing here would convert every call into that refusal.
   it("leaves absence alone against a boolean false schema", () => {
+    // An absent payload must keep passing a `false` schema — a supplied one is
+    // already refused by the validator ("schema rejects all values"), and
+    // normalizing here would convert every call into that refusal.
+
     expect(normalizeAbsentVerbPayload(undefined, false)).toBeUndefined();
   });
 
@@ -4492,9 +4497,10 @@ describe("normalizeAbsentVerbPayload", () => {
     })).toBeUndefined();
   });
 
-  // Refuse only on proof: a $ref nobody can resolve proves nothing about the
-  // event being an object, so absence keeps today's pass-through behavior.
   it("leaves absence alone when the top-level $ref cannot be resolved", () => {
+    // Refuse only on proof: a $ref nobody can resolve proves nothing about the
+    // event being an object, so absence keeps today's pass-through behavior.
+
     expect(normalizeAbsentVerbPayload(undefined, {
       $ref: "#/$defs/Absent",
       asCell: ["stream"],
@@ -4502,10 +4508,11 @@ describe("normalizeAbsentVerbPayload", () => {
     } as JSONSchema)).toBeUndefined();
   });
 
-  // A boolean definition is a resolvable target that still proves nothing
-  // about the event being an object — absence passes through, like any other
-  // non-object target.
   it("leaves absence alone when the top-level $ref names a boolean def", () => {
+    // A boolean definition is a resolvable target that still proves nothing
+    // about the event being an object — absence passes through, like any other
+    // non-object target.
+
     expect(normalizeAbsentVerbPayload(undefined, {
       $ref: "#/$defs/Anything",
       asCell: ["stream"],
@@ -4513,12 +4520,13 @@ describe("normalizeAbsentVerbPayload", () => {
     } as JSONSchema)).toBeUndefined();
   });
 
-  // An allOf conjunction with an object-schema branch IS an object schema —
-  // no branch choice is involved, so `{}` is exactly as meaningful as for a
-  // direct object root, and the gate then judges it the same way (refused
-  // when non-defaulted required survives relaxation, dispatched with defaults
-  // engaging when it does not).
   it("normalizes absence to {} against an allOf of object schemas", () => {
+    // An allOf conjunction with an object-schema branch IS an object schema —
+    // no branch choice is involved, so `{}` is exactly as meaningful as for a
+    // direct object root, and the gate then judges it the same way (refused
+    // when non-defaulted required survives relaxation, dispatched with defaults
+    // engaging when it does not).
+
     expect(normalizeAbsentVerbPayload(undefined, {
       allOf: [
         {
@@ -4542,10 +4550,11 @@ describe("normalizeAbsentVerbPayload", () => {
     } as unknown as JSONSchema)).toEqual({});
   });
 
-  // Disjunctive roots stay out of scope (the D5 rule's recorded combinator
-  // boundary): normalizing `{}` against anyOf/oneOf would pick among
-  // alternatives on the caller's behalf.
   it("leaves absence alone against anyOf/oneOf roots", () => {
+    // Disjunctive roots stay out of scope (the D5 rule's recorded combinator
+    // boundary): normalizing `{}` against anyOf/oneOf would pick among
+    // alternatives on the caller's behalf.
+
     expect(normalizeAbsentVerbPayload(undefined, {
       anyOf: [{ type: "object", properties: {} }],
     } as unknown as JSONSchema)).toBeUndefined();
@@ -4554,10 +4563,11 @@ describe("normalizeAbsentVerbPayload", () => {
     } as unknown as JSONSchema)).toBeUndefined();
   });
 
-  // The schema-less handler-input shape (`{ asCell: ["stream"] }` with no
-  // type and no properties) is not an object schema; `{}` means nothing
-  // there.
   it("leaves absence alone against a schema-less stream marker", () => {
+    // The schema-less handler-input shape (`{ asCell: ["stream"] }` with no
+    // type and no properties) is not an object schema; `{}` means nothing
+    // there.
+
     expect(normalizeAbsentVerbPayload(undefined, {
       asCell: ["stream"],
     } as JSONSchema)).toBeUndefined();
@@ -4616,10 +4626,11 @@ describe("reportVerbInputErrorOrRethrow", () => {
     expect(printed[1]).toMatch(/<piece>/);
   });
 
-  // Anything that is not an input rejection has to keep traveling: a network
-  // failure reported as a payload problem would send an agent to fix a payload
-  // that was fine.
   it("re-throws an unrelated failure untouched", () => {
+    // Anything that is not an input rejection has to keep traveling: a network
+    // failure reported as a payload problem would send an agent to fix a
+    // payload that was fine.
+
     const { printed, exited, deps } = sink();
     const original = new Error("network unreachable");
 
@@ -4683,10 +4694,11 @@ describe("the pre-dispatch gate on the forced-stream path", () => {
 });
 
 describe("runtimeErrorLog", () => {
-  // Pinned directly rather than left to incidental coverage: which execution
-  // paths hand this a non-object runtime varies by run and sharding, and the
-  // coverage gate has flagged the resulting phantom deltas on unrelated PRs.
   it("returns [] for non-object runtimes and runtimes without a log", () => {
+    // Pinned directly rather than left to incidental coverage: which execution
+    // paths hand this a non-object runtime varies by run and sharding, and the
+    // coverage gate has flagged the resulting phantom deltas on unrelated PRs.
+
     expect(runtimeErrorLog(undefined)).toEqual([]);
     expect(runtimeErrorLog("not a runtime")).toEqual([]);
     expect(runtimeErrorLog({})).toEqual([]);
@@ -4702,11 +4714,12 @@ describe("runtimeErrorLog", () => {
 });
 
 describe("schemaIsObjectShaped", () => {
-  // Pinned directly: the gate's caller pre-filters non-object roots, so the
-  // defensive boolean-target guard is unreachable through it, and the
-  // combinator boundary this function encodes (allOf conjunctions count,
-  // disjunctions never) deserves its own record.
   it("rejects boolean schemas and accepts object shapes", () => {
+    // Pinned directly: the gate's caller pre-filters non-object roots, so the
+    // defensive boolean-target guard is unreachable through it, and the
+    // combinator boundary this function encodes (allOf conjunctions count,
+    // disjunctions never) deserves its own record.
+
     expect(schemaIsObjectShaped(true, true)).toBe(false);
     expect(schemaIsObjectShaped(false, false)).toBe(false);
     expect(schemaIsObjectShaped({ type: "object" }, {})).toBe(true);

--- a/packages/cli/test/verb-emitted-address.test.ts
+++ b/packages/cli/test/verb-emitted-address.test.ts
@@ -49,11 +49,12 @@ describe("verb-emitted-address", () => {
         .toEqual({ value: { on: ENVELOPE } });
     });
 
-    // The compiled contract spells a named reference `{$ref: …, asCell: […]}`
-    // — the marker rides the REFERENCE SITE. A walk that resolves the `$ref`
-    // before looking loses it and converts nothing, which is exactly how the
-    // first live probe of this feature failed.
     it("reads the marker off the `$ref` site, where the compiled contract carries it", () => {
+      // The compiled contract spells a named reference `{$ref: …, asCell: […]}`
+      // — the marker rides the REFERENCE SITE. A walk that resolves the `$ref`
+      // before looking loses it and converts nothing, which is exactly how the
+      // first live probe of this feature failed.
+
       const schema: JSONSchema = {
         type: "object",
         properties: { on: { $ref: "#/$defs/Item", asCell: ["cell"] } },
@@ -95,10 +96,11 @@ describe("verb-emitted-address", () => {
       );
     });
 
-    // `#argument` names a piece's arguments cell for commands that take
-    // `--input`; as a verb argument it addresses nothing a reference position
-    // can hold.
     it("refuses the `#argument` suffix at a reference position", () => {
+      // `#argument` names a piece's arguments cell for commands that take
+      // `--input`; as a verb argument it addresses nothing a reference position
+      // can hold.
+
       const resolved = resolveEmittedAddressArguments(
         { on: `${ADDRESS}#argument` },
         inlineMarker,
@@ -106,10 +108,11 @@ describe("verb-emitted-address", () => {
       expect(resolved.refusal).toContain("is not an address");
     });
 
-    // The parser THROWS on an unknown suffix rather than declining; the walk
-    // absorbs that into the same refusal, so a caller never sees a parser
-    // stack where a refusal was owed.
     it("refuses a suffix the address grammar rejects outright", () => {
+      // The parser THROWS on an unknown suffix rather than declining; the walk
+      // absorbs that into the same refusal, so a caller never sees a parser
+      // stack where a refusal was owed.
+
       const resolved = resolveEmittedAddressArguments(
         { on: `${ADDRESS}#bogus` },
         inlineMarker,
@@ -145,9 +148,10 @@ describe("verb-emitted-address", () => {
         .toEqual({ value: payload });
     });
 
-    // The event root is where the payload ITSELF sits; a marker there says
-    // how the runtime holds the event, not that the caller sends an address.
     it("never converts at the event root", () => {
+      // The event root is where the payload ITSELF sits; a marker there says
+      // how the runtime holds the event, not that the caller sends an address.
+
       const schema: JSONSchema = {
         type: "object",
         asCell: ["cell"],
@@ -199,10 +203,11 @@ describe("verb-emitted-address", () => {
       ).toEqual({ value: { pair: ["label", ENVELOPE, ADDRESS] } });
     });
 
-    // A record schema names no key at all: its values are declared on
-    // `additionalProperties`, which is where a map of references puts its
-    // marker. Reading only `properties` skips every one of them.
     it("walks a record schema's values through `additionalProperties`", () => {
+      // A record schema names no key at all: its values are declared on
+      // `additionalProperties`, which is where a map of references puts its
+      // marker. Reading only `properties` skips every one of them.
+
       const schema: JSONSchema = {
         type: "object",
         additionalProperties: { type: "object", asCell: ["cell"] },
@@ -214,9 +219,10 @@ describe("verb-emitted-address", () => {
       ).toContain('"nope" at <event>.anything is not an address');
     });
 
-    // A named key keeps its own account; `additionalProperties` covers only
-    // what `properties` does not name.
     it("prefers a named property over `additionalProperties`", () => {
+      // A named key keeps its own account; `additionalProperties` covers only
+      // what `properties` does not name.
+
       const schema: JSONSchema = {
         type: "object",
         properties: { plain: { type: "string" } },
@@ -244,9 +250,10 @@ describe("verb-emitted-address", () => {
       ).toContain('"nope" at <event>.on is not an address');
     });
 
-    // Choosing a disjunction branch is the caller's; converting inside one
-    // would pick it for them.
     it("passes over disjunction interiors", () => {
+      // Choosing a disjunction branch is the caller's; converting inside one
+      // would pick it for them.
+
       const schema: JSONSchema = {
         type: "object",
         properties: {
@@ -326,9 +333,10 @@ describe("verb-emitted-address", () => {
       expect((event.$defs as Record<string, unknown>).Item).toBeDefined();
     });
 
-    // A stream two handler nodes share is still a verb, but it names no
-    // single contract — matching what its declared result does.
     it("maps a stream two handler nodes share to `undefined`", () => {
+      // A stream two handler nodes share is still a verb, but it names no
+      // single contract — matching what its declared result does.
+
       const argumentSchema = {
         type: "object",
         properties: { $event: eventDef, $ctx: true },
@@ -576,13 +584,14 @@ describe("verb-emitted-address", () => {
       });
     });
 
-    // #5560 in its sharpest form, and the one the published schema alone
-    // cannot catch: a copy carrying every field the target declares, which
-    // validates precisely BECAUSE it matches the shape. Refusing the
-    // incomplete copy above while accepting this one would leave the
-    // corruption exactly where it was found — silent, and shaped like
-    // success.
     it("refuses a copy that satisfies the published shape in full", async () => {
+      // #5560 in its sharpest form, and the one the published schema alone
+      // cannot catch: a copy carrying every field the target declares, which
+      // validates precisely BECAUSE it matches the shape. Refusing the
+      // incomplete copy above while accepting this one would leave the
+      // corruption exactly where it was found — silent, and shaped like
+      // success.
+
       await withProbe("emitted-address-refuses-full-copy", async (probe) => {
         const complete = {
           "$NAME": "complete",
@@ -616,14 +625,15 @@ describe("verb-emitted-address", () => {
       });
     });
 
-    // The dispatch-cost contract, and the bound on the copy check above.
-    // Sanitization strips the reference MARKER and keeps the SHAPE, so a
-    // string at a declared reference is refused by the published schema
-    // before the gate asks, and only two payloads can have their reading
-    // changed by the contract: one the shape refused, and one it accepted
-    // carrying an inline object. A flat payload of scalars is neither, and
-    // dispatches without loading the compiled pattern.
     it("loads the pattern only where the contract can change the answer", async () => {
+      // The dispatch-cost contract, and the bound on the copy check above.
+      // Sanitization strips the reference MARKER and keeps the SHAPE, so a
+      // string at a declared reference is refused by the published schema
+      // before the gate asks, and only two payloads can have their reading
+      // changed by the contract: one the shape refused, and one it accepted
+      // carrying an inline object. A flat payload of scalars is neither, and
+      // dispatches without loading the compiled pattern.
+
       await withProbe("emitted-address-load-cost", async (probe) => {
         await probe.call("note", { body: "no load" });
         expect(probe.patternLoads()).toBe(0);
@@ -638,10 +648,11 @@ describe("verb-emitted-address", () => {
       });
     });
 
-    // A conversion repairs one position; it does not vouch for the rest of
-    // the payload. What the published shape still refuses after it is the
-    // refusal the caller reads — the REMAINING problem, not the solved one.
     it("re-judges a converted payload, and reports what still fails", async () => {
+      // A conversion repairs one position; it does not vouch for the rest of
+      // the payload. What the published shape still refuses after it is the
+      // refusal the caller reads — the REMAINING problem, not the solved one.
+
       await withProbe("emitted-address-rejudge", async (probe) => {
         const failure = await probe.call("tag", { on: probe.address })
           .then(() => undefined, (error: unknown) => String(error));
@@ -651,10 +662,11 @@ describe("verb-emitted-address", () => {
       });
     });
 
-    // Degradation, not a crash: a pattern that will not load costs the call
-    // its conversion — the plain shape refusal stands — while a payload the
-    // published shape accepts still dispatches.
     it("keeps the plain refusal when the pattern will not load", async () => {
+      // Degradation, not a crash: a pattern that will not load costs the call
+      // its conversion — the plain shape refusal stands — while a payload the
+      // published shape accepts still dispatches.
+
       await withProbe("emitted-address-no-pattern", async (probe) => {
         await expect(probe.call("relate", { on: probe.address }))
           .rejects.toThrow("does not match type object");

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -303,10 +303,11 @@ describe("verb-undeclared-field", () => {
       );
     });
 
-    // A transposition is one slip to the caller who made it, whatever it costs
-    // to spell as substitutions, and the threshold for a four-character key is
-    // one edit.
     it("counts an adjacent transposition as one edit", () => {
+      // A transposition is one slip to the caller who made it, whatever it
+      // costs to spell as substitutions, and the threshold for a four-character
+      // key is one edit.
+
       expect(undeclaredVerbFieldError({ doen: true }, addItem)).toMatch(
         /Did you mean "done"\?/,
       );
@@ -326,18 +327,20 @@ describe("verb-undeclared-field", () => {
       expect(undeclaredVerbFieldError({ anything: 1 }, true)).toBeUndefined();
     });
 
-    // A position with no property map is open by construction: the runtime
-    // delivers the whole payload there, so nothing is dropped and nothing is
-    // refused.
     it("returns `undefined` for an object schema stating no `properties`", () => {
+      // A position with no property map is open by construction: the runtime
+      // delivers the whole payload there, so nothing is dropped and nothing is
+      // refused.
+
       expect(undeclaredVerbFieldError({ anything: 1 }, { type: "object" }))
         .toBeUndefined();
     });
 
-    // The other reading of "declares no fields": an explicit empty map, which
-    // the runtime answers by delivering nothing at all. Every field a caller
-    // writes there is refused, and there is no vocabulary to offer instead.
     it("refuses every field against an explicitly empty `properties` map", () => {
+      // The other reading of "declares no fields": an explicit empty map, which
+      // the runtime answers by delivering nothing at all. Every field a caller
+      // writes there is refused, and there is no vocabulary to offer instead.
+
       expect(
         undeclaredVerbFieldError({ title: "Milk" }, {
           type: "object",
@@ -349,9 +352,10 @@ describe("verb-undeclared-field", () => {
       );
     });
 
-    // `additionalProperties` is what makes the runtime deliver a field no map
-    // names, so a position carrying one honors what it is sent.
     it("returns `undefined` where the position declares `additionalProperties`", () => {
+      // `additionalProperties` is what makes the runtime deliver a field no map
+      // names, so a position carrying one honors what it is sent.
+
       for (const additionalProperties of [true, {}, { type: "string" }]) {
         expect(
           undeclaredVerbFieldError({ title: "Milk", colour: "red" }, {
@@ -362,10 +366,11 @@ describe("verb-undeclared-field", () => {
       }
     });
 
-    // The position half of the message is load-bearing: a field goes missing
-    // wherever its enclosing position drops what it does not name, not only at
-    // the root.
     it("names a nested object position", () => {
+      // The position half of the message is load-bearing: a field goes missing
+      // wherever its enclosing position drops what it does not name, not only
+      // at the root.
+
       expect(
         undeclaredVerbFieldError({ item: { id: "1", lable: "Milk" } }, {
           type: "object",
@@ -419,9 +424,10 @@ describe("verb-undeclared-field", () => {
       ).toMatch(/"titel" at <event> .* Did you mean "title"\?/);
     });
 
-    // Below the root a marked position is where a caller may write a link
-    // instead of a value, and `"/"` is not a field anybody declared.
     it("returns `undefined` inside a position marked `asCell`", () => {
+      // Below the root a marked position is where a caller may write a link
+      // instead of a value, and `"/"` is not a field anybody declared.
+
       const schema: JSONSchema = {
         type: "object",
         properties: {
@@ -442,10 +448,11 @@ describe("verb-undeclared-field", () => {
       ).toBeUndefined();
     });
 
-    // A payload need satisfy only one branch of a disjunction, and schema
-    // traversal unions the branches before deciding which children exist, so a
-    // field only one branch names is one the runtime still delivers.
     it("returns `undefined` at a position carrying a combinator", () => {
+      // A payload need satisfy only one branch of a disjunction, and schema
+      // traversal unions the branches before deciding which children exist, so
+      // a field only one branch names is one the runtime still delivers.
+
       expect(
         undeclaredVerbFieldError({ title: "Milk", colour: "red" }, {
           type: "object",
@@ -462,10 +469,11 @@ describe("verb-undeclared-field", () => {
     });
   });
 
-  // Every shape `schemaIsObjectShaped` recognizes drops what its maps do not
-  // name, so every one of them is judged. An explicit `type: "object"` is only
-  // the most common of the four.
   describe('an object-shaped position with no explicit `type: "object"`', () => {
+    // Every shape `schemaIsObjectShaped` recognizes drops what its maps do not
+    // name, so every one of them is judged. An explicit `type: "object"` is
+    // only the most common of the four.
+
     const bareProperties: JSONSchema = {
       properties: { title: { type: "string" } },
     } as JSONSchema;
@@ -510,9 +518,10 @@ describe("verb-undeclared-field", () => {
         );
     });
 
-    // A payload satisfying a conjunction satisfies every member, so the fields
-    // it declares are the union across them.
     it("takes the fields a conjunction declares as the union across its members", () => {
+      // A payload satisfying a conjunction satisfies every member, so the
+      // fields it declares are the union across them.
+
       const schema = {
         type: "object",
         properties: { title: { type: "string" } },
@@ -539,9 +548,10 @@ describe("verb-undeclared-field", () => {
       );
     });
 
-    // A member spelled `true` constrains nothing and declares nothing, so the
-    // rest of the conjunction is the whole vocabulary.
     it("takes nothing from a conjunction member that is a boolean schema", () => {
+      // A member spelled `true` constrains nothing and declares nothing, so the
+      // rest of the conjunction is the whole vocabulary.
+
       const schema = {
         type: "object",
         properties: { title: { type: "string" } },
@@ -555,10 +565,11 @@ describe("verb-undeclared-field", () => {
       );
     });
 
-    // A definition whose conjunction names itself contributes its fields once
-    // and terminates, which is what lets a recursive event schema be judged at
-    // all.
     it("takes the fields of a conjunction that names itself, once", () => {
+      // A definition whose conjunction names itself contributes its fields once
+      // and terminates, which is what lets a recursive event schema be judged
+      // at all.
+
       const schema = {
         type: "object",
         properties: { title: { type: "string" } },
@@ -579,9 +590,11 @@ describe("verb-undeclared-field", () => {
       );
     });
 
-    // The array counterpart of the object type union: schema traversal descends
-    // the array branch, so the element's undeclared field goes missing there.
     it("refuses an undeclared field inside a type union admitting an array", () => {
+      // The array counterpart of the object type union: schema traversal
+      // descends the array branch, so the element's undeclared field goes
+      // missing there.
+
       expect(
         undeclaredVerbFieldError({ tags: [{ name: "a", colour: "red" }] }, {
           type: "object",
@@ -611,10 +624,11 @@ describe("verb-undeclared-field", () => {
       expect(await dispatchedPayload(conjunction, payload)).toEqual(payload);
     });
 
-    // A disjunction inside a conjunction makes the whole position honor
-    // everything: the branch a payload was meant for may name a field the
-    // others do not.
     it("dispatches an undeclared field where a conjunction holds a disjunction", async () => {
+      // A disjunction inside a conjunction makes the whole position honor
+      // everything: the branch a payload was meant for may name a field the
+      // others do not.
+
       const schema = {
         allOf: [
           { type: "object", properties: { title: { type: "string" } } },
@@ -630,9 +644,10 @@ describe("verb-undeclared-field", () => {
       expect(await dispatchedPayload(schema, payload)).toEqual(payload);
     });
 
-    // An untyped position naming `items` describes an array the same way an
-    // untyped position naming `properties` describes an object.
     it("refuses an undeclared field inside an untyped `items` position", () => {
+      // An untyped position naming `items` describes an array the same way an
+      // untyped position naming `properties` describes an object.
+
       expect(
         undeclaredVerbFieldError({ tags: [{ name: "a", colour: "red" }] }, {
           type: "object",
@@ -674,6 +689,7 @@ describe("verb-undeclared-field", () => {
     // never undertook to judge. Asserted here rather than through the flag
     // door, because each guard below answers for a schema shape no flag
     // parser can construct on its own.
+
     it("judges a schema that names fields and admits no others", () => {
       expect(eventSchemaJudgesRootFields({
         type: "object",
@@ -780,9 +796,11 @@ describe("verb-undeclared-field", () => {
       expect(await dispatchedPayload(schema, payload)).toEqual(payload);
     });
 
-    // No `items` beside the `type: "array"`, so the element has no schema and
-    // nothing there declares anything. The runtime delivers the element whole.
     it("dispatches an array element whose position declares no schema", async () => {
+      // No `items` beside the `type: "array"`, so the element has no schema and
+      // nothing there declares anything. The runtime delivers the element
+      // whole.
+
       const schema: JSONSchema = {
         type: "object",
         properties: { tags: { type: "array" } },
@@ -791,9 +809,10 @@ describe("verb-undeclared-field", () => {
       expect(await dispatchedPayload(schema, payload)).toEqual(payload);
     });
 
-    // A `$ref` naming a definition spelled `true` resolves to the wildcard
-    // schema, which declares nothing and refuses nothing.
     it("dispatches a position whose `$ref` resolves to a boolean schema", async () => {
+      // A `$ref` naming a definition spelled `true` resolves to the wildcard
+      // schema, which declares nothing and refuses nothing.
+
       const schema = {
         type: "object",
         properties: { detail: { $ref: "#/$defs/Anything" } },
@@ -803,9 +822,10 @@ describe("verb-undeclared-field", () => {
       expect(await dispatchedPayload(schema, payload)).toEqual(payload);
     });
 
-    // The marker rides the DEFINITION rather than the reference site, so it is
-    // reached only after the reference resolves.
     it("dispatches a position whose `asCell` marker rides the `$ref` target", async () => {
+      // The marker rides the DEFINITION rather than the reference site, so it
+      // is reached only after the reference resolves.
+
       const schema = {
         type: "object",
         properties: { target: { $ref: "#/$defs/Target" } },
@@ -829,10 +849,11 @@ describe("verb-undeclared-field", () => {
       required: ["title"],
     };
 
-    // Both refusals hold for this payload: `title` is missing and `titel` is
-    // undeclared. Only one of the two answers names something the caller
-    // wrote, and that is the one they get.
     it("reports the undeclared field ahead of the required one it displaced", () => {
+      // Both refusals hold for this payload: `title` is missing and `titel` is
+      // undeclared. Only one of the two answers names something the caller
+      // wrote, and that is the one they get.
+
       expect(verbInputSchemaError({ titel: "Milk" }, addItem)).toBe(
         '"titel" at <event> is not a field this verb declares. ' +
           'Did you mean "title"? <event> takes "title"',
@@ -938,10 +959,12 @@ describe("verb-undeclared-field", () => {
     });
   });
 
-  // The same two shapes on a running piece, reached through a verb whose event
-  // schema the pattern writes out. `count` reads what committed, so a dispatch
-  // is stated as the handling landing rather than as the command returning.
   describe("cf piece call on a verb whose event schema states no `type`", () => {
+    // The same two shapes on a running piece, reached through a verb whose
+    // event schema the pattern writes out. `count` reads what committed, so a
+    // dispatch is stated as the handling landing rather than as the command
+    // returning.
+
     const withExplicit = <T>(
       passphrase: string,
       body: (tracker: Tracker) => Promise<T>,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `cli` to the "Commenting a block" rule in
`unit-test-coding-style.md`: a comment about a test or a group of tests goes
inside the block's callback, as its first content, followed by a blank line.

62 comments in 11 files.

- **49 move** into the block they describe.
- **3 stay** and take only the blank line: the note heading
  `eventSchemaJudgesRootFields()`, which is about every guard under it;
  `schemaIsObjectShaped()`'s, which names both cases under it (the unreachable
  boolean-target guard and the combinator boundary, the second of those being
  the second case almost verbatim); and the control-plane URL note in
  `ingest-channels.test.ts`, which states the bug its group exists for.
- **10 are left exactly as they are**, in two kinds the rule does not reach.

Fifteen of the moved blocks overflowed 80 columns at the new indent and are
reflowed. The conversion compares each block's word sequence before and after
rather than trusting the reflow.

## The ten left alone

**Seven sit above a hook written as a single expression**, such as
`afterEach(() => setQuietMode(false));` in `piece-repair.test.ts:86`. There is
no body for the comment to open, so it stays beside the statement it describes
-- the same disposition `code-comment-style.md` already gives a `//` note on a
declaration with no inside. The rule's text does not name this case yet.

**Three describe a run of two sibling `it()`s that no block groups**, all in
`piece-call-cyclic-result-live.test.ts` (lines 345, 409, 537); each opens "the
pair below" or names two contrasting cases explicitly. Moving one inside the
first `it()` would leave it covering half of what it says, and the sibling
would carry no rationale. Grouping each pair under a `describe()` is the real
fix, but that renames tests, which is not a comment change.

The same shape turned up once in the previous batch and is reverted there, so
the two changes agree on it.

## What the diff is, as a property

Across the 11 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0).
- Per file, the multiset of comment words is unchanged.
- Per file, the multiset of non-comment lines is unchanged.
- No added line exceeds 80 characters. Counted in characters rather than bytes,
  since several comments carry em dashes.

A re-run of the census over the package finds 10 remaining comments above a
test-block opener -- exactly the ten named above, and none other.

## Gates

`deno fmt --check` and `deno lint` pass over the package. `deno task test` in
`packages/cli`: 210 passed / 0 failed (214 steps, 2m22s).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


