### PR TITLE
docs(topics): center the agent skill on verbs

### DIFF
--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -74,27 +74,24 @@ a default is the only one of them a board can grant itself.
 
 | stage | carries | state |
 | --- | --- | --- |
-| A | compatible updates: verb and event prose, the describe layer, `setTitle`, a compact `addTopic` result | landed in source |
+| A | compatible updates: verb and event prose, the describe layer, `setTitle`, a compact `addTopic` result | landed and deployed |
 | B | one rehearsed break, four items batched | landed and deployed |
 | C | items gated on platform work | designed for, not started |
 
 ### Stage A
 
-Landed. Every item passed the update gate as an ordinary deploy. `setTitle`
-went onto the topic's own output rather than the shared projection, which is
-the pattern every new verb follows until Stage B lands.
-
-Stage A is not yet deployed to the team board: no deployed topic carries a
-`setTitle` stream.
+Landed and deployed. Every item passed the update gate as an ordinary deploy.
+`setTitle` went onto the topic's own output rather than the shared projection,
+which is the pattern every new verb follows.
 
 ### Stage B
 
 Four items, batched into a single rehearsed migration rather than paying the
 rehearsal four times:
 
-All four landed together in #6143 and are deployed: the Estuary board and
-every one of its 125 topics run these patterns. They merged together or not at
-all, which is what batching a single rehearsed migration means.
+All four landed together in #6143 and are deployed: the Estuary board and every
+Topic on it run these patterns. They merged together or not at all, which is
+what batching a single rehearsed migration means.
 
 The migration itself is recorded in
 [`../history/topics-board-migration-2026-08-28.md`](../history/topics-board-migration-2026-08-28.md).
@@ -106,9 +103,10 @@ side's demand moved rather than of this board.
 
 1. **Narrow the board's `topics` demand and the topic's `mentionable`
    demand** to the fields above.
-2. **Require `agentName` on every verb**, retiring the unsigned legacy path and
-   with it the misattribution where an unsigned body edit leaves the previous
-   author's name on content they did not write.
+2. **Require `agentName` on every authored-content verb**, eliminating the
+   unsigned path and with it the misattribution where an unsigned body edit
+   leaves the previous author's name on content they did not write. The
+   reference-only `mention` and `unmention` calls carry no content attribution.
 3. **Retire `myName`, `setMyName`, `createdByName`, `authorName`** and their
    mirrors in results.
 4. **Open the `kind` value domains** on links and authors, which are closed

--- a/packages/patterns/baselines/topics/main.tsx/20260831T174843Z-iQFp3QQPN2zAkRuJ.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260831T174843Z-iQFp3QQPN2zAkRuJ.json
@@ -1,0 +1,368 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board publishes onward as each topic's\n`mentionable` entry — and `cf-code-editor` requires it there. Dropping it\ncosts no type error and silently empties every `@`-mention completion.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's durable topic list. `addTopic` appends here; direct writes\nare legitimate but unattributed, and a whole-array write forfeits the\nmergeability the verb's append keeps.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal.\n\nRequired, for the reason given on `AgentAuthoredEvent`: acceptance widens\ncompatibly and narrows only through a break, so tolerating an unsigned\ncreate is a tolerance that could never be withdrawn.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "description": "The topic's title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicDemand": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "The display name, which the board publishes onward as each topic's\n`mentionable` entry — and `cf-code-editor` requires it there. Dropping it\ncosts no type error and silently empties every `@`-mention completion.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "mentions": {
+            "default": [],
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "mentions",
+          "$NAME",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "description": "Coalesced to 0 for a cold or older topic whose derived path is absent,\nso the row itself never carries the mixed-version undefined.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Who filed the topic. A record without structured authorship materializes\nthe inert `{ kind: \"person\", name: \"\" }` default, which\n`topicAuthorLabel()` renders as `someone`."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.\n\nHeadless use: survey the whole board with one bounded read of `index` — a\nrow is its Topic, so select the row's own address alongside `title` and use\nthat canonical address as the piece for the Topic's reads and verbs.\nFile with `addTopic`, title and optional initial body in one call, then work\non the Topic directly: the body is its living document, the thread its\nappend-only deliberation. Sign every authored-content mutation with\n`agentName`; Fabric records the human principal behind the key, and the name\nsays which agent acted under it. Reference-only `mention` and `unmention`\ncalls carry no content signature.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "File a topic. The atomic unit takes the initial body with the title, so\nno reader observes a title-only halfway state and no follow-up `setBody`\nfinishes a create. Returns the created topic as its survey row — the\nreference plus the write-time facts the pattern resolved."
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The board's mention pivot, one row per topic: the topic, and the topics\nthat mention it. Published so a topic composed outside `addTopic` can be\nwired to the same table the board's own children read — the graph is\nderived once, here, and never per topic.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "The full-board survey surface: one bounded row per topic, carrying the\nscalars a survey reads. A row IS its topic, so a row's own address is the\ntopic's — `--select index[].@` reads it, and an index into this array is\nnot a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "description": "The same list, under the name the topic pattern's editor autocompletes\nover — what `addTopic` wires into each child as its mention universe.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile.",
+        "tier": "wrapper"
+      },
+      "topicCount": {
+        "description": "How many topics the board holds, nulls included.",
+        "type": "number"
+      },
+      "topics": {
+        "description": "The board's topics, in filing order, through the shape the board demands\nof them: the display scalars and the mention universe, and no verbs. A\ncaller that means to mutate a topic addresses the topic itself, where its\nown schema governs. Survey through `index` instead; read this when you\nalready know which topic you are expanding.",
+        "items": {
+          "$ref": "#/$defs/TopicDemand"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260831T181712Z-hoTDhhCHJzB2Umnc.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260831T181712Z-hoTDhhCHJzB2Umnc.json
@@ -1,0 +1,828 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's own topics list — the mention universe the body editor\nautocompletes over. A reference to the tracker's array, wired at creation\nand backfillable as a one-time link-bind. Absent, the editor simply offers\nno completions.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as append-only, point-in-time\n`addComment` records. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order: append-only point-in-time records, each\ncarrying its author snapshot and `sentAt`.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editingBody": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author\nsnapshot and `addedAt`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -38,11 +38,11 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   viewer's canonical `#profile` name/avatar and store a `{ kind: "person", … }`
   snapshot. There is no free-text “commenting as” field.
 - **Wish-free agent handlers.** CLI streams do not depend on profile wishes.
-  Blank `agentName` values reject the mutation, and the signature is carried in
-  the same event as the content, avoiding shared mutable attribution state.
-  During the deployed-schema migration, omission (distinct from an explicit
-  blank value) remains accepted for old callers; topic/comment attribution then
-  falls back to their hidden legacy `myName`.
+  Every authored-content verb requires a non-blank `agentName`, and the
+  signature is carried in the same event as the content, avoiding shared mutable
+  attribution state. `mention` and `unmention` carry no authored content, so
+  they take only the referenced piece; Fabric still retains the authenticated
+  principal behind the edge.
 - **Mergeable writes everywhere users collide**: comments, links, and topics are
   `push` appends; concurrent writers all land. The body and the title are single
   strings (whole-value conflict semantics), so both edit through an explicit
@@ -54,12 +54,11 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
   duplicate nor an application-level revision/CAS protocol. If Fabric cannot
   preserve history or safely arbitrate concurrent body writes, this dogfood
   surface should expose the framework gap rather than conceal it mechanically.
-- **Compatibility is temporary but honest.** The previous result contract made
-  `myName`, `createdByName`, and `authorName` observable, and its mutation
-  streams omitted `agentName`. Those surfaces remain deprecated but functional:
-  new structured writes mirror the legacy display strings, while old unsigned
-  topic/comment calls use `myName` and the other streams preserve their prior
-  behavior. New browser and agent callers never depend on them.
+- **Stored compatibility is explicit.** Durable records may lack a structured
+  author snapshot, so stored author fields remain optional or defaulted. Every
+  current authored-content verb writes structured attribution; the public result
+  and mutation contracts contain no mutable "current author" state or
+  display-name mirrors.
 - **`mentionable` is a structural reference, not derived data.** The board
   passes its own topics list at creation; the topic's body editor autocompletes
   `@`-mentions over it. Backfillable as a one-time link-bind on pieces created
@@ -155,18 +154,18 @@ lineage: Linear CT-1878, which this pattern exists to absorb).
 
 ## Headless / agent use
 
-Agents are first-class participants. **Deployed lag:** a live board can run an
-older pattern than this source — the Estuary team board does today — and an
-older schema silently discards fields it does not declare. Until a migration
-lands, `body`-at-create and the loud rejections described here may not be live
-on a given board; check `cf piece verbs`, whose listing carries the deployed
-pattern's source identity, before relying on either. Against a deployed board
-piece:
+Agents are first-class participants. Treat the running piece as authoritative:
+start with `cf piece describe --piece <piece>`,
+`cf piece verbs --piece <piece> --json`, and
+`cf call --piece <piece> <verb> --help --json`. The default verb listing is the
+contract surface; `--all` additionally shows UI wrappers and deprecated verbs.
+Against a deployed board piece:
 
 ```bash
-cf call --piece <board> addTopic \
+cf call --piece <board> \
+  --schema '{"properties":{"topic":{"$link":true}}}' addTopic \
   '{"title":"...","body":"the initial living document","agentName":"Sol"}'
-# -> { "result": { "topic": … } }: the topic this call created
+# -> { "result": { "topic": { "$link": "/of:fid1:..." } } }
 cf get --piece <board> topics --input \
   --select title,createdAt,lastActivityAt,commentCount
 cf call --piece <topic> addComment \
@@ -176,19 +175,25 @@ cf call --piece <topic> setBody \
 cf call --piece <topic> setTitle \
   '{"title":"a sharper name for the same attention","agentName":"Sol"}'
 cf call --piece <topic> addLink \
-  '{"kind":"pr","url":"https://github.com/org/repo/pull/123","label":"PR #123","agentName":"Sol"}'
+  '{"url":"https://github.com/org/repo/pull/123","kind":"pr","label":"PR #123","agentName":"Sol"}'
+cf call --piece <topic> mention '{"topic":"/of:fid1:other-topic"}'
+cf call --piece <topic> unmention '{"topic":"/of:fid1:other-topic"}'
 ```
 
-`addLink` still requires `kind` and `label` even though the handler would
-default them (`"web"`, the URL): the compat gate compares a verb's event schema
-in the result direction, where required-to-optional is refused, so the
-relaxation rides the next acknowledged schema break. `setTitle` renames with
-attribution — it stamps `titleUpdatedBy`/`titleUpdatedAt` and moves
+`addLink` requires `url` and `agentName`; `kind` defaults to `"web"`, and a
+blank or omitted `label` defaults to the URL. `setTitle` renames with
+attribution: it stamps `titleUpdatedBy`/`titleUpdatedAt` and moves
 `lastActivityAt`, so a renamed topic surfaces in the board's most-recent sort.
 It lives on the topic's direct interface rather than the shared `TopicPiece`
 projection: a holder's required demands are write-once, so a verb added to the
 projection every board embeds would refuse those boards' updates. Address the
 topic itself and the verb is there.
+
+`mention` and `unmention` take a canonical piece reference in the inline JSON
+event. The CLI recognizes the declared reference position and turns `/of:...`
+into the live piece link; neither verb takes `agentName` or returns a value. Do
+not use `-- --topic /of:...`: the schema-derived flag parses its declared object
+before reference resolution and rejects a bare address.
 
 **A full-board survey is one bounded read of `index`.** Each row IS the topic it
 describes, declared through a schema of scalar summaries (`title`, `createdAt`,
@@ -201,16 +206,17 @@ cf get --piece <board> index --step
 ```
 
 A row's own address is the address of the topic it describes — the one to pass
-as `--piece` for that topic's own reads and verbs. `--select index[].@` resolves
-it. An address names a position and a filtered array's survivors no longer say
-which positions they came from, so `@` and `--filter` do not combine: read the
-index, which the row schema keeps narrow enough to read whole, and pick the row
-you want.
+as `--piece` for that topic's own reads and verbs. Reading the `index` path with
+`--select @,title` resolves it. An address names a position and a filtered
+array's survivors no longer say which positions they came from, so `@` and
+`--filter` do not combine: read the index, which the row schema keeps narrow
+enough to read whole, and pick the row you want.
 
-The board input links to complete Topic objects, including bodies, threads, and
-handlers. Targeted headless discovery beyond the index should therefore combine
-an exact/range `--filter` with a concise `--select` instead of materializing the
-whole corpus:
+The board input is declared through `TopicDemand`: the card/index fields and
+reference-graph inputs, with no Topic verbs or full thread. Targeted headless
+discovery beyond the index should combine an exact/range `--filter` with a
+concise `--select`, then address one Topic directly for its body, comments,
+links, and verbs:
 
 ```bash
 cf get --piece <board> index --step \
@@ -219,8 +225,8 @@ cf get --piece <board> topics --input \
   --filter '.lastActivityAt >= <epoch-milliseconds>' \
   --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 cf get --piece <topic> comments --input \
-  --filter '.author.name == "Sol" or .authorName == "Sol"' \
-  --select sentAt,author.kind,author.name,authorName,body
+  --filter '.author.name == "Sol"' \
+  --select sentAt,author.kind,author.name,body
 cf get --piece <topic> links --input \
   --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
@@ -234,9 +240,11 @@ filter/map/lift expressions. The durable `topics --input` list remains evidence
 when the computed `index --step` read cannot materialize, but only a successful
 index row supplies a Topic's address.
 
-Every agent-authored mutation carries `agentName`; there is no preceding “set
-current name” call. Fabric's operation history retains the authenticated human
-principal, while the stored snapshot disambiguates which agent acted.
+Every agent-authored content mutation carries `agentName`; there is no preceding
+“set current name” call. Fabric's operation history retains the authenticated
+human principal, while the stored snapshot disambiguates which agent acted.
+Reference-only `mention` and `unmention` calls are not content authorship and
+carry no agent signature.
 
 **Every content verb returns what it recorded** — `mention` and `unmention` sit
 outside the claim: they record an edge, a reference with nothing resolved about
@@ -271,9 +279,7 @@ _update_: `bodyUpdatedBy`/`bodyUpdatedAt` stay unset.
 
 Invalid mutations **throw** instead of silently returning (verb contract rule
 4): an empty title, an empty comment body, a blank or non-http(s) link URL, and
-a blank `agentName` on any verb all surface as a failed call — a nonzero CLI
-exit — never as apparent success. An _omitted_ `agentName` remains the tolerated
-legacy-caller path on the verbs that predate signing; `setTitle` postdates it,
-so there the field is simply required. The UI composer wrappers keep their
-silent guards: an empty draft is a non-event in a composer, not a headless
+a blank `agentName` on an authored-content verb all surface as a failed call — a
+nonzero CLI exit — never as apparent success. The UI composer wrappers keep
+their silent guards: an empty draft is a non-event in a composer, not a headless
 mutation.

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -53,48 +53,18 @@ export type {
 } from "./topic.tsx";
 
 /**
- * What the board USES of a stored topic — its demand, not the topic's truth.
+ * What the board uses of a stored topic — its demand, not the topic's complete
+ * contract.
  *
- * Written by the consumer, which is the point: a holder writes down what it
- * reads or writes and the verbs it calls, never what the other pattern IS
- * ([designing verbs so they can change](../../../docs/plans/verb-evolution.md),
- * "a holder demands only what it uses"). This board calls NO topic verb, so
- * its demand names none — and once it names none, adding a verb to a topic
- * stops touching the board's shape at all.
+ * A holder names only the fields it reads and verbs it calls; see
+ * [designing verbs so they can change](../../../docs/plans/verb-evolution.md).
+ * This board calls no Topic verb, so the demand names none. Callers take a
+ * Topic's address from `index` and reach its verbs on the Topic itself.
  *
- * That is what keeps a verb NON-OPTIONAL. The alternative, and the reason
- * this type exists, is that a verb reachable through the board's projection
- * has to be declared optional there — a stream cannot carry a default, so
- * optional is the only form an older generation tolerates — and every
- * consumer then pays a maybe at the call site, whose obvious spelling
- * (`piece.verb?.send(...)`) skips in silence.
- *
- * The membership, measured rather than guessed. Seven fields the board
- * READS: the card list renders `title`, `body`, `commentCount`, `createdBy`
- * and `lastActivityAt`; `index` publishes `title`,
- * `createdAt`, `createdBy`, `commentCount`, `lastActivityAt` — the same
- * array declared through a narrower row schema, which is why a field it
- * names has to be demanded here to resolve at all; `crossrefTable` joins on
- * `mentions`; `cardsByActivity` sorts on `lastActivityAt`; `topicCount`
- * reads only a length.
- *
- * Eight members, then, because `[NAME]` is demanded for a reason none of
- * those readers show: the board hands this same array on as each topic's
- * mention universe, so the name has to survive the demand to reach the
- * editor. Counting only what the board reads is what nearly dropped it.
- * No verbs.
- *
- * `createdByName` is deliberately NOT among them, though the card once read
- * it. It is `topicAuthorLabel`'s fallback for a topic written before
- * structured authorship, and every one of the deployed board's 113 topics
- * carries a structured `createdBy.name`, so the fallback is reached by none
- * of them. Demanding it would write a field this plan retires into the one
- * schema that cannot drop it later.
- *
- * Every field carries a default, and that is load-bearing rather than
- * stylistic: a demanded path an older topic cannot produce makes the WHOLE
- * array unreadable, while a default materializes in its place and the read
- * succeeds. Measured, not inferred.
+ * The eight fields cover the card, compact index, activity sort, reference
+ * pivot, and mention autocomplete. Seven carry defaults so a missing path does
+ * not make the whole array unreadable. `createdAt` is the exception: the Topic
+ * pattern defaults its input and publishes that path unconditionally.
  */
 export interface TopicDemand extends TopicSummary {
   /** The display name, which the board publishes onward as each topic's
@@ -134,10 +104,8 @@ export interface AddTopicEvent {
 
 export interface AddTopicResult {
   /** The topic this call created — the piece itself, not a manufactured
-   * identifier. It reaches the caller as a link to the child, which the CLI
-   * renders as an address (`cf call --show-links`). A caller therefore
-   * addresses the new topic straight from the create, instead of filing it and
-   * then searching the board's index for the topic it just made.
+   * identifier. `cf call` can project the child link with a `$link` marker;
+   * the returned canonical reference composes directly into the next command.
    *
    * Declared through the index's row schema rather than the full `TopicPiece`,
    * and the narrowness is the contract: the declared schema bounds the default
@@ -159,12 +127,9 @@ export interface TopicIndexRow {
   title: string;
   createdAt: number;
 
-  /** Who filed the topic. A topic written without structured authorship
-   * materializes the declared default — the inert legacy sentinel
-   * `{ kind: "person", name: "" }` — so a blank name here means "unsigned",
-   * and there is nothing further to consult: the display-name mirror this
-   * once pointed at is retired, and `topicAuthorLabel` renders the sentinel
-   * as `someone`. */
+  /** Who filed the topic. A record without structured authorship materializes
+   * the inert `{ kind: "person", name: "" }` default, which
+   * `topicAuthorLabel()` renders as `someone`. */
   createdBy?: TopicAuthor | Default<{ kind: "person"; name: "" }> | undefined;
 
   /** Coalesced to 0 for a cold or older topic whose derived path is absent,
@@ -351,12 +316,14 @@ const cardsByActivity = lift(
  * for the team; PR workflows stay in GitHub and arrive here as links.
  *
  * Headless use: survey the whole board with one bounded read of `index` — a
- * row IS its topic, so a row's own address (`--select index[].@`) is what
- * that topic's reads and verbs take as the piece. File with `addTopic`,
- * title and optional initial body in one call, then work on the topic
- * directly: the body is its living document, the thread its append-only
- * deliberation. Sign every mutation with `agentName` — Fabric records the
- * human principal behind the key; the name says which agent acted under it.
+ * row is its Topic, so select the row's own address alongside `title` and use
+ * that canonical address as the piece for the Topic's reads and verbs.
+ * File with `addTopic`, title and optional initial body in one call, then work
+ * on the Topic directly: the body is its living document, the thread its
+ * append-only deliberation. Sign every authored-content mutation with
+ * `agentName`; Fabric records the human principal behind the key, and the name
+ * says which agent acted under it. Reference-only `mention` and `unmention`
+ * calls carry no content signature.
  */
 export interface TopicsOutput {
   [NAME]: string;

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -53,11 +53,9 @@ export interface AgentAuthoredEvent {
    * identity key. Fabric authenticates the write with that key; this says
    * which agent acted under it.
    *
-   * Required, and required from the start of a caller's life rather than
-   * eventually: acceptance can widen later but not narrow, so a verb that
-   * tolerates an unsigned call can never stop tolerating one without a break.
-   * Taking it here means the arrival of execution provenance can relax this
-   * to optional compatibly, which is the direction that costs nothing. */
+   * Required so every authored-content call carries structured attribution.
+   * Authenticated execution provenance can supersede the field by relaxing it
+   * to optional without breaking existing callers. */
   agentName: string;
 }
 
@@ -78,9 +76,7 @@ export interface AddLinkEvent extends AgentAuthoredEvent {
    * viewer's session. */
   url: string;
 
-  /** Display label. Optional, and a blank one falls back to the URL — the
-   * handler has always done that, and requiring the field only kept callers
-   * from relying on it. */
+  /** Display label. Optional, and a blank one falls back to the URL. */
   label?: string;
 }
 
@@ -96,8 +92,7 @@ export interface SetTitleEvent {
   title: string;
 
   /** The agent making this mutation, stored as structured attribution beside
-   * the write time. Required: this verb postdates the unsigned-caller era,
-   * so it carries no legacy fallback. */
+   * the write time. Required so every successful rename is attributed. */
   agentName: string;
 }
 
@@ -113,15 +108,12 @@ export interface MentionEvent {
   /** The piece to reference — the piece itself, not an address. Identity here
    * is the cell, so this is what a caller passes and what gets stored.
    *
-   * Declared through the ONE field every topic has rather than `unknown`, and
-   * the narrowness is what makes a non-reference CHEAP TO CATCH — not what
-   * catches it. An `asCell` payload is wrapped whole without validating what
-   * is behind it, so naming a property refuses nothing at the boundary: an
-   * address sent as text, which an inline CLI call argument produces by being
-   * parsed as plain JSON, arrives here as readily as a piece does. What the
-   * named property buys is a one-field read that tells the two apart —
-   * `topic.get()` is `undefined` for a value that is not a reference and an
-   * object for any piece — and `mention` spends it before storing anything.
+   * Declared through the one field every Topic has rather than `unknown`. The
+   * cell declaration marks this as a reference position, so the CLI resolves a
+   * canonical `/of:...` value from an inline JSON event into the live piece
+   * link. It also bounds the validation read: `topic.get()` is `undefined` for
+   * a value that is not a reference and an object for any piece, and `mention`
+   * checks it before storing anything.
    *
    * `title` is also the most this can safely name: this schema reaches every
    * topic in `mentionable`, so a property without a default would be demanded
@@ -169,9 +161,8 @@ export interface SetBodyResult {
    * whitespace-sensitive Markdown survived the round trip. */
   body: string;
 
-  /** Attribution written for this save. Both are absent when the caller sent
-   * no `agentName`: an unattributed save leaves the previous attribution
-   * standing rather than overwriting it. */
+  /** Attribution written for this save. A successful call includes both
+   * fields because `setBody` requires `agentName`. */
   bodyUpdatedBy?: TopicAuthor;
   bodyUpdatedAt?: number;
 }
@@ -192,13 +183,9 @@ export interface TopicComment {
    * array elements have stable entity identity; future editing addresses
    * elements by reference (`equals()`), not by a synthetic key.
    *
-   * Every comment written from now on carries one, because `addComment`
-   * requires a signature. Still OPTIONAL, and that is not a hedge: a comment
-   * stored by the unsigned path has no author, and a stored record type has to
-   * accept what is already stored. Requiring it here does not make old comments
-   * signed — it makes a deployed piece holding one impossible to update at all,
-   * which `deno task pattern-vintage` refuses rather than discovers in
-   * production. */
+   * Optional because durable Topics may contain a comment without structured
+   * authorship. Current `addComment` calls require `agentName` and always write
+   * this snapshot. */
   author?: TopicAuthor;
   body: string | Default<"">;
   sentAt: number | Default<0>;
@@ -236,8 +223,8 @@ export interface TopicInput {
 
   /** The board's own topics list — the mention universe the body editor
    * autocompletes over. A reference to the tracker's array, wired at creation
-   * like `myName` (and backfillable as a one-time link-bind on pieces created
-   * before it existed). Absent, the editor simply offers no completions. */
+   * and backfillable as a one-time link-bind. Absent, the editor simply offers
+   * no completions. */
   mentionable?: Writable<TopicMentionable[] | Default<[]>>;
 
   /** Where this topic's `[Label][key]` mentions point, keyed by the token that
@@ -464,28 +451,17 @@ export interface TopicPiece extends TopicSummary {
 
   /** Replace the living document whole — read it, revise it, write it back
    * complete; the body is one value with whole-value conflict semantics.
-   * Returns the persisted body and any attribution written. */
+   * Requires `agentName` and returns the persisted body with its attribution. */
   setBody: Stream<SetBodyEvent, SetBodyResult>;
 
   /** Reference another piece from this topic — the payload is the piece
-   * itself, stored as a reference. The browser equivalent is picking a
-   * completion in the body editor, which writes the same map.
-   *
-   * Required, like the verbs beside them. They were optional because a topic
-   * deployed before they existed carries neither, and a required property a
-   * piece cannot produce refuses its update — but an optional verb is its own
-   * defect: it pushes a maybe to every call site whose obvious spelling,
-   * `piece.verb?.send(...)`, skips in silence rather than failing. This change
-   * is already a rehearsed break that rewrites every topic, so the generation
-   * that lacked them does not survive it, and the reason for the optionality
-   * goes with it. */
+   * itself, stored as a reference. Takes no `agentName` and returns no value;
+   * Fabric retains the authenticated principal behind the edge. */
   mention: Stream<MentionEvent>;
 
   /** Stop referencing a piece: removes every `mention`-made entry naming it.
    * References made in the prose are retracted by editing the prose, not by
-   * this. Required on the projection for the same reason as `mention`, and
-   * the pair has to move together: a caller that can make a reference and
-   * only maybe retract it is the worse half of both contracts. */
+   * this. Takes no `agentName` and returns no value. */
   unmention: Stream<UnmentionEvent>;
 }
 
@@ -497,11 +473,12 @@ export interface TopicPiece extends TopicSummary {
  *
  * Durable conclusions get folded up into the body — revise it whole with
  * `setBody`; the thread holds the deliberation as append-only, point-in-time
- * `addComment` records. Sign every mutation with `agentName`: Fabric records
- * the human principal behind the key; the name says which agent acted under
- * it. The session-draft cells and `submit*` streams below belong to the
- * rendered page, not the headless contract — they read state only this
- * session holds.
+ * `addComment` records. Sign every authored-content mutation with `agentName`:
+ * Fabric records the human principal behind the key; the name says which
+ * agent acted under it. Reference-only `mention` and `unmention` calls carry
+ * no content signature. The session-draft cells and `submit*` streams below
+ * belong to the rendered page, not the headless contract — they read state
+ * only this session holds.
  */
 export interface TopicOutput extends TopicPiece {
   [UI]: VNode;
@@ -533,15 +510,9 @@ export interface TopicOutput extends TopicPiece {
    */
   referencesDraft: PerSession<Writable<TopicMentionRefMap>>;
 
-  /** Rename the topic. Lives on the direct interface rather than the shared
-   * `TopicPiece` projection, and the placement is the contract: a holder's
-   * required demands are write-once, so a required verb added to the
-   * projection every board embeds refuses those boards' updates unless an
-   * acknowledged break rewrites them. That is what `mention` above costs, and
-   * it is worth paying only for a verb the projection has to carry. A rename
-   * is a direct-address mutation with no place on the projection at all, so
-   * it never faces the question. Requires `agentName` and returns the
-   * persisted title with the attribution written. */
+  /** Rename the topic. Requires `agentName` and returns the persisted title
+   * with its attribution. This direct-address verb stays outside the board's
+   * narrow `TopicPiece` demand. */
   setTitle: Stream<SetTitleEvent, SetTitleResult>;
 
   /** Attribution of the last rename; unset until the first `setTitle`.
@@ -692,10 +663,10 @@ const LINK_KIND_ITEMS = [
 ];
 
 /** The one place a comment record is built and appended. The contract verb
- * and the browser composer both ride it, so the trim rule, the legacy-name
- * mirror, and the write-time stamp cannot drift between them. Callers guard
- * emptiness on their own terms first — the verb rejects, the composer
- * silently declines. Mergeable append: concurrent comments all land. */
+ * and the browser composer both ride it, so the trim rule, structured author,
+ * and write-time stamp cannot drift between them. Callers guard emptiness on
+ * their own terms first — the verb rejects, the composer silently declines.
+ * Mergeable append: concurrent comments all land. */
 export const appendComment = (
   comments: Writable<TopicComment[] | Default<[]>>,
   body: string,
@@ -1082,10 +1053,6 @@ export default pattern<TopicInput, TopicOutput>(
           rejectMutation("setBody", "agentName must be non-blank");
         const persisted = text ?? "";
         body.set(persisted);
-        // Every edit stamps. The unsigned path used to write the body and
-        // leave these alone, which left the PREVIOUS author's name sitting on
-        // content they did not write — a misattribution the verb reported as
-        // success.
         const bodyUpdatedAtValue = Date.now();
         bodyUpdatedBy.set(author);
         bodyUpdatedAt.set(bodyUpdatedAtValue);
@@ -1100,8 +1067,6 @@ export default pattern<TopicInput, TopicOutput>(
     const setTitle = action<SetTitleEvent, SetTitleResult>(
       ({ title: text, agentName }) => {
         const trimmed = (text ?? "").trim();
-        // No legacy fallback and no omission tolerance: this verb postdates
-        // the unsigned-caller era, so attribution is simply required.
         const author = topicAuthorFromAgent(agentName ?? "") ??
           rejectMutation("setTitle", "agentName must be non-blank");
         if (!trimmed) rejectMutation("setTitle", "title must be non-empty");

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -2,303 +2,209 @@
 name: topics
 description: Interact with the Common Fabric team's Topics board on Estuary through
   the Labs cf CLI. Use when reading, creating, or updating Topics; posting Topic
-  progress comments; or attaching pull request links to Topics.
+  progress comments; attaching pull request links; or adding references between
+  Topics.
 ---
 
 # Topics on Estuary
 
-Topics is the team's minimal issue tracker. This skill names the deployed board,
-its CLI surface, and the team's authorship and editorial conventions. For the
-general CLI map, use `skills/cf/SKILL.md`; for Topics semantics, the canonical
-source is `packages/patterns/topics/README.md` and the handlers in
-`packages/patterns/topics/main.tsx` and `packages/patterns/topics/topic.tsx`.
+Topics is the team's minimal issue tracker. This skill names the Estuary
+deployment, the deployed verb contract, and the team's authorship and editorial
+conventions. Use `skills/cf/SKILL.md` for the general CLI surface. The pattern's
+canonical semantics live in `packages/patterns/topics/README.md`; its verb
+contracts live in `packages/patterns/topics/main.tsx` and
+`packages/patterns/topics/topic.tsx`.
 
-## Deployment
+## Deployment and identity
 
-Run commands from the Labs repository root. This skill is intentionally specific
-to the current Estuary dogfood deployment:
+Run from the Labs repository root so `cf` uses that checkout:
 
 ```bash
-export TOPICS_BOARD_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
-export CF_IDENTITY="<exact path to the key your human user uses>"
+export CF_API_URL='https://estuary.saga-castor.ts.net'
+export CF_SPACE='topics-dev-476ea34f'
+export TOPICS_BOARD='/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
+export CF_IDENTITY='<exact path to the key your human user uses>'
 ```
 
-The board space is `topics-dev-476ea34f`. A topic URL has the same host and
-space, with the topic's `fid1:...` in place of the board fid.
+Use the same Estuary identity key as your human user. Do not mint an agent key,
+guess a key path, use another human's key, or use the publicly derivable
+`implicit trust` identity. If the exact path is not already explicit, ask.
 
-## Identity and authorship
+Every authored-content mutation carries `agentName` in the same event. Use one
+stable agent name, without decorating titles, labels, bodies, or comments with a
+second signature. Fabric retains the human principal authenticated by the key;
+Topics stores the agent name as structured content attribution.
 
-For now, use the same Estuary identity key as your human user. Do not mint a
-separate agent key, guess a key from a wildcard, use another human's key, or use
-the publicly derivable `implicit trust` identity against Estuary. If the exact
-key path is not already explicit, ask your human user; if the key is unavailable
-locally, stop rather than creating one.
+`mention` and `unmention` are the intentional exception: they record only a
+reference edge, take no `agentName`, and return no value.
 
-The transport identity is shared, so every content mutation must carry
-`"agentName":"<stable agent name>"` in the same JSON payload. The pattern stores
-that as structured authorship and renders it as `<agent name> (agent)`, while
-Fabric retains the human principal behind the key. Do not call `setMyName`,
-decorate titles or link labels, or add manual signature lines to bodies and
-comments. If your stable agent name is unclear, ask before writing.
+## Start from the deployed verbs
 
-Legacy boards and topics may still contain `myName`, `createdByName`, or
-`authorName`. The pattern temporarily mirrors those fields for consumers of the
-previous deployed schema. Treat them as output-only compatibility details: never
-set or copy them into agent mutations.
-
-## Reading Topics
-
-Bounded reads are a measured necessity, not a style preference: an unprojected
-board read transfers the whole board and filters client-side, and every listing
-appends a read-set commit to the space that scales with everything the read
-observed. Against a remote board that is megabytes of upload per survey and tens
-of seconds of wall clock, and it grows the space's database as a side effect.
-Survey through `index` and project with `--select`; expand one Topic at a time.
-
-Every read below names its target with `--url`, and that settles a choice the
-CLI otherwise offers two spellings of. `--input` reads a piece's arguments cell
-rather than its result cell; a canonical reference ending `#argument` selects
-that same cell, on the commands that take `--input`. A `--url` carries no
-canonical reference and its fragment is dropped rather than refused, so
-`--input` is the spelling that reaches the arguments cell in every example here.
-The suffix is what to reach for once an address from `--select @` is the target
-instead. `skills/cf/SKILL.md` says where each is accepted, and
-`docs/common/workflows/reading-and-writing.md` walks the difference.
-
-The current pattern exports `index` — a compact discovery result whose rows ARE
-the Topics, declared through scalar summaries, so one read surveys the whole
-board without expanding any Topic:
+The running piece is authoritative. Orient before mutating it:
 
 ```bash
-deno task cf get --url "$TOPICS_BOARD_URL" index --step
+cf piece describe --piece "$TOPICS_BOARD"
+cf piece verbs --piece "$TOPICS_BOARD" --json
+cf call --piece "$TOPICS_BOARD" addTopic --help --json
 ```
 
-A deployed board can run an older pattern without `index` — the read above
-erroring on an unknown path is the tell. Survey such a board through the durable
-`topics` input instead, projected immediately: an unprojected row follows the
-linked Topic and can include its body, comments, and handlers.
+Repeat `describe`, `verbs`, and `call <verb> --help --json` after selecting a
+Topic. `piece verbs` lists contract verbs by default; `--all` additionally shows
+UI wrappers and deprecated verbs. The board's published Topic rows deliberately
+contain no verbs: take a row's address and call that Topic directly.
+
+The current declared contract is:
+
+| Piece | Verb         | Input                                           | Declared result       |
+| ----- | ------------ | ----------------------------------------------- | --------------------- |
+| Board | `addTopic`   | `title`, optional `body`, `agentName`           | created `topic`       |
+| Topic | `addComment` | `body`, `agentName`                             | appended `comment`    |
+| Topic | `addLink`    | `url`, optional `kind` and `label`, `agentName` | appended `link`       |
+| Topic | `setBody`    | complete `body`, `agentName`                    | body and attribution  |
+| Topic | `setTitle`   | `title`, `agentName`                            | title and attribution |
+| Topic | `mention`    | Topic reference                                 | none                  |
+| Topic | `unmention`  | Topic reference                                 | none                  |
+
+## Discover and read
+
+Survey through the compact `index`. Its rows are Topics, and `@` asks for each
+row's canonical address without expanding its body, thread, or verbs:
 
 ```bash
-deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
-  --filter '.title != null' \
-  --select title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+cf get "$TOPICS_BOARD" index --step \
+  --select @,title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
 
-The title predicate keeps discovery output uniformly object-shaped by omitting
-valid null rows. Concise projection itself preserves nullable rows and follows
-declared nested arrays without exposing sibling fields.
+Keep discovery bounded. An unprojected board or durable `topics` read can follow
+every Topic into its body, thread, and verbs, transfer the whole graph, and
+append a read-set commit proportional to what it observed. Survey the projected
+`index`, then expand one Topic at a time.
 
-`--filter` is useful for exact field and range searches. It runs before
-`--select`, so a predicate can inspect a field that the result omits:
+Take the selected row's `$link` value unchanged as `TOPIC`; canonical references
+compose directly into later commands. The space prefix appears only when the
+reference's space differs from the command's target space, so never reconstruct
+or edit the emitted address.
 
-```bash
-# Find one Topic by exact title.
-deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
-  --filter '.title == "<exact title>"' \
-  --select title,lastActivityAt,commentCount
-
-# Find Topics active at or after an epoch-millisecond threshold.
-deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
-  --filter '.lastActivityAt >= 1785074400000' \
-  --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
-
-# Combine predicates for a narrower field search.
-deno task cf get --url "$TOPICS_BOARD_URL" topics --input \
-  --filter '.createdBy.name == "<name>" and .commentCount > 0' \
-  --select title,lastActivityAt,commentCount
-```
-
-Filtering preserves board order; it does not sort by activity. The predicate
-language supports paths, JSON literals, comparisons, boolean operators, and
-parentheses, but not substring, regex, sorting, or arbitrary jq programs. Use
-exact known fields or numeric ranges to shrink the corpus, then inspect the
-small result. Always combine a Topic-list filter with `--select`; filter alone
-returns every property of each match.
-
-Address a selected Topic by the address its own `index` row carries. Project
-that computed index to ask for it:
+Read one Topic's durable input before changing it:
 
 ```bash
-deno task cf get --url "$TOPICS_BOARD_URL" index --step \
-  --select @,title,lastActivityAt,commentCount
-export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
-deno task cf get --url "$TOPIC_URL" title --input
-deno task cf get --url "$TOPIC_URL" body --input
-deno task cf get --url "$TOPIC_URL" comments --input \
-  --select sentAt,author.kind,author.name,authorName,body
-deno task cf get --url "$TOPIC_URL" links --input \
+cf get --piece "$TOPIC" title --input
+cf get --piece "$TOPIC" body --input
+cf get --piece "$TOPIC" comments --input \
+  --select sentAt,author.kind,author.name,body
+cf get --piece "$TOPIC" links --input \
   --select kind,url,label,addedAt,addedBy.kind,addedBy.name
-
-# Search within a selected Topic's arrays.
-deno task cf get --url "$TOPIC_URL" comments --input \
-  --filter '.author.name == "<agent>" or .authorName == "<legacy name>"' \
-  --select sentAt,author.kind,author.name,authorName,body
-deno task cf get --url "$TOPIC_URL" links --input \
-  --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 
-A `--select` segment ending in `@` returns that position's address instead of a
-copy of what is behind it, which is what a following `cf call` needs. It does
-not compose with `--filter` — a filtered array's survivors no longer say which
-positions they came from — so ask for an address in its own unfiltered read:
+Use exact-field or range `--filter` predicates to narrow arrays, then project
+with `--select`. Do not combine an address marker with `--filter`: filtering
+changes positions, so a surviving row cannot carry its original address.
+
+Input reads are the durable source of truth. Use `--step` for computed results
+such as the board's `index` and a Topic's `commentCount`, `lastActivityAt`,
+`mentions`, or `referencedBy`.
+
+## Create and recover the address
+
+Mint one invocation session for the agent run. Replace every angle-bracketed
+invocation placeholder below with an id unique to that logical mutation, and
+reuse that id only to retry the same mutation. Create through the board and
+project the returned Topic to its address:
 
 ```bash
-deno task cf get --url "$TOPICS_BOARD_URL" index --step \
-  --select @,title
+export CF_INVOCATION_SESSION="$(cf invocation-session new)"
+CREATE="$(cf call --piece "$TOPICS_BOARD" \
+  --invocation '<unique-topic-create-id>' \
+  --schema '{"properties":{"topic":{"$link":true}}}' \
+  addTopic \
+  '{"title":"<title>","body":"<initial living document>","agentName":"Sol"}')"
+TOPIC="$(printf '%s\n' "$CREATE" | jq -r '.result.topic["$link"] // empty')"
 ```
 
-An index row IS its Topic, so the row's own address is the Topic's. Prefer it to
-the intermediate wrapper link stored in the board's topics array. Read the
-existing topic's input before changing it, especially its full body, comments,
-and links. Input reads are durable and do not need `--step`; use `--step` on
-result reads that must be current.
+When the result is present, carry `TOPIC` into the next command. Use JSON
+encoding or schema-derived flags for multiline Markdown; do not interpolate
+unescaped content into JSON.
 
-A board too old to publish `index` publishes `crossrefs` instead — the removed
-reference-graph result. Its rows carry a row-level `fid`, which is that board's
-address source, so it answers the same question. Search it by `.topic.title`
-rather than `.title`: the row-level `title` was added to `crossrefs` later than
-`index` was, so a board old enough to need this read is one whose rows do not
-have it, and `.topic.title` is the form that works on every generation that
-publishes `crossrefs` at all. On such a board this is the only address source,
-so reach for it there and nowhere else:
+Current Estuary calls have a known observation asymmetry: `addTopic` has both
+reported an error after committing and reported success without committing.
+Treat every call envelope as an observation, not proof of durable state. Read
+back after every mutation. For `addTopic`, use a distinctive title and compare
+the narrow board index before and after the call; if the result is uncertain,
+recover its `$link` there rather than blindly creating another Topic.
 
 ```bash
-deno task cf get --url "$TOPICS_BOARD_URL" crossrefs --step \
-  --filter '.topic.title == "<exact title>"' --select fid,topic.title
+cf get "$TOPICS_BOARD" index --step --select @,title
+cf get --piece "$TOPIC" title --input
 ```
 
-If `topics --input` is non-empty while neither computed read materializes, do
-not infer that the board is empty. The non-null rows from a compact
-`topics --input` search remain valid evidence, but the search does not expose a
-Topic's address, so report the materialization blocker rather than guessing one.
+Use one invocation session per agent run and an explicit invocation id per
+logical mutation. Retry an uncertain mutation only with that same session/id
+pair. The full retry and receipt model is in `skills/cf/SKILL.md` and
+`docs/common/verbs/over-the-cli.md`.
 
-## Creating and updating
-
-Create a topic through the board rather than deploying the Topic pattern
-directly:
+## Update through Topic verbs
 
 ```bash
-deno task cf call --url "$TOPICS_BOARD_URL" addTopic \
-  '{"title":"<title>","agentName":"<agent name>"}'
-deno task cf get --url "$TOPICS_BOARD_URL" index --step --select @,title
+cf call --piece "$TOPIC" --invocation '<unique-set-title-id>' setTitle \
+  '{"title":"<complete new title>","agentName":"Sol"}'
+cf call --piece "$TOPIC" --invocation '<unique-set-body-id>' setBody \
+  '{"body":"<complete revised body>","agentName":"Sol"}'
+cf call --piece "$TOPIC" --invocation '<unique-add-comment-id>' addComment \
+  '{"body":"<point-in-time update>","agentName":"Sol"}'
+cf call --piece "$TOPIC" --invocation '<unique-add-link-id>' addLink \
+  '{"url":"<PR URL>","kind":"pr","label":"<label>","agentName":"Sol"}'
 ```
 
-Redeploying a board's pattern (`setsrc`) is gated on schema compatibility: an
-ordinary deploy is REJECTED when a newly required field has no `Default<>`
-(`newly required argument field has no default`). Give the field a `Default<>`
-rather than reaching for the escape hatch — `setsrc` does expose
-`--dangerously-allow-incompatible-schema`, which skips the compatibility
-assertion entirely, and it is not yours to use against the real board without
-the team's explicit authorization. Rehearse any board pattern update against a
-writable copy first: `docs/development/space-clone-rehearsal.md`.
+`kind` defaults to `web`; a blank or omitted `label` defaults to the URL.
+Current authored-content verbs reject blank required content or attribution
+instead of reporting apparent success.
 
-`addTopic` returns the topic it created, so a board running this source hands
-back the new topic on the call itself, and the follow-up read is only a
-convenience. An older deployed `addTopic` returns nothing, and a board that old
-may also predate `index` — in which case the `crossrefs --step` lookup under
-"Reading Topics" is what works there. Establish which board you are talking to
-BEFORE creating anything: `cf piece verbs` reports the deployed pattern's source
-identity, and a create whose fid you then cannot find leaves a topic you cannot
-address. All handler arguments are JSON; encode multiline Markdown rather than
-passing an unescaped string.
+Verify the relevant durable input after each call (`title`, `body`, `comments`,
+or `links`). Use `--step` as a second check when the expected change is
+computed, such as a count or board-index row.
+
+A cross-Topic connection is a reference, not an address pasted into prose. Pass
+the canonical reference in the declared reference position; the CLI turns it
+into the live piece link the verb expects. Set `OTHER_TOPIC` to the `$link` from
+the index row for the Topic being referenced:
 
 ```bash
-deno task cf call --url "$TOPIC_URL" setBody \
-  '{"body":"<complete revised body>","agentName":"<agent name>"}'
-deno task cf call --url "$TOPIC_URL" addComment \
-  '{"body":"<point-in-time update>","agentName":"<agent name>"}'
-deno task cf call --url "$TOPIC_URL" addLink \
-  '{"kind":"pr","url":"<PR URL>","label":"<PR label>","agentName":"<agent name>"}'
-deno task cf get --url "$TOPIC_URL" commentCount --step
+export OTHER_TOPIC='<canonical /of:... address from another index row>'
+cf call --piece "$TOPIC" --invocation '<unique-mention-id>' mention \
+  "{\"topic\":\"$OTHER_TOPIC\"}"
+cf call --piece "$TOPIC" --invocation '<unique-unmention-id>' unmention \
+  "{\"topic\":\"$OTHER_TOPIC\"}"
 ```
 
-Each of these three returns the record it wrote — the appended comment or link,
-or the persisted body plus its attribution — which spares the verification read
-above. That result rides `plainResultReceipts`, on by default; only an explicit
-`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` discards it. The write happens either
-way, so treat an absent result as "not enabled here", never as "the mutation did
-not land".
+Use inline JSON for these reference events. The schema-derived `--topic` flag
+parses its declared object before reference resolution and therefore rejects a
+bare canonical address.
 
-Name mutations so an interrupted run can retry them safely: mint one invocation
-session per run
-(`export CF_INVOCATION_SESSION="$(deno task cf invocation-session new)"`) and
-pass `--invocation <your-key>` on mutating calls. A retry with the same pair
-settles on the original outcome instead of posting twice — the handler body
-re-runs, but nothing commits twice. The settled envelope also carries `receipt`,
-the address of the outcome, which `deno task cf get --piece <receipt id>` reads
-back later without re-invoking.
+`unmention` removes every `mention`-made edge to that Topic. References created
+inside the body are removed by editing the body. An `addLink` URL that resolves
+to a piece also contributes to the reference graph.
 
-The body is the living big-picture document. Replace it in place with the full
-revised body so a reader sees the current state without replaying the thread,
-while retaining the Topic's meaningful narrative and decisions. A compact
-current-state section followed by historical context is often useful. Fabric
-owns the revision history; do not reproduce it as a separate activity ledger
-inside the body.
+## Editorial conventions
 
-Comments are append-only, point-in-time progress records. Add one after a
-meaningful work increment to explain what changed, what was learned or decided,
-and what comes next; use the body for the synthesized narrative rather than
-trying to revise earlier comments.
+- Treat the body as the living big-picture document. Replace it whole with the
+  current state while preserving meaningful context and decisions. Fabric owns
+  revision history; do not duplicate it as an activity log.
+- Treat comments as append-only, point-in-time progress records. Record what
+  changed, what was learned or decided, and what comes next.
+- Add every relevant pull request explicitly with `addLink` and `kind: "pr"`;
+  mentioning a PR only in prose is not enough.
+- Use references for relationships between Topics. Do not rely on pasted fids or
+  prose scanning.
 
-Add every relevant pull request explicitly with `addLink` and `kind: "pr"`;
-mentioning it only in prose is not enough.
+## Production pattern updates
 
-A connection to another Topic is a **reference**, not a string. `mention` takes
-the piece itself, and `unmention` removes every entry naming that piece —
-writing the fid into the body does nothing, because nothing scans prose for
-addresses.
+Changing content through verbs is normal. Changing the board or Topic pattern
+source is a production migration over team-critical data. Before any `setsrc`,
+read `docs/development/space-clone-rehearsal.md` and the latest Topics migration
+record in `docs/history/topics-board-migration-2026-08-28.md`. Do not use
+`--dangerously-allow-incompatible-schema` without explicit team authorization.
 
-Reach them from the topic's own page rather than the CLI. An inline call
-argument is parsed as plain JSON, so an address written in one arrives as the
-string it looks like rather than as the topic it names: the call settles, and
-the reference it stored points at the text. Record a connection through the
-References card, whose @-mention picker hands the verb the piece.
-
-A person retracts one from the same place — the References card lists what was
-added this way, each row with a remove control. A mention written into the prose
-is not listed there: it is removed by editing the prose. Both are mergeable, so
-concurrent callers all land, and mentioning the same piece twice is still one
-edge — the graph asks whether anything names a topic, not how often. Each Topic
-publishes what it points at as `mentions`, and who points at it as
-`referencedBy` — both derived, so retracting a mention removes the edge and
-nothing is left behind in the target. An `addLink` whose URL names a piece also
-becomes a reference; one that names a web page stays a web page.
-
-## Persistence and computed results
-
-Topics handlers commit source writes before result recomputation. Verify bodies,
-comments, links, titles, and the board's topic list with `cf get ... --input`.
-To read `topicCount`, `index`, `commentCount`, `lastActivityAt`, or other
-computed results, use `cf get ... --step`. This keeps start, pull,
-recomputation, synchronization, read, and stop in one CLI runtime; a separate
-`piece step` process cannot carry session-scoped materialization into a later
-`cf get` process.
-
-An unstepped result read with stored raw data but unresolved required values
-exits nonzero and points to `--step`; it is not an empty or absent result. If
-`--step` itself reports that a required value did not materialize, use input
-reads to establish what committed, but do not claim result-dependent
-verification succeeded.
-
-## Troubleshooting
-
-- If initial CLI synchronization times out, no piece read or mutation ran.
-  Report the blocker; rerun only after Tailnet/API reachability or identity
-  authorization has been re-established.
-- If a mutation fails or times out after `invocation:` was announced on stderr,
-  the write may still have committed. Do not re-send it blind: re-invoke with
-  the same `--invocation` id under the same session — it deduplicates against a
-  committed outcome and executes fresh only if nothing landed.
-- If `topics --input` is non-empty while the board's fid index — `index --step`,
-  or `crossrefs --step` on a board that predates it — is empty or fails, do not
-  call the board empty. Preserve the input evidence and report the
-  result-materialization failure.
-- A compact transformed read of a present source exits nonzero when its value
-  cannot materialize and explicitly says the failure is not JSON `null`. A
-  printed `null` is a valid projected null or an absent optional source, not an
-  empty array or proof of no matches; use `--filter '.title != null'` when null
-  Topic rows are irrelevant.
-- Do not substitute `piece ls` for the board's topic list. Pieces created inside
-  handlers can be absent from that listing; `index --step` is the canonical fid
-  index — `crossrefs --step` on a board that predates it — with `topics --input`
-  as the durable fallback for everything except the fid.
+Do not substitute `piece ls` for the board index: handler-created Topics need
+not appear in the registry. If a deployed field or verb differs from this map,
+trust `piece describe`, `piece verbs`, and verb help, then update this skill in
+the same change that updates the deployment contract.


### PR DESCRIPTION
## Summary

- rewrite the Estuary Topics skill around deployed verb discovery, canonical piece references, structured `agentName` attribution, and verb-result composition
- document the current live call/result asymmetry, stable invocation identities, durable read-back, and no-blind-retry recovery for `addTopic`
- align the Topics README, verb-surface plan, and caller-facing pattern JSDoc with the shipped Stage B contract, including reference-only `mention`/`unmention` and optional link metadata
- record the two generated compatibility baselines required because caller-facing JSDoc is emitted into the pattern contract
- remove legacy author-field, old CLI, stale deployment-lag, and full-Topic-demand guidance

## Validation

- `deno task check-skill-facts`
- `deno task check-docs`
- `deno task cfcheck`
- `deno task pattern-compat` (353 evaluated patterns compatible; 91 without contracts)
- `deno task check-baselines-append-only`
- `deno fmt --check`
- `deno lint`
- `deno task cf test packages/patterns/topics/topics.test.tsx` (38 passed)
- `deno task cf test packages/patterns/topics/topics-rejections.test.tsx` (18 passed; 17 expected runtime rejections)
- `deno task cf test packages/patterns/topics/render-shape.test.tsx` (2 passed)
- `deno task cf test packages/patterns/topics/multi-user.test.tsx` (7 passed)
- read-only Estuary `piece describe` and bounded board-index smoke test (130 Topics)
- confirmed both new Topics baselines are structurally identical to their preceding contracts after removing `description`

No live Topics state was mutated by this change.
