### PR TITLE
docs(topics): the Stage C removal decisions, and why unmention is not among them

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -93,10 +93,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   board and topic grow their verbs without breaking the pieces already holding
   data: the shape the board demands of a stored topic, the one rehearsed break
   that narrowing it needs, and the items waiting on platform work.
-- Topics migration rehearsal has been executed and is archived at
-  [`../history/plans/topics-migration-rehearsal.md`](../history/plans/topics-migration-rehearsal.md);
-  what the live run found, including where that script was wrong, is in
-  [`../history/topics-board-migration-2026-08-28.md`](../history/topics-board-migration-2026-08-28.md).
 - [`cf space clone` rehearsal](space-clone-rehearsal.md) records the design for
   rehearsal-grade copies of populated spaces. The tooling has shipped (`cf
   space`, `cf inspect churn`); the operating procedure lives in

--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -142,7 +142,8 @@ Each item waits on platform work rather than on this plan:
 
 - **`removeLink`, and comment edit and removal.** References-as-arguments has
   landed, so these are buildable. They go on the topic's own interface and need
-  no migration; the no-synthetic-ids rule is what prepared for them.
+  no migration; the no-synthetic-ids rule is what prepared for them. The
+  decisions they turn on are settled and recorded below.
 - **`AgentActor` execution provenance** replacing per-event `agentName`, when
   the retention-and-provenance track clears its review. Required-now relaxes to
   optional-then-deprecated, which is the compatible direction and the reason
@@ -205,10 +206,42 @@ Two preconditions belong to the board rather than to the code:
 - A result narrowing happens in place rather than under a new verb name;
   breaking source-level consumers is accepted and updating them is part of the
   work.
-- `removeLink` waits for references-as-arguments rather than taking a
-  URL-keyed interim form.
+- `removeLink` takes a reference, the form `unmention` established. It carries
+  a URL spelling as well, which is not the interim form this plan once weighed
+  against waiting: it is an addition on top of the reference form, and it earns
+  its inconsistency by being the only way an agent can retract a link, since a
+  link record has no fid to name from the CLI. Where a URL appears more than
+  once the spelling stamps the newest un-tombstoned record, so removing twice
+  removes two.
+- **A removal is stamped, not performed.** `removeLink` and comment removal
+  write `removedAt` onto the record and leave it in place; the reader does not
+  render it by default. Three consequences, and the first is the reason:
+  `lastActivityAt` is a max over the array, so a real removal would move a
+  topic's activity *backwards* and visibly reorder the board, while a stamped
+  one cannot. `lastActivityOf` therefore keeps counting stamped records, and
+  changing it to skip them reintroduces that silently. `commentCount` is the
+  other side: it counts the array's length today, so it has to exclude stamped
+  records or a card reads more comments than the topic shows. Both are
+  computations rather than schema, so neither needs a migration.
+- Every field a stamped removal adds is optional, for the reason recorded on
+  `TopicComment`: a stored record type has to accept what is already stored,
+  and the deployed board holds records written before these fields existed.
+- **Anyone may remove or edit anyone's comment or link**, matching the
+  References card, which already lets anyone retract any mention. Narrowing
+  this to the author is expected to come later.
+- An edited comment carries `editedAt` beside its original `sentAt`, and the
+  edit does not rewrite the author.
+- **`unmention` keeps removing rather than stamping**, and the pattern carries
+  two removal semantics until [#6573] closes it. Not because an edge matters
+  less than content, but because a mention is a bare reference with no record
+  to stamp: giving it one means changing what the array's elements are, and
+  `mentions` is in the board's demand and is a union of three sources, only one
+  of which `unmention` reaches. The gap underneath is that a mention is the
+  only authored act here with no attribution at all.
 - Stage B keeps the existing verb names. The rehearsed break is the *one*
   deliberate break in this plan: anything break-shaped discovered along the way
   rides it, and every other change stays gate-clean.
 - The board's demand names the eight members above, and losing the excluded
   fields from the board's published projection is accepted.
+
+[#6573]: https://github.com/commontoolsinc/labs/issues/6573


### PR DESCRIPTION
## Why

Stage C item 1 — `removeLink`, comment edit and removal — is buildable now that
references-as-arguments has landed. It turned on four open choices, and this
records them before the code exists, so the reasons survive it rather than
being reconstructed from the implementation later.

One of them changes the shape of the feature: **a removal is stamped, not
performed.** The reason is a consequence that is easy to miss until the board
reorders itself. `lastActivityAt` is a max over the comment and link arrays, so
a real removal moves a topic's activity *backwards*. Every verb up to now only
appended or stamped forward. A stamped removal cannot do that, and it keeps the
evidence.

The cost moves to `commentCount`, which counts the array's length and now has
to exclude stamped records, or a card reads more comments than the topic shows.
Both are computations rather than schema, so neither needs a migration —
which is what makes this affordable so soon after the Stage B one.

`unmention` is deliberately left out, and that asymmetry is recorded rather
than tolerated. A mention is a bare reference with no record to stamp; giving
it one changes what the array's elements are, and `mentions` is in the board's
demand and is a union of three sources that `unmention` reaches only one of.
The gap underneath — a mention is the only authored act on a Topic with no
attribution at all — is filed as #6573.

Prior PR in this arc: #6496.

## What Changed

Documentation only, two files.

`docs/plans/topics-verb-surface.md` — the four Stage C decisions: stamped
removals, anyone-may-remove, `editedAt` on an edited comment, and a URL
spelling for `removeLink` alongside the reference form.

- The existing `removeLink` decision is updated rather than contradicted. It
  read "waits for references-as-arguments rather than taking a URL-keyed
  interim form"; references have landed, and the URL spelling is an addition on
  top of the reference form rather than the interim substitute that decision
  weighed against waiting. It earns its inconsistency by being the only way an
  agent can retract a link, since a link record has no fid to name from the CLI.
- A note that every field a stamped removal adds must be optional, for the
  reason already recorded on `TopicComment`: a stored record type has to accept
  what is already stored.

`docs/plans/README.md` — removes a bullet describing the Topics migration
rehearsal as executed and archived, from a section this file defines as plans
that have not been executed. It arrived in #6496 and cubic caught it here. The
rehearsal stays reachable through the Topics verb surface plan, which links
both the archived script and the record of the live run, and through the
history index; `deno task docs-links --orphan` reports nothing orphaned.

## Test plan

Documentation only; no code changes. `deno fmt --check`, `deno lint`,
`deno task check-docs`, `deno task check-docs-history-index`,
`deno task check-conflict-markers`, and `deno task check-skill-facts` all pass,
as does `deno task docs-links --orphan` for the removed bullet.