### PR TITLE
test: give each run-spanning comment a region that closes

### DIFF
--- a/packages/cf-harness/test/seed-pattern-index.test.ts
+++ b/packages/cf-harness/test/seed-pattern-index.test.ts
@@ -89,9 +89,14 @@ describe("seed-pattern-index", () => {
       ]);
     });
 
+    //
+    // Refusals
+    //
     // An atom the index cannot be searched for is worth less than no atom, and
     // one described by a guess is worse than either, so each of these stops the
     // run before anything is published.
+    //
+
     it("refuses an atom with no doc comment", () => {
       expect(() => seedMetadataFromSource("atom", "export const X = 1;\n"))
         .toThrow(/no leading doc comment/);

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -132,10 +132,15 @@ describe("data-uri-codec", () => {
       expect(Object.is(parsed.i, -Infinity)).toBe(true);
     });
 
+    //
+    // Distinctness
+    //
     // Distinctness is a separate property from round-tripping, and the more
     // important one here: these URIs are content addresses, so two values that
     // are not equal must not mint the same identifier. A codec could round-trip
     // every value faithfully and still collide.
+    //
+
     it("mints distinct URIs for `-0` and `+0`", () => {
       expect(dataUriFromValue(-0)).not.toBe(dataUriFromValue(0));
       expect(dataUriFromValue({ z: -0 })).not.toBe(dataUriFromValue({ z: 0 }));

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -315,12 +315,17 @@ namespace Local {
       });
     });
 
+    //
+    // The synthetic index-signature branch
+    //
     // CT-1615 Berni review §4.2: lock in the new IndexSignatureDeclaration
-    // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler.
-    // Without it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes
-    // routed through node-based analysis silently drop their index signature
-    // (e.g. via the SchemaInjection lift-revisit that feeds `any` as the
-    // paired Type — see ts-transformers/src/transformers/schema-injection.ts).
+    // branch added to `analyzeTypeNodeStructure`'s TypeLiteral handler. Without
+    // it, synthetic `{ [k: string]: V }` / `Record<K, V>` shapes routed through
+    // node-based analysis silently drop their index signature (e.g. via the
+    // SchemaInjection lift-revisit that feeds `any` as the paired Type — see
+    // ts-transformers/src/transformers/schema-injection.ts).
+    //
+
     it("emits additionalProperties for synthetic { [k: string]: V } index signature", async () => {
       const generator = new SchemaGenerator();
       const { checker } = await getTypeFromCode(

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
@@ -83,10 +83,15 @@ describe("memwrite-trace", () => {
       expect(vhashOf(a)).toBe(vhashOf(b));
     });
 
+    //
+    // Why the canonical hash, not a JSON round-trip
+    //
     // The reason for using the canonical `FabricValue` hash over a JSON
     // round-trip: a JSON-derived hash collapses values that the runtime treats
     // as distinct, so the trace would report a false "same value" and hide a
     // real divergence.
+    //
+
     it("distinguishes values a JSON round-trip would collapse (undefined fields)", () => {
       // `JSON.stringify` drops `undefined`-valued keys, so both would serialize
       // to `{}`; the canonical hash keys on the present `a` field.

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
@@ -124,6 +124,14 @@ describe("memwrite-trace", () => {
       expect(vhashOf(inf)).not.toBe(vhashOf(nul));
     });
 
+    //
+    // When the hasher refuses
+    //
+    // The cost of that choice, rather than a reason for it: a value the
+    // canonical hasher cannot encode must not take the rest of the commit's
+    // ops down with it.
+    //
+
     it("never throws on a value the canonical hasher rejects", () => {
       // Not expected for a real FabricValue, but the trace must stay alive: a
       // value the hasher can't encode (here, a function) yields a sentinel

--- a/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis-flap-coverage.test.ts
@@ -150,13 +150,13 @@ Deno.test(
   },
 );
 
-// Branch: `updateLocalCollectionBinding` deletes the tracked map-value binding
-// when two `.set()` calls store non-equal sources so their merge is undefined
-// (capability-analysis.ts ~1977-1979). Contrast with a single `.set()`, where
-// the binding survives and a later `.get(k).name` resolves through it.
 Deno.test(
   "a single map .set() lets a later .get().member resolve through the value binding",
   () => {
+    // Branch: with a single `.set()`, the tracked map-value binding survives,
+    // so a later `.get(k).name` resolves through it. The contrast is the
+    // conflicting-sources case below.
+
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input) => {
@@ -176,6 +176,10 @@ Deno.test(
 Deno.test(
   "conflicting map .set() values drop the value binding so .get().member no longer resolves",
   () => {
+    // Branch: `updateLocalCollectionBinding` deletes the tracked map-value
+    // binding when two `.set()` calls store non-equal sources, so their merge
+    // is undefined (capability-analysis.ts ~1977-1979).
+
     const input = getPaths(
       analyzeNoChecker(
         `const fn = (input) => {

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -31,9 +31,14 @@ describe("topics-rehearsal-lib", () => {
       );
     });
 
+    //
+    // A retired field leaves no record to be missing from
+    //
     // A migration that retires a whole top-level field leaves no surviving
     // record for a key to be missing from, so absence is reported about the
     // compared value itself.
+    //
+
     it("names the whole value when a retired scalar reads back absent", () => {
       expect(retiredKeys("a legacy display name", undefined)).toEqual([
         WHOLE_VALUE,
@@ -50,9 +55,14 @@ describe("topics-rehearsal-lib", () => {
       expect(retiredKeys(undefined, undefined)).toEqual([]);
     });
 
+    //
+    // Present but changed is not absence
+    //
     // The distinction the whole approach rests on: a field the schema still
-    // declares reads back present even when its value was lost, so genuine
-    // loss is a difference rather than a gap and must not be forgiven.
+    // declares reads back present even when its value was lost, so genuine loss
+    // is a difference rather than a gap and must not be forgiven.
+    //
+
     it("does not name a key that is present but changed", () => {
       expect(retiredKeys({ body: "kept" }, { body: "" })).toEqual([]);
     });
@@ -82,8 +92,13 @@ describe("topics-rehearsal-lib", () => {
         .toBeUndefined();
     });
 
+    //
+    // The two together
+    //
     // Together these are what let a restore across a migration report success
     // for a retired field while still failing on a body that came back wrong.
+    //
+
     it("leaves a changed value in place for the comparison to catch", () => {
       const retired = retiredKeys({ authorName: "a", body: "x" }, {
         body: "wrong",

--- a/scripts/topics-snapshot-lib.test.ts
+++ b/scripts/topics-snapshot-lib.test.ts
@@ -30,6 +30,13 @@ describe("topics-snapshot-lib", () => {
       expect(argumentIdOf(document)).toBe("of:fid1:arg");
     });
 
+    //
+    // Neither encoding
+    //
+    // A document that links nothing, and one whose `argument` is not a link at
+    // all, both read as no argument entity.
+    //
+
     it("returns undefined when the document links nothing", () => {
       expect(argumentIdOf({})).toBeUndefined();
       expect(argumentIdOf({ argument: "not a link" })).toBeUndefined();

--- a/scripts/topics-snapshot-lib.test.ts
+++ b/scripts/topics-snapshot-lib.test.ts
@@ -10,9 +10,14 @@ import { argumentIdOf } from "./topics-snapshot-lib.ts";
 
 describe("topics-snapshot-lib", () => {
   describe("argumentIdOf", () => {
-    // Both encodings reach a reader of a real snapshot, and a reader that
-    // knows only one of them reports the other as "no argument entity" — for
-    // the export, that aborts the run rather than skipping a field.
+    //
+    // Both encodings
+    //
+    // Both encodings reach a reader of a real snapshot, and a reader that knows
+    // only one of them reports the other as "no argument entity" — for the
+    // export, that aborts the run rather than skipping a field.
+    //
+
     it("reads the id out of a sigil-encoded link", () => {
       const document = {
         argument: { "/": { "link@1": { id: "of:fid1:arg" } } },


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The "Commenting a block" rule in `unit-test-coding-style.md` says a comment
applying to more than one test must be a section marker whose region is closed
— by another marker, or by the end of the block or file it sits in. Adjacent
above the first of a run is never a resting place.

When each package was conformed, nine such comments were left parked. This
change gives each one a region that closes. Seven files, all tests.

## What each one became

**Eight become markers**, and two of those needed a second marker to close
them, so ten frames in all:

| File | Title | Members | Region closes at |
|---|---|---|---|
| `cf-harness/.../seed-pattern-index` | Refusals | 4 | end of the enclosing describe |
| `data-model/.../data-uri-codec` | Distinctness | 5 | end of the enclosing describe |
| `schema-generator/.../schema-generator` | The synthetic index-signature branch | 2 | end of the enclosing describe |
| `toolshed/.../memwrite-trace` | Why the canonical hash, not a JSON round-trip | 2 | the next marker |
| `toolshed/.../memwrite-trace` | When the hasher refuses | 1 | end of the enclosing describe |
| `scripts/topics-rehearsal-lib` | A retired field leaves no record to be missing from | 3 | the next marker |
| `scripts/topics-rehearsal-lib` | Present but changed is not absence | 3 | end of the enclosing describe |
| `scripts/topics-rehearsal-lib` | The two together | 2 | end of the enclosing describe |
| `scripts/topics-snapshot-lib` | Both encodings | 2 | the next marker |
| `scripts/topics-snapshot-lib` | Neither encoding | 1 | end of the enclosing describe |

The two closers exist because the first title in each pair does not own the
whole region it would otherwise open. "Both encodings" ran on into a test about
a document that links nothing, which is a fact about neither encoding. "Why the
canonical hash, not a JSON round-trip" argues for a choice, and the test below
its pair argues neither for it nor against the alternative — it pins that a
value the hasher cannot encode yields a sentinel rather than taking the rest of
the commit's ops down, which is the cost of the choice. Each closer titles the
case it heads, and the two markers in each file read as one sequence.

The first two markers in `topics-rehearsal-lib` close each other, so that file
reads as one sequence rather than three unrelated frames.

**One splits.** In `capability-analysis-flap-coverage`, the comment named a
contrast between two tests one at a time — `updateLocalCollectionBinding`
dropping the map-value binding when two `.set()` calls disagree, against a
single `.set()` where the binding survives. Each clause moves inside the test it
describes, which is what every other `Deno.test` in that file already does. Its
apparent region held five tests, but the three beyond the pair each carry their
own `Branch:` note inside the callback: those notes are what bounded this
comment, and a `Branch:` note per test is the file's own convention.

## What the diff is, as a property

Measured over the whole diff against the merge-base, at this head:

- Comments adjacent above a test-block opener, over these seven files: **9 at
  the merge-base and 0 at head.**
- Marker frames go from **0 to 10**, counting a frame as a `//` run whose first
  and last lines hold nothing but `//`.
- Added or removed lines that are neither a `//` comment nor blank: **0**. No
  non-comment line is repositioned either (count 0), so no executable content
  moves and no test is renamed.
- Per file, the multiset of comment words **loses nothing**, in all seven. What
  each file gains: four of them gain exactly the words of the titles added
  (`seed-pattern-index`, `data-uri-codec`, `schema-generator`,
  `topics-rehearsal-lib`); `memwrite-trace` and `topics-snapshot-lib` gain a
  title plus their closer's description; and the split file rewords, so that
  each half reads on its own.
- Counting comment runs across the diff: 9 vanished, 12 are new, and no
  surviving run changed its line breaks.
- No added line exceeds 80 characters that is not already in the base verbatim,
  counted in characters rather than bytes.

## Not in this change

Three files hold a parked comment whose honest region needs a marker vocabulary
designed across the whole file rather than a single conversion, so they are
left for a change of their own:
`cli/.../piece-call-cyclic-result-live` (three comments, each saying "the pair
below" while heading longer runs),
`html/.../worker-reconciler-cfc-render-policy` (one comment heading a long run
of `t.step`s, of which its title owns the first few), and
`html/.../worker-keying` ("the two things" heading four).

## Gates

`deno fmt --check` and `deno lint` pass over the workspace (exit 0).
`deno task test`, all exit 0: `cf-harness` 857 passed / 0 failed,
`data-model` 48 / 0, `schema-generator` 57 / 0, `toolshed` 147 / 0,
`ts-transformers` 1164 / 0, and the two `scripts` test files 2 / 0.
