### PR TITLE
test: what two reviews found in the four PRs, read on main

### DIFF
--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -33,7 +33,7 @@ function nameOffsetOf(doc: Document, name: string): number {
 }
 
 //
-// createSemantics: build success path that the !program guard backstops
+// createSemantics: build's own isolation, which the !program guard backstops
 //
 
 Deno.test("semantics: a healthy build returns a Program (the !program guard is a backstop)", () => {
@@ -148,7 +148,7 @@ const x = 1;`;
 });
 
 //
-// createDiffSemantics: build success path the failure guards backstop
+// createDiffSemantics: where the failure guards are backstops
 //
 
 const FILE_TEXT = `export function double(n: number): number {

--- a/packages/memory/test/v2-explicit-read.test.ts
+++ b/packages/memory/test/v2-explicit-read.test.ts
@@ -603,6 +603,7 @@ Deno.test("stage A: a lease holder names two instances of one (branch, id, scope
   // the service instance and a demander's instance of one doc). The wire
   // collapse guard stays for everyone else: a NON-holder's wire carries scope
   // names only, so its ambiguous read set is still refused loudly.
+
   const server = newServer("memory://explicit-read-two-instances");
   setServerExecutionConfig(true);
   try {

--- a/packages/memory/test/v2-sqlite-row-label.test.ts
+++ b/packages/memory/test/v2-sqlite-row-label.test.ts
@@ -57,6 +57,20 @@ function emailSpec(): RowLabelSpec {
   return schema.rowLabel as RowLabelSpec;
 }
 
+function expectError(
+  spec: RowLabelSpec,
+  row: Record<string, unknown>,
+  ctx: { dbOwner?: string },
+  needle: string,
+) {
+  const res = evaluateRowLabel(spec, row, ctx);
+  assert("error" in res, `expected {error} for ${JSON.stringify(row)}`);
+  assert(
+    res.error.includes(needle),
+    `error "${res.error}" should mention "${needle}"`,
+  );
+}
+
 //
 // Builder -> AST
 //
@@ -599,20 +613,6 @@ Deno.test("constant() injects a literal atom; intersect() meets integrity atom s
 // Each returns {error}, never a partial label.
 //
 
-function expectError(
-  spec: RowLabelSpec,
-  row: Record<string, unknown>,
-  ctx: { dbOwner?: string },
-  needle: string,
-) {
-  const res = evaluateRowLabel(spec, row, ctx);
-  assert("error" in res, `expected {error} for ${JSON.stringify(row)}`);
-  assert(
-    res.error.includes(needle),
-    `error "${res.error}" should mention "${needle}"`,
-  );
-}
-
 Deno.test("a referenced field absent from the row fails closed", () => {
   expectError(
     emailSpec(),
@@ -681,8 +681,8 @@ Deno.test("dbOwner() with no owner in ctx fails closed", () => {
 // evaluateRowLabel — OR-clause evaluation (Epic E1)
 //
 // An anyOf node evaluates to one structural OR-clause rather than to flattened
-// atoms, and a conjunction smuggled in as an alternative fails closed instead
-// of widening into one.
+// atoms, a conjunction smuggled in as an alternative fails closed instead of
+// widening into one, and an all() of any()-clauses composes into proper CNF.
 //
 
 Deno.test("an anyOf node evaluates to a structural OR-clause (Epic E1)", () => {

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -765,8 +765,8 @@ describe("cf-code-editor cursor stability", () => {
   //
   // Race conditions, timing edges, and awkward updates
   //
-  // Awkward in both senses: content the editor must render intact, and an
-  // update that changes nothing.
+  // Awkward covers content the editor must render intact, an update that
+  // changes nothing, and an echo that comes back altered.
   //
 
   it("ADVERSARIAL: Cell update at exact debounce boundary should not corrupt state", async () => {

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -790,9 +790,9 @@ describe("stage G outbox + sqlite discharge", () => {
   // Refusals and failures at delivery
   //
   // What the drain does at the floor: a declared userless row delivers, an
-  // undeclared one retires, a deterministic rejection retires after writing
-  // its failure notice back onto the source event, and a transport failure
-  // keeps the row for the next drain.
+  // undeclared one retires, a deterministic rejection retires — one of them
+  // after writing its failure notice back onto the source event — and a
+  // transport failure keeps the row for the next drain.
   //
 
   it("does not retry an LT4 deterministic admission rejection: the row is deleted and counted failed", async () => {

--- a/packages/runner/test/runtime-dispose-withheld-commit.test.ts
+++ b/packages/runner/test/runtime-dispose-withheld-commit.test.ts
@@ -56,13 +56,12 @@ function makeServer(): MemoryV2Server.Server {
 }
 
 Deno.test("runtime.dispose() resolves while a commit is withheld in flight", async () => {
-  // runtime.dispose() tears down storage as part of shutdown. Storage teardown
-  // used to flush in-flight commits — awaiting their confirmation — BEFORE
-  // closing the client that would settle them. A commit whose response is
-  // withheld past dispose never confirms on its own, so that pre-teardown flush
-  // deadlocked, and dispose() hung. Teardown must reject in-flight commits (the
-  // way it already rejects in-flight reads) rather than wait on a response that
-  // may never come.
+  // runtime.dispose() tears down storage as part of shutdown, and teardown
+  // rejects in-flight commits the way it already rejects in-flight reads,
+  // rather than awaiting a confirmation that may never arrive. A commit whose
+  // response is withheld past dispose never confirms on its own, so a teardown
+  // that flushed before closing the client that settles them would wait for
+  // this one forever.
 
   const signer = await Identity.fromPassphrase(
     "runtime-dispose-withheld-commit",

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -39,12 +39,15 @@ Deno.test("spans carry both the service attributes and the SDK defaults", () => 
 });
 
 //
+// Which copy of the tracer SDK is in use
+//
 // `OpenInferenceBatchSpanProcessor` subclasses `BatchSpanProcessor`, but
 // @arizeai/openinference-vercel imports @opentelemetry/sdk-trace-base without
 // declaring it as a dependency, and the range it names in its development
 // dependencies stops below the major this workspace resolves. Which copy it
 // subclasses is therefore decided by the workspace import map rather than by
-// anything the package states, and the span export above depends on the answer.
+// anything the package states, and the span export in this section depends on
+// the answer.
 //
 
 Deno.test("the OpenInference processor extends the tracer SDK in use", () => {

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -476,6 +476,43 @@ export default pattern((state: State) => {
   assertEquals(liftInputSchemas(root), [readSchema, readSchema]);
 });
 
+Deno.test("assert leaves an operator it does not record alone", async () => {
+  const root = await transformed(patternSource(`
+  const check = assert(() => (a.get(), b.get() === 2));
+  return { check };`));
+
+  // A comma yields its right operand; neither side is an operand of a
+  // comparison, so there is nothing to record. The body is still a record.
+  assertEquals(assertCaptures(root), []);
+  assertEquals(recordSource(root), "(a.get(), b.get() === 2)");
+});
+
+Deno.test("assert leaves a namespace receiver alone when nothing else records", async () => {
+  const root = await transformed(patternSource(`
+  const check = assert(() => Object.is(1, 1));
+  return { check };`));
+
+  // Both arguments are literals, so the receiver is reached for — but
+  // `Object` is a namespace, and its value would say nothing.
+  assertEquals(assertCaptures(root), []);
+  assertEquals(recordSource(root), "Object.is(1, 1)");
+});
+
+Deno.test("assert leaves an optional-call receiver alone", async () => {
+  const root = await transformed(
+    `import { assert, cell, pattern } from "commonfabric";
+export default pattern(() => {
+  const maybe = cell<number[] | undefined>(undefined);
+  const check = assert(() => maybe.get()?.includes(1) ?? false);
+  return { check };
+});`,
+  );
+
+  // Recording the receiver of `?.` would need the chain rebuilt around the
+  // recording call; the operand itself is recorded instead.
+  assertEquals(assertCaptureLabels(root), ["maybe.get()?.includes(1)"]);
+});
+
 //
 // What the stage leaves alone
 //
@@ -528,41 +565,4 @@ Deno.test("assert leaves a body with no return alone", async () => {
 
   assertEquals(assertCaptures(root), []);
   assertEquals(recordSource(root), undefined);
-});
-
-Deno.test("assert leaves an operator it does not record alone", async () => {
-  const root = await transformed(patternSource(`
-  const check = assert(() => (a.get(), b.get() === 2));
-  return { check };`));
-
-  // A comma yields its right operand; neither side is an operand of a
-  // comparison, so there is nothing to record. The body is still a record.
-  assertEquals(assertCaptures(root), []);
-  assertEquals(recordSource(root), "(a.get(), b.get() === 2)");
-});
-
-Deno.test("assert leaves a namespace receiver alone when nothing else records", async () => {
-  const root = await transformed(patternSource(`
-  const check = assert(() => Object.is(1, 1));
-  return { check };`));
-
-  // Both arguments are literals, so the receiver is reached for — but
-  // `Object` is a namespace, and its value would say nothing.
-  assertEquals(assertCaptures(root), []);
-  assertEquals(recordSource(root), "Object.is(1, 1)");
-});
-
-Deno.test("assert leaves an optional-call receiver alone", async () => {
-  const root = await transformed(
-    `import { assert, cell, pattern } from "commonfabric";
-export default pattern(() => {
-  const maybe = cell<number[] | undefined>(undefined);
-  const check = assert(() => maybe.get()?.includes(1) ?? false);
-  return { check };
-});`,
-  );
-
-  // Recording the receiver of `?.` would need the chain rebuilt around the
-  // recording call; the operand itself is recorded instead.
-  assertEquals(assertCaptureLabels(root), ["maybe.get()?.includes(1)"]);
 });

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -13,7 +13,7 @@ import {
 import { collect, parseModule } from "./transformed-ast.ts";
 
 //
-// Structural inspection of printed type nodes.
+// Structural inspection of printed type nodes
 //
 // `printTypeNode` renders a `ts.TypeNode` to text. Asserting on that text with
 // `assertStringIncludes` is weak: it matches on formatting and cannot tell a
@@ -79,7 +79,7 @@ function hasQualifiedRef(node: ts.Node, left: string, right: string): boolean {
 }
 
 //
-// Harness (mirrors test/type-shrinking.test.ts so cases stay comparable).
+// Harness (mirrors test/type-shrinking.test.ts so cases stay comparable)
 //
 
 function createProgram(source: string): {

--- a/tasks/check-tripwires.test.ts
+++ b/tasks/check-tripwires.test.ts
@@ -72,10 +72,10 @@ Deno.test("the real manifest passes end to end", async () => {
 // quietly stops working. Beside them sit the intact baseline, the legitimate
 // resolved weakness, and the driver that reports them all.
 //
-// No case points at a real repository file: four write their own fixture,
-// and two name a path the repository does not have.
-// Self-reference bites here: a literal ".ignore(" anywhere in this file would
-// make the healthy case trip the DISABLED branch.
+// No case points at a real repository file: four write their own fixture, and
+// two name a path the repository does not have. Self-reference bites here: a
+// literal ".ignore(" anywhere in this file would make the healthy case trip the
+// DISABLED branch.
 //
 
 const SENTINEL = "@tripwire:probe-sentinel";

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -37,8 +37,9 @@ Deno.test("importsAlias matches a dynamic import", () => {
 });
 
 //
-// These next few pin the specifier shapes that the matcher must keep handling:
-// dropping the `\s*` or an alternative from the lead would reintroduce a false
+// The specifier shapes the lead must keep matching
+//
+// Dropping the `\s*` or an alternative from the lead would reintroduce a false
 // positive on ordinary code, yet leave the happy-path tests above green.
 //
 
@@ -208,7 +209,7 @@ Deno.test("owningMember does not match a member that is only a path-segment pref
 });
 
 //
-// parsing
+// Parsing the config files
 //
 
 Deno.test("parseImportMap returns the imports block", () => {

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -164,10 +164,9 @@ Deno.test("every workflow and composite action is valid YAML", async () => {
   // Every other check in this file reads the workflow files as TEXT (regex over
   // job and step blocks), so none of them can notice that a file has stopped
   // being valid YAML — and a workflow that does not parse produces ZERO jobs on
-  // every push while every text-level check here stays green. That happened: an
-  // unquoted `default: ` inside two step names turned deno.yml into a nested
-  // mapping the runner refused, and CI silently ran nothing for a whole stack
-  // of pushes. This is the one check that would have caught it.
+  // every push while every text-level check here stays green. Parsing is what
+  // catches that, and an unquoted `default: ` inside a step name is enough to
+  // turn a workflow into a nested mapping the runner refuses.
 
   const broken: string[] = [];
   for await (const path of githubYamlPaths()) {
@@ -336,6 +335,7 @@ Deno.test("every step we name carries a phase marker", async () => {
   // "other", which is how a job's setup time goes missing from the timings
   // people read when deciding what to make faster. The classifier reads the
   // marker rather than the wording, so the check is the classifier itself.
+
   const unmarked: string[] = [];
   let steps = 0;
   for await (const path of githubYamlPaths()) {
@@ -364,6 +364,7 @@ Deno.test("every work step is bounded before its job is", async () => {
   // upload steps around it normally need. Both bounds are aliases to an anchor,
   // so each is a name here rather than a number, and the minutes behind the
   // names are written once.
+
   const headroom = 10;
   const contents = await workflow("deno.yml");
   const anchors = anchoredMinutes(contents);
@@ -513,6 +514,7 @@ Deno.test("pattern shard selection fails loudly instead of running an empty shar
   // internally-sharded files), so empty output is only ever a failure; the
   // exit status is the discriminator, and only a plain command
   // substitution propagates it under `bash -e`.
+
   const contents = withoutComments(await workflow("deno.yml"));
   for (
     const jobId of [
@@ -607,6 +609,7 @@ Deno.test("One commit publishes one set of release artifacts", async () => {
   // tarball beside the other build's checksum, which is what the deploy's
   // `sha256sum -c` reports as a failure. docs/development/deploying.md covers
   // the invariant.
+
   const contents = await workflow("deno.yml");
 
   // Main can receive the same head commit twice, which starts two runs of that
@@ -664,6 +667,7 @@ Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () =
   // prints its usage and exits 1, failing the deploy job. That script belongs
   // to the infra repository, so nothing else here sees it and the call sites
   // are checked instead. docs/development/deploying.md covers the seam.
+
   const environments = ["estuary", "rapids"];
   // The revision has to expand to a full SHA, which is a property of what the
   // expression reads rather than of the expression itself. `github.ref_name`
@@ -797,6 +801,7 @@ Deno.test("every test-records artifact name is store-safe and unique", async () 
   // these names, so distinct names stay distinct in the store. Uniqueness
   // matters per workflow: object names carry the run id, so two different
   // workflows can reuse a name.
+
   let shipSteps = 0;
   for (const name of await workflowNames()) {
     const contents = withoutComments(await workflow(name));

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -371,6 +371,8 @@ function generatedPortOffsets(): number[] {
 }
 
 //
+// Port offsets, and the ports they must not land on
+//
 // A port offset shifts every dev server together, and the servers bind whatever
 // port arithmetic lands on. Browsers and Deno's `fetch` both refuse to open a
 // connection to a port on the WHATWG bad-port list, so an offset that lands a


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two adversarial reviews read the four comment-arc PRs as they now stand on
`main`, rather than as diffs. Seventeen findings; this applies the sixteen in
scope. Six of them are defects the arc's own last round introduced.

## Regions that stopped owning what they hold

`v2-sqlite-row-label.test.ts` — splitting one fail-closed region into three left
`expectError` declared inside the first of them, where it serves all three:
its ten call sites went from eight inside the declaring region to six. It moves
above the file's first marker, where shared setup belongs. In the same file, an
OR-clause region's description names two behaviors over three members; the
third, an `all()` of `any()`-clauses composing into proper CNF, is now named.

`executor-outbox.test.ts` — a description reworded to say "a deterministic
rejection retires after writing its failure notice back onto the source event",
over a region whose first member carries its own comment saying the notice is
another phase's machinery. The clause now names the one member that pins it.

`assert-diagnostics.test.ts` — the file's one region says the stage "leaves the
call alone rather than emit a broken body", over seven tests. Three of them do
emit: they record an operand or a receiver and leave only part alone. Those
three move above the marker, into the unmarked prefix where the other
recording-choice cases already sit. No test name changes, so nothing needs a
test-identity alias.

`view-semantics-gate.test.ts` — two titles claim a "build success path" over
regions where the later members do not build at all: one passes a hostile cwd
so `build()` latches failed, another is rejected by containment before `build()`
runs, a third returns undefined before a service is constructed.

## Titles and their files

`ci-workflow.test.ts` showed both blank-line shapes at once — two preambles set
off, six flush. All eight are set off now.

Three frames the arc created by framing an existing comment were left without a
title: `otel.test.ts`, `integration.test.ts`, and one in
`check-unused-deps.test.ts` whose first line was a full sentence ending in a
colon. Each takes a noun-phrase title over its existing description. The same
file's bare lowercase `parsing` becomes a title; the file's other lowercase
titles are all identifier-led, and `parsing` is not an identifier.
`type-shrinking-coverage.test.ts` had two of five titles carrying a trailing
period.

`otel.test.ts`'s description also said "the span export above depends on the
answer", where the span-export test is below it, inside the same region.

## Prose that narrated the bug

`code-comment-style.md` says a test added in response to a bug "reads like every
other test: it states the behavior being pinned". Two preambles narrated the
incident instead, and setting them off made the narration each block's headline
claim. Both now state the requirement: what teardown does with an in-flight
commit, and what parsing catches that a text-level check cannot.

`cf-code-editor.test.ts` said "Awkward in both senses" over a region holding a
third: an echo that comes back altered is neither rendered intact nor a
no-change update. The count is dropped rather than raised, a count in a comment
being the thing that drifts.

`v2-explicit-read.test.ts` had a whole-test preamble left flush against its
first statement, 290 lines above a structurally identical one that was set off.

## What the reviews checked and found clean

Placement across all 37 files touched by the four PRs: zero comments adjacent
above, or floating one blank line above, any of 1617 block openers, with a
detector that fires on both shapes in a control. Line width counted in
characters: zero regressions across both merges, maximum added line exactly 80.
Reflow fidelity: a per-file word-multiset diff shows changes only where a title
was deliberately rewritten. Every enumeration in the three governing documents
against its list. The options-object carve-out against its population: exactly
four sites in the tree, out of 361 options-object sites.

## Verification

`deno fmt --check` and `deno lint` pass on the thirteen files; no added comment
line exceeds eighty characters. Suites, each at exit 0 with zero failures:
`runner` 1324, `cli` 1736 + 1 + 210, `ts-transformers` 1164, `tasks` 647,
`memory` 592, `toolshed` 147.

## Not fixed here

Eight file headers written as `//` blocks, and sixty pre-existing sites in
`#6609`'s files where a block preamble sits flush against its first statement —
those nineteen files were never in the blank-line sweep, which makes it a gap in
the sweep rather than a defect of that change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

