### PR TITLE
test: set six markers off from what they head, and finish one enumeration

### DIFF
--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1623,7 +1623,9 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
 
     // Reactive-update companions to the two mount-time tests above. They guard
     // the composed semantics across cell updates: a block must reach every
-    // enclosing boundary, and an unblock must clear every enclosing boundary.
+    // enclosing boundary, an unblock must clear every enclosing boundary, and
+    // an inner boundary that stops verifying must make the enclosing one
+    // recompute.
     const nestedAuthorshipTree = (innerChild: unknown) => ({
       type: "vnode",
       name: "div",

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -170,6 +170,7 @@ async function cleanup(
 // pass one. Instead it runs the same scenario once more, untimed and with the
 // callback, and reports what came back. The reports are per bench name, once.
 //
+
 type Account = (tx: IExtendedStorageTransaction) => void;
 
 const reported = new Set<string>();
@@ -214,6 +215,7 @@ function updateLine({ docs, bytes }: WriteAccount): string {
 //
 // 1. WRITE: one flat array in ONE doc, via a single Cell.set()
 //
+
 async function writeOneDoc(
   N: number,
   b?: Deno.BenchContext,
@@ -241,6 +243,7 @@ async function writeOneDoc(
 //
 // 2. WRITE: one doc PER ITEM (parent array holds cell links)
 //
+
 async function writePerItem(
   N: number,
   b?: Deno.BenchContext,
@@ -310,6 +313,7 @@ for (const N of SIZES) {
 //
 // 3. READ: one whole-array get() in a fresh tx, then repeated reads in one tx
 //
+
 for (const N of SIZES) {
   Deno.bench({
     name: `flat list read - fresh-tx schemaless get() (${N} items)`,

--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -205,6 +205,7 @@ function op(binding: FabricExecValue, links: Links = withSchema): void {
 //
 // deno bench cases
 //
+
 for (const aliases of [10, 30, 100, 300]) {
   const binding = makeUiBinding({ aliases, pathDepth: 2 });
   Deno.bench(
@@ -216,6 +217,7 @@ for (const aliases of [10, 30, 100, 300]) {
 //
 // direct-run study harness
 //
+
 function time(
   label: string,
   binding: FabricExecValue,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two small things, both found by checks written after the comment-placement work
rather than during it.

## Six markers were not set off from what they head

A section marker is separated from the block it heads by a blank line. Measured
over all 2276 test and bench files: **702 marker frames have that blank line and
six do not**, so the six are the outliers rather than an alternative style. All
six are in two bench files, and each heads a declaration — a `type`, a
`function`, a `for` loop — rather than a test.

The diff adds six blank lines and changes nothing else: **added or removed lines
that are not blank: 0.**

## One enumeration was short by one

`worker-reconciler-cfc-render-policy`'s reactive-companion comment says its
tests guard "a block must reach every enclosing boundary, and an unblock must
clear every enclosing boundary" — two guarantees, while **three** reactive tests
follow it. The third, that an inner boundary which stops verifying makes the
enclosing one recompute, is now named alongside the other two. No word is
removed.

That mismatch is worth naming as a check in its own right: **when a comment
enumerates a count, that count has to equal what follows it.** It needs no
judgment, and it is what caught this.

## Not addressed, deliberately

A review of an earlier change noted that `memory/v2-explicit-read`'s interior
comment at line 846 heads three tests without a frame. It is left alone. Its
region interleaves — one identity test, three lifecycle tests, one more identity
test — so framing it strands the fifth member unless a test moves, and the
enclosing marker's description names an obligation that fifth member is the only
one to satisfy. Framing it would trade one looseness for another; separating
them properly is a change about that file's structure, not about marker syntax.

## Gates

`deno fmt --check` and `deno lint` pass over the workspace (exit 0).
`deno task test` in `packages/html`: 26 passed / 0 failed. Both bench files
type-check (`deno check`, exit 0); they are benches, so they have no test run.
A tree-wide re-scan finds **zero** markers missing a blank line above or below.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

