### PR TITLE
test: regions the arc severed, widened, or left describing half of itself

### DIFF
--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -3597,16 +3597,14 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", asyn
   assertEquals(tree.lookup(state.piecesIno, "My-Note-2") !== undefined, true);
 });
 
-//
-// Regression: on a cold runtime the piece list doesn't load the linked piece
-// docs, so a synchronous piece.name() read returns undefined until the NAME
-// doc is synced. addPieceToSpace must await that sync before choosing the
-// directory name — otherwise the piece mounts under the opaque id-derived
-// fallback name, permanently if no later change event fires (CI fuse-exec
-// "Timed out waiting for path: pieces/Fuse-Exec-Fixture").
-//
-
 Deno.test("CellBridge.addPieceToSpace syncs a late-loading name before naming the directory", async () => {
+  // Regression: on a cold runtime the piece list doesn't load the linked piece
+  // docs, so a synchronous piece.name() read returns undefined until the NAME
+  // doc is synced. addPieceToSpace must await that sync before choosing the
+  // directory name — otherwise the piece mounts under the opaque id-derived
+  // fallback name, permanently if no later change event fires (CI fuse-exec
+  // "Timed out waiting for path: pieces/Fuse-Exec-Fixture").
+
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
   const state = buildTestSpace(bridge, "home", []);

--- a/packages/memory/test/v2-sqlite-column-origin.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin.test.ts
@@ -161,6 +161,13 @@ function origins(
   }
 }
 
+//
+// Column-origin soundness
+//
+// What the bound library reports for a query, once the picking rule above
+// has chosen a file.
+//
+
 Deno.test({
   name: "column-origin metadata is reachable in this deployment",
   sanitizeResources: false,

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -212,10 +212,12 @@ describe("Cell Static Methods", () => {
     // The static-data walk over special objects
     //
     // The static-data validation walk descends anything `typeof === "object"`,
-    // which admits a `FabricSpecialObject`. Such a value survives it because it
-    // has zero enumerable own properties: `Object.keys()` is empty, the descent
-    // ends there, and the walk only ever reads -- it never rebuilds. Nothing
-    // guards that, so these pin it.
+    // which admits a `FabricSpecialObject`. A `FabricPrimitive` survives it
+    // because it has zero enumerable own properties: `Object.keys()` is empty,
+    // the descent ends there, and the walk only ever reads -- it never
+    // rebuilds. A `FabricInstance` is refused instead, its codec contents being
+    // able to hold a `Cell` the walk would never reach by property name.
+    // Nothing guards either, so these pin both.
     //
 
     it("should accept a `FabricBytes` in static data", () => {
@@ -281,7 +283,7 @@ describe("Cell Static Methods", () => {
     });
 
     //
-    // Ordinary values
+    // More `Cell.of()` value cases
     //
 
     it("should create a cell with undefined value", () => {
@@ -349,6 +351,10 @@ describe("Cell Static Methods", () => {
         expect(cell.get()).toEqual(complex);
       });
     });
+
+    //
+    // The schema parameter
+    //
 
     it("should accept a schema as second parameter", () => {
       withinHandlerContext(runtime, space, tx, () => {

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -61,14 +61,13 @@ const programOf = (contents: string): RuntimeProgram => ({
   files: [{ name: "/main.tsx", contents }],
 });
 
-//
-// The repair keys on ONE variant of the handler-stream failure — the
-// setup-missing "marker was never written" case. Its two siblings are NOT
-// setup-missing (re-running setup would not fix them), so they must not trigger
-// a repair. These messages mirror `describeHandlerStreamFailure`'s three shapes.
-//
-
 describe("isMissingStreamMarkerFailure discriminates the setup-missing variant", () => {
+  // The repair keys on ONE variant of the handler-stream failure — the
+  // setup-missing "marker was never written" case. Its two siblings are NOT
+  // setup-missing (re-running setup would not fix them), so they must not
+  // trigger a repair. These messages mirror `describeHandlerStreamFailure`'s
+  // three shapes.
+
   it("matches the marker-never-written variant", () => {
     expect(
       isMissingStreamMarkerFailure(

--- a/packages/static/scripts/strip-withheld-globals.test.ts
+++ b/packages/static/scripts/strip-withheld-globals.test.ts
@@ -162,6 +162,10 @@ Deno.test("throws when a declaration closes more braces than it opens", () => {
 // finds nothing to remove and rewrites nothing.
 //
 
+//
+// The command over the checked-in libraries
+//
+
 Deno.test("runCli --check passes on the stripped libraries", async () => {
   assertEquals(await runCli(["--check"]), 0);
 });

--- a/packages/static/scripts/strip-withheld-globals.test.ts
+++ b/packages/static/scripts/strip-withheld-globals.test.ts
@@ -157,13 +157,11 @@ Deno.test("throws when a declaration closes more braces than it opens", () => {
 });
 
 //
+// The command over the checked-in libraries
+//
 // The checked-in type libraries are kept stripped, so the CLI run over them is
 // the up-to-date path: --check reports clean and returns 0, and a plain run
 // finds nothing to remove and rewrites nothing.
-//
-
-//
-// The command over the checked-in libraries
 //
 
 Deno.test("runCli --check passes on the stripped libraries", async () => {
@@ -176,6 +174,10 @@ Deno.test("runCli without --check leaves up-to-date libraries unchanged", async 
   assertEquals(await runCli([]), 0);
   assertEquals(await Deno.readTextFile(path), before);
 });
+
+//
+// The entry-point gate
+//
 
 Deno.test("cliMain does nothing unless this module is the entry point", async () => {
   let called: number | undefined;
@@ -190,7 +192,9 @@ Deno.test("cliMain exits with the CLI status when it is the entry point", async 
 });
 
 //
-// The error and write paths are driven with injected files rather than the
+// The error and write paths
+//
+// Driven with injected files rather than the
 // checked-in libraries, which are kept clean.
 //
 
@@ -227,6 +231,14 @@ Deno.test("runCli without --check writes the stripped text back", async () => {
   assertEquals(writes.length, 1);
   assertEquals(writes[0][1], "");
 });
+
+//
+// Stripping a namespace
+//
+// The members a withheld namespace declares, and the shapes that make finding
+// their bounds hard: braces in prose, a signature wrapped across lines, a
+// declaration split across blocks.
+//
 
 Deno.test("strips a namespace's value members and keeps its types", () => {
   const { text, removed } = stripWithheldGlobals(

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -52,16 +52,21 @@ Deno.test("every obligation names concrete, runnable next steps", () => {
   }
 });
 
+//
+// The real manifest
+//
+
 Deno.test("the real manifest passes end to end", async () => {
   assertEquals(await main(), 0);
 });
 
 //
-// the evasion paths
+// The evasion paths, and the cases that are not
 //
-// Each of these is a way someone silences the reminder without meaning to.
-// They were originally verified by hand, once; a guard whose failure modes are
-// only ever checked manually is a guard that quietly stops working.
+// Each evasion is a way someone silences the reminder without meaning to, and
+// a guard whose failure modes are only ever checked by hand is a guard that
+// quietly stops working. Beside them sit the intact baseline, the legitimate
+// resolved weakness, and the driver that reports them all.
 //
 // Each case writes its own fixture file rather than pointing at a real one.
 // Self-reference bites here: a literal ".ignore(" anywhere in this file would


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Six files closing out the findings from this arc's reviews that had not yet
reached a change.

## A marker that cut a group in half

`packages/fuse/cell-bridge.test.ts` — a regression note about a cold runtime
was framed as a marker, and it landed *between* two tests of "Group 2:
addPieceToSpace — name collision". So it terminated Group 2 after one test,
and its own region swallowed the group's remaining suffix test, which its words
say nothing about.

The note is one test's contract. It moves inside that test, and Group 2
reunites with all three of its members.

## A description asserting the opposite of half its region

`packages/runner/test/cell-static-methods.test.ts` — the static-data marker
says a `FabricSpecialObject` "survives it because it has zero enumerable own
properties … so these pin it", over four members of which two assert that
`Cell.of()` **throws**.

Both classes are `FabricSpecialObject`s, so the title is right; it is the
description that covers only half. A `FabricPrimitive` survives and a
`FabricInstance` is refused — its codec contents can hold a `Cell` the walk
would never reach by property name — and the description now says both.

## A title claiming a kind its region does not hold

The same file's "Ordinary values" region ran to the close of its `describe`
over nine members, five of which are not value cases: a callback-helper
rejection, an update after creation, and three about `Cell.of()`'s second
argument. The schema tests take a region of their own, and the title stops
claiming only ordinary values.

## Three regions that ran past their subject

- `nested-piece-setup-repair.test.ts` — the marker's closing sentence is the
  discriminator describe's fixture contract, and the region owned the
  cold-start repair describe as well. It moves inside the describe it
  describes.
- `v2-sqlite-column-origin.test.ts` — the picking-rule region ran on over the
  four column-origin soundness tests, which now have a region naming them.
- `strip-withheld-globals.test.ts` — the injected-files region ran on over ten
  namespace-stripping unit tests.

## A region whose members are the opposite of its title

`tasks/check-tripwires.test.ts` — the obligation region owned the
real-manifest test, which belongs with the manifest marker above it. And "the
evasion paths" owned the intact baseline, the legitimate resolved weakness and
the main driver, none of which is an evasion. The first region closes; the
second says what sits beside the evasions, and takes a capitalized title like
the file's others.

## Verification

Every edit asserted its target appeared exactly once before substituting, and a
check after each confirmed no file lost a marker while another remained above
it.

`deno fmt --check` and `deno lint` pass. Suites: `runner` 1324 passed (7897
steps), `memory` 592, `fuse` 372, `static` 23, and the `check-tripwires` file
10 — 0 failed throughout.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

