### PR TITLE
fix(cf-harness): initialize space before assigning slug

### DIFF
--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -179,15 +179,17 @@ export const namedPieceUrl = (
 
 /**
  * Puts `cell` in the space's piece list unless the list already holds it.
- * The registry's addPiece handler appends unconditionally, so membership is
- * asked first — by piece id over the registered list — rather than by
- * re-adding and hoping.
+ * Establishes the space root first because the registry belongs to it. The
+ * registry's addPiece handler appends unconditionally, so membership is asked
+ * first — by piece id over the registered list — rather than by re-adding and
+ * hoping.
  */
 const ensureRegistered = async (
   pieces: PiecesController,
   cell: Parameters<PiecesController["add"]>[0][number],
   targetId: string,
 ): Promise<void> => {
+  await pieces.ensureDefaultPattern();
   const registered = await pieces.getRegisteredPieces();
   if (registered.some((piece) => piece.id === targetId)) {
     return;

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -11,7 +11,12 @@ import { normalize } from "@std/path/posix";
 import { createSession, Identity } from "@commonfabric/identity";
 import { assignSlug, resolvePieceAddress } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { entityIdFrom, Runtime, slugIdForSpace } from "@commonfabric/runner";
+import {
+  entityIdFrom,
+  getEntityId,
+  Runtime,
+  slugIdForSpace,
+} from "@commonfabric/runner";
 import { parseLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -91,12 +96,22 @@ describe("assign-slug", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let pieces: PiecesController;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    const patternFetch: typeof globalThis.fetch = () =>
+      Promise.resolve(
+        new Response(DEFAULT_PATTERN_SOURCE, {
+          headers: { "content-type": "text/typescript-jsx" },
+        }),
+      );
+    globalThis.fetch = patternFetch;
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
+      fetch: patternFetch,
     });
     pieces = new PiecesController(
       await createSession({
@@ -111,6 +126,7 @@ describe("assign-slug", () => {
   afterEach(async () => {
     await runtime?.dispose();
     await storageManager?.close();
+    globalThis.fetch = originalFetch;
   });
 
   function createEngine() {
@@ -243,10 +259,7 @@ describe("assign-slug", () => {
       expect(registered.map((piece) => piece.id)).toEqual([created.pieceId]);
     });
 
-    it("reports the listing failure when an already-named piece cannot join a missing registry", async () => {
-      // Same pre-state as above, but the space has no default pattern, so
-      // ensuring membership has no registry to join. Both halves of the
-      // contract cannot hold, and the answer says which one failed.
+    it("initializes the space when an already-named piece has no registry to join", async () => {
       const engine = createEngine();
       const created = await createPiece(engine);
       const cell = pieces.runtime.getCellFromLink(
@@ -259,9 +272,11 @@ describe("assign-slug", () => {
         token: created.resultRef,
         slug: "doubling-report",
       });
-      const output = result.output as AssignSlugToolErrorOutput;
-      expect(output.status).toBe("error");
-      expect(output.message).toContain("failed while listing");
+      const output = result.output as AssignSlugToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(await pieces.getDefaultPattern(false)).toBeDefined();
+      const registered = await pieces.getRegisteredPieces();
+      expect(registered.map((piece) => piece.id)).toEqual([created.pieceId]);
     });
 
     it("does not list the piece twice when retried after a failed assignment", async () => {
@@ -538,20 +553,82 @@ describe("assign-slug", () => {
       expect(output.message).toContain("requires a token");
     });
 
-    it("reports the naming failure when the space has no piece registry to join", async () => {
-      // No default pattern linked, so `pieces.add` has nothing to register
-      // through. The piece stays reachable by its handle; only the naming
-      // failed, and the message says which step.
+    it("initializes a fresh space before registering and naming the piece", async () => {
+      const engine = createEngine();
+      const created = await createPiece(engine);
+      expect(await pieces.getDefaultPattern(false)).toBeUndefined();
+
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: created.resultRef,
+        slug: "doubling-report",
+      });
+      const output = result.output as AssignSlugToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(await pieces.getDefaultPattern(false)).toBeDefined();
+      const registered = await pieces.getRegisteredPieces();
+      expect(registered.map((piece) => piece.id)).toEqual([created.pieceId]);
+      expect(await resolvePieceAddress(pieces, "doubling-report")).toBe(
+        created.pieceId,
+      );
+    });
+
+    it("reports the naming failure when the space root cannot be initialized", async () => {
+      const engine = createEngine();
+      const created = await createPiece(engine);
+      const originalEnsureDefaultPattern = pieces.ensureDefaultPattern;
+      pieces.ensureDefaultPattern = () =>
+        Promise.reject(new Error("space root unavailable"));
+
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: created.resultRef,
+        slug: "doubling-report",
+      });
+      pieces.ensureDefaultPattern = originalEnsureDefaultPattern;
+
+      const output = result.output as AssignSlugToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("failed while naming");
+      expect(output.message).toContain("space root unavailable");
+    });
+
+    it("leaves an initialized space root untouched while assigning the slug", async () => {
+      await linkDefaultPattern();
+      const existingRoot = await pieces.getDefaultPattern(false);
+      expect(existingRoot).toBeDefined();
+      const existingRootId = getEntityId(existingRoot!);
+      const originalEnsureDefaultPattern = pieces.ensureDefaultPattern.bind(
+        pieces,
+      );
+      const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+      let ensureCalls = 0;
+      let rootWriteAttempts = 0;
+      pieces.ensureDefaultPattern = async () => {
+        ensureCalls++;
+        runtime.editWithRetry = ((fn, maxRetries) => {
+          rootWriteAttempts++;
+          return originalEditWithRetry(fn, maxRetries);
+        }) as typeof runtime.editWithRetry;
+        try {
+          return await originalEnsureDefaultPattern();
+        } finally {
+          runtime.editWithRetry = originalEditWithRetry;
+        }
+      };
+
       const engine = createEngine();
       const created = await createPiece(engine);
       const result = await engine.invokeBuiltinTool("assign_slug", {
         token: created.resultRef,
         slug: "doubling-report",
       });
-      const output = result.output as AssignSlugToolErrorOutput;
-      expect(output.status).toBe("error");
-      expect(output.message).toContain("failed while naming");
-      expect(output.message).toContain("default pattern");
+      pieces.ensureDefaultPattern = originalEnsureDefaultPattern;
+
+      const output = result.output as AssignSlugToolSuccessOutput;
+      expect(output.status).toBe("ok");
+      expect(ensureCalls).toBe(1);
+      expect(rootWriteAttempts).toBe(0);
+      const rootAfterAssignment = await pieces.getDefaultPattern(false);
+      expect(getEntityId(rootAfterAssignment!)).toEqual(existingRootId);
     });
 
     it("surfaces a rejected session construction as a structured error", async () => {

--- a/packages/cf-harness/test/assign-slug.test.ts
+++ b/packages/cf-harness/test/assign-slug.test.ts
@@ -279,6 +279,30 @@ describe("assign-slug", () => {
       expect(registered.map((piece) => piece.id)).toEqual([created.pieceId]);
     });
 
+    it("reports an initialization failure while listing an already-named piece", async () => {
+      const engine = createEngine();
+      const created = await createPiece(engine);
+      const cell = pieces.runtime.getCellFromLink(
+        parseLLMFriendlyLink(created.resultRef, pieces.getSpace()),
+      );
+      await cell.sync();
+      await assignSlug(pieces, cell, "doubling-report");
+      const originalEnsureDefaultPattern = pieces.ensureDefaultPattern;
+      pieces.ensureDefaultPattern = () =>
+        Promise.reject(new Error("space root unavailable"));
+
+      const result = await engine.invokeBuiltinTool("assign_slug", {
+        token: created.resultRef,
+        slug: "doubling-report",
+      });
+      pieces.ensureDefaultPattern = originalEnsureDefaultPattern;
+
+      const output = result.output as AssignSlugToolErrorOutput;
+      expect(output.status).toBe("error");
+      expect(output.message).toContain("failed while listing");
+      expect(output.message).toContain("space root unavailable");
+    });
+
     it("does not list the piece twice when retried after a failed assignment", async () => {
       // A first call can join the registry and then fail at the slug write.
       // The retry must settle the name without appending a second entry.


### PR DESCRIPTION
## Summary

- initialize the space root before `assign_slug` reads or appends to its piece registry
- mirror the established `cf piece new` precondition without changing `PiecesController.add()` semantics
- cover fresh stores, the already-named fresh-store path, initialization failure, and initialized-root no-op behavior

## Root cause

CT-2097 combined a tool bug with an operational backend swap. The failing toolshed was genuinely backed by a fresh worktree-local store with no space cell or default-pattern root. `run_pattern` could populate that store without initializing the root; `assign_slug` then called `pieces.add()` directly and hit its valid precondition error. The full two-database diagnosis is recorded on CT-2097. The separate worktree-local `MEMORY_DIR` trap is tracked in CT-2146 and is intentionally outside this PR.

## Verification

Pinned Deno: `/Users/ben/.local/share/mise/installs/deno/2.9.4/bin/deno`

- red-first focused regression: 3 failing steps before the source change
- focused `assign-slug.test.ts`: 23 steps passed
- `packages/cf-harness`: 857 tests / 1,356 steps passed
- repo-wide `deno fmt --check`
- repo-wide `deno lint`
- `deno task check`: 601 paths / 46 package groups passed

Linear: https://linear.app/common-tools/issue/CT-2097/assign-slug-fails-on-uninitialized-spaces-cannot-add-pieces-default
Operational follow-up: https://linear.app/common-tools/issue/CT-2146/toolsheds-in-different-worktrees-silently-fork-the-same-space-into

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

