### PR TITLE
docs(patterns): the emitted descriptions name commands that run

### DIFF
--- a/packages/patterns/baselines/gideon-tests/select-initial-value-repro.tsx/20260831T151726Z-n_3gqi0OsMaeEYme.json
+++ b/packages/patterns/baselines/gideon-tests/select-initial-value-repro.tsx/20260831T151726Z-n_3gqi0OsMaeEYme.json
@@ -1,0 +1,28 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "gideon-tests/select-initial-value-repro.tsx",
+  "resultSchema": {
+    "description": "Reproduction case for cf-select not displaying initial values from backend.\n\nBug: When a cf-select is bound to a cell via $value, the dropdown would show\nthe placeholder \"-\" instead of the actual cell value on initial page load.\nThe value was present in the cell, but the component's onChange callback\nwasn't being called when the subscription received backend updates.\n\nRoot cause: CellController._setupCellSubscription() only called\nhost.requestUpdate() when cell values changed, but didn't call the onChange\ncallback. Components like cf-select rely on onChange to sync their DOM state.\n\nFix: In cell-controller.ts, the subscription callback now calls onChange\nwhen the cell value changes from the backend.\n\nTo test:\n1. Deploy this pattern with `piece new`\n2. Use CLI to set values: echo '\"video\"' | cf set --piece ID type ...\n3. Refresh the page - the dropdown should show \"🎬 Video\", not \"-\"\n4. The \"Current value\" text should also display \"video\"",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "type",
+      "status",
+      "$NAME"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/gideon-tests/select-initial-value-repro.tsx
+++ b/packages/patterns/gideon-tests/select-initial-value-repro.tsx
@@ -17,7 +17,7 @@ import { NAME, pattern, UI, Writable } from "commonfabric";
  *
  * To test:
  * 1. Deploy this pattern with `piece new`
- * 2. Use CLI to set values: echo '"video"' | cf piece set --piece ID type ...
+ * 2. Use CLI to set values: echo '"video"' | cf set --piece ID type ...
  * 3. Refresh the page - the dropdown should show "🎬 Video", not "-"
  * 4. The "Current value" text should also display "video"
  */

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -135,7 +135,7 @@ export interface AddTopicEvent {
 export interface AddTopicResult {
   /** The topic this call created — the piece itself, not a manufactured
    * identifier. It reaches the caller as a link to the child, which the CLI
-   * renders as an address (`cf piece call --show-links`). A caller therefore
+   * renders as an address (`cf call --show-links`). A caller therefore
    * addresses the new topic straight from the create, instead of filing it and
    * then searching the board's index for the topic it just made.
    *


### PR DESCRIPTION
## Why

A doc comment on a pattern is not a comment by the time it reaches a caller.
The generator emits it into the pattern's schema, where `cf piece verbs` and a
piece's own description surface it — so two of them currently teach a caller to
run `cf piece call --show-links` and `cf piece set`, which [#6004](https://github.com/commontoolsinc/labs/pull/6004)
removes. After that lands, a caller following the emitted instructions hits a
command the CLI refuses.

This is split out of #6004 deliberately: it is the only part of that sweep that
touches a pattern's emitted schema, and it wants its own compatibility run
rather than riding a CLI removal.

## What changed

Two comments, one word each.

- `packages/patterns/topics/main.tsx` — `cf piece call --show-links` → `cf call --show-links`
- `packages/patterns/gideon-tests/select-initial-value-repro.tsx` — `cf piece set` → `cf set`

Plus the one contract this records, appended.

## Does this break a deployed piece?

No, and the reason is mechanical rather than a judgement. `description` is in
`ANNOTATION_KEYS` in `packages/piece/src/schema-compatibility.ts` — validation-neutral
by spec, so it may change freely across a pattern update. Nothing about what any
deployed piece accepts or provides moves.

Measured, not assumed:

- `topics/main.tsx` records **no** new contract. Its comment does not reach the
  recorded contract at all, so the deployed board needs nothing.
- `gideon-tests/select-initial-value-repro.tsx` records **one**, appended as a
  new file. No existing baseline is modified.

## Test plan

- `deno task pattern-compat` — passes. On unmodified `main` it also passes while
  printing 14 informational `topics/topic.tsx` lines; those are pre-existing and
  tolerated, confirmed by running the control before attributing anything to this
  change.
- `deno task pattern-compat --update` — "353 pattern(s) can be updated from every
  recorded contract."
- `deno task cfcheck` — 444 pattern files, exit 0.
- `check-baselines-append-only`, `fmt --check`, `lint`, `check-control-characters`,
  `check-conflict-markers` — all pass.

## Order

Independent of #6004 and safe either side of it. Landing it first closes the
window where the emitted prose teaches a removed command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

