### PR TITLE
test: a preamble comment stops touching the first statement

### DIFF
--- a/packages/runner/test/linked-stale-read-conflict.test.ts
+++ b/packages/runner/test/linked-stale-read-conflict.test.ts
@@ -29,6 +29,7 @@ const space = signer.did();
 
 describe("stale linked read across two clients", () => {
   // Two StorageManagers sharing ONE real server, each with its own replicas.
+
   let server: MemoryV2Server.Server;
   let storageA: EmulatedStorageManager;
   let storageB: EmulatedStorageManager;

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -1101,6 +1101,7 @@ Deno.test("pattern coverage records a piece authored without coverage and resume
   // exist. The resume then falls back to cold recovery — a recompile from the
   // stored source closure — which is the only place the instrumentation can
   // come from.
+
   const signer = await Identity.fromPassphrase(
     "cold-recovery pattern coverage",
   );

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -833,6 +833,7 @@ Deno.test("ingest merges hit-only data against another realm's spans", () => {
   // The realm that compiled the pattern owns the spans; a realm that only
   // warm-loaded the already-instrumented bytes reports hits with no spans. The
   // union carries both, keyed by the fileName the transformer baked in.
+
   const compiler = new PatternCoverageCollector();
   compiler.registerSpan({
     fileName: "/subject.tsx",
@@ -868,6 +869,7 @@ Deno.test("ingest merges hit-only data against another realm's spans", () => {
 Deno.test("ingest ignores zero-count hits", () => {
   // A realm that ran the instrumented bytes but never reached a statement
   // reports it with count 0; merging that must not mark the line covered.
+
   const collector = new PatternCoverageCollector();
   collector.registerSpan({
     fileName: "/subject.tsx",

--- a/packages/runner/test/replica-eviction-invariants.test.ts
+++ b/packages/runner/test/replica-eviction-invariants.test.ts
@@ -130,6 +130,7 @@ describe("a list projection survives its input emptying", () => {
 describe("a cross-replica conflict settles", () => {
   // Two managers over one in-process server, so a commit on one can conflict
   // with a commit on the other.
+
   let server: MemoryV2Server.Server;
   let storageA: EmulatedStorageManager;
   let storageB: EmulatedStorageManager;

--- a/packages/runner/test/resume-by-identity.test.ts
+++ b/packages/runner/test/resume-by-identity.test.ts
@@ -14,6 +14,7 @@ describe("resume a result cell by {identity, symbol}", () => {
   // symbol} pattern reference at setup; a fresh runtime resuming that result
   // cell from storage loads the pattern straight from the compiled cache BY
   // IDENTITY (no TS source pulled, no meta-cell roundtrip), and re-runs it.
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
   const RESULT_CAUSE = "resume-by-identity result cell";

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -63,6 +63,7 @@ Deno.test("runtime.dispose() resolves while a commit is withheld in flight", asy
   // deadlocked, and dispose() hung. Teardown must reject in-flight commits (the
   // way it already rejects in-flight reads) rather than wait on a response that
   // may never come.
+
   const signer = await Identity.fromPassphrase(
     "runtime-dispose-withheld-commit",
   );

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -276,6 +276,7 @@ describe("stage A: instance keying — unit pins", () => {
     // that contract — a keyed remove resolves to the named instance, an
     // unkeyed one to the own instance — so both halves together are what
     // keeps the own doc intact.
+
     const replica = storageManager.open(space).replica as unknown as {
       getDocument: (
         id: string,
@@ -531,6 +532,7 @@ describe("stage A: instance keying — unit pins", () => {
     // and the pending-load park cross-matches them), and `presyncInputs`
     // is handed the same actor (so the handler's inputs load AS the
     // actor). Absent on client-side events, byte-identical there.
+
     runtime.installSealDestination(
       { seal: (tx: IExtendedStorageTransaction) => tx.tx.commit() },
       {
@@ -649,6 +651,7 @@ describe("stage A: instance keying — unit pins", () => {
     // seen; a schema-driven read follows the link, finds the target
     // absent, and kicks `ensureLinkedDocLoaded` — the stage-A site
     // threads the traversal's run identity into that kick.
+
     const target = runtime.getCell<{ label: string }>(
       space,
       "stagea-kick-target",
@@ -792,6 +795,7 @@ describe("stage A: instance keying — unit pins", () => {
     // value into another doc is the seed site (data-updating.ts): the
     // seed writes the default into the target when absent, memoized per
     // (space, INSTANCE, id) under the writing run's identity.
+
     const seedCell = runtime.getCell<string>(
       space,
       "stagea-seed-target",

--- a/packages/runner/test/storage-instance-keying.test.ts
+++ b/packages/runner/test/storage-instance-keying.test.ts
@@ -884,6 +884,7 @@ describe("stage A: OFF-arm serialized forms carry no scopeKey", () => {
   // address, reactivity-log address, replica state, or replica document carries
   // a `scopeKey` own-property. Adopted from the review's probe
   // (`zz-review-off-notification-probe`).
+
   let offManager: ReturnType<typeof StorageManager.emulate>;
   let offRuntime: Runtime;
 

--- a/packages/static/scripts/compile-type-lib.test.ts
+++ b/packages/static/scripts/compile-type-lib.test.ts
@@ -10,6 +10,7 @@ Deno.test("compileMain resolves references and strips withheld globals", async (
   // TypeScript tree: a target that references a second file, and a withheld
   // `declare var` that must not survive into the output while its interface
   // does.
+
   const dir = await Deno.makeTempDir();
   try {
     await Deno.writeTextFile(

--- a/packages/toolshed/lib/build-info.test.ts
+++ b/packages/toolshed/lib/build-info.test.ts
@@ -184,6 +184,7 @@ Deno.test("readShellServerExecutionDefineFrom", async (t) => {
   // packages/shell/felt.config.ts bakes as the shell's define). CI's
   // server-execution lanes read it back through /api/meta to verify the posture
   // the binary actually carries; a missing/unset value reads null.
+
   const tempDir = await Deno.makeTempDir({ prefix: "build-info-sx-test-" });
   const pathFor = (name: string) => `${tempDir}/${name}`;
   try {

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -19,6 +19,7 @@ Deno.test("spans carry both the service attributes and the SDK defaults", () => 
   // over. Both halves are read off a span the real provider produced, since a
   // span carries the resource the exporter will stamp on it. The span is left
   // unended so nothing is queued for export.
+
   const span = provider.getTracer("otel-test").startSpan(
     "resource-probe",
   ) as unknown as ReadableSpan;

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -21,6 +21,7 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
   // storage manager passes through untouched; EXPERIMENTAL_* flags come from
   // the injected env reader via the canonical mapping; and the shared
   // first-party posture (the CFC pin) rides along from the preset.
+
   const storageManager = {
     sentinel: true,
   } as unknown as RuntimeOptions["storageManager"];
@@ -59,6 +60,7 @@ Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", as
   // on OTEL_ENABLED it attaches and flips the preflight-telemetry gate. Without
   // a registered OTel provider the API hands the bridge no-op instruments, so
   // the enabled path is safe to exercise in a test.
+
   const signer = await Identity.fromPassphrase("runtime-options-otel-test");
   const config = {
     MEMORY_URL: "http://memory.test:8000/",
@@ -118,6 +120,7 @@ Deno.test("createToolshedRuntime publishes the posture it resolved", async () =>
   // the constructed Runtime rather than re-read from the environment, so the
   // published posture includes the defaults and preset resolution the server is
   // actually running under — a second reading could disagree with the first.
+
   const signer = await Identity.fromPassphrase("runtime-options-posture-test");
   const storageManager = StorageManager.emulate({ as: signer });
   publishExperimentalPosture(null);

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -109,6 +109,7 @@ Deno.test("namesResolverInCode ignores a string literal", () => {
 Deno.test("namesResolverInCode reads past a comment marker inside a string", () => {
   // A scan that blanked a line from its first `//` would stop reading here at
   // the URL and never reach the construction that follows it.
+
   assert(
     namesResolverInCode(
       `const docs = "https://example.com/x"; const r = new FileSystemProgramResolver(m);`,
@@ -141,6 +142,7 @@ Deno.test("namesResolverInCode parses markup in a .tsx file", () => {
 Deno.test("namesResolverInCode ignores a same-named property of another object", () => {
   // A property access still names the resolver, so it counts; a property whose
   // name merely resembles it does not.
+
   assertFalse(
     namesResolverInCode(
       `const x = { fileSystemProgramResolver: 1 };`,

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -259,6 +259,7 @@ Deno.test("main reports the offender and the route to take instead", async () =>
 Deno.test("scan reports a tracked path it cannot read for another reason", async () => {
   // A tracked path that has become a directory is not a deletion, so the read
   // fails for a reason the scan has no answer for and the failure carries.
+
   const root = await fixtureRepo({
     "packages/foo/build.ts":
       "export const r = new FileSystemProgramResolver(main);\n",
@@ -277,6 +278,7 @@ Deno.test("the check runs as a program over this repository", async () => {
   // Runs the check the way CI does, as a program rather than as an import. The
   // repository passes it, so this doubles as the end-to-end case: the entry
   // point wires the scan to an exit code, and the tree it ships is clean.
+
   const script = fromFileUrl(
     new URL("./check-local-program.ts", import.meta.url),
   );

--- a/tasks/check-single-copy-deps.test.ts
+++ b/tasks/check-single-copy-deps.test.ts
@@ -104,6 +104,7 @@ Deno.test("main reports the duplicate and returns 1", async () => {
   // main() reads deno.lock from the root it is given, so a temp tree with a
   // duplicated lockfile drives the reporting path the passing repo never does:
   // the message, the per-copy listing, and the non-zero exit.
+
   const root = await Deno.makeTempDir({ prefix: "check-single-copy-deps-" });
   try {
     const lock = singleCopyLock();

--- a/tasks/check-single-copy-deps.test.ts
+++ b/tasks/check-single-copy-deps.test.ts
@@ -73,6 +73,7 @@ Deno.test("findProblems reports a package resolved twice", () => {
   // The shape of the bug this check exists for: rolling the arizeai packages
   // alone leaves the AI SDK resolved twice, once for toolshed and once for
   // @ai-sdk/otel.
+
   const lock = singleCopyLock();
   lock.npm["ai@5.0.27_zod@3.25.76"] = {};
 

--- a/tasks/combine-coverage-lcov.test.ts
+++ b/tasks/combine-coverage-lcov.test.ts
@@ -34,6 +34,7 @@ Deno.test("normalizeSourcePath handles a dotted repository name", () => {
 Deno.test("normalizeSourcePath anchors on the checkout, not an earlier repeat", () => {
   // A self-hosted runner whose work directory itself repeats the repo name must
   // still anchor on the deepest doubled segment (the checkout root).
+
   assertEquals(
     normalizeSourcePath(
       "/srv/labs/labs/_work/labs/labs/scripts/build.ts",
@@ -63,6 +64,7 @@ Deno.test("normalizeSourcePath leaves synthetic pattern paths unchanged", () => 
 Deno.test("mergeLcovReports sums line coverage for a file seen in two jobs", () => {
   // The two jobs reach the file under different runner checkout roots and
   // include the function/branch records deno emits, which the merge drops.
+
   const jobA = [
     "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
     "FN:1,add",

--- a/tasks/combine-coverage-lcov.test.ts
+++ b/tasks/combine-coverage-lcov.test.ts
@@ -272,6 +272,7 @@ Deno.test("the CLI entry point runs the task as a process", async () => {
   // Run the task as its own process so the `import.meta.main` entry point is
   // exercised end to end. Lockfile isolation keeps the real deno.lock
   // untouched, and all inputs and outputs live under temporary directories.
+
   const dir = await Deno.makeTempDir({ prefix: "combine-lcov-cli-" });
   try {
     const inputDir = path.join(dir, "in");

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -404,6 +404,7 @@ Deno.test("every recorded blocked port is one fetch refuses", async () => {
   // probes at a host that cannot resolve reaches no network service: the
   // blocked answer arrives first, and any other port would fail on the name
   // instead.
+
   const stillBlocked: number[] = [];
   for (const port of ports.blockedPorts) {
     try {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A comment that sits directly above a statement documents that statement. A
comment that introduces the whole block it heads needs a blank line under it,
or the two readings collapse and the block-level comment is read as a note
about whichever line happens to come first.

Twenty-eight test-block preambles across fourteen files were in the collapsed
form. Each gets a blank line; nothing else changes.

## What the diff contains

Fourteen files, twenty-eight insertions, zero deletions. Every inserted line is
empty: `git diff -U0` against the merge base yields zero non-blank added lines
and zero removed lines. No comment word changes, no code line changes, and no
existing line moves. `deno fmt --check` and `deno lint` pass on all fourteen,
and the formatter check matters here because `deno fmt` removes a blank line
placed directly after an opening brace — none of these blank lines lands in
that position, since each goes under a comment run rather than under the brace.

## Every site in these files, not a nominated subset

A scan for the shape reports twenty-eight sites across these fourteen files and
none afterward, so no file is left showing the two forms at once. Each site was
opened and read before the blank line went in: all twenty-eight state what
their test establishes rather than what the statement below them does.

The distinction is not mechanical. A comment naming the value on the next line,
or labelling the first of several cases whose siblings carry their own comments
mid-block, is about that statement and keeps its adjacency. A separate check
lists, for every set-off preamble, the `//` runs at the same indent inside the
same block that are themselves preceded by a blank line — the shape that
distinguishes a run of parallel case labels from a preamble followed by step
notes. It reports five blocks in these files, and reading them confirms all
five are preambles.

## Sites judged and declined

One site was read and left alone: the comment in `tasks/check-skill-facts.test.ts`
that sits inside an argument array immediately above `"--allow-read"`, where it
is a statement comment about that entry and the adjacency is correct.

## A run ending in a lint pragma is about the statement

A comment run that ends in `// deno-lint-ignore …` is presumed to be about the
statement rather than the block: the prose above the pragma is usually the
reason the suppression is warranted, so the whole run keeps its adjacency and
takes no blank line. Only where the leading text is independently a block
preamble does the run split, with the blank going above the pragma so the
pragma stays adjacent to the line it governs.

These fourteen files hold two pragma lines
(`replica-eviction-invariants.test.ts:88` and `:106`). Neither is touched, and
both remain adjacent to their statement.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


