### PR TITLE
perf(runner): editWithRetry reconciles unexamined absences before committing

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -865,6 +865,7 @@ function cellAsLink(value: object | ((...args: never[]) => unknown)): unknown {
  */
 export class Runtime {
   #tearingDownWrites = false;
+  readonly #writeTeardown = new AbortController();
 
   readonly id: string;
   readonly scheduler: Scheduler;
@@ -1884,6 +1885,7 @@ export class Runtime {
       // point onward, no delayed reconciliation or retry may mint new work
       // behind the teardown barriers below.
       this.#tearingDownWrites = true;
+      this.#writeTeardown.abort();
       // Abort any pending (not-yet-started) queued jobs so they don't start
       // after storage is torn down.
       for (const queue of this.#queues.values()) {
@@ -1941,6 +1943,7 @@ export class Runtime {
       await this.scheduler.idle();
     } finally {
       this.#tearingDownWrites = true;
+      this.#writeTeardown.abort();
       // Released whatever happened above. `storageManager.close()` can reject
       // — through a provider's `replica.close()` — and it is the one await
       // here that can. Every statement below is synchronous field-clearing
@@ -2515,7 +2518,10 @@ export class Runtime {
       return tx.commit().then(async ({ error }) => {
         if (error) {
           if (maxRetries > 0 && isRetryableCommitRejection(error)) {
-            await this.awaitCommitRetryReadiness(error);
+            await this.awaitCommitRetryReadiness(
+              error,
+              this.#writeTeardown.signal,
+            );
             if (this.#tearingDownWrites) return teardownResult();
             return this.editWithRetry<T>(fn, maxRetries - 1);
           } else {
@@ -2639,16 +2645,40 @@ export class Runtime {
    * Every step is best-effort by design: this resolves rather than throws,
    * because the retry's commit — not this readiness — is what decides.
    */
-  async awaitCommitRetryReadiness(error: unknown): Promise<void> {
+  async awaitCommitRetryReadiness(
+    error: unknown,
+    teardownSignal?: AbortSignal,
+  ): Promise<void> {
+    const waitUnlessTeardown = async (
+      operation: PromiseLike<unknown>,
+    ): Promise<boolean> => {
+      if (teardownSignal === undefined) {
+        await operation;
+        return true;
+      }
+      if (teardownSignal.aborted) return false;
+      const aborted = Promise.withResolvers<boolean>();
+      const onAbort = () => aborted.resolve(false);
+      teardownSignal.addEventListener("abort", onAbort, { once: true });
+      try {
+        return await Promise.race([
+          Promise.resolve(operation).then(() => true),
+          aborted.promise,
+        ]);
+      } finally {
+        teardownSignal.removeEventListener("abort", onAbort);
+      }
+    };
     const readyToRetry = (error as { readyToRetry?: () => unknown })
       ?.readyToRetry;
     if (typeof readyToRetry === "function") {
       try {
-        await readyToRetry();
+        if (!await waitUnlessTeardown(Promise.resolve(readyToRetry()))) return;
       } catch {
         // Readiness aborted — the retry's commit decides.
       }
     }
+    if (teardownSignal?.aborted) return;
     const conflict = (error as {
       conflict?: { space?: MemorySpace; of?: string };
     })?.conflict;
@@ -2658,9 +2688,11 @@ export class Runtime {
       conflict.of !== "of:unknown"
     ) {
       try {
-        await this.storageManager.open(conflict.space).sync(
-          conflict.of as unknown as URI,
-          { path: [], schema: false },
+        await waitUnlessTeardown(
+          this.storageManager.open(conflict.space).sync(
+            conflict.of as unknown as URI,
+            { path: [], schema: false },
+          ),
         );
       } catch {
         // Pull failed — the retry's commit decides.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -864,6 +864,8 @@ function cellAsLink(value: object | ((...args: never[]) => unknown)): unknown {
  * ```
  */
 export class Runtime {
+  #tearingDownWrites = false;
+
   readonly id: string;
   readonly scheduler: Scheduler;
   readonly patternManager: PatternManager;
@@ -1878,6 +1880,10 @@ export class Runtime {
       // it cannot spin: every round awaits real promises, so a runtime that keeps
       // working keeps the barrier open rather than busy-looping.
       if (!closeStorage) await this.settled(Infinity);
+      // Kept-storage disposal first drains tracked writebacks above. From this
+      // point onward, no delayed reconciliation or retry may mint new work
+      // behind the teardown barriers below.
+      this.#tearingDownWrites = true;
       // Abort any pending (not-yet-started) queued jobs so they don't start
       // after storage is torn down.
       for (const queue of this.#queues.values()) {
@@ -1934,6 +1940,7 @@ export class Runtime {
       // Wait for any pending operations
       await this.scheduler.idle();
     } finally {
+      this.#tearingDownWrites = true;
       // Released whatever happened above. `storageManager.close()` can reject
       // — through a provider's `replica.close()` — and it is the one await
       // here that can. Every statement below is synchronous field-clearing
@@ -2467,6 +2474,17 @@ export class Runtime {
   ): Promise<
     { ok: T; error?: undefined } | { ok?: undefined; error: CommitError }
   > {
+    const teardownResult = (): {
+      ok?: undefined;
+      error: CommitError;
+    } => ({
+      error: {
+        name: "StorageTransactionAborted" as const,
+        message: "editWithRetry stopped because the runtime is disposing",
+        reason: new Error("runtime disposing"),
+      },
+    });
+    if (this.#tearingDownWrites) return Promise.resolve(teardownResult());
     const tx = this.edit();
     tx.tx.immediate = true;
     (tx.tx as { deferRunnerStartUntilCommit?: boolean })
@@ -2489,11 +2507,16 @@ export class Runtime {
     const commitPrepared = (): Promise<
       { ok: T; error?: undefined } | { ok?: undefined; error: CommitError }
     > => {
+      if (this.#tearingDownWrites) {
+        tx.abort("editWithRetry stopped because the runtime is disposing");
+        return Promise.resolve(teardownResult());
+      }
       this.prepareTxForCommit(tx);
       return tx.commit().then(async ({ error }) => {
         if (error) {
           if (maxRetries > 0 && isRetryableCommitRejection(error)) {
             await this.awaitCommitRetryReadiness(error);
+            if (this.#tearingDownWrites) return teardownResult();
             return this.editWithRetry<T>(fn, maxRetries - 1);
           } else {
             return { error };
@@ -2534,6 +2557,10 @@ export class Runtime {
       : 0;
     if (typeof reconciliation === "number") return commitPrepared();
     return reconciliation.then((present) => {
+      if (this.#tearingDownWrites) {
+        tx.abort("editWithRetry stopped because the runtime is disposing");
+        return teardownResult();
+      }
       if (present > 0) {
         tx.abort(
           `editWithRetry re-run: ${present} document(s) read as absent ` +

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2567,8 +2567,17 @@ export class Runtime {
     for (const space of spaces) {
       const provider = this.storageManager.open(space);
       if (provider.loadUnexaminedAbsences === undefined) continue;
-      const answer = provider.loadUnexaminedAbsences(tx.tx);
-      if (typeof answer !== "number") pending.push(answer);
+      try {
+        const answer = provider.loadUnexaminedAbsences(tx.tx);
+        if (typeof answer !== "number") {
+          // Reconciliation only front-runs the authoritative commit verdict.
+          // A provider that cannot perform the best-effort load leaves the
+          // transaction's original absence claim for the server to judge.
+          pending.push(answer.catch(() => 0));
+        }
+      } catch {
+        // Same fallback for providers that fail before returning a promise.
+      }
     }
     if (pending.length === 0) return 0;
     return Promise.all(pending).then((counts) =>

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -38,6 +38,7 @@ import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isDeno } from "@commonfabric/utils/env";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import { popFrame, pushFrame } from "./builder/pattern.ts";
+import { getDirectTransactionReadActivities } from "./storage/transaction-inspection.ts";
 import type {
   ChangeGroup,
   CommitError,
@@ -2485,26 +2486,94 @@ export class Runtime {
         },
       });
     }
-    this.prepareTxForCommit(tx);
-    return tx.commit().then(async ({ error }) => {
-      if (error) {
-        if (maxRetries > 0 && isRetryableCommitRejection(error)) {
-          await this.awaitCommitRetryReadiness(error);
-          return this.editWithRetry<T>(fn, maxRetries - 1);
-        } else {
-          return { error };
+    const commitPrepared = (): Promise<
+      { ok: T; error?: undefined } | { ok?: undefined; error: CommitError }
+    > => {
+      this.prepareTxForCommit(tx);
+      return tx.commit().then(async ({ error }) => {
+        if (error) {
+          if (maxRetries > 0 && isRetryableCommitRejection(error)) {
+            await this.awaitCommitRetryReadiness(error);
+            return this.editWithRetry<T>(fn, maxRetries - 1);
+          } else {
+            return { error };
+          }
         }
+        return { ok: result };
+      }).catch((error) => {
+        return {
+          error: {
+            name: "StorageTransactionAborted" as const,
+            message: `editWithRetry commit rejected: ${error}`,
+            reason: error,
+          },
+        };
+      });
+    };
+
+    // Absence reconciliation, before the read set is exported: a read of a
+    // document this client never synced resolves as absent and would commit
+    // as a `seq: 0` confirmed read — the claim that no such document exists.
+    // Where one does exist, the engine's rejection of that claim is correct
+    // and `fn` re-runs here anyway, after a server round trip, the
+    // conflict's catch-up gate, and a rebuilt commit — once per LAYER of
+    // cold documents, since each re-run can follow the arrived layer's links
+    // into the next. Loading the whole cohort up front and re-running
+    // locally is the same convergence, minus the wire: each round consumes a
+    // retry from the same budget a rejection would.
+    //
+    // Two gates on the load. Budget: loading the documents without re-running
+    // would let the commit export their REAL seqs under a traversal that read
+    // them as absent — an accepted commit derived from an absence that was
+    // never there — so with no budget to re-run, the honest move is the
+    // unexamined claim itself, judged by the server as before. Synchrony: a
+    // transaction with nothing to examine commits on the same synchronous
+    // path as ever, which the commit-gated runner start depends on.
+    const reconciliation = maxRetries > 0
+      ? this.#loadUnexaminedAbsences(tx)
+      : 0;
+    if (typeof reconciliation === "number") return commitPrepared();
+    return reconciliation.then((present) => {
+      if (present > 0) {
+        tx.abort(
+          `editWithRetry re-run: ${present} document(s) read as absent ` +
+            "are present; the action re-runs against them",
+        );
+        return this.editWithRetry<T>(fn, maxRetries - 1);
       }
-      return { ok: result };
-    }).catch((error) => {
-      return {
-        error: {
-          name: "StorageTransactionAborted" as const,
-          message: `editWithRetry commit rejected: ${error}`,
-          reason: error,
-        },
-      };
+      return commitPrepared();
     });
+  }
+
+  /**
+   * Load every document `tx` read as absent that no involved replica has
+   * examined, resolving with how many exist after all — the signal that the
+   * transaction's reads ran against documents it did not hold. One call per
+   * space the transaction read from, each answered by that space's provider
+   * ({@link IStorageProvider.loadUnexaminedAbsences}); a provider without
+   * the capability contributes zero and keeps the server-judged path.
+   */
+  #loadUnexaminedAbsences(
+    tx: IExtendedStorageTransaction,
+  ): number | Promise<number> {
+    const reads = getDirectTransactionReadActivities(tx.tx);
+    if (!reads) return 0;
+    const spaces = new Set<MemorySpace>();
+    for (const read of reads) spaces.add(read.space);
+    // A synchronous answer is always zero — anything unexamined needs a
+    // pull — so a round with no cold reads never leaves the synchronous
+    // path, and only the spaces that owe a pull contribute a promise.
+    const pending: Promise<number>[] = [];
+    for (const space of spaces) {
+      const provider = this.storageManager.open(space);
+      if (provider.loadUnexaminedAbsences === undefined) continue;
+      const answer = provider.loadUnexaminedAbsences(tx.tx);
+      if (typeof answer !== "number") pending.push(answer);
+    }
+    if (pending.length === 0) return 0;
+    return Promise.all(pending).then((counts) =>
+      counts.reduce((total, count) => total + count, 0)
+    );
   }
 
   /**

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -593,6 +593,27 @@ export interface IStorageProvider {
    */
   synced(): Promise<void>;
 
+  /**
+   * Load the documents `source` read as absent without this replica ever
+   * having examined them (no local record; session-scoped instances
+   * excluded, since a fresh session instance cannot exist server-side), and
+   * resolve with how many turned out to exist.
+   *
+   * An unexamined absence becomes a `seq: 0` confirmed read in the
+   * transaction's commit — the claim that no such document exists — which
+   * the server rejects whenever one does. `Runtime.editWithRetry` consults
+   * this before committing: a non-zero count means the transaction's reads
+   * ran against documents it did not hold, so the attempt is re-run locally
+   * against the now-loaded documents instead of being rejected on the wire.
+   * Returns `0` synchronously when the transaction holds no unexamined
+   * absences, so commit paths that are synchronous stay synchronous.
+   * Optional: a provider without it simply leaves that convergence to the
+   * server's rejection and the retry gate, exactly as before.
+   */
+  loadUnexaminedAbsences?(
+    source: IStorageTransaction | undefined,
+  ): number | Promise<number>;
+
   /** INBOUND settlement only (server-execution v2 stage F): outstanding
    * watch refreshes/pulls, EXCLUDING commit settlement AND update
    * processing — the serving loop's wave-settle barrier. Both exclusions

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4793,30 +4793,44 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   /** Remove graph watches whose caller needed only a one-shot absence probe. */
   async #removeWatchIds(watchIds: readonly string[]): Promise<void> {
     if (watchIds.length === 0) return;
-    try {
-      const { session } = await this.#activeSessionHandle();
-      const { view, precedingSyncs, sync } = await session.watchRemoveSync(
-        watchIds,
-      );
-      if (this.#closed) {
-        view.close();
-        return;
-      }
-      this.#watchView = view;
+    let lastError: unknown;
+    // A failed watchRemoveSync has already removed these ids from the
+    // SpaceSession's reconnect intent. Reissuing it therefore sends the full
+    // corrected watch set; Client.request waits for an in-progress reconnect,
+    // so one retry also repairs the resumed-session ambiguity where the server
+    // may still hold the old watches.
+    for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        for (const precedingSync of precedingSyncs) {
-          this.applySessionSync(precedingSync, "integrate");
+        const { session } = await this.#activeSessionHandle();
+        const { view, precedingSyncs, sync } = await session.watchRemoveSync(
+          watchIds,
+        );
+        if (this.#closed) {
+          view.close();
+          return;
         }
-        this.applySessionSync(sync, "integrate");
+        this.#watchView = view;
+        try {
+          for (const precedingSync of precedingSyncs) {
+            this.applySessionSync(precedingSync, "integrate");
+          }
+          this.applySessionSync(sync, "integrate");
+        } catch (error) {
+          view.close();
+          throw error;
+        }
+        this.#consumeWatchView(view);
+        return;
       } catch (error) {
-        view.close();
-        throw error;
+        lastError = error;
+        if (this.#closed) return;
       }
-      this.#consumeWatchView(view);
-    } catch {
-      // Best effort. SpaceSession removes these ids from reconnect intent
-      // before issuing the request; if the session itself is gone, its server
-      // watches disappear with it.
+    }
+    if (!this.#closed) {
+      console.warn(
+        "failed to remove temporary graph watches after retry",
+        lastError,
+      );
     }
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5845,13 +5845,14 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * documents — the same convergence the engine's rejection would force,
    * without the round trip, the catch-up gate, or the wasted upload.
    *
-   * Session-scoped reads are excluded: a session instance is keyed by this
-   * connection's own fresh session id, so no server-side revision can exist
-   * under it and its absence claims can never conflict. Space- and
-   * user-scoped instances persist across sessions and stay covered.
+   * Session-scoped reads of this replica's own fresh session are excluded,
+   * because no unseen server-side revision can exist under that instance.
+   * A served run can carry another session's identity, though, and that
+   * explicit instance is reconciled like a user-scoped one.
    *
-   * The instance key matches {@link buildReads}, which builds the read set
-   * against the replica's own instances.
+   * The instance key matches {@link buildReads}: a served run uses the
+   * transaction's scope identity, while ordinary client transactions use the
+   * replica's own identity.
    */
   loadUnexaminedAbsences(
     source: IStorageTransaction | undefined,
@@ -5859,6 +5860,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     if (source === undefined) return 0;
     const reads = getDirectTransactionReadActivities(source);
     if (!reads) return 0;
+    const identity = source.scopeKeyIdentity;
     // Documents this transaction writes are its own creations in flight:
     // reading one as absent and then writing it is what creating a document
     // IS, and the paired absence claim is what the engine validates the
@@ -5867,22 +5869,30 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     const ownWrites = new Set<string>();
     for (const write of getTransactionWriteAttempts(source) ?? []) {
       if (write.space !== this.#space) continue;
-      ownWrites.add(docKey(write.id, this.instanceKey(write.scope)));
+      ownWrites.add(docKey(write.id, this.instanceKey(write.scope, identity)));
     }
     const unexamined = new Map<string, WatchAddress>();
     for (const read of this.commitReadActivities(source, reads)) {
-      if (
-        normalizeCellScope(read.scope) === "session"
-      ) {
+      const scope = normalizeCellScope(read.scope);
+      // A malformed/incomplete served identity cannot name the instance on
+      // the wire. Leave its claim for commit admission rather than pulling a
+      // different instance under the replica identity.
+      if (identity !== undefined && !canResolveScopeKey(scope, identity)) {
         continue;
       }
-      const key = docKey(read.id, this.instanceKey(read.scope));
+      const instance = this.instanceKey(scope, identity);
+      const ownInstance = this.instanceKey(scope);
+      if (scope === "session" && instance === ownInstance) continue;
+      const key = docKey(read.id, instance);
       if (ownWrites.has(key)) continue;
       if (this.#docs.has(key) || unexamined.has(key)) continue;
       unexamined.set(key, {
         id: read.id,
         type: DOCUMENT_MIME as MIME,
-        scope: normalizeCellScope(read.scope),
+        scope,
+        ...(scope !== "space" && instance !== ownInstance
+          ? { scopeKey: instance as ScopeKey }
+          : {}),
       });
     }
     // Synchronous zero: with nothing to examine there is nothing to await,
@@ -5924,7 +5934,10 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
         const covered = Promise.resolve({ ok: {} } as Result<Unit, PullError>);
         for (let index = 0; index < entries.length; index++) {
           const [address, selector] = entries[index];
-          const key = docKey(address.id, this.instanceKey(address.scope));
+          const key = docKey(
+            address.id,
+            this.instanceKey(address.scope, identity, address.scopeKey),
+          );
           if ((this.#docs.get(key)?.confirmed.seq ?? 0) === 0) {
             absentWatchIds.push(watchIds[index]);
             continue;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -91,6 +91,7 @@ import {
   IMergedChanges,
   IOperationStorageCapability,
   IPreconditionFailedError,
+  IReadActivity,
   IRemoteStorageProviderSettings,
   ISpaceReplica,
   IStorageManager,
@@ -4684,6 +4685,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   private async refreshWatchSet(
     entries: Iterable<[WatchAddress, SchemaPathSelector]>,
     type: "pull" | "integrate" = "pull",
+    watchBranch = "",
   ): Promise<Result<Unit, PullError>> {
     try {
       const { session } = await this.#activeSessionHandle();
@@ -4738,7 +4740,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       }
 
       const watches = watchEntries.map(([address, selector]) => ({
-        id: watchIdForEntry(address, selector, ""),
+        id: watchIdForEntry(address, selector, watchBranch),
         kind: "graph" as const,
         query: {
           roots: [{
@@ -4785,6 +4787,36 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       return { ok: {} };
     } catch (error) {
       return { error: toPullError(error) };
+    }
+  }
+
+  /** Remove graph watches whose caller needed only a one-shot absence probe. */
+  async #removeWatchIds(watchIds: readonly string[]): Promise<void> {
+    if (watchIds.length === 0) return;
+    try {
+      const { session } = await this.#activeSessionHandle();
+      const { view, precedingSyncs, sync } = await session.watchRemoveSync(
+        watchIds,
+      );
+      if (this.#closed) {
+        view.close();
+        return;
+      }
+      this.#watchView = view;
+      try {
+        for (const precedingSync of precedingSyncs) {
+          this.applySessionSync(precedingSync, "integrate");
+        }
+        this.applySessionSync(sync, "integrate");
+      } catch (error) {
+        view.close();
+        throw error;
+      }
+      this.#consumeWatchView(view);
+    } catch {
+      // Best effort. SpaceSession removes these ids from reconnect intent
+      // before issuing the request; if the session itself is gone, its server
+      // watches disappear with it.
     }
   }
 
@@ -5710,6 +5742,81 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
   }
 
   /**
+   * Return the raw reads that become commit-time concurrency preconditions.
+   * Reconciliation and commit construction must use the same set: loading a
+   * read that buildReads later drops can spend a retry on an observation the
+   * server would never validate.
+   */
+  private commitReadActivities(
+    source: IStorageTransaction,
+    reads: Iterable<IReadActivity>,
+  ): IReadActivity[] {
+    // A mergeable op resolves against durable state, so it does not depend on
+    // the document's prior value. Reads incidental to the op are excluded,
+    // while a handler's own explicit read remains a real dependency.
+    const mergeableOpPathsByEntity = new Map<
+      string,
+      (readonly string[])[]
+    >();
+    for (const op of getDirectTransactionMergeableOpAddresses(source) ?? []) {
+      if (op.space !== this.#space) continue;
+      const key = `${op.id}\0${normalizeCellScope(op.scope)}`;
+      const paths = mergeableOpPathsByEntity.get(key);
+      if (paths) {
+        paths.push(op.path);
+      } else {
+        mergeableOpPathsByEntity.set(key, [op.path]);
+      }
+    }
+
+    const commitReads: IReadActivity[] = [];
+    for (const read of reads) {
+      if (
+        read.space !== this.#space ||
+        (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
+        hasDataUriScheme(read.id) ||
+        // Content-addressed documents cannot change, so their reads carry no
+        // commit-time concurrency precondition.
+        read.id.startsWith("cid:") ||
+        // Blind UI-input write-target reads are replaced by one structural
+        // parent read after buildReads' main loop.
+        isReadIgnoredForCommit(read.meta) ||
+        // Reference-resolution shape reads stay reactive but do not constrain
+        // the commit; recursive reads remain value dependencies.
+        (isReadExcludedFromConflict(read.meta) &&
+          read.nonRecursive === true) ||
+        // Runtime verifier reads of the CFC label are point-in-time policy
+        // observations, not consumed values.
+        (isInternalVerifierRead(read.meta) && isCfcLabelPath(read.path))
+      ) {
+        continue;
+      }
+
+      const scope = normalizeCellScope(read.scope);
+      const opPaths = mergeableOpPathsByEntity.get(`${read.id}\0${scope}`);
+      // A read of an op array's length is a genuine dependency: the handler
+      // used the element count that a concurrent mergeable op changes.
+      const readsMergeableOpArrayLength = opPaths !== undefined &&
+        opPaths.some((opPath) => isArrayLengthChildPath(opPath, read.path));
+      if (
+        opPaths !== undefined &&
+        !readsMergeableOpArrayLength &&
+        (isMergeableOpRead(read.meta) ||
+          isReadMarkedAsAttemptedWrite(read.meta) ||
+          isCfcLabelPath(read.path) ||
+          opPaths.some((opPath) =>
+            isStrictPrefixPath(opPath, read.path) ||
+            (read.nonRecursive === true && isSamePath(opPath, read.path))
+          ))
+      ) {
+        continue;
+      }
+      commitReads.push(read);
+    }
+    return commitReads;
+  }
+
+  /**
    * Load the documents a transaction read as absent without the replica ever
    * having examined them, and report how many turned out to exist.
    *
@@ -5749,15 +5856,8 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       ownWrites.add(docKey(write.id, this.instanceKey(write.scope)));
     }
     const unexamined = new Map<string, WatchAddress>();
-    for (const read of reads) {
+    for (const read of this.commitReadActivities(source, reads)) {
       if (
-        read.space !== this.#space ||
-        (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
-        hasDataUriScheme(read.id) ||
-        // Content-addressed reads carry no commit-time concurrency
-        // precondition at all, so `buildReads` drops them before any seq is
-        // exported.
-        read.id.startsWith("cid:") ||
         normalizeCellScope(read.scope) === "session"
       ) {
         continue;
@@ -5776,24 +5876,71 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
     // the commit-gated runner start among them.
     if (unexamined.size === 0) return 0;
     return (async () => {
+      // Like pull(), a one-shot probe must not reuse a session invalidated by
+      // an ACL change merely because the normal selector tracker is bypassed.
+      this.#consumeOwedSessionRemount();
+      const entries = normalizeSyncEntries(
+        [...unexamined.values()].map((
+          address,
+        ): [WatchAddress, SchemaPathSelector] => [
+          address,
+          // Fetch the document itself and follow no links. The basis needs
+          // this document's revision, not a schema-guided closure.
+          { path: [], schema: false },
+        ]),
+      );
+      // These probes own distinct watches so an absent result can be removed
+      // without disturbing a concurrent or pre-existing ordinary pull.
+      const watchBranch = `absence:${crypto.randomUUID()}`;
+      const watchIds = entries.map(([address, selector]) =>
+        watchIdForEntry(address, selector, watchBranch)
+      );
       try {
-        // `schema: false` asks for the document and follows nothing: what a
-        // basis needs is the document's own version, not the closure a
-        // schema-guided read would reach.
-        await this.pull(
-          [...unexamined.values()].map((
-            address,
-          ): [WatchAddress, SchemaPathSelector] => [
-            address,
-            { path: [], schema: false },
-          ]),
+        const result = await this.refreshWatchSet(
+          entries,
+          "pull",
+          watchBranch,
         );
+        if (result.error) {
+          await this.#removeWatchIds(watchIds);
+          return 0;
+        }
+
+        const absentWatchIds: string[] = [];
+        const covered = Promise.resolve({ ok: {} } as Result<Unit, PullError>);
+        for (let index = 0; index < entries.length; index++) {
+          const [address, selector] = entries[index];
+          const key = docKey(address.id, this.instanceKey(address.scope));
+          if ((this.#docs.get(key)?.confirmed.seq ?? 0) === 0) {
+            absentWatchIds.push(watchIds[index]);
+            continue;
+          }
+          // A discovered document is now a real dependency of the retry.
+          // Retain its watch and teach ordinary pulls that the selector is
+          // covered, even though this probe used a distinct watch id.
+          this.#watchSelectorTracker.add(
+            {
+              id: address.id,
+              type: DOCUMENT_MIME,
+              scope: normalizeCellScope(address.scope),
+              ...(address.scopeKey !== undefined
+                ? { scopeKey: address.scopeKey }
+                : {}),
+            },
+            selector,
+            covered,
+          );
+        }
+        // A never-created id must not become permanent live subscription
+        // state merely because one transaction asserted its absence.
+        await this.#removeWatchIds(absentWatchIds);
         let present = 0;
         for (const key of unexamined.keys()) {
           if ((this.#docs.get(key)?.confirmed.seq ?? 0) > 0) present += 1;
         }
         return present;
       } catch {
+        await this.#removeWatchIds(watchIds);
         // Best-effort, like the retry gate it front-runs: an unexamined
         // absence is what this path exported before, and the commit's own
         // verdict still decides.
@@ -5924,111 +6071,8 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       }
     };
 
-    // A mergeable op resolves against durable state, so it does not depend on
-    // the document's prior value. On an entity touched by a mergeable op, the
-    // reads the op ITSELF issues are dropped from conflict detection — its own
-    // value read (marked `mergeableOpRead`), its write-target reads (marked
-    // attempted-write), and the CFC write-policy label at ["cfc"] — so disjoint
-    // and stale-base writes merge and the op applies on top of a concurrent
-    // whole-entity write. A handler's OWN explicit read of the entity is kept,
-    // so a conditional mergeable write (e.g. dedup-then-push) still conflicts
-    // and retries. Server-side write authorization is enforced at apply time.
-    const mergeableOpPathsByEntity = new Map<string, (readonly string[])[]>();
-    for (const op of getDirectTransactionMergeableOpAddresses(source) ?? []) {
-      if (op.space !== this.#space) continue;
-      const key = `${op.id}\0${normalizeCellScope(op.scope)}`;
-      const paths = mergeableOpPathsByEntity.get(key);
-      if (paths) {
-        paths.push(op.path);
-      } else {
-        mergeableOpPathsByEntity.set(key, [op.path]);
-      }
-    }
-
-    for (const read of reads) {
-      if (
-        read.space !== this.#space ||
-        (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
-        hasDataUriScheme(read.id) ||
-        // Content-addressed documents carry no commit-time concurrency
-        // precondition at all: their content can never change (the engine
-        // and every replica refuse content that does not hash to the id),
-        // so there is no staleness for a conflict check to find — while
-        // the client's confirmed basis for a cid: doc it resolved from
-        // its overlay or the realm registry is 0, and the doc's first
-        // INSTALL is a real revision row, so exporting that read killed
-        // the commit as `stale confirmed read: cid:… at seq 0` exactly
-        // in the delivery-gap window the resolution fallbacks serve
-        // (layer-indifference extended from layers to seqs; the
-        // server-side closure validation owns presence).
-        read.id.startsWith("cid:")
-      ) {
-        continue;
-      }
-      // A read tagged `ignoreReadForCommit` (UI-input blind-leaf-write mode) is not
-      // a value-equality concurrency precondition: a blind `set` must not lose the
-      // own-write race on its own write-target read. Drop it from the conflict set.
-      // Its structural replacement — one nonRecursive read at the cell's PARENT — is
-      // emitted once after the loop from the threaded `structuralTarget`, since the
-      // logical write path is known only at handleCellSet, not from this diff.
-      if (isReadIgnoredForCommit(read.meta)) {
-        continue;
-      }
-
-      // Reference-resolution reads (e.g. asCell argument materialization following
-      // a write-redirect to construct the Cell) are tagged excludeReadFromConflict.
-      // Scoped to NONRECURSIVE (shape/topology) reads: those resolve a reference,
-      // not consume a value, so they must not enter the conflict set (they stay in
-      // the journal for reactivity). A RECURSIVE read in the same scope is a real
-      // value dependency (a by-value arg) and is kept. Inert unless reads are marked.
-      if (isReadExcludedFromConflict(read.meta) && read.nonRecursive === true) {
-        continue;
-      }
-
-      // A runtime-internal read of a document's CFC metadata path resolves
-      // labels. It is outside the attempt's consumed set (CFC spec §18.6.2,
-      // read exclusions for runtime-internal reads), and a derived label
-      // records the join the attempt observed rather than subscribing to its
-      // sources (§8.9.4, point-in-time semantics). The read stays in the
-      // journal, so reactivity re-runs when the envelope changes; only the
-      // commit's conflict precondition drops it. A handler's own label
-      // introspection consumes through an explicit observation record rather
-      // than through this raw read.
-      if (isInternalVerifierRead(read.meta) && isCfcLabelPath(read.path)) {
-        continue;
-      }
-
+    for (const read of this.commitReadActivities(source, reads)) {
       const scope = normalizeCellScope(read.scope);
-
-      const opPaths = mergeableOpPathsByEntity.get(`${read.id}\0${scope}`);
-      // A read of the op array's own `length` is the handler depending on the
-      // element count, which a mergeable append / add-unique / remove-by-value
-      // changes. The op itself never reads `length` (it reads the array value
-      // and its new-element slots), so this read is a genuine dependency and is
-      // kept from every drop below: a push whose new element's index or id came
-      // from the length conflicts and retries against a concurrent append.
-      const readsMergeableOpArrayLength = opPaths !== undefined &&
-        opPaths.some((opPath) => isArrayLengthChildPath(opPath, read.path));
-      if (
-        opPaths !== undefined &&
-        !readsMergeableOpArrayLength &&
-        (isMergeableOpRead(read.meta) ||
-          isReadMarkedAsAttemptedWrite(read.meta) ||
-          isCfcLabelPath(read.path) ||
-          // Deep reads under the op path (link resolution, element sub-reads) are
-          // incidental to the op. A shape-only (nonRecursive) read AT the op path
-          // is also incidental — it is the container read a view of the array
-          // records, which must not false-conflict with a concurrent mergeable
-          // op on that array. A RECURSIVE read AT the op path is the
-          // handler's explicit read of the collection, and is kept so a
-          // conditional mergeable write still conflicts and retries.
-          opPaths.some((opPath) =>
-            isStrictPrefixPath(opPath, read.path) ||
-            (read.nonRecursive === true && isSamePath(opPath, read.path))
-          ))
-      ) {
-        continue;
-      }
       pushCommitRead(
         read.id as URI,
         scope,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -125,6 +125,7 @@ import {
 import {
   getDirectTransactionMergeableOpAddresses,
   getDirectTransactionReadActivities,
+  getTransactionWriteAttempts,
 } from "./transaction-inspection.ts";
 import {
   getBlindStructuralTarget,
@@ -2333,6 +2334,13 @@ class Provider implements IStorageProvider, IOperationStorageCapability {
     ) as Promise<
       Result<Unit, Error>
     >;
+  }
+
+  /** See {@link SpaceReplica.loadUnexaminedAbsences}. */
+  loadUnexaminedAbsences(
+    source: IStorageTransaction | undefined,
+  ): number | Promise<number> {
+    return this.replica.loadUnexaminedAbsences(source);
   }
 
   async #replaySync(
@@ -5699,6 +5707,99 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
       this.#rejectedPendingLayers.delete(localSeq);
       dropped.resolve();
     }
+  }
+
+  /**
+   * Load the documents a transaction read as absent without the replica ever
+   * having examined them, and report how many turned out to exist.
+   *
+   * A read of a document the replica never synced resolves as absent, and
+   * {@link buildReads} exports that as `seq: 0` — the claim that no such
+   * document exists. The engine rejects the commit as `stale confirmed read`
+   * whenever one does, and the rejection is right: the reading run followed
+   * a link into a document it did not hold, so its traversal is sound only
+   * if that document really is absent. `Runtime.editWithRetry` calls this
+   * between running its action and committing, and a non-zero return is its
+   * signal to discard the attempt and re-run against the now-local
+   * documents — the same convergence the engine's rejection would force,
+   * without the round trip, the catch-up gate, or the wasted upload.
+   *
+   * Session-scoped reads are excluded: a session instance is keyed by this
+   * connection's own fresh session id, so no server-side revision can exist
+   * under it and its absence claims can never conflict. Space- and
+   * user-scoped instances persist across sessions and stay covered.
+   *
+   * The instance key matches {@link buildReads}, which builds the read set
+   * against the replica's own instances.
+   */
+  loadUnexaminedAbsences(
+    source: IStorageTransaction | undefined,
+  ): number | Promise<number> {
+    if (source === undefined) return 0;
+    const reads = getDirectTransactionReadActivities(source);
+    if (!reads) return 0;
+    // Documents this transaction writes are its own creations in flight:
+    // reading one as absent and then writing it is what creating a document
+    // IS, and the paired absence claim is what the engine validates the
+    // create against. Only reads with no such write are absences the
+    // transaction merely relied on.
+    const ownWrites = new Set<string>();
+    for (const write of getTransactionWriteAttempts(source) ?? []) {
+      if (write.space !== this.#space) continue;
+      ownWrites.add(docKey(write.id, this.instanceKey(write.scope)));
+    }
+    const unexamined = new Map<string, WatchAddress>();
+    for (const read of reads) {
+      if (
+        read.space !== this.#space ||
+        (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
+        hasDataUriScheme(read.id) ||
+        // Content-addressed reads carry no commit-time concurrency
+        // precondition at all, so `buildReads` drops them before any seq is
+        // exported.
+        read.id.startsWith("cid:") ||
+        normalizeCellScope(read.scope) === "session"
+      ) {
+        continue;
+      }
+      const key = docKey(read.id, this.instanceKey(read.scope));
+      if (ownWrites.has(key)) continue;
+      if (this.#docs.has(key) || unexamined.has(key)) continue;
+      unexamined.set(key, {
+        id: read.id,
+        type: DOCUMENT_MIME as MIME,
+        scope: normalizeCellScope(read.scope),
+      });
+    }
+    // Synchronous zero: with nothing to examine there is nothing to await,
+    // and callers whose commit path is synchronous today stay synchronous —
+    // the commit-gated runner start among them.
+    if (unexamined.size === 0) return 0;
+    return (async () => {
+      try {
+        // `schema: false` asks for the document and follows nothing: what a
+        // basis needs is the document's own version, not the closure a
+        // schema-guided read would reach.
+        await this.pull(
+          [...unexamined.values()].map((
+            address,
+          ): [WatchAddress, SchemaPathSelector] => [
+            address,
+            { path: [], schema: false },
+          ]),
+        );
+        let present = 0;
+        for (const key of unexamined.keys()) {
+          if ((this.#docs.get(key)?.confirmed.seq ?? 0) > 0) present += 1;
+        }
+        return present;
+      } catch {
+        // Best-effort, like the retry gate it front-runs: an unexamined
+        // absence is what this path exported before, and the commit's own
+        // verdict still decides.
+        return 0;
+      }
+    })();
   }
 
   private buildReads(

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -435,6 +435,51 @@ describe("editWithRetry absence reconciliation", () => {
     }
   });
 
+  it("stops retry readiness before and between waits when teardown is signaled", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    try {
+      const alreadyAborted = new AbortController();
+      alreadyAborted.abort();
+      let firstGateConsulted = false;
+      await runtime.awaitCommitRetryReadiness({
+        readyToRetry: () => {
+          firstGateConsulted = true;
+          return Promise.resolve();
+        },
+      }, alreadyAborted.signal);
+      expect(firstGateConsulted).toBe(true);
+
+      // Model teardown landing after the catch-up gate has settled but before
+      // the conflict-document pull begins. The helper removes its listener as
+      // it leaves the first wait; making that removal observe the teardown
+      // deterministically exercises the same inter-phase race without timing.
+      let abortedBetweenWaits = false;
+      const interveningSignal = {
+        get aborted() {
+          return abortedBetweenWaits;
+        },
+        addEventListener() {},
+        removeEventListener() {
+          abortedBetweenWaits = true;
+        },
+      } as unknown as AbortSignal;
+      await runtime.awaitCommitRetryReadiness({
+        readyToRetry: () => Promise.resolve(),
+        conflict: { space, of: "of:must-not-be-pulled" },
+      }, interveningSignal);
+      expect(abortedBetweenWaits).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+
   it("does not resume a reconciled edit after runtime disposal", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -382,6 +382,59 @@ describe("editWithRetry absence reconciliation", () => {
     }
   });
 
+  it("cancels a retry readiness wait when kept-storage disposal begins", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const readiness = Promise.withResolvers<void>();
+    const waiting = Promise.withResolvers<void>();
+    let editing: ReturnType<Runtime["editWithRetry"]> | undefined;
+    let disposed = false;
+    try {
+      editing = runtime.editWithRetry((tx) => {
+        tx.commit = (() =>
+          Promise.resolve({
+            error: {
+              name: "ConflictError",
+              message: "synthetic conflict with a stuck catch-up gate",
+              readyToRetry: () => {
+                waiting.resolve();
+                return readiness.promise;
+              },
+            },
+          })) as typeof tx.commit;
+      });
+      await waiting.promise;
+
+      await runtime.dispose({ closeStorage: false });
+      disposed = true;
+
+      const timeout = Symbol("retry readiness timeout");
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        editing,
+        new Promise<typeof timeout>((resolve) => {
+          timer = setTimeout(() => resolve(timeout), 250);
+        }),
+      ]);
+      if (timer !== undefined) clearTimeout(timer);
+      expect(outcome).not.toBe(timeout);
+      if (outcome !== timeout) {
+        expect(outcome.error?.name).toBe("StorageTransactionAborted");
+        expect(outcome.error?.message).toContain("runtime is disposing");
+      }
+    } finally {
+      readiness.resolve();
+      await editing?.catch(() => undefined);
+      if (!disposed) await runtime.dispose({ closeStorage: false });
+      await sm.close();
+      await server.close();
+    }
+  });
+
   it("does not resume a reconciled edit after runtime disposal", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("absence reconciliation test");
+const space = signer.did();
+
+const valueSchema = {
+  type: "object",
+  properties: { value: { type: "number" } },
+} as const;
+
+describe("editWithRetry absence reconciliation", () => {
+  // A transaction that reads a document this replica never synced records an
+  // absence, which the commit would export as a `seq: 0` confirmed read — a
+  // claim the engine rejects whenever the document exists. `editWithRetry`
+  // loads such documents before committing and re-runs its action locally
+  // when any turn out to exist, so convergence costs local rounds instead of
+  // wire rejections. These tests pin the local path apart from the wire path
+  // by whether the conflict machinery (`awaitCommitRetryReadiness`) is ever
+  // consulted: both paths converge to the same result, only one of them
+  // round-trips a doomed commit to get there.
+  it("re-runs locally against a document another client already wrote, without a wire conflict", async () => {
+    const server = newSharedServer();
+    const smA = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: smA,
+    });
+    let smB: EmulatedStorageManager | undefined;
+    let runtimeB: Runtime | undefined;
+    try {
+      // Client A creates the document and settles it server-side.
+      const txA = runtimeA.edit();
+      runtimeA.getCell(space, "shared-absence-doc", valueSchema, txA)
+        .set({ value: 42 });
+      await txA.commit();
+      await smA.synced();
+
+      // Client B is a cold replica of the same space.
+      smB = EmulatedStorageManager.connectTo(server, { as: signer });
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smB,
+      });
+      let readinessConsulted = 0;
+      const readiness = runtimeB.awaitCommitRetryReadiness.bind(runtimeB);
+      runtimeB.awaitCommitRetryReadiness = (error: unknown) => {
+        readinessConsulted++;
+        return readiness(error);
+      };
+
+      let runs = 0;
+      let observed: { value?: number } | undefined;
+      const result = await runtimeB.editWithRetry((tx) => {
+        runs++;
+        // Reads the foreign document cold: absent on the first run, so the
+        // read would commit as an absence claim over an existing document.
+        observed = runtimeB!.getCell(
+          space,
+          "shared-absence-doc",
+          valueSchema,
+          tx,
+        ).get();
+        runtimeB!.getCell(space, "b-own-doc", valueSchema, tx)
+          .set({ value: runs });
+      });
+
+      expect(result.error).toBeUndefined();
+      // One local re-run: the loaded document changes what the action reads.
+      expect(runs).toBe(2);
+      expect(observed).toEqual({ value: 42 });
+      // The discriminator: convergence never consulted the wire-conflict
+      // machinery. Without the pre-commit load, the same outcome arrives via
+      // a rejected commit and this counter.
+      expect(readinessConsulted).toBe(0);
+    } finally {
+      await runtimeB?.dispose();
+      await runtimeA.dispose();
+      await smB?.close();
+      await smA.close();
+      await server.close();
+    }
+  });
+
+  it("commits on the first run when the absent documents are absent everywhere", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    try {
+      let runs = 0;
+      const result = await runtime.editWithRetry((tx) => {
+        runs++;
+        // A document nobody ever wrote: the absence is sound, so it commits
+        // as an examined absence rather than forcing a re-run.
+        runtime.getCell(space, "never-written-doc", valueSchema, tx).get();
+        runtime.getCell(space, "own-doc", valueSchema, tx).set({ value: 1 });
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(runs).toBe(1);
+    } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("reports through the provider how many unexamined absences exist", async () => {
+    const server = newSharedServer();
+    const smA = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtimeA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: smA,
+    });
+    let smB: EmulatedStorageManager | undefined;
+    let runtimeB: Runtime | undefined;
+    try {
+      const txA = runtimeA.edit();
+      runtimeA.getCell(space, "provider-level-doc", valueSchema, txA)
+        .set({ value: 7 });
+      await txA.commit();
+      await smA.synced();
+
+      smB = EmulatedStorageManager.connectTo(server, { as: signer });
+      runtimeB = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: smB,
+      });
+      const txB = runtimeB.edit();
+      runtimeB.getCell(space, "provider-level-doc", valueSchema, txB).get();
+      runtimeB.getCell(space, "provider-level-absent", valueSchema, txB).get();
+
+      const provider = smB.open(space);
+      expect(provider.loadUnexaminedAbsences).toBeDefined();
+      // Of the two cold reads, exactly one document turns out to exist; the
+      // other's absence is examined and stays a sound claim.
+      expect(await provider.loadUnexaminedAbsences!(txB.tx)).toBe(1);
+      // Loaded is loaded: a second pass finds nothing left unexamined.
+      expect(await provider.loadUnexaminedAbsences!(txB.tx)).toBe(0);
+      txB.abort("inspection only");
+    } finally {
+      await runtimeB?.dispose();
+      await runtimeA.dispose();
+      await smB?.close();
+      await smA.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -3,6 +3,8 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
+import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
+import { toMemorySpaceAddress } from "../src/link-types.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("absence reconciliation test");
@@ -106,6 +108,184 @@ describe("editWithRetry absence reconciliation", () => {
       expect(result.error).toBeUndefined();
       expect(runs).toBe(1);
     } finally {
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("removes the temporary watch after confirming an absence", async () => {
+    const server = newSharedServer();
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    let writerStorage: EmulatedStorageManager | undefined;
+    let writerRuntime: Runtime | undefined;
+    let probedAddress:
+      | ReturnType<typeof toMemorySpaceAddress>
+      | undefined;
+    try {
+      const result = await readerRuntime.editWithRetry((tx) => {
+        const probed = readerRuntime.getCell(
+          space,
+          "temporary-absence-watch-doc",
+          valueSchema,
+          tx,
+        );
+        probedAddress = toMemorySpaceAddress(probed.getAsNormalizedFullLink());
+        tx.read(probedAddress, { trackReadWithoutLoad: true });
+        readerRuntime.getCell(
+          space,
+          "temporary-absence-watch-output",
+          valueSchema,
+          tx,
+        ).set({ value: 1 });
+      });
+      expect(result.error).toBeUndefined();
+
+      // Create the probed document only after the absence transaction has
+      // committed. If reconciliation retained its one-shot watch, this later
+      // update would be pushed into the reader's replica.
+      writerStorage = EmulatedStorageManager.connectTo(server, { as: signer });
+      writerRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: writerStorage,
+      });
+      const create = writerRuntime.edit();
+      writerRuntime.getCell(
+        space,
+        "temporary-absence-watch-doc",
+        valueSchema,
+        create,
+      ).set({ value: 9 });
+      expect((await create.commit()).error).toBeUndefined();
+      await writerStorage.synced();
+      await server.flushSessions([space]);
+      await readerStorage.synced();
+
+      expect(
+        readerStorage.open(space).replica.getDocument(
+          probedAddress!.id,
+          probedAddress!.scope,
+        ),
+      ).toBeUndefined();
+    } finally {
+      await writerRuntime?.dispose();
+      await readerRuntime.dispose();
+      await writerStorage?.close();
+      await readerStorage.close();
+      await server.close();
+    }
+  });
+
+  it("does not reconcile reads excluded from the commit conflict set", async () => {
+    const server = newSharedServer();
+    const writerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const writerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    let readerStorage: EmulatedStorageManager | undefined;
+    let readerRuntime: Runtime | undefined;
+    try {
+      const excludedAddress = {
+        space,
+        id: "of:excluded-cold-read-doc" as const,
+        type: "application/json" as const,
+        scope: "space" as const,
+        path: [] as string[],
+      };
+      const seed = writerRuntime.edit();
+      seed.writeValueOrThrow(excludedAddress, { value: 17 });
+      expect((await seed.commit()).error).toBeUndefined();
+      await writerStorage.synced();
+
+      readerStorage = EmulatedStorageManager.connectTo(server, { as: signer });
+      readerRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: readerStorage,
+      });
+      let runs = 0;
+      const result = await readerRuntime.editWithRetry((tx) => {
+        runs++;
+        tx.read(
+          excludedAddress,
+          {
+            meta: excludeReadFromConflict,
+            nonRecursive: true,
+            trackReadWithoutLoad: true,
+          },
+        );
+        readerRuntime!.getCell(
+          space,
+          "excluded-cold-read-output",
+          valueSchema,
+          tx,
+        ).set({ value: runs });
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(runs).toBe(1);
+      expect(
+        readerStorage.open(space).replica.getDocument(
+          excludedAddress.id,
+          excludedAddress.scope,
+        ),
+      ).toBeUndefined();
+    } finally {
+      await readerRuntime?.dispose();
+      await writerRuntime.dispose();
+      await readerStorage?.close();
+      await writerStorage.close();
+      await server.close();
+    }
+  });
+
+  it("falls back to the commit verdict when reconciliation providers fail", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const provider = sm.open(space);
+    const original = provider.loadUnexaminedAbsences;
+    try {
+      const failures = [
+        () => {
+          throw new Error("synchronous reconciliation failure");
+        },
+        () => Promise.reject(new Error("asynchronous reconciliation failure")),
+      ];
+      for (let index = 0; index < failures.length; index++) {
+        provider.loadUnexaminedAbsences = failures[index];
+        let runs = 0;
+        const result = await runtime.editWithRetry((tx) => {
+          runs++;
+          runtime.getCell(
+            space,
+            `provider-failure-cold-${index}`,
+            valueSchema,
+            tx,
+          ).get();
+          runtime.getCell(
+            space,
+            `provider-failure-output-${index}`,
+            valueSchema,
+            tx,
+          ).set({ value: 1 });
+        });
+        expect(result.error).toBeUndefined();
+        expect(runs).toBe(1);
+      }
+    } finally {
+      provider.loadUnexaminedAbsences = original;
       await runtime.dispose();
       await sm.close();
       await server.close();

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -8,6 +8,10 @@ import {
 import { resolveScopeKey } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
+import type {
+  IExtendedStorageTransaction,
+  IStorageTransaction,
+} from "../src/storage/interface.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
 import { toMemorySpaceAddress } from "../src/link-types.ts";
@@ -290,8 +294,88 @@ describe("editWithRetry absence reconciliation", () => {
         expect(result.error).toBeUndefined();
         expect(runs).toBe(1);
       }
+
+      // The capability is optional. A provider that predates absence
+      // reconciliation must retain the original server-judged commit path.
+      provider.loadUnexaminedAbsences = undefined;
+      const result = await runtime.editWithRetry((tx) => {
+        runtime.getCell(
+          space,
+          "provider-without-reconciliation-capability",
+          valueSchema,
+          tx,
+        ).get();
+        runtime.getCell(
+          space,
+          "provider-without-reconciliation-output",
+          valueSchema,
+          tx,
+        ).set({ value: 1 });
+      });
+      expect(result.error).toBeUndefined();
     } finally {
       provider.loadUnexaminedAbsences = original;
+      await runtime.dispose();
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("aborts an edit when disposal begins inside its action", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    let disposing: Promise<void> | undefined;
+    try {
+      const result = await runtime.editWithRetry((tx) => {
+        runtime.getCell(
+          space,
+          "dispose-before-edit-commit",
+          valueSchema,
+          tx,
+        ).set({ value: 1 });
+        // The closing path sets the write gate synchronously before its first
+        // awaited teardown barrier. editWithRetry must abort this prepared
+        // transaction instead of committing behind disposal.
+        disposing = runtime.dispose();
+      });
+
+      expect(result.error?.name).toBe("StorageTransactionAborted");
+      expect(result.error?.message).toContain("runtime is disposing");
+      await disposing;
+    } finally {
+      await disposing?.catch(() => undefined);
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("returns a transaction error when commit rejects its promise", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const failure = new Error("synthetic commit rejection");
+    let attempted: IExtendedStorageTransaction | undefined;
+    try {
+      const result = await runtime.editWithRetry((tx) => {
+        attempted = tx;
+        tx.commit = (() => Promise.reject(failure)) as typeof tx.commit;
+        return "uncommitted";
+      }, 0);
+
+      expect(result.error?.name).toBe("StorageTransactionAborted");
+      expect(result.error?.message).toContain("synthetic commit rejection");
+      expect((result.error as { reason?: unknown } | undefined)?.reason).toBe(
+        failure,
+      );
+    } finally {
+      attempted?.abort("synthetic commit completed");
       await runtime.dispose();
       await sm.close();
       await server.close();
@@ -503,12 +587,40 @@ describe("editWithRetry absence reconciliation", () => {
 
       const provider = smB.open(space);
       expect(provider.loadUnexaminedAbsences).toBeDefined();
+      expect(await provider.loadUnexaminedAbsences!(undefined)).toBe(0);
+      expect(
+        await provider.loadUnexaminedAbsences!({
+          getReadActivities: () => undefined,
+        } as unknown as IStorageTransaction),
+      ).toBe(0);
+
+      // A write in another space is irrelevant to this replica's own-write
+      // exclusion, and must be skipped rather than keyed here.
+      const otherSpace = (await Identity.fromPassphrase(
+        "absence reconciliation unrelated space",
+      )).did();
+      runtimeB.getCell(otherSpace, "unrelated-write", valueSchema, txB)
+        .set({ value: 1 });
       // Of the two cold reads, exactly one document turns out to exist; the
       // other's absence is examined and stays a sound claim.
       expect(await provider.loadUnexaminedAbsences!(txB.tx)).toBe(1);
       // Loaded is loaded: a second pass finds nothing left unexamined.
       expect(await provider.loadUnexaminedAbsences!(txB.tx)).toBe(0);
       txB.abort("inspection only");
+
+      // A partial served identity cannot name a session instance on the wire.
+      // Leave that absence for ordinary commit admission.
+      const incomplete = runtimeB.edit();
+      incomplete.tx.scopeKeyIdentity = { principal: signer.did() };
+      incomplete.read({
+        space,
+        id: "of:incomplete-served-session-identity",
+        type: "application/json",
+        scope: "session",
+        path: [],
+      }, { trackReadWithoutLoad: true });
+      expect(await provider.loadUnexaminedAbsences!(incomplete.tx)).toBe(0);
+      incomplete.abort("inspection only");
     } finally {
       await runtimeB?.dispose();
       await runtimeA.dispose();

--- a/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
+++ b/packages/runner/test/edit-with-retry-absence-reconciliation.test.ts
@@ -1,8 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import {
+  ExecutionLeaseCycle,
+  executionLeaseHolder,
+} from "@commonfabric/memory/v2/execution-lease";
+import { resolveScopeKey } from "@commonfabric/memory/v2";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
+import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
 import { toMemorySpaceAddress } from "../src/link-types.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
@@ -288,6 +294,184 @@ describe("editWithRetry absence reconciliation", () => {
       provider.loadUnexaminedAbsences = original;
       await runtime.dispose();
       await sm.close();
+      await server.close();
+    }
+  });
+
+  it("does not resume a reconciled edit after runtime disposal", async () => {
+    const server = newSharedServer();
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    const provider = sm.open(space);
+    const original = provider.loadUnexaminedAbsences;
+    const reconciliation = Promise.withResolvers<number>();
+    let reconciliationCalled = false;
+    let disposed = false;
+    let outputAddress:
+      | ReturnType<typeof toMemorySpaceAddress>
+      | undefined;
+    try {
+      provider.loadUnexaminedAbsences = () => {
+        reconciliationCalled = true;
+        return reconciliation.promise;
+      };
+      const editing = runtime.editWithRetry((tx) => {
+        runtime.getCell(
+          space,
+          "dispose-during-reconciliation-input",
+          valueSchema,
+          tx,
+        ).get();
+        const output = runtime.getCell(
+          space,
+          "dispose-during-reconciliation-output",
+          valueSchema,
+          tx,
+        );
+        outputAddress = toMemorySpaceAddress(
+          output.getAsNormalizedFullLink(),
+        );
+        output.set({ value: 1 });
+      });
+      expect(reconciliationCalled).toBe(true);
+
+      await runtime.dispose({ closeStorage: false });
+      disposed = true;
+      reconciliation.resolve(0);
+      const result = await editing;
+
+      expect(result.error?.name).toBe("StorageTransactionAborted");
+      expect(
+        provider.replica.getDocument(
+          outputAddress!.id,
+          outputAddress!.scope,
+        ),
+      ).toBeUndefined();
+    } finally {
+      provider.loadUnexaminedAbsences = original;
+      reconciliation.resolve(0);
+      if (!disposed) await runtime.dispose({ closeStorage: false });
+      await sm.close();
+      await server.close();
+    }
+  });
+
+  it("reconciles the served transaction's user and session instances", async () => {
+    const actor = await Identity.fromPassphrase(
+      "absence reconciliation served actor",
+    );
+    const service = await Identity.fromPassphrase(
+      "absence reconciliation serving runtime",
+    );
+    const actorIdentity = {
+      principal: actor.did(),
+      sessionId: "absence-actor-session",
+    };
+    const server = newSharedServer();
+    let actorStorage: EmulatedStorageManager | undefined =
+      EmulatedStorageManager.connectTo(server, {
+        as: actor,
+        id: actorIdentity.sessionId,
+      });
+    let actorRuntime: Runtime | undefined = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: actorStorage,
+    });
+    let servingStorage: EmulatedStorageManager | undefined;
+    let servingRuntime: Runtime | undefined;
+    let lease: ExecutionLeaseCycle | undefined;
+    try {
+      const userCell = actorRuntime.getCell<{ value: number }>(
+        space,
+        "served-identity-user",
+        valueSchema,
+        undefined,
+        "user",
+      );
+      const sessionCell = actorRuntime.getCell<{ value: number }>(
+        space,
+        "served-identity-session",
+        valueSchema,
+        undefined,
+        "session",
+      );
+      const seed = actorRuntime.edit();
+      userCell.withTx(seed).set({ value: 11 });
+      sessionCell.withTx(seed).set({ value: 22 });
+      expect((await seed.commit()).error).toBeUndefined();
+      await actorStorage.synced();
+      const userId = userCell.getAsNormalizedFullLink().id;
+      const sessionId = sessionCell.getAsNormalizedFullLink().id;
+      await actorRuntime.dispose();
+      actorRuntime = undefined;
+      await actorStorage.close();
+      actorStorage = undefined;
+
+      const holder = executionLeaseHolder(service.did());
+      servingStorage = EmulatedStorageManager.connectTo(server, {
+        as: service,
+        id: holder,
+        servingHomeSpace: space,
+      });
+      servingRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: servingStorage,
+        servingPosture: true,
+        experimental: { serverExecution: true },
+      });
+      const engine = await server.engineForSpace(space);
+      lease = new ExecutionLeaseCycle({ engine, space, holder });
+      expect(lease.acquire()).toBe(true);
+
+      const tx = servingRuntime.edit();
+      stampWaveRunContext(tx, {
+        actionId: "reconcile-served-identity",
+        kind: "derivation",
+        scopeKeyIdentity: actorIdentity,
+        actionScopeKey: resolveScopeKey("user", actorIdentity),
+      });
+      tx.read({
+        space,
+        id: userId,
+        type: "application/json",
+        scope: "user",
+        path: [],
+      }, { trackReadWithoutLoad: true });
+      tx.read({
+        space,
+        id: sessionId,
+        type: "application/json",
+        scope: "session",
+        path: [],
+      }, { trackReadWithoutLoad: true });
+
+      const provider = servingStorage.open(space);
+      expect(await provider.loadUnexaminedAbsences!(tx.tx)).toBe(2);
+      expect(
+        (provider.replica.getDocument(userId, "user", actorIdentity)?.value as
+          | { value?: number }
+          | undefined)?.value,
+      ).toBe(11);
+      expect(
+        (provider.replica.getDocument(
+          sessionId,
+          "session",
+          actorIdentity,
+        )?.value as { value?: number } | undefined)?.value,
+      ).toBe(22);
+      expect(provider.replica.getDocument(userId, "user")).toBeUndefined();
+      expect(provider.replica.getDocument(sessionId, "session"))
+        .toBeUndefined();
+      tx.abort("inspection only");
+    } finally {
+      lease?.release();
+      await servingRuntime?.dispose();
+      await actorRuntime?.dispose();
+      await servingStorage?.close();
+      await actorStorage?.close();
       await server.close();
     }
   });

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -111,13 +111,15 @@ class WatchAddRemoveTransport extends ScriptedSessionTransport {
 // corrected complete set and acknowledges cleanup.
 class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
   watchRemovalAttempts = 0;
+  readonly #failuresBeforeSuccess: number;
 
-  constructor() {
+  constructor(failuresBeforeSuccess = 1) {
     super({
       name: "watch-removal-retry",
       sessionId: "session:watch-removal-retry",
       space,
     });
+    this.#failuresBeforeSuccess = failuresBeforeSuccess;
   }
 
   protected override handle(message: ScriptedTransportMessage): void {
@@ -149,7 +151,7 @@ class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
       }
       case "session.watch.set":
         this.watchRemovalAttempts++;
-        if (this.watchRemovalAttempts === 1) {
+        if (this.watchRemovalAttempts <= this.#failuresBeforeSuccess) {
           this.respond({
             type: "response",
             requestId: message.requestId!,
@@ -235,6 +237,92 @@ Deno.test("absence reconciliation retries a failed temporary watch removal", asy
     assertEquals(await provider.loadUnexaminedAbsences(tx.tx), 0);
     assertEquals(transport.watchRemovalAttempts, 2);
   } finally {
+    tx.abort("inspection only");
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence reconciliation retries when applying a watch removal sync fails", async () => {
+  const transport = new FailFirstWatchRemovalTransport(0);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-removal-apply-retry"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space);
+  const replica = provider.replica as unknown as {
+    applySessionSync(sync: unknown, type: string): void;
+  };
+  const originalApply = replica.applySessionSync.bind(replica);
+  let applyCalls = 0;
+  replica.applySessionSync = (sync, type) => {
+    applyCalls++;
+    if (applyCalls === 2) {
+      replica.applySessionSync = originalApply;
+      throw new Error("synthetic watch removal apply failure");
+    }
+    originalApply(sync, type);
+  };
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-removal-apply-retry-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+
+  try {
+    assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
+    assertEquals(transport.watchRemovalAttempts, 2);
+  } finally {
+    replica.applySessionSync = originalApply;
+    tx.abort("inspection only");
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence reconciliation warns after temporary watch cleanup exhausts retries", async () => {
+  const transport = new FailFirstWatchRemovalTransport(2);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-removal-exhausted"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space);
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-removal-exhausted-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+  const originalWarn = console.warn;
+  const warnings: unknown[][] = [];
+  console.warn = (...values: unknown[]) => warnings.push(values);
+
+  try {
+    assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
+    assertEquals(transport.watchRemovalAttempts, 2);
+    assertEquals(
+      warnings.some((values) =>
+        values[0] === "failed to remove temporary graph watches after retry"
+      ),
+      true,
+    );
+  } finally {
+    console.warn = originalWarn;
     tx.abort("inspection only");
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -14,6 +14,7 @@ import {
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
 import type { IStorageProvider } from "../src/storage/interface.ts";
+import { Runtime } from "../src/runtime.ts";
 import {
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -104,6 +105,82 @@ class WatchAddRemoveTransport extends ScriptedSessionTransport {
   }
 }
 
+// The first full watch-set update fails without changing server state. The
+// runner must issue it again: watchRemoveSync has already removed the probe id
+// from the session's local watch intent, so the second request carries the
+// corrected complete set and acknowledges cleanup.
+class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
+  watchRemovalAttempts = 0;
+
+  constructor() {
+    super({
+      name: "watch-removal-retry",
+      sessionId: "session:watch-removal-retry",
+      space,
+    });
+  }
+
+  protected override handle(message: ScriptedTransportMessage): void {
+    switch (message.type) {
+      case "session.watch.add": {
+        const roots =
+          message.watches?.flatMap((watch) =>
+            watch.query?.roots?.map((root) => root.id as URI) ?? []
+          ) ?? [];
+        this.respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 1,
+            sync: {
+              type: "sync",
+              fromSeq: 0,
+              toSeq: 1,
+              upserts: [],
+              removes: roots.map((id) => ({
+                branch: "",
+                id,
+                scope: "space" as const,
+              })),
+            } satisfies SessionSync,
+          },
+        });
+        return;
+      }
+      case "session.watch.set":
+        this.watchRemovalAttempts++;
+        if (this.watchRemovalAttempts === 1) {
+          this.respond({
+            type: "response",
+            requestId: message.requestId!,
+            error: {
+              name: "ConnectionError",
+              message: "synthetic first removal failure",
+            },
+          });
+          return;
+        }
+        this.respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 1,
+            sync: {
+              type: "sync",
+              fromSeq: 1,
+              toSeq: 1,
+              upserts: [],
+              removes: [],
+            } satisfies SessionSync,
+          },
+        });
+        return;
+      default:
+        throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+  }
+}
+
 Deno.test("memory v2 runner applies removes carried in a watch refresh batch", async () => {
   const docA = `of:watch-remove-keep-${crypto.randomUUID()}` as URI;
   const docB = `of:watch-remove-drop-${crypto.randomUUID()}` as URI;
@@ -126,6 +203,40 @@ Deno.test("memory v2 runner applies removes carried in a watch refresh batch", a
     assertEquals(getObjectValue(provider, docA), { label: docA });
     assertEquals(provider.get(docB), undefined);
   } finally {
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence reconciliation retries a failed temporary watch removal", async () => {
+  const transport = new FailFirstWatchRemovalTransport();
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-removal-retry"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space);
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-removal-retry-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+
+  try {
+    if (provider.loadUnexaminedAbsences === undefined) {
+      throw new Error("absence reconciliation capability unavailable");
+    }
+    assertEquals(await provider.loadUnexaminedAbsences(tx.tx), 0);
+    assertEquals(transport.watchRemovalAttempts, 2);
+  } finally {
+    tx.abort("inspection only");
+    await runtime.dispose();
     await storageManager.close();
   }
 });

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -111,15 +111,19 @@ class WatchAddRemoveTransport extends ScriptedSessionTransport {
 // corrected complete set and acknowledges cleanup.
 class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
   watchRemovalAttempts = 0;
+  onWatchAdded?: () => void;
   readonly #failuresBeforeSuccess: number;
+  readonly #precedingId?: URI;
+  #serverSeq = 1;
 
-  constructor(failuresBeforeSuccess = 1) {
+  constructor(failuresBeforeSuccess = 1, precedingId?: URI) {
     super({
       name: "watch-removal-retry",
       sessionId: "session:watch-removal-retry",
       space,
     });
     this.#failuresBeforeSuccess = failuresBeforeSuccess;
+    this.#precedingId = precedingId;
   }
 
   protected override handle(message: ScriptedTransportMessage): void {
@@ -129,15 +133,16 @@ class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
           message.watches?.flatMap((watch) =>
             watch.query?.roots?.map((root) => root.id as URI) ?? []
           ) ?? [];
+        this.onWatchAdded?.();
         this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
-            serverSeq: 1,
+            serverSeq: this.#serverSeq,
             sync: {
               type: "sync",
               fromSeq: 0,
-              toSeq: 1,
+              toSeq: this.#serverSeq,
               upserts: [],
               removes: roots.map((id) => ({
                 branch: "",
@@ -162,15 +167,30 @@ class FailFirstWatchRemovalTransport extends ScriptedSessionTransport {
           });
           return;
         }
+        if (this.#precedingId !== undefined) {
+          const fromSeq = this.#serverSeq;
+          this.#serverSeq++;
+          this.emitSync({
+            type: "sync",
+            fromSeq,
+            toSeq: this.#serverSeq,
+            upserts: [
+              doc(this.#precedingId, this.#serverSeq, {
+                value: { label: "preceding cleanup sync" },
+              }),
+            ],
+            removes: [],
+          });
+        }
         this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
-            serverSeq: 1,
+            serverSeq: this.#serverSeq,
             sync: {
               type: "sync",
-              fromSeq: 1,
-              toSeq: 1,
+              fromSeq: this.#serverSeq,
+              toSeq: this.#serverSeq,
               upserts: [],
               removes: [],
             } satisfies SessionSync,
@@ -237,6 +257,123 @@ Deno.test("absence reconciliation retries a failed temporary watch removal", asy
     assertEquals(await provider.loadUnexaminedAbsences(tx.tx), 0);
     assertEquals(transport.watchRemovalAttempts, 2);
   } finally {
+    tx.abort("inspection only");
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence cleanup integrates syncs that precede its watch mutation", async () => {
+  const precedingId =
+    `of:watch-removal-preceding-${crypto.randomUUID()}` as URI;
+  const transport = new FailFirstWatchRemovalTransport(0, precedingId);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-removal-preceding"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space) as TestProvider;
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-removal-preceding-probe-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+
+  try {
+    assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
+    assertEquals(getObjectValue(provider, precedingId), {
+      label: "preceding cleanup sync",
+    });
+  } finally {
+    tx.abort("inspection only");
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence cleanup closes a returned view when the replica closes concurrently", async () => {
+  const transport = new FailFirstWatchRemovalTransport(0);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-removal-close-race"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space);
+  let closing: Promise<void> | undefined;
+  transport.onWatchAdded = () => {
+    const session = sessionFactory.session!;
+    const original = session.watchRemoveSync.bind(session);
+    session.watchRemoveSync = async (watchIds) => {
+      const result = await original(watchIds);
+      closing = (provider.replica as unknown as { close(): Promise<void> })
+        .close();
+      return result;
+    };
+    transport.onWatchAdded = undefined;
+  };
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-removal-close-race-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+
+  try {
+    assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
+    await closing;
+  } finally {
+    tx.abort("inspection only");
+    await closing;
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("absence reconciliation cleans up after an unexpected probe exception", async () => {
+  const transport = new FailFirstWatchRemovalTransport(0);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-probe-exception"),
+  }, sessionFactory);
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const provider = storageManager.open(space);
+  const replica = provider.replica as unknown as {
+    refreshWatchSet(...args: unknown[]): Promise<unknown>;
+  };
+  const originalRefresh = replica.refreshWatchSet.bind(replica);
+  replica.refreshWatchSet = () =>
+    Promise.reject(new Error("synthetic unexpected probe exception"));
+  const tx = runtime.edit();
+  tx.read({
+    space,
+    id: `of:watch-probe-exception-${crypto.randomUUID()}`,
+    type: "application/json",
+    scope: "space",
+    path: [],
+  }, { trackReadWithoutLoad: true });
+
+  try {
+    assertEquals(await provider.loadUnexaminedAbsences!(tx.tx), 0);
+    assertEquals(transport.watchRemovalAttempts, 1);
+  } finally {
+    replica.refreshWatchSet = originalRefresh;
     tx.abort("inspection only");
     await runtime.dispose();
     await storageManager.close();


### PR DESCRIPTION
A transaction that reads a document its replica never synced records an absence, and the commit exports it as a `seq: 0` confirmed read — the claim that no such document exists. Where one does, the engine rejects the commit as `stale confirmed read`, the client waits out the conflict's catch-up gate, re-runs, and rebuilds — once per **layer** of cold documents, since each re-run follows the arrived layer's links into the next cold one.

`editWithRetry` now loads the unexamined documents before committing (one batched schema-free pull per space) and, when any turn out to exist, re-runs its action locally against them instead of shipping a doomed commit. Each local round consumes a retry from the same budget a rejection would.

## Why this is where the setsrc budget goes

Measured on a clone of the real topics space (106 topics, Aug-18 vintage, loopback), applying `packages/patterns/topics/topic.tsx` to one topic piece with `cf piece setsrc`. Replaying the engine's own conflict predicate (`findConflictSeq`: tier-1 set/delete path-blind, tier-2 patch overlap) offline against the clone's revision log:

- **Attempt 1 carries 510 conflicting absence claims over 255 distinct existing documents** — 219 of them baseline-era, i.e. real production data, all tier-1. The engine names only the first conflict per attempt, so this cohort surfaces as "2 conflicts per apply."
- **One catch-up gate converges a whole layer**: all 255 appear in attempt 2 at real seqs. Attempt 2's single residual conflict is a document attempt 1 never claimed — the re-run followed links through the arrived layer into the next cold document. Retry count = cold-link depth, not document count.
- Of attempt 1's 2,631 seq-0 claims, **2,112 are session/user-instance scoped**; a fresh session instance cannot exist server-side, so the conflict story lives entirely in the space-scoped remainder.
- The catch-up gates the retries wait on end with **empty** `session/effect` sync markers (`fromSeq == toSeq`, no upserts) after 1.4–6.4 s — pure ack latency, the term that scales with the serving shard's flush cadence.

## Measured (interleaved with main, same clone, same source)

| | main | this PR |
| --- | ---: | ---: |
| wall clock | 17.5 / 18.5 / 17.3 s | **6.4 / 6.2 / 6.7 s** |
| setup commits on the wire | 3 | **1** |
| rejections | 2 | **0** |
| upload payload | 17.8 MB | **7.3 MB** |

The single commit carries the same converged read set (2,017 examined absence claims) that main reaches on its third attempt; deployed pattern identity is byte-identical across arms, and migrated pieces read back and run. Loopback wall times are a floor: each avoided gate is 1.4–6.4 s here and rides the flush cadence on a deployed shard.

## The boundaries carry the semantics

- **Caller-owned.** The same semantics at `commitNative` failed 120 runner tests: every commit path pays there, and most callers own no re-run loop. `editWithRetry` is the caller that does.
- **Budget-gated.** With no retries left the load is skipped entirely. Loading without re-running would let `buildReads` export the documents' real seqs under a traversal that read them as absent — an accepted commit derived from an absence that was never there.
- **Synchronous zero-work path.** A transaction with nothing to examine keeps the fully synchronous commit path, which the commit-gated runner start depends on. The provider answers `0` synchronously in that case.
- **Own writes exempt.** Reading a document as absent and then writing it is what creating a document is; the paired absence claim is what the engine validates the create against.
- **Session-scoped reads exempt.** A session instance is keyed by this connection's fresh session id; no server-side revision can exist under it.

Tests pin the mechanism, not just the outcome: the discriminating assertion is that convergence never consults `awaitCommitRetryReadiness` (the wire-conflict path), verified by mutation — disabling the load flips exactly that assertion.

## Deliberately out of scope, for discussion

- **Commit-time basis repair.** A document arriving between a read and its commit silently upgrades the exported claim from `seq: 0` to the real seq under a traversal that read it as absent — pre-existing, and empirically confirmed during this work (an earlier draft that loaded without re-running produced *accepted* commits over stale traversals). This PR avoids the hazard rather than fixing it.
- **First-conflict throw.** `validateConfirmedReads` rejects on the first stale read, which masked the 255-document cohort as "2 conflicts" throughout. The wave path already names every failing precondition by index; the ordinary commit path could too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

