### PR TITLE
Run the CLI integration `wish` step in CI

### DIFF
--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1277,6 +1277,11 @@ run_piece_data_files() {
 # Each step records as its own test, named "integration.sh <step>"; the begin
 # markers close the previous step's record and the exit trap closes the last
 # one, so a failing step is recorded with the failure.
+#
+# `all` runs every step, and every step also runs under one of the sections CI
+# dispatches: piece-values, piece-call, and piece-links. Both hold in
+# packages/cli/test/integration-sections.test.ts, which reads this table and
+# the cli-integration-test matrix in .github/workflows/deno.yml.
 case "$SECTION" in
   all)
     cf_test_step_begin piece-values
@@ -1291,6 +1296,16 @@ case "$SECTION" in
     run_piece_call_retry
     cf_test_step_begin three-topic-fixture
     run_three_topic_fixture
+    cf_test_step_begin verbs-walkthrough
+    run_verbs_walkthrough
+    cf_test_step_begin verb-session-gaps
+    run_verb_session_gaps
+    cf_test_step_begin completion-walkthrough
+    run_completion_walkthrough
+    cf_test_step_begin topics-restore-drill
+    run_topics_restore_drill
+    cf_test_step_begin bulk-survey-drill
+    run_bulk_survey_drill
     cf_test_step_begin wish
     run_wish
     ;;
@@ -1309,6 +1324,8 @@ case "$SECTION" in
   piece-links)
     cf_test_step_begin piece-links
     run_piece_links
+    cf_test_step_begin wish
+    run_wish
     ;;
   piece-call)
     cf_test_step_begin piece-call

--- a/packages/cli/test/integration-sections.test.ts
+++ b/packages/cli/test/integration-sections.test.ts
@@ -8,8 +8,8 @@
  * someone runs it by hand, and no run of the repository reports on it. `wish`
  * was in that state, reachable only from `all`, while test/wish.test.ts
  * described the session-backed read as covered by the integration lane. These
- * hold the table to reaching every step from both directions, and hold the
- * recorded step names to matching the functions that run them.
+ * hold the table to reaching every step from both directions, and hold each
+ * recorded step name to naming a function the script actually defines.
  *
  * What they read is the text of the table and of the matrix, so they see which
  * steps are dispatched and nothing about what a step does once it runs. They
@@ -135,6 +135,7 @@ function ciSections(workflow: string): string[] {
 const { arms, malformed } = parseDispatchTable(SCRIPT);
 const bySection = new Map(arms.map((arm) => [arm.section, arm.steps]));
 const everyStep = [...new Set(arms.flatMap((arm) => arm.steps))].sort();
+const defined = new Set(definedFunctions(SCRIPT));
 
 describe("integration-sections", () => {
   it("pairs every recorded step name with the function that runs it", () => {
@@ -143,9 +144,18 @@ describe("integration-sections", () => {
 
   it("dispatches every step runner the script defines", () => {
     const dispatched = new Set(everyStep.map(stepFunction));
-    const orphans = definedFunctions(SCRIPT)
-      .filter((fn) => !dispatched.has(fn));
+    const orphans = [...defined].filter((fn) => !dispatched.has(fn));
     expect(orphans).toEqual([]);
+  });
+
+  it("defines a runner for every step it dispatches", () => {
+    // The other direction. Deleting a runner and leaving its call behind is
+    // valid shell that the pairing check reads as well-formed, because the
+    // pairing is between two names; `bash -n` accepts it too, and the script
+    // reaches `command not found` only once CI has a server up.
+    const missing = everyStep.filter((step) => !defined.has(stepFunction(step)))
+      .map(stepFunction);
+    expect(missing).toEqual([]);
   });
 
   it("runs every step under `all`", () => {

--- a/packages/cli/test/integration-sections.test.ts
+++ b/packages/cli/test/integration-sections.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The `case "$SECTION"` table at the end of integration/integration.sh decides
+ * which steps a run executes. CI dispatches three of its arms, one per leg of
+ * the cli-integration-test matrix, and a run with no section argument
+ * dispatches `all`.
+ *
+ * A step no CI arm reaches runs nowhere: it is maintained and it passes when
+ * someone runs it by hand, and no run of the repository reports on it. `wish`
+ * was in that state, reachable only from `all`, while test/wish.test.ts
+ * described the session-backed read as covered by the integration lane. These
+ * hold the table to reaching every step from both directions, and hold the
+ * recorded step names to matching the functions that run them.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+const SCRIPT = await Deno.readTextFile(
+  new URL("../integration/integration.sh", import.meta.url),
+);
+const WORKFLOW = await Deno.readTextFile(
+  new URL("../../../.github/workflows/deno.yml", import.meta.url),
+);
+
+/** The shell function that runs a step, by the table's naming rule. */
+function stepFunction(step: string): string {
+  return `run_${step.replaceAll("-", "_")}`;
+}
+
+/** One section of the dispatch table and the steps it runs, in order. */
+interface Arm {
+  section: string;
+  steps: string[];
+}
+
+interface DispatchTable {
+  arms: Arm[];
+
+  /** Body lines that are not a recorded step name paired with its call. */
+  malformed: string[];
+}
+
+/**
+ * Reads the dispatch table. An arm's body is pairs of a
+ * `cf_test_step_begin <step>` line and the call that runs that step; anything
+ * else is reported through `malformed` rather than dropped, so a step written
+ * in an unexpected form cannot slip past the coverage checks below.
+ */
+function parseDispatchTable(script: string): DispatchTable {
+  const lines = script.split("\n");
+  const open = lines.indexOf('case "$SECTION" in');
+  if (open < 0) {
+    throw new Error('integration.sh has no `case "$SECTION" in` table');
+  }
+  const arms: Arm[] = [];
+  const malformed: string[] = [];
+  let arm: Arm | undefined;
+  let pending: string | undefined;
+  const unpaired = (step: string) =>
+    `${arm?.section}: ${step} is not followed by ${stepFunction(step)}`;
+  for (const line of lines.slice(open + 1)) {
+    if (line === "esac") break;
+    const opened = line.match(/^ {2}(\S+)\)$/);
+    if (opened) {
+      if (pending !== undefined) malformed.push(unpaired(pending));
+      pending = undefined;
+      // `*)` is the unknown-section error, not a list of steps.
+      arm = opened[1] === "*" ? undefined : { section: opened[1], steps: [] };
+      if (arm !== undefined) arms.push(arm);
+      continue;
+    }
+    if (arm === undefined) continue;
+    if (line === "    ;;") {
+      if (pending !== undefined) malformed.push(unpaired(pending));
+      pending = undefined;
+      arm = undefined;
+      continue;
+    }
+    const begins = line.match(/^ {4}cf_test_step_begin (\S+)$/);
+    if (begins) {
+      if (pending !== undefined) malformed.push(unpaired(pending));
+      pending = begins[1];
+      continue;
+    }
+    if (pending === undefined) {
+      malformed.push(`${arm.section}: ${line.trim()} runs outside a step`);
+      continue;
+    }
+    if (line === `    ${stepFunction(pending)}`) {
+      arm.steps.push(pending);
+    } else {
+      malformed.push(unpaired(pending));
+    }
+    pending = undefined;
+  }
+  return { arms, malformed };
+}
+
+/** Every step runner the script defines. */
+function definedFunctions(script: string): string[] {
+  return [...script.matchAll(/^(run_[a-z_]+)\(\) \{$/gm)].map((m) => m[1]);
+}
+
+/** The cli-integration-test job's block of the workflow. */
+function ciJobBlock(workflow: string): string {
+  const start = workflow.indexOf("\n  cli-integration-test:\n");
+  if (start < 0) throw new Error("deno.yml has no cli-integration-test job");
+  const rest = workflow.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
+/** The sections that job's matrix dispatches, one per leg. */
+function ciSections(workflow: string): string[] {
+  return [...ciJobBlock(workflow).matchAll(/^ +core_section: (\S+)$/gm)]
+    .map((m) => m[1]);
+}
+
+const { arms, malformed } = parseDispatchTable(SCRIPT);
+const bySection = new Map(arms.map((arm) => [arm.section, arm.steps]));
+const everyStep = [...new Set(arms.flatMap((arm) => arm.steps))].sort();
+
+describe("integration-sections", () => {
+  it("pairs every recorded step name with the function that runs it", () => {
+    expect(malformed).toEqual([]);
+  });
+
+  it("dispatches every step runner the script defines", () => {
+    const dispatched = new Set(everyStep.map(stepFunction));
+    const orphans = definedFunctions(SCRIPT)
+      .filter((fn) => !dispatched.has(fn));
+    expect(orphans).toEqual([]);
+  });
+
+  it("runs every step under `all`", () => {
+    const all = new Set(bySection.get("all") ?? []);
+    expect(everyStep.filter((step) => !all.has(step))).toEqual([]);
+  });
+
+  it("runs every step under a section CI dispatches", () => {
+    const sections = ciSections(WORKFLOW);
+    expect(sections.length).toBeGreaterThan(0);
+    const unknown = sections.filter((section) => !bySection.has(section));
+    expect(unknown).toEqual([]);
+    const covered = new Set(
+      sections.flatMap((section) => bySection.get(section) ?? []),
+    );
+    expect(everyStep.filter((step) => !covered.has(step))).toEqual([]);
+  });
+
+  it("reads the CI section from the matrix leg it is named for", () => {
+    expect(ciJobBlock(WORKFLOW)).toContain(
+      "CF_CLI_INTEGRATION_SECTION: ${{ matrix.core_section }}",
+    );
+  });
+});

--- a/packages/cli/test/integration-sections.test.ts
+++ b/packages/cli/test/integration-sections.test.ts
@@ -10,14 +10,22 @@
  * described the session-backed read as covered by the integration lane. These
  * hold the table to reaching every step from both directions, and hold the
  * recorded step names to matching the functions that run them.
+ *
+ * What they read is the text of the table and of the matrix, so they see which
+ * steps are dispatched and nothing about what a step does once it runs. They
+ * also say nothing about the arms CI does not dispatch: `piece-basics` and the
+ * one-step arms are local conveniences, free to hold any subset.
  */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+/** The integration script, whose tail holds the dispatch table. */
 const SCRIPT = await Deno.readTextFile(
   new URL("../integration/integration.sh", import.meta.url),
 );
+
+/** The CI workflow, whose cli-integration-test job names the sections. */
 const WORKFLOW = await Deno.readTextFile(
   new URL("../../../.github/workflows/deno.yml", import.meta.url),
 );
@@ -27,13 +35,18 @@ function stepFunction(step: string): string {
   return `run_${step.replaceAll("-", "_")}`;
 }
 
-/** One section of the dispatch table and the steps it runs, in order. */
+/** One section of the dispatch table and the steps it runs. */
 interface Arm {
+  /** The section name, as `CF_CLI_INTEGRATION_SECTION` names it. */
   section: string;
+
+  /** The steps the arm runs, in the order it runs them. */
   steps: string[];
 }
 
+/** What one reading of the dispatch table found. */
 interface DispatchTable {
+  /** Every arm of the table, in the order they are written. */
   arms: Arm[];
 
   /** Body lines that are not a recorded step name paired with its call. */
@@ -44,7 +57,10 @@ interface DispatchTable {
  * Reads the dispatch table. An arm's body is pairs of a
  * `cf_test_step_begin <step>` line and the call that runs that step; anything
  * else is reported through `malformed` rather than dropped, so a step written
- * in an unexpected form cannot slip past the coverage checks below.
+ * in an unexpected form cannot slip past the coverage checks below. A step the
+ * table reaches through anything other than a literal call on its own line —
+ * a variable, a helper, a loop — is one of those unexpected forms, and is
+ * reported rather than counted.
  */
 function parseDispatchTable(script: string): DispatchTable {
   const lines = script.split("\n");


### PR DESCRIPTION
The `case "$SECTION"` table at the end of
packages/cli/integration/integration.sh decides which steps a run of the CLI integration script executes. The CI workflow dispatches three of its arms, one per leg of the cli-integration-test matrix: `piece-values`, `piece-call`, and `piece-links`. The `wish` step appeared in none of those three, only in the `all` arm and in a standalone `wish` arm, and nothing in CI dispatches either of those. The step therefore never ran in CI, which a fold of the CI record store confirms: it holds records for every other `integration.sh <step>` identity and none at all for `integration.sh wish`.

Nothing else covers what the step covers. packages/cli/test/wish.test.ts exercises the wish read core, `resolveWish`, against an emulated runtime, and its header says the full `readWish` — the one that adds a session-backed `loadPieces` — is "covered by the integration lane". That was not true while the only step exercising it ran nowhere. The step drives `cf wish '#profile'` against a real server on a fresh identity, which is the zero-profile error path, and then the same read with `--allow-empty`, which turns that error into `null` on stdout.

So the step now runs in the `piece-links` leg, which has the most room for it. Across three recent runs of the workflow on main, that leg's "Run CLI integration suite" step took 24, 25 and 31 seconds against its ten-minute bound, where the `piece-call` leg took 437, 438 and 449 seconds against the same bound. Run locally against a dev toolshed with a prebuilt `cf` on PATH, the whole `piece-links` leg with the step appended takes about thirteen seconds, and the step alone accounts for roughly two of those. It goes nowhere near either bound, and it does not touch the critical path of the wave, which the `piece-call` leg sets.

The `all` arm had a gap of its own in the other direction: five steps reached only through the `piece-call` arm — `verbs-walkthrough`, `verb-session-gaps`, `completion-walkthrough`, `topics-restore-drill` and `bulk-survey-drill` — were missing from it, so a run with no section argument covered less than CI did. They are added, and `all` now runs every step the script defines.

A new test, packages/cli/test/integration-sections.test.ts, reads the dispatch table and the workflow matrix and holds four things: every recorded step name is followed by the function that runs it, every step runner the script defines is dispatched by some arm, `all` runs every step, and every step runs under a section CI dispatches. Each was checked by injecting the corresponding regression into the real script and confirming the matching assertion failed and named the offending step.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

