### PR TITLE
test: what the fixes claimed, measured against what they cover

### DIFF
--- a/packages/cf-harness/test/http-fetch.test.ts
+++ b/packages/cf-harness/test/http-fetch.test.ts
@@ -1,8 +1,8 @@
 /**
  * Importing through the package barrel keeps `defaultHarnessFetch` reachable
- * from the public entry point that consumers use, alongside the gateway
- * client that falls back to it, and what that default forwards to the global
- * fetch.
+ * from the public entry point that consumers use, alongside the gateway client
+ * that falls back to it. What that default forwards to the global fetch is
+ * pinned here too.
  */
 
 import { assertEquals, assertStrictEquals } from "@std/assert";

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -138,8 +138,9 @@ describe("data-uri-codec", () => {
     // Canonical sameness
     //
     // The other direction, and the reason distinctness is not the whole
-    // property: equal values mint one URI. Every `NaN` payload collapses to
-    // the same identifier, and a repeated value mints deterministically.
+    // property: equal values mint one URI. Key order and a UTF-16 sort do not
+    // show through, every `NaN` payload collapses to the same identifier, and
+    // a repeated value mints deterministically.
     //
 
     it("mints the same URI regardless of key insertion order", () => {

--- a/packages/toolshed/lib/ai-telemetry.test.ts
+++ b/packages/toolshed/lib/ai-telemetry.test.ts
@@ -210,7 +210,7 @@ Deno.test("metadataAttributeValue drops values that have no attribute form", () 
 });
 
 //
-// Non-string metadata
+// Metadata into runtime context
 //
 // A request may carry non-string metadata, and every value it can carry has
 // to reach the spans, not just the string ones.

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -481,7 +481,8 @@ export default pattern((state: State) => {
 //
 // The stage sees the AST before type-checking has rejected anything, so it has
 // to survive a callback it cannot read and leave the call alone rather than
-// emit a broken body. These sources are deliberately not well-typed.
+// emit a broken body. Some of these sources are deliberately ill-typed, the stage running
+// before type-checking has rejected them.
 //
 
 Deno.test("assert leaves a callback it was not given inline alone", async () => {

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -2,8 +2,8 @@
  * Full DOM interaction tests (input events, Cell two-way binding, timing
  * strategy integration, validation UI) require Lit's rendering pipeline and
  * shadow DOM, which are not available in Deno's headless test runner. These
- * cover property defaults, validation patterns, Cell property acceptance, and
- * basic configuration; a browser-based harness carries the rest.
+ * cover property defaults, validation patterns, Cell property acceptance,
+ * host ARIA semantics, and basic configuration; a browser-based harness carries the rest.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/ui/src/v2/utils/audio-conversion.test.ts
+++ b/packages/ui/src/v2/utils/audio-conversion.test.ts
@@ -11,7 +11,8 @@ import {
 } from "./audio-conversion.ts";
 
 describe("audio-conversion", () => {
-  // These cover the exported helper functions directly. `convertToWav` itself
+  // These cover the exported helper functions directly, plus two format
+  // details asserted in place. `convertToWav` itself
   // requires a browser AudioContext, which Deno's test runner does not
   // provide.
 

--- a/tasks/check-skill-facts.test.ts
+++ b/tasks/check-skill-facts.test.ts
@@ -481,6 +481,13 @@ Deno.test("readWorkspaceExports surfaces an unreadable member config", async () 
   }
 });
 
+//
+// The real repository
+//
+// The two runs that read this tree rather than a fixture, which is what makes
+// the gate answer for the repository as it stands.
+//
+
 /**
  * Runs the script as `deno task check-skill-facts` does. This is what exercises
  * the entry point, and the only thing that proves the permissions the shebang
@@ -491,13 +498,6 @@ Deno.test("readWorkspaceExports surfaces an unreadable member config", async () 
  * inherit the test runner's lock flags and resolving its imports must not write
  * to the real deno.lock.
  */
-//
-// The real repository
-//
-// The two runs that read this tree rather than a fixture, which is what makes
-// the gate answer for the repository as it stands.
-//
-
 Deno.test("the script runs as a command over the real repo", async () => {
   const root = fromFileUrl(new URL("..", import.meta.url));
   const output = await runDenoCommandWithTemporaryLock({
@@ -606,6 +606,10 @@ Deno.test("a package AGENTS.md resolves paths inside its own package", async () 
     await Deno.remove(root, { recursive: true });
   }
 });
+
+//
+// The conservative half of the heuristic
+//
 
 Deno.test("a relative citation with no matching directory is left alone", async () => {
   // The conservative half of the heuristic, which the widened scan leans on

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -115,7 +115,8 @@ Deno.test("importsAlias matches @ts-types with single quotes and spaces", () => 
 // What an alias reaches, and what it does not
 //
 // Subpaths and slash-terminated forms, against the near misses: a longer
-// sibling, a bare identifier, a substring of another specifier.
+// sibling, a bare identifier, a substring of another specifier — and the
+// deliberate over-match, where an occurrence inside a comment counts.
 //
 
 Deno.test("importsAlias matches a subpath import of a bare alias", () => {
@@ -230,10 +231,10 @@ Deno.test("parseWorkspaceMembers returns empty when there is no workspace array"
 });
 
 //
-// Running against this repository
+// The entry point, and the git fallback
 //
-// The entry point over the real tree, and the git helper it leans on when
-// that tree is not a checkout at all.
+// The entry point over the real tree, and what the git helper answers when
+// the `git` binary is not there to run.
 //
 
 Deno.test("runs as a command-line program against the repository", async () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A review of this effort's own merged changes read them cold and found nine
places where a title or description says more than its region holds. That is
the defect those changes exist to remove, committed by them — which is the
argument for reviewing a fix the same way the thing it fixed was reviewed.

## A marker between a doc comment and its declaration

`tasks/check-skill-facts.test.ts` — the new "The real repository" marker was
inserted directly on the closing `*/` of the doc comment describing the test
below it. Nothing comes between a doc comment and the declaration it
documents, and a frame there also runs into the comment above it, so the two
read as one.

The marker moves above the pair, so the doc comment and its test sit inside
the region rather than being split by it.

## Two enumerations that grew while their words did not

`packages/data-model/test/data-uri-codec.test.ts` — an earlier change moved
two tests *into* the "Canonical sameness" region, whose description enumerates
its members, and left the description naming the two it held before. That
change's own prose states the new counts correctly. The count where it was
being explained was right; the count where it lives was wrong.

`tasks/check-unused-deps.test.ts` — a list of six near-miss shapes stands over
a seven-member region. The seventh is the deliberate over-match, where an
occurrence inside a comment counts as a use.

## Four regions their words do not own

- The git-fallback region says the helper is leaned on "when that tree is not
  a checkout at all"; its second member passes a missing `git` binary against
  the repository, which is a checkout.
- `assert-diagnostics` kept "These sources are deliberately not well-typed"
  over a region where four of seven members are well-typed.
- `ai-telemetry`'s "Non-string metadata" title stood over three tests, the
  middle one being the case where there is no metadata at all.
- `check-skill-facts`'s "three kinds of document" title covered a fourth
  member about a path-recognition heuristic, which now takes its own region.

## Two headers that understate their file

`cf-input`'s header lists four coverage families; the file's largest is host
ARIA semantics, unnamed. Promoting that list from a `//` block to a file
header is what made it a claim about the whole file.

`audio-conversion`'s comment says these cover the exported helpers directly,
where two of its describes call nothing the file imports at all.

`cf-harness`'s header had a third conjunct that did not hang off its own
sentence; it becomes one.

## Verification

Every edit asserted its target appeared exactly once before substituting, and
a check after each confirmed no file lost a marker while another remained
above it.

`deno fmt --check` and `deno lint` pass. Suites: `ts-transformers` 1164 passed
(918 steps), `cf-harness` 857, `toolshed` 147, `ui` 52, `data-model` 48 (2747
steps), and the two `tasks` files 82 — 0 failed throughout.

## Noticed, out of scope

`packages/ui/src/v2/utils/audio-conversion.test.ts` lines 179-217 hold two
describes that import nothing from the module under test and assert only on
arithmetic they perform inline in the test body. They cannot fail for any
change to `audio-conversion.ts`. That is a test-coverage question rather than
a comment one, so it is named here rather than changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

