### PR TITLE
docs(agents): an agent is told to read the coding guidelines before writing code

### DIFF
--- a/.agents/skills/writing-code
+++ b/.agents/skills/writing-code
@@ -1,0 +1,1 @@
+../../skills/writing-code

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -79,13 +79,15 @@ subtree — which it usually is not.
 So a rule here is a way to say more, at the moment it matters, to one agent. It
 is not a way to move something out of `AGENTS.md`. Anything an agent must not
 get wrong still needs a line in the root `AGENTS.md`, where every agent sees
-it. The "Automated gates" section there is that floor, and each rule in this
-directory expands on one of its lines.
+it. Each rule here expands on one of those lines: the "Automated gates"
+section holds the ones a check enforces, and the engineering-practice sections
+hold the ones only a reviewer will catch.
 
 ## The rules
 
 | Rule                     | Covers                                          |
 | ------------------------ | ----------------------------------------------- |
+| `source-code.md`         | every `.ts` and `.tsx` file                     |
 | `tests.md`               | test, bench, and integration files              |
 | `workspace-packages.md`  | `deno.jsonc`, at the root and in every package  |
 | `documentation.md`       | everything under `docs/`                        |

--- a/.claude/rules/source-code.md
+++ b/.claude/rules/source-code.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+---
+
+# Writing code
+
+The map is the `writing-code` skill at `skills/writing-code/SKILL.md`: which
+document governs what you are about to touch, and what to run before pushing.
+The two it says to read first are `docs/development/DEVELOPMENT.md` and
+`docs/development/code-comment-style.md`.
+
+What follows is only the part that survives every gate, so that a green run
+tells you nothing about it.
+
+## A green run is not evidence about style
+
+`deno fmt` settles line width, indent, semicolons, and quotes. `deno lint` and
+`deno task check` settle types and import mechanics. Nothing settles the shape
+of a class, the grouping of imports, the wording of a comment, or the words
+themselves — and a reviewer will raise all four.
+
+The class rules are the ones most often missed, because the wrong form compiles
+and passes: `#privateName` rather than TypeScript's `private`, no enumerable
+properties on a class, and the member order in
+`docs/development/DEVELOPMENT.md`, § Classes. A `private` field is an own
+enumerable property once the modifier is erased, so `private` is not a quieter
+spelling of `#`.
+
+## The document is part of the change
+
+Changing behavior a live document describes means editing that document in the
+same change, not filing a follow-up. `docs/README.md` has the rules, including
+which tree a new document belongs in.

--- a/.claude/skills/writing-code
+++ b/.claude/skills/writing-code
@@ -1,0 +1,1 @@
+../../skills/writing-code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,32 @@ the rules therein. These include:
 
 ## Engineering principles and coding style
 
+### Writing Code
+
+Before writing or changing code anywhere in this tree, read
+`docs/development/DEVELOPMENT.md` and `docs/development/code-comment-style.md`.
+That obligation does not depend on which part of the tree you are working in, on
+how small the change is, or on whether you would call the work "development".
+
+The `writing-code` skill at `skills/writing-code/SKILL.md` is the map: which
+document governs the thing you are about to touch, what to run before pushing,
+and — the part a green run tells you nothing about — the conventions no gate
+enforces, which are therefore left to a reviewer to find by reading. `skills/`
+is the canonical authored source; Codex discovers the repo-local mirror through
+`.agents/skills/`, and Claude through `.claude/skills/`.
+
+### Reviewing Code
+
+Reviewing a changeset — including reviewing your own before you push — goes
+through the `cf-review` skill at `skills/cf-review/SKILL.md`. It holds code to
+the same documents `writing-code` hands the author, so that a convention
+enforced in review is one its author was told about. A general-purpose review
+command supplied by your agent harness knows nothing about this repository and
+is not a substitute for it.
+
+`docs/development/pr-review-comments.md` covers reading and answering the review
+comments a pull request collects.
+
 ### Avoid timeouts, retry loops, and sleeps
 
 Timeouts cause flakiness because they put an upper bound on success: anything

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -224,10 +224,22 @@ Mostly Improvement / Nit — don't drown the report in these. Dead code, unused
 exports, superfluous abstraction, unclear names. Types: no needless `any`; no
 needless casts (an `as Something` that isn't required for correctness) and no
 unjustified `as unknown as Something`, especially one erasing `Immutable<T>` /
-`Readonly<T>`. For the rest — named exports, JSDoc on exports and public
-members, import grouping, `@commonfabric/api` xor `/interface`, module-graph
-hygiene — follow `docs/development/DEVELOPMENT.md` and point to it rather than
-relisting it.
+`Readonly<T>`.
+
+For the rest the authority is `docs/development/DEVELOPMENT.md`, § Style &
+Conventions: follow it and point to it rather than relisting it. Its subsections
+seed what to look for — e.g. named exports, JSDoc on exports and public members,
+import grouping and collation, `@commonfabric/api` xor `/interface`,
+module-graph hygiene. Two of them seed nothing any gate will ever raise, which
+is where a diff-reading reviewer earns their keep: **§ Classes** —
+`#privateName` over TypeScript's `private`, a class exposing no enumerable
+properties, and the member order; the wrong form compiles and type-checks clean,
+and an erased `private` leaves an own enumerable property behind — and **§ Word
+choice**, American spelling and one word per concept, which reaches comments and
+error and log messages as much as it reaches documents.
+
+`skills/writing-code/SKILL.md` is what an author is handed for this same
+material. A finding here that it does not cover is a gap in the skill; say so.
 
 ### 7. Test rigor — the special-attention area
 
@@ -299,6 +311,8 @@ file.
   `docs/development/skill-authoring.md`
 - Pattern rules + severity taxonomy: `docs/common/ai/pattern-critique-guide.md`
 - Design principles & idioms: `docs/development/DEVELOPMENT.md`
+- What an author is handed for the same conventions:
+  `skills/writing-code/SKILL.md`
 - Comment style, `//` and JSDoc alike, file headers included:
   `docs/development/code-comment-style.md`
 - Transformer semantics: `docs/specs/ts-transformer/README.md`

--- a/skills/writing-code/SKILL.md
+++ b/skills/writing-code/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: writing-code
+description: Conventions for writing or changing code in this repository — the two documents to read before the first edit, which document governs the thing you are about to touch, and which conventions no automated gate will catch. Use before writing, changing, or refactoring TypeScript anywhere in the tree. Patterns need `pattern-dev` as well; this skill covers what is true of all code here.
+---
+
+# Writing Code in Common Fabric
+
+This skill is a **map**, not a recipe. It assumes you know how to write
+TypeScript. What it supplies is the part you cannot derive from the tree: which
+of this repository's documents governs what you are about to touch, and which of
+its conventions nothing will catch for you.
+
+All paths are relative to the repo root.
+
+## Read these before your first edit
+
+- `docs/development/DEVELOPMENT.md` — coding style and design principles. §
+  Style & Conventions is the part that applies to every edit; § Code Design &
+  Principles is the part a reviewer will hold a new abstraction to.
+- `docs/development/code-comment-style.md` — how a comment is written, `//` and
+  JSDoc alike. A comment describes the system as it stands, and nothing comes
+  between a doc comment and the declaration it documents.
+
+Everything below this line is read-when-it-applies. Reach for it by what you are
+doing, not by reading the list through.
+
+## What governs what you are touching
+
+- **Adding or reordering class members** — `docs/development/DEVELOPMENT.md`, §
+  Classes.
+- **Adding an import** — the same document, § Imports, for how imports are
+  grouped and collated; `docs/development/imports.md` for what may not import
+  what at all.
+- **Writing a new file** — `docs/development/code-comment-style.md`, "File
+  headers".
+- **Writing or changing a test** — `docs/development/unit-test-coding-style.md`
+  before the first one, and `docs/development/TESTING.md` for how the suites
+  run. Not every file in the tree follows the conventions, so a neighbor is not
+  evidence of them.
+- **Making anything wait** — `docs/development/waiting-in-tests.md`. Avoiding
+  timeouts, retry loops, and sleeps is a repository-wide principle, not a
+  testing one.
+- **Adding or changing an experimental flag** —
+  `docs/development/EXPERIMENTAL_OPTIONS.md`, which is the registry as well as
+  the guidance, and is updated in the same change.
+- **Adding a dependency** — `docs/development/DEPENDENCIES.md`.
+- **Adding a workspace package** — `AGENTS.md`, "Adding New Packages". The
+  missing `test` task is the one that hangs CI rather than failing it.
+- **Writing a pattern** — the `pattern-dev` skill at
+  `skills/pattern-dev/SKILL.md`, in addition to this one.
+- **Changing behavior a live document describes** — `docs/README.md`. That
+  document is part of your change, not a follow-up to it.
+
+`docs/development/README.md` indexes the rest; `docs/features/README.md` indexes
+one document per subsystem. Read the relevant one before changing a subsystem
+you have not worked in before.
+
+## The conventions nothing will catch
+
+This is the part worth knowing by heart, because a green run is not evidence
+about any of it. `deno fmt` settles line width, indent, semicolons, and quotes;
+`deno lint` and `deno task check` settle types, untagged TODOs, and import
+mechanics; the gates in `AGENTS.md`, § Automated gates settle the rest of what a
+machine can settle. Everything here passes all of that and can still be wrong,
+so it is the set a reviewer is left to find by reading. Tells include, for
+example:
+
+- **Class shape.** `#privateName` over TypeScript's `private`; a class exposes
+  no enumerable properties; members run in the order § Classes gives. A
+  `private` field type-checks clean and is still an own enumerable property.
+- **Import grouping and collation.** Every specifier naming the same package
+  sits in one contiguous run. Nothing sorts imports here.
+- **Word choice.** American spelling, and one word per concept — this reaches
+  comments, error and log messages, and test descriptions as much as it reaches
+  documents. § Word choice holds the list.
+- **What a comment is for.** A doc comment states the contract; mechanics go in
+  `//`. A comment that litigates what the code does _not_ do, or narrates how it
+  got here, is a comment to cut.
+- **Layer direction.** Imports run down the pace layers in `AGENTS.md`. Only
+  mutual cycles are gated, so an existing upward import is not a precedent.
+
+## Before you push
+
+`deno fmt --check`, `deno lint`, `deno task check`, and the `deno task test` of
+every package you touched. Each misses what the others catch, and none of them
+runs the separate gates listed under § Automated gates — `check-docs` among
+them, which is why a TypeScript block in a document can break on a change that
+never opened one.
+
+Patterns are the exception `deno task check` does not own: `deno task cfcheck`
+is the authoritative pattern type-check.
+
+## When you think you are done
+
+`skills/cf-review/SKILL.md` is the house reviewer, and self-review before
+pushing is one of the things it is for. It holds code to the documents above —
+so if it finds something here that this skill never pointed you at, that gap is
+itself worth reporting.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## The gap

Every authoring activity in this repository carries an unconditional
pre-read except one:

| Activity | Instruction |
| --- | --- |
| Write a document | `docs/README.md` — "Read it before you write a document" |
| Write a test file | `unit-test-coding-style.md` — "Read it before writing a new test file" |
| Add or change a flag | `EXPERIMENTAL_OPTIONS.md` — "Read it before adding, changing, or removing a flag" |
| `setsrc` a real space | `space-clone-rehearsal.md` — "Read it before any `setsrc`" |
| Author a skill | `skill-authoring.md`, `skill-audit.md` |
| **Write code** | *"If you are developing runtime code, start with:"* |

Three things kept that last row from doing the work. It is conditional on
an agent first classifying its own task as "developing runtime code";
"start with" heads a reading list rather than stating an obligation; and
`DEVELOPMENT.md` is the least emphatic of the eight bullets under it,
while a sibling in the same list carries "Read it before writing a new
test file".

The mechanical surfaces had the same hole. The `paths` globs across
`.claude/rules/` covered documentation, workflows, skills, test and bench
files, and `deno.jsonc` — nothing matched an ordinary source file, so
opening `foo.test.ts` loaded guidance and opening `foo.ts` beside it
loaded none.

## The review side

`AGENTS.md` had no review section at all, so `cf-review` was invisible to
anyone starting there, and a general-purpose review command supplied by
an agent harness — which knows nothing about this repository — has the
more guessable name.

Separately, the craft pass in `cf-review` read as complete when it was
not. "For the rest —" followed by five items closes the set, and those
five map onto two of the five subsections of `DEVELOPMENT.md`, § Style &
Conventions. Unrepresented: § Classes, 123 lines holding `#privateName`
over `private`, the no-enumerable-properties rule, and the eight-group
member order — all diff-visible, none gated — and § Word choice, which
`AGENTS.md` separately says reaches comments, error and log messages, and
test descriptions.

`skill-authoring.md` names this exact shape as the thing to avoid: "The
specific thing that caps an agent is a closed list presented as
complete... when you enumerate, mark the list as seed, not boundary."
The framework-fit pass in the same skill already does that, marking its
tells as "seeds, drawn from". The craft pass now does too.

## The change

- `AGENTS.md` gains **Writing Code** and **Reviewing Code**, adjacent, at
  the head of the engineering section. The first states the pre-read
  unconditionally; the second names the house reviewer.
- `skills/writing-code/SKILL.md` is the map: which document governs the
  thing being touched, what to run before pushing, and the conventions
  that pass every gate and can still be wrong — the set a reviewer is
  otherwise left to find by reading.
- `.claude/rules/source-code.md` scopes the same pointers to `.ts` and
  `.tsx`, at zero cost to sessions not touching source.
- `cf-review` reframes the craft enumeration as a seed and names §
  Classes and § Word choice; the two skills now cite each other, so a
  convention enforced in review is one its author was handed.

Both mirrors are in place, so the skill reaches Codex through
`.agents/skills/` and Claude through `.claude/skills/`. The rule is
Claude Code's mechanism alone, which is why the obligation itself sits in
the root `AGENTS.md` — the floor `.claude/rules/README.md` describes,
whose own sentence about what a rule expands on is updated to match.

## Verification

`check-skill-facts`, `check-conflict-markers`, `check-control-characters`,
and `check-docs-history-index` pass, as does repo-wide `deno fmt --check`.
No TypeScript changed.

The skill-facts gate was controlled rather than assumed: breaking one
cited path in each of the two new files turned it red, naming both files
and lines, and restoring them byte-for-byte returned it to green.

```
.claude/rules/source-code.md:12  path does not exist: docs/development/NO-SUCH-FILE-A.md
skills/writing-code/SKILL.md:46  path does not exist: docs/development/NO-SUCH-FILE-B.md
```

## Known limitation

The cross-reference between the two skills is prose, and no gate reads
prose — `check-skill-facts` verifies that a cited path resolves, not that
a claim about another document is still true. The symmetry will drift
silently, the way stale prose does. Teaching that gate to verify a
declared cross-reference pair would close it, and is left as a follow-up
rather than smuggled in here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

