### PR TITLE
test(runner): a block's comment moves inside the block it describes (1 of 4)

### DIFF
--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -122,10 +122,12 @@ describe("mergeable array appends", () => {
     await server?.close();
   });
 
-  // Two sessions append to the same list against the SAME base, neither having
-  // observed the other's append before committing. Both appends represent real
-  // user intent on disjoint tail slots, so both must survive durably.
   it("two concurrent appends to the same list both survive", async () => {
+    // Two sessions append to the same list against the SAME base, neither
+    // having observed the other's append before committing. Both appends
+    // represent real user intent on disjoint tail slots, so both must survive
+    // durably.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -178,12 +180,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A CONDITIONAL push — the handler reads the list explicitly before pushing
-  // (the dedup-then-push shape) — must keep its read in the conflict set, so a
-  // concurrent append makes it conflict (and, in the live system, retry). This
-  // is the opposite of the unconditional case above, which merges. It proves the
-  // read drop is scoped to the op's own reads, not the handler's explicit read.
   it("a conditional push (explicit read before push) conflicts with a concurrent append", async () => {
+    // A CONDITIONAL push — the handler reads the list explicitly before pushing
+    // (the dedup-then-push shape) — must keep its read in the conflict set, so
+    // a concurrent append makes it conflict (and, in the live system, retry).
+    // This is the opposite of the unconditional case above, which merges. It
+    // proves the read drop is scoped to the op's own reads, not the handler's
+    // explicit read.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -226,17 +230,18 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A push whose new element is derived from the array's LENGTH is a conditional
-  // push: its correctness depends on the count it read. The length read is
-  // recorded as the array's own `length` child path — the shape produced by a
-  // `for...of`/spread over the array, a shape-only `length` access, or
-  // `key("length")`. That read must stay in the conflict set: a mergeable append
-  // changes the length, so a concurrent append has to make this commit conflict
-  // (and retry against the new tail) instead of the push merging with a stale
-  // index. Before the length read was kept, session 2 read length 1, both
-  // sessions computed the same index, and the append silently merged with a
-  // duplicate index.
   it("a length-derived push conflicts with a concurrent append", async () => {
+    // A push whose new element is derived from the array's LENGTH is a
+    // conditional push: its correctness depends on the count it read. The
+    // length read is recorded as the array's own `length` child path — the
+    // shape produced by a `for...of`/spread over the array, a shape-only
+    // `length` access, or `key("length")`. That read must stay in the conflict
+    // set: a mergeable append changes the length, so a concurrent append has to
+    // make this commit conflict (and retry against the new tail) instead of the
+    // push merging with a stale index. Before the length read was kept, session
+    // 2 read length 1, both sessions computed the same index, and the append
+    // silently merged with a duplicate index.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -279,10 +284,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The same protection through the query-result proxy's iterator: a handler that
-  // counts the array with `for...of` (or a spread) before pushing records the
-  // array's `length` read, so a concurrent append conflicts.
   it("a for...of count before a push conflicts with a concurrent append", async () => {
+    // The same protection through the query-result proxy's iterator: a handler
+    // that counts the array with `for...of` (or a spread) before pushing
+    // records the array's `length` read, so a concurrent append conflicts.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -323,12 +329,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The length read stays precise: it conflicts with a change to the element
-  // COUNT (an append), not with an edit to an existing element. A concurrent
-  // edit to an element the length-reading session did not append leaves the
-  // length unchanged, so the append still merges — the length read must not
-  // over-conflict the way a whole-array `.get()` read would.
   it("a length-derived push merges past a concurrent edit to an existing element", async () => {
+    // The length read stays precise: it conflicts with a change to the element
+    // COUNT (an append), not with an edit to an existing element. A concurrent
+    // edit to an element the length-reading session did not append leaves the
+    // length unchanged, so the append still merges — the length read must not
+    // over-conflict the way a whole-array `.get()` read would.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -372,15 +379,16 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Bare `.length` on the query-result proxy (the get trap) reads the whole
-  // array recursively at the op path, so it is already kept as the handler's
-  // explicit read and conflicts with a concurrent append even without the
-  // length-child carve-out. This pins that end-to-end guarantee for the most
-  // common form: a change that ever recorded bare `.length` as a shape-only read
-  // AT the op path (which `buildReads` drops as the proxy's incidental container
-  // read) would fail here, forcing the count dependency to stay in the conflict
-  // set.
   it("a bare proxy `.length` read before a push conflicts with a concurrent append", async () => {
+    // Bare `.length` on the query-result proxy (the get trap) reads the whole
+    // array recursively at the op path, so it is already kept as the handler's
+    // explicit read and conflicts with a concurrent append even without the
+    // length-child carve-out. This pins that end-to-end guarantee for the most
+    // common form: a change that ever recorded bare `.length` as a shape-only
+    // read AT the op path (which `buildReads` drops as the proxy's incidental
+    // container read) would fail here, forcing the count dependency to stay in
+    // the conflict set.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -420,13 +428,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Enumerating the array's keys (`Object.keys`/`values`/`entries`, or an object
-  // spread) observes the present-key set — the proxy's ownKeys trap records a
-  // recursive read of the array for that. So a push whose new element came from
-  // `Object.keys(arr).length` conflicts with a concurrent append (and, per the
-  // sparse test below, with a concurrent hole edit); an unconditional push, which
-  // never enumerates, still merges.
   it("an Object.keys(proxy).length-derived push conflicts with a concurrent append", async () => {
+    // Enumerating the array's keys (`Object.keys`/`values`/`entries`, or an
+    // object spread) observes the present-key set — the proxy's ownKeys trap
+    // records a recursive read of the array for that. So a push whose new
+    // element came from `Object.keys(arr).length` conflicts with a concurrent
+    // append (and, per the sparse test below, with a concurrent hole edit); an
+    // unconditional push, which never enumerates, still merges.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -466,12 +475,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The carve-out is not push-specific: it keeps the length read for every
-  // mergeable op. An addUnique whose added value or decision depended on the
-  // count must conflict with a concurrent count-changing op, even when the added
-  // element is a distinct key that would otherwise merge. A transaction that
-  // reads the length forfeits that transaction's distinct-element merge.
   it("a length-read addUnique conflicts with a concurrent addUnique", async () => {
+    // The carve-out is not push-specific: it keeps the length read for every
+    // mergeable op. An addUnique whose added value or decision depended on the
+    // count must conflict with a concurrent count-changing op, even when the
+    // added element is a distinct key that would otherwise merge. A transaction
+    // that reads the length forfeits that transaction's distinct-element merge.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -510,11 +520,12 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A single session appends to a list whose durable head it has not yet
-  // observed (the rehydration-race shape): it reads the list as shorter/empty
-  // than it durably is, then appends. The append must land at the durable tail,
-  // never clobbering elements it could not see.
   it("an append against a stale-short base does not clobber the durable tail", async () => {
+    // A single session appends to a list whose durable head it has not yet
+    // observed (the rehydration-race shape): it reads the list as shorter/empty
+    // than it durably is, then appends. The append must land at the durable
+    // tail, never clobbering elements it could not see.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -558,10 +569,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A single transaction that both edits an existing element and appends must
-  // keep the edit: the append op covers only the appended tail, not the edited
-  // prefix slot.
   it("an edit to an existing element survives alongside a push in the same tx", async () => {
+    // A single transaction that both edits an existing element and appends must
+    // keep the edit: the append op covers only the appended tail, not the
+    // edited prefix slot.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -592,12 +604,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Two different mergeable op kinds on the same array path in one transaction.
-  // The intent map holds one op per path, so the second would replace the first
-  // and the diff-suppression would then drop the first op's element from the
-  // commit. The path is poisoned instead and the whole-array diff carries both
-  // changes.
   it("addUnique then push in one tx commits both (no silent drop)", async () => {
+    // Two different mergeable op kinds on the same array path in one
+    // transaction. The intent map holds one op per path, so the second would
+    // replace the first and the diff-suppression would then drop the first op's
+    // element from the commit. The path is poisoned instead and the whole-array
+    // diff carries both changes.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -621,10 +634,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The "update my entry" idiom: remove the old value and add the new one in one
-  // handler. remove-by-value and add-unique are different op kinds, so the path
-  // is poisoned and the whole-array diff commits the correct result.
   it("removeByValue then addUnique in one tx commits both", async () => {
+    // The "update my entry" idiom: remove the old value and add the new one in
+    // one handler. remove-by-value and add-unique are different op kinds, so
+    // the path is poisoned and the whole-array diff commits the correct result.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -649,9 +663,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A whole-array Cell.set after a push reshapes the array; the append intent is
-  // poisoned so the commit emits the set's array, not a tail op sliced from it.
   it("push then a whole-array set commits the set array", async () => {
+    // A whole-array Cell.set after a push reshapes the array; the append intent
+    // is poisoned so the commit emits the set's array, not a tail op sliced
+    // from it.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -675,15 +691,17 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A whole-array set that REPLACES every element without changing the length or
-  // the hole layout, then a push. This one is deliberately NOT abandoned, and
-  // pins that: a dense same-length replacement diffs into per-index candidates
-  // that all sit below the tail start, so they survive the op's suppression and
-  // commit alongside the append. (Characterization, not a regression guard — it
-  // holds on the unfixed code too. It is here so a future tightening of the
-  // guard to full prefix VALUE comparison has to justify losing this. Changing
-  // the hole layout is a different matter and is abandoned — see below.)
   it("a same-length whole-array set then a push commits the replaced list", async () => {
+    // A whole-array set that REPLACES every element without changing the length
+    // or the hole layout, then a push. This one is deliberately NOT abandoned,
+    // and pins that: a dense same-length replacement diffs into per-index
+    // candidates that all sit below the tail start, so they survive the op's
+    // suppression and commit alongside the append. (Characterization, not a
+    // regression guard — it holds on the unfixed code too. It is here so a
+    // future tightening of the guard to full prefix VALUE comparison has to
+    // justify losing this. Changing the hole layout is a different matter and
+    // is abandoned — see below.)
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -712,12 +730,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A same-length set that changes the array's HOLE LAYOUT, then a push. Length
-  // equality is satisfied, but the diff cannot express a presence change per
-  // index — it falls back to a whole-array replacement, which is the one
-  // candidate the op's suppression drops outright. Sparse arrays are preserved
-  // elsewhere in the runner, so the hole must survive the round trip.
   it("a set that punches a hole then a push commits the hole", async () => {
+    // A same-length set that changes the array's HOLE LAYOUT, then a push.
+    // Length equality is satisfied, but the diff cannot express a presence
+    // change per index — it falls back to a whole-array replacement, which is
+    // the one candidate the op's suppression drops outright. Sparse arrays are
+    // preserved elsewhere in the runner, so the hole must survive the round
+    // trip.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -755,12 +775,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // No base at all: a previously absent cell set to a sparse array, then pushed.
-  // With no base the whole working array is the op's payload, so the hole is in
-  // the payload rather than in a prefix the diff would carry — the density check
-  // has to run whether or not there was a base. Without it the write does not
-  // merely flatten the hole, it fails to land at all.
   it("an absent cell set to a sparse array then pushed commits the hole", async () => {
+    // No base at all: a previously absent cell set to a sparse array, then
+    // pushed. With no base the whole working array is the op's payload, so the
+    // hole is in the payload rather than in a prefix the diff would carry — the
+    // density check has to run whether or not there was a base. Without it the
+    // write does not merely flatten the hole, it fails to land at all.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -813,10 +834,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The reverse: the base is sparse and the set FILLS the hole, same length.
-  // Without the layout check the fill is dropped and, because the whole-array
-  // candidate carried every element, so is the rest of the replacement.
   it("a set that fills a hole then a push commits the filled value", async () => {
+    // The reverse: the base is sparse and the set FILLS the hole, same length.
+    // Without the layout check the fill is dropped and, because the whole-array
+    // candidate carried every element, so is the rest of the replacement.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -843,13 +865,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // An element edit alongside a push is the composition the fallback must NOT
-  // swallow: the edit is a per-index candidate below the tail, it survives
-  // suppression, and the push stays mergeable. This is the case that stops the
-  // guard from being tightened into "the prefix must be untouched", and that
-  // pins the poison's direction — a write BENEATH an array must not reach the
-  // array's own intent.
   it("a push then an element edit keeps the push mergeable and commits both", async () => {
+    // An element edit alongside a push is the composition the fallback must NOT
+    // swallow: the edit is a per-index candidate below the tail, it survives
+    // suppression, and the push stays mergeable. This is the case that stops
+    // the guard from being tightened into "the prefix must be untouched", and
+    // that pins the poison's direction — a write BENEATH an array must not
+    // reach the array's own intent.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -896,11 +919,12 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A whole-array set that SHRINKS the list, then a push. The set removed "b"
-  // and "c"; a tail op cannot express that removal, and its suppression covers
-  // the very diff candidates that would have carried it, so the removal must
-  // keep the path off the mergeable fast path.
   it("a shrinking whole-array set then a push commits the shrunk list", async () => {
+    // A whole-array set that SHRINKS the list, then a push. The set removed "b"
+    // and "c"; a tail op cannot express that removal, and its suppression
+    // covers the very diff candidates that would have carried it, so the
+    // removal must keep the path off the mergeable fast path.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -929,11 +953,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The clear-and-reseed idiom: empty the list, then add the replacement members
-  // back with `addUnique`. The replacements are new values, so the server's
-  // add-unique dedup cannot mask the lost clear — the durable list must hold the
-  // reseeded members alone, not the cleared ones plus the additions.
   it("a whole-array set([]) then addUnique commits only the added members", async () => {
+    // The clear-and-reseed idiom: empty the list, then add the replacement
+    // members back with `addUnique`. The replacements are new values, so the
+    // server's add-unique dedup cannot mask the lost clear — the durable list
+    // must hold the reseeded members alone, not the cleared ones plus the
+    // additions.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -962,10 +988,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The same reshape reached from a PARENT path, landing BEFORE the op — so no
-  // intent exists yet for the ancestor write to poison, and the tail op's own
-  // prefix check is what has to catch it.
   it("a parent-object set that shrinks a nested list then a push commits the shrunk list", async () => {
+    // The same reshape reached from a PARENT path, landing BEFORE the op — so
+    // no intent exists yet for the ancestor write to poison, and the tail op's
+    // own prefix check is what has to catch it.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1013,13 +1040,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Nested tail ops where one op's PAYLOAD contains the other's target: push a
-  // new inner list onto the outer list, then push into that inner list. A tail
-  // op's payload is read from the working array at commit, so the outer append
-  // already carries the inner list complete with the element the inner append
-  // would add again — the store would apply it twice. Only the durable value
-  // shows it: the writer's own local value is correct throughout.
   it("a push into a just-appended nested list commits its element once", async () => {
+    // Nested tail ops where one op's PAYLOAD contains the other's target: push
+    // a new inner list onto the outer list, then push into that inner list. A
+    // tail op's payload is read from the working array at commit, so the outer
+    // append already carries the inner list complete with the element the inner
+    // append would add again — the store would apply it twice. Only the durable
+    // value shows it: the writer's own local value is correct throughout.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1054,14 +1082,16 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The same two pushes with the inner one landing BEFORE the outer tail: that
-  // element is not in the outer append's payload, so both ops are sent and the
-  // durable value has to come out of the two of them applied together. That
-  // combination is what this pins; that the inner op stays a live intent rather
-  // than falling back is pinned on the intents themselves ("nested tail ops
-  // abandon only the contained one", below) — a durable value cannot show it,
-  // since a concurrent append is add-wins and lands either way.
   it("a push into a pre-existing nested list stays mergeable alongside an outer push", async () => {
+    // The same two pushes with the inner one landing BEFORE the outer tail:
+    // that element is not in the outer append's payload, so both ops are sent
+    // and the durable value has to come out of the two of them applied
+    // together. That combination is what this pins; that the inner op stays a
+    // live intent rather than falling back is pinned on the intents themselves
+    // ("nested tail ops abandon only the contained one", below) — a durable
+    // value cannot show it, since a concurrent append is add-wins and lands
+    // either way.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1119,11 +1149,12 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A poisoned path forfeits merge-friendliness: because it commits as a
-  // whole-array diff whose reads are kept, a mixed-op transaction conflicts with
-  // a concurrent append instead of merging — the intended trade for never losing
-  // data on the mixed-op path.
   it("a mixed-op (poisoned) transaction conflicts with a concurrent append", async () => {
+    // A poisoned path forfeits merge-friendliness: because it commits as a
+    // whole-array diff whose reads are kept, a mixed-op transaction conflicts
+    // with a concurrent append instead of merging — the intended trade for
+    // never losing data on the mixed-op path.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1164,9 +1195,10 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Probing whether a numeric index exists (`n in arr`) observes the element
-  // count, so an `n in arr`-derived push conflicts with a concurrent append.
   it("an `n in arr`-derived push conflicts with a concurrent append", async () => {
+    // Probing whether a numeric index exists (`n in arr`) observes the element
+    // count, so an `n in arr`-derived push conflicts with a concurrent append.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1204,12 +1236,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Arrays can be sparse (holes below `length`). Filling or punching a hole
-  // changes the present-key set without changing `length`, so an enumeration or
-  // `n in arr` probe that fed a push must conflict with a concurrent same-length
-  // hole edit. A `length`-only dependency would miss it; the ownKeys/has traps
-  // record a recursive read for arrays, which a hole edit invalidates.
   it("an `n in arr`-derived push conflicts with a concurrent same-length hole fill", async () => {
+    // Arrays can be sparse (holes below `length`). Filling or punching a hole
+    // changes the present-key set without changing `length`, so an enumeration
+    // or `n in arr` probe that fed a push must conflict with a concurrent
+    // same-length hole edit. A `length`-only dependency would miss it; the
+    // ownKeys/has traps record a recursive read for arrays, which a hole edit
+    // invalidates.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1254,9 +1288,10 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Two sessions add distinct elements to the same set against the same base.
-  // Both are real intents on the set, so both must survive.
   it("two concurrent add-uniques of distinct elements both survive", async () => {
+    // Two sessions add distinct elements to the same set against the same base.
+    // Both are real intents on the set, so both must survive.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1297,9 +1332,10 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Two sessions add the SAME element against the same base. add-unique dedups
-  // against durable state on the server, so the element appears once.
   it("concurrent add-unique of the same element is idempotent", async () => {
+    // Two sessions add the SAME element against the same base. add-unique
+    // dedups against durable state on the server, so the element appears once.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1338,9 +1374,10 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Two sessions increment the same counter against the same base. Increments
-  // sum against durable state rather than clobber via last-write-wins.
   it("two concurrent increments sum", async () => {
+    // Two sessions increment the same counter against the same base. Increments
+    // sum against durable state rather than clobber via last-write-wins.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1378,9 +1415,10 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Incrementing a counter that was never set treats the missing value as a
-  // zero default: the durable value becomes the increment amount.
   it("increment on a missing value implies a zero default", async () => {
+    // Incrementing a counter that was never set treats the missing value as a
+    // zero default: the durable value becomes the increment amount.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1397,9 +1435,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Two sessions remove distinct elements concurrently; both removals must land
-  // (they merge against durable state rather than clobber via a whole-array set).
   it("two concurrent removeByValue of distinct elements both land", async () => {
+    // Two sessions remove distinct elements concurrently; both removals must
+    // land (they merge against durable state rather than clobber via a
+    // whole-array set).
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1442,14 +1482,16 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The ordinary "edit one row and delete another in the same handler" shape. A
-  // remove-by-value suppresses the array path AND everything under it, so the
-  // edit's per-index candidate has no surviving carrier: without the builder's
-  // own commit-time check the store applies the removal to the untouched base
-  // and the edit is gone, while the writing session's local value shows it. The
-  // edit writes BENEATH the array, so it deliberately does not poison the
-  // intent — the check at build is the only thing that can catch this.
   it("an element edit before a removeByValue survives the removal", async () => {
+    // The ordinary "edit one row and delete another in the same handler" shape.
+    // A remove-by-value suppresses the array path AND everything under it, so
+    // the edit's per-index candidate has no surviving carrier: without the
+    // builder's own commit-time check the store applies the removal to the
+    // untouched base and the edit is gone, while the writing session's local
+    // value shows it. The edit writes BENEATH the array, so it deliberately
+    // does not poison the intent — the check at build is the only thing that
+    // can catch this.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1478,10 +1520,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The same composition in the other order. Recording the op first does not
-  // help: the edit still lands beneath the array and leaves the intent alive, so
-  // the suppression discards it just the same.
   it("an element edit after a removeByValue survives the removal", async () => {
+    // The same composition in the other order. Recording the op first does not
+    // help: the edit still lands beneath the array and leaves the intent alive,
+    // so the suppression discards it just the same.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1510,12 +1553,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A whole-array set BEFORE the removal: no intent exists yet for the set's
-  // write to poison, so the op is recorded against an array the transaction had
-  // already replaced. Its suppression then discards the set's entire diff and
-  // only the removals reach the store, leaving the durable list untouched apart
-  // from them.
   it("a whole-array set before a removeByValue commits the set array", async () => {
+    // A whole-array set BEFORE the removal: no intent exists yet for the set's
+    // write to poison, so the op is recorded against an array the transaction
+    // had already replaced. Its suppression then discards the set's entire diff
+    // and only the removals reach the store, leaving the durable list untouched
+    // apart from them.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1544,12 +1588,13 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // Creating the array and removing from it in one transaction: there is no base
-  // array for the op to describe at all. The removals alone say nothing about
-  // the elements the transaction created, and the subtree suppression discards
-  // the diff that carries them — so without the fallback the entity is never
-  // written and the durable value stays absent.
   it("a removeByValue on an array the transaction created commits the array", async () => {
+    // Creating the array and removing from it in one transaction: there is no
+    // base array for the op to describe at all. The removals alone say nothing
+    // about the elements the transaction created, and the subtree suppression
+    // discards the diff that carries them — so without the fallback the entity
+    // is never written and the durable value stays absent.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1594,10 +1639,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The same reshape reached from a PARENT path — a `set` on the enclosing
-  // object, landing before the op, so neither the write-time poison (nothing
-  // recorded yet) nor a check scoped to the array's own path would see it.
   it("a parent-object set before a nested removeByValue commits the set list", async () => {
+    // The same reshape reached from a PARENT path — a `set` on the enclosing
+    // object, landing before the op, so neither the write-time poison (nothing
+    // recorded yet) nor a check scoped to the array's own path would see it.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1645,14 +1691,15 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // The fallback is scoped: a removal that IS the transaction's only change to
-  // the array stays mergeable, so two sessions removing distinct elements
-  // against the same base still merge. Without this the fix would trade one
-  // silent loss for the clobbering the mergeable op exists to prevent. (The
-  // sibling test above removes concurrently from a shared base; this one pins
-  // that a same-transaction change to a DIFFERENT array leaves the removal
-  // mergeable.)
   it("a removeByValue stays mergeable when the other change is to a sibling field", async () => {
+    // The fallback is scoped: a removal that IS the transaction's only change
+    // to the array stays mergeable, so two sessions removing distinct elements
+    // against the same base still merge. Without this the fix would trade one
+    // silent loss for the clobbering the mergeable op exists to prevent. (The
+    // sibling test above removes concurrently from a shared base; this one pins
+    // that a same-transaction change to a DIFFERENT array leaves the removal
+    // mergeable.)
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1723,8 +1770,9 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A zero increment is a programming no-op and is rejected.
   it("increment(0) throws", async () => {
+    // A zero increment is a programming no-op and is rejected.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1739,13 +1787,14 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A stale framed addUnique must not rewrite the array's existing prefix.
-  // Its base-array read is excluded from the commit's conflict set, which is
-  // only safe while the op writes nothing below the tail: anchoring (or
-  // otherwise rewriting) untouched inline prefix elements would let this
-  // stale commit apply positional replacements over a newer concurrent
-  // element edit without any conflict, silently losing that edit.
   it("a stale framed addUnique does not clobber a concurrent element edit", async () => {
+    // A stale framed addUnique must not rewrite the array's existing prefix.
+    // Its base-array read is excluded from the commit's conflict set, which is
+    // only safe while the op writes nothing below the tail: anchoring (or
+    // otherwise rewriting) untouched inline prefix elements would let this
+    // stale commit apply positional replacements over a newer concurrent
+    // element edit without any conflict, silently losing that edit.
+
     const OBJ_CAUSE = "mergeable-addunique-objects";
     const objListSchema = {
       type: "array",
@@ -1837,10 +1886,11 @@ describe("mergeable array appends", () => {
     }
   });
 
-  // A non-finite amount is not a meaningful increment for a concurrent-sum
-  // counter (it would set the counter to an absorbing `NaN`/`±Infinity`), so it
-  // is rejected before any local write or mergeable-op record.
   it("increment(non-finite) throws", async () => {
+    // A non-finite amount is not a meaningful increment for a concurrent-sum
+    // counter (it would set the counter to an absorbing `NaN`/`±Infinity`), so
+    // it is rejected before any local write or mergeable-op record.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1923,9 +1973,11 @@ describe("keyed collections via elementById", () => {
     await server?.close();
   });
 
-  // The key resolves to the same entity in a session that never saw the write,
-  // so a second session can read and then remove the element purely by key.
   it("an element addressed by key is readable and removable from another session", async () => {
+    // The key resolves to the same entity in a session that never saw the
+    // write, so a second session can read and then remove the element purely by
+    // key.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -1978,9 +2030,10 @@ describe("keyed collections via elementById", () => {
     }
   });
 
-  // Two sessions cast votes under different keys against the same base; both
-  // memberships merge instead of clobbering.
   it("two sessions add distinct keyed elements concurrently — both survive", async () => {
+    // Two sessions cast votes under different keys against the same base; both
+    // memberships merge instead of clobbering.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2044,9 +2097,11 @@ describe("keyed collections via elementById", () => {
     }
   });
 
-  // Two sessions cast the same vote (same key) concurrently. The key derives to
-  // the same entity, so add-unique dedups by link to a single membership entry.
   it("two sessions add the same keyed element concurrently — dedups to one", async () => {
+    // Two sessions cast the same vote (same key) concurrently. The key derives
+    // to the same entity, so add-unique dedups by link to a single membership
+    // entry.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2104,9 +2159,11 @@ describe("keyed collections via elementById", () => {
     }
   });
 
-  // Editing a field of one keyed entity touches that entity's document, not the
-  // list, so a concurrent edit to a different field of the same entity merges.
   it("concurrent edits to different fields of one keyed element both land", async () => {
+    // Editing a field of one keyed entity touches that entity's document, not
+    // the list, so a concurrent edit to a different field of the same entity
+    // merges.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2401,10 +2458,12 @@ describe("mergeable op guards and single-session branches", () => {
     }
   });
 
-  // A cell whose transaction is a TransactionWrapper (the wrapper Cell.sample()
-  // and Cell.sink() install for child cells) routes its mergeable ops through
-  // the wrapper's record* delegations to the inner transaction.
   it("mergeable ops route through a TransactionWrapper", () => {
+    // A cell whose transaction is a TransactionWrapper (the wrapper
+    // Cell.sample() and Cell.sink() install for child cells) routes its
+    // mergeable ops through the wrapper's record* delegations to the inner
+    // transaction.
+
     const inner = rt.edit();
     const wrapper = new TransactionWrapper(inner, { childCellTx: inner });
 
@@ -2426,17 +2485,19 @@ describe("mergeable op guards and single-session branches", () => {
     expect(counter.get()).toBe(3);
   });
 
-  // A whole-value write reaches the intents BENEATH it, not just the one at the
-  // exact path it wrote. Asserted on the recorded intents rather than on a
-  // commit outcome, because the reshaping `set` also records reads of its own
-  // that conflict independently — a commit-level assertion would pass whether or
-  // not the intent survived.
-  //
-  // The sequence is the one length arithmetic alone cannot catch: push, reshape
-  // the enclosing object, push. The two pushes sum to a `count` that spans the
-  // reshape, so the recorded tail lands back on the base length while covering
-  // an element the reshape supplied rather than one an op appended.
   it("an ancestor write poisons the tail intent beneath it", () => {
+    // A whole-value write reaches the intents BENEATH it, not just the one at
+    // the exact path it wrote. Asserted on the recorded intents rather than on
+    // a commit outcome, because the reshaping `set` also records reads of its
+    // own that conflict independently — a commit-level assertion would pass
+    // whether or not the intent survived.
+    //
+    // The sequence is the one length arithmetic alone cannot catch: push,
+    // reshape the enclosing object, push. The two pushes sum to a `count` that
+    // spans the reshape, so the recorded tail lands back on the base length
+    // while covering an element the reshape supplied rather than one an op
+    // appended.
+
     const docSchema = {
       type: "object",
       properties: { rows: { type: "array", items: { type: "string" } } },
@@ -2464,13 +2525,14 @@ describe("mergeable op guards and single-session branches", () => {
     expect(doc.get()).toEqual({ rows: ["m", "n", "o", "r", "q"] });
   });
 
-  // Abandoning at build time must remove the intent from the transaction, not
-  // just skip the wire op — a surviving intent keeps narrowing reads out of the
-  // conflict set for an op that is no longer being sent. Asserted directly on
-  // the intents after `getNativeCommit`, because the reshaping write happens to
-  // leave an unmarked read at the path anyway, so no commit outcome
-  // distinguishes the two.
   it("a build-time abandon removes the intent from the transaction", async () => {
+    // Abandoning at build time must remove the intent from the transaction, not
+    // just skip the wire op — a surviving intent keeps narrowing reads out of
+    // the conflict set for an op that is no longer being sent. Asserted
+    // directly on the intents after `getNativeCommit`, because the reshaping
+    // write happens to leave an unmarked read at the path anyway, so no commit
+    // outcome distinguishes the two.
+
     // Asserting on the built commit rather than on the committed transaction
     // matters: finishing a commit clears the intents anyway, so a post-commit
     // assertion would pass whether or not the build dropped them.
@@ -2502,16 +2564,17 @@ describe("mergeable op guards and single-session branches", () => {
     );
   });
 
-  // Two tail ops where one op's payload contains the other's target: exactly one
-  // intent — the CONTAINED one — is abandoned, and the containing op survives to
-  // carry the combined value. Which of the two is dropped only shows here: both
-  // choices commit the same durable value in the simple case, but abandoning the
-  // outer would forfeit the outer list's merge-friendliness instead of the inner
-  // one's.
-  //
-  // The same assertion pins the guard's lower edge: a nested push landing BEFORE
-  // the outer tail is in no payload, so both intents survive.
   it("nested tail ops abandon only the contained one", async () => {
+    // Two tail ops where one op's payload contains the other's target: exactly
+    // one intent — the CONTAINED one — is abandoned, and the containing op
+    // survives to carry the combined value. Which of the two is dropped only
+    // shows here: both choices commit the same durable value in the simple
+    // case, but abandoning the outer would forfeit the outer list's
+    // merge-friendliness instead of the inner one's.
+    //
+    // The same assertion pins the guard's lower edge: a nested push landing
+    // BEFORE the outer tail is in no payload, so both intents survive.
+
     const nested = {
       type: "array",
       items: { type: "array", items: { type: "string" } },
@@ -2558,12 +2621,14 @@ describe("mergeable op guards and single-session branches", () => {
     }
   });
 
-  // The other direction, and the one that pins the predicate: a write BENEATH an
-  // array (an element edit) must leave that array's intent alone. Asserted on
-  // the intents, and with the push FIRST — the durable value cannot discriminate
-  // here, because a concurrent append is add-wins and lands either way, and the
-  // reverse order records no intent for a wrongly-widened poison to destroy.
   it("a write beneath an array leaves the array's intent intact", () => {
+    // The other direction, and the one that pins the predicate: a write BENEATH
+    // an array (an element edit) must leave that array's intent alone. Asserted
+    // on the intents, and with the push FIRST — the durable value cannot
+    // discriminate here, because a concurrent append is add-wins and lands
+    // either way, and the reverse order records no intent for a wrongly-widened
+    // poison to destroy.
+
     const docSchema = {
       type: "object",
       properties: { rows: { type: "array", items: { type: "string" } } },
@@ -2584,9 +2649,10 @@ describe("mergeable op guards and single-session branches", () => {
     expect(doc.get()).toEqual({ rows: ["A", "b", "p"] });
   });
 
-  // A sibling write must NOT poison a tail intent: only paths at or beneath the
-  // write are covered, so an unrelated field keeps the push mergeable.
   it("a sibling write leaves the tail intent intact", () => {
+    // A sibling write must NOT poison a tail intent: only paths at or beneath
+    // the write are covered, so an unrelated field keeps the push mergeable.
+
     const docSchema = {
       type: "object",
       properties: {
@@ -2609,10 +2675,11 @@ describe("mergeable op guards and single-session branches", () => {
       .toBe(1);
   });
 
-  // An increment that sums to zero is a no-op the op builder drops. Pairing it
-  // with another change on the same entity forces the entity to commit, so the
-  // builder still visits (and drops) the zero increment.
   it("a net-zero increment alongside another change is dropped", async () => {
+    // An increment that sums to zero is a no-op the op builder drops. Pairing
+    // it with another change on the same entity forces the entity to commit, so
+    // the builder still visits (and drops) the zero increment.
+
     const docSchema = {
       type: "object",
       properties: {
@@ -2654,10 +2721,11 @@ describe("mergeable op guards and single-session branches", () => {
     }
   });
 
-  // A recorded append whose path is overwritten by a whole-value set before
-  // commit is dropped: a non-array (or empty) value at the path produces no
-  // tail-relative op, and the whole-value write stands.
   it("an append superseded by a non-array set is dropped", async () => {
+    // A recorded append whose path is overwritten by a whole-value set before
+    // commit is dropped: a non-array (or empty) value at the path produces no
+    // tail-relative op, and the whole-value write stands.
+
     const cause = "append-then-scalar";
     const tx = rt.edit();
     // deno-lint-ignore no-explicit-any
@@ -2782,9 +2850,10 @@ describe("keyed object list (home spaces shape)", () => {
     await server?.close();
   });
 
-  // Two sessions add spaces with distinct names against the same base; both
-  // memberships merge rather than the second clobbering the first.
   it("two sessions add distinct names concurrently — both survive", async () => {
+    // Two sessions add spaces with distinct names against the same base; both
+    // memberships merge rather than the second clobbering the first.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2844,9 +2913,10 @@ describe("keyed object list (home spaces shape)", () => {
     }
   });
 
-  // Two sessions add the SAME name against the same base; the key derives to the
-  // same entity, so add-unique dedups by link to one membership entry.
   it("two sessions add the same name concurrently — dedups to one", async () => {
+    // Two sessions add the SAME name against the same base; the key derives to
+    // the same entity, so add-unique dedups by link to one membership entry.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2905,9 +2975,10 @@ describe("keyed object list (home spaces shape)", () => {
     }
   });
 
-  // Two sessions remove different spaces by key concurrently; both removals land
-  // instead of clobbering through a whole-list rewrite.
   it("two sessions remove distinct names concurrently — both land", async () => {
+    // Two sessions remove different spaces by key concurrently; both removals
+    // land instead of clobbering through a whole-list rewrite.
+
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,

--- a/packages/runner/test/attestation-data-uri.test.ts
+++ b/packages/runner/test/attestation-data-uri.test.ts
@@ -96,9 +96,10 @@ describe("attestation `load()` of `data:` URIs", () => {
     expect(error?.name).toBe("UnsupportedMediaTypeError");
   });
 
-  // A parameterized header passes the prefix pre-gate but is not the exact
-  // media type (this format has no parameters).
   it("errors on a parameterized header", () => {
+    // A parameterized header passes the prefix pre-gate but is not the exact
+    // media type (this format has no parameters).
+
     const payload = toUnpaddedBase64url(
       new TextEncoder().encode(jsonFromFabricValue({ a: 1 })),
     );
@@ -109,9 +110,10 @@ describe("attestation `load()` of `data:` URIs", () => {
     expect(error?.name).toBe("UnsupportedMediaTypeError");
   });
 
-  // Extraction-level failure (as opposed to payload-decode failure): a
-  // percent-encoded payload is not base64url.
   it("errors on a percent-encoded payload", () => {
+    // Extraction-level failure (as opposed to payload-decode failure): a
+    // percent-encoded payload is not base64url.
+
     const { ok, error } = load({
       id: `data:${DATA_URI_MEDIA_TYPE},${
         encodeURIComponent(jsonFromFabricValue({ a: 1 }))

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -70,23 +70,25 @@ describe("commonfabric `FabricSpecialObject` classes", () => {
   >;
 
   describe("runtime bindings", () => {
-    // This is what stops the per-class checks below from passing vacuously.
-    // Each of them is driven by the derived list and looks its expectation up
-    // in the table, so a name that appears in only one of the two would
-    // compare `undefined` against `undefined` and assert nothing. Requiring
-    // the two to match exactly also catches a derivation that matched fewer
-    // classes than it should have, which a mere non-empty check would not.
     it("derives exactly the classes this test knows how to check", () => {
+      // This is what stops the per-class checks below from passing vacuously.
+      // Each of them is driven by the derived list and looks its expectation up
+      // in the table, so a name that appears in only one of the two would
+      // compare `undefined` against `undefined` and assert nothing. Requiring
+      // the two to match exactly also catches a derivation that matched fewer
+      // classes than it should have, which a mere non-empty check would not.
+
       expect([...declaredClasses].sort()).toEqual(
         Object.keys(expectedBindings).sort(),
       );
     });
 
     for (const name of declaredClasses) {
-      // Presence, not constructibility: `FabricSpecialObject` is abstract, and
-      // exists at runtime so that `instanceof` works rather than so that it can
-      // be `new`-ed. Constructibility is checked per-class below.
       it(`exposes \`${name}\` as a runtime value on the pattern surface`, () => {
+        // Presence, not constructibility: `FabricSpecialObject` is abstract,
+        // and exists at runtime so that `instanceof` works rather than so that
+        // it can be `new`-ed. Constructibility is checked per-class below.
+
         expect(typeof commonfabric[name]).toBe("function");
       });
 
@@ -122,6 +124,7 @@ describe("commonfabric `FabricSpecialObject` classes", () => {
   describe("FabricRegExp", () => {
     // Both declared constructor overloads, since the pattern-visible
     // declaration offers both and only one of them is the obvious one.
+
     it("constructs an instance from a native `RegExp`", () => {
       const BoundFabricRegExp = commonfabric
         .FabricRegExp as typeof FabricRegExp;
@@ -182,10 +185,11 @@ describe("commonfabric `FabricSpecialObject` classes", () => {
       expect(instance.message).toBe("nope");
     });
 
-    // Unlike the other exposed classes, this one is mutable until frozen, so
-    // pattern code can reach its extras bag. Pinned because exposing writable
-    // members is a choice rather than a side effect of exposing the class.
     it("allows extras to be set and read back", () => {
+      // Unlike the other exposed classes, this one is mutable until frozen, so
+      // pattern code can reach its extras bag. Pinned because exposing writable
+      // members is a choice rather than a side effect of exposing the class.
+
       const BoundFabricError = commonfabric.FabricError as typeof FabricError;
       const instance = new BoundFabricError({
         type: "Error",
@@ -202,16 +206,18 @@ describe("commonfabric `FabricSpecialObject` classes", () => {
     });
   });
 
-  // What a pattern actually receives is not `createBuilder().commonfabric` but
-  // that object after `freezeSandboxValue()`, which -- unlike `deepFreeze` --
-  // recurses into functions and freezes each exposed constructor's
-  // `.prototype`. A class that behaves on the unfrozen surface could fail here
-  // and nowhere else, so the delivered surface gets its own checks.
-  //
-  // Deliberately coarser than the per-class checks above: freezing is one
-  // operation over the whole surface, so a failure would take every class at
-  // once and per-name diagnostics would add nothing.
   describe("the frozen sandbox surface", () => {
+    // What a pattern actually receives is not `createBuilder().commonfabric`
+    // but that object after `freezeSandboxValue()`, which -- unlike
+    // `deepFreeze` -- recurses into functions and freezes each exposed
+    // constructor's `.prototype`. A class that behaves on the unfrozen surface
+    // could fail here and nowhere else, so the delivered surface gets its own
+    // checks.
+    //
+    // Deliberately coarser than the per-class checks above: freezing is one
+    // operation over the whole surface, so a failure would take every class at
+    // once and per-name diagnostics would add nothing.
+
     const sandboxCommonfabric = getRuntimeModuleExports()
       .runtimeExports["commonfabric"] as unknown as Record<string, unknown>;
 

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -2285,15 +2285,16 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     ).toBe(true);
   });
 
-  // Regression: before bd98e01a4, compiled docs were stamped with a per-user
-  // `cf-compiled-by:<did>` atom. A second user's cold-compile writeback of the
-  // SAME content into the same space was rejected by the CFC label merge
-  // ("addIntegrity cannot be weakened at /") because the deployer's per-DID
-  // atom was already present and could not be merged with a different user's
-  // atom. The constant system-compiler atom (COMPILED_INTEGRITY_ATOM) makes
-  // the cache shared: a re-write of the same content by any user merges
-  // cleanly because both sides carry the identical atom.
   it("second user's writeback of the same content commits cleanly (per-user DID collision regression)", async () => {
+    // Regression: before bd98e01a4, compiled docs were stamped with a per-user
+    // `cf-compiled-by:<did>` atom. A second user's cold-compile writeback of
+    // the SAME content into the same space was rejected by the CFC label merge
+    // ("addIntegrity cannot be weakened at /") because the deployer's per-DID
+    // atom was already present and could not be merged with a different user's
+    // atom. The constant system-compiler atom (COMPILED_INTEGRITY_ATOM) makes
+    // the cache shared: a re-write of the same content by any user merges
+    // cleanly because both sides carry the identical atom.
+
     const { modules, entryIdentity } = toModules(PROGRAM);
 
     // First writer (the deployer) populates the cache.

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1209,12 +1209,13 @@ describe("Cell raw methods: frozen-or-not", () => {
   });
 });
 
-// Result-meta round-trip across commit + fresh-tx reload. These tests assert
-// end-to-end correctness of the standard result meta link round-trip: the
-// round-trip preserves the result-link object, and a raw `tx.read` of
-// `path: ["result"]` returns it as an object link record (with own-property
-// `"/"`), never as a string.
 describe(`Cell result-meta round-trip`, () => {
+  // Result-meta round-trip across commit + fresh-tx reload. These tests assert
+  // end-to-end correctness of the standard result meta link round-trip: the
+  // round-trip preserves the result-link object, and a raw `tx.read` of
+  // `path: ["result"]` returns it as an object link record (with own-property
+  // `"/"`), never as a string.
+
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -208,11 +208,16 @@ describe("Cell Static Methods", () => {
       });
     });
 
+    //
+    // The static-data walk over special objects
+    //
     // The static-data validation walk descends anything `typeof === "object"`,
     // which admits a `FabricSpecialObject`. Such a value survives it because it
     // has zero enumerable own properties: `Object.keys()` is empty, the descent
     // ends there, and the walk only ever reads -- it never rebuilds. Nothing
     // guards that, so these pin it.
+    //
+
     it("should accept a `FabricBytes` in static data", () => {
       withinHandlerContext(runtime, space, tx, () => {
         const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
@@ -274,6 +279,10 @@ describe("Cell Static Methods", () => {
         expect(() => Cell.of({ a: shared, b: shared })).not.toThrow();
       });
     });
+
+    //
+    // Ordinary values
+    //
 
     it("should create a cell with undefined value", () => {
       withinHandlerContext(runtime, space, tx, () => {

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1337,12 +1337,9 @@ Deno.bench(
   },
 );
 
-//
 // Benchmark: Notebook/Notes pattern - tests History.claim() optimization impact
-//
 // These benchmarks measure repeated .get() calls on a notebook with linked notes
 // The claim optimization removes O(n²) overhead during reads
-//
 
 const noteSchema: JSONSchema = {
   type: "object",

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1230,9 +1230,10 @@ Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
 });
 
 //
-// Benchmark: Complex linked document graph (MentionablePiece pattern) This
-// tests .get() performance on a medium-complexity object spread across many
-// documents
+// Benchmark: Complex linked document graph (MentionablePiece pattern)
+//
+// This tests .get() performance on a medium-complexity object spread across
+// many documents
 //
 
 Deno.bench(
@@ -1349,9 +1350,12 @@ Deno.bench(
   },
 );
 
-// Benchmark: Notebook/Notes pattern - tests History.claim() optimization impact
-// These benchmarks measure repeated .get() calls on a notebook with linked notes
-// The claim optimization removes O(n²) overhead during reads
+//
+// Notebook/Notes pattern: the History.claim() optimization's impact
+//
+// These benchmarks measure repeated .get() calls on a notebook with linked
+// notes. The claim optimization removes O(n²) overhead during reads.
+//
 
 const noteSchema: JSONSchema = {
   type: "object",
@@ -1427,10 +1431,6 @@ async function benchmarkNotebookReads(noteCount: number, readCount: number) {
   await storageManager.close();
 }
 
-//
-// 10 notes
-//
-
 Deno.bench("Notebook read - 10 notes, 0 reads (setup only)", async () => {
   await benchmarkNotebookReads(10, 0);
 });
@@ -1442,10 +1442,6 @@ Deno.bench("Notebook read - 10 notes, 100 reads", async () => {
 Deno.bench("Notebook read - 10 notes, 1000 reads", async () => {
   await benchmarkNotebookReads(10, 1000);
 });
-
-//
-// 100 notes
-//
 
 Deno.bench("Notebook read - 100 notes, 0 reads (setup only)", async () => {
   await benchmarkNotebookReads(100, 0);

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -618,11 +618,13 @@ Deno.bench("Cell withTx - transaction switching (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
+// Benchmark: Query result proxy operations
+//
+
 Deno.bench(
   "Cell getAsQueryResult - proxy creation schemaless (100x)",
   async () => {
-    // Benchmark: Query result proxy operations
-
     const { runtime, storageManager, tx } = setup();
 
     const cell = runtime.getCell<{
@@ -649,9 +651,11 @@ Deno.bench(
   },
 );
 
-Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
-  // Schema-based get operations for complex objects
+//
+// Schema-based get operations for complex objects
+//
 
+Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -1044,9 +1048,11 @@ Deno.bench("Cell complex - nested cell references (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell schema - complex validation (100x)", async () => {
-  // Benchmark: Schema validation
+//
+// Benchmark: Schema validation
+//
 
+Deno.bench("Cell schema - complex validation (100x)", async () => {
   const { runtime, storageManager } = setup();
 
   const complexSchema = {
@@ -1164,9 +1170,11 @@ Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
-  // Benchmark: Concurrent operations
+//
+// Benchmark: Concurrent operations
+//
 
+Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
   const { runtime, storageManager, tx } = setup();
 
   // Create multiple cells
@@ -1190,9 +1198,11 @@ Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
-  // Benchmark: Cell equals comparison
+//
+// Benchmark: Cell equals comparison
+//
 
+Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
   const { runtime, storageManager, tx } = setup();
 
   const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);
@@ -1219,13 +1229,15 @@ Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
+// Benchmark: Complex linked document graph (MentionablePiece pattern) This
+// tests .get() performance on a medium-complexity object spread across many
+// documents
+//
+
 Deno.bench(
   "Cell complex - MentionablePiece graph (10 top-level, 20 linked each, 100x get)",
   async () => {
-    // Benchmark: Complex linked document graph (MentionablePiece pattern) This
-    // tests .get() performance on a medium-complexity object spread across many
-    // documents
-
     const { runtime, storageManager, tx } = setup();
 
     // Schema for MentionablePiece with self-referential mentioned/backlinks

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -31,9 +31,8 @@ async function cleanup(
   await runtime.dispose();
 }
 
+// Benchmark: Cell creation
 Deno.bench("Cell creation - simple schemaless (100x)", async () => {
-  // Benchmark: Cell creation
-
   const { runtime, storageManager } = setup();
 
   for (let i = 0; i < 100; i++) {
@@ -85,9 +84,8 @@ Deno.bench("Cell creation - immutable (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+// Schema-based cell creation benchmarks
 Deno.bench("Cell creation - simple with schema (100x)", async () => {
-  // Schema-based cell creation benchmarks
-
   const { runtime, storageManager } = setup();
 
   const schema = { type: "number" } as const satisfies JSONSchema;
@@ -171,9 +169,8 @@ Deno.bench("Cell creation - array with schema (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+// Benchmark: Cell get operations
 Deno.bench("Cell get - simple value schemaless (100x)", async () => {
-  // Benchmark: Cell get operations
-
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<number>(space, "bench-get", undefined, tx);
@@ -240,9 +237,8 @@ Deno.bench("Cell getRaw - complex object schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Schema-based get operations
 Deno.bench("Cell get - simple value with schema (100x)", async () => {
-  // Schema-based get operations
-
   const { runtime, storageManager, tx } = setup();
 
   const schema = { type: "number", minimum: 0 } as const satisfies JSONSchema;
@@ -299,9 +295,8 @@ Deno.bench("Cell get - complex object with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Benchmark: Cell set operations
 Deno.bench("Cell set - simple value schemaless (100x)", async () => {
-  // Benchmark: Cell set operations
-
   const { runtime, storageManager } = setup();
 
   const cell = runtime.getCell<number>(space, "bench-set", undefined);
@@ -363,9 +358,8 @@ Deno.bench(
   },
 );
 
+// Schema-based set operations
 Deno.bench("Cell set - simple value with schema (100x)", async () => {
-  // Schema-based set operations
-
   const { runtime, storageManager } = setup();
 
   const schema = {
@@ -421,9 +415,8 @@ Deno.bench(
   },
 );
 
+// Benchmark: Nested cell operations
 Deno.bench("Cell key - nested access schemaless (100x)", async () => {
-  // Benchmark: Nested cell operations
-
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{
@@ -464,9 +457,8 @@ Deno.bench("Cell key - array access schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Schema-based nested operations
 Deno.bench("Cell key - nested access with schema (100x)", async () => {
-  // Schema-based nested operations
-
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -547,9 +539,8 @@ Deno.bench("Cell key - array access with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Benchmark: Cell derivation
 Deno.bench("Cell asSchema - schema transformation (100x)", async () => {
-  // Benchmark: Cell derivation
-
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{
@@ -673,9 +664,8 @@ Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Benchmark: Array operations
 Deno.bench("Cell push - array append schemaless (100x)", async () => {
-  // Benchmark: Array operations
-
   const { runtime, storageManager } = setup();
 
   const cell = runtime.getCell<{ items: number[] }>(
@@ -721,9 +711,8 @@ Deno.bench("Cell array - proxy map operation schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Schema-based array operations
 Deno.bench("Cell push - array append with schema (100x)", async () => {
-  // Schema-based array operations
-
   const { runtime, storageManager } = setup();
 
   const schema = {
@@ -781,9 +770,8 @@ Deno.bench("Cell array - map operation with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Benchmark: Link operations
 Deno.bench("Cell getAsLink - link generation schemaless (100x)", async (b) => {
-  // Benchmark: Link operations
-
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{ value: number }>(
@@ -835,9 +823,8 @@ Deno.bench("Cell getAsLink - with options (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
+// Benchmark: Subscription operations
 Deno.bench("Cell sink - subscription execution (100x)", async () => {
-  // Benchmark: Subscription operations
-
   const { runtime, storageManager } = setup();
 
   let tx = runtime.edit();
@@ -917,9 +904,8 @@ Deno.bench(
   },
 );
 
+// Benchmark: Complex nested operations
 Deno.bench("Cell complex - schema with asCell references (100x)", async () => {
-  // Benchmark: Complex nested operations
-
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -1072,9 +1058,8 @@ Deno.bench("Cell schema - complex validation (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+// Benchmark: Large data structures
 Deno.bench("Cell large - array with 1000 items (100x get)", async () => {
-  // Benchmark: Large data structures
-
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
@@ -1385,9 +1370,8 @@ async function benchmarkNotebookReads(noteCount: number, readCount: number) {
   await storageManager.close();
 }
 
+// 10 notes
 Deno.bench("Notebook read - 10 notes, 0 reads (setup only)", async () => {
-  // 10 notes
-
   await benchmarkNotebookReads(10, 0);
 });
 
@@ -1399,9 +1383,8 @@ Deno.bench("Notebook read - 10 notes, 1000 reads", async () => {
   await benchmarkNotebookReads(10, 1000);
 });
 
+// 100 notes
 Deno.bench("Notebook read - 100 notes, 0 reads (setup only)", async () => {
-  // 100 notes
-
   await benchmarkNotebookReads(100, 0);
 });
 

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -31,8 +31,9 @@ async function cleanup(
   await runtime.dispose();
 }
 
-// Benchmark: Cell creation
 Deno.bench("Cell creation - simple schemaless (100x)", async () => {
+  // Benchmark: Cell creation
+
   const { runtime, storageManager } = setup();
 
   for (let i = 0; i < 100; i++) {
@@ -84,8 +85,9 @@ Deno.bench("Cell creation - immutable (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
-// Schema-based cell creation benchmarks
 Deno.bench("Cell creation - simple with schema (100x)", async () => {
+  // Schema-based cell creation benchmarks
+
   const { runtime, storageManager } = setup();
 
   const schema = { type: "number" } as const satisfies JSONSchema;
@@ -169,8 +171,9 @@ Deno.bench("Cell creation - array with schema (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
-// Benchmark: Cell get operations
 Deno.bench("Cell get - simple value schemaless (100x)", async () => {
+  // Benchmark: Cell get operations
+
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<number>(space, "bench-get", undefined, tx);
@@ -237,8 +240,9 @@ Deno.bench("Cell getRaw - complex object schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Schema-based get operations
 Deno.bench("Cell get - simple value with schema (100x)", async () => {
+  // Schema-based get operations
+
   const { runtime, storageManager, tx } = setup();
 
   const schema = { type: "number", minimum: 0 } as const satisfies JSONSchema;
@@ -295,8 +299,9 @@ Deno.bench("Cell get - complex object with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Cell set operations
 Deno.bench("Cell set - simple value schemaless (100x)", async () => {
+  // Benchmark: Cell set operations
+
   const { runtime, storageManager } = setup();
 
   const cell = runtime.getCell<number>(space, "bench-set", undefined);
@@ -358,8 +363,9 @@ Deno.bench(
   },
 );
 
-// Schema-based set operations
 Deno.bench("Cell set - simple value with schema (100x)", async () => {
+  // Schema-based set operations
+
   const { runtime, storageManager } = setup();
 
   const schema = {
@@ -415,8 +421,9 @@ Deno.bench(
   },
 );
 
-// Benchmark: Nested cell operations
 Deno.bench("Cell key - nested access schemaless (100x)", async () => {
+  // Benchmark: Nested cell operations
+
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{
@@ -457,8 +464,9 @@ Deno.bench("Cell key - array access schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Schema-based nested operations
 Deno.bench("Cell key - nested access with schema (100x)", async () => {
+  // Schema-based nested operations
+
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -539,8 +547,9 @@ Deno.bench("Cell key - array access with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Cell derivation
 Deno.bench("Cell asSchema - schema transformation (100x)", async () => {
+  // Benchmark: Cell derivation
+
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{
@@ -591,10 +600,11 @@ Deno.bench("Cell withTx - transaction switching (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Query result proxy operations
 Deno.bench(
   "Cell getAsQueryResult - proxy creation schemaless (100x)",
   async () => {
+    // Benchmark: Query result proxy operations
+
     const { runtime, storageManager, tx } = setup();
 
     const cell = runtime.getCell<{
@@ -621,8 +631,9 @@ Deno.bench(
   },
 );
 
-// Schema-based get operations for complex objects
 Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
+  // Schema-based get operations for complex objects
+
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -662,8 +673,9 @@ Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Array operations
 Deno.bench("Cell push - array append schemaless (100x)", async () => {
+  // Benchmark: Array operations
+
   const { runtime, storageManager } = setup();
 
   const cell = runtime.getCell<{ items: number[] }>(
@@ -709,8 +721,9 @@ Deno.bench("Cell array - proxy map operation schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Schema-based array operations
 Deno.bench("Cell push - array append with schema (100x)", async () => {
+  // Schema-based array operations
+
   const { runtime, storageManager } = setup();
 
   const schema = {
@@ -768,8 +781,9 @@ Deno.bench("Cell array - map operation with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Link operations
 Deno.bench("Cell getAsLink - link generation schemaless (100x)", async (b) => {
+  // Benchmark: Link operations
+
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{ value: number }>(
@@ -821,8 +835,9 @@ Deno.bench("Cell getAsLink - with options (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Subscription operations
 Deno.bench("Cell sink - subscription execution (100x)", async () => {
+  // Benchmark: Subscription operations
+
   const { runtime, storageManager } = setup();
 
   let tx = runtime.edit();
@@ -902,8 +917,9 @@ Deno.bench(
   },
 );
 
-// Benchmark: Complex nested operations
 Deno.bench("Cell complex - schema with asCell references (100x)", async () => {
+  // Benchmark: Complex nested operations
+
   const { runtime, storageManager, tx } = setup();
 
   const schema = {
@@ -1000,8 +1016,9 @@ Deno.bench("Cell complex - nested cell references (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Schema validation
 Deno.bench("Cell schema - complex validation (100x)", async () => {
+  // Benchmark: Schema validation
+
   const { runtime, storageManager } = setup();
 
   const complexSchema = {
@@ -1055,8 +1072,9 @@ Deno.bench("Cell schema - complex validation (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
-// Benchmark: Large data structures
 Deno.bench("Cell large - array with 1000 items (100x get)", async () => {
+  // Benchmark: Large data structures
+
   const { runtime, storageManager, tx } = setup();
 
   const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
@@ -1116,8 +1134,9 @@ Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Concurrent operations
 Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
+  // Benchmark: Concurrent operations
+
   const { runtime, storageManager, tx } = setup();
 
   // Create multiple cells
@@ -1141,8 +1160,9 @@ Deno.bench("Cell concurrent - multiple cells (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Cell equals comparison
 Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
+  // Benchmark: Cell equals comparison
+
   const { runtime, storageManager, tx } = setup();
 
   const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);
@@ -1169,11 +1189,13 @@ Deno.bench("Cell equals - comparison operations (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
-// Benchmark: Complex linked document graph (MentionablePiece pattern)
-// This tests .get() performance on a medium-complexity object spread across many documents
 Deno.bench(
   "Cell complex - MentionablePiece graph (10 top-level, 20 linked each, 100x get)",
   async () => {
+    // Benchmark: Complex linked document graph (MentionablePiece pattern) This
+    // tests .get() performance on a medium-complexity object spread across many
+    // documents
+
     const { runtime, storageManager, tx } = setup();
 
     // Schema for MentionablePiece with self-referential mentioned/backlinks
@@ -1363,8 +1385,9 @@ async function benchmarkNotebookReads(noteCount: number, readCount: number) {
   await storageManager.close();
 }
 
-// 10 notes
 Deno.bench("Notebook read - 10 notes, 0 reads (setup only)", async () => {
+  // 10 notes
+
   await benchmarkNotebookReads(10, 0);
 });
 
@@ -1376,8 +1399,9 @@ Deno.bench("Notebook read - 10 notes, 1000 reads", async () => {
   await benchmarkNotebookReads(10, 1000);
 });
 
-// 100 notes
 Deno.bench("Notebook read - 100 notes, 0 reads (setup only)", async () => {
+  // 100 notes
+
   await benchmarkNotebookReads(100, 0);
 });
 

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -31,7 +31,10 @@ async function cleanup(
   await runtime.dispose();
 }
 
+//
 // Benchmark: Cell creation
+//
+
 Deno.bench("Cell creation - simple schemaless (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -84,7 +87,10 @@ Deno.bench("Cell creation - immutable (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+//
 // Schema-based cell creation benchmarks
+//
+
 Deno.bench("Cell creation - simple with schema (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -169,7 +175,10 @@ Deno.bench("Cell creation - array with schema (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+//
 // Benchmark: Cell get operations
+//
+
 Deno.bench("Cell get - simple value schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -237,7 +246,10 @@ Deno.bench("Cell getRaw - complex object schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Schema-based get operations
+//
+
 Deno.bench("Cell get - simple value with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -295,7 +307,10 @@ Deno.bench("Cell get - complex object with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Benchmark: Cell set operations
+//
+
 Deno.bench("Cell set - simple value schemaless (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -358,7 +373,10 @@ Deno.bench(
   },
 );
 
+//
 // Schema-based set operations
+//
+
 Deno.bench("Cell set - simple value with schema (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -415,7 +433,10 @@ Deno.bench(
   },
 );
 
+//
 // Benchmark: Nested cell operations
+//
+
 Deno.bench("Cell key - nested access schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -457,7 +478,10 @@ Deno.bench("Cell key - array access schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Schema-based nested operations
+//
+
 Deno.bench("Cell key - nested access with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -539,7 +563,10 @@ Deno.bench("Cell key - array access with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Benchmark: Cell derivation
+//
+
 Deno.bench("Cell asSchema - schema transformation (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -664,7 +691,10 @@ Deno.bench("Cell get - complex object with asCell schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Benchmark: Array operations
+//
+
 Deno.bench("Cell push - array append schemaless (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -711,7 +741,10 @@ Deno.bench("Cell array - proxy map operation schemaless (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Schema-based array operations
+//
+
 Deno.bench("Cell push - array append with schema (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -770,7 +803,10 @@ Deno.bench("Cell array - map operation with schema (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Benchmark: Link operations
+//
+
 Deno.bench("Cell getAsLink - link generation schemaless (100x)", async (b) => {
   const { runtime, storageManager, tx } = setup();
 
@@ -823,7 +859,10 @@ Deno.bench("Cell getAsLink - with options (100x)", async (b) => {
   await cleanup(runtime, storageManager, tx);
 });
 
+//
 // Benchmark: Subscription operations
+//
+
 Deno.bench("Cell sink - subscription execution (100x)", async () => {
   const { runtime, storageManager } = setup();
 
@@ -904,7 +943,10 @@ Deno.bench(
   },
 );
 
+//
 // Benchmark: Complex nested operations
+//
+
 Deno.bench("Cell complex - schema with asCell references (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -1058,7 +1100,10 @@ Deno.bench("Cell schema - complex validation (100x)", async () => {
   await cleanup(runtime, storageManager);
 });
 
+//
 // Benchmark: Large data structures
+//
+
 Deno.bench("Cell large - array with 1000 items (100x get)", async () => {
   const { runtime, storageManager, tx } = setup();
 
@@ -1292,9 +1337,12 @@ Deno.bench(
   },
 );
 
+//
 // Benchmark: Notebook/Notes pattern - tests History.claim() optimization impact
+//
 // These benchmarks measure repeated .get() calls on a notebook with linked notes
 // The claim optimization removes O(n²) overhead during reads
+//
 
 const noteSchema: JSONSchema = {
   type: "object",
@@ -1370,7 +1418,10 @@ async function benchmarkNotebookReads(noteCount: number, readCount: number) {
   await storageManager.close();
 }
 
+//
 // 10 notes
+//
+
 Deno.bench("Notebook read - 10 notes, 0 reads (setup only)", async () => {
   await benchmarkNotebookReads(10, 0);
 });
@@ -1383,7 +1434,10 @@ Deno.bench("Notebook read - 10 notes, 1000 reads", async () => {
   await benchmarkNotebookReads(10, 1000);
 });
 
+//
 // 100 notes
+//
+
 Deno.bench("Notebook read - 100 notes, 0 reads (setup only)", async () => {
   await benchmarkNotebookReads(100, 0);
 });

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -127,7 +127,7 @@ describe("CFC additive-required default preserves old documents", () => {
   });
 
   //
-  // The same rule through a real compile
+  // The same rule end to end
   //
 
   it("materializes the real home pattern over a pre-favorites root under enforcement", async () => {

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -121,11 +121,12 @@ describe("CFC additive-required default preserves old documents", () => {
     );
   });
 
-  // Faithful end-to-end: run the real home pattern's setup over a realistic
-  // old home root, with enforcement ON. Before the fix, the setup commit is
-  // rejected (defaultProfile, then the handler streams). After the fix it
-  // commits and the home heals.
   it("materializes the real home pattern over a pre-favorites root under enforcement", async () => {
+    // Faithful end-to-end: run the real home pattern's setup over a realistic
+    // old home root, with enforcement ON. Before the fix, the setup commit is
+    // rejected (defaultProfile, then the handler streams). After the fix it
+    // commits and the home heals.
+
     const storageManager = StorageManager.emulate({ as: alice });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -198,13 +199,14 @@ describe("CFC additive-required default preserves old documents", () => {
     }
   });
 
-  // The producer→consumer token contract, end to end at the runner layer:
-  // mergeRequired throws CfcSchemaMigrationError → the prepare catch records it
-  // as a TAGGED reason → the COMMIT rejection message carries the framed
-  // `: <token>: ` the piece backstop keys on. The piece tests synthesize this
-  // string; this test proves the runner actually produces it, so the two ends
-  // stay in lockstep if either side's wording drifts.
   it("frames a real additive-required-no-default commit rejection with the migration token", async () => {
+    // The producer→consumer token contract, end to end at the runner layer:
+    // mergeRequired throws CfcSchemaMigrationError → the prepare catch records
+    // it as a TAGGED reason → the COMMIT rejection message carries the framed
+    // `: <token>: ` the piece backstop keys on. The piece tests synthesize this
+    // string; this test proves the runner actually produces it, so the two ends
+    // stay in lockstep if either side's wording drifts.
+
     const storageManager = StorageManager.emulate({ as: alice });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -73,9 +73,14 @@ const compileHomePattern = async (
 };
 
 describe("CFC additive-required default preserves old documents", () => {
-  // Tight pin on the guard itself: a generated output does not need a default,
-  // while an unclassified document field still does. This isolates the
-  // role-aware schema-merge rule from the full home compile.
+  //
+  // Tight pin on the guard itself
+  //
+  // A generated output does not need a default, while an unclassified document
+  // field still does. This isolates the role-aware schema-merge rule from the
+  // full home compile.
+  //
+
   it("exempts an additive-required generated output from the default requirement", () => {
     const stored: JSONSchema = {
       type: "object",
@@ -120,6 +125,10 @@ describe("CFC additive-required default preserves old documents", () => {
       /required field title needs a default/,
     );
   });
+
+  //
+  // The same rule through a real compile
+  //
 
   it("materializes the real home pattern over a pre-favorites root under enforcement", async () => {
     // Faithful end-to-end: run the real home pattern's setup over a realistic

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -19,15 +19,16 @@ type StoredEntry = {
   observes?: string;
 };
 
-// An array-diff shrink truncates slots by writing `length` alone; without an
-// explicit delete write per truncated slot, the removed slots' per-slot link
-// entries survive in the labelMap. Any later read/diff of such a slot (e.g. a
-// list growing back) consumes the stale entry as a followRef observation
-// (SC-8) and re-imports the departed member's taint into the reader's flow
-// join — the echo behind the #4525 probe's A3 step. The diff layer now emits
-// the same explicit slot deletes the direct `length`-write path always has,
-// and the flow-clear drops the stale entries like any other covered write.
 describe("CFC: array shrink clears truncated slots' link labels", () => {
+  // An array-diff shrink truncates slots by writing `length` alone; without an
+  // explicit delete write per truncated slot, the removed slots' per-slot link
+  // entries survive in the labelMap. Any later read/diff of such a slot (e.g. a
+  // list growing back) consumes the stale entry as a followRef observation
+  // (SC-8) and re-imports the departed member's taint into the reader's flow
+  // join — the echo behind the #4525 probe's A3 step. The diff layer now emits
+  // the same explicit slot deletes the direct `length`-write path always has,
+  // and the flow-clear drops the stale entries like any other covered write.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-ceiling-empty.test.ts
+++ b/packages/runner/test/cfc-ceiling-empty.test.ts
@@ -8,13 +8,15 @@ import { cfcObservationFitsCeiling } from "../src/cfc/observation.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-ceiling-empty");
 
-// Regression guard for empty-ceiling semantics (audit minor / W0.7).
-//
-// A declared but empty maxConfidentiality means "public only" — no confidential
-// atom is permitted. It was conflated with undefined ("no ceiling"), so an empty
-// ceiling let confidential data through. undefined stays no-ceiling; public data
-// (no confidentiality atoms) still fits any ceiling, including the empty one.
 describe("cfcObservationFitsCeiling empty ceiling", () => {
+  // Regression guard for empty-ceiling semantics (audit minor / W0.7).
+  //
+  // A declared but empty maxConfidentiality means "public only" — no
+  // confidential atom is permitted. It was conflated with undefined ("no
+  // ceiling"), so an empty ceiling let confidential data through. undefined
+  // stays no-ceiling; public data (no confidentiality atoms) still fits any
+  // ceiling, including the empty one.
+
   it("treats undefined ceiling as no ceiling", () => {
     expect(cfcObservationFitsCeiling(["secret"], undefined)).toBe(true);
   });

--- a/packages/runner/test/cfc-clause-ceiling-fit.test.ts
+++ b/packages/runner/test/cfc-clause-ceiling-fit.test.ts
@@ -113,6 +113,7 @@ describe("CFC clause-aware ceiling fit", () => {
   describe("meet is the pairwise alternative-set union (decision 6)", () => {
     // Full coverage (incl. the both-direction property test) lives in
     // cfc-clause-meet.test.ts; these pin the fit-facing behavior.
+
     it("flat meet keeps flat-label decisions of the old atom intersection", () => {
       const met = meetCfcObservationCeilings([A, B], [B, C]);
       expect(cfcObservationFitsCeiling([B], met)).toBe(true);

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -19,20 +19,21 @@ type StoredEntry = {
   observes?: string;
 };
 
-// A document-creating write lands at the RAW document root: writeOrThrow's
-// missing-doc retry constructs the envelope `{value: ...}` and writes it at
-// storage path []. `valueWriteTargets` canonicalizes the write PATH but used
-// to keep the RAW envelope as the written value, so the pure-link container
-// walk descended through the `value` wrapper key and emitted raw-projected
-// container paths — the membership stamp (origin:"structure",
-// observes:"enumerate") then persisted anchored at ["value"] instead of the
-// canonical container path []. Consumption compares stored anchors against
-// canonical read paths, so nothing at the canonical path consumed the
-// membership label until the next write's carry-forward re-anchored it; the
-// window was only masked by the co-minted frozen existence entry carrying
-// the same creating join. These tests pin the canonical anchoring at
-// creation itself.
 describe("CFC: creation anchors membership at the canonical container path", () => {
+  // A document-creating write lands at the RAW document root: writeOrThrow's
+  // missing-doc retry constructs the envelope `{value: ...}` and writes it at
+  // storage path []. `valueWriteTargets` canonicalizes the write PATH but used
+  // to keep the RAW envelope as the written value, so the pure-link container
+  // walk descended through the `value` wrapper key and emitted raw-projected
+  // container paths — the membership stamp (origin:"structure",
+  // observes:"enumerate") then persisted anchored at ["value"] instead of the
+  // canonical container path []. Consumption compares stored anchors against
+  // canonical read paths, so nothing at the canonical path consumed the
+  // membership label until the next write's carry-forward re-anchored it; the
+  // window was only masked by the co-minted frozen existence entry carrying
+  // the same creating join. These tests pin the canonical anchoring at
+  // creation itself.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -121,12 +121,14 @@ const isLinkReference = (atom: unknown): atom is {
     "https://commonfabric.org/cfc/atom/LinkReference";
 
 describe("CFC cross-space integrity", () => {
-  // Primitive: a value gets integrity. Declared `ifc.integrity` with a
-  // non-reserved atom persists as an `origin: "declared"` entry, exactly like
-  // declared confidentiality. (Reserved runtime-minted atoms — LlmDerived,
-  // PolicyCertified, … — are gated to builtin identities and would be stripped
-  // here; a plain string or custom-URL atom is the author-mintable form.)
   it("scenario 1a — a value created in a space gets integrity (declared)", async () => {
+    // Primitive: a value gets integrity. Declared `ifc.integrity` with a
+    // non-reserved atom persists as an `origin: "declared"` entry, exactly like
+    // declared confidentiality. (Reserved runtime-minted atoms — LlmDerived,
+    // PolicyCertified, … — are gated to builtin identities and would be
+    // stripped here; a plain string or custom-URL atom is the author-mintable
+    // form.)
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -163,10 +165,11 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Same-space verbatim copy: `exactCopyOf` is content-address verified and
-  // carries the SOURCE integrity onto the copy (§8.4). This is the "verbatim
-  // copy retains integrity" primitive — but note the space constraint below.
   it("scenario 1b — same-space exactCopyOf carries integrity onto the copy", async () => {
+    // Same-space verbatim copy: `exactCopyOf` is content-address verified and
+    // carries the SOURCE integrity onto the copy (§8.4). This is the "verbatim
+    // copy retains integrity" primitive — but note the space constraint below.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -208,13 +211,14 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Scenario 1 proper (reference / no-copy): space B holds a LINK to the
-  // labeled value in space A. Traversing the link yields the source integrity
-  // PRESERVED plus a runtime-minted `LinkReference` endorsement that records
-  // BOTH spaces (§3.7.2: integrity = target ∪ link-endorsement), and the
-  // source confidentiality carried across the boundary (§3.7.1). This is the
-  // mechanism that genuinely crosses spaces today.
   it("scenario 1c — a cross-space link retains the source integrity (+ endorsement)", async () => {
+    // Scenario 1 proper (reference / no-copy): space B holds a LINK to the
+    // labeled value in space A. Traversing the link yields the source integrity
+    // PRESERVED plus a runtime-minted `LinkReference` endorsement that records
+    // BOTH spaces (§3.7.2: integrity = target ∪ link-endorsement), and the
+    // source confidentiality carried across the boundary (§3.7.1). This is the
+    // mechanism that genuinely crosses spaces today.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -266,14 +270,16 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Verbatim copy across spaces, DONE RIGHT: carry the REFERENCE. `exactCopyOf`
-  // compares two paths within one value tree — but a path may HOLD a link into
-  // another space, and the label it copies is that path's (link-carried) label.
-  // So a field whose source is a cross-space link is (a) verified as an exact
-  // copy AND (b) carries the source's integrity across the boundary. This is the
-  // "verbatim copy retains integrity across spaces" scenario — the reference is
-  // the carrier, and exactCopyOf is the verified claim on top of it.
   it("scenario 1d — exactCopyOf of a cross-space link carries integrity and verifies the copy", async () => {
+    // Verbatim copy across spaces, DONE RIGHT: carry the REFERENCE.
+    // `exactCopyOf` compares two paths within one value tree — but a path may
+    // HOLD a link into another space, and the label it copies is that path's
+    // (link-carried) label. So a field whose source is a cross-space link is
+    // (a) verified as an exact copy AND (b) carries the source's integrity
+    // across the boundary. This is the "verbatim copy retains integrity across
+    // spaces" scenario — the reference is the carrier, and exactCopyOf is the
+    // verified claim on top of it.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -355,13 +361,14 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // The boundary of scenario 1d: copying the RESOLVED VALUE (plain bytes)
-  // rather than the reference does NOT carry the label. Once a handler
-  // materializes bytes, the runtime has no basis to attest they are the same
-  // labeled thing, so the copy is a fresh, unendorsed value. This is not a bug —
-  // it is why the REFERENCE (link) is load-bearing for cross-space integrity:
-  // carry the link (scenario 1c/1d), not the extracted bytes.
   it("scenario 1e — a resolved-byte copy across spaces is unendorsed (carry the reference, not the bytes)", async () => {
+    // The boundary of scenario 1d: copying the RESOLVED VALUE (plain bytes)
+    // rather than the reference does NOT carry the label. Once a handler
+    // materializes bytes, the runtime has no basis to attest they are the same
+    // labeled thing, so the copy is a fresh, unendorsed value. This is not a
+    // bug — it is why the REFERENCE (link) is load-bearing for cross-space
+    // integrity: carry the link (scenario 1c/1d), not the extracted bytes.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -411,11 +418,12 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // GAP (remaining): the spec's reference annotation (§8.2 `passThrough`) is
-  // unimplemented; a write through a schema declaring it FAILS CLOSED rather
-  // than being silently ignored. Reference behaviors stay reachable via
-  // per-path labels and links (scenarios 1c / 3).
   it("scenario 3a [GAP] — the passThrough ifc annotation fails closed (unimplemented)", async () => {
+    // GAP (remaining): the spec's reference annotation (§8.2 `passThrough`) is
+    // unimplemented; a write through a schema declaring it FAILS CLOSED rather
+    // than being silently ignored. Reference behaviors stay reachable via
+    // per-path labels and links (scenarios 1c / 3).
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -442,14 +450,15 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Scenario 3a′ — the §8.3 `projection` annotation IS implemented: the
-  // ergonomic "declare this field is a scoped projection" syntax verifies at
-  // commit (the target must equal the claimed source field) and carries the
-  // source's confidentiality in full plus its integrity SCOPED to the
-  // projected pointer, so the projected field can never claim whole-object
-  // integrity. Mismatch/wildcard/malformed fail-closed behavior and the
-  // provenance-class drops live in cfc-projection.test.ts.
   it("scenario 3a′ — the projection ifc annotation verifies and carries a scoped label", async () => {
+    // Scenario 3a′ — the §8.3 `projection` annotation IS implemented: the
+    // ergonomic "declare this field is a scoped projection" syntax verifies at
+    // commit (the target must equal the claimed source field) and carries the
+    // source's confidentiality in full plus its integrity SCOPED to the
+    // projected pointer, so the projected field can never claim whole-object
+    // integrity. Mismatch/wildcard/malformed fail-closed behavior and the
+    // provenance-class drops live in cfc-projection.test.ts.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -497,11 +506,12 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Scenario 3 (reference variant): referencing only a SUBSET. A link to a
-  // sub-path of the source carries only that sub-path's label — the sibling
-  // field's label stays behind. This is the "solve the subset with references,
-  // at least partially" case.
   it("scenario 3b — a cross-space link to a sub-path carries only that subset's label", async () => {
+    // Scenario 3 (reference variant): referencing only a SUBSET. A link to a
+    // sub-path of the source carries only that sub-path's label — the sibling
+    // field's label stays behind. This is the "solve the subset with
+    // references, at least partially" case.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -553,17 +563,19 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Subset — the SUBTLE part. Source data carries MORE fields than the
-  // destination schema declares:
-  //   { foo: { bar, secret }, baz, secret }   vs   { foo: { bar }, baz }
-  //
-  // GOTCHA: linking the WHOLE object does NOT project it to the schema. The
-  // link carries the source's FULL labelMap — the undeclared `foo.secret` and
-  // top-level `secret` labels come across too. A narrower destination schema is
-  // a read-time VIEW, not a projection: it does not sanitize the reference. The
-  // secret fields stay confined by their OWN confidentiality labels (so this is
-  // safe, not a leak), but "only the right fields crossed" is FALSE here.
   it("scenario 3d — a whole-object cross-space link carries undeclared sibling labels (no projection)", async () => {
+    // Subset — the SUBTLE part. Source data carries MORE fields than the
+    // destination schema declares:
+    //   { foo: { bar, secret }, baz, secret }   vs   { foo: { bar }, baz }
+    //
+    // GOTCHA: linking the WHOLE object does NOT project it to the schema. The
+    // link carries the source's FULL labelMap — the undeclared `foo.secret` and
+    // top-level `secret` labels come across too. A narrower destination schema
+    // is a read-time VIEW, not a projection: it does not sanitize the
+    // reference. The secret fields stay confined by their OWN confidentiality
+    // labels (so this is safe, not a leak), but "only the right fields crossed"
+    // is FALSE here.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -627,11 +639,13 @@ describe("CFC cross-space integrity", () => {
     }
   });
 
-  // Subset — DONE RIGHT: link the specific sub-paths. Only the selected fields'
-  // labels cross; the undeclared `secret` fields are never referenced, so their
-  // labels (and values) stay entirely behind. This is how you copy a genuine
-  // subset by reference, integrity-preserving and leak-free.
   it("scenario 3e — per-field cross-space links copy exactly the chosen subset", async () => {
+    // Subset — DONE RIGHT: link the specific sub-paths. Only the selected
+    // fields' labels cross; the undeclared `secret` fields are never
+    // referenced, so their labels (and values) stay entirely behind. This is
+    // how you copy a genuine subset by reference, integrity-preserving and
+    // leak-free.
+
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime(storageManager);
     try {
@@ -758,8 +772,9 @@ const publishRule: ExchangeRule = {
 };
 
 describe("CFC declassification while copying (exchange rules)", () => {
-  // Declassify by WIDENING the audience, integrity retained.
   it("scenario 2a — releasing to a reader widens confidentiality, integrity untouched", () => {
+    // Declassify by WIDENING the audience, integrity retained.
+
     const result = evaluateExchangeRules(
       { confidentiality: [spaceASecret], integrity: [bobReadsA, gpsReading] },
       snapshotOf([spaceReaderRule]),
@@ -776,8 +791,9 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContainEqual(bobReadsA);
   });
 
-  // Declassify FULLY (drop the clause → public), integrity retained.
   it("scenario 2b — a publish approval drops the clause; integrity survives", () => {
+    // Declassify FULLY (drop the clause → public), integrity retained.
+
     const result = evaluateExchangeRules(
       {
         confidentiality: [spaceASecret],
@@ -793,9 +809,10 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContainEqual(PUBLISH_APPROVED);
   });
 
-  // No evidence → no declassification (fail-closed). The confidentiality clause
-  // stands; nothing is released.
   it("scenario 2c — without the evidence, nothing is declassified", () => {
+    // No evidence → no declassification (fail-closed). The confidentiality
+    // clause stands; nothing is released.
+
     const result = evaluateExchangeRules(
       { confidentiality: [spaceASecret], integrity: [gpsReading] },
       snapshotOf([spaceReaderRule, publishRule]),
@@ -805,13 +822,14 @@ describe("CFC declassification while copying (exchange rules)", () => {
     expect(result.label.integrity).toContain(gpsReading);
   });
 
-  // Scenario 3 (declassify only the SUBSET): clause-locality. A `referenced`
-  // policy fires only on the clause that carries its hash-bound ref atom — its
-  // "home clause" — leaving sibling clauses confined even when the same
-  // evidence would satisfy the guard there. Combined with per-path labels
-  // (scenario 3b), this scopes a declassification to exactly one part of the
-  // value; integrity is still untouched.
   it("scenario 3c — a referenced policy declassifies only its home clause", () => {
+    // Scenario 3 (declassify only the SUBSET): clause-locality. A `referenced`
+    // policy fires only on the clause that carries its hash-bound ref atom —
+    // its "home clause" — leaving sibling clauses confined even when the same
+    // evidence would satisfy the guard there. Combined with per-path labels
+    // (scenario 3b), this scopes a declassification to exactly one part of the
+    // value; integrity is still untouched.
+
     const spaceB2 = cfcAtom.space(spaceB);
     const bobReadsB = cfcAtom.hasRole(BOB, spaceB, "reader");
     const shareSnapshot = buildCfcPolicySnapshot([{

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -223,9 +223,10 @@ const rewriteStoredEntries = async (
 };
 
 describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
-  // Characterization: what the re-mint does TODAY, with no gate dial.
-  // These pin the `off`/`observe` byte-compat contract.
   describe("current behavior (characterization — the off/observe contract)", () => {
+    // Characterization: what the re-mint does TODAY, with no gate dial.
+    // These pin the `off`/`observe` byte-compat contract.
+
     it("(a) a schema dropping a confidentiality clause is rejected by the schema merge", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
       const runtime = makeRuntime({ storageManager });
@@ -466,8 +467,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // The dial: cfcDeclaredMonotonicity, mirroring cfcWriteFloor exactly.
   describe("the cfcDeclaredMonotonicity dial", () => {
+    // The dial: cfcDeclaredMonotonicity, mirroring cfcWriteFloor exactly.
+
     it("the enforce pin cannot be weakened mid-transaction", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
       const runtime = makeRuntime({
@@ -524,10 +526,11 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // The exception seam: the per-tx privileged widening exemption
-  // (§8.12.7 route 2b; design doc §4). Setter discipline only here —
-  // the gate-facing semantics are in the enforce block below.
   describe("the widening-exemption seam (setter discipline)", () => {
+    // The exception seam: the per-tx privileged widening exemption
+    // (§8.12.7 route 2b; design doc §4). Setter discipline only here —
+    // the gate-facing semantics are in the enforce block below.
+
     const EXEMPTION = () => ({
       space: signer.did(),
       id: "of:some-doc",
@@ -755,8 +758,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     }
   };
 
-  // The gate under enforce: §8.12.1 weakenings fail closed.
   describe("enforce: non-monotone declared re-mints fail closed", () => {
+    // The gate under enforce: §8.12.1 weakenings fail closed.
+
     it("a dropped confidentiality clause rejects, naming doc, path and direction", async () => {
       const result = await seededRemintScenario({
         storageManager: StorageManager.emulate({ as: signer }),
@@ -989,8 +993,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // The gate under enforce: §8.12.1 tightenings pass.
   describe("enforce: monotone tightenings pass", () => {
+    // The gate under enforce: §8.12.1 tightenings pass.
+
     it("an added clause passes and persists", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
       const runtime = makeRuntime({
@@ -1249,8 +1254,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // §8.12.8 component scoping: only declared↔declared is ever compared.
   describe("component scoping (§8.12.8)", () => {
+    // §8.12.8 component scoping: only declared↔declared is ever compared.
+
     it("legacy (origin-less) stored entries are not gated", async () => {
       // A seeded LEGACY entry whose integrity the fresh declared mint does
       // not cover: were the gate to compare against it, [X] ⊄ [Y] would
@@ -1291,8 +1297,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // off/observe: byte-compat with the characterization block.
   describe("off/observe byte-compat", () => {
+    // off/observe: byte-compat with the characterization block.
+
     it("off: the seeded weakening persists exactly as characterized, no diagnostic", async () => {
       const result = await seededRemintScenario({
         storageManager: StorageManager.emulate({ as: signer }),
@@ -1414,8 +1421,9 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // The exemption seam consumed by the gate (§8.12.7 route 2b semantics).
   describe("enforce: the widening exemption", () => {
+    // The exemption seam consumed by the gate (§8.12.7 route 2b semantics).
+
     const withExemption = (
       clauseDigest: string,
       path: string[] = ["out"],
@@ -1596,10 +1604,11 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // Reason dedup on degenerate duplicate entries (direct unit call: the
-  // walk mints one declared entry per path and dedups atoms, so the
-  // duplicate arms are reachable only through the exported function).
   describe("violation-reason dedup (unit)", () => {
+    // Reason dedup on degenerate duplicate entries (direct unit call: the
+    // walk mints one declared entry per path and dedups atoms, so the
+    // duplicate arms are reachable only through the exported function).
+
     it("reports each violated clause and added atom once across duplicate entries", () => {
       const violations = collectDeclaredMonotonicityViolations({
         space: signer.did(),
@@ -1638,9 +1647,10 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
   });
 
-  // Non-taint: the gate's stored-entry reads ride the internal-verifier
-  // meta and must not enter the consumed set.
   describe("non-taint", () => {
+    // Non-taint: the gate's stored-entry reads ride the internal-verifier
+    // meta and must not enter the consumed set.
+
     it("the observe-mode gate adds nothing to the prepared consumed set", async () => {
       const consumedReadsFor = async (
         dial: CfcDeclaredMonotonicityMode,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

First of four batches conforming `runner` to the "Commenting a block" rule in
`unit-test-coding-style.md`: a comment about a test or a group of tests goes
inside the block's callback, as its first content, followed by a blank line.
`runner` holds 453 such comments in 124 files, which is why it is split; this
batch covers `array-push-mergeable.test.ts` through
`cfc-declared-monotonicity.test.ts`, in file-name order.

119 comments in 14 files, all of which the diff touches.

- **92 move** into the block they describe.
- **2 stay** at the top of the group they head, taking only the blank line: the
  constructor-overload note in `builder-fabric-classes.test.ts`, whose
  `describe("FabricRegExp")` holds exactly the two cases it names, and the
  fit-facing note in `cfc-clause-ceiling-fit.test.ts`.
- **23 become section markers.** Twenty-one are the labels `cell.bench.ts` is
  organized by; the other two are the `FabricSpecialObject` walk note in
  `cell-static-methods.test.ts` and the guard note in
  `cfc-additive-default-preserves-old-doc.test.ts`, neither of which could take
  a top-of-block slot. Every region closes, at the next marker or at the end of
  its block or file.
- **2 are deleted**: `// 10 notes` and `// 100 notes`, which say no more than
  the benches under them ("Notebook read - 10 notes, ...").

`cell.bench.ts` is one series of region labels, and half of it in marker form
and half inside a bench read two ways -- the inside ones had also stopped
delimiting, so the markers around them absorbed benches they do not name. All
of them are markers now, single-bench regions included, and the Notebook/Notes
umbrella heads its whole region rather than sitting in a third form.

Four titles are written, and they are the only words added: "Ordinary values"
and "The same rule end to end" for two closers, "The static-data walk over
special objects" for the walk region, and "Tight pin on the guard itself",
which that comment already opened with.

57 of the moved blocks overflowed 80 columns at the new indent and are
reflowed.

## What the diff is, as a property

Across the 13 files:

- No added or removed line is anything but a `//` comment or a blank line
  (measured on `git diff -U0`, count 0; no code line is even repositioned).
- Per file, the multiset of comment words is unchanged, except for the four
  written titles above, the colon and capital that split one of them from
  its description, and the two deleted labels' words.
- Per file, the multiset of non-comment lines is unchanged.
- No added line exceeds 80 characters, counted in characters rather than bytes.
- Counting comment runs across the whole diff: four runs' words vanish (two
  absorbed into title-bearing markers, two deleted) and four are new (two
  written closers and the two absorbed runs' marker forms); 57 surviving runs
  changed their line breaks.

A re-run of the census over these files finds **no** comment left adjacent
above a test-block opener: every one is inside the block it describes, at the
top of the group it describes, or a closed section marker over the run it
describes.

## Gates

`deno fmt --check` and `deno lint` pass over `packages/runner`.
`deno task test` in `packages/runner`: 1324 passed / 0 failed (7891 steps).

## The coverage line

The coverage check reports `packages/runner` one line worse and attributes it
itself: "Regression not attributable to this PR's added lines: 1 line(s) across
1 unchanged file(s) that the baseline run covered." That agrees with what this
change is -- the diff adds and removes nothing but `//` comments and blank
lines, so it contributes no executable line for coverage to measure, in either
direction. The runner total is known to move by a line between runs on
identical source.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->









