### PR TITLE
test: three regions that never ended where their words did

### DIFF
--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1276,17 +1276,15 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
   }
 });
 
-//
-// CT-1824 contract: a stale-read ConflictError must name the conflicted
-// entity BOTH structurally (of/seq/conflictSeq — read in-process by
-// editWithRetry's pull) AND in the message with this exact shape — server
-// Error fields do not survive serialization to the browser, so the runner
-// client re-derives `of` by parsing the message (runner storage/v2.ts
-// toRejectedError). Changing either surface breaks conflict recovery for
-// blind writes.
-//
-
 Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted entity structurally and in the message", async () => {
+  // CT-1824 contract: a stale-read ConflictError must name the conflicted
+  // entity BOTH structurally (of/seq/conflictSeq — read in-process by
+  // editWithRetry's pull) AND in the message with this exact shape — server
+  // Error fields do not survive serialization to the browser, so the runner
+  // client re-derives `of` by parsing the message (runner storage/v2.ts
+  // toRejectedError). Changing either surface breaks conflict recovery for
+  // blind writes.
+
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";
   const principal = "did:key:alice";

--- a/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin-unbound.test.ts
@@ -15,6 +15,7 @@ Deno.test("columnOrigins throws before the FFI is bound", () => {
   // Runs first, while nothing has bound the FFI and no reason has been
   // recorded: columnOrigins must refuse rather than read through a null library
   // handle, and the message names the call the caller skipped.
+
   assertThrows(
     () => columnOrigins(null, 1),
     Error,

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -449,6 +449,9 @@ Deno.test("main --filter: prints the surviving files on stdout, the report + DRO
   }
 });
 
+//
+// What `--ignore` binds to
+//
 // The mechanism's BINDING, pinned by spawning deno on both shapes (Phase 7
 // fixer, 2026-08-16): `deno test --ignore=<file>` filters only the modules
 // deno DISCOVERS — a glob it expands itself — and silently ignores nothing
@@ -456,6 +459,8 @@ Deno.test("main --filter: prints the surviving files on stdout, the report + DRO
 // the pattern shards' file list). Until this pin, every ON-arm skip since
 // Phase 4 rode a shell-expanded glob and never took effect. If deno's
 // semantics ever change, these two tests say which shape moved.
+//
+
 async function collectedTestFiles(args: string[], cwd: string) {
   const command = new Deno.Command(Deno.execPath(), {
     args: ["test", "--no-lock", "--no-check", ...args],


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Three sites from an ex-post-facto review of the test-block comment arc, each
a region that does not end where its words do.

## A marker whose words belong to one test

`packages/memory/test/v2-engine.test.ts` frames the CT-1824 stale-read
contract in `//` delimiters. The text is the contract of the test directly
beneath it, near enough word for word, and it is the only marker in a file of
some 3,700 lines — so its region runs to the end of the file, over roughly
twenty tests it says nothing about: the leaf-only, splice, pending-read,
snapshot and branch cases among them.

A marker covering a single block is not marking a region. It becomes that
test's comment, which is where a rationale this specific belongs.

## A run's comment parked on the helper the run shares

`tasks/server-execution-on-skips.test.ts` carries a comment ending "these two
tests say which shape moved", sitting adjacent above `collectedTestFiles()`.
In that position it reads as the helper's documentation, and the two tests it
speaks for are further down.

Framed as a marker, its region closes at the end of the file and genuinely
owns the helper and both tests. This is the class #6575 swept in seven files;
this file was not among them.

## A block comment that ran into its first statement

`packages/memory/test/v2-sqlite-column-origin-unbound.test.ts` has a comment
whose last clause — "the message names the call the caller skipped" — is
pinned by the *second* `assertThrows`, not the first. Without a blank line
under it, the comment reads as being about the statement it touches, which is
a different claim from the one it makes. It takes the blank line.

Worth recording why this one survived: it was created by a move, and the
blank-line pass that followed that move covered only the `describe()` sites
it had created, not `Deno.test` bodies. A pass narrower than the change it
was cleaning up leaves exactly this residue, and nothing downstream looked
again.

## Verification

Each edit asserted its target text appeared exactly once before substituting.
Comment word multisets against `3c95ccc39`: `v2-engine` and `v2-sqlite` are
identical — the first is a pure indent, every line of it fitting at the
deeper margin without reflowing — and `server-execution-on-skips` gains
exactly the four words of the marker title.

No comment line over 80 characters is added. The 26 in `v2-engine` and the
one in `v2-sqlite` were already there, established by differencing the
over-80 sets against the base rather than by comparing counts.

`deno fmt --check` and `deno lint` pass over the changed files. `deno task
test` in `packages/memory` reports 592 passed, 0 failed;
`tasks/server-execution-on-skips.test.ts` reports 17 passed, 0 failed.

## Coverage

ACCEPT_COVERAGE_DEBT: packages/memory +2 lines

The Coverage Check names `packages/memory/v2/server.ts` lines 329 and 330,
which this branch does not touch: it changes three test files, and every
added or removed line across the whole diff is a comment or a blank, with no
non-comment line among them. The gate's own message says the lines are "not
introduced by this PR and were previously covered on `main`", and attributes
that to lines inconsistently covered there.

## Not included

Three further findings in these files each admit two defensible repairs, and
choosing between them is a judgment about the tests rather than about the
comments:

- `tasks/check-deno-pins.test.ts:207` — a marker true of two tests, running
  to end of file over some fifteen more and two helpers. Either split the
  rationale into the two tests it belongs to, or keep the marker and close
  the region with another before the tests it does not cover.
- `packages/identity/test/key-store.test.ts:19` — a marker for two "arm"
  tests, swallowing an unrelated default-name test. Closing the region needs
  a marker that would head a single test, which the rule disfavors, so the
  alternative is to group the pair instead.
- `scripts/topics-rehearsal-lib.test.ts:34` — a region widened by one test
  when it was closed at the next marker rather than at the end of its run.
  Either move that test above the marker or extend the description to own
  the boundary case it states.

The `key-store` one is the arc's delimiter trap in a third form: the marker's
region was bounded in practice by an adjacent comment on a later test, and
moving that comment inside its block — a correct move — removed the last
thing showing where the region ended.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


