### PR TITLE
test: give nineteen more blank-separated labels a shape the rule has

### DIFF
--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -667,9 +667,13 @@ describe("verb-undeclared-field", () => {
     });
   });
 
-  // Positions the walk cannot judge, each asserted as the call GOING OUT
-  // rather than as no refusal coming back. The two are different facts, and
-  // only the first one states that a caller can still make the call.
+  //
+  // Positions the walk cannot judge
+  //
+  // Positions the walk cannot judge, each asserted as the call GOING OUT rather
+  // than as no refusal coming back. The two are different facts, and only the
+  // first one states that a caller can still make the call.
+  //
 
   describe("a schema that forbids undeclared fields", () => {
     it("refuses the undeclared field rather than letting it be dropped", () => {

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -667,14 +667,6 @@ describe("verb-undeclared-field", () => {
     });
   });
 
-  //
-  // Positions the walk cannot judge
-  //
-  // Positions the walk cannot judge, each asserted as the call GOING OUT rather
-  // than as no refusal coming back. The two are different facts, and only the
-  // first one states that a caller can still make the call.
-  //
-
   describe("a schema that forbids undeclared fields", () => {
     it("refuses the undeclared field rather than letting it be dropped", () => {
       const schema: JSONSchema = {
@@ -783,6 +775,10 @@ describe("verb-undeclared-field", () => {
   });
 
   describe("a position the walk cannot judge", () => {
+    // Positions the walk cannot judge, each asserted as the call GOING OUT
+    // rather than as no refusal coming back. The two are different facts, and
+    // only the first one states that a caller can still make the call.
+
     it("dispatches an array whose elements all carry declared fields", async () => {
       const schema: JSONSchema = {
         type: "object",

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1723,10 +1723,14 @@ describe("JsonCodecEngine", () => {
       expect(Object.isFrozen(result)).toBe(true);
     });
 
-    // Every arm of the dispatch, so that the guarantee does not depend on
-    // which one produced the value. `isDeepFrozen()` rather than
-    // `Object.isFrozen()`: an arm that froze only the value it built, and not
-    // what it wrapped, would pass the shallow check.
+    //
+    // Every arm of the dispatch
+    //
+    // Every arm of the dispatch, so that the guarantee does not depend on which
+    // one produced the value. `isDeepFrozen()` rather than `Object.isFrozen()`:
+    // an arm that froze only the value it built, and not what it wrapped, would
+    // pass the shallow check.
+    //
 
     it("deep-freezes an `UnknownValue` from an unrecognized tag", () => {
       const result = fromEncodedFormat(

--- a/packages/fuse/verify-structs.test.ts
+++ b/packages/fuse/verify-structs.test.ts
@@ -1,7 +1,9 @@
-// verify-structs.test.ts — Compile and run verify-structs.c to validate
-// that the hardcoded struct offsets in platform-linux.ts are correct.
-//
-// This test only runs on Linux where libfuse3 headers are available.
+/**
+ * verify-structs.test.ts — Compile and run verify-structs.c to validate that
+ * the hardcoded struct offsets in platform-linux.ts are correct.
+ *
+ * This test only runs on Linux where libfuse3 headers are available.
+ */
 
 Deno.test({
   name: "Linux struct offsets match C headers",

--- a/packages/llm/src/client.test.ts
+++ b/packages/llm/src/client.test.ts
@@ -593,9 +593,13 @@ describe("mock response gate", () => {
 describe("failureHint", () => {
   const PARAMETERS = "messages, prompt, model, etc.";
 
-  // The hint is the first thing a developer reads in the console when a
-  // request fails, and for most of a working day the failure is not theirs.
-  // Each status class has to send them to the right place.
+  //
+  // The failure hint
+  //
+  // The hint is the first thing a developer reads in the console when a request
+  // fails, and for most of a working day the failure is not theirs. Each status
+  // class has to send them to the right place.
+  //
 
   it("sends a rate-limited caller away to wait rather than to their arguments", () => {
     for (const status of [429, 503]) {

--- a/packages/memory/test/commit-telemetry.test.ts
+++ b/packages/memory/test/commit-telemetry.test.ts
@@ -26,6 +26,10 @@ const sqliteOperation: Operation = {
 };
 
 describe("commit-telemetry", () => {
+  // Server-execution v2 stage C.2 removed the scheduler-observation wire
+  // fields, so no commit can classify as `scheduler_observation` anymore;
+  // the kind stays in the union so dashboards keep their shape.
+
   it("returns `semantic` for non-SQLite entity operations", () => {
     expect(classifyCommitTelemetry(commit([semanticOperation]))).toEqual({
       kind: "semantic",
@@ -34,10 +38,6 @@ describe("commit-telemetry", () => {
       sqliteOperationCount: 0,
     });
   });
-
-  // Server-execution v2 stage C.2 removed the scheduler-observation wire
-  // fields, so no commit can classify as `scheduler_observation` anymore;
-  // the kind stays in the union so dashboards keep their shape.
 
   it("returns `sqlite` for SQLite-only requests", () => {
     expect(classifyCommitTelemetry(commit([sqliteOperation]))).toEqual({

--- a/packages/memory/test/session-open-auth.test.ts
+++ b/packages/memory/test/session-open-auth.test.ts
@@ -123,7 +123,9 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // expiry
+  //
+  // Expiry
+  //
 
   it("accepts an unexpired open", async () => {
     const msg = await buildOpen(signedFields({ iat: now, exp: now + 300 }));
@@ -196,7 +198,9 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // challenge binding
+  //
+  // Challenge binding
+  //
 
   it("accepts a challenged open with the matching challenge", async () => {
     const msg = await buildOpen(signedFields());
@@ -243,7 +247,9 @@ describe("verifySessionOpenAuthorization", () => {
     );
   });
 
-  // audience binding
+  //
+  // Audience binding
+  //
 
   it("accepts an audience-bound open at the matching host", async () => {
     assertEquals(

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -582,12 +582,16 @@ Deno.test("the persisted lease-holder exemption does not survive session resume 
   }
 });
 
-// Instance identity across the wire seam (threads r3731191411 and
-// r3731191526): the wire strips scope KEYS (frames carry scope names), so
-// the server must refuse what the wire cannot express — one watch set (or
-// query) resolving TWO instances of one (branch, id, scope) — and must
-// treat a changed `entityScopeKey` on an existing watch id as a changed
-// spec, never silently the same watch.
+//
+// Instance identity across the wire seam
+//
+// Instance identity across the wire seam (threads r3731191411 and r3731191526):
+// the wire strips scope KEYS (frames carry scope names), so the server must
+// refuse what the wire cannot express — one watch set (or query) resolving TWO
+// instances of one (branch, id, scope) — and must treat a changed
+// `entityScopeKey` on an existing watch id as a changed spec, never silently
+// the same watch.
+//
 
 Deno.test("stage A: a lease holder names two instances of one (branch, id, scope) and receives BOTH, keyed — watch.set, watch.add, graph.query, and the push frame; the collapse guard still refuses a non-holder (OW17's wire leg)", async () => {
   // OW17's wire leg (server-execution v2 stage A, 2026-08-16): a LIVE lease

--- a/packages/runner/test/prototype-named-properties.test.ts
+++ b/packages/runner/test/prototype-named-properties.test.ts
@@ -180,8 +180,12 @@ describe("properties named after Object.prototype members", () => {
     expect(stored.toLocaleString).toBe("written");
   });
 
+  //
+  // More public paths with the same predicate
+  //
   // Review of the first pass found four more public paths with the same
   // predicate. Each is pinned here through the surface a caller actually uses.
+  //
 
   it("removing such a property actually removes it", () => {
     const c = runtime.getCell<Record<string, unknown>>(

--- a/packages/runner/test/prototype-named-properties.test.ts
+++ b/packages/runner/test/prototype-named-properties.test.ts
@@ -16,6 +16,9 @@
 // control case using an ordinary name, so a harness that stops exercising the
 // path fails loudly rather than passing vacuously.
 //
+// Review of the first pass found four more public paths with the same
+// predicate. Each is pinned here through the surface a caller actually uses.
+//
 // Sibling of the same bug class in the query-result proxy's
 // `getOwnPropertyDescriptor` trap (#5357).
 
@@ -179,13 +182,6 @@ describe("properties named after Object.prototype members", () => {
     const stored = c.get() as Record<string, unknown>;
     expect(stored.toLocaleString).toBe("written");
   });
-
-  //
-  // More public paths with the same predicate
-  //
-  // Review of the first pass found four more public paths with the same
-  // predicate. Each is pinned here through the surface a caller actually uses.
-  //
 
   it("removing such a property actually removes it", () => {
     const c = runtime.getCell<Record<string, unknown>>(

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -2635,10 +2635,14 @@ describe("cell-handle", () => {
         }),
       }) as unknown as RuntimeClient;
 
+    //
+    // Three methods that serialize
+    //
     // Three methods serialize, and each used to refuse a `FabricSpecialObject`
-    // through a different caller contract. All three carry one now, and
-    // pinning all three is what keeps a later refactor from carrying it on
-    // only the path `set()` takes.
+    // through a different caller contract. All three carry one now, and pinning
+    // all three is what keeps a later refactor from carrying it on only the
+    // path `set()` takes.
+    //
 
     it("carries one through `push()`", () => {
       const requests: Array<{ values?: unknown[] }> = [];

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,3 +1,11 @@
+/**
+ * The EXPERIMENTAL_* → ExperimentalOptions mapping (including its tri-state
+ * unset/true/false fidelity) now lives in the runner's canonical
+ * `experimentalOptionsFromEnv` / `EXPERIMENTAL_ENV_VARS` (CT-1814), shared by
+ * toolshed, the CLI, and the background-piece-service; its coverage lives in
+ * `packages/runner/test/runtime-presets.test.ts`.
+ */
+
 import { assertEquals } from "@std/assert";
 import { EnvSchema } from "@/env.ts";
 
@@ -53,12 +61,6 @@ Deno.test("MEMORY_ACL_MODE defaults to enforce and accepts rollout overrides", (
   assertEquals(aclMode("observe"), "observe");
   assertEquals(aclMode("enforce"), "enforce");
 });
-
-// The EXPERIMENTAL_* → ExperimentalOptions mapping (including its tri-state
-// unset/true/false fidelity) now lives in the runner's canonical
-// `experimentalOptionsFromEnv` / `EXPERIMENTAL_ENV_VARS` (CT-1814), shared by
-// toolshed, the CLI, and the background-piece-service; its coverage lives in
-// `packages/runner/test/runtime-presets.test.ts`.
 
 Deno.test("INGEST_SELF_SERVE_ENABLED is off unless explicitly enabled", () => {
   // The self-serve ingest control plane must be OFF unless a deployment opts

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.auth.test.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.auth.test.ts
@@ -10,19 +10,19 @@ if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-// The POSITIVE auth path, which nothing else covers: a genuinely signed
-// first-party request reaching a handler. Everything before this asserted only
-// that bad requests are rejected — "the real thing is accepted" is the half
-// that actually has to work.
-//
-// Under test the `runtime` singleton these handlers import is uninitialized, so
-// any path touching storage answers 502. That is itself the storage-error
-// contract, and it proves the request cleared the signature check, the rate
-// limiter, and body validation to get there. The authorization logic proper is
-// tested against a real ACL-enforcing memory server in
-// ingest-channels.utils.test.ts.
-
 describe("Ingest channels route (authenticated)", () => {
+  // The POSITIVE auth path, which nothing else covers: a genuinely signed
+  // first-party request reaching a handler. Everything before this asserted
+  // only that bad requests are rejected — "the real thing is accepted" is the
+  // half that actually has to work.
+  //
+  // Under test the `runtime` singleton these handlers import is uninitialized,
+  // so any path touching storage answers 502. That is itself the storage-error
+  // contract, and it proves the request cleared the signature check, the rate
+  // limiter, and body validation to get there. The authorization logic proper
+  // is tested against a real ACL-enforcing memory server in
+  // ingest-channels.utils.test.ts.
+
   // A distinct client per request: the limiters are module-level, so sharing a
   // key across tests turns a later 502 expectation into a 429.
   let clientCounter = 0;

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.utils.test.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.utils.test.ts
@@ -48,17 +48,17 @@ const err = (result: ControlResult<unknown>): string => {
   return result.body.error;
 };
 
-// The brief's acceptance criteria, run against a REAL memory server with
-// `acl: { mode: "enforce" }`: a user holding only their own identity key can
-// mint a channel for their own space, is refused when naming a space they do
-// not control, can list / rotate / revoke, and a revoked token stops working.
-//
-// Ownership is enforced against a space with a CONCRETE, non-derived owner.
-// That matters: on a deployment where space DIDs derive from a public
-// passphrase, anyone can sign as the space and grant themselves OWNER, so a
-// test against such a space would prove nothing about the check.
-
 describe("ingest-channels control plane", () => {
+  // The brief's acceptance criteria, run against a REAL memory server with
+  // `acl: { mode: "enforce" }`: a user holding only their own identity key can
+  // mint a channel for their own space, is refused when naming a space they do
+  // not control, can list / rotate / revoke, and a revoked token stops working.
+  //
+  // Ownership is enforced against a space with a CONCRETE, non-derived owner.
+  // That matters: on a deployment where space DIDs derive from a public
+  // passphrase, anyone can sign as the space and grant themselves OWNER, so a
+  // test against such a space would prove nothing about the check.
+
   let server: MemoryV2Server.Server;
   let factory: LoopbackSessionFactory;
   let operator: Identity;

--- a/packages/ts-transformers/test/module-scope-function-hardening.test.ts
+++ b/packages/ts-transformers/test/module-scope-function-hardening.test.ts
@@ -1,13 +1,15 @@
+/**
+ * Module-scope function hardening emits an identity annotation for a top-level
+ * binding that a WriteAuthorizedBy type references. The existing coverage of
+ * that annotation comes from `const name = handler(...)` variable bindings;
+ * the statement-form path for a plain `function` declaration ran only as a
+ * side effect of patterns compiling through the transformer in CI. These tests
+ * drive it directly.
+ */
+
 import { assertEquals } from "@std/assert";
 import { transformSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
-
-// Module-scope function hardening emits an identity annotation for a top-level
-// binding that a WriteAuthorizedBy type references. The existing coverage of
-// that annotation comes from `const name = handler(...)` variable bindings; the
-// statement-form path for a plain `function` declaration ran only as a side
-// effect of patterns compiling through the transformer in CI. These tests drive
-// it directly.
 
 Deno.test(
   "trusted WriteAuthorizedBy function declaration gets a statement-form binding annotation",

--- a/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
@@ -254,6 +254,13 @@ Deno.test(
   },
 );
 
+//
+// A binding the walker never has to enter
+//
+// The parentheses and assertions here wrap the binding VALUE, not a type, so
+// no substitution happens and the walker is not reached at all.
+//
+
 Deno.test(
   "supported binding wrapped in parentheses and assertions is accepted",
   async () => {

--- a/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/write-authorized-by-validation-coverage.test.ts
@@ -116,13 +116,17 @@ Deno.test(
   },
 );
 
+//
+// The substitution walker's branches
+//
 // The following cases place the generic alias parameter *inside* the schema
-// type argument of WriteAuthorizedBy, wrapped in a distinct type shape. When the
-// validator substitutes the actual type into the alias parameter, it must
+// type argument of WriteAuthorizedBy, wrapped in a distinct type shape. When
+// the validator substitutes the actual type into the alias parameter, it must
 // descend through that shape to rebuild the WriteAuthorizedBy reference. Each
 // case pins one branch of the substitution walker (array, union, intersection,
 // type operator, parenthesized, index signature) and asserts the binding is
 // still validated afterward.
+//
 
 Deno.test(
   "generic alias substitutes schema through array element types",

--- a/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.test.ts
+++ b/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.test.ts
@@ -3,15 +3,15 @@ import { describe, it } from "@std/testing/bdd";
 import { CFCellContext } from "./index.ts";
 import { resetRetiredElementWarnings } from "../../core/retired-element.ts";
 
-// The contract for a retired element, exercised on the first one.
-//
-// It stays REGISTERED — that is the whole point. Durable pattern source names
-// it, a piece runs the source it was stored with, and an element the browser
-// does not know is one nothing can warn about. It renders its children and
-// nothing else, and it accepts the props the old source passes without acting
-// on them.
-
 describe("CFCellContext (retired)", () => {
+  // The contract for a retired element, exercised on the first one.
+  //
+  // It stays REGISTERED — that is the whole point. Durable pattern source names
+  // it, a piece runs the source it was stored with, and an element the browser
+  // does not know is one nothing can warn about. It renders its children and
+  // nothing else, and it accepts the props the old source passes without acting
+  // on them.
+
   it("is still registered under its tag", () => {
     expect(customElements.get("cf-cell-context")).toBe(CFCellContext);
   });

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
@@ -3,12 +3,12 @@ import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import { CFTextarea } from "./index.ts";
 
-// NOTE: Full DOM interaction tests (input events, Cell two-way binding,
-// auto-resize, timing strategy integration) require Lit's rendering
-// pipeline and shadow DOM. Tests below cover property defaults, Cell
-// property acceptance, and basic configuration.
-
 describe("CFTextarea", () => {
+  // NOTE: Full DOM interaction tests (input events, Cell two-way binding,
+  // auto-resize, timing strategy integration) require Lit's rendering
+  // pipeline and shadow DOM. Tests below cover property defaults, Cell
+  // property acceptance, and basic configuration.
+
   it("should be defined", () => {
     expect(CFTextarea).toBeDefined();
   });

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -361,8 +361,12 @@ Deno.test("the polling-waitFor ALLOWLIST has no stale entries", async () => {
   );
 });
 
+//
+// The command entry point
+//
 // The next two tests drive the command entry point over a temp fixture tree, so
 // they cover the clean and violation paths without depending on the real tree.
+//
 
 Deno.test(
   "check-no-waitfor main reports success and returns 0 on a clean tree",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A group label separated from the block below it by a blank line sits in no place
the "Commenting a block" rule names: not adjacent above an opener, not inside
the block, not a framed section marker. The adjacency census cannot see that
shape, which is how these survived every batch that conformed their packages.

This change takes the nineteen whose reach already matches what they say.
Seventeen files, across eleven packages.

## What each one became

**Seven head a run and become section markers**, each region closing at the next
marker or the end of its block: `write-authorized-by-validation-coverage` ("The substitution
walker's branches", 7), `client` ("The failure hint", 4), `v2-explicit-read`
("Instance identity across the wire seam", 5), `JsonCodecEngine` ("Every arm of
the dispatch", 3), `cell-handle` ("Three methods that serialize", 3),
`prototype-named-properties` ("More public paths with the same predicate", 3),
and `check-no-waitfor` ("The command entry point", 2). Each keeps every word it
had; the title line is the only addition.

**Three become a sequence.** `session-open-auth` carried three bare labels —
`expiry`, `challenge binding`, `audience binding` — which were already titles.
Framed as **Expiry** (5) → **Challenge binding** (4) → **Audience binding** (3),
each closing the one before, so the file reads as one series.

**Four move inside the single block they head**: the retired-element contract in
`cf-cell-context`, the DOM-coverage note in `cf-textarea`, and the two
`ingest-channels` briefs. The two `ingest-channels` comments were reflowed
paragraph by paragraph, because the extra indent pushed them past 80 columns
while their `//` separators had to survive; every word is unchanged.

**Three become file headers.** `verify-structs`, `env`, and
`module-scope-function-hardening` each carried a note about what the file is
for, or about where the coverage it does not hold lives — file-scoped prose that
had been sitting against one test.

**One moves to the group it describes.** `commit-telemetry`'s note explains why
no commit can classify as `scheduler_observation` any more. It described an
absence rather than the five tests below it, so it is now its describe's
top-of-block comment.

## What the diff is, as a property

- Blank-separated group labels over these files: **19 at the base and 0 at
  head.**
- Marker frames go from **7 to 18**.
- Added or removed lines that are neither a comment nor blank: **0**. No
  executable content moves, and no test is renamed.
- Every marker's region was enumerated member by member against its title, and
  every frame carries a blank line above and below it.
- No added line exceeds 80 characters that is not already in the base verbatim,
  counted in characters rather than bytes.

## Three labels that turned out not to fit where they sat

A review answered the open question in this PR's first revision and found two
more of the same kind.

`prototype-named-properties`' "four more public paths" does span two describes —
the fix commit enumerates removal, required, path helpers and piece paths, and
only the first two are in the block the label headed. Its scope is the file, so
it now joins the file header.

`verb-undeclared-field`'s label had been orphaned by two describes inserted
after it was written; its reach is one block, so it moves inside that block.

`write-authorized-by-validation-coverage`'s region reached a seventh test that
never enters the substitution walker at all, and now closes before it.

## Gates

`deno fmt --check` and `deno lint` pass over the workspace (exit 0).
`deno task test`, every one exit 0: `cli` 210 / 0, `data-model` 48 / 0, `fuse`
372 / 0, `llm` 7 / 0, `memory` 592 / 0, `runner` 1324 / 0, `runtime-client`
16 / 0, `toolshed` 147 / 0, `ts-transformers` 1164 / 0, `ui` 52 / 0, and
`tasks/check-no-waitfor.test.ts` 33 / 0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


