### PR TITLE
test: a marker's title claims only what its region holds

### DIFF
--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -92,7 +92,11 @@ Deno.test("keying - generateKey", async (t) => {
   });
 
   //
-  // The two things a render node may hold that are not `FabricValue`s
+  // Beyond `FabricValue`
+  //
+  // An event handler — one of the two things a render node holds that is not
+  // a `FabricValue` — and the coarse key that comes back for a node the keyer
+  // cannot hash.
   //
 
   await t.step("keys an event handler without falling back", () => {

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2676,11 +2676,6 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
       },
     );
 
-    // Default render ceiling (spec §8.10.6, S16 phase D)
-    // A host-supplied root ceiling gates labeled cells with NO authored
-    // boundary in the tree: atoms render only when listed exactly or when
-    // they are Caveat atoms of an allow-listed kind.
-
     const PROMPT_INFLUENCE_KIND =
       "https://commonfabric.org/cfc/concepts/prompt-influence";
     const influenceCaveatAtom = {
@@ -2729,8 +2724,10 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     //
     // The default ceiling
     //
-    // What the configured ceiling admits and blocks on its own, and how an
-    // authored boundary narrows it.
+    // What a host-supplied root ceiling (spec §8.10.6, S16 phase D) admits
+    // and blocks on its own, and how an authored boundary narrows it. With no
+    // authored boundary in the tree, atoms render only when listed exactly,
+    // or when they are Caveat atoms of an allow-listed kind.
     //
 
     await t.step(
@@ -2858,8 +2855,9 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     //
     // A ceiling over a labeled cell
     //
-    // The same ceiling reached through a labeled cell rather than a plain atom,
-    // including one mounted as the root.
+    // The ceiling as it applies to a labeled cell: mounted as the root,
+    // absent entirely, shaped as an acting-user DID or backed by a resolver,
+    // and failing closed on a read-failure marker or a malformed ceiling.
     //
 
     await t.step(

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -2638,10 +2638,10 @@ describe("cell-handle", () => {
     //
     // Three methods that serialize
     //
-    // Three methods serialize, and each used to refuse a `FabricSpecialObject`
-    // through a different caller contract. All three carry one now, and pinning
-    // all three is what keeps a later refactor from carrying it on only the
-    // path `set()` takes.
+    // Each write path serializes through its own caller contract, so a
+    // refactor can carry a value on one and drop it on another. `push()` and
+    // `send()` are pinned carrying a `FabricSpecialObject`; `set()` is pinned
+    // on the non-object `FabricValue` arm.
     //
 
     it("carries one through `push()`", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Four sites from an ex-post-facto review of the test-block comment arc, all of
one shape, and the shape is worth naming because it is a cost of the arc's
own late work rather than something it inherited.

A comment sitting above a run of blocks is a label. It has to gesture at what
follows and no more; a reader takes it as an introduction. The same words
framed as a section marker become a **title**, and a title asserts that the
region *is* what it names. Several of the arc's last PRs converted labels to
markers by lifting the existing words into the title slot. Where the words
were loose in the way a label is allowed to be, the conversion made them
false.

Three of the four below were promoted to titles by the arc (#6579, #6580);
the fourth is a label the arc left standing while subdividing the ground
underneath it.

## A region that claims a pin it does not hold

`packages/runtime-client/test/cell-handle.test.ts` — the marker says three
methods serialize and "All three carry one now", meaning a
`FabricSpecialObject`. The third member carries a `bigint`, and that test's
own comment says "Not an object, so the `FabricSpecialObject` branch never
sees it."

Nothing in the file pins `set()` carrying a special object end to end, so the
description advertised a guarantee a reader would go looking for and not
find. It now says what the region pins: `push()` and `send()` carrying a
special object, and `set()` on the non-object `FabricValue` arm.

The alternative was to add a `set(new FabricBytes(...))` case and let the
words stand. That is a test-coverage decision rather than a comment one, so
it is left alone and named here instead.

## A title naming two things, over a region holding one of them

`packages/html/test/worker-keying.test.ts` — "The two things a render node
may hold that are not `FabricValue`s". Per `src/worker/keying.ts`, those two
are a `Cell` and a function. The region holds the function case and a `Map`
fallback whose own comment says "no render node holds one" — so the second
member is not one of the two, and `Cell` does not appear in the test file at
all (zero occurrences, against four in `keying.ts`).

The title now names what the region holds, and mentions the function as one
of the two rather than promising both.

## A contrast that distinguishes nothing

`packages/html/test/worker-reconciler-cfc-render-policy.test.ts` — "The same
ceiling reached through a labeled cell rather than a plain atom" fails on
both halves. The preceding region's members gate labeled cells too, so
"rather than a plain atom" contrasts with nothing. And "the same ceiling"
holds of the first member only: of seven, one configures no ceiling at all,
and the others reach it through an acting-user DID profile, a resolver, and a
malformed ceiling.

The description now names what the seven actually share — the ceiling as it
applies to a labeled cell, by whichever route.

## An umbrella label left standing over its own replacements

The same file carries a "Default render ceiling (spec §8.10.6, S16 phase D)"
label above the ceiling fixtures. It is a run-spanning label with nothing to
close it, reaching over the three marker regions that follow — which is the
shape the arc existed to remove. It survived because #6579 subdivided the
territory beneath it, adding three markers, and removed nothing.

Its content, spec citation included, folds into the first of those regions.

## Verification

Each edit asserted its target text appeared exactly once before substituting.
Comment word multisets per file against `3c95ccc39` differ by exactly the
rewritten descriptions.

No comment line over 80 characters is added — the six in the render-policy
file and the two in `cell-handle` were already there, confirmed by comparing
the over-80 sets against the base rather than by counting.

`deno fmt --check` and `deno lint` pass over the changed files. `deno task
test` passes in both packages touched: `html` 26 passed (276 steps), 0
failed; `runtime-client` 16 passed (461 steps), 0 failed.

## Not included

One further finding in the render-policy file: the "Strict text integrity"
marker owns twelve steps, while seven more whose names open with those same
words sit earlier in the file, outside any region. The title is not too wide
for its region — it names a subject the file splits in two, so a reader
navigating by markers finds half of it. Repairing that means either giving
the earlier run its own marker, which makes it the file's first and leaves a
long stretch above as front matter, or retitling this region by what
distinguishes its members. Both are structural choices about a large file
rather than corrections, so it is left for a decision.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

