### PR TITLE
test: preambles set off from the first statement, across data-model

### DIFF
--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -234,6 +234,7 @@ describe("cloneIfNecessary()", () => {
       // A `FabricError` with no `cause` or extras is deep-frozen as soon
       // as the wrapper is `Object.freeze`'d (the wrapper itself is the
       // canonical state). `cloneIfNecessary` therefore returns identity.
+
       const error = FabricError.fromNativeError(new Error("test"));
       Object.freeze(error);
       const result = cloneIfNecessary(error);
@@ -243,6 +244,7 @@ describe("cloneIfNecessary()", () => {
 
     it("deep-clones a `FabricError` with a mutable cause", () => {
       // Wrapper frozen but `cause` not -> not deep-frozen -> clone.
+
       const error = FabricError.fromNativeError(
         new Error("test", { cause: { mutable: true } }),
       );
@@ -257,6 +259,7 @@ describe("cloneIfNecessary()", () => {
     it("produces a mutable `FabricError` clone (deep, `frozen=false`)", () => {
       // Deep clone with `frozen: false` yields a fresh *mutable*
       // `FabricError`.
+
       const error = FabricError.fromNativeError(new Error("test"));
       Object.freeze(error);
       const result = cloneIfNecessary(
@@ -272,6 +275,7 @@ describe("cloneIfNecessary()", () => {
     it("preserves a nested already-deep-frozen `FabricError` by identity", () => {
       // Container is rebuilt (mutable input -> frozen output) but the
       // nested deep-frozen FabricError is returned by identity.
+
       const error = FabricError.fromNativeError(new Error("nested"));
       Object.freeze(error);
       const value = { err: error, x: 42 };
@@ -287,6 +291,7 @@ describe("cloneIfNecessary()", () => {
     it("shallow-clones an object containing a `FabricError` (`deep=false`)", () => {
       // Shallow clone of a container shares the nested instance by
       // reference -- it is never traversed or rebuilt.
+
       const error = FabricError.fromNativeError(new Error("nested"));
       const value = { err: error, x: 42 };
       const result = cloneIfNecessary(value, { deep: false }) as Record<
@@ -334,6 +339,7 @@ describe("cloneIfNecessary()", () => {
     // clone leaves in the shape a `FabricPlainObject` has -- the same
     // answer the array case gives an `Array` subclass -- rather than
     // propagating a shape the model has no representation for.
+
     function nullProto(
       fields: Record<string, unknown>,
     ): Record<string, unknown> {
@@ -378,6 +384,7 @@ describe("cloneIfNecessary()", () => {
     it("produces a value `isValidFabricValue()` accepts", () => {
       // The point of canonicalizing: what comes out is a member of the type,
       // where the input was not.
+
       const value = nullProto({ a: 1 });
       expect(isValidFabricValue(value)).toBe(false);
       expect(isValidFabricValue(cloneIfNecessary(value as FabricValue))).toBe(
@@ -423,6 +430,7 @@ describe("cloneIfNecessary()", () => {
     // optimization must not apply to one: returning it as-is would carry a
     // live prototype into stored state, where an overridden `Symbol.iterator`
     // yields content that the indices never show.
+
     class Smuggler extends Array<unknown> {
       override *[Symbol.iterator](): Generator<unknown> {
         yield "smuggled";
@@ -438,6 +446,7 @@ describe("cloneIfNecessary()", () => {
 
     it("does not report a frozen subclass instance as deep-frozen", () => {
       // This is what turns off the identity optimization below.
+
       expect(isValidDeepFrozenFabricValue(frozenSmuggler()))
         .toBe(false);
     });

--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -89,6 +89,7 @@ describe("BaseCodecEngine", () => {
 
     it("reads the kind from the codec's base class, not from its state", () => {
       // The clinching case: identical states in, different wire forms out.
+
       const { engine } = newProbeEngine();
 
       expect((engine.encode(TERMINAL_HOST) as Tagged).state)
@@ -143,6 +144,7 @@ describe("BaseCodecEngine", () => {
       // encoded, and the walk expands that state. Without the enter/leave
       // around the tagged form, this recurses until the stack gives out
       // instead of being refused.
+
       class SelfNaming {}
 
       const selfNaming = new SelfNaming() as unknown as FabricValue;
@@ -182,6 +184,7 @@ describe("BaseCodecEngine", () => {
       // as the walk leaves each value rather than only grown. A `Marker`
       // rather than a plain object, because that bookkeeping lives on the
       // codec-matched path and a container never reaches it.
+
       const { engine } = newProbeEngine();
       const shared = new Marker() as unknown as FabricValue;
 
@@ -216,6 +219,7 @@ describe("BaseCodecEngine", () => {
       // A cycle need not run through a container at all: the state under a tag
       // is walked for an unknown tag, as it is for a nonterminal codec, so
       // guarding only the container arms would follow this one forever.
+
       const { engine } = newProbeEngine({ lenient: true });
       const state: Record<string, ProbeValue> = {};
       const tagged = new Tagged("Zz@1", state);
@@ -246,6 +250,7 @@ describe("BaseCodecEngine", () => {
       // The same node twice over is not a cycle, so `seen` has to be unwound as
       // the walk leaves each node rather than only grown. Both a container and
       // a tagged node, those being entered by the same call site.
+
       const { engine } = newProbeEngine();
       const shared: Record<string, ProbeValue> = { v: 1 };
       const tagged = new Tagged("Zz@1", 2);
@@ -284,6 +289,7 @@ describe("BaseCodecEngine", () => {
       // An unrecognized tag becomes an `UnknownValue` only if it is a tag.
       // `hole` is a meta-tag, well-formed only in the context that defines
       // it, and nowhere else a type this or any registry could carry.
+
       const { engine } = newProbeEngine();
 
       expect(() => engine.decode(new Tagged("hole", 5), ENV))
@@ -293,6 +299,7 @@ describe("BaseCodecEngine", () => {
     it("rejects a tag that is not a string at all", () => {
       // A format finds a tag wherever its own shape puts one, and what it
       // finds off the wire need not be a string.
+
       const { engine } = newProbeEngine();
 
       expect(() => engine.decode(new Tagged(42 as never, "x"), ENV))
@@ -303,6 +310,7 @@ describe("BaseCodecEngine", () => {
       // `MarkerCodec.decode()` returns a mutable nested object. Every other
       // codec here returns a primitive, which is deep-frozen however the
       // engine behaves, and so could not witness this.
+
       const { engine } = newProbeEngine();
       const result = engine.decode(new Tagged("M@1", "m"), ENV);
 
@@ -317,6 +325,7 @@ describe("BaseCodecEngine", () => {
       // what needs pinning is that the entry point consults the factory per
       // call, and a test that only calls the factory stays green even if
       // `encode()` starts memoizing one act for the engine's lifetime.
+
       const seen: unknown[] = [];
       const { registry } = newProbeEngine();
       // The spy sits on the act rather than the engine, and records `this`:
@@ -373,6 +382,7 @@ describe("BaseCodecEngine", () => {
       // engine rather than per act, an encode reached from INSIDE another one
       // shares the outer walk's set, so entering a container the outer walk is
       // currently inside reports a cycle that is not there.
+
       class Reentrant {}
 
       const outer: FabricValue[] = [];
@@ -419,6 +429,7 @@ describe("BaseCodecEngine", () => {
       // is not there. The differential is the message: with the leave in a
       // `finally` the second visit fails the same way the first did; without
       // it, the second fails as a circular reference instead.
+
       class Boom {}
 
       const codec = new (class BoomCodec extends BaseTerminalCodec<ProbeValue> {
@@ -455,6 +466,7 @@ describe("BaseCodecEngine", () => {
       // tree itself, so its walk guards cycles; with one act shared across
       // calls, an inner decode entering a node the outer walk is inside would
       // report a cycle that is not there.
+
       let reentered = false;
       let innerResult: unknown;
       const outer: ProbeValue[] = [];
@@ -547,6 +559,7 @@ describe("BaseCodecEngine", () => {
       it("turns a `ProblematicValue` a codec returned into a throw", () => {
         // The half that used to do nothing: this rejection stood either way
         // before, so the setting governed only the codecs that threw.
+
         const { engine } = newProbeEngine();
 
         expect(() => engine.decode(RETURNED, ENV))
@@ -559,6 +572,7 @@ describe("BaseCodecEngine", () => {
         // through the codec-facing `catch`. `cause` is what says it arrives
         // unaltered: a rebuilt error carries the original there, and this one
         // carries nothing, the facts alone being no proof either way.
+
         const { engine } = newProbeEngine();
 
         try {
@@ -584,6 +598,7 @@ describe("BaseCodecEngine", () => {
 
       it("wraps an unclaimed tag in an `UnknownValue` regardless", () => {
         // Not a rejection, so the setting has no say in it.
+
         const { engine } = newProbeEngine();
 
         expect(engine.decode(UNCLAIMED, ENV)).toBeInstanceOf(UnknownValue);
@@ -594,6 +609,7 @@ describe("BaseCodecEngine", () => {
         // choice and say nothing about what a caller wants, so a strict
         // failure must look the same either way. It did not: the returned
         // form used to become a bare `Error`.
+
         const { engine } = newProbeEngine();
 
         for (
@@ -615,6 +631,7 @@ describe("BaseCodecEngine", () => {
       it("raises a `ProblematicStateError` carrying tag and state", () => {
         // The strict counterpart of the `ProblematicValue` the lenient side
         // returns: the same three facts, disposed of by throwing.
+
         const { engine } = newProbeEngine();
 
         try {
@@ -630,6 +647,7 @@ describe("BaseCodecEngine", () => {
       it("keeps what a codec threw as `cause`", () => {
         // Rethrowing as-is would lose the state; building afresh would lose
         // the original. Neither is acceptable, so the original is the cause.
+
         const { engine } = newProbeEngine();
 
         try {
@@ -690,6 +708,7 @@ describe("BaseCodecEngine", () => {
 
       it("deep-freezes a `ProblematicValue` a codec returned", () => {
         // The codec arm's freeze: this report is the codec's own product.
+
         const { engine } = newProbeEngine({ lenient: true });
 
         expect(isDeepFrozen(engine.decode(RETURNED, ENV))).toBe(true);
@@ -699,6 +718,7 @@ describe("BaseCodecEngine", () => {
         // The other arm, and a separate line of code: one is the engine
         // wrapping a throw, the other the walk reporting a malformation.
         // Neither stands in for the other.
+
         const { engine } = newProbeEngine({ lenient: true });
 
         expect(isDeepFrozen(engine.decode(THROWN, ENV))).toBe(true);

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -229,6 +229,7 @@ describe("CodecRegistry", () => {
       // Spec §9 makes a bare `/` key an encoding error whatever follows it,
       // and the decoder reports it as one. A codec registered under it could
       // encode a value that this same system would then refuse to read back.
+
       const codec = new TestCodec("", FabricRegExp);
       const registry = new CodecRegistry(TEST_FORMAT);
 
@@ -241,6 +242,7 @@ describe("CodecRegistry", () => {
       // The register-time counterpart of the decoder's check: `hole` is a
       // meta-tag rather than a type, so a decoder refuses it, and a codec
       // indexed under it would emit exactly what the decoder refuses.
+
       const codec = new TestCodec("hole", FabricRegExp);
       const registry = new CodecRegistry(TEST_FORMAT);
 
@@ -252,6 +254,7 @@ describe("CodecRegistry", () => {
     it("registers a codec whose recognized tag is `undefined`", () => {
       // Not a tag, and not an error: it marks a codec whose tag is read from
       // each value rather than fixed.
+
       const codec = new TestCodec(undefined, FabricRegExp);
       const registry = new CodecRegistry(TEST_FORMAT);
 
@@ -296,6 +299,7 @@ describe("CodecRegistry", () => {
       // A registry holds its format and reads the symbol on every class
       // registration, so a mutable one could change what a class supplies
       // partway through the registry being built.
+
       const unfrozen: WireFormat<string> = { codecSymbol: TEST_CODEC };
 
       expect(() => new CodecRegistry(unfrozen)).toThrow(
@@ -337,6 +341,7 @@ describe("CodecRegistry", () => {
       it("prefers `[CODEC]` over the format's symbol when a class binds both", () => {
         // The format-neutral codec is the one that serves every format, so it
         // wins wherever a class offers a choice.
+
         const neutral = new TestCodec("Neutral@1", FabricRegExp);
         const formatted = new TestTerminalCodec("Formatted@1", FabricRegExp);
         class Both {
@@ -367,6 +372,7 @@ describe("CodecRegistry", () => {
       it("ignores a codec bound under some other format's symbol", () => {
         // Two formats' symbols on one class is the arrangement this exists to
         // serve; a registry reads only its own.
+
         const other: unique symbol = Symbol("other.codec");
         const codec = new TestTerminalCodec("Other@1", FabricRegExp);
         class OtherFormatOnly {

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -61,6 +61,7 @@ describe("ProblematicValue", () => {
       // call site: `Object.freeze()` throws on a typed array with elements,
       // and this class deep-freezes its state. Reporting a failure must not
       // itself fail.
+
       const ps = new ProblematicValue("T@1", new Uint8Array([1, 2, 3]), "b");
 
       expect(() => deepFreeze(ps)).not.toThrow();
@@ -71,6 +72,7 @@ describe("ProblematicValue", () => {
       // `isValidFabricValue()` itself has a defect, since throwing here would
       // replace the failure being reported rather than add to it. A hostile
       // proxy is the only way to provoke that from outside.
+
       const hostile = new Proxy({}, {
         get() {
           throw new Error("hostile");
@@ -166,6 +168,7 @@ describe("ProblematicValue", () => {
       it("compares a non-string tag by the rendering it kept", () => {
         // The tag is normalized on the way in, so two instances built from the
         // same unusable tag agree.
+
         expect(new ProblematicValue(42, "s", "boom").equals(
           new ProblematicValue(42, "s", "boom"),
         )).toBe(true);
@@ -180,6 +183,7 @@ describe("ProblematicValue", () => {
           // A preserved tag need not be a tag, so it cannot be the tag this
           // encodes under; `UnknownValue` is the class that round-trips to
           // what it preserved.
+
           const preserved = new ProblematicValue("Weird@7", "s", "oops");
           const malformed = new ProblematicValue("hole", "s", "oops");
 
@@ -212,6 +216,7 @@ describe("ProblematicValue", () => {
 
         it("returns `true` for a `state` present and `undefined`", () => {
           // Every `FabricValue` is a valid state, `undefined` among them.
+
           expect(ProblematicValue[CODEC].canDecode(
             { tag: "Weird@7", state: undefined, error: "oops" },
           )).toBe(true);
@@ -221,6 +226,7 @@ describe("ProblematicValue", () => {
           // An absent property is the only thing that marks a record this
           // codec did not write. Filling it in would put a reshaped record
           // back on the wire rather than reporting the one that arrived.
+
           expect(ProblematicValue[CODEC].canDecode(
             { tag: "Weird@7", error: "oops" },
           )).toBe(false);

--- a/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
+++ b/packages/data-model/test/codec-common/isCodecTypeTag.test.ts
@@ -10,6 +10,7 @@ describe("isCodecTypeTag", () => {
     // The constants are the definition of the syntax, so a predicate that
     // rejected one of them would be wrong whatever it said about anything
     // else.
+
     for (const tag of Object.values(CODEC_TYPE_TAGS)) {
       expect(isCodecTypeTag(tag)).toBe(true);
     }
@@ -18,6 +19,7 @@ describe("isCodecTypeTag", () => {
   it("returns `false` for every tag in `CODEC_META_TAGS`", () => {
     // A meta-tag is a structural marker its format handles itself, and is
     // outside this syntax by design.
+
     for (const tag of Object.values(CODEC_META_TAGS)) {
       expect(isCodecTypeTag(tag)).toBe(false);
     }
@@ -25,6 +27,7 @@ describe("isCodecTypeTag", () => {
 
   it("returns `true` for a tag naming a type nothing here defines", () => {
     // Syntax, not recognition: this is what an `UnknownValue` is made of.
+
     expect(isCodecTypeTag("FutureType@2")).toBe(true);
     expect(isCodecTypeTag("X@1")).toBe(true);
     expect(isCodecTypeTag("Abc123@1234")).toBe(true);
@@ -57,6 +60,7 @@ describe("isCodecTypeTag", () => {
     // states, and this is what holds every format to it. The case decides
     // whether an unclaimed tag round-trips as an `UnknownValue` or is refused
     // as a malformation, so a reader cannot be left to infer it.
+
     expect(isCodecTypeTag("bytes@1")).toBe(false);
     expect(isCodecTypeTag("lowerCamel@1")).toBe(false);
     expect(isCodecTypeTag("link@1")).toBe(false);
@@ -67,6 +71,7 @@ describe("isCodecTypeTag", () => {
     // and a Unicode-property spelling of the same syntax would not honor. A
     // tag crosses between systems, so the set of names it can carry cannot
     // depend on which alphabet a decoder reads it with.
+
     expect(isCodecTypeTag("\u00c9clair@1")).toBe(false);
     expect(isCodecTypeTag("Caf\u00e9@1")).toBe(false);
     expect(isCodecTypeTag("\u0411ytes@1")).toBe(false);
@@ -77,6 +82,7 @@ describe("isCodecTypeTag", () => {
     // tag does not make the string one. The newline pair is the only case in
     // this file that catches a stray `m` flag; an unanchored match would let
     // all four through.
+
     expect(isCodecTypeTag(" Bytes@1")).toBe(false);
     expect(isCodecTypeTag("Bytes@1 ")).toBe(false);
     expect(isCodecTypeTag("\nBytes@1")).toBe(false);

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -312,6 +312,7 @@ describe("JsonCodecEngine", () => {
     it("expands a nonterminal codec's state on the way to the encoded form", () => {
       // The `/quote` wrapper is the walker's mark: it saw a plain object with
       // a reserved key and escaped it.
+
       expect(encodedFormatFrom(new ProbeNonterminalCodec())).toEqual({
         [`/${PROBE_TAG}`]: { "/quote": { "/Bytes@1": "AQID" } },
       });
@@ -337,6 +338,7 @@ describe("JsonCodecEngine", () => {
       // `BigInt@1` sees a non-string and rejects it, which is the judgment
       // this pins; a lenient engine keeps that verdict as a value, naming the
       // tag whose codec made it.
+
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
 
       const result = jsonCodecEngine.decode(
@@ -357,6 +359,7 @@ describe("JsonCodecEngine", () => {
       // The same rejection, through a strict engine. `BigInt@1` reports by
       // RETURNING a `ProblematicValue` rather than throwing, and the engine
       // settles the two reporting styles into one answer.
+
       const jsonCodecEngine = newDefaultJsonCodecEngine();
 
       expect(jsonCodecEngine.lenient).toBe(false);
@@ -421,6 +424,7 @@ describe("JsonCodecEngine", () => {
       // wrong shape for this format settles against `lenient` exactly as a
       // malformation inside a well-formed one does. Anything else would make
       // the outermost check the one refusal `lenient` could not contain.
+
       const decoded = newDefaultJsonCodecEngine({ lenient: true })
         .decode(NOT_OURS, new TestLiveEnvironment());
 
@@ -442,6 +446,7 @@ describe("JsonCodecEngine", () => {
       // is a refusal of the serialized form just as an absent tag is, so it
       // settles the same way -- otherwise `lenient` would contain one half of
       // "is this well-formed?" and not the other.
+
       const decoded = newDefaultJsonCodecEngine({ lenient: true })
         .decode("fvj1:{not json", new TestLiveEnvironment());
 
@@ -612,6 +617,7 @@ describe("JsonCodecEngine", () => {
       // registry key), so no codec claims them. A default-configured
       // `JsonCodecEngine` must then fail loudly rather than silently flatten the
       // symbol to `{}`.
+
       const { jsonCodecEngine } = makeTestCodec();
       expect(() => jsonCodecEngine.encode(Symbol("nope"))).toThrow(
         "no applicable codec",
@@ -686,6 +692,7 @@ describe("JsonCodecEngine", () => {
     it("throws on a non-plain object with no codec (e.g. a raw `Map`)", () => {
       // A non-plain object that is neither a FabricInstance nor codec-handled
       // must fail loudly, not be mis-encoded as a plain object.
+
       const { jsonCodecEngine } = makeTestCodec();
       expect(() => jsonCodecEngine.encode(new Map() as unknown as FabricValue))
         .toThrow("no applicable codec");
@@ -768,6 +775,7 @@ describe("JsonCodecEngine", () => {
     it("returns a `ProblematicValue` given a count past the array maximum", () => {
       // A safe integer can still be more elements than an array can hold, in
       // which case setting the length is what would fail.
+
       const result = decodeArray(["a", { "/hole": 2 ** 40 }, "b"]);
 
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -779,6 +787,7 @@ describe("JsonCodecEngine", () => {
     it("returns a `ProblematicValue` when later entries carry the total past it", () => {
       // The run alone is exactly what an array can hold; the two entries
       // placed after it are what make the total too large.
+
       const result = decodeArray([{ "/hole": 2 ** 32 - 1 }, "a", "b"]);
 
       expect(result).toBeInstanceOf(ProblematicValue);
@@ -793,6 +802,7 @@ describe("JsonCodecEngine", () => {
       // index and the array is exactly as long as one may be. A step further
       // and the entry would become a plain property rather than an element,
       // which the previous case is what catches.
+
       const result = decodeArray(
         [{ "/hole": (2 ** 32 - 1) - 1 }, "z"],
       ) as FabricValue[];
@@ -819,6 +829,7 @@ describe("JsonCodecEngine", () => {
   describe("sparse arrays", () => {
     it("encodes `[1,,3]` with `/hole`", () => {
       // deno-lint-ignore no-sparse-arrays
+
       const arr = [1, , 3];
       const result = toEncodedFormat(arr) as JsonCodecValue[];
       expect(result.length).toBe(3);
@@ -829,6 +840,7 @@ describe("JsonCodecEngine", () => {
 
     it("round-trips `[1,,3]` preserving holes", () => {
       // deno-lint-ignore no-sparse-arrays
+
       const arr = [1, , 3];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(3);
@@ -839,6 +851,7 @@ describe("JsonCodecEngine", () => {
 
     it("encodes consecutive holes as run-length encoded", () => {
       // deno-lint-ignore no-sparse-arrays
+
       const arr = [1, , , , 5];
       const result = toEncodedFormat(arr) as JsonCodecValue[];
       expect(result.length).toBe(3); // [1, {"/hole": 3}, 5]
@@ -849,6 +862,7 @@ describe("JsonCodecEngine", () => {
 
     it("round-trips `[1,,,,5]`", () => {
       // deno-lint-ignore no-sparse-arrays
+
       const arr = [1, , , , 5];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(5);
@@ -861,6 +875,7 @@ describe("JsonCodecEngine", () => {
 
     it("round-trips all-holes array `[,,,]`", () => {
       // deno-lint-ignore no-sparse-arrays
+
       const arr = [, , ,];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(3);
@@ -975,6 +990,7 @@ describe("JsonCodecEngine", () => {
         // U+10000 (UTF-16: D800 DC00; UTF-8: F0 90 80 80) sorts AFTER U+E000
         // (UTF-16: E000; UTF-8: EE 80 80) in UTF-8 byte order, but BEFORE it in
         // JS native (UTF-16) order. The encoder must use UTF-8 order.
+
         const obj = {
           ["\u{10000}"]: 1,
           [""]: 2,
@@ -986,6 +1002,7 @@ describe("JsonCodecEngine", () => {
       it("matches the key order used by `value-hash.ts`", () => {
         // Both subsystems must agree on the canonical sort order. Cross-check
         // via `utf8SortedKeysOf`, which is the function value-hash.ts uses.
+
         const obj = {
           ["\u{1F600}"]: 1,
           b: 2,
@@ -1073,6 +1090,7 @@ describe("JsonCodecEngine", () => {
         // *through* the array; otherwise the inner wrapper survives into the
         // output, and decoding -- which strips exactly one `/quote` layer --
         // hands back the wrapper instead of the object the caller wrote.
+
         const obj = { "/outer": [{ "/inner": "val" }] };
         expect(toEncodedFormat(obj)).toEqual({
           "/quote": { "/outer": [{ "/inner": "val" }] },
@@ -1199,6 +1217,7 @@ describe("JsonCodecEngine", () => {
         it("produces `ProblematicValue` for a multi-key object with a `/`-prefixed key", () => {
           // Wire data without a `/quote` or `/object` wrapper: the decoder must
           // not silently round-trip it as a plain object.
+
           const data = { a: 1, "/b": 2 } as JsonCodecValue;
           const result = fromEncodedFormat(data, true);
           expect(result).toBeInstanceOf(ProblematicValue);
@@ -1209,6 +1228,7 @@ describe("JsonCodecEngine", () => {
           // after stripping the leading slash) is an encoding error. Decoding
           // must produce a `ProblematicValue`, not an `UnknownValue` with an
           // empty tag.
+
           const data = { "/": "x" } as JsonCodecValue;
           const result = fromEncodedFormat(data, true);
           expect(result).toBeInstanceOf(ProblematicValue);
@@ -1241,6 +1261,7 @@ describe("JsonCodecEngine", () => {
         // the plain-object path, so they produce an `UnknownValue` for the
         // unrecognized tag and never reach the multi-key guard's
         // `ProblematicValue`.
+
         const data = { "/Future@7": { id: "x" } } as JsonCodecValue;
         const result = fromEncodedFormat(data);
         expect(result).toBeInstanceOf(UnknownValue);
@@ -1254,6 +1275,7 @@ describe("JsonCodecEngine", () => {
         // literal whose content happens to be `{"/quote": "x"}`. Decoding must
         // return that inner object as a frozen plain object, and must _not_
         // recurse into it and return just `x`.
+
         const encoded = { "/quote": { "/quote": "x" } } as JsonCodecValue;
         const result = fromEncodedFormat(encoded) as Record<
           string,
@@ -1266,6 +1288,7 @@ describe("JsonCodecEngine", () => {
         // In `{"/x": {"/quote": "inner"}}`, the value at `/x` is user data
         // that happens to have a `/quote` key. It must survive encode and
         // decode intact.
+
         const obj = { "/x": { "/quote": "inner" } };
         const result = roundTrip(obj) as Record<
           string,
@@ -1289,6 +1312,7 @@ describe("JsonCodecEngine", () => {
         // property, so a literal cannot express this encoded shape at all.
         // `JSON.parse()`, which is how such bytes actually arrive, does create
         // the own property.
+
         expect(
           fromEncodedFormat({ ["__proto__"]: { hostile: true }, a: 1 }, true),
         )
@@ -1304,6 +1328,7 @@ describe("JsonCodecEngine", () => {
         // the key is dropped in the rebuild, and on one without, it reaches
         // the wire as text this same decoder refuses -- written and never
         // readable.
+
         for (const key of ["__proto__", "constructor"]) {
           const value = Object.defineProperty({ a: 1 }, key, {
             value: "payload",
@@ -1343,6 +1368,7 @@ describe("JsonCodecEngine", () => {
         // what browsers have and what this code also runs under, and pins the
         // outcome the refusal exists to produce: nothing decoded, and no
         // prototype repointed.
+
         const saved = Object.getOwnPropertyDescriptor(
           Object.prototype,
           "__proto__",
@@ -1443,6 +1469,7 @@ describe("JsonCodecEngine", () => {
 
     it("preserves the `UnknownValue` tag in the encoded form via `encode()`", () => {
       // Encoding an UnknownValue produces the original tagged form.
+
       const us = new UnknownValue("FutureType@2", { some: "data" });
       const encodedFormat = toEncodedFormat(us);
       expect(encodedFormat).toEqual({
@@ -1463,6 +1490,7 @@ describe("JsonCodecEngine", () => {
       // Per spec §9, `UnknownValue` is for a syntactically well-formed tag no
       // codec claims. `hole` is a meta-tag, meaningful only among array
       // elements, and is a structural violation anywhere else.
+
       const data = { "/hole": 5 } as JsonCodecValue;
 
       expect(() => fromEncodedFormat(data)).toThrow(/malformed tag/);
@@ -1618,6 +1646,7 @@ describe("JsonCodecEngine", () => {
       // What the state assertion pins is what the *report* carries, which is
       // the encoded form. That the *codec* is handed the encoded form is a separate
       // fact, pinned separately above.
+
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const data = { "/Undefined@1": { "/Bytes@1": "AQID" } } as JsonCodecValue;
 
@@ -1640,6 +1669,7 @@ describe("JsonCodecEngine", () => {
       // witnesses the deep-frozen contract on the lenient path. The codecs
       // that report by RETURNING one are frozen by the arm above instead, so
       // neither arm stands in for the other.
+
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const data = { "/Undefined@1": { "/Bytes@1": "AQID" } } as JsonCodecValue;
 
@@ -1756,6 +1786,7 @@ describe("JsonCodecEngine", () => {
     it("deep-freezes a `ProblematicValue` from a malformed tag", () => {
       // `malformed`, because the wrap helper validates with a strict decode
       // and would otherwise reject the very payload this case is made of.
+
       const result = fromEncodedFormat(
         { "/": { a: 1 } } as JsonCodecValue,
         true,
@@ -1775,6 +1806,7 @@ describe("JsonCodecEngine", () => {
     it("deep-freezes a codec-produced value at the boundary", () => {
       // `/EpochNsec@1` dispatches through a registered codec; the
       // decoded FabricEpochNsec must be deep-frozen on return.
+
       const result = fromEncodedFormat(
         { "/EpochNsec@1": "AA" } as JsonCodecValue,
       );
@@ -1787,6 +1819,7 @@ describe("JsonCodecEngine", () => {
       // lenient catch produces a ProblematicValue -- still a codec-arm return,
       // so the contract deep-freezes it (not a crash: it is the value
       // lenient mode produces precisely to avoid crashing).
+
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestLiveEnvironment();
       const result = jsonCodecEngine.decode(
@@ -1879,6 +1912,7 @@ describe("JsonCodecEngine", () => {
       // An object whose keys are all /-prefixed but whose values are all
       // quote-safe routes through the encode-side /quote path, then back
       // through the decode /quote `return state` arm.
+
       const value = {
         "/a": 1,
         "/b": { plain: [1, 2] },
@@ -1970,6 +2004,7 @@ describe("JsonCodecEngine", () => {
         // The same detection, kept as a value. Which side of this a caller
         // gets is `lenient` and nothing else -- notably not whether a codec
         // or the walk noticed, which these cases are the walk noticing.
+
         expect(fromEncodedFormat(encoded, true)).toBeInstanceOf(
           ProblematicValue,
         );
@@ -2032,6 +2067,7 @@ describe("JsonCodecEngine", () => {
       // The `@1` in the tag makes this a versioned encoded surface, so the exact
       // shape asserted below is the contract rather than an implementation
       // detail.
+
       const se = FabricError.fromNativeError(new TypeError("compat test"));
       const encoded = toEncodedFormat(
         se,
@@ -2074,6 +2110,7 @@ describe("JsonCodecEngine", () => {
     it("returns `false` for plain JSON without the prefix", () => {
       // These are plain JSON without the prefix, so the dispatch must reject
       // them.
+
       expect(JsonCodecEngine.seemsLikeEncoded("true")).toBe(false);
       expect(JsonCodecEngine.seemsLikeEncoded("false")).toBe(false);
       expect(JsonCodecEngine.seemsLikeEncoded("null")).toBe(false);
@@ -2119,6 +2156,7 @@ describe("JsonCodecEngine", () => {
       it("preserves a value plain JSON could not carry", () => {
         // The case that motivates having a golden format at all: these survive
         // the trip only as tagged forms.
+
         const encoded = newDefaultJsonCodecEngine().encode(
           { z: -0, n: NaN, i: -Infinity },
         );
@@ -2136,6 +2174,7 @@ describe("JsonCodecEngine", () => {
       it("throws given a string carrying no tag", () => {
         // The whole point of the tag: untagged JSON is not one of ours, however
         // well-formed it happens to be.
+
         expect(() => JsonCodecEngine.unwrapEncodedValueForTesting("42"))
           .toThrow();
       });
@@ -2148,6 +2187,7 @@ describe("JsonCodecEngine", () => {
       it("throws given a tag with nothing after it", () => {
         // `seemsLikeEncoded()` accepts this, so only the throwaway decode
         // catches it.
+
         expect(() =>
           JsonCodecEngine.unwrapEncodedValueForTesting(ENCODING_PREFIX)
         )
@@ -2183,6 +2223,7 @@ describe("JsonCodecEngine", () => {
       it("decodes a pretty-printed body", () => {
         // The re-encoded form is not compared against the input, so whitespace
         // is immaterial -- which is what lets a golden file be readable.
+
         const pretty = JSON.stringify({ a: 1, b: [2, 3] }, null, 2);
         const encoded = JsonCodecEngine.wrapEncodedValueForTesting(pretty);
         const { runtime } = makeTestCodec();
@@ -2203,6 +2244,7 @@ describe("JsonCodecEngine", () => {
       it("throws given an already-tagged string", () => {
         // Double-tagging is a mistake worth catching: the tag is not part of
         // the JSON, so the result would not parse.
+
         const encoded = newDefaultJsonCodecEngine().encode(42);
         expect(() => JsonCodecEngine.wrapEncodedValueForTesting(encoded))
           .toThrow();
@@ -2214,6 +2256,7 @@ describe("JsonCodecEngine", () => {
       // payload the codec cannot decode. Reaching that codec takes a
       // registry that has it: against the format-only default, `Map@1` is
       // merely an unrecognized tag and decodes to an `UnknownValue`.
+
       const undecodable = JSON.stringify({ "/Map@1": [["key", "value"]] });
 
       it("refuses a payload undecodable by the given registry's codecs", () => {
@@ -2250,6 +2293,7 @@ describe("JsonCodecEngine", () => {
         // Malformed means malformed: the flag is a caller saying the payload is
         // broken on purpose, so nothing is checked and the tag simply goes on
         // the front.
+
         expect(JsonCodecEngine.wrapEncodedValueForTesting("{nope", true))
           .toBe(`${ENCODING_PREFIX}{nope`);
       });
@@ -2266,6 +2310,7 @@ describe("JsonCodecEngine", () => {
       it("still requires the tag on unwrap, however deliberate", () => {
         // Not a judgment about the payload: stripping a prefix that is not
         // there yields nonsense, not the body.
+
         expect(() => JsonCodecEngine.unwrapEncodedValueForTesting("42", true))
           .toThrow();
       });

--- a/packages/data-model/test/codec-realm/RealmCodecEngine.test.ts
+++ b/packages/data-model/test/codec-realm/RealmCodecEngine.test.ts
@@ -107,6 +107,7 @@ describe("RealmCodecEngine", () => {
       // cycle that is not there -- and says so, naming a circular reference
       // where the real fault was the child. The differential is the message:
       // both attempts must fail the same way the first did.
+
       const engine = newDefaultRealmCodecEngine();
       const act = new RealmEncodeAct(engine, NULL_LIVE_ENVIRONMENT);
       // A function is no kind of `FabricValue`, so encoding the element throws
@@ -125,6 +126,7 @@ describe("RealmCodecEngine", () => {
       // calls, which is what lets a peer's payload decode here at all.
       // Distinct: each call mints its own, which is what makes an earlier
       // encoding's marker ordinary data when it turns up inside a later one.
+
       const first = realmFromFabricValue(null)[0];
       const second = realmFromFabricValue(null)[0];
 
@@ -183,6 +185,7 @@ describe("RealmCodecEngine", () => {
     it("encodes a `FabricBytes` to a buffer covering exactly its bytes", () => {
       // A transfer hands over the whole buffer, so a state covering more than
       // the value would cede bytes that are not part of it.
+
       const payload = payloadOf(realmFromFabricValue(
         new FabricBytes(new Uint8Array([1, 2, 250])),
       ));
@@ -236,6 +239,7 @@ describe("RealmCodecEngine", () => {
     it("encodes an interned symbol to its registry key", () => {
       // Cloning refuses every symbol, so this is the one JavaScript primitive
       // the format has to encode at all.
+
       const payload = payloadOf(
         realmFromFabricValue(Symbol.for("k") as FabricValue),
       );
@@ -247,6 +251,7 @@ describe("RealmCodecEngine", () => {
       // A unique symbol has no key to carry, so there is nothing to encode
       // that would decode back to it. Coercing one to a registry symbol would
       // hand the far side a different symbol wearing its description.
+
       expect(() => realmFromFabricValue(Symbol("d") as FabricValue))
         .toThrow(/no applicable codec/);
       expect(() => realmFromFabricValue(Symbol() as FabricValue))
@@ -317,12 +322,14 @@ describe("RealmCodecEngine", () => {
     it("returns a plain payload as it stands", () => {
       // With no tagged form anywhere in it, an ordinary value decodes to
       // itself once the outer envelope is stripped.
+
       expect(fabricFromRealmValue(wire({ a: 1 }))).toEqual({ a: 1 });
     });
 
     it("throws when given a form this format never emits", () => {
       // Cloning carries a `Date`; this format has no codec that produces one,
       // so it can only have come from something other than an `encode()`.
+
       expect(() => fabricFromRealmValue(wire(new Date()))).toThrow(
         /not a form this format emits/,
       );
@@ -333,6 +340,7 @@ describe("RealmCodecEngine", () => {
       // one such type this format's own value union contains, legitimate only
       // as the state under a byte-carrying tag and never on its own. Cloning
       // carries each of these, so a peer can send one.
+
       for (
         const bad of [
           new Uint8Array([1, 2]).buffer,
@@ -351,6 +359,7 @@ describe("RealmCodecEngine", () => {
       // the cycle rule of Section 4 -- both of which refuse these outright in
       // a walked container -- never reach inside one. `Hash@1` reads `tag`
       // and `hash` and never looks at the rest.
+
       const state: Record<string, unknown> = {
         tag: "fid1",
         hash: new Uint8Array([1, 2, 3]).buffer,
@@ -375,6 +384,7 @@ describe("RealmCodecEngine", () => {
       // The control for the case above, and what bounds it: the same key in a
       // position the walk reaches IS refused. Without this pair, the opacity
       // case alone would read as the rule not existing.
+
       const walked: Record<string, unknown> = { a: 1 };
 
       Object.defineProperty(walked, "constructor", {
@@ -391,6 +401,7 @@ describe("RealmCodecEngine", () => {
       // Section 7.1: every field of this codec's state defaults when absent,
       // which is what lets a narrower encoder omit what it has nothing to say
       // about.
+
       const decoded = fabricFromRealmValue(wire(tagged("RegExp@1", {})));
 
       expect(decoded).toBeInstanceOf(FabricRegExp);
@@ -404,6 +415,7 @@ describe("RealmCodecEngine", () => {
       // where the difference can arise: cloning carries `undefined` directly,
       // so a peer can send one on purpose, and defaulting it would answer a
       // question the wire did ask.
+
       const engine = newDefaultRealmCodecEngine({ lenient: true });
       const decoded = engine.decode(
         wire(tagged("RegExp@1", { source: undefined })),
@@ -418,6 +430,7 @@ describe("RealmCodecEngine", () => {
     it("throws when given a `Map`, which is no form this format emits", () => {
       // Cloning carries one faithfully, so a peer can send one; nothing here
       // makes one, so finding one is a malformation like any other.
+
       expect(() => fabricFromRealmValue(wire(new Map([["a", 1]]))))
         .toThrow(/not a form this format emits/);
     });
@@ -430,6 +443,7 @@ describe("RealmCodecEngine", () => {
       // refuses them. The empty array reaches the same clause, having no
       // second slot rather than a bad marker; only `"nope"` and `42` are
       // refused for not being arrays at all.
+
       for (
         const bad of [
           [],
@@ -452,6 +466,7 @@ describe("RealmCodecEngine", () => {
       // `undefined` is a value this format carries directly, so a payload can
       // put one in slot zero for free, and identity against an absent marker
       // would match it and read the array as a tagged form.
+
       class Exposed extends RealmCodecEngine {
         decodeWithoutMarker(data: unknown): FabricValue {
           const act = new RealmDecodeAct(this, NULL_LIVE_ENVIRONMENT);
@@ -481,6 +496,7 @@ describe("RealmCodecEngine", () => {
       // requirement rather than an observation. Lenient, because the report is
       // what is under test -- strictly these raise, which the cases above
       // already cover.
+
       const engine = newDefaultRealmCodecEngine({ lenient: true });
       const bad = (tag: string, state: unknown) => {
         const result = engine.decode(
@@ -533,6 +549,7 @@ describe("RealmCodecEngine", () => {
       // -- but `decode()` is callable in the realm that built its argument,
       // and passing them through would leave a value in the result that this
       // format cannot emit and `encode()` will not take.
+
       expect(() => fabricFromRealmValue(wire(Symbol("u"))))
         .toThrow(/Cannot decode symbol/);
       expect(() => fabricFromRealmValue(wire(() => 1)))
@@ -548,6 +565,7 @@ describe("RealmCodecEngine", () => {
       // same primitive would reproduce the marker. The rest are refused
       // because a marker this build did not write is one whose encoding it
       // cannot claim to understand.
+
       const bad = [
         // Primitives, which cannot mark anything.
         "fvr1",
@@ -575,6 +593,7 @@ describe("RealmCodecEngine", () => {
     it("refuses an envelope that is not exactly two slots", () => {
       // Without the slot count, a tagged form arriving here would be read as
       // an envelope and its tag handed back as the tree.
+
       const marker = ["fvr1"];
 
       for (
@@ -593,6 +612,7 @@ describe("RealmCodecEngine", () => {
       // The control for the case above, and the property that lets a peer
       // send a well-formed payload at all: what is checked is the marker's
       // shape and version, never its identity against one this realm minted.
+
       expect(fabricFromRealmValue([["fvr1"], { a: 1 }] as never))
         .toEqual({ a: 1 });
     });
@@ -601,6 +621,7 @@ describe("RealmCodecEngine", () => {
       // A genuine payload cannot hold the current marker at all, but a peer
       // can send anything. Slot count is checked before identity, so this is
       // an array and not a tagged form missing its state.
+
       const marker = realmFromFabricValue(null)[0];
       const decoded = fabricFromRealmValue(
         [marker, { a: [marker, "EpochDay@1"] }] as never,
@@ -613,6 +634,7 @@ describe("RealmCodecEngine", () => {
     it("throws when given an outer envelope nested as its own payload", () => {
       // `E = [m, E]`. The walk visits `E` again beneath itself, where the guard
       // has it, so this is a cycle rather than an unbounded descent.
+
       const envelope: unknown[] = [["fvr1"], null];
       envelope[1] = envelope;
 
@@ -624,6 +646,7 @@ describe("RealmCodecEngine", () => {
       // Three elements and a lookalike marker in slot zero, and still data:
       // recognition is identity, and this array's slot zero is some other
       // object however equal it looks.
+
       const lookalike = ["fvr1"];
       const decoded = fabricFromRealmValue(
         wire({ a: [lookalike, "EpochDay@1", 7n] }),
@@ -641,6 +664,7 @@ describe("RealmCodecEngine", () => {
       // non-string in tag position where JSON never can. The engine hands it
       // over as it found it, and the shared tag check judges it, so what is
       // refused here is refused the same way under any format.
+
       expect(() => fabricFromRealmValue(wire(tagged(42, "x"))))
         .toThrow(/malformed tag/);
       expect(() => fabricFromRealmValue(wire(tagged(Symbol("s"), "x"))))
@@ -667,6 +691,7 @@ describe("RealmCodecEngine", () => {
       // A codec's own rejection rather than the walk's: the tag is claimed,
       // and `FabricBytes` wants an `ArrayBuffer` where this carries a string.
       // The default engine is strict, so this throws.
+
       try {
         fabricFromRealmValue(wire(tagged("Bytes@1", "nope")));
         throw new Error("Should have thrown.");
@@ -684,6 +709,7 @@ describe("RealmCodecEngine", () => {
     it("returns that same rejection as a `ProblematicValue` when lenient", () => {
       // Every realm codec reports by returning one, as its JSON
       // counterpart does; `lenient` is what decides which a caller sees.
+
       const engine = newDefaultRealmCodecEngine({ lenient: true });
       const decoded = engine.decode(
         wire(tagged("Bytes@1", "nope")),
@@ -701,6 +727,7 @@ describe("RealmCodecEngine", () => {
       // of this format's codecs do. The tag rides on the error whichever way a
       // codec reports, so one throwing an `Error` of its own that named the
       // tag would have the message say it a second time.
+
       try {
         fabricFromRealmValue(wire(tagged("Symbol@1", 42)));
         throw new Error("Should have thrown.");
@@ -716,6 +743,7 @@ describe("RealmCodecEngine", () => {
       // Three slots headed by the marker ARE the tagged form, so this is a
       // well-formed value carrying a tag no codec claims -- a different thing
       // from a malformation.
+
       const decoded = fabricFromRealmValue(wire(tagged("Nope@1", 1)));
 
       expect(decoded).toBeInstanceOf(UnknownValue);
@@ -727,6 +755,7 @@ describe("RealmCodecEngine", () => {
       // `JSON.parse()` cannot produce one -- this format can actually be sent
       // a cycle by a peer. Without a guard the walk recurses until the stack
       // gives out, which is the one refusal `lenient` could not contain.
+
       const object: Record<string, RealmCodecValue> = { a: 1 };
       object.self = object;
       const array: RealmCodecValue[] = [1];
@@ -745,6 +774,7 @@ describe("RealmCodecEngine", () => {
       // again for a nonterminal codec, for a tag no codec claims, and for a
       // tag that is not one. So a graph of tagged forms can close a cycle with no
       // plain container in it at all, and cloning carries one faithfully.
+
       const unknownTag = tagged("Nope@1", null) as unknown as unknown[];
       unknownTag[2] = unknownTag;
 
@@ -779,6 +809,7 @@ describe("RealmCodecEngine", () => {
       // value that holds one instance twice yields two nodes and revisits
       // nothing. A hand-built node is reused directly to get the sharing this
       // needs.
+
       const shared = tagged("EpochDay@1", 7n);
       const decoded = fabricFromRealmValue(
         wire({ x: shared, y: shared }),
@@ -793,6 +824,7 @@ describe("RealmCodecEngine", () => {
       // in-progress set on its way out. Without that, the second position
       // holding the same object would be read as a back-edge and reported as
       // a cycle -- the right refusal for the wrong reason.
+
       const offender = Object.defineProperty({ a: 1 }, "constructor", {
         value: "c",
         enumerable: true,
@@ -832,6 +864,7 @@ describe("RealmCodecEngine", () => {
       // prototype. The key is computed on purpose: in an object literal a
       // `__proto__:` sets the prototype rather than creating a property, so a
       // literal cannot express this shape at all.
+
       const data = Object.defineProperty({ a: 1 }, "__proto__", {
         value: { hostile: true },
         enumerable: true,
@@ -924,6 +957,7 @@ describe("RealmCodecEngine", () => {
       // before a second starts, so per-act and per-engine markers look
       // identical. What discriminates them is a tagged form built AFTER the
       // nested call returns, which must still carry the outer marker.
+
       class Reentrant {}
 
       let nestedMarker: unknown;
@@ -975,6 +1009,7 @@ describe("RealmCodecEngine", () => {
       // asserted is only that: whether the walk passed the subtree through or
       // rebuilt it, the same older marker object lands in slot zero either
       // way, and the point is that it is not this call's.
+
       const earlier = realmFromFabricValue(new FabricEpochDay(7n));
       const value = Object.freeze({
         smuggled: payloadOf(earlier) as FabricValue,
@@ -994,6 +1029,7 @@ describe("RealmCodecEngine", () => {
       // The control for the case above, and what makes the pair a statement
       // about identity rather than about shape: the very same slots, under the
       // marker the outer envelope carries, do decode as the value they name.
+
       const marker = realmFromFabricValue(null)[0];
       const decoded = fabricFromRealmValue(
         [marker, [marker, "EpochDay@1", 7n]] as never,
@@ -1007,6 +1043,7 @@ describe("RealmCodecEngine", () => {
       // it costs. A control sits beside it: a tree with no byte-carrying value
       // decodes as often as it likes, so what the first case pins is the
       // buffer and not decoding in general.
+
       const withBytes = realmFromFabricValue(
         { blob: new FabricBytes(new Uint8Array([1, 2, 250])) },
       );
@@ -1030,6 +1067,7 @@ describe("RealmCodecEngine", () => {
       // The same property, and the reason to state it of both: a `FabricHash`
       // reaches the take-over through a record rather than as a bare buffer,
       // so a change that spared one could miss the other.
+
       const encoded = realmFromFabricValue(
         { digest: new FabricHash(new Uint8Array(32).fill(7), "sha256") },
       );
@@ -1044,6 +1082,7 @@ describe("RealmCodecEngine", () => {
       // which the two cases above pin only on the strict side. The report
       // lands where the bytes would have been, the rest of the value
       // surviving around it.
+
       const encoded = realmFromFabricValue({
         blob: new FabricBytes(new Uint8Array([1, 2, 250])),
         n: 7,
@@ -1102,6 +1141,7 @@ describe("RealmCodecEngine", () => {
       // that element, which the rebuild's copy-the-prefix path must carry; and
       // one sits AFTER it, which the main loop must skip. Either alone leaves
       // the other path unexercised.
+
       const sparse: FabricValue[] = [
         1,
         2,
@@ -1159,6 +1199,7 @@ describe("RealmCodecEngine", () => {
       // bytes down can carry it; cloning carries the key itself, and what has
       // to be shown is that what lands on the far side is still that key
       // rather than a shape resembling it.
+
       const source = await crypto.subtle.generateKey(
         { name: "Ed25519" },
         false,
@@ -1225,6 +1266,7 @@ describe("RealmCodecEngine", () => {
     // record of strings, a walk that descends into it and one that passes it
     // through emit the same thing -- so the declaration is asserted directly,
     // which is also how `CodecRegistry` reads it.
+
     for (
       const [name, cls] of [
         ["FabricBytes", FabricBytes],

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -193,6 +193,7 @@ describe("deep-freeze", () => {
       it("returns `true` after an object is frozen (no stale negative cache)", () => {
         // Regression test: isDeepFrozen must not cache `false` results, because
         // an object that is unfrozen now may be deep-frozen later.
+
         const obj = { a: 1, b: { c: 2 } };
         expect(isDeepFrozen(obj)).toBe(false); // unfrozen
         deepFreeze(obj);
@@ -203,6 +204,7 @@ describe("deep-freeze", () => {
         // Verify caching actually works by wrapping a frozen object in a Proxy
         // that counts property accesses. First call should access properties;
         // second call should hit the cache and skip traversal.
+
         const inner = Object.freeze({ x: 1, y: 2 });
         let accessCount = 0;
         const proxy = new Proxy(inner, {
@@ -283,6 +285,7 @@ describe("deep-freeze", () => {
         // The recursing slots on a `FabricError` are `cause` and any extras.
         // Construct one whose `cause` is a mutable plain object, and freeze
         // only the wrapper.
+
         const err = new Error("partial", { cause: { mutable: true } });
         const fe = FabricError.fromNativeError(err);
         Object.freeze(fe);
@@ -299,6 +302,7 @@ describe("deep-freeze", () => {
         // Here the wrapper is frozen and every enumerable slot is a frozen
         // primitive, but the extras bag holds a mutable array -> not
         // deep-frozen.
+
         const fe = FabricError.fromNativeError(new Error("has-extras"));
         fe.setExtra("payload", [1, 2, 3]);
         Object.freeze(fe);
@@ -313,6 +317,7 @@ describe("deep-freeze", () => {
         // graph is cycle-safe for read-side traversal too. (FabricError
         // snapshots its FabricValue state at construction, so the `cause`
         // must be wired BEFORE `fromNativeError`.)
+
         const wrapper: Record<string, unknown> = {};
         const err = new Error("cycle-cause", { cause: wrapper });
         const fe = FabricError.fromNativeError(err);
@@ -390,6 +395,7 @@ describe("deep-freeze", () => {
 
     it("returns `false` (no throw) for a non-canonical-form instance", () => {
       // Wrapper frozen but `cause` left unfrozen -> not deep-frozen.
+
       const err = new Error("partial", { cause: { mutable: true } });
       const fe = FabricError.fromNativeError(err);
       Object.freeze(fe);
@@ -402,6 +408,7 @@ describe("deep-freeze", () => {
     it("returns `false` for a frozen array with enumerable named properties", () => {
       // An array carrying a named property has no fabric representation, so it
       // is not a valid `FabricValue` even when fully frozen.
+
       const arr = [1, 2, 3] as unknown[] & { foo?: string };
       arr.foo = "bar";
       Object.freeze(arr);
@@ -430,6 +437,7 @@ describe("deep-freeze", () => {
       // executes it and can return a different value every time. Such an
       // object must not be granted the trust level of a deep-frozen
       // `FabricValue`.
+
       const obj = { a: 1 };
       Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
       Object.freeze(obj);
@@ -447,6 +455,7 @@ describe("deep-freeze", () => {
     it("returns `false` for a frozen array with a getter-backed index", () => {
       // The same principle applies with an array as the container: an index
       // whose reads execute code is not inert, frozen or not.
+
       const arr = [1, 2, 3];
       Object.defineProperty(arr, 1, {
         get: () => 22,

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -58,6 +58,7 @@ describe("FabricError", () => {
     // The `FabricInstance` contract, checked on the state-heaviest of the
     // concrete classes: an own property here would leak into any structural
     // view of the instance (spread, `Object.keys()`, a debug rendering).
+
     const se = FabricError.fromNativeError(new Error("test"));
     se.setExtra("extra", 1);
     expect(Object.getOwnPropertyNames(se)).toEqual([]);
@@ -89,6 +90,7 @@ describe("FabricError", () => {
       // The name has to come from something that could have constructed the
       // value. A `constructor` that is not callable did not, so it names no
       // class, and the value is recorded as the `Error` it still is.
+
       class Sneaky extends Error {}
       Object.defineProperty(Sneaky.prototype, "constructor", {
         value: { name: "RangeError" },
@@ -100,6 +102,7 @@ describe("FabricError", () => {
       // Reading the class is this conversion's business; failing to read it is
       // not the caller's problem, and the accessor's error must not arrive in
       // place of a converted value.
+
       class Hostile extends Error {}
       Object.defineProperty(Hostile.prototype, "constructor", {
         get() {
@@ -113,6 +116,7 @@ describe("FabricError", () => {
       // `message` is inherited from `Error.prototype` unless the constructor
       // was given one, so severing the prototype takes it away entirely.
       // `FabricError` declares a `string`.
+
       const bare = Object.setPrototypeOf(new Error(), null) as Error;
       const converted = FabricError.fromNativeError(bare);
       expect(typeof converted.message).toBe("string");
@@ -123,6 +127,7 @@ describe("FabricError", () => {
       // Such a value names no class at all. It is still an error --
       // `Error.isError()` sees it, and the dispatch tags it so -- and the
       // conversion has to produce something rather than fail reading a name.
+
       const severed = Object.setPrototypeOf(new Error("severed"), null);
       expect(FabricError.fromNativeError(severed).type).toBe("Error");
     });
@@ -583,6 +588,7 @@ describe("FabricError", () => {
       it("does NOT identity-return a merely-shallowly-frozen instance", () => {
         // Frozen wrapper, but a still-mutable nested `cause`: not deep-frozen,
         // so the deep-clone identity gate must allocate rather than alias.
+
         const fe = FabricError.fromNativeError(new Error("outer"));
         fe.cause = { detail: 1 }; // mutable nested FabricValue
         Object.freeze(fe); // shallow freeze only
@@ -653,6 +659,7 @@ describe("FabricError", () => {
 
         it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
           // TypeError: name === constructor.name === "TypeError".
+
           const se = FabricError.fromNativeError(new TypeError("type check"));
           const state = codec.encode(se, env) as Record<string, unknown>;
           expect(state.type).toBe("TypeError");
@@ -684,6 +691,7 @@ describe("FabricError", () => {
           // Wire state is untrusted input. Without this check these decode
           // into a `FabricError` bearing a default type and an empty message,
           // which is a malformation admitted silently rather than reported.
+
           for (const state of ["hello", 42, true, null, [1, 2]]) {
             expect(codec.canDecode(state as never)).toBe(false);
           }
@@ -862,6 +870,7 @@ describe("FabricError", () => {
           // wrapping an Error whose cause is itself a FabricError (not a raw
           // Error). Encoding's recurse on `[CODEC]` `encode()` output must find
           // a FabricValue, not a raw Error.
+
           const innerSe = FabricError.fromNativeError(new Error("inner"));
           const outerErr = new Error("outer");
           outerErr.cause = innerSe;
@@ -924,6 +933,7 @@ describe("FabricError", () => {
 
         it("round-trips an `Error` with mismatched `name` and `type`", () => {
           // Error constructor is "Error" but name is overridden.
+
           const err = new Error("mismatch");
           err.name = "CustomName";
           const se = FabricError.fromNativeError(err);

--- a/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
@@ -104,6 +104,7 @@ describe("FabricKeyPair", () => {
       // The names agree and the key types are right, so this is refused by the
       // parameter check alone. A P-256 public key and a P-384 private key
       // cannot operate together.
+
       const { publicKey } = await crypto.subtle.generateKey(
         { name: "ECDSA", namedCurve: "P-256" },
         false,
@@ -124,6 +125,7 @@ describe("FabricKeyPair", () => {
       // `publicExponent` byte array, both of which the parameter check
       // compares. A genuine pair reports them identically on both keys, so
       // deepening the check must not have made this one refusable.
+
       const pair = await crypto.subtle.generateKey(
         {
           name: "RSASSA-PKCS1-v1_5",
@@ -182,6 +184,7 @@ describe("FabricKeyPair", () => {
         // fresh, its contents are not. A `CryptoKey` is an opaque handle, and
         // two calls handing back different handles would be a different
         // contract entirely.
+
         const source = { publicKey: PUBLIC_KEY, privateKey: PRIVATE_KEY };
         const pair = new FabricKeyPair(source);
 
@@ -439,6 +442,7 @@ describe("FabricKeyPair", () => {
           // The one thing the constructor refuses about an algorithm name.
           // Left to `decode()`, it would arrive as a constructor throw, which
           // that method reports as a detached buffer.
+
           expect(
             codec.canDecode({
               algorithm: "",
@@ -512,6 +516,7 @@ describe("FabricKeyPair", () => {
       // State lives in private fields and reaches a caller through prototype
       // accessors, so a structural view of an instance sees nothing -- which
       // is what keeps an own accessor property off it.
+
       expect(Object.getOwnPropertyNames(materialPair())).toEqual([]);
       expect(
         Object.getOwnPropertyNames(new FabricKeyPair(await generatePair())),
@@ -522,6 +527,7 @@ describe("FabricKeyPair", () => {
       // Both directions, and every accessor, so that adding one to a class
       // whose whole contract is "the other arm's accessors throw" cannot
       // quietly leave the new one answering for both states.
+
       const handles = new FabricKeyPair(await generatePair());
       const material = materialPair();
 
@@ -575,6 +581,7 @@ describe("FabricKeyPair", () => {
     it("hashes a swapped pair differently from the original", () => {
       // The two keys are fed in a fixed order, so a pair holding them the
       // other way round is a different value rather than the same one.
+
       const swapped = new FabricKeyPair(
         "ExampleAlgorithm",
         PRIVATE_BYTES,

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -308,6 +308,7 @@ describe("native-conversion", () => {
 
     it("deeply unwraps `Error` internals (C2)", () => {
       // `Error` with a `FabricError` cause and a custom `FabricMap` property.
+
       const innerErr = new Error("inner");
       const innerSe = FabricError.fromNativeError(innerErr);
       const outerErr = new Error("outer");
@@ -441,6 +442,7 @@ describe("native-conversion", () => {
       it("is deep-frozen when `shouldDeepFreeze` is `true`, mutable when `false`", () => {
         // Tag travels separately; the bare inner state is the codec payload,
         // which for this class is a record of the three facts it preserves.
+
         const state = { tag: "Bad@1", state: { x: 1 }, error: "oops" };
         const frozen = ProblematicValue[CODEC].decode(
           "Bad@1",
@@ -489,6 +491,7 @@ describe("native-conversion", () => {
         // `deepFreeze(wrapper)` runs Arm 4 it recurses into the FabricError
         // (Arm 3), which subFreezes `error.cause` = wrapper, which re-enters
         // `deepFreeze()` -> the FabricError again -> ...
+
         const err = new Error("cycle-cause");
         const fe = FabricError.fromNativeError(err);
         const wrapper: Record<string, unknown> = { fe };
@@ -530,6 +533,7 @@ describe("native-conversion", () => {
       // recursing slots. Both must terminate, both must end deep-frozen.
       // FabricError snapshots its FabricValue state at construction, so wire
       // up the native Error's `cause` BEFORE `fromNativeError`.
+
       const peShared: Record<string, unknown> = { tag: "shared" };
       const pv = new ProblematicValue(
         "Cycle@1",
@@ -549,6 +553,7 @@ describe("native-conversion", () => {
   describe("shallowFabricFromNativeObjectElseUndefined()", () => {
     // The `FabricNativeObject`s that have a fabric form, each with the class
     // it mints.
+
     const MINTED: ReadonlyArray<[string, unknown, FabricClass]> = [
       ["a `Date`", new Date(1234), FabricEpochNsec],
       ["a `Uint8Array`", new Uint8Array([1, 2, 3]), FabricBytes],
@@ -751,6 +756,7 @@ describe("native-conversion", () => {
       it("leaves an `Error` `cause` unconverted (shallow)", () => {
         // Shallow conversion wraps the top-level `Error` but does not recurse
         // into its `cause`, which therefore stays a raw `Error`.
+
         const cause = new Error("root cause");
         const error = new Error("wrapper", { cause });
         const result = shallowFabricFromNativeValue(error) as FabricError;
@@ -783,6 +789,7 @@ describe("native-conversion", () => {
       // the pass-through is a `switch` with one `case` per class and a
       // throwing `default`, so a class missing a `case` is invisible to any
       // test that only ever hands it a different one.
+
       const PRIMITIVES: readonly FabricPrimitive[] = [
         new FabricBytes(new Uint8Array([1, 2, 3])),
         new FabricEpochDay(1n),
@@ -902,6 +909,7 @@ describe("native-conversion", () => {
       it("returns a plain object's `toJSON` as an ordinary member", () => {
         // Shallow conversion validates the container, not its members, so the
         // method comes through as the value it is rather than being called.
+
         const toJSON = () => ({ exposed: true });
         expect(shallowFabricFromNativeValue({ secret: "internal", toJSON }))
           .toEqual({ secret: "internal", toJSON });
@@ -910,6 +918,7 @@ describe("native-conversion", () => {
       it("throws for an array carrying `toJSON()`", () => {
         // An array is handled by the array rule whatever it carries, and that
         // rule rejects the named own property `toJSON` is.
+
         const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
         arr.toJSON = () => "custom array";
         expect(() => shallowFabricFromNativeValue(arr)).toThrow(
@@ -936,6 +945,7 @@ describe("native-conversion", () => {
         // Type dispatch reads the constructor from the prototype, so an own
         // `constructor` property does not decide the value's type. It reaches
         // the object rule, which names it as the reserved property it is.
+
         expect(() => fabricFromNativeValue({ ["constructor"]: "c" })).toThrow(
           "Not representable as a `FabricValue`: object with a property name " +
             "this runtime reserves (`constructor`)",
@@ -1142,6 +1152,7 @@ describe("native-conversion", () => {
         // of what a value says as data -- it would not survive the first
         // encoding boundary. Rejecting says so, where accepting would mean
         // carrying a distinction that quietly stops existing.
+
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
         expect(() => shallowFabricFromNativeValue(obj, true)).toThrow(
@@ -1210,6 +1221,7 @@ describe("native-conversion", () => {
       it("returns an already-converted `FabricError` as-is", () => {
         // `fabricFromNativeValue(Error)` produces a deep-frozen `FabricError`;
         // feeding that back in is an identity passthrough.
+
         const fe = fabricFromNativeValue(new Error("test"));
         expect(fabricFromNativeValue(fe)).toBe(fe);
       });
@@ -1570,6 +1582,7 @@ describe("native-conversion", () => {
       it("throws for a plain object whose `toJSON` is its only member", () => {
         // The deep conversion reaches the member and refuses it for what it
         // is, rather than calling it.
+
         expect(() => fabricFromNativeValue({ toJSON: () => ({ x: 1 }) }))
           .toThrow("Not representable as a `FabricValue`: function");
       });
@@ -1657,6 +1670,7 @@ describe("native-conversion", () => {
       it("throws for an array with a getter-backed index", () => {
         // An accessor is live code, not a value: converting would silently
         // flatten it to its momentary answer. Reject it loudly instead.
+
         const arr = [1, 2, 3];
         Object.defineProperty(arr, 1, {
           get: () => 22,
@@ -1689,6 +1703,7 @@ describe("native-conversion", () => {
       it("throws even for an already-frozen array with named properties", () => {
         // Such an array is not a valid `FabricValue`, so it must not slip
         // through the deep-frozen identity short-circuit.
+
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
         Object.freeze(arr);
@@ -1708,6 +1723,7 @@ describe("native-conversion", () => {
       it("throws for an object with a symbol-keyed property", () => {
         // Previously such a property was silently dropped, which is exactly the
         // confusion the array rule already refuses to allow.
+
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
         expect(() => fabricFromNativeValue(obj)).toThrow(
@@ -1744,6 +1760,7 @@ describe("native-conversion", () => {
         // it to array handling even though `Array.isArray()` is `false` for it.
         // It has no fabric representation as either an array or an object, so
         // it must be rejected rather than quietly converted.
+
         const fake = Object.create(Array.prototype) as Record<string, unknown>;
         fake[0] = "a";
         fake.length = 1;
@@ -1785,6 +1802,7 @@ describe("native-conversion", () => {
         // through unconverted, prototype and all: iteration yields content
         // that the indices never show, and freezing the instance does nothing
         // about the prototype that does it.
+
         class Smuggler extends Array {
           override *[Symbol.iterator](): Generator<unknown> {
             yield "smuggled";
@@ -1812,6 +1830,7 @@ describe("native-conversion", () => {
       it("throws for a subclass instance carrying `toJSON()`", () => {
         // No property an array carries can route it away from the array rule,
         // on the prototype or as an own key.
+
         class ProtoJson extends Array<unknown> {
           toJSON(): unknown[] {
             return [7, 8];
@@ -1905,6 +1924,7 @@ describe("native-conversion", () => {
       it("round-trips interned symbols with stable identity", () => {
         // Same registry key in any realm yields the same symbol instance
         // -- so the result equals the constructed sentinel by identity.
+
         const out = fabricFromNativeValue(Symbol.for("identity-check"));
         expect(Object.is(out, Symbol.for("identity-check"))).toBe(true);
       });
@@ -1914,6 +1934,7 @@ describe("native-conversion", () => {
         // regardless of the `freeze` flag -- the deep-frozen fast-path
         // (`isValidDeepFrozenFabricValue`) must not admit it and short-circuit
         // the validation that `freeze=false` performs (see below).
+
         expect(() => fabricFromNativeValue(Symbol("bad"))).toThrow(
           "Not representable as a `FabricValue`: unique (uninterned) symbol",
         );
@@ -2387,6 +2408,7 @@ describe("native-conversion", () => {
     it("preserves trailing holes, so `length` survives", () => {
       // Assigning element-by-element without setting `length` first would
       // truncate these away.
+
       const arr: unknown[] = [];
       arr[0] = 1;
       arr.length = 10;
@@ -2402,6 +2424,7 @@ describe("native-conversion", () => {
       // engine still scans the index range to find which keys exist, so this
       // is not O(present elements); what it pins is that the scan is not done
       // here, one property access at a time.
+
       const target: unknown[] = [];
       target.length = 1_000_000;
       target[5] = "x";
@@ -2429,6 +2452,7 @@ describe("native-conversion", () => {
       // A `Proxy` chooses its own key order, so index keys need not come first
       // the way they do on an ordinary array. Stopping at the first non-index
       // key would therefore silently drop elements -- here, all of them.
+
       const target = [10, 20];
       const reordered = new Proxy(target, {
         ownKeys: () => ["foo", "0", "1", "length"],

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -128,6 +128,7 @@ describe("type-check", () => {
         // validation is `isValidFabricConvertibleValue()`'s job. A nested
         // value that is not a `FabricValue` does not make the container itself
         // fail the per-se check.
+
         expect(isValidFabricValueLayer({ a: Symbol("x") })).toBe(true);
         expect(isValidFabricValueLayer([Symbol("x")])).toBe(true);
       });
@@ -159,6 +160,7 @@ describe("type-check", () => {
       it("returns `false` for an accessor-backed property", () => {
         // An accessor is live code, not inert data: a read executes it and can
         // return a different value every time. Freezing does not change that.
+
         const obj = { a: 1 };
         Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
         expect(isValidFabricValueLayer(obj)).toBe(false);
@@ -181,6 +183,7 @@ describe("type-check", () => {
         // inert, and a runtime that does not route assignment through a
         // prototype chain would carry it fine. It is refused because in this
         // host the name cannot survive the copy that every boundary performs.
+
         expect(isValidFabricValueLayer({ ["__proto__"]: 1, other: 2 })).toBe(
           false,
         );
@@ -192,6 +195,7 @@ describe("type-check", () => {
         // is not part of what a value says as data and would not survive
         // encoding, so a value carrying a different one is refused rather than
         // accepted and quietly changed.
+
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
         expect(isValidFabricValueLayer(obj)).toBe(false);
@@ -215,6 +219,7 @@ describe("type-check", () => {
       it("returns `false` for an array with an accessor-backed index", () => {
         // An accessor is live code, not inert data: a read executes it and can
         // return a different value every time. Freezing does not change that.
+
         const arr = [1, 2, 3];
         Object.defineProperty(arr, 1, {
           get: () => 22,
@@ -234,6 +239,7 @@ describe("type-check", () => {
       it("returns `false` for an `Array` subclass instance", () => {
         // A subclass prototype is live code just as an accessor is, and
         // freezing the instance does not change that.
+
         class Sub extends Array {}
         const sub = new Sub();
         sub.push(1, 2);
@@ -250,6 +256,7 @@ describe("type-check", () => {
       it("returns `false` for a sparse array with extra named properties", () => {
         // Length 3, hole at index 1, plus a named property "foo": still
         // `false` because the named property isn't a valid array index.
+
         const sparse = [] as unknown[] & { foo?: string };
         sparse[0] = 1;
         sparse[2] = 3;
@@ -285,6 +292,7 @@ describe("type-check", () => {
       // stop an ordinary schema being a `FabricValue` at all. That hazard is
       // handled where a property can become callable, in the value proxies,
       // rather than by refusing the name here.
+
       expect(isValidFabricValue({
         type: "object",
         if: { properties: { kind: { const: "a" } } },
@@ -325,6 +333,7 @@ describe("type-check", () => {
       it("returns `true` for an interned symbol", () => {
         // Registry-interned symbols are portable and are members, matching
         // `isValidFabricValueLayer()`.
+
         expect(isValidFabricValue(Symbol.for("k"))).toBe(true);
       });
 
@@ -415,6 +424,7 @@ describe("type-check", () => {
       it("returns `true` for an unfrozen plain object and array", () => {
         // Structurally valid but not frozen: still a `FabricValue`. This is the
         // deliberate difference from `isValidDeepFrozenFabricValue()`.
+
         const obj = { a: 1, nested: { b: 2 } };
         expect(Object.isFrozen(obj)).toBe(false);
         expect(isValidFabricValue(obj)).toBe(true);
@@ -425,6 +435,7 @@ describe("type-check", () => {
         // A `FabricInstance` is a member by type. Membership does not require
         // it to be deep-frozen, and does not recurse into its private
         // interior.
+
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(Object.isFrozen(fe)).toBe(false);
         expect(isValidFabricValue(fe)).toBe(true);
@@ -460,6 +471,7 @@ describe("type-check", () => {
       it("returns `false` for an accessor-backed property, at any depth", () => {
         // An accessor is live code, not inert data: a read executes it and can
         // return a different value every time. Freezing does not change that.
+
         const top = { a: 1 };
         Object.defineProperty(top, "g", { get: () => 2, enumerable: true });
         expect(isValidFabricValue(top)).toBe(false);
@@ -498,6 +510,7 @@ describe("type-check", () => {
       it("returns `false` for an accessor-backed array index, at any depth", () => {
         // An accessor is live code, not inert data, no matter the container:
         // an array index reaches it just as a plain-object key does.
+
         const top = [1, 2, 3];
         Object.defineProperty(top, 1, {
           get: () => 22,
@@ -523,6 +536,7 @@ describe("type-check", () => {
         // A subclass prototype is live code no matter the container: an
         // overridden `Symbol.iterator` makes iteration yield content the
         // indices never show, and freezing does not reach the prototype.
+
         class Sub extends Array {}
         const top = new Sub();
         top.push(1, 2);
@@ -603,6 +617,7 @@ describe("type-check", () => {
       it("returns `false` for a null-prototype object", () => {
         // The narrowing `isFabricPlainObject()` accepts this one; membership
         // requires an `Object.prototype`-rooted record.
+
         const obj = Object.create(null) as Record<string, never>;
 
         expect(isFabricPlainObject(obj as FabricValue)).toBe(true);
@@ -735,6 +750,7 @@ describe("type-check", () => {
       it("returns `false` for a non-plain class instance (`Date`, `Map`, …)", () => {
         // Not representable as a `FabricPlainObject`, and reachable only via
         // an unsound cast, so the guard is fed them as `unknown`.
+
         expect(isFabricPlainObject(new Date() as unknown as FabricValue))
           .toBe(false);
         expect(isFabricPlainObject(new Map() as unknown as FabricValue))
@@ -774,6 +790,7 @@ describe("type-check", () => {
       // `toJSON()` is not consulted, and carrying one decides nothing: what
       // rejects this value is being a plain object. The `Date` below carries
       // one too and is accepted, which is what holds the two apart.
+
       expect(isValidFabricNativeObject({ toJSON: () => "x" })).toBe(false);
       expect(typeof Date.prototype.toJSON).toBe("function");
       expect(isValidFabricNativeObject(new Date())).toBe(true);
@@ -794,6 +811,7 @@ describe("type-check", () => {
     // same values through the fabric classes as well. Deciding a subset of one
     // answer by a different road is only correct if the two agree on every arm,
     // which is what the corpus is for.
+
     const nativeObjectTags: ReadonlyArray<string> = [
       VALUE_TAGS.Error,
       VALUE_TAGS.Map,
@@ -858,6 +876,7 @@ describe("type-check", () => {
       // The vet decides exactly what the predicate decides. That the corpus
       // lands on both answers is asserted rather than assumed, agreement being
       // free for one that has drifted to a side.
+
       const accepted: string[] = [];
       const refused: string[] = [];
 
@@ -912,6 +931,7 @@ describe("type-check", () => {
       // exception: conversion has a say over one, and either mints its fabric
       // form or refuses it there. The vet has no say and does not pretend to,
       // which its own group below covers.
+
       for (const [label, value] of LAYER_CORPUS) {
         if (isValidFabricNativeObject(value)) continue;
         it(`gives ${label} the same verdict, in the same words`, () => {
@@ -971,6 +991,7 @@ describe("type-check", () => {
         // value would let a value choose the name it is refused under, and
         // would let it make the refusal fail instead of report. Each case
         // below is refused as `Widget`, which is what its prototype says.
+
         class Widget {}
 
         function widgetWith(descriptor: PropertyDescriptor): unknown {
@@ -1011,6 +1032,7 @@ describe("type-check", () => {
         it("refuses a value whose class will not say its name", () => {
           // `name` is an accessor too, so guarding the constructor read alone
           // leaves the next read out in the open.
+
           class NameThrows {}
           Object.defineProperty(NameThrows.prototype, "constructor", {
             value: Object.defineProperty(function () {}, "name", {
@@ -1029,6 +1051,7 @@ describe("type-check", () => {
         it("refuses a value whose constructor traps `prototype`", () => {
           // A callable `Proxy` can throw from any read, `.prototype` included,
           // which is what the class lookup would otherwise ask it for.
+
           const trapped = new Proxy(function () {}, {
             get(target, key) {
               if (key === "prototype") {
@@ -1053,6 +1076,7 @@ describe("type-check", () => {
           // reason-picking probe and the name lookup fail on it, and the
           // refusal has to survive each: an error raised while explaining a
           // refusal would arrive in place of the refusal.
+
           class Unreadable {}
           Object.defineProperty(Unreadable.prototype, "constructor", {
             get() {

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -54,6 +54,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns `-0` as `-0` and not as `0`", () => {
       // `toBe` is `Object.is`, which is the only matcher that can tell the two
       // apart; `toEqual` would pass either way.
+
       expect(toStructuredDebugValue(-0)).toBe(-0);
     });
 
@@ -93,6 +94,7 @@ describe("toStructuredDebugValue()", () => {
 
     it("returns `<anonymous>(...)` for a function with no name", () => {
       // A bare arrow assigned to nothing has an empty `name`.
+
       expect(toStructuredDebugValue((() => () => {})()))
         .toEqual({ "/function": "<anonymous>(...)" });
     });
@@ -106,6 +108,7 @@ describe("toStructuredDebugValue()", () => {
       // The failure is reported within the wrapper rather than in place of
       // it, so the result still says a function was here, and the sibling
       // properties are unaffected.
+
       const value = new Proxy(function real() {}, {
         get(target, key, receiver) {
           if (key === "name") throw new Error("name trap");
@@ -145,6 +148,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns nested containers converted all the way down", () => {
       // The converting value sits at the bottom of an object-array-object
       // chain, so reaching it at all is the assertion.
+
       expect(toStructuredDebugValue({ a: [{ b: Symbol("deep") }] }))
         .toEqual({ a: [{ b: { "/uniqueSymbol": "deep" } }] });
     });
@@ -169,6 +173,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns a sparse array without visiting the indices it has no element at", () => {
       // A very sparse array has to cost its element count and not its
       // `length`, which is what visiting only the keys it has buys.
+
       const probed: string[] = [];
       const target: unknown[] = [];
       target.length = 1000;
@@ -199,6 +204,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns a null-prototype object as an ordinary plain object", () => {
       // Were it treated as a general instance instead, the result would carry
       // a class-name tag rather than the object's own keys.
+
       const value = Object.assign(Object.create(null), { m: new Map() });
       expect(toStructuredDebugValue(value)).toEqual({ m: { "/Map": "/..." } });
     });
@@ -208,6 +214,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns a `/`-prefixed key with one more `/` prepended", () => {
       // Without the escape, a key of `/circle` would be indistinguishable
       // from the cycle marker this module writes.
+
       expect(toStructuredDebugValue({ "/circle": 3 }))
         .toEqual({ "//circle": 3 });
     });
@@ -251,6 +258,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns each `FabricInstance` under the tag of its own class", () => {
       // The tag comes from the value's codec, so a second class must not
       // arrive under the first one's tag.
+
       const value = new FabricLink({
         id: "of:fid1:abc",
         path: ["x"],
@@ -297,6 +305,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns `/...` rather than `{}` when there is nothing to show", () => {
       // Claiming an empty object about a `Map` would be a lie; `/...` says
       // "contents not represented", which is true.
+
       expect(toStructuredDebugValue(new Map([["a", 1]])))
         .toEqual({ "/Map": "/..." });
       expect(toStructuredDebugValue(new Set([1, 2])))
@@ -326,6 +335,7 @@ describe("toStructuredDebugValue()", () => {
       // Only ancestors count as a cycle. A value reached twice by different
       // paths is shown at both, since identical siblings are an ordinary
       // shape and calling the second one circular would misdescribe it.
+
       const shared = { s: 1 };
       expect(toStructuredDebugValue({ x: shared, y: shared }))
         .toEqual({ x: { s: 1 }, y: { s: 1 } });
@@ -348,12 +358,14 @@ describe("toStructuredDebugValue()", () => {
     it("returns content within the limit unelided", () => {
       // The converting leaf makes this say that conversion reached the
       // bottom, not merely that nothing was elided on the way.
+
       expect(toStructuredDebugValue({ a: { b: Symbol("leaf") } }, 3))
         .toEqual({ a: { b: { "/uniqueSymbol": "leaf" } } });
     });
 
     it("returns a `FabricPrimitive` at the limit rather than eliding it", () => {
       // A primitive is atomic, so including it adds no nesting to the result.
+
       const value = new FabricEpochNsec(123n);
       expect((toStructuredDebugValue({ t: value }, 2) as { t: unknown }).t)
         .toBe(value);
@@ -410,6 +422,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns the converted replacement, not the replacement verbatim", () => {
       // The replacement re-enters conversion, so a value the replacer hands
       // back still gets escaped, tagged, and depth-limited like any other.
+
       const result = toStructuredDebugValue(
         { a: 1 },
         undefined,
@@ -421,6 +434,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns the original value when the `replacer` throws", () => {
       // A failed replacement reads as a refusal to replace rather than as a
       // conversion error, so the rest of the result is unaffected.
+
       const result = toStructuredDebugValue(
         { a: 1, m: new Map() },
         undefined,
@@ -464,6 +478,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns the failure at the property whose read threw", () => {
       // The read of a property is part of converting it, so a getter that
       // throws costs its own property and no other.
+
       const value = {
         before: "kept",
         get boom(): number {
@@ -496,6 +511,7 @@ describe("toStructuredDebugValue()", () => {
     it("returns the failure in place for a throwing proxy trap", () => {
       // These traps are reached before any single property is, so each costs
       // the whole proxy. The `get` trap, reached per-property, is below.
+
       const traps: ProxyHandler<object>[] = [
         {
           getPrototypeOf() {
@@ -577,6 +593,7 @@ describe("toStructuredDebugValue()", () => {
       it("returns the stringification when a message is not a string", () => {
         // An `Error` may carry a non-string `message`, in which case the
         // whole value is stringified rather than the message read out.
+
         const error = new Error("ignored");
         (error as unknown as Record<string, unknown>).message = 5;
         expect(messageFor(error)).toBe("Error: 5");
@@ -585,6 +602,7 @@ describe("toStructuredDebugValue()", () => {
       it("returns a fixed token when the thrown value resists stringifying", () => {
         // A null-prototype object has no `toString` to reach, so `String()`
         // throws on it; the message derivation must not throw in turn.
+
         expect(messageFor(Object.create(null))).toBe("/unconvertibleError");
       });
 
@@ -592,6 +610,7 @@ describe("toStructuredDebugValue()", () => {
         // Nothing is lost by not falling back to stringifying this one:
         // `Error.prototype.toString()` reads `message` too, so `String()`
         // throws on it just the same.
+
         const error = new Error("ignored");
         Object.defineProperty(error, "message", {
           get() {
@@ -604,6 +623,7 @@ describe("toStructuredDebugValue()", () => {
 
       it("returns a fixed token when the `instanceof` check itself throws", () => {
         // A thrown value can refuse even to be asked what it is.
+
         const thrown = new Proxy({}, {
           getPrototypeOf() {
             throw new Error("proto trap");
@@ -619,6 +639,7 @@ describe("toStructuredDebugValue()", () => {
       // The contract is what the two shipped bugs broke: a unique symbol's
       // payload and a reserved key each produced a result the membership
       // check refuses.
+
       const cyclic: Record<string, unknown> = { name: "root" };
       cyclic.self = cyclic;
 

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -97,6 +97,7 @@ describe("value-debug", () => {
       // A user string that just happens to read "undefined" or "42n" should
       // remain a quoted string in the output -- only sentinel-wrapped payloads
       // get unquoted.
+
       expect(toCompactDebugString("undefined"))
         .toBe('"undefined"');
       expect(toCompactDebugString("42n")).toBe('"42n"');
@@ -119,6 +120,7 @@ describe("value-debug", () => {
 
     it("renders an anonymous arrow function as a bare abbreviated form", () => {
       // An immediately-passed arrow expression has no `name`.
+
       expect(toCompactDebugString((() => 1) as unknown))
         .toBe("(...) => {...}");
     });
@@ -126,6 +128,7 @@ describe("value-debug", () => {
     it("renders an anonymous `function` expression as a bare abbreviated form", () => {
       // Force an empty `name` to simulate a true anonymous function expression
       // (`(function(){}).name === ""`).
+
       const anon = function () {};
       Object.defineProperty(anon, "name", { value: "" });
       expect(toCompactDebugString(anon)).toBe("(...) => {...}");
@@ -266,6 +269,7 @@ describe("value-debug", () => {
       it("renders shared non-cyclic refs in full at each occurrence", () => {
         // Sibling references to the same object are not a cycle, so each
         // occurrence is rendered fully rather than treated as a back-edge.
+
         const x = { v: 1 };
         expect(toCompactDebugString({ a: x, b: x }))
           .toBe('{"a":{"v":1},"b":{"v":1}}');
@@ -280,6 +284,7 @@ describe("value-debug", () => {
         // The formatter is most likely to be reached for a value that is
         // already malformed, so it renders what it can rather than adding a
         // second failure on top of the first.
+
         class RogueSpecial extends FabricSpecialObject {}
 
         expect(toCompactDebugString(new RogueSpecial())).toBe(
@@ -290,6 +295,7 @@ describe("value-debug", () => {
       it("honors a normal `toJSON()` and renders its return value", () => {
         // Sanity check that `toJSON()` is consulted in the usual way; this is
         // the happy-path counterpart to the throw cases below.
+
         const v = { toJSON: () => ({ simplified: 1 }) };
         expect(toCompactDebugString(v)).toBe('{"simplified":1}');
       });
@@ -499,6 +505,7 @@ describe("value-debug", () => {
       // An object whose prototype was sliced out has no usable
       // `constructor` chain; the predicate returns "object" as a final
       // fallback.
+
       const weird = Object.create({ constructor: undefined as unknown });
       expect(toDebugKindString(weird)).toBe("object");
     });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A comment directly above a statement documents that statement. A comment that
introduces the whole block it heads needs a blank line under it, or the two
readings collapse and the block-level comment is read as a note about whichever
line happens to come first.

Fourteen files under `packages/data-model`, 236 blank lines, and nothing else.

## What the diff contains

`git diff -U0` against the merge base yields **236 added lines, every one
empty, and zero removed lines**. No comment word changes, no code line changes,
and no existing line moves. `deno fmt --check` and `deno lint` pass on all
fourteen; the formatter check matters because `deno fmt` removes a blank line
placed directly after an opening brace, and none of these lands in that
position.

`packages/data-model`: 48 passed (2747 steps), 0 failed.

## Every site was opened, and that is what the rule costs

Not every comment run that opens a block introduces it. Four shapes do not, and
each has been got wrong at least once in this arc: a preamble followed by a note
about the first statement, where the blank goes between them; a lint pragma with
its own rationale above it, where the whole run belongs to the statement; the
first of several co-ordinate case labels, each introducing its own case further
down; and a run whose later sibling continues its sentence, where the ellipsis
elides the preamble's own predicate.

Three files in this package were opened and left alone, their comments being
derivations of the value beneath them rather than introductions to a block:

- `value-hash.test.ts` — `// [0x22, 0x01]` above a call hashing those bytes.
- `codec-json/BigIntCodec.test.ts` — six of its ten spell out a base64
  derivation directly above the assertion that asserts it.
- `cloneForMutation.test.ts` — a tree diagram legending the fixture below it, a
  colon-terminated label, and a paragraph of authoring notes.

One further site is held back inside a file that was converted:
`cloneIfNecessary.test.ts` opens a block in which every statement carries its
own note, so its first comment is one of four co-ordinate labels.

Where a block is short enough to give no structural clue, the line between the
two kinds is what the sentence is about: **a derivation of the literal below it
annotates that literal, and a property of the system introduces the block.**
`// 42n -> [0x2a] -> base64 "Kg"` is the first. `// Validity of the contents is
decode()'s question` is the second. Both sit above a single assertion.

Roughly a fifth of the candidate sites in this package fall on the wrong side of
that line, which is why the sweep is read rather than run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

