### PR TITLE
test: name the sections these five files were already organized into

### DIFF
--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -533,7 +533,7 @@ describe("cf piece call on a piece that points back at its container", () => {
   });
 
   //
-  // Refusals, and what they cost
+  // When the result will not render, and what that costs
   //
   // What the command does when the result will not render, and that it
   // does not pay to produce what it will not use.

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -342,13 +342,18 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
+  //
+  // The other half of "a caller's own shape wins"
+  //
   // The pair below is the other half of "a caller's own shape wins": a
   // selection that asks for an ADDRESS at one position and keeps the circle at
   // another. The address is the caller's whole answer where they asked for it,
   // and a bound that closed the object over the declared fields instead would
-  // answer `{}` there — contents where an address was asked for, which reads
-  // as a successful answer to a question nobody asked. Both bounds reach that
+  // answer `{}` there — contents where an address was asked for, which reads as
+  // a successful answer to a question nobody asked. Both bounds reach that
   // position, so both halves are here.
+  //
+
   it("keeps an address the caller asked for while the shape bounds the rest", async () => {
     await withTracker("cyclic-compact-marked", async ({ call }) => {
       const result = await call("addChildRow", ["--title", "Marked"], {
@@ -406,6 +411,9 @@ describe("cf piece call on a piece that points back at its container", () => {
     });
   });
 
+  //
+  // `item.title` against `item`: narrowing past the circle, or naming it whole
+  //
   // The pair below is one contrast, and it is the whole point of both halves:
   // `item.title` narrows PAST the position where the declared type re-enters,
   // so the value it produces holds no circle and nothing derived touches it;
@@ -414,6 +422,8 @@ describe("cf piece call on a piece that points back at its container", () => {
   // are a selection, and only one of them leaves a readback with nothing to do
   // — a suite holding either alone tests half of that and reads like it tests
   // all of it.
+  //
+
   it("leaves a caller's own selection in charge of the shape", async () => {
     await withTracker("cyclic-explicit-selection", async ({ call }) => {
       const result = await call("addChild", ["--title", "Selected"], {
@@ -457,6 +467,157 @@ describe("cf piece call on a piece that points back at its container", () => {
       expect(Object.hasOwn(result.item, "addChild")).toBe(false);
     });
   });
+
+  //
+  // The `--filter` pair
+  //
+  // The `--filter` pair, and the same contrast: a predicate hands back the
+  // elements themselves, so it can only keep a circle, never narrow past one.
+  // What decides between the two is the projection written beside it.
+  //
+
+  it("returns the elements a `--filter` keeps where the projection beside it renders", async () => {
+    await withTracker("cyclic-filter-renders", async ({ call }) => {
+      const result = await call("addChildren", ["--title", "Kept"], {
+        selection: {
+          filter: parseSelectionFilter('.title == "Kept"'),
+          projection: parseSelectProjection("title"),
+        },
+      }) as any;
+
+      // The projection beside the predicate narrows past the circle, so the
+      // surviving element renders and nothing is derived. An implementation
+      // that refused every cyclic-verb `--filter` outright would fail here.
+      expect(result).toEqual([{ title: "Kept" }]);
+    });
+  });
+
+  it("refuses a `--filter` that keeps the circle, naming the committed write", async () => {
+    await withTracker(
+      "cyclic-filter-retains",
+      async ({ call, patternLoads, root }) => {
+        const error = await call("addChildren", ["--title", "Filtered"], {
+          selection: { filter: parseSelectionFilter('.title == "Filtered"') },
+        }).then(() => undefined, (thrown: unknown) => thrown);
+
+        // Without the projection above, the predicate's survivor is the item
+        // itself, circle and all. Nothing can bound it: the bound is written in
+        // addresses, and the selection step refuses an address beside a
+        // `--filter` because a filtered array's elements no longer say which
+        // positions they came from. So the answer here is a refusal rather than
+        // a bound — and a legible one, rather than the `JSON.stringify` throw
+        // an unrenderable result reaches the terminal as, which says nothing
+        // about the write.
+        expect(error).toBeInstanceOf(CyclicResultError);
+        const message = (error as Error).message;
+        expect(message).toContain('closes a circle at "/0/parent/children/0"');
+        expect(message).toContain(
+          "This call's --filter is answered with the elements themselves",
+        );
+        expect(message).toContain("COMMITTED");
+        // Neither of the other two wordings: the declaration is never consulted
+        // here, so a refusal claiming it bounds nothing would be a false
+        // statement about the verb.
+        expect(message).not.toContain("declares no result");
+        expect(message).not.toContain("leaves the closing position");
+        // And no compiled pattern was loaded to reach that declaration with. A
+        // derivation that cannot be applied is not worth a pattern load, which
+        // is why the `--filter` is decided before the declaration is reached
+        // for.
+        expect(patternLoads()).toBe(0);
+        // The handling landed, which is what the refusal says and what makes it
+        // a rendering failure rather than a failed call.
+        expect(childTitles(root)).toEqual(["Filtered"]);
+      },
+    );
+  });
+
+  //
+  // Refusals, and what they cost
+  //
+  // What the command does when the result will not render, and that it
+  // does not pay to produce what it will not use.
+  //
+
+  it("refuses legibly, naming the committed write, where the declaration bounds nothing", async () => {
+    await withTracker("cyclic-undeclared", async ({ call, root }) => {
+      const error = await call("addChildLoose", ["--title", "Unbounded"])
+        .then(() => undefined, (thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(CyclicResultError);
+      const message = (error as Error).message;
+      // Where the circle closes, so a caller can see which field to bound.
+      expect(message).toContain(
+        'closes a circle at "/container/children/0/parent"',
+      );
+      // The property worth not losing: an unrenderable result is not a failed
+      // mutation, and the message says so rather than leaving a stack trace to
+      // read as "the call failed".
+      expect(message).toContain("COMMITTED");
+      expect(message).toContain("cf get --piece of:");
+      expect(message).toContain("declared result leaves the closing position");
+
+      // And the write did land.
+      expect(childTitles(root)).toEqual(["Unbounded"]);
+    });
+  });
+
+  it("refuses a verb it can match no declaration to without consulting a pattern", async () => {
+    await withTracker(
+      "cyclic-no-declaration",
+      async ({ call, patternLoads, root }) => {
+        // `fileUnder` is the piece's own `addChild`, reached on the input cell.
+        // The dispatch and the circle are identical; what differs is that this
+        // resolution carries no declared result to bound the readback with.
+        const error = await call("fileUnder", ["--title", "Undeclared"])
+          .then(() => undefined, (thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(CyclicResultError);
+        const message = (error as Error).message;
+        expect(message).toContain(
+          "This verb declares no result for `cf` to bound the readback with.",
+        );
+        // Nothing bounds the readback, so the position named is where the walk
+        // itself closes: the returned item, reached again from inside its own
+        // container. With a declaration in hand the cut lands at `parent` and
+        // the walk never gets this far.
+        expect(message).toContain(
+          'closes a circle at "/item/parent/children/0"',
+        );
+        expect(message).toContain("COMMITTED");
+        expect(message).toContain("cf get --piece of:");
+        expect(message).not.toContain("leaves the closing position");
+        // No pattern was loaded to look for a declaration, because this
+        // resolution attaches no thunk to reach one through.
+        expect(patternLoads()).toBe(0);
+        // And the handling landed. The refusal is a rendering failure over a
+        // write that committed, which is why it is a throw and not an
+        // invocation whose `result` is quietly omitted — an omitted `result`
+        // reports a verb that returned nothing.
+        expect(childTitles(root)).toEqual(["Undeclared"]);
+      },
+    );
+  });
+
+  it("pays for the declared result only where the result will not render", async () => {
+    await withTracker(
+      "cyclic-pattern-load-cost",
+      async ({ call, patternLoads }) => {
+        await call("finish", ["--note", "Shipped"]);
+        // A result that renders is written out exactly as it was read: nothing
+        // is derived, so no compiled pattern is loaded to derive it from.
+        expect(patternLoads()).toBe(0);
+
+        await call("addChild", ["--title", "Bounded"]);
+        expect(patternLoads()).toBe(1);
+      },
+    );
+  });
+  //
+  // Miscellaneous cases
+  //
+  // Cases that belong to none of the pairs above.
+  //
 
   it("returns that position alone for a `--select` naming the closing position", async () => {
     await withTracker("cyclic-selection-names-cut", async ({ call }) => {
@@ -532,139 +693,5 @@ describe("cf piece call on a piece that points back at its container", () => {
       expect(parseLLMFriendlyLink(result.item.parent.$link).path)
         .toEqual(["parent"]);
     });
-  });
-
-  // The `--filter` pair, and the same contrast: a predicate hands back the
-  // elements themselves, so it can only keep a circle, never narrow past one.
-  // What decides between the two is the projection written beside it.
-  it("returns the elements a `--filter` keeps where the projection beside it renders", async () => {
-    await withTracker("cyclic-filter-renders", async ({ call }) => {
-      const result = await call("addChildren", ["--title", "Kept"], {
-        selection: {
-          filter: parseSelectionFilter('.title == "Kept"'),
-          projection: parseSelectProjection("title"),
-        },
-      }) as any;
-
-      // The projection beside the predicate narrows past the circle, so the
-      // surviving element renders and nothing is derived. An implementation
-      // that refused every cyclic-verb `--filter` outright would fail here.
-      expect(result).toEqual([{ title: "Kept" }]);
-    });
-  });
-
-  it("refuses a `--filter` that keeps the circle, naming the committed write", async () => {
-    await withTracker(
-      "cyclic-filter-retains",
-      async ({ call, patternLoads, root }) => {
-        const error = await call("addChildren", ["--title", "Filtered"], {
-          selection: { filter: parseSelectionFilter('.title == "Filtered"') },
-        }).then(() => undefined, (thrown: unknown) => thrown);
-
-        // Without the projection above, the predicate's survivor is the item
-        // itself, circle and all. Nothing can bound it: the bound is written in
-        // addresses, and the selection step refuses an address beside a
-        // `--filter` because a filtered array's elements no longer say which
-        // positions they came from. So the answer here is a refusal rather than
-        // a bound — and a legible one, rather than the `JSON.stringify` throw
-        // an unrenderable result reaches the terminal as, which says nothing
-        // about the write.
-        expect(error).toBeInstanceOf(CyclicResultError);
-        const message = (error as Error).message;
-        expect(message).toContain('closes a circle at "/0/parent/children/0"');
-        expect(message).toContain(
-          "This call's --filter is answered with the elements themselves",
-        );
-        expect(message).toContain("COMMITTED");
-        // Neither of the other two wordings: the declaration is never consulted
-        // here, so a refusal claiming it bounds nothing would be a false
-        // statement about the verb.
-        expect(message).not.toContain("declares no result");
-        expect(message).not.toContain("leaves the closing position");
-        // And no compiled pattern was loaded to reach that declaration with. A
-        // derivation that cannot be applied is not worth a pattern load, which
-        // is why the `--filter` is decided before the declaration is reached
-        // for.
-        expect(patternLoads()).toBe(0);
-        // The handling landed, which is what the refusal says and what makes it
-        // a rendering failure rather than a failed call.
-        expect(childTitles(root)).toEqual(["Filtered"]);
-      },
-    );
-  });
-
-  it("refuses legibly, naming the committed write, where the declaration bounds nothing", async () => {
-    await withTracker("cyclic-undeclared", async ({ call, root }) => {
-      const error = await call("addChildLoose", ["--title", "Unbounded"])
-        .then(() => undefined, (thrown: unknown) => thrown);
-
-      expect(error).toBeInstanceOf(CyclicResultError);
-      const message = (error as Error).message;
-      // Where the circle closes, so a caller can see which field to bound.
-      expect(message).toContain(
-        'closes a circle at "/container/children/0/parent"',
-      );
-      // The property worth not losing: an unrenderable result is not a failed
-      // mutation, and the message says so rather than leaving a stack trace to
-      // read as "the call failed".
-      expect(message).toContain("COMMITTED");
-      expect(message).toContain("cf get --piece of:");
-      expect(message).toContain("declared result leaves the closing position");
-
-      // And the write did land.
-      expect(childTitles(root)).toEqual(["Unbounded"]);
-    });
-  });
-
-  it("refuses a verb it can match no declaration to without consulting a pattern", async () => {
-    await withTracker(
-      "cyclic-no-declaration",
-      async ({ call, patternLoads, root }) => {
-        // `fileUnder` is the piece's own `addChild`, reached on the input cell.
-        // The dispatch and the circle are identical; what differs is that this
-        // resolution carries no declared result to bound the readback with.
-        const error = await call("fileUnder", ["--title", "Undeclared"])
-          .then(() => undefined, (thrown: unknown) => thrown);
-
-        expect(error).toBeInstanceOf(CyclicResultError);
-        const message = (error as Error).message;
-        expect(message).toContain(
-          "This verb declares no result for `cf` to bound the readback with.",
-        );
-        // Nothing bounds the readback, so the position named is where the walk
-        // itself closes: the returned item, reached again from inside its own
-        // container. With a declaration in hand the cut lands at `parent` and
-        // the walk never gets this far.
-        expect(message).toContain(
-          'closes a circle at "/item/parent/children/0"',
-        );
-        expect(message).toContain("COMMITTED");
-        expect(message).toContain("cf get --piece of:");
-        expect(message).not.toContain("leaves the closing position");
-        // No pattern was loaded to look for a declaration, because this
-        // resolution attaches no thunk to reach one through.
-        expect(patternLoads()).toBe(0);
-        // And the handling landed. The refusal is a rendering failure over a
-        // write that committed, which is why it is a throw and not an
-        // invocation whose `result` is quietly omitted — an omitted `result`
-        // reports a verb that returned nothing.
-        expect(childTitles(root)).toEqual(["Undeclared"]);
-      },
-    );
-  });
-
-  it("pays for the declared result only where the result will not render", async () => {
-    await withTracker(
-      "cyclic-pattern-load-cost",
-      async ({ call, patternLoads }) => {
-        await call("finish", ["--note", "Shipped"]);
-        // A result that renders is written out exactly as it was read: nothing
-        // is derived, so no compiled pattern is loaded to derive it from.
-        expect(patternLoads()).toBe(0);
-
-        await call("addChild", ["--title", "Bounded"]);
-        expect(patternLoads()).toBe(1);
-      },
-    );
   });
 });

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -613,6 +613,7 @@ describe("cf piece call on a piece that points back at its container", () => {
       },
     );
   });
+
   //
   // Miscellaneous cases
   //

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -91,7 +91,10 @@ Deno.test("keying - generateKey", async (t) => {
     assertNotEquals(key({ n: 1n }), key({ n: 1 }));
   });
 
-  // The two things a render node may hold that are not `FabricValue`s.
+  //
+  // The two things a render node may hold that are not `FabricValue`s
+  //
+
   await t.step("keys an event handler without falling back", () => {
     const key = (props: Record<string, unknown>) =>
       generateKey({ type: "vnode", name: "div", props });
@@ -114,6 +117,13 @@ Deno.test("keying - generateKey", async (t) => {
     assertEquals(typeof generateKey({ n: new Map() }), "string");
     assertEquals(generateKey({ n: new Map() }), generateKey({ n: new Map() }));
   });
+
+  //
+  // A hole and a cycle
+  //
+  // Neither is a value the keyer can hash: one is a gap where an element
+  // would be, the other a structure that would not terminate if followed.
+  //
 
   await t.step("keys a hole apart from an undefined element", () => {
     const hole = [1, , 3];

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -121,8 +121,9 @@ Deno.test("keying - generateKey", async (t) => {
   //
   // A hole and a cycle
   //
-  // Neither is a value the keyer can hash: one is a gap where an element
-  // would be, the other a structure that would not terminate if followed.
+  // Neither is a value the keyer can hash by following it: one is a gap where
+  // an element would be, the other a structure that would not terminate if
+  // followed.
   //
 
   await t.step("keys a hole apart from an undefined element", () => {

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1471,20 +1471,19 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // Nested authorship text-integrity boundaries. These assert the INTENDED
-    // composed semantics and are EXPECTED TO FAIL on current main until the
-    // childRenderPolicyForNode composition fix lands.
-    // (tracking: CT-1796 / branch
-    // gideon/ct-1796-nested-cf-cfc-authorship-text-integrity-boundaries-dont)
     //
-    // A text-integrity boundary must compose monotonically: nesting can only
+    // Nested authorship text-integrity boundaries (CT-1796)
+    //
+    // A text-integrity boundary composes monotonically: nesting can only
     // tighten the requirement (requiredIntegrity composes as the union of all
     // enclosing boundaries; allowLiteralText composes as parent && inner, so an
     // inner boundary can never relax an enclosing one), and an enclosing
-    // boundary's textIntegrityState="ok" must mean every node it transitively
-    // encloses met its bar. Neither holds on main today: childRenderPolicyForNode
-    // REPLACES parentPolicy.textIntegrity at an inner boundary, and a block is
-    // attributed to (and refreshed for) only the nearest boundary.
+    // boundary's textIntegrityState="ok" means every node it transitively
+    // encloses met its bar. These pin that composition, and that a block is
+    // attributed to and refreshed for every enclosing boundary rather than the
+    // nearest.
+    //
+
     await t.step(
       "nested text integrity propagates a block to every enclosing boundary",
       async () => {
@@ -1811,6 +1810,10 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    //
+    // Strict text integrity
+    //
 
     await t.step(
       "strict text integrity allows matching visible content props",
@@ -2724,6 +2727,13 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       children: [child as never],
     });
 
+    //
+    // The default ceiling
+    //
+    // What the configured ceiling admits and blocks on its own, and how an
+    // authored boundary narrows it.
+    //
+
     await t.step(
       "default ceiling blocks unlisted atoms with no authored boundary",
       async () => {
@@ -2845,6 +2855,13 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    //
+    // A ceiling over a labeled cell
+    //
+    // The same ceiling reached through a labeled cell rather than a plain atom,
+    // including one mounted as the root.
+    //
 
     await t.step(
       "default ceiling gates a labeled cell mounted as the root",
@@ -3396,6 +3413,13 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    //
+    // Resolving a ceiling, and re-rendering when access changes
+    //
+    // A ceiling resolved against a real principal or ACL rather than a literal
+    // list, and what happens when the answer changes after the mount.
+    //
 
     await t.step(
       "reactively re-renders a Space(X) cell once its ACL grants READ",

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -3412,7 +3412,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     );
 
     //
-    // Resolving a ceiling, and re-rendering when access changes
+    // Re-rendering when access changes
     //
     // A ceiling resolved against a real principal or ACL rather than a literal
     // list, and what happens when the answer changes after the mount.

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1534,9 +1534,9 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           // The inner boundary sees the mismatch and blocks the text.
           assertEquals(lastTextIntegrityStateFor(innerId), "blocked");
           // Composed semantics: the enclosing boundary transitively encloses
-          // content that fails its own (X) requirement, so it must ALSO report
-          // blocked. (Red on main today: the block is attributed only to the
-          // inner boundary, so the outer stays "ok".)
+          // content that fails its own (X) requirement, so it ALSO reports
+          // blocked — the block is attributed to every enclosing boundary, not
+          // only the innermost.
           assertEquals(lastTextIntegrityStateFor(outerId), "blocked");
 
           // The failing text is hidden.
@@ -1602,9 +1602,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
           // Composed semantics (option i): allowLiteralText composes as
           // parent && inner, so the inner cannot re-enable literals the outer
-          // forbade. The attacker-shaped literal must be hidden, not rendered.
-          // (Red on main today: the inner replaces the outer's policy, so the
-          // literal renders clean.)
+          // forbade. The attacker-shaped literal is hidden, not rendered.
           const renderedText = collector.getOpsOfType("create-text")
             .map((op) => op.text);
           assertEquals(renderedText.includes(attackerText), false);
@@ -1613,9 +1611,8 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             true,
           );
 
-          // Both boundaries must report blocked: the enclosing boundary's
-          // stricter literal-text rule applies transitively through the inner.
-          // (Red on main today: both stay "ok".)
+          // Both boundaries report blocked: the enclosing boundary's stricter
+          // literal-text rule applies transitively through the inner.
           assertEquals(lastTextIntegrityStateFor(innerId), "blocked");
           assertEquals(lastTextIntegrityStateFor(outerId), "blocked");
         } finally {

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -1070,6 +1070,18 @@ describe("Cell Static Methods", () => {
       }
     };
 
+    //
+    // Date normalization on `set()`
+    //
+    // The `Cell.of(new Date(...))` cases (top-level and nested) are absent.
+    // Unlike `set()`, the `Cell.of` initial-value path doesn't normalize native
+    // values (see the TODO in `createWithDefault` in `cell.ts`), so the raw
+    // `Date` reaches encode and throws under the strict codec. `get()`
+    // *appears* to convert (read-side projection), but the committed form is
+    // still raw. Add `... (Cell.of)` cases once that path normalizes its
+    // initial value the way `set()` does.
+    //
+
     it("normalizes a top-level Date to FabricEpochNsec (set)", async () => {
       await inFreshRuntime((Cell) => {
         const cell = Cell.of<unknown>(0);
@@ -1086,13 +1098,9 @@ describe("Cell Static Methods", () => {
       });
     });
 
-    // The `Cell.of(new Date(...))` cases (top-level and nested) are absent.
-    // Unlike `set()`, the `Cell.of` initial-value path
-    // doesn't normalize native values (see the TODO in `createWithDefault` in
-    // `cell.ts`), so the raw `Date` reaches encode and throws under the strict
-    // codec. `get()` *appears* to convert (read-side projection), but the
-    // committed form is still raw. Add `... (Cell.of)` cases once that path
-    // normalizes its initial value the way `set()` does.
+    //
+    // Mixed type arrays
+    //
 
     it("should handle creating cell with mixed type array", () => {
       withinHandlerContext(runtime, space, tx, () => {

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -3733,6 +3733,13 @@ type AdmissionReplica = {
   noteCaughtUpLocalSeq(localSeq: number | undefined): void;
 };
 
+//
+// Read repair, and commits minted against it
+//
+// A rejection whose repair has not yet landed, and what happens to a commit
+// that reads the base while the repair is in flight.
+//
+
 Deno.test("memory v2 stacked commits: preempt-mode admission rejects a floored commit without sending", async () => {
   setConflictAdmissionMode("preempt");
   const harness = await createHarness();
@@ -3763,13 +3770,6 @@ Deno.test("memory v2 stacked commits: preempt-mode admission rejects a floored c
     await harness.close();
   }
 });
-
-//
-// Read repair, and commits minted against it
-//
-// A rejection whose repair has not yet landed, and what happens to a commit
-// that reads the base while the repair is in flight.
-//
 
 Deno.test("memory v2 stacked commits: conflict rejection delivered before the winning update holds the revert until read repair", async () => {
   const harness = await createHarness();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2773,6 +2773,13 @@ Deno.test("memory v2 stacked commits: a REJECTED own write that was shadowing fo
   }
 });
 
+//
+// The verdict, and when a parked accept applies
+//
+// A parked accept waits for its covering marker. These pin the verdict round
+// trip and the occasions that apply a parked accept without one.
+//
+
 Deno.test("memory v2 stacked commits: rejection round trip — verdict, repair frame, regenerate against the repaired base (CT-1927)", async () => {
   const harness = await markerHarness();
   try {
@@ -3095,6 +3102,13 @@ class PreStackTransport extends ScriptedModelTransport {
   }
 }
 
+//
+// An older server
+//
+// A peer advertising fewer capabilities than the current one, and the holds the
+// client takes on its behalf.
+//
+
 Deno.test("memory v2 stacked commits: a server without pendingReadStacks receives scalar top-of-stack reads", async () => {
   const harness = await createHarness({
     transport: (model) => new PreStackTransport(model),
@@ -3234,6 +3248,14 @@ Deno.test("memory v2 stacked commits: old-server hold releases once every omitte
     await harness.close();
   }
 });
+
+//
+// Cascading a dropped dependency
+//
+// A dropped write dooms what depends on it. These pin how far the cascade
+// reaches, what each victim reports, and what a late verdict may no longer
+// change.
+//
 
 Deno.test("memory v2 stacked commits: dropped dependency locally rejects the in-flight dependant before its server verdict", async () => {
   const harness = await createHarness();
@@ -3742,6 +3764,13 @@ Deno.test("memory v2 stacked commits: preempt-mode admission rejects a floored c
   }
 });
 
+//
+// Read repair, and commits minted against it
+//
+// A rejection whose repair has not yet landed, and what happens to a commit
+// that reads the base while the repair is in flight.
+//
+
 Deno.test("memory v2 stacked commits: conflict rejection delivered before the winning update holds the revert until read repair", async () => {
   const harness = await createHarness();
   try {
@@ -4146,6 +4175,13 @@ Deno.test("memory v2 stacked commits: a commit sitting on two rejected layers wa
   }
 });
 
+//
+// Materializing pending state, and invalidating it
+//
+// The cache over a stack of pending writes: what it reuses as the stack is
+// confirmed, and what it must drop when a write below it goes away.
+//
+
 Deno.test("memory v2 stacked commits: repeated pending reads reuse the latest materialized state", async () => {
   const harness = await createHarness();
   try {
@@ -4497,6 +4533,13 @@ Deno.test("memory v2 stacked commits: dropping an earlier pending write invalida
   }
 });
 
+//
+// Pending visibility
+//
+// What a pending overlay shows a reader before it is confirmed, and the patches
+// it declines to apply over a branch their ops cannot reach.
+//
+
 Deno.test("memory v2 stacked commits: pending visibility preserves `FabricValue`s", async () => {
   const harness = await createHarness();
   let commitPromise: Promise<any> | undefined;
@@ -4764,6 +4807,10 @@ Deno.test("memory v2 stacked commits: pending visibility skips a patch over an a
     await harness.close();
   }
 });
+
+//
+// Miscellaneous cases
+//
 
 Deno.test("memory v2 stacked commits: C1->C2->C3 where C2 fails and C3 error is pending-dependency, not stale-read", async () => {
   const harness = await createHarness();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -4984,6 +4984,7 @@ Deno.test("memory v2 stacked commits: a dependant stranded by a dropped optimist
     await harness.close();
   }
 });
+
 //
 // CT-1872 Class 1a pins (ported from #4608, expectations rewritten for the
 // ops-replay contract): a pending patch layer renders by REPLAYING ITS OPS


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Five files hold a comment that reaches further than any place the "Commenting a
block" rule names: a label over a run of tests, with nothing to close its
region. Closing one honestly needs a name for a group nobody had named, so this
change is a **proposal** as much as a fix — the titles below are the part worth
arguing with.

## The names, per file

**`html/.../worker-keying`** — "The two things a render node may hold that are
not `FabricValue`s" (2 steps) → **"A hole and a cycle"** (2). A hole and a cycle
are two further things a node may hold, and neither is a value the keyer can
hash. The closer is deliberately a bare restatement rather than a
characterization.

**`cli/.../piece-call-cyclic-result-live`** — three labels each said "the pair
below" while reaching five tests. Each pair keeps its label; the refusals become
a group; and the cases belonging to no pair **move to the end**:

| Title | Members |
|---|---|
| `The other half of "a caller's own shape wins"` | 2 |
| `` `item.title` against `item`: narrowing past the circle, or naming it whole `` | 2 |
| `` The `--filter` pair `` | 2 |
| **When the result will not render, and what that costs** | 3 |
| **Miscellaneous cases** | 3 |

**`html/.../worker-reconciler-cfc-render-policy`** — one label reached thirty
`t.step`s. Four regions now: "Nested authorship text-integrity boundaries
(CT-1796)" (5) → **"Strict text integrity"** (12) → **"The default ceiling"**
(4) → **"A ceiling over a labeled cell"** (7) → **"Re-rendering when access changes"** (2). The first three titles are the steps'
own words.

**`runner/.../cell-static-methods`** — the note explaining why the
`Cell.of(new Date(...))` cases are absent had floated above two unrelated tests.
It now heads the `set()` Date pair it completes, as **"Date normalization on
`set()`"** (2), closed by **"Mixed type arrays"** (2).

**`runner/.../memory-v2-stacked-commit`** — "The settle input barrier" reached
roughly forty tests where its title owned seven. Seven markers divide the rest:
**"The verdict, and when a parked accept applies"** (5), **"An older server"**
(3), **"Cascading a dropped dependency"** (7), **"Read repair, and commits
minted against it"** (4), **"Materializing pending state, and invalidating
it"** (5), **"Pending visibility"** (7), **"Miscellaneous cases"** (3). The
barrier now owns exactly its seven shadow and parked-write tests.

## A stale claim, corrected

`worker-reconciler-cfc-render-policy`'s label said its five nested tests "are
EXPECTED TO FAIL on current main until the childRenderPolicyForNode composition
fix lands", and that "childRenderPolicyForNode REPLACES
parentPolicy.textIntegrity at an inner boundary".

Neither holds. All five pass, and `#childRenderPolicyForNode` composes:
`requiredIntegrity` is the union of the parent's and the node's, and
`allowLiteralText` is `parent && inner` — exactly the behavior the comment says
must happen and claims does not. CT-1796 landed; the prose describes the world
before it. The marker now states what holds, keeping the CT-1796 reference and
dropping a merged branch name.

## What the diff is, as a property

- Comments adjacent above a test-block opener, over these five files: **5 at the
  base and 0 at head.** Blank-separated labels: 1 and 0.
- Marker frames go from **5 to 26**.
- Added or removed lines that are neither a `//` comment nor blank: **108**, and
  every one is in `piece-call-cyclic-result-live`, where three tests move to the
  end of the describe. The multiset of that file's non-comment lines is
  **identical** to its base — nothing added, nothing removed, only order changed.
  No other file changes a non-comment line, and no test is renamed anywhere.
- Every marker's region was enumerated member by member against its title.

## Gates

`deno fmt --check` and `deno lint` pass over the workspace (exit 0).
`deno task test`: `cli` 210 passed / 0 failed, `html` 26 passed / 0 failed.
`runner` reports 1323 passed / 1 failed, and the failure is
`executor-effect-channel.test.ts` timing out on a 20-second `waitUntil` poll —
a file this change does not touch, in a package whose CI runs are green. That
step has now failed three times today under local load, on three branches and
two machines, and passed on CI every time.

## Known, and left as a decision

`memory-v2-stacked-commit`'s **"Miscellaneous cases"** (3) owns its members only
in the weak sense that none of them belongs to a pair above. Two of the three
are cascade tests by their own words — one says "Distinct from the basic cascade
test above" and "the client-side cascade off T1's drop", the other asserts a
victim's reported error kind, which is the cascade region's own subject. Only
the duplicate-ids test is genuinely miscellaneous.

The `cli` file in this same change solved that shape by MOVING tests to their
group. This file does not, because the two would travel some fifteen hundred
lines, and the remainder would then need a marker of its own to keep the region
above it from swallowing it. The bucket is accepted knowingly rather than
silently, and moving them is the obvious follow-up if that reads wrong.


## The coverage line

The coverage check reports `packages/runner` one line worse and attributes it
itself, to an unchanged file the baseline run covered. That agrees with what
this change is: within `packages/runner` it touches two test files and alters
no line that is not a comment or blank, and it touches no `src/` file in any
package, so it contributes no executable line for coverage to measure in either
direction. Two runs of the check produce the same +1, so it is the baseline
that moved, not this branch.

ACCEPT_COVERAGE_DEBT: packages/runner +1 line
