### PR TITLE
test: titles read against the regions they ended up over

### DIFF
--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -343,10 +343,9 @@ describe("cf piece call on a piece that points back at its container", () => {
   });
 
   //
-  // The other half of "a caller's own shape wins"
+  // A selection that asks for an address and keeps a circle
   //
-  // The pair below is the other half of "a caller's own shape wins": a
-  // selection that asks for an ADDRESS at one position and keeps the circle at
+  // The pair here asks for an ADDRESS at one position and keeps the circle at
   // another. The address is the caller's whole answer where they asked for it,
   // and a bound that closed the object over the declared fields instead would
   // answer `{}` there — contents where an address was asked for, which reads as
@@ -471,9 +470,9 @@ describe("cf piece call on a piece that points back at its container", () => {
   //
   // The `--filter` pair
   //
-  // The `--filter` pair, and the same contrast: a predicate hands back the
-  // elements themselves, so it can only keep a circle, never narrow past one.
-  // What decides between the two is the projection written beside it.
+  // A predicate hands back the elements themselves, so it can only keep a
+  // circle, never narrow past one. What decides between the two is the
+  // projection written beside it.
   //
 
   it("returns the elements a `--filter` keeps where the projection beside it renders", async () => {
@@ -535,8 +534,9 @@ describe("cf piece call on a piece that points back at its container", () => {
   //
   // When the result will not render, and what that costs
   //
-  // What the command does when the result will not render, and that it
-  // does not pay to produce what it will not use.
+  // A result the command cannot render is refused with the committed write
+  // named, and the declaration behind that bound is reached for only where
+  // the refusal needs it.
   //
 
   it("refuses legibly, naming the committed write, where the declaration bounds nothing", async () => {
@@ -617,7 +617,7 @@ describe("cf piece call on a piece that points back at its container", () => {
   //
   // Miscellaneous cases
   //
-  // Cases that belong to none of the pairs above.
+  // Cases that belong to none of the groups above.
   //
 
   it("returns that position alone for a `--select` naming the closing position", async () => {

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -83,10 +83,10 @@ Deno.test("a run the kernel killed names the signal", function () {
 });
 
 //
-// What the harness keeps out of a run's streams
+// Filtering a run's streams
 //
-// Download noise before the harness boundary goes; what a test itself wrote
-// stays, control sequences included.
+// Download noise before the harness boundary goes, and what a test itself
+// wrote stays, control sequences included.
 //
 
 Deno.test("dependency downloads before the harness boundary are removed", function () {

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -94,9 +94,9 @@ Deno.test("keying - generateKey", async (t) => {
   //
   // Beyond `FabricValue`
   //
-  // An event handler — one of the two things a render node holds that is not
-  // a `FabricValue` — and the coarse key that comes back for a node the keyer
-  // cannot hash.
+  // An event handler, which is not a `FabricValue` and so cannot be hashed as
+  // one, and the coarse key that comes back for a node the keyer cannot hash
+  // at all.
   //
 
   await t.step("keys an event handler without falling back", () => {

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1822,8 +1822,8 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     // Strict text integrity over visible props
     //
     // The same integrity applied to the props a node renders rather than to
-    // its child text, and what becomes of the blocked state when children are
-    // reused, a sibling changes, or the policy is removed.
+    // its child text, and what becomes of the blocked state as children and
+    // policy change around it.
     //
 
     await t.step(

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -531,7 +531,7 @@ describe("cf-code-editor cursor stability", () => {
   });
 
   //
-  // NEGATIVE TESTS: Verify cursor DOES move when it should
+  // Where the cursor should move
   //
 
   it("should apply external update and move cursor after editor blur", async () => {
@@ -583,7 +583,7 @@ describe("cf-code-editor cursor stability", () => {
   });
 
   //
-  // STRESS TESTS: Edge cases and rapid operations
+  // Rapid operations and edge cases
   //
 
   it("should handle multiple rapid external updates correctly", async () => {
@@ -763,7 +763,7 @@ describe("cf-code-editor cursor stability", () => {
   });
 
   //
-  // ADVERSARIAL TESTS: Race conditions, timing attacks, edge cases
+  // Race conditions and timing edges
   //
 
   it("ADVERSARIAL: Cell update at exact debounce boundary should not corrupt state", async () => {

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1092,11 +1092,11 @@ describe("CFC browser helpers", () => {
   });
 
   //
-  // Filling and typing
+  // Filling, typing, and submitting
   //
-  // The helpers that put text into a control rather than click one: the same
-  // settle discipline as the click helpers, and what happens when a commit
-  // replaces the control they were typing into.
+  // The helpers that reach a control by its keyboard rather than by a click:
+  // the same settle discipline as the click helpers, and what happens when a
+  // commit replaces the control they were typing into.
   //
 
   it("settles the view before pressing Enter in a submit input", async () => {
@@ -1832,8 +1832,9 @@ describe("CFC browser helpers", () => {
   //
   // Where the click actually landed
   //
-  // A click can reach the DOM and still not reach the control the caller aimed
-  // at. These report where it went.
+  // A click can reach the DOM and still not reach the control the caller
+  // aimed at. These cover what the helper does about that — report it, re-mark
+  // the control, or stand aside for an interaction that is not its own.
   //
 
   it("leaves the page's own clicks to the page while a click is in flight", async () => {

--- a/packages/runner/test/cell-set-flat-index-list.bench.ts
+++ b/packages/runner/test/cell-set-flat-index-list.bench.ts
@@ -421,14 +421,19 @@ for (const N of SIZES) {
   });
 }
 
-// 4. UPDATE: three writer profiles for "one item changed", distinguished
-//    because they have wildly different write footprints:
-//      a. REGENERATE from scratch (what a derivation/lift recompute does):
-//         fresh objects carry no doc identity → every element re-minted.
-//      b. READ-MODIFY-WRITE (the idiomatic handler edit): objects returned
-//         by get() carry their doc identity → only the changed element and
-//         the parent write.
-//      c. TARGETED key(i).set: bypasses the array diff entirely.
+//
+// 4. UPDATE: three writer profiles for "one item changed"
+//
+// They are distinguished because they have wildly different write footprints:
+//
+//   a. REGENERATE from scratch (what a derivation/lift recompute does):
+//      fresh objects carry no doc identity → every element re-minted.
+//   b. READ-MODIFY-WRITE (the idiomatic handler edit): objects returned
+//      by get() carry their doc identity → only the changed element and
+//      the parent write.
+//   c. TARGETED key(i).set: bypasses the array diff entirely.
+//
+
 async function updateRegenerate(
   N: number,
   b?: Deno.BenchContext,

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -1073,13 +1073,8 @@ describe("Cell Static Methods", () => {
     //
     // Date normalization on `set()`
     //
-    // The `Cell.of(new Date(...))` cases (top-level and nested) are absent.
-    // Unlike `set()`, the `Cell.of` initial-value path doesn't normalize native
-    // values (see the TODO in `createWithDefault` in `cell.ts`), so the raw
-    // `Date` reaches encode and throws under the strict codec. `get()`
-    // *appears* to convert (read-side projection), but the committed form is
-    // still raw. Add `... (Cell.of)` cases once that path normalizes its
-    // initial value the way `set()` does.
+    // A native `Date` written through `set()` normalizes to a
+    // `FabricEpochNsec`, at the top level and nested inside a record.
     //
 
     it("normalizes a top-level Date to FabricEpochNsec (set)", async () => {

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -1074,7 +1074,7 @@ describe("Cell Static Methods", () => {
     // Date normalization on `set()`
     //
     // A native `Date` written through `set()` normalizes to a
-    // `FabricEpochNsec`, at the top level and nested inside a record.
+    // `FabricEpochNsec`, at the top level and nested inside an array.
     //
 
     it("normalizes a top-level Date to FabricEpochNsec (set)", async () => {

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2240,9 +2240,9 @@ Deno.test("memory v2 stacked commits: whenApplied resolves at the parked accept'
 // materialized view (and therefore the change notification) reflects the
 // own overlay, not the foreign value, until the marker promotes the parked
 // accept. `unappliedForeignSeqFloor` reports the shadowed seqs so the
-// serving loop's W advance can exclude them, and — flag ON — the
-// promotion fires the shadow-flip notification the moment the foreign
-// value becomes visible.
+// serving loop's W advance can exclude them, and — flag ON — the shadow
+// flip fires the moment the foreign value becomes visible, whether that is
+// the parked accept promoting or the shadowing write being dropped.
 //
 
 const shadowFloorOf = (harness: Harness): number | undefined =>
@@ -3250,11 +3250,12 @@ Deno.test("memory v2 stacked commits: old-server hold releases once every omitte
 });
 
 //
-// Cascading a dropped dependency
+// Cascading a local rejection
 //
-// A dropped write dooms what depends on it. These pin how far the cascade
-// reaches, what each victim reports, and what a late verdict may no longer
-// change.
+// A doomed in-flight dependant is rejected locally rather than waiting for a
+// server verdict — whether its dependency was dropped or the replica holding
+// it was reset. These pin how far the cascade reaches, what each victim
+// reports, and what a late verdict may no longer change.
 //
 
 Deno.test("memory v2 stacked commits: dropped dependency locally rejects the in-flight dependant before its server verdict", async () => {

--- a/packages/test-support/src/isolated-deno.test.ts
+++ b/packages/test-support/src/isolated-deno.test.ts
@@ -13,17 +13,17 @@ function decode(bytes: Uint8Array): string {
 }
 
 Deno.test({
-  // Three test tasks build their own run allowlist with `--allow-run=$(deno
-  // eval "console.log(Deno.execPath())")`, which names the binary the tests
-  // start only while a task's `deno` is the Deno running the task. A `deno`
-  // found on `PATH` instead would name a different binary whenever the shell's
-  // Deno is not the pinned one, which is the case those tasks exist to handle.
-  // The decoy below is the only `deno` on the child's `PATH`, so it runs if the
-  // resolution ever goes through `PATH`.
-
   name: "a task's `deno` is the Deno running the task, not one on PATH",
   ignore: Deno.build.os === "windows",
   async fn() {
+    // Three test tasks build their own run allowlist with `--allow-run=$(deno
+    // eval "console.log(Deno.execPath())")`, which names the binary the tests
+    // start only while a task's `deno` is the Deno running the task. A `deno`
+    // found on `PATH` instead would name a different binary whenever the
+    // shell's Deno is not the pinned one, which is the case those tasks exist
+    // to handle. The decoy below is the only `deno` on the child's `PATH`, so
+    // it runs if the resolution ever goes through `PATH`.
+
     const directory = await Deno.makeTempDir({
       prefix: "commonfabric-task-deno-",
     });

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -78,7 +78,8 @@ Deno.test("spans pass through the OpenInference processor to the exporter", asyn
 //
 // The module's telemetry lifecycle
 //
-// Registration on import, and what shutdown does before and after it.
+// The module registers its integration on import, and shutdown behaves
+// differently before that has happened and after.
 //
 
 Deno.test("importing the module registers an AI SDK telemetry integration", () => {

--- a/packages/toolshed/routes/ai/llm/errors.test.ts
+++ b/packages/toolshed/routes/ai/llm/errors.test.ts
@@ -24,8 +24,9 @@ function providerFailure(statusCode: number): APICallError {
 //
 // The routes ask the AI SDK for a single attempt, so these shapes do not
 // reach the classifier from them. They are what the classifier sees if a call
-// site ever asks for retries again, and the status has to survive the wrapping
-// either way.
+// site ever asks for retries again, and the status has to survive however it
+// is wrapped — including a cause graph that loops back on itself, which must
+// not trap the search.
 //
 
 Deno.test("a status survives a retry wrapper", () => {
@@ -53,8 +54,8 @@ Deno.test("a cycle among causes does not trap the search", () => {
 //
 // Where a status comes from
 //
-// The SDK raising over the request, the service's own error types, and the
-// fallback for an error that names no origin at all.
+// A status comes from the SDK raising over the request, from the service's
+// own error types, or from the fallback for an error that names no origin.
 //
 
 Deno.test("a request the SDK would not send is the caller's mistake", () => {

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -712,7 +712,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
   //
   // Type-arg form against inline form
   //
-  // Type-arg form vs inline form: schemas must be identical
+  // The two spellings of a signature — a type argument, or an annotated
+  // callback parameter — must produce identical schemas.
   //
 
   await t.step(
@@ -2030,7 +2031,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
   // Validating array item reads
   //
   // Reading an item property the element type does not have is an error,
-  // whether or not the array is readonly.
+  // whether or not the array is readonly, and whether the read stands alone
+  // or sits beside a read of the array root.
   //
 
   await t.step(

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -713,7 +713,8 @@ Deno.test("Schema Shrink Validation", async (t) => {
   // Type-arg form against inline form
   //
   // The two spellings of a signature — a type argument, or an annotated
-  // callback parameter — must produce identical schemas.
+  // callback parameter — should produce the same schemas. Optional-property
+  // encoding is a known remaining divergence, noted where it bites.
   //
 
   await t.step(

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -717,7 +717,8 @@ Deno.test("a configured presence URL reaches every shell bundle CI builds", asyn
   // shell. Every check the wiring performs therefore sits inside an
   // `if [ -n "$PRESENCE_URL" ]` that a repository without the variable never
   // enters, so those checks cannot report on the wiring itself: remove the
-  // same runs stay green. The properties a configured value depends on are
+  // wiring and the same runs stay green. The properties a configured value
+  // depends on are
   // checked here instead, against the workflow text, where repository
   // configuration does not get to decide whether the check runs.
 

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -714,9 +714,9 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
 Deno.test("a configured presence URL reaches every shell bundle CI builds", async () => {
   // Both shells CI builds take their co-presence endpoint from a repository
   // variable, and an unset variable is a supported state that builds a working
-  // shell. Every check the wiring performs therefore sits inside an `if [ -n
-  // "$PRESENCE_URL" ]` that a repository without the variable never enters, so
-  // those checks cannot report on the wiring itself: remove the wiring and the
+  // shell. Every check the wiring performs therefore sits inside an
+  // `if [ -n "$PRESENCE_URL" ]` that a repository without the variable never
+  // enters, so those checks cannot report on the wiring itself: remove the
   // same runs stay green. The properties a configured value depends on are
   // checked here instead, against the workflow text, where repository
   // configuration does not get to decide whether the check runs.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Fourteen files closing out the ex-post-facto review of the test-comment arc.
Every one is a title or description that was true of what it introduced and
stopped being true of what it came to own.

## Titles that name something their region does not hold

`runner/test/memory-v2-stacked-commit.test.ts` — "Cascading a dropped
dependency" owns seven tests, and in the seventh nothing is dropped: a replica
is reset and its in-flight dependants are swept. What all seven share is the
local rejection, not the cause, so the title names that.

The same file's settle-barrier description ends "the promotion fires the
shadow-flip notification the moment the foreign value becomes visible" — and
the region's own last member fires that flip with **no promotion at all**, its
name saying so ("the floor lifts without a promotion").

`runner/test/cell-static-methods.test.ts` — a "Date normalization on `set()`"
marker whose entire description was about the `Cell.of` cases that are *not*
there, ending in a plan to add them. Its two members normalize a `Date`
through `set()`, at the top level and nested, which is what it now says. The
absent-case reasoning is already carried by a `TODO` in `createWithDefault`,
so it is not lost.

## Descriptions that restate their titles

`cli/test/piece-call-cyclic-result-live.test.ts` had a title quoting a phrase —
"the other half of 'a caller's own shape wins'" — that appears nowhere in the
file except inside that marker, so a reader looking for the first half finds no
region by that name. Two more descriptions there open with their own title
verbatim, and one enumeration calls four regions "pairs" where one holds three.

`ts-transformers/test/schema-shrink-validation.test.ts` — "Type-arg form
against inline form", described as "Type-arg form vs inline form: schemas must
be identical". The same words with a preposition swapped, and no predicate.
Another description there names two shapes over a three-member region.

## Conversions that stopped at the delimiters

`patterns/integration/cf-code-editor.test.ts` — three titles kept the all-caps
banner voice of the `====` rule lines they replaced, one of them an imperative
clause ("NEGATIVE TESTS: Verify cursor DOES move when it should"). The file's
fourth marker shows the reshaped form.

`patterns/integration/cfc-browser-helpers.test.ts` — "Filling and typing"
opens on a case that puts no text anywhere (it presses Enter in an empty
field), and "where the click actually landed" owns two cases that report
nothing about a landing.

`runner/test/cell-set-flat-index-list.bench.ts` numbers its sections one to
four. An arc PR framed sections one, two and three and left the fourth as a
bare label — so the one member of the enumeration it did not touch became the
only one not in the file's own form, and nothing but that label closed section
three. All four now match.

## Residues in this review's own fix PRs

Found by reviewing the fix PRs, which is the second time that has paid.

Two descriptions of mine under-counted their regions, each caught
independently by two reviewers: the visible-props list named three
blocked-state cases where the region holds four, and the keying description
kept a count whose second member is nowhere in the file. Both now make a claim
rather than a closed list.

Dropping the word "two" from the llm error marker was an incomplete fix —
"either way" still enumerated two over three tests, and the marker's
single-attempt rationale owned neither the cause-cycle case. Removing a wrong
number can hide the mismatch it was announcing.

A comment landed first inside a `Deno.test({...})` options object, above
`name:`, rather than inside the callback. Two descriptions were fragments in
files whose other markers are sentences. One title named removal over a region
two thirds about retention. One rewrap split an inline code span across a line
break.

## A claim of mine that does not hold

#6590's body says each of its three replacement markers "closes where the
removed frame used to end it". In `deno-web-test/test/base.test.ts` it does
not: the replacement sits one test lower, so that region grew by the
kernel-killed case.

The placement is nonetheless right — the marker's own words name "the process
is killed" among the failure reasons, which is exactly what that test pins. So
the region stands and the sentence was wrong. Recording it rather than moving a
marker to make a merged claim retroactively true.

## Verification

Every edit asserted its target appeared exactly once before substituting, and a
check after each confirmed no file lost a marker while another remained above
it. No comment line over 80 characters is added, established by differencing
the over-80 sets against the base rather than by counting.

`deno fmt --check` and `deno lint` pass over all fourteen. Suites: `runner`
1324 passed (7897 steps), `ts-transformers` 1164, `cli` 210, `toolshed` 147,
`deno-web-test` 35, `html` 26, `test-support` 19, and the `ci-workflow` file 20
— 0 failed throughout.

The two `packages/patterns/integration` files are browser tests, which this
change does not run: they launch Chrome, and the session preparing this could
not. Their edits are comment-only and pass `deno lint`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

