### PR TITLE
test(cf-harness): a block's comment moves inside the block it describes

### DIFF
--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -239,13 +239,22 @@ describe("console/src/cell-chip", () => {
         ...over,
       }) as ConsoleCellLabelView;
 
+    //
+    // The positive half
+    //
+
     it("lets a reading that covered the whole of a bare cell say so", () => {
       expect(spaceHoldsNoLabel(view())).toBe(true);
     });
 
-    // The negative half, stated state by state. The claim is a conjunction,
-    // so an edit that drops one of its terms widens it without failing
-    // anything that only checks the positive case.
+    //
+    // The negative half
+    //
+    // Stated state by state. The claim is a conjunction, so an edit that drops
+    // one of its terms widens it without failing anything that only checks the
+    // positive case.
+    //
+
     it("refuses a cell no reading recorded", () => {
       expect(spaceHoldsNoLabel(view({ recorded: false }))).toBe(false);
     });

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -243,11 +243,10 @@ describe("console/src/cell-chip", () => {
       expect(spaceHoldsNoLabel(view())).toBe(true);
     });
 
+    // The negative half, stated state by state. The claim is a conjunction,
+    // so an edit that drops one of its terms widens it without failing
+    // anything that only checks the positive case.
     it("refuses a cell no reading recorded", () => {
-      // The negative half, stated state by state. The claim is a conjunction,
-      // so an edit that drops one of its terms widens it without failing
-      // anything that only checks the positive case.
-
       expect(spaceHoldsNoLabel(view({ recorded: false }))).toBe(false);
     });
 

--- a/packages/cf-harness/test/console/src/cell-chip.test.ts
+++ b/packages/cf-harness/test/console/src/cell-chip.test.ts
@@ -243,10 +243,11 @@ describe("console/src/cell-chip", () => {
       expect(spaceHoldsNoLabel(view())).toBe(true);
     });
 
-    // The negative half, stated state by state. The claim is a conjunction,
-    // so an edit that drops one of its terms widens it without failing
-    // anything that only checks the positive case.
     it("refuses a cell no reading recorded", () => {
+      // The negative half, stated state by state. The claim is a conjunction,
+      // so an edit that drops one of its terms widens it without failing
+      // anything that only checks the positive case.
+
       expect(spaceHoldsNoLabel(view({ recorded: false }))).toBe(false);
     });
 

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -64,11 +64,12 @@ describe("fabric-session", () => {
       expect(calls).toBe(1);
     });
 
-    // Only a HEALTHY session is cached: a rejected construction clears the
-    // cache so a later tool call retries the factory instead of replaying a
-    // terminal failure for the rest of the run. This deliberately supersedes
-    // the earlier behavior of caching the rejection forever.
     it("invokes a synchronously-throwing factory again after its rejection settles, and a later attempt can succeed", async () => {
+      // Only a HEALTHY session is cached: a rejected construction clears the
+      // cache so a later tool call retries the factory instead of replaying a
+      // terminal failure for the rest of the run. This deliberately supersedes
+      // the earlier behavior of caching the rejection forever.
+
       let calls = 0;
       const session = {} as HarnessFabricSession;
       const cached = cacheHarnessFabricSessionFactory(() => {

--- a/packages/cf-harness/test/seed-pattern-index.test.ts
+++ b/packages/cf-harness/test/seed-pattern-index.test.ts
@@ -217,9 +217,10 @@ describe("seed-pattern-index", () => {
       expect(parseArguments(["-h"]).help).toBe(true);
     });
 
-    // A dropped flag would seed more than the caller asked for, against a
-    // shared corpus, so an argument the parser cannot place stops the run.
     it("refuses an argument it cannot place", () => {
+      // A dropped flag would seed more than the caller asked for, against a
+      // shared corpus, so an argument the parser cannot place stops the run.
+
       expect(() => parseArguments(["counter"])).toThrow(SeedUsageError);
     });
 
@@ -361,9 +362,11 @@ describe("seed-pattern-index", () => {
       expect(r.published).toEqual(["id-for-counter.tsx"]);
     });
 
-    // Re-running must not create duplicates: the index answers `created:false`
-    // for an identity it already holds, and that records no further event.
     it("records no event for an atom the index already holds", async () => {
+      // Re-running must not create duplicates: the index answers
+      // `created:false` for an identity it already holds, and that records no
+      // further event.
+
       const r = recorder({
         publish: (request) =>
           Promise.resolve({ patternId: request.patternId, created: false }),
@@ -377,9 +380,10 @@ describe("seed-pattern-index", () => {
       expect(r.lines.at(-1)).toContain("0 published, 6 already held");
     });
 
-    // An entry under a keyless identity could never be loaded by anything
-    // else, so the run stops rather than seeding one.
     it("publishes nothing when an atom compiles to no durable identity", async () => {
+      // An entry under a keyless identity could never be loaded by anything
+      // else, so the run stops rather than seeding one.
+
       const r = recorder({
         compile: () =>
           Promise.resolve({
@@ -418,9 +422,10 @@ describe("seed-pattern-index", () => {
       expect(durableEntryIdentity(undefined)).toBeUndefined();
     });
 
-    // An entry published under a keyless identity could never be loaded by
-    // any other runtime, so it must not reach the index at all.
     it("refuses a keyless identity", () => {
+      // An entry published under a keyless identity could never be loaded by
+      // any other runtime, so it must not reach the index at all.
+
       expect(durableEntryIdentity("keyless:abc123")).toBeUndefined();
     });
   });
@@ -633,11 +638,12 @@ describe("seed-pattern-index", () => {
   describe("the formatting guard", () => {
     const directory = join(REPO_ROOT, SEED_DIRECTORY);
 
-    // An entry identity is a hash of the source bytes, so publishing
-    // unformatted source mints an id the repository cannot reproduce: the next
-    // `deno fmt` changes the bytes and the same atom seeds again under a second
-    // id. One atom, two entries, competing in search.
     it("publishes nothing when an atom is not formatted, and names it", async () => {
+      // An entry identity is a hash of the source bytes, so publishing
+      // unformatted source mints an id the repository cannot reproduce: the
+      // next `deno fmt` changes the bytes and the same atom seeds again under a
+      // second id. One atom, two entries, competing in search.
+
       const published: string[] = [];
       const errors: string[] = [];
       const compiled: string[] = [];
@@ -699,21 +705,23 @@ describe("seed-pattern-index", () => {
       expect(published).toEqual(["id"]);
     });
 
-    // The guard is only as good as the check behind it, so the real one is
-    // exercised against the atoms as committed.
     it("finds the committed atoms already formatted", async () => {
+      // The guard is only as good as the check behind it, so the real one is
+      // exercised against the atoms as committed.
+
       const paths = await seedSourcePaths(directory);
       expect(await denoFmtCheck(paths)).toEqual([]);
     });
 
-    // Deliberately mixes a formatted file in with the unformatted one, and
-    // asserts BOTH that the offender is named and that the innocent file is
-    // not. Given a single path those two claims coincide with "blame
-    // everything I was given", which is what `denoFmtCheck` falls back to when
-    // it cannot read deno's answer — so a one-file version of this test passes
-    // against a parse that never worked, and passed against a fixture that did
-    // not exist at all.
     it("names only the unformatted file among several", async () => {
+      // Deliberately mixes a formatted file in with the unformatted one, and
+      // asserts BOTH that the offender is named and that the innocent file is
+      // not. Given a single path those two claims coincide with "blame
+      // everything I was given", which is what `denoFmtCheck` falls back to
+      // when it cannot read deno's answer — so a one-file version of this test
+      // passes against a parse that never worked, and passed against a fixture
+      // that did not exist at all.
+
       // Written outside the repository so the repo's own formatting gates
       // cannot rewrite the thing under test.
       const directory = await Deno.makeTempDir();
@@ -734,10 +742,11 @@ describe("seed-pattern-index", () => {
       }
     });
 
-    // The fallback itself: a non-zero exit deno named no file for is still a
-    // refusal to publish, because seeding on an unreadable answer is the
-    // silence this guard exists to prevent.
     it("refuses everything it was given when deno names no file", async () => {
+      // The fallback itself: a non-zero exit deno named no file for is still a
+      // refusal to publish, because seeding on an unreadable answer is the
+      // silence this guard exists to prevent.
+
       const directory = await Deno.makeTempDir();
       await Deno.remove(directory, { recursive: true });
       const absent = join(directory, "gone.ts");
@@ -827,10 +836,11 @@ describe("seed-pattern-index", () => {
       indexBaseUrl: "https://index.example",
     };
 
-    // Which setting reaches the fabric and which reaches the index are both
-    // strings, so wiring one to the other compiles and fails only in the
-    // deployment. This is the assertion that catches it.
     it("wires the fabric settings to the session and the index URL to the client", async () => {
+      // Which setting reaches the fabric and which reaches the index are both
+      // strings, so wiring one to the other compiles and fails only in the
+      // deployment. This is the assertion that catches it.
+
       let sessionArgs: unknown;
       let clientArgs: unknown[] = [];
       const deps = await fabricSeedDeps(
@@ -863,9 +873,10 @@ describe("seed-pattern-index", () => {
       expect(deps.checkFormatting).toBe(denoFmtCheck);
     });
 
-    // Exercises the constructions it performs by default rather than the
-    // stand-ins, and fails on the keyfile before reaching any network.
     it("fails when the identity keyfile is absent", async () => {
+      // Exercises the constructions it performs by default rather than the
+      // stand-ins, and fails on the keyfile before reaching any network.
+
       await expect(
         fabricSeedDeps(
           { ...settings, identityKeyPath: "/keys/definitely-absent.pkcs8" },
@@ -878,16 +889,17 @@ describe("seed-pattern-index", () => {
   });
 
   describe("as a program", () => {
-    // The one path that runs the file as a script rather than importing it.
-    // `--help` neither connects to a fabric nor writes anything, so this is a
-    // smoke test of the entry point itself: it parses, prints, and exits 0.
-    //
-    // Runs through the isolated-lock helper, which points the child at a copy
-    // of `deno.lock` so resolving dependencies cannot rewrite the real one,
-    // and which spawns `Deno.execPath()` rather than whichever `deno` is on
-    // PATH — a different Deno reads transpiled sources from its own part of
-    // the cache, and reports coverage with every file missing.
     it("prints usage and exits zero", async () => {
+      // The one path that runs the file as a script rather than importing it.
+      // `--help` neither connects to a fabric nor writes anything, so this is a
+      // smoke test of the entry point itself: it parses, prints, and exits 0.
+      //
+      // Runs through the isolated-lock helper, which points the child at a copy
+      // of `deno.lock` so resolving dependencies cannot rewrite the real one,
+      // and which spawns `Deno.execPath()` rather than whichever `deno` is on
+      // PATH — a different Deno reads transpiled sources from its own part of
+      // the cache, and reports coverage with every file missing.
+
       const output = await runDenoCommandWithTemporaryLock({
         root: REPO_ROOT,
         args: (lock) => [
@@ -933,9 +945,10 @@ describe("seed-pattern-index", () => {
       expect(request.program.main).toBe("/primitives/counter.tsx");
     });
 
-    // The seed sets no discoverability field: an omitted one is discoverable,
-    // and these atoms are the curated tier.
     it("sets no field that would withhold an atom from discovery", () => {
+      // The seed sets no discoverability field: an omitted one is discoverable,
+      // and these atoms are the curated tier.
+
       expect("nonDiscoverable" in publishRequestFor(entry)).toBe(false);
     });
 

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -71,10 +71,11 @@ Deno.test("keying - generateKey", async (t) => {
     assertEquals(generateKey(true), generateKey(true));
   });
 
-  // Members a child can differ by, each of which must key it apart: two
-  // children keying alike are reconciled as one, and the second one's content
-  // never reaches the DOM. Each of these is a value `WorkerProps` admits.
   await t.step("keys members that differ only in fabric terms", () => {
+    // Members a child can differ by, each of which must key it apart: two
+    // children keying alike are reconciled as one, and the second one's content
+    // never reaches the DOM. Each of these is a value `WorkerProps` admits.
+
     const key = (props: Record<string, unknown>) =>
       generateKey({ type: "vnode", name: "div", props });
 

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2846,11 +2846,12 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // The mounted root cell is an egress like any descendant cell: its own
-    // label must pass the root policy before its resolved content renders.
     await t.step(
       "default ceiling gates a labeled cell mounted as the root",
       async () => {
+        // The mounted root cell is an egress like any descendant cell: its own
+        // label must pass the root policy before its resolved content renders.
+
         const blocked = createOpsCollector();
         const blockedReconciler = new WorkerReconciler({
           onOps: blocked.onOps,
@@ -2913,15 +2914,16 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // Epic H3a: the shell's initial ceiling profile (spec §8.10.6, mirrors
-    // lib-shell's defaultRenderConfidentialityCeiling) uses the acting user's
-    // DID *string* as the exact-match identity atom. Pin that the string form
-    // gates correctly: the same ceiling admits the acting user's own content
-    // and fail-closes an identity atom it omits (another user's). Exchange
-    // resolution (PersonalSpace/HasRole forms) is H3b.
     await t.step(
       "acting-user DID-string ceiling admits own content, blocks another user's",
       async () => {
+        // Epic H3a: the shell's initial ceiling profile (spec §8.10.6, mirrors
+        // lib-shell's defaultRenderConfidentialityCeiling) uses the acting
+        // user's DID *string* as the exact-match identity atom. Pin that the
+        // string form gates correctly: the same ceiling admits the acting
+        // user's own content and fail-closes an identity atom it omits (another
+        // user's). Exchange resolution (PersonalSpace/HasRole forms) is H3b.
+
         const otherUserDid = "did:key:z6MkOtherUserOutsideCeiling";
         const seedTx = runtime.edit();
         const seedUserScoped = (id: string, value: string, atom: string) => {
@@ -3000,13 +3002,15 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // Epic H3b: the render gate resolves §15.2 principal shapes through the
-    // runner-side exchange evaluator (spec §8.10.6) before the fit check. The
-    // reconciler consumes the resolved label; a display-class BoundaryContext
-    // and the acting user's HasRole membership facts drive resolution.
     await t.step(
       "H3b resolver admits User/Space-via-HasRole and blocks the unresolvable",
       async () => {
+        // Epic H3b: the render gate resolves §15.2 principal shapes through the
+        // runner-side exchange evaluator (spec §8.10.6) before the fit check.
+        // The reconciler consumes the resolved label; a display-class
+        // BoundaryContext and the acting user's HasRole membership facts drive
+        // resolution.
+
         const seedTx = runtime.edit();
         const seedLabeled = (id: string, value: string, atom: CfcAtom) => {
           const cell = runtime.getCell<string>(
@@ -3099,13 +3103,15 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // With the resolver active, the clause-aware fit still routes each
-    // still-offending clause through the same per-clause admission as the H3a
-    // path: the read-failure marker stays ungrantable (audit item 22), an
-    // allow-listed caveat kind renders, and an author-declassified atom renders.
     await t.step(
       "resolved-path fit honors marker / caveat-kind / declassification",
       async () => {
+        // With the resolver active, the clause-aware fit still routes each
+        // still-offending clause through the same per-clause admission as the
+        // H3a path: the read-failure marker stays ungrantable (audit item 22),
+        // an allow-listed caveat kind renders, and an author-declassified atom
+        // renders.
+
         const resolver = createRenderConfidentialityResolver({
           actingPrincipal: signer.did(),
           memberSpaces: [signer.did()],
@@ -3266,13 +3272,14 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // Audit item 22 (ungrantable marker): "cfc:label-read-failed" means
-    // "the label could not be read", so it must never fit a render policy —
-    // even one that names the exported marker string — in either the
-    // ceiling or the declassification direction.
     await t.step(
       "neither ceiling nor declassification admits the read-failure marker",
       async () => {
+        // Audit item 22 (ungrantable marker): "cfc:label-read-failed" means
+        // "the label could not be read", so it must never fit a render policy —
+        // even one that names the exported marker string — in either the
+        // ceiling or the declassification direction.
+
         const seedTx = runtime.edit();
         const markerCellSeed = runtime.getCell<string>(
           signer.did(),
@@ -3359,12 +3366,13 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // The ceiling crosses the postMessage seam unvalidated; a malformed
-    // shape must fail CLOSED (empty ceiling — public-only rendering), never
-    // crash the mount and never fail open to unbounded.
     await t.step(
       "a malformed ceiling fails closed instead of crashing the mount",
       async () => {
+        // The ceiling crosses the postMessage seam unvalidated; a malformed
+        // shape must fail CLOSED (empty ceiling — public-only rendering), never
+        // crash the mount and never fail open to unbounded.
+
         const collector = createOpsCollector();
         const reconciler = new WorkerReconciler({
           onOps: collector.onOps,
@@ -3389,15 +3397,17 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // §4.9.3 Stage 2 (reactive upgrade): a cell labeled Space(X) where X's ACL
-    // has not yet synced fails closed (Stage 1); when the membership provider
-    // later reports X grants the acting user READ and fires its subscription,
-    // the cell re-renders and admits — WITHOUT a new value on the cell. Proves
-    // the reconciler wires the provider's ACL-change subscription into the
-    // cell's cancel group and re-evaluates the render gate on change.
     await t.step(
       "reactively re-renders a Space(X) cell once its ACL grants READ",
       async () => {
+        // §4.9.3 Stage 2 (reactive upgrade): a cell labeled Space(X) where X's
+        // ACL has not yet synced fails closed (Stage 1); when the membership
+        // provider later reports X grants the acting user READ and fires its
+        // subscription, the cell re-renders and admits — WITHOUT a new value on
+        // the cell. Proves the reconciler wires the provider's ACL-change
+        // subscription into the cell's cancel group and re-evaluates the render
+        // gate on change.
+
         const teamSpace = "did:key:z6MkTeamSpaceStage4Reactive";
         const seedTx = runtime.edit();
         const teamCell = runtime.getCell<string>(
@@ -3549,11 +3559,12 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // The root-mounted cell is an egress too (codex P2): a Space(X) cell
-    // mounted AS the root gets the same reactive upgrade as a descendant.
     await t.step(
       "reactively re-renders a root-mounted Space(X) cell once its ACL grants READ",
       async () => {
+        // The root-mounted cell is an egress too (codex P2): a Space(X) cell
+        // mounted AS the root gets the same reactive upgrade as a descendant.
+
         const teamSpace = "did:key:z6MkTeamSpaceStage4Root";
         const seedTx = runtime.edit();
         const teamCell = runtime.getCell<string>(

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -822,14 +822,15 @@ describe("opening a space root", () => {
     ).toBeUndefined();
   });
 
-  // The boot path (ensureDefaultPattern) reconciles an unloadable root before
-  // start — but registry listings, `cf piece ls`, FUSE, and the shell's list
-  // cells all resolve the root through PiecesController.getDefaultPattern instead,
-  // which used to inherit NO heal: the load failure propagated and every
-  // listing died with the root (2026-07-29 vendor gate, the cf-cell-context
-  // type retirement). The controller choke point must run the same awaited
-  // updater check and retry once.
   it("heals an unloadable stale root on the REGISTRY path (not just boot)", async () => {
+    // The boot path (ensureDefaultPattern) reconciles an unloadable root before
+    // start — but registry listings, `cf piece ls`, FUSE, and the shell's list
+    // cells all resolve the root through PiecesController.getDefaultPattern
+    // instead, which used to inherit NO heal: the load failure propagated and
+    // every listing died with the root (2026-07-29 vendor gate, the
+    // cf-cell-context type retirement). The controller choke point must run the
+    // same awaited updater check and retry once.
+
     await setup();
     const piece = await controller.ensureDefaultPattern();
     const root = piece.getCell();

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -106,8 +106,10 @@ describe("Piece reference detection", () => {
     assertEquals(foundPiece2, true, "Should find reference to piece2");
   });
 
-  // Test specifically the issue where only one reference is found when there are multiple
   it("should find multiple references in argument data that matches the reported issue", () => {
+    // Test specifically the issue where only one reference is found when there
+    // are multiple
+
     // Mock the scenario where a piece's argument refers to two other pieces
     const mockPiece1Id = entityRefFromString("piece-1-id");
     const mockPiece2Id = entityRefFromString("piece-2-id");
@@ -220,8 +222,9 @@ describe("Piece reference detection", () => {
     // references are found first, potentially causing some to be missed
   });
 
-  // Test for n-depth reference detection
   it("should follow result metadata chains to find deeply nested references", () => {
+    // Test for n-depth reference detection
+
     // Mock test data
     const mockPiece1Id = entityRefFromString("piece-1-source");
     const mockPiece2Id = entityRefFromString("piece-2-intermediate");

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -107,9 +107,6 @@ describe("Piece reference detection", () => {
   });
 
   it("should find multiple references in argument data that matches the reported issue", () => {
-    // Test specifically the issue where only one reference is found when there
-    // are multiple
-
     // Mock the scenario where a piece's argument refers to two other pieces
     const mockPiece1Id = entityRefFromString("piece-1-id");
     const mockPiece2Id = entityRefFromString("piece-2-id");
@@ -223,8 +220,6 @@ describe("Piece reference detection", () => {
   });
 
   it("should follow result metadata chains to find deeply nested references", () => {
-    // Test for n-depth reference detection
-
     // Mock test data
     const mockPiece1Id = entityRefFromString("piece-1-source");
     const mockPiece2Id = entityRefFromString("piece-2-intermediate");

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -7751,17 +7751,18 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
     }
   });
 
-  // The narrow read reaches a path below an asCell slot with a plain `key()`
-  // chain, letting link resolution follow the handle mid-path rather than
-  // dereferencing it by hand. This pins the two properties that choice has to
-  // keep: the terminal handle still applies the scoped-link relaxation (so a
-  // scoped child voids only itself, not its whole object), and a path THROUGH
-  // the handle still lands on the right document.
-  // #5231 moved the asCell scope cap into the runner's own projection, which
-  // let the narrow read drop its resolveAsCell() routing. That routing was the
-  // only thing keeping a capped handle capped here, so pin the behavior at
-  // this layer rather than trusting the runner test to stand in for it.
   it("keeps a capped asCell handle capped through the narrow read", async () => {
+    // The narrow read reaches a path below an asCell slot with a plain `key()`
+    // chain, letting link resolution follow the handle mid-path rather than
+    // dereferencing it by hand. This pins the two properties that choice has to
+    // keep: the terminal handle still applies the scoped-link relaxation (so a
+    // scoped child voids only itself, not its whole object), and a path THROUGH
+    // the handle still lands on the right document. #5231 moved the asCell
+    // scope cap into the runner's own projection, which let the narrow read
+    // drop its resolveAsCell() routing. That routing was the only thing keeping
+    // a capped handle capped here, so pin the behavior at this layer rather
+    // than trusting the runner test to stand in for it.
+
     const tx = writerRuntime.edit();
     const target = writerRuntime.getCell(
       writerPieces.getSpace(),

--- a/packages/piece/test/reference-detection.test.ts
+++ b/packages/piece/test/reference-detection.test.ts
@@ -7,8 +7,9 @@ import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
  * without requiring the full PiecesController setup
  */
 describe("Reference detection core functionality", () => {
-  // Test detection of object structures similar to cell links
   it("should identify object structures with cell and path properties", () => {
+    // Test detection of object structures similar to cell links
+
     // Create an object with a structure similar to a cell link
     const objWithCellAndPath = {
       cell: {/* mock cell properties */},
@@ -28,8 +29,9 @@ describe("Reference detection core functionality", () => {
     );
   });
 
-  // Test finding aliases with different structures
   it("should find aliases in nested objects", () => {
+    // Test finding aliases with different structures
+
     // Create test data with different alias structures
     const testData = {
       directAlias: {
@@ -82,8 +84,9 @@ describe("Reference detection core functionality", () => {
     assertEquals(arrayAliasIndex, 1, "Should detect alias in array");
   });
 
-  // Test recursive search for references
   it("should recursively search for references in deep structures", () => {
+    // Test recursive search for references
+
     const foundReferences: string[] = [];
 
     // Mock a recursive search function similar to what we use in getReadingFrom
@@ -158,8 +161,9 @@ describe("Reference detection core functionality", () => {
     );
   });
 
-  // Test the behavior of our reference detection with mixed reference types
   it("should handle mixed reference types", () => {
+    // Test the behavior of our reference detection with mixed reference types
+
     const foundReferences: Array<{ type: string; id: string }> = [];
 
     // Mock a detection function that handles both cell links and aliases

--- a/packages/piece/test/reference-detection.test.ts
+++ b/packages/piece/test/reference-detection.test.ts
@@ -8,8 +8,6 @@ import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
  */
 describe("Reference detection core functionality", () => {
   it("should identify object structures with cell and path properties", () => {
-    // Test detection of object structures similar to cell links
-
     // Create an object with a structure similar to a cell link
     const objWithCellAndPath = {
       cell: {/* mock cell properties */},
@@ -30,8 +28,6 @@ describe("Reference detection core functionality", () => {
   });
 
   it("should find aliases in nested objects", () => {
-    // Test finding aliases with different structures
-
     // Create test data with different alias structures
     const testData = {
       directAlias: {
@@ -85,8 +81,6 @@ describe("Reference detection core functionality", () => {
   });
 
   it("should recursively search for references in deep structures", () => {
-    // Test recursive search for references
-
     const foundReferences: string[] = [];
 
     // Mock a recursive search function similar to what we use in getReadingFrom
@@ -162,8 +156,6 @@ describe("Reference detection core functionality", () => {
   });
 
   it("should handle mixed reference types", () => {
-    // Test the behavior of our reference detection with mixed reference types
-
     const foundReferences: Array<{ type: string; id: string }> = [];
 
     // Mock a detection function that handles both cell links and aliases

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -41,17 +41,19 @@ const oldPattern = pattern(
 );
 
 describe("piece schema compatibility", () => {
-  // A CFC write authorization (`TrustedActionWrite`) lowers to an
-  // `ifc.writeAuthorizedBy.__ctWriterIdentityOf` whose `moduleIdentity` is the
-  // content-addressed hash of the authoring module. Editing that module at all
-  // — a type annotation, a comment, whitespace — rehashes it, so `moduleIdentity`
-  // changes while `file`, `path`, and the `uiContract` stay identical. That is a
-  // recompile of the same authorization, not a narrowed contract, so the
-  // backward-compatibility check accepts it: the content-addressed identity is
-  // normalized out of the `ifc` comparison. The ten baselined patterns that
-  // carry a CFC write (system/home, system/profile-*, lobby, and the cfc-*
-  // demos) depend on this to stay editable.
   it("accepts a recompile that only changes writeAuthorizedBy moduleIdentity", () => {
+    // A CFC write authorization (`TrustedActionWrite`) lowers to an
+    // `ifc.writeAuthorizedBy.__ctWriterIdentityOf` whose `moduleIdentity` is
+    // the content-addressed hash of the authoring module. Editing that module
+    // at all — a type annotation, a comment, whitespace — rehashes it, so
+    // `moduleIdentity` changes while `file`, `path`, and the `uiContract` stay
+    // identical. That is a recompile of the same authorization, not a narrowed
+    // contract, so the backward-compatibility check accepts it: the
+    // content-addressed identity is normalized out of the `ifc` comparison. The
+    // ten baselined patterns that carry a CFC write (system/home,
+    // system/profile-*, lobby, and the cfc-* demos) depend on this to stay
+    // editable.
+
     const resultSchema = (moduleIdentity: string): JSONSchema => ({
       type: "object",
       properties: {
@@ -131,15 +133,16 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
-  // A writer claim's `file` is the module's source-file spelling, and that
-  // spelling is resolver-dependent: the same module compiles to a different
-  // `file` under piece-deploy staging, a piece manifest, and HTTP resolution,
-  // while its content-addressed `moduleIdentity` agrees everywhere (labs#4772).
-  // The runtime authorizes a write on `moduleIdentity` plus the binding `path`
-  // and never on `file`, so a cross-resolver recompile that re-spells only the
-  // `file` — same `moduleIdentity`, same `path`, same `uiContract` — is the same
-  // authorization, and the update is accepted.
   it("accepts a cross-resolver recompile that only re-spells the writeAuthorizedBy file", () => {
+    // A writer claim's `file` is the module's source-file spelling, and that
+    // spelling is resolver-dependent: the same module compiles to a different
+    // `file` under piece-deploy staging, a piece manifest, and HTTP resolution,
+    // while its content-addressed `moduleIdentity` agrees everywhere
+    // (labs#4772). The runtime authorizes a write on `moduleIdentity` plus the
+    // binding `path` and never on `file`, so a cross-resolver recompile that
+    // re-spells only the `file` — same `moduleIdentity`, same `path`, same
+    // `uiContract` — is the same authorization, and the update is accepted.
+
     const respelled = (file: string): JSONSchema =>
       trustedWriteResult({ ...baselineIdentity, file }, baselineUiContract);
     expect(() =>
@@ -150,12 +153,13 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
-  // `file` carries no authorization signal beyond the content-addressed
-  // `moduleIdentity` (which the runtime re-verifies live) and the binding
-  // `path`, so it is normalized out of the comparison entirely rather than made
-  // spelling-tolerant. Any `file` change is accepted while the `path` and
-  // `uiContract` are unchanged.
   it("accepts a writeAuthorizedBy binding file change", () => {
+    // `file` carries no authorization signal beyond the content-addressed
+    // `moduleIdentity` (which the runtime re-verifies live) and the binding
+    // `path`, so it is normalized out of the comparison entirely rather than
+    // made spelling-tolerant. Any `file` change is accepted while the `path`
+    // and `uiContract` are unchanged.
+
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         pattern(

--- a/packages/piece/test/setsrc-writer-file-spelling.test.ts
+++ b/packages/piece/test/setsrc-writer-file-spelling.test.ts
@@ -40,21 +40,23 @@ function writerAuthorizedProgram(fileName: string): RuntimeProgram {
   };
 }
 
-// End-to-end counterpart to the writer-claim cases in
-// `schema-compatibility.test.ts`, exercised through the real `cf piece setsrc`
-// boundary (`piece.setPattern`) rather than the compatibility helper alone.
-//
-// A field typed `WriteAuthorizedBy` lowers to a writer claim that records the
-// authoring module three ways: its content hash (`moduleIdentity`), its
-// source-file spelling (`file`), and the binding `path` within the module. The
-// runtime authorizes a write on `moduleIdentity` plus the binding `path` and
-// never consults `file`. Relocating the pattern to a new source file, with the
-// handler and its binding path unchanged, re-spells `file` (and, because the
-// hash covers the module's name, re-hashes `moduleIdentity`), while the
-// backward-compatibility gate ignores both of those and holds the `path` and
-// `uiContract` fixed. So the update carries the same authorization and is
-// accepted, and the settled piece points at the relocated pattern.
 describe("setsrc over a writer-authorized field's source-file spelling", () => {
+  // End-to-end counterpart to the writer-claim cases in
+  // `schema-compatibility.test.ts`, exercised through the real `cf piece
+  // setsrc` boundary (`piece.setPattern`) rather than the compatibility helper
+  // alone.
+  //
+  // A field typed `WriteAuthorizedBy` lowers to a writer claim that records the
+  // authoring module three ways: its content hash (`moduleIdentity`), its
+  // source-file spelling (`file`), and the binding `path` within the module.
+  // The runtime authorizes a write on `moduleIdentity` plus the binding `path`
+  // and never consults `file`. Relocating the pattern to a new source file,
+  // with the handler and its binding path unchanged, re-spells `file` (and,
+  // because the hash covers the module's name, re-hashes `moduleIdentity`),
+  // while the backward-compatibility gate ignores both of those and holds the
+  // `path` and `uiContract` fixed. So the update carries the same authorization
+  // and is accepted, and the settled piece points at the relocated pattern.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let pieces: PiecesController;

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -2325,12 +2325,13 @@ describe("runtime-processor", () => {
       expect("source" in atom).toBe(false);
     });
 
-    // Inv-12 Stage 0, step 3: the display redaction applied to the top-level
-    // cfcLabel at the three IPC response sites also covers the cfcLabelView
-    // copies riding sigil links INSIDE response values (attached by
-    // convertCellsToLinks includeCfcLabelView). Safe now that the worker
-    // neither persists nor re-imports inbound views (steps 1–2).
     it("redacts Caveat.source in sigil label views inside handleCellGet values", () => {
+      // Inv-12 Stage 0, step 3: the display redaction applied to the top-level
+      // cfcLabel at the three IPC response sites also covers the cfcLabelView
+      // copies riding sigil links INSIDE response values (attached by
+      // convertCellsToLinks includeCfcLabelView). Safe now that the worker
+      // neither persists nor re-imports inbound views (steps 1–2).
+
       const ref: CellRef = {
         id: "of:cfc-value-view-cell" as CellRef["id"],
         space: "did:key:test" as CellRef["space"],
@@ -3911,14 +3912,15 @@ describe("runtime-processor", () => {
   });
 
   describe("runtime-client CellRef conversion", () => {
-    // Inv-12 Stage 0 (SC-25 prerequisite): a cfcLabelView riding an inbound
-    // CellRef is a main-thread display artifact — round-tripped through
-    // CellHandle.deserialize and back — and must not re-enter the worker as
-    // label state. Forwarding it onto the written sigil link previously fed
-    // recordLinkWritePolicyInput, whose entries prepareBoundaryCommit
-    // persisted as link-origin labels; the worker now re-derives those from
-    // its own stored source metadata instead.
     it("does not forward an inbound label view into worker sigil links", () => {
+      // Inv-12 Stage 0 (SC-25 prerequisite): a cfcLabelView riding an inbound
+      // CellRef is a main-thread display artifact — round-tripped through
+      // CellHandle.deserialize and back — and must not re-enter the worker as
+      // label state. Forwarding it onto the written sigil link previously fed
+      // recordLinkWritePolicyInput, whose entries prepareBoundaryCommit
+      // persisted as link-origin labels; the worker now re-derives those from
+      // its own stored source metadata instead.
+
       const cfcLabelView: CfcLabelView = {
         version: 1,
         entries: [{
@@ -3973,11 +3975,12 @@ describe("runtime-processor", () => {
       expect(seen).toEqual([undefined]);
     });
 
-    // Raw sigil links inside inbound values (hand-crafted JSON, or a
-    // CellHandle serialized into CustomEvent.detail via toJSON) bypass the
-    // CellRef path — the value walker must drop their label views too
-    // (codex/cubic review on the Stage 0 PR).
     it("strips label views from raw sigil links in inbound values", () => {
+      // Raw sigil links inside inbound values (hand-crafted JSON, or a
+      // CellHandle serialized into CustomEvent.detail via toJSON) bypass the
+      // CellRef path — the value walker must drop their label views too
+      // (codex/cubic review on the Stage 0 PR).
+
       const linkWithView = {
         "/": {
           "link@1": {
@@ -4151,12 +4154,13 @@ describe("runtime-processor", () => {
   });
 
   describe("RuntimeProcessor VDom event label-view ingress", () => {
-    // CustomEvent.detail is JSON.stringify'd on the main thread (invoking
-    // CellHandle.toJSON) and re-enters the worker here, bypassing
-    // getCell/cellRefToSigilLink — a handler writing event.detail.sourceCell
-    // would persist the ref's view through the sigil-link write path. The
-    // worker strips inbound views at this ingress too (codex/cubic review).
     it("strips label views from sigil links in inbound VDOM events", () => {
+      // CustomEvent.detail is JSON.stringify'd on the main thread (invoking
+      // CellHandle.toJSON) and re-enters the worker here, bypassing
+      // getCell/cellRefToSigilLink — a handler writing event.detail.sourceCell
+      // would persist the ref's view through the sigil-link write path. The
+      // worker strips inbound views at this ingress too (codex/cubic review).
+
       const dispatched: unknown[] = [];
       const processor = {
         vdomMounts: new Map([[
@@ -4764,10 +4768,11 @@ describe("runtime-processor", () => {
     });
   });
 
-  // Federation PR2: one worker serves page operations for many spaces.
-  // getSpaceCtx resolves the per-space PiecesController, lazily for
-  // foreign spaces, over the shared runtime/storage.
   describe("RuntimeProcessor per-space piece contexts", () => {
+    // Federation PR2: one worker serves page operations for many spaces.
+    // getSpaceCtx resolves the per-space PiecesController, lazily for
+    // foreign spaces, over the shared runtime/storage.
+
     const getSpaceCtx = (RuntimeProcessor.prototype as any).getSpaceCtx;
 
     function makeProcessorState() {
@@ -5056,10 +5061,11 @@ describe("runtime-processor", () => {
     });
   });
 
-  // S16 phase D: the host's render confidentiality ceiling must reach every
-  // mount's reconciler — a ceiling configured at initialization that never
-  // arrives at the egress surface is silently unbounded rendering.
   describe("RuntimeProcessor vdom mount render policy", () => {
+    // S16 phase D: the host's render confidentiality ceiling must reach every
+    // mount's reconciler — a ceiling configured at initialization that never
+    // arrives at the egress surface is silently unbounded rendering.
+
     const handleVDomMount = (RuntimeProcessor.prototype as any).handleVDomMount;
     const handleVDomUnmount =
       (RuntimeProcessor.prototype as any).handleVDomUnmount;
@@ -5154,12 +5160,13 @@ describe("runtime-processor", () => {
     });
   });
 
-  // handleVDomEvent forwards a main-thread DOM event to the owning mount's
-  // reconciler. The reconciler's dispatchEvent returns false when no handler is
-  // registered for the handlerId, meaning the event was dropped. The processor
-  // surfaces that drop as a console.warn carrying the mountId and handlerId so a
-  // silently-dropped click is traceable.
   describe("RuntimeProcessor handleVDomEvent dropped-event warning", () => {
+    // handleVDomEvent forwards a main-thread DOM event to the owning mount's
+    // reconciler. The reconciler's dispatchEvent returns false when no handler
+    // is registered for the handlerId, meaning the event was dropped. The
+    // processor surfaces that drop as a console.warn carrying the mountId and
+    // handlerId so a silently-dropped click is traceable.
+
     const handleVDomEvent = (RuntimeProcessor.prototype as any).handleVDomEvent;
 
     function makeState(dispatchResult: boolean, calls: unknown[][]) {

--- a/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
+++ b/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
@@ -192,10 +192,12 @@ describe("web-worker-console-bridge", () => {
     });
   });
 
-  // NOTE: this describe must stay AFTER the console-bridge one. Initializing the
-  // worker sets the entry module's `worker`/`workerInitialization` for the rest
-  // of the file, and the bridge test asserts pre-initialization behavior.
   describe("web worker request ledger and timing", () => {
+    // NOTE: this describe must stay AFTER the console-bridge one. Initializing
+    // the worker sets the entry module's `worker`/`workerInitialization` for
+    // the rest of the file, and the bridge test asserts pre-initialization
+    // behavior.
+
     const ledgerCount = (key: string) =>
       getLogger("runtime-worker.ipc").countsByKey[key]?.total ?? 0;
     const timingCount = (...keys: string[]) =>

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -324,11 +324,12 @@ describe("cell-handle", () => {
       }]);
     });
 
-    // Inv-12 Stage 0: the link a handle names itself by re-enters the worker
-    // without passing getCell/cellRefToSigilLink, so the ref's display view
-    // must not ride it (codex/cubic review on the Stage 0 PR). Like
-    // toWireString, only addressing fields (+schema) go.
     it("does not serialize the ref-carried label view into sigil links", () => {
+      // Inv-12 Stage 0: the link a handle names itself by re-enters the worker
+      // without passing getCell/cellRefToSigilLink, so the ref's display view
+      // must not ride it (codex/cubic review on the Stage 0 PR). Like
+      // toWireString, only addressing fields (+schema) go.
+
       const runtime = {
         [$conn]: () => ({
           request: () => Promise.resolve({}),

--- a/packages/runtime-client/test/runtime-client.test.ts
+++ b/packages/runtime-client/test/runtime-client.test.ts
@@ -579,9 +579,11 @@ describe("RuntimeClient", () => {
   });
 
   describe("boot-window diagnostics", () => {
-    // Both getters are main-thread snapshots forwarded straight from the
-    // connection (no worker round-trip), so a connection stub pins the wiring.
     it("exposes pending-request and request-timeline snapshots", () => {
+      // Both getters are main-thread snapshots forwarded straight from the
+      // connection (no worker round-trip), so a connection stub pins the
+      // wiring.
+
       const pending = [{ msgId: 7, type: RequestType.Idle, ageMs: 12 }];
       const timeline = [
         { msgId: 7, type: RequestType.Idle, sentAtMs: 3, doneAtMs: 8 },


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `cf-harness`, `piece`, `html` and `runtime-client` to the
"Commenting a block" rule in `unit-test-coding-style.md`: a comment about a
test or a group of tests goes inside the block's callback, as its first
content, followed by a blank line.

48 comments in 15 files.

- **38 move** into the block they describe.
- **6 are deleted** -- see below.
- **4 stay exactly where they are**, because each describes a run of sibling
  blocks that nothing groups. `seed-pattern-index.test.ts:92` covers four
  `refuses an atom ...` cases; `cell-chip.test.ts:246` states a conjunction one
  term per test across four `refuses ...` cases; `worker-keying.test.ts:93`
  ("the two things a render node may hold that are not `FabricValue`s") covers
  the handler case and the unhashable-node case; and
  `worker-reconciler-cfc-render-policy.test.ts`'s nested-boundary note covers
  the nested text-integrity steps under it. Inside the first block, each would
  stop reaching the rest. The other batches in this arc leave the same shape
  alone.

Sixteen of the moved blocks overflowed 80 columns at the new indent and are
reflowed. The conversion compares each block's word sequence before and after
rather than trusting the reflow.

## Six comments that only restate the test below them

`piece/test/reference-detection.test.ts` and `piece/test/piece-references.test.ts`
carried six one-line comments saying what their `it()` description already says
-- "Test detection of object structures similar to cell links" over
`it("should identify object structures with cell and path properties")`, and
five more of that shape. They are deleted, on the same ground that retired five
nominal section markers earlier in this arc: they add nothing beyond what the
code already states.

## What the diff is, as a property

Across the 15 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0).
- Per file, the multiset of comment words is unchanged, except the two `piece`
  files above, where the words removed are exactly those six comments and none
  is added.
- Per file, the multiset of non-comment lines is unchanged.
- No added line exceeds 80 characters, counted in characters rather than bytes.

A re-run of the census over the four packages finds 4 remaining comments above
a test-block opener -- exactly the four named above, and none other. Counting
comment runs across the whole diff: 6 runs' words vanish (the six deletions),
0 runs' words are new, and 16 surviving runs changed their line breaks.

## Gates

`deno fmt --check` and `deno lint` pass over all four packages. `deno task test`:
`cf-harness` 857 passed / 0 failed (1354 steps), `piece` 51 passed / 0 failed
(759 steps), `html` 26 passed / 0 failed (276 steps), `runtime-client` 16
passed / 0 failed (461 steps).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



