### PR TITLE
test(toolshed): each comment sits where its reach says it should

### DIFF
--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -14,6 +14,7 @@ Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () =
   // true, which would silently enable telemetry (and, with the all-span
   // exporter, ship every HTTP request span) when an operator set
   // OTEL_ENABLED=false to disable it.
+
   const otel = (v: string | undefined) =>
     EnvSchema.parse(v === undefined ? {} : { OTEL_ENABLED: v }).OTEL_ENABLED;
 
@@ -29,12 +30,11 @@ Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () =
   assertEquals(otel(undefined), false);
 });
 
-//
-// The sibling boolean flags shared the same z.coerce.boolean() trap and now use
-// the strict boolFlag() parse. Guard them so they can't silently regress.
-//
-
 Deno.test("DISABLE_LOG_REQ_RES / PLAID_SYNC_ALL_TRANSACTIONS parse strictly", () => {
+  // The sibling boolean flags use the strict boolFlag() parse rather than
+  // z.coerce.boolean(), which reads "false" as true. Guard them so they
+  // can't silently regress.
+
   const flag = (key: string, v: string | undefined) =>
     (EnvSchema.parse(v === undefined ? {} : { [key]: v }) as Record<
       string,
@@ -89,6 +89,7 @@ Deno.test("MEMORY_WS_IDLE_TIMEOUT_SECONDS defaults to 300 and accepts overrides"
   // must exceed the memory server's longest synchronous busy stretch, which an
   // operator observes in production, and 0 must disable the timeout entirely
   // (Deno.upgradeWebSocket's contract for idleTimeout).
+
   const idle = (value: string | undefined) =>
     EnvSchema.parse(
       value === undefined ? {} : { MEMORY_WS_IDLE_TIMEOUT_SECONDS: value },

--- a/packages/toolshed/lib/ai-telemetry.test.ts
+++ b/packages/toolshed/lib/ai-telemetry.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Per-request metadata reaches spans only when it is passed as runtime context
+ * and named in `includeRuntimeContext`. Nothing throws when that wiring is
+ * wrong: the spans are still exported, just without the attributes. These
+ * tests assert the attributes are present.
+ */
+
 import { assert, assertEquals } from "@std/assert";
 import { registerTelemetry, streamText } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
@@ -12,11 +19,6 @@ import {
   metadataAttributeValue,
   runtimeContextFromMetadata,
 } from "@/lib/ai-telemetry.ts";
-
-// Per-request metadata reaches spans only when it is passed as runtime context
-// and named in `includeRuntimeContext`. Nothing throws when that wiring is
-// wrong: the spans are still exported, just without the attributes. These tests
-// assert the attributes are present.
 
 function mockModel() {
   return new MockLanguageModelV4({

--- a/packages/toolshed/lib/rate-limit.test.ts
+++ b/packages/toolshed/lib/rate-limit.test.ts
@@ -1,14 +1,14 @@
+/**
+ * This is the whole of toolshed's rate limiting. The properties worth pinning
+ * are the ones an abuse bound depends on: that a burst is actually capped,
+ * that keys do not share a bucket, that eviction cannot be used as a reset
+ * primitive, and that a caller cannot choose which bucket they land in.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createRateLimiter } from "@/lib/rate-limit.ts";
 import { clientKey } from "@/middlewares/rate-limit.ts";
-
-//
-// Toolshed had no rate limiting before self-serve minting, so this is the whole
-// of it. The properties worth pinning are the ones an abuse bound depends on:
-// that a burst is actually capped, that keys do not share a bucket, and that
-// eviction cannot be used as a reset primitive.
-//
 
 describe("token bucket", () => {
   it("allows a burst up to capacity, then refuses", () => {

--- a/packages/toolshed/lib/server-execution.test.ts
+++ b/packages/toolshed/lib/server-execution.test.ts
@@ -14,19 +14,19 @@ import {
   publishExperimentalPosture,
 } from "@/lib/experimental-posture.ts";
 
-// The Phase-6 env knobs (serving-loop.md §5) are the production
-// multi-tenancy bound: a runaway fan-out must degrade only its own space,
-// so the outstanding-effect cap is ON by default and only the LITERAL `0`
-// opts out. The property worth pinning is that a typo cannot disable it:
-// garbage must fall back to the default (loudly), never read as the
-// opt-out (the Phase-6 independent review's F4 — the pre-fix parser
-// mapped "abc"/"-1" to `undefined` = unbounded, indistinguishable from
-// the explicit `0`).
-
 const envOf = (values: Record<string, string | undefined>) => (name: string) =>
   values[name];
 
 describe("serverExecutionPolicyFromEnv", () => {
+  // The Phase-6 env knobs (serving-loop.md §5) are the production
+  // multi-tenancy bound: a runaway fan-out must degrade only its own space,
+  // so the outstanding-effect cap is ON by default and only the LITERAL `0`
+  // opts out. The property worth pinning is that a typo cannot disable it:
+  // garbage must fall back to the default (loudly), never read as the
+  // opt-out (the Phase-6 independent review's F4 — the pre-fix parser
+  // mapped "abc"/"-1" to `undefined` = unbounded, indistinguishable from
+  // the explicit `0`).
+
   it("defaults the outstanding cap ON when the knob is unset or empty", () => {
     const warnings: string[] = [];
     expect(serverExecutionPolicyFromEnv(envOf({}), (m) => warnings.push(m)))

--- a/packages/toolshed/lib/space-authority.test.ts
+++ b/packages/toolshed/lib/space-authority.test.ts
@@ -17,14 +17,14 @@ import {
   isValidSpaceDid,
 } from "@/lib/space-authority.ts";
 
-// The narrow entitlement predicate. Cheap, exhaustive, and the place the
-// wildcard attack is pinned — see the "*" cases.
-
 // Shaped like real ed25519 did:keys, and valid base58btc (no 0, O, I or l).
 const ALICE = "did:key:z6MkaaaabbbbccccddddeeeeffffgggghhhhAAAA";
 const MALLORY = "did:key:z6MkmmmmnnnnppppqqqqrrrrssssttttuuuuBBBB";
 
 describe("isExplicitSpaceOwner", () => {
+  // The narrow entitlement predicate. Cheap, exhaustive, and the place the
+  // wildcard attack is pinned — see the "*" cases.
+
   it("admits an explicit concrete OWNER grant", () => {
     expect(isExplicitSpaceOwner({ [ALICE]: "OWNER" }, ALICE)).toBe(true);
   });
@@ -106,18 +106,14 @@ describe("isValidSpaceDid", () => {
   });
 });
 
-//
-// Against a REAL memory-v2 server with ACL enforcement on.
-//
-// This is the fixture the existing ingest suite lacks: ingest.utils.test.ts uses
-// StorageManager.emulate, whose server is constructed with no `acl` option at
-// all, so `#aclMode()` returns "off" and no authorization is exercised. Without
-// the harness below, the central security property of this feature — "refused
-// when naming a space you don't control" — is not testable, and a regression
-// would pass CI silently.
-//
-
 describe("authorizeSpaceOwner against real ACL enforcement", () => {
+  // This is the fixture the existing ingest suite lacks: ingest.utils.test.ts
+  // uses StorageManager.emulate, whose server is constructed with no `acl`
+  // option at all, so `#aclMode()` returns "off" and no authorization is
+  // exercised. Without the harness below, the central security property of
+  // this feature — "refused when naming a space you don't control" — is not
+  // testable, and a regression would pass CI silently.
+
   let server: MemoryV2Server.Server;
   let factory: LoopbackSessionFactory;
   let operator: Identity;

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.utils.test.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.utils.test.ts
@@ -29,11 +29,11 @@ import {
   saveRegistration,
 } from "@/routes/ingest/ingest.utils.ts";
 
-/** Narrow a ControlResult to its success body, failing loudly otherwise. */
 // Shaped like a real derived channel id: ids are validated before they become
 // a cell cause in the operator's service space.
 const WELL_FORMED_ID = "ing_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
+/** Narrow a ControlResult to its success body, failing loudly otherwise. */
 const ok = <T>(result: ControlResult<T>): T => {
   assert(
     result.status === 200,
@@ -220,6 +220,7 @@ describe("ingest-channels control plane", () => {
     // `did:web:commonfabric.org#oauth2` and `#plaid` are the token-less
     // integration audiences; the segment charset is what keeps a minted
     // audience out of that namespace.
+
     const res = await mint(alice, "req-c", {
       installId: "did:web:commonfabric.org#oauth2",
     });
@@ -831,6 +832,7 @@ describe("ingest-channels control plane", () => {
     it("a malformed space DID shares the ownership denial, not its own error", async () => {
       // A distinguishable shape error would be a free probe for whether a
       // space exists, so it must answer exactly like "not an owner".
+
       const res = await processMint(deps, alice.did(), {
         space: "not-a-did",
         installId: "phone-1",
@@ -1451,6 +1453,7 @@ describe("ingest-channels control plane", () => {
       // Bob owns the space and grants Alice OWNER; Alice mints; the grant is
       // then removed. Alice's token keeps working, so Bob has to be able to
       // discover and revoke it.
+
       const shared = await sharedSpace();
       const minted = await processMint(deps, alice.did(), {
         space: shared,
@@ -1588,6 +1591,7 @@ describe("ingest-channels control plane", () => {
   it("clamps an absurd ttlDays instead of throwing a RangeError", async () => {
     // `new Date(now + 1e15 * 86_400_000).toISOString()` throws RangeError, and
     // that line sits outside the try — it would escape as an uncaught 500.
+
     const res = await mint(alice, "req-ttl", { ttlDays: 1e15 });
     expect(res.status).toBe(200);
     expect(Date.parse(ok(res).expiresAt ?? "")).toBeGreaterThan(Date.now());
@@ -1602,7 +1606,8 @@ describe("ingest-channels control plane", () => {
         requestId: "shared-id",
       })).status,
     ).toBe(200);
-    // Same requestId, different caller, different installId -> must not collide.
+    // Same requestId, different caller, different installId -> must not
+    // collide.
     const other = await processMint(deps, mallory.did(), {
       space: shared,
       installId: "phone-2",

--- a/packages/toolshed/routes/ingest/ingest.utils.test.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.test.ts
@@ -27,7 +27,8 @@ const GOLDEN_ID = "of:fid1:d7_RmD4fNpTUheithVm0Q1Vha0Rn32c06qA_hOHE8x8";
 
 // Golden channel id — rotate-in-place is a security property, so pin the exact
 // derivation: a drift means "rotation" mints a NEW registration and leaves the
-// old token live. A failure = coordinate a change, never just update the literal.
+// old token live. A failure = coordinate a change, never just update the
+// literal.
 const GOLDEN_CHANNEL_ID = "ing_jMjaGfRO0Kg0BUegs9mzwImZ-CKcmlVw-wDbmV41_bs";
 
 describe("ingest journal sink", () => {
@@ -131,6 +132,7 @@ describe("ingest journal sink", () => {
   it("a never-written partition cell reads back ABSENT (undefined), not []", async () => {
     // The load-bearing tri-state invariant: absent (never captured) must be
     // distinguishable from empty. The schema must not inject a [] default.
+
     const cell = journalCell(runtime, reg(), "1999-01-01");
     await cell.sync();
     expect(cell.get()).toBeUndefined();
@@ -158,6 +160,7 @@ describe("ingest journal sink", () => {
     // space and mints there. CAVEAT: emulate has NO ACL layer, so this does NOT
     // prove a production memory server AUTHORIZES the cross-space commit — that
     // is the deploy-time probe (MEMORY_ACL_MODE), not a unit test.
+
     const other = await Identity.fromPassphrase("some-other-user");
     const otherSpace = other.did();
     const r = reg({ space: otherSpace, installId: "install-2" });
@@ -229,12 +232,19 @@ describe("ingest journal sink", () => {
     // loom READS by recomputing this exact id from the cause string. If the
     // `FabricHash` format changes, this literal breaks CI loudly instead of
     // silently orphaning loom's reader.
+
     const cell = journalCell(runtime, reg(), "2026-07-01");
     await cell.sync();
     expect(cell.getAsNormalizedFullLink().id).toBe(GOLDEN_ID);
   });
 
-  // processIngest: the full auth + validation contract
+  //
+  // processIngest: the auth and validation contract
+  //
+  // Over the two helpers below. The claim on a request id that its writes
+  // rest on is pinned in its own block within this region.
+  //
+
   const savedReg = async (
     overrides: Partial<IngestRegistration> = {},
   ): Promise<{ r: IngestRegistration; secret: string }> => {
@@ -429,10 +439,11 @@ describe("ingest journal sink", () => {
     expect(res.status).toBe(400);
   });
 
-  // The one deliberate departure from blanket 401 equalization. It is reachable
-  // ONLY with a correct token, so it leaks nothing to a guesser — and it is what
-  // lets a beacon that was offline across a rotation know to re-pair instead of
-  // dropping its buffer or retrying a "broken server" forever.
+  // The one deliberate departure from blanket 401 equalization. It is
+  // reachable ONLY with a correct token, so it leaks nothing to a guesser —
+  // and it is what lets a beacon that was offline across a rotation know to
+  // re-pair instead of dropping its buffer or retrying a "broken server"
+  // forever.
   const REPAIR_BODY = { partition: "2026-07-01", records: [{ x: 1 }] };
 
   it("processIngest: VALID token + disabled -> 403 re-pair, no write", async () => {
@@ -603,6 +614,10 @@ describe("ingest journal sink", () => {
     await cell.sync();
     expect(cell.get()).toBeUndefined();
   });
+
+  //
+  // Registration and last-seen bookkeeping
+  //
 
   it("saveRegistration indexes ids exactly once", async () => {
     await saveRegistration(runtime, space, reg({ id: "ing_i1" }));

--- a/packages/toolshed/routes/shell/shell.test.ts
+++ b/packages/toolshed/routes/shell/shell.test.ts
@@ -112,6 +112,7 @@ describe("Shell cross-origin isolation posture", () => {
     // The posture must hold for every served path, not just the document root,
     // because any same-origin response can establish or reuse the page's agent
     // cluster.
+
     const response = await app.request("/assets/app.js");
     await response.text();
 
@@ -153,13 +154,11 @@ describe("Shell route CORS", () => {
   });
 });
 
-//
-// With no compiled frontend and no SHELL_URL proxy target — the unit-test
-// environment — the shell router answers with a 404 that tells an operator how
-// to bring the shell up. This guards that operator hint and its port.
-//
-
 describe("Shell dev fallback without a compiled build or proxy", () => {
+  // With no compiled frontend and no SHELL_URL proxy target — the unit-test
+  // environment — the shell router answers with a 404 that tells an operator
+  // how to bring the shell up. This guards that operator hint and its port.
+
   it("returns 404 with a hint naming SHELL_URL and the shell port", async () => {
     const response = await app.request("/anything");
     const body = await response.text();
@@ -241,6 +240,7 @@ describe("createShellStaticRouter", () => {
     // The request resolves outside the static root; the traversal guard (and
     // URL normalization) keep it from reaching the sentinel, so the client-side
     // routing fallback serves index.html instead.
+
     const response = await staticApp.request("/../shell-sentinel.txt");
     expect(response.status).toBe(200);
     const body = await response.text();
@@ -260,6 +260,7 @@ describe("createShellStaticRouter behind composed app middleware", () => {
     // Exercises middleware ordering on a real 200 document rather than only on
     // the dev 404 fallback: the served index.html must still carry the
     // cross-origin header the shell wires up ahead of the static router.
+
     const response = await composedApp.request("/");
     expect(response.status).toBe(200);
     expect(await response.text()).toBe(INDEX_HTML);
@@ -270,7 +271,8 @@ describe("createShellStaticRouter behind composed app middleware", () => {
 describe("StaticResponse", () => {
   const encoder = new TextEncoder();
 
-  // In-memory file set so StaticResponse can be exercised without touching disk.
+  // In-memory file set so StaticResponse can be exercised without touching
+  // disk.
   const files: Record<string, Uint8Array> = {
     "/root/index.html": encoder.encode(INDEX_HTML),
     "/root/app.js": encoder.encode(APP_JS),

--- a/packages/toolshed/scripts/ingest-channel-scripts.test.ts
+++ b/packages/toolshed/scripts/ingest-channel-scripts.test.ts
@@ -31,10 +31,11 @@ import {
 } from "./retire-ingest-channels.ts";
 
 describe("ingest channel operator scripts", () => {
-  // The two operator scripts behind the retirement procedure. They are the only
-  // tooling that makes a trust-condition cutover answerable, so the selection
-  // logic — what gets retired, what is skipped, what the audit reports — is
-  // worth pinning even though the entrypoints themselves are thin.
+  // The operator scripts behind the retirement procedure — audit, retire, and
+  // the break-glass provision path. They are the only tooling that makes a
+  // trust-condition cutover answerable, so the selection logic — what gets
+  // retired, what is skipped, what the audit reports — is worth pinning even
+  // though the entrypoints themselves are thin.
 
   let signer: Identity;
   let serviceSpace: string;
@@ -103,9 +104,8 @@ describe("ingest channel operator scripts", () => {
   });
 
   describe("recovering a channel the index never learned about", () => {
-    // Until this change the audit-index write was best-effort and its failure
-    // swallowed, so a channel can exist that the index never learned about. An
-    // audit that walks only the index cannot find it — repairing an index by
+    // A channel can exist that the audit index never learned about. An audit
+    // that walks only the index cannot find it — repairing an index by
     // enumerating that same index only ever confirms what is already there —
     // and the affected space's owner cannot see or revoke it.
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

An ex-post-facto review pass over the test-block comment arc, covering the
`toolshed` files that arc touched. A reviewer read the current content of
each file on `main` rather than any single diff, since later batches
re-touched files earlier ones had changed. Twelve sites came back where a
comment's placement, or its words, disagree with what it heads.

## Regions wider than their title owns

Three section markers framed a region that ran to the end of the file while
their words were true only of the block directly below them. Each becomes
that block's comment.

- `routes/shell/shell.test.ts` — the dev-fallback marker covered three
  further unrelated describes.
- `env.test.ts` — the boolean-flag marker covered an enum test and a number
  test.
- `lib/space-authority.test.ts` — the marker's region held exactly one
  block, so it was not marking a region at all. Its opening sentence
  restated the describe's own name and is dropped rather than moved.

## Statements about a file, written as notes about a declaration

`lib/ai-telemetry.test.ts` and `lib/rate-limit.test.ts` each carried a
comment describing the whole file, placed below the import block. That
position reads as the doc comment of the first declaration under it, so both
become file headers. `rate-limit`'s named three properties while its region
also covered the `clientKey` describe, which none of the three reach; the
header names that fourth property.

## Comments that headed the wrong thing

- `lib/space-authority.test.ts` — a label for `isExplicitSpaceOwner` sat
  three declarations above it, separated by a blank line.
- `lib/server-execution.test.ts` — a label for
  `serverExecutionPolicyFromEnv` sat above the `envOf` helper. Every line
  fits at the deeper indentation, so it moves without reflowing.
- `routes/ingest-channels/ingest-channels.utils.test.ts` — the doc comment
  for the `ok()` helper bound to a string constant, with a second comment
  between it and the declaration it documents.
- `routes/ingest/ingest.utils.test.ts` — a label introducing some fifteen
  `processIngest` cases and their two shared helpers sat adjacent above one
  of the helpers. It becomes a framed marker, and the registration and
  last-seen cases that follow the run take a second marker that closes it.

## Comments whose words are not true of what follows

- `scripts/ingest-channel-scripts.test.ts` — "the two operator scripts"
  heads a block exercising three: audit, retire, and the break-glass
  provision path with its own `provisionMain` cases. Moving the comment
  inside the block made its reach exactly that block, which is what turns a
  loose preface into a wrong count.
- The same file narrated an audit-index write that "until this change" was
  best-effort with its failure swallowed. `saveRegistration` states the
  opposite — "Every index is written with the registration, and none of them
  is best-effort" — so the clause describes a state that no longer holds and
  is dropped. The same sentence appears in `scripts/audit-ingest-channels.ts`
  and is left for a change that owns that file.

## Mechanical

Twelve block comments ran straight into the first statement of their
callback. Without the blank line under it, such a comment is about that
statement rather than about the block, which is the ordinary use and is a
different thing from what these say. Six comment lines ran past 80
characters and are rewrapped.

These twelve predate the arc, and saying so is worth the sentence. Every
comment the arc moved into a block got its blank line; a later review
established that by reading every hunk of every arc commit over its own
files. What the arc could not reach is a comment that was already inside its
block, because the sweep looked above block openers. That is the whole of
this population here, and there are several hundred more of them across the
tree. These twelve are the ones in files this pass had open, not the result
of a decision to take that on.

## Verification

Each edit asserted its target text appeared exactly once before
substituting. Comment word multisets were compared against `3c95ccc39` per
file; they are identical wherever the change was a move or a rewrap, and the
deltas elsewhere are exactly the restatements described above. The check was
controlled by deleting a word and confirming it appeared as lost.

`deno fmt --check` and `deno lint` pass over the changed files. `deno task
test` in `packages/toolshed` reports `ok | 147 passed (463 steps) | 0 failed`.

## Not included

One further finding wants the four 403 re-pair cases in
`routes/ingest/ingest.utils.test.ts` wrapped in a `describe()` so their
shared rationale has a block to sit in. That renames four tests, and
`tasks/test-identity-aliases.jsonl` carries no `toolshed` entry to follow,
so the rename is left for a decision about whether these tests reach the
test-run record store. The width half of that finding is applied here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


