### PR TITLE
test: regions that own their helpers, and headers that are one header

### DIFF
--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -53,6 +53,7 @@ describe("CFC template population (Stage A): the two under-taints", () => {
   // {path:[...container,"*"], origin:"structure", observes} for observes ∈
   // {shape, value, followRef} — all carrying the same per-tx J, under the same
   // replace-from-criteria discipline.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -551,6 +552,7 @@ describe("CFC template population (SC-8 remainder): generic pure-link containers
   // into the next op's action chain (the measured phase-B pointwise re-smear
   // that kept the route off in Stage A). The end-to-end smear pin is the
   // cfc-flow-pointwise map test, which runs with the generic route on.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -773,6 +775,7 @@ describe("CFC template population (Stage A): class-split resolution", () => {
   // Resolution semantics over hand-seeded template entries with DISTINCT
   // per-class atoms — the runtime mints identical labels per class, so the
   // class split is only observable with seeded metadata.
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -1051,6 +1054,7 @@ describe("CFC template population (Stage A): record-only additionalProperties wa
   // as a `*` segment; mixed properties+additionalProperties schemas mint NO `*`
   // entry (pinned — the restriction is load-bearing, `*` matches any segment
   // and would over-taint the named fields).
+
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 
@@ -1181,6 +1185,7 @@ describe("CFC template population (Stage A): cross-space label protection", () =
   // cross-space representation transform at mint exactly like the container
   // stamps they accompany — a membership J fed by a foreign labeled read
   // persists in commitment form under `enforce`.
+
   const userAtom = { type: CFC_ATOM_TYPE.User, subject: "did:key:alice" };
 
   it("templates with cross-space J persist commitment forms under enforce", async () => {
@@ -1274,6 +1279,7 @@ describe("CFC template population (Stage A): cross-space label protection", () =
 describe("CFC template population (Stage A): canonical form with `*` paths", () => {
   // Canonicalization and coalescing over multi-`*` paths (design §3.3 "no
   // changes required" — verified, not assumed).
+
   const entry = (
     path: string[],
     atom: string,

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -1,9 +1,15 @@
 /**
- * Defense-in-depth on the real registrar (run-once / closed-window /
- * transactional) lives in cfreg-builder-identity.test.ts. What verifier-gating
- * relies on is pinned here: the rejecting variant, the trust gate, and the
- * approval signal, alongside the transformer↔verifier round trip and
- * re-registration under one identity.
+ * Security invariants for the `__cfReg` content-addressed registration
+ * mechanism (CT-1623). The compiled module body is treated as UNTRUSTED, and
+ * the defenses live in four layers: the verifier, the registrar capability,
+ * the per-value trust gate, and content addressing.
+ *
+ * The runtime layers are pinned here — the approval signal, the rejecting
+ * registrar and the sink it leaves untouched, the trust gate, the
+ * transformer↔verifier round trip, and re-registration under one identity.
+ * The adversarial verifier corpus lives in esm-verifier-adversarial.test.ts,
+ * and defense-in-depth on the real registrar (run-once, closed-window,
+ * transactional) in cfreg-builder-identity.test.ts.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -20,12 +26,6 @@ import {
   isTrustedBuilderArtifact,
   noteDerivedCopy,
 } from "../src/builder/pattern-metadata.ts";
-
-// Security invariants for the `__cfReg` content-addressed registration mechanism
-// (CT-1623). The compiled module body is treated as UNTRUSTED; defenses live in
-// four layers (verifier, registrar capability, per-value trust gate, content
-// addressing). The adversarial *verifier* corpus lives in
-// esm-verifier-adversarial.test.ts; this file pins the runtime layers.
 
 const IMPORT = `const cf = require("commonfabric");`;
 

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -364,7 +364,7 @@ Deno.bench(
 );
 
 //
-// Also run the regression delta over all parking bodies summed
+// Regression delta, all parking bodies summed
 //
 
 Deno.bench(

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -385,9 +385,7 @@ describe("stage G outbox + sqlite discharge", () => {
   });
 
   //
-  // The durable half: rows in the wave's own transaction
-  //
-  // (FP1)
+  // The durable half (FP1): rows in the wave's own transaction
   //
 
   it("lands outbound append rows INSIDE the wave's engine transaction, for surviving contributions only (FP1; the model's committed-only fold)", async () => {
@@ -480,9 +478,7 @@ describe("stage G outbox + sqlite discharge", () => {
   });
 
   //
-  // Delivery: admit at the target, then delete
-  //
-  // (FP1 closure)
+  // Delivery (FP1 closure): admit at the target, then delete
   //
 
   it("delivers pending rows: delegated admission at the target stamps firedAt from the CARRIED actor (LT5 envelope), then deletes the row; a re-sent duplicate dedupes at the eventId horizon", async () => {
@@ -667,6 +663,14 @@ describe("stage G outbox + sqlite discharge", () => {
       "evt-fifo-3",
     ]);
   });
+
+  //
+  // The fold's completeness, and the gate at the source
+  //
+  // What the durable half must still carry — a foreign-only survivor's
+  // appends, and a tx that sealed nothing but staged some — and the refusal
+  // that happens at enqueue rather than at delivery.
+  //
 
   it("folds a FOREIGN-only-seal survivor's appends into the home batch's outbox rows (FP1 fold completeness; the stage-G review's M-A)", async () => {
     // A contribution whose only sealed space is FOREIGN (the Phase-5
@@ -853,6 +857,13 @@ describe("stage G outbox + sqlite discharge", () => {
     wave.abandon("test over");
     lease.release();
   });
+
+  //
+  // Refusals and failures at delivery
+  //
+  // What the drain does with a row it cannot deliver: a deterministic
+  // rejection retires, a transport failure does not.
+  //
 
   it("does not retry an LT4 deterministic admission rejection: the row is deleted and counted failed", async () => {
     // The accumulator refuses userless entries at the source (above),
@@ -1123,9 +1134,7 @@ describe("stage G outbox + sqlite discharge", () => {
   });
 
   //
-  // The sqliteQuery memo decision
-  //
-  // (B1's fix, serving-loop.md §4/§6)
+  // The sqliteQuery memo decision (serving-loop.md §4/§6)
   //
 
   it("sqliteQuery memo decision: a settled result is a hit, a bare claim never is; an orphaned claim re-issues ONLY under the serving posture", () => {
@@ -1184,7 +1193,13 @@ describe("stage G outbox + sqlite discharge", () => {
     })).toBe("issue");
   });
 
-  // the sqlite bound's discharge
+  //
+  // Discharging a sqlite op through the attachment hook
+  //
+  // What the decision above leads to: a folded op applied atomically through
+  // the hook, and a loud refusal everywhere else — no hook, no resolved scope
+  // key, or a foreign batch.
+  //
 
   // Unique per test run: the cell-db FILE for a memory-URL engine lives
   // at a deterministic TMPDIR path keyed by (space, id) — a stable id
@@ -1225,13 +1240,6 @@ describe("stage G outbox + sqlite discharge", () => {
       ? { sqliteScopeKeys: [{ op: 1, scopeKey: "space" }] }
       : { sqliteScopeKeys: options.scopeKeys }),
   });
-
-  //
-  // Discharging a sqlite op through the attachment hook
-  //
-  // What the decision above leads to: a folded op applied atomically where the
-  // hook exists, and a loud refusal where it does not.
-  //
 
   it("applies a folded sqlite op in a HOME wave batch atomically via the server's attachment hook (the stage-D bound discharged)", async () => {
     const lease = liveLease();

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -676,9 +676,7 @@ describe("stage G SpaceServer recovery seams", () => {
   });
 
   //
-  // Stage P2-F: late-notice accounting
-  //
-  // (the sx2 unskip flake)
+  // Stage P2-F: late-notice accounting (the sx2 unskip flake)
   //
 
   it("counts an authored notice that arrives AFTER a higher-seq echo (the two-producer notice race): late records still count and re-arm, and coverage stays in-order", async () => {
@@ -741,6 +739,13 @@ describe("stage G SpaceServer recovery seams", () => {
   /** A facade whose watch registry names exactly the given demanded
    * roots — the unit-level stand-in for client sessions' watches (the
    * production feed is pinned in the serving-loop E2E). */
+  //
+  // The demand-seam apparatus
+  //
+  // The helpers the regions below share: what they hand-feed, and the shape
+  // demand takes under (d′).
+  //
+
   // W0 (d′) SCRATCH: these seams hand-feed DEMAND with no client session.
   // Under (d′) demand is the tracked-ids CLOSURE (`demandedInstancesForSpace`
   // rows: instance-keyed, `root` marked) — a client watching a piece's

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -224,12 +224,16 @@ Deno.bench("array element resolution in circular structures", () => {
   storageManager.close();
 });
 
+//
+// Reactive-list scans
+//
 // A list scanned through the reactive proxy: what a lift does when it reads a
 // collection of linked entries, and the shape the transaction-scoped memo
 // exists for. `elements per pass` is the per-element cost; `whole array` is
 // one pass over the whole thing. The unmemoized cost of both is linear in the
 // number of resolutions, so a scan that touches each element more than once
 // pays it again per touch.
+//
 const LIST_LENGTH = 50;
 
 const listBoardSetup = () => {
@@ -286,6 +290,10 @@ Deno.bench("reactive list: whole array read per element", () => {
   runtime.dispose();
   storageManager.close();
 });
+
+//
+// A path that never stops growing
+//
 
 Deno.bench("resolveLink with infinitely growing path (A->A/foo)", () => {
   const storageManager = StorageManager.emulate({

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -1388,7 +1388,7 @@ describe("legacy-envelope tolerance on cold load (CT-1838)", () => {
   //
   // Tolerance on the remaining load paths
   //
-  // The battery above drives the plain cold load. T9 crosses a JS-trailer
+  // The T1-T6 battery drives the plain cold load. T9 crosses a JS-trailer
   // module variant through that same path, and T10 the authoring path, which
   // feeds storage-fetched mounts through its own `injectMountSources` call
   // and so needs the tolerance in a second place.

--- a/packages/runner/test/mergeable-op-registry.test.ts
+++ b/packages/runner/test/mergeable-op-registry.test.ts
@@ -233,6 +233,7 @@ describe("mergeable remove-by-value build guards", () => {
   // working array must be exactly the base with the removed values taken out.
   // Anything else the transaction changed on that array would otherwise be
   // silently discarded.
+
   const removeIntent = (...values: string[]) =>
     ({ op: "remove-by-value", path: ["value"], values }) as const;
 
@@ -327,10 +328,12 @@ describe("mergeable op payload containment", () => {
   // already had its change applied by the containing op, whose payload is read
   // from the working array at commit. `buildMergeableOps` abandons the
   // contained intent; this pins the per-op answers it asks for.
-  // A tail op sends `array.slice(tailStart)` — live values out of the working
-  // document — so it carries every path at or past that index, at any depth.
 
   it("a tail op contains the paths at or past its tail start", () => {
+    // A tail op sends `array.slice(tailStart)` — live values out of the
+    // working document — so it carries every path at or past that index, at
+    // any depth.
+
     const ctx = {
       workingArray: [["a"], ["x"]],
       hadInitialArray: true,

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -533,7 +533,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
   });
 
   //
-  // filter builtin tests
+  // Filter builtin tests
   //
 
   it("should filter an array by predicate", async () => {
@@ -919,7 +919,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
   });
 
   //
-  // flatMap builtin tests
+  // FlatMap builtin tests
   //
 
   it("should flatMap an array", async () => {

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -1138,8 +1138,8 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
   //
   // The class THREADING (the predicate's plumbing)
   //
-  // The replica records the covering commit's class
-  // on its confirmed record — from the frame's `coverClass` on integrate,
+  // The replica records the covering commit's class on its confirmed record
+  // — from the frame's `coverClass` on integrate,
   // preserved across a same-seq re-upsert without one, dropped when the seq
   // moves without one, and `authored` for an own commit's promotion — and
   // `speculationRetirementView` surfaces it to the sweep.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Ten `runner` files from the ex-post-facto review of the test-comment arc.

Reviewers have now covered every conversion PR in this arc, and the pattern
they converge on is worth stating: **the arc's core move worked, and its
framing is where the defects are.** Adjacency counts of comments still sitting
above a block opener went 89→0, 6→0, 5→0 across the batches, each with a
positive control on the pre-PR file. What the conversions introduced is
regions — and a region has a boundary, a title that asserts rather than
gestures, and contents that the boundary captures.

## A region that owned three tests it does not describe

`executor-outbox.test.ts` titled a region "Delivery: admit at the target, then
delete" over ten tests. Three are not delivery: two FP1 fold cases that never
run a drain, and a refusal whose own name says it happens "at the SOURCE —
fail-closed ahead of the delegated floor that would destroy it at delivery".

Delivery now holds the two cases it describes. The fold's completeness and the
source gate take a region of their own, and the five refusal and failure cases
re-open delivery under a title that covers them.

## Helpers captured by a region that never uses them

The same file kept a blank-separated label above the sqlite helpers — the
shape this part of the arc existed to remove — while a marker *below* those
helpers said the same thing in proper form. The label goes and the marker
moves up, so the helpers sit in the region whose tests use them.

`executor-space-server.test.ts` has the same shape: the demand helpers sat
inside a region whose single test never touches them, while every use is in
the three regions below. They take a marker naming them.

## Two headers where a file may have one

`cfreg-security.test.ts` carried two file-scope descriptions, in two forms, in
two places — a doc comment at the top and a `//` block below the imports, each
pointing a reader at a different sibling file. A reader hits both and cannot
tell which is the file's. One header now says what the file is, and names what
all six of its describes cover.

## A blank line that rescoped a comment

In `mergeable-op-registry.test.ts` two comments sat fused with no separator: a
group premise for the `describe()`, and a note about the first test alone. The
arc added a blank line *under the pair* — correct-looking, and the reason it
matters is that the blank line is the reach signal. Adding it promoted the
second comment from a misplaced test note into part of the group comment.

The note moves inside the test it is about. The same PR had performed exactly
this split correctly on a different note in the same file.

A second describe there ran its premise straight into a helper declaration,
where the file's other three all carry the blank line.

## Smaller

`link-resolution.bench.ts` held a run comment naming both reactive-list
benches, sitting adjacent above a constant, with nothing closing it before an
unrelated bench; it takes a framed, closed region.
`esm-verifier.bench.ts` had a marker titled with an imperative sentence among
six noun-phrase siblings. Four bare parentheticals — `(FP1)`, `(FP1 closure)`,
`(B1's fix, …)`, `(the sx2 unskip flake)` — stood where a grammatical
description belongs, and fold onto their title lines.

`cfc-template-population.test.ts` takes the blank line under six group
comments, which the arc added elsewhere in the same batch and here did not.
`load-by-identity.test.ts` said "The battery above drives the plain cold
load", where the region above is about memoization; it names the T1-T6 battery
it means.

## Verification

Every edit asserted its target text appeared exactly once before
substituting. After each, a check confirmed no file lost a marker while
another remained above it.

Three files are comment-word-identical against the base — the blank-line
additions, the fused-pair split, and the reflow are pure. The rest differ by
exactly the titles and descriptions described above.

`deno fmt --check` and `deno lint` pass. `deno task test` in `packages/runner`
reports 1324 passed (7897 steps), 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

