### PR TITLE
test: name the sections in six more files, and delete one label that named none

### DIFF
--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -207,8 +207,6 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       rootCell: MockCell,
     ): () => void => reconciler.mount(rootCell as any);
 
-    // Test cases
-
     await t.step("Cell<Props> renders primitive props", async () => {
       const collector = createOpsCollector();
       const reconciler = new WorkerReconciler({

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -530,9 +530,9 @@ describe("cf-code-editor cursor stability", () => {
     assertEquals(cursorAfterEcho, expectedText.length);
   });
 
-  // ==========================================================================
+  //
   // NEGATIVE TESTS: Verify cursor DOES move when it should
-  // ==========================================================================
+  //
 
   it("should apply external update and move cursor after editor blur", async () => {
     // This is a NEGATIVE test: cursor SHOULD move when user is not actively editing
@@ -582,9 +582,9 @@ describe("cf-code-editor cursor stability", () => {
     await waitForEditorContent(page, "External update");
   });
 
-  // ==========================================================================
+  //
   // STRESS TESTS: Edge cases and rapid operations
-  // ==========================================================================
+  //
 
   it("should handle multiple rapid external updates correctly", async () => {
     // Stress test: rapid Cell updates should all apply correctly
@@ -762,9 +762,9 @@ describe("cf-code-editor cursor stability", () => {
     );
   });
 
-  // ==========================================================================
+  //
   // ADVERSARIAL TESTS: Race conditions, timing attacks, edge cases
-  // ==========================================================================
+  //
 
   it("ADVERSARIAL: Cell update at exact debounce boundary should not corrupt state", async () => {
     // This tests the race condition where a Cell update arrives exactly
@@ -1387,6 +1387,9 @@ describe("cf-code-editor backlink title sync", () => {
     if (cc) await cc.dispose();
   });
 
+  //
+  // How the remote rename is delivered
+  //
   // The linked piece's real title is not synced to the editor's runtime in
   // these tests: the editor's mentionable projection carries only NAME, so a
   // cross-document linked piece's title only reaches the editor inside the full
@@ -1394,6 +1397,7 @@ describe("cf-code-editor backlink title sync", () => {
   // editor's own _handleExternalTitleChange with a stand-in piece cell whose
   // title and NAME are the renamed values, exactly what a real title
   // subscription would call.
+  //
 
   it("preserves a remote title change over a pending local edit", async () => {
     const page = shell.page();

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -802,10 +802,14 @@ describe("CFC browser helpers", () => {
     );
   });
 
+  //
+  // Co-resident marks
+  //
   // Every mark predicate adds its token to the marks already on the element, so
   // a target another click has spoken for keeps that claim. The grouped test
   // above exercises that for the by-selector predicate; these two cover the
   // indexed and trusted-action ones.
+  //
 
   it("keeps a co-resident mark when tagging an indexed target", async () => {
     await page.evaluate((clickTargetAttr: string) => {
@@ -910,12 +914,16 @@ describe("CFC browser helpers", () => {
     assertEquals(result.marks, ["held-by-another-click"]);
   });
 
+  //
+  // Click helpers that reach a control
+  //
   // The three tests below cover the click helpers that reach their control by
   // index, by `data-ui-action`, and by button text. Each drives a control that
   // is in the DOM from the start but receives its click handler only when the
   // view settles — the ordinary case of a vdom batch that has not yet crossed
   // to the main thread. A helper that marks its control without settling around
   // it clicks an element with nothing bound, and `clickedAtSettle` stays zero.
+  //
 
   it("settles the view before clicking an indexed control", async () => {
     await page.evaluate(() => {
@@ -1082,6 +1090,13 @@ describe("CFC browser helpers", () => {
     );
     assertEquals(result.settleCalls, 2);
   });
+
+  //
+  // Filling and typing
+  //
+  // The same settle discipline as the click helpers, for the helpers that put
+  // text into a control rather than click one.
+  //
 
   it("settles the view before pressing Enter in a submit input", async () => {
     await page.evaluate(() => {
@@ -1479,6 +1494,13 @@ describe("CFC browser helpers", () => {
     }
   });
 
+  //
+  // A target that moves under the aim
+  //
+  // The control is found, then its box or its surface changes before the click
+  // lands.
+  //
+
   it("waits for a marked target's shifting box to settle before clicking", async () => {
     await page.evaluate((clickTargetAttr: string) => {
       const host = document.createElement("div");
@@ -1805,6 +1827,13 @@ describe("CFC browser helpers", () => {
       "the click did not reach the control after the press and release split",
     );
   });
+
+  //
+  // Where the click actually landed
+  //
+  // A click can reach the DOM and still not reach the control the caller aimed
+  // at. These report where it went.
+  //
 
   it("leaves the page's own clicks to the page while a click is in flight", async () => {
     // Components raise clicks of their own — a label forwarding to its control,
@@ -2195,6 +2224,13 @@ describe("CFC browser helpers", () => {
       await presentationPage.close();
     }
   });
+
+  //
+  // A control the page does not fully render
+  //
+  // A page that is not rendering at all, a control only partly inside the
+  // viewport, one the edge cuts off, and one with no part inside it.
+  //
 
   it("clicks a control on a page that is not being rendered", async () => {
     // A page sharing a browser with a fronted page is hidden, and a hidden page

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -2528,6 +2528,13 @@ describe("CFC browser helpers", () => {
     }
   });
 
+  //
+  // The click-to-own-render echo
+  //
+  // Not about where a control sits, but about what the sender observes coming
+  // back from its own click — including through a shadow root.
+  //
+
   it("samples the sender's click-to-own-render echo, shadow roots included", async () => {
     const echoPage = await browser.newPage();
     try {

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1094,8 +1094,9 @@ describe("CFC browser helpers", () => {
   //
   // Filling and typing
   //
-  // The same settle discipline as the click helpers, for the helpers that put
-  // text into a control rather than click one.
+  // The helpers that put text into a control rather than click one: the same
+  // settle discipline as the click helpers, and what happens when a commit
+  // replaces the control they were typing into.
   //
 
   it("settles the view before pressing Enter in a submit input", async () => {

--- a/packages/patterns/vehicles.test.ts
+++ b/packages/patterns/vehicles.test.ts
@@ -12,9 +12,9 @@ import {
   type Vehicle,
 } from "./vehicles.ts";
 
-// ============================================================
+//
 // normalizePlateId
-// ============================================================
+//
 
 Deno.test("normalizePlateId: uppercases and strips non-alphanumerics", () => {
   assertEquals(normalizePlateId("7abc-123!"), "7ABC123");
@@ -32,9 +32,9 @@ Deno.test("normalizePlateId: empty string → empty string", () => {
   assertEquals(normalizePlateId(""), "");
 });
 
-// ============================================================
+//
 // modelsForMake
-// ============================================================
+//
 
 Deno.test("modelsForMake: returns models for a known make", () => {
   const models = modelsForMake("Honda");
@@ -50,9 +50,9 @@ Deno.test("modelsForMake: returns empty array for empty string", () => {
   assertEquals(modelsForMake(""), []);
 });
 
-// ============================================================
+//
 // formatVehicle
-// ============================================================
+//
 
 Deno.test("formatVehicle: full vehicle", () => {
   const v: Vehicle = {
@@ -87,9 +87,9 @@ Deno.test("formatVehicle: no plateState", () => {
   assertEquals(formatVehicle(v), "XYZ");
 });
 
-// ============================================================
+//
 // normalizeVehicle
-// ============================================================
+//
 
 Deno.test("normalizeVehicle: normalizes plate and defaults state", () => {
   const result = normalizeVehicle({
@@ -215,9 +215,9 @@ Deno.test("normalizeVehicle: invalid color dropped", () => {
   assertEquals(result.color, "");
 });
 
-// ============================================================
+//
 // normalizeVehicles
-// ============================================================
+//
 
 Deno.test("normalizeVehicles: drops blank-plate entries", () => {
   const result = normalizeVehicles([

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -50,6 +50,9 @@ type ArrayElementType<ArrayType extends readonly unknown[]> = ArrayType extends
   readonly (infer ElementType)[] ? ElementType : never;
 
 describe("Schema-to-TS Type Conversion", () => {
+  // These tests verify the type conversion at compile time
+  // They don't have runtime assertions but help ensure the Schema type works correctly
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -73,9 +76,6 @@ describe("Schema-to-TS Type Conversion", () => {
     await runtime?.dispose();
     await storageManager?.close();
   });
-
-  // These tests verify the type conversion at compile time
-  // They don't have runtime assertions but help ensure the Schema type works correctly
 
   it("should convert primitive types", () => {
     type StringSchema = Schema<{ type: "string" }>;

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -50,8 +50,9 @@ type ArrayElementType<ArrayType extends readonly unknown[]> = ArrayType extends
   readonly (infer ElementType)[] ? ElementType : never;
 
 describe("Schema-to-TS Type Conversion", () => {
-  // These tests verify the type conversion at compile time
-  // They don't have runtime assertions but help ensure the Schema type works correctly
+  // These tests verify the type conversion at compile time. Most carry no
+  // runtime assertions and exist to ensure the Schema type works correctly;
+  // the last drives real data through the runtime.
 
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -709,7 +709,11 @@ Deno.test("Schema Shrink Validation", async (t) => {
     },
   );
 
+  //
+  // Type-arg form against inline form
+  //
   // Type-arg form vs inline form: schemas must be identical
+  //
 
   await t.step(
     "handler<E, T> generates same schemas as handler((e: E, t: T) => ...)",
@@ -1142,6 +1146,15 @@ Deno.test("Schema Shrink Validation", async (t) => {
       );
     },
   );
+
+  //
+  // What shrinking keeps
+  //
+  // The shrinker follows a value through the callback and drops what nothing
+  // reads. These pin the reads it must follow — through loops, fallbacks,
+  // aliases, chained array methods, and cell wrappers — so that a field in use
+  // survives.
+  //
 
   await t.step(
     "lift object-literal input preserves property schemas",
@@ -1941,6 +1954,13 @@ Deno.test("Schema Shrink Validation", async (t) => {
     },
   );
 
+  //
+  // When usage is a wildcard
+  //
+  // Usage the analysis cannot narrow, where the honest answer is to keep the
+  // whole shape.
+  //
+
   await t.step(
     "lift wildcard usage keeps conservative full-shape input schema",
     async () => {
@@ -2005,6 +2025,13 @@ Deno.test("Schema Shrink Validation", async (t) => {
       assert(names.has("bar"));
     },
   );
+
+  //
+  // Validating array item reads
+  //
+  // Reading an item property the element type does not have is an error,
+  // whether or not the array is readonly.
+  //
 
   await t.step(
     "errors when an array item access names a property the element type lacks",
@@ -2071,6 +2098,13 @@ Deno.test("Schema Shrink Validation", async (t) => {
       assertGreater(shrinkErrors.length, 0);
     },
   );
+
+  //
+  // Cell arguments across a call boundary
+  //
+  // What a cell argument's shape becomes once it is handed to a callee whose
+  // own signature declares how it will be used.
+  //
 
   await t.step(
     "keeps auth writable when handlers pass it to provider clients that refresh tokens",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Six files each held a label reaching further than any place the "Commenting a
block" rule names — a run of tests with nothing closing the region. Where a name
had to be invented, that name is the part worth arguing with; four of the six
turned out to need none at all.

## Four needed no new name

**`patterns/vehicles`** was already divided into five titled sections —
`normalizePlateId`, `modelsForMake`, `formatVehicle`, `normalizeVehicle`,
`normalizeVehicles` — drawn with `=` rulers instead of the frame the rest of the
tree uses. The titles carry over unchanged, and each region holds exactly its
function's tests (4, 3, 3, 9, 5).

**`patterns/integration/cf-code-editor`** likewise had three ruler-drawn
sections (NEGATIVE / STRESS / ADVERSARIAL), converted the same way. Its one
remaining label, over a pair, becomes "How the remote rename is delivered" —
the only new name in that file.

**`runner/schema-to-ts`**'s label describes its whole `describe()`; it had simply
come to rest after the declarations and hooks. It is now that block's first
content, so no marker is needed.

**`html/worker-reconciler-cell-props`** separated its helpers from its steps with
`// Test cases`. That says nothing a file of twenty-five test cases does not, and
the blank line already separates them, so the rule deletes it.

## Two needed names

**`patterns/integration/cfc-browser-helpers`** — its label said "The three tests
below" while its region reached twenty-four. Six regions now:

| Title | Members |
|---|---|
| Co-resident marks | 2 |
| Click helpers that reach a control | 3 |
| **Filling and typing** | 7 |
| **A target that moves under the aim** | 4 |
| **Where the click actually landed** | 5 |
| **A control the page does not fully render** | 4 |
| **The click-to-own-render echo** | 1 |

**`ts-transformers/schema-shrink-validation`** — one label over thirty-nine
steps. Five regions:

| Title | Members |
|---|---|
| Type-arg form against inline form | 8 |
| **What shrinking keeps** | 21 |
| **When usage is a wildcard** | 2 |
| **Validating array item reads** | 3 |
| **Cell arguments across a call boundary** | 5 |

## What the diff is, as a property

- Blank-separated group labels over these files: **14 at the base and 0 at
  head** (six prose labels and eight ruler-drawn ones); comments adjacent above an opener: **0**.
- Added or removed lines that are neither a comment nor blank: **0**. No
  executable content moves, and no test is renamed.
- Every region was enumerated member by member against its title, and every
  frame carries a blank line above and below it.
- No added line exceeds 80 characters that is not already in the base verbatim.

## Two things to weigh

**"What shrinking keeps" (21 members)** is the largest invented region here. Its
members are all `lift preserves / validates / shrinks / narrows …`, and the
reading behind the title is that they pin which reads the shrinker must follow
so that a field still in use survives. If that framing is wrong, twenty-one
tests carry the mistake.

**Converting the ruler style** in `vehicles` and `cf-code-editor` is a style
call, not something the rule demands: those were already section markers, drawn
differently. It makes the tree uniform and lets the marker census see them, but
it is the one change here that could equally well be left undone.

## Gates

`deno fmt --check` and `deno lint` pass over the workspace (exit 0).
`deno task test`: `html` 26 / 0, `ts-transformers` 1164 / 0, `patterns/vehicles`
24 / 0. `runner` reports 1323 passed / 1 failed, and the failure is
`executor-effect-channel.test.ts` timing out on a 20-second `waitUntil` poll — a
file this change does not touch. The runner file it does change passes on its
own (`schema-to-ts.test.ts`: 1 passed, 29 steps, 0 failed). That step has now
failed four times today under local load, across four branches and two machines,
and passes on CI every time.
