### PR TITLE
docs(development): what the arc's two open rule questions resolve to

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -271,11 +271,10 @@ comment; without the one below, the frame reads as a note on the declaration it
 touches rather than as a heading over what follows.
 
 Directly under an opening bracket there is nothing above to separate from, and
-`deno fmt` removes a blank line there in any case. A frame in that position is
-also the first content of the block, which is where a comment about the whole
-block goes, so the two shapes are indistinguishable to a reader: put the
-region's first marker after the block's shared setup instead, or let the
-whole-block comment do the work.
+`deno fmt` removes a blank line there in any case. A frame there takes no blank
+line above it, and reads as the first region of the block rather than as a note
+on it. Where the block opens with shared setup instead, the region's first
+marker goes after it.
 
 **A region has an end, and writing the marker is choosing it.** A marker opens
 a region that runs to the next marker at the same level, or to the end of the

--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -270,9 +270,11 @@ Three nearby shapes are not this one:
   description above it is not worth writing.
 
   Two things stop that. Where a file marks its regions in a series and this
-  marker is one of the series, it stays; a file with one way of showing its
-  regions beats a file that demotes eleven markers and leaves the twelfth
-  reading as an omission. And where the marker closes the region above it,
+  marker is one of the series, it stays. The series is what says where each
+  region begins and ends, so a marker missing from the middle of one leaves
+  the region above it looking wider than it is. The text can say no more
+  than the block does and the marker still earns its place, because what it
+  carries is the boundary. And where the marker closes the region above it,
   removing it reopens that region, so it is replaced rather than removed —
   by a marker titling what follows, or by wrapping the region above in a
   `describe()` that ends it.

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -683,15 +683,6 @@ Deno.test("parse: a computed-callee call is labeled by its first source line", (
 });
 
 //
-// safe() catch path (lines 1725-1727)
-//
-// safe() swallows exceptions in metadata extraction. Hard to force a throw from
-// well-formed input; instead, confirm the surrounding metadata still appears
-// for a normal node (the try path), and rely on malformed schema input below to
-// drive readSchemaProps over odd shapes without throwing.
-//
-
-//
 // importMeta: default name + namespace import (lines 1740, 1743)
 //
 

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -2204,7 +2204,6 @@ describe("opening a space root", () => {
     // symbol-differs sibling below proves the gate does NOT short-circuit when
     // only the identity matches.
 
-    // Disable the updater so startup reaches the cold-start repair path.
     await setupHome();
     await controller.recreateDefaultPattern({
       customProgram: {

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -180,11 +180,12 @@ function createContext(sourceFile: ts.SourceFile): {
 }
 
 //
-// Shrinking and wrapping the shapes that match
+// Shrinking and wrapping: the paths that resolve, and the ones that do not
 //
-// The arms where a path resolves: array items and their unions, nested
+// The arms where a path resolves — array items and their unions, nested
 // leaves, identity paths across members, and the cell capabilities carried
-// through them.
+// through them — beside the diagnostics and the untouched nodes that a path
+// failing to resolve produces.
 //
 
 Deno.test("applyShrinkAndWrap shrinks Array<T> reference items to accessed fields", () => {
@@ -983,10 +984,11 @@ Deno.test("applyShrinkAndWrap applies cell capabilities through parenthesized li
 });
 
 //
-// The unchanged and no-match arms
+// Node shapes taken one at a time
 //
-// Each identity-path node shape where nothing matches, with the remaining
-// array-element and default clusters.
+// Each shape the walk can meet — arrays and their aliases, parenthesized and
+// wrapper references, unions, and the defaults applied through them —
+// whether or not a path matches inside it.
 //
 
 Deno.test("applyShrinkAndWrap keeps Array<T> unchanged for an unresolved identity item path", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Five things the comment arc's review filed and left open. Two are decisions
about the rule itself; three are findings held back because another change had
the files.

## A frame directly under an opening bracket

`.claude/rules/tests.md` and `code-comment-style.md` disagreed about it. The
first sanctions the position — a frame is "set off by a blank line below it and
above it where there is anything above" — and the second told a reader not to
write one there, offering two remedies.

A census settles which way to resolve it. Of 1093 `//` frames in the tree, none
sits at a file's first line and nine sit directly under an opening bracket, so
the sanctioning clause has no population other than the position the other
document forbade. Eight of those nine are the first of a series of markers at
the same indent: the marker IS the block's first content, so "put the region's
first marker after the block's shared setup" cannot be done, and "let the
whole-block comment do the work" makes the comment false, because the marker
names one region of several.

`code-comment-style.md` now says the position is legal and a frame there takes
no blank line above, keeping the shared-setup remedy for the case it is true
of. No site in the tree changes.

## Why a single-block marker in a series stays

The carve-out already existed; what it gave was a preference — one way of
showing regions "beats" a file that demotes eleven markers and leaves the
twelfth reading as an omission. The reason is structural rather than aesthetic,
and saying so is what makes the rule applicable: the series is what says where
each region begins and ends, so a marker missing from the middle of one leaves
the region above it looking wider than it is. The text may say no more than the
block does and the marker still earns its place, because what it carries is the
boundary.

That also draws the line the preference could not. A marker whose region is
empty carries no boundary, and one such frame is removed below.

## A comment naming an action its test does not take

`check-update-default-pattern.test.ts` read "Disable the updater so startup
reaches the cold-start repair path" above `await setupHome();`. That helper
takes only `cfcEnforcementMode`, is called there with no argument, and disables
nothing; the test drives `ensureDefaultPattern()` rather than startup. The
sentence predates this arc. It is removed rather than reworded: all sixteen
`await setupHome()` calls in the file now carry no comment, which is what the
other fifteen already did.

## A frame marking nothing, describing a difficulty that has since gone

`view-parse-cov.test.ts` carried a frame whose region was empty — the next
frame opened two lines below it. Its text said a throw is "hard to force from
well-formed input", which was true when it was written and is not now:
`view-parse-cov2.test.ts` forces exactly that throw through the test-only
handle. Removed. A scan of that file reports 26 frames and none marking an
empty region.

## Two titles claiming a division their members do not honor

`type-shrinking-coverage.test.ts` divides its cases into regions by batch, and
two titles described the division as though it were by outcome.

"Shrinking and wrapping the shapes that match" headed 24 tests, of which seven
are diagnostics or explicit no-matches — one of them named "keeps an interface
reference when no identity path matches". Its sibling "The unchanged and
no-match arms" headed twelve, of which about seven are matches, including a
parenthesized root rebuilt when a leaf changes and a writable capability
selected for a read-and-write leaf.

Both titles now describe what their region holds. Making a sharp title true
instead would mean re-cutting the regions, which is moving tests rather than
editing comments.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

