### PR TITLE
test(runner): fix the served-intent flake, and share one waitUntil across 22 suites

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -848,6 +848,19 @@ boundary the test can await without adding one to production code.
   it at quiescence. The equivalent reads in `counter.test.ts` and
   `nested-counter.test.ts` resolve a `defer()` from an existing
   `resultCell.sink(...)`.
+- `packages/runner/test/support/wait-until.ts` — the `waitUntil` the runner's
+  server-execution suites share. Twenty-two test files wait through it on state
+  the serving loop produces as a side effect of its own cycles: an engine row,
+  a watermark advance, a stats counter. Nothing reports those. `SpaceServer`
+  exposes `stats()` and `spaceServer()` and no notification, and the engine is
+  a synchronous store, so there is no event boundary without adding one to
+  production code. Its deadline is a stuck-condition backstop rather than a
+  bound at the call site, and it stays for a second reason: the serving loop
+  holds the event loop open through its lease-renew interval, so the fail-fast
+  described above never fires and an unbounded wait there would hang a run
+  instead of failing it. The failure names elapsed milliseconds and the poll
+  count, which is what separates a predicate that never came true from one the
+  test never got to evaluate.
 
 ### A pull that drives its own loading
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -850,17 +850,17 @@ boundary the test can await without adding one to production code.
   `resultCell.sink(...)`.
 - `packages/runner/test/support/wait-until.ts` — the `waitUntil` the runner's
   server-execution suites share. Twenty-two test files wait through it on state
-  the serving loop produces as a side effect of its own cycles: an engine row,
-  a watermark advance, a stats counter. Nothing reports those. `SpaceServer`
-  exposes `stats()` and `spaceServer()` and no notification, and the engine is
-  a synchronous store, so there is no event boundary without adding one to
-  production code. Its deadline is a stuck-condition backstop rather than a
-  bound at the call site, and it stays for a second reason: the serving loop
-  holds the event loop open through its lease-renew interval, so the fail-fast
-  described above never fires and an unbounded wait there would hang a run
-  instead of failing it. The failure names elapsed milliseconds and the poll
-  count, which is what separates a predicate that never came true from one the
-  test never got to evaluate.
+  the serving loop produces as a side effect of its own cycles: an engine row, a
+  watermark advance, a stats counter. Nothing reports those. `ExecutorHost`
+  exposes `stats()` and `spaceServer()` and no notification, `SpaceServer`
+  raises no event of its own, and the engine is a synchronous store, so there is
+  no event boundary without adding one to production code. Its deadline is a
+  stuck-condition backstop rather than a bound at the call site, and it stays
+  for a second reason: the serving loop holds the event loop open through its
+  lease-renew interval, so the fail-fast described above never fires and an
+  unbounded wait there would hang a run instead of failing it. The failure names
+  elapsed milliseconds and the poll count, which is what separates a predicate
+  that never came true from one the test never got to evaluate.
 
 ### A pull that drives its own loading
 

--- a/packages/runner/test/event-append-client.test.ts
+++ b/packages/runner/test/event-append-client.test.ts
@@ -43,24 +43,11 @@ import {
   flushMicrotasks,
   scriptedIntentManager,
 } from "./speculation-intent-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("event append space");
 const space = spaceSigner.did() as MemorySpace;
 const aliceSigner = await Identity.fromPassphrase("event append alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const namedError = (name: string, message: string): Error => {
   const error = new Error(message);

--- a/packages/runner/test/executor-cooperative-yield.test.ts
+++ b/packages/runner/test/executor-cooperative-yield.test.ts
@@ -42,6 +42,7 @@ import type {
 import { ExecutorHost } from "../src/executor/host.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { CooperativeYield } from "../src/scheduler/cooperative-yield.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const newSharedServer = () =>
   new MemoryV2Server.Server({
@@ -61,21 +62,6 @@ const serviceSigner = await Identity.fromPassphrase(
   "cooperative yield service",
 );
 const aliceSigner = await Identity.fromPassphrase("cooperative yield alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-  pollMs = 5,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-};
 
 /** Synchronous CPU work — a stand-in for one demand-walk instance run. */
 const burn = (ms: number): void => {

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -57,6 +57,7 @@ import {
   setPatternEnvironment,
 } from "../src/builder/env.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
   static override connectTo(
@@ -85,20 +86,6 @@ const foreignSpace = foreignSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("cross-space service");
 const aliceSigner = await Identity.fromPassphrase("cross-space alice");
 const bobSigner = await Identity.fromPassphrase("cross-space bob");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 10_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("Phase 5 cross-space serving", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/executor-dprime-w0.test.ts
+++ b/packages/runner/test/executor-dprime-w0.test.ts
@@ -43,6 +43,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("dprime w0 space");
 const space = spaceSigner.did() as MemorySpace;
@@ -50,21 +51,6 @@ const serviceSigner = await Identity.fromPassphrase("dprime w0 service");
 const aliceSigner = await Identity.fromPassphrase("dprime w0 alice");
 const bobSigner = await Identity.fromPassphrase("dprime w0 bob");
 const carolSigner = await Identity.fromPassphrase("dprime w0 carol");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string | (() => string),
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      const rendered = typeof label === "function" ? label() : label;
-      throw new Error(`timed out waiting for ${rendered}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const FAN_OUT_PATTERN = [
   "import { computed, Default, pattern, PerUser, Writable } from 'commonfabric';",

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -393,10 +393,13 @@ describe("Phase 4 client-effect channel", () => {
   };
 
   it("the served intent (T2 hops 1–4): fire → wave computes navigateTo → the §5 entry lands in the FIRING session's instance, issuedIn stamped, annotations addressing + acting", async () => {
-    const navigations: string[] = [];
+    // HEADLESS (no navigate callback): the §5 entry these assertions
+    // read stays unacked and durable. A client that CAN enact acks the
+    // nonce and the next wave retires the entry, so the state hops 1–4
+    // name is one an enacting client races to clear. Hops 5–6 are the
+    // client half's own test.
     ({ manager: clientManager, runtime: clientRuntime } = openClient(
       aliceSigner,
-      { navigations },
     ));
     const engine = await server.engineForSpace(space);
     const { argument, result } = await standUp(

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -385,6 +385,7 @@ describe("Phase 4 client-effect channel", () => {
     // nonce and the next wave retires the entry, so the state hops 1–4
     // name is one an enacting client races to clear. Hops 5–6 are the
     // client half's own test.
+
     ({ manager: clientManager, runtime: clientRuntime } = openClient(
       aliceSigner,
     ));

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -65,6 +65,7 @@ import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { WaveAccumulator, waveRunContextOf } from "../src/executor/wave.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 /** The settle-gate seam (see executor-events-down.test.ts): holds the
  * serving loop's settle so a test can dispose a client INSIDE the
@@ -98,20 +99,6 @@ const sidecarIdsIn = (engine: Engine.Engine): string[] =>
   (engine.database.prepare(
     `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
   ).all() as Array<{ id: string }>).map((row) => row.id);
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /** The highest AUTHORED seq that wrote `docId` — the only seq class a
  * kick-and-await-W barrier may target (protocol.md §4: settled for a

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -64,6 +64,7 @@ import {
   markRendererTrustedEvent,
 } from "../src/cfc/ui-contract.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 /** The serving-loop harness's settle-gate seam (see
  * executor-serving-loop.test.ts): when set, the loop's settle hangs at
@@ -244,20 +245,6 @@ const sidecarIdsIn = (engine: Engine.Engine): string[] =>
   (engine.database.prepare(
     `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
   ).all() as Array<{ id: string }>).map((row) => row.id);
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const BUMP_PATTERN = [
   "import { handler, pattern, Stream, Writable } from 'commonfabric';",

--- a/packages/runner/test/executor-fan-out.test.ts
+++ b/packages/runner/test/executor-fan-out.test.ts
@@ -46,6 +46,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("fan-out stage B");
 const space = spaceSigner.did() as MemorySpace;
@@ -54,21 +55,6 @@ const aliceSigner = await Identity.fromPassphrase("fan-out stage B alice");
 const bobSigner = await Identity.fromPassphrase("fan-out stage B bob");
 const carolSigner = await Identity.fromPassphrase("fan-out stage B carol");
 const daveSigner = await Identity.fromPassphrase("fan-out stage B dave");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string | (() => string),
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      const rendered = typeof label === "function" ? label() : label;
-      throw new Error(`timed out waiting for ${rendered}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /** A piece with a PerUser draft its derivation READS (narrows to user),
  * a PerSession note a second derivation reads (narrows to session), and

--- a/packages/runner/test/executor-instance-keyed-replica.test.ts
+++ b/packages/runner/test/executor-instance-keyed-replica.test.ts
@@ -43,6 +43,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 /** The serving runtime's storage manager, with the serving-loop suite's
  * settle-gate seam: while `settleGate` is set, the loop's settle hangs
@@ -75,21 +76,6 @@ const aliceSigner = await Identity.fromPassphrase(
   "instance-keyed replica alice",
 );
 const bobSigner = await Identity.fromPassphrase("instance-keyed replica bob");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string | (() => string),
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      const rendered = typeof label === "function" ? label() : label;
-      throw new Error(`timed out waiting for ${rendered}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /** A piece with per-user state on both sides of the run: a PerUser
  * draft the derivations READ, a PerUser save slot the handler WRITES,

--- a/packages/runner/test/executor-no-op-wave.test.ts
+++ b/packages/runner/test/executor-no-op-wave.test.ts
@@ -41,25 +41,12 @@ import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { readWatermarkSeq, waitForSettled } from "../src/executor/watermark.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("no-op wave space");
 const space = spaceSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("no-op wave service");
 const aliceSigner = await Identity.fromPassphrase("no-op wave alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("all-no-op wave (the land-off tx-boundary pin)", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/executor-outbox-budget.test.ts
+++ b/packages/runner/test/executor-outbox-budget.test.ts
@@ -35,6 +35,7 @@ import type { PostCommitSideEffect } from "../src/cfc/types.ts";
 import { SpaceOutbox } from "../src/executor/outbox.ts";
 import { emptyServingLoopStats } from "../src/executor/stats.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const signer = await Identity.fromPassphrase("executor outbox budget test");
 const space = signer.did() as MemorySpace;
@@ -55,20 +56,6 @@ describe("Phase 6 outbox budgets (serving-loop.md §5)", () => {
   afterEach(async () => {
     await server.close();
   });
-
-  const waitUntil = async (
-    predicate: () => boolean,
-    label: string,
-    timeoutMs = 10_000,
-  ): Promise<void> => {
-    const deadline = Date.now() + timeoutMs;
-    while (!predicate()) {
-      if (Date.now() > deadline) {
-        throw new Error(`timed out waiting for ${label}`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-  };
 
   const heldEffect = (
     id: string,

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -47,6 +47,7 @@ import {
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { getArtifactEntryRef } from "../src/builder/pattern-metadata.ts";
 import { getLogger } from "@commonfabric/utils/logger";
+import { waitUntil } from "./support/wait-until.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
   // Delegate to the base connectTo (shared-harness extraction, CT-1962):
@@ -92,21 +93,6 @@ const space = spaceSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("serving loop service");
 const aliceSigner = await Identity.fromPassphrase("serving loop alice");
 const bobSigner = await Identity.fromPassphrase("serving loop bob");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string | (() => string),
-  timeoutMs = 10_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      const rendered = typeof label === "function" ? label() : label;
-      throw new Error(`timed out waiting for ${rendered}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("stage F serving loop", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/executor-session-remount.test.ts
+++ b/packages/runner/test/executor-session-remount.test.ts
@@ -65,6 +65,7 @@ import type { MemorySpace, URI } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { ACLManager } from "../src/index.ts";
 import { TEST_SESSION_OPEN_AUDIENCE } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const serviceSigner = await Identity.fromPassphrase("session remount service");
 const homeSigner = await Identity.fromPassphrase("session remount home");
@@ -74,20 +75,6 @@ const strangerSigner = await Identity.fromPassphrase(
 );
 const servingSigner = await Identity.fromPassphrase("session remount serving");
 const servingSpace = servingSigner.did() as MemorySpace;
-
-const waitUntil = async (
-  predicate: () => boolean | Promise<boolean>,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!(await predicate())) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /**
  * The optional IStorageManager hook the fix adds. Read through a

--- a/packages/runner/test/executor-settle-advance.test.ts
+++ b/packages/runner/test/executor-settle-advance.test.ts
@@ -70,25 +70,12 @@ import {
 import { stampSpeculationRunContext } from "../src/speculation/overlay-destination.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("settle advance space");
 const space = spaceSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("settle advance service");
 const aliceSigner = await Identity.fromPassphrase("settle advance alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("S1 drain-settle quiescence advance (RULED 2026-08-19)", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/executor-space-root-ensure.test.ts
+++ b/packages/runner/test/executor-space-root-ensure.test.ts
@@ -60,6 +60,7 @@ import {
   resolveEntryIdentity,
 } from "../src/index.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("space root ensure space");
 const space = spaceSigner.did() as MemorySpace;
@@ -81,20 +82,6 @@ function rootSource(marker: string): string {
     "",
   ].join("\n");
 }
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -55,6 +55,7 @@ import {
   type ServingLoopStats,
 } from "../src/executor/stats.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("space-server test space");
 const space = spaceSigner.did() as MemorySpace;
@@ -63,20 +64,6 @@ const targetSpace = targetSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase(
   "space-server test service",
 );
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 10_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const pendingRowStream = { id: "of:space-server-stream", path: [] as string[] };
 const pendingRowSidecar = streamEntriesDocId(pendingRowStream);

--- a/packages/runner/test/executor-trust-attribution.test.ts
+++ b/packages/runner/test/executor-trust-attribution.test.ts
@@ -45,6 +45,7 @@ import type { CfcTrustConfigInput } from "../src/cfc/trust.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { markRendererTrustedEvent } from "../src/cfc/ui-contract.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("trust attribution space");
 const space = spaceSigner.did() as MemorySpace;
@@ -61,22 +62,6 @@ const sidecarIdsIn = (engine: Engine.Engine): string[] =>
   (engine.database.prepare(
     `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
   ).all() as Array<{ id: string }>).map((row) => row.id);
-
-// Bounded poll over DURABLE server state (the executor family's honest
-// wait: the engine exposes no event for "a background wave landed this").
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const BUMP_PATTERN = [
   "import { handler, pattern, Stream, Writable } from 'commonfabric';",

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -42,6 +42,7 @@ import {
   serverSeq,
 } from "@commonfabric/memory/v2/engine";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
   static override connectTo(
@@ -67,25 +68,6 @@ const homeSigner = await Identity.fromPassphrase("warm request home");
 const homeSpace = homeSigner.did() as MemorySpace;
 const serviceSigner = await Identity.fromPassphrase("warm request service");
 const aliceSigner = await Identity.fromPassphrase("warm request alice");
-
-// Bounded observation of engine/host state that becomes true as a side
-// effect of the serving loop's own cycles — no event boundary exists for
-// a test-side waiter without adding one to production code
-// (waiting-in-tests.md: the no-callback-to-hang-a-promise-on shape; the
-// same helper the neighboring executor E2Es use).
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 10_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("executor-warm-request", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -70,24 +70,11 @@ import {
   stampSpeculationRunContext,
 } from "../src/speculation/overlay-destination.ts";
 import { readWatermarkSeq as readWatermark } from "../src/executor/watermark.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("arrival gate space");
 const space = spaceSigner.did() as MemorySpace;
 const aliceSigner = await Identity.fromPassphrase("arrival gate alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /** A per-user derivation: `echo` reads a PerUser draft, so its output
  * narrows into the reader's user instance — exactly the shape whose

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -80,6 +80,7 @@ import {
   flushMicrotasks,
   scriptedIntentManager,
 } from "./speculation-intent-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const SPACE = "did:key:z6MkIntentListenerSpace" as MemorySpace;
 const SIDECAR = "of:stream-events:listener-a";
@@ -1202,20 +1203,6 @@ const JOIN_CASCADE_PATTERN = [
   "  };",
   "});",
 ].join("\n");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 20_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 const sidecarIdsIn = (engine: Engine.Engine): string[] =>
   (engine.database.prepare(

--- a/packages/runner/test/speculation-overlay.test.ts
+++ b/packages/runner/test/speculation-overlay.test.ts
@@ -59,6 +59,7 @@ import { isTerminalRejection } from "../src/storage/rejection.ts";
 import type { PostCommitSideEffect } from "../src/cfc/types.ts";
 import { readStoredCfcMetadata } from "../src/cfc/metadata.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("speculation overlay space");
 const space = spaceSigner.did() as MemorySpace;
@@ -66,20 +67,6 @@ const serviceSigner = await Identity.fromPassphrase(
   "speculation overlay service",
 );
 const aliceSigner = await Identity.fromPassphrase("speculation overlay alice");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 describe("Phase 2 speculation overlay", () => {
   let server: MemoryV2Server.Server;

--- a/packages/runner/test/support/wait-until.ts
+++ b/packages/runner/test/support/wait-until.ts
@@ -1,0 +1,45 @@
+// The bounded poll shared by the suites that drive a live memory server or a
+// live ExecutorHost. What they wait on — an engine row, a watermark advance, a
+// stats counter — becomes true as a side effect of the serving loop's own
+// cycles, and nothing exposes an event for it: `SpaceServer` offers `stats()`
+// and `spaceServer()` and no notification, and the engine is a synchronous
+// store. So this is `waiting-in-tests.md`'s "no page, and no callback to hang
+// a promise on" shape, where a poll is the honest observation.
+//
+// The deadline is a stuck-condition backstop, not a bound on how long the work
+// may legitimately take. It stays: a wait here can outlive a defect that
+// produces no event at all, and the serving loop holds the event loop open
+// through its lease-renew interval, so an unbounded wait would hang a run
+// rather than fail it.
+
+/**
+ * Polls `predicate` every `pollMs` until it holds, and throws naming `label`
+ * once `timeoutMs` has elapsed. A thunk `label` is rendered only on failure,
+ * and an asynchronous `predicate` is awaited once per poll.
+ */
+export const waitUntil = async (
+  predicate: () => boolean | Promise<boolean>,
+  label: string | (() => string),
+  timeoutMs = 20_000,
+  pollMs = 20,
+): Promise<void> => {
+  const started = Date.now();
+  const deadline = started + timeoutMs;
+  let polls = 0;
+  for (;;) {
+    polls += 1;
+    if (await predicate()) return;
+    if (Date.now() > deadline) {
+      const rendered = typeof label === "function" ? label() : label;
+      // The poll count separates two failures that read alike. A predicate
+      // polled at the full rate that never came true names a defect in what
+      // it watches; one polled a handful of times over the same span says the
+      // event loop was starved and the test barely looked.
+      throw new Error(
+        `timed out waiting for ${rendered} after ${Date.now() - started} ms ` +
+          `and ${polls} polls`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+};

--- a/packages/runner/test/support/wait-until.ts
+++ b/packages/runner/test/support/wait-until.ts
@@ -1,21 +1,13 @@
-// The bounded poll shared by the suites that drive a live memory server or a
-// live ExecutorHost. What they wait on — an engine row, a watermark advance, a
-// stats counter — becomes true as a side effect of the serving loop's own
-// cycles, and nothing exposes an event for it: `SpaceServer` offers `stats()`
-// and `spaceServer()` and no notification, and the engine is a synchronous
-// store. So this is `waiting-in-tests.md`'s "no page, and no callback to hang
-// a promise on" shape, where a poll is the honest observation.
-//
-// The deadline is a stuck-condition backstop, not a bound on how long the work
-// may legitimately take. It stays: a wait here can outlive a defect that
-// produces no event at all, and the serving loop holds the event loop open
-// through its lease-renew interval, so an unbounded wait would hang a run
-// rather than fail it.
-
 /**
  * Polls `predicate` every `pollMs` until it holds, and throws naming `label`
  * once `timeoutMs` has elapsed. A thunk `label` is rendered only on failure,
  * and an asynchronous `predicate` is awaited once per poll.
+ *
+ * The deadline is a stuck-condition backstop, not a bound on how long the
+ * awaited work may legitimately take, and a caller sizes it for that: crossing
+ * it says the state never arrived, never that it arrived slowly. Which suites
+ * wait this way rather than on an event, and why, is recorded under "Where the
+ * polling `waitFor` stays" in `docs/development/waiting-in-tests.md`.
  */
 export const waitUntil = async (
   predicate: () => boolean | Promise<boolean>,

--- a/packages/runner/test/ui-cell-write-conflict-retry.test.ts
+++ b/packages/runner/test/ui-cell-write-conflict-retry.test.ts
@@ -47,6 +47,7 @@ import {
   isRetryableCommitRejection,
   isStaleReadConflict,
 } from "../src/storage/rejection.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("ui-cell-write space");
 const space = spaceSigner.did() as MemorySpace;
@@ -66,20 +67,6 @@ const schema = {
 } as const;
 
 type Doc = { drafts: { message?: string; other?: string } };
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /**
  * The engine's stale-read rejection, byte-shaped like the live tap evidence

--- a/packages/runner/test/unresolved-input-lift.test.ts
+++ b/packages/runner/test/unresolved-input-lift.test.ts
@@ -36,25 +36,12 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { waitUntil } from "./support/wait-until.ts";
 
 const spaceSigner = await Identity.fromPassphrase("unresolved input space");
 const space = spaceSigner.did() as MemorySpace;
 const readerSigner = await Identity.fromPassphrase("unresolved input reader");
 const writerSigner = await Identity.fromPassphrase("unresolved input writer");
-
-const waitUntil = async (
-  predicate: () => boolean,
-  label: string,
-  timeoutMs = 15_000,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${label}`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-};
 
 /** A lift that CRASHES on an undefined input — the OW51 shape: the
  * body's guard covers the schema's stated absent value (`null`), not


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two commits. The first fixes an intermittent failure in
`executor-effect-channel.test.ts`; the second retires the 22 hand-rolled copies
of the poll that reported it.

## The flake was a test defect, not a slow wait

`Phase 4 client-effect channel > the served intent (T2 hops 1-4)` failed
intermittently under load with `timed out waiting for the intent to land in
alice's session instance`. The natural reading — a 20-second ceiling crossed on
a busy machine, cutting off work that would have finished — is wrong.
Reproduced under six concurrent full runner suites with the throw replaced by a
raised deadline, so the shipped 20-second ceiling did not end it, the wait ran
**300 002 ms over 13 653 polls**, 22 ms per poll, the full nominal rate. The
event loop was healthy and the test looked 13 653 times. More time never helped.

The serving-side counters, frozen across the stall, say why:

    wavesBudgetExhausted: 0    waves: 3    derivedCommits: 3
    events: { appended: 1, processed: 1 }    effectAcks: 1

`effectAcks: 1` is only reachable if the intent was issued, pushed to the
client, enacted, and acked — and a later wave then retires the entry. The T2
journey had **completed**. The predicate wants a *live* entry, and retirement
clears the ack mark along with it, so the settled end state carries no trace of
the journey beyond that counter.

The cause is the client the test opens. It passed a `navigations` array it never
asserts on, and that array is what gives a client an enactment surface. So the
test's own client acked the intent away before the first read. The fix is to
open it headless: the effects channel never enacts and never acks while
`navigateCallback` is undefined, leaving the entry unacked and durable. That
also matches what the test covers — hops 1-4 end at the entry, and hops 5-6 are
the client half's own test, which keeps its enacting client.

Every sibling was checked rather than assumed. Six tests in the file wait on a
live entry; four open headless clients — the authoritative-enactment-failure
test's first life among them, its own comment calling it the headless posture —
and the LT8 reload test is the one structural barrier, disposing its client
mid-wave behind the `settleGate` seam so the reload precedes any ack. This was
the only mismatch.

### Evidence

A three-second pause before the first read reproduces it deterministically, with
no load, and separates the two postures:

| | entries | acks | effectAcks | result |
|---|---|---|---|---|
| enacting client + 3 s | 0 | `{}` | 1 | fails |
| headless client + 3 s | 1 | `{}` | 0 | passes |

Under the load configuration that stalled 2 of 6 concurrent full runner suites
before, all 6 now report 1324 passed / 0 failed. An independent control also
rules out the flush deadline: forcing `flushDeadlineMs: 1`, so every wave is
cut, does not reproduce it.

## One shared `waitUntil`

22 test files each defined their own bounded poll, across 516 call sites. The
copies had drifted into four shapes and three ceilings. The four shapes are
nested generalizations of one function — a lazy label rendered only on failure,
a tunable poll interval, an awaited predicate — so a single signature covers all
of them and **every call site compiles unchanged**; keeping `timeoutMs` and
`pollMs` positional leaves untouched the 104 sites that pass a timeout, one of
which also passes an interval. 35 insertions, 320 deletions.

The ceiling unifies at 20 seconds, which only ever loosens. Two files polled
faster than 20 ms and were checked for coupling to it:
`executor-outbox-budget` asserts on counters and no timing, and
`executor-cooperative-yield`'s one measurement-coupled wait passes its 2 ms
interval explicitly and keeps it.

The failure message now names elapsed milliseconds **and the poll count** —
the pair this diagnosis turned on, and which all 22 copies discarded. A
predicate polled at the full rate that never came true names a defect in what it
watches; one polled a handful of times over the same span says the event loop
was starved and the test barely looked.

The deadline deliberately stays a stuck-condition backstop rather than becoming
an event-driven wait. Nothing reports the state these suites watch —
`ExecutorHost` exposes `stats()` and `spaceServer()` and no notification,
`SpaceServer` raises no event of its own, and the engine is a synchronous store — and the serving loop holds the event loop open
through its lease-renew interval, so the fail-fast that makes an unbounded
in-process wait safe elsewhere never fires here. An unbounded wait would have
turned this red test into a hung run. `waiting-in-tests.md` now records the
family under "Where the polling `waitFor` stays", which no document had covered.

## Gates

`deno task check`, `deno lint` (5269 files), `deno fmt --check` (5419 files),
`deno task check-docs` (589 blocks) all clean; the runner suite reports 1324
passed / 0 failed on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXxcNSaXdeWDLjupVEEGWZ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



