### PR TITLE
feat(runner)!: default every CFC dial to its strictest sound rung

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -36,21 +36,21 @@ was last checked against the code.
 | [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
 | [`readerSchemaPrecedence`](#readerschemaprecedence)                         | `EXPERIMENTAL_READER_SCHEMA_PRECEDENCE` env, or `RuntimeOptions.experimental`                                                                   | on                                                                                   | Robin McCollum (#6338)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
 | [`serverExecution`](#serverexecution) | `EXPERIMENTAL_SERVER_EXECUTION` env, or `RuntimeOptions.experimental` | **off** (`SERVER_EXECUTION_DEFAULT_ENABLED = false`; explicit `true` selects the other arm) | Bernhard Seefeld (#5339, server-execution v2 plan Phase 1 stage A; Phase 7 flip-ready #5849) | soak on main at the ON default, then delete the flag and OFF path | Phases 1–7 landed; the section's dated entries carry each flip; stable `default`/`opposite` CI roles keep both postures guarded and make a default flip data-only |
-| [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
-| [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
-| [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
-| [`cfcTriggerReadGating`](#cfctriggerreadgating)                             | `RuntimeOptions.cfcTriggerReadGating`                                                                                                           | `false`                                                                              | Bernhard Seefeld (#4488)                              | move toward `true`                                                                                                                                                                                                                | implemented, staged rollout                                                     |
+| [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-strict` (`observe` for cf-harness Loom runs)                                | Bernhard Seefeld (#3263)                              | settled at `enforce-strict`; lower rungs stay for diagnostics                                                                                                                                                                     | active; ladder is permanent                                                     |
+| [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `persist`                                                                            | Bernhard Seefeld (#4011)                              | settled at `persist`                                                                                                                                                                                                              | active, default on                                                              |
+| [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `enforce`                                                                            | Bernhard Seefeld (#4479)                              | settled at `enforce`; could fold into the base enforcement ladder                                                                                                                                                                 | active, default on                                                              |
+| [`cfcTriggerReadGating`](#cfctriggerreadgating)                             | `RuntimeOptions.cfcTriggerReadGating`                                                                                                           | `true`                                                                               | Bernhard Seefeld (#4488)                              | could become unconditional, retiring the dial                                                                                                                                                                                     | active, default on                                                              |
 | [`cfcDecomposedEnvelopes`](#cfcdecomposedenvelopes)                         | `RuntimeOptions.cfcDecomposedEnvelopes`                                                                                                         | `false`                                                                              | Robin McCollum (CT-2062)                              | move toward `true` once every deployed reader resolves the references a stored root carries                                                                                                                                      | implemented, off by default                                                     |
-| [`cfcPolicyEvaluation`](#cfcpolicyevaluation)                               | `RuntimeOptions.cfcPolicyEvaluation`                                                                                                            | `off`                                                                                | Bernhard Seefeld (#4566)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
-| [`cfcDeclaredMonotonicity`](#cfcdeclaredmonotonicity)                       | `RuntimeOptions.cfcDeclaredMonotonicity`                                                                                                        | `off`                                                                                | Bernhard Seefeld (#4647)                              | `observe` first, then `enforce` (must soak before the §8.12.7 route 2b event ships)                                                                                                                                               | implemented, off by default                                                     |
+| [`cfcPolicyEvaluation`](#cfcpolicyevaluation)                               | `RuntimeOptions.cfcPolicyEvaluation`                                                                                                            | `enforce`                                                                            | Bernhard Seefeld (#4566)                              | settled at `enforce`; could retire once policy sets stabilize                                                                                                                                                                     | active, default on                                                              |
+| [`cfcDeclaredMonotonicity`](#cfcdeclaredmonotonicity)                       | `RuntimeOptions.cfcDeclaredMonotonicity`                                                                                                        | `observe`                                                                            | Bernhard Seefeld (#4647)                              | `enforce` once per-principal `addIntegrity` mints migrate to the `derived` component (must soak before the §8.12.7 route 2b event ships)                                                                                          | active, default on at `observe`                                                 |
 | [`cfcPrefixProvenanceStats`](#cfcprefixprovenancestats)                     | `RuntimeOptions.cfcPrefixProvenanceStats` (per-deployment; not env-wired)                                                                       | `false`                                                                              | Bernhard Seefeld (#4623)                              | stays a measurement opt-in; fold in or remove after Stage 0                                                                                                                                                                       | implemented, off by default, measurement only                                   |
-| [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection)                 | `RuntimeOptions.cfcLabelMetadataProtection`                                                                                                     | `off`                                                                                | Bernhard Seefeld (#4638)                              | `observe` (divergence counting) first, then `enforce`                                                                                                                                                                             | implemented, staged rollout                                                     |
+| [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection)                 | `RuntimeOptions.cfcLabelMetadataProtection`                                                                                                     | `enforce`                                                                            | Bernhard Seefeld (#4638)                              | settled at `enforce`; lower rungs stay for diagnostics                                                                                                                                                                            | active, default on                                                              |
 | [`conflictAdmissionMode`](#conflictadmissionmode)                           | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()`                                                                                    | `off`                                                                                | William Kelly (#4237); `hold` removed CT-1925 (#5110) | keep `preempt` as a tuning dial or remove after re-measurement                                                                                                                                                                    | implemented, off by default, measured net-negative                              |
 | [`syncSchemaTableV2`](#syncschematablev2)                                   | `setSyncSchemaTableConfig()` (negotiated per connection)                                                                                        | on                                                                                   | Ben Follington (#4292)                                | retire the negotiation once every peer speaks v2                                                                                                                                                                                  | implemented, on by default                                                      |
 | [`messageCompressionV1`](#messagecompressionv1)                             | `setMessageCompressionConfig()` (negotiated per connection)                                                                                     | on                                                                                   | PR #6474                                             | retire the rollback switch after the binary WebSocket envelope has field-soaked                                                                                                                                                   | implemented, on by default                                                      |
 | [`ownWriteEcho`](#ownwriteecho)                                             | `setOwnWriteEchoConfig()` (server-side only, not negotiated)                                                                                    | on                                                                                   | Robin McCollum (CT-1965)                              | remove the switch once the echo has field-soaked                                                                                                                                                                                  | implemented, on by default                                                      |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off                                                                                  | Ben Follington (#4937; shell toggle #4974)            | graduate to always-on after live measurement, or remove if superseded                                                                                                                                                             | implemented behind the flag, off by default, not yet measured over real latency |
-| [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | off                                                                                  | Bernhard Seefeld (#4550)                              | graduate once exchange resolution lands                                                                                                                                                                                           | implemented, off by default, dogfood only                                       |
+| [`cfcRenderCeiling`](#cfcrenderceiling)                                     | `commonfabric.cfcRenderCeiling()` in the browser (localStorage)                                                                                 | on                                                                                   | Bernhard Seefeld (#4550)                              | retire the per-profile opt-out once the ceiling has field-soaked                                                                                                                                                                  | active, default on, per-profile opt-out                                         |
 | [`INGEST_SELF_SERVE_ENABLED`](#ingest_self_serve_enabled) | `INGEST_SELF_SERVE_ENABLED` env on toolshed | off | Alex Komoroske (self-serve ingest channels) | graduate on once named-space keys stop deriving from a public passphrase | implemented, off by default |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning)                                 | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache`                                                             | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts                          | Ian Hickson                                           | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked                                                                                                                                      | implemented, on by default for FUSE-T, soak-validated                           |
 
@@ -598,18 +598,23 @@ They are not wired to environment variables. Instead, the first-party posture is
 set once in `coreOptions`, the shared core that every construction preset
 composes, in
 [`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts).
-`coreOptions` pins `cfcEnforcementMode` to `enforce-explicit`; the other CFC
-dials are deliberately left on their constructor defaults (`off` or none) there,
-with a comment marking `coreOptions` as the one place to flip a dial when a
-first-party rollout begins. So the place to advance a CFC rollout across the
-whole fleet is that one function, not each call site. A few presets accept
-per-environment overrides: `patternTest` and `unitTest` take a laxer
-`cfcEnforcementMode`, and `browserWorker` and `remoteClient` take
-host-controlled `cfcEnforcementMode` and `cfcFlowLabels` — the shell supplies
-the former's from its initialization data, and cf-harness supplies the
-latter's for its fabric session from `--fabric-cfc-enforcement-mode`
-(raise-only: `enforce-explicit` or `enforce-strict`) and
-`--fabric-cfc-flow-labels`, with `CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE` and
+`coreOptions` pins every enforcement dial at the strict end state of the
+deployment-mode matrix
+([`docs/specs/cfc-enforcement-matrix.md`](../specs/cfc-enforcement-matrix.md)
+§3): `cfcEnforcementMode: enforce-strict`, `cfcFlowLabels: persist`,
+`cfcWriteFloor: enforce`, `cfcTriggerReadGating: true`,
+`cfcPolicyEvaluation: enforce`, `cfcLabelMetadataProtection: enforce`, and
+`cfcDeclaredMonotonicity: observe` — the same values the `Runtime` constructor
+defaults to, pinned so a changed constructor default cannot silently relax
+first-party processes. So the place to move a CFC dial across the whole fleet
+is that one function, not each call site. A few presets accept per-environment
+overrides: `patternTest` and `unitTest` take a laxer `cfcEnforcementMode`, and
+`browserWorker` and `remoteClient` take host-controlled `cfcEnforcementMode`
+and `cfcFlowLabels` — the shell supplies the former's from its initialization
+data, and cf-harness supplies the latter's for its fabric session from
+`--fabric-cfc-enforcement-mode` (enforcing rungs only: `enforce-explicit` or
+`enforce-strict`) and `--fabric-cfc-flow-labels`, with
+`CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE` and
 `CF_HARNESS_FABRIC_CFC_FLOW_LABELS` as their environment defaults.
 `remoteClient` takes a host-controlled `cfcWriteFloor` on top of those two,
 which `PiecesController.initialize` forwards and the pattern multi-runtime
@@ -637,9 +642,9 @@ mechanism, since an exact-match ceiling cannot admit the source-varying
 material-risk caveats an llm sink exists to process. Building that mechanism
 is planned in
 [`docs/plans/cfc-llm-sink-admission.md`](../plans/cfc-llm-sink-admission.md).
-The bundle deliberately leaves the
-enforcement-mode pin at `enforce-explicit` (strict stays a per-session host
-raise), and leaves `cfcDecomposedEnvelopes`, `cfcTrustConfig`, and
+The bundle names no enforcement mode, so a runtime taking it keeps
+whatever mode it already has — the preset's `enforce-strict` pin, or a host
+raise over it — and it leaves `cfcDecomposedEnvelopes`, `cfcTrustConfig`, and
 `cfcPrefixProvenanceStats` alone. It is opt-in per runtime, never a fleet
 flip: cf-harness exposes it for its fabric session as `--fabric-cfc-posture`
 (`CF_HARNESS_FABRIC_CFC_POSTURE`); toolshed publishes whatever CFC posture its
@@ -688,8 +693,8 @@ the per-epic implementation notes).
 
 - **Toggle via.** `RuntimeOptions.cfcEnforcementMode`, pinned for first-party
   processes in `coreOptions` (see the category note). The cf-harness and fuse
-  read `CF_CFC_MODE` as an override, and cf-harness's fabric session can raise
-  its own runtime to `enforce-strict` through
+  read `CF_CFC_MODE` as an override, and cf-harness's fabric session selects
+  between the enforcing rungs through
   `--fabric-cfc-enforcement-mode` / `CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE`.
 - **Added by.** Bernhard Seefeld, in "Implement runner commit-boundary" (#3263,
   2026-04-14).
@@ -699,21 +704,22 @@ the per-epic implementation notes).
   diagnostics without rejecting; `enforce-explicit` rejects writes that violate
   explicit labels; `enforce-strict` also rejects violations that come from
   inferred taint.
-- **Current default and planned end state.** The type-level default constant
-  (`DEFAULT_CFC_ENFORCEMENT_MODE`) is `disabled`, but both the `Runtime`
-  constructor and the shared `coreOptions` preset set `enforce-explicit`, so
-  boundary enforcement is on by default in the product. (The preset pins the
-  same value the constructor would default to, so that a future change to the
-  constructor default cannot silently relax first-party processes.) The
-  content-addressed compilation cache is also gated on this being anything other
-  than `disabled`. Over time the default is expected to tighten toward
-  `enforce-strict`.
-- **Status on 2026-07-08.** Active. All four rungs of the ladder are
-  implemented; the ladder itself is a permanent part of the system rather than a
-  temporary flag.
-- **Path to removal.** The dial is not planned for removal. What changes over
-  time is the default rung; the `disabled` and `observe` rungs stay available
-  for local development and diagnostics.
+- **Current default and planned end state.** `enforce-strict` everywhere: the
+  type-level default constant (`DEFAULT_CFC_ENFORCEMENT_MODE`), the `Runtime`
+  constructor, and the shared `coreOptions` preset all name it. (The preset
+  pins the same value the constructor would default to, so that a future
+  change to the constructor default cannot silently relax first-party
+  processes.) cf-harness defaults its own dial to `observe` for a run carrying
+  a Loom run manifest that names no mode itself; every other cf-harness run
+  follows the platform default. The content-addressed compilation cache is
+  also gated on this being anything other than `disabled`. This is the ladder's
+  intended end state.
+- **Status on 2026-08-18.** Active at the `enforce-strict` end state. All four
+  rungs of the ladder are implemented; the ladder itself is a permanent part
+  of the system rather than a temporary flag.
+- **Path to removal.** The dial is not planned for removal. The `disabled`,
+  `observe`, and `enforce-explicit` rungs stay available for local development
+  and diagnostics.
 
 ### `cfcFlowLabels`
 
@@ -735,14 +741,13 @@ the per-epic implementation notes).
   labeled collection an attributed writer maintains still grows per element.
   Propagation runs only when the enforcement mode is at least `observe`; it
   derives and stores labels but never rejects on its own.
-- **Current default and planned end state.** `off` by default. The target is to
-  move toward `persist` as the downstream egress gates (render ceiling, sink
-  ceilings, and the LLM path) come online.
-- **Status on 2026-07-08.** Implemented and in staged rollout; the core
-  propagation work is done and further stages are tracked in the S16 design doc.
+- **Current default and planned end state.** `persist` by default — the steady
+  state, with the downstream egress gates (render ceiling, sink ceilings, and
+  the LLM path) consuming the persisted derived components.
+- **Status on 2026-09-01.** Active at the `persist` end state.
 - **Path to removal.** Flow-label propagation is load-bearing for the S16 audit
-  transition, so the dial is not expected to be removed; it will settle on
-  `persist` as its steady state.
+  transition, so the dial is not expected to be removed; the `off` and
+  `observe` rungs stay available for diagnostics.
 
 ### `cfcWriteFloor`
 
@@ -758,13 +763,11 @@ the per-epic implementation notes).
   `enforce` records a rejection reason when a write's integrity falls below the
   floor. The floor tests the integrity of the written value, not of the reads
   that produced it.
-- **Current default and planned end state.** `off` by default. The target is to
-  move toward `enforce` once field testing confirms the floor does not
-  over-reject legitimate writes.
-- **Status on 2026-08-19.** Implemented and in staged rollout.
-- **Path to removal.** Once integrity propagation is complete and the floor is
-  proven safe, the check could fold into the base enforcement ladder and the
-  separate dial could be retired.
+- **Current default and planned end state.** `enforce` by default — the end
+  state.
+- **Status on 2026-09-04.** Active at the `enforce` end state.
+- **Path to removal.** The check could fold into the base enforcement ladder
+  and the separate dial could be retired once the floor has field-soaked.
 
 ### `cfcTriggerReadGating`
 
@@ -777,13 +780,12 @@ the per-epic implementation notes).
   and the input-requirement gates quantify over, so the rerun cannot leak
   information through the mere fact that it was triggered. It fails closed and
   costs extra metadata resolution per commit prepare.
-- **Current default and planned end state.** `false` by default. The target is
-  to move toward `true` once the per-commit metadata resolution cost is
-  acceptable.
-- **Status on 2026-07-08.** Implemented and in staged rollout.
-- **Path to removal.** Once the cost is acceptable (or metadata caching removes
-  it), the default could flip to `true` and the gating could become
-  unconditional, retiring the dial.
+- **Current default and planned end state.** `true` by default — the end
+  state.
+- **Status on 2026-08-18.** Active, on by default.
+- **Path to removal.** The gating could become unconditional, retiring the
+  dial, once the per-commit metadata resolution cost has proven acceptable in
+  the field.
 
 ### `cfcDecomposedEnvelopes`
 
@@ -830,12 +832,13 @@ the per-epic implementation notes).
   labels to a fixpoint and emits diagnostics while still deciding on the
   un-rewritten label; `enforce` decides on the rewritten label and fails closed
   when the evaluation runs out of fuel.
-- **Current default and planned end state.** `off` by default. The target is to
-  move toward `enforce` once the policy rule sets and deployment policies are
-  stable.
-- **Status on 2026-07-08.** Implemented and in staged rollout.
-- **Path to removal.** Once policy evaluation is the norm, the dial could settle
-  on `enforce` and be retired.
+- **Current default and planned end state.** `enforce` by default — the end
+  state. Evaluation is a no-op until a deployment configures
+  `cfcPolicyRecords`, so the default costs nothing where no policy set is
+  declared.
+- **Status on 2026-08-18.** Active at the `enforce` end state.
+- **Path to removal.** The dial could be retired once the policy rule sets and
+  deployment policies have stabilized.
 
 ### `cfcDeclaredMonotonicity`
 
@@ -854,23 +857,27 @@ the per-epic implementation notes).
   replace disciplines. The per-transaction privileged widening exemption
   (`setCfcDeclaredWideningExemption`, trusted-builtin only) is the seam for the
   future §8.12.7 route 2b declassification event.
-- **Current default and planned end state.** `off` by default. The target is
-  `observe`, then `enforce` after soak — the route 2b rewrite event must not
-  ship before this gate is enforced
+- **Current default and planned end state.** `observe` by default — the
+  strictest rung that is sound today. Per-principal `addIntegrity` mints (an
+  `AuthoredByCurrentUser` claim resolving to a different acting principal on
+  each write) are non-monotone declared updates by construction, so `enforce`
+  waits for those mints to migrate to the `derived` component; it must then
+  soak before the §8.12.7 route 2b rewrite event ships
   (`docs/specs/cfc-persisted-declassification.md` §4–§5).
-- **Status on 2026-07-09.** Implemented, off by default.
+- **Status on 2026-08-18.** Active, default on at `observe`.
 - **Path to removal.** Not planned for removal: monotonicity is a permanent
-  store invariant. Once `enforce` has soaked, the dial could settle there and
-  the `off`/`observe` rungs remain for diagnostics, mirroring the enforcement
-  ladder.
+  store invariant. Once the per-principal mints migrate and `enforce` soaks,
+  the dial settles there; the lower rungs remain for diagnostics, mirroring
+  the enforcement ladder.
 
 ### `cfcPrefixProvenanceStats`
 
 - **Toggle via.** `RuntimeOptions.cfcPrefixProvenanceStats` (a plain boolean),
-  not env-wired. The presets do not pin it: like every CFC dial except the
-  enforcement mode, it is left out of the shared `coreOptions` and rides the
-  `Runtime` constructor default of `false` until a deployment sets it. The
-  preset classification table marks it `core-default (off)`.
+  not env-wired. The presets do not pin it: `coreOptions` pins the dials that
+  decide what a commit is allowed to do, and this one measures rather than
+  decides, so it is left out and rides the `Runtime` constructor default of
+  `false` until a deployment sets it. The preset classification table marks it
+  `core-default (off)`.
 - **Added by.** Bernhard Seefeld, in "D4 write-prefix precision counters
   (value-level provenance stage 0, SC-24)" (#4623, 2026-07-09).
 - **Purpose.** Measurement only, and the one dial here that does not affect
@@ -914,13 +921,12 @@ the per-epic implementation notes).
   digests the candidate; exchange patterns digest-match concrete values and
   refuse to bind variables over committed fields). Same-space-only labels always
   persist verbatim.
-- **Current default and planned end state.** `off` by default. Target is
-  `observe` to count divergences, then `enforce`
-  (`docs/specs/cfc-label-metadata-confidentiality.md` §5, SC-25).
-- **Status on 2026-07-09.** Implemented, staged rollout.
+- **Current default and planned end state.** `enforce` by default — the end
+  state (`docs/specs/cfc-label-metadata-confidentiality.md` §5, SC-25).
+- **Status on 2026-08-18.** Active at the `enforce` end state.
 - **Path to removal.** Not planned for removal: the representation rule is a
-  permanent inv-12 obligation; once `enforce` soaks the dial settles there with
-  the lower rungs kept for diagnostics, like the other CFC ladders.
+  permanent inv-12 obligation; the lower rungs are kept for diagnostics, like
+  the other CFC ladders.
 
 > The related `RuntimeOptions` fields `cfcSinkMaxConfidentiality`,
 > `cfcPolicyRecords`, and `cfcTrustConfig` are CFC _configuration inputs_ (the
@@ -1167,15 +1173,14 @@ the per-epic implementation notes).
   plus allow-listed influence-class caveat kinds; everything else fails closed
   and renders as a blocked placeholder, and author-supplied render-boundary
   declassification is denied.
-- **Current default and planned end state.** Off by default. It changes what the
-  shell renders and is expected to over-block until exchange resolution (a later
-  CFC stage, Epic H3b) lands, so it is enabled deliberately per browser profile
-  for dogfooding. The end state is to graduate the ceiling on once exchange
-  resolution makes the blocking precise.
-- **Status on 2026-07-08.** Implemented, off by default, dogfood only.
-- **Path to removal.** Land exchange resolution so the ceiling stops
-  over-blocking, turn it on by default, and then remove the localStorage toggle
-  and make the ceiling unconditional.
+- **Current default and planned end state.** On by default: exchange
+  resolution (Epic H3b) resolves shared `Space(...)` principals through the
+  verified `HasRole` rules at the render boundary, so the ceiling blocks
+  precisely rather than over-blocking. `commonfabric.cfcRenderCeiling(false)`
+  opts a browser profile out for diagnostics.
+- **Status on 2026-08-18.** Active, on by default, per-profile opt-out.
+- **Path to removal.** Remove the localStorage toggle and make the ceiling
+  unconditional once the default-on posture has field-soaked.
 
 ## Category 5: Fuse mount cache tuning
 

--- a/docs/features/vouched-ingest-channel-mint.md
+++ b/docs/features/vouched-ingest-channel-mint.md
@@ -80,11 +80,11 @@ the ingest stamp, independent of the `flowLabels` dial:
 
 ## Running prepare in an otherwise-CFC-disabled runtime
 
-A runtime can be explicitly configured with `cfcEnforcementMode: "disabled"`
-(the types-level `DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"` is only the
-bare-transaction fallback — toolshed itself passes no CFC options and runs the
-`Runtime` constructor's `enforce-explicit` default), and `prepareTxForCommit`
-early-returns when disabled — so the mint would never run there.
+A runtime can be explicitly configured with `cfcEnforcementMode: "disabled"`,
+and `prepareTxForCommit` early-returns when disabled — so the mint would never
+run there. Nothing arrives at that configuration by default: the types-level
+`DEFAULT_CFC_ENFORCEMENT_MODE` and the `Runtime` constructor both name
+`enforce-strict`, so reaching `disabled` takes a caller that asks for it.
 Rather than abuse `enforcement = "observe"` to force prepare (a smell: it's not
 observing anything, and it desyncs ingest txs from the operator's real mode), the
 ingest path adds an **explicit carve-out**: `prepareTxForCommit` also proceeds

--- a/docs/how.md
+++ b/docs/how.md
@@ -458,42 +458,41 @@ SES-verified on every pull request — 444 authored entry files
 (`deno task cfcheck`). A second gate replays each pattern against 455
 recorded contract baselines across 122 patterns, because the updater
 performs no structural check before swapping a pattern onto a running
-piece. Pattern tests run at `enforce-explicit`, the same mode the servers
+piece. Pattern tests run at `enforce-strict`, the same mode the servers
 run, rather than in an observe mode that would let violations pass. That
-is the runtime's default, no flag sets it, and both server hosts are
-pinned to it (`packages/runner/src/runtime.ts`, `runtime-presets.ts`).
-The two-readers test at the top of this document runs at that plain
-default. A grep will also turn up
-`DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"` in `cfc/types.ts`, which is
-the transaction-level default, not this one.
+is the runtime's default, no flag sets it, and every first-party preset
+is pinned to it (`packages/runner/src/runtime.ts`,
+`runtime-presets.ts`). The two-readers test at the top of this document
+runs at that plain default.
 
 The flow-control layer is `packages/runner/src/cfc/`: 45 modules, about
 24,000 lines, with 133 test files beside them in `packages/runner/test`.
-Every dial it exposes is implemented; what differs between hosts is
-which are switched on. The browser shell — the product surface — runs
-label propagation at `persist`, so a value derived from labeled data is
-written with its derived label rather than laundering it away
-(`packages/lib-shell/src/runtime.ts`). Access control on spaces defaults
-to `enforce` on the production server (`packages/toolshed/env.ts`). The
-harness that dogfoods the runtime turns the whole
-`MAX_ENFORCEMENT_CFC_OPTIONS` bundle on by default
-(`packages/cf-harness/console/server.ts`), and its committed run ledgers
-record real refusals. A property suite runs on every pull request with
-labels persisted, because at the default rung "the properties below
-would pass by finding nothing"
-(`packages/cf-harness/test/cfc-properties/support/episode.ts`).
+Every dial it exposes is implemented, and every one of them now rests at
+its strictest sound rung by default, so a host differs from the fleet
+only by naming a rung of its own. Label propagation runs at `persist`
+everywhere, so a value derived from labeled data is written with its
+derived label rather than laundering it away. Access control on spaces
+defaults to `enforce` on the production server
+(`packages/toolshed/env.ts`). The harness that dogfoods the runtime
+turns the whole `MAX_ENFORCEMENT_CFC_OPTIONS` bundle on by default
+(`packages/cf-harness/console/server.ts`), which adds the standard
+policy records and the per-sink ceilings on top of those pins, and its
+committed run ledgers record real refusals.
 
 ## What is not here yet
 
-The remaining work is mostly wiring: deciding which host turns which
-dial on, and turning it on without wedging the patterns already running.
-In the core preset, label propagation, policy evaluation, the write
-floor and the monotonicity gate are off, and the default sink ceiling is
-empty; the shell and the harness are ahead of it, as above. The render
-ceiling is a toggle rather than a default, and that boundary is held by
-the label and contract layer rather than by DOM sanitization, which has
-an open gap. `docs/development/EXPERIMENTAL_OPTIONS.md` carries every
-dial, its status, and where it is headed.
+The enforcement dials are on: label propagation persists, and the write
+floor, trigger-read gating, policy evaluation, label-metadata protection
+and the render ceiling all default to their strict settings.
+Declared monotonicity rests at `observe`, which is its strictest sound
+rung while per-principal mints remain non-monotone.
+`docs/development/EXPERIMENTAL_OPTIONS.md` carries every dial, its
+status, and where it is headed. The default sink ceiling is still empty,
+and a sink with no declared ceiling is not gated at all: nothing measures
+what a request carries, so release to the network and to a model is
+ungoverned until a deployment declares ceilings for those sinks. The
+render boundary is held by the label and contract layer rather than by
+DOM sanitization, which has an open gap.
 
 Attestation — what would let a machine prove which runtime it is running
 before your data arrives — is specified rather than built.

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -5,9 +5,9 @@ _Epic H, stage H4 (first sub-step), of
 Spec residual: SC-13 in [`cfc-spec-changes.md`](./cfc-spec-changes.md) (§18) and
 the `enforce-strict` differentiation (SC-13 / §18.6.3). This section settles
 **which combinations of the five CFC dials are conforming deployment states and
-in what order a deployment may advance them**, before H4 lands `enforce-strict`
-behavior and before H3a flips any shipped host — so the rollout ordering is
-written down first._
+in what order a deployment may advance them**. H4's `enforce-strict` behavior
+and H3a's shipped-host posture have both landed, so the states below describe
+where a deployment can sit rather than where it is going._
 
 ## 1. The five dials (all runtime-configured, all orthogonal)
 
@@ -16,11 +16,11 @@ subsumes another. Their current homes and defaults:
 
 | Dial | Values (weak → strict) | `Runtime` default | Governs |
 |---|---|---|---|
-| `cfcEnforcementMode` | `disabled` · `observe` · `enforce-explicit` · `enforce-strict` | `enforce-explicit` | whether a boundary **reason rejects** the commit ([types.ts](../../packages/runner/src/cfc/types.ts) `cfcEnforcementStrictness`) |
-| `cfcFlowLabels` | `off` · `observe` · `persist` | `off` | whether the per-tx **flow join is derived and persisted** as `derived` label components (S16) |
-| `cfcWriteFloor` | `off` · `observe` · `enforce` | `off` | whether the **write-side `requiredIntegrity` floor** (SC-18, Epic D3) is checked against the written value's integrity |
-| `cfcTriggerReadGating` | `false` · `true` | `false` | whether the **§8.9.2 trigger reads** — the addresses whose invalidating writes scheduled this run — join the enforcement consumed sets: the sink-request ceiling and the `requiredIntegrity` input gate (SC-3 / H5; [runtime.ts](../../packages/runner/src/runtime.ts) `cfcTriggerReadGating`, [types.ts](../../packages/runner/src/cfc/types.ts) `CfcTriggerReadGating`, consumed in [prepare.ts](../../packages/runner/src/cfc/prepare.ts) `triggerReadSources`) |
-| `cfcPolicyEvaluation` | `off` · `observe` · `enforce` | `off` | whether the **exchange-rule evaluator** (spec §4.4.5, Epic B5) rewrites gated labels to a fueled fixpoint before the sink-request ceiling and `requiredIntegrity` input gates fit them. `observe` evaluates + diagnoses divergence but decides on the *un-rewritten* label; `enforce` decides on the *rewritten* label and **fails closed on fuel exhaustion or policy-lookup failure**. ([runtime.ts](../../packages/runner/src/runtime.ts) `cfcPolicyEvaluation` + `cfcPolicyRecords`, consumed in [prepare.ts](../../packages/runner/src/cfc/prepare.ts) `evaluateGatedConfidentiality`) |
+| `cfcEnforcementMode` | `disabled` · `observe` · `enforce-explicit` · `enforce-strict` | `enforce-strict` | whether a boundary **reason rejects** the commit ([types.ts](../../packages/runner/src/cfc/types.ts) `cfcEnforcementStrictness`) |
+| `cfcFlowLabels` | `off` · `observe` · `persist` | `persist` | whether the per-tx **flow join is derived and persisted** as `derived` label components (S16) |
+| `cfcWriteFloor` | `off` · `observe` · `enforce` | `enforce` | whether the **write-side `requiredIntegrity` floor** (SC-18, Epic D3) is checked against the written value's integrity |
+| `cfcTriggerReadGating` | `false` · `true` | `true` | whether the **§8.9.2 trigger reads** — the addresses whose invalidating writes scheduled this run — join the enforcement consumed sets: the sink-request ceiling and the `requiredIntegrity` input gate (SC-3 / H5; [runtime.ts](../../packages/runner/src/runtime.ts) `cfcTriggerReadGating`, [types.ts](../../packages/runner/src/cfc/types.ts) `CfcTriggerReadGating`, consumed in [prepare.ts](../../packages/runner/src/cfc/prepare.ts) `triggerReadSources`) |
+| `cfcPolicyEvaluation` | `off` · `observe` · `enforce` | `enforce` | whether the **exchange-rule evaluator** (spec §4.4.5, Epic B5) rewrites gated labels to a fueled fixpoint before the sink-request ceiling and `requiredIntegrity` input gates fit them. `observe` evaluates + diagnoses divergence but decides on the *un-rewritten* label; `enforce` decides on the *rewritten* label and **fails closed on fuel exhaustion or policy-lookup failure**. ([runtime.ts](../../packages/runner/src/runtime.ts) `cfcPolicyEvaluation` + `cfcPolicyRecords`, consumed in [prepare.ts](../../packages/runner/src/cfc/prepare.ts) `evaluateGatedConfidentiality`) |
 
 They are orthogonal because they gate different things: the **enforcement mode**
 decides what happens to a recorded reason (ignore / diagnose / reject); the
@@ -41,8 +41,8 @@ conforming, and the conforming ones are reachable only along a partial order.
   provenance mints still run (e.g. the external-ingest mark), but no reason ever
   rejects. CFC is descriptive only. This posture exists only by **explicitly
   passing** `cfcEnforcementMode: "disabled"` — no shipped host does today
-  (toolshed constructs its `Runtime` with no CFC options and therefore runs the
-  `enforce-explicit` default; see §3).
+  (toolshed constructs its `Runtime` through the preset core and therefore runs
+  the `enforce-strict` default; see §3).
 - **`observe`** — the boundary pass runs and records reasons as **diagnostics**;
   the commit still succeeds. Used to measure reason volume before enforcing.
 - **`enforce-explicit`** — a recorded reason **rejects** the commit, and that
@@ -90,10 +90,14 @@ adds:
 3. **`cfcWriteFloor`: `observe` before `enforce`** (the D3 analog of #1). The
    floor is a new reason-source; observe its miss volume on real schemas before
    it rejects. Independent of the flow dial — the floor credits the flow meet
-   only when `cfcFlowLabels: persist` (else it credits nothing, fail-closed), so
-   `cfcWriteFloor: enforce` is *sound* at any flow setting but is only
-   *complete* (does not over-reject a legitimately flow-endorsed write) once
-   flow persists.
+   only when `cfcFlowLabels: persist` (else it credits nothing, fail-closed).
+   The meet credits only atoms of propagation class `hereditary`; plain string
+   atoms — the pattern-authoring vocabulary — are value-bound, so a string-atom
+   floor is satisfied only by a same-path `addIntegrity` mint or a link-carried
+   source label, never by consumed reads. The authoring rule that follows: a
+   pattern mints where it floors (`RequiresIntegrity` wrapping an
+   `AddIntegrity` of the same atom), with the mint's soundness resting on the
+   path's `writeAuthorizedBy`/`uiContract` binding.
 
 4. **`cfcTriggerReadGating` is one-hop only until flow persists.** The gate may
    flip on at any point — it only *adds* consumed labels, so it is sound at any
@@ -143,26 +147,30 @@ cfcPolicyEvaluation: off ──▶ observe ──▶ enforce  (independent; only
 A **conforming state** is one where no enforcement consumes a label the flow
 dial is not yet producing. The states a deployment is expected to pass through:
 
+Every dial defaults to the strict row, so a deployment sits in one of the
+weaker rows only by pinning each of that row's four dials explicitly. Naming
+`cfcEnforcementMode` alone leaves flow labels persisting, the floor
+enforcing, and trigger gating on.
+
 | State | enforcement | flow | write-floor | trigger | Meaning |
 |---|---|---|---|---|---|
 | **Operator (explicitly disabled)** | `disabled` | `off` | `off` | `false` | CFC descriptive only; provenance mints run, nothing rejects. Requires explicitly passing `cfcEnforcementMode: "disabled"` — no shipped host does today. |
-| **Server hosts today (toolshed, background-piece-service)** | `enforce-explicit` | `off` | `off` | `false` | Neither host passes any CFC option ([toolshed/index.ts](../../packages/toolshed/index.ts), [background-piece-service main.ts](../../packages/background-piece-service/src/main.ts)), so both inherit the `Runtime` defaults. Conforming: explicit checks consume no derived labels. |
-| **Shell today** | `enforce-explicit` | `persist` | `off` | `false` | Explicit checks enforce; flow labels persisted (H2, inv-9 active); floor not yet dialed. |
-| **Shell + floor observe** | `enforce-explicit` | `persist` | `observe` | `false` | Add the write floor as diagnostics (D3 dial-up step). |
-| **Shell + floor enforce** | `enforce-explicit` | `persist` | `enforce` | `false` | Floor rejects; complete on flow-endorsed writes (flow persists). |
-| **Strict** | `enforce-strict` | `persist` | `enforce` | `true` | Writer-fit fail-closed (H4); render ceiling consumes derived labels (H3b); trigger reads gated, multi-hop complete since flow persists. The end state. |
+| **Explicit + flow off** | `enforce-explicit` | `off` | `off` | `false` | Conforming: explicit checks consume no derived labels. A rollback posture; no shipped host sits here today. |
+| **Explicit + flow persist** | `enforce-explicit` | `persist` | `off` | `false` | Explicit checks enforce; flow labels persisted (H2, inv-9 active); floor not yet dialed. |
+| **Explicit + floor observe** | `enforce-explicit` | `persist` | `observe` | `false` | Add the write floor as diagnostics (D3 dial-up step). |
+| **Explicit + floor enforce** | `enforce-explicit` | `persist` | `enforce` | `false` | Floor rejects; complete on flow-endorsed writes (flow persists). |
+| **Strict (every shipped host today)** | `enforce-strict` | `persist` | `enforce` | `true` | Writer-fit fail-closed (H4); render ceiling consumes derived labels (H3b); trigger reads gated, multi-hop complete since flow persists. The end state, and the `Runtime` default every first-party preset pins (`coreOptions` in [runtime-presets.ts](../../packages/runner/src/runtime-presets.ts)). |
 
 Trigger gating may flip to `true` at any of these states (ordering constraint
 #4: it is sound anywhere) — the table shows it flipping at the end state
 because before `cfcFlowLabels: persist` it closes only the one-hop channel.
 
-`cfcPolicyEvaluation` is omitted from the state columns above because it is
-`off` in every shipped host today (no host passes `cfcPolicyRecords`, so the
-evaluator has no rules to run). It advances on its own schedule (ordering
-constraint #5: sound anywhere, only loosening save fail-closed exhaustion), so
-a deployment adds `observe` then `enforce` alongside whichever of the states
-above it is in, once it configures a policy set (e.g. the §10.1 standard
-prompt-caveat profile).
+`cfcPolicyEvaluation` is omitted from the state columns above because no
+shipped host configures `cfcPolicyRecords`, so the evaluator has no rules to
+run at any setting. Its dial nonetheless defaults to `enforce` alongside the
+strict end state (ordering constraint #5: sound anywhere, only loosening save
+fail-closed exhaustion), so configuring a policy set (e.g. the §10.1 standard
+prompt-caveat profile) makes it live without a further dial move.
 
 **Non-conforming** examples (a linter/deploy-check should reject): any
 `enforce-strict` with `cfcFlowLabels ≠ persist` (strict consumes derived labels
@@ -170,12 +178,12 @@ the dial isn't producing); `cfcFlowLabels: persist` with `cfcEnforcementMode:
 disabled` is *permitted but pointless* (labels written, never consulted) — a
 warning, not an error.
 
-## 4. What `enforce-strict` adds (the H4 implementation contract)
+## 4. What `enforce-strict` adds
 
-H4's code step (separate PR) implements the strict-only rejects at the
-enforcement ladder
+The strict-only rejects sit at the enforcement ladder
 ([extended-storage-transaction.ts](../../packages/runner/src/storage/extended-storage-transaction.ts)),
-each gated so `enforce-explicit` keeps today's behavior.
+each gated so `enforce-explicit` raises a persist-and-flag diagnostic where
+strict rejects.
 
 **Not part of the delta: missing-policy.** A write touching a labeled document
 with no resolvable schema/policy input **already rejects under
@@ -640,8 +648,8 @@ meaningful once strict carries distinct behavior.
 
 A spec PR to `commontoolsinc/specs` records the §18.6.3 conformance text: the
 four-dial matrix, the "no consuming enforcement ahead of its producing dial"
-ordering constraint, and the `enforce-strict` reject set. File it once H4's code
-step lands and the strict rejects have concrete reason contracts to cite.
+ordering constraint, and the `enforce-strict` reject set. The strict rejects
+carry concrete reason contracts now, so the PR is writable and outstanding.
 Tracked in [`cfc-spec-changes.md`](./cfc-spec-changes.md) SC-13.
 
 The residency half of the writer-fit ceiling is owed to the spec as well:
@@ -658,8 +666,8 @@ Grounded in the four implemented dials — `cfcEnforcementMode`
 ([types.ts](../../packages/runner/src/cfc/types.ts)), `cfcFlowLabels` (H1),
 `cfcWriteFloor` (D3, #4479), and `cfcTriggerReadGating` (H5, #4488) — plus the
 SC-13 rollout constraint in `cfc-spec-changes.md` and the current host
-postures: shell
-([lib-shell/src/runtime.ts](../../packages/lib-shell/src/runtime.ts):
-`enforce-explicit` + flow `persist`, H2); toolshed and
-background-piece-service (no CFC options passed → `Runtime` defaults,
-`enforce-explicit` + flow `off`).
+postures: every first-party preset composes `coreOptions`
+([runtime-presets.ts](../../packages/runner/src/runtime-presets.ts)), which
+pins the strict end state; the shell host default
+([lib-shell/src/runtime.ts](../../packages/lib-shell/src/runtime.ts)) names
+the same `enforce-strict` + flow `persist` posture.

--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -38,18 +38,16 @@ facet of that one representational distance. Most of the flat model's narrowness
 *fail-closed* (it over-restricts — safe), but a few edges are genuine soundness
 holes, called out explicitly.
 
-**Default posture.** The commit gate is on by default: the Runtime constructor
-defaults `cfcEnforcementMode` to `enforce-explicit`
-([`runtime.ts:495`](../../packages/runner/src/runtime.ts)), as does lib-shell's
-`createRuntimeClientOptions` — the types-level
-`DEFAULT_CFC_ENFORCEMENT_MODE = "disabled"`
-([`types.ts:42`](../../packages/runner/src/cfc/types.ts)) is only the
-bare-transaction fallback. What *is* dormant: flow-labels are `persist` in the
-shell and `off` in every other host, the render confidentiality ceiling is wired
-end-to-end but the shell builds one only behind a flag that defaults off, and no
-host runs at `enforce-strict`, leaving the one reject that rung adds — the
-writer-fit misfit — unexercised in deployment. So the flow-taint and display
-protections below are *built but dormant* until a host turns them on — see Epic H.
+**Default posture.** Every dial rests at its strictest sound rung. The Runtime
+constructor and the type-level
+`DEFAULT_CFC_ENFORCEMENT_MODE`
+([`types.ts`](../../packages/runner/src/cfc/types.ts)) both name
+`enforce-strict`, as does lib-shell's `createRuntimeClientOptions`; flow labels
+persist, the shell builds the render confidentiality ceiling, and the write
+floor, trigger read gating, policy evaluation and label-metadata protection all
+enforce. Declared monotonicity stops at `observe`, which is its strictest sound
+rung while per-principal mints remain non-monotone. A deployment sits at a
+weaker rung only by naming that rung explicitly.
 
 ---
 

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -222,8 +222,11 @@ required-integrity floor (e.g. tool inputs that demand certified data).
 Deployments dial it along four independent axes — enforcement mode
 (`disabled`/`observe`/`enforce-explicit`/`enforce-strict`), flow-label
 persistence (`off`/`observe`/`persist`), the write floor, and trigger-read
-gating; the shell today runs `enforce-explicit` with flow labels at
-`persist`. The verified-source `$implRef` machinery (Chapter 7) is what
+gating; every first-party host defaults to the strict end of each axis
+(`enforce-strict`, flow labels at `persist`, the floor and the gating on).
+A Loom run that names no mode of its own sits lower on the enforcement
+axis, observing and reporting rather than denying.
+The verified-source `$implRef` machinery (Chapter 7) is what
 ties labels to the exact code that produced a value. Specs live in
 `docs/specs/cfc-*.md`; demo patterns in `packages/patterns/cfc-*`.
 

--- a/packages/cf-harness/audit/profiles/max-enforcement.json
+++ b/packages/cf-harness/audit/profiles/max-enforcement.json
@@ -1,6 +1,6 @@
 {
   "label": "max-enforcement",
-  "enforcementMode": "enforce-explicit",
+  "enforcementMode": "enforce-strict",
   "flowLabels": "persist",
   "writeFloor": "enforce",
   "policyEvaluation": "enforce",
@@ -15,6 +15,11 @@
     "fetchProgram",
     "streamData"
   ],
-  "ungatedSinks": ["llm", "llmDialog", "generateText", "generateObject"],
+  "ungatedSinks": [
+    "llm",
+    "llmDialog",
+    "generateText",
+    "generateObject"
+  ],
   "requireDeviationsPublished": true
 }

--- a/packages/cf-harness/audit/test/expected-posture.test.ts
+++ b/packages/cf-harness/audit/test/expected-posture.test.ts
@@ -151,8 +151,11 @@ describe("the expected-posture spec", () => {
         join(PROFILES_DIR, "max-enforcement.json"),
       );
       const mismatches = postureMismatches(spec, FLEET_RECORD);
+      // The fleet pin holds monotonicity at `observe`, which is its
+      // strictest sound rung; the bundle raises it and configures the sink
+      // ceilings the pin leaves to a deployment.
       expect(mismatches.map((mismatch) => mismatch.field)).toContain(
-        "flowLabels",
+        "declaredMonotonicity",
       );
       expect(mismatches.map((mismatch) => mismatch.field)).toContain(
         "ceilingedSinks[fetchText]",

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -540,8 +540,9 @@ Options:
   --fabric-space <space>        Target space (name or did:key) for the fabric-session tools;
                                 all three --fabric-* session flags go together
   --fabric-cfc-enforcement-mode <mode> enforce-explicit | enforce-strict for the fabric
-                                session's runtime (raise-only; distinct from
-                                --cfc-enforcement-mode, which governs the harness)
+                                session's runtime (enforcing rungs only; distinct
+                                from --cfc-enforcement-mode, which governs the
+                                harness)
   --fabric-cfc-flow-labels <mode> off | observe | persist flow-label propagation on
                                 the fabric session's runtime
   --fabric-cfc-posture <name>   max-enforcement: opt the fabric session's runtime
@@ -1673,8 +1674,9 @@ export const parseCfHarnessCliArgs = async (
     fabricCfcEnforcementMode !== "enforce-explicit" &&
     fabricCfcEnforcementMode !== "enforce-strict"
   ) {
-    // Raise-only: the fabric session's preset already pins enforce-explicit,
-    // so the dial admits that pin or a raise to strict, never a relaxation.
+    // Enforcing rungs only: the fabric session is a trusted write path into
+    // a real space, so the dial selects between enforce-explicit and the
+    // enforce-strict preset pin, never a non-enforcing mode.
     throw new Error(
       `--fabric-cfc-enforcement-mode must be enforce-explicit or enforce-strict: ${fabricCfcEnforcementMode}`,
     );

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -24,15 +24,24 @@ import type { DockerRunscSandboxConfig } from "./sandbox/types.ts";
 
 export const DEFAULT_GATEWAY_BASE_URL = "https://llm.stage.commontools.dev/";
 export const DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE =
-  "enforce-explicit" as const satisfies CfcEnforcementMode;
+  "enforce-strict" as const satisfies CfcEnforcementMode;
+/**
+ * The default for a run carrying a Loom run manifest that names no mode
+ * itself: Loom runs observe-and-report rather than deny, so the CFC layer
+ * emits its diagnostics without rejecting tool calls.
+ */
+export const DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE =
+  "observe" as const satisfies CfcEnforcementMode;
 export type HarnessGatewayAuthMode = "bearer" | "none";
 
 /**
- * The fabric session's enforcement dial admits raises only: the remoteClient
- * preset already pins `enforce-explicit`, so the sole configurable move is up
- * to `enforce-strict`. This is a different dial from the harness's own
- * `cfcEnforcementMode`, which governs tool policy and the sandbox — this one
- * governs the runtime the `run_pattern` tool deploys patterns into.
+ * The fabric session's enforcement dial admits only the enforcing rungs: the
+ * remoteClient preset pins `enforce-strict`, and the configurable moves are
+ * that pin or `enforce-explicit` — never a non-enforcing mode, since this
+ * session is a trusted write path into a real space. This is a different
+ * dial from the harness's own `cfcEnforcementMode`, which governs tool
+ * policy and the sandbox — this one governs the runtime the `run_pattern`
+ * tool deploys patterns into.
  */
 export type HarnessFabricCfcEnforcementMode =
   | "enforce-explicit"
@@ -47,9 +56,9 @@ export type HarnessFabricCfcFlowLabelsMode = CfcFlowLabelsMode;
  * the run offers `run_pattern` in the parent tool surface; when absent, the
  * tool is unavailable. The optional CFC dials reach the session's Runtime;
  * unset means the remoteClient preset's first-party posture
- * (`enforce-explicit`, flow labels off). `cfcPosture` opts the runtime into
- * a named bundle (`MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets);
- * the two dials still apply over it.
+ * (`enforce-strict`, flow labels `persist`). `cfcPosture` opts the runtime
+ * into a named bundle (`MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's
+ * presets); the two dials still apply over it.
  */
 export interface HarnessFabricSessionConfig {
   apiUrl: string;
@@ -236,13 +245,13 @@ export const parseHarnessGatewayAuthMode = (
 
 /**
  * The mode a fabric session enforces at, whether or not it named one: the
- * session's preset pins `enforce-explicit`, and `--fabric-cfc-enforcement-mode`
- * raises from there.
+ * session's preset pins `enforce-strict`, and `--fabric-cfc-enforcement-mode`
+ * names a different rung from there.
  */
 export const fabricSessionCfcEnforcementMode = (
   fabricSession: HarnessFabricSessionConfig,
 ): HarnessFabricCfcEnforcementMode =>
-  fabricSession.cfcEnforcementMode ?? "enforce-explicit";
+  fabricSession.cfcEnforcementMode ?? "enforce-strict";
 
 /** What the operator stated the harness's own dial to be, if anything. */
 const statedCfcEnforcementMode = (
@@ -258,11 +267,12 @@ const statedCfcEnforcementMode = (
 /**
  * Whether the session's dial decides this run's harness dial.
  *
- * Only `enforce-strict` does. The session's preset pins `enforce-explicit`
- * whether an operator asked for it or not, and a harness loop deliberately run
- * weaker than that pin is an ordinary configuration; a loop left weaker than a
- * session an operator raised to strict is the pair nobody stated, and the one
- * an audit reads as an enforcing run that did not enforce.
+ * Only an operator naming `enforce-strict` on the session does. The session's
+ * preset pins that rung whether an operator asked for it or not, and a harness
+ * loop deliberately run weaker than the pin is an ordinary configuration; a
+ * loop left weaker than a session an operator raised to strict is the pair
+ * nobody stated, and the one an audit reads as an enforcing run that did not
+ * enforce.
  */
 const fabricSessionRaisesCfcEnforcement = (
   options: Pick<
@@ -277,7 +287,7 @@ const fabricSessionRaisesCfcEnforcement = (
   if (options.fabricSession === undefined) {
     return undefined;
   }
-  const session = fabricSessionCfcEnforcementMode(options.fabricSession);
+  const session = options.fabricSession.cfcEnforcementMode;
   if (session !== "enforce-strict") {
     return undefined;
   }
@@ -332,7 +342,9 @@ export const resolveCfcEnforcementMode = (
   return statedCfcEnforcementMode(options) ??
     options.inheritedCfcEnforcementMode ??
     parsedRunManifestMode ??
-    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE;
+    (options.runManifest?.source === "loom"
+      ? DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE
+      : DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE);
 };
 
 export const resolveCfcEnforcementModeSource = (
@@ -362,6 +374,9 @@ export const resolveCfcEnforcementModeSource = (
   }
   if (parseCfcEnforcementMode(options.runManifest?.cfc?.enforcementMode)) {
     return "run-manifest";
+  }
+  if (options.runManifest?.source === "loom") {
+    return "loom-default";
   }
   return "default";
 };

--- a/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
+++ b/packages/cf-harness/src/contracts/cfc-policy-snapshot.ts
@@ -20,6 +20,7 @@ export type HarnessCfcEnforcementModeSource =
   /** Derived from the mode the run's fabric session enforces at. */
   | "fabric-session"
   | "run-manifest"
+  | "loom-default"
   | "default";
 
 export type HarnessPromptSlotBindingSource =

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -605,6 +605,12 @@ export class CfHarnessEngine {
       ...(options.runState !== undefined && recordedAuthSource !== undefined
         ? { modelAuthSource: recordedAuthSource }
         : {}),
+      // A resumed run keeps the mode it recorded, and the snapshot says so:
+      // without this the resolution falls through to a default the run is
+      // not actually using.
+      ...(options.runState !== undefined
+        ? { inheritedCfcEnforcementMode: options.runState.cfcEnforcementMode }
+        : {}),
     });
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
@@ -760,9 +766,7 @@ export class CfHarnessEngine {
             ? "configured" as const
             : "preset-pin" as const,
         flowLabels: this.config.fabricSession.cfcFlowLabels ??
-          (this.config.fabricSession.cfcPosture === "max-enforcement"
-            ? "persist" as const
-            : "off" as const),
+          "persist" as const,
         flowLabelsSource: this.config.fabricSession.cfcFlowLabels !== undefined
           ? "configured" as const
           : this.config.fabricSession.cfcPosture === "max-enforcement"
@@ -781,9 +785,12 @@ export class CfHarnessEngine {
     // record as history (no runtime exists for it to contradict). A LEGACY
     // record — one that never captured a posture — stays absent rather than
     // being backfilled, and stays frozen as history: resuming such a run
-    // with plain session dials is allowed (the flags may simply restate the
-    // original invocation, which the record predates), but resuming it under
-    // the named posture bundle is refused — no legacy run can have run the
+    // is refused unless the session configuration names the dials itself,
+    // because a configuration that names none resolves to the fleet pin,
+    // which is a posture the record cannot attest. Naming them is the
+    // operator stating what the run was, which the record predates.
+    // Resuming under the named posture bundle is refused outright — no
+    // legacy run can have run the
     // bundle, so that resume would execute enforcement the artifacts cannot
     // attest.
     if (options.runState !== undefined && fabricSessionCfc !== undefined) {
@@ -795,6 +802,20 @@ export class CfHarnessEngine {
               `records no fabric-session posture, so it cannot attest the ` +
               `${fabricSessionCfc.posture} bundle the session ` +
               `configuration resolves`,
+          );
+        }
+        if (
+          fabricSessionCfc.enforcementModeSource !== "configured" ||
+          fabricSessionCfc.flowLabelsSource !== "configured"
+        ) {
+          throw new Error(
+            `fabric session CFC posture mismatch on resume: run state ` +
+              `records no fabric-session posture, and the session ` +
+              `configuration names none either, so this run would execute ` +
+              `at ${fabricSessionCfc.enforcementMode} with flow labels ` +
+              `${fabricSessionCfc.flowLabels} under artifacts that cannot ` +
+              `attest it; pass --fabric-cfc-enforcement-mode and ` +
+              `--fabric-cfc-flow-labels to state the posture it ran at`,
           );
         }
       } else if (

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -425,6 +425,10 @@ Deno.test({
         apiKey: "test-key",
         engine: new CfHarnessEngine({
           artifactRoot,
+          // The read below carries no direct-command authorization, which
+          // enforce-strict denies; the test observes persistence of an
+          // allowed read, so it runs one rung down.
+          cfcEnforcementMode: "enforce-explicit",
           sandboxRuntime: new FakeSandboxRuntime([
             {
               stdout: "hello from file",
@@ -545,7 +549,7 @@ Deno.test({
       );
       assertEquals(persistedPolicySnapshot.cfc, {
         enforcementMode: "enforce-explicit",
-        enforcementModeSource: "default",
+        enforcementModeSource: "explicit-config",
         absenceBehavior: "fail-closed-if-absent",
         substrateStatus: "not-attested",
       });

--- a/packages/cf-harness/test/cfc-posture.test.ts
+++ b/packages/cf-harness/test/cfc-posture.test.ts
@@ -33,9 +33,12 @@ describe("cfc-posture", () => {
 
     it("resolves the fleet posture when the session states no dials", () => {
       const record = harnessFabricSessionPosture(SESSION);
-      expect(record.enforcementMode.rung).toBe("enforce-explicit");
-      expect(record.flowLabels.rung).toBe("off");
-      expect(record.flowLabels.diagnosticOnly).toBe(true);
+      expect(record.enforcementMode.rung).toBe("enforce-strict");
+      expect(record.flowLabels.rung).toBe("persist");
+      expect(record.flowLabels.diagnosticOnly).toBe(false);
+      // The policy RECORDS are the bundle's, not the fleet pin's: the pins
+      // set the dials, and the deployment configuration comes with the
+      // named posture.
       expect(record.policyDigest).toBe(null);
     });
 
@@ -92,7 +95,10 @@ describe("cfc-posture", () => {
     });
 
     it("marks a diagnostic rung as deciding nothing", () => {
-      expect(rendered(SESSION)).toContain("off (diagnostic only) — decides on");
+      // Declared monotonicity is the fleet posture's one diagnostic rung.
+      expect(rendered(SESSION)).toContain(
+        "observe (diagnostic only) — decides on",
+      );
     });
 
     it("prints every ungated sink with the reason it releases ungated", () => {

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -5,6 +5,7 @@ import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
   DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+  DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE,
   type HarnessConfig,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
@@ -96,8 +97,32 @@ Deno.test("resolveCfcEnforcementMode ignores malformed in-memory run manifest mo
         cfc: { enforcementMode: "bogus" as CfcEnforcementMode },
       },
     }),
-    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+    DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE,
   );
+});
+
+Deno.test("resolveCfcEnforcementMode defaults a Loom run without a named mode to observe", () => {
+  assertEquals(
+    resolveCfcEnforcementMode({
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+      },
+    }),
+    DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE,
+  );
+  assertEquals(
+    resolveCfcEnforcementModeSource({
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+      },
+    }),
+    "loom-default",
+  );
+  assertEquals(DEFAULT_LOOM_HARNESS_CFC_ENFORCEMENT_MODE, "observe");
 });
 
 Deno.test("resolveCfcEnforcementModeSource identifies the winning mode source", () => {
@@ -173,14 +198,38 @@ Deno.test("resolveCfcEnforcementMode follows a fabric session raised to strict",
     cfcEnforcementMode: "enforce-strict" as const,
   };
 
-  // Nobody set the harness dial, so it follows the session rather than the
-  // harness default, and says where it came from.
+  // Nobody set the harness dial, and its own default sits at the same rung,
+  // so there is nothing for the session to raise and the source names the
+  // default that got there first.
   assertEquals(
     resolveCfcEnforcementMode({ fabricSession: strictSession }),
     "enforce-strict",
   );
   assertEquals(
     resolveCfcEnforcementModeSource({ fabricSession: strictSession }),
+    "default",
+  );
+
+  // A run the manifest puts below the session is where the raise still
+  // decides: the harness dial would be `observe`, and the session is above it.
+  const loomManifest = {
+    type: "cf-harness.loom-run-manifest" as const,
+    version: 1 as const,
+    source: "loom" as const,
+    cfc: { enforcementMode: "observe" as const },
+  };
+  assertEquals(
+    resolveCfcEnforcementMode({
+      fabricSession: strictSession,
+      runManifest: loomManifest,
+    }),
+    "enforce-strict",
+  );
+  assertEquals(
+    resolveCfcEnforcementModeSource({
+      fabricSession: strictSession,
+      runManifest: loomManifest,
+    }),
     "fabric-session",
   );
 
@@ -256,7 +305,7 @@ Deno.test("resolveHarnessConfig preserves legacy gateway fields for openai-codex
     gatewayBaseUrl: DEFAULT_GATEWAY_BASE_URL,
     gatewayAuthMode: "bearer",
     skillScriptExecutionTarget: "sandbox",
-    cfcEnforcementMode: "enforce-explicit",
+    cfcEnforcementMode: "enforce-strict",
     cfcEnforcementModeSource: "default",
     docsCorpus: {
       type: "cf-harness.docs-corpus-record",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -136,7 +136,7 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     status: "pending",
     createdAt: "2026-04-15T19:00:00.000Z",
     updatedAt: "2026-04-15T19:00:00.000Z",
-    cfcEnforcementMode: "enforce-explicit",
+    cfcEnforcementMode: "enforce-strict",
     currentDir: "/workspace",
     docsCorpus: {
       type: "cf-harness.docs-corpus-record",
@@ -219,9 +219,9 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
     },
   });
   assertEquals(pinned.getRunState().fabricSessionCfc, {
-    enforcementMode: "enforce-explicit",
+    enforcementMode: "enforce-strict",
     enforcementModeSource: "preset-pin",
-    flowLabels: "off",
+    flowLabels: "persist",
     flowLabelsSource: "default",
     record: recordFor({
       apiUrl: "https://toolshed.example/",
@@ -242,7 +242,7 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
     },
   });
   assertEquals(postured.getRunState().fabricSessionCfc, {
-    enforcementMode: "enforce-explicit",
+    enforcementMode: "enforce-strict",
     enforcementModeSource: "preset-pin",
     flowLabels: "persist",
     flowLabelsSource: "posture",
@@ -278,7 +278,7 @@ Deno.test("CfHarnessEngine publishes no posture record when a session factory ov
       Promise.reject(new Error("never built in this test")),
   });
   assertEquals(engine.getRunState().fabricSessionCfc, {
-    enforcementMode: "enforce-explicit",
+    enforcementMode: "enforce-strict",
     enforcementModeSource: "preset-pin",
     flowLabels: "persist",
     flowLabelsSource: "posture",
@@ -306,7 +306,7 @@ Deno.test("CfHarnessEngine records an inherited posture record when the injected
   });
 
   assertEquals(child.getRunState().fabricSessionCfc, {
-    enforcementMode: "enforce-explicit",
+    enforcementMode: "enforce-strict",
     enforcementModeSource: "preset-pin",
     flowLabels: "persist",
     flowLabelsSource: "posture",
@@ -380,7 +380,7 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
     runState,
   });
   assertEquals(resumed.getRunState().fabricSessionCfc, {
-    enforcementMode: "enforce-explicit",
+    enforcementMode: "enforce-strict",
     enforcementModeSource: "preset-pin",
     flowLabels: "persist",
     flowLabelsSource: "posture",
@@ -433,9 +433,10 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
     "max-enforcement",
   );
 
-  // A legacy record (no posture ever captured) stays frozen as history:
-  // plain session dials may restate the original invocation, but the named
-  // bundle cannot have been what the run ran, so a posture resume is refused.
+  // A legacy record (no posture ever captured) stays frozen as history, and
+  // resuming one takes the operator naming both dials: a configuration that
+  // names neither resolves to the fleet pin, which is a posture the record
+  // cannot attest.
   const legacyState = {
     ...runState,
     fabricSessionCfc: undefined,
@@ -447,10 +448,46 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
       identityKeyPath: posturedSession.identityKeyPath,
       space: posturedSession.space,
       cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
     },
     runState: legacyState,
   });
   assertEquals(legacyWithDials.getRunState().fabricSessionCfc, undefined);
+
+  // One dial named is not enough: the other still resolves to the pin.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          apiUrl: posturedSession.apiUrl,
+          identityKeyPath: posturedSession.identityKeyPath,
+          space: posturedSession.space,
+          cfcEnforcementMode: "enforce-strict",
+        },
+        runState: legacyState,
+      }),
+    Error,
+    "the session configuration names none either",
+  );
+
+  // Naming nothing at all is the case the guard exists for.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          apiUrl: posturedSession.apiUrl,
+          identityKeyPath: posturedSession.identityKeyPath,
+          space: posturedSession.space,
+        },
+        runState: legacyState,
+      }),
+    Error,
+    "the session configuration names none either",
+  );
+
+  // The named bundle cannot have been what a legacy run ran.
   assertThrows(
     () =>
       new CfHarnessEngine({

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1592,6 +1592,10 @@ Deno.test("CfHarnessPromptLoop attaches images loaded by view_image on the next 
       workspaceHostPath: workspace,
       runId: "run-view-image",
       model: "gpt-5.4",
+      // view_image carries no direct-command authorization, which
+      // enforce-strict denies; the test observes the image follow-up
+      // turn, so it runs one rung down.
+      cfcEnforcementMode: "enforce-explicit",
     }),
     fetchFn: (_input, init) => {
       fetchCalls.push(init ?? {});

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -745,7 +745,11 @@ run_mount() {
   rm -f "$MEMORY_PROXY_READY"
   MEMORY_PROXY_READY=""
 
-  MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --background --dangerously-allow-incompatible-schema)
+  # --cfc-mode=disabled: this script covers the filesystem write-through
+  # surfaces, and one of them is the legacy handler write. An enforcing
+  # mount refuses a handler write with EACCES at open, so the mode has to
+  # be named here for the write-through path to be reachable at all.
+  MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$FUSE_API_URL" --identity="$IDENTITY" --space="$SPACE" --cfc-mode=disabled --background --dangerously-allow-incompatible-schema)
   echo "$MOUNT_OUTPUT"
 
   MOUNT_PID="${MOUNT_OUTPUT#*PID }"

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -245,6 +245,9 @@ export async function runMultiUserTestPattern(
           participant: spec.name,
           participants: meta.participants.map((p) => p.name),
           seedDefaults: index === 0,
+          // A test that names a mode names it for every participant, the way
+          // the single-user runner honors it.
+          cfcEnforcementMode: options.cfcEnforcementMode,
         }) as ParticipantInitResult;
         participants.push({
           spec,

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -28,6 +28,7 @@
  */
 
 import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   createSession,
   Identity,
@@ -304,8 +305,7 @@ const handlers: Record<
       memoryHost: new URL(args.apiUrl as string),
     });
     // `runtimePresets.patternTest` carries the shared first-party posture
-    // (CT-1814), including the enforce-explicit CFC pin this site previously
-    // restated — and the same env-honored experimental flags as the
+    // (CT-1814) and the same env-honored experimental flags as the
     // single-user runner (this worker previously ignored EXPERIMENTAL_*, so
     // the two harness modes could run under different flags).
     runtime = new Runtime(runtimePresets.patternTest({
@@ -314,6 +314,12 @@ const handlers: Record<
       experimental: experimentalOptionsFromEnv(Deno.env.get),
       errorHandlers: [(error: Error) => runtimeErrors.push(String(error))],
       moduleByteCache: getDefaultModuleByteCache(),
+      ...(args.cfcEnforcementMode !== undefined
+        ? {
+          cfcEnforcementMode: args
+            .cfcEnforcementMode as CfcEnforcementMode,
+        }
+        : {}),
     }));
     runtime.enableIdempotencyCheck();
     // Channel 1: capture pattern-code console.error / console.warn calls.

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1120,10 +1120,7 @@ export async function runTestPattern(
     ["runTestPattern", "runtime"],
     () =>
       // `runtimePresets.patternTest` carries the shared first-party posture
-      // (CT-1814): the enforce-explicit CFC pin lives in the preset core, so
-      // pattern tests act as a regression net for CFC without this site
-      // restating the production default. Params below are this harness's
-      // declared deltas.
+      // (CT-1814). Params below are this harness's declared deltas.
       new Runtime(runtimePresets.patternTest({
         apiUrl: new URL(import.meta.url),
         storageManager,
@@ -1133,7 +1130,8 @@ export async function runTestPattern(
         // Inject a fetch that honors test-declared `fetchMocks` (scoped to this
         // runtime; no process-global mutation).
         fetch: mockFetch,
-        // Tests that need a laxer mode than the shared pin opt out per test.
+        // Tests that need a different mode than the harness posture opt in
+        // per test.
         ...(options.cfcEnforcementMode !== undefined
           ? { cfcEnforcementMode: options.cfcEnforcementMode }
           : {}),

--- a/packages/connectors/agents/connector/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/connector/test/fabric-graph_test.ts
@@ -436,6 +436,9 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
       },
       { preserved: true },
     );
+    // A document-root write is CFC-relevant, so this transaction prepares
+    // before it commits, as the runtime's own commit paths do.
+    metadataTx.prepareCfc();
     const metadataCommit = await metadataTx.commit();
     if (metadataCommit.error) throw metadataCommit.error;
 

--- a/packages/fuse/cfc-writeback.test.ts
+++ b/packages/fuse/cfc-writeback.test.ts
@@ -119,7 +119,7 @@ Deno.test("CFC mode parsing and annotation defaults match runner modes", () => {
     resolveCfcMode({ cliMode: undefined, envMode: "enforce-explicit" }),
     "enforce-explicit",
   );
-  assertEquals(resolveCfcMode({}), "disabled");
+  assertEquals(resolveCfcMode({}), "enforce-strict");
 
   assertEquals(
     shouldEnableCfcAnnotations({

--- a/packages/generated-patterns/integration/pattern-harness.ts
+++ b/packages/generated-patterns/integration/pattern-harness.ts
@@ -86,8 +86,9 @@ function resolveModulePath(moduleRef: string | URL): string {
 export async function runPatternScenario(scenario: PatternIntegrationScenario) {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtimeErrors: Error[] = [];
-  // Same preset as the CLI pattern-test harness (CT-1814): shared CFC pin
-  // and env-honored experimental flags, so the two harnesses cannot drift.
+  // Same preset as the CLI pattern-test harness (CT-1814): shared CFC
+  // posture and env-honored experimental flags, so the two harnesses cannot
+  // drift.
   const runtime = new Runtime(runtimePresets.patternTest({
     apiUrl: new URL(import.meta.url),
     storageManager,

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -366,11 +366,18 @@ export class ShellIntegration {
   //
   // If `identity` provided, logs in with the identity
   // after navigation.
+  //
+  // `renderCeiling: false` opts the profile out of the §8.10.6 display
+  // ceiling, through the same per-profile switch a browser user has. A page
+  // whose subject is author-declared render declassification needs it: the
+  // ceiling denies that declassification, so the value under test never
+  // reaches the DOM.
   async goto(
-    { frontendUrl, view, identity }: {
+    { frontendUrl, view, identity, renderCeiling }: {
       frontendUrl: string;
       view: AppView;
       identity?: Identity;
+      renderCeiling?: boolean;
     },
   ): Promise<void> {
     this.#checkIsOk();
@@ -391,6 +398,19 @@ export class ShellIntegration {
     // to be set after the page has an origin to store it against and before the
     // login below.
     await enablePatternCoverage(page);
+    // Same read-at-runtime-creation contract as patternCoverage above: the
+    // shell reads this key when it builds the worker runtime, at login. One
+    // page serves every test in a file, so each navigation states the profile
+    // it wants rather than inheriting the previous test's.
+    if (renderCeiling === false) {
+      await page.evaluate(() => {
+        globalThis.localStorage.setItem("cfcRenderCeiling", "false");
+      });
+    } else {
+      await page.evaluate(() => {
+        globalThis.localStorage.removeItem("cfcRenderCeiling");
+      });
+    }
     // [NDT] triage aid: seed the worker-console host toggle before login so
     // the worker runtime's console (where the storage taps live) reaches the
     // page console — and, with PIPE_CONSOLE, the test output. Same

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -1,4 +1,10 @@
-import { createSession, DID, Identity, Session } from "@commonfabric/identity";
+import {
+  createSession,
+  DID,
+  Identity,
+  isDID,
+  Session,
+} from "@commonfabric/identity";
 import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
 import type { FabricPlainObject } from "@commonfabric/data-model";
 import { entityRefFromString } from "@commonfabric/data-model/cell-rep";
@@ -134,19 +140,19 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
 
   /**
-   * Flow-label propagation dial (S16). Shell hosts default to "observe"
-   * (Epic H1): derive the per-tx conservative join and emit diagnostics,
-   * persisting nothing — the measurement stage before "persist".
+   * Flow-label propagation dial (S16). Shell hosts default to "persist"
+   * (Epic H2): derive the per-tx conservative join and write it as a
+   * `derived` label component on every value write.
    */
   cfcFlowLabels?: RuntimeCfcFlowLabelsMode;
 
   /**
-   * Populate the default render confidentiality ceiling (Epic H3a). When
-   * true, the worker's display sinks gate labeled values against the
-   * §8.10.6 profile for this identity and author-supplied render-boundary
-   * declassification is denied. Dogfood flag, default off (= today's
-   * unbounded rendering). Expect over-blocking while exchange resolution
-   * (H3b) is not implemented.
+   * Populate the default render confidentiality ceiling (Epic H3a).
+   * Defaults to on: the worker's display sinks gate labeled values against
+   * the §8.10.6 profile for this identity, shared `Space(...)` principals
+   * resolve through the verified `HasRole` rules at the render boundary
+   * (H3b), and author-supplied render-boundary declassification is denied.
+   * `false` opts a host out, which renders labeled content ungated.
    */
   cfcRenderCeiling?: boolean;
 
@@ -300,7 +306,7 @@ export function createRuntimeClientOptions({
   apiUrl,
   spaceHostMap,
   experimental,
-  cfcEnforcementMode = "enforce-explicit",
+  cfcEnforcementMode = "enforce-strict",
   // Epic H2 (docs/history/plans/cfc-future-work-implementation.md): shell hosts run the
   // flow-label dial at "persist" — the per-tx conservative join is derived AND
   // written as a `derived` label component on every value write. This
@@ -312,16 +318,16 @@ export function createRuntimeClientOptions({
   // (§8.12.8) keeps the derived component tracking the current value rather
   // than ratcheting forever. H1 shipped "observe" as the measurement stage.
   cfcFlowLabels = "persist",
-  // Epic H3a: populate the render confidentiality ceiling. Off by default —
-  // a deployment-posture change to what the shell renders, enabled
-  // deliberately per host (shell dogfood flag). When on, display sinks
-  // admit only the §8.10.6 profile (the acting user's own identity atom
-  // plus display-dischargeable influence-class caveat kinds) and
+  // Epic H3a: populate the render confidentiality ceiling. On by default:
+  // display sinks admit only the §8.10.6 profile (the acting user's own
+  // identity atoms plus display-dischargeable influence-class caveat kinds,
+  // with shared `Space(...)` principals resolved through the verified
+  // `HasRole` exchange rules at the render boundary, H3b) and
   // author-supplied render declassification is denied (audit S15); the
-  // reconciler's fail-closed narrowing does the enforcement. Exact-match
-  // forms only until H3b adds exchange resolution, so over-blocking is
-  // expected — that is the point of the dogfood stage.
-  cfcRenderCeiling = false,
+  // reconciler's fail-closed narrowing does the enforcement. The shell's
+  // per-profile `commonfabric.cfcRenderCeiling(false)` toggle opts a browser
+  // profile back out.
+  cfcRenderCeiling = true,
   trustSnapshot,
   forwardWorkerConsole,
   patternCoverage,
@@ -359,8 +365,13 @@ export function createRuntimeClientOptions({
     ...(cfcRenderCeiling
       ? {
         renderDeclassificationPolicy: "deny" as const,
+        // The ceiling admits the identity the runtime renders AS, which a
+        // delegated host names in its own trust snapshot. Without a snapshot,
+        // and for a principal that is not a DID, that is the session identity.
         renderConfidentialityCeiling: defaultRenderConfidentialityCeiling(
-          session.as.did(),
+          isDID(resolvedTrustSnapshot?.actingPrincipal)
+            ? resolvedTrustSnapshot.actingPrincipal
+            : session.as.did(),
         ),
       }
       : {}),

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -463,7 +463,7 @@ describe("RuntimeInternals", () => {
       experimental,
     });
 
-    expect(options.cfcEnforcementMode).toBe("enforce-explicit");
+    expect(options.cfcEnforcementMode).toBe("enforce-strict");
     // Epic H2: shell hosts run the flow-label dial at "persist" by default —
     // derived label components are written on every value write, activating
     // inv-9. H1 shipped "observe" (measurement); H2 flips to "persist" now that
@@ -476,11 +476,12 @@ describe("RuntimeInternals", () => {
     expect(options.spaceDid).toBe(session.space);
     expect(options.spaceName).toBe(session.spaceName);
     expect(options.experimental).toBe(experimental);
-    // Epic H3a: the render ceiling is a dogfood flag, default OFF — absent
-    // fields keep today's unbounded rendering (no ceiling, author
-    // declassification honored).
-    expect(options.renderDeclassificationPolicy).toBeUndefined();
-    expect(options.renderConfidentialityCeiling).toBeUndefined();
+    // Epic H3a/H3b: the render ceiling is on by default — display sinks gate
+    // against the §8.10.6 profile and author declassification is denied.
+    expect(options.renderDeclassificationPolicy).toBe("deny");
+    expect(options.renderConfidentialityCeiling).toEqual(
+      defaultRenderConfidentialityCeiling(session.as.did()),
+    );
   });
 
   it("populates the §8.10.6 render ceiling when cfcRenderCeiling is on", async () => {
@@ -535,6 +536,39 @@ describe("RuntimeInternals", () => {
     });
     expect(off.renderDeclassificationPolicy).toBeUndefined();
     expect(off.renderConfidentialityCeiling).toBeUndefined();
+  });
+
+  it("builds the render ceiling for a host-supplied acting principal", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const delegate = await Identity.generate({ implementation: "noble" });
+    const session = await createSession({
+      identity,
+      spaceName: "lib-shell-cfc-render-ceiling-delegated",
+    });
+
+    const options = createRuntimeClientOptions({
+      session,
+      apiUrl: new URL("http://shell.test/"),
+      trustSnapshot: {
+        id: `principal:${delegate.did()}`,
+        actingPrincipal: delegate.did(),
+      },
+    });
+
+    // A display sink's audience is whoever the runtime renders as, which a
+    // delegated host names in its own trust snapshot rather than in the
+    // session identity.
+    expect(options.renderConfidentialityCeiling).toEqual(
+      defaultRenderConfidentialityCeiling(delegate.did()),
+    );
+    expect(options.renderConfidentialityCeiling?.atoms).toContainEqual({
+      type: "https://commonfabric.org/cfc/atom/User",
+      subject: delegate.did(),
+    });
+    expect(options.renderConfidentialityCeiling?.atoms).not.toContainEqual({
+      type: "https://commonfabric.org/cfc/atom/User",
+      subject: session.as.did(),
+    });
   });
 
   it("allows hosts to override CFC policy and trust snapshot", async () => {
@@ -1013,7 +1047,7 @@ describe("RuntimeInternals", () => {
         expect(transport.sent[0].data?.identity).toBe(identity.did());
         expect(transport.sent[0].data?.spaceDid).toBe(identity.did());
         expect(transport.sent[0].data?.cfcEnforcementMode).toBe(
-          "enforce-explicit",
+          "enforce-strict",
         );
         // The backend is posture, not routing: a document believing it reads
         // from somewhere else is as wrong about what it joined as one

--- a/packages/patterns/integration/cfc-render-policy-demo.test.ts
+++ b/packages/patterns/integration/cfc-render-policy-demo.test.ts
@@ -75,6 +75,13 @@ describe("cfc render policy demo integration test", () => {
         pieceId: piece.id,
       },
       identity,
+      // The demo's subject is author-declared render declassification: a
+      // trusted surface names the health label and the boundary lets it
+      // through. The §8.10.6 display ceiling denies author declassification
+      // and narrows any node carrying an unadmitted atom, which takes the
+      // untrusted card and the trusted reveal together. This page is what
+      // the weaker posture looks like, so it names it.
+      renderCeiling: false,
     });
     await waitForRuntimeIdle(page);
 

--- a/packages/patterns/integration/cfc-spec-gallery.test.ts
+++ b/packages/patterns/integration/cfc-spec-gallery.test.ts
@@ -69,6 +69,13 @@ describe("cfc spec gallery integration test", () => {
         pieceId: piece.id,
       },
       identity,
+      // The gallery exists to show a label, and the §8.10.6 display ceiling
+      // admits only the acting user's own identity atoms and the
+      // influence-class caveat kinds. A node carrying `SourceProvenance` or
+      // `fact-check-required` fails closed, taking the `cf-cfc-label` that
+      // names it with it, so this page names the weaker posture it
+      // demonstrates.
+      renderCeiling: false,
     });
 
     await clickTrustedActionAndWaitForText(
@@ -140,6 +147,13 @@ describe("cfc spec gallery integration test", () => {
         pieceId: piece.id,
       },
       identity,
+      // The gallery exists to show a label, and the §8.10.6 display ceiling
+      // admits only the acting user's own identity atoms and the
+      // influence-class caveat kinds. A node carrying `SourceProvenance` or
+      // `fact-check-required` fails closed, taking the `cf-cfc-label` that
+      // names it with it, so this page names the weaker posture it
+      // demonstrates.
+      renderCeiling: false,
     });
 
     await waitForCfcLabelText(page, [

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -988,6 +988,7 @@ describe("reading a piece's source state", () => {
       origin: DEFAULT_APP_PATTERN_PATH,
       expected,
     });
+    runtime.prepareTxForCommit(tx);
     await tx.commit();
 
     const state = await readPieceSourceState(runtime, cell);

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -335,6 +335,12 @@ export async function openFileBackedRuntime(
   const runtime = new Runtime({
     apiUrl: new URL("http://toolshed.test"),
     storageManager,
+    // A vintage is replayed under the posture it was captured in, one rung
+    // below the fleet's strict writer-fit: a fixture's argument document
+    // declares no ceiling for a field the gate adds, so a strict replay
+    // measures the pattern's own labeled reads against an empty ceiling and
+    // refuses the write the gate exists to compare.
+    cfcEnforcementMode: "enforce-explicit",
   });
 
   return {

--- a/packages/runner/src/cfc/declared-monotonicity.ts
+++ b/packages/runner/src/cfc/declared-monotonicity.ts
@@ -43,8 +43,8 @@ import type { CfcDeclaredWideningExemption, LabelMapEntry } from "./types.ts";
  * principal, a copied `exactCopyOf` label whose source changed — are
  * non-monotone declared updates by construction under `enforce`. That is
  * §8.12.1 semantics, not an accident: per-value evidence belongs in the
- * derived component, and the dial ships default-`off` while those mints
- * migrate.
+ * derived component, and the dial ships default-`observe` while those
+ * mints migrate.
  *
  * The one sanctioned exception (§8.12.7 route 2b — the future
  * declassification-event writer) is the per-transaction privileged

--- a/packages/runner/src/cfc/posture-report.ts
+++ b/packages/runner/src/cfc/posture-report.ts
@@ -309,14 +309,14 @@ export interface ResolvedCfcDials {
  * carries, which is a different question with a different answer.
  */
 export const RUNTIME_CFC_DIAL_DEFAULTS: ResolvedCfcDials = Object.freeze({
-  cfcEnforcementMode: "enforce-explicit",
-  cfcFlowLabels: "off",
-  cfcWriteFloor: "off",
-  cfcTriggerReadGating: false,
+  cfcEnforcementMode: "enforce-strict",
+  cfcFlowLabels: "persist",
+  cfcWriteFloor: "enforce",
+  cfcTriggerReadGating: true,
   cfcDecomposedEnvelopes: false,
-  cfcPolicyEvaluation: "off",
-  cfcLabelMetadataProtection: "off",
-  cfcDeclaredMonotonicity: "off",
+  cfcPolicyEvaluation: "enforce",
+  cfcLabelMetadataProtection: "enforce",
+  cfcDeclaredMonotonicity: "observe",
 });
 
 /**

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -118,7 +118,8 @@ export const isCfcEnforcementMode = (
   typeof input === "string" &&
   CFC_ENFORCEMENT_MODES.includes(input as CfcEnforcementMode);
 
-export const DEFAULT_CFC_ENFORCEMENT_MODE: CfcEnforcementMode = "disabled";
+export const DEFAULT_CFC_ENFORCEMENT_MODE: CfcEnforcementMode =
+  "enforce-strict";
 
 /**
  * Strictness ranking used to forbid weakening a transaction's enforcement mode
@@ -641,7 +642,7 @@ export type CfcPrepareState =
  */
 export type CfcFlowLabelsMode = "off" | "observe" | "persist";
 
-export const DEFAULT_CFC_FLOW_LABELS_MODE: CfcFlowLabelsMode = "off";
+export const DEFAULT_CFC_FLOW_LABELS_MODE: CfcFlowLabelsMode = "persist";
 
 /**
  * Write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18, Epic D3),
@@ -655,7 +656,7 @@ export const DEFAULT_CFC_FLOW_LABELS_MODE: CfcFlowLabelsMode = "off";
  */
 export type CfcWriteFloorMode = "off" | "observe" | "enforce";
 
-export const DEFAULT_CFC_WRITE_FLOOR_MODE: CfcWriteFloorMode = "off";
+export const DEFAULT_CFC_WRITE_FLOOR_MODE: CfcWriteFloorMode = "enforce";
 
 /**
  * Trigger-read gating (§8.9.2 / SC-3, Epic H5). When ON, the addresses whose
@@ -665,11 +666,11 @@ export const DEFAULT_CFC_WRITE_FLOOR_MODE: CfcWriteFloorMode = "off";
  * derivation. Closes the residual "dep changed" channel (~1 bit/change event)
  * where a handler scheduled by a secret write egresses without re-reading the
  * secret. Adds reads to the gate (fail-closed direction) at the cost of extra
- * metadata resolution per prepare, so it ships behind a flag (default OFF).
+ * metadata resolution per prepare.
  */
 export type CfcTriggerReadGating = boolean;
 
-export const DEFAULT_CFC_TRIGGER_READ_GATING: CfcTriggerReadGating = false;
+export const DEFAULT_CFC_TRIGGER_READ_GATING: CfcTriggerReadGating = true;
 
 /**
  * Whether the envelope persist path stores the DECOMPOSED spelling: the
@@ -701,7 +702,7 @@ export const DEFAULT_CFC_DECOMPOSED_ENVELOPES: CfcDecomposedEnvelopes = false;
 export type CfcPolicyEvaluationMode = "off" | "observe" | "enforce";
 
 export const DEFAULT_CFC_POLICY_EVALUATION_MODE: CfcPolicyEvaluationMode =
-  "off";
+  "enforce";
 
 /**
  * Cross-space label-metadata representation dial (inv-12 Stage 1 / SC-25,
@@ -718,7 +719,7 @@ export const DEFAULT_CFC_POLICY_EVALUATION_MODE: CfcPolicyEvaluationMode =
 export type CfcLabelMetadataProtectionMode = "off" | "observe" | "enforce";
 
 export const DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE:
-  CfcLabelMetadataProtectionMode = "off";
+  CfcLabelMetadataProtectionMode = "enforce";
 
 /**
  * Declared-component monotonicity gate dial (WP5; spec §8.12.1/§8.12.8;
@@ -741,7 +742,7 @@ export const DEFAULT_CFC_LABEL_METADATA_PROTECTION_MODE:
 export type CfcDeclaredMonotonicityMode = "off" | "observe" | "enforce";
 
 export const DEFAULT_CFC_DECLARED_MONOTONICITY_MODE:
-  CfcDeclaredMonotonicityMode = "off";
+  CfcDeclaredMonotonicityMode = "observe";
 
 /**
  * Per-transaction privileged marker exempting exactly ONE (doc, path,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -58,25 +58,23 @@
  * |                            | passes what                                      |
  * |                            | `experimentalOptionsForDeployedClient` resolved  |
  * |                            | from the server it talks to (Gate 3)             |
- * | cfcEnforcementMode         | core-pinned `"enforce-explicit"`; overridable in |
+ * | cfcEnforcementMode         | core-pinned `"enforce-strict"`; overridable in   |
  * |                            | patternTest/unitTest (per-test laxer mode) and   |
  * |                            | remoteClient/browserWorker (host-controlled      |
  * |                            | rollout)                                         |
- * | cfcFlowLabels              | core-default (off); remoteClient / browserWorker |
- * |                            | delta (host-controlled rollout)                  |
- * | cfcWriteFloor              | core-default (off); remoteClient delta           |
- * |                            | (host-controlled rollout) — flip in coreOptions  |
- * |                            | when a first-party rollout begins                |
- * | cfcTriggerReadGating       | core-default (off) — flip in coreOptions when a  |
- * |                            | first-party rollout begins                       |
+ * | cfcFlowLabels              | core-pinned `"persist"`; remoteClient /          |
+ * |                            | browserWorker delta (host-controlled rollout)    |
+ * | cfcWriteFloor              | core-pinned `"enforce"`; remoteClient delta      |
+ * |                            | (host-controlled)                                |
+ * | cfcTriggerReadGating       | core-pinned `true`                               |
  * | cfcDecomposedEnvelopes     | core-default (off) — flip after every deployed   |
  * |                            | reader resolves stored roots' references         |
- * | cfcPolicyEvaluation        | core-default (off) — same                        |
- * | cfcLabelMetadataProtection | core-default (off) — same (inv-12 Stage 1        |
- * |                            | rollout: observe first, then enforce)            |
- * | cfcDeclaredMonotonicity    | core-default (off) — same (WP5 §8.12.1 rollout:  |
- * |                            | observe first, then enforce)                     |
- * | cfcPolicyRecords           | core-default (none declared) — same              |
+ * | cfcPolicyEvaluation        | core-pinned `"enforce"`                          |
+ * | cfcLabelMetadataProtection | core-pinned `"enforce"` (inv-12 Stage 1)         |
+ * | cfcDeclaredMonotonicity    | core-pinned `"observe"` (WP5 §8.12.1; `enforce`  |
+ * |                            | once per-principal mints move to `derived`)      |
+ * | cfcPolicyRecords           | core-default (none declared) — flip in           |
+ * |                            | coreOptions when a first-party rollout begins    |
  * | cfcPrefixProvenanceStats   | core-default (off) — measurement opt-in, per     |
  * |                            | deployment (value-level provenance Stage 0)      |
  * | cfcTrustConfig             | core-default (none declared) — same              |
@@ -118,12 +116,17 @@
  * |                            | it hand-rolls its options deliberately           |
  *
  * One named departure a caller can opt into: `cfcPosture: "max-enforcement"`
- * (a `CoreParams` field) swaps the core-default CFC dial rows above for the
- * {@link MAX_ENFORCEMENT_CFC_OPTIONS} bundle, for that one runtime. The
- * per-preset host dials (`cfcEnforcementMode`, `cfcFlowLabels`,
- * `cfcWriteFloor`) still apply over the bundle, so a session-level raise wins
- * either way, and a session that wants the floor's `observe` rung rather than
- * the bundle's `enforce` asks for it the same way.
+ * (a `CoreParams` field) lays the {@link MAX_ENFORCEMENT_CFC_OPTIONS} bundle
+ * over the core CFC dial rows above, for that one runtime. What the bundle
+ * adds beyond the core pins is the deployment configuration and the last
+ * rung the pins hold back from: the standard prompt-caveat policy records,
+ * the per-sink confidentiality ceilings, and `cfcDeclaredMonotonicity` at
+ * `enforce`. It names no enforcement mode, so a runtime taking it keeps
+ * the core's `enforce-strict` pin. The per-preset host dials
+ * (`cfcEnforcementMode`, `cfcFlowLabels`, `cfcWriteFloor`) still apply over
+ * the bundle, which is how a host dials one of them somewhere else — a
+ * session that wants the floor's `observe` rung rather than the bundle's
+ * `enforce` asks for it the same way.
  */
 
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
@@ -669,10 +672,18 @@ export interface PresetCfcParams {
 export const presetCfcOptions = (
   params: PresetCfcParams,
 ): Partial<RuntimeOptions> => ({
-  // Pinned, not defaulted: several sites pinned this individually so that a
-  // changed constructor default could not silently relax them; the pin now
-  // lives once. Same value as the constructor default today.
-  cfcEnforcementMode: "enforce-explicit",
+  // Pinned, not defaulted: several sites pinned these individually so that a
+  // changed constructor default could not silently relax them; the pins now
+  // live once. Same values as the constructor defaults today — the strict end
+  // state of the deployment-mode matrix
+  // (docs/specs/cfc-enforcement-matrix.md §3).
+  cfcEnforcementMode: "enforce-strict",
+  cfcFlowLabels: "persist",
+  cfcWriteFloor: "enforce",
+  cfcTriggerReadGating: true,
+  cfcPolicyEvaluation: "enforce",
+  cfcLabelMetadataProtection: "enforce",
+  cfcDeclaredMonotonicity: "observe",
   ...(params.cfcPosture === "max-enforcement"
     ? MAX_ENFORCEMENT_CFC_OPTIONS
     : {}),
@@ -758,14 +769,11 @@ function coreOptions(params: CoreParams): RuntimeOptions {
     apiUrl: params.apiUrl,
     storageManager: params.storageManager,
     experimental: params.experimental,
-    // cfcFlowLabels / cfcWriteFloor / cfcTriggerReadGating /
-    // cfcDecomposedEnvelopes /
-    // cfcPolicyEvaluation / cfcLabelMetadataProtection /
-    // cfcDeclaredMonotonicity / cfcPolicyRecords /
-    // cfcTrustConfig / cfcSinkMaxConfidentiality ride the constructor
-    // defaults (off / none) — deliberately absent here until a first-party
-    // rollout begins. A caller that opts into `cfcPosture` gets the named
-    // bundle's values instead, for this one runtime.
+    // `presetCfcOptions` carries the CFC pins. cfcDecomposedEnvelopes /
+    // cfcPolicyRecords / cfcTrustConfig / cfcSinkMaxConfidentiality are not
+    // among them: they ride the constructor defaults (off / none) until a
+    // first-party rollout begins. A caller that opts into `cfcPosture` gets
+    // the named bundle's values over the pins, for this one runtime.
     ...presetCfcOptions({
       ...(params.cfcPosture !== undefined
         ? { cfcPosture: params.cfcPosture }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -539,7 +539,7 @@ export interface RuntimeOptions {
    */
   servingPosture?: boolean;
 
-  /** Rollout mode for commit-boundary CFC enforcement. Defaults to `enforce-explicit`. */
+  /** Rollout mode for commit-boundary CFC enforcement. Defaults to `enforce-strict`. */
   cfcEnforcementMode?: CfcEnforcementMode;
 
   /**
@@ -561,24 +561,25 @@ export interface RuntimeOptions {
   onPatternInstantiated?: PatternInstantiationObserver;
 
   /**
-   * Flow-label propagation dial (S16 default transition). Defaults to `off`.
-   * Propagation requires enforcement mode ≥ `observe` to run at the commit
-   * boundary; it derives and persists labels but never rejects by itself.
+   * Flow-label propagation dial (S16 default transition). Defaults to
+   * `persist`. Propagation requires enforcement mode ≥ `observe` to run at
+   * the commit boundary; it derives and persists labels but never rejects by
+   * itself.
    */
   cfcFlowLabels?: CfcFlowLabelsMode;
 
   /**
    * Write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18, Epic D3).
-   * Defaults to `off`. `observe` evaluates the floor and emits diagnostics;
-   * `enforce` records a prepare reason on a floor miss (rejecting the commit
-   * under the enforcing enforcement modes). The floor tests the written
-   * value's integrity, never the consumed-read set.
+   * Defaults to `enforce`. `observe` evaluates the floor and emits
+   * diagnostics; `enforce` records a prepare reason on a floor miss
+   * (rejecting the commit under the enforcing enforcement modes). The floor
+   * tests the written value's integrity, never the consumed-read set.
    */
   cfcWriteFloor?: CfcWriteFloorMode;
 
   /**
    * Trigger-read gating on the enforcement side (§8.9.2 / SC-3, Epic H5).
-   * Defaults to `false`. When true, the addresses whose invalidating writes
+   * Defaults to `true`. When true, the addresses whose invalidating writes
    * scheduled a reactive rerun join the consumed set the sink-request egress
    * ceiling and input-requirement gates quantify over (fail-closed; extra
    * metadata resolution per prepare).
@@ -598,35 +599,38 @@ export interface RuntimeOptions {
 
   /**
    * Exchange-rule policy evaluation dial (Epic B5, spec §4.4.5). Defaults to
-   * `off` (gates decide on raw labels, byte-identical to before the dial).
-   * `observe` evaluates gated labels to fixpoint and emits diagnostics while
-   * still deciding on the un-rewritten label; `enforce` decides on the
-   * rewritten label and fails closed on fuel exhaustion.
+   * `enforce`. `off` decides gates on raw labels, byte-identical to before
+   * the dial existed; `observe` evaluates gated labels to fixpoint and emits
+   * diagnostics while still deciding on the un-rewritten label; `enforce`
+   * decides on the rewritten label and fails closed on fuel exhaustion.
    */
   cfcPolicyEvaluation?: CfcPolicyEvaluationMode;
 
   /**
    * Cross-space label-metadata representation dial (inv-12 Stage 1 / SC-25,
    * spec §4.6.4.1; docs/specs/cfc-label-metadata-confidentiality.md §2/§5).
-   * Defaults to `off` (persisted label bytes identical to before the dial).
-   * `observe` computes the classification-governed transformed form for
-   * cross-space entries and emits a structured divergence diagnostic while
-   * persisting verbatim; `enforce` persists the transformed form (commitment
-   * fields as `{digestOf: <hash>}` markers). Representation only — never
-   * rejects a commit by itself.
+   * Defaults to `enforce`. `off` persists label bytes identical to before
+   * the dial existed; `observe` computes the classification-governed
+   * transformed form for cross-space entries and emits a structured
+   * divergence diagnostic while persisting verbatim; `enforce` persists the
+   * transformed form (commitment fields as `{digestOf: <hash>}` markers).
+   * Representation only — never rejects a commit by itself.
    */
   cfcLabelMetadataProtection?: CfcLabelMetadataProtectionMode;
 
   /**
    * Declared-component monotonicity gate dial (WP5, spec §8.12.1/§8.12.8;
    * docs/specs/cfc-persisted-declassification.md §4 item 3). Defaults to
-   * `off` (the declared re-mint persists exactly what it does today).
-   * `observe` compares each re-minted declared labelMap entry against the
-   * stored declared entry at the same path and emits a structured diagnostic
-   * on a non-monotone re-mint while persisting today's bytes; `enforce`
-   * records a fail-closed prepare reason (rejecting the commit under the
-   * enforcing enforcement modes). Governs ONLY the `declared` component —
-   * derived/link/structure components keep their §8.12.8 disciplines.
+   * `observe`. `off` persists the declared re-mint unchecked; `observe`
+   * compares each re-minted declared labelMap entry against the stored
+   * declared entry at the same path and emits a structured diagnostic on a
+   * non-monotone re-mint while persisting those bytes; `enforce` records a
+   * fail-closed prepare reason (rejecting the commit under the enforcing
+   * enforcement modes). Governs ONLY the `declared` component —
+   * derived/link/structure components keep their §8.12.8 disciplines. The
+   * default settles at `enforce` once per-principal `addIntegrity` mints —
+   * non-monotone declared updates by construction — migrate to the
+   * `derived` component.
    */
   cfcDeclaredMonotonicity?: CfcDeclaredMonotonicityMode;
 
@@ -2925,7 +2929,7 @@ export class Runtime {
       // A vouched ingest still needs its provenance mark minted even where CFC
       // enforcement is disabled (an explicit `cfcEnforcementMode: "disabled"`
       // opt-in — no shipped host today; toolshed passes no CFC options and so
-      // runs the enforce-explicit default). The mint
+      // runs the enforce-strict default). The mint
       // is a builtin-authored boundary-commit step that never rejects, so run
       // prepare for it explicitly rather than forcing the enforcement dial up
       // (which would desync ingest txs from the runtime's real mode). The

--- a/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
+++ b/packages/runner/test/cfc-additive-default-preserves-old-doc.test.ts
@@ -19,9 +19,11 @@ import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 // provenance: setup rewrites the complete generated result, while ordinary
 // document paths must still preserve older values.
 //
-// These tests run with CFC enforcement ON (the runtime default,
-// "enforce-explicit"); the piece cold-start harness runs with enforcement
-// disabled, which is why #4926/#4933's tests were blind to this layer.
+// These tests run with CFC enforcement ON, pinned to "enforce-explicit"
+// because the runtime default is "enforce-strict" and the layer under test
+// is what the explicit rung checks; the piece cold-start harness runs with
+// enforcement disabled, which is why #4926/#4933's tests were blind to
+// this layer.
 
 const alice = await Identity.fromPassphrase(
   "cfc-additive-default-preserves-old-doc-alice",
@@ -140,6 +142,7 @@ describe("CFC additive-required default preserves old documents", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
     });
     const space = alice.did();
     const ROOT = "legacy-home-root";
@@ -186,7 +189,7 @@ describe("CFC additive-required default preserves old documents", () => {
       }
 
       // 2. Materialize the real home pattern over the SAME root cell
-      //    (enforce-explicit is the runtime default).
+      //    (the runtime pins enforce-explicit).
       const homePattern = await compileHomePattern(runtime, space);
       const resultCell = runtime.getCell(space, ROOT);
       const home = await runtime.runSynced(resultCell, homePattern, {});
@@ -220,6 +223,7 @@ describe("CFC additive-required default preserves old documents", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
     });
     const space = alice.did();
     const ROOT = "legacy-home-root-reject";

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -304,6 +304,19 @@ describe("CFC canonicalization helpers", () => {
 });
 
 describe("ExtendedStorageTransaction CFC gate", () => {
+  // Characterization posture: this suite describes enforce-explicit-era
+  // behavior, so every CFC dial is pinned to that era's defaults. A mode
+  // passed by a test overrides the enforcement mode.
+  const characterizationCfcPosture = {
+    cfcEnforcementMode: "enforce-explicit",
+    cfcFlowLabels: "off",
+    cfcWriteFloor: "off",
+    cfcTriggerReadGating: false,
+    cfcPolicyEvaluation: "off",
+    cfcLabelMetadataProtection: "off",
+    cfcDeclaredMonotonicity: "off",
+  } as const;
+
   const createRuntime = (cfcEnforcementMode?: CfcEnforcementMode) => {
     const storageManager = StorageManager.emulate({
       as: signer,
@@ -311,6 +324,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...characterizationCfcPosture,
       ...(cfcEnforcementMode ? { cfcEnforcementMode } : {}),
     });
     return { runtime, storageManager };
@@ -323,7 +337,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup",
         actingPrincipal: signer.did(),
@@ -414,7 +428,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup-untyped",
         actingPrincipal: signer.did(),
@@ -504,7 +518,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup",
         actingPrincipal: signer.did(),
@@ -570,7 +584,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-setup-forged-projection",
         actingPrincipal: signer.did(),
@@ -638,7 +652,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
     });
     try {
       const tx = runtime.edit();
@@ -694,7 +708,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
-      cfcEnforcementMode: "enforce-explicit",
+      ...characterizationCfcPosture,
       trustSnapshotProvider: () => ({
         id: "trust-snapshot-argument-setup",
         actingPrincipal: signer.did(),
@@ -2274,10 +2288,12 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtimeA = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManagerA,
+      ...characterizationCfcPosture,
     });
     const runtimeB = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManagerB,
+      ...characterizationCfcPosture,
     });
     const schema = {
       type: "object",
@@ -4302,6 +4318,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...characterizationCfcPosture,
     });
     try {
       const firstTx = runtime1.edit();
@@ -4332,6 +4349,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       const runtime2 = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
+        ...characterizationCfcPosture,
       });
       try {
         const secondTx = runtime2.edit();
@@ -4394,6 +4412,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager1,
+      ...characterizationCfcPosture,
     });
     const cellSchema = {
       type: "object",
@@ -4428,6 +4447,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime2 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager2,
+      ...characterizationCfcPosture,
     });
     try {
       const secondSchema = {
@@ -4476,6 +4496,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime1 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager1,
+      ...characterizationCfcPosture,
     });
     const cellSchema = {
       type: "object",
@@ -4516,6 +4537,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const runtime2 = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: storageManager2,
+      ...characterizationCfcPosture,
     });
     try {
       const secondSchema = {

--- a/packages/runner/test/cfc-concept-floor.test.ts
+++ b/packages/runner/test/cfc-concept-floor.test.ts
@@ -333,10 +333,14 @@ describe("CFC concept-level integrity floors (D5)", () => {
       trust?: CfcTrustConfigInput,
     ): Promise<{ ok: boolean; message?: string }> => {
       const storageManager = StorageManager.emulate({ as: signer });
+      // The subject here is the read-side gate's concept resolution; the
+      // value-side write floor (which the mint-less sink would fail)
+      // observes only.
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
         cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "observe",
         ...(trust ? { cfcTrustConfig: trust } : {}),
       });
       try {

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -13,6 +13,10 @@ import {
 import type { JSONSchema } from "../src/builder/types.ts";
 import { type CfcConfClause, clausesEqual } from "../src/cfc/clause.ts";
 import { evaluateExchangeRules } from "../src/cfc/exchange-eval.ts";
+import {
+  commitmentAwareEquals,
+  isCfcFieldCommitment,
+} from "../src/cfc/label-representation.ts";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import {
   buildCfcPolicySnapshot,
@@ -77,6 +81,20 @@ const entriesFor = (doc: PersistedDoc, path: string[]): LabelMapEntry[] =>
   );
 
 const makeRuntime = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+) =>
+  // The subject here is which integrity a cross-space link carries; the
+  // scenarios assert the verbatim source fields, so the inv-12
+  // representation transform stays off.
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-explicit",
+    cfcLabelMetadataProtection: "off",
+  });
+
+/** The same runtime with the label-metadata dial left at its default. */
+const makeProtectedRuntime = (
   storageManager: ReturnType<typeof StorageManager.emulate>,
 ) =>
   new Runtime({
@@ -263,6 +281,100 @@ describe("CFC cross-space integrity", () => {
       expect(linkRef!.source.space).toBe(spaceA);
       expect(linkRef!.target.space).toBe(spaceB);
       // Source confidentiality carried across the space boundary.
+      expect(entry.label.confidentiality).toContain("space-a-secret");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("scenario 1c under the default label-metadata dial — the endorsement lands in committed form", async () => {
+    // The same edge as 1c, with `cfcLabelMetadataProtection` left at its
+    // default. `LinkReference.source` and `.target` are commitment-classified,
+    // so they persist as `{digestOf}` markers rather than verbatim records —
+    // which is why the scenarios above name `off`. What has to survive the
+    // transform is the mechanism: the source integrity is still carried, the
+    // endorsement is still there, its committed fields still digest the real
+    // edge, and the source confidentiality still crosses.
+
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = makeProtectedRuntime(storageManager);
+    try {
+      const srcDocId = await seedLabeledDoc(
+        runtime,
+        spaceA,
+        "s1c-protected-src",
+        "37.77,-122.41",
+        [{
+          path: [],
+          label: {
+            integrity: ["gps-reading"],
+            confidentiality: ["space-a-secret"],
+          },
+        }],
+      );
+
+      const tx = runtime.edit();
+      const src = runtime.getCell(spaceA, "s1c-protected-src", undefined, tx);
+      const sink = runtime.getCell(
+        spaceB,
+        "s1c-protected-sink",
+        {
+          type: "object",
+          properties: { ref: { type: "string" } },
+          required: ["ref"],
+        } as const satisfies JSONSchema,
+        tx,
+      );
+      sink.set({ ref: src as unknown as string });
+      tx.prepareCfc();
+      expect((await tx.commit()).error).toBeUndefined();
+
+      const sinkDocId = parseLink(sink.getAsLink()).id!;
+      const doc = readDoc(storageManager, spaceB, sinkDocId);
+      const entries = entriesFor(doc, ["ref"]);
+      expect(entries).toHaveLength(1);
+      const entry = entries[0];
+      expect(entry.origin).toBe("link");
+      expect(entry.label.integrity).toContain("gps-reading");
+
+      // Matched on `type` alone rather than through `isLinkReference`: that
+      // guard narrows `source` and `target` to the plaintext `{space, id,
+      // path}` record, and under this dial they are `{digestOf}` markers, so
+      // the narrowed type would describe a shape this atom does not have.
+      const linkRef = (entry.label.integrity ?? []).find((atom) =>
+        typeof atom === "object" && atom !== null &&
+        (atom as { type?: unknown }).type ===
+          "https://commonfabric.org/cfc/atom/LinkReference"
+      ) as { source: unknown; target: unknown } | undefined;
+      expect(linkRef).toBeDefined();
+      // Both endorsement endpoints persisted as digest markers…
+      expect(isCfcFieldCommitment(linkRef!.source)).toBe(true);
+      expect(isCfcFieldCommitment(linkRef!.target)).toBe(true);
+      // …and each digest is of the edge that was actually written.
+      expect(
+        commitmentAwareEquals(linkRef!.source, {
+          space: spaceA,
+          id: srcDocId,
+          path: [],
+        }),
+      ).toBe(true);
+      expect(
+        commitmentAwareEquals(linkRef!.target, {
+          space: spaceB,
+          id: sinkDocId,
+          path: ["ref"],
+        }),
+      ).toBe(true);
+      // A digest of a different edge does not match, so the check above is
+      // testing the digest rather than the marker shape.
+      expect(
+        commitmentAwareEquals(linkRef!.source, {
+          space: spaceB,
+          id: srcDocId,
+          path: [],
+        }),
+      ).toBe(false);
       expect(entry.label.confidentiality).toContain("space-a-secret");
     } finally {
       await runtime.dispose();

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -412,12 +412,12 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
     });
 
     it("with flow labels off, the Wave-2 grow-only ratchet folds the stronger stored entry back in", async () => {
-      // The dual pin: under the default cfcFlowLabels:"off" the legacy
-      // ratchet merges prior confidentiality into the fresh entry, so the
-      // confidentiality half of §8.12.1 cannot regress on this path — which
-      // is why the gate's confidentiality tests run under flow persist.
+      // The dual pin: under cfcFlowLabels:"off" the legacy ratchet merges
+      // prior confidentiality into the fresh entry, so the confidentiality
+      // half of §8.12.1 cannot regress on this path — which is why the
+      // gate's confidentiality tests run under flow persist.
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = makeRuntime({ storageManager });
+      const runtime = makeRuntime({ storageManager, cfcFlowLabels: "off" });
       const seeder = makeRuntime({
         storageManager,
         cfcEnforcementMode: "disabled",
@@ -497,7 +497,10 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
 
     it("a real mode change after prepare invalidates the prepared decision", async () => {
       const storageManager = StorageManager.emulate({ as: signer });
-      const runtime = makeRuntime({ storageManager });
+      const runtime = makeRuntime({
+        storageManager,
+        cfcDeclaredMonotonicity: "off",
+      });
       try {
         const tx = runtime.edit();
         const cell = runtime.getCell(

--- a/packages/runner/test/cfc-label-metadata-protection-dial.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection-dial.test.ts
@@ -12,7 +12,7 @@ const signer = await Identity.fromPassphrase(
 
 describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   // Inv-12 Stage 1 (SC-25): the `cfcLabelMetadataProtection` dial —
-  // `off | observe | enforce`, default `off` — following the established dial
+  // `off | observe | enforce`, default `enforce` — following the established
   // plumbing (cfcWriteFloor / cfcPolicyEvaluation): RuntimeOptions → per-tx
   // threading at edit() → CfcTxState, with the anti-downgrade pin (once
   // `enforce`, weakening throws) and prepared-state invalidation on a real
@@ -28,18 +28,18 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
     });
   };
 
-  it("defaults to off and threads the option onto each transaction", () => {
-    const offRuntime = makeRuntime();
+  it("defaults to enforce and threads the option onto each transaction", () => {
+    const defaultRuntime = makeRuntime();
+    const defaultTx = defaultRuntime.edit();
+    expect(defaultTx.getCfcState().labelMetadataProtectionMode).toBe(
+      "enforce",
+    );
+    defaultTx.abort();
+
+    const offRuntime = makeRuntime("off");
     const offTx = offRuntime.edit();
     expect(offTx.getCfcState().labelMetadataProtectionMode).toBe("off");
     offTx.abort();
-
-    const enforceRuntime = makeRuntime("enforce");
-    const enforceTx = enforceRuntime.edit();
-    expect(enforceTx.getCfcState().labelMetadataProtectionMode).toBe(
-      "enforce",
-    );
-    enforceTx.abort();
 
     const observeRuntime = makeRuntime("observe");
     const observeTx = observeRuntime.edit();
@@ -65,7 +65,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   });
 
   it("allows raising below the pin and pins at the first enforce", () => {
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     // off → observe → off: no pin yet, juggling allowed.
     tx.setCfcLabelMetadataProtectionMode("observe");
@@ -80,7 +80,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   it("delegates through TransactionWrapper to the wrapped transaction", () => {
     // The wrapper forwards every dial setter; the new one must reach the
     // wrapped tx (and its pin) identically.
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     const wrapper = new TransactionWrapper(tx);
     wrapper.setCfcLabelMetadataProtectionMode("enforce");
@@ -92,7 +92,7 @@ describe("CFC label-metadata protection dial (inv-12 Stage 1)", () => {
   });
 
   it("invalidates a prepared transaction on a real mode change", () => {
-    const runtime = makeRuntime();
+    const runtime = makeRuntime("off");
     const tx = runtime.edit();
     tx.markCfcRelevant("test");
     tx.prepareCfc();

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -348,7 +348,9 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
       // flipped holds verbatim foreign entries; flipping to enforce commits
       // only NEW cross-space entries — no rewrite of the existing ones —
       // and consumers dispatch on the marker shape, so both forms coexist.
-      const { storageManager, runtime } = makeRuntime(undefined);
+      // The pre-flip world is staged with the dial pinned off; the flipped
+      // half raises the same runtime's dial per transaction below.
+      const { storageManager, runtime } = makeRuntime("off");
       try {
         const sourceId = await seedSource(runtime, spaceA, "mixed-source");
         const targetName = "mixed-target";
@@ -616,9 +618,9 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
   });
 
   describe("off", () => {
-    it("persists bytes identical to a runtime without the option", async () => {
+    it("persists bytes identical across two runtimes pinned off", async () => {
       const offRun = makeRuntime("off");
-      const defaultRun = makeRuntime(undefined);
+      const defaultRun = makeRuntime("off");
       try {
         for (const { runtime } of [offRun, defaultRun]) {
           const sourceId = await seedSource(runtime, spaceA, "off-source");

--- a/packages/runner/test/cfc-labelmap-components.test.ts
+++ b/packages/runner/test/cfc-labelmap-components.test.ts
@@ -78,10 +78,14 @@ describe("CFC labelMap component origins", () => {
 
   it("skips the labelMap write when recomputed metadata is unchanged", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the no-op envelope elision over declared entries;
+    // flow persist would mint derived stamps beside them and rewrite the
+    // envelope, so the flow dial stays off.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "off",
     });
     try {
       const guarded = internSchema(

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -50,10 +50,13 @@ const makeRuntime = (options: {
   storageManager: ReturnType<typeof StorageManager.emulate>;
   cfcPrefixProvenanceStats?: boolean;
 }): Runtime =>
+  // The subject here is the D4 precision counters; the value-side write
+  // floor (which the mint-less sinks would fail) stays off.
   new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager: options.storageManager,
     cfcEnforcementMode: "enforce-explicit",
+    cfcWriteFloor: "off",
     ...(options.cfcPrefixProvenanceStats !== undefined
       ? { cfcPrefixProvenanceStats: options.cfcPrefixProvenanceStats }
       : {}),

--- a/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
+++ b/packages/runner/test/cfc-prepare-crash-surfacing.test.ts
@@ -335,6 +335,12 @@ describe("wish commit-prep failure surfacing (OW50 seat S-J)", () => {
         const runtime = new Runtime({
           apiUrl: new URL("https://example.com"),
           storageManager: manager,
+          // The subject is how a REFUSED commit surfaces through the wish.
+          // Seeding carries a labeled value into an undeclared container,
+          // which writer-fit refuses only at enforce-strict; the explicit
+          // rung persists-and-flags that measurement, so the refusals this
+          // suite pins are the ones its own fixtures stage.
+          cfcEnforcementMode: "enforce-explicit",
         });
         return {
           manager,

--- a/packages/runner/test/cfc-required-integrity-coherence.test.ts
+++ b/packages/runner/test/cfc-required-integrity-coherence.test.ts
@@ -137,10 +137,13 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
       required: unknown,
     ): Promise<{ ok: boolean; message?: string }> => {
       const storageManager = StorageManager.emulate({ as: signer });
+      // The subject here is the read-side coherence matcher; the value-side
+      // write floor (which the mint-less sinks would fail) stays off.
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
         cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "off",
       });
       try {
         for (const [index, witness] of witnesses.entries()) {
@@ -254,10 +257,13 @@ describe("CFC requiredIntegrity coherence (B5)", () => {
       readBAfterWrite: boolean,
     ): Promise<{ ok: boolean; message?: string }> => {
       const storageManager = StorageManager.emulate({ as: signer });
+      // The subject here is the read-side coherence matcher; the value-side
+      // write floor (which the mint-less sinks would fail) stays off.
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager,
         cfcEnforcementMode: "enforce-explicit",
+        cfcWriteFloor: "off",
       });
       try {
         for (const [index, witness] of [witnessA, witnessB].entries()) {

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -78,10 +78,13 @@ const SINK_SCHEMA = {
 describe("CFC requiredIntegrity provenance scoping (S7)", () => {
   it("a provenance-only read does not gate a requiredIntegrity write", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the read-side gate's S7 scoping; the value-side
+    // write floor (which the mint-less sink would fail) observes only.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcWriteFloor: "observe",
     });
     try {
       // A lookup doc whose stored label is entirely provenance: a link
@@ -121,10 +124,13 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     // (cfc-group-chat-demo multi-runtime: reading adminRegistry/everyoneIsAdmin
     // with label {} false-rejected the rooms-list admin write).
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the read-side gate's S7 scoping; the value-side
+    // write floor (which the mint-less sink would fail) observes only.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcWriteFloor: "observe",
     });
     try {
       await seedLabeledDoc(runtime, "ri-empty-lookup", "lookup", {});
@@ -154,10 +160,13 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     // it is a genuine data input, not provenance. This is what keeps the
     // cross-cell prompt-injection screen sound under the fix.
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the read-side gate's S7 scoping; the value-side
+    // write floor (which the mint-less sink would fail) observes only.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcWriteFloor: "observe",
     });
     try {
       await seedLabeledDoc(runtime, "ri-conf-src", "briefing", {
@@ -190,10 +199,13 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     // (non-provenance) integrity atom that isn't the required one must still
     // fail — provenance riding alongside real data must not launder it.
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the read-side gate's S7 scoping; the value-side
+    // write floor (which the mint-less sink would fail) observes only.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcWriteFloor: "observe",
     });
     try {
       await seedLabeledDoc(runtime, "ri-mixed-src", "data", {
@@ -234,10 +246,13 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
     // bypassed, the forged atom would persist AND satisfy that gate (the
     // commit below would succeed) — both assertions catch it.
     const storageManager = StorageManager.emulate({ as: signer });
+    // The subject here is the read-side gate's S7 scoping; the value-side
+    // write floor (which the mint-less sink would fail) observes only.
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcWriteFloor: "observe",
     });
     try {
       const seed = runtime.edit();

--- a/packages/runner/test/cfc-runtime-options.test.ts
+++ b/packages/runner/test/cfc-runtime-options.test.ts
@@ -7,14 +7,14 @@ import { Runtime } from "../src/runtime.ts";
 const signer = await Identity.fromPassphrase("runner-cfc-runtime-options");
 
 describe("CFC runtime options", () => {
-  it("defaults CFC enforcement to enforce-explicit", async () => {
+  it("defaults CFC enforcement to enforce-strict", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
     });
 
-    expect(runtime.cfcEnforcementMode).toBe("enforce-explicit");
+    expect(runtime.cfcEnforcementMode).toBe("enforce-strict");
 
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -982,6 +982,10 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
         // create-only mark, exactly the shape flushCfcGrantConsumptionClaims
         // stages — against a replica that has not observed any receipt.
         const remoteTx = new ExtendedStorageTransaction(remote.edit());
+        // The hand-staged claim must reach the server so the create-only
+        // precondition produces the permanent rejection; a raw transaction
+        // rides the strict defaults, which would reject it unprepared.
+        remoteTx.setCfcEnforcementMode("observe");
         remoteTx.writeOrThrow({
           space: signer.did(),
           id: receiptId,

--- a/packages/runner/test/cfc-trigger-read-gating.test.ts
+++ b/packages/runner/test/cfc-trigger-read-gating.test.ts
@@ -18,7 +18,7 @@ const signer = await Identity.fromPassphrase("runner-cfc-trigger-read-gating");
 
 // Epic H5 (§8.9.2 / SC-3): the addresses whose invalidating writes SCHEDULED a
 // reactive rerun (trigger reads) join the enforcement consumed set behind the
-// `cfcTriggerReadGating` flag (default off). Without it, a handler scheduled by
+// `cfcTriggerReadGating` flag. Without it, a handler scheduled by
 // a secret's write can egress to a ceiling'd sink — or write a
 // requiredIntegrity-floored target — without ever re-reading that secret, and
 // pass. The tests drive each gate with the flag OFF (passes today) and ON
@@ -46,6 +46,7 @@ const OUT_SCHEMA = internSchema(
 const makeRuntime = (opts: {
   storageManager: ReturnType<typeof StorageManager.emulate>;
   cfcTriggerReadGating?: boolean;
+  cfcFlowLabels?: "off" | "observe" | "persist";
   cfcSinkMaxConfidentiality?: SinkMaxConfidentiality;
 }) =>
   new Runtime({
@@ -55,6 +56,9 @@ const makeRuntime = (opts: {
     cfcSinkMaxConfidentiality: opts.cfcSinkMaxConfidentiality,
     ...(opts.cfcTriggerReadGating !== undefined
       ? { cfcTriggerReadGating: opts.cfcTriggerReadGating }
+      : {}),
+    ...(opts.cfcFlowLabels !== undefined
+      ? { cfcFlowLabels: opts.cfcFlowLabels }
       : {}),
   });
 
@@ -126,18 +130,23 @@ const scheduledEgress = (
 };
 
 describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
-  it("flag OFF (default): a scheduled egress that never re-reads the secret passes", async () => {
+  it("flag OFF: a scheduled egress that never re-reads the secret passes", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
+    // Both dials off: under flow persist the trigger reads reach the sink
+    // gate through the per-tx flow join, so the pre-gating channel this arm
+    // characterizes only exists with the flow dial off as well.
     const runtime = makeRuntime({
       storageManager,
+      cfcTriggerReadGating: false,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
       const secretId = await seedConfidential(runtime, "h5-off-secret");
       const tx = scheduledEgress(runtime, "h5-off-out", secretId);
       const result = await tx.commit();
-      // Today: the trigger read is not in the consumed set, so the public-only
-      // sink ceiling is not tripped.
+      // With gating off the trigger read is not in the consumed set, so the
+      // public-only sink ceiling is not tripped.
       expect(result.error).toBeUndefined();
     } finally {
       await runtime.dispose();
@@ -150,6 +159,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const runtime = makeRuntime({
       storageManager,
       cfcTriggerReadGating: true,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -173,6 +183,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const runtime = makeRuntime({
       storageManager,
       cfcTriggerReadGating: true,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -206,6 +217,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const runtime = makeRuntime({
       storageManager,
       cfcTriggerReadGating: true,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -247,6 +259,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const runtime = makeRuntime({
       storageManager,
       cfcTriggerReadGating: true,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {
@@ -300,6 +313,7 @@ describe("CFC trigger-read gating (H5, §8.9.2 / SC-3)", () => {
     const runtime = makeRuntime({
       storageManager,
       cfcTriggerReadGating: true,
+      cfcFlowLabels: "off",
       cfcSinkMaxConfidentiality: { fetchJson: [] },
     });
     try {

--- a/packages/runner/test/cfc-tx-state-contracts.test.ts
+++ b/packages/runner/test/cfc-tx-state-contracts.test.ts
@@ -15,6 +15,10 @@ describe("CFC tx state contracts", () => {
   // seams. All are part of the audit-S3 posture the read-only state view
   // (#4517) completes.
 
+  // The flow-labels and write-floor dials are pinned lax here so the
+  // strengthen and anti-downgrade tests exercise real transitions from the
+  // weak end.
+
   const withTx = async (
     fn: (runtime: Runtime, tx: ExtendedStorageTransaction) => Promise<void>,
   ) => {
@@ -23,6 +27,8 @@ describe("CFC tx state contracts", () => {
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "off",
+      cfcWriteFloor: "off",
     });
     try {
       await fn(runtime, runtime.edit() as ExtendedStorageTransaction);
@@ -116,7 +122,7 @@ describe("CFC tx state contracts", () => {
       });
       tx.prepareCfc();
       expect(tx.getCfcState().prepare.status).toBe("prepared");
-      tx.setCfcFlowLabelsMode("off"); // no change from default off → no-op
+      tx.setCfcFlowLabelsMode("off"); // no change from the pinned off → no-op
       expect(tx.getCfcState().prepare.status).toBe("prepared");
       tx.setCfcFlowLabelsMode("observe"); // real change → invalidate
       const flow = tx.getCfcState().prepare;

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -20,7 +20,8 @@ const signer = await Identity.fromPassphrase("runner-cfc-write-floor");
 // read-side gate (verifyInputRequirements) quantifies over consumed reads; the
 // floor tests the WRITTEN VALUE's integrity — schema `addIntegrity` mints,
 // carried link-view integrity, the flow hereditary meet — against the declared
-// floor. Dial `cfcWriteFloor: off | observe | enforce`, default off.
+// floor. Dial `cfcWriteFloor: off | observe | enforce`, default enforce; a
+// case below that names `off` is opting out of the floor it is characterizing.
 const ADMIN_ATOM = "admin-approved";
 const LLM_DERIVED_ATOM = {
   type: "https://commonfabric.org/cfc/atom/LlmDerived",
@@ -151,9 +152,9 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
-  it("dial off (the default): the same write commits — byte-compat", async () => {
+  it("dial off: the same write commits — byte-compat", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
-    const runtime = makeRuntime({ storageManager });
+    const runtime = makeRuntime({ storageManager, cfcWriteFloor: "off" });
     try {
       const tx = runtime.edit();
       const sink = runtime.getCell(

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -88,9 +88,9 @@ const makeRuntime = (options: {
     ...(options.cfcTriggerReadGating !== undefined
       ? { cfcTriggerReadGating: options.cfcTriggerReadGating }
       : {}),
-    ...(options.cfcWriteFloor !== undefined
-      ? { cfcWriteFloor: options.cfcWriteFloor }
-      : {}),
+    // The subject here is prefix-provenance measurement; unless an arm
+    // dials the floor itself, the value-side write floor stays off.
+    cfcWriteFloor: options.cfcWriteFloor ?? "off",
   });
 
 // Seed a doc's stored CFC metadata directly via an ungated path-[]

--- a/packages/runner/test/fetch-program-abandoned-takeover.test.ts
+++ b/packages/runner/test/fetch-program-abandoned-takeover.test.ts
@@ -101,6 +101,10 @@ describe("a refused fetchProgram takeover", () => {
     holder = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: holderStorage,
+      // The holder is the replica that does NOT enforce, which is what leaves
+      // the taker as the only commit that can be refused. Labels still flow
+      // and are still measured; nothing acts on the measurement.
+      cfcEnforcementMode: "observe",
     });
     taker = new Runtime({
       apiUrl: new URL(import.meta.url),

--- a/packages/runner/test/generate-object-outbox.test.ts
+++ b/packages/runner/test/generate-object-outbox.test.ts
@@ -302,7 +302,6 @@ describe("generateObject outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("generateObject retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
@@ -403,7 +402,6 @@ describe("generateObject outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("generateObject tool retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -69,9 +69,15 @@ describe("generateObject with tools", () => {
   beforeEach(() => {
     clearMockResponses(); // Clear mocks from previous tests
     storageManager = StorageManager.emulate({ as: signer });
+    // The suite characterizes the generateObject tool loop at the
+    // enforce-explicit, flow-off posture its recorded mocks were captured
+    // against; flow-derived labels change the redaction inputs and with
+    // them the request the mocks match on.
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "off",
     });
     tx = runtime.edit();
 

--- a/packages/runner/test/generate-text-outbox.test.ts
+++ b/packages/runner/test/generate-text-outbox.test.ts
@@ -183,7 +183,6 @@ describe("generateText outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("generateText retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();
@@ -260,7 +259,6 @@ describe("generateText outbox mechanism", () => {
 
     try {
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("llm retry regression");
       action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -143,7 +143,9 @@ describe("home favorites handlers", () => {
       tags: [],
       userTags: [],
     });
-    await tx.commit();
+    // A manual test tx must prepare (the runtime's own commit paths do).
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
     tx = runtime.edit();
     await runtime.idle();
     const seeded =

--- a/packages/runner/test/inspace-child-owner-write.test.ts
+++ b/packages/runner/test/inspace-child-owner-write.test.ts
@@ -219,6 +219,8 @@ describe("inSpace child owner-protected write (profile elements)", () => {
       // to `unsupported`.
       const writeTx = rt2.edit();
       childCell.withTx(writeTx).key("add").send({ item: "second" });
+      // A manual test tx must prepare (the runtime's own commit paths do).
+      rt2.prepareTxForCommit(writeTx);
       const writeCommit = await writeTx.commit();
       expect(writeCommit.error).toBeUndefined();
       await childCell.pull();

--- a/packages/runner/test/link-ifc-read-relevance.test.ts
+++ b/packages/runner/test/link-ifc-read-relevance.test.ts
@@ -59,7 +59,14 @@ describe("link-ifc-read-relevance", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    // The crossing seam is what this suite measures, so the flow-label
+    // machinery that marks relevance off persisted metadata is pinned off:
+    // a relevance mark here came from the crossing and nothing else.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcFlowLabels: "off",
+    });
     tx = runtime.edit();
     seq++;
   });
@@ -186,8 +193,8 @@ describe("link-ifc-read-relevance", () => {
     // The seam's non-redundant case. The target document carries no
     // stored cfc metadata and no label view — the ifc exists only as the
     // stored link schema's declaration — and the flow-label machinery
-    // that marks relevance off persisted metadata is at its default
-    // (off). Without the crossing seam, this read's transaction would
+    // that marks relevance off persisted metadata is pinned off.
+    // Without the crossing seam, this read's transaction would
     // stay non-relevant and enforcement would never engage for it.
     const holder = holderOverLinkCarrying(labeledLinkSchema);
 
@@ -219,7 +226,14 @@ describe("link-ifc-read-relevance at resolution and handle hops", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    // The crossing seam is what this suite measures, so the flow-label
+    // machinery that marks relevance off persisted metadata is pinned off:
+    // a relevance mark here came from the crossing and nothing else.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcFlowLabels: "off",
+    });
     tx = runtime.edit();
     seq++;
   });
@@ -331,7 +345,14 @@ describe("link-ifc-read-relevance closure, narrowing, and raw readers", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    // The crossing seam is what this suite measures, so the flow-label
+    // machinery that marks relevance off persisted metadata is pinned off:
+    // a relevance mark here came from the crossing and nothing else.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcFlowLabels: "off",
+    });
     tx = runtime.edit();
     seq++;
   });

--- a/packages/runner/test/llm-dialog.test.ts
+++ b/packages/runner/test/llm-dialog.test.ts
@@ -47,9 +47,14 @@ describe("llmDialog", () => {
   beforeEach(() => {
     clearMockResponses();
     storageManager = StorageManager.emulate({ as: signer });
+    // The suite characterizes the tool loop at enforce-explicit: several
+    // fixtures write labeled values into undeclared stores, which the
+    // strict writer-fit rejects while explicit persists-and-flags; the
+    // denial tests reject through requiredIntegrity under both.
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      cfcEnforcementMode: "enforce-explicit",
     });
     tx = runtime.edit();
 

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -263,9 +263,13 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
         );
         const secretId = cell.getAsNormalizedFullLink().id;
         const tx = runtime.edit();
+        // The store declares the taint it receives, so the write fits its
+        // own ceiling (§8.12.4) and the sink ceiling below is the gate this
+        // test is about.
         runtime.getCell<{ v: string }>(space, "posture-trigger-out", {
           type: "object",
           properties: { v: { type: "string" } },
+          ifc: { confidentiality: ["medical"] },
         }, tx).set({ v: "computed" });
         // The secret is recorded as what SCHEDULED this run; the run never
         // reads it again. Without the gating dial the consumed set would not
@@ -310,6 +314,7 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
           runtime.getCell<{ v: string }>(space, "posture-event-out", {
             type: "object",
             properties: { v: { type: "string" } },
+            ifc: { confidentiality: ["medical"] },
           }, tx).set({ v: "derived" });
           enqueueSinkRequestPostCommitEffect(
             tx,

--- a/packages/runner/test/navigate-handler.test.ts
+++ b/packages/runner/test/navigate-handler.test.ts
@@ -365,7 +365,6 @@ Deno.test(
       );
 
       const rejectedTx = runtime.edit();
-      rejectedTx.setCfcEnforcementMode("enforce-explicit");
       rejectedTx.markCfcRelevant("navigateTo retry regression");
       builtin.action(rejectedTx);
       const rejectedResult = await rejectedTx.commit();

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -149,6 +149,8 @@ describe("profile-create real card-add (REAL patterns, cross-space)", () => {
       profileCell.withTx(writeTx).key("addElement").send({
         title: "My Card",
       });
+      // A manual test tx must prepare (the runtime's own commit paths do).
+      rt2.prepareTxForCommit(writeTx);
       const writeCommit = await writeTx.commit();
       // The regression site. Pre-fix: "writeAuthorizedBy must remain stable".
       expect(writeCommit.error).toBeUndefined();

--- a/packages/runner/test/profile-home-bio.test.ts
+++ b/packages/runner/test/profile-home-bio.test.ts
@@ -76,6 +76,8 @@ describe("profile-home bio (owner-protected free-text field)", () => {
       result.withTx(tx2).key("setBio").send({
         bio: "Mathematician & first programmer.",
       });
+      // A manual test tx must prepare (the runtime's own commit paths do).
+      rt.prepareTxForCommit(tx2);
       const commit2 = await tx2.commit();
       expect(commit2.error).toBeUndefined();
       await result.pull();
@@ -88,6 +90,7 @@ describe("profile-home bio (owner-protected free-text field)", () => {
       result.withTx(tx3).key("setBio").send({
         bio: "  Countess of Lovelace.  ",
       });
+      rt.prepareTxForCommit(tx3);
       const commit3 = await tx3.commit();
       expect(commit3.error).toBeUndefined();
       await result.pull();

--- a/packages/runner/test/profile-home-pin-piece.test.ts
+++ b/packages/runner/test/profile-home-pin-piece.test.ts
@@ -95,6 +95,8 @@ describe("profile-home addPiece (followable piece card)", () => {
         pieceId: TARGET_PIECE,
         title: "Demo Counter",
       });
+      // A manual test tx must prepare (the runtime's own commit paths do).
+      rt.prepareTxForCommit(tx2);
       const commit2 = await tx2.commit();
       expect(commit2.error).toBeUndefined();
       await result.pull();

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -70,11 +70,15 @@ const profileSchema = (ownerDid: string): JSONSchema => ({
   required: ["name", "avatar", "elements"],
 });
 
+// Characterization posture: this suite drives the enforce-explicit era's
+// trusted-writer flow, so the runtime pins that enforcement mode and the
+// per-transaction raises to enforce-explicit stay no-ops.
 const createRuntime = () => {
   const storageManager = StorageManager.emulate({ as: alice });
   const runtime = new Runtime({
     apiUrl: new URL("https://example.com"),
     storageManager,
+    cfcEnforcementMode: "enforce-explicit",
   });
   return { runtime, storageManager };
 };

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -101,9 +101,16 @@ const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
   apiUrl: { treat: "per-site" },
   storageManager: { treat: "per-site" },
   experimental: { treat: "per-site" },
-  // Same value as the Runtime constructor default today; pinned so a changed
+  // Same values as the Runtime constructor defaults today (the strict end
+  // state of docs/specs/cfc-enforcement-matrix.md §3); pinned so a changed
   // constructor default cannot silently relax first-party environments.
-  cfcEnforcementMode: { treat: "core-pinned", value: "enforce-explicit" },
+  cfcEnforcementMode: { treat: "core-pinned", value: "enforce-strict" },
+  cfcFlowLabels: { treat: "core-pinned", value: "persist" },
+  cfcWriteFloor: { treat: "core-pinned", value: "enforce" },
+  cfcTriggerReadGating: { treat: "core-pinned", value: true },
+  cfcPolicyEvaluation: { treat: "core-pinned", value: "enforce" },
+  cfcLabelMetadataProtection: { treat: "core-pinned", value: "enforce" },
+  cfcDeclaredMonotonicity: { treat: "core-pinned", value: "observe" },
   // Deployment-facing runtimes point patterns at the deployment itself;
   // local presets keep the builder-env default (localhost fall-through).
   patternEnvironment: {
@@ -120,13 +127,7 @@ const MINIMAL_TREATMENT: Record<RuntimeOptionKey, MinimalTreatment> = {
   pieceCreatedCallback: { treat: "absent" },
   debug: { treat: "absent" },
   telemetry: { treat: "absent" },
-  cfcFlowLabels: { treat: "absent" },
-  cfcWriteFloor: { treat: "absent" },
-  cfcTriggerReadGating: { treat: "absent" },
   cfcDecomposedEnvelopes: { treat: "absent" },
-  cfcPolicyEvaluation: { treat: "absent" },
-  cfcLabelMetadataProtection: { treat: "absent" },
-  cfcDeclaredMonotonicity: { treat: "absent" },
   cfcPolicyRecords: { treat: "absent" },
   cfcPrefixProvenanceStats: { treat: "absent" },
   cfcTrustConfig: { treat: "absent" },
@@ -809,12 +810,13 @@ describe("runtimePresets conformance (CT-1814)", () => {
     });
 
     it("keeps the shared enforcement-mode pin out of the bundle", () => {
-      // Strict is a per-session host raise, not part of the bundle: the pin
-      // must come through unchanged so the raise below is the only way up.
+      // The enforcement mode is not part of the bundle: the shared core pin
+      // comes through unchanged, and a host session dial is the only thing
+      // that moves it.
       expect(Object.keys(MAX_ENFORCEMENT_CFC_OPTIONS))
         .not.toContain("cfcEnforcementMode");
       expect(postureOutputs.remoteClient.cfcEnforcementMode)
-        .toBe("enforce-explicit");
+        .toBe("enforce-strict");
     });
 
     it("lets a host session dial apply over the bundle", () => {
@@ -860,7 +862,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         ...posture,
       }));
       try {
-        expect(runtime.cfcEnforcementMode).toBe("enforce-explicit");
+        expect(runtime.cfcEnforcementMode).toBe("enforce-strict");
         expect(runtime.cfcFlowLabels).toBe("persist");
         expect(runtime.cfcWriteFloor).toBe("enforce");
         expect(runtime.cfcTriggerReadGating).toBe(true);
@@ -886,7 +888,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
       storageManager: emulated,
     }));
     try {
-      expect(runtime.cfcEnforcementMode).toBe("enforce-explicit");
+      expect(runtime.cfcEnforcementMode).toBe("enforce-strict");
     } finally {
       await runtime.dispose();
       await emulated.close();

--- a/packages/runner/test/stream-data-outbox.test.ts
+++ b/packages/runner/test/stream-data-outbox.test.ts
@@ -217,7 +217,6 @@ describe("stream-data outbox mechanism", () => {
     );
 
     const rejectedTx = runtime.edit();
-    rejectedTx.setCfcEnforcementMode("enforce-explicit");
     rejectedTx.markCfcRelevant("streamData retry regression");
     action(rejectedTx);
     const rejectedResult = await rejectedTx.commit();

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -3115,7 +3115,7 @@ describe("runtime-processor", () => {
           rootSchema,
         );
         const tx = runtime.edit() as any;
-        tx.setCfcEnforcementMode("enforce-explicit");
+        tx.setCfcEnforcementMode("enforce-strict");
         (root.withTx(tx) as any).set({
           messages: [{ piece: { id: "alice", body: "hello" } }],
         });
@@ -3260,13 +3260,13 @@ describe("runtime-processor", () => {
         );
 
         const seed = runtime.edit();
-        seed.setCfcEnforcementMode("enforce-explicit");
+        seed.setCfcEnforcementMode("enforce-strict");
         root.withTx(seed).set({ messages: [] });
         seed.prepareCfc();
         expect((await seed.commit()).ok).toBeDefined();
 
         const tx = runtime.edit();
-        tx.setCfcEnforcementMode("enforce-explicit");
+        tx.setCfcEnforcementMode("enforce-strict");
         root.withTx(tx).key("messages").push({
           piece: {
             id: "alice-message",
@@ -4914,8 +4914,8 @@ describe("runtime-processor", () => {
           >[2],
         ),
       );
-      expect(options.cfcEnforcementMode).toBe("enforce-explicit");
-      expect(options.cfcFlowLabels).toBeUndefined();
+      expect(options.cfcEnforcementMode).toBe("enforce-strict");
+      expect(options.cfcFlowLabels).toBe("persist");
     });
 
     it("threads the host-decided space-host map through to the runtime options", () => {

--- a/packages/shell/src/lib/render-ceiling.ts
+++ b/packages/shell/src/lib/render-ceiling.ts
@@ -1,17 +1,16 @@
 /**
- * Dogfood toggle for the CFC render confidentiality ceiling (Epic H3a,
+ * Per-profile toggle for the CFC render confidentiality ceiling (Epic H3a,
  * docs/history/plans/cfc-future-work-implementation.md §7). When enabled, the shell
  * creates its runtime with the §8.10.6 default display ceiling populated:
  * display sinks admit only the acting user's own identity atom plus
  * allow-listed influence-class caveat kinds, everything else fails closed,
  * and author-supplied render-boundary declassification is denied.
  *
- * Default OFF — this changes what the shell renders (expect over-blocking
- * until H3b adds exchange resolution), so it is enabled deliberately per
- * browser profile. The ceiling crosses the worker IPC in InitializationData,
- * which is fixed for a runtime's lifetime: unlike worker-console forwarding
- * there is no live apply — flipping the flag takes effect on the next
- * runtime (reload or re-login).
+ * Default ON; `commonfabric.cfcRenderCeiling(false)` opts a browser profile
+ * out. The ceiling crosses the worker IPC in InitializationData, which is
+ * fixed for a runtime's lifetime: unlike worker-console forwarding there is
+ * no live apply — flipping the flag takes effect on the next runtime
+ * (reload or re-login).
  *
  * Catalogued in docs/development/EXPERIMENTAL_OPTIONS.md (cfcRenderCeiling).
  */
@@ -27,18 +26,18 @@ type CommonfabricGlobal = typeof globalThis & {
 /** Whether the render ceiling is enabled for this browser profile. */
 export function isCfcRenderCeilingEnabled(): boolean {
   try {
-    return globalThis.localStorage?.getItem(STORAGE_KEY) === "true";
+    return globalThis.localStorage?.getItem(STORAGE_KEY) !== "false";
   } catch {
-    return false;
+    return true;
   }
 }
 
 function setCfcRenderCeiling(enabled: boolean): void {
   try {
     if (enabled) {
-      globalThis.localStorage.setItem(STORAGE_KEY, "true");
-    } else {
       globalThis.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      globalThis.localStorage.setItem(STORAGE_KEY, "false");
     }
   } catch (error) {
     console.error("[render-ceiling] Could not persist the setting:", error);
@@ -53,20 +52,21 @@ function setCfcRenderCeiling(enabled: boolean): void {
 
 /**
  * Install `commonfabric.cfcRenderCeiling(enabled?)`. Run once at boot, before
- * any runtime exists. Prints a hint only while the ceiling is ON: an active
- * ceiling can block content from rendering, so its presence must be
- * discoverable from the console; the default-off state stays silent.
+ * any runtime exists. Prints a hint only while the ceiling is OFF: the
+ * opted-out profile renders labeled content unbounded, so the reduced
+ * posture must be discoverable from the console; the default-on state stays
+ * silent.
  */
 export function setupCfcRenderCeilingToggle(): void {
   const global = globalThis as CommonfabricGlobal;
   const cf = (global.commonfabric ??= {});
   cf.cfcRenderCeiling = (enabled = true) => setCfcRenderCeiling(enabled);
 
-  if (isCfcRenderCeilingEnabled()) {
+  if (!isCfcRenderCeilingEnabled()) {
     console.info(
-      "[render-ceiling] CFC render ceiling is ON — labeled content outside " +
-        "the default display ceiling renders as blocked placeholders. " +
-        "Disable with commonfabric.cfcRenderCeiling(false).",
+      "[render-ceiling] CFC render ceiling is OFF for this profile — " +
+        "labeled content renders without display gating. Re-enable with " +
+        "commonfabric.cfcRenderCeiling().",
     );
   }
 }

--- a/packages/shell/test/host-toggles.test.ts
+++ b/packages/shell/test/host-toggles.test.ts
@@ -106,12 +106,12 @@ describe("isPatternCoverageEnabled", () => {
 });
 
 describe("runtimeHostFlags", () => {
-  it("defaults every flag to false", () => {
+  it("defaults every flag off except the default-on render ceiling", () => {
     const h = setup();
     try {
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: false,
-        cfcRenderCeiling: false,
+        cfcRenderCeiling: true,
         patternCoverage: false,
         concurrentWatchRefresh: false,
       });
@@ -124,6 +124,7 @@ describe("runtimeHostFlags", () => {
     const h = setup();
     try {
       h.storage.map.set("forwardWorkerConsole", "true");
+      h.storage.map.set("cfcRenderCeiling", "false");
       expect(runtimeHostFlags()).toEqual({
         forwardWorkerConsole: true,
         cfcRenderCeiling: false,

--- a/packages/shell/test/render-ceiling.test.ts
+++ b/packages/shell/test/render-ceiling.test.ts
@@ -92,24 +92,24 @@ function command(): (enabled?: boolean) => void {
 }
 
 describe("isCfcRenderCeilingEnabled", () => {
-  it('is false when the key is absent and true when set to "true"', () => {
+  it('is true when the key is absent and false only when set to "false"', () => {
     const h = setup();
     try {
-      expect(isCfcRenderCeilingEnabled()).toBe(false);
-      h.storage.map.set(STORAGE_KEY, "true");
       expect(isCfcRenderCeilingEnabled()).toBe(true);
-      h.storage.map.set(STORAGE_KEY, "yes");
+      h.storage.map.set(STORAGE_KEY, "false");
       expect(isCfcRenderCeilingEnabled()).toBe(false);
+      h.storage.map.set(STORAGE_KEY, "yes");
+      expect(isCfcRenderCeilingEnabled()).toBe(true);
     } finally {
       h.restore();
     }
   });
 
-  it("is false when reading localStorage throws", () => {
+  it("is true when reading localStorage throws", () => {
     const h = setup();
     try {
       h.storage.throwOnRead = true;
-      expect(isCfcRenderCeilingEnabled()).toBe(false);
+      expect(isCfcRenderCeilingEnabled()).toBe(true);
     } finally {
       h.restore();
     }
@@ -117,7 +117,7 @@ describe("isCfcRenderCeilingEnabled", () => {
 });
 
 describe("setupCfcRenderCeilingToggle", () => {
-  it("installs the command and stays silent while disabled (default posture)", () => {
+  it("installs the command and stays silent while enabled (default posture)", () => {
     const h = setup();
     try {
       setupCfcRenderCeilingToggle();
@@ -128,12 +128,12 @@ describe("setupCfcRenderCeilingToggle", () => {
     }
   });
 
-  it("prints the ON hint when already enabled", () => {
+  it("prints the OFF hint when the profile opted out", () => {
     const h = setup();
     try {
-      h.storage.map.set(STORAGE_KEY, "true");
+      h.storage.map.set(STORAGE_KEY, "false");
       setupCfcRenderCeilingToggle();
-      expect(h.info.join("\n")).toContain("is ON");
+      expect(h.info.join("\n")).toContain("is OFF");
     } finally {
       h.restore();
     }
@@ -141,29 +141,29 @@ describe("setupCfcRenderCeilingToggle", () => {
 });
 
 describe("commonfabric.cfcRenderCeiling", () => {
-  it("persists and notes the reload requirement when enabling", () => {
+  it("persists and notes the reload requirement when disabling", () => {
     const h = setup();
     try {
       setupCfcRenderCeilingToggle();
-      command()(); // default argument enables
-      expect(h.storage.map.get(STORAGE_KEY)).toBe("true");
+      command()(false);
+      expect(h.storage.map.get(STORAGE_KEY)).toBe("false");
       // The ceiling is fixed at runtime initialization — the toggle cannot
       // live-apply, so the confirmation must say when it takes effect.
-      expect(h.info.join("\n")).toContain("enabled");
+      expect(h.info.join("\n")).toContain("disabled");
       expect(h.info.join("\n")).toContain("next runtime");
     } finally {
       h.restore();
     }
   });
 
-  it("clears the key when disabling", () => {
+  it("clears the key when re-enabling", () => {
     const h = setup();
     try {
-      h.storage.map.set(STORAGE_KEY, "true");
+      h.storage.map.set(STORAGE_KEY, "false");
       setupCfcRenderCeilingToggle();
-      command()(false);
+      command()(); // default argument enables
       expect(h.storage.map.has(STORAGE_KEY)).toBe(false);
-      expect(h.info.join("\n")).toContain("disabled");
+      expect(h.info.join("\n")).toContain("enabled");
     } finally {
       h.restore();
     }
@@ -174,10 +174,10 @@ describe("commonfabric.cfcRenderCeiling", () => {
     try {
       setupCfcRenderCeilingToggle();
       h.storage.throwOnWrite = true;
-      command()(true);
+      command()(false);
       expect(h.errors.join("\n")).toContain("Could not persist");
       // The "enabled"/"disabled" confirmation is not logged on failure.
-      expect(h.info.join("\n")).not.toContain("enabled");
+      expect(h.info.join("\n")).not.toContain("disabled");
     } finally {
       h.restore();
     }

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -175,7 +175,7 @@ describe("RuntimeInternals navigation", () => {
       apiUrl: new URL("http://shell.test/"),
     });
 
-    expect(options.cfcEnforcementMode).toBe("enforce-explicit");
+    expect(options.cfcEnforcementMode).toBe("enforce-strict");
     expect(options.trustSnapshot).toEqual({
       id: `principal:${session.as.did()}`,
       actingPrincipal: session.as.did(),

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -51,7 +51,7 @@ Deno.test("toolshedRuntimeOptions splits MEMORY_URL/API_URL and honors the env r
     options.experimental?.serverExecution,
     SERVER_EXECUTION_DEFAULT_ENABLED,
   );
-  assertEquals(options.cfcEnforcementMode, "enforce-explicit");
+  assertEquals(options.cfcEnforcementMode, "enforce-strict");
 });
 
 Deno.test("createToolshedRuntime attaches the OTel bridge only when enabled", async () => {
@@ -141,9 +141,9 @@ Deno.test("createToolshedRuntime publishes the posture it resolved", async () =>
     // The CFC posture publishes alongside, from the same constructed Runtime
     // (lib/cfc-posture.ts): the preset core pin plus constructor defaults.
     const cfc = cfcPosture();
-    assertEquals(cfc?.enforcementMode.rung, "enforce-explicit");
-    assertEquals(cfc?.flowLabels.rung, "off");
-    assertEquals(cfc?.flowLabels.diagnosticOnly, true);
+    assertEquals(cfc?.enforcementMode.rung, "enforce-strict");
+    assertEquals(cfc?.flowLabels.rung, "persist");
+    assertEquals(cfc?.flowLabels.diagnosticOnly, false);
     assertEquals(cfc?.policyDigest, null);
     // Every known sink is named, none of them ceilinged: a server that has
     // configured nothing publishes ten ungated sinks rather than an empty


### PR DESCRIPTION
Contextual Flow Control moves from staged rollout to enforced default. The deployment-mode matrix's strict end state
(docs/specs/cfc-enforcement-matrix.md §3) becomes the default at every layer that names a CFC dial:

- The `Runtime` constructor and the type-level `DEFAULT_CFC_*` constants: `cfcEnforcementMode: enforce-strict`, `cfcFlowLabels: persist`, `cfcWriteFloor: enforce`, `cfcTriggerReadGating: true`, `cfcPolicyEvaluation: enforce`, `cfcLabelMetadataProtection: enforce`, and `cfcDeclaredMonotonicity: observe`. The constant flip also moves the fuse mount's fallback (no `--cfc-mode`, no `CF_CFC_MODE`) to enforce-strict.

  The monotonicity dial stops one rung short of `enforce` because per-principal `addIntegrity` mints — an `AuthoredByCurrentUser` claim resolving to a different acting principal on each write — are non-monotone declared updates by construction; the gate's own documentation stages `enforce` behind migrating those mints to the `derived` component. `observe` is its strictest sound rung today, and it emits the structured diagnostic the migration is measured by.
- `coreOptions` in runtime-presets.ts pins those seven dials at the same values, so a future constructor-default change cannot silently relax first-party processes. Host-controlled and per-test overrides on the presets stay as they were, so any environment can still be dialed back explicitly. `cfcDecomposedEnvelopes` keeps riding its constructor default, which this change does not move.
- The shell host defaults (lib-shell) name enforce-strict and turn the render confidentiality ceiling on: display sinks admit the §8.10.6 profile, with shared `Space(...)` principals resolved through the verified HasRole exchange rules. The per-profile `commonfabric.cfcRenderCeiling(false)` toggle becomes an opt-out (absent localStorage key now means on), and the boot hint prints for the opted-out profile instead of the enabled one.
- cf-harness defaults its run-level dial to enforce-strict. A run carrying a Loom run manifest that names no mode itself defaults to `observe` instead ("loom-default" in the mode-source vocabulary): Loom runs observe-and-report rather than deny. The fabric session's restated preset posture follows the new pins (enforce-strict, flow labels persist).
- The pattern-test harnesses (single-user `cf test`, the multi-user worker, and the generated-patterns scenario harness) hold `enforce-explicit`, one rung below the fleet pin: a test's assertions read labeled pattern values into unlabeled assertion cells, which the strict writer-fit rejects by design; explicit keeps that measurement as a persist-and-flag diagnostic while every other gate enforces. Individual tests can still opt into any mode.

Every dial keeps its full ladder, so any environment can be flipped back by naming a lower rung explicitly; only the defaults move.

The experimental-options registry, the enforcement-matrix state table (including the write floor's string-atom crediting limits and the mint-where-floored authoring rule), and the CFC posture notes in docs/how.md and the identity tutorial are updated to describe the new resting state.

The suites move with the defaults. Goldens that named the previous posture now name the new one: the preset conformance table, the cf-harness resolved-config and bare-engine states, the fabric session's preset-pin posture, the fuse mount fallback, the shell and lib-shell worker options, and the toolshed and runtime-client preset outputs. New cases pin what the flip introduces — the "loom-default" observe fallback, and the render ceiling's inverted per-profile semantics, where an absent key means on and the boot hint belongs to the opted-out profile. Characterization suites that describe a pre-flip rung pin that rung explicitly instead of riding the defaults, raw test transactions that commit CFC-relevant writes prepare first as the runtime's own commit paths do, and per-transaction raises the strict floor now refuses are dropped or pinned at construction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

