### PR TITLE
docs(development): what a section marker's region is

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -60,13 +60,21 @@ surrounding code:
 - A comment about a test or a group of tests goes inside the block, as the
   first thing in the callback and followed by a blank line. Above the
   `describe()` or `it()` line, the next block inserted there lands between the
-  comment and what it describes. Hooks are the exception -- a `beforeEach()`
-  reads like any other statement with a comment over it -- and a comment
-  covering several adjacent tests is telling you those tests want a
+  comment and what it describes. Two shapes are exceptions: hooks — a
+  `beforeEach()` reads like any other statement with a comment over it — and a
+  callback with no body of its own, a bare expression or `{}` on the opener's
+  line, which keeps its comment beside it.
+- A comment covering several adjacent tests is telling you those tests want a
   `describe()` of their own, or says one thing per case and belongs in each.
-  A section marker covers the region up to the next marker or the end of the
-  block. None of this is checked mechanically; a file that reads better than
-  the rule wins.
+  Wrapping a run renames every test in it; bridge the rename per
+  `docs/development/test-records.md`.
+- A section marker covers the region up to the next marker or the end of the
+  block, so writing one means choosing where it ends and putting a marker
+  there. Its title is a claim about everything in that region, and the region
+  holds the helpers and fixtures sitting in it as well as the blocks. Moving
+  or deleting a comment takes away whatever boundary it was providing for the
+  region above it. None of this is checked mechanically; a file that reads
+  better than the rule wins.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -265,6 +265,35 @@ after a blank line:
 export function fry(): void {}
 ```
 
+A blank line sets the frame off above as well as below. Without the one above,
+the marker runs into whatever comment precedes it and the two read as one
+comment; without the one below, the frame reads as a note on the declaration it
+touches rather than as a heading over what follows.
+
+**A region has an end, and writing the marker is choosing it.** A marker opens
+a region that runs to the next marker at the same level, or to the end of the
+enclosing block or file. Read what sits between the marker and that point and
+check the title covers all of it. Where the material the title owns stops before
+the enclosing block does, put a marker there titling what follows. A file whose
+last marker does not head the file's last section has a region whose end nobody
+chose.
+
+**A title is a claim about everything in its region**, not an introduction to
+what comes next. The same words that pass as a label above the first of a run
+become false as a title over a region holding more than they name: "the two
+things that are not values" is a fact about a region with two of them in it.
+When a region grows, its title is read against it again.
+
+A title can be wrong by being too narrow as easily as too wide. Where the
+subject it names also appears outside its region, either the region is in the
+wrong place or the title names something smaller than its subject.
+
+**A region holds more than its blocks.** Everything between the marker and the
+region's end falls inside it: a helper function, a fixture constant, a
+`beforeEach()`. A helper that serves the whole file but happens to sit inside
+one region reads as belonging to that region, so shared setup goes above the
+first marker.
+
 **CSS takes a block comment.** CSS has no line comments, so a section marker in
 a `.css` file, a `css` template literal, or a `<style>` block is a `/* */`
 block, with each delimiter on its own line and every line at the same

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -241,7 +241,10 @@ Three nearby shapes are not this one:
   adjacent cases that each pin one part of what it says — has no home inside
   any one of them. That comment is telling you the run wants a
   `describe()`: give the run its own block, and the comment goes inside that
-  block by the rule above, which is where a long rationale belongs anyway. A
+  block by the rule above, which is where a long rationale belongs anyway.
+  Wrapping a run renames every test in it, so where the history is worth
+  keeping, bridge the rename as
+  [test records](test-records.md) describes. A
   run that should not become a block takes a
   [section marker](code-comment-style.md#section-markers) instead, and then the
   region needs closing — a second marker after the run — or a reader cannot
@@ -254,11 +257,21 @@ Three nearby shapes are not this one:
   top-level `describe()`.
 - A [section marker](code-comment-style.md#section-markers) titles a region of
   the file holding several blocks. Reach is what tells the two apart, not
-  length or subject matter. A marker covering a single block is not marking a
-  region. Where it says something about that block, it becomes a block comment
-  in the form above. Where it only restates the block's own description, it is
-  deleted. A comment that would say no more than the description above it is
-  not worth writing.
+  length or subject matter.
+
+  A marker covering a single block is usually a block comment in the wrong
+  frame: where it says something about that block, it becomes a block comment
+  in the form above, and where it says no more than the block's own
+  description, it is deleted. A comment that would say no more than the
+  description above it is not worth writing.
+
+  Two things stop that. Where a file marks its regions in a series and this
+  marker is one of the series, it stays; a file with one way of showing its
+  regions beats a file that demotes eleven markers and leaves the twelfth
+  reading as an omission. And where the marker closes the region above it,
+  removing it reopens that region, so it is replaced rather than removed —
+  by a marker titling what follows, or by giving the region above a closer of
+  its own.
 
 ### The shape to aim for
 
@@ -275,6 +288,12 @@ Give a file one way of showing its regions and keep to it. Where a file marks
 regions, a marker ends the one before it, so a series of them reads as a series
 and a lone label in another form leaves the region above it looking wider than
 it is.
+
+Moving a comment into its block takes a boundary away with it. Whatever sat
+above was bounded in practice by that comment being there, and with the comment
+inside a callback the thing above reaches past where the comment held it. Look
+up before moving one: where a region ends at the comment, it needs a closer of
+its own in the same change. Deleting a comment does the same thing.
 
 None of this is checked mechanically, on purpose: the cases that do not fit
 keep arriving, and a gate would only make them expensive. It is guidance. A


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Ten reviews of the test-comment work are complete, and they converge on one
finding: **the arc's central move worked and its framing did not.**

Comments moved into the blocks they describe came back clean everywhere, with
positive controls to prove it — adjacency counts of comments still sitting
above a block opener went 119→0, 89→0, 6→0, 5→0 across the batches, no moved
comment lost its blank line, no reflow rejoined a word, no line went over 80.

Nearly every defect found came from the other half: framing a comment into a
section marker. There were around sixty, in seven recurring shapes. The rule as
written names two of them.

The reason is visible in the documents. The rule is complete about **where a
comment goes** and nearly silent about **what a region is** — and the
`describe()`/`it()` half never needed a region model. `code-comment-style.md`'s
section on markers was written for the closed, three-marker class layout in
`DEVELOPMENT.md`: `Subclass contract`, `Instance members`, `Static members`,
where each marker is closed by the next or by the class's brace and the
questions below cannot come up. An open set of test-file regions asks all of
them at once.

## What `code-comment-style.md` gains

Four properties of a marker, in the section that defines one.

**A region has an end, and writing the marker is choosing it.** Reach was
stated as a fact — "up to the next marker or the end of the block" — and never
turned into a step. That absence is what let a marker whose words are one
test's contract come to own the twenty tests after it, more than once.

**A title is a claim about everything in its region**, not an introduction to
what comes next. This is the single largest gap: the document said what a
marker means and never said to check that it is true. The same words that pass
as a label above the first of a run become false as a title over a region
holding more than they name. A title can also be wrong by being **too narrow**,
where the subject it names appears outside its region too.

**A region holds more than its blocks** — the helper, the fixture constant, the
`beforeEach()` that happen to sit in it. Two reviews found regions that had
swallowed their file's entire shared harness, every helper of which was used
only below.

**The frame is set off above as well as below.** This was already being
enforced, and was written nowhere.

## The contradiction in `unit-test-coding-style.md`

Two passages, nine lines apart in the same section, gave opposite
instructions. A marker covering a single block "is deleted"; and "a marker ends
the one before it", the same passage naming an over-wide region as the defect —
which deleting the first marker produces. Reviewers hit this four separate
times and each declined to apply the rule, with nothing to cite.

The disposition now names the two things that stop it: a marker that is one of
a file's series stays, and a marker that closes the region above it is
**replaced rather than removed**.

There are about 171 single-block markers in the tree, several files using the
shape systematically as a per-test separator. The old wording condemned all of
them by omission.

## The cost of the move, stated where the move is

Moving a comment into its block takes away whatever boundary that comment was
providing for the thing above it. Deleting one does the same. That is the
mechanical cost of the rule the document states, and it appeared nowhere —
while the rule's own "a label that only restates its block is deleted"
instructs exactly the deletion that causes it.

Wrapping a run in a `describe()` — the first remedy the rule offers for a
run-spanning comment — renames every test in it and splits its recorded
history unless bridged. The section recommending it did not say so.

## `.claude/rules/tests.md`

It stated the rule with one of its three exceptions. The body-less callback was
missing entirely, which matters because that file is what an agent loads on
opening a test file: applying it as written, an agent tries to move a comment
inside `it("...", () => expect(f(x)).toBeUndefined())` and has nowhere to put
it. Its densest bullet carried six rules in one paragraph, with the two most
often applied wrong as its last two sentences; it splits into three.

## Verification

`deno task check-docs` passes all 589 blocks, and `check-skill-facts` passes 49
documents. No line in any of the three files exceeds 80 characters. Markdown is
outside `deno fmt`'s scope in this repository, confirmed against an untouched
document.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

