### PR TITLE
test: each marker's region owns what it holds

### DIFF
--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1724,12 +1724,13 @@ describe("JsonCodecEngine", () => {
     });
 
     //
-    // Every arm of the dispatch
+    // The fallback arms, deep-frozen
     //
-    // Every arm of the dispatch, so that the guarantee does not depend on which
-    // one produced the value. `isDeepFrozen()` rather than `Object.isFrozen()`:
-    // an arm that froze only the value it built, and not what it wrapped, would
-    // pass the shallow check.
+    // These pin the guarantee on the arms that wrap wire state rather than
+    // decode it — an `UnknownValue` and a `ProblematicValue`. They assert
+    // with `isDeepFrozen()` rather than `Object.isFrozen()`, because an arm
+    // that froze only the value it built, and not what it wrapped, would pass
+    // the shallow check.
     //
 
     it("deep-freezes an `UnknownValue` from an unrecognized tag", () => {

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -157,6 +157,14 @@ describe("data-uri-codec", () => {
       expect(dataUriFromValue(NaN)).not.toBe(dataUriFromValue(-Infinity));
     });
 
+    //
+    // Canonical sameness
+    //
+    // The other direction, and the reason distinctness is not the whole
+    // property: equal values mint one URI. Every `NaN` payload collapses to
+    // the same identifier, and a repeated value mints deterministically.
+    //
+
     it("mints one URI for every `NaN`, whatever its payload", () => {
       // Arithmetic only ever yields one `NaN` bit pattern, so `NaN` and `0 / 0`
       // are the same value and comparing them proves only determinism. A

--- a/packages/schema-generator/test/stream-result.test.ts
+++ b/packages/schema-generator/test/stream-result.test.ts
@@ -3,14 +3,13 @@ import { describe, it } from "@std/testing/bdd";
 import { SchemaGenerator } from "../src/schema-generator.ts";
 import { asObjectSchema, getTypeFromCode } from "./utils.ts";
 
-/**
- * A verb's declared result rides a second type parameter on `Stream`
- * (verb contract WS-C/C1). Schema generation must keep recognizing the
- * property as a stream when that parameter is present — the marker and the
- * event schema both come off the same type check, so if two type arguments
- * confused it, a returning verb would stop being a verb.
- */
 describe("Stream with a declared result", () => {
+  // A verb's declared result rides a second type parameter on `Stream` (verb
+  // contract WS-C/C1). Schema generation must keep recognizing the property as
+  // a stream when that parameter is present — the marker and the event schema
+  // both come off the same type check, so if two type arguments confused it, a
+  // returning verb would stop being a verb.
+
   async function schemaFor(code: string) {
     const { type, checker, typeNode } = await getTypeFromCode(
       code,

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -66,7 +66,11 @@ function referenceEncode(value: bigint): Uint8Array {
 }
 
 //
-// Fixtures, both main and reference
+// Fixtures, and the check that pins the oracle
+//
+// Both fixture sets — the main ones the per-function loops consume, and the
+// hand-written reference bytes — and then the block that pins
+// `referenceEncode()` against those bytes.
 //
 
 interface Fixture {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Four sites an ex-post-facto review of the test-block comment arc turned up,
each one a region whose contents and whose title disagree. Reviewers read the
current content of the arc's files on `main` rather than any single diff,
since later batches re-touched files that earlier ones had changed; three of
these four files were last shaped by a different arc PR than the one that
first touched them.

## A marker deleted correctly, and what went with it

`packages/utils/test/bigint.test.ts` shows a failure the arc's rules do not
name, and which the reviews found on their own.

A marker reading "Tests to validate reference encoder" sat over
`describe("`referenceEncode()` (test oracle)")`. It restated the block below
it and added nothing, so it was removed — the right disposition, and the one
the rule asks for.

But that marker was also the closer of the region above it. With it gone,
"Fixtures, both main and reference" runs from its own frame all the way to
the next marker, and a test block is now filed under a title naming fixture
machinery.

This is the delimiter trap in a form worth writing down: the arc already knew
that *moving* a comment into its block widens the comment above it. Deletion
does the same thing, and is harder to catch, because there is no relocated
comment to inspect afterward — the evidence of what the region used to end at
is gone with it. A label that says no more than its block can still be doing
a second job.

The marker takes a title and a description that own the whole region.

## A region contradicted by its own contents

`packages/data-model/test/data-uri-codec.test.ts` frames a "Distinctness"
region whose description says two values that are not equal must not mint the
same identifier. Three cases inside assert exactly that. Two more assert the
opposite direction: every `NaN` payload mints one URI whatever its bits, and
a repeated value mints deterministically.

Those two take a "Canonical sameness" marker, which gives them a title that
covers them and closes the distinctness region where its subject ends.

## A title that claims more than its region holds

`packages/data-model/test/codec-json/JsonCodecEngine.test.ts` titles a region
"Every arm of the dispatch". The region holds three cases, covering the
unknown-tag and malformed-tag fallback arms. The codec arm is in the next
block; the remaining arms sit above the marker, outside it.

The words worked as a label introducing a run. Promoted to a title, they
claim the region is every arm, which it is not. The description also opened
by repeating the title verbatim as a sentence fragment. The title now names
the fallback arms and the description is a sentence.

## A comment the sweep could not see

`packages/schema-generator/test/stream-result.test.ts` keeps a group comment
above its top-level `describe()`, below the import block — a position that
reads as the doc comment of the declaration under it.

It survived because it is written as a `/** */` doc comment rather than a
`//` block, and the sweep was oriented to `//`. The arc moved a different
comment in this same file correctly. It now moves inside the callback, which
is that file's own idiom.

## Verification

Each edit asserted its target text appeared exactly once before substituting.
Comment word multisets were compared per file against `3c95ccc39`:
`stream-result.test.ts` is identical across the move and its reflow, and the
other three differ by exactly the retitled or added marker text.

`deno fmt --check` and `deno lint` pass over the changed files. `deno task
test` passes in each package touched — `utils` 99 passed, 0 failed;
`data-model` 48 passed (2747 steps), 0 failed; `schema-generator` 57 passed,
0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

