### PR TITLE
test: a region that stops where its subject does

### DIFF
--- a/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
+++ b/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
@@ -80,6 +80,7 @@ describe("relaxDefaultedRequired", () => {
       })).toBeUndefined();
     });
   });
+
   it("relaxes a default the subtree's own $defs scope provides", () => {
     // A subtree that declares its own `$defs` opens a new local-ref scope
     // (`cfcSchemaChildRoot`), so its refs must resolve against ITS definitions,
@@ -141,6 +142,7 @@ describe("relaxDefaultedRequired", () => {
       })).toBeUndefined();
     });
   });
+
   it("follows a $ref chain to find the default", () => {
     expect(relaxedValidationError({}, {
       type: "object",

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -406,6 +406,13 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     });
   });
 
+  //
+  // Shared harness
+  //
+  // A labeled cell, a policyState-guarded sink rule, a Runtime, and the grant
+  // writer and reader the regions below share.
+  //
+
   const SECRET_SCHEMA = internSchema(
     {
       type: "object",

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1675,8 +1675,10 @@ describe("redactSigilCfcLabelViewsForDisplay", () => {
   // copy-on-write gate: such a value has zero enumerable own properties, so no
   // member can come back changed, `changed` stays false, and the original goes
   // back by identity. That is a real guarantee resting on nothing but the
-  // zero-property fact, so these pin it -- give a special object an enumerable
-  // property and this walk starts flattening values on the ingress path.
+  // zero-property fact -- give a special object an enumerable property and
+  // this walk starts flattening values on the ingress path. Where the walk
+  // cannot make that guarantee it refuses instead, rather than leaving a view
+  // in place.
   //
 
   it("keeps a `FabricBytes` whole while stripping a sibling's view", () => {

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -56,6 +56,7 @@ describe("mergeCfcSchemaEnvelopes", () => {
       expect((rows.ifc as { observes?: string }).observes).toBeUndefined();
     });
   });
+
   it("allows additive required fields when a default preserves old documents", () => {
     const merged = mergeCfcSchemaEnvelopes({
       type: "object",
@@ -894,6 +895,7 @@ describe("mergeCfcSchemaEnvelopes", () => {
       ).toThrow(/divergent anyOf branches/);
     });
   });
+
   it("rejects divergent ifc branches nested under a tuple slot", () => {
     // CT-1895: the guard's recursion visited only properties and items, so
     // a divergent-ifc shape under a prefixItems slot escaped it.

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -185,9 +185,14 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
     });
   });
 
-  // Shared harness (cfc-grant-records.test.ts style): a labeled cell, a
-  // policyState-guarded sink rule, and a Runtime whose experimental
-  // commitPreconditions flag is the receipts dial.
+  //
+  // Shared harness
+  //
+  // In `cfc-grant-records.test.ts` style: a labeled cell, a policyState-guarded
+  // sink rule, and a Runtime whose experimental commitPreconditions flag is the
+  // receipts dial. Every region below draws on these.
+  //
+
   const SECRET_SCHEMA = internSchema(
     {
       type: "object",

--- a/packages/runner/test/scheduler.bench.ts
+++ b/packages/runner/test/scheduler.bench.ts
@@ -565,8 +565,6 @@ Deno.bench(
   "Overhead - setup/teardown only",
   { group: "overhead" },
   async () => {
-    // Benchmark: Just setup/teardown overhead
-
     const { runtime, storageManager, tx } = setup();
     await cleanup(runtime, storageManager, tx);
   },
@@ -576,8 +574,6 @@ Deno.bench(
   "Overhead - create 100 cells (getCell + set)",
   { group: "overhead" },
   async () => {
-    // Benchmark: Cell creation overhead
-
     const { runtime, storageManager, tx } = setup();
 
     for (let i = 0; i < 100; i++) {
@@ -598,8 +594,6 @@ Deno.bench(
   "Overhead - 100x getCell only (no set)",
   { group: "overhead" },
   async () => {
-    // Benchmark: Just getCell without set
-
     const { runtime, storageManager, tx } = setup();
 
     for (let i = 0; i < 100; i++) {
@@ -619,8 +613,6 @@ Deno.bench(
   "Overhead - 100x set on existing cells",
   { group: "overhead" },
   async () => {
-    // Benchmark: set on pre-created cells
-
     const { runtime, storageManager, tx } = setup();
 
     // Pre-create cells
@@ -645,8 +637,6 @@ Deno.bench(
   "Overhead - runtime.idle() empty",
   { group: "overhead" },
   async () => {
-    // Benchmark: runtime.idle() overhead with no work
-
     const { runtime, storageManager, tx } = setup();
     await runtime.idle();
     await cleanup(runtime, storageManager, tx);
@@ -690,8 +680,6 @@ Deno.bench(
   "Overhead - empty commit",
   { group: "overhead" },
   async () => {
-    // Benchmark: just commit with no writes
-
     const { runtime, storageManager, tx } = setup();
     await tx.commit();
     await runtime.dispose();

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -899,8 +899,6 @@ describe("Schema-to-TS Type Conversion", () => {
   });
 
   it("should work with real data at runtime", () => {
-    // Runtime tests to verify the Schema type works with actual data
-
     // Define a schema that uses various features
     const schema = {
       type: "object",

--- a/packages/runner/test/sqlite-read-labeling.test.ts
+++ b/packages/runner/test/sqlite-read-labeling.test.ts
@@ -206,12 +206,11 @@ describe({
   };
 
   it({
+    // FFI loads the column-metadata lib (process-lifetime by design); exempt
+    // this test from the dynamic-library leak detector.
     name: "labeled db: result columns carry the TRUE origin (alias resolved)",
     sanitizeResources: false,
   }, async () => {
-    // FFI loads the column-metadata lib (process-lifetime by design); exempt
-    // this test from the dynamic-library leak detector.
-
     const db: SqliteDbRef = {
       id: `of:lbl-${crypto.randomUUID()}`,
       tables: labeledTables,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Eight `runner` files from the ex-post-facto review of the test-comment arc.

## Regions that owned the file's shared harness

`cfc-single-use-grants.test.ts` promoted "Item 2: the consumption receipt
identity" to a marker, and the region it opened ran on over the whole shared
harness — `SECRET_SCHEMA`, `seedLabeledCell`, `sinkShareRule`, `withRuntime`,
`writeGrant`, `grantIdFor`, `buildRelease`, `readReceipt`,
`stagedReceiptWrite`. Not one is used inside that region: the first use of
every one is at line 426 or later, in the regions below.

`cfc-grant-records.test.ts` has the same shape, where `readThenSink` has all
ten of its call sites in the egress-gate region below the one that owns it.

In both, the existing "Shared harness" note becomes a marker. That closes the
item-2 region where its subject ends and gives the fixtures a region that
names them — one edit for both halves.

This is a cost of framing that a comment above a run does not have. A label
introduces what follows and stops; a region takes in everything between its
marker and its end, the helpers that happen to sit there included.

## Markers that also read as a block comment

Both files opened their first marker on the line directly after the top-level
`describe(...)`. A comment that is the first content of a callback, with a
blank line under it, is that callback's block comment — so a `//` frame in
that position is two things at once. Each takes the blank line above that
makes it a frame.

## Boundaries the files themselves say should be there

Four sibling boundaries lost their blank line, all at the close of a
`describe()` group the arc created. The files settle it: `cfc-schema-merge`
has 55 boundaries with a blank line and two without, and both of those are the
new groups' closes. `cfc-defaulted-required-relaxation` is 24 against two, the
same way.

## A description contradicted by its own second member

`cfc-label-view`'s marker says a `FabricSpecialObject` survives the strip
because it has zero enumerable own properties, "so these pin it" — over a
region of two tests, the second of which pins a *refusal*. The prose was
already there and already plural; framing it as a region description is what
turned a loose label into a claim about both. The title is true of both, so
the description now covers the refusal too.

## A note moved away from what it explains

In `sqlite-read-labeling.test.ts` a note explaining an `it()`'s
`sanitizeResources: false` had been moved into the callback body, while the
sibling `describe({...})` four lines above keeps the identical sentence inside
its options object, beside the option. The body-less allowance exists for
exactly this: a comment about an option belongs where the option is.

## One rule, applied once

`scheduler.bench.ts` had the "a label that only restates its block is deleted"
rule applied to two labels and not to six identical siblings — "Benchmark:
Just setup/teardown overhead" over `Overhead - setup/teardown only`, and five
more of that kind. The six go, which is the disposition the arc chose for the
other two. The thirteen labels that remain each say something the bench name
does not.

`schema-to-ts.test.ts` drops a comment restating its test's own name, which a
later PR's describe-level comment also covers.

## Verification

Every edit asserted its target appeared exactly once before substituting, and
a check after each confirmed no file lost a marker while another remained
above it.

Three files are comment-word-identical against the base — the blank lines and
the option move are pure. The rest differ by exactly the two new harness
markers, the widened description, and the words of the deleted labels.

`deno fmt --check` and `deno lint` pass. `deno task test` in `packages/runner`
reports 1324 passed (7897 steps), 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

