### PR TITLE
test(ts-transformers): a block's comment moves inside the block it describes

### DIFF
--- a/packages/schema-generator/test/brand-payload-defaults.test.ts
+++ b/packages/schema-generator/test/brand-payload-defaults.test.ts
@@ -193,17 +193,18 @@ describe("brand-payload recovery on the expanded path (no typeNode)", () => {
   });
 });
 
-// The payloads above are all literal TYPES, which the checker hands over
-// directly. A `typeof SOME_CONST` payload naming an object or array cannot be
-// carried that way — the values are recovered by reading the const's
-// INITIALIZER off the AST.
-//
-// That reader's handling of numbers in their non-literal spellings is pinned by
-// the `default-typeof-const-numbers` fixture, whose golden can hold `-0`, `NaN`
-// and the infinities directly. What stays here is the one case a golden cannot
-// state: that a shadowed global is NOT folded, which is an assertion about what
-// does not happen.
 describe("defaults recovered from a `typeof CONST` initializer", () => {
+  // The payloads above are all literal TYPES, which the checker hands over
+  // directly. A `typeof SOME_CONST` payload naming an object or array cannot be
+  // carried that way — the values are recovered by reading the const's
+  // INITIALIZER off the AST.
+  //
+  // That reader's handling of numbers in their non-literal spellings is pinned
+  // by the `default-typeof-const-numbers` fixture, whose golden can hold `-0`,
+  // `NaN` and the infinities directly. What stays here is the one case a golden
+  // cannot state: that a shadowed global is NOT folded, which is an assertion
+  // about what does not happen.
+
   const transformer = new SchemaGenerator();
 
   async function defaultOfX(declarations: string): Promise<unknown> {

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -315,15 +315,13 @@ namespace Local {
       });
     });
 
+    // CT-1615 Berni review §4.2: lock in the new IndexSignatureDeclaration
+    // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler.
+    // Without it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes
+    // routed through node-based analysis silently drop their index signature
+    // (e.g. via the SchemaInjection lift-revisit that feeds `any` as the
+    // paired Type — see ts-transformers/src/transformers/schema-injection.ts).
     it("emits additionalProperties for synthetic { [k: string]: V } index signature", async () => {
-      // CT-1615 Berni review §4.2: lock in the new IndexSignatureDeclaration
-      // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler.
-      // Without it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes
-      // routed through node-based analysis silently drop their index signature
-      // (e.g. via the SchemaInjection lift-revisit that feeds `any` as the
-      // paired Type — see
-      // ts-transformers/src/transformers/schema-injection.ts).
-
       const generator = new SchemaGenerator();
       const { checker } = await getTypeFromCode(
         "type Dummy = unknown;",

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -315,13 +315,15 @@ namespace Local {
       });
     });
 
-    // CT-1615 Berni review §4.2: lock in the new IndexSignatureDeclaration
-    // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler.
-    // Without it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes
-    // routed through node-based analysis silently drop their index signature
-    // (e.g. via the SchemaInjection lift-revisit that feeds `any` as the
-    // paired Type — see ts-transformers/src/transformers/schema-injection.ts).
     it("emits additionalProperties for synthetic { [k: string]: V } index signature", async () => {
+      // CT-1615 Berni review §4.2: lock in the new IndexSignatureDeclaration
+      // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler.
+      // Without it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes
+      // routed through node-based analysis silently drop their index signature
+      // (e.g. via the SchemaInjection lift-revisit that feeds `any` as the
+      // paired Type — see
+      // ts-transformers/src/transformers/schema-injection.ts).
+
       const generator = new SchemaGenerator();
       const { checker } = await getTypeFromCode(
         "type Dummy = unknown;",

--- a/packages/schema-generator/test/schema/cfc-authoring.test.ts
+++ b/packages/schema-generator/test/schema/cfc-authoring.test.ts
@@ -171,12 +171,13 @@ describe("Schema: CFC authoring aliases", () => {
     expect(labeled.ifc?.confidentiality).toEqual(["prompt-influence"]);
   });
 
-  // The collection/opaque aliases below are NOT canonical (the helpers were
-  // removed from @commonfabric/api/cfc because the runner rejects those ifc
-  // keys fail-closed) — with explicit type arguments they resolve through
-  // the Cfc carrier as plain payload passthrough, which is the structural
-  // mechanism this test covers alongside the remaining canonical aliases.
   it("lowers the remaining canonical metadata aliases and merges nested Cfc metadata", async () => {
+    // The collection/opaque aliases below are NOT canonical (the helpers were
+    // removed from @commonfabric/api/cfc because the runner rejects those ifc
+    // keys fail-closed) — with explicit type arguments they resolve through
+    // the Cfc carrier as plain payload passthrough, which is the structural
+    // mechanism this test covers alongside the remaining canonical aliases.
+
     const code = `
       type Cfc<T, Meta> = T & { readonly __ct_cfc__?: Meta };
       type Confidential<T, X extends readonly unknown[]> = Cfc<T, { confidentiality: X }>;

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -234,15 +234,16 @@ describe("Schema: Default in unions", () => {
     expect(result.default).toEqual({ theme: "dark", retries: 3 });
   });
 
-  // A `typeof CONST` payload reads the const's initializer off the AST, so the
-  // const must be found through its import when it lives in another module —
-  // the shape a pattern that keeps its defaults in a `contract.ts` has.
-  // `getSymbolAtLocation` on the import returns the alias symbol, whose
-  // valueDeclaration is the ImportSpecifier, not the const; without the alias
-  // hop the default silently disappears from the schema (2026-08-28, found
-  // through the pattern-iframe wrapper: every deployed guest hydrated to
-  // `undefined`).
   describe("typeof values imported from another module", () => {
+    // A `typeof CONST` payload reads the const's initializer off the AST, so
+    // the const must be found through its import when it lives in another
+    // module — the shape a pattern that keeps its defaults in a `contract.ts`
+    // has. `getSymbolAtLocation` on the import returns the alias symbol, whose
+    // valueDeclaration is the ImportSpecifier, not the const; without the alias
+    // hop the default silently disappears from the schema (2026-08-28, found
+    // through the pattern-iframe wrapper: every deployed guest hydrated to
+    // `undefined`).
+
     const contract = `
       export interface Config {
         theme: string;
@@ -313,11 +314,12 @@ describe("Schema: Default in unions", () => {
     });
   });
 
-  // A default the reader cannot fully evaluate is withheld, never shipped as
-  // a fragment: a partial object satisfies every "is there a default?" check
-  // while missing a required member, and the runtime's own `Writable(CONST)`
-  // holds the whole value, so schema and runtime would disagree.
   describe("a payload the reader cannot fully evaluate", () => {
+    // A default the reader cannot fully evaluate is withheld, never shipped as
+    // a fragment: a partial object satisfies every "is there a default?" check
+    // while missing a required member, and the runtime's own `Writable(CONST)`
+    // holds the whole value, so schema and runtime would disagree.
+
     async function defaultFor(main: string) {
       const { type, checker, typeNode } = await getTypeFromFiles(
         {

--- a/packages/schema-generator/test/stream-result.test.ts
+++ b/packages/schema-generator/test/stream-result.test.ts
@@ -77,12 +77,13 @@ interface SchemaRoot {
     expect(JSON.stringify(returning)).not.toContain("fid");
   });
 
-  // C1 puts the result in the TYPE; emitting it into the schema is C3. Until
-  // then a returning verb and a value-less one generate byte-identical
-  // schemas and the result type never reaches `$defs` at all. Pinned so that
-  // C3 has a baseline to move rather than a belief to check, and so the day
-  // this stops being true is a failing test rather than a discovery.
   it("does not yet carry the result into the schema — that is C3", async () => {
+    // C1 puts the result in the TYPE; emitting it into the schema is C3. Until
+    // then a returning verb and a value-less one generate byte-identical
+    // schemas and the result type never reaches `$defs` at all. Pinned so that
+    // C3 has a baseline to move rather than a belief to check, and so the day
+    // this stops being true is a failing test rather than a discovery.
+
     const schema = await schemaFor(`
 interface AddTopic {
   title: string;

--- a/packages/schema-generator/test/value-equality.test.ts
+++ b/packages/schema-generator/test/value-equality.test.ts
@@ -57,10 +57,11 @@ Deno.test("dedupeByValueEqual: collapses genuinely equal schemas", () => {
   assertEquals(deduped, [{ type: "number", default: 5 }, { type: "string" }]);
 });
 
-// An executable statement of why the previous comparisons were wrong, so that
-// if these ever start passing the refactor is no longer load-bearing and can be
-// revisited.
 Deno.test("contrast: JSON.stringify and Set conflate what dedupeByValueEqual separates", () => {
+  // An executable statement of why the previous comparisons were wrong, so that
+  // if these ever start passing the refactor is no longer load-bearing and can
+  // be revisited.
+
   // JSON.stringify collides the values the value model distinguishes...
   assertEquals(JSON.stringify(-0), JSON.stringify(0)); // both "0"
   assertEquals(JSON.stringify(NaN), JSON.stringify(null)); // both "null"

--- a/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-iife-coverage.test.ts
@@ -141,12 +141,13 @@ Deno.test(
   },
 );
 
-// This test covers the `createLiftAppliedCall` sub-path directly: a zero-arg
-// IIFE reading a top-level pattern cell inside an `ifElse` branch, which the
-// array-method tests above never reach.
 Deno.test(
   "zero-arg IIFE reading a top-level cell inside an ifElse branch wraps the whole IIFE in a lift applied to that cell",
   async () => {
+    // This test covers the `createLiftAppliedCall` sub-path directly: a
+    // zero-arg IIFE reading a top-level pattern cell inside an `ifElse` branch,
+    // which the array-method tests above never reach.
+
     const output = parseModule(
       await transformSource(
         `/// <cts-enable />

--- a/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
@@ -9,12 +9,13 @@ function getOpaqueGetErrors(diagnostics: readonly TransformationDiagnostic[]) {
   );
 }
 
-// isReactiveExpression: identifier bound to a pattern-callback parameter is a
-// reactive value, so calling .get() on it (via a structural fallback, not a
-// branded type) is flagged as an invalid opaque .get() call.
 Deno.test(
   "opaque-get flags .get() on a destructured pattern-callback parameter",
   async () => {
+    // isReactiveExpression: identifier bound to a pattern-callback parameter is
+    // a reactive value, so calling .get() on it (via a structural fallback, not
+    // a branded type) is flagged as an invalid opaque .get() call.
+
     const source = `      import { pattern } from "commonfabric";
 
       interface State { title: string; }
@@ -36,13 +37,14 @@ Deno.test(
   },
 );
 
-// isPatternCallbackParameter: the whole pattern input parameter (not
-// destructured) is reactive, so member access rooted at it and then .get() is
-// flagged. This drives the walk up to the enclosing function and its builder
-// call.
 Deno.test(
   "opaque-get flags .get() on a member of the whole pattern input parameter",
   async () => {
+    // isPatternCallbackParameter: the whole pattern input parameter (not
+    // destructured) is reactive, so member access rooted at it and then .get()
+    // is flagged. This drives the walk up to the enclosing function and its
+    // builder call.
+
     const source = `      import { pattern } from "commonfabric";
 
       interface State { nested: { value: number }; }
@@ -61,11 +63,12 @@ Deno.test(
   },
 );
 
-// isReactiveInitializer: a local variable initialized directly from a
-// reactive-origin call (computed()) is reactive; .get() on it is flagged.
 Deno.test(
   "opaque-get flags .get() on a local initialized from computed()",
   async () => {
+    // isReactiveInitializer: a local variable initialized directly from a
+    // reactive-origin call (computed()) is reactive; .get() on it is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern<{ count: number }>(({ count }) => {
@@ -83,12 +86,13 @@ Deno.test(
   },
 );
 
-// isReactiveInitializer unwrapping: the reactive-origin call is wrapped in a
-// parenthesized / non-null / property-access chain before assignment, and the
-// validator peels those layers off to find the origin call underneath.
 Deno.test(
   "opaque-get flags .get() on a local initialized from a wrapped reactive-origin call",
   async () => {
+    // isReactiveInitializer unwrapping: the reactive-origin call is wrapped in
+    // a parenthesized / non-null / property-access chain before assignment, and
+    // the validator peels those layers off to find the origin call underneath.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       interface Shape { inner: number; }
@@ -108,13 +112,14 @@ Deno.test(
   },
 );
 
-// isReactiveInitializer reads the shared transparent-wrapper set, so every
-// spelling that wraps the origin call without changing it reaches the same
-// diagnostic. `satisfies` is the spelling most easily left out of a
-// hand-written wrapper list, so it is pinned here alongside its neighbours.
 Deno.test(
   "opaque-get flags .get() on a local initialized through each wrapper spelling",
   async () => {
+    // isReactiveInitializer reads the shared transparent-wrapper set, so every
+    // spelling that wraps the origin call without changing it reaches the same
+    // diagnostic. `satisfies` is the spelling most easily left out of a
+    // hand-written wrapper list, so it is pinned here alongside its neighbours.
+
     const initializers = [
       "computed(() => count * 2)",
       "(computed(() => count * 2))",
@@ -146,12 +151,13 @@ Deno.test(
   },
 );
 
-// isReactiveExpression binding-element branch: a value destructured out of a
-// local whose initializer is a reactive-origin call is still reactive, so
-// .get() on the destructured binding is flagged.
 Deno.test(
   "opaque-get flags .get() on a binding destructured from a reactive local",
   async () => {
+    // isReactiveExpression binding-element branch: a value destructured out of
+    // a local whose initializer is a reactive-origin call is still reactive, so
+    // .get() on the destructured binding is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       interface Shape { a: number; b: number; }
@@ -171,14 +177,15 @@ Deno.test(
   },
 );
 
-// isPatternCallbackParameter walks up from the enclosing function to its
-// builder call. When the callback is wrapped in parentheses, the function's
-// immediate parent is not the call expression, so the walk climbs through the
-// parenthesized wrapper before reaching pattern(). The .get() on the reactive
-// input must still be flagged.
 Deno.test(
   "opaque-get flags .get() when the pattern callback is parenthesized",
   async () => {
+    // isPatternCallbackParameter walks up from the enclosing function to its
+    // builder call. When the callback is wrapped in parentheses, the function's
+    // immediate parent is not the call expression, so the walk climbs through
+    // the parenthesized wrapper before reaching pattern(). The .get() on the
+    // reactive input must still be flagged.
+
     const source = `      import { pattern } from "commonfabric";
 
       interface State { title: string; }
@@ -197,13 +204,14 @@ Deno.test(
   },
 );
 
-// isReactiveExpression bails out when the receiver identifier has no resolved
-// symbol: an unresolvable receiver cannot be proven reactive, so no
-// opaque-get diagnostic is produced for it (the structural fallback returns
-// false at the missing-symbol guard).
 Deno.test(
   "opaque-get does not flag .get() on an unresolvable identifier",
   async () => {
+    // isReactiveExpression bails out when the receiver identifier has no
+    // resolved symbol: an unresolvable receiver cannot be proven reactive, so
+    // no opaque-get diagnostic is produced for it (the structural fallback
+    // returns false at the missing-symbol guard).
+
     const source = `      import { pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -220,11 +228,13 @@ Deno.test(
   },
 );
 
-// A .get() on a genuine Cell/Writable must NOT be flagged by this validator:
-// cellKind === "cell" returns early, exercising the non-reactive path.
 Deno.test(
   "opaque-get does not flag .get() on a Writable cell",
   async () => {
+    // A .get() on a genuine Cell/Writable must NOT be flagged by this
+    // validator: cellKind === "cell" returns early, exercising the non-reactive
+    // path.
+
     const source = `      import { pattern, Cell } from "commonfabric";
 
       export default pattern<{ count: Cell<number> }>(({ count }) => {

--- a/packages/ts-transformers/test/pattern-context-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/pattern-context-validation-coverage.test.ts
@@ -14,14 +14,15 @@ function errorsOfType(
   return getErrors(diagnostics).filter((d) => d.type === type);
 }
 
-// validateComputationExpression -> findProblematicAccess: a reactive property
-// access used in a bare statement-position arithmetic computation is at a
-// restricted (non-lowerable) site, so it is rejected with
-// pattern-context:computation. findProblematicAccess locates the first
-// property access ('input.a') and names it in the message.
 Deno.test(
   "computation over reactive property in statement position names the access",
   async () => {
+    // validateComputationExpression -> findProblematicAccess: a reactive
+    // property access used in a bare statement-position arithmetic computation
+    // is at a restricted (non-lowerable) site, so it is rejected with
+    // pattern-context:computation. findProblematicAccess locates the first
+    // property access ('input.a') and names it in the message.
+
     const source = `      import { pattern } from "commonfabric";
 
       export default pattern<{ a: number }>((input) => {
@@ -38,13 +39,14 @@ Deno.test(
   },
 );
 
-// validateLocalReactiveAliasUsage: an if-statement condition that reads a
-// reactive value created locally inside the enclosing computed() callback is
-// rejected with compute-context:local-reactive-use, and the message tells the
-// author to move the use into a nested computed().
 Deno.test(
   "if-condition over locally created computed result is rejected",
   async () => {
+    // validateLocalReactiveAliasUsage: an if-statement condition that reads a
+    // reactive value created locally inside the enclosing computed() callback
+    // is rejected with compute-context:local-reactive-use, and the message
+    // tells the author to move the use into a nested computed().
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -70,12 +72,13 @@ Deno.test(
   },
 );
 
-// validateLocalReactiveAliasUsage while/for/switch statement heads: reading a
-// locally created reactive value in a while/for/switch head is rejected the
-// same way as an if-condition.
 Deno.test(
   "while/for/switch heads over locally created computed results are rejected",
   async () => {
+    // validateLocalReactiveAliasUsage while/for/switch statement heads: reading
+    // a locally created reactive value in a while/for/switch head is rejected
+    // the same way as an if-condition.
+
     const whileSource = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -135,12 +138,13 @@ Deno.test(
   },
 );
 
-// findProblematicUse member-access branch: a topmost property access rooted at
-// a locally created reactive value (`local.flag`) is itself the culprit, so
-// reading it in an if-condition is rejected.
 Deno.test(
   "member access on a locally created reactive result is rejected",
   async () => {
+    // findProblematicUse member-access branch: a topmost property access rooted
+    // at a locally created reactive value (`local.flag`) is itself the culprit,
+    // so reading it in an if-condition is rejected.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern<{ obj: { flag: boolean } }>(({ obj }) => {
@@ -165,12 +169,13 @@ Deno.test(
   },
 );
 
-// findProblematicUse call branch: a `.get()`/`.key()`/`.for()` chain on a
-// locally created reactive value is a provenance-preserving opaque-source call,
-// so using it in an if-condition is rejected as a local reactive use.
 Deno.test(
   "opaque-source call on a locally created reactive result is rejected",
   async () => {
+    // findProblematicUse call branch: a `.get()`/`.key()`/`.for()` chain on a
+    // locally created reactive value is a provenance-preserving opaque-source
+    // call, so using it in an if-condition is rejected as a local reactive use.
+
     const source =
       `      import { computed, pattern, Cell } from "commonfabric";
 
@@ -196,12 +201,14 @@ Deno.test(
   },
 );
 
-// checkExpression skips a missing expression: a for-statement with no condition
-// (`for (;;)`) passes an undefined condition to checkExpression, which returns
-// early. The loop body still reports the local reactive use inside it.
 Deno.test(
   "for-statement without a condition still reports the local reactive use",
   async () => {
+    // checkExpression skips a missing expression: a for-statement with no
+    // condition (`for (;;)`) passes an undefined condition to checkExpression,
+    // which returns early. The loop body still reports the local reactive use
+    // inside it.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -227,13 +234,14 @@ Deno.test(
   },
 );
 
-// findProblematicUse nested-function skip: when the checked expression contains
-// a nested callback (an array-method arrow), the walk does not descend into
-// that nested function, but still finds the local reactive use in the
-// surrounding condition.
 Deno.test(
   "condition with a nested callback still reports the local reactive use",
   async () => {
+    // findProblematicUse nested-function skip: when the checked expression
+    // contains a nested callback (an array-method arrow), the walk does not
+    // descend into that nested function, but still finds the local reactive use
+    // in the surrounding condition.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern<{ items: number[] }>(({ items }) => {
@@ -258,12 +266,13 @@ Deno.test(
   },
 );
 
-// validateObjectMemberCreation: `toJSON` is an ordinary member name, so a
-// method carrying it is rejected like any other object-literal method -- the
-// data model stores no function-valued member whatever it is called.
 Deno.test(
   "toJSON member on a pattern object literal is rejected",
   async () => {
+    // validateObjectMemberCreation: `toJSON` is an ordinary member name, so a
+    // method carrying it is rejected like any other object-literal method --
+    // the data model stores no function-valued member whatever it is called.
+
     const source = `      import { pattern, UI } from "commonfabric";
 
       export default pattern<{ name: string }>(({ name }) => {
@@ -283,12 +292,13 @@ Deno.test(
   },
 );
 
-// validateStandaloneFunction: a standalone (module-scope) function that calls a
-// reactive-origin builder like computed() is rejected, since standalone
-// functions cannot capture reactive closures.
 Deno.test(
   "standalone function calling computed() is rejected",
   async () => {
+    // validateStandaloneFunction: a standalone (module-scope) function that
+    // calls a reactive-origin builder like computed() is rejected, since
+    // standalone functions cannot capture reactive closures.
+
     const source = `      import { computed } from "commonfabric";
 
       export function makeDoubled(n: number) {
@@ -307,12 +317,13 @@ Deno.test(
   },
 );
 
-// validateStandaloneFunction reactive-array-method branch: a standalone
-// function that calls a reactive array method (.map on a Cell array) is
-// rejected, and the message names the offending method family.
 Deno.test(
   "standalone function calling a reactive array method is rejected",
   async () => {
+    // validateStandaloneFunction reactive-array-method branch: a standalone
+    // function that calls a reactive array method (.map on a Cell array) is
+    // rejected, and the message names the offending method family.
+
     const source = `      import { Cell } from "commonfabric";
 
       export function run(items: Cell<number[]>) {
@@ -331,12 +342,13 @@ Deno.test(
   },
 );
 
-// validateCallbackSelfContainment with a parameter default initializer that
-// references an enclosing callable: the initializer is visited and the capture
-// is flagged.
 Deno.test(
   "callback parameter default initializer capturing a helper is flagged",
   async () => {
+    // validateCallbackSelfContainment with a parameter default initializer that
+    // references an enclosing callable: the initializer is visited and the
+    // capture is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -356,13 +368,15 @@ Deno.test(
   },
 );
 
-// isCallableReference non-callable-capture path: a captured uninitialized local
-// (a `let` with a non-function type, no initializer) is neither a call use-site
-// nor an inference-checkable binding, so the validator classifies it as
-// non-callable and does NOT emit a callable-capture diagnostic for it.
 Deno.test(
   "capturing a non-callable uninitialized local is not flagged",
   async () => {
+    // isCallableReference non-callable-capture path: a captured uninitialized
+    // local (a `let` with a non-function type, no initializer) is neither a
+    // call use-site nor an inference-checkable binding, so the validator
+    // classifies it as non-callable and does NOT emit a callable-capture
+    // diagnostic for it.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -386,14 +400,16 @@ Deno.test(
   },
 );
 
-// isSyntacticCallable parameter-type branch -> isCallableTypeNode: a callback
-// whose parameter is explicitly typed as a function type (with no initializer,
-// so the type node is inspected rather than an initializer) is callable, and
-// capturing that parameter inside a nested computed callback is flagged. This
-// exercises isCallableTypeNode's plain function-type branch.
 Deno.test(
   "callback capturing a function-typed parameter is flagged",
   async () => {
+    // isSyntacticCallable parameter-type branch -> isCallableTypeNode: a
+    // callback whose parameter is explicitly typed as a function type (with no
+    // initializer, so the type node is inspected rather than an initializer) is
+    // callable, and capturing that parameter inside a nested computed callback
+    // is flagged. This exercises isCallableTypeNode's plain function-type
+    // branch.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -414,12 +430,13 @@ Deno.test(
   },
 );
 
-// isCallableTypeNode parenthesized-type branch: a parameter typed with a
-// parenthesized function type unwraps to the inner function type and is
-// recognized as callable, so capturing it is flagged.
 Deno.test(
   "callback capturing a parenthesized-function-typed parameter is flagged",
   async () => {
+    // isCallableTypeNode parenthesized-type branch: a parameter typed with a
+    // parenthesized function type unwraps to the inner function type and is
+    // recognized as callable, so capturing it is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -438,12 +455,13 @@ Deno.test(
   },
 );
 
-// isCallableTypeNode union-type branch: a parameter typed as a union that
-// contains a function type has at least one callable member, so capturing it is
-// flagged.
 Deno.test(
   "callback capturing a union-function-typed parameter is flagged",
   async () => {
+    // isCallableTypeNode union-type branch: a parameter typed as a union that
+    // contains a function type has at least one callable member, so capturing
+    // it is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -463,12 +481,13 @@ Deno.test(
   },
 );
 
-// isCallableTypeNode intersection-type branch: a parameter typed as an
-// intersection that contains a function type has a callable member, so
-// capturing it is flagged.
 Deno.test(
   "callback capturing an intersection-function-typed parameter is flagged",
   async () => {
+    // isCallableTypeNode intersection-type branch: a parameter typed as an
+    // intersection that contains a function type has a callable member, so
+    // capturing it is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -488,12 +507,13 @@ Deno.test(
   },
 );
 
-// isCallableTypeNode Function-reference branch: a parameter typed as the global
-// Function type is recognized as callable by its type reference name, so
-// capturing it is flagged.
 Deno.test(
   "callback capturing a Function-typed parameter is flagged",
   async () => {
+    // isCallableTypeNode Function-reference branch: a parameter typed as the
+    // global Function type is recognized as callable by its type reference
+    // name, so capturing it is flagged.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {
@@ -512,12 +532,13 @@ Deno.test(
   },
 );
 
-// report() dedup: when a single captured helper is referenced multiple times in
-// one callback, the callable-capture diagnostic is emitted only once (keyed by
-// identifier text), exercising the diagnosticsSeen guard.
 Deno.test(
   "a helper captured multiple times is reported once",
   async () => {
+    // report() dedup: when a single captured helper is referenced multiple
+    // times in one callback, the callable-capture diagnostic is emitted only
+    // once (keyed by identifier text), exercising the diagnosticsSeen guard.
+
     const source = `      import { computed, pattern } from "commonfabric";
 
       export default pattern(() => {

--- a/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
@@ -150,15 +150,13 @@ Deno.test(
   },
 );
 
+// Branch: `updateLocalCollectionBinding` deletes the tracked map-value binding
+// when two `.set()` calls store non-equal sources so their merge is undefined
+// (capability-analysis.ts ~1977-1979). Contrast with a single `.set()`, where
+// the binding survives and a later `.get(k).name` resolves through it.
 Deno.test(
   "a single map .set() lets a later .get().member resolve through the value binding",
   () => {
-    // Branch: `updateLocalCollectionBinding` deletes the tracked map-value
-    // binding when two `.set()` calls store non-equal sources so their merge is
-    // undefined (capability-analysis.ts ~1977-1979). Contrast with a single
-    // `.set()`, where the binding survives and a later `.get(k).name` resolves
-    // through it.
-
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input) => {

--- a/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
@@ -110,14 +110,15 @@ type Cell<T> = {
   push(...items: unknown[]): number;
 };`;
 
-// Branch: the fallthrough `trackReadRef(resolvedSource, { identityOnly: true })`
-// (capability-analysis.ts ~2833-2837). Reached when an alias used as the
-// argument of a known identity call is itself a dynamic source: the three
-// earlier `!dynamic` guards all fall through, and because the ref is dynamic the
-// read widens the whole parameter root to wildcard.
 Deno.test(
   "identity call on a dynamic alias widens the parameter root to wildcard",
   () => {
+    // Branch: the fallthrough `trackReadRef(resolvedSource, { identityOnly:
+    // true })` (capability-analysis.ts ~2833-2837). Reached when an alias used
+    // as the argument of a known identity call is itself a dynamic source: the
+    // three earlier `!dynamic` guards all fall through, and because the ref is
+    // dynamic the read widens the whole parameter root to wildcard.
+
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input, k) => {
@@ -149,13 +150,15 @@ Deno.test(
   },
 );
 
-// Branch: `updateLocalCollectionBinding` deletes the tracked map-value binding
-// when two `.set()` calls store non-equal sources so their merge is undefined
-// (capability-analysis.ts ~1977-1979). Contrast with a single `.set()`, where
-// the binding survives and a later `.get(k).name` resolves through it.
 Deno.test(
   "a single map .set() lets a later .get().member resolve through the value binding",
   () => {
+    // Branch: `updateLocalCollectionBinding` deletes the tracked map-value
+    // binding when two `.set()` calls store non-equal sources so their merge is
+    // undefined (capability-analysis.ts ~1977-1979). Contrast with a single
+    // `.set()`, where the binding survives and a later `.get(k).name` resolves
+    // through it.
+
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input) => {
@@ -197,13 +200,15 @@ Deno.test(
   },
 );
 
-// Branch: an array-identity writer (`push`) whose argument aliases an
-// array element reads that element's path (capability-analysis.ts ~3128-3130).
-// The `.find()` result carries an array-element binding, so pushing it records a
-// read of the element path rather than treating the pushed value as opaque.
 Deno.test(
   "push() of an array-element alias reads the element path",
   () => {
+    // Branch: an array-identity writer (`push`) whose argument aliases an array
+    // element reads that element's path (capability-analysis.ts ~3128-3130).
+    // The `.find()` result carries an array-element binding, so pushing it
+    // records a read of the element path rather than treating the pushed value
+    // as opaque.
+
     const input = getPaths(
       analyze(
         `${CELL}
@@ -236,14 +241,16 @@ export declare function notify(target: Stream<string>): void;
 export declare function assign(target: Writable<string>): void;`,
 };
 
-// Branch: `Stream<T>` is the wrapper whose capability is neither read nor
-// write, so a parameter passed to one is recorded as an opaque path
-// (capability-analysis.ts ~377-378 and ~2540-2543). Which pattern in the
-// corpus passes a stream to a declared `Stream<T>` parameter decides whether
-// the branch runs at all, so it is covered on some CI runs and not others.
 Deno.test(
   "a stream argument is recorded opaque while a writable argument is read and written",
   () => {
+    // Branch: `Stream<T>` is the wrapper whose capability is neither read nor
+    // write, so a parameter passed to one is recorded as an opaque path
+    // (capability-analysis.ts ~377-378 and ~2540-2543). Which pattern in the
+    // corpus passes a stream to a declared `Stream<T>` parameter decides
+    // whether the branch runs at all, so it is covered on some CI runs and not
+    // others.
+
     const input = getPaths(
       analyze(
         `import type { Stream, Writable } from "commonfabric";
@@ -265,13 +272,15 @@ Deno.test(
   },
 );
 
-// Branch: `aliasBindingEquals` falls through to `false` when the two bindings
-// are of different shapes -- one a reference to a parameter path, the other a
-// record of properties (capability-analysis.ts ~1237). The two branches above
-// it, which compare two references or two records, are reached far more often.
 Deno.test(
   "map values of different binding shapes drop the value binding",
   () => {
+    // Branch: `aliasBindingEquals` falls through to `false` when the two
+    // bindings are of different shapes -- one a reference to a parameter path,
+    // the other a record of properties (capability-analysis.ts ~1237). The two
+    // branches above it, which compare two references or two records, are
+    // reached far more often.
+
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input) => {

--- a/packages/ts-transformers/test/replacement-source-map-range.test.ts
+++ b/packages/ts-transformers/test/replacement-source-map-range.test.ts
@@ -781,13 +781,14 @@ describe("replacement source-map ranges", () => {
     );
   });
 
-  // The cases above pin the sites this file knows about by name. This one is
-  // the drift gate: it makes the same guarantee over every fixture, so a NEW
-  // stage that rebuilds a JSX node without carrying its range fails here
-  // instead of waiting for someone to notice a wrong debug position. The
-  // fixtures declared above are included because the corpus reaches no
-  // UI-helper element, which would otherwise leave that family ungated.
   it("recovers an authored position for every synthesized JSX node in the corpus", async () => {
+    // The cases above pin the sites this file knows about by name. This one is
+    // the drift gate: it makes the same guarantee over every fixture, so a NEW
+    // stage that rebuilds a JSX node without carrying its range fails here
+    // instead of waiting for someone to notice a wrong debug position. The
+    // fixtures declared above are included because the corpus reaches no
+    // UI-helper element, which would otherwise leave that family ungated.
+
     const fixturePaths = await collectFixturePaths();
     expect(fixturePaths.length, "fixture corpus is non-empty").toBeGreaterThan(
       100,

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -2680,11 +2680,12 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
     },
   );
 
-  // The rule ignores the body, so reactive reads laundered through these shapes
-  // are caught without a body scanner.
   await t.step(
     "errors regardless of how the body reads the reactive value",
     async () => {
+      // The rule ignores the body, so reactive reads laundered through these
+      // shapes are caught without a body scanner.
+
       const bodies = [
         "{ get t() { const { token } = value; return token; } }", // destructuring
         "{ read() { return { ...value }; } }", // spread
@@ -2705,10 +2706,11 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
     },
   );
 
-  // Closing the JSX hole: an object-literal member function in a JSX data
-  // position is not lowered there and is rejected, but JSX event handlers and
-  // render/array-method callbacks stay legal.
   await t.step("errors on a function-valued property inside JSX", async () => {
+    // Closing the JSX hole: an object-literal member function in a JSX data
+    // position is not lowered there and is rejected, but JSX event handlers and
+    // render/array-method callbacks stay legal.
+
     const { diagnostics } = await validateSource(
       `      import { computed, pattern, h } from "commonfabric";
 
@@ -2798,12 +2800,14 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
     assertEquals(memberErrors(diagnostics).length, 0);
   });
 
-  // A class in pattern context is flagged by pattern-context:function-creation
-  // (the class rule), not by the object-member rule — object-member is scoped to
-  // object-literal members. This pins the division between the two diagnostics.
   await t.step(
     "flags a class via function-creation, not via object-member",
     async () => {
+      // A class in pattern context is flagged by
+      // pattern-context:function-creation (the class rule), not by the
+      // object-member rule — object-member is scoped to object-literal members.
+      // This pins the division between the two diagnostics.
+
       const { diagnostics } = await validateSource(
         `      import { computed, pattern } from "commonfabric";
 
@@ -2825,13 +2829,14 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
     },
   );
 
-  // A function-valued property may be wrapped in transparent expressions
-  // (parentheses, `as`, `satisfies`, `!`, `<T>`) before the property assignment.
-  // The wrapped spelling is the same member and reports object-member, not
-  // function-creation, in and out of JSX.
   await t.step(
     "reports object-member for transparently-wrapped function properties",
     async () => {
+      // A function-valued property may be wrapped in transparent expressions
+      // (parentheses, `as`, `satisfies`, `!`, `<T>`) before the property
+      // assignment. The wrapped spelling is the same member and reports
+      // object-member, not function-creation, in and out of JSX.
+
       const wrapped = [
         "{ read: (() => value?.token) as () => string | undefined }", // as-cast
         "{ read: (() => value?.token) }", // parentheses
@@ -2877,13 +2882,14 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
     },
   );
 
-  // `toJSON` is an ordinary member name here. The rule is body-agnostic for it
-  // as for every other member: the reactive-read lowering pass does not descend
-  // into any function body, and a member the data model cannot store is
-  // unstorable whatever it reads.
   await t.step(
     "flags a toJSON() member that reads nothing reactive",
     async () => {
+      // `toJSON` is an ordinary member name here. The rule is body-agnostic for
+      // it as for every other member: the reactive-read lowering pass does not
+      // descend into any function body, and a member the data model cannot
+      // store is unstorable whatever it reads.
+
       const { diagnostics } = await validateSource(
         `      import { pattern } from "commonfabric";
 
@@ -4999,14 +5005,15 @@ Deno.test("Inline reactive-root chain rewrite", async (t) => {
 });
 
 Deno.test("Module-extracted reactive callback bodies (CT-1587)", async (t) => {
-  // ClosureTransformer hoists reactive callback bodies (computed/lift/etc.)
-  // into top-level `const __cfModuleCallback_N = ...` declarations. Those
-  // bodies must still receive the reactive-root lowering pass so chains like
-  // `cell.result` get lowered to `cell.key("result")` — otherwise the access
-  // stays as plain JS and unwraps the cell at runtime.
   await t.step(
     "lowers property access on opaque roots inside computed() bodies",
     async () => {
+      // ClosureTransformer hoists reactive callback bodies (computed/lift/etc.)
+      // into top-level `const __cfModuleCallback_N = ...` declarations. Those
+      // bodies must still receive the reactive-root lowering pass so chains
+      // like `cell.result` get lowered to `cell.key("result")` — otherwise the
+      // access stays as plain JS and unwraps the cell at runtime.
+
       const source = `
         import { computed, Default, pattern, wish } from "commonfabric";
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `ts-transformers` and `schema-generator` to the "Commenting a block"
rule in `unit-test-coding-style.md`: a comment about a test or a group of tests
goes inside the block's callback, as its first content, followed by a blank
line.

47 comments in 12 files. Forty-five move into the block they describe.

Two stay where they are, because each covers a pair of sibling tests that
nothing groups. `capability-analysis-flap-coverage.test.ts`'s
`updateLocalCollectionBinding` note names the delete branch and then its
contrast, and the delete branch is the second of the two tests. The CT-1615
note in `schema-generator.test.ts` names both the index-signature and the
`Record<K, V>` shape, and the two tests split on exactly that line.

Thirty-seven of the moved blocks overflowed 80 columns at the new indent and
are reflowed; the conversion compares each block's word sequence before and
after rather than trusting the reflow.

Most of these sites are `Deno.test()` with a multi-line signature, where the
callback's brace is two or three lines below the call. The comment lands inside
that callback, at the body's indent.

## What the diff is, as a property

Across the 12 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0).
- Per file, the multiset of comment words is unchanged.
- Per file, the multiset of non-comment lines is unchanged.
- No added line exceeds 80 characters, counted in characters rather than bytes.

These test files embed TypeScript fixtures as template literals, and those
fixtures carry `//` comments of their own. The suites are what rule out a move
having reached into one: both run green, and the non-comment line multiset
being unchanged means nothing outside a comment moved.

## Gates

`deno fmt --check` and `deno lint` pass over both packages. `deno task test`:
`schema-generator` 57 passed / 0 failed (330 steps), `ts-transformers` 1164
passed / 0 failed (918 steps). A re-run of the census over both packages finds
no remaining comment above a test-block opener.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


