### PR TITLE
test: titles that own their regions, and preambles set off from the first statement

### DIFF
--- a/packages/cli/test/declaredResultProjection.test.ts
+++ b/packages/cli/test/declaredResultProjection.test.ts
@@ -78,6 +78,7 @@ describe("declaredResultProjection", () => {
     // document also names `Item`, and that one does not recurse. A private
     // pointer parser resolving every reference against the outer root read
     // the wrong definition and silently derived nothing.
+
     const declared: JSONSchema = {
       type: "object",
       properties: {
@@ -118,6 +119,7 @@ describe("declaredResultProjection", () => {
     // scope closes the circle, so the nested leaf derives its contents while
     // the outer `parent` still cuts — a spelling-keyed cycle set would render
     // the finite leaf as an address.
+
     const declared: JSONSchema = {
       type: "object",
       properties: { item: { $ref: "#/$defs/Item" } },
@@ -162,6 +164,7 @@ describe("declaredResultProjection", () => {
     // `properties` alone would close the position and drop them — an answer
     // narrower than the verb declared, over a bound that is only supposed to
     // remove the circle.
+
     const declared: JSONSchema = {
       type: "object",
       properties: { item: { $ref: "#/$defs/Item" } },
@@ -224,6 +227,7 @@ describe("declaredResultProjection", () => {
       // Closing that position would hand back less than the verb states it
       // returns, which is the one thing a bound over a committed handling must
       // not do.
+
       expect(
         declaredResultProjection({
           type: "object",
@@ -261,6 +265,7 @@ describe("declaredResultProjection", () => {
       // it is the bound. Written closed it would drop the keys the index
       // signature declares; written open they read as they always did, and the
       // narrowing below still stands.
+
       expect(
         declaredResultProjection({
           type: "object",
@@ -300,6 +305,7 @@ describe("declaredResultProjection", () => {
       // A declaration writing `additionalProperties: false` closed the
       // position itself, so the shape bound is stating what the author already
       // stated rather than narrowing anything.
+
       expect(
         declaredResultProjection({
           type: "object",
@@ -330,6 +336,7 @@ describe("declaredResultProjection", () => {
       // `additionalProperties: false` and is the second, so the shape bound
       // has something to hold the position to and `{}` is what comes back —
       // which is a bound, and bounds a circle sitting at that position.
+
       expect(
         declaredResultProjection({
           type: "object",
@@ -365,6 +372,7 @@ describe("declaredResultProjection", () => {
       // The contrast is the whole reason the stronger bound exists, and the
       // default is the weaker one: a declaration that re-enters nowhere bounds
       // nothing on its own, so a result that renders is never narrowed.
+
       expect(declaredResultProjection(ROW)).toBeUndefined();
       expect(declaredResultProjection(ROW, "recursion")).toBeUndefined();
     });
@@ -373,6 +381,7 @@ describe("declaredResultProjection", () => {
       // The stronger bound adds to the weaker one rather than replacing it:
       // `parent` is where the declared type re-enters, and it renders its
       // address under both.
+
       expect(declaredResultProjection(declarationBeside({}), "shape")?.schema)
         .toEqual({
           type: "object",
@@ -388,6 +397,7 @@ describe("declaredResultProjection", () => {
       // bound where none was found. `{ type: "object", properties: {} }` is
       // what an empty interface lowers to: it names no fields and closes
       // nothing, which accepts whatever is stored.
+
       expect(declaredResultProjection({ type: "object" }, "shape"))
         .toBeUndefined();
       expect(declaredResultProjection({}, "shape")).toBeUndefined();
@@ -416,6 +426,7 @@ describe("declaredResultProjection", () => {
       // the position is left wide under this bound too — the same answer
       // `allOf` gets, and for the same reason. Only re-entry turns a union
       // into an address.
+
       expect(
         declaredResultProjection({
           type: "object",
@@ -525,6 +536,7 @@ describe("declaredResultProjection", () => {
     // `anyOf`/`oneOf` are a choice of shape, and a projection states one shape
     // per position. An address answers every branch at once, since it names the
     // position rather than describing what sits at it.
+
     expect(derivedSchemaBeside({
       origin: { anyOf: [{ $ref: "#/$defs/Item" }, { type: "null" }] },
     })).toEqual({
@@ -542,6 +554,7 @@ describe("declaredResultProjection", () => {
     // The derivation cannot state two shapes at one position, so it leaves the
     // position as wide as it was declared; a readback that then still closes a
     // circle refuses legibly, naming the position it closes at.
+
     expect(derivedSchemaBeside({
       origin: {
         allOf: [
@@ -587,6 +600,7 @@ describe("declaredResultProjection", () => {
     it("returns `true` at a position whose `$ref` walks past a name the declaration does not have", () => {
       // `$defs/Item` has no `title` of its own — the title sits under
       // `properties` — so the walk runs out of document with a segment left.
+
       expect(
         derivedSchemaBeside({ origin: { $ref: "#/$defs/Item/title/type" } }),
       ).toEqual(unbounded);

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -151,6 +151,7 @@ function assertIncrementalMatches(
 Deno.test("createHighlighter: an edit inside a multi-line template matches a full parse", () => {
   // The template literal spans several lines; an edit on a later line of it
   // re-highlights from the statement boundary and matches a full parse.
+
   const base = "const t = `line one\nline two\nline three`;\nconst x = 1;\n";
   assertIncrementalMatches(base, base.replace("line two", "line TWO"));
 });
@@ -176,6 +177,7 @@ Deno.test("createHighlighter: editing a statement whose line opens inside an ear
   // `const b` statement. Editing `const b` makes safeStartLine walk back from
   // line 1 to line 0 (the line the comment opened on), since line 1's start is
   // inside the still-open comment.
+
   const base = "const a = 1; /* c\nomment tail */ const b = 2;\nconst c = 3;\n";
   assertIncrementalMatches(base, base.replace("const b = 2", "const b = 22"));
 });
@@ -189,6 +191,7 @@ Deno.test("createHighlighter: an edit near a JSDoc comment stays one whole comme
   // Editing the statement *above* widens the rebuild range down across that
   // function, so collectTokensInRange visits and skips the JSDoc nodes rather
   // than tokenising them as code.
+
   const base = [
     "const head = 1;",
     "",
@@ -288,6 +291,7 @@ Deno.test("parse: a synthetic name in property-access position is a cfHelper", (
   // `obj.__cfHandler_1` — the synthetic name is the `.name` of a property
   // access, not a callee and not a builder, so the property-access synthetic
   // branch classifies it as cfHelper.
+
   const doc = parseDocument("const r = registry.__cfHandler_1;\n", "m.ts");
   assert(
     classesOf(doc, "__cfHandler_1").has("cfHelper"),
@@ -297,6 +301,7 @@ Deno.test("parse: a synthetic name in property-access position is a cfHelper", (
 
 Deno.test("parse: a builder reached via property access is a builderCall", () => {
   // `x.pattern(…)` — property-access callee whose name is a builder.
+
   const doc = parseDocument("const z = obj.lift(fn);\n", "m.ts");
   assert(
     classesOf(doc, "lift").has("builderCall"),
@@ -307,6 +312,7 @@ Deno.test("parse: a builder reached via property access is a builderCall", () =>
 Deno.test("parse: a synthetic identifier used as a type name is a cfHelper", () => {
   // `__cfHelpers.JSONSchema` in type position — isTypePosition true and the
   // name is synthetic, so the type-position synthetic branch fires.
+
   const doc = parseDocument(
     "let v: __cfHelpers.JSONSchema = x;\n",
     "m.ts",
@@ -344,6 +350,7 @@ Deno.test("parse: type parameters, typeof queries and heritage clauses are type 
 Deno.test("parse: a generic type parameter declaration name is a typeName", () => {
   // The declared `T` in `gen<T>` has a TypeParameter parent — not a TypeNode —
   // so isTypePosition resolves it through the type-parameter branch.
+
   const doc = parseDocument("function gen<T>(x) { return x; }\n", "m.ts");
   assert(classesOf(doc, "T").has("typeName"), "type parameter declaration");
 });
@@ -354,6 +361,7 @@ Deno.test("parse: a generic type parameter declaration name is a typeName", () =
 
 Deno.test("parse: comments are merged into the structure tree in source order", () => {
   // Several comments at the same nesting level batch and merge via mergeByStart.
+
   const src = [
     "// first note",
     "const a = 1;",
@@ -395,6 +403,7 @@ Deno.test("parse: a named binding registers a definition", () => {
   // registerDefinition is only called when desc.name is set, but the early `if
   // (!desc.name) return` is reached when called for a name. A named binding
   // exercises the body; the guard line itself runs every call.
+
   const doc = parseDocument("const namedThing = 1;\n", "m.ts");
   assert(doc.definitions.has("namedThing"), "named binding is in the index");
   const def = doc.definitions.get("namedThing")![0];
@@ -518,6 +527,7 @@ Deno.test("parse: labeled statements and jump statements are reachable nodes", (
 Deno.test("parse: an unusual statement still becomes a reachable statement node", () => {
   // A `with` statement is not specially handled, so it falls through to the
   // generic in-statement-list branch.
+
   const doc = parseDocument("with (obj) { doThing(); }\n", "m.ts");
   const node = findNode(
     doc,
@@ -583,6 +593,7 @@ Deno.test("parse: a binding whose initializer is a plain object is an object nod
 
 Deno.test("parse: a bare arrow-function expression statement is a closure node", () => {
   // An expression statement whose expression is an arrow function.
+
   const doc = parseDocument("(x) => x + 1;\n", "m.ts");
   const node = findNode(doc, (n) => n.kind === "closure");
   assert(node, `expected a closure node, got ${labels(doc).join(" | ")}`);
@@ -660,6 +671,7 @@ Deno.test("parse: every control-flow shape gets its distinct label", () => {
 Deno.test("parse: a computed-callee call is labeled by its first source line", () => {
   // `(obj["m"])(…)` — the callee is neither a plain identifier nor a property
   // access, so calleeName falls back to nodeFirstLine.
+
   const doc = parseDocument(`const r = (table["run"])(1);\n`, "m.ts");
   const node = findNode(doc, (n) => n.name === "r");
   assert(node, "the binding is a node");
@@ -938,6 +950,7 @@ Deno.test("parse: describeInitializer reports closure for a function initializer
 Deno.test("parse: a non-reactive call binding records describeInitializer text", () => {
   // `const out = compute(x);` is a non-reactive call, so bindingDesc keeps it a
   // variable and variableMeta -> describeInitializer runs over the call.
+
   const doc = parseDocument("const out = compute(x, y);\n", "m.ts");
   const node = findNode(doc, (n) => n.name === "out");
   assert(node, "the binding is a node");

--- a/packages/cli/test/view-parse-cov2.test.ts
+++ b/packages/cli/test/view-parse-cov2.test.ts
@@ -1,8 +1,8 @@
 /**
- * Second-round coverage tests for `lib/view/languages/typescript/parse.ts`, extending
- * `view-parse.test.ts` and `view-parse-cov.test.ts`. The dead and duplicate
- * branches these originally documented were removed or folded away at the
- * source; the tests here exercise the reachable behavior around them:
+ * Second-round coverage tests for `lib/view/languages/typescript/parse.ts`,
+ * extending `view-parse.test.ts` and `view-parse-cov.test.ts`. The dead and
+ * duplicate branches these originally documented were removed or folded away at
+ * the source; the tests here exercise the reachable behavior around them:
  * identifier classification, type-position resolution (qualified names,
  * `typeof`, heritage types), comment merging, definition registration, control
  * labels, and metadata extraction on malformed input, plus `safe`'s
@@ -49,6 +49,7 @@ Deno.test("qualified name in a type annotation resolves as a type name", () => {
   // `a.b.c.D` in type position climbs the qualified-name chain in
   // isTypePosition and resolves via ts.isTypeNode on the TypeReference, so the
   // final identifier `D` is a typeName, not a plain reference.
+
   const doc = parseDocument("let x: a.b.c.D = null as never;");
   const classes = classesOf(doc, "D");
   assert(
@@ -65,6 +66,7 @@ Deno.test("typeof in a type annotation resolves the operand as a type name", () 
   // `typeof foo` as a type produces a TypeQueryNode parent for `foo`. Because a
   // TypeQueryNode is itself a TypeNode, isTypePosition returns at the
   // ts.isTypeNode check before the more-specific TypeQuery branch.
+
   const doc = parseDocument("const foo = 1;\nlet y: typeof foo = foo;");
   // The `foo` inside the type query is a typeName; the value `foo` references
   // remain non-type classes, so both classifications appear for the token.
@@ -82,7 +84,9 @@ Deno.test("typeof in a type annotation resolves the operand as a type name", () 
 Deno.test("class heritage type resolves as a type name", () => {
   // `extends Base<number>` produces an ExpressionWithTypeArguments whose
   // expression is `Base`. That node is also a TypeNode, so `Base` resolves as a
-  // typeName at line 914, never reaching the ExpressionWithTypeArguments branch.
+  // typeName at line 914, never reaching the ExpressionWithTypeArguments
+  // branch.
+
   const doc = parseDocument("class A extends Base<number> {}");
   const classes = classesOf(doc, "Base");
   assert(
@@ -216,6 +220,7 @@ Deno.test("metadata extraction survives malformed but parseable input", () => {
   // These all parse (via TypeScript error recovery) into nodes with valid
   // ranges, so the metadata extractors run their bodies without throwing and
   // the safe() catch is never taken.
+
   const cases = [
     "type Bad = ;",
     "interface Q extends { }",
@@ -248,6 +253,7 @@ Deno.test("import metadata is extracted without error", () => {
 Deno.test("a raw arrow initializer becomes a closure node, not a variable", () => {
   // bindingDesc routes the arrow to a closure before variableMeta /
   // describeInitializer would run, so describeInitializer never sees an arrow.
+
   const doc = parseDocument("const handler = () => 1;");
   const node = findNode(doc, (n) => n.name === "handler");
   assert(node, "expected a node bound to `handler`");
@@ -257,6 +263,7 @@ Deno.test("a raw arrow initializer becomes a closure node, not a variable", () =
 Deno.test("a parenthesised arrow initializer also becomes a closure node", () => {
   // peelExpr strips the parentheses before the arrow check, so this too is a
   // closure and bypasses describeInitializer.
+
   const doc = parseDocument("const wrapped = (() => 2);");
   const node = findNode(doc, (n) => n.name === "wrapped");
   assert(node, "expected a node bound to `wrapped`");
@@ -266,6 +273,7 @@ Deno.test("a parenthesised arrow initializer also becomes a closure node", () =>
 Deno.test("describeInitializer reports non-closure initializers", () => {
   // The reachable describeInitializer outputs: the no-initializer case and the
   // nodeFirstLine fall-through. These run for the variable-kind nodes below.
+
   const doc = parseDocument(
     "let pending;\nconst result = computeValue();\nconst total = a + b;",
   );
@@ -305,7 +313,7 @@ Deno.test("incremental highlighter updates a line that adds a closure", () => {
 });
 
 //
-// safe(): the throwing path, through the test-only handle
+// safe(): both arms, reached through the test-only handle
 //
 
 Deno.test("safe(): a throwing extractor degrades to undefined", () => {
@@ -313,6 +321,7 @@ Deno.test("safe(): a throwing extractor degrades to undefined", () => {
   // feeds them a node that throws, so the catch is exercised directly through
   // the test-only handle: a throwing extractor degrades to undefined, a
   // succeeding one returns its value.
+
   assertEquals(
     _internal.safe(() => {
       throw new Error("boom");

--- a/packages/cli/test/view-semantics-cov.test.ts
+++ b/packages/cli/test/view-semantics-cov.test.ts
@@ -37,6 +37,7 @@ function nameOffsetOf(doc: Document, name: string): number {
 Deno.test("semantics: createSemantics returns a service for a single-section blob", () => {
   // No section headers: the fallback single section runs, the service builds,
   // and a plain binding types — exercising the non-error setup path.
+
   const blob = `const n: number = 1;\nconst s = n;`;
   const doc = parseDocument(blob);
   const sem = createSemantics(blob, { cwd: CWD });
@@ -47,6 +48,7 @@ Deno.test("semantics: createSemantics returns a service for a single-section blo
 Deno.test("semantics: prewarm builds the program off the query path", () => {
   // prewarm() runs build() ahead of the first real query; a subsequent type
   // query then reuses the cached program and still answers.
+
   const blob = `// transformed: /m.ts
 const value: string = "x";
 const echo = value;`;
@@ -151,6 +153,7 @@ Deno.test("semantics: JSONC import map survives block comments and escapes", () 
   // A block comment AND a string value containing an escaped quote and a `//`
   // sequence force every branch of stripJsonc: the escape step, the block-
   // comment skip, and the in-string passthrough.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -182,6 +185,7 @@ Deno.test("semantics: a deno.json with no usable imports yields an empty map", (
   // imports present but every value is a non-local specifier (jsr:/npm:) — the
   // isLocalSpecifier filter drops them all, leaving an empty import map; and a
   // non-string value is ignored by parseImports.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -224,6 +228,7 @@ Deno.test("semantics: typeStringAt returns null when no node holds the offset", 
   // A run of trailing blank space after the only statement, all inside the
   // single section: those offsets land in no AST node, so nodeAt returns
   // undefined and typeStringAt returns null.
+
   const blob = `// transformed: /m.ts
 const x = 1;
 
@@ -239,6 +244,7 @@ Deno.test("semantics: a section header path TS cannot load types to null", () =>
   // A bare (slashless, extension-less) header path is not a virtual source file
   // the program can serve: build() succeeds, but getSourceFile(section.name)
   // returns undefined, so typeStringAt returns null via its `!sf` guard.
+
   const blob = `// transformed: m
 const x = 1;
 const y = x;`;
@@ -250,6 +256,7 @@ const y = x;`;
 Deno.test("semantics: definitionOf preview on a last line with no trailing newline", () => {
   // The external definition sits on the file's final line, which has no
   // trailing newline — lineAndPreview's `end < 0` branch clamps to the end.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -287,6 +294,7 @@ Deno.test("semantics: classifies a resolved .tsx import (extensionOf Tsx)", () =
   // The import-map value points directly at a `.tsx` file; resolveRelative
   // returns it verbatim, and extensionOf tags it as Tsx during resolution. The
   // service stays usable whether or not the binding's type flows through.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -392,6 +400,7 @@ Deno.test("semantics: a directory named as a dependency reads as undefined", () 
   // The blob imports an absolute path that resolves to a directory. The host's
   // readReal hits the read-failure catch (a directory is not a text file) and
   // returns undefined; the service must not throw.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(join(root, "deno.json"), JSON.stringify({}));
@@ -412,6 +421,7 @@ Deno.test("semantics: an unreadable in-root dependency degrades to no type", () 
   // (mode 000): the host's readReal hits its read-failure catch and returns
   // undefined, so the binding referencing it has no knowable type and the
   // service stays alive.
+
   const root = Deno.makeTempDirSync();
   const extPath = join(root, "ext.ts");
   try {
@@ -440,6 +450,7 @@ Deno.test("semantics: the same external file is read once and cached by the host
   // cache (fileExists + getScriptSnapshot + readFile all funnel through it)
   // serves the repeat reads from the cache, and the service's realFiles cache
   // serves definitionOf's repeat read.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -762,6 +773,7 @@ function throwingMaps(
 Deno.test("diff semantics: typeAt swallows a throw from the offset map", () => {
   // build() succeeds (real root files), then maps.toFile throws inside typeAt's
   // try — the catch returns null rather than propagating.
+
   const { root, ws, done } = tempDiffRoot();
   try {
     const model = parseDiff(DIFF)!;
@@ -781,6 +793,7 @@ Deno.test("diff semantics: typeAt swallows a throw from the offset map", () => {
 Deno.test("diff semantics: definitionOf swallows a throw and caches empty", () => {
   // After build, maps.fromFile throws while classifying a resolved definition;
   // definitionOf's catch resets to an empty list and caches it.
+
   const { root, ws, done } = tempDiffRoot();
   try {
     const model = parseDiff(DIFF)!;
@@ -804,6 +817,7 @@ Deno.test("diff semantics: a definition resolving to a lib file is skipped", () 
   // `Set` resolves into lib.d.ts (outside the workspace); fromFile returns null
   // (not in the diff) and readReal returns undefined, so the def is skipped via
   // the `content === undefined` continue.
+
   const { root, ws, done } = tempDiffRoot();
   try {
     Deno.writeTextFileSync(

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -40,6 +40,7 @@ Deno.test("semantics: a healthy build returns a Program (the !program guard is a
   // build() runs createLanguageService + getProgram and returns a real Program,
   // so the subsequent query answers a concrete type. The `if (!program)` latch
   // exists only for a host that yields no Program, which this one never does.
+
   const blob = `// transformed: /m.ts
 const x: number = 1;
 const y = x;`;
@@ -53,6 +54,7 @@ Deno.test("semantics: prewarm never sees a throw because build isolates its own"
   // A hostile cwd makes build()'s own try/catch latch `failed`; the throw is
   // swallowed inside build(), so prewarm()'s surrounding try/catch observes
   // nothing. The service stays silent on every later query.
+
   const blob = `// transformed: /m.ts
 const x = 1;
 const y = x;`;
@@ -72,6 +74,7 @@ Deno.test("semantics: the host reads each real file once (cache populated, not r
   // Under Bundler resolution the host loads each resolved file a single time;
   // the file cache is filled on that read. The cache-hit return is a backstop
   // for resolution modes that probe the same path repeatedly.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(
@@ -103,13 +106,14 @@ const b = ext();`;
 });
 
 //
-// within()/realDir: a child resolves => its ancestor root resolves too
+// within()/realDir: the child resolves first, and the root only after
 //
 
 Deno.test("semantics: within() resolves a real child under a real root (realDir succeeds)", () => {
   // realDir(root) is only reached after the child's realPathSync succeeds; the
   // child sits under the root, so the root resolves too and realDir's catch is
   // never taken. The read therefore succeeds.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(join(root, "deno.json"), JSON.stringify({}));
@@ -128,6 +132,7 @@ Deno.test("semantics: a child whose realpath fails is rejected before realDir ru
   // When the child itself cannot be realpath-resolved, within() throws on the
   // child read and is caught before realDir(root) is consulted — the read
   // degrades to null. (This is the path that pre-empts realDir's own catch.)
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(join(root, "deno.json"), JSON.stringify({}));
@@ -161,10 +166,11 @@ function diffMapsFor(file: string): DiffMaps {
 }
 
 Deno.test("diff semantics: build succeeds over real root files, so typeAt's !prog guard is a backstop", () => {
-  // The diff factory passes its containment check, build() makes a host over the
-  // real root file and returns a Program. typeAt's `if (!prog) return null`
+  // The diff factory passes its containment check, build() makes a host over
+  // the real root file and returns a Program. typeAt's `if (!prog) return null`
   // never triggers on the build itself; a null here comes from the offset map,
   // not a failed build.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(join(root, "deno.json"), "{}");
@@ -189,6 +195,7 @@ Deno.test("diff semantics: a hostile cwd is rejected by containment before build
   // The diff factory filters root files through the workspace-containment check
   // first; a cwd the path helpers reject makes that check throw out of the
   // factory, so build()'s own failure arms are never the thing that fires.
+
   const root = Deno.makeTempDirSync();
   try {
     Deno.writeTextFileSync(join(root, "m.ts"), "export const a = 1;\n");
@@ -207,8 +214,10 @@ Deno.test("diff semantics: a hostile cwd is rejected by containment before build
 });
 
 Deno.test("diff semantics: no in-workspace root file means no service (not a failed build)", () => {
-  // With every root file filtered out, the factory returns undefined up front — the
-  // service is never constructed, so build()'s failure guards are not in play.
+  // With every root file filtered out, the factory returns undefined up front —
+  // the service is never constructed, so build()'s failure guards are not in
+  // play.
+
   const sem = createDiffSemantics(
     "difftext",
     { rootFiles: [], toFile: () => null, fromFile: () => null },
@@ -226,6 +235,7 @@ Deno.test("lazyProgram: caches a success and latches a failed build", () => {
   // configured host never makes it fail, so its failure isolation is exercised
   // directly: a build is cached after the first success, and a throwing or
   // program-less build latches so it is not retried.
+
   const fake = {} as unknown as ts.Program;
 
   let okCalls = 0;
@@ -257,12 +267,14 @@ Deno.test("lazyProgram: caches a success and latches a failed build", () => {
 });
 
 //
-// makeHost's readReal memoizes real-file reads. Under the pager's module
-// resolution TypeScript reads each file once, so the cache hit never fires
-// there; reading the same path twice through the host exercises it directly.
+// makeHost: the readReal memo
 //
 
 Deno.test("makeHost: a repeated read of the same file is served from the cache", () => {
+  // makeHost's readReal memoizes real-file reads. Under the pager's module
+  // resolution TypeScript reads each file once, so the cache hit never fires
+  // there; reading the same path twice through the host exercises it directly.
+
   const dir = Deno.makeTempDirSync();
   try {
     const file = join(dir, "dep.ts");
@@ -280,7 +292,7 @@ Deno.test("makeHost: a repeated read of the same file is served from the cache",
 });
 
 //
-// Signed numeric definitions
+// signedNumericElementDefinitions: which positions name a key
 //
 
 Deno.test("signed numeric definitions reject positions that do not name a supported key", () => {

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -162,7 +162,6 @@ Deno.test("any() rejects a conjunctive alternative — no (A∧B)∨C → A∨B�
   // A direct all() as an any() alternative is rejected: union-flattening it
   // would make the row readable by A alone even though the author required
   // A AND B.
-
   assertThrows(
     () =>
       table(EMAIL_COLUMNS, (f) => ({

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -131,12 +131,13 @@ Deno.test("match() forces the global flag so split-on-match works", () => {
 });
 
 //
-// Fail-closed at authoring (table() throws)
+// any(): the OR-clauses it authors, and the shape it refuses
 //
 
 Deno.test("any() builds and validates an OR-clause (Epic E1)", () => {
   // any() no longer throws at table() time — it produces an authored OR-clause
   // the runner's clause-aware profile enforces by subsumption.
+
   const schema = table(EMAIL_COLUMNS, (f) => ({
     confidentiality: any(
       principal("mailto", match(f.from, ADDR)),
@@ -161,6 +162,7 @@ Deno.test("any() rejects a conjunctive alternative — no (A∧B)∨C → A∨B�
   // A direct all() as an any() alternative is rejected: union-flattening it
   // would make the row readable by A alone even though the author required
   // A AND B.
+
   assertThrows(
     () =>
       table(EMAIL_COLUMNS, (f) => ({
@@ -194,6 +196,10 @@ Deno.test("any() rejects a conjunctive alternative — no (A∧B)∨C → A∨B�
     Error,
   );
 });
+
+//
+// Static analysis of an authored rule (no row required)
+//
 
 Deno.test("ruleCommonAlternatives: the static readers of EVERY clause (Epic E2)", () => {
   const OWNER = "did:key:zOwner";
@@ -300,6 +306,7 @@ Deno.test("ruleConstrainsConfidentiality: confidentiality present vs integrity-o
   // An integrity-only rule imposes NO confidentiality constraint — an aggregate
   // over it is public, not a refusal. Distinguished from a rule that DOES
   // constrain (any nesting of at least one clause).
+
   const integrityOnly = table(EMAIL_COLUMNS, (f) => ({
     integrity: authoredBy(principal("mailto", match(f.from, ADDR))),
   })).rowLabel as RowLabelSpec;
@@ -319,6 +326,10 @@ Deno.test("ruleConstrainsConfidentiality: confidentiality present vs integrity-o
   })).rowLabel as RowLabelSpec;
   assertEquals(ruleConstrainsConfidentiality(nested), true);
 });
+
+//
+// Fail-closed at authoring, and again on a spec that arrives built
+//
 
 Deno.test("a rule referencing an unknown column throws", () => {
   assertThrows(
@@ -584,7 +595,9 @@ Deno.test("constant() injects a literal atom; intersect() meets integrity atom s
 });
 
 //
-// evaluateRowLabel — fail-closed branches (each returns {error}, never partial)
+// evaluateRowLabel — fail-closed on the row and the context
+//
+// Each returns {error}, never a partial label.
 //
 
 function expectError(
@@ -665,9 +678,18 @@ Deno.test("dbOwner() with no owner in ctx fails closed", () => {
   );
 });
 
+//
+// evaluateRowLabel — OR-clause evaluation (Epic E1)
+//
+// An anyOf node evaluates to one structural OR-clause rather than to flattened
+// atoms, and a conjunction smuggled in as an alternative fails closed instead
+// of widening into one.
+//
+
 Deno.test("an anyOf node evaluates to a structural OR-clause (Epic E1)", () => {
   // any(dbOwner ∨ from-participants): the row is readable by the owner OR any
   // sender — ONE OR-clause, not flattened into bare atoms.
+
   const spec = table(EMAIL_COLUMNS, (f) => ({
     confidentiality: any(dbOwner(), principal("mailto", match(f.from, ADDR))),
   })).rowLabel as RowLabelSpec;
@@ -685,6 +707,7 @@ Deno.test("evalConf fails closed on a conjunctive any() alternative that bypasse
   // with a conjunction as an any() alternative must fail closed at eval —
   // never union-flatten (A∧B)∨C into A∨B∨C. Both the direct all() and the
   // when()-wrapped all() shapes are rejected.
+
   const direct: RowLabelSpec = {
     version: 1,
     confidentiality: {
@@ -717,6 +740,7 @@ Deno.test("evalConf fails closed on a conjunctive any() alternative that bypasse
 
 Deno.test("an all() of any()-clauses is proper CNF (Epic E1)", () => {
   // all(any(owner ∨ from), to-participants) → (owner∨from) ∧ to.
+
   const spec = table(EMAIL_COLUMNS, (f) => ({
     confidentiality: all(
       any(dbOwner(), principal("mailto", match(f.from, ADDR))),
@@ -734,6 +758,10 @@ Deno.test("an all() of any()-clauses is proper CNF (Epic E1)", () => {
     "did:mailto:bob@example.com",
   ]);
 });
+
+//
+// evaluateRowLabel — fail-closed on the spec itself
+//
 
 Deno.test("an unknown op reaching the evaluator fails closed", () => {
   const spec: RowLabelSpec = {
@@ -763,6 +791,7 @@ Deno.test("an unsupported spec version fails closed", () => {
 
 Deno.test("endorsedBy mints claimed-endorsed-by", () => {
   // endorsedBy variant mints the endorsed claim kind.
+
   const schema = table(
     { reviewer: "text" },
     (f) => ({
@@ -783,6 +812,7 @@ Deno.test("endorsedBy mints claimed-endorsed-by", () => {
 Deno.test("zero matches in an integrity position mints no claim", () => {
   // Zero matches in an integrity position mints nothing (the claim simply is
   // not made) — distinct from >1 which is an error.
+
   const schema = table(
     { reviewer: "text" },
     (f) => ({
@@ -870,6 +900,7 @@ const DUAL_PRINCIPAL_OWNER: RowLabelSpec = {
 
 Deno.test("a dual-op confidentiality node in a wire spec is rejected (ambiguous, fail closed)", () => {
   // The probe from the report: {principal, dbOwner}.
+
   const reason = validateRowLabelSpec(DUAL_PRINCIPAL_OWNER, ["from"]);
   assert(typeof reason === "string", "a dual-op node must not validate");
   assert(reason.includes("ambiguous"), `unexpected reason: ${reason}`);
@@ -968,6 +999,7 @@ Deno.test("ruleCommonAlternatives never counts a dual-op node's owner as a commo
   // principal, so the owner is not an alternative in ANY row's label — the
   // static analysis must not report it (an ambiguous node contributes no
   // static reader; the aggregate refuses).
+
   assertEquals(
     ruleCommonAlternatives(DUAL_PRINCIPAL_OWNER, { dbOwner: OWNER }),
     [],
@@ -994,6 +1026,7 @@ Deno.test("an ambiguous allOf wrapper is opaque to the static analysis (no unwra
   // the allOf key alone and unwrap it: that silently drops the smuggled
   // sibling op and hands the inner conjuncts to the static analysis, which
   // would report a guaranteed reader for a node the evaluator refuses.
+
   const ambiguousWrapper = {
     version: 1,
     confidentiality: { allOf: [{ dbOwner: true }], constant: "x" },
@@ -1020,6 +1053,7 @@ Deno.test("evaluateRowLabel fails closed on a dual-op node that bypassed validat
   // Defense in depth (like the conjunctive-anyOf-alternative check): a wire
   // spec that skipped validation must refuse at eval, never silently pick one
   // op by precedence.
+
   expectError(
     DUAL_PRINCIPAL_OWNER,
     { from: "alice@a.example" },

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -790,8 +790,6 @@ Deno.test("an unsupported spec version fails closed", () => {
 //
 
 Deno.test("endorsedBy mints claimed-endorsed-by", () => {
-  // endorsedBy variant mints the endorsed claim kind.
-
   const schema = table(
     { reviewer: "text" },
     (f) => ({
@@ -900,7 +898,6 @@ const DUAL_PRINCIPAL_OWNER: RowLabelSpec = {
 
 Deno.test("a dual-op confidentiality node in a wire spec is rejected (ambiguous, fail closed)", () => {
   // The probe from the report: {principal, dbOwner}.
-
   const reason = validateRowLabelSpec(DUAL_PRINCIPAL_OWNER, ["from"]);
   assert(typeof reason === "string", "a dual-op node must not validate");
   assert(reason.includes("ambiguous"), `unexpected reason: ${reason}`);

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1463,6 +1463,7 @@ describe("opening a space root", () => {
   it("rolls the home root forward when its source moves", async () => {
     // A home space (session space == the identity DID) follows its origin like
     // any other piece. Same in-place semantics: no new piece minted.
+
     await setupHome();
     const piece = await controller.ensureDefaultPattern();
     const rootLinkBefore = JSON.stringify(piece.getCell().getAsLink());
@@ -1576,6 +1577,7 @@ describe("opening a space root", () => {
     // { "$stream": true } markers for handler nodes the old program never
     // had. A handler-less roll target (every other test here) cannot see
     // this; home.tsx is handler-rich.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -1619,6 +1621,7 @@ describe("opening a space root", () => {
     // TODO(hixie): migrate the root's data onto the candidate instead. As it
     // stands the root silently stops following its own origin, and nobody is
     // told.
+
     const SOURCE_INCOMPATIBLE = [
       "import { pattern } from 'commonfabric';",
       "export default pattern<{ mustHave: string }>(({ mustHave }) => ({",
@@ -1650,6 +1653,7 @@ describe("opening a space root", () => {
     // cold-starts the piece — and Runner.startCore's initial instantiation
     // does not run the setup phase, so the incoming pattern's
     // { "$stream": true } markers were never materialized on the reused doc.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -1697,6 +1701,7 @@ describe("opening a space root", () => {
     // entries or stream markers for that pattern. On the next boot the
     // identity compares current, so no further swap fires — the doc must be
     // healed at cold start itself.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -1744,6 +1749,7 @@ describe("opening a space root", () => {
     // orchestration test. The runnability backstop must roll the root forward
     // to the current official identity and materialize it, including a live
     // handler stream.
+
     await setupHome();
     expect(runtime.cfcEnforcementMode).not.toBe("disabled");
 
@@ -2004,6 +2010,7 @@ describe("opening a space root", () => {
     // reflect ordering/policy/provenance faults, not "the pinned pattern is
     // wrong", so the backstop must NOT repoint the root. The bare-prefix
     // predicate this replaces would have wrongly rolled forward here.
+
     const { root, oldRef, officialId } = await pinOldRequiredHome();
     const restore = patchRunSynced((opts) =>
       opts?.expectedPatternIdentity?.identity === oldRef.identity
@@ -2041,6 +2048,7 @@ describe("opening a space root", () => {
     // named `/cfc-schema-migration-incompatible` — a bare `includes(token)`
     // would misclassify it as recoverable and repoint the root. It must stay
     // fail-closed.
+
     const { root, oldRef, officialId } = await pinOldRequiredHome();
     const restore = patchRunSynced((opts) =>
       opts?.expectedPatternIdentity?.identity === oldRef.identity
@@ -2081,6 +2089,7 @@ describe("opening a space root", () => {
     // root to a THIRD (loadable) identity, then reject with the migration
     // signal so the roll-forward proceeds to the swap — where the precondition
     // must see the changed identity and abort.
+
     const { root, oldRef, officialId } = await pinOldRequiredHome();
 
     // A distinct, loadable identity for the "concurrent heal" to install.
@@ -2157,6 +2166,7 @@ describe("opening a space root", () => {
     // migrate the reused doc, the operator gets ONE error that names WHY —
     // the pinned pattern's migration failure and the official's — instead of
     // reverse-engineering scattered logs.
+
     const { oldRef, officialId } = await pinOldRequiredHome();
     const restore = patchRunSynced((opts) =>
       // Reject BOTH the same-identity repair AND the official materialize.
@@ -2246,6 +2256,7 @@ describe("opening a space root", () => {
     // migration; the heal MUST NOT short-circuit on the shared identity — it
     // must roll forward to the official `default` entry. A gate that compared
     // identity alone treated this as already-official and left it unhealable.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2321,6 +2332,7 @@ describe("opening a space root", () => {
     // The roll-forward's compile of the official source is a failure surface
     // too: if the toolshed serves un-compilable source, the operator gets one
     // clear "could not be compiled" error, not a raw compiler stack.
+
     const { oldRef } = await pinOldRequiredHome();
     stub.setSource("this is not valid typescript @@@ export default");
     const restore = patchRunSynced((opts) =>
@@ -2344,6 +2356,7 @@ describe("opening a space root", () => {
   it("surfaces a clear error when the official pattern yields no entry identity", async () => {
     // Defensive branch: compile succeeds but the artifact has no entry ref.
     // The heal must not proceed with an undefined identity — clear error.
+
     const { oldRef } = await pinOldRequiredHome();
     const pm = runtime.patternManager as unknown as {
       getArtifactEntryRef: (p: unknown) => unknown;
@@ -2373,6 +2386,7 @@ describe("opening a space root", () => {
     // Defensive branch: the swap transaction itself fails to commit (a storage
     // fault, not the precondition abort). The underlying error is chained and
     // the pinned identity is left untouched.
+
     const { oldRef } = await pinOldRequiredHome();
     const realEdit = runtime.editWithRetry.bind(runtime);
     (runtime as unknown as {
@@ -2417,6 +2431,7 @@ describe("opening a space root", () => {
     // just passes, since the stored argument satisfies both schemas. A
     // commit-layer failure is what reliably exercises the fail-closed path
     // without also asserting the argument contract.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2482,6 +2497,7 @@ describe("opening a space root", () => {
     // Cold start of a doc in the already-swapped state whose (current)
     // identity cannot be loaded: the repair's own load sees the same
     // outcome, and each guard must surface the ORIGINAL start error.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2541,6 +2557,7 @@ describe("opening a space root", () => {
     // A root whose patternIdentity meta is present but malformed: start
     // fails, and the repair cannot even name a pattern to load — the
     // ref-undefined guard must surface the original start failure.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2570,6 +2587,7 @@ describe("opening a space root", () => {
     // that cannot load is a dead space regardless of kind. The displaced
     // ref is recorded for non-home too — it is the recovery pointer if
     // the replaced root was a custom program.
+
     await setup();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2614,6 +2632,7 @@ describe("opening a space root", () => {
     // A thrown probe is a failed CHECK, not evidence of a dead root — a
     // transient storage/backend failure must not authorize replacing an
     // ambiguous sourceless root. Fail closed, mutate nothing.
+
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {
@@ -2649,6 +2668,7 @@ describe("opening a space root", () => {
     // unsupported" rather than "artifact dead" and authorizes nothing. The
     // root that cannot start therefore surfaces its failure rather than being
     // replaced.
+
     await setupHome({ cfcEnforcementMode: "disabled" });
     await controller.recreateDefaultPattern({
       customProgram: {

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -2203,6 +2203,7 @@ describe("opening a space root", () => {
     // clear "already the pinned entry" error instead of looping. The
     // symbol-differs sibling below proves the gate does NOT short-circuit when
     // only the identity matches.
+
     // Disable the updater so startup reaches the cold-start repair path.
     await setupHome();
     await controller.recreateDefaultPattern({

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -209,6 +209,7 @@ describe("piece schema compatibility", () => {
     // The derived component is replace-on-overwrite, not a ratchet, so this
     // comparison has no opinion either way. A pattern whose writes stop
     // satisfying its own floor fails at the write, where its tests are.
+
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         pattern(flooredList(floorAndMint), { type: "object" }),
@@ -223,6 +224,7 @@ describe("piece schema compatibility", () => {
     // The two sides differ by a mint, which is dropped, so what is left to
     // compare is the claim itself. Comparing two schemas that are equal all
     // the way down would settle before reaching it.
+
     const claimWith = (mint: boolean): JSONSchema => ({
       type: "object",
       properties: {
@@ -247,6 +249,7 @@ describe("piece schema compatibility", () => {
     // Same binding path, same uiContract, and a content hash and file spelling
     // the runtime re-derives rather than holds fixed. That is a recompile of
     // one authorization, so it is accepted.
+
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         pattern(
@@ -265,6 +268,7 @@ describe("piece schema compatibility", () => {
     // `literalDidSubjectsForPrincipalClaim` walks arrays and object values, so
     // an atom nested inside another structure still authorizes the write.
     // Losing it has to read as a change here rather than slip through.
+
     const ownerNode = (withEvidence: boolean): JSONSchema => ({
       type: "object",
       properties: {
@@ -299,6 +303,7 @@ describe("piece schema compatibility", () => {
     // A malformed mint carries no represents-principal atom, so there is
     // nothing for the owner check to match and nothing for this comparison to
     // hold. It reduces the same as a node that mints nothing at all.
+
     const ownerNode = (withMint: boolean): JSONSchema =>
       JSON.parse(
         `{"type":"object","properties":{"bio":{"type":"string","ifc":{` +
@@ -318,6 +323,7 @@ describe("piece schema compatibility", () => {
     // Only `represents-principal` evidence feeds the owner check. An atom
     // beside it is a label nothing consults, so losing it leaves the write
     // authorized exactly as before and is not a contract change.
+
     const ownerNode = (extra: boolean): JSONSchema => ({
       type: "object",
       properties: {
@@ -348,6 +354,7 @@ describe("piece schema compatibility", () => {
     // The reduction leaves nothing behind on one side and finds an already
     // empty extension on the other. Both say the same thing, so they compare
     // equal rather than reading as a change.
+
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         pattern(flooredList({ addIntegrity: ["group-chat-admin"] }), {
@@ -363,6 +370,7 @@ describe("piece schema compatibility", () => {
     // atom the runtime matches against the owner before authorizing a write.
     // Losing it there refuses writes that used to be accepted, so the mint is
     // part of the contract on such a node rather than a derived label.
+
     const ownerNode = (mint: boolean): JSONSchema => ({
       type: "object",
       properties: {
@@ -1502,6 +1510,7 @@ describe("piece schema compatibility", () => {
   it("treats `FabricPrimitive` types as subtypes of object (one-way)", () => {
     // A "FabricBytes" source widens safely into an "object" target; the
     // reverse narrows and must be flagged. Same-type stays compatible.
+
     expect(() =>
       assertSchemaSubset({ type: "FabricBytes" }, { type: "object" })
     ).not.toThrow();
@@ -2488,6 +2497,7 @@ describe("piece schema compatibility", () => {
     // update rewrites stored data verbatim -- so any such value would
     // survive the update only to be rejected by every subsequent read.
     // See the note in `schemaSubsetIssue`.
+
     const brand = "@commonfabric/FabricSpecialObject";
     const oldBytes: JSONSchema = {
       type: "object",
@@ -2517,6 +2527,7 @@ describe("piece schema compatibility", () => {
       // subtypes of "object", members are present via `in`, and the brand
       // is exempt for instances). Nothing is stranded, so no allowance is
       // involved -- this holds through the ordinary subset machinery.
+
       expect(() =>
         assertPatternSchemasBackwardCompatible(
           pattern(true, withField(oldBytes)),
@@ -2570,6 +2581,7 @@ describe("verb event closed-world transitions", () => {
   // so open→closed surfaces silent loss as rule 1's typed rejection
   // (accepted-and-STRIPPED was never contract, decided 2026-08-03), and
   // closed→open must stay free for `never`-derived closure cleanup.
+
   const verbPattern = (event: JSONSchema, viaRef = true): Pattern => {
     const argument: JSONSchema = viaRef
       ? {
@@ -2718,6 +2730,7 @@ describe("listing marks are annotation-class", () => {
   // updates. Classified before the generator emits them — the checker
   // equality-compares unknown keywords, so an unclassified mark would be
   // refused in both directions: the C3 append-only lesson.
+
   const verbArgument = (marks: Record<string, unknown>): Pattern =>
     pattern(
       {
@@ -2750,6 +2763,7 @@ describe("listing marks are annotation-class", () => {
   it("still refuses a genuinely unknown keyword (control)", () => {
     // The pin proves classification, not a checker that stopped looking:
     // an unclassified key on the same node is refused exactly as before.
+
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         unmarked,

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -28,6 +28,7 @@ describe("json-faithfulness", () => {
     it("returns an empty list for JSON-faithful shapes", () => {
       // The whitelist: null, booleans, strings, finite numbers other than -0,
       // dense arrays of accepted values, plain objects of accepted values.
+
       const schema = {
         type: "object",
         properties: {
@@ -67,6 +68,7 @@ describe("json-faithfulness", () => {
     it("reports a `bigint`", () => {
       // JSON.stringify throws on a bigint; caught here so the failure names the
       // value rather than surfacing as an opaque serialization error.
+
       const found = findJsonUnfaithfulValues({ default: 42n });
       expect(found).toEqual([{
         pointer: "/default",
@@ -77,6 +79,7 @@ describe("json-faithfulness", () => {
     it("reports `undefined` -- dropped, not a bad number", () => {
       // A blacklist of bad numbers would miss this: `{ default: undefined }`
       // serializes to `{}`, silently losing the default.
+
       const found = findJsonUnfaithfulValues({ default: undefined });
       expect(found).toHaveLength(1);
       expect(found[0]!.pointer).toBe("/default");
@@ -90,6 +93,7 @@ describe("json-faithfulness", () => {
 
     it("reports a sparse array hole (becomes `null`)", () => {
       // A hole is exactly what is under test.
+
       // deno-lint-ignore no-sparse-arrays
       const holed = [1, , 3];
       const found = findJsonUnfaithfulValues({ default: holed });
@@ -112,6 +116,7 @@ describe("json-faithfulness", () => {
     it("reports a non-index property on an array", () => {
       // `JSON.stringify` serializes an array's indices only; an extra own
       // property is dropped. The indices themselves stay faithful.
+
       const withExtra = Object.assign([1, 2], { foo: 3 });
       const found = findJsonUnfaithfulValues({ default: withExtra });
       expect(found).toHaveLength(1);
@@ -122,6 +127,7 @@ describe("json-faithfulness", () => {
     it("reports a _non-enumerable_ non-index property on an array", () => {
       // `JSON.stringify` drops it just the same, so an enumerable-only walk
       // would certify a value that JSON demonstrably mangles.
+
       const withHidden: unknown[] = [1, 2];
       Object.defineProperty(withHidden, "foo", { value: 3, enumerable: false });
 
@@ -135,6 +141,7 @@ describe("json-faithfulness", () => {
     it("does not report an array's own `length` as a dropped property", () => {
       // `length` is a non-index own name on every array, so walking own
       // property names rather than enumerable keys must not start flagging it.
+
       expect(findJsonUnfaithfulValues({ default: [1, 2, 3] })).toHaveLength(0);
     });
 
@@ -142,6 +149,7 @@ describe("json-faithfulness", () => {
       // Such an index is a real element -- `JSON.stringify` emits it -- so
       // it is not an offender even though it is invisible to an
       // enumerable-only walk.
+
       const arr: unknown[] = [1, 2, 3];
       Object.defineProperty(arr, "0", { value: 9, enumerable: false });
 
@@ -152,6 +160,7 @@ describe("json-faithfulness", () => {
     it("reports a `toJSON()` hook, even non-enumerable", () => {
       // `toJSON` replaces the value before JSON sees its contents, so the walk
       // cannot certify what would be sent.
+
       expect(findJsonUnfaithfulValues({ a: 1, toJSON: () => 5 })).toHaveLength(
         1,
       );
@@ -170,6 +179,7 @@ describe("json-faithfulness", () => {
     it("reports a non-plain object (a class instance)", () => {
       // A class instance keeps its data in private fields, so `JSON.stringify`
       // finds nothing to emit. Any class instance is rejected.
+
       class Holder {
         #data = 5;
         get() {
@@ -184,6 +194,7 @@ describe("json-faithfulness", () => {
     it("reports a cycle, but not a shared reference", () => {
       // A shared subtree at sibling positions is fine -- JSON.stringify
       // duplicates it. Only an actual cycle throws, so only that is reported.
+
       const shared = { k: 1 };
       expect(findJsonUnfaithfulValues({ a: shared, b: shared })).toEqual([]);
 
@@ -207,6 +218,7 @@ describe("json-faithfulness", () => {
     it("escapes `~` and `/` in pointer tokens", () => {
       // RFC 6901: `~` -> `~0`, `/` -> `~1`. A property named `a/b` must not
       // read as two path steps.
+
       const found = findJsonUnfaithfulValues({ "a/b~c": NaN });
       expect(found[0]!.pointer).toBe("/a~1b~0c");
     });

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -93,7 +93,6 @@ describe("json-faithfulness", () => {
 
     it("reports a sparse array hole (becomes `null`)", () => {
       // A hole is exactly what is under test.
-
       // deno-lint-ignore no-sparse-arrays
       const holed = [1, , 3];
       const found = findJsonUnfaithfulValues({ default: holed });

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -191,6 +191,7 @@ describe("runtime-processor", () => {
       // createSession({ spaceName }) derives a home-space DID distinct from the
       // acting principal; the session-authorized workspace is a verified member,
       // so its own Space(...) label resolves rather than over-blocking.
+
       const { runtime, storageManager } = createRuntime();
       const sessionSpace = "did:key:z6MkSessionWorkspaceDistinct";
       try {
@@ -234,6 +235,7 @@ describe("runtime-processor", () => {
       // §4.9.3 membership lookup: the helper wires a runtime-backed provider that
       // reads each space's ACL doc. A space whose declared ACL grants the acting
       // user READ resolves; one that does not (no ACL / residency only) blocks.
+
       const { runtime, storageManager } = createRuntime();
       const grantedSpace = "did:key:z6MkGrantedSpaceForRenderTest";
       const deniedSpace = "did:key:z6MkDeniedSpaceForRenderTest";
@@ -630,6 +632,7 @@ describe("runtime-processor", () => {
       // `typeof` is not what says which: it renders an array and `null` alike,
       // as `object`, and those are two of the three kinds that get here. The
       // message exists to explain the refusal, so it names the value.
+
       const space = "did:key:z6Mk-runtime-processor-create" as const;
       const processor = { getSpaceCtx: () => ({}) };
       const refusalFor = async (argument: unknown) => {
@@ -664,6 +667,7 @@ describe("runtime-processor", () => {
       // carries a `FabricBytes` whole, so one reaches this guard as itself
       // rather than as the `{}` a shape-blind copy would leave -- and a piece's
       // entire input is not one value, whatever that value is.
+
       const space = "did:key:z6Mk-runtime-processor-create" as const;
       const processor = { getSpaceCtx: () => ({}) };
 
@@ -698,6 +702,7 @@ describe("runtime-processor", () => {
     it("admits a record that holds a fabric class instance", async () => {
       // The other side of the same line, and the case that has to keep
       // working: the guard asks what the argument *is*, not what it holds.
+
       const space = "did:key:z6Mk-runtime-processor-create" as const;
       const created: unknown[] = [];
       const processor = {
@@ -965,6 +970,7 @@ describe("runtime-processor", () => {
       // the bare routing form; the pageId intake must resolve both to the SAME
       // entity. Without normalization, "of:fid1:H" parses as a hash whose tag
       // is "of:fid1" and silently addresses the nonexistent of:of:fid1:H.
+
       const received: string[] = [];
       const processor = {
         getSpaceCtx: homeSpaceCtx,
@@ -1348,6 +1354,7 @@ describe("runtime-processor", () => {
         // wrong. Each value here is one raw structured clone refuses outright,
         // or one it accepts only by stripping it to something that misdescribes
         // it.
+
         const cyclic: Record<string, unknown> = { n: 1 };
         cyclic.self = cyclic;
         const values: unknown[] = [
@@ -1374,6 +1381,7 @@ describe("runtime-processor", () => {
         // The whole point of encoding rather than naming: the receiver hands
         // these to `console.log()`, and a devtools inspector shows more of a
         // live value than of a name for one.
+
         const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
         const arrived = acrossTheWire({ payload: bytes }) as Record<
           string,
@@ -1424,6 +1432,7 @@ describe("runtime-processor", () => {
       it("returns a query result as its ref together with its data", async () => {
         // Both halves matter: the ref says what the proxy stands for, and the
         // data is what a reader logged it to see.
+
         const { cell, done } = await withCell();
         try {
           const result = toConsoleDebugValue(cell.get()) as Record<
@@ -1441,6 +1450,7 @@ describe("runtime-processor", () => {
       it("returns a query result that holds itself as a cycle", async () => {
         // A query result is a fresh proxy per read, so the rendering has to be
         // stable across the reads for the cycle to be seen as one at all.
+
         const { cell, done } = await withCell();
         try {
           const result = toConsoleDebugValue(cell.get()) as Record<
@@ -1457,6 +1467,7 @@ describe("runtime-processor", () => {
         // The ref and the readable keys all survive one key that does not: a
         // debug dump of a value that is misbehaving is exactly the dump that
         // must still arrive.
+
         const { cell, done } = await withCell();
         try {
           const hostile = new Proxy(cell.get() as Record<string, unknown>, {
@@ -1481,6 +1492,7 @@ describe("runtime-processor", () => {
         // The rendering a proxy is held under is the finished one, so a proxy
         // that fails before its keys can be read reports that failure wherever
         // it appears rather than a half-built record at its later positions.
+
         const { cell, done } = await withCell();
         try {
           const keysThrow = new Proxy(cell.get() as Record<string, unknown>, {
@@ -1549,6 +1561,7 @@ describe("runtime-processor", () => {
       it("returns a `FabricInstance` as its codec's encoding", () => {
         // The conversion descends an instance rather than carrying it, since
         // its contents are not reachable by property name.
+
         const result = toConsoleDebugValue(
           FabricError.fromNativeError(new Error("boom")),
         ) as Record<string, Record<string, unknown>>;
@@ -1569,6 +1582,7 @@ describe("runtime-processor", () => {
         // encode refuses. Producing one takes deliberate effort, so it is not
         // worth a second walk of every console argument to find early; it is
         // left to fail where the encoding is actually done.
+
         const forged = Object.create(FabricBytes.prototype);
         expect(isValidFabricValue(toConsoleDebugValue(forged))).toBe(true);
         expect(() => realmFromFabricValue(toConsoleDebugValue(forged)))
@@ -1578,6 +1592,7 @@ describe("runtime-processor", () => {
       it("returns a unique symbol as its marker", () => {
         // Unlike an interned one, this has no encoding: the description is all
         // that can be said about it on the far side.
+
         expect(toConsoleDebugValue(Symbol("x")))
           .toEqual({ "/uniqueSymbol": "x" });
       });
@@ -1588,6 +1603,7 @@ describe("runtime-processor", () => {
         // Shared, not circular: neither position is inside the other. Reporting
         // the second as a cycle would misdescribe the data the dump exists to
         // show.
+
         const shared = { n: 1 };
         expect(toConsoleDebugValue({ x: shared, y: shared }))
           .toEqual({ x: { n: 1 }, y: { n: 1 } });
@@ -1689,6 +1705,7 @@ describe("runtime-processor", () => {
         // The limit sits above what the old walk reached, because the rendering
         // spends levels of its own on an instance's tag and a query result's
         // ref. Plain data is legible past where it used to stop.
+
         const deep = { l1: { l2: { l3: { l4: { l5: { l6: "leaf" } } } } } };
         expect(toConsoleDebugValue(deep)).toEqual(deep);
       });
@@ -2035,6 +2052,7 @@ describe("runtime-processor", () => {
       // and never starts the pattern directly. A metadata shortcut in front of
       // the controller would skip that repair, and with the flag unset (every
       // default deployment) nothing else heals an aged home root.
+
       const defaultPatternRef: CellRef = {
         id: "of:default-pattern-result" as CellRef["id"],
         space: "did:key:test-home" as CellRef["space"],
@@ -4010,6 +4028,7 @@ describe("runtime-processor", () => {
       // own properties, so the record branch would rebuild one as `{}`. A
       // primitive is atomic and holds no link, so passing it through is the
       // whole answer.
+
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
 
       expect(mapCellRefsToSigilLinks(bytes)).toBe(bytes);
@@ -4026,6 +4045,7 @@ describe("runtime-processor", () => {
       // A tripwire, not a limitation to route around: an instance's codec
       // contents can hold a link that this walk cannot reach, so refusing beats
       // the `{}` the record branch would otherwise produce.
+
       const error = FabricError.fromNativeError(new Error("boom"));
       const message =
         "Cannot yet handle `FabricError` (a `FabricInstance`) when mapping " +
@@ -4041,6 +4061,7 @@ describe("runtime-processor", () => {
   describe("RuntimeProcessor.getLoggerCounts", () => {
     // The handler reads process-global logger state, so each case raises its own
     // flag and clears it again rather than leaving one for the next.
+
     function withFlag(
       metadata: Record<string, unknown>,
       body: () => void,
@@ -4056,6 +4077,7 @@ describe("runtime-processor", () => {
 
     it("carries a raised flag's metadata through to the response", () => {
       // No `this` is read, so the handler runs against a bare receiver.
+
       const processor = {} as unknown as RuntimeProcessor;
 
       withFlag({ a: 1 }, () => {
@@ -4079,6 +4101,7 @@ describe("runtime-processor", () => {
     it("refuses to answer at all when a flag holds unsendable metadata", () => {
       // The assertion is wired into the handler, not merely available beside it:
       // a `Date` raised anywhere in the process stops this read.
+
       const processor = {} as unknown as RuntimeProcessor;
 
       withFlag({ when: new Date(0) }, () => {
@@ -4096,6 +4119,7 @@ describe("runtime-processor", () => {
     it("accepts metadata that vets, and a flag raised without any", () => {
       // A `Logger` takes `Record<string, unknown>` and constrains it no further,
       // so what it holds is established here or not at all.
+
       const flags = {
         runner: {
           "action invalid input": {
@@ -4115,6 +4139,7 @@ describe("runtime-processor", () => {
       // `FabricValue`s being one itself -- so a flag named one of them cannot
       // cross, and saying so is the point rather than a limitation to route
       // around.
+
       const flags = { runner: { constructor: { "id:1": { a: 1 } } } };
 
       expect(() => assertFabricLoggerFlags(flags)).toThrow(
@@ -4125,6 +4150,7 @@ describe("runtime-processor", () => {
     it("throws, rendering what it refused", () => {
       // A `Date` clones perfectly well and is not a `FabricValue`, so it is the
       // shape that would otherwise cross as something the far side cannot read.
+
       const flags = {
         runner: {
           "action invalid input": { "action:bad": { when: new Date(0) } },
@@ -4144,6 +4170,7 @@ describe("runtime-processor", () => {
       // The disposition itself, asserted: dropping the metadata would leave the
       // payload reporting a flag whose contents had silently gone, which is the
       // loss "Death before confusion!" rules out.
+
       const flags = {
         runner: { sample: { "id:1": { fn: () => 0 } } },
       };
@@ -4880,6 +4907,7 @@ describe("runtime-processor", () => {
         // commit durability — rather than runtime.idle() (reactive quiescence
         // only). A fake exposing ONLY idleWithPendingCommits pins the wiring: a
         // regression to runtime.idle() throws here.
+
         const handleIdle = (RuntimeProcessor.prototype as any).handleIdle;
         let calls = 0;
         const fake = {
@@ -5257,6 +5285,7 @@ describe("runtime-processor", () => {
     // Base the fake on the real prototype so handleNotification's delegation to
     // handleVDomEvent / handleVDomBatchApplied resolves, while vdomMounts is a
     // stub that records what the reconciler is asked to do.
+
     function fakeProcessor() {
       const events: Array<{ handlerId: number; event: unknown }> = [];
       const acks: number[] = [];
@@ -5320,6 +5349,7 @@ describe("runtime-processor", () => {
     // `getPatternSources` reads two things: which patterns the graph is running,
     // and each one's program. Everything else on the runtime is beside the point
     // here, so the processor is those two answers and nothing more.
+
     const processorOver = (
       programs: Record<string, unknown>,
     ): RuntimeProcessor =>

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -367,6 +367,7 @@ describe("cell-handle", () => {
       // `toSigilLink()` is for a caller that has recognized the handle, and
       // `toJSON()` for the protocol that reaches one without recognizing it.
       // They are two names, not two answers.
+
       const runtime = {
         [$conn]: () => ({
           request: () => Promise.resolve({}),
@@ -733,6 +734,7 @@ describe("cell-handle", () => {
     // `$alias` records are Pattern-binding vocabulary, only meaningful inside
     // Pattern objects the client never interprets. In data they are inert plain
     // values: hydration must not turn them into CellHandles (PR #4895).
+
     const makeRuntime = () =>
       ({
         [$conn]: () => ({
@@ -824,6 +826,7 @@ describe("cell-handle", () => {
     it("does not re-notify on an unchanged NaN value", () => {
       // Value equality is `Object.is`-based: `NaN` equals itself, so a
       // delivery repeating a NaN-bearing value is not a change.
+
       const cell = new CellHandle<number>(makeRuntime(), ref);
       const calls: Array<number | undefined> = [];
       cell.subscribe((value) => {
@@ -853,6 +856,7 @@ describe("cell-handle", () => {
       // Two `FabricBytes` over different bytes are different values, and their
       // state is private -- so a walk over enumerable own properties sees `{}`
       // on both sides and would call them equal.
+
       const cell = new CellHandle<FabricBytes>(makeRuntime(), ref);
       const calls: Array<unknown> = [];
       cell.subscribe((value) => {
@@ -871,6 +875,7 @@ describe("cell-handle", () => {
       // an instance out of a cell is this refusal rather than a lossy arrival.
       // It is `applyValue()`'s, and it runs first, which is why the comparison
       // after it needs no arm of its own.
+
       const cell = new CellHandle<unknown>(makeRuntime(), ref);
       cell.subscribe(() => {});
       const link = new FabricLink(
@@ -886,6 +891,7 @@ describe("cell-handle", () => {
       // A handle holds its state privately, so a walk over enumerable own
       // properties reads `{}` off it -- equal to any other key-less object,
       // `{}` included, which would drop the update and tell no subscriber.
+
       const cell = new CellHandle<{ a: unknown }>(makeRuntime(), ref);
       const calls: Array<unknown> = [];
       cell.subscribe((value) => {
@@ -906,6 +912,7 @@ describe("cell-handle", () => {
     it("notifies on a 0 -> -0 change", () => {
       // `0` and `-0` are distinct stored values (the content hash
       // distinguishes them); the update must not be dropped.
+
       const cell = new CellHandle<number>(makeRuntime(), ref);
       const calls: Array<number | undefined> = [];
       cell.subscribe((value) => {
@@ -2344,6 +2351,7 @@ describe("cell-handle", () => {
       // A leaf: stopping at it is the whole job, and it must be stopped at
       // before the record branch, which would rebuild it from enumerable own
       // properties it does not have and yield `{}`.
+
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
 
       expect(CellHandle.deserialize(makeHandle(), bytes)).toBe(bytes);
@@ -2358,6 +2366,7 @@ describe("cell-handle", () => {
       // A container, reached by its codec contents rather than by property
       // name, so a sigil link can sit inside one where this walk cannot see
       // it. Nothing delivers one today; this is the tripwire.
+
       const link = new FabricLink(
         Object.freeze({ id: "of:fid1:hydration-refusal", path: [] }),
       );
@@ -2404,6 +2413,7 @@ describe("cell-handle", () => {
     it("returns one nested in a record as itself", () => {
       // The branch this has to precede is the record one, so the nested
       // position is the case that pins the ordering rather than the check.
+
       const nsec = new FabricEpochNsec(1n);
 
       const wire = CellHandle.serialize({ a: { b: nsec } }) as {
@@ -2426,6 +2436,7 @@ describe("cell-handle", () => {
       // the worker sent, and its record branch rebuilds from enumerable own
       // properties a fabric class does not have -- so without the same
       // ordering the value the connection just carried whole arrives as `{}`.
+
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
       const handle = new CellHandle(makeRuntime(), makeRef());
 
@@ -2454,6 +2465,7 @@ describe("cell-handle", () => {
       // by property name, so a cell can sit inside one where these walks
       // cannot see it -- passing one through would send a handle unconverted,
       // or hand back a link where a handle belongs. Death before confusion.
+
       const link = new FabricLink(
         Object.freeze({ id: "of:fid1:instance-refusal", path: [] }),
       );
@@ -2471,6 +2483,7 @@ describe("cell-handle", () => {
     it("returns a `bigint` and a `symbol` as themselves", () => {
       // Both are `FabricValue` arms that the connection used to refuse
       // outright, for want of anywhere to put them.
+
       const marker = Symbol.for("a-marker");
 
       expect(CellHandle.serialize(7n)).toBe(7n);
@@ -2484,6 +2497,7 @@ describe("cell-handle", () => {
       // so it survives a connection that carries the class. Pinned to the
       // whole message, situation string included, which is what says the
       // refusal goes through the shared helper every other site uses.
+
       expect(() =>
         CellHandle.serialize(FabricError.fromNativeError(new Error("boom")))
       ).toThrow(
@@ -2501,6 +2515,7 @@ describe("cell-handle", () => {
       // dropped entirely. Carrying a _present_ `undefined` is one of the
       // properties a `FabricValue` has and a `JSONValue` does not, which makes
       // it the half of this fixture most worth actually asserting.
+
       expect(CellHandle.serialize({ a: 1, b: [true, null], c: undefined }))
         .toStrictEqual({ a: 1, b: [true, null], c: undefined });
     });
@@ -2544,6 +2559,7 @@ describe("cell-handle", () => {
       // synchronously out of `request()`, before there is a promise for any
       // `.catch()` to attach to. What each path *carries* is pinned
       // separately, below.
+
       const sends: number[] = [];
       const cell = new CellHandle<unknown>(encodingRuntime(sends), ref);
 
@@ -2567,6 +2583,7 @@ describe("cell-handle", () => {
       // who tightened `#applyLocalAndSend()` to serialize-then-send-then-apply
       // would be changing what a subscriber sees, not just where a throw comes
       // from.
+
       const cell = new CellHandle<unknown>(encodingRuntime(), ref);
       const seen: unknown[] = [];
       cell.subscribe((value) => {
@@ -2589,6 +2606,7 @@ describe("cell-handle", () => {
       // A push is optimistic while its mergeable write is in flight, but a
       // refused or unencodable request restores the authoritative base. The
       // strict form exposes that refusal to its caller.
+
       const cell = new CellHandle<unknown[]>(encodingRuntime(), ref);
       cell[$onCellUpdate]([1]);
       const seen: unknown[] = [];
@@ -2671,6 +2689,7 @@ describe("cell-handle", () => {
       // Not an object, so the `FabricSpecialObject` branch never sees it. It
       // is a `FabricValue` arm all the same, and the encoding carries one as
       // itself rather than as the `1` its text would suggest.
+
       const requests: Array<{ value?: unknown }> = [];
       const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
 

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -191,6 +191,7 @@ Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed field
   // Array element node building via type-driven shrinking (Array<T> reference).
   // Lines ~1185-1202, 1194-1199: TypeReference to `Array` resolved through the
   // checker, element shrunk, array node rebuilt.
+
   const { sourceFile, checker } = createProgram(`
     type Item = { id: string; title: string; unused: number };
     type Input = Array<Item>;
@@ -226,6 +227,7 @@ Deno.test("applyShrinkAndWrap collapses length-only Array<T> reads to unknown[]"
   // length-only access on an Array<T> reference emits unknown[] (array-root
   // only path). Exercises the `allNonItem` array branch in the node-driven
   // path.
+
   const { sourceFile, checker } = createProgram(`
     type Item = { id: string; title: string };
     type Input = Array<Item>;
@@ -252,6 +254,7 @@ Deno.test("applyShrinkAndWrap shrinks each member of a source-authored union", (
   // Union of object shapes: shrink each non-nullish member; nullish member
   // preserved. Exercises the union branch in buildShrunkTypeNodeFromTypeNode
   // (lines ~1278-1301) via a source-authored union node.
+
   const { sourceFile, checker } = createProgram(`
     type Input =
       | { shared: string; onlyA: number }
@@ -282,6 +285,7 @@ Deno.test("applyShrinkAndWrap collapses a shrunk union to its single non-nullish
   // Union `T | undefined` where only one member holds the accessed property.
   // After shrinking the non-nullish member, a single member remains and the
   // union collapses to that member (line ~1299-1301 `all.length === 1`).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { keep: string; drop: number };
   `);
@@ -317,6 +321,7 @@ Deno.test("applyShrinkAndWrap re-appends undefined when type-driven shrinking a 
   // Type-driven union nullish re-wrapping (buildShrunkTypeNodeFromType,
   // ~856-895) and line 888 (`nullishMembers.length === 0` short-circuit not
   // taken). Drive with a synthetic base node to force the type-driven path.
+
   const { sourceFile, checker } = createProgram(`
     type Payload = { keep: string; drop: number };
     type Input = Payload | undefined;
@@ -353,6 +358,7 @@ Deno.test("applyShrinkAndWrap keeps nested primitive leaves intact under type-dr
   // Nested primitive leaf on a type-driven shrink: `text.length` keeps the
   // string leaf intact instead of shrinking `text` to `{ length }` (lines
   // ~934-962 primitive-scalar branch through the type-driven path).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { text: string; other: number };
   `);
@@ -386,6 +392,7 @@ Deno.test("applyShrinkAndWrap represents index-signature access as an optional m
   // is not a named property resolves through the index signature and the
   // emitted member is optional (lines ~913-936: `isOptional = true`,
   // `984-989`).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { [key: string]: { name: string; unused: number } };
   `);
@@ -417,6 +424,7 @@ Deno.test("applyShrinkAndWrap resolves an interface reference and drops unaccess
   // isUnchangedShrink: a TypeReference whose members are all accessed with no
   // nested change is kept as the original reference to preserve $ref/$defs
   // (lines ~1453-1474 return `node`).
+
   const { sourceFile, checker } = createProgram(`
     interface Point { x: number; y: number; z: number; }
     type Input = Point;
@@ -449,6 +457,7 @@ Deno.test("applyShrinkAndWrap merges inherited interface members and honors over
   // inherited members that are merged and de-duplicated (mergeResolvedMembers,
   // ~1416-1442; resolveMembersFromDeclaration heritage branch ~1388-1414). An
   // overriding property in the derived interface wins.
+
   const { sourceFile, checker } = createProgram(`
     interface Base { shared: string; baseOnly: number; }
     interface Derived extends Base { shared: string; derivedOnly: boolean; }
@@ -479,6 +488,7 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for unknown base with 
   // Diagnostics: unknown base type with property access reports
   // schema:unknown-type-access (lines ~1876-1893). Driven through
   // applyShrinkAndWrap with a context + fnNode so validateShrinkCoverage runs.
+
   const { sourceFile, checker } = createProgram(`
     type Input = unknown;
   `);
@@ -514,6 +524,7 @@ Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", 
   // Diagnostics: concrete type but an accessed path is absent reports
   // schema:path-not-in-type (lines ~1938-1954, and the missing filter
   // 1939-1941).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { present: string };
   `);
@@ -547,6 +558,7 @@ Deno.test("applyShrinkAndWrap reports path-not-in-type for a missing property", 
 Deno.test("applyShrinkAndWrap reports unknown-typed property access", () => {
   // Diagnostics: concrete type with a property typed `unknown` reports
   // schema:unknown-type-access (case 2, lines ~1900-1935).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { amounts: unknown };
   `);
@@ -581,6 +593,7 @@ Deno.test("applyShrinkAndWrap skips validation for a never base type", () => {
   // Diagnostics: `never` base type skips validation entirely (lines
   // ~1857-1862). A `never`-typed parameter with reads must produce no
   // diagnostics.
+
   const { sourceFile, checker } = createProgram(`
     type Input = never;
   `);
@@ -611,6 +624,7 @@ Deno.test("applyShrinkAndWrap reports unknown-type-access for an unknown wildcar
   // Diagnostics: wildcard param typed `unknown` passed to an opaque function
   // reports the wildcard-specific unknown-type-access branch (lines
   // ~1733-1750).
+
   const { sourceFile, checker } = createProgram(`
     type Input = unknown;
   `);
@@ -644,6 +658,7 @@ Deno.test("applyShrinkAndWrap validates array item paths against the element typ
   // Validation over an array base: item-level paths validate against the
   // element type. A missing item property reports through the array-element
   // recursion (lines ~1795-1833, getArrayElementTypeNode paths ~1656-1709).
+
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; }
     type Input = Row[];
@@ -679,6 +694,7 @@ Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base typ
   // gets applied to the fallback shape when the direct node application misses.
   // Also exercises applyCapabilityDefaultsToTypeNode fallback (~2919-2945) and
   // buildDefaultsOnlyFallbackPaths leaf expansion (~2954-2956, 3001-3026).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { title: string; count: number };
     type TitleDefault = "Untitled";
@@ -712,6 +728,7 @@ Deno.test("applyShrinkAndWrap applies defaults-only fallback across the base typ
 Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple index", () => {
   // applyCapabilityDefaultsToTypeNode: default applied directly through a tuple
   // index (applySingleDefaultToTypeNode tuple branch ~2825-2850).
+
   const { sourceFile, checker } = createProgram(`
     type Input = [{ name?: string }, number];
     type NameDefault = "Anon";
@@ -742,6 +759,7 @@ Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a tuple i
 Deno.test("applyCapabilityDefaultsToTypeNode ignores an out-of-range tuple index", () => {
   // applyCapabilityDefaultsToTypeNode: out-of-range tuple index leaves the node
   // unchanged (tuple guard ~2827-2831). No __cfHelpers.Default wrapper appears.
+
   const { sourceFile, checker } = createProgram(`
     type Input = [{ name?: string }];
     type NameDefault = "Anon";
@@ -769,6 +787,7 @@ Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", ()
   // Identity-only root on a union base: each union member is replaced with the
   // identity-only shape; nullish members are rebuilt as-is
   // (createIdentityOnlyRootTypeNode union branch ~2367-2400).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { a: string } | { b: number } | undefined;
   `);
@@ -805,6 +824,7 @@ Deno.test("applyShrinkAndWrap replaces identity-only union roots per member", ()
 Deno.test("applyShrinkAndWrap rebuilds an identity-only nullish root as undefined", () => {
   // Identity-only root that is nullish (`undefined`): rebuilt via
   // createIdentityOnlyNullishTypeNode (lines ~2357-2365, 2311-2331).
+
   const { sourceFile, checker } = createProgram(`
     type Input = undefined;
   `);
@@ -831,6 +851,7 @@ Deno.test("applyShrinkAndWrap descends identity item paths through Array<T> refe
   // Identity paths descending through an array item interface reference
   // resolved via the checker (applyIdentityOnlyPathsToTypeNode Array<T> ref
   // branch ~2557-2583) using an Array<T> reference (not `T[]`).
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -863,6 +884,7 @@ Deno.test("applyShrinkAndWrap applies identity paths across union members", () =
   // Identity paths through a union base node (applyIdentityOnlyPathsToTypeNode
   // union branch ~2728-2752): each union member is visited and changed members
   // force a rebuilt union.
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -901,6 +923,7 @@ Deno.test("applyShrinkAndWrap keeps an interface reference when no identity path
   // child path) so the `!changed` early return keeps the reference
   // (applyIdentityOnlyPathsToTypeNode reference branch ~2669-2725, unchanged
   // return ~2721-2723).
+
   const { sourceFile, checker } = createProgram(`
     interface Outer { inner: { keep: string }; other: string; }
     type Input = Outer;
@@ -930,6 +953,7 @@ Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized li
   // applyCellCapabilityPathsToTypeNode through a parenthesized type node
   // (~2181-2193) plus per-property cell capability selection where read+write
   // paths on the same leaf select `writable`.
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type Writable<T> = { readonly value?: T };
@@ -969,6 +993,7 @@ Deno.test("applyShrinkAndWrap keeps Array<T> unchanged for an unresolved identit
   // Identity item path on an Array<T> reference that names no member leaves the
   // whole array reference unchanged (Array<T> ref `updated === inner`
   // ~2574-2576).
+
   const { sourceFile, checker } = createProgram(`
     interface Item { keep: string; }
     type Input = Array<Item>;
@@ -996,6 +1021,7 @@ Deno.test("applyShrinkAndWrap keeps a readonly array unchanged for an unresolved
   // Identity item path on a readonly array that names no member leaves the
   // readonly-array node unchanged (readonly-array `updated === elementType`
   // ~2546-2548).
+
   const { sourceFile, checker } = createProgram(`
     interface Item { keep: string; }
     type Input = readonly Item[];
@@ -1029,6 +1055,7 @@ Deno.test("applyShrinkAndWrap rebuilds a parenthesized identity root when a leaf
   // Identity path through a parenthesized literal that DOES change a leaf: the
   // parenthesized wrapper is rebuilt around the updated inner
   // (createIdentityOnly paren branch ~2485-2498, change arm).
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -1061,6 +1088,7 @@ Deno.test("applyShrinkAndWrap descends identity paths through a Cell-like wrappe
   // Identity path through a Cell-like wrapper reference descends into the inner
   // type argument (applyIdentityOnlyPathsToTypeNode cell-ref branch
   // ~2642-2667).
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type OpaqueCell<T> = { readonly opaque?: T };
@@ -1098,6 +1126,7 @@ Deno.test("applyShrinkAndWrap recognizes an array type-alias reference as array-
   // array detection (buildShrunkTypeNodeFromTypeNode ~1086-1096, 1185-1202).
   // The alias reference is recognized as array-shaped and preserved as a
   // reference so schema generation keeps its $ref.
+
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; title: string; unused: number; }
     type Rows = Row[];
@@ -1126,6 +1155,7 @@ Deno.test("applyShrinkAndWrap shrinks array-like type literals with numeric inde
   // Array-like TypeLiteral (numeric index + length) drives the
   // getArrayLikeTypeLiteralElementType path (~557-577) and element shrinking of
   // a literal element node (~565-567). Item field access shrinks the element.
+
   const { sourceFile, checker } = createProgram(`
     type Input = {
       length: number;
@@ -1158,6 +1188,7 @@ Deno.test("applyShrinkAndWrap resolves a union-only property during type-driven 
   // findPropertySymbol resolves a property that lives only on one union
   // constituent (findPropertySymbol union recursion ~684-689) during
   // type-driven shrinking of a union base node.
+
   const { sourceFile, checker } = createProgram(`
     type Input = { common: string } & ({ onlyHere: number } | { alt: boolean });
   `);
@@ -1189,6 +1220,7 @@ Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven 
   // (buildShrunkTypeNodeFromType `!shrunkChild && !hasDirectAccess` continue,
   // ~978-989 region). Access a valid head plus an invalid deep path on the same
   // property.
+
   const { sourceFile, checker } = createProgram(`
     type Input = { data: { present: string }; other: number };
   `);
@@ -1218,6 +1250,7 @@ Deno.test("applyShrinkAndWrap drops an unresolved deep child during type-driven 
 Deno.test("applyCapabilityDefaultsToTypeNode applies a default through a union member", () => {
   // applyCapabilityDefaultsToTypeNode applies a default through a union member
   // (applySingleDefaultToTypeNode union branch ~2852-2870).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { a?: string } | { b?: number };
     type ADefault = "x";
@@ -1247,6 +1280,7 @@ Deno.test("applyShrinkAndWrap expands nested defaults-only fallback leaves", () 
   // fallback path builder expands the child's leaves so the default lands
   // (buildDefaultsOnlyFallbackPaths nested-head expansion ~2954-2956,
   // 3009-3026).
+
   const { sourceFile, checker } = createProgram(`
     type Input = { group: { title: string; note: string }; count: number };
     type TitleDefault = "Untitled";
@@ -1283,6 +1317,7 @@ Deno.test("applyShrinkAndWrap replaces an identity-only root that has no resolva
   // Identity-only root whose resolved semantic type is undefined falls back to
   // the replacement type node (createIdentityOnlyRootTypeNode `!resolvedType`
   // branch ~2345-2354) — driven by a synthetic node with no base type.
+
   const { sourceFile, checker } = createProgram(`type Marker = string;`);
   // A synthetic reference to a name that resolves to nothing under noLib.
   const syntheticNode = ts.factory.createTypeReferenceNode("Unresolvable");
@@ -1309,6 +1344,7 @@ Deno.test("applyShrinkAndWrap selects writable capability for read-and-write cel
   // Cell-capability application over a plain object literal member whose value
   // is a cell wrapper (applyCellCapabilityPathsToTypeNode literal member branch
   // ~2199-2264): a read+write access selects the `writable` capability.
+
   const { sourceFile, checker } = createProgram(`
     declare namespace __cfHelpers {
       export type Writable<T> = { readonly value?: T };
@@ -1349,6 +1385,7 @@ Deno.test("applyShrinkAndWrap accepts item paths present on a nullable array uni
   // no diagnostic, exercising getArrayElementTypeNode's union branch
   // (~1643-1657): the nullish member is skipped and the array member yields the
   // element type.
+
   const { sourceFile, checker } = createProgram(`
     interface Row { id: string; }
     type Input = Row[] | undefined;
@@ -1383,6 +1420,7 @@ Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk me
   // member (buildShrunkTypeNodeFromTypeNode union `all.length === 1`
   // ~1298-1301). A one-element union node with one accessed property drives the
   // collapse.
+
   const { sourceFile, checker } = createProgram(`
     type Input = { keep: string; drop: number };
   `);
@@ -1414,6 +1452,7 @@ Deno.test("applyShrinkAndWrap collapses a one-member union node to the shrunk me
 Deno.test("applyShrinkAndWrap leaves an all-nullish union node unchanged", () => {
   // A union node with only nullish members is returned unchanged
   // (buildShrunkTypeNodeFromTypeNode `nonNullish.length === 0` ~1278).
+
   const { sourceFile, checker } = createProgram(`type Input = string;`);
   const nullOnly = ts.factory.createUnionTypeNode([
     ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
@@ -1451,6 +1490,7 @@ Deno.test("applyCapabilityDefaultsToTypeNode ignores a tuple default whose neste
   // A valid tuple index whose nested default path does not resolve leaves the
   // tuple unchanged (applySingleDefaultToTypeNode tuple `!updatedChild.applied`
   // arm ~2841-2843).
+
   const { sourceFile, checker } = createProgram(`
     type Input = [{ present?: string }];
     type D = "x";

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -186,6 +186,7 @@ describe("CFCodeEditor reference-map housekeeping", () => {
     it("returns the map's keys and the document's together", () => {
       // A key pasted into the text is spoken for even before the map has it,
       // and minting over it would point two mentions at one entry.
+
       const { self } = editorThis(`[A][${OTHER}]`, { [KEY]: {} });
       expect(call("_takenRefKeys", self)).toEqual(new Set([KEY, OTHER]));
     });
@@ -202,6 +203,7 @@ describe("CFCodeEditor reference-map housekeeping", () => {
     it("keeps a key it never saw at load", () => {
       // Another editor added it while this one was open; this editor has no
       // reason to believe it was ever in its document.
+
       const t = editorThis("no tokens left", { [KEY]: {} });
       call("_collectUnreferencedRefEntries", t.self);
       expect(t.deleted).toEqual([]);
@@ -217,6 +219,7 @@ describe("CFCodeEditor reference-map housekeeping", () => {
     it("collects nothing against a document that has not loaded", () => {
       // An empty document names nothing, which is not the same as a document
       // that names nothing — reading it as the latter empties the map.
+
       const t = editorThis("", { [KEY]: {} });
       (t.self._refKeysAtLoad as Set<string>).add(KEY);
       call("_collectUnreferencedRefEntries", t.self);
@@ -227,6 +230,7 @@ describe("CFCodeEditor reference-map housekeeping", () => {
       // The deletion that made the entry collectable is still in the
       // debounce; losing it after the entry is gone leaves a token with no
       // destination in the durable document.
+
       const t = editorThis("no tokens left", { [KEY]: {} });
       (t.self._refKeysAtLoad as Set<string>).add(KEY);
       call("_collectUnreferencedRefEntries", t.self);
@@ -310,6 +314,7 @@ describe("CFCodeEditor pasted-mention decision", () => {
     // name a piece. Preventing the paste and then declining swallowed it.
     // The space is a DID on purpose: a named space is refused one check
     // earlier, so this would not reach the branch under test.
+
     const result = paste(
       pasteThis(),
       `https://fabric.example/${SPACE}/my-note`,

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -38,6 +38,7 @@ describe("objects", () => {
 
       it("accepts a key whose value is `undefined`", () => {
         // A present key holding `undefined` is still an enumerable string key.
+
         expect(isInertPlainObject({ a: undefined }))
           .toBe(true);
       });
@@ -45,6 +46,7 @@ describe("objects", () => {
       it("accepts an index-shaped string key", () => {
         // Unlike an array, an object has no notion of an index key; `"0"` is
         // just a string name here.
+
         expect(isInertPlainObject({ 0: "a", 1: "b" }))
           .toBe(true);
       });
@@ -76,6 +78,7 @@ describe("objects", () => {
       it("rejects a registry-interned symbol-keyed property", () => {
         // Such a symbol is a valid fabric *value*, but still not a property
         // *name*.
+
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol.for("s")] = 2;
         expect(isInertPlainObject(obj)).toBe(false);
@@ -95,6 +98,7 @@ describe("objects", () => {
 
       it("rejects a non-enumerable string key whose value is `undefined`", () => {
         // The key's presence is what disqualifies it, not what it holds.
+
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", {
           value: undefined,
@@ -140,6 +144,7 @@ describe("objects", () => {
 
       it("rejects a frozen object with a getter", () => {
         // Freezing does not make an accessor inert: reads still execute it.
+
         const obj = { a: 1 };
         Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
         expect(isInertPlainObject(Object.freeze(obj)))
@@ -185,6 +190,7 @@ describe("objects", () => {
         // would mean carrying a distinction that stops existing at the first
         // storage boundary. `shallowCleanPlainObject()` is how a caller says
         // it means to shed one.
+
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
         expect(isInertPlainObject(obj)).toBe(false);
@@ -215,6 +221,7 @@ describe("objects", () => {
     it("sees through a `Proxy` to its target's shape", () => {
       // `Object.getPrototypeOf` and the key traps forward to the target, so a
       // pass-through proxy over a plain object is judged on the target.
+
       expect(
         isInertPlainObject(new Proxy({ a: 1 }, {})),
       ).toBe(true);
@@ -231,6 +238,7 @@ describe("objects", () => {
       // then returns `undefined` for. Inertness cannot be established, so the
       // answer is `false`; only a trap that throws on its own account takes
       // this check off its "answers rather than throws" contract.
+
       const ghosted = new Proxy({ a: 1 }, {
         ownKeys: () => ["a", "ghost"],
         getOwnPropertyDescriptor: (target, key) =>
@@ -268,6 +276,7 @@ describe("objects", () => {
     it("agrees with `constructorOfObject()` on the same object", () => {
       // The two are one question asked from two places, so an object's answer
       // must not depend on which of them was asked.
+
       for (
         const value of [{}, [], new Map(), new Date(), Object.create(null)]
       ) {
@@ -294,6 +303,7 @@ describe("objects", () => {
     it("returns the class of an instance whose prototype was replaced", () => {
       // The prototype is the whole of the answer, so re-pointing it re-points
       // the answer -- which is the property, not a wrinkle in it.
+
       const value = Object.setPrototypeOf({}, Map.prototype);
       expect(constructorOfObject(value)).toBe(Map);
     });
@@ -303,6 +313,7 @@ describe("objects", () => {
       // that happens to share a name with the thing that decides a class, and a
       // caller dispatching on the answer would otherwise let a plain record pass
       // for whatever it named.
+
       for (
         const [label, forged] of [
           ["`Error`", Error],

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -116,6 +116,7 @@ describe("check-command-docs", () => {
     it("returns no entry for the help cliffy propagates to every command", () => {
       // It is generated onto every descendant, so it is nobody's command and
       // no document owes it prose.
+
       const tree = new Command().name("cf").command(
         "brew",
         new Command().description("d"),
@@ -128,6 +129,7 @@ describe("check-command-docs", () => {
       // real tree hides `completion complete` and every installed completion
       // function invokes it on every Tab. A gate that walked past it would
       // report a count having never asked about the last command.
+
       const tree = new Command()
         .name("cf")
         .command("brew", new Command().description("make a glaze"))
@@ -141,6 +143,7 @@ describe("check-command-docs", () => {
     it("walks into a hidden command's own subcommands", () => {
       // The hidden one is a group in the real tree, and its child is the
       // command that actually runs.
+
       const tree = new Command().name("cf").command(
         "completion",
         new Command()
@@ -165,6 +168,7 @@ describe("check-command-docs", () => {
     it("reads a path spelled with either separator", () => {
       // The rules are written in slashes and the path arrives in the host's
       // separator, so a Windows spelling has to reach the same verdict.
+
       expect(isLiveDoc("docs/guide.md", packageDocs)).toBe(true);
       expect(isLiveDoc("docs\\guide.md", packageDocs)).toBe(true);
       expect(isLiveDoc("docs/history/report.md", packageDocs)).toBe(false);
@@ -178,6 +182,7 @@ describe("check-command-docs", () => {
       // A dependency's own README travels with the dependency. Without this
       // rule a vendored copy under `docs/` would read as live documentation,
       // and a command named in it would satisfy the gate.
+
       expect(isLiveDoc("docs/node_modules/dep/README.md", packageDocs))
         .toBe(false);
       expect(isLiveDoc("skills/cf/node_modules/dep/guide.md", packageDocs))
@@ -190,6 +195,7 @@ describe("check-command-docs", () => {
     it("takes a README under a package to be the package's own or nothing", () => {
       // A fixture corpus and a test directory keep READMEs of their own, and
       // neither is somewhere a caller is sent to read.
+
       expect(isLiveDoc("packages/oven/README.md", packageDocs)).toBe(true);
       expect(isLiveDoc("packages/oven/test/README.md", packageDocs))
         .toBe(false);
@@ -232,6 +238,7 @@ describe("check-command-docs", () => {
       // A config without the key is not a config with an empty one by
       // accident: no member means no package README counts, and the walk
       // simply finds nothing under `packages/`.
+
       const root = await Deno.makeTempDir();
       try {
         await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "tasks": {} }`);
@@ -245,6 +252,7 @@ describe("check-command-docs", () => {
       // The member list is data from a file, so a malformed entry is a
       // possibility rather than a type error. It contributes no README
       // instead of a `[object Object]/README.md` that matches nothing.
+
       const root = await Deno.makeTempDir();
       try {
         await Deno.writeTextFile(
@@ -265,6 +273,7 @@ describe("check-command-docs", () => {
 
     it("needs a boundary before the command as well as after it", () => {
       // Otherwise a word ending in the command's letters names it.
+
       expect(commandPattern("brew", commands).test("Run `cf brew`.")).toBe(
         true,
       );
@@ -279,6 +288,7 @@ describe("check-command-docs", () => {
     it("does not let a child stand in for the parent it hangs under", () => {
       // A reader looking up `cf glaze` finds nothing about it in a document
       // that only ever writes `cf glaze set`.
+
       const glaze = commandPattern("glaze", commands);
       expect(glaze.test("Run `cf glaze set` first.")).toBe(false);
       expect(glaze.test("Run `cf glaze setsrc` first.")).toBe(false);
@@ -327,6 +337,7 @@ describe("check-command-docs", () => {
     it("does not let a longer command satisfy a shorter one", async () => {
       // `cf glaze setsrc` is its own command with its own obligation, so it
       // must not stand in for `cf glaze set`.
+
       await withDocs({ "docs/guide.md": "Run `cf glaze setsrc`." }, async (
         root,
       ) => {
@@ -346,6 +357,7 @@ describe("check-command-docs", () => {
     it("ignores a record of a moment rather than a description", async () => {
       // A command named only in an archived report or a pending plan is not
       // documented: neither describes a surface a reader can use today.
+
       await withDocs({
         "docs/history/report.md": "We ran `cf brew` in July.",
         "docs/plans/later.md": "`cf brew` will gain a flag.",
@@ -357,6 +369,7 @@ describe("check-command-docs", () => {
     it("does not take an instruction written for an agent as documentation", async () => {
       // `.claude/` addresses one agent mid-task. A command it is told to run
       // is still a command no caller can look up, so it covers nothing.
+
       await withDocs({
         ".claude/agents/baker.md": "Run `cf brew` before you glaze.",
         "skills/baking/SKILL.md": "`cf glaze set` picks the flavor.",
@@ -381,6 +394,7 @@ describe("check-command-docs", () => {
       // checkout behaves. A root that exists and cannot be walked is a
       // different fact: reading past it would silently drop every document
       // it holds and report the commands they name as undocumented.
+
       const root = await Deno.makeTempDir();
       try {
         await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "workspace": [] }`);
@@ -395,6 +409,7 @@ describe("check-command-docs", () => {
 
     it("reads the package's own README and not an internal one", async () => {
       // A fixture corpus documents the fixtures, for whoever maintains them.
+
       await withDocs({
         "packages/oven/README.md": "`cf brew` heats the glaze.",
         "packages/oven/test/fixtures/README.md": "`cf glaze set` here too.",
@@ -429,6 +444,7 @@ describe("check-command-docs", () => {
 
     it("names an allowance for a command the tree no longer accepts", () => {
       // A recorded decision cannot outlive the thing it was about.
+
       const allowed = new Map([["retired", "gone"]]);
       expect(
         reportCommandDocs(declared, new Set(declared), allowed).staleAllowance,
@@ -459,6 +475,7 @@ describe("check-command-docs", () => {
     it("returns 0 for the CLI's own command tree", async () => {
       // The gate itself. Every command the CLI accepts is described in a live
       // document, or recorded as deliberately without prose.
+
       expect(await main()).toBe(0);
     });
 
@@ -473,6 +490,7 @@ describe("check-command-docs", () => {
       // Against a root holding no documents at all, every command the CLI
       // declares is undocumented — which is the shape of the failure a real
       // one takes, one command at a time.
+
       const { code, err } = await withFailure();
       expect(code).toBe(1);
       expect(err).toContain("Command documentation check failed.");
@@ -489,6 +507,7 @@ describe("check-command-docs", () => {
     it("lists the undocumented commands and succeeds when asked for the list", async () => {
       // `--list` is the working view: it answers what is undocumented
       // without failing, so the list can be read while it is worked through.
+
       let captured = { code: -1, out: "", err: "" };
       await withEmptyRoot(async (root) => {
         captured = await captureConsole(() => main(["--list"], root));
@@ -524,6 +543,7 @@ describe("check-command-docs", () => {
     it("exits 0 printing nothing to list when every command is documented", async () => {
       // The gate is green on this repository, so the working view is empty —
       // and an empty list is a result, not a silence to be read as an error.
+
       const { code, out } = await runAsProgram("--list");
       expect(code).toBe(0);
       expect(out.trim()).toBe("");

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -175,6 +175,7 @@ describe("check-completion-slots", () => {
     it("names the commands a scoped provider does not answer on", () => {
       // A provider restricted to one command answers nothing on the other, so
       // the slot there is as silent as one with no entry at all.
+
       expect(
         reportFor({ providerOptions: { from: ["clone"] } }, twoMeaningsTree())
           .undecidedOptions,
@@ -184,6 +185,7 @@ describe("check-completion-slots", () => {
     it("takes no bare allowance for an option a provider answers somewhere", () => {
       // `--from` has candidates on `clone`, so a bare allowance saying it has
       // none is false wherever it is read; the other command needs its own.
+
       const bare = reportFor(
         { providerOptions: { from: ["clone"] }, allowedOptions: ["from"] },
         twoMeaningsTree(),
@@ -214,6 +216,7 @@ describe("check-completion-slots", () => {
     it("names a provider entry that matches no slot on the tree", () => {
       // The same subtraction the other way: this is what found `log-file` and
       // `state-path`, which belonged to commands declaring no Cliffy options.
+
       expect(
         reportFor({
           providerOptions: everywhere("log-file"),
@@ -226,6 +229,7 @@ describe("check-completion-slots", () => {
     it("names a command a scoped provider claims and the tree does not", () => {
       // A scope naming a command that never declared the option is the same
       // dead entry, one level down.
+
       expect(
         reportFor(
           { providerOptions: { from: ["clone", "pull"] } },
@@ -236,6 +240,7 @@ describe("check-completion-slots", () => {
 
     it("names an allowlist entry that decides no slot", () => {
       // A decision cannot outlive the thing it was about.
+
       expect(
         reportFor({ allowedOptions: ["gone"], allowedPositionals: ["gone:x"] })
           .staleAllowlist,
@@ -245,6 +250,7 @@ describe("check-completion-slots", () => {
     it("names an allowance for a slot a provider already answers", () => {
       // Two records of one decision, disagreeing: the provider offers
       // candidates the allowance says are not there.
+
       expect(
         reportFor({
           providerOptions: everywhere("select"),
@@ -271,6 +277,7 @@ describe("check-completion-slots", () => {
     it("names the entry to delete when one reaches nothing", () => {
       // The subtraction run the other way has its own paragraph, and it has to
       // name the dead entry: the fix is to delete that line, not to add a slot.
+
       const text = describeFailures(reportFor({
         providerOptions: everywhere("space", "select", "log-file"),
         providerArguments: ["get:path"],
@@ -287,6 +294,7 @@ describe("check-completion-slots", () => {
     it("returns 0 for the CLI's own command tree", () => {
       // The gate itself. Every slot the CLI declares is answered by a provider,
       // by an enumerated set, or by an allowlist entry carrying its reason.
+
       expect(main()).toBe(0);
     });
 
@@ -304,6 +312,7 @@ describe("check-completion-slots", () => {
     it("lists the undecided slots and succeeds when asked for the list", () => {
       // `--list` is the working view: it answers what is undecided without
       // failing, so the list can be read while it is worked through.
+
       const { code, out } = captureConsole(() =>
         main(["--list"], unknownTree())
       );
@@ -317,6 +326,7 @@ describe("check-completion-slots", () => {
     it("records a reason for every allowance, so none is a bare exemption", () => {
       // Trimmed, because a blank reason and a spaces-only one exempt a slot
       // just as silently.
+
       for (const [key, reason] of [...NO_CANDIDATES, ...NO_OPTION_CANDIDATES]) {
         expect(reason.trim().length, `${key} has no reason`).toBeGreaterThan(0);
       }

--- a/tasks/check-skill-facts.test.ts
+++ b/tasks/check-skill-facts.test.ts
@@ -108,6 +108,7 @@ Deno.test("Tree knows files, directories, and their ancestors", () => {
 Deno.test("Tree.has resolves a path below a symlinked directory", () => {
   // git cannot say what is under .claude/skills/lit-component, so a citation
   // through it must not be reported as missing when it reads fine on disk.
+
   assert(TREE.has(".claude/skills/lit-component/SKILL.md"));
   assert(TREE.has(".claude/skills/lit-component/references/theme-system.md"));
   // A sibling that is not below a symlink is still judged normally.
@@ -118,6 +119,7 @@ Deno.test("Tree.has rejects a path below an ordinary file", () => {
   // The exception above is for symlinks only. Where a directory has since been
   // collapsed into a file, a citation that still points inside it is stale, and
   // git can say so — `docs/common/concepts/computed` is a file, not a symlink.
+
   assert(TREE.has("docs/common/concepts/computed"));
   assertEquals(TREE.has("docs/common/concepts/computed/computed.md"), false);
   assertEquals(TREE.has("packages/runner/src/cell.ts/nested.ts"), false);
@@ -154,6 +156,7 @@ Deno.test("citedPath strips a leading ./ or /, a #fragment, and trailing slashes
 
 Deno.test("citedPath rejects command lines", () => {
   // Skills backtick whole commands; the path inside one is not the citation.
+
   assertEquals(citedPath("./scripts/restart-local-dev.sh --force"), null);
   assertEquals(citedPath("deno run -A packages/cli/mod.ts"), null);
   assertEquals(citedPath("cat ~/code/labs/packages/patterns/index.md"), null);
@@ -192,6 +195,7 @@ Deno.test("isRooted accepts a directory inside the citing skill", () => {
 Deno.test("isRooted rejects prose, flags, specifiers, and mount paths", () => {
   // The conservative half of the heuristic: none of these start with a real
   // directory, so none are treated as repo paths.
+
   assertEquals(isRooted("async/await", "skills/cf-review", TREE), false);
   assertEquals(isRooted("-s/--space", "skills/cf", TREE), false);
   assertEquals(
@@ -214,6 +218,7 @@ Deno.test("resolvesInTree accepts a repo-root-relative citation", () => {
 Deno.test("resolvesInTree accepts a skill-relative citation", () => {
   // skills/agent-browser names scripts/form-automation.sh, which lives in the
   // skill, not in the repo-root scripts/ directory.
+
   assert(
     resolvesInTree("scripts/form-automation.sh", "skills/agent-browser", TREE),
   );
@@ -302,6 +307,7 @@ Deno.test("collectDrift reports a package that left the workspace", () => {
 Deno.test("collectDrift resolves each doc against its own skill", () => {
   // The same token, cited by two skills, resolves for the one that carries the
   // script and fails for the one that does not.
+
   const docs = [
     {
       path: "skills/agent-browser/SKILL.md",
@@ -317,6 +323,7 @@ Deno.test("collectDrift resolves each doc against its own skill", () => {
 Deno.test("collectDrift reports a package that declares no exports", () => {
   // A workspace member with no `exports` key: nothing resolves against it, not
   // even the root.
+
   const docs = [{
     path: "skills/cf-review/SKILL.md",
     text: 'Import "@commonfabric/bare".\n',
@@ -470,6 +477,7 @@ Deno.test("readWorkspaceExports rejects invalid JSONC", async () => {
 Deno.test("readWorkspaceExports surfaces an unreadable member config", async () => {
   // A deno.jsonc that is a directory: not NotFound, so it is config breakage
   // rather than an absent member, and must not be skipped silently.
+
   const root = await fixtureRepo({
     "deno.jsonc": '{ "workspace": ["./packages/ui"] }',
     "packages/ui/deno.jsonc/placeholder": "",
@@ -524,6 +532,7 @@ Deno.test("the script runs as a command over the real repo", async () => {
 Deno.test("every cited path and specifier resolves", async () => {
   // Runs against the real repository: every fact every covered document cites
   // must resolve.
+
   const root = fromFileUrl(new URL("..", import.meta.url));
   const tree = await readTree(root);
   const docs = await readSkillDocs(root, tree);
@@ -568,6 +577,7 @@ Deno.test("a rule resolves its citations against the repo root", async () => {
   // A rule lives in .claude/rules/, which holds no code, so every path it names
   // is repo-relative. Both cases are pinned here because skillDirOf hands the
   // resolver ".claude/rules" as the doc's own directory.
+
   const root = await fixtureRepo({
     "deno.jsonc": '{ "workspace": [] }',
     "packages/ui/src/index.ts": "",
@@ -587,6 +597,7 @@ Deno.test("a package AGENTS.md resolves paths inside its own package", async () 
   // packages/shell/AGENTS.md cites `shared/app/state.ts`, meaning the file in
   // that package. The same token cited by a package that has a `shared/` of its
   // own, without that file in it, is drift.
+
   const root = await fixtureRepo({
     "deno.jsonc": '{ "workspace": [] }',
     "packages/shell/shared/app/state.ts": "",
@@ -617,6 +628,7 @@ Deno.test("a relative citation with no matching directory is left alone", async 
   // names no real directory is prose or a shell fragment, not a path, so it is
   // skipped rather than reported. Without this, every `src/index.ts` written as
   // an illustration would fail the build.
+
   const root = await fixtureRepo({
     "deno.jsonc": '{ "workspace": [] }',
     "packages/other/mod.ts": "",

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -131,6 +131,7 @@ Deno.test("importsAlias matches a subpath import of a bare alias", () => {
 Deno.test("importsAlias does not treat a longer alias as importing a shorter sibling by name only", () => {
   // "@std/http-extras" is not "@std/http": the slash boundary in the subpath
   // rule is what separates them, so a bare "@std/http" must not match here.
+
   assertEquals(
     importsAlias('import x from "@std/http-extras";', "@std/http"),
     false,
@@ -144,6 +145,7 @@ Deno.test("importsAlias matches any specifier under a slash-terminated alias", (
 
 Deno.test("importsAlias ignores a slash-terminated alias with nothing after it", () => {
   // "@/" maps a prefix; a specifier that is only the prefix imports no module.
+
   assertEquals(importsAlias('const s = "@/";', "@/"), false);
 });
 
@@ -153,6 +155,7 @@ Deno.test("importsAlias ignores a bare identifier that is not an import", () => 
 
 Deno.test("importsAlias ignores a substring of a different specifier", () => {
   // "notesEntry" contains "sentry" but imports nothing named sentry.
+
   assertEquals(
     importsAlias('import { notesEntry } from "./notes.ts";', "sentry"),
     false,
@@ -163,6 +166,7 @@ Deno.test("importsAlias counts a commented-out import as used", () => {
   // The loose matching is deliberate: an occurrence inside a comment or string
   // counts as used. That can only ever hide a dead alias, never flag a live
   // one, so the check does not misfire on a real dependency.
+
   assert(importsAlias('// import { x } from "zod";', "zod"));
 });
 
@@ -196,6 +200,7 @@ Deno.test("owningMember returns undefined for a file under no member", () => {
 
 Deno.test("owningMember does not match a member that is only a path-segment prefix", () => {
   // "packages/mem" must not own a file under "packages/memory".
+
   assertEquals(
     owningMember("packages/memory/interface.ts", ["packages/mem"]),
     undefined,
@@ -241,6 +246,7 @@ Deno.test("runs as a command-line program against the repository", async () => {
   // Exercises the module's command-line entry point (the import.meta.main
   // guard). It runs against the real repository, which the "no unused import
   // map entries" test asserts is clean, so the check prints success and exits 0.
+
   const script = fromFileUrl(
     new URL("./check-unused-deps.ts", import.meta.url),
   );
@@ -258,6 +264,7 @@ Deno.test("runs as a command-line program against the repository", async () => {
 Deno.test("gitTrackedFiles returns null when git is not available", async () => {
   // A missing git binary makes Deno.Command throw; the scan falls back to a
   // filesystem walk rather than failing.
+
   assertEquals(
     await gitTrackedFiles(".", "git-binary-that-does-not-exist-xyz"),
     null,
@@ -387,6 +394,7 @@ Deno.test("main returns 1 and names the offender on an unused entry", async () =
 Deno.test("main checks a member whose config is deno.json", async () => {
   // Deno accepts deno.json as well as deno.jsonc for a member. An unused entry
   // in a deno.json member must still be found, and reported at its real path.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(
@@ -417,6 +425,7 @@ Deno.test("main reads a deno.json root's own import map", async () => {
   // reported at deno.json, which happens only if the root deno.json is read at
   // all. With deno.json support absent the root goes unread, no entries are
   // collected, and the check passes — so this fails unless the path works.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(
@@ -455,6 +464,7 @@ Deno.test("main reads a deno.json root's own import map", async () => {
 Deno.test("main flags a member alias imported only by another member", async () => {
   // The alias is imported, but under a different member, so the declaring
   // member's entry is still unused: its own files never reach it.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(
@@ -496,6 +506,7 @@ Deno.test("main flags a member alias imported only by another member", async () 
 Deno.test("main counts an importer under an output-named directory", async () => {
   // A file under a directory named `build` is authored source, not generated
   // output: the scan must read it, or its imports' aliases look unused.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(
@@ -526,6 +537,7 @@ Deno.test("main counts an importer under an output-named directory", async () =>
 Deno.test("main tolerates a workspace member with no config file", async () => {
   // A directory listed as a member but carrying neither deno.jsonc nor
   // deno.json contributes no entries; collecting from it must not fail.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(
@@ -560,6 +572,7 @@ Deno.test("main tolerates a workspace member with no config file", async () => {
 Deno.test("main skips a tracked file missing from the working tree", async () => {
   // In a real git tree, git may list a file the working tree no longer holds.
   // Reading it fails, and the scan must skip it rather than throw.
+
   const root = await Deno.makeTempDir({ prefix: "check-unused-deps-" });
   try {
     await Deno.writeTextFile(

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -348,7 +348,6 @@ Deno.test("unknownAcceptedMetrics names an accepted group nothing measured", () 
 Deno.test("baseline override parser reads only a marker starting a line", () => {
   // A description explaining the mechanism carries no acceptance, and is not a
   // malformed one either.
-
   const prose =
     "Rebasing changes what an ACCEPT_COVERAGE_DEBT: total means, so it " +
     "accepts a rise instead.";

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -82,6 +82,7 @@ Deno.test("coverage baseline files round-trip stable metric samples", () => {
 Deno.test("coverage baseline files read a file the performance gate wrote", () => {
   // Written when the artifact also carried CI timing metrics: the file names
   // the run's page, and the uncovered-line count sits under `durationSeconds`.
+
   const legacy = JSON.stringify({
     version: 1,
     generatedAt: "2026-01-01T00:00:00Z",
@@ -207,6 +208,7 @@ Deno.test("cache state parsing poisons the collection on any bad record", () => 
   // A record that fails to parse could be the cold shard; surviving records
   // must not tag its family warm, so the whole parse degrades to null
   // (unknown) — same policy as an artifact download failure.
+
   const originalWarn = console.warn;
   const warnings: string[] = [];
   try {
@@ -232,6 +234,7 @@ Deno.test("cache state parsing poisons the collection on any bad record", () => 
 Deno.test("cache state parsing keeps valid unknown-family records inert", () => {
   // An unknown family name is forward-compatible data, not corruption: it
   // parses cleanly and aggregation simply never assigns it a state.
+
   const records = parseCacheStateFiles([
     '{"family":"runner","shard":"1","matchedKey":"","exactHit":false}',
     '{"family":"pattern-integration","shard":"2","matchedKey":"compile-abc","exactHit":false}',
@@ -283,6 +286,7 @@ Deno.test("baseline override parser rejects a total in place of an increment", (
   // An acceptance naming a total says nothing about how much debt the pull
   // request adds, and means something different against every baseline, so it
   // is rejected rather than read as though it were an increment.
+
   assertThrows(
     () =>
       parseBaselineOverrides(
@@ -344,6 +348,7 @@ Deno.test("unknownAcceptedMetrics names an accepted group nothing measured", () 
 Deno.test("baseline override parser reads only a marker starting a line", () => {
   // A description explaining the mechanism carries no acceptance, and is not a
   // malformed one either.
+
   const prose =
     "Rebasing changes what an ACCEPT_COVERAGE_DEBT: total means, so it " +
     "accepts a rise instead.";
@@ -424,6 +429,7 @@ Deno.test("legacy override parsing ignores the defunct timing form", () => {
   // NEW_PERF_BASELINE once accepted timing regressions too; those gate nothing
   // now, so a legacy timing line is ignored rather than rejected — a merged PR
   // that carried one must still yield its coverage-debt acceptance.
+
   const overrides = parseBaselineOverrides(
     "NEW_PERF_BASELINE: job: Check = 7s\n" +
       "NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 9 lines",
@@ -749,6 +755,7 @@ Deno.test("buildCoverageResolvedComment reports a group that gained uncovered li
   // than `main` when the regression was accepted with a per-group acceptance or
   // the coverage reset marker. The table reports the increase rather than
   // hiding it.
+
   const resolved = buildCoverageResolvedComment(0, [
     { group: "packages/runner", baseline: 12, current: 15 },
   ]);
@@ -762,6 +769,7 @@ Deno.test("buildCoverageResolvedComment reports a group that gained uncovered li
 Deno.test("buildCoverageResolvedComment says the debt was overridden, not improved", () => {
   // The gate passed because the debt was accepted, so the summary must not
   // imply the new code is covered, even when a group also improved.
+
   const resolved = buildCoverageResolvedComment(
     4,
     [{ group: "packages/runner", baseline: 12, current: 15 }],
@@ -807,6 +815,7 @@ Deno.test("buildCoverageResolvedComment names the files an accepted debt stands 
 Deno.test("buildCoverageResolvedComment names no files when the debt was covered", () => {
   // Coverage that improved has no acceptance to account for, so a file list
   // would be describing debt that is not there.
+
   const resolved = buildCoverageResolvedComment(
     5,
     [{ group: "tasks", baseline: 1857, current: 1852 }],
@@ -1324,6 +1333,7 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
 Deno.test("buildCoverageDebtUnattributedComment omits run identity it does not have", () => {
   // A local run of the checker has no workflow run behind it, and a group can
   // reach the comment without a baseline run to name.
+
   const local = buildCoverageDebtUnattributedComment({
     groups: [{ group: "tasks", target: 0, current: 1 }],
     files: [{ relativePath: "tasks/test-records.ts", lines: [90] }],

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -399,6 +399,7 @@ Deno.test("a merged PR's unreadable acceptance leaves the rest of it standing", 
   // A description that merged before the acceptance form changed cannot be
   // rewritten to suit this parser, so the marker it carries is passed over and
   // the reset marker beside it is still read.
+
   const warnings: string[] = [];
   const overrides = parseMergedBaselineOverrides(
     {
@@ -419,6 +420,7 @@ Deno.test("merged PR legacy coverage-debt acceptance is honored", () => {
   // A baseline PR merged before the marker rename accepted debt with
   // NEW_PERF_BASELINE; its acceptance must still register so it truncates the
   // baseline timeline.
+
   const overrides = parseMergedBaselineOverrides({
     number: 125,
     body:
@@ -1510,6 +1512,7 @@ Deno.test("walkBaselineRuns prefers the base-branch commit's own run", async () 
 Deno.test("walkBaselineRuns falls back to the nearest ancestor with a run", async () => {
   // The base-branch commit's run uploaded no baseline artifact, so its parent
   // stands in rather than the gate giving up.
+
   const walked = await walk([
     [RUN_AT_BASE, reading(RUN_AT_BASE, {})],
     [RUN_ONE_BACK, reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 })],
@@ -1523,6 +1526,7 @@ Deno.test("walkBaselineRuns falls back to the nearest ancestor with a run", asyn
 Deno.test("walkBaselineRuns ranks the ancestry rather than trusting run order", async () => {
   // The nearer ancestor's run arrives second, as a history rewrite or two
   // pushes in one second can leave it. The nearer commit still wins.
+
   const walked = await walk([
     [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
     [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5760 })],
@@ -1545,6 +1549,7 @@ Deno.test("walkBaselineRuns reads the first of two runs for one commit", async (
 
 Deno.test("walkBaselineRuns ignores a run that is not an ancestor", async () => {
   // Landed after this run started, so it measured code the run lacks.
+
   const sibling = makeRun(4, "dddddddddddddddddddddddddddddddddddddddd");
   const walked = await walk([
     [sibling, reading(sibling, { [RUNNER_METRIC]: 5700 })],
@@ -1585,6 +1590,7 @@ Deno.test("walkBaselineRuns takes a cold ancestor when every ancestor is cold", 
 Deno.test("walkBaselineRuns ignores an acceptance that is not an ancestor", async () => {
   // A reset that merged after this run's base-branch commit is not in this
   // run's code, so it sets no floor here and the ancestry still gates.
+
   const later = makeRun(4, "dddddddddddddddddddddddddddddddddddddddd");
   const walked = await walk([
     [later, reading(later, { [RUNNER_METRIC]: 7000 }, { reset: true })],
@@ -1629,6 +1635,7 @@ Deno.test("walkBaselineRuns stops at the run whose PR accepted the debt", async 
   // what later runs are held to. Every run that measured it is cold, so the
   // accepting run stands as the baseline rather than the metric losing one.
   // The memory group was not accepted, so its walk carries on to the warm run.
+
   const walked = await walk(
     [
       [RUN_AT_BASE, reading(RUN_AT_BASE, {}, { cold: true })],
@@ -1680,6 +1687,7 @@ Deno.test("walkBaselineRuns stops every coverage metric at a merged reset", asyn
 Deno.test("walkBaselineRuns walks past an acceptance that measured nothing", async () => {
   // The accepting run uploaded no baseline artifact, so it has no level to
   // hold later runs to and the search continues past it.
+
   const walked = await walk([
     [RUN_ONE_BACK, reading(RUN_ONE_BACK, {}, { accepts: [RUNNER_METRIC] })],
     [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
@@ -2128,6 +2136,7 @@ Deno.test("buildCoverageRows stamps every row with where it was measured", () =>
   // The comment for a regression the pull request did not cause reads these
   // back to say which run produced the numbers and which `main` commit that
   // run merged, so every row carries them whatever the gate decides.
+
   const { rows } = rowsFor(
     { [RUNNER_METRIC]: 5747, [MEMORY_METRIC]: 3 },
     {
@@ -2250,6 +2259,7 @@ Deno.test("buildCoverageRows accepts the same rise after the baseline moves", ()
   // What a rebase does: the base branch uncovers 30 lines of its own, so both
   // the baseline and this run's count rise by 30. The pull request still adds
   // the 54 lines it accepted, and the same acceptance line still passes it.
+
   const overrides = {
     metrics: new Map([[RUNNER_METRIC, 54]]),
     coverageBaselineReset: false,
@@ -2547,6 +2557,7 @@ Deno.test("combinedLcovFromArtifacts joins every artifact's uploaded report", as
 Deno.test("combinedLcovFromArtifacts refuses to report on no artifacts at all", async () => {
   // An empty set is not an empty report: it means the run uploaded nothing,
   // which must be an error rather than a workspace scored as uncovered.
+
   await assertRejects(
     () => combinedLcovFromArtifacts([]),
     Error,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two comment defects, kept separable in the diff: three files whose section
markers assert more than their regions hold, and seventeen whose test-block
preambles sit on the first statement of the block they introduce.

## Titles that did not own their regions

A section marker's title is an assertion about everything from that marker to
the next one. Three files had titles that were true of some members and false
of others.

`packages/memory/test/v2-sqlite-row-label.test.ts` — "Fail-closed at authoring
(table() throws)" headed twelve tests, of which two are static-analysis readers
that throw nothing and one is an `any()` test whose own comment says it no
longer throws at `table()` time. "evaluateRowLabel — fail-closed branches (each
returns {error}, never partial)" headed eleven, two of which assert successful
evaluation. Both regions are split so that each title owns its members:
`any()`'s authored OR-clauses, static analysis with no row, fail-closed at
authoring and on a spec that arrives built; and on the evaluator side,
fail-closed on the row and the context, OR-clause evaluation, fail-closed on
the spec itself.

`packages/cli/test/view-semantics-gate.test.ts` — a frame opened with a
sentence rather than a title; it gets one, and the three sentences explaining
why the cache hit never fires under the pager move into the single test they
describe. "within()/realDir: a child resolves => its ancestor root resolves
too" headed that case and its opposite, where the child's realpath fails and
`realDir` is never consulted; the title now covers both. "Signed numeric
definitions" was a bare noun phrase where every other marker in the file is
`identifier: description`.

`packages/cli/test/view-parse-cov2.test.ts` — "safe(): the throwing path"
headed a test that also asserts the succeeding one.

## Preambles set off from the first statement

A comment directly above a statement documents that statement. A comment
introducing the whole block it heads needs a blank line under it, or the two
readings collapse.

A scan reports 298 sites across the twenty files at the merge base and three
after. The three that remain are deliberate, and the reason is the same in each
case: not every comment run that opens a block is a preamble.

## What a run that opens a block can be

**A run can be two comments fused**, a preamble followed by a comment about the
first statement. The blank line goes between them, so the preamble is set off
and the statement comment keeps its adjacency. That is the shape at
`check-update-default-pattern.test.ts:2205`, where a six-line rationale is
followed by a one-line note about the call beneath it.

**A run can be a lint pragma and its own rationale.** A comment run ending in
`// deno-lint-ignore …` is presumed to be about the statement — the prose above
the pragma is usually the reason the suppression is warranted — so the whole
run keeps its adjacency and takes no blank line. Only where the leading text is
independently a block preamble does the run split, with the blank above the
pragma. `json-faithfulness.test.ts:95` is the first kind: "A hole is exactly
what is under test" says why `no-sparse-arrays` is waived, and read as a
preamble it adds nothing to the test's own description one line above it.

**A run can be the first of several co-ordinate case labels**, each adjacent to
the case it introduces. Setting the first one off promotes it into a claim
about the whole block that its siblings falsify.
`v2-sqlite-row-label.test.ts:900` names one class of ambiguous node and the
block goes on to three others, each with its own label; `ci-check-lib.test.ts:349`
is the first of four cases that test walks.

A check for the last shape lists, for every set-off preamble, the comment runs
later in the same block at the preamble's own indentation. Across these files
62 blocks qualify; reading all 62 finds those two and no others, the rest being
preambles whose later comments are waypoints or sub-cases rather than
alternatives.

## What the diff contains

Twenty files: 299 blank lines added, 38 non-blank added and 18 deleted, the
last two entirely in the three files whose markers changed. No comment word
changes in the seventeen blank-line-only files, no code line changes, and no
existing line moves.

`deno fmt --check` and `deno lint` pass on all twenty. The formatter check
matters because `deno fmt` removes a blank line placed directly after an
opening brace; none of these lands in that position, since each goes under a
comment run rather than under the brace.

Four comment lines over eighty characters were rewrapped, in the three files
this change already edits prose in. Each rewrap preserves the comment's word
multiset, checked against a control that drops one word and fires.

## A prose defect this surfaced, not fixed here

`check-update-default-pattern.test.ts:2207` reads "Disable the updater so
startup reaches the cold-start repair path", which names an action the test
does not take: `setupHome()` accepts only `cfcEnforcementMode` and is called
with no argument, and the test drives `ensureDefaultPattern()` rather than
startup. It wants a decision on its own account rather than a blank line.

## The coverage check

The gate reports three lines of `packages/memory/v2/client.ts` as newly
uncovered. This change does not touch that file: all twenty files it changes
are test files, every non-blank line it adds is a comment, and every line it
removes is a comment or a blank. Nothing here can alter which lines of a source
file execute, so the three lines are inconsistently covered on `main` rather
than regressed here.

ACCEPT_COVERAGE_DEBT: packages/memory +3 lines

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




