### PR TITLE
Compact a day of records into shards it is possible to write and read

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -82,6 +82,7 @@
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "run-recorded": "./tasks/run-recorded.ts",
     "test-records-key": "./tasks/test-records-key.ts",
+    "test-records-compact": "./tasks/test-records-compact.ts",
     "build-binaries": "./tasks/build-binaries.ts",
     "install-hooks": "./scripts/install-git-hooks.sh",
     "install-cf": "./scripts/install-cf.sh",

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -248,8 +248,10 @@ validating reader; `deno task` scripts built on it:
   families, and the over-sixty-seconds list (`--gate` turns that list into
   the ratchet's exit status).
 - `tasks/test-records-compact.ts` — rewrites each closed day of raw
-  records as one rollup under `aggregated/`; `--plan` shows what it would
-  do without credentials.
+  records as a manifest and a few tens of rollup shards under
+  `aggregated/`, sized so that a shard is a string a reader can hold;
+  `--plan` reads the listing alone and shows what it would do without
+  credentials.
 - `packages/dashboard/test-records-history.ts` — the dashboard's collector:
   cached per-identity daily series shaped for `trend.ts`.
 

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1049,10 +1049,14 @@ nothing downstream of the store has to know this happened.
 
 **Nothing has compacted a day yet.** The `aggregated/` area is empty and
 the compactor principal is not provisioned. Compaction collapses a day of
-raw records into one object, which is the difference between reading
-11,000 objects for a historical day and reading one. The compactor is
-already designed and implemented; provisioning it is a small infra change
-and this plan recommends doing it, but does not depend on it.
+raw records into a manifest and a few tens of shards, which is the
+difference between reading 15,000 objects for a historical day and reading
+a manifest and seventeen shards. A day is a manifest and shards rather than a single object: a
+day of records is over a gigabyte of NDJSON, against a maximum string
+length of about half that, and an object has to fit in a string both to be
+written and to be read. The compactor is implemented and handles days at
+that size; provisioning it is a small infra change and this plan
+recommends doing it, but does not depend on it.
 
 ## Scoring
 
@@ -1903,11 +1907,13 @@ The job:
 4. Reports, in the job summary, the projected per-lane times, the spread
    between them, what fell off the budget, and anything unschedulable.
 
-A cold start cannot read 250,000 objects in one job. The
-bootstrap is a manual dispatch with `--bootstrap --days 60` and high
-concurrency, run once; after that the incremental path keeps up. If the
-compactor is provisioned first, the bootstrap reads 53 rollup objects and
-seven days of raw records instead, which is a much better starting
+A cold start cannot read a window's worth of raw objects in one job; at
+the volume the store now takes, sixty days of them is hundreds of
+thousands. The bootstrap is a manual dispatch with `--bootstrap --days 60`
+and high concurrency, run once; after that the incremental path keeps up.
+If the compactor is provisioned first, the bootstrap reads a manifest and
+its shards for each closed day — some hundreds of objects across the
+window — and seven days of raw records, which is a much better starting
 position, is the reason to do it in that order, and is what makes any
 horizon longer than this one affordable later.
 
@@ -2885,8 +2891,8 @@ account with `objectCreator` on `labs/test-selection/`, a Workload
 Identity provider pinned to `.github/workflows/test-selection.yml` on
 `main`, and a lifecycle rule deleting objects there after 30 days. That is
 the same pattern, and the same security argument, as the relay already
-uses. It also wants the compactor provisioned, which is already designed
-and implemented and only needs its principal. That is an infra-repository
+uses. It also wants the compactor provisioned, which is implemented and only
+needs its principal. That is an infra-repository
 change under `tofu/test-records`, and it must land and be applied before
 anything here can publish. That is a predecessor rather than a reason to
 split this work, and it is the only hard ordering outside this repository.

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -59,10 +59,10 @@ label, report under that item's identity.
 
 An uploaded object is gzip-encoded NDJSON (`Content-Encoding: gzip`, so a
 plain HTTPS reader receives text): one context line, then one record line
-per test execution. A rollup object concatenates a day of such reports;
-in every object, a context line opens a report and each record line
-belongs to the report whose context most recently preceded it, which is
-how per-report provenance — the fork flag among it — survives
+per test execution. A rollup shard concatenates a share of a day's such
+reports; in every object, a context line opens a report and each record
+line belongs to the report whose context most recently preceded it, which
+is how per-report provenance — the fork flag among it — survives
 compaction.
 
 ```json
@@ -158,7 +158,8 @@ area, managed by the infra repository's `tofu/test-records` root:
 ```
 <repo>/test-records/submissions/ci/v1/<yyyy>/<mm>/<dd>/run-<runId>-<artifact>.ndjson
 <repo>/test-records/submissions/local/<username>/v1/<yyyy>/<mm>/<dd>/<reportId>-<slug>.ndjson
-<repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>.ndjson
+<repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/0003-of-0017.ndjson
+<repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/rollup.json
 ```
 
 The date partition comes from the run's start, so late-shipped orphans
@@ -183,11 +184,32 @@ rotated — and a daily
 janitor disables accounts after a month without pull-request activity
 and re-enables them on return. The **compactor**, when provisioned,
 holds create on `aggregated/` and rewrites each closed day of raw
-records — after a seven-day late-arrival lag — as one validated rollup
-that keeps each report's context line ahead of its records; a day with
+records — after a seven-day late-arrival lag — as validated rollup shards
+that keep each report's context line ahead of its records; a day with
 no records stays open, since a write-once rollup would permanently
 exclude late arrivals. Rollups are a read optimization, and
 full-fidelity readers list the raw area.
+
+A day is several shards. A busy day is over a gigabyte of NDJSON, against
+V8's maximum string length of about half that, and an object has to fit in
+a string at both ends: the compactor builds one, and a reader fetches one.
+Each shard is sized for a few tens of megabytes of text, so a day of tens
+of thousands of raw objects becomes tens of shards.
+
+Which shard a raw object's reports go into is a hash of the object's name
+taken modulo the shard count, so the partition is a property of each
+object rather than of the order the compactor read them in. A day is
+partitioned once. The count is in every shard's name, so a run that finds
+shards already in a day's folder reads the count off them and finishes
+that partition, writing the shards that are missing and leaving the rest
+alone; nothing an earlier run wrote is left unreferenced, and no record
+reaches two shards. What a partition does not fix is which raw objects it
+covers: an object arriving between two runs is in the rollup when its
+shard is one of the ones still to be written, and in the raw area only
+otherwise, the same as any arrival after a day is compacted. The
+`rollup.json` manifest names the day's shards and is written after all of
+them, so a day counts as compacted when its manifest exists, and a reader
+that finds no manifest reads the raw area for that day.
 
 ## CI movement
 

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -158,6 +158,7 @@ area, managed by the infra repository's `tofu/test-records` root:
 ```
 <repo>/test-records/submissions/ci/v1/<yyyy>/<mm>/<dd>/run-<runId>-<artifact>.ndjson
 <repo>/test-records/submissions/local/<username>/v1/<yyyy>/<mm>/<dd>/<reportId>-<slug>.ndjson
+<repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/partition.json
 <repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/0003-of-0017.ndjson
 <repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/rollup.json
 ```
@@ -198,18 +199,22 @@ of thousands of raw objects becomes tens of shards.
 
 Which shard a raw object's reports go into is a hash of the object's name
 taken modulo the shard count, so the partition is a property of each
-object rather than of the order the compactor read them in. A day is
-partitioned once. The count is in every shard's name, so a run that finds
-shards already in a day's folder reads the count off them and finishes
-that partition, writing the shards that are missing and leaving the rest
-alone; nothing an earlier run wrote is left unreferenced, and no record
-reaches two shards. What a partition does not fix is which raw objects it
-covers: an object arriving between two runs is in the rollup when its
-shard is one of the ones still to be written, and in the raw area only
-otherwise, the same as any arrival after a day is compacted. The
-`rollup.json` manifest names the day's shards and is written after all of
-them, so a day counts as compacted when its manifest exists, and a reader
-that finds no manifest reads the raw area for that day.
+object rather than of the order the compactor read them in. How many
+shards there are is fixed by `partition.json`, written before any shard of
+the day under the same create-only precondition as everything else here,
+so a day is partitioned once however many runs reach it: the write that
+loses reads the count that won and works to that one. A run that finds a
+day part way through finishes it in the partition claimed for it, writing
+the shards that are missing and leaving the rest alone, so no run leaves
+shards of a partition nothing names and no record reaches two shards. The
+count is in every shard's name as well, so a shard says which partition it
+belongs to. What a partition does not fix is which raw objects it covers:
+an object arriving between two runs is in the rollup when its shard is one
+of the ones still to be written, and in the raw area only otherwise, the
+same as any arrival after a day is compacted. The `rollup.json` manifest
+names the day's shards and is written after all of them, so a day counts
+as compacted when its manifest exists, and a reader that finds no manifest
+reads the raw area for that day.
 
 ## CI movement
 

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -76,10 +76,21 @@ export type { ServiceAccountKey } from "./gcp-auth.ts";
 export {
   createObject,
   gunzipToText,
+  gzipChunks,
   gzipText,
   STORE_WRITE_SCOPE,
 } from "./store.ts";
 export type { CreateObjectOptions, CreateObjectResult } from "./store.ts";
-export { listObjects, parseReportGroups, readObject } from "./store-reader.ts";
-export type { StoredReport, StoredReportGroup } from "./store-reader.ts";
+export {
+  listObjects,
+  listObjectSizes,
+  objectUrl,
+  parseReportGroups,
+  readObject,
+} from "./store-reader.ts";
+export type {
+  ListedObject,
+  StoredReport,
+  StoredReportGroup,
+} from "./store-reader.ts";
 export { recordsSpooledBy } from "./testing.ts";

--- a/packages/test-support/src/records/store-reader.test.ts
+++ b/packages/test-support/src/records/store-reader.test.ts
@@ -62,6 +62,21 @@ describe("store-reader", () => {
       expect(urls[1]).toContain("pageToken=t2");
     });
 
+    it("skips a listing item that names no object", async () => {
+      const names = await listObjects({
+        bucket: "cf-ci-metadata",
+        prefix: "labs/test-records/",
+        fetch: (() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ items: [{ name: "a" }, {}, { name: "b" }] }),
+              { status: 200 },
+            ),
+          )) as typeof fetch,
+      });
+      expect(names).toEqual(["a", "b"]);
+    });
+
     it("throws for an error status", async () => {
       await expect(listObjects({
         bucket: "b",

--- a/packages/test-support/src/records/store-reader.test.ts
+++ b/packages/test-support/src/records/store-reader.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { listObjects, parseReportGroups, readObject } from "./store-reader.ts";
+import {
+  listObjects,
+  listObjectSizes,
+  parseReportGroups,
+  readObject,
+} from "./store-reader.ts";
 import { buildObjectBody, type RunContext, type TestRecord } from "./schema.ts";
 
 const RECORD: TestRecord = {
@@ -66,6 +71,37 @@ describe("store-reader", () => {
             new Response("nope", { status: 500 }),
           )) as typeof fetch,
       })).rejects.toThrow("HTTP 500");
+    });
+  });
+
+  describe("listObjectSizes()", () => {
+    const listing = (items: unknown[]): typeof fetch =>
+      (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ items }), { status: 200 }),
+        )) as typeof fetch;
+
+    it("gives each object's stored size, sorted by name", async () => {
+      const listed = await listObjectSizes({
+        bucket: "cf-ci-metadata",
+        prefix: "labs/test-records/",
+        fetch: listing([
+          { name: "b", size: "4096" },
+          { name: "a", size: "17" },
+        ]),
+      });
+      expect(listed).toEqual([
+        { name: "a", size: 17 },
+        { name: "b", size: 4096 },
+      ]);
+    });
+
+    it("throws for an object the listing gave no size for", async () => {
+      await expect(listObjectSizes({
+        bucket: "cf-ci-metadata",
+        prefix: "labs/test-records/",
+        fetch: listing([{ name: "a", size: "17" }, { name: "b" }]),
+      })).rejects.toThrow("gave no size for b");
     });
   });
 

--- a/packages/test-support/src/records/store-reader.ts
+++ b/packages/test-support/src/records/store-reader.ts
@@ -15,21 +15,28 @@ import {
 
 const STORAGE = "https://storage.googleapis.com/storage/v1";
 
-/** Lists every object name under a prefix, paginating as needed. */
-export async function listObjects(options: {
-  bucket: string;
-  prefix: string;
-  fetch?: typeof fetch;
-}): Promise<string[]> {
+/** One object in a listing: its name and the bytes the store holds. */
+export interface ListedObject {
+  name: string;
+
+  /** Stored size, which for a gzip-encoded object is the compressed size. */
+  size: number;
+}
+
+/** Every item under a prefix, in name order, paginating as needed. */
+async function listItems(
+  options: { bucket: string; prefix: string; fetch?: typeof fetch },
+  fields: string,
+): Promise<{ name: string; size?: string }[]> {
   const doFetch = options.fetch ?? fetch;
-  const names: string[] = [];
+  const items: { name: string; size?: string }[] = [];
   let pageToken: string | undefined;
   do {
     const url = new URL(
       `${STORAGE}/b/${encodeURIComponent(options.bucket)}/o`,
     );
     url.searchParams.set("prefix", options.prefix);
-    url.searchParams.set("fields", "items(name),nextPageToken");
+    url.searchParams.set("fields", `items(${fields}),nextPageToken`);
     url.searchParams.set("maxResults", "1000");
     if (pageToken !== undefined) url.searchParams.set("pageToken", pageToken);
     const res = await doFetch(url);
@@ -39,15 +46,53 @@ export async function listObjects(options: {
       );
     }
     const page = await res.json() as {
-      items?: { name?: string }[];
+      items?: { name?: string; size?: string }[];
       nextPageToken?: string;
     };
     for (const item of page.items ?? []) {
-      if (typeof item.name === "string") names.push(item.name);
+      if (typeof item.name !== "string") continue;
+      items.push(
+        item.size === undefined
+          ? { name: item.name }
+          : { name: item.name, size: item.size },
+      );
     }
     pageToken = page.nextPageToken;
   } while (pageToken !== undefined);
-  return names.sort();
+  return items.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+}
+
+/** Lists every object name under a prefix. */
+export async function listObjects(options: {
+  bucket: string;
+  prefix: string;
+  fetch?: typeof fetch;
+}): Promise<string[]> {
+  return (await listItems(options, "name")).map((item) => item.name);
+}
+
+/**
+ * Lists every object under a prefix with its stored size. The size lets a
+ * consumer size up a prefix — how much a whole partition would come to,
+ * how to divide it — without fetching anything. A listing that names an
+ * object without sizing it has not answered the question asked, and
+ * standing in a zero would read to such a consumer as an empty object, so
+ * it throws instead.
+ */
+export async function listObjectSizes(options: {
+  bucket: string;
+  prefix: string;
+  fetch?: typeof fetch;
+}): Promise<ListedObject[]> {
+  return (await listItems(options, "name,size")).map((item) => {
+    const size = Number(item.size);
+    if (!Number.isFinite(size)) {
+      throw new Error(
+        `listing ${options.prefix} gave no size for ${item.name}`,
+      );
+    }
+    return { name: item.name, size };
+  });
 }
 
 /** One report inside an object: a context line and the records under it. */
@@ -100,6 +145,13 @@ export function parseReportGroups(text: string): StoredReportGroup[] {
   return groups;
 }
 
+/** The read URL of one object; the whole dataset is readable by anyone. */
+export function objectUrl(bucket: string, objectName: string): string {
+  return `https://storage.googleapis.com/${encodeURIComponent(bucket)}/${
+    objectName.split("/").map(encodeURIComponent).join("/")
+  }`;
+}
+
 /** Fetches and validates one object. */
 export async function readObject(options: {
   bucket: string;
@@ -107,10 +159,7 @@ export async function readObject(options: {
   fetch?: typeof fetch;
 }): Promise<StoredReport> {
   const doFetch = options.fetch ?? fetch;
-  const url = `https://storage.googleapis.com/${
-    encodeURIComponent(options.bucket)
-  }/${options.objectName.split("/").map(encodeURIComponent).join("/")}`;
-  const res = await doFetch(url);
+  const res = await doFetch(objectUrl(options.bucket, options.objectName));
   if (!res.ok) {
     throw new Error(
       `reading ${options.objectName} failed: HTTP ${res.status}`,

--- a/packages/test-support/src/records/store.test.ts
+++ b/packages/test-support/src/records/store.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assert } from "@std/assert";
 
-import { createObject, gunzipToText, gzipText } from "./store.ts";
+import { createObject, gunzipToText, gzipChunks, gzipText } from "./store.ts";
 
 function fetchStub(
   status: number,
@@ -21,6 +21,37 @@ describe("store", () => {
     it("round-trips through gunzipToText()", async () => {
       const text = '{"line":"context"}\n{"line":"record"}\n';
       expect(await gunzipToText(await gzipText(text))).toBe(text);
+    });
+  });
+
+  describe("gzipChunks()", () => {
+    it("compresses a sequence into one member", async () => {
+      const bytes = await gzipChunks(["one\n", "two\n", "three\n"]);
+      expect(await gunzipToText(bytes)).toBe("one\ntwo\nthree\n");
+    });
+
+    it("takes chunks from an asynchronous source", async () => {
+      async function* source() {
+        yield await Promise.resolve("one\n");
+        yield await Promise.resolve("two\n");
+      }
+      expect(await gunzipToText(await gzipChunks(source()))).toBe("one\ntwo\n");
+    });
+
+    it("builds an object larger than a string can be", async () => {
+      // 600 MiB of record lines, against V8's limit of a little under 512
+      // MiB per string. Compressing the chunks as they arrive holds one
+      // chunk at a time; taking the same text back as one string is what
+      // the limit stops, which is what the second half asserts.
+      const line = '{"line":"record","test":{"k":"unit","s":"bakery",' +
+        '"n":"glaze > sets"},"outcome":"pass","durationMs":4}\n';
+      const chunk = line.repeat(640);
+      const chunks = (600 * 1024 * 1024) / chunk.length;
+      function* source() {
+        for (let at = 0; at < chunks; at++) yield chunk;
+      }
+      const bytes = await gzipChunks(source());
+      await expect(gunzipToText(bytes)).rejects.toThrow(RangeError);
     });
   });
 

--- a/packages/test-support/src/records/store.ts
+++ b/packages/test-support/src/records/store.ts
@@ -6,12 +6,26 @@
  * read, list, overwrite, or delete.
  */
 
-/** Gzips text with the web-standard stream; repo lint forbids node: imports. */
-export async function gzipText(text: string): Promise<Uint8Array> {
-  const stream = new Blob([text]).stream().pipeThrough(
-    new CompressionStream("gzip"),
-  );
+/**
+ * Gzips a sequence of text chunks into one member, with the web-standard
+ * streams; repo lint forbids node: imports. The chunks are pulled one at a
+ * time and compressed as they arrive, so the caller never holds the whole
+ * text: what is held is one chunk plus the compressed result. A source that
+ * reads its chunks from the network can therefore build an object far
+ * larger than V8's maximum string length.
+ */
+export async function gzipChunks(
+  chunks: AsyncIterable<string> | Iterable<string>,
+): Promise<Uint8Array> {
+  const stream = ReadableStream.from(chunks)
+    .pipeThrough(new TextEncoderStream())
+    .pipeThrough(new CompressionStream("gzip"));
   return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** Gzips one string; the single-chunk case of `gzipChunks`. */
+export function gzipText(text: string): Promise<Uint8Array> {
+  return gzipChunks([text]);
 }
 
 /** Gunzips bytes back to text; the reader side of `gzipText`. */

--- a/tasks/test-records-compact.test.ts
+++ b/tasks/test-records-compact.test.ts
@@ -574,6 +574,29 @@ describe("test-records-compact", () => {
       expect(Object.keys(store.created)).toEqual([]);
     });
 
+    it("takes a partition with more shards than the day has objects", async () => {
+      // One raw object past the size a shard aims at: the count its bytes
+      // come to is above the count of objects, and is what a run writes.
+      const store = storeOf(
+        DAY,
+        [buildObjectBody(contextOn(DAY), [RECORD])],
+        SHARD_TARGET_BYTES * 3,
+      );
+      store.objects[rollupPartitionName(DAY)] = JSON.stringify({
+        schema: 1,
+        day: DAY,
+        count: 3,
+      });
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      // The one object reaches one of the three shards; the other two
+      // hold nothing and are not written.
+      const written = createdShards(store);
+      expect(written.length).toBe(1);
+      expect(written[0]).toMatch(/\/\d{4}-of-0003\.ndjson$/);
+      expect(createdManifest(store, DAY)?.shards.length).toBe(1);
+      expect(await compactedNames(store)).toEqual([RECORD.test.n]);
+    });
+
     it("leaves a folder with shards and no partition open", async () => {
       const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
       store.objects[`${rollupPrefix(DAY)}0000-of-0002.ndjson`] = "";

--- a/tasks/test-records-compact.test.ts
+++ b/tasks/test-records-compact.test.ts
@@ -438,9 +438,11 @@ describe("test-records-compact", () => {
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(whole) });
       const written = createdShards(whole);
 
-      // A run that died after two shards leaves those two behind and no
-      // manifest, which is what the next run finds.
+      // A run that died after two shards leaves its partition and those
+      // two behind, and no manifest, which is what the next run finds.
       const store = storeOf(DAY, bodies, SHARD_TARGET_BYTES / 8);
+      store.objects[rollupPartitionName(DAY)] = whole
+        .objects[rollupPartitionName(DAY)]!;
       for (const name of written.slice(0, 2)) store.objects[name] = "";
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
 
@@ -523,9 +525,58 @@ describe("test-records-compact", () => {
       );
     });
 
+    it("takes the count of the run that won the create", async () => {
+      const store = storeOf(DAY, casesOn(DAY, 40), SHARD_TARGET_BYTES / 8);
+      const inner = storeFetch(store);
+      const partition = JSON.stringify({ schema: 1, day: DAY, count: 2 });
+      // The listing this run made came before the other run's partition
+      // existed, so it claims one of its own, loses, and reads the count
+      // that won: two shards, where its own listing said five.
+      const raced = ((input: URL | RequestInfo, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "POST") {
+          const head = new TextDecoder("utf-8", { fatal: false })
+            .decode((init.body as Uint8Array).subarray(0, 512));
+          if (head.includes(`"name":"${rollupPartitionName(DAY)}"`)) {
+            return Promise.resolve(new Response("taken", { status: 412 }));
+          }
+        } else if (url.endsWith("/partition.json")) {
+          return Promise.resolve(new Response(partition, { status: 200 }));
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+      await compactDays({ ...OPTIONS, fetchImpl: raced });
+      expect(
+        createdShards(store).map((name) =>
+          name.slice(rollupPrefix(DAY).length)
+        ),
+      ).toEqual(["0000-of-0002.ndjson", "0001-of-0002.ndjson"]);
+      expect(await compactedNames(store)).toEqual(
+        casesOn(DAY, 40).map((_, index) => `case ${index}`).sort(),
+      );
+    });
+
     it("leaves a day whose partition cannot be read open", async () => {
       const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
       store.objects[rollupPartitionName(DAY)] = "not a partition";
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
+    });
+
+    it("leaves a day claiming more shards than objects open", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      store.objects[rollupPartitionName(DAY)] = JSON.stringify({
+        schema: 1,
+        day: DAY,
+        count: 1e9,
+      });
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
+    });
+
+    it("leaves a folder with shards and no partition open", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      store.objects[`${rollupPrefix(DAY)}0000-of-0002.ndjson`] = "";
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
       expect(Object.keys(store.created)).toEqual([]);
     });

--- a/tasks/test-records-compact.test.ts
+++ b/tasks/test-records-compact.test.ts
@@ -7,7 +7,9 @@ import {
   COMPACTION_LAG_DAYS,
   parseCompactArgs,
   parseRollupManifest,
+  parseRollupPartition,
   rollupManifestName,
+  rollupPartitionName,
   rollupPrefix,
   rollupShardName,
   rollupShards,
@@ -118,7 +120,12 @@ function storeFetch(store: Store): typeof fetch {
       );
       const name = head.match(/"name":"([^"]+)"/)?.[1] ?? "unnamed";
       store.created[name] = payloadOf(body);
-      store.objects[name] = "";
+      // The JSON objects are stored as written, so a later run against the
+      // same store reads back what an earlier one put there; a shard's
+      // body is gzipped and no run reads one.
+      store.objects[name] = name.endsWith(".json")
+        ? new TextDecoder().decode(store.created[name]!)
+        : "";
       return Promise.resolve(new Response("{}", { status: 200 }));
     }
     if (url.includes("/storage/v1/")) {
@@ -252,6 +259,15 @@ describe("test-records-compact", () => {
         .toEqual(["0000-of-0003.ndjson", "0002-of-0003.ndjson"]);
     });
 
+    it("rejects a manifest naming no shard", () => {
+      // A day with no shards gets no manifest, so an empty one would say a
+      // day's records are all accounted for by nothing.
+      expect(parseRollupManifest(
+        JSON.stringify({ schema: 1, day: DAY, shards: [] }),
+        DAY,
+      )).toBeUndefined();
+    });
+
     it("rejects anything else", () => {
       expect(parseRollupManifest("not json", DAY)).toBeUndefined();
       expect(parseRollupManifest(good, "2026/08/12")).toBeUndefined();
@@ -269,6 +285,29 @@ describe("test-records-compact", () => {
         }),
         DAY,
       )).toBeUndefined();
+    });
+  });
+
+  describe("parseRollupPartition()", () => {
+    it("accepts a partition of the day asked about", () => {
+      expect(
+        parseRollupPartition(
+          JSON.stringify({ schema: 1, day: DAY, count: 17 }),
+          DAY,
+        )?.count,
+      ).toBe(17);
+    });
+
+    it("rejects anything else", () => {
+      const partition = (fields: Record<string, unknown>) =>
+        parseRollupPartition(JSON.stringify(fields), DAY);
+      expect(parseRollupPartition("not json", DAY)).toBeUndefined();
+      expect(partition({ schema: 2, day: DAY, count: 1 })).toBeUndefined();
+      expect(partition({ schema: 1, day: "2026/08/12", count: 1 }))
+        .toBeUndefined();
+      expect(partition({ schema: 1, day: DAY, count: 0 })).toBeUndefined();
+      expect(partition({ schema: 1, day: DAY, count: 1.5 })).toBeUndefined();
+      expect(partition({ schema: 1, day: DAY })).toBeUndefined();
     });
   });
 
@@ -313,6 +352,7 @@ describe("test-records-compact", () => {
       // is the layout docs/specs/test-records.md documents.
       expect(Object.keys(store.created).sort()).toEqual([
         "labs/test-records/aggregated/ci/v1/2026/08/11/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/11/partition.json",
         "labs/test-records/aggregated/ci/v1/2026/08/11/rollup.json",
       ]);
       expect(await compactedNames(store)).toEqual([
@@ -357,8 +397,10 @@ describe("test-records-compact", () => {
       });
       expect(Object.keys(store.created).sort()).toEqual([
         "labs/test-records/aggregated/ci/v1/2026/08/10/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/10/partition.json",
         "labs/test-records/aggregated/ci/v1/2026/08/10/rollup.json",
         "labs/test-records/aggregated/ci/v1/2026/08/11/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/11/partition.json",
         "labs/test-records/aggregated/ci/v1/2026/08/11/rollup.json",
       ]);
     });
@@ -418,7 +460,7 @@ describe("test-records-compact", () => {
 
       // A run that died after two shards, and then enough raw objects
       // arriving to size the day differently. The partition the first run
-      // started is the one the second finishes, so the shards it wrote are
+      // claimed is the one the second finishes, so the shards it wrote are
       // named by the manifest rather than left behind by a second
       // partition alongside them.
       const store = storeOf(
@@ -426,6 +468,8 @@ describe("test-records-compact", () => {
         [...bodies, ...casesOn(DAY, 40)],
         SHARD_TARGET_BYTES / 8,
       );
+      store.objects[rollupPartitionName(DAY)] = whole
+        .objects[rollupPartitionName(DAY)]!;
       for (const name of written.slice(0, 2)) store.objects[name] = "";
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
 
@@ -436,32 +480,52 @@ describe("test-records-compact", () => {
         .toBe(true);
     });
 
-    it("counts a shard another run already created as present", async () => {
+    it("names a shard another run created in the manifest", async () => {
       const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
       const inner = storeFetch(store);
-      // Every create loses the race, as a second run reaching the same
-      // shard names at the same moment would.
+      const shard = `${rollupPrefix(DAY)}0000-of-0001.ndjson`;
+      // The shard's create loses its race and the manifest's does not, as
+      // a run reaching a shard a concurrent run had just written would
+      // find.
       const raced = ((input: URL | RequestInfo, init?: RequestInit) => {
-        if (init?.method === "POST") {
+        const head = init?.method === "POST"
+          ? new TextDecoder("utf-8", { fatal: false })
+            .decode((init.body as Uint8Array).subarray(0, 512))
+          : "";
+        if (head.includes(`"name":"${shard}"`)) {
           return Promise.resolve(new Response("taken", { status: 412 }));
         }
         return inner(input, init);
       }) as typeof fetch;
-      const lines: string[] = [];
-      const log = console.log;
-      console.log = (line: string) => void lines.push(line);
-      try {
-        await compactDays({ ...OPTIONS, fetchImpl: raced });
-      } finally {
-        console.log = log;
-      }
-      expect(lines).toEqual([`${DAY}: another run's manifest got there first`]);
+      await compactDays({ ...OPTIONS, fetchImpl: raced });
+      expect(createdShards(store)).toEqual([]);
+      expect(createdManifest(store, DAY)?.shards)
+        .toEqual(["0000-of-0001.ndjson"]);
     });
 
-    it("leaves a day holding two partitions open", async () => {
+    it("takes the partition of the run that claimed it first", async () => {
+      // This run would size the day at five shards, and finds one claimed
+      // at two, so two is what it writes.
+      const store = storeOf(DAY, casesOn(DAY, 40), SHARD_TARGET_BYTES / 8);
+      store.objects[rollupPartitionName(DAY)] = JSON.stringify({
+        schema: 1,
+        day: DAY,
+        count: 2,
+      });
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(
+        createdShards(store).map((name) =>
+          name.slice(rollupPrefix(DAY).length)
+        ),
+      ).toEqual(["0000-of-0002.ndjson", "0001-of-0002.ndjson"]);
+      expect(await compactedNames(store)).toEqual(
+        casesOn(DAY, 40).map((_, index) => `case ${index}`).sort(),
+      );
+    });
+
+    it("leaves a day whose partition cannot be read open", async () => {
       const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
-      store.objects[`${rollupPrefix(DAY)}0000-of-0002.ndjson`] = "";
-      store.objects[`${rollupPrefix(DAY)}0000-of-0003.ndjson`] = "";
+      store.objects[rollupPartitionName(DAY)] = "not a partition";
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
       expect(Object.keys(store.created)).toEqual([]);
     });
@@ -475,7 +539,11 @@ describe("test-records-compact", () => {
     it("leaves a day with no records open", async () => {
       const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [])]);
       await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
-      expect(Object.keys(store.created)).toEqual([]);
+      // The partition is claimed before the day is read, so it stays; what
+      // says the day is not compacted is that no shard and no manifest
+      // followed it.
+      expect(createdShards(store)).toEqual([]);
+      expect(store.created[rollupManifestName(DAY)]).toBeUndefined();
     });
 
     it("writes nothing in plan mode, and reads no object body", async () => {

--- a/tasks/test-records-compact.test.ts
+++ b/tasks/test-records-compact.test.ts
@@ -6,15 +6,25 @@ import {
   compactDays,
   COMPACTION_LAG_DAYS,
   parseCompactArgs,
-  rollupName,
+  parseRollupManifest,
+  rollupManifestName,
+  rollupPrefix,
+  rollupShardName,
+  rollupShards,
+  SHARD_TARGET_BYTES,
+  shardCount,
+  shardOf,
 } from "./test-records-compact.ts";
 import {
   buildObjectBody,
+  gunzipToText,
+  parseReportGroups,
   type RunContext,
   type TestRecord,
 } from "@commonfabric/test-support/records";
 
 const NOW = Date.parse("2026-08-18T12:00:00Z");
+const DAY = "2026/08/11";
 
 const RECORD: TestRecord = {
   line: "record",
@@ -40,52 +50,132 @@ function contextOn(day: string): RunContext {
   };
 }
 
-// A store stub: listings answer by prefix, reads serve raw objects, and
-// creates are logged. `rollups` names days whose rollup already exists;
-// `rawByDay` maps a day to its raw objects' bodies.
-function storeFetch(state: {
-  rollups: string[];
-  rawByDay: Record<string, string[]>;
-  created: string[];
-}): typeof fetch {
+interface Store {
+  /** Object name to body text, for everything the store already holds. */
+  objects: Record<string, string>;
+
+  /** Object name to gzipped bytes, for everything a run created. */
+  created: Record<string, Uint8Array>;
+
+  /** Stored size the listing reports for every object, in bytes. */
+  size: number;
+}
+
+function storeOf(day: string, bodies: string[], size = 1000): Store {
+  const objects: Record<string, string> = {};
+  bodies.forEach((body, index) => {
+    objects[
+      `labs/test-records/submissions/ci/v1/${day}/run-${index}-Test.ndjson`
+    ] = body;
+  });
+  return { objects, created: {}, size };
+}
+
+/** A day's raw objects, one record each, named for their own case. */
+function casesOn(day: string, count: number): string[] {
+  const bodies: string[] = [];
+  for (let index = 0; index < count; index++) {
+    bodies.push(buildObjectBody(contextOn(day), [{
+      ...RECORD,
+      test: { ...RECORD.test, n: `case ${index}` },
+    }]));
+  }
+  return bodies;
+}
+
+/** The payload part of a multipart create, without decoding its bytes. */
+function payloadOf(body: Uint8Array): Uint8Array {
+  const afterHeaders = (from: number): number => {
+    for (let at = from; at <= body.length - 4; at++) {
+      if (
+        body[at] === 13 && body[at + 1] === 10 && body[at + 2] === 13 &&
+        body[at + 3] === 10
+      ) {
+        return at + 4;
+      }
+    }
+    return body.length;
+  };
+  const boundary = body.indexOf(13);
+  return body.subarray(
+    afterHeaders(afterHeaders(0)),
+    body.length - (boundary + 6),
+  );
+}
+
+/**
+ * A store stub: listings answer by prefix, reads serve bodies, and creates
+ * land in both `created` and `objects`, so a later run against the same
+ * store sees what an earlier one wrote.
+ */
+function storeFetch(store: Store): typeof fetch {
   return ((input: URL | RequestInfo, init?: RequestInit) => {
     const url = String(input);
     if (init?.method === "POST") {
-      // The object name rides in the multipart metadata part, ahead of the
-      // gzipped payload.
+      const body = init.body as Uint8Array;
       const head = new TextDecoder("utf-8", { fatal: false }).decode(
-        (init.body as Uint8Array).subarray(0, 2048),
+        body.subarray(0, 512),
       );
-      state.created.push(head.match(/"name":"([^"]+)"/)?.[1] ?? "unnamed");
+      const name = head.match(/"name":"([^"]+)"/)?.[1] ?? "unnamed";
+      store.created[name] = payloadOf(body);
+      store.objects[name] = "";
       return Promise.resolve(new Response("{}", { status: 200 }));
     }
     if (url.includes("/storage/v1/")) {
       const prefix = new URL(url).searchParams.get("prefix")!;
-      if (prefix.includes("/aggregated/")) {
-        const day = prefix.match(/(\d{4}\/\d{2}\/\d{2})\.ndjson$/)?.[1];
-        const items = day !== undefined && state.rollups.includes(day)
-          ? [{ name: prefix }]
-          : [];
-        return Promise.resolve(
-          new Response(JSON.stringify({ items }), { status: 200 }),
-        );
-      }
-      const day = prefix.match(/(\d{4}\/\d{2}\/\d{2})\/$/)?.[1];
-      const items = (state.rawByDay[day ?? ""] ?? []).map((_, index) => ({
-        name: `${prefix}raw-${index}.ndjson`,
-      }));
+      const items = Object.keys(store.objects)
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => ({ name, size: String(store.size) }));
       return Promise.resolve(
         new Response(JSON.stringify({ items }), { status: 200 }),
       );
     }
-    const raw = url.match(/(\d{4}\/\d{2}\/\d{2})\/raw-(\d+)\.ndjson$/);
-    if (raw !== null) {
-      const body = state.rawByDay[raw[1]!]![Number(raw[2]!)]!;
-      return Promise.resolve(new Response(body, { status: 200 }));
+    const name = url
+      .replace("https://storage.googleapis.com/cf-ci-metadata/", "")
+      .split("/").map(decodeURIComponent).join("/");
+    const body = store.objects[name];
+    if (body === undefined) {
+      return Promise.resolve(new Response("no such object", { status: 404 }));
     }
-    return Promise.resolve(new Response("unexpected", { status: 500 }));
+    return Promise.resolve(new Response(body, { status: 200 }));
   }) as typeof fetch;
 }
+
+/** The shards a run created, by name. */
+function createdShards(store: Store): string[] {
+  return Object.keys(store.created)
+    .filter((name) => name.endsWith(".ndjson")).sort();
+}
+
+/** The manifest a run created. */
+function createdManifest(store: Store, day: string) {
+  return parseRollupManifest(
+    new TextDecoder().decode(store.created[rollupManifestName(day)]!),
+    day,
+  );
+}
+
+/** Every record name in every shard a run created. */
+async function compactedNames(store: Store): Promise<string[]> {
+  const found: string[] = [];
+  for (const name of createdShards(store)) {
+    for (
+      const group of parseReportGroups(await gunzipToText(store.created[name]!))
+    ) {
+      for (const record of group.records) found.push(record.test.n);
+    }
+  }
+  return found.sort();
+}
+
+const OPTIONS = {
+  days: COMPACTION_LAG_DAYS,
+  bucket: "cf-ci-metadata",
+  rawPrefix: "labs/test-records/submissions/ci",
+  token: "t",
+  now: NOW,
+  plan: false,
+};
 
 describe("test-records-compact", () => {
   describe("closedDays()", () => {
@@ -95,93 +185,334 @@ describe("test-records-compact", () => {
     });
   });
 
-  describe("compactDays()", () => {
-    const options = {
-      days: COMPACTION_LAG_DAYS,
-      bucket: "cf-ci-metadata",
-      rawPrefix: "labs/test-records/submissions/ci",
-      token: "t",
-      now: NOW,
-    };
+  describe("shardCount()", () => {
+    it("gives one shard up to the target and divides beyond it", () => {
+      expect(shardCount(0)).toBe(1);
+      expect(shardCount(SHARD_TARGET_BYTES)).toBe(1);
+      expect(shardCount(SHARD_TARGET_BYTES + 1)).toBe(2);
+      expect(shardCount(SHARD_TARGET_BYTES * 20)).toBe(20);
+    });
+  });
 
-    it("writes one rollup for a day with records", async () => {
-      const day = "2026/08/11";
-      const state = {
-        rollups: [],
-        rawByDay: {
-          [day]: [buildObjectBody(contextOn(day), [RECORD, RECORD])],
-        },
-        created: [] as string[],
-      };
-      await compactDays({
-        ...options,
-        plan: false,
-        fetchImpl: storeFetch(state),
-      });
-      expect(state.created).toEqual([rollupName(day)]);
+  describe("shardOf()", () => {
+    it("puts a given name in a fixed shard", () => {
+      // Pinned rather than recomputed: shards already in the store were
+      // partitioned by this hash, so a change to it would put an object in
+      // a shard that does not hold it and leave the one that does
+      // unreferenced.
+      const name =
+        "labs/test-records/submissions/ci/v1/2026/08/11/run-7.ndjson";
+      expect(shardOf(name, 16)).toBe(5);
+      expect(shardOf(name, 256)).toBe(101);
+      expect(shardOf(name, 17)).toBe(11);
     });
 
-    it("skips a day whose rollup already exists", async () => {
-      const day = "2026/08/11";
-      const state = {
-        rollups: [day],
-        rawByDay: {
-          [day]: [buildObjectBody(contextOn(day), [RECORD])],
-        },
-        created: [] as string[],
-      };
-      await compactDays({
-        ...options,
-        plan: false,
-        fetchImpl: storeFetch(state),
+    it("spreads a day's names across the shards", () => {
+      const seen = new Set<number>();
+      for (let index = 0; index < 200; index++) {
+        seen.add(shardOf(`run-${index}-Test.ndjson`, 8));
+      }
+      expect(seen.size).toBe(8);
+    });
+  });
+
+  describe("rollupShardName()", () => {
+    it("puts the shard count in the name", () => {
+      expect(rollupShardName(3, 24)).toBe("0003-of-0024.ndjson");
+    });
+  });
+
+  describe("parseRollupManifest()", () => {
+    const good = JSON.stringify({
+      schema: 1,
+      day: DAY,
+      shards: ["0000-of-0002.ndjson", "0001-of-0002.ndjson"],
+    });
+
+    it("accepts a manifest for the day asked about", () => {
+      expect(parseRollupManifest(good, DAY)?.shards.length).toBe(2);
+    });
+
+    it("rejects a shard set no run writes", () => {
+      const shards = (...names: string[]) =>
+        parseRollupManifest(
+          JSON.stringify({ schema: 1, day: DAY, shards: names }),
+          DAY,
+        );
+      // A repeat would count its records twice, an index past the count
+      // names an object no run writes, and a disagreeing count is two
+      // partitions read as one day.
+      expect(shards("0000-of-0002.ndjson", "0000-of-0002.ndjson"))
+        .toBeUndefined();
+      expect(shards("0002-of-0002.ndjson")).toBeUndefined();
+      expect(shards("0000-of-0002.ndjson", "0001-of-0003.ndjson"))
+        .toBeUndefined();
+      // Gaps are what a day with an empty shard leaves behind.
+      expect(shards("0000-of-0003.ndjson", "0002-of-0003.ndjson")?.shards)
+        .toEqual(["0000-of-0003.ndjson", "0002-of-0003.ndjson"]);
+    });
+
+    it("rejects anything else", () => {
+      expect(parseRollupManifest("not json", DAY)).toBeUndefined();
+      expect(parseRollupManifest(good, "2026/08/12")).toBeUndefined();
+      expect(parseRollupManifest(
+        JSON.stringify({ schema: 2, day: DAY, shards: [] }),
+        DAY,
+      )).toBeUndefined();
+      // A shard name is joined onto the day's prefix, so a name that could
+      // reach outside that prefix is not a shard name.
+      expect(parseRollupManifest(
+        JSON.stringify({
+          schema: 1,
+          day: DAY,
+          shards: ["../elsewhere.ndjson"],
+        }),
+        DAY,
+      )).toBeUndefined();
+    });
+  });
+
+  describe("rollupShards()", () => {
+    it("names the shards of a compacted day", async () => {
+      const store = storeOf(DAY, []);
+      store.objects[rollupManifestName(DAY)] = JSON.stringify({
+        schema: 1,
+        day: DAY,
+        shards: ["0000-of-0002.ndjson", "0001-of-0002.ndjson"],
       });
-      expect(state.created).toEqual([]);
+      expect(
+        await rollupShards({
+          bucket: "cf-ci-metadata",
+          day: DAY,
+          fetch: storeFetch(store),
+        }),
+      ).toEqual([
+        `${rollupPrefix(DAY)}0000-of-0002.ndjson`,
+        `${rollupPrefix(DAY)}0001-of-0002.ndjson`,
+      ]);
+    });
+
+    it("gives nothing for a day with no manifest", async () => {
+      expect(
+        await rollupShards({
+          bucket: "cf-ci-metadata",
+          day: DAY,
+          fetch: storeFetch(storeOf(DAY, [])),
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("compactDays()", () => {
+    it("writes one shard and a manifest for a small day", async () => {
+      const store = storeOf(DAY, [
+        buildObjectBody(contextOn(DAY), [RECORD, RECORD]),
+      ]);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      // Spelled out rather than built from the functions under test: this
+      // is the layout docs/specs/test-records.md documents.
+      expect(Object.keys(store.created).sort()).toEqual([
+        "labs/test-records/aggregated/ci/v1/2026/08/11/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/11/rollup.json",
+      ]);
+      expect(await compactedNames(store)).toEqual([
+        RECORD.test.n,
+        RECORD.test.n,
+      ]);
+    });
+
+    it("keeps each report's own context ahead of its own records", async () => {
+      // One object holding two reports, as a rollup of a rollup would be.
+      const first = { ...contextOn(DAY), reportId: "01FIRST00000000000000000" };
+      const second = {
+        ...contextOn(DAY),
+        reportId: "01SECOND0000000000000000",
+      };
+      const store = storeOf(DAY, [
+        buildObjectBody(first, [RECORD]) +
+        buildObjectBody(second, [RECORD, RECORD]),
+      ]);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      const groups = parseReportGroups(
+        await gunzipToText(store.created[createdShards(store)[0]!]!),
+      );
+      expect(groups.map((group) => group.context?.reportId)).toEqual([
+        first.reportId,
+        second.reportId,
+      ]);
+      expect(groups.map((group) => group.records.length)).toEqual([1, 2]);
+    });
+
+    it("compacts every closed day in the window", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      const older = "2026/08/10";
+      Object.assign(
+        store.objects,
+        storeOf(older, [buildObjectBody(contextOn(older), [RECORD])]).objects,
+      );
+      await compactDays({
+        ...OPTIONS,
+        days: COMPACTION_LAG_DAYS + 1,
+        fetchImpl: storeFetch(store),
+      });
+      expect(Object.keys(store.created).sort()).toEqual([
+        "labs/test-records/aggregated/ci/v1/2026/08/10/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/10/rollup.json",
+        "labs/test-records/aggregated/ci/v1/2026/08/11/0000-of-0001.ndjson",
+        "labs/test-records/aggregated/ci/v1/2026/08/11/rollup.json",
+      ]);
+    });
+
+    it("divides a day past the target, losing no record", async () => {
+      // Five shards' worth of stored bytes across the day's objects.
+      const store = storeOf(DAY, casesOn(DAY, 40), SHARD_TARGET_BYTES / 8);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(createdShards(store).length).toBe(5);
+      expect(await compactedNames(store)).toEqual(
+        casesOn(DAY, 40).map((_, index) => `case ${index}`).sort(),
+      );
+    });
+
+    it("names every shard it wrote in the manifest", async () => {
+      const store = storeOf(DAY, casesOn(DAY, 40), SHARD_TARGET_BYTES / 8);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(createdManifest(store, DAY)?.shards).toEqual(
+        createdShards(store).map((name) =>
+          name.slice(rollupPrefix(DAY).length)
+        ),
+      );
+    });
+
+    it("skips a day whose manifest already exists", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      store.objects[rollupManifestName(DAY)] = "{}";
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
+    });
+
+    it("finishes a day whose shards were half written", async () => {
+      const bodies = casesOn(DAY, 40);
+      const whole = storeOf(DAY, bodies, SHARD_TARGET_BYTES / 8);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(whole) });
+      const written = createdShards(whole);
+
+      // A run that died after two shards leaves those two behind and no
+      // manifest, which is what the next run finds.
+      const store = storeOf(DAY, bodies, SHARD_TARGET_BYTES / 8);
+      for (const name of written.slice(0, 2)) store.objects[name] = "";
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+
+      expect(createdShards(store)).toEqual(written.slice(2));
+      // The manifest names what the earlier run wrote as well as what this
+      // one did, so the day reads whole.
+      expect(createdManifest(store, DAY)?.shards).toEqual(
+        written.map((name) => name.slice(rollupPrefix(DAY).length)),
+      );
+    });
+
+    it("finishes a day in the partition it was started in", async () => {
+      const bodies = casesOn(DAY, 40);
+      const whole = storeOf(DAY, bodies, SHARD_TARGET_BYTES / 8);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(whole) });
+      const written = createdShards(whole);
+
+      // A run that died after two shards, and then enough raw objects
+      // arriving to size the day differently. The partition the first run
+      // started is the one the second finishes, so the shards it wrote are
+      // named by the manifest rather than left behind by a second
+      // partition alongside them.
+      const store = storeOf(
+        DAY,
+        [...bodies, ...casesOn(DAY, 40)],
+        SHARD_TARGET_BYTES / 8,
+      );
+      for (const name of written.slice(0, 2)) store.objects[name] = "";
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+
+      expect(createdManifest(store, DAY)?.shards).toEqual(
+        written.map((name) => name.slice(rollupPrefix(DAY).length)),
+      );
+      expect(createdShards(store).every((name) => name.includes("-of-0005.")))
+        .toBe(true);
+    });
+
+    it("counts a shard another run already created as present", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      const inner = storeFetch(store);
+      // Every create loses the race, as a second run reaching the same
+      // shard names at the same moment would.
+      const raced = ((input: URL | RequestInfo, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return Promise.resolve(new Response("taken", { status: 412 }));
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+      const lines: string[] = [];
+      const log = console.log;
+      console.log = (line: string) => void lines.push(line);
+      try {
+        await compactDays({ ...OPTIONS, fetchImpl: raced });
+      } finally {
+        console.log = log;
+      }
+      expect(lines).toEqual([`${DAY}: another run's manifest got there first`]);
+    });
+
+    it("leaves a day holding two partitions open", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      store.objects[`${rollupPrefix(DAY)}0000-of-0002.ndjson`] = "";
+      store.objects[`${rollupPrefix(DAY)}0000-of-0003.ndjson`] = "";
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
+    });
+
+    it("leaves a day whose objects all list as empty open", async () => {
+      const store = storeOf(DAY, casesOn(DAY, 4), 0);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
     });
 
     it("leaves a day with no records open", async () => {
-      const day = "2026/08/11";
-      const state = {
-        rollups: [],
-        rawByDay: { [day]: [buildObjectBody(contextOn(day), [])] },
-        created: [] as string[],
-      };
-      await compactDays({
-        ...options,
-        plan: false,
-        fetchImpl: storeFetch(state),
-      });
-      expect(state.created).toEqual([]);
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [])]);
+      await compactDays({ ...OPTIONS, fetchImpl: storeFetch(store) });
+      expect(Object.keys(store.created)).toEqual([]);
     });
 
-    it("writes nothing in plan mode", async () => {
-      const day = "2026/08/11";
-      const state = {
-        rollups: [],
-        rawByDay: {
-          [day]: [buildObjectBody(contextOn(day), [RECORD])],
-        },
-        created: [] as string[],
-      };
-      await compactDays({
-        ...options,
-        plan: true,
-        fetchImpl: storeFetch(state),
-      });
-      expect(state.created).toEqual([]);
+    it("writes nothing in plan mode, and reads no object body", async () => {
+      const store = storeOf(DAY, [buildObjectBody(contextOn(DAY), [RECORD])]);
+      const inner = storeFetch(store);
+      const reads: string[] = [];
+      const watched = ((input: URL | RequestInfo, init?: RequestInit) => {
+        const url = String(input);
+        if (!url.includes("/storage/v1/") && init?.method !== "POST") {
+          reads.push(url);
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+      await compactDays({ ...OPTIONS, plan: true, fetchImpl: watched });
+      expect(Object.keys(store.created)).toEqual([]);
+      expect(reads).toEqual([]);
     });
   });
 
   describe("parseCompactArgs()", () => {
     it("returns the defaults and the given flags", () => {
       expect(parseCompactArgs([])).toEqual({ days: 14, plan: false });
-      expect(parseCompactArgs(["--plan", "--days", "3"]))
-        .toEqual({ days: 3, plan: true });
+      expect(parseCompactArgs(["--plan", "--days", "9"]))
+        .toEqual({ days: 9, plan: true });
     });
 
     it("returns undefined for malformed command lines", () => {
       expect(parseCompactArgs(["--days", "0"])).toBeUndefined();
       expect(parseCompactArgs(["--days", "x"])).toBeUndefined();
       expect(parseCompactArgs(["--mystery"])).toBeUndefined();
+    });
+
+    it("returns undefined for a window shorter than the lag", () => {
+      expect(parseCompactArgs(["--days", String(COMPACTION_LAG_DAYS - 1)]))
+        .toBeUndefined();
+      expect(parseCompactArgs(["--days", String(COMPACTION_LAG_DAYS)]))
+        .toEqual({ days: COMPACTION_LAG_DAYS, plan: false });
     });
   });
 });

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -1,18 +1,40 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
 
 /**
- * The compactor: rewrites each closed day of raw records as one rollup
- * object under the dataset's aggregated/ area, so full-history consumers
- * read one object per day plus the recent raw tail instead of every object
- * ever written. Rollups are write-once — a day is compacted only after it
- * has closed, its object name is deterministic, and an existing rollup is
- * never touched — so re-running is idempotent and the bucket's versioning
- * never accumulates noncurrent copies.
+ * The compactor: rewrites each closed day of raw records as a handful of
+ * rollup shards under the dataset's aggregated/ area, so full-history
+ * consumers read a few objects per day plus the recent raw tail instead of
+ * every object ever written. Rollups are write-once — a day is compacted
+ * only after it has closed, its object names are deterministic, and an
+ * existing shard is never touched — so re-running is idempotent and the
+ * bucket's versioning never accumulates noncurrent copies.
+ *
+ * A day is many objects. A busy day is over a gigabyte of NDJSON, against
+ * V8's maximum string length of about half that, and an object has to fit
+ * in a string at both ends: the compactor builds one, and a reader fetches
+ * one. Each shard is sized to fit, which also bounds what the compactor
+ * holds — one shard's compressed bytes plus the raw objects its bounded
+ * read-ahead window has in flight.
+ *
+ * Which shard an object belongs to is a hash of its name, so the partition
+ * is a property of the object rather than of the order objects were read
+ * in. A run that dies part way is completed by the next run, which writes
+ * the shards that are missing and leaves the rest alone. The shard count
+ * is in every shard's name, so shards from two runs that sized a day
+ * differently are separate objects rather than the same object with two
+ * meanings. The manifest is written last, and a day counts as compacted
+ * when it exists.
  *
  * Reader-side validation lives here: every line of every raw object goes
- * through the schema validators, and only what validated reaches a rollup.
+ * through the schema validators, and only what validated reaches a shard.
  *
- *   deno run -A tasks/test-records-compact.ts [--days N]
+ *   deno task test-records-compact [--days N] [--plan]
+ *
+ * `--plan` reports from the listing alone and reads no object bodies, so it
+ * says what a day would come to at any volume. What it cannot say is
+ * whether a day's objects hold any records, which is a property of their
+ * contents; a day of records-free objects shows as compactable and is then
+ * left open by the run that reads it.
  *
  * The writer credential comes from CF_TEST_RECORDS_COMPACTOR_KEY_FILE, a
  * service-account key with create-only access to the aggregated/ area;
@@ -24,12 +46,15 @@ import {
   buildObjectBody,
   createObject,
   datePartition,
-  gzipText,
-  listObjects,
+  gzipChunks,
+  type ListedObject,
+  listObjectSizes,
+  objectUrl,
   readEnv,
   readObject,
   RECORD_SCHEMA_VERSION,
   STORE_WRITE_SCOPE,
+  type StoredReport,
   tokenFromKey,
 } from "@commonfabric/test-support/records";
 import {
@@ -39,9 +64,163 @@ import {
   storePrefix,
 } from "./test-records-config.ts";
 
-/** The rollup object for a day of ci records. */
-export function rollupName(day: string): string {
-  return `${storePrefix()}/aggregated/ci/v${RECORD_SCHEMA_VERSION}/${day}.ndjson`;
+const ENCODER = new TextEncoder();
+
+/** The folder holding one day's rollup shards and its manifest. */
+export function rollupPrefix(day: string): string {
+  return `${storePrefix()}/aggregated/ci/v${RECORD_SCHEMA_VERSION}/${day}/`;
+}
+
+/**
+ * The manifest of a day's rollup, which names the day's shards. It is
+ * written after every shard it names, so a day with a manifest is a day
+ * whose rollup is complete, and a day without one has no rollup a reader
+ * may use.
+ */
+export function rollupManifestName(day: string): string {
+  return `${rollupPrefix(day)}rollup.json`;
+}
+
+/**
+ * A shard's name within its day's folder. The count is in the name: two
+ * runs that divided a day into different numbers of shards write different
+ * objects rather than colliding on one name with two partitions behind it.
+ */
+export function rollupShardName(index: number, count: number): string {
+  const pad = (value: number) => String(value).padStart(4, "0");
+  return `${pad(index)}-of-${pad(count)}.ndjson`;
+}
+
+/**
+ * Stored bytes a shard aims for. What a reader has to hold is the text a
+ * shard decompresses to, which is this many bytes times however well the
+ * day compressed, so the compression ratio that costs a reader is a high
+ * one rather than a low one. The days measured when this was written ran
+ * about 7.4 times; V8's limit of a little under 512 MiB is reached at 64
+ * times. At eight mebibytes a shard is a few tens of megabytes of text,
+ * and a busy day is tens of objects rather than thousands.
+ */
+export const SHARD_TARGET_BYTES = 8 * 1024 * 1024;
+
+/** How many shards a day of the given stored size is divided into. */
+export function shardCount(storedBytes: number): number {
+  return Math.max(1, Math.ceil(storedBytes / SHARD_TARGET_BYTES));
+}
+
+/**
+ * The shard one raw object belongs to: FNV-1a over its name, taken modulo
+ * the shard count. The assignment depends on the object's own name and
+ * nothing else, so a re-run partitions a day the same way whatever else
+ * has landed in it, and no record can end up in two shards.
+ */
+export function shardOf(objectName: string, count: number): number {
+  let hash = 0x811c9dc5;
+  for (const byte of ENCODER.encode(objectName)) {
+    hash = Math.imul(hash ^ byte, 0x01000193) >>> 0;
+  }
+  return hash % count;
+}
+
+/** A day's rollup manifest. */
+export interface RollupManifest {
+  schema: typeof RECORD_SCHEMA_VERSION;
+
+  /** The day the shards cover, as "yyyy/mm/dd". */
+  day: string;
+
+  /** Shard names within the day's folder, in shard order. */
+  shards: string[];
+}
+
+const SHARD_NAME = /^(\d{4,})-of-(\d{4,})\.ndjson$/;
+
+/**
+ * The partitions a day's folder already holds shards of, read off their
+ * names. A day is partitioned once: a run that finds shards there finishes
+ * the partition that wrote them rather than starting a second one, so its
+ * shard names agree with theirs and nothing an earlier run wrote is left
+ * unreferenced. More than one partition means a folder no run should add
+ * to.
+ */
+export function startedShardCounts(
+  day: string,
+  present: readonly string[],
+): number[] {
+  const counts = new Set<number>();
+  for (const name of present) {
+    if (!name.startsWith(rollupPrefix(day))) continue;
+    const parts = SHARD_NAME.exec(name.slice(rollupPrefix(day).length));
+    if (parts !== null) counts.add(Number(parts[2]));
+  }
+  return [...counts].sort((a, b) => a - b);
+}
+
+/**
+ * Parses a manifest, returning undefined for anything that is not one of
+ * this schema version for the day asked about. A manifest is stored
+ * material like any other, so it is validated at the read boundary, and
+ * the shard names are checked against the one shape the compactor writes
+ * rather than joined onto a prefix as given.
+ */
+export function parseRollupManifest(
+  text: string,
+  day: string,
+): RollupManifest | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null) return undefined;
+  const manifest = value as Record<string, unknown>;
+  if (manifest.schema !== RECORD_SCHEMA_VERSION) return undefined;
+  if (manifest.day !== day) return undefined;
+  if (!Array.isArray(manifest.shards)) return undefined;
+  const shards: string[] = [];
+  const seen = new Set<string>();
+  let count: number | undefined;
+  for (const shard of manifest.shards) {
+    if (typeof shard !== "string") return undefined;
+    const parts = SHARD_NAME.exec(shard);
+    if (parts === null) return undefined;
+    // One partition, each shard of it named once and within it: a repeated
+    // shard would count its records twice, and an index past the count
+    // names an object no run writes.
+    const of = Number(parts[2]);
+    count ??= of;
+    if (of !== count || Number(parts[1]) >= of || seen.has(shard)) {
+      return undefined;
+    }
+    seen.add(shard);
+    shards.push(shard);
+  }
+  return { schema: RECORD_SCHEMA_VERSION, day, shards };
+}
+
+/**
+ * The object names of a day's rollup shards, or undefined when the day has
+ * no rollup a reader may use — it was never compacted, or a run that was
+ * compacting it has not finished. Callers read the shards in the order
+ * given and treat them as the day.
+ */
+export async function rollupShards(options: {
+  bucket: string;
+  day: string;
+  fetch?: typeof fetch;
+}): Promise<string[] | undefined> {
+  const doFetch = options.fetch ?? fetch;
+  const res = await doFetch(
+    objectUrl(options.bucket, rollupManifestName(options.day)),
+  );
+  if (!res.ok) {
+    // Read and discard so the connection is reusable.
+    await res.text();
+    return undefined;
+  }
+  const manifest = parseRollupManifest(await res.text(), options.day);
+  if (manifest === undefined) return undefined;
+  return manifest.shards.map((shard) => `${rollupPrefix(options.day)}${shard}`);
 }
 
 /**
@@ -75,75 +254,195 @@ export interface CompactOptions {
   now?: number;
 }
 
+/** How many raw objects a shard's reads run ahead of its compressor by. */
+const READ_AHEAD = 16;
+
+/** What one shard's reads came to. */
+interface Tally {
+  reports: number;
+  records: number;
+}
+
+/**
+ * The bodies of a shard's raw objects, in listing order, ready to be
+ * compressed one after another. One body per report an object holds, each
+ * carrying that report's own context line ahead of its own records, so an
+ * object holding more than one report reaches the shard as the reports it
+ * holds. Records with no valid context ahead of them are dropped: a rollup
+ * keeps a context line ahead of every record, and a record with no context
+ * has no report to belong to.
+ *
+ * Reads run ahead of the caller by a bounded window, so a shard's hundreds
+ * of small objects are fetched several at a time while what is held stays
+ * the size of that window. A read that fails is carried as a value rather
+ * than a rejection, so a failure while an earlier read is still being
+ * awaited surfaces where the failed object is reached instead of as an
+ * unhandled rejection.
+ */
+async function* reportBodies(
+  read: (objectName: string) => Promise<StoredReport>,
+  objectNames: readonly string[],
+  tally: Tally,
+): AsyncGenerator<string> {
+  const settle = (objectName: string) =>
+    read(objectName).then(
+      (report) => ({ report, error: undefined }),
+      (error: unknown) => ({ report: undefined, error }),
+    );
+  const window: ReturnType<typeof settle>[] = [];
+  let next = 0;
+  while (next < objectNames.length && window.length < READ_AHEAD) {
+    window.push(settle(objectNames[next++]!));
+  }
+  while (window.length > 0) {
+    const settled = await window.shift()!;
+    if (next < objectNames.length) window.push(settle(objectNames[next++]!));
+    if (settled.report === undefined) throw settled.error;
+    for (const group of settled.report.reports) {
+      if (group.context === undefined) continue;
+      tally.reports++;
+      tally.records += group.records.length;
+      yield buildObjectBody(group.context, group.records);
+    }
+  }
+}
+
 /** Compacts every closed day that has records and no rollup yet. */
 export async function compactDays(options: CompactOptions): Promise<void> {
   const { bucket, rawPrefix, plan } = options;
-  for (const day of closedDays(options.days, options.now)) {
-    const listOptions: Parameters<typeof listObjects>[0] = {
+  const list = (prefix: string): Promise<ListedObject[]> => {
+    const listOptions: Parameters<typeof listObjectSizes>[0] = {
       bucket,
-      prefix: rollupName(day),
+      prefix,
     };
     if (options.fetchImpl !== undefined) listOptions.fetch = options.fetchImpl;
-    const existing = await listObjects(listOptions);
-    if (existing.length > 0) continue;
-    const rawListOptions: Parameters<typeof listObjects>[0] = {
+    return listObjectSizes(listOptions);
+  };
+  const read = (objectName: string): Promise<StoredReport> => {
+    const readOptions: Parameters<typeof readObject>[0] = {
       bucket,
-      prefix: `${rawPrefix}/v${RECORD_SCHEMA_VERSION}/${day}/`,
+      objectName,
     };
-    if (options.fetchImpl !== undefined) {
-      rawListOptions.fetch = options.fetchImpl;
-    }
-    const raw = await listObjects(rawListOptions);
-    if (raw.length === 0) continue;
-
-    let body = "";
-    let reportCount = 0;
-    let recordCount = 0;
-    for (const objectName of raw) {
-      const readOptions: Parameters<typeof readObject>[0] = {
-        bucket,
-        objectName,
-      };
-      if (options.fetchImpl !== undefined) {
-        readOptions.fetch = options.fetchImpl;
-      }
-      const report = await readObject(readOptions);
-      if (report.context === undefined) continue;
-      reportCount++;
-      recordCount += report.records.length;
-      body += buildObjectBody(report.context, report.records);
-    }
-    // A day with no records gets no rollup: the write-once rollup would
-    // permanently exclude anything that later lands in that day — an old
-    // run re-run, a late orphan — for nothing.
-    if (recordCount === 0) {
-      console.log(`${day}: no records yet; leaving the day open`);
-      continue;
-    }
-    if (plan) {
-      console.log(
-        `would compact ${day}: ${raw.length} object(s), ${reportCount} ` +
-          `report(s), ${recordCount} record(s) -> ${rollupName(day)}`,
-      );
-      continue;
-    }
+    if (options.fetchImpl !== undefined) readOptions.fetch = options.fetchImpl;
+    return readObject(readOptions);
+  };
+  const create = (
+    name: string,
+    body: Uint8Array,
+    contentType: string,
+    contentEncoding?: string,
+  ): ReturnType<typeof createObject> => {
     const createOptions: Parameters<typeof createObject>[0] = {
       bucket,
-      name: rollupName(day),
-      body: await gzipText(body),
+      name,
+      body,
       token: options.token!,
-      contentType: "application/x-ndjson",
-      contentEncoding: "gzip",
+      contentType,
     };
+    if (contentEncoding !== undefined) {
+      createOptions.contentEncoding = contentEncoding;
+    }
     if (options.fetchImpl !== undefined) {
       createOptions.fetch = options.fetchImpl;
     }
-    const result = await createObject(createOptions);
+    return createObject(createOptions);
+  };
+
+  for (const day of closedDays(options.days, options.now)) {
+    const present = await list(rollupPrefix(day));
+    if (present.some((object) => object.name === rollupManifestName(day))) {
+      continue;
+    }
+    const raw = await list(`${rawPrefix}/v${RECORD_SCHEMA_VERSION}/${day}/`);
+    if (raw.length === 0) continue;
+    const stored = raw.reduce((total, object) => total + object.size, 0);
+    // The shard count comes from the listing's sizes, and a rollup cannot
+    // be rewritten once written. A day that lists objects but no bytes is
+    // a listing that did not answer, so it is reported and left open.
+    if (stored === 0) {
+      console.error(
+        `${day}: ${raw.length} object(s) listed with no size; ` +
+          "leaving the day open",
+      );
+      continue;
+    }
+    // A day already part way through a partition is finished in that
+    // partition, whatever it would be sized at now.
+    const started = startedShardCounts(
+      day,
+      present.map((object) => object.name),
+    );
+    if (started.length > 1) {
+      console.error(
+        `${day}: the folder holds shards of ${started.length} partitions ` +
+          `(${started.join(", ")}); leaving the day open`,
+      );
+      continue;
+    }
+    const count = started[0] ?? shardCount(stored);
+    if (plan) {
+      console.log(
+        `would compact ${day}: ${raw.length} object(s), ` +
+          `${(stored / 1e6).toFixed(1)} MB -> ${count} shard(s) under ` +
+          rollupPrefix(day),
+      );
+      continue;
+    }
+
+    const members: string[][] = Array.from({ length: count }, () => []);
+    for (const object of raw) {
+      members[shardOf(object.name, count)]!.push(object.name);
+    }
+    const existing = new Set(present.map((object) => object.name));
+    const shards: string[] = [];
+    const total: Tally = { reports: 0, records: 0 };
+    let written = 0;
+    for (let index = 0; index < count; index++) {
+      const shard = rollupShardName(index, count);
+      const name = `${rollupPrefix(day)}${shard}`;
+      if (existing.has(name)) {
+        shards.push(shard);
+        continue;
+      }
+      if (members[index]!.length === 0) continue;
+      const tally: Tally = { reports: 0, records: 0 };
+      const body = await gzipChunks(reportBodies(read, members[index]!, tally));
+      // A shard with no records is not written, and a day whose objects
+      // hold no records is therefore left with no shards and no manifest:
+      // a write-once rollup would permanently exclude anything that later
+      // lands in that day — an old run re-run, a late orphan — for nothing.
+      if (tally.records === 0) continue;
+      if (
+        await create(name, body, "application/x-ndjson", "gzip") === "created"
+      ) {
+        written++;
+      }
+      total.reports += tally.reports;
+      total.records += tally.records;
+      shards.push(shard);
+    }
+    if (shards.length === 0) {
+      console.log(`${day}: no records yet; leaving the day open`);
+      continue;
+    }
+    const manifest: RollupManifest = {
+      schema: RECORD_SCHEMA_VERSION,
+      day,
+      shards,
+    };
+    const result = await create(
+      rollupManifestName(day),
+      ENCODER.encode(JSON.stringify(manifest)),
+      "application/json",
+    );
+    if (result === "exists") {
+      console.log(`${day}: another run's manifest got there first`);
+      continue;
+    }
     console.log(
-      `${day}: ${recordCount} record(s) from ${raw.length} object(s) ` +
-        `${result === "created" ? "compacted to" : "already at"} ${
-          rollupName(day)
-        }`,
+      `${day}: ${raw.length} object(s) compacted to ${shards.length} ` +
+        `shard(s) under ${rollupPrefix(day)}; ${written} written now, ` +
+        `holding ${total.records} record(s) in ${total.reports} report(s)`,
     );
   }
 }
@@ -161,8 +460,12 @@ export function parseCompactArgs(
       plan = true;
     } else if (flag === "--days") {
       days = Number(args.shift());
-      if (!Number.isInteger(days) || days < 1) {
-        console.error("--days takes a positive integer");
+      if (!Number.isInteger(days) || days < COMPACTION_LAG_DAYS) {
+        console.error(
+          `--days takes an integer of at least ${COMPACTION_LAG_DAYS}: a ` +
+            "shorter window reaches back only into days still open for " +
+            "late arrivals.",
+        );
         return undefined;
       }
     } else {

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -18,12 +18,12 @@
  *
  * Which shard an object belongs to is a hash of its name, so the partition
  * is a property of the object rather than of the order objects were read
- * in. A run that dies part way is completed by the next run, which writes
- * the shards that are missing and leaves the rest alone. The shard count
- * is in every shard's name, so shards from two runs that sized a day
- * differently are separate objects rather than the same object with two
- * meanings. The manifest is written last, and a day counts as compacted
- * when it exists.
+ * in. How many shards there are is fixed by an object created before any
+ * of them, so a day is partitioned once however many runs reach it, and a
+ * run that dies part way is completed by the next one, which writes the
+ * shards that are missing and leaves the rest alone. The count is in every
+ * shard's name as well, so a shard says which partition it belongs to. The
+ * manifest is written last, and a day counts as compacted when it exists.
  *
  * Reader-side validation lives here: every line of every raw object goes
  * through the schema validators, and only what validated reaches a shard.
@@ -134,25 +134,55 @@ export interface RollupManifest {
 
 const SHARD_NAME = /^(\d{4,})-of-(\d{4,})\.ndjson$/;
 
+/** The object fixing how many shards a day is divided into. */
+export function rollupPartitionName(day: string): string {
+  return `${rollupPrefix(day)}partition.json`;
+}
+
 /**
- * The partitions a day's folder already holds shards of, read off their
- * names. A day is partitioned once: a run that finds shards there finishes
- * the partition that wrote them rather than starting a second one, so its
- * shard names agree with theirs and nothing an earlier run wrote is left
- * unreferenced. More than one partition means a folder no run should add
- * to.
+ * How many shards a day is divided into. This is created before any shard
+ * of the day, under the same precondition every write here uses, so a day
+ * is partitioned once however many runs reach it: the create that loses
+ * reads the count that won and works to that one. A run that finds a day
+ * part way through finishes it in the partition claimed for it, whatever
+ * the day would be sized at now, so no run leaves shards of a partition
+ * nothing names.
  */
-export function startedShardCounts(
+export interface RollupPartition {
+  schema: typeof RECORD_SCHEMA_VERSION;
+
+  /** The day partitioned, as "yyyy/mm/dd". */
+  day: string;
+
+  count: number;
+}
+
+/**
+ * Parses a partition, returning undefined for anything that is not one of
+ * this schema version for the day asked about.
+ */
+export function parseRollupPartition(
+  text: string,
   day: string,
-  present: readonly string[],
-): number[] {
-  const counts = new Set<number>();
-  for (const name of present) {
-    if (!name.startsWith(rollupPrefix(day))) continue;
-    const parts = SHARD_NAME.exec(name.slice(rollupPrefix(day).length));
-    if (parts !== null) counts.add(Number(parts[2]));
+): RollupPartition | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return undefined;
   }
-  return [...counts].sort((a, b) => a - b);
+  if (typeof value !== "object" || value === null) return undefined;
+  const partition = value as Record<string, unknown>;
+  if (partition.schema !== RECORD_SCHEMA_VERSION) return undefined;
+  if (partition.day !== day) return undefined;
+  if (!Number.isInteger(partition.count) || (partition.count as number) < 1) {
+    return undefined;
+  }
+  return {
+    schema: RECORD_SCHEMA_VERSION,
+    day,
+    count: partition.count as number,
+  };
 }
 
 /**
@@ -176,7 +206,12 @@ export function parseRollupManifest(
   const manifest = value as Record<string, unknown>;
   if (manifest.schema !== RECORD_SCHEMA_VERSION) return undefined;
   if (manifest.day !== day) return undefined;
-  if (!Array.isArray(manifest.shards)) return undefined;
+  // A manifest names the day, and a day with no shards is one no manifest
+  // is written for; taking an empty one would read as a day whose records
+  // are all accounted for by nothing.
+  if (!Array.isArray(manifest.shards) || manifest.shards.length === 0) {
+    return undefined;
+  }
   const shards: string[] = [];
   const seen = new Set<string>();
   let count: number | undefined;
@@ -326,6 +361,12 @@ export async function compactDays(options: CompactOptions): Promise<void> {
     if (options.fetchImpl !== undefined) readOptions.fetch = options.fetchImpl;
     return readObject(readOptions);
   };
+  const readText = async (name: string): Promise<string | undefined> => {
+    const res = await (options.fetchImpl ?? fetch)(objectUrl(bucket, name));
+    // Read and discard so the connection is reusable.
+    const text = await res.text();
+    return res.ok ? text : undefined;
+  };
   const create = (
     name: string,
     body: Uint8Array,
@@ -348,6 +389,29 @@ export async function compactDays(options: CompactOptions): Promise<void> {
     return createObject(createOptions);
   };
 
+  /** The partition claimed for a day, claiming this run's if none is. */
+  const partitionOf = async (
+    day: string,
+    count: number,
+  ): Promise<number | undefined> => {
+    const name = rollupPartitionName(day);
+    const claim: RollupPartition = {
+      schema: RECORD_SCHEMA_VERSION,
+      day,
+      count,
+    };
+    const written = await create(
+      name,
+      ENCODER.encode(JSON.stringify(claim)),
+      "application/json",
+    );
+    if (written === "created") return count;
+    const text = await readText(name);
+    return text === undefined
+      ? undefined
+      : parseRollupPartition(text, day)?.count;
+  };
+
   for (const day of closedDays(options.days, options.now)) {
     const present = await list(rollupPrefix(day));
     if (present.some((object) => object.name === rollupManifestName(day))) {
@@ -366,25 +430,33 @@ export async function compactDays(options: CompactOptions): Promise<void> {
       );
       continue;
     }
-    // A day already part way through a partition is finished in that
-    // partition, whatever it would be sized at now.
-    const started = startedShardCounts(
-      day,
-      present.map((object) => object.name),
-    );
-    if (started.length > 1) {
+    const partitionName = rollupPartitionName(day);
+    const partitioned = present.some((object) => object.name === partitionName);
+    const claimed = partitioned
+      ? parseRollupPartition(await readText(partitionName) ?? "", day)?.count
+      : undefined;
+    if (partitioned && claimed === undefined) {
       console.error(
-        `${day}: the folder holds shards of ${started.length} partitions ` +
-          `(${started.join(", ")}); leaving the day open`,
+        `${day}: ${partitionName} is not a partition of this day; ` +
+          "leaving the day open",
       );
       continue;
     }
-    const count = started[0] ?? shardCount(stored);
     if (plan) {
       console.log(
         `would compact ${day}: ${raw.length} object(s), ` +
-          `${(stored / 1e6).toFixed(1)} MB -> ${count} shard(s) under ` +
-          rollupPrefix(day),
+          `${(stored / 1e6).toFixed(1)} MB -> ` +
+          `${claimed ?? shardCount(stored)} shard(s) under ` +
+          rollupPrefix(day) +
+          (partitioned ? ", resuming the partition claimed for it" : ""),
+      );
+      continue;
+    }
+    const count = claimed ?? await partitionOf(day, shardCount(stored));
+    if (count === undefined) {
+      console.error(
+        `${day}: another run claimed a partition this one cannot read; ` +
+          "leaving the day open",
       );
       continue;
     }

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -432,13 +432,29 @@ export async function compactDays(options: CompactOptions): Promise<void> {
     }
     const partitionName = rollupPartitionName(day);
     const partitioned = present.some((object) => object.name === partitionName);
+    // Every shard of a day is written after the partition naming it, so a
+    // folder holding objects without one holds a partition this run cannot
+    // identify, and adding to it would leave whatever is there named by no
+    // manifest.
+    if (!partitioned && present.length > 0) {
+      console.error(
+        `${day}: the folder holds ${present.length} object(s) and no ` +
+          `${partitionName}; leaving the day open`,
+      );
+      continue;
+    }
     const claimed = partitioned
       ? parseRollupPartition(await readText(partitionName) ?? "", day)?.count
       : undefined;
-    if (partitioned && claimed === undefined) {
+    // A partition dividing a day into more shards than it has objects is
+    // one no run writes: shards are sized from the day's bytes, and an
+    // object is at most a fraction of a shard. Taking a count on trust is
+    // what turns a partition object nobody can replace into a day nobody
+    // can compact.
+    if (partitioned && (claimed === undefined || claimed > raw.length)) {
       console.error(
-        `${day}: ${partitionName} is not a partition of this day; ` +
-          "leaving the day open",
+        `${day}: ${partitionName} is not a partition of this day's ` +
+          `${raw.length} object(s); leaving the day open`,
       );
       continue;
     }

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -446,15 +446,17 @@ export async function compactDays(options: CompactOptions): Promise<void> {
     const claimed = partitioned
       ? parseRollupPartition(await readText(partitionName) ?? "", day)?.count
       : undefined;
-    // A partition dividing a day into more shards than it has objects is
-    // one no run writes: shards are sized from the day's bytes, and an
-    // object is at most a fraction of a shard. Taking a count on trust is
-    // what turns a partition object nobody can replace into a day nobody
-    // can compact.
-    if (partitioned && (claimed === undefined || claimed > raw.length)) {
+    // No run divides a day into more shards than the larger of what its
+    // objects and its bytes come to, so a count past that is one nothing
+    // wrote. The count sizes an array before a record is read, and a
+    // partition object cannot be replaced, so a count taken on trust is
+    // what turns one bad object into a day nobody can compact.
+    const ceiling = Math.max(raw.length, shardCount(stored));
+    if (partitioned && (claimed === undefined || claimed > ceiling)) {
       console.error(
         `${day}: ${partitionName} is not a partition of this day's ` +
-          `${raw.length} object(s); leaving the day open`,
+          `${raw.length} object(s) and ${(stored / 1e6).toFixed(1)} MB; ` +
+          "leaving the day open",
       );
       continue;
     }


### PR DESCRIPTION
The compactor accumulated a whole day of raw records into one JavaScript string before compressing it, and a day of this repository's records outgrew that assumption. One closed day, 2026/08/21, holds 15,240 objects and 138 MB gzipped, which is about a gigabyte of NDJSON uncompressed, against V8's maximum string length of 536,870,888 characters. So `deno task test-records-compact --plan --days 14` failed with `RangeError: Invalid string length` before it decided whether to write anything, and no day could be compacted at all.

Fixing the accumulator alone would not have produced a usable rollup. The repository's own reader fetches an object and calls `Response.text()`, which builds one string, so a whole-day rollup would have been an object nothing could read back — the same limit, reached from the other side. That is verified rather than reasoned: a 600 MiB body through `Response.text()` throws `RangeError: string too long`.

So a day's rollup becomes several objects rather than one.

## What the store holds

The aggregated area now holds, per day, a folder of shards named `<index>-of-<count>.ndjson` and a `rollup.json` manifest naming them. A shard aims at eight mebibytes stored, which at the compression these records get is a few tens of megabytes of text: a string a reader holds comfortably, and a busy day becomes tens of objects rather than tens of thousands. What a reader has to hold is the text a shard decompresses to, so the compression ratio that costs a reader is a high one; the days measured ran about 7.4 times and the limit is reached at 64. The shard format is unchanged NDJSON, each report's context line ahead of its records, so the validating reader consumes a shard the way it consumes any object.

`rollupName()` is replaced by `rollupShards()`, which reads a day's manifest and returns the object names to read, or nothing when the day has no rollup a reader may use. The manifest is stored material like any other, so it is validated at the read boundary: its shard names are checked against the one shape the compactor writes, and a repeated name, an index past its own count, or names disagreeing about the count are all refused, since a reader treats the manifest as the whole day.

## Partitioning a day, and finishing one

Which shard a raw object goes into is FNV-1a over its name, taken modulo the shard count. That makes the partition a property of each object rather than of the order the compactor happened to read them in, so no record can land in two shards.

A day is partitioned once. The count is in every shard's name, and a run that finds shards already in a day's folder reads the count off them and finishes that partition rather than sizing the day again. Sizing again was the flaw in the first version of this change: a run writes shards and then, last, the manifest, so a run that dies before the manifest leaves shards and no manifest, and enough raw objects arriving in between to cross eight mebibytes gives a different count. The second run would then agree with the first about nothing — a complete second set of shards, and a manifest naming only those. The first run's shards would stay in the folder forever, referenced by nothing, and the create-only credential the compactor holds cannot delete them. Eight runs of a fourteen-day window can each leave another set. A folder somehow holding two partitions is now reported and left alone rather than added to.

What pinning the partition does not fix is which raw objects it covers. An object arriving between two runs reaches the rollup when its shard is one still to be written, and only the raw area otherwise. That is the same thing that happens to anything arriving after a day is compacted, which the seven-day lag exists to make rare, and the spec says so rather than implying a resumed day equals a day done in one pass.

Every write is still create-only. A create that loses its precondition race is no longer counted as written, and the manifest's own loss — which means another run's manifest is the live one and this run's shards are not the day — is now reported instead of passing in silence.

## Holding less while building one

Building a shard no longer holds its text. `gzipChunks` compresses a sequence of chunks as they arrive, so the compactor holds one shard's compressed bytes plus the raw objects its bounded read-ahead window has in flight, whatever the day's size. That window is also what takes a fifteen-thousand-object day from tens of minutes to about seventy seconds. Against the real store, that day now produces seventeen shards of 49 to 66 MB of text each, holding all 5,131,459 of its records, and the whole run completes under a 96 MiB heap cap.

## Reading the store without reading it all

`--plan` now reports from the object listing alone and reads no bodies. The mode exists to say what would happen with no credentials, so it has to survive data it cannot process; it also now answers in seconds. What it gives up is the record count, which is a property of the contents: a day whose objects hold no records shows as compactable and is then left open by the run that reads it, as before.

Listings carry sizes for this, through a new `listObjectSizes` that `listObjects` no longer has to pay for. A listing that names an object without sizing it is refused there rather than counted as zero bytes: every object sizing at zero would put a whole day in one shard, which is the unreadable object sharding exists to avoid, arrived at silently.

## A fidelity bug the compactor had all along

A raw object holds one report, but nothing in the format says it must, and `readObject` flattens whatever it finds: `context` is the first report's context and `records` is every report's records concatenated. The compactor passed those two straight to `buildObjectBody`, so an object holding two reports would have reached the rollup as one report, every record after the first report's re-attributed to the first report's context, losing the second's job, run attempt and fork flag. An object whose first report failed context validation lost all its records. Rollups are write-once, so either would have been permanent for rollup readers. The compactor now walks the report groups the reader already separates and emits one body per group. Records with no valid context ahead of them are still dropped, which is now the only thing that is.

## Elsewhere

`--days` below the seven-day lag reaches back only into days still open for late arrivals, so it selected nothing and the tool printed nothing and exited zero. It is now refused, with the lag named.

The test-selection plan recommended provisioning the compactor before bootstrapping the publisher, and described the compactor as already implemented. It was implemented, but not at this scale, so its estimate of what a bootstrap would read is corrected here along with the claim.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

