### PR TITLE
cf-harness: locate measurement runs from artifacts (CT-2138)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -146,6 +146,20 @@ clearing. **New session** goes back to an empty page and the list. A session
 that cannot take another turn — closed, or left with a transcript that did not
 survive a restart — says so in the feed when the follow-up is refused.
 
+### Status route
+
+`GET /api/status` returns the console's absolute `artifactRoot` and a `sessions`
+array. Each session status carries its lifecycle, timestamps, model, workspace,
+capabilities, policy, and, once a run has started, its own `artifactRoot`. A
+`sessionId` query narrows that array to the matching live session. Clients that
+need a run's artifacts use the session's root when it is present and the
+top-level root as the console-wide fallback.
+
+Like every `/api` route, status requires the per-process token cookie obtained
+by loading the console page. The top-level fields are present even before the
+console has any sessions, so an unattended client can check the route contract
+before starting a model turn.
+
 ## CFC
 
 This surface exists partly to show CFC working, so the fabric session's runtime

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -918,9 +918,10 @@ export class ConsoleServer {
       return Response.json(await this.#sessions());
     }
     if (request.method === "GET" && url.pathname === "/api/status") {
-      return Response.json(
-        this.#service.status(url.searchParams.get("sessionId") ?? undefined),
-      );
+      return Response.json({
+        artifactRoot: this.#config.artifactRoot,
+        ...this.#service.status(url.searchParams.get("sessionId") ?? undefined),
+      });
     }
     if (request.method === "GET" && url.pathname === "/api/events") {
       return this.#events(url);

--- a/packages/cf-harness/docs/pattern-index-measurement.md
+++ b/packages/cf-harness/docs/pattern-index-measurement.md
@@ -123,16 +123,29 @@ defaults to `CF_HARNESS_FABRIC_API_URL`, then to `http://localhost:8000`. Point
 it at the same server the console was started against, or the report describes a
 machine the runs never touched. Add `--expect-git-sha=<sha>` to refuse the batch
 unless that server reports the commit you meant to measure, and `--base` to ask
-ancestry against a branch other than `main`.
+ancestry against a branch other than `main`. A commit known to be off that base
+also refuses by default. `--allow-diverged` is the explicit opt-out for a batch
+that intentionally measures such a server; a commit that cannot be checked
+remains a non-fatal `unchecked` reading.
 
 The runner loads the console page to pick up the token cookie every `/api` route
-is gated on, reads the index, and then runs each task in its own session. It
-waits on the console's own `turn_completed`, `turn_failed` or `turn_canceled`
-event, read off the server-sent event stream, and on nothing else. There is no
-timeout: a turn that hangs is a batch that hangs, which an operator can see and
-release with a `POST /api/cancel`, rather than a bound that turns a slow run
-into a failed one. It writes `report.md` and `report.json` under `--out`, and
-exits non-zero if any task ended other than completed.
+is gated on. Before reading the index or starting a paid model turn, it requires
+`/api/status` to carry an absolute top-level `artifactRoot` and a `sessions`
+array. It then reads the index and runs each task in its own session. It waits
+on the console's own `turn_completed`, `turn_failed` or `turn_canceled` event,
+read off the server-sent event stream, and on nothing else. There is no timeout:
+a turn that hangs is a batch that hangs, which an operator can see and release
+with a `POST /api/cancel`, rather than a bound that turns a slow run into a
+failed one.
+
+After a turn settles, the runner locates its root run under the session's
+`artifactRoot`, falling back to the console-wide root. A candidate must have
+been created after the batch began and its transcript's first user message must
+exactly equal the suite task. No match is recorded as not measured. More than
+one match is an ambiguity, also recorded as not measured with every candidate
+run identifier; directory order never chooses a run silently. The runner writes
+`report.md` and `report.json` under `--out`, and exits non-zero if any task
+ended other than completed.
 
 Measuring runs that are already on disk needs no console:
 
@@ -362,13 +375,14 @@ asks the local repository whether that commit is on `main`, and records
 `ancestor`, `diverged`, or `unchecked` — a commit this clone does not hold is
 `unchecked`, which is not the same reading as one known to be off the branch.
 
-Two rules about that recording, both load-bearing.
+Two rules about that reading, both load-bearing.
 
-**It records, it does not refuse.** Running against a deliberately mismatched
-server is documented practice, so a `diverged` reading is a fact for the reader
-rather than grounds to refuse a night's work. The one refusal is an expectation
-the batch was given explicitly: `--expect-git-sha=<sha>` refuses when the server
-reports a different commit.
+**Knowing a commit is wrong differs from not knowing.** A `diverged` reading
+refuses before the first task unless the operator passes `--allow-diverged` to
+record an intentional mismatch. An `unchecked` reading stays non-fatal: a clone
+that does not hold the commit, or a git command that could not answer, has not
+shown the server to be off the branch. An explicit `--expect-git-sha=<sha>` is
+stricter still and refuses whenever the server reports a different commit.
 
 **The server's CFC block is never differenced against the console's.** They
 describe different runtimes. `cfcFlowLabels` is core-default off and the
@@ -401,7 +415,8 @@ wrong from the inside — that is the whole difficulty. The rules that follow fr
 it are the ones this document keeps repeating: an unread reading is recorded as
 unread and never as a zero; two readings that could differ are printed side by
 side rather than differenced; a refusal is a refusal rather than a warning; and
-a check refuses only on something it was told, never on something it inferred.
+a known-diverged server refuses unless the operator explicitly allows that
+mismatch, while an unread ancestry remains non-fatal.
 
 ## Changing this
 

--- a/packages/cf-harness/scripts/run-measurement-batch.ts
+++ b/packages/cf-harness/scripts/run-measurement-batch.ts
@@ -28,11 +28,12 @@
  *   deno task measure-batch suite.json --out=./measurements/tonight
  *   deno task measure-batch suite.json --fabric-api-url=http://localhost:8040
  *   deno task measure-batch suite.json --expect-git-sha=<sha>
+ *   deno task measure-batch suite.json --allow-diverged
  */
 
 import { parseArgs } from "@std/cli/parse-args";
 import { ensureDir } from "@std/fs";
-import { join } from "@std/path";
+import { isAbsolute, join } from "@std/path";
 
 import type {
   HarnessChatEventEnvelope,
@@ -345,15 +346,18 @@ export type AncestryReading =
 /**
  * What the server said it was running, taken before the first task.
  *
- * This records rather than judges, with one exception: a batch told which
- * commit to expect refuses when the server disagrees. Nothing is inferred.
- * Running against a deliberately mismatched server is documented practice, so
- * an undeclared mismatch is a fact for the report, not grounds to refuse a
- * night's work.
+ * A known-diverged commit refuses unless the operator explicitly allows it.
+ * An unchecked ancestry remains a reading because not knowing differs from
+ * knowing the server is wrong.
  */
 export type PosturePreflight =
   | { kind: "read"; meta: ServerMeta; ancestry: AncestryReading }
-  | { kind: "refused"; reason: string; meta?: ServerMeta };
+  | {
+    kind: "refused";
+    reason: string;
+    meta?: ServerMeta;
+    ancestry?: AncestryReading;
+  };
 
 /**
  * Whether the index answered a search at all, taken before the first task.
@@ -368,6 +372,11 @@ export type PosturePreflight =
  */
 export type IndexPreflight =
   | { kind: "answered"; results: number; candidates?: number }
+  | { kind: "refused"; reason: string };
+
+/** Whether the console exposes the fields the batch reads before any task. */
+export type ConsolePreflight =
+  | { kind: "ready"; artifactRoot: string }
   | { kind: "refused"; reason: string };
 
 /**
@@ -479,13 +488,8 @@ const defaultGitRun = async (
 };
 
 /**
- * Reads what the server is running, and refuses only a commit the batch was
- * told to expect and did not find.
- *
- * The ancestry reading is recorded and never refused on. A server on a commit
- * off `main` is what a matched local toolshed looks like from here, and it is
- * also what a stale process from another worktree looks like — the report says
- * which commit and whether it is on the branch, and a reader decides.
+ * Reads what the server is running. An expected-commit mismatch always
+ * refuses; a known-diverged commit refuses unless explicitly allowed.
  */
 export const preflightPosture = async (
   fabricApiUrl: string,
@@ -495,6 +499,7 @@ export const preflightPosture = async (
   run: (
     args: readonly string[],
   ) => Promise<{ success: boolean; code: number }> = defaultGitRun,
+  allowDiverged = false,
 ): Promise<PosturePreflight> => {
   const meta = await readServerMeta(fabricApiUrl, fetchImpl);
   if ("error" in meta) return { kind: "refused", reason: meta.error };
@@ -508,11 +513,18 @@ export const preflightPosture = async (
       meta,
     };
   }
-  return {
-    kind: "read",
-    meta,
-    ancestry: await readAncestry(meta.gitSha, base, run),
-  };
+  const ancestry = await readAncestry(meta.gitSha, base, run);
+  if (ancestry.kind === "diverged" && !allowDiverged) {
+    return {
+      kind: "refused",
+      reason: `the fabric server reports ${
+        meta.gitSha ?? "no commit"
+      }, which is off ${base}; pass --allow-diverged only when that mismatch is intentional`,
+      meta,
+      ancestry,
+    };
+  }
+  return { kind: "read", meta, ancestry };
 };
 
 /**
@@ -791,6 +803,46 @@ export class ConsoleClient {
       `/api/status?sessionId=${encodeURIComponent(sessionId)}`,
     ) as { sessions?: readonly HarnessChatSessionStatus[] };
     return answer.sessions?.[0];
+  }
+
+  /** Checks the status response fields the batch reads before starting work. */
+  async preflightStatus(): Promise<ConsolePreflight> {
+    let answer: unknown;
+    try {
+      answer = await this.#json("/api/status");
+    } catch (error) {
+      return {
+        kind: "refused",
+        reason: `/api/status could not be read: ${describeError(error)}`,
+      };
+    }
+    if (typeof answer !== "object" || answer === null) {
+      return {
+        kind: "refused",
+        reason: "/api/status did not return a JSON object",
+      };
+    }
+    const { artifactRoot, sessions } = answer as Record<string, unknown>;
+    if (typeof artifactRoot !== "string") {
+      return {
+        kind: "refused",
+        reason: "/api/status is missing the top-level artifactRoot field",
+      };
+    }
+    if (!isAbsolute(artifactRoot)) {
+      return {
+        kind: "refused",
+        reason:
+          `/api/status returned a non-absolute artifactRoot: ${artifactRoot}`,
+      };
+    }
+    if (!Array.isArray(sessions)) {
+      return {
+        kind: "refused",
+        reason: "/api/status is missing the top-level sessions array",
+      };
+    }
+    return { kind: "ready", artifactRoot };
   }
 
   /** What the index holds, read through the console's own signed proxy. */
@@ -1073,6 +1125,7 @@ export interface BatchResult {
   indexUrl: string | null;
   startedAt: string;
   endedAt: string;
+  consolePreflight: ConsolePreflight;
   preflight: IndexPreflight;
   posture: PosturePreflight;
 
@@ -1124,6 +1177,107 @@ const readSkillRegistry = async (
   };
 };
 
+/** A root run whose first user message exactly matches one batch task. */
+interface RunCandidate {
+  runId: string;
+}
+
+/** Candidates found and in-scope artifacts the scan could not read. */
+interface RunCandidateScan {
+  candidates: readonly RunCandidate[];
+  directories: readonly string[];
+  unread: readonly string[];
+}
+
+/**
+ * Finds root runs created during this batch whose first user message matches
+ * `taskText`. Ambiguity is left for the caller to refuse rather than settled
+ * by directory order.
+ */
+const runCandidates = async (
+  artifactRoot: string,
+  taskText: string,
+  batchStartedAt: string,
+): Promise<RunCandidateScan> => {
+  const candidates: RunCandidate[] = [];
+  const directories: string[] = [];
+  const unread: string[] = [];
+  for await (const entry of Deno.readDir(artifactRoot)) {
+    if (!entry.isDirectory) continue;
+    directories.push(entry.name);
+    const runStatePath = join(artifactRoot, entry.name, "run-state.json");
+    let runState: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(await Deno.readTextFile(runStatePath));
+      if (
+        typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+      ) {
+        unread.push(`${entry.name}/run-state.json was not an object`);
+        continue;
+      }
+      runState = parsed as Record<string, unknown>;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) continue;
+      unread.push(
+        `${entry.name}/run-state.json could not be read: ${
+          describeError(error)
+        }`,
+      );
+      continue;
+    }
+    const createdAt = typeof runState.createdAt === "string"
+      ? Date.parse(runState.createdAt)
+      : Number.NaN;
+    if (
+      runState.runId !== entry.name ||
+      !Number.isFinite(createdAt) ||
+      createdAt < Date.parse(batchStartedAt) ||
+      (runState.lineage as { role?: unknown } | undefined)?.role === "subagent"
+    ) {
+      continue;
+    }
+    const transcriptPath = join(
+      artifactRoot,
+      entry.name,
+      "transcript.json",
+    );
+    let transcript: unknown;
+    try {
+      transcript = JSON.parse(await Deno.readTextFile(transcriptPath));
+    } catch (error) {
+      unread.push(
+        `${entry.name}/transcript.json could not be read: ${
+          describeError(error)
+        }`,
+      );
+      continue;
+    }
+    if (!Array.isArray(transcript)) {
+      unread.push(`${entry.name}/transcript.json was not a message list`);
+      continue;
+    }
+    const firstUser = transcript.find((message) =>
+      typeof message === "object" && message !== null &&
+      (message as Record<string, unknown>).role === "user"
+    ) as Record<string, unknown> | undefined;
+    if (firstUser?.content !== taskText) continue;
+    candidates.push({ runId: entry.name });
+  }
+  return {
+    candidates: candidates.sort((left, right) =>
+      left.runId.localeCompare(right.runId)
+    ),
+    directories,
+    unread,
+  };
+};
+
+/** Fields the batch supplies to locate the run one task created. */
+export interface RunTaskOptions {
+  batchStartedAt: string;
+  artifactRoot: string;
+}
+
 /**
  * Where each pattern the batch composed came from, resolved one hop through
  * the index. Called once per distinct identifier, after the tasks have run.
@@ -1166,50 +1320,34 @@ export const runTask = async (
   client: ConsoleClient,
   task: MeasurementTask,
   log: (line: string) => void,
+  options: RunTaskOptions,
 ): Promise<TaskResult> => {
   log(`task ${task.id}: starting`);
   const started = await client.startTask(task.text);
   const outcome = await client.awaitTurn(started);
   log(`task ${task.id}: ${outcome.kind}`);
   const session = await client.session(started.sessionId);
-  const runId = session?.harnessRunId;
-  const artifactRoot = session?.artifactRoot;
-  const base: TaskResult = {
+  const artifactRoot = session?.artifactRoot ?? options.artifactRoot;
+  const base = {
     task,
     sessionId: started.sessionId,
     turnId: started.turnId,
     outcome,
-    ...(runId !== undefined ? { runId } : {}),
-    ...(artifactRoot !== undefined ? { artifactRoot } : {}),
+    artifactRoot,
     configuration: {
       ...(session?.model !== undefined ? { model: session.model } : {}),
       ...(session?.policy?.cfcEnforcementMode !== undefined
         ? { cfcEnforcementMode: session.policy.cfcEnforcementMode }
         : {}),
     },
-  };
-  if (runId === undefined || artifactRoot === undefined) {
-    return {
-      ...base,
-      configuration: {
-        ...base.configuration,
-        skillsUnread:
-          "the console named no run, so no skill registry could be read",
-      },
-      measurementUnread:
-        "the console named no run and artifact root for this session",
-    };
-  }
-  const members: string[] = [];
+  } satisfies Omit<TaskResult, "runId" | "measurement" | "measurementUnread">;
+  let scan: RunCandidateScan;
   try {
-    for await (const entry of Deno.readDir(artifactRoot)) {
-      if (
-        entry.isDirectory &&
-        (entry.name === runId || entry.name.startsWith(`${runId}.`))
-      ) {
-        members.push(entry.name);
-      }
-    }
+    scan = await runCandidates(
+      artifactRoot,
+      task.text,
+      options.batchStartedAt,
+    );
   } catch (error) {
     return {
       ...base,
@@ -1218,6 +1356,37 @@ export const runTask = async (
       }`,
     };
   }
+  if (scan.candidates.length !== 1 || scan.unread.length > 0) {
+    const candidates = scan.candidates;
+    let reason: string;
+    if (candidates.length > 1) {
+      reason = `the run lookup is ambiguous: ${
+        candidates.map((candidate) => candidate.runId).join(", ")
+      } all have this task as their first user message`;
+    } else if (scan.unread.length > 0) {
+      reason = candidates.length === 1
+        ? `the run lookup found ${
+          candidates[0].runId
+        } but could not rule out another match: ${scan.unread.join("; ")}`
+        : `the run lookup could not read ${scan.unread.join("; ")}`;
+    } else {
+      reason =
+        `no root run created after ${options.batchStartedAt} has this task as its first user message`;
+    }
+    return {
+      ...base,
+      configuration: {
+        ...base.configuration,
+        skillsUnread: "no run was selected, so no skill registry could be read",
+      },
+      measurementUnread: reason,
+    };
+  }
+  const runId = scan.candidates[0].runId;
+  const located = { ...base, runId };
+  const members = scan.directories.filter((name) =>
+    name === runId || name.startsWith(`${runId}.`)
+  );
   const registries = await Promise.all(
     members.map((member) => readSkillRegistry(join(artifactRoot, member))),
   );
@@ -1225,7 +1394,7 @@ export const runTask = async (
     registry.skillsRoot !== undefined
   );
   const configuration: SessionConfiguration = {
-    ...base.configuration,
+    ...located.configuration,
     ...(scanned[0] ?? {}),
     ...(scanned.length === 0
       ? { skillsUnread: registries[0]?.skillsUnread ?? "no run was read" }
@@ -1234,7 +1403,7 @@ export const runTask = async (
     runsInFamily: registries.length,
   };
   return {
-    ...base,
+    ...located,
     configuration,
     measurement: await measureRunFamily(artifactRoot, runId, members.sort()),
   };
@@ -1446,15 +1615,16 @@ const renderBlock = (
  */
 const renderPosture = (posture: PosturePreflight): string => {
   const meta = posture.meta;
-  const ancestry = posture.kind !== "read"
+  const reading = posture.ancestry;
+  const ancestry = reading === undefined
     ? "not reached"
-    : posture.ancestry.kind === "ancestor"
-    ? `on ${posture.ancestry.base}`
-    : posture.ancestry.kind === "diverged"
-    ? `NOT on ${posture.ancestry.base} — this server is not running the code on that branch`
-    : `NOT CHECKED — ${posture.ancestry.reason}`;
+    : reading.kind === "ancestor"
+    ? `on ${reading.base}`
+    : reading.kind === "diverged"
+    ? `NOT on ${reading.base} — this server is not running the code on that branch`
+    : `NOT CHECKED — ${reading.reason}`;
   const header = posture.kind === "refused"
-    ? `**The fabric server was not the one this batch was told to expect, and the batch refused to start.** ${posture.reason}\n\nNothing below ran.`
+    ? `**The fabric server did not satisfy the batch's commit contract, and the batch refused to start.** ${posture.reason}\n\nNothing below ran.`
     : "Read from the fabric server's own `/api/meta`. These are the **server's** dials, under its production-server preset; the console's line below is its own runtime's, under a remoteClient preset. The two are different runtimes and a difference between them is ordinarily the design, not a fault — they are recorded side by side and never differenced.";
   return `${header}\n\n- Server commit: ${
     meta?.gitSha ?? "NOT REPORTED"
@@ -1503,12 +1673,18 @@ const renderSupersededVisibility = (
 /** What the index answered the pre-flight search with. */
 const renderPreflight = (preflight: IndexPreflight): string =>
   preflight.kind === "refused"
-    ? `**The batch refused to start, so no task ran.** ${preflight.reason}\n\nNothing below ran. An index that refuses a query answers a run exactly as an empty index does, so a batch started into one produces evidence for a discovery problem that is an authorization problem.\n`
+    ? `**The batch refused to start, so no task ran.** ${preflight.reason}\n\nNothing below ran. A failed pre-flight is not measured through: doing so would spend a batch producing evidence for a different system than the report names.\n`
     : `The index answered a search before the first task: ${preflight.results} results${
       preflight.candidates === undefined
         ? ""
         : ` over ${preflight.candidates} candidates examined`
     }. So a run that found nothing below was answered and found nothing, rather than refused.\n`;
+
+/** What the console status contract answered before the first task. */
+const renderConsolePreflight = (preflight: ConsolePreflight): string =>
+  preflight.kind === "ready"
+    ? `The console reported an absolute artifact root before the first task: \`${preflight.artifactRoot}\`. Its \`sessions\` field was an array.\n`
+    : `**The console status contract was refused, so no task ran.** ${preflight.reason}\n`;
 
 /**
  * Which task imported which published pattern.
@@ -1636,6 +1812,9 @@ export const renderBatchReport = (batch: BatchResult): string => {
     lines.push(batch.suite.notes, "");
   }
   lines.push(
+    "## Did the console expose the measurement contract",
+    "",
+    renderConsolePreflight(batch.consolePreflight),
     "## What the fabric server reported it was running",
     "",
     renderPosture(batch.posture),
@@ -1721,9 +1900,11 @@ export const renderBatchReport = (batch: BatchResult): string => {
 export const main = async (
   args: readonly string[],
   log: (line: string) => void = console.log,
+  postureReader: typeof preflightPosture = preflightPosture,
 ): Promise<number> => {
   const flags = parseArgs([...args], {
     string: ["console", "out", "fabric-api-url", "base", "expect-git-sha"],
+    boolean: ["allow-diverged"],
     default: {
       console: DEFAULT_CONSOLE_URL,
       "fabric-api-url": Deno.env.get("CF_HARNESS_FABRIC_API_URL") ??
@@ -1733,7 +1914,9 @@ export const main = async (
   });
   const suitePath = flags._.map(String)[0];
   if (suitePath === undefined) {
-    log("usage: measure-batch <suite.json> [--console=URL] [--out=DIR]");
+    log(
+      "usage: measure-batch <suite.json> [--console=URL] [--out=DIR] [--allow-diverged]",
+    );
     return 2;
   }
   const suite = parseMeasurementSuite(
@@ -1741,15 +1924,22 @@ export const main = async (
   );
   const client = await ConsoleClient.open(flags.console);
   const startedAt = new Date().toISOString();
-  // Read what the fabric server is running, and refuse only a commit this
-  // batch was told to expect and did not find. Everything else about the
-  // server is recorded for the report rather than judged: its CFC block is its
-  // own preset's, not the console's, and differencing the two would refuse
-  // every correctly configured night.
-  const posture = await preflightPosture(
+  const consolePreflight = await client.preflightStatus();
+  if (consolePreflight.kind === "refused") {
+    log(
+      `the console status contract was refused, so no task ran: ${consolePreflight.reason}`,
+    );
+  }
+  // The server's CFC block is recorded rather than differenced against the
+  // console's because the two runtimes use different presets. A known commit
+  // divergence refuses unless the operator explicitly allows it.
+  const posture = await postureReader(
     flags["fabric-api-url"],
     flags.base,
     flags["expect-git-sha"],
+    undefined,
+    undefined,
+    flags["allow-diverged"],
   );
   if (posture.kind === "refused") {
     log(
@@ -1765,7 +1955,13 @@ export const main = async (
   // The index pre-flight is the unambiguous one: an index that does not answer
   // reads to a run exactly as an empty corpus does, so a batch that started
   // into one would spend the night producing evidence for the wrong problem.
-  const preflight = posture.kind === "refused"
+  const preflight = consolePreflight.kind === "refused"
+    ? {
+      kind: "refused" as const,
+      reason:
+        "the console status pre-flight refused first, so the index was not asked",
+    }
+    : posture.kind === "refused"
     ? {
       kind: "refused" as const,
       reason: "the commit pre-flight refused first, so the index was not asked",
@@ -1785,7 +1981,9 @@ export const main = async (
     )
     : await readSupersededVisibility(client, suite.supersededPatternIds ?? []);
   const results: TaskResult[] = [];
-  if (preflight.kind === "refused") {
+  if (consolePreflight.kind === "refused") {
+    // The named refusal was logged when the status was read.
+  } else if (preflight.kind === "refused") {
     log(`the index did not answer, so no task ran: ${preflight.reason}`);
   } else {
     log(
@@ -1793,7 +1991,12 @@ export const main = async (
     );
     log(`index before: ${renderIndexSnapshot(indexBefore)}`);
     for (const task of suite.tasks) {
-      results.push(await runTask(client, task, log));
+      results.push(
+        await runTask(client, task, log, {
+          batchStartedAt: startedAt,
+          artifactRoot: consolePreflight.artifactRoot,
+        }),
+      );
     }
   }
   const importedPatternIds = [
@@ -1821,6 +2024,7 @@ export const main = async (
     indexUrl: Deno.env.get("CF_HARNESS_PATTERN_INDEX_URL") ?? null,
     startedAt,
     endedAt: new Date().toISOString(),
+    consolePreflight,
     preflight,
     posture,
     importedPatternOrigins,
@@ -1848,6 +2052,7 @@ export const main = async (
   // A refused pre-flight is a distinct exit code from a batch whose tasks ran
   // and did not all complete: the first is a machine to fix before trying
   // again, the second is a result to read.
+  if (consolePreflight.kind === "refused") return 5;
   if (posture.kind === "refused") return 4;
   if (preflight.kind === "refused") return 3;
   return results.every((result) => result.outcome.kind === "turn_completed")

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -471,6 +471,20 @@ describe("console/server", () => {
     });
   });
 
+  describe("GET /api/status", () => {
+    it("answers with the configured artifact root before a task is started", async () => {
+      const response = await server.handle(
+        getRequest("/api/status", { cookie }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        artifactRoot: config().artifactRoot,
+        sessions: [],
+      });
+    });
+  });
+
   describe("POST /api/task", () => {
     it("starts a follow-up turn in the session the request names", async () => {
       const started = await startTask({ text: "track my books" });

--- a/packages/cf-harness/test/run-measurement-batch.test.ts
+++ b/packages/cf-harness/test/run-measurement-batch.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { copy } from "@std/fs";
 import { fromFileUrl } from "@std/path";
 
 import {
+  type BatchResult,
   classifyImportedPattern,
   ConsoleClient,
   indexChangeOf,
@@ -14,16 +16,34 @@ import {
   readServerMeta,
   readSseFrames,
   readSupersededVisibility,
-  renderBatchReport,
+  renderBatchReport as renderBatchReportImpl,
   resolveImportedPatternOrigins,
   runTask,
 } from "../scripts/run-measurement-batch.ts";
 import { main } from "../scripts/run-measurement-batch.ts";
 import { emptyTotals as emptyMeasurementTotals } from "../scripts/measure-runs.ts";
+import observedStatus from "./support/measurement-console-status.json" with {
+  type: "json",
+};
 
 const FIXTURE_ROOT = fromFileUrl(
   new URL("./support/measure-runs/runs", import.meta.url),
 );
+
+const RUN_TASK_OPTIONS = {
+  batchStartedAt: "2026-08-28T21:00:00.000Z",
+  artifactRoot: FIXTURE_ROOT,
+};
+
+const CONSOLE_PREFLIGHT = {
+  kind: "ready" as const,
+  artifactRoot: FIXTURE_ROOT,
+};
+
+const renderBatchReport = (
+  batch: Omit<BatchResult, "consolePreflight">,
+): string =>
+  renderBatchReportImpl({ ...batch, consolePreflight: CONSOLE_PREFLIGHT });
 
 const TOKEN = "cf_harness_console_token=fixture-token";
 
@@ -99,6 +119,9 @@ interface FakeConsoleOptions {
   }[];
   runId?: string;
   artifactRoot?: string;
+  touchRunState?: boolean;
+  statusArtifactRoot?: unknown;
+  statusSessions?: unknown;
   patterns?: readonly Record<string, unknown>[];
 
   /** What `/api/index/call` answers, and with what status. */
@@ -154,6 +177,17 @@ const startFakeConsole = (options: FakeConsoleOptions): FakeConsole => {
     if (url.pathname === "/api/task") {
       const body = await request.json() as { text: string };
       taskTexts.push(body.text);
+      if (
+        options.touchRunState && options.runId !== undefined &&
+        options.artifactRoot !== undefined
+      ) {
+        const path = `${options.artifactRoot}/${options.runId}/run-state.json`;
+        const state = JSON.parse(await Deno.readTextFile(path));
+        await Deno.writeTextFile(
+          path,
+          JSON.stringify({ ...state, createdAt: new Date().toISOString() }),
+        );
+      }
       return Response.json({
         sessionId: "session-1",
         turnId: "turn-1",
@@ -178,13 +212,18 @@ const startFakeConsole = (options: FakeConsoleOptions): FakeConsole => {
       );
     }
     if (url.pathname === "/api/status") {
+      const observedSession = observedStatus.sessions[0];
+      const requestedSessionId = url.searchParams.get("sessionId");
       return Response.json({
-        sessions: [{
-          sessionId: url.searchParams.get("sessionId"),
-          status: "idle",
-          ...(options.runId !== undefined
-            ? { harnessRunId: options.runId }
-            : {}),
+        ...(options.statusArtifactRoot === null ? {} : {
+          artifactRoot: options.statusArtifactRoot ??
+            options.artifactRoot ?? FIXTURE_ROOT,
+        }),
+        sessions: options.statusSessions ?? [{
+          ...observedSession,
+          ...(requestedSessionId === null
+            ? {}
+            : { sessionId: requestedSessionId }),
           ...(options.artifactRoot !== undefined
             ? { artifactRoot: options.artifactRoot }
             : {}),
@@ -292,7 +331,36 @@ const gitRun = (
       : { success: ancestor, code: ancestor ? 0 : 1 },
   );
 
+/** Writes the two artifacts the batch uses to identify a root run. */
+const writeRunCandidate = async (
+  artifactRoot: string,
+  runId: string,
+  createdAt: string,
+  firstUserMessage: string,
+): Promise<void> => {
+  const root = `${artifactRoot}/${runId}`;
+  await Deno.mkdir(root, { recursive: true });
+  await Deno.writeTextFile(
+    `${root}/run-state.json`,
+    JSON.stringify({ runId, createdAt }),
+  );
+  await Deno.writeTextFile(
+    `${root}/transcript.json`,
+    JSON.stringify([{ role: "user", content: firstUserMessage }]),
+  );
+};
+
 describe("run-measurement-batch", () => {
+  describe("captured console status", () => {
+    it("records the live route without an invented harness run identifier", () => {
+      expect(Array.isArray(observedStatus.sessions)).toBe(true);
+      const session = observedStatus.sessions[0] as Record<string, unknown>;
+      expect("harnessRunId" in session).toBe(false);
+      expect(typeof session.artifactRoot).toBe("string");
+      expect(typeof session.createdAt).toBe("string");
+    });
+  });
+
   describe("parseMeasurementSuite()", () => {
     it("returns the suite for a well-formed file", () => {
       expect(parseMeasurementSuite({
@@ -955,7 +1023,7 @@ describe("run-measurement-batch", () => {
   });
 
   describe("preflightPosture()", () => {
-    it("returns the reading, and does not refuse, for a server on a commit off the branch", async () => {
+    it("returns a refusal for a server on a commit off the branch", async () => {
       const posture = await preflightPosture(
         "http://server",
         "main",
@@ -963,11 +1031,27 @@ describe("run-measurement-batch", () => {
         metaFetch(META),
         gitRun(true, false),
       );
+      expect(posture.kind).toBe("refused");
+      expect(posture.kind === "refused" ? posture.reason : "").toContain(
+        "off main",
+      );
+      expect(posture.kind === "refused" ? posture.ancestry : undefined)
+        .toEqual({ kind: "diverged", base: "main" });
+    });
+
+    it("returns the reading for an explicitly allowed divergent server", async () => {
+      const posture = await preflightPosture(
+        "http://server",
+        "main",
+        undefined,
+        metaFetch(META),
+        gitRun(true, false),
+        true,
+      );
       expect(posture.kind).toBe("read");
-      expect(posture.kind === "read" ? posture.ancestry : undefined).toEqual({
-        kind: "diverged",
-        base: "main",
-      });
+      expect(posture.kind === "read" ? posture.ancestry.kind : undefined).toBe(
+        "diverged",
+      );
     });
 
     it("returns a reading for a server whose CFC dials are off, which is the production-server preset rather than a fault", async () => {
@@ -1148,6 +1232,39 @@ describe("run-measurement-batch", () => {
       const snapshot = await (await clientWithNoServer()).indexSnapshot();
       expect(snapshot.kind).toBe("unread");
       expect(snapshot.kind === "unread" ? snapshot.reason : "").not.toBe("");
+    });
+
+    it("refuses the status pre-flight when the console has gone away", async () => {
+      const preflight = await (await clientWithNoServer()).preflightStatus();
+      expect(preflight.kind).toBe("refused");
+      expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+        "/api/status could not be read",
+      );
+    });
+  });
+
+  describe("status pre-flight response shapes", () => {
+    it("refuses a status answer that is not an object", async () => {
+      const server = Deno.serve({ port: 0, onListen: () => {} }, (request) => {
+        const url = new URL(request.url);
+        if (url.pathname === "/") {
+          return new Response("", {
+            headers: { "set-cookie": `${TOKEN}; Path=/` },
+          });
+        }
+        return Response.json("not an object");
+      });
+      try {
+        const client = await ConsoleClient.open(
+          `http://127.0.0.1:${(server.addr as Deno.NetAddr).port}`,
+        );
+        expect(await client.preflightStatus()).toEqual({
+          kind: "refused",
+          reason: "/api/status did not return a JSON object",
+        });
+      } finally {
+        await server.shutdown();
+      }
     });
   });
 
@@ -1373,7 +1490,7 @@ describe("run-measurement-batch", () => {
   });
 
   describe("runTask()", () => {
-    it("measures the run family the console named for the session", async () => {
+    it("measures the run family whose first user message matches the task", async () => {
       const console_ = startFakeConsole({
         streams: [completedStream()],
         runId: "fixture-run",
@@ -1385,6 +1502,7 @@ describe("run-measurement-batch", () => {
           client,
           { id: "books", text: "Track the books I am reading." },
           () => {},
+          RUN_TASK_OPTIONS,
         );
         expect(console_.taskTexts).toEqual(["Track the books I am reading."]);
         expect(result.runId).toBe("fixture-run");
@@ -1396,6 +1514,29 @@ describe("run-measurement-batch", () => {
         expect(result.measurement?.totals.searchesRefused).toBe(1);
         expect(result.configuration.skillsRoot).toBe("/repo/skills");
         expect(result.configuration.skillsFound).toBe(2);
+      } finally {
+        await console_.close();
+      }
+    });
+
+    it("prefers the session artifact root to the console-wide fallback", async () => {
+      const console_ = startFakeConsole({
+        streams: [completedStream()],
+        artifactRoot: FIXTURE_ROOT,
+        statusArtifactRoot: "/a/different/console-wide/root",
+      });
+      try {
+        const client = await ConsoleClient.open(console_.url);
+        const result = await runTask(
+          client,
+          { id: "books", text: "Track the books I am reading." },
+          () => {},
+          {
+            ...RUN_TASK_OPTIONS,
+            artifactRoot: "/no/such/fallback/root",
+          },
+        );
+        expect(result.measurement?.totals.runPatterns).toBe(4);
       } finally {
         await console_.close();
       }
@@ -1413,6 +1554,7 @@ describe("run-measurement-batch", () => {
           client,
           { id: "books", text: "Track the books I am reading." },
           () => {},
+          RUN_TASK_OPTIONS,
         );
         expect(result.measurement).toBeUndefined();
         expect(result.measurementUnread).toContain(
@@ -1426,14 +1568,15 @@ describe("run-measurement-batch", () => {
     it("counts no skills for a registry whose skills field is not a list", async () => {
       const dir = await Deno.makeTempDir();
       try {
-        await Deno.mkdir(`${dir}/fixture-run`);
+        await writeRunCandidate(
+          dir,
+          "fixture-run",
+          "2026-08-28T21:00:01.000Z",
+          "do a thing",
+        );
         await Deno.writeTextFile(
           `${dir}/fixture-run/skill-registry.json`,
           JSON.stringify({ skillsRoot: "/repo/skills", skills: "lots" }),
-        );
-        await Deno.writeTextFile(
-          `${dir}/fixture-run/transcript.json`,
-          JSON.stringify([{ role: "user", content: "hi" }]),
         );
         const console_ = startFakeConsole({
           streams: [completedStream()],
@@ -1446,6 +1589,7 @@ describe("run-measurement-batch", () => {
             client,
             { id: "a", text: "do a thing" },
             () => {},
+            RUN_TASK_OPTIONS,
           );
           expect(result.configuration.skillsRoot).toBe("/repo/skills");
           expect(result.configuration.skillsFound).toBe(0);
@@ -1460,13 +1604,13 @@ describe("run-measurement-batch", () => {
     it("records a skill registry that could not be read for a reason other than absence", async () => {
       const dir = await Deno.makeTempDir();
       try {
-        await Deno.mkdir(`${dir}/fixture-run/skill-registry.json`, {
-          recursive: true,
-        });
-        await Deno.writeTextFile(
-          `${dir}/fixture-run/transcript.json`,
-          JSON.stringify([{ role: "user", content: "hi" }]),
+        await writeRunCandidate(
+          dir,
+          "fixture-run",
+          "2026-08-28T21:00:01.000Z",
+          "do a thing",
         );
+        await Deno.mkdir(`${dir}/fixture-run/skill-registry.json`);
         const console_ = startFakeConsole({
           streams: [completedStream()],
           runId: "fixture-run",
@@ -1478,6 +1622,7 @@ describe("run-measurement-batch", () => {
             client,
             { id: "a", text: "do a thing" },
             () => {},
+            RUN_TASK_OPTIONS,
           );
           expect(result.configuration.skillsUnread).toContain(
             "skill-registry.json could not be read",
@@ -1493,14 +1638,15 @@ describe("run-measurement-batch", () => {
     it("records a skill registry that names no skills root as its own reading", async () => {
       const dir = await Deno.makeTempDir();
       try {
-        await Deno.mkdir(`${dir}/fixture-run`);
+        await writeRunCandidate(
+          dir,
+          "fixture-run",
+          "2026-08-28T21:00:01.000Z",
+          "do a thing",
+        );
         await Deno.writeTextFile(
           `${dir}/fixture-run/skill-registry.json`,
           JSON.stringify({ type: "cf-harness.skill-registry", skills: [] }),
-        );
-        await Deno.writeTextFile(
-          `${dir}/fixture-run/transcript.json`,
-          JSON.stringify([{ role: "user", content: "hi" }]),
         );
         const console_ = startFakeConsole({
           streams: [completedStream()],
@@ -1513,6 +1659,7 @@ describe("run-measurement-batch", () => {
             client,
             { id: "books", text: "do a thing" },
             () => {},
+            RUN_TASK_OPTIONS,
           );
           expect(result.configuration.skillsUnread).toBe(
             "skill-registry.json names no skills root",
@@ -1526,23 +1673,272 @@ describe("run-measurement-batch", () => {
     });
 
     it("records why a session's run could not be measured rather than reporting no calls", async () => {
-      const console_ = startFakeConsole({ streams: [completedStream()] });
+      const artifactRoot = await Deno.makeTempDir();
       try {
-        const client = await ConsoleClient.open(console_.url);
-        const result = await runTask(
-          client,
-          { id: "books", text: "Track the books I am reading." },
-          () => {},
-        );
-        expect(result.measurement).toBeUndefined();
-        expect(result.measurementUnread).toBe(
-          "the console named no run and artifact root for this session",
-        );
-        expect(result.configuration.skillsUnread).toBe(
-          "the console named no run, so no skill registry could be read",
-        );
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            { ...RUN_TASK_OPTIONS, artifactRoot },
+          );
+          expect(result.measurement).toBeUndefined();
+          expect(result.measurementUnread).toBe(
+            "no root run created after 2026-08-28T21:00:00.000Z has this task as its first user message",
+          );
+          expect(result.configuration.skillsUnread).toBe(
+            "no run was selected, so no skill registry could be read",
+          );
+        } finally {
+          await console_.close();
+        }
       } finally {
-        await console_.close();
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    });
+
+    it("does not select a root run whose first user message is for another task", async () => {
+      const artifactRoot = await Deno.makeTempDir();
+      try {
+        await writeRunCandidate(
+          artifactRoot,
+          "another-task",
+          "2026-08-31T05:00:01.000Z",
+          "Create a shopping list.",
+        );
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            {
+              batchStartedAt: "2026-08-31T05:00:00.000Z",
+              artifactRoot,
+            },
+          );
+          expect(result.runId).toBeUndefined();
+          expect(result.measurementUnread).toContain(
+            "no root run created after 2026-08-31T05:00:00.000Z",
+          );
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    });
+
+    it("ignores a matching run created before the batch started", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeRunCandidate(
+          dir,
+          "before-batch",
+          "2026-08-31T04:59:59.000Z",
+          "Track the books I am reading.",
+        );
+        await writeRunCandidate(
+          dir,
+          "during-batch",
+          "2026-08-31T05:00:01.000Z",
+          "Track the books I am reading.",
+        );
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot: dir,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            {
+              batchStartedAt: "2026-08-31T05:00:00.000Z",
+              artifactRoot: dir,
+            },
+          );
+          expect(result.runId).toBe("during-batch");
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("records every candidate when two runs match the same task", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        for (const runId of ["candidate-one", "candidate-two"]) {
+          await writeRunCandidate(
+            dir,
+            runId,
+            "2026-08-31T05:00:01.000Z",
+            "Track the books I am reading.",
+          );
+        }
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot: dir,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            {
+              batchStartedAt: "2026-08-31T05:00:00.000Z",
+              artifactRoot: dir,
+            },
+          );
+          expect(result.measurement).toBeUndefined();
+          expect(result.measurementUnread).toContain("candidate-one");
+          expect(result.measurementUnread).toContain("candidate-two");
+          expect(result.measurementUnread).toContain("ambiguous");
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("records a malformed current run artifact rather than reporting no matching run", async () => {
+      const artifactRoot = await Deno.makeTempDir();
+      try {
+        await writeRunCandidate(
+          artifactRoot,
+          "malformed-run",
+          "2026-08-31T05:00:01.000Z",
+          "Track the books I am reading.",
+        );
+        await Deno.writeTextFile(
+          `${artifactRoot}/malformed-run/transcript.json`,
+          "{",
+        );
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            {
+              batchStartedAt: "2026-08-31T05:00:00.000Z",
+              artifactRoot,
+            },
+          );
+          expect(result.measurement).toBeUndefined();
+          expect(result.measurementUnread).toContain("malformed-run");
+          expect(result.measurementUnread).toContain("transcript.json");
+          expect(result.measurementUnread).not.toContain("no root run");
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    });
+
+    it("records unread and non-object run states rather than treating them as no run", async () => {
+      const artifactRoot = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(`${artifactRoot}/not-a-run.txt`, "note");
+        await Deno.mkdir(`${artifactRoot}/not-an-object`);
+        await Deno.writeTextFile(
+          `${artifactRoot}/not-an-object/run-state.json`,
+          "[]",
+        );
+        await Deno.mkdir(`${artifactRoot}/unread-state/run-state.json`, {
+          recursive: true,
+        });
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            { ...RUN_TASK_OPTIONS, artifactRoot },
+          );
+          expect(result.measurement).toBeUndefined();
+          expect(result.measurementUnread).toContain(
+            "not-an-object/run-state.json was not an object",
+          );
+          expect(result.measurementUnread).toContain(
+            "unread-state/run-state.json could not be read",
+          );
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
+      }
+    });
+
+    it("records unread and non-list transcripts rather than treating them as no run", async () => {
+      const artifactRoot = await Deno.makeTempDir();
+      try {
+        await writeRunCandidate(
+          artifactRoot,
+          "not-a-list",
+          "2026-08-31T05:00:01.000Z",
+          "Track the books I am reading.",
+        );
+        await Deno.writeTextFile(
+          `${artifactRoot}/not-a-list/transcript.json`,
+          "{}",
+        );
+        await writeRunCandidate(
+          artifactRoot,
+          "unread-transcript",
+          "2026-08-31T05:00:01.000Z",
+          "Track the books I am reading.",
+        );
+        await Deno.remove(`${artifactRoot}/unread-transcript/transcript.json`);
+        await Deno.mkdir(`${artifactRoot}/unread-transcript/transcript.json`);
+        const console_ = startFakeConsole({
+          streams: [completedStream()],
+          artifactRoot,
+        });
+        try {
+          const client = await ConsoleClient.open(console_.url);
+          const result = await runTask(
+            client,
+            { id: "books", text: "Track the books I am reading." },
+            () => {},
+            { ...RUN_TASK_OPTIONS, artifactRoot },
+          );
+          expect(result.measurement).toBeUndefined();
+          expect(result.measurementUnread).toContain(
+            "not-a-list/transcript.json was not a message list",
+          );
+          expect(result.measurementUnread).toContain(
+            "unread-transcript/transcript.json could not be read",
+          );
+        } finally {
+          await console_.close();
+        }
+      } finally {
+        await Deno.remove(artifactRoot, { recursive: true });
       }
     });
   });
@@ -1566,25 +1962,40 @@ describe("run-measurement-batch", () => {
       options: FakeConsoleOptions,
       suite: unknown,
       extraArgs: readonly string[] = [],
+      postureReader: typeof preflightPosture = preflightPosture,
     ): Promise<{ code: number; logs: string[]; dir: string }> => {
-      const console_ = startFakeConsole(options);
       const dir = await Deno.makeTempDir();
       // Registered before anything can throw, so the directory is removed
       // however this call ends. A caller's own `finally` cannot do that: if
       // `await runMain(...)` rejects, the destructuring throws and the
       // caller's cleanup never runs at all.
       temporaryDirectories.push(dir);
+      let consoleOptions = options;
+      if (options.artifactRoot === FIXTURE_ROOT) {
+        const artifactRoot = `${dir}/runs`;
+        await copy(FIXTURE_ROOT, artifactRoot);
+        consoleOptions = {
+          ...options,
+          artifactRoot,
+          touchRunState: true,
+        };
+      }
+      const console_ = startFakeConsole(consoleOptions);
       try {
         const suitePath = `${dir}/suite.json`;
         await Deno.writeTextFile(suitePath, JSON.stringify(suite));
         const logs: string[] = [];
-        const code = await main([
-          suitePath,
-          `--console=${console_.url}`,
-          `--fabric-api-url=${console_.url}`,
-          `--out=${dir}/out`,
-          ...extraArgs,
-        ], (line) => logs.push(line));
+        const code = await main(
+          [
+            suitePath,
+            `--console=${console_.url}`,
+            `--fabric-api-url=${console_.url}`,
+            `--out=${dir}/out`,
+            ...extraArgs,
+          ],
+          (line) => logs.push(line),
+          postureReader,
+        );
         return { code, logs, dir };
       } finally {
         await console_.close();
@@ -1658,7 +2069,7 @@ describe("run-measurement-batch", () => {
         expect(code).toBe(4);
         const report = await Deno.readTextFile(`${dir}/out/report.md`);
         expect(report).toContain(
-          "**The fabric server was not the one this batch was told to expect",
+          "**The fabric server did not satisfy the batch's commit contract",
         );
         // Pin the reason, not just the header: a `/api/meta` this stand-in
         // refused outright would print the same header and mean something
@@ -1672,6 +2083,75 @@ describe("run-measurement-batch", () => {
       } finally {
         // the directory is removed by this block's afterEach
       }
+    });
+
+    it("returns 4 for known divergence unless the explicit opt-out is passed", async () => {
+      const postureReader: typeof preflightPosture = (
+        _url,
+        base,
+        _expectGitSha,
+        _fetch,
+        _run,
+        allowDiverged,
+      ) =>
+        Promise.resolve(
+          allowDiverged
+            ? { kind: "read", meta: META, ancestry: { kind: "diverged", base } }
+            : {
+              kind: "refused",
+              meta: META,
+              ancestry: { kind: "diverged", base },
+              reason: `the server is off ${base}`,
+            },
+        );
+      const refused = await runMain(
+        { streams: [completedStream()] },
+        ONE_TASK,
+        [],
+        postureReader,
+      );
+      expect(refused.code).toBe(4);
+      const allowed = await runMain(
+        {
+          streams: [completedStream()],
+          artifactRoot: FIXTURE_ROOT,
+        },
+        ONE_TASK,
+        ["--allow-diverged"],
+        postureReader,
+      );
+      expect(allowed.code).toBe(0);
+    });
+
+    it("returns 5 and runs no task when status names no top-level artifact root", async () => {
+      const { code, dir, logs } = await runMain({
+        streams: [completedStream()],
+        statusArtifactRoot: null,
+      }, ONE_TASK);
+      expect(code).toBe(5);
+      expect(logs.join("\n")).toContain("artifactRoot");
+      const report = JSON.parse(
+        await Deno.readTextFile(`${dir}/out/report.json`),
+      );
+      expect(report.results).toEqual([]);
+    });
+
+    it("returns 5 and runs no task when status names a relative artifact root", async () => {
+      const { code, logs } = await runMain({
+        streams: [completedStream()],
+        statusArtifactRoot: "relative/runs",
+      }, ONE_TASK);
+      expect(code).toBe(5);
+      expect(logs.join("\n")).toContain("absolute");
+    });
+
+    it("returns 5 and runs no task when status sessions is not an array", async () => {
+      const { code, logs } = await runMain({
+        streams: [completedStream()],
+        statusSessions: {},
+      }, ONE_TASK);
+      expect(code).toBe(5);
+      expect(logs.join("\n")).toContain("sessions");
     });
 
     it("returns 1 for a batch whose task did not complete", async () => {
@@ -1784,6 +2264,7 @@ describe("run-measurement-batch", () => {
           client,
           { id: "books", text: "Track the books I am reading." },
           () => {},
+          RUN_TASK_OPTIONS,
         );
         return renderBatchReport({
           suite: {
@@ -1840,6 +2321,7 @@ describe("run-measurement-batch", () => {
           client,
           { id: "books", text: "Track the books I am reading." },
           () => {},
+          RUN_TASK_OPTIONS,
         );
         const report = renderBatchReport({
           suite: {
@@ -1881,6 +2363,7 @@ describe("run-measurement-batch", () => {
           client,
           { id: "books", text: "Track the books I am reading." },
           () => {},
+          RUN_TASK_OPTIONS,
         );
         const report = renderBatchReport({
           suite: {

--- a/packages/cf-harness/test/support/measure-runs/runs/fixture-run/run-state.json
+++ b/packages/cf-harness/test/support/measure-runs/runs/fixture-run/run-state.json
@@ -1,0 +1,4 @@
+{
+  "runId": "fixture-run",
+  "createdAt": "2026-08-28T21:00:01.000Z"
+}

--- a/packages/cf-harness/test/support/measure-runs/runs/fixture-run/transcript.json
+++ b/packages/cf-harness/test/support/measure-runs/runs/fixture-run/transcript.json
@@ -5,7 +5,7 @@
   },
   {
     "role": "user",
-    "content": "Keep track of the books I am reading."
+    "content": "Track the books I am reading."
   },
   {
     "role": "assistant",

--- a/packages/cf-harness/test/support/measurement-console-status.json
+++ b/packages/cf-harness/test/support/measurement-console-status.json
@@ -1,0 +1,59 @@
+{
+  "sessions": [
+    {
+      "sessionId": "cff207fc-e8a1-4af5-a68f-348e446a56cf",
+      "status": "idle",
+      "reusable": true,
+      "turnCount": 1,
+      "createdAt": "2026-08-31T05:14:20.874Z",
+      "updatedAt": "2026-08-31T05:14:23.242Z",
+      "workspace": {
+        "hostPath": "/Users/ben/.bb/worktrees/env_j49cb9z7jg/labs/packages/cf-harness/.cf-harness-console/workspace"
+      },
+      "model": "gpt-5.6-terra",
+      "artifactRoot": "/private/tmp/ct-2138-console-runs",
+      "capabilities": {
+        "partialTextStream": false,
+        "toolTelemetry": true,
+        "fileMutationEvents": true,
+        "browserProfile": true,
+        "browserAccessLease": true,
+        "delegation": true,
+        "readonlyMode": true,
+        "imageAttachments": true,
+        "cfcEnforcement": true,
+        "structuredErrors": true
+      },
+      "policy": {
+        "type": "cf-harness.chat-policy",
+        "toolMode": "workspace-write",
+        "allowedToolIds": [
+          "bash",
+          "read_file",
+          "view_image",
+          "read_skill_resource",
+          "edit_file",
+          "write_file",
+          "delegate_task",
+          "describe_handle",
+          "run_pattern",
+          "assign_slug"
+        ],
+        "allowedSubagentProfiles": [
+          "default",
+          "pattern-author"
+        ],
+        "promptSlot": {
+          "type": "https://commonfabric.org/cfc/atom/PromptSlotBound",
+          "source": {
+            "type": "cf-harness.cli-input",
+            "surface": "console-web"
+          },
+          "role": "direct-command",
+          "kernelName": "cf-harness",
+          "surface": "console-web"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the console-wide absolute artifact root to the authenticated status response and document the route
- preflight the live status contract before index reads or model turns
- locate each task run by run creation time plus exact first-user-message matching, refusing ambiguous candidates by name
- refuse known git divergence by default with an explicit allow-diverged opt-out; keep unchecked ancestry non-fatal
- commit the exact status payload captured from a real current-main console as the fake-console fixture

## Red-first evidence

Each new contract was observed failing before implementation: missing route field, missing/relative artifact root, non-array sessions, stale-run exclusion, duplicate candidate ambiguity, captured fixture without harnessRunId, per-session root precedence, and divergence flag wiring.

## Verification

- cf-harness package: 890 tests, 1430 steps
- focused measurement runner: 139 steps
- repository fmt and lint
- repository typecheck: 601 paths in 46 package groups
- docs check: 589 code blocks

Fixes CT-2138.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

