### PR TITLE
test: what four reviews found in the fixes, and in the rule they applied

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -57,13 +57,14 @@ surrounding code:
   function", not "rejects a bare function".
 - `expect()` over `assert*()`, always for structured values. Plain `assert(x)`
   only where truthiness itself is the assertion.
-- A comment about a test or a group of tests goes inside the block, as the
-  first thing in the callback and followed by a blank line. Above the
-  `describe()` or `it()` line, the next block inserted there lands between the
-  comment and what it describes. Two shapes are exceptions: hooks — a
-  `beforeEach()` reads like any other statement with a comment over it — and a
-  callback with no body of its own, a bare expression or `{}` on the opener's
-  line, which keeps its comment beside it.
+- A comment about a test or a group of tests goes inside the block, as the first
+  thing in the callback and followed by a blank line. Above the `describe()` or
+  `it()` line, the next block inserted there lands between the comment and what
+  it describes. Two shapes are exceptions: hooks — a `beforeEach()` reads like
+  any other statement with a comment over it — and a callback with no body of
+  its own, which keeps its comment beside it. That second shape covers a bare
+  expression, `{}` on the opener's line, and a `Deno.test({ … })` whose `fn`
+  names a function declared elsewhere.
 - A comment covering several adjacent tests is telling you those tests want a
   `describe()` of their own, or says one thing per case and belongs in each.
   Wrapping a run renames every test in it; bridge the rename per
@@ -71,14 +72,14 @@ surrounding code:
 - A section marker is a `//` frame: an opening `//` line, a noun-phrase title,
   optionally a blank `//` line and a description, and a closing `//` line, set
   off by a blank line below it and above it where there is anything above.
-- A section marker covers the region up to the next marker at the same level,
-  or the end of the block, so writing one means choosing where it ends and
-  putting a marker there. Its title is a claim about everything in that
-  region, and the region holds the helpers and fixtures sitting in it as well
-  as the blocks, so shared setup goes above the file's first marker. Moving
-  or deleting a comment takes away whatever boundary it was providing for the
-  region above it. None of this is checked mechanically; a file that reads
-  better than the rule wins.
+- A section marker covers the region up to the next marker at the same level, or
+  the end of the block or file, so writing one means choosing where it ends and
+  putting a marker there. Its title is a claim about everything in that region,
+  and the region holds the helpers and fixtures sitting in it as well as the
+  blocks, so shared setup goes above the file's first marker. Moving or deleting
+  a comment takes away whatever boundary it was providing for the region above
+  it. None of this is checked mechanically; a file that reads better than the
+  rule wins.
 
 On placement: a test goes in the package's `test/` tree, mirroring `src/`. The
 exception is a directory of independent components, `packages/ui` and
@@ -149,7 +150,7 @@ nothing about it.
 Each test execution produces a telemetry record named by what the runner
 reports — the describe chain, the `Deno.test` name, the pattern file path.
 Nothing to instrument when adding a test to an existing suite; the runners
-record on their own. Two consequences worth knowing while writing one:
+record on their own. Three consequences worth knowing while writing one:
 
 - The reported name is the test's identity across history. Prefer stable,
   content-derived wording over positional counters (`#${i}`) or

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -233,13 +233,13 @@ Deno.test("would-pass", function () {});
 Deno.test({ name: "derive array leak", fn: runTest, sanitizeOps: false });
 ```
 
-An options object whose `fn` is written out — `fn() { … }` or
-`fn: async () => { … }` — has a body like any other callback, and the
-comment goes inside it.
-
 This is the same allowance
 [`code-comment-style.md`](code-comment-style.md#where-one-goes) makes for a
 declaration with no body to put a note in.
+
+An options object whose `fn` is written out — `fn() { … }` or
+`fn: async () => { … }` — has a body like any other callback, and the
+comment goes inside it.
 
 Three nearby shapes are not this one:
 

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -220,16 +220,22 @@ This holds for a test and for a group of them: `describe()`, `it()`, and
 not reach the `beforeEach()` family. A hook is setup rather than a case, and
 reads the way any other statement does with a line or two of `//` over it.
 
-A callback that opens no body of its own has nowhere to hold a comment, and
-the note stays beside it. Two shapes do that — a body that is a bare
-expression, and an empty body written on the opener's line:
+A callback that opens no body of its own has nowhere to hold a comment, and the
+note stays beside it. Three shapes do that — a body that is a bare expression,
+an empty body written on the opener's line, and an options object whose `fn` is
+the name of a function declared elsewhere:
 
 ```ts
 // Shown for illustration only.
 
 it("returns `undefined` for a bad name", () => expect(f(x)).toBeUndefined());
 Deno.test("would-pass", function () {});
+Deno.test({ name: "derive array leak", fn: runTest, sanitizeOps: false });
 ```
+
+An options object whose `fn` is written out — `fn() { … }` or
+`fn: async () => { … }` — has a body like any other callback, and the
+comment goes inside it.
 
 This is the same allowance
 [`code-comment-style.md`](code-comment-style.md#where-one-goes) makes for a
@@ -237,19 +243,18 @@ declaration with no body to put a note in.
 
 Three nearby shapes are not this one:
 
-- A comment whose subject is a **run of sibling blocks** — two or three
-  adjacent cases that each pin one part of what it says — has no home inside
-  any one of them. That comment is telling you the run wants a
-  `describe()`: give the run its own block, and the comment goes inside that
-  block by the rule above, which is where a long rationale belongs anyway.
-  Wrapping a run renames every test in it, so where the history is worth
-  keeping, bridge the rename as [test records](test-records.md) describes. A
-  run that should not become a block takes a
-  [section marker](code-comment-style.md#section-markers) instead, and then the
-  region needs closing — a second marker after the run, or the end of the
-  enclosing block — or a reader cannot see where it ends. And where what you
-  have to say names the cases one at a time, say each part in the case it
-  belongs to rather than all of it in one place.
+- A comment whose subject is a **run of sibling blocks** — two or three adjacent
+  cases that each pin one part of what it says — has no home inside any one of
+  them. That comment is telling you the run wants a `describe()`: give the run
+  its own block, and the comment goes inside that block by the rule above, which
+  is where a long rationale belongs anyway. Wrapping a run renames every test in
+  it, so where the history is worth keeping, bridge the rename as [test
+  records](test-records.md) describes. A run that should not become a block
+  takes a [section marker](code-comment-style.md#section-markers) instead, and
+  then the region needs closing — a second marker after the run, or the end of
+  the enclosing block or file — or a reader cannot see where it ends. And where
+  what you have to say names the cases one at a time, say each part in the case
+  it belongs to rather than all of it in one place.
 - A comment describing the **file** rather than any block in it is a file
   header. It goes at the top of the file as a doc comment, per
   [File headers](code-comment-style.md#file-headers), and not above the
@@ -277,11 +282,11 @@ Three nearby shapes are not this one:
 A reader should be able to tell what a comment covers from where it sits, and
 each place carries one reach. First thing inside a callback, it covers that
 block — the single case, or the whole group, whichever the callback opens.
-Framed as a section marker, it covers the region running to the next marker or
-to the end of the block. Beside a hook or a body-less callback, it covers the
-statement it touches. At the top of the file, as a doc comment, it covers the
-file. Write each comment into the place that matches its reach and a reader
-never has to guess.
+Framed as a section marker, it covers the region running to the next marker at
+the same level, or to the end of the enclosing block or file. Beside a hook or a
+body-less callback, it covers the statement it touches. At the top of the file,
+as a doc comment, it covers the file. Write each comment into the place that
+matches its reach and a reader never has to guess.
 
 Give a file one way of showing its regions and keep to it. Where a file marks
 regions, a marker ends the one before it, so a series of them reads as a series

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -3557,7 +3557,7 @@ Deno.test("CellBridge.hydratePieceProp labels void handlers as no-arg callables 
 });
 
 //
-// Group 2: addPieceToSpace — name collision
+// Group 2: addPieceToSpace — the directory name
 //
 
 Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", async () => {

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -845,18 +845,6 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
   }
 });
 
-// The exemption LIFECYCLE under the keyed wire (fan-out stage A's
-// independent review, finding 1 — 2026-08-17). Two halves of one
-// invariant: (i) a session's wire vocabulary is STICKY once it was
-// admitted explicit-instance reads — an instance delivered KEYED is
-// always retracted KEYED, so a former holder's catch-up names exactly the
-// foreign instances it retracts and never the session's own (an unkeyed
-// remove resolves against the client's OWN instance: the wipe); (ii) the
-// DELIVERY of foreign instances is live-lease-gated per pass, and a lapse
-// RE-ARMS on the first live pass with a full evaluation that re-delivers
-// what the lapse withheld — a renewal blip the SpaceServer survives
-// in-process must not leave its serving replica silently stale.
-
 /** Every session/effect frame's upserts at or past `from`, with keys. */
 const effectUpserts = (
   messages: ServerMessage[],
@@ -902,6 +890,18 @@ const writeOwnProfile = async (
 };
 
 Deno.test("finding 1 (wire half): a former holder's catch-up RETRACTS a keyed-delivered foreign instance BY KEY — its own instance of the same doc is never named; and once the lease is back, the next foreign write's pass re-arms and re-delivers the instance keyed (no re-issued watch)", async () => {
+  // The exemption LIFECYCLE under the keyed wire (fan-out stage A's
+  // independent review, finding 1 — 2026-08-17). Two halves of one
+  // invariant: (i) a session's wire vocabulary is STICKY once it was
+  // admitted explicit-instance reads — an instance delivered KEYED is
+  // always retracted KEYED, so a former holder's catch-up names exactly the
+  // foreign instances it retracts and never the session's own (an unkeyed
+  // remove resolves against the client's OWN instance: the wipe); (ii) the
+  // DELIVERY of foreign instances is live-lease-gated per pass, and a lapse
+  // RE-ARMS on the first live pass with a full evaluation that re-delivers
+  // what the lapse withheld — a renewal blip the SpaceServer survives
+  // in-process must not leave its serving replica silently stale.
+
   const server = newServer("memory://explicit-read-keyed-retract");
   setServerExecutionConfig(true);
   try {

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -1305,11 +1305,12 @@ Deno.test("watch.add with a changed entityScopeKey on an existing watch id is a 
 });
 
 //
-// Delivery-failure rollback for explicit foreign instances (thread
-// r3731191415): the wire frame carries scope NAMES, so rollback cannot
-// recover the instance from the frame alone — the server must retain the
-// frame's true instance keys. A lost foreign-instance frame must be
-// REDELIVERED once sends succeed again.
+// Delivery-failure rollback
+//
+// For explicit foreign instances (thread r3731191415): the wire frame carries
+// scope NAMES, so rollback cannot recover the instance from the frame alone —
+// the server must retain the frame's true instance keys. A lost
+// foreign-instance frame must be REDELIVERED once sends succeed again.
 //
 
 Deno.test("a failed delivery of an explicit foreign-instance frame is redelivered (rollback keys the exact instance)", async () => {

--- a/packages/memory/test/v2-patch.test.ts
+++ b/packages/memory/test/v2-patch.test.ts
@@ -361,6 +361,8 @@ Deno.test("memory v2 patch reuses unchanged branches across sibling updates", ()
 });
 
 //
+// `append`
+//
 // An `append` op is tail-relative: it inserts `values` at the array's live tail,
 // creating the array (and the path to it) when absent. This is what lets a client
 // whose base is stale or empty still land its elements after whatever durably
@@ -406,6 +408,8 @@ Deno.test("memory v2 append rejects a non-array target", () => {
   assert(threw, "append onto a non-array must throw");
 });
 
+//
+// `add-unique`
 //
 // `add-unique` appends each value only if no existing element equals it, and
 // creates the array if absent. It is idempotent against durable state.
@@ -476,6 +480,8 @@ Deno.test("memory v2 add-unique on the weird numbers", () => {
   assert(Object.is(zero.value[1], +0), "the added +0 must be distinct");
 });
 
+//
+// `increment`
 //
 // `increment` adds `by` to the number at the path, treats an absent value as 0,
 // creates the path if absent, and sums when composed.
@@ -551,6 +557,8 @@ Deno.test("memory v2 increment rejects a non-finite amount", () => {
 });
 
 //
+// `remove-by-value`
+//
 // `remove-by-value` removes every element equal to the given value (by stored
 // value), idempotently, and is a no-op on a missing/non-array target.
 //
@@ -618,10 +626,12 @@ Deno.test("memory v2 remove-by-value is a no-op when absent", () => {
 });
 
 //
+// Targets an op refuses
+//
 // A non-array target is rejected once the path resolves to a traversable
 // container (an object) rather than to a scalar. A scalar target is caught
 // earlier by the spine thaw with a "not traversable" message; an object target
-// reaches the op's own array-shape check.
+// reaches the op's own array-shape check. The root path is refused outright.
 //
 
 Deno.test("memory v2 append rejects a non-array object target", () => {
@@ -688,6 +698,8 @@ Deno.test("memory v2 remove-by-value is a no-op through a missing array index", 
   assertEquals(out, { items: [["a"]] });
 });
 
+//
+// `applyPatchToDocument`
 //
 // `applyPatchToDocument` is the shared "replay these ops over whatever this
 // document currently is" entry point (server-side reconstruction and the

--- a/packages/memory/test/v2-sqlite-column-origin.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin.test.ts
@@ -75,6 +75,8 @@ Deno.test("pinned libsqlite3 release matches the resolved @db/sqlite", () => {
 });
 
 //
+// Picking the library file
+//
 // Provenance has to be read from the same libsqlite3 image that runs the query,
 // so the only acceptable file is the one `@db/sqlite` picks. These cover the
 // picking rule and the refusal to substitute a different file for one that

--- a/packages/memory/test/v2-sqlite-column-origin.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin.test.ts
@@ -142,8 +142,8 @@ Deno.test("a local @db/sqlite build reports rather than binding another file", a
 //
 // Reading column origins
 //
-// That the symbols bind at all, and what the bound library reports for a
-// query, once the picking rule above has chosen a file.
+// These cover that the symbols bind at all, and what the bound library
+// reports for a query once the picking rule above has chosen a file.
 //
 
 function seed(path: string): void {

--- a/packages/memory/test/v2-sqlite-column-origin.test.ts
+++ b/packages/memory/test/v2-sqlite-column-origin.test.ts
@@ -137,6 +137,13 @@ Deno.test("a local @db/sqlite build reports rather than binding another file", a
   );
 });
 
+//
+// Reading column origins
+//
+// That the symbols bind at all, and what the bound library reports for a
+// query, once the picking rule above has chosen a file.
+//
+
 function seed(path: string): void {
   const db = new Database(path); // writable for setup
   db.exec("CREATE TABLE emails (from_email TEXT, subject TEXT, body TEXT)");
@@ -160,13 +167,6 @@ function origins(
     stmt.finalize();
   }
 }
-
-//
-// Column-origin soundness
-//
-// What the bound library reports for a query, once the picking rule above
-// has chosen a file.
-//
 
 Deno.test({
   name: "column-origin metadata is reachable in this deployment",

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -283,7 +283,9 @@ describe("Cell Static Methods", () => {
     });
 
     //
-    // More `Cell.of()` value cases
+    // More `Cell.of()` cases
+    //
+    // The values it takes, and the cell it hands back.
     //
 
     it("should create a cell with undefined value", () => {

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -265,7 +265,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
   };
 
   //
-  // Build-order item 1: the `policyState` guard kind.
+  // Build-order item 1: the `policyState` guard kind
   //
 
   describe("policyState guard validation (boot, fail closed)", () => {
@@ -488,7 +488,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
   });
 
   //
-  // Build-order item 2: grant records + reserved-path storage discipline.
+  // Build-order item 2: grant records + reserved-path storage discipline
   //
 
   describe("grant document addressing", () => {
@@ -783,7 +783,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
   });
 
   //
-  // Resolution wired into the egress gate (build-order items 1+3).
+  // Resolution wired into the egress gate (build-order items 1+3)
   //
 
   describe("grant resolution at the sink egress gate", () => {

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -112,8 +112,9 @@ const aliceShareFact = (audience: CfcAtom = userBob) => ({
 });
 
 describe("CFC grant records (§8.12.7 route 2a)", () => {
-  // The shared harness every region below draws on: a labeled cell, a
-  // policyState-guarded sink rule, a Runtime, and the grant writer and reader.
+  // The shared harness the regions from build-order item 2 on draw on: a
+  // labeled cell, a policyState-guarded sink rule, a Runtime, and the grant
+  // writer and reader.
 
   const SECRET_SCHEMA = internSchema(
     {

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -188,9 +188,9 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
   //
   // Shared harness
   //
-  // In `cfc-grant-records.test.ts` style: a labeled cell, a policyState-guarded
-  // sink rule, and a Runtime whose experimental commitPreconditions flag is the
-  // receipts dial. Every region below draws on these.
+  // A labeled cell, a policyState-guarded sink rule, and a Runtime whose
+  // experimental commitPreconditions flag is the receipts dial. Every region
+  // below draws on these.
   //
 
   const SECRET_SCHEMA = internSchema(

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -74,7 +74,7 @@ const baseInput = {
 
 describe("CFC single-use grants (§2.2 single-use releases)", () => {
   //
-  // Item 1: the `singleUse` field.
+  // Item 1: the `singleUse` field
   //
 
   describe("singleUse field (writer validation)", () => {
@@ -165,7 +165,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
   });
 
   //
-  // Item 2: the consumption receipt identity.
+  // Item 2: the consumption receipt identity
   //
 
   describe("consumption receipt derivation", () => {
@@ -698,7 +698,7 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
   });
 
   //
-  // Claim staging arms.
+  // Claim staging arms
   //
 
   describe("claim staging (flushCfcGrantConsumptionClaims)", () => {

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -207,10 +207,14 @@ console.error(
     `total body bytes: ${parkingBodies.reduce((s, [, b]) => s + b.length, 0)}`,
 );
 
-// Bench naming: performance tracking keys each benchmark's timeline by the
-// origin file, group, and verbatim name, so groups and names must stay
-// stable across commits — no content hashes, byte counts, or module counts.
-// Volatile sizes go to stderr.
+//
+// Bench naming, and the module labels it needs
+//
+// Performance tracking keys each benchmark's timeline by the origin file,
+// group, and verbatim name, so groups and names must stay stable across
+// commits — no content hashes, byte counts, or module counts. Volatile
+// sizes go to stderr.
+//
 
 /** Basenames too vague to identify a module on their own. */
 const GENERIC_BASENAMES = new Set([

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -790,8 +790,9 @@ describe("stage G outbox + sqlite discharge", () => {
   // Refusals and failures at delivery
   //
   // What the drain does at the floor: a declared userless row delivers, an
-  // undeclared one and a deterministic rejection retire, and a transport
-  // failure keeps the row for the next drain.
+  // undeclared one retires, a deterministic rejection retires after writing
+  // its failure notice back onto the source event, and a transport failure
+  // keeps the row for the next drain.
   //
 
   it("does not retry an LT4 deterministic admission rejection: the row is deleted and counted failed", async () => {

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -797,9 +797,11 @@ describe("stage G SpaceServer recovery seams", () => {
     return rows;
   };
 
-  /** A facade whose watch registry names exactly the given demanded
-   * roots — the unit-level stand-in for client sessions' watches (the
-   * production feed is pinned in the serving-loop E2E). */
+  /**
+   * A facade whose watch registry names exactly the given demanded roots — the
+   * unit-level stand-in for client sessions' watches (the production feed is
+   * pinned in the serving-loop E2E).
+   */
   const demandFacade = (
     roots: Array<{
       id: string;

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -229,10 +229,10 @@ Deno.bench("array element resolution in circular structures", () => {
 //
 // A list scanned through the reactive proxy: what a lift does when it reads a
 // collection of linked entries, and the shape the transaction-scoped memo
-// exists for. `one element read` is the per-element cost; `whole array read
-// per element` is a full pass for each element. The unmemoized cost of both is linear in the
-// number of resolutions, so a scan that touches each element more than once
-// pays it again per touch.
+// exists for. `one element read` is the per-element cost; `whole array read per
+// element` is a full pass for each element. The unmemoized cost of both is
+// linear in the number of resolutions, so a scan that touches each element more
+// than once pays it again per touch.
 //
 
 const LIST_LENGTH = 50;

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -1285,7 +1285,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
   });
 
   //
-  // WithPattern variant tests
+  // `filterWithPattern` and `flatMapWithPattern` variants
   //
 
   it("should filter with a pre-defined pattern (filterWithPattern)", async () => {

--- a/packages/runner/test/prototype-named-properties.test.ts
+++ b/packages/runner/test/prototype-named-properties.test.ts
@@ -12,10 +12,9 @@
 //     inherited function as the bound value;
 //   - writing `undefined` to such a key looked like a no-op and was dropped.
 //
-// These pin the fix at every path reachable from the public API, each through
-// the surface a caller actually uses. Each has a control case using an
-// ordinary name, so a harness that stops exercising the path fails loudly
-// rather than passing vacuously.
+// These pin the fix on the paths below, each through the surface a caller
+// actually uses. Each has a control case using an ordinary name, so a harness
+// that stops exercising the path fails loudly rather than passing vacuously.
 //
 // Sibling of the same bug class in the query-result proxy's
 // `getOwnPropertyDescriptor` trap (#5357).
@@ -250,8 +249,8 @@ describe("properties named after Object.prototype members", () => {
 });
 
 describe("path helpers and prototype-named segments", () => {
-  // `path-utils` and `piece-helpers` are exported surfaces, so they get direct
-  // coverage rather than being exercised only through a cell.
+  // `path-utils` is an exported surface, so it gets direct coverage rather
+  // than being exercised only through a cell.
 
   it("getValueAtPath does not hand back an inherited member", () => {
     expect(getValueAtPath({}, ["toString"])).toBe(undefined);

--- a/packages/static/scripts/strip-withheld-globals.test.ts
+++ b/packages/static/scripts/strip-withheld-globals.test.ts
@@ -194,8 +194,8 @@ Deno.test("cliMain exits with the CLI status when it is the entry point", async 
 //
 // The error and write paths
 //
-// Driven with injected files rather than the
-// checked-in libraries, which are kept clean.
+// Driven with injected files rather than the checked-in libraries, which are
+// kept clean.
 //
 
 Deno.test("runCli --check fails when a library still declares a withheld global", async () => {
@@ -464,6 +464,8 @@ Deno.test("drops a namespace value member's trailing blank line", () => {
   );
 });
 
+//
+// `stillDeclared` on a namespace
 //
 // `stillDeclared` is the post-strip safety net. `runCli` only ever hands it
 // already-stripped text, where a withheld namespace has no value members left,

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,6 +1,6 @@
 /**
- * Parsing tests for toolshed's `EnvSchema`: each strict-boolean and defaulted
- * variable is pinned against the misparse its type invites.
+ * Parsing tests for toolshed's `EnvSchema`: strict-boolean flags and
+ * defaulted variables, pinned against the misparse their types invite.
  *
  * The EXPERIMENTAL_* → ExperimentalOptions mapping (including its tri-state
  * unset/true/false fidelity) now lives in the runner's canonical

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -269,7 +269,7 @@ Deno.test("importsPollingWaitFor ignores an import in a line-continued string", 
 });
 
 //
-// Which relative paths reach the same `waitFor`, and which do not.
+// Relative paths that reach the same `waitFor`, and those that do not
 //
 
 Deno.test("importsPollingWaitFor detects a relative import of the package's utils.ts", () => {

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -70,7 +70,7 @@ Deno.test("importsPollingWaitFor detects an aliased import", () => {
 });
 
 //
-// Type-only imports, which cannot poll
+// Type members, and the value imports beside them
 //
 // A type-only import binds the type of `waitFor` and is erased before the test
 // runs, so it cannot poll. The value forms below it still have to be caught.
@@ -228,6 +228,8 @@ Deno.test("importsPollingWaitFor ignores an import inside a template literal", (
 });
 
 //
+// Blanking comments and strings
+//
 // The blanking of comments and strings must not swallow the code around them.
 //
 
@@ -267,7 +269,7 @@ Deno.test("importsPollingWaitFor ignores an import in a line-continued string", 
 });
 
 //
-// A relative path reaches the same waitFor without naming the package.
+// Which relative paths reach the same `waitFor`, and which do not.
 //
 
 Deno.test("importsPollingWaitFor detects a relative import of the package's utils.ts", () => {
@@ -349,6 +351,8 @@ Deno.test("isIntegrationTestFile excludes non-integration and non-ts files", () 
   );
 });
 
+//
+// The repository's own tree
 //
 // The following two tests run against the real repository tree. Together they
 // assert that the set of in-scope files importing the polling `waitFor` equals

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -68,7 +68,8 @@ Deno.test("the real manifest passes end to end", async () => {
 // quietly stops working. Beside them sit the intact baseline, the legitimate
 // resolved weakness, and the driver that reports them all.
 //
-// Each case writes its own fixture file rather than pointing at a real one.
+// No case points at a real repository file: four write their own fixture,
+// and two name a path the repository does not have.
 // Self-reference bites here: a literal ".ignore(" anywhere in this file would
 // make the healthy case trip the DISABLED branch.
 //

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -5,6 +5,8 @@ import { checkTripwire, main, TRIPWIRES } from "./check-tripwires.ts";
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
 //
+// The manifest against the tree
+//
 // The check is only as good as its manifest: a typo'd path would make it pass
 // vacuously while reporting "intact", which is the failure mode that matters
 // most for a guard nobody looks at until the day it fires.
@@ -35,6 +37,8 @@ Deno.test("every tripwire's weakness is currently present", async () => {
   }
 });
 
+//
+// The obligation text
 //
 // The obligation text IS the deliverable — it is the only thing the person who
 // trips this will read. A tripwire whose instructions have gone stale is a


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Nineteen files. Every change answers a finding an adversarial review raised
against work already on `main`, and each was checked against the code before
being applied rather than accepted from the report.

## Titles that asserted more than their region holds

`packages/toolshed/env.test.ts` claimed "each strict-boolean and defaulted
variable is pinned against the misparse its type invites". `EnvSchema` has five
`boolFlag()` variables, of which four appear in the test file and
`RATE_LIMIT_TRUST_FORWARDED_FOR` does not, and fifty-one defaulted variables,
of which two are pinned. The header now says what it covers without the
universal.

`tasks/check-no-waitfor.test.ts` — "Type-only imports, which cannot poll"
headed six tests, two of which are value imports the gate does flag; the
description said so, which is why it read correctly as prose and failed as a
title. "A relative path reaches the same waitFor without naming the package"
headed four, two of which are the opposite case. Both retitled, and the file's
two remaining title-less frames gained titles so it shows its regions one way.

`packages/memory/test/v2-patch.test.ts` — a region whose description is about
an array op meeting an object target also held `increment` at the root path,
which reaches no array-shape check. All seven frames in the file now carry
titles; one had been titled and six had not.

`packages/memory/test/v2-sqlite-column-origin.test.ts` — a marker sat below the
two helpers its region owns. Every call site of `seed()` and `origins()` is in
the region below it, so the frame moves above them, and its title now covers
its first member, which pins availability rather than soundness.

## Prose that stopped being true

`packages/runner/test/cfc-grant-records.test.ts` — a harness comment was moved
to the head of the top-level `describe()` and reworded to "every region below
draws on". The first region below uses none of the six harness members: a grep
for each over that region returns nothing, while the module-scope helpers it
does use return eleven, eight and three hits.

`cfc-single-use-grants.test.ts` opened its harness description with "In
`cfc-grant-records.test.ts` style", naming a frame deleted from that file. Its
own "Every region below draws on these" was checked against all four regions
below and left standing.

`prototype-named-properties.test.ts` claimed the tests pin the fix "at every
path reachable from the public API", which nothing here establishes, and named
`piece-helpers` as a covered surface — a module the file references exactly
once, in that comment.

## Shapes the style rules name

A ninety-three-column comment line in `link-resolution.bench.ts`, introduced
when a repair lengthened a bench name and left the paragraph unwrapped;
`deno fmt` does not rewrap comments, so nothing mechanical catches one. A
"Pre-compilation" marker in `esm-verifier.bench.ts` owning fifty lines of
module-labeling apparatus, now closed where it ends, with the floating
bench-naming note as the new region's description. A four-outcome enumeration
in `executor-outbox.test.ts` over six tests where the fifth is about a failure
notice nothing named. A doc comment in `executor-space-server.test.ts` carrying
both delimiters on lines with text, which `code-comment-style.md` gives as its
counterexample. A ragged reflow and a fifth untitled frame in
`strip-withheld-globals.test.ts`. A duplicated label in `v2-explicit-read.test.ts`
sitting on top of a doc comment, forty-five lines above the test it describes,
now inside that test.

## The documents

`.claude/rules/tests.md` said "Two consequences worth knowing while writing
one" over three bullets — the middle one added later, leaving the count behind,
which is the same drift the rule's own prose diagnoses. It now says three, and
every other enumeration in both documents was checked against what follows it.

The region-end rule is stated in three places and said three different things.
`unit-test-coding-style.md`'s "The shape to aim for" was missing both "at the
same level" and "or file"; without the first it says a nested marker closes an
outer region. All three now agree.

Both documents gain a carve-out for an options-object test whose `fn` names a
function declared elsewhere, which neither documented exemption reached. It is
sized to its population: four sites in the tree write `fn` as a bare name,
against three hundred and fifty-seven whose `fn` has a callback body the
ordinary rule already covers, and a closing sentence says so, so the carve-out
cannot spread to the rest.

## Verification

`deno fmt --check` and `deno lint` pass on the seventeen TypeScript files.
Suites, each at exit 0 with zero failures: `runner` 1324, `tasks` 647, `memory`
592, `fuse` 372, `toolshed` 147, `static` 67 + 23. The three gates that read
what this change edits — `deno task check-docs`, `deno task check-skill-facts`
and `deno task check-no-waitfor` — all exit 0; the last matters because two of
the retitled regions are inside `check-no-waitfor.test.ts` itself.

## The same two defects, where this change already had the files open

A review of the repairs above found both of their rationales unapplied at nine
further sites, all pre-existing and all in files this change already edits.
Leaving them would have made the change inconsistent within its own file set.

Six marker titles carried a trailing period: three of four in
`cfc-grant-records.test.ts` and three of seven in `cfc-single-use-grants.test.ts`.
Three frames had no title where their siblings do: two in
`check-tripwires.test.ts` and one in `v2-explicit-read.test.ts`. Splitting a
title out of the last of those left its description a line short, which is the
ragged-reflow defect this change fixes in `strip-withheld-globals.test.ts`, so
the paragraph is refilled with its word multiset checked.

The description this change added to `v2-sqlite-column-origin.test.ts` was a
sentence fragment where its sibling frame in the same file is a sentence. It
now takes the sibling's form.

One title in `cfc-single-use-grants.test.ts` keeps its position: that frame sits
directly under its `describe(` opener, which is the position the two documents
disagree about, so only its period is removed.

## The coverage check

The gate reports lines of `packages/runner/src/executor/space-server.ts` as
newly uncovered — five of them. This change touches no file under any `src/` tree: its
nineteen files are seventeen tests and benches and two documents, and across
those the count of non-comment lines added or removed is zero. Nothing here can
alter which lines of a source file execute, so those lines are inconsistently
covered on `main` rather than regressed here.

ACCEPT_COVERAGE_DEBT: packages/runner +5 lines

## Left for a decision

Two findings are recorded and not acted on here. `.claude/rules/tests.md` and
`code-comment-style.md` contradict each other on a marker frame written
directly under an opening bracket: the first sanctions it, the second says not
to write one there. A census finds no frame at a file's first line and nine
under a bracket, so the sanctioning clause has no population except the
position the other document forbids — and neither of that document's two
remedies is applicable at eight of the nine, which are the first of a marker
series with no shared setup to follow. Separately, the marker added to
`tasks/check-tripwires.test.ts` by earlier work is defensible under the
single-block carve-out but is not the change its own description claims.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




