### PR TITLE
docs(patterns): two comments named commands 6b removed

### DIFF
--- a/packages/patterns/baselines/gideon-tests/select-initial-value-repro.tsx/20260831T153123Z-VE57c3gMDXycwCgM.json
+++ b/packages/patterns/baselines/gideon-tests/select-initial-value-repro.tsx/20260831T153123Z-VE57c3gMDXycwCgM.json
@@ -1,0 +1,28 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "gideon-tests/select-initial-value-repro.tsx",
+  "resultSchema": {
+    "description": "Reproduction case for cf-select not displaying initial values from backend.\n\nBug: When a cf-select is bound to a cell via $value, the dropdown would show\nthe placeholder \"-\" instead of the actual cell value on initial page load.\nThe value was present in the cell, but the component's onChange callback\nwasn't being called when the subscription received backend updates.\n\nRoot cause: CellController._setupCellSubscription() only called\nhost.requestUpdate() when cell values changed, but didn't call the onChange\ncallback. Components like cf-select rely on onChange to sync their DOM state.\n\nFix: In cell-controller.ts, the subscription callback now calls onChange\nwhen the cell value changes from the backend.\n\nTo test:\n1. Deploy this pattern with `cf piece new`\n2. Use CLI to set values: echo '\"video\"' | cf set --piece ID type ...\n3. Refresh the page - the dropdown should show \"🎬 Video\", not \"-\"\n4. The \"Current value\" text should also display \"video\"",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "type",
+      "status",
+      "$NAME"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/gideon-tests/select-initial-value-repro.tsx
+++ b/packages/patterns/gideon-tests/select-initial-value-repro.tsx
@@ -16,8 +16,8 @@ import { NAME, pattern, UI, Writable } from "commonfabric";
  * when the cell value changes from the backend.
  *
  * To test:
- * 1. Deploy this pattern with `piece new`
- * 2. Use CLI to set values: echo '"video"' | cf piece set --piece ID type ...
+ * 1. Deploy this pattern with `cf piece new`
+ * 2. Use CLI to set values: echo '"video"' | cf set --piece ID type ...
  * 3. Refresh the page - the dropdown should show "🎬 Video", not "-"
  * 4. The "Current value" text should also display "video"
  */

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -135,7 +135,7 @@ export interface AddTopicEvent {
 export interface AddTopicResult {
   /** The topic this call created — the piece itself, not a manufactured
    * identifier. It reaches the caller as a link to the child, which the CLI
-   * renders as an address (`cf piece call --show-links`). A caller therefore
+   * renders as an address (`cf call --show-links`). A caller therefore
    * addresses the new topic straight from the create, instead of filing it and
    * then searching the board's index for the topic it just made.
    *


### PR DESCRIPTION
## Why

Step 6b removed `cf piece get`, `cf piece set` and `cf piece call`. Two pattern comments still named them, and one is instructions someone would follow:

- `packages/patterns/gideon-tests/select-initial-value-repro.tsx` — its own "To test" steps say `echo '"video"' | cf piece set --piece ID type`. Anyone reproducing the bug now gets a command that does not exist.
- `packages/patterns/topics/main.tsx` — a doc comment on the topic a create returns cites `cf piece call --show-links` as how the address renders.

## What Changed

Both cite the surviving spelling. The repro's step 1 also gains its missing `cf` (`piece new` → `cf piece new`).

A new contract baseline for the repro pattern, because **a pattern's doc comment reaches its schema**: editing one mints a new contract even when nothing about the shape moved. `deno task pattern-compat` named it and `--update` recorded it. Worth knowing generally — a typo fix in a pattern comment costs a baseline file.

## What I deliberately left alone

Two other live references to the removed spellings are correct as they stand, and changing them would weaken a guard:

- `packages/cli/test/json-command.test.ts:50` — the comment explains why the test asserts `["piece", "get", "path"]` reserves nothing. It names the spelling *because* it is gone.
- `packages/cli/test/main-command.test.ts:225` — a guard against the spelling coming back.

`docs/plans/cli-surface-implementation.md` also names them in past tense, and stays live: its stage 4 is the merges, which is step 7 and has not started. Not archivable yet.

## Test plan

`deno fmt --check`, `deno lint`, `deno task cfcheck` (444 pattern files), `deno task check-baselines-append-only`, `deno task pattern-compat` (353 patterns updatable from every recorded contract), `deno task pattern-vintage` (8 vintages, 82 targets updated cleanly).

The `topics/topic.tsx` compatibility notices in that output are the recorded demand-narrowing break and are unrelated to this change.

— via Claude Opus 5, on behalf of @mpsalisbury

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

