### PR TITLE
test: two repairs that made their claim less true

### DIFF
--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -763,7 +763,7 @@ describe("cf-code-editor cursor stability", () => {
   });
 
   //
-  // Race conditions and timing edges
+  // Race conditions, timing edges, and awkward content
   //
 
   it("ADVERSARIAL: Cell update at exact debounce boundary should not corrupt state", async () => {

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -763,7 +763,10 @@ describe("cf-code-editor cursor stability", () => {
   });
 
   //
-  // Race conditions, timing edges, and awkward content
+  // Race conditions, timing edges, and awkward updates
+  //
+  // Awkward in both senses: content the editor must render intact, and an
+  // update that changes nothing.
   //
 
   it("ADVERSARIAL: Cell update at exact debounce boundary should not corrupt state", async () => {

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1094,9 +1094,10 @@ describe("CFC browser helpers", () => {
   //
   // Filling, typing, and submitting
   //
-  // The helpers that reach a control by its keyboard rather than by a click:
-  // the same settle discipline as the click helpers, and what happens when a
-  // commit replaces the control they were typing into.
+  // The helpers that work a control without clicking it — filling a value,
+  // typing into it, pressing Enter to submit: the same settle discipline as
+  // the click helpers, and what happens when a commit replaces the control
+  // they were typing into.
   //
 
   it("settles the view before pressing Enter in a submit input", async () => {

--- a/packages/toolshed/lib/ai-telemetry.test.ts
+++ b/packages/toolshed/lib/ai-telemetry.test.ts
@@ -212,8 +212,8 @@ Deno.test("metadataAttributeValue drops values that have no attribute form", () 
 //
 // Metadata into runtime context
 //
-// A request may carry non-string metadata, and every value it can carry has
-// to reach the spans, not just the string ones.
+// A request may carry metadata of any type, or none, and every value it can
+// carry has to reach the spans, not just the string ones.
 //
 
 Deno.test("runtimeContextFromMetadata carries every value that has an attribute form", () => {

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -78,8 +78,9 @@ Deno.test("spans pass through the OpenInference processor to the exporter", asyn
 //
 // The module's telemetry lifecycle
 //
-// The module registers its integration on import, and shutdown behaves
-// differently before that has happened and after.
+// The module registers an AI SDK telemetry integration on import, and
+// `shutdownOpenTelemetry()` behaves differently before `initOpenTelemetry()`
+// has run and after.
 //
 
 Deno.test("importing the module registers an AI SDK telemetry integration", () => {

--- a/packages/toolshed/routes/ai/llm/errors.test.ts
+++ b/packages/toolshed/routes/ai/llm/errors.test.ts
@@ -22,6 +22,8 @@ function providerFailure(statusCode: number): APICallError {
 }
 
 //
+// Wrapped and chained causes
+//
 // The routes ask the AI SDK for a single attempt, so these shapes do not
 // reach the classifier from them. They are what the classifier sees if a call
 // site ever asks for retries again, and the status has to survive however it

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -481,8 +481,7 @@ export default pattern((state: State) => {
 //
 // The stage sees the AST before type-checking has rejected anything, so it has
 // to survive a callback it cannot read and leave the call alone rather than
-// emit a broken body. Some of these sources are deliberately ill-typed, the stage running
-// before type-checking has rejected them.
+// emit a broken body. Some of these sources are deliberately ill-typed.
 //
 
 Deno.test("assert leaves a callback it was not given inline alone", async () => {

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -3,7 +3,8 @@
  * strategy integration, validation UI) require Lit's rendering pipeline and
  * shadow DOM, which are not available in Deno's headless test runner. These
  * cover property defaults, validation patterns, Cell property acceptance,
- * host ARIA semantics, and basic configuration; a browser-based harness carries the rest.
+ * host ARIA semantics, and basic configuration; a browser-based harness
+ * carries the rest.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -718,9 +718,8 @@ Deno.test("a configured presence URL reaches every shell bundle CI builds", asyn
   // `if [ -n "$PRESENCE_URL" ]` that a repository without the variable never
   // enters, so those checks cannot report on the wiring itself: remove the
   // wiring and the same runs stay green. The properties a configured value
-  // depends on are
-  // checked here instead, against the workflow text, where repository
-  // configuration does not get to decide whether the check runs.
+  // depends on are checked here instead, against the workflow text, where
+  // repository configuration does not get to decide whether the check runs.
 
   const deno = await workflow("deno.yml");
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A review of the previous round found five defects in it. Two are repairs that
were worse than what they replaced, which is worth separating from the ordinary
kind.

## A repair that widened the falsehood

`packages/patterns/integration/cfc-browser-helpers.test.ts` — the region was
titled "Filling and typing" and opened on a case that presses Enter into an
empty field, putting no text anywhere. That was the finding.

The repair retitled it "Filling, typing, and submitting" and described the
members as "the helpers that reach a control by its **keyboard** rather than by
a click". They do not. `fillCfInput` focuses the field, sets the value through
the native `HTMLInputElement.prototype.value` setter, and dispatches synthetic
events — and the helper's own comment says so: "the fill drives the field
through focus and dispatched events rather than a coordinate click".

So the original description was false of one of seven members, and the repair
made it false of three. It now names what the helpers do — work a control
without clicking it — without asserting how.

## A retitle that dropped the clause four members needed

`packages/patterns/integration/cf-code-editor.test.ts` — the title
`ADVERSARIAL TESTS: Race conditions, timing attacks, edge cases` was reshaped
into noun-phrase voice as "Race conditions and timing edges". Reshaping the
voice was right; dropping "edge cases" was not. Four of the region's thirteen
members are neither races nor timing: a long-content cursor clamp, an echo with
trimmed whitespace, unicode and newline content, and repeated identical updates
as no-ops.

The clause comes back in the new voice.

## Three smaller

The llm error marker was rewritten to own the cause-cycle case its old
enumeration excluded — correct — and still carries no noun-phrase title, where
the other marker in that same file does. It takes one.

`otel`'s description said shutdown "behaves differently before **that** has
happened and after", where "that" pointed at the module import. The import
registers the AI SDK integration and is always already done; the before/after
is about `initOpenTelemetry()`. It names the call.

And restoring the three words a reflow had dropped left the paragraph ragged —
a 19-character line mid-paragraph. It fills, in eight lines where there were
nine.

## Verification

`tasks/ci-workflow.test.ts` is comment-word-identical to base, so the restored
words are still all there. No comment line over 80 characters is added,
established by differencing the over-80 sets against the base rather than by
counting.

`deno fmt --check` and `deno lint` pass. `toolshed` reports 147 passed (464
steps), and the `ci-workflow` file 20 — 0 failed.

The two `packages/patterns/integration` files are browser tests this change
does not run; their edits are comment-only and pass `deno lint`.


## A title too narrow, found by reviewing this change

An adversarial review of this PR found that `cf-code-editor.test.ts`'s
retitled region covers three of the four members the retitle was for. The
thirteenth member, `ADVERSARIAL: Repeated identical Cell updates should be
no-ops`, sets `"Static content"` ten times and asserts the cursor stays at 7:
the content is ordinary and unchanging, and what the test pins is idempotence.
"Awkward content" is not true of it.

The title now reads "Race conditions, timing edges, and awkward updates", with
a description saying which sense of awkward reaches which member.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


