### PR TITLE
test: a marker whose words are one block's contract moves inside it

### DIFF
--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -335,15 +335,13 @@ Deno.test("shell: the page watches its own stream and reopens one that stops del
   assertStringIncludes(html, `addEventListener('online', paint);`);
 });
 
-//
-// The functions the page runs are authored as TypeScript here and reach the
-// browser as the text of `Function.prototype.toString()`. That text has to be
-// JavaScript the browser accepts, and it has to stand alone: a reference to
-// anything outside the function is a name the page does not have. Neither
-// property is visible to a test that only looks for substrings.
-//
-
 Deno.test("shell: the injected script is JavaScript, and each injected function stands alone", () => {
+  // The functions the page runs are authored as TypeScript here and reach the
+  // browser as the text of `Function.prototype.toString()`. That text has to be
+  // JavaScript the browser accepts, and it has to stand alone: a reference to
+  // anything outside the function is a name the page does not have. Neither
+  // property is visible to a test that only looks for substrings.
+
   const scripts = [...shell("", "", 0, 45_000, TEST_VERSION, "good")
     .matchAll(/<script>([\s\S]*?)<\/script>/g)].map((match) => match[1]);
   // Parses every script without running it, which is where a leftover type

--- a/packages/dashboard/test-records-history.test.ts
+++ b/packages/dashboard/test-records-history.test.ts
@@ -96,12 +96,10 @@ Deno.test("collectDay separates variant records from default history", async () 
   }]);
 });
 
-//
-// A body holding two reports, the second fork-authored: its records must
-// not reach the decision-feeding aggregates.
-//
-
 Deno.test("collectDay excludes fork-authored reports", async () => {
+  // A body holding two reports, the second fork-authored: its records must not
+  // reach the decision-feeding aggregates.
+
   const forkContext = JSON.stringify({
     schema: 1,
     line: "context",

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -289,12 +289,10 @@ Deno.test("discord snapshot: absent Team aliases do not produce a valid snapshot
   assertEquals(missing, null);
 });
 
-//
-// This is the first test that reaches the history, so it is the one that sees the
-// file being loaded. The load happens once per process, on first use.
-//
-
 Deno.test("discord online: a snapshot -> good; the reloaded history draws the chart, stale samples age out", async () => {
+  // This is the first test that reaches the history, so it is the one that sees
+  // the file being loaded. The load happens once per process, on first use.
+
   clock = T0;
   const persisted = [
     { t: T0 - 90 * DAY, team: 1, visitors: 1 }, // past the 60-day retention window

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -72,17 +72,22 @@ Deno.test("an assertion that holds says nothing", function () {
   runWith().assert(true, "test successful");
 });
 
-//
-// No real run in this suite is killed by a signal, so this states one. The
-// transcript names the signal rather than only the exit code it comes with.
-//
-
 Deno.test("a run the kernel killed names the signal", function () {
+  // No real run in this suite is killed by a signal, so this states one. The
+  // transcript names the signal rather than only the exit code it comes with.
+
   const transcript = runWith({ code: 137, signal: "SIGKILL" }).transcript();
 
   assertStringIncludes(transcript, "SIGKILL");
   assertStringIncludes(transcript, "137");
 });
+
+//
+// What the harness keeps out of a run's streams
+//
+// Download noise before the harness boundary goes; what a test itself wrote
+// stays, control sequences included.
+//
 
 Deno.test("dependency downloads before the harness boundary are removed", function () {
   const encoder = new TextEncoder();

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -42,16 +42,14 @@ Deno.test("a stuck test fails by name and the run continues", async function () 
   );
 });
 
-//
-// The detector is only worth having while it fires before astral does. Astral
-// gives each `page.evaluate` five retried 10-second deadlines and throws a
-// `RetryError` once they run out, measured at 53 to 57 seconds; past that the
-// run dies without naming the test. Raising the default above that would put
-// the diagnostic back out of reach, so the relationship is pinned here rather
-// than left in a comment.
-//
-
 Deno.test("the default fires before astral's retries run out", function () {
+  // The detector is only worth having while it fires before astral does. Astral
+  // gives each `page.evaluate` five retried 10-second deadlines and throws a
+  // `RetryError` once they run out, measured at 53 to 57 seconds; past that the
+  // run dies without naming the test. Raising the default above that would put
+  // the diagnostic back out of reach, so the relationship is pinned here rather
+  // than left in a comment.
+
   assert(
     DEFAULT_TEST_TIMEOUT_MS < 50_000,
     `${DEFAULT_TEST_TIMEOUT_MS}ms leaves no room before astral's RetryError`,

--- a/packages/memory/test/v2-sqlite-guard.test.ts
+++ b/packages/memory/test/v2-sqlite-guard.test.ts
@@ -17,17 +17,15 @@ import {
 } from "../v2/sqlite/guard.ts";
 import { open } from "../v2/engine.ts";
 
-//
-// S4: the guard's core-table denylist is hand-maintained, but unqualified
-// pattern-SQL names resolve to the attached cell-db ONLY because `main` (the
-// core store) has no table of that name. If the engine ever adds a `main` table
-// whose name a pattern also uses and that name is NOT in CORE_TABLE_NAMES, a
-// pattern write could silently hit core storage. This asserts the denylist
-// covers every real `main` table, so adding an engine table without updating the
-// guard fails CI.
-//
-
 describe("CORE_TABLE_NAMES vs the engine schema", () => {
+  // S4: the guard's core-table denylist is hand-maintained, but unqualified
+  // pattern-SQL names resolve to the attached cell-db ONLY because `main` (the
+  // core store) has no table of that name. If the engine ever adds a `main`
+  // table whose name a pattern also uses and that name is NOT in
+  // CORE_TABLE_NAMES, a pattern write could silently hit core storage. This
+  // asserts the denylist covers every real `main` table, so adding an engine
+  // table without updating the guard fails CI.
+
   it("covers every table the engine creates in `main`", async () => {
     const path = await Deno.makeTempFile({ suffix: ".sqlite" });
     const engine = await open({ url: toFileUrl(path) });

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -76,21 +76,18 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
   }
 });
 
-//
-// Server-execution v2 Phase 2's compile gate (the builtin's flag-ON
-// posture, stated truthfully): compilation is an EFFECTFUL step whose
-// launch is a floating promise the overlay destination cannot
-// intercept, so the gate lives in the builtin and suppresses fresh
-// compiles for EVERY flag-ON non-wave run — client derivation runs,
-// F10 handler runs, imperative flows alike. Until the serving port
-// lands (stage G's out-of-scope note; the serving side refuses the
-// writebacks), fresh compile-and-run is INERT in the ON arm everywhere:
-// memo'd results still read through, `pending` renders the ordinary
-// loading state. A WAVE-STAMPED run passes the gate (the seam the
-// serving port will drive), and the OFF arm is untouched.
-//
-
 Deno.test("compileAndRun's Phase-2 gate: flag-ON non-wave runs launch NO fresh compile (pending stands), a wave-stamped run passes, and the OFF arm is unaffected", async () => {
+  // Server-execution v2 Phase 2's compile gate (the builtin's flag-ON posture,
+  // stated truthfully): compilation is an EFFECTFUL step whose launch is a
+  // floating promise the overlay destination cannot intercept, so the gate
+  // lives in the builtin and suppresses fresh compiles for EVERY flag-ON
+  // non-wave run — client derivation runs, F10 handler runs, imperative flows
+  // alike. Until the serving port lands (stage G's out-of-scope note; the
+  // serving side refuses the writebacks), fresh compile-and-run is INERT in the
+  // ON arm everywhere: memo'd results still read through, `pending` renders the
+  // ordinary loading state. A WAVE-STAMPED run passes the gate (the seam the
+  // serving port will drive), and the OFF arm is untouched.
+
   const identity = await Identity.fromPassphrase("compile and run gate");
   const space = identity.did();
 

--- a/packages/test-support/src/isolated-deno.test.ts
+++ b/packages/test-support/src/isolated-deno.test.ts
@@ -12,17 +12,15 @@ function decode(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes);
 }
 
-//
-// Three test tasks build their own run allowlist with
-// `--allow-run=$(deno eval "console.log(Deno.execPath())")`, which names the
-// binary the tests start only while a task's `deno` is the Deno running the
-// task. A `deno` found on `PATH` instead would name a different binary whenever
-// the shell's Deno is not the pinned one, which is the case those tasks exist
-// to handle. The decoy below is the only `deno` on the child's `PATH`, so it
-// runs if the resolution ever goes through `PATH`.
-//
-
 Deno.test({
+  // Three test tasks build their own run allowlist with `--allow-run=$(deno
+  // eval "console.log(Deno.execPath())")`, which names the binary the tests
+  // start only while a task's `deno` is the Deno running the task. A `deno`
+  // found on `PATH` instead would name a different binary whenever the shell's
+  // Deno is not the pinned one, which is the case those tasks exist to handle.
+  // The decoy below is the only `deno` on the child's `PATH`, so it runs if the
+  // resolution ever goes through `PATH`.
+
   name: "a task's `deno` is the Deno running the task, not one on PATH",
   ignore: Deno.build.os === "windows",
   async fn() {

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -76,12 +76,16 @@ Deno.test("spans pass through the OpenInference processor to the exporter", asyn
 });
 
 //
-// The `ai` package collects no spans until a telemetry integration is
-// registered, and it reports nothing when none is: the LLM spans simply stop
-// being produced. Importing this module is what registers ours.
+// The module's telemetry lifecycle
+//
+// Registration on import, and what shutdown does before and after it.
 //
 
 Deno.test("importing the module registers an AI SDK telemetry integration", () => {
+  // The `ai` package collects no spans until a telemetry integration is
+  // registered, and it reports nothing when none is: the LLM spans simply stop
+  // being produced. Importing this module is what registers ours.
+
   assert(
     (globalThis.AI_SDK_TELEMETRY_INTEGRATIONS?.length ?? 0) > 0,
     "no AI SDK telemetry integration registered; LLM spans would not be collected",

--- a/packages/toolshed/routes/ai/llm/errors.test.ts
+++ b/packages/toolshed/routes/ai/llm/errors.test.ts
@@ -22,7 +22,7 @@ function providerFailure(statusCode: number): APICallError {
 }
 
 //
-// The routes ask the AI SDK for a single attempt, so these two shapes do not
+// The routes ask the AI SDK for a single attempt, so these shapes do not
 // reach the classifier from them. They are what the classifier sees if a call
 // site ever asks for retries again, and the status has to survive the wrapping
 // either way.
@@ -51,12 +51,17 @@ Deno.test("a cycle among causes does not trap the search", () => {
 });
 
 //
-// The AI SDK raises these over what the caller sent, before any provider is
-// asked. Reporting them against the provider would send the caller looking in
-// the wrong place.
+// Where a status comes from
+//
+// The SDK raising over the request, the service's own error types, and the
+// fallback for an error that names no origin at all.
 //
 
 Deno.test("a request the SDK would not send is the caller's mistake", () => {
+  // The AI SDK raises these over what the caller sent, before any provider is
+  // asked. Reporting them against the provider would send the caller looking in
+  // the wrong place.
+
   assertEquals(
     httpStatusForError(
       new InvalidPromptError({

--- a/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
+++ b/packages/ts-transformers/test/cfc-transformer-coverage.test.ts
@@ -59,17 +59,15 @@ Deno.test("transformer coverage: projection paths lower as canonical pointers", 
   });
 });
 
-//
-// The canonical OpaqueInput helper was removed (the runner rejects ifc.opaque
-// fail-closed), but a non-canonical local alias with EXPLICIT type arguments
-// still resolves through the Cfc carrier — the generic payload passthrough.
-// The resulting schema fails closed at commit, so this covers the structural
-// lowering mechanism, not an advertised capability. Defaulted type arguments
-// are NOT recovered on non-canonical aliases (only the canonical name
-// registry hardcoded defaults), so `OpaqueInput<string>` would emit no ifc.
-//
-
 Deno.test("transformer coverage: non-canonical Cfc payloads lower structurally", async () => {
+  // The canonical OpaqueInput helper was removed (the runner rejects ifc.opaque
+  // fail-closed), but a non-canonical local alias with EXPLICIT type arguments
+  // still resolves through the Cfc carrier — the generic payload passthrough.
+  // The resulting schema fails closed at commit, so this covers the structural
+  // lowering mechanism, not an advertised capability. Defaulted type arguments
+  // are NOT recovered on non-canonical aliases (only the canonical name
+  // registry hardcoded defaults), so `OpaqueInput<string>` would emit no ifc.
+
   const source = `/// <cts-enable />
     import { toSchema } from "commonfabric";
 

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -117,12 +117,10 @@ Deno.test("namesResolverInCode reads past a comment marker inside a string", () 
   );
 });
 
-//
-// Likewise for a block-comment opener: taken literally it would swallow the
-// rest of the file.
-//
-
 Deno.test("namesResolverInCode reads past a block-comment marker inside a string", () => {
+  // Likewise for a block-comment opener: taken literally it would swallow the
+  // rest of the file.
+
   assert(
     namesResolverInCode(
       `const glob = "/*"; const r = new FileSystemProgramResolver(m);\nconst end = "*/";`,

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -160,17 +160,15 @@ function workflowTriggers(contents: string): string {
   return contents.slice(0, concurrencyStart);
 }
 
-//
-// Every other check in this file reads the workflow files as TEXT (regex over
-// job and step blocks), so none of them can notice that a file has stopped
-// being valid YAML — and a workflow that does not parse produces ZERO jobs on
-// every push while every text-level check here stays green. That happened: an
-// unquoted `default: ` inside two step names turned deno.yml into a nested
-// mapping the runner refused, and CI silently ran nothing for a whole stack of
-// pushes. This is the one check that would have caught it.
-//
-
 Deno.test("every workflow and composite action is valid YAML", async () => {
+  // Every other check in this file reads the workflow files as TEXT (regex over
+  // job and step blocks), so none of them can notice that a file has stopped
+  // being valid YAML — and a workflow that does not parse produces ZERO jobs on
+  // every push while every text-level check here stays green. That happened: an
+  // unquoted `default: ` inside two step names turned deno.yml into a nested
+  // mapping the runner refused, and CI silently ran nothing for a whole stack
+  // of pushes. This is the one check that would have caught it.
+
   const broken: string[] = [];
   for await (const path of githubYamlPaths()) {
     const contents = await Deno.readTextFile(path);
@@ -713,18 +711,16 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
   }
 });
 
-//
-// Both shells CI builds take their co-presence endpoint from a repository
-// variable, and an unset variable is a supported state that builds a working
-// shell. Every check the wiring performs therefore sits inside an
-// `if [ -n "$PRESENCE_URL" ]` that a repository without the variable never
-// enters, so those checks cannot report on the wiring itself: remove the
-// wiring and the same runs stay green. The properties a configured value
-// depends on are checked here instead, against the workflow text, where
-// repository configuration does not get to decide whether the check runs.
-//
-
 Deno.test("a configured presence URL reaches every shell bundle CI builds", async () => {
+  // Both shells CI builds take their co-presence endpoint from a repository
+  // variable, and an unset variable is a supported state that builds a working
+  // shell. Every check the wiring performs therefore sits inside an `if [ -n
+  // "$PRESENCE_URL" ]` that a repository without the variable never enters, so
+  // those checks cannot report on the wiring itself: remove the wiring and the
+  // same runs stay green. The properties a configured value depends on are
+  // checked here instead, against the workflow text, where repository
+  // configuration does not get to decide whether the check runs.
+
   const deno = await workflow("deno.yml");
 
   // Each job that builds a shell, and the directory its build leaves the

--- a/tasks/compile-cache-state.test.ts
+++ b/tasks/compile-cache-state.test.ts
@@ -109,14 +109,12 @@ Deno.test("classifyRunAgainstPredecessor fails open to unknown", async () => {
   );
 });
 
-//
-// The drift guard: COMPILE_CACHE_KEY_GLOBS mirrors the FIRST hashFiles(...)
-// argument list of every cc-* compile-cache key in the workflow. If this
-// fails, update the constant and the workflow together (and matcherForGlob
-// if a new glob shape appeared).
-//
-
 Deno.test("COMPILE_CACHE_KEY_GLOBS matches the cc-* cache keys in deno.yml", async () => {
+  // The drift guard: COMPILE_CACHE_KEY_GLOBS mirrors the FIRST hashFiles(...)
+  // argument list of every cc-* compile-cache key in the workflow. If this
+  // fails, update the constant and the workflow together (and matcherForGlob if
+  // a new glob shape appeared).
+
   const workflow = await Deno.readTextFile(
     new URL("../.github/workflows/deno.yml", import.meta.url),
   );


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

An ex-post-facto review of the test-comment arc's earlier phase found the
defect that phase manufactures, and it is uniform enough to name precisely.

`#6458` wrapped `//` frames around eighty existing labels. Its diff is a pure
addition — 211 insertions, no deletions — so no word changed, **no title was
written, and no region end was ever chosen.** A comment that correctly
described one test became a title-less marker owning everything to the next
marker, which in a file with no other marker is the end of the file.

The reviewer counted 24 of its markers owning blocks their words do not
cover, 14 of those running to EOF. This clears the largest class: fourteen
files where the marker's words are one block's contract.

## What each one had come to own

- `tasks/ci-workflow.test.ts` — "This is the one check that would have caught
  it" owned about twelve unrelated CI tests. A second marker in the same file,
  a presence-URL rationale, owned five test-records tests.
- `packages/dashboard/tiles/discord-online.test.ts` — "This is the first test
  that reaches the history" owned thirteen tests.
- `packages/memory/test/v2-sqlite-guard.test.ts` — a denylist rationale owned
  five describes and some seventeen cases.
- `tasks/check-local-program.test.ts`, `packages/dashboard/render.test.ts`,
  `packages/dashboard/test-records-history.test.ts`,
  `packages/runner/test/compile-and-run.test.ts`,
  `tasks/compile-cache-state.test.ts`, `packages/toolshed/lib/otel.test.ts`,
  `packages/toolshed/routes/ai/llm/errors.test.ts`,
  `packages/test-support/src/isolated-deno.test.ts`,
  `packages/deno-web-test/test/base.test.ts`,
  `packages/deno-web-test/test/timeout.test.ts`, and
  `packages/ts-transformers/test/cfc-transformer-coverage.test.ts` — the same
  shape at smaller scale.

Each comment moves inside the block it describes, as first content with a
blank line under it, and the frame goes.

## Removing a marker removes a delimiter

Three of those files kept an *earlier* marker, whose region the removal would
have widened — the same trap this change exists to repair, running the other
way. It was caught by asking, for every file, whether the marker count fell
while one remained above.

Each of the three now closes where the removed frame used to end it, under a
title of its own: the telemetry lifecycle in `otel`, what the harness keeps
out of a run's streams in `deno-web-test`'s base suite, and where a status
comes from in the llm error suite. That last also drops a count that named
two shapes while standing over three tests.

## Verification

The moves were made by a helper rather than by hand, and controlling it
before use caught three defects in it: a closing-delimiter search that
stopped at a paragraph separator, an extractor that fused paragraphs by
discarding those separators, and `textwrap`'s default of breaking on hyphens,
which split `compile-and-run` across a line boundary into two tokens. The
last was caught by the word-multiset assertion rather than by reading. The
helper refuses rather than guesses when a frame does not head a test block,
which a negative control confirms.

Eleven of the fourteen files are comment-word-identical against
`41b5609d2`, the moves being pure; the three others gain exactly the added
markers' text and lose the one word.

`deno fmt --check` and `deno lint` pass. Suites: `runner` 1324 passed (7897
steps), `ts-transformers` 1164, `memory` 592, `toolshed` 147, `deno-web-test`
35, `test-support` 19, `dashboard` 6, and the three `tasks` files 55 — 0
failed throughout.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

