### PR TITLE
test: boundaries the moves took away, and a note about an absence

### DIFF
--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -304,6 +304,10 @@ Deno.test("incremental highlighter updates a line that adds a closure", () => {
   assert(/=>/.test(joined), "updated text should contain the arrow");
 });
 
+//
+// safe(): the throwing path, through the test-only handle
+//
+
 Deno.test("safe(): a throwing extractor degrades to undefined", () => {
   // safe() wraps the best-effort metadata extractors. The public API never
   // feeds them a node that throws, so the catch is exercised directly through

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -217,6 +217,10 @@ Deno.test("diff semantics: no in-workspace root file means no service (not a fai
   assertEquals(sem, undefined);
 });
 
+//
+// lazyProgram: the shared build, cache and latch
+//
+
 Deno.test("lazyProgram: caches a success and latches a failed build", () => {
   // lazyProgram is the shared build/cache/latch both factories use. The
   // configured host never makes it fail, so its failure isolation is exercised
@@ -274,6 +278,10 @@ Deno.test("makeHost: a repeated read of the same file is served from the cache",
     Deno.removeSync(dir, { recursive: true });
   }
 });
+
+//
+// Signed numeric definitions
+//
 
 Deno.test("signed numeric definitions reject positions that do not name a supported key", () => {
   const fileName = "/signed-numeric.ts";

--- a/packages/cli/test/view-session-cov2.test.ts
+++ b/packages/cli/test/view-session-cov2.test.ts
@@ -60,6 +60,7 @@ Deno.test("session: Enter on a reference whose line is in no node reports nothin
   // that line falls outside every structure node's range, both findTargetIndex
   // (no offset) and nodeAtLine (no containing node) fail, so resolveTargetNode
   // returns null and Enter reports there is nothing to open.
+
   // Real card with real targets, but the structure tree is trimmed to just the
   // subject node — placed so the use site sits below its range, outside every
   // node — so following the use reference resolves to no node.

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -753,6 +753,14 @@ Deno.test("an unsupported spec version fails closed", () => {
   );
 });
 
+//
+// Claim minting variants
+//
+// What the evaluator mints when it does not fail closed: the endorsed-by kind,
+// and the no-claim answer that zero matches gives where more than one would
+// have been an error.
+//
+
 Deno.test("endorsedBy mints claimed-endorsed-by", () => {
   // endorsedBy variant mints the endorsed claim kind.
   const schema = table(

--- a/packages/piece/test/piece-references.test.ts
+++ b/packages/piece/test/piece-references.test.ts
@@ -13,8 +13,7 @@ type MockDoc = {
 };
 
 describe("Piece reference detection", () => {
-  // Create a mock environment for testing reference detection
-  // Test the core logic of direct reference finding without maybeGetCellLink
+  // The core logic of direct reference finding, without maybeGetCellLink.
 
   it("should find all direct references in an argument structure", () => {
     // Create mock data with multiple references

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -215,9 +215,9 @@ async function runTest() {
   console.log(`Counter reached ${finalValue} (expected ${expectedValue})`);
 }
 
+// The test runs without a per-test deadline. See
+// docs/development/waiting-in-tests.md.
 Deno.test({
-  // The test runs without a per-test deadline. See
-  // docs/development/waiting-in-tests.md.
   name: "derive array leak test",
   fn: runTest,
   sanitizeResources: false,

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -433,8 +433,6 @@ export default pattern<{ out: string }>(({ out }) => ({
 });
 
 describe("$implRef resolution arm (Runner.#resolveJavaScriptFunction)", () => {
-  // (The "provenance bundleId fallback" suite retired with the bundleId
-  // verification arm — identity E5, data-wipe decision.)
   let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
   let runtime: Runtime | undefined;
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Seven files from a review whose findings had not yet reached a change. They
share one cause, and it is the cost of the arc's central move rather than a
mistake in any one edit.

**Any adjacent comment is also a delimiter.** A region above it ends there in
practice, whatever the rule says about reach. Moving that comment inside its
block is correct on its own terms and takes the boundary away with it, so the
region runs past where a reader used to stop.

## Regions that ran on after their bound was moved

`cli/test/view-parse-cov2.test.ts` — the incremental-highlighter region ran to
the end of the file, over `safe(): a throwing extractor degrades to undefined`.
Before the arc, that test's own adjacent comment ended the region; the arc
moved it inside.

`cli/test/view-semantics-gate.test.ts` — the build-success region ran over
`lazyProgram: caches a success and latches a failed build`. `lazyProgram` is
the helper *both* factories share, not one factory's success path. Same cause.
The same file's read-cache region also owned a test about signed numeric
definitions, which is not about the cache.

Each closes now, under a title for what follows.

## A region whose last members do the opposite of its words

`memory/test/v2-sqlite-row-label.test.ts` frames "fail-closed branches (each
returns `{error}`, never partial)" over a region whose last two members mint
claims successfully — one of them minting *no* claim where more than one match
would have been an error. Before the arc, each of those two carried an
adjacent label that at least broke the region visually; the arc moved both
inside, so nothing signalled the exception any more.

They take a region naming what the evaluator mints when it does not fail
closed.

## A note whose subject was an absence

`runner/test/content-addressed-identity.test.ts` carried:

> (The "provenance bundleId fallback" suite retired with the bundleId
> verification arm — identity E5, data-wipe decision.)

Its subject was an absence at the position it occupied, between two describes.
Moved inside one of them it describes neither that block nor the statement
under it, and a comment about something not being somewhere has no home inside
the thing it is not in. It goes.

## Two fusions and a misplaced note

A moved comment landing directly against a pre-existing one leaves two
different reaches reading as a single comment.
`cli/test/view-session-cov2.test.ts` fused a test-level rationale with a setup
note; they separate. `piece/test/piece-references.test.ts` fused a vestigial
"create a mock environment" label — describing nothing that follows — with the
group's actual comment; the vestige goes and the surviving sentence is the
group's.

`runner/integration/derive_array_leak.test.ts` had a note about running
without a per-test deadline sitting first inside a `Deno.test({...})` options
object, above `name:`. That call opens no callback body of its own, so the
body-less allowance applies and the note belongs beside the call.

## Coverage

ACCEPT_COVERAGE_DEBT: packages/piece +2 lines
ACCEPT_COVERAGE_DEBT: packages/runner +5 lines

The Coverage Check names `packages/piece/src/ops/pieces-controller.ts` and
`packages/runner/src/executor/space-server.ts`, neither of which this branch
touches: it changes seven test files, and every added or removed line across
the whole diff is a comment or a blank, with no non-comment line among them.
The gate's own message says the lines are "not introduced by this PR and were
previously covered on `main`", attributing them to lines inconsistently
covered there.

## Verification

Every edit asserted its target appeared exactly once before substituting, and
a check after each confirmed no file lost a marker while another remained
above it. Comment word multisets against the base are identical for
`view-session-cov2` and `derive_array_leak` — those two are pure — and differ
elsewhere by exactly the added titles and the deleted note.

`deno fmt --check` and `deno lint` pass. Suites: `runner` 1324 passed (7897
steps), `cli` 210, `memory` 592, `piece` 51 — 0 failed throughout.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



