### PR TITLE
test: a marker put where nothing was read first

### DIFF
--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -174,7 +174,7 @@ async function loadParkingCoordinatorProgram(): Promise<RuntimeProgram> {
 }
 
 //
-// Pre-compile everything (outside bench timing)
+// Pre-compilation (outside bench timing)
 //
 
 const parkingCoordinatorProgram = await loadParkingCoordinatorProgram();

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -592,78 +592,6 @@ describe("stage G outbox + sqlite discharge", () => {
     lease2.release();
   });
 
-  it("stops the drain at a transport failure: the failed row AND its successors stay, preserving per-stream FIFO; the re-drain delivers in order (round-2 thread 7)", async () => {
-    // Three rows to ONE target stream, inserted directly (the crashed-
-    // before-delivery shape the drain recovers).
-    const fifoStream = { id: "of:fifo-stream-link", path: [] as string[] };
-    const fifoSidecar = streamEntriesDocId(fifoStream);
-    insertExecutionOutboxRows(engine, {
-      branch: "",
-      createdSeq: 1,
-      rows: [1, 2, 3].map((n) => ({
-        targetSpace,
-        targetStream: fifoSidecar,
-        targetStreamLink: fifoStream,
-        eventId: `evt-fifo-${n}`,
-        payload: { n },
-        actingPrincipal: "user:alice",
-        actingSession: "sess-1",
-        capabilityRef: "cap-fifo",
-      })),
-    });
-
-    // A transport that fails the FIRST delivery attempt only.
-    let failuresLeft = 1;
-    const flakyOnce = new Proxy(server, {
-      get(target, prop, receiver) {
-        if (prop === "commitDelegatedAppend" && failuresLeft > 0) {
-          return () => {
-            failuresLeft -= 1;
-            return Promise.reject(new Error("transport down"));
-          };
-        }
-        const value = Reflect.get(target, prop, receiver);
-        return typeof value === "function" ? value.bind(target) : value;
-      },
-    });
-    const flakyOutbox = new SpaceOutbox({
-      stats: emptyServingLoopStats(),
-      server: flakyOnce as typeof server,
-      engine,
-      sessionId: holder,
-      localSeqRef,
-    });
-
-    // The failed first row STOPS the drain: nothing delivered, ALL
-    // three rows kept (pre-fix, rows 2 and 3 delivered past the
-    // retained row 1 — the per-stream FIFO break the re-send then
-    // completes: 2, 3, 1).
-    const first = await flakyOutbox.deliverPendingAppends();
-    expect(first.remaining).toBe(3);
-    expect(selectPendingExecutionOutboxRows(engine, { branch: "" }).length)
-      .toBe(3);
-    const targetEngine = await server.engineForSpace(targetSpace);
-    const empty = Engine.read(targetEngine, { id: fifoSidecar });
-    expect(
-      ((empty?.value as { entries?: Array<unknown> })?.entries ?? []).length,
-    ).toBe(0);
-
-    // The healthy re-drain delivers everything IN INSERTION ORDER.
-    const second = await flakyOutbox.deliverPendingAppends();
-    expect(second.remaining).toBe(0);
-    expect(selectPendingExecutionOutboxRows(engine, { branch: "" }).length)
-      .toBe(0);
-    const after = Engine.read(targetEngine, { id: fifoSidecar });
-    const entries =
-      (after?.value as { entries?: Array<{ eventId?: string }> })?.entries ??
-        [];
-    expect(entries.map((entry) => entry.eventId)).toEqual([
-      "evt-fifo-1",
-      "evt-fifo-2",
-      "evt-fifo-3",
-    ]);
-  });
-
   //
   // The fold's completeness, and the gate at the source
   //
@@ -861,8 +789,9 @@ describe("stage G outbox + sqlite discharge", () => {
   //
   // Refusals and failures at delivery
   //
-  // What the drain does with a row it cannot deliver: a deterministic
-  // rejection retires, a transport failure does not.
+  // What the drain does at the floor: a declared userless row delivers, an
+  // undeclared one and a deterministic rejection retire, and a transport
+  // failure keeps the row for the next drain.
   //
 
   it("does not retry an LT4 deterministic admission rejection: the row is deleted and counted failed", async () => {
@@ -1075,6 +1004,78 @@ describe("stage G outbox + sqlite discharge", () => {
     lease.release();
   });
 
+  it("stops the drain at a transport failure: the failed row AND its successors stay, preserving per-stream FIFO; the re-drain delivers in order (round-2 thread 7)", async () => {
+    // Three rows to ONE target stream, inserted directly (the crashed-
+    // before-delivery shape the drain recovers).
+    const fifoStream = { id: "of:fifo-stream-link", path: [] as string[] };
+    const fifoSidecar = streamEntriesDocId(fifoStream);
+    insertExecutionOutboxRows(engine, {
+      branch: "",
+      createdSeq: 1,
+      rows: [1, 2, 3].map((n) => ({
+        targetSpace,
+        targetStream: fifoSidecar,
+        targetStreamLink: fifoStream,
+        eventId: `evt-fifo-${n}`,
+        payload: { n },
+        actingPrincipal: "user:alice",
+        actingSession: "sess-1",
+        capabilityRef: "cap-fifo",
+      })),
+    });
+
+    // A transport that fails the FIRST delivery attempt only.
+    let failuresLeft = 1;
+    const flakyOnce = new Proxy(server, {
+      get(target, prop, receiver) {
+        if (prop === "commitDelegatedAppend" && failuresLeft > 0) {
+          return () => {
+            failuresLeft -= 1;
+            return Promise.reject(new Error("transport down"));
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const flakyOutbox = new SpaceOutbox({
+      stats: emptyServingLoopStats(),
+      server: flakyOnce as typeof server,
+      engine,
+      sessionId: holder,
+      localSeqRef,
+    });
+
+    // The failed first row STOPS the drain: nothing delivered, ALL
+    // three rows kept (pre-fix, rows 2 and 3 delivered past the
+    // retained row 1 — the per-stream FIFO break the re-send then
+    // completes: 2, 3, 1).
+    const first = await flakyOutbox.deliverPendingAppends();
+    expect(first.remaining).toBe(3);
+    expect(selectPendingExecutionOutboxRows(engine, { branch: "" }).length)
+      .toBe(3);
+    const targetEngine = await server.engineForSpace(targetSpace);
+    const empty = Engine.read(targetEngine, { id: fifoSidecar });
+    expect(
+      ((empty?.value as { entries?: Array<unknown> })?.entries ?? []).length,
+    ).toBe(0);
+
+    // The healthy re-drain delivers everything IN INSERTION ORDER.
+    const second = await flakyOutbox.deliverPendingAppends();
+    expect(second.remaining).toBe(0);
+    expect(selectPendingExecutionOutboxRows(engine, { branch: "" }).length)
+      .toBe(0);
+    const after = Engine.read(targetEngine, { id: fifoSidecar });
+    const entries =
+      (after?.value as { entries?: Array<{ eventId?: string }> })?.entries ??
+        [];
+    expect(entries.map((entry) => entry.eventId)).toEqual([
+      "evt-fifo-1",
+      "evt-fifo-2",
+      "evt-fifo-3",
+    ]);
+  });
+
   it("keeps the row on a transport-class delivery failure (admit-before-delete): the next drain delivers exactly one entry", async () => {
     const transportStream = { id: "of:transport-stream", path: [] as string[] };
     const transportSidecar = streamEntriesDocId(transportStream);
@@ -1134,7 +1135,7 @@ describe("stage G outbox + sqlite discharge", () => {
   });
 
   //
-  // The sqliteQuery memo decision (serving-loop.md §4/§6)
+  // The sqliteQuery memo decision (B1's fix, serving-loop.md §4/§6)
   //
 
   it("sqliteQuery memo decision: a settled result is a hit, a bare claim never is; an orphaned claim re-issues ONLY under the serving posture", () => {

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -734,11 +734,6 @@ describe("stage G SpaceServer recovery seams", () => {
     expect(created.watermark).toBeGreaterThanOrEqual(second.seq);
   });
 
-  // stage P2-F: the demand-cycle terminal state (OW19)
-
-  /** A facade whose watch registry names exactly the given demanded
-   * roots — the unit-level stand-in for client sessions' watches (the
-   * production feed is pinned in the serving-loop E2E). */
   //
   // The demand-seam apparatus
   //
@@ -801,6 +796,10 @@ describe("stage G SpaceServer recovery seams", () => {
     }
     return rows;
   };
+
+  /** A facade whose watch registry names exactly the given demanded
+   * roots — the unit-level stand-in for client sessions' watches (the
+   * production feed is pinned in the serving-loop E2E). */
   const demandFacade = (
     roots: Array<{
       id: string;

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -229,11 +229,12 @@ Deno.bench("array element resolution in circular structures", () => {
 //
 // A list scanned through the reactive proxy: what a lift does when it reads a
 // collection of linked entries, and the shape the transaction-scoped memo
-// exists for. `elements per pass` is the per-element cost; `whole array` is
-// one pass over the whole thing. The unmemoized cost of both is linear in the
+// exists for. `one element read` is the per-element cost; `whole array read
+// per element` is a full pass for each element. The unmemoized cost of both is linear in the
 // number of resolutions, so a scan that touches each element more than once
 // pays it again per touch.
 //
+
 const LIST_LENGTH = 50;
 
 const listBoardSetup = () => {

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -533,7 +533,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
   });
 
   //
-  // Filter builtin tests
+  // `filter` builtin tests
   //
 
   it("should filter an array by predicate", async () => {
@@ -919,7 +919,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
   });
 
   //
-  // FlatMap builtin tests
+  // `flatMap` builtin tests
   //
 
   it("should flatMap an array", async () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A review of this effort's own merged changes found eight defects in one of
them. The reviewer also named the reflex behind the worst of them, which is
the useful part:

> "put the closer immediately before the first test of the next region",
> **without looking at what sits between**.

That reflex produced the *same* defect in two separate changes, which is why
it is worth naming rather than just fixing.

## A marker wedged into a doc comment, for the second time

`packages/runner/test/executor-space-server.test.ts` — a new frame landed
directly on the closing `*/` of a doc comment. By then the declaration that
doc comment describes, `demandFacade`, sat sixty lines below it, behind the
frame, a stranded label, and the whole of another helper.

The frame moves above the pair. The doc comment goes back onto `demandFacade`,
where it belongs and now has its blank line. And the label above it —
`// stage P2-F: the demand-cycle terminal state (OW19)` — goes: it duplicated
the title of a marker further down and sat over the wrong region entirely.

## A test in the region whose title contradicts it

`packages/runner/test/executor-outbox.test.ts` — the region titled "Delivery
(FP1 closure): admit at the target, **then delete**" held `stops the drain at
a transport failure: the failed row AND its successors stay`, whose entire
point is that the row is *not* deleted.

Its twin — `keeps the row on a transport-class delivery failure` — was in the
region below, whose description explicitly says "a transport failure does
not". The same subject in two regions, one of them contradicting its own
title. It joins its twin, leaving Delivery with the single case its title
states.

That region's description also said it covers "a row it cannot deliver", where
its third member is `OW15: a DECLARED userless row delivers`.

## A description naming a bench that does not exist

`packages/runner/test/link-resolution.bench.ts` — the promoted description
says "`elements per pass` is the per-element cost; `whole array` is one pass
over the whole thing". The file's two benches are `reactive list: one element
read` and `reactive list: whole array read per element`, and the second runs a
filter per element — a full pass *for each element*, not one pass over the
whole thing. The prose predates the change; framing it as a region description
is what re-asserted it.

The same frame had no blank line below it, so it read as a note on the
constant it touched rather than a heading over what follows.

## Three smaller

`esm-verifier.bench.ts` still carried a second imperative title
("Pre-compile everything…") where the change claimed to have fixed the file's
only one. `patterns-dynamic.test.ts` had `filter` and `flatMap` title-cased
into `Filter` and `FlatMap`, which name no identifier. And folding a
parenthetical onto a title line silently dropped `B1's fix` — in a change
whose body described those edits as folds.

## Verification

Both moved blocks are provably code-identical: the non-comment line multiset
of each file is unchanged. Every edit asserted its target appeared exactly once
before substituting.

`deno fmt --check` and `deno lint` pass. `deno task test` in `packages/runner`
reports 1324 passed (7897 steps), 0 failed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

