### PR TITLE
test(memory): a block's comment moves inside the block it describes

### DIFF
--- a/packages/background-piece-service/test/otel.test.ts
+++ b/packages/background-piece-service/test/otel.test.ts
@@ -120,11 +120,12 @@ describe("OpenTelemetry setup", () => {
   );
 });
 
-// The setup tests above only prove a provider object exists, which stays true
-// even if nothing is wired to an exporter. These drive the real span processor,
-// metric reader and OTLP exporters against a receiver on the loopback interface
-// and check what actually lands on the wire.
 describe("OpenTelemetry export", () => {
+  // The setup tests above only prove a provider object exists, which stays true
+  // even if nothing is wired to an exporter. These drive the real span
+  // processor, metric reader and OTLP exporters against a receiver on the
+  // loopback interface and check what actually lands on the wire.
+
   interface Request {
     path: string;
     body: string;

--- a/packages/identity/test/key-store.test.ts
+++ b/packages/identity/test/key-store.test.ts
@@ -57,11 +57,13 @@ Deno.test("KeyStore recovers a key pair holding handles as one", async () => {
   );
 });
 
-// The database name is persisted browser state, so it is pinned to its literal
-// here rather than to the constant: reading the constant on both sides of the
-// comparison would agree with itself no matter what the name became, and a
-// silent change to it would orphan every key a user has already stored.
 Deno.test("KeyStore.open() with no name opens `common-key-store`", async () => {
+  // The database name is persisted browser state, so it is pinned to its
+  // literal here rather than to the constant: reading the constant on both
+  // sides of the comparison would agree with itself no matter what the name
+  // became, and a silent change to it would orphan every key a user has already
+  // stored.
+
   assert(KeyStore.DEFAULT_DB_NAME === "common-key-store");
 
   const defaulted = await KeyStore.open();

--- a/packages/integration/test/describe-thrown.test.ts
+++ b/packages/integration/test/describe-thrown.test.ts
@@ -47,10 +47,11 @@ describe("describe-thrown", () => {
       );
     });
 
-    // A caller that reports a failure it does not own — the page probe inside
-    // a state-wait report — attaches someone else's error as the cause, so a
-    // summary that deferred to "the cause" would name the wrong failure.
     it("keeps a deeply nested value to one line", () => {
+      // A caller that reports a failure it does not own — the page probe inside
+      // a state-wait report — attaches someone else's error as the cause, so a
+      // summary that deferred to "the cause" would name the wrong failure.
+
       expect(describeThrown({ a: { b: { c: { d: 1 } } }, list: [1, 2, 3] }))
         .toBe("{ a: [Object], list: [Array] }");
     });

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -519,11 +519,12 @@ describe("RuntimeInternals", () => {
     ).toBeUndefined();
   });
 
-  // create() builds the client options and sends the Initialize request; this
-  // covers that path end to end and asserts the host flags reach the worker.
-  // A stub worker completes the READY handshake, then fails Initialize so
-  // create() aborts without a real runtime.
   describe("create() forwards host flags to the worker", () => {
+    // create() builds the client options and sends the Initialize request; this
+    // covers that path end to end and asserts the host flags reach the worker.
+    // A stub worker completes the READY handshake, then fails Initialize so
+    // create() aborts without a real runtime.
+
     type CapturedInitData = {
       forwardWorkerConsole?: boolean;
       concurrentWatchRefresh?: boolean;
@@ -609,10 +610,11 @@ describe("RuntimeInternals", () => {
     });
   });
 
-  // A deployed page must keep its worker and lazy chunks on the same immutable
-  // module graph. Local/legacy builds retain the root worker URL and manifest
-  // cache-buster.
   describe("worker URL versioning", () => {
+    // A deployed page must keep its worker and lazy chunks on the same
+    // immutable module graph. Local/legacy builds retain the root worker URL
+    // and manifest cache-buster.
+
     async function workerUrlFromCreate(
       options: {
         getBuildHash: () => Promise<string | undefined>;
@@ -719,11 +721,12 @@ describe("RuntimeInternals", () => {
     });
   });
 
-  // CT-1623: starting a piece is expensive (pattern instantiation + eager
-  // dependency collection in the worker). Read-only consumers like the header
-  // pieces menu must be able to resolve page handles WITHOUT starting, and a
-  // non-started cache entry must not block a later display-path start.
   describe("getPattern start semantics", () => {
+    // CT-1623: starting a piece is expensive (pattern instantiation + eager
+    // dependency collection in the worker). Read-only consumers like the header
+    // pieces menu must be able to resolve page handles WITHOUT starting, and a
+    // non-started cache entry must not block a later display-path start.
+
     const spaceDid = "did:key:z6Mk-lib-shell-runtime-did-pattern" as DID;
 
     function makeRuntime() {
@@ -810,9 +813,10 @@ describe("RuntimeInternals", () => {
     });
   });
 
-  // One runtime serves every space; a pattern's address is (space, id)
-  // and the cache is keyed by that address.
   describe("getPattern multi-space", () => {
+    // One runtime serves every space; a pattern's address is (space, id)
+    // and the cache is keyed by that address.
+
     const homeDid = "did:key:z6Mk-lib-shell-runtime-home" as DID;
     const otherDid = "did:key:z6Mk-lib-shell-runtime-other" as DID;
 

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -2791,19 +2791,20 @@ Deno.test("memory v2 engine resolves pending reads and rejects stale pending rea
   }
 });
 
-// CT-1872 1c: an array localSeq names every pending layer the read sat on.
-// Non-highest elements impose resolution ONLY (the dependency must have an
-// accepted commit row) — staleness is based at the HIGHEST element, so a
-// foreign write that lands before the highest element's resolution must NOT
-// reject the read, while an unresolved element still must.
-//
-// NOTE: this pins main's de-facto basis semantics made explicit on the wire,
-// not an endorsement of the scan interval. The staleness scan starts at the
-// highest layer's resolution seq, so foreign writes in (reader's confirmed
-// basis, that resolution] go unscanned — a pre-existing gap tracked as
-// CT-1910 (pending-read basis over-advance), whose fix (own-session
-// exclusion + true-basis validation) supersedes the max-basis rule.
 Deno.test("memory v2 engine: array pending reads scan at the highest layer and require every layer to resolve", async () => {
+  // CT-1872 1c: an array localSeq names every pending layer the read sat on.
+  // Non-highest elements impose resolution ONLY (the dependency must have an
+  // accepted commit row) — staleness is based at the HIGHEST element, so a
+  // foreign write that lands before the highest element's resolution must NOT
+  // reject the read, while an unresolved element still must.
+  //
+  // NOTE: this pins main's de-facto basis semantics made explicit on the wire,
+  // not an endorsement of the scan interval. The staleness scan starts at the
+  // highest layer's resolution seq, so foreign writes in (reader's confirmed
+  // basis, that resolution] go unscanned — a pre-existing gap tracked as
+  // CT-1910 (pending-read basis over-advance), whose fix (own-session
+  // exclusion + true-basis validation) supersedes the max-basis rule.
+
   const { engine, path } = await createEngine();
 
   try {
@@ -3022,23 +3023,24 @@ Deno.test("memory v2 engine: array pending reads scan at the highest layer and r
   }
 });
 
-// CT-1872 1c, end to end at the engine: a fabricated composite must die on
-// the resolution edge, because no staleness scan can catch it.
-//
-//   base:  D = { items: [] }                                  (seq 1)
-//   T1  (localSeq 10): items = ["A"]  — REJECTED (stale read on title)
-//   T1.5 (localSeq 11): blind append "B", zero reads — APPLIED → items ["B"]
-//   T2  (localSeq 12): observed items ["A","B"] through the client stack
-//
-// T2's observation is not STALE — ["A","B"] never existed at any seq; "A"
-// lived only in the client's optimistic layer for a commit the server
-// refused. An under-declared T2 (scalar top-of-stack read: what a client
-// emits toward a server without the `pendingReadStacks` flag) passes both
-// resolution (T1.5 has a commit row) and the staleness scan (nothing touched
-// items after seq(T1.5)) and is durably ACCEPTED with a phantom premise.
-// The full-stack array shape (#4606) also names T1, and the missing commit
-// row rejects it.
 Deno.test("memory v2 engine: full-stack dependency recording rejects a fabricated composite an under-declared commit smuggles through", async () => {
+  // CT-1872 1c, end to end at the engine: a fabricated composite must die on
+  // the resolution edge, because no staleness scan can catch it.
+  //
+  //   base:  D = { items: [] }                                  (seq 1)
+  //   T1  (localSeq 10): items = ["A"]  — REJECTED (stale read on title)
+  //   T1.5 (localSeq 11): blind append "B", zero reads — APPLIED → items ["B"]
+  //   T2  (localSeq 12): observed items ["A","B"] through the client stack
+  //
+  // T2's observation is not STALE — ["A","B"] never existed at any seq; "A"
+  // lived only in the client's optimistic layer for a commit the server
+  // refused. An under-declared T2 (scalar top-of-stack read: what a client
+  // emits toward a server without the `pendingReadStacks` flag) passes both
+  // resolution (T1.5 has a commit row) and the staleness scan (nothing touched
+  // items after seq(T1.5)) and is durably ACCEPTED with a phantom premise.
+  // The full-stack array shape (#4606) also names T1, and the missing commit
+  // row rejects it.
+
   const { engine, path } = await createEngine();
 
   try {

--- a/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
@@ -27,11 +27,13 @@ Deno.test("columnOrigins throws before the FFI is bound", () => {
   );
 });
 
-// Point @db/sqlite's own loader at a file that is not a library — the shape of a
-// libsqlite3 built without SQLITE_ENABLE_COLUMN_METADATA, which loads for
-// @db/sqlite but exposes no column-origin symbols. ensureColumnOriginAvailable
-// must resolve false, record why, and make a later labeled read throw the reason.
 Deno.test("a bind failure is recorded and surfaces in the reason and the throw", async () => {
+  // Point @db/sqlite's own loader at a file that is not a library — the shape
+  // of a libsqlite3 built without SQLITE_ENABLE_COLUMN_METADATA, which loads
+  // for @db/sqlite but exposes no column-origin symbols.
+  // ensureColumnOriginAvailable must resolve false, record why, and make a
+  // later labeled read throw the reason.
+
   const notALibrary = Deno.makeTempFileSync({ suffix: ".dylib" });
   Deno.writeTextFileSync(notALibrary, "not a library");
   const previous = Deno.env.get("DENO_SQLITE_PATH");

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -63,14 +63,15 @@ describe("shell login tests", () => {
     assert(result.afterKeyStore.hasRegister);
   });
 
-  // The shell publishes `globalThis.app` at the end of its bootstrap, after
-  // the key store opens and Navigation is installed, so a driver that
-  // navigates or reloads and logs in straight away can arrive before the app
-  // is published. The property installed below is that window with the timing
-  // taken out of it: the first read of `globalThis.app` answers `undefined`,
-  // and every read after it answers the root element. Logging in through that
-  // property means waiting for the boundary rather than reading through it.
   it("logs in while the app is still unpublished", async () => {
+    // The shell publishes `globalThis.app` at the end of its bootstrap, after
+    // the key store opens and Navigation is installed, so a driver that
+    // navigates or reloads and logs in straight away can arrive before the app
+    // is published. The property installed below is that window with the timing
+    // taken out of it: the first read of `globalThis.app` answers `undefined`,
+    // and every read after it answers the root element. Logging in through that
+    // property means waiting for the boundary rather than reading through it.
+
     const identity = await Identity.generate({ implementation: "noble" });
     const page = shell.page();
 

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -526,10 +526,11 @@ describe("piece context menu", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  // The menu and its panels are cf-piece-menu's, mounted on document.body by
-  // cf-render. Driving them through a real right-click is what proves the
-  // announcement, the portalled overlay, and the worker read all line up.
   it("shows a piece's source, origin, and space access rights", async () => {
+    // The menu and its panels are cf-piece-menu's, mounted on document.body by
+    // cf-render. Driving them through a real right-click is what proves the
+    // announcement, the portalled overlay, and the worker read all line up.
+
     const page = shell.page();
     const { identity } = await writeTempIdentity({ implementation: "noble" });
 

--- a/packages/shell/integration/reload.test.ts
+++ b/packages/shell/integration/reload.test.ts
@@ -18,13 +18,15 @@ describe("shell reload tests", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  // `globalThis.app` is the handle every driver reaches the shell through, and
-  // the shell publishes it as the last step of its bootstrap module. That
-  // module body runs on past the document's load event, so a navigation that
-  // returns on load can return while the shell is still booting, and a driver
-  // that reads the shell right then reads nothing. A test that reloads should
-  // not have to know that: when a reload returns, the shell behind it answers.
   it("answers for its state as soon as a reload returns", async () => {
+    // `globalThis.app` is the handle every driver reaches the shell through,
+    // and the shell publishes it as the last step of its bootstrap module. That
+    // module body runs on past the document's load event, so a navigation that
+    // returns on load can return while the shell is still booting, and a driver
+    // that reads the shell right then reads nothing. A test that reloads should
+    // not have to know that: when a reload returns, the shell behind it
+    // answers.
+
     const identity = await Identity.generate({ implementation: "noble" });
     const spaceName = globalThis.crypto.randomUUID();
     const page = shell.page();

--- a/packages/ui/src/v2/components/cf-markdown/heading-id.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/heading-id.test.ts
@@ -5,11 +5,12 @@ import { Lexer, type Tokens } from "marked";
 
 import { HeadingIds } from "./heading-id.ts";
 
-// marked generated these ids itself until version 5, under a `headerIds`
-// option that defaulted to on, and dropped them in a later major. The expected
-// ids below are the ones marked 4 produced, because fragment links written
-// against the old output point at them.
 describe("heading-id", () => {
+  // marked generated these ids itself until version 5, under a `headerIds`
+  // option that defaulted to on, and dropped them in a later major. The
+  // expected ids below are the ones marked 4 produced, because fragment links
+  // written against the old output point at them.
+
   const idsOf = (markdown: string): string[] => {
     const ids = new HeadingIds();
     return Lexer.lex(markdown, { breaks: true, gfm: true })

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
@@ -17,12 +17,14 @@ describe("seal-liveness", () => {
     expect(typeof prefersReducedMotion()).toBe("boolean");
   });
 
-  // The visual sheen math needs a real browser (cursor geometry,
-  // getBoundingClientRect) and is exercised by the prototype, not here. What we
-  // CAN guard cheaply is the leak: the shared controller must add exactly one
-  // pointer listener + rAF on the first seal and remove both when the last seal
-  // unregisters — otherwise a mount/unmount churn leaks listeners and frames.
   it("starts one pointer listener + rAF on the first seal and tears both down when the last unregisters", () => {
+    // The visual sheen math needs a real browser (cursor geometry,
+    // getBoundingClientRect) and is exercised by the prototype, not here. What
+    // we CAN guard cheaply is the leak: the shared controller must add exactly
+    // one pointer listener + rAF on the first seal and remove both when the
+    // last seal unregisters — otherwise a mount/unmount churn leaks listeners
+    // and frames.
+
     const g = globalThis as Record<string, unknown>;
     const saved = {
       raf: g.requestAnimationFrame,

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -16,9 +16,10 @@ import {
 
 describe("topics-rehearsal-lib", () => {
   describe("retiredKeys", () => {
-    // The case this exists for: an export taken before a migration carries a
-    // field the migrated schema no longer declares.
     it("names a key the live read does not surface", () => {
+      // The case this exists for: an export taken before a migration carries a
+      // field the migrated schema no longer declares.
+
       const exported = [{ author: { name: "a" }, authorName: "a", body: "x" }];
       const live = [{ author: { name: "a" }, body: "x" }];
       expect(retiredKeys(exported, live)).toEqual(["[].authorName"]);
@@ -30,10 +31,11 @@ describe("topics-rehearsal-lib", () => {
       );
     });
 
-    // A migration that retires a whole top-level field leaves no surviving
-    // record for a key to be missing from, so absence is reported about the
-    // compared value itself.
     it("names the whole value when a retired scalar reads back absent", () => {
+      // A migration that retires a whole top-level field leaves no surviving
+      // record for a key to be missing from, so absence is reported about the
+      // compared value itself.
+
       expect(retiredKeys("a legacy display name", undefined)).toEqual([
         WHOLE_VALUE,
       ]);
@@ -49,10 +51,11 @@ describe("topics-rehearsal-lib", () => {
       expect(retiredKeys(undefined, undefined)).toEqual([]);
     });
 
-    // The distinction the whole approach rests on: a field the schema still
-    // declares reads back present even when its value was lost, so genuine
-    // loss is a difference rather than a gap and must not be forgiven.
     it("does not name a key that is present but changed", () => {
+      // The distinction the whole approach rests on: a field the schema still
+      // declares reads back present even when its value was lost, so genuine
+      // loss is a difference rather than a gap and must not be forgiven.
+
       expect(retiredKeys({ body: "kept" }, { body: "" })).toEqual([]);
     });
 
@@ -60,9 +63,10 @@ describe("topics-rehearsal-lib", () => {
       expect(retiredKeys("a legacy display name", "changed")).toEqual([]);
     });
 
-    // `null` is how a declared-but-empty field reads back, so it is a present
-    // value that lost its content — a difference, never a retirement.
     it("does not name a whole value that reads back null", () => {
+      // `null` is how a declared-but-empty field reads back, so it is a present
+      // value that lost its content — a difference, never a retirement.
+
       expect(retiredKeys("a legacy display name", null)).toEqual([]);
     });
   });
@@ -90,10 +94,11 @@ describe("topics-rehearsal-lib", () => {
         .toEqual({ body: "x" });
     });
 
-    // The verdict the restore actually reaches, asked the way it asks it:
-    // read the field back, forgive what the schema retired, compare the rest.
-    // A retired top-level field passes; a damaged one still fails.
     it("forgives a wholly retired field and nothing else", () => {
+      // The verdict the restore actually reaches, asked the way it asks it:
+      // read the field back, forgive what the schema retired, compare the rest.
+      // A retired top-level field passes; a damaged one still fails.
+
       const survives = (exported: unknown, live: unknown) =>
         deepEqual(
           live,
@@ -113,9 +118,10 @@ describe("topics-rehearsal-lib", () => {
   });
 
   describe("isAbsentPathError", () => {
-    // The restore forgives an absent field as retired, so only a read that
-    // landed and reported the path missing may present as absent.
     it("recognizes the runtime's missing-property failure through cf", () => {
+      // The restore forgives an absent field as retired, so only a read that
+      // landed and reported the path missing may present as absent.
+
       const error = new Error(
         "cf get -q --input authorName exited 1\nCannot access path " +
           '"authorName" - property "authorName" not found. ' +
@@ -221,16 +227,17 @@ describe("topics-rehearsal-lib", () => {
     });
   });
 
-  // `topics-restore.ts` declares `--allow-run --allow-read --allow-env` in its
-  // shebang and talks to a running server over `cf`. `@db/sqlite` opens its
-  // dynamic library with a top-level `await dlopen`, and the only entry point
-  // `@commonfabric/state-inspector` publishes re-exports the module that
-  // imports it — so one import of that barrel anywhere in the restore's graph
-  // makes the script die at module load with a permission error, whatever
-  // permissions the pure function it wanted actually needs. Twice now that
-  // failure was hidden by testing the script under `deno run -A`, which is why
-  // this asks the graph rather than trusting the run.
   describe("import graph", () => {
+    // `topics-restore.ts` declares `--allow-run --allow-read --allow-env` in
+    // its shebang and talks to a running server over `cf`. `@db/sqlite` opens
+    // its dynamic library with a top-level `await dlopen`, and the only entry
+    // point `@commonfabric/state-inspector` publishes re-exports the module
+    // that imports it — so one import of that barrel anywhere in the restore's
+    // graph makes the script die at module load with a permission error,
+    // whatever permissions the pure function it wanted actually needs. Twice
+    // now that failure was hidden by testing the script under `deno run -A`,
+    // which is why this asks the graph rather than trusting the run.
+
     it("names no store-reader dependency in the restore's graph", async () => {
       // Static `from "…"` specifiers followed through relative hops, which is
       // the whole of these scripts' own graph: they use no dynamic import and

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -31,11 +31,10 @@ describe("topics-rehearsal-lib", () => {
       );
     });
 
+    // A migration that retires a whole top-level field leaves no surviving
+    // record for a key to be missing from, so absence is reported about the
+    // compared value itself.
     it("names the whole value when a retired scalar reads back absent", () => {
-      // A migration that retires a whole top-level field leaves no surviving
-      // record for a key to be missing from, so absence is reported about the
-      // compared value itself.
-
       expect(retiredKeys("a legacy display name", undefined)).toEqual([
         WHOLE_VALUE,
       ]);
@@ -51,11 +50,10 @@ describe("topics-rehearsal-lib", () => {
       expect(retiredKeys(undefined, undefined)).toEqual([]);
     });
 
+    // The distinction the whole approach rests on: a field the schema still
+    // declares reads back present even when its value was lost, so genuine
+    // loss is a difference rather than a gap and must not be forgiven.
     it("does not name a key that is present but changed", () => {
-      // The distinction the whole approach rests on: a field the schema still
-      // declares reads back present even when its value was lost, so genuine
-      // loss is a difference rather than a gap and must not be forgiven.
-
       expect(retiredKeys({ body: "kept" }, { body: "" })).toEqual([]);
     });
 
@@ -118,10 +116,10 @@ describe("topics-rehearsal-lib", () => {
   });
 
   describe("isAbsentPathError", () => {
-    it("recognizes the runtime's missing-property failure through cf", () => {
-      // The restore forgives an absent field as retired, so only a read that
-      // landed and reported the path missing may present as absent.
+    // The restore forgives an absent field as retired, so only a read that
+    // landed and reported the path missing may present as absent.
 
+    it("recognizes the runtime's missing-property failure through cf", () => {
       const error = new Error(
         "cf get -q --input authorName exited 1\nCannot access path " +
           '"authorName" - property "authorName" not found. ' +

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -508,12 +508,12 @@ describe("check-command-docs", () => {
   });
 
   describe("as the task runs it", () => {
-    it("exits 0 reporting the commands it walked", async () => {
-      // Calling main() above would still pass if the entry point never ran it,
-      // or if the permissions the task declares were too narrow to walk the
-      // tree. This is the promise the CI job makes: the command exits 0, having
-      // done the work.
+    // Calling main() above would still pass if the entry point never ran it,
+    // or if the permissions the task declares were too narrow to walk the
+    // tree. This is the promise the CI job makes: the command exits 0, having
+    // done the work.
 
+    it("exits 0 reporting the commands it walked", async () => {
       const { code, out } = await runAsProgram();
       expect(code).toBe(0);
       expect(out).toContain("Command documentation OK");

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -508,11 +508,12 @@ describe("check-command-docs", () => {
   });
 
   describe("as the task runs it", () => {
-    // Calling main() above would still pass if the entry point never ran it,
-    // or if the permissions the task declares were too narrow to walk the
-    // tree. This is the promise the CI job makes: the command exits 0, having
-    // done the work.
     it("exits 0 reporting the commands it walked", async () => {
+      // Calling main() above would still pass if the entry point never ran it,
+      // or if the permissions the task declares were too narrow to walk the
+      // tree. This is the promise the CI job makes: the command exits 0, having
+      // done the work.
+
       const { code, out } = await runAsProgram();
       expect(code).toBe(0);
       expect(out).toContain("Command documentation OK");

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -324,11 +324,12 @@ describe("check-completion-slots", () => {
   });
 
   describe("as the task runs it", () => {
-    // Calling main() above would still pass if the entry point never ran it,
-    // or if the permissions the task declares were too narrow to walk the
-    // tree. This is the promise the CI job makes: the command exits 0, having
-    // done the work.
     it("exits 0 reporting the slots it walked", async () => {
+      // Calling main() above would still pass if the entry point never ran it,
+      // or if the permissions the task declares were too narrow to walk the
+      // tree. This is the promise the CI job makes: the command exits 0, having
+      // done the work.
+
       const { code, out } = await runAsProgram();
       expect(code).toBe(0);
       expect(out).toContain("Completion slots OK");

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -324,12 +324,12 @@ describe("check-completion-slots", () => {
   });
 
   describe("as the task runs it", () => {
-    it("exits 0 reporting the slots it walked", async () => {
-      // Calling main() above would still pass if the entry point never ran it,
-      // or if the permissions the task declares were too narrow to walk the
-      // tree. This is the promise the CI job makes: the command exits 0, having
-      // done the work.
+    // Calling main() above would still pass if the entry point never ran it,
+    // or if the permissions the task declares were too narrow to walk the
+    // tree. This is the promise the CI job makes: the command exits 0, having
+    // done the work.
 
+    it("exits 0 reporting the slots it walked", async () => {
       const { code, out } = await runAsProgram();
       expect(code).toBe(0);
       expect(out).toContain("Completion slots OK");

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -63,10 +63,11 @@ Deno.test("parseMisePins returns every pin in order", () => {
   );
 });
 
-// TOML rejects a key defined twice even when both values agree, so mise fails
-// to load the file. Reading only the first pin would report the toolchain as
-// aligned while `mise install` — the documented way to get it — is broken.
 Deno.test("findProblems flags a Deno pin defined twice", () => {
+  // TOML rejects a key defined twice even when both values agree, so mise fails
+  // to load the file. Reading only the first pin would report the toolchain as
+  // aligned while `mise install` — the documented way to get it — is broken.
+
   for (
     const miseToml of [
       '[tools]\ndeno = "2.8.1"\ndeno = "2.8.1"\n',
@@ -128,9 +129,10 @@ Deno.test("compareVersions compares components numerically", () => {
   assertEquals(compareVersions("2.8.1", "2.8.1"), 0);
 });
 
-// Reading only the leading components would compare "2.8.0.1" as "2.8.0" and
-// answer as though the trailing component were not there.
 Deno.test("compareVersions rejects a version that is not exact", () => {
+  // Reading only the leading components would compare "2.8.0.1" as "2.8.0" and
+  // answer as though the trailing component were not there.
+
   for (const bad of ["2.8.0.1", "2.8", "abc", "", "v2.8.0"]) {
     assertThrows(
       () => compareVersions(bad, "2.8.0"),
@@ -255,10 +257,11 @@ Deno.test("findProblems flags a range that excludes the pin", () => {
   assert(problems[0].includes("range"));
 });
 
-// The name mise.toml stays in the action's description and comments after the
-// read is replaced by a literal, so this fixture is what a "just inline the
-// version" refactor actually leaves behind.
 Deno.test("findProblems flags an action that stops reading mise.toml", () => {
+  // The name mise.toml stays in the action's description and comments after the
+  // read is replaced by a literal, so this fixture is what a "just inline the
+  // version" refactor actually leaves behind.
+
   const files = {
     ...alignedFiles(),
     denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +

--- a/tasks/executable-source.test.ts
+++ b/tasks/executable-source.test.ts
@@ -187,12 +187,13 @@ describe("executable-source", () => {
       expect(hasExecutableCode("// nothing here\n", "mod.js")).toBe(false);
     });
 
-    // The coverage gate rests on a claim about Deno: a file this function calls
-    // non-executable has no line Deno's coverage can report as uncovered, so
-    // charging it nothing loses nothing. Deno transpiles with swc and this
-    // function asks the TypeScript compiler, so a real coverage pass over
-    // fixture modules holds the two to the same answer.
     describe("against a real coverage run", () => {
+      // The coverage gate rests on a claim about Deno: a file this function
+      // calls non-executable has no line Deno's coverage can report as
+      // uncovered, so charging it nothing loses nothing. Deno transpiles with
+      // swc and this function asks the TypeScript compiler, so a real coverage
+      // pass over fixture modules holds the two to the same answer.
+
       // Resolved, because the report names the real path and a temporary
       // directory can be reached through a symlink (macOS puts one in front of
       // it).

--- a/tasks/pattern-compat-accepted-breaks.test.ts
+++ b/tasks/pattern-compat-accepted-breaks.test.ts
@@ -49,10 +49,11 @@ describe("pattern-compat-accepted-breaks", () => {
       }
     });
 
-    // The run indexes entries into one map keyed by pattern and baseline, so a
-    // pair named twice keeps only the later entry's paths and silently drops
-    // the earlier one's.
     it("names each pattern and baseline pair once", () => {
+      // The run indexes entries into one map keyed by pattern and baseline, so
+      // a pair named twice keeps only the later entry's paths and silently
+      // drops the earlier one's.
+
       const seen = new Set<string>();
       const repeated: string[] = [];
       for (const accepted of ACCEPTED_CONTRACT_BREAKS) {
@@ -65,10 +66,11 @@ describe("pattern-compat-accepted-breaks", () => {
       expect(repeated).toEqual([]);
     });
 
-    // A finding is forgiven only when every path it blames is one the entry
-    // named, and the proof spells a path as its role followed by the schema
-    // pointer. A path under any other name forgives nothing.
     it("spells every path as an argument or result path", () => {
+      // A finding is forgiven only when every path it blames is one the entry
+      // named, and the proof spells a path as its role followed by the schema
+      // pointer. A path under any other name forgives nothing.
+
       for (const accepted of ACCEPTED_CONTRACT_BREAKS) {
         expect(accepted.paths.length).toBeGreaterThan(0);
         for (const path of accepted.paths) {

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -137,22 +137,23 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-// The patterns list is EMPTY again — lunch-poll-vote's FILE entry, the
-// LAST entry in any suite, lifted 2026-08-28 (the THIRD lift) on the
-// owner-ruled 3b close: the owner ruled "go with (1) plus the (2-D)
-// kick", and both mechanisms are landed red-first — (1) event-driven
-// re-supply (a supply-class replication failure parks under the WANTED
-// identity and the matching persist RECORD re-issues it; the
-// registration-time map check covers a record that landed inside the
-// read window) and (2-D) the sidecar serve-time closure kick (the
-// demanding space's supplier registered at page-serve time, covered by
-// the ticket await). Campaign R 8/8 quiet-and-loaded at the lift head,
-// and the lift PR's own ON-lane board is the direct-CI unskip probe
-// (PROBE 6). What stays open is recorded in the register's RULING block
-// (cross-replica never-records supplier; prior-session third-space
-// closure; the recursive-(b) sliver). Evidence chain:
-// verification-coverage.md OW45's lunch blocks.
 Deno.test("main: the patterns list is EMPTY after the ruled 3b close and the flip bar's list-EMPTY precondition is met", async () => {
+  // The patterns list is EMPTY again — lunch-poll-vote's FILE entry, the
+  // LAST entry in any suite, lifted 2026-08-28 (the THIRD lift) on the
+  // owner-ruled 3b close: the owner ruled "go with (1) plus the (2-D)
+  // kick", and both mechanisms are landed red-first — (1) event-driven
+  // re-supply (a supply-class replication failure parks under the WANTED
+  // identity and the matching persist RECORD re-issues it; the
+  // registration-time map check covers a record that landed inside the
+  // read window) and (2-D) the sidecar serve-time closure kick (the
+  // demanding space's supplier registered at page-serve time, covered by
+  // the ticket await). Campaign R 8/8 quiet-and-loaded at the lift head,
+  // and the lift PR's own ON-lane board is the direct-CI unskip probe
+  // (PROBE 6). What stays open is recorded in the register's RULING block
+  // (cross-replica never-records supplier; prior-session third-space
+  // closure; the recursive-(b) sliver). Evidence chain:
+  // verification-coverage.md OW45's lunch blocks.
+
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // No entries: no --ignore flag on stdout…
@@ -292,13 +293,14 @@ Deno.test("validation binds a step entry: the file must name the step and call t
   ]);
 });
 
-// The runner list emptied with the arrival-witness lift (RULED 2026-08-22,
-// candidate (B) of the OW33 fork memo); the LAST list anywhere emptied
-// (a third time) with the lunch-poll-vote ruled-3b-close lift
-// (2026-08-28). This pin holds the whole-registry EMPTY state: any new
-// entry in ANY suite reddens it, so a skip is a deliberate change,
-// never a leftover.
 Deno.test("main: the runner list is EMPTY and NO suite carries any entry — the ON-skip registry is EMPTY after the ruled 3b close", async () => {
+  // The runner list emptied with the arrival-witness lift (RULED 2026-08-22,
+  // candidate (B) of the OW33 fork memo); the LAST list anywhere emptied
+  // (a third time) with the lunch-poll-vote ruled-3b-close lift
+  // (2026-08-28). This pin holds the whole-registry EMPTY state: any new
+  // entry in ANY suite reddens it, so a skip is a deliberate change,
+  // never a leftover.
+
   const { out, err, io } = captureIo();
   assertEquals(await main(["runner"], io), 0);
   // No entries: no --ignore flag on stdout…


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms the arc's remaining tail to the "Commenting a block" rule in
`unit-test-coding-style.md`: a comment about a test or a group of tests goes
inside the block's callback, as its first content, followed by a blank line.
The packages are `memory`, `lib-shell`, `shell`, `ui`,
`background-piece-service`, `identity`, `integration` and `deno-web-test`,
plus the `tasks/` and `scripts/` trees. After this, only `runner` is left.

39 comments across 22 files.

- **27 move** into the block they describe.
- **3 stay** at the top of the group they head, taking only the blank line: the
  absent-path rule in `topics-rehearsal-lib.test.ts`, whose `describe` holds
  exactly the landed-read case and the never-reached one, and the entry-point
  rationale in `check-completion-slots.test.ts` and `check-command-docs.test.ts`,
  which is why those groups run the task as a subprocess at all.
- **9 stay exactly where they are**, in three kinds the rule does not reach.

## The seven

**A hook** (1). `background-piece-service/test/service-modules.test.ts:526`
heads an `afterEach`. A hook is closer to ordinary code than to a test case,
and reads normally with a line or two of `//` above it.

**No body to move into** (4). Three sit above an `it()` whose callback is a
bare expression --
`it("UPDATE OR REPLACE target", () => expect(...).toBe("emails"))` in
`memory/test/v2-sqlite-write-targets.test.ts` -- and one above
`Deno.test("would-pass", function () {});` in `deno-web-test`, whose body is
`{}` on the same line. A callback with no braces has no inside, so the comment
stays beside the statement.

**A run of sibling blocks** (4). `scripts/topics-snapshot-lib.test.ts`
("Both encodings reach a reader of a real snapshot") covers the sigil-link case
and the `FabricLink` case; `scripts/topics-rehearsal-lib.test.ts`'s "Together
these ..." names both the retired-field case above it and the changed-value
case below it, and its retired-field rule and present-but-changed distinction
are each stated once for a scalar and once for a whole value. Inside one block,
each would stop reaching the rest.

The three `v2-sqlite-write-targets.test.ts` comments are both kinds at once:
each covers a run of two or three expression-bodied `it()`s.

## What the diff is, as a property

Across the 18 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0).
- Per file, the multiset of comment words is unchanged.
- Per file, the multiset of non-comment lines is unchanged.
- No added line exceeds 80 characters, counted in characters rather than bytes.

A re-run of the census over these trees finds 9 remaining comments above a
test-block opener -- exactly the nine named above, and none other. Counting
comment runs across the whole diff: 0 runs' words vanish, 0 are new, and 10
surviving runs changed their line breaks.

## Gates

`deno task check` passes over the workspace. `deno fmt --check` and `deno lint`
pass over every touched tree. `deno task test`: `memory` 592 passed / 0 failed,
`ui` 172 + 52 passed / 0 failed, `integration` 52 passed / 0 failed,
`deno-web-test` 35 passed / 0 failed, `identity` 26 passed / 0 failed,
`background-piece-service` 14 passed / 0 failed, `lib-shell` 5 passed / 0
failed; the seven touched `tasks/` and `scripts/` files, 55 passed / 0 failed.

The three touched `shell` files are browser integration tests, which CI runs;
they are not covered by a local suite here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


