### PR TITLE
docs(development): three shapes the block-comment rule does not reach

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -60,7 +60,10 @@ surrounding code:
 - A comment about a test or a group of tests goes inside the block, as the
   first thing in the callback and followed by a blank line. Above the
   `describe()` or `it()` line, the next block inserted there lands between the
-  comment and what it describes.
+  comment and what it describes. Hooks are the exception -- a `beforeEach()`
+  reads like any other statement with a comment over it -- and a comment
+  covering several adjacent tests is telling you those tests want a
+  `describe()` of their own.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -63,8 +63,10 @@ surrounding code:
   comment and what it describes. Hooks are the exception -- a `beforeEach()`
   reads like any other statement with a comment over it -- and a comment
   covering several adjacent tests is telling you those tests want a
-  `describe()` of their own, or wants splitting across them. None of this is
-  checked mechanically; a file that reads better than the rule wins.
+  `describe()` of their own, or says one thing per case and belongs in each.
+  A section marker covers the region up to the next marker or the end of the
+  block. None of this is checked mechanically; a file that reads better than
+  the rule wins.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -63,7 +63,8 @@ surrounding code:
   comment and what it describes. Hooks are the exception -- a `beforeEach()`
   reads like any other statement with a comment over it -- and a comment
   covering several adjacent tests is telling you those tests want a
-  `describe()` of their own.
+  `describe()` of their own, or wants splitting across them. None of this is
+  checked mechanically; a file that reads better than the rule wins.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -85,7 +85,9 @@ implementation.
 
 Group related tests with nested `describe()` blocks rather than comment
 banners. A `describe()` title appears in the test run transcript, where it
-tells a reader which group failed; a comment does not.
+tells a reader which group failed; a comment does not. A comment that turns out
+to describe several adjacent tests is the usual sign that a group is missing;
+see [Commenting a block](#commenting-a-block).
 
 ### Describing a class
 
@@ -213,12 +215,28 @@ The blank line under it separates the two jobs a `//` comment does here. With
 one, the comment is about the block. Without one, it is about the statement
 directly beneath it, which is the ordinary use and is untouched by any of this.
 
-Every block that takes a body works this way: `describe()`, `it()`, the
-`beforeEach()` family, and `Deno.test()`, `Deno.bench()` and `t.step()` where a
-file uses them.
+This holds for a test and for a group of them: `describe()`, `it()`, and
+`Deno.test()`, `Deno.bench()` and `t.step()` where a file uses them. It does
+not reach the `beforeEach()` family. A hook is setup rather than a case, and
+reads the way any other statement does with a line or two of `//` over it.
 
-Two nearby shapes are not this one:
+A callback with no braces has no inside, and its comment stays where it is.
+`it("rejects a schema-qualified target", () => expect(f(x)).toBeUndefined())`
+is one, and so is `Deno.test("would-pass", function () {});`. This is the same
+allowance [`code-comment-style.md`](code-comment-style.md#where-one-goes) makes
+for a declaration with no body to put a note in.
 
+Three nearby shapes are not this one:
+
+- A comment whose subject is a **run of sibling blocks** — two or three
+  adjacent cases that each pin one part of what it says — has no home inside
+  any one of them. That comment is telling you the run wants a
+  `describe()`: give the run its own block, and the comment goes inside that
+  block by the rule above, which is where a long rationale belongs anyway. A
+  run that should not become a block takes a
+  [section marker](code-comment-style.md#section-markers) instead, and then the
+  region needs closing — a second marker after the run — or a reader cannot
+  see where it ends.
 - A comment describing the **file** rather than any block in it is a file
   header. It goes at the top of the file as a doc comment, per
   [File headers](code-comment-style.md#file-headers), and not above the

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -263,12 +263,13 @@ Three nearby shapes are not this one:
 ### The shape to aim for
 
 A reader should be able to tell what a comment covers from where it sits, and
-there are only four places it can sit. Inside a block, it is about that block.
-At the top of a group, it is about the group. Framed as a section marker, it is
-about the region running to the next marker or to the end of the block. Beside
-a hook or a body-less callback, it is about the statement it touches. Write
-each comment into the place that matches its reach and a reader never has to
-guess.
+each place carries one reach. First thing inside a callback, it covers that
+block — the single case, or the whole group, whichever the callback opens.
+Framed as a section marker, it covers the region running to the next marker or
+to the end of the block. Beside a hook or a body-less callback, it covers the
+statement it touches. At the top of the file, as a doc comment, it covers the
+file. Write each comment into the place that matches its reach and a reader
+never has to guess.
 
 Give a file one way of showing its regions and keep to it. Where a file marks
 regions, a marker ends the one before it, so a series of them reads as a series

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -245,9 +245,9 @@ Three nearby shapes are not this one:
   run that should not become a block takes a
   [section marker](code-comment-style.md#section-markers) instead, and then the
   region needs closing — a second marker after the run — or a reader cannot
-  see where it ends. Where the comment's clauses name the cases one by one,
-  splitting it is simpler than either: each half becomes its own case's
-  comment.
+  see where it ends. And where what you have to say names the cases one at a
+  time, say each part in the case it belongs to rather than all of it in one
+  place.
 - A comment describing the **file** rather than any block in it is a file
   header. It goes at the top of the file as a doc comment, per
   [File headers](code-comment-style.md#file-headers), and not above the
@@ -257,22 +257,27 @@ Three nearby shapes are not this one:
   length or subject matter. A marker covering a single block is not marking a
   region. Where it says something about that block, it becomes a block comment
   in the form above. Where it only restates the block's own description, it is
-  deleted — the disposition for any comment that says no more than the
-  description above it.
+  deleted. A comment that would say no more than the description above it is
+  not worth writing.
 
-### Where these run out
+### The shape to aim for
 
-A comment above a block delimits: it ends the reach of whatever comment heads
-the run before it. Move one inside its block and the comment above it quietly
-covers more than it used to. So where a file is organized by a series of region
-labels, the series carries weight no single label does, and a series that reads
-one way throughout is worth more than each of its members being separately
-right.
+A reader should be able to tell what a comment covers from where it sits, and
+there are only four places it can sit. Inside a block, it is about that block.
+At the top of a group, it is about the group. Framed as a section marker, it is
+about the region running to the next marker or to the end of the block. Beside
+a hook or a body-less callback, it is about the statement it touches. Write
+each comment into the place that matches its reach and a reader never has to
+guess.
 
-That is the shape of every hard case here, and the reason none of this is
-checked mechanically: the exceptions keep coming, and a gate would only make
-them expensive. Take all of it as guidance. Where following it would leave a
-file reading worse, the file wins.
+Give a file one way of showing its regions and keep to it. Where a file marks
+regions, a marker ends the one before it, so a series of them reads as a series
+and a lone label in another form leaves the region above it looking wider than
+it is.
+
+None of this is checked mechanically, on purpose: the cases that do not fit
+keep arriving, and a gate would only make them expensive. It is guidance. A
+file that reads better than the guidance is the better file.
 
 ## Assertions
 

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -245,7 +245,9 @@ Three nearby shapes are not this one:
   run that should not become a block takes a
   [section marker](code-comment-style.md#section-markers) instead, and then the
   region needs closing — a second marker after the run — or a reader cannot
-  see where it ends.
+  see where it ends. Where the comment's clauses name the cases one by one,
+  splitting it is simpler than either: each half becomes its own case's
+  comment.
 - A comment describing the **file** rather than any block in it is a file
   header. It goes at the top of the file as a doc comment, per
   [File headers](code-comment-style.md#file-headers), and not above the
@@ -255,7 +257,22 @@ Three nearby shapes are not this one:
   length or subject matter. A marker covering a single block is not marking a
   region. Where it says something about that block, it becomes a block comment
   in the form above. Where it only restates the block's own description, it is
-  deleted.
+  deleted — the disposition for any comment that says no more than the
+  description above it.
+
+### Where these run out
+
+A comment above a block delimits: it ends the reach of whatever comment heads
+the run before it. Move one inside its block and the comment above it quietly
+covers more than it used to. So where a file is organized by a series of region
+labels, the series carries weight no single label does, and a series that reads
+one way throughout is worth more than each of its members being separately
+right.
+
+That is the shape of every hard case here, and the reason none of this is
+checked mechanically: the exceptions keep coming, and a gate would only make
+them expensive. Take all of it as guidance. Where following it would leave a
+file reading worse, the file wins.
 
 ## Assertions
 

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -220,11 +220,20 @@ This holds for a test and for a group of them: `describe()`, `it()`, and
 not reach the `beforeEach()` family. A hook is setup rather than a case, and
 reads the way any other statement does with a line or two of `//` over it.
 
-A callback with no braces has no inside, and its comment stays where it is.
-`it("rejects a schema-qualified target", () => expect(f(x)).toBeUndefined())`
-is one, and so is `Deno.test("would-pass", function () {});`. This is the same
-allowance [`code-comment-style.md`](code-comment-style.md#where-one-goes) makes
-for a declaration with no body to put a note in.
+A callback that opens no body of its own has nowhere to hold a comment, and
+the note stays beside it. Two shapes do that — a body that is a bare
+expression, and an empty body written on the opener's line:
+
+```ts
+// Shown for illustration only.
+
+it("returns `undefined` for a bad name", () => expect(f(x)).toBeUndefined());
+Deno.test("would-pass", function () {});
+```
+
+This is the same allowance
+[`code-comment-style.md`](code-comment-style.md#where-one-goes) makes for a
+declaration with no body to put a note in.
 
 Three nearby shapes are not this one:
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforming the tree to "Commenting a block" turned up three cases the rule as
written has no answer for. Each was settled by hand during the arc; this states
them where a reader meets the question.

**A hook is not a test case.** `beforeEach()` and its family are setup, and read
the way any other statement does with a line or two of `//` over them. The rule
currently lists "the `beforeEach()` family" among the blocks that take an
inside comment, which is the opposite of how the tree's hooks are now written;
it stops naming them.

**A callback with no braces has no inside.** An `it()` whose body is a bare
expression, or a `Deno.test` whose body is `{}` on the same line, has nowhere
to put a comment, so the note stays beside it. Framed as the same allowance
[`code-comment-style.md`](../../docs/development/code-comment-style.md) already
makes for a declaration with no body, rather than as a new exception.

**A comment whose subject is a run of adjacent cases is a missing `describe()`
announcing itself.** Moved into the first of the run it covers a fraction of
what it says; left above the run it is the ambiguous shape the rule exists to
remove. What it is actually reporting is that the run wants a block of its own
-- and that block is then where a long rationale belongs, by the placement rule
itself. A run that should not become a block takes a section marker instead,
and then the region needs a second marker after it, or a reader cannot see
where it ends.

The grouping advice under "One top-level `describe()`" gains the link that
connects it to all this: a comment describing several adjacent tests is the
usual sign that a group is missing.

`.claude/rules/tests.md` carries the two short forms.

## Where this came from

Across 818 sites in 239 files, the hook case appeared 17 times, the brace-less
callback 4, and the run-spanning comment about 20 -- and the last of those was
the arc's most common defect by a wide margin. Six of the seven conformance
PRs reviewed had at least one comment moved into the first case of a run it
described, each caught by reading the comment against the siblings that follow
it rather than by any mechanical check.

The run-spanning comments still sitting above their runs across the tree are
left for a follow-up that decides, per site, between a `describe()` and a
bounded section marker. Converting a run to a `describe()` renames its tests,
so that change owes `tasks/test-identity-aliases.jsonl` entries and is not a
comment change.

## Gates

`deno task check-docs` passes (589 blocks). `deno task check-skill-facts`
passes. `docs/` and `.claude/` are excluded from `deno fmt`, so the prose is
hand-wrapped at 80 columns; no added line exceeds it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

