### PR TITLE
fix(dashboard): keep the runner's directory away from the browser

### DIFF
--- a/packages/dashboard/test-runner.test.ts
+++ b/packages/dashboard/test-runner.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { dirname, join } from "@std/path";
 import { runDashboardTests, TEST_COMMANDS } from "./test/runner.ts";
 
 Deno.test("dashboard test runner isolates caches and stops after a failure", async () => {
@@ -24,17 +25,11 @@ Deno.test("dashboard test runner isolates caches and stops after a failure", asy
   assertEquals(calls, [
     {
       args: TEST_COMMANDS[0],
-      env: {
-        TMPDIR: "dashboard-test-cache",
-        DASHBOARD_CACHE_DIR: "dashboard-test-cache",
-      },
+      env: { DASHBOARD_CACHE_DIR: "dashboard-test-cache" },
     },
     {
       args: TEST_COMMANDS[1],
-      env: {
-        TMPDIR: "dashboard-test-cache",
-        DASHBOARD_CACHE_DIR: "dashboard-test-cache",
-      },
+      env: { DASHBOARD_CACHE_DIR: "dashboard-test-cache" },
     },
   ]);
   assertEquals(removed, ["dashboard-test-cache"]);
@@ -179,5 +174,180 @@ Deno.test("dashboard browser tests disable the Chromium sandbox in CI", async ()
   } finally {
     if (previous === undefined) Deno.env.delete("CI");
     else Deno.env.set("CI", previous);
+  }
+});
+
+/**
+ * The first half of the fixture standing in for a test command that leaves a
+ * process running behind it. Run as `deno eval`, it starts the second half
+ * with the script it is handed as an argument, and exits without waiting for
+ * it.
+ *
+ * That is what the browser task does: it launches Chrome, and Chrome's crash
+ * handler, zygote, and GPU processes are still running when the Deno process
+ * that launched Chrome exits. The second half inherits the environment the
+ * first half was given, which is how those helper processes come by whatever
+ * temporary directory the dashboard test runner hands its commands.
+ *
+ * Both halves are inline scripts importing nothing, so the isolated-deno
+ * lockfile helper does not apply: there is no module graph to freeze, and that
+ * helper waits for the child to exit, which is the moment this test needs to
+ * look at from the outside.
+ */
+const START_LEFTOVER_PROCESS = `
+new Deno.Command(Deno.execPath(), {
+  args: ["eval", Deno.args[0]],
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+}).spawn().unref();
+`;
+
+/**
+ * The second half of that fixture. It writes `ready`, waits for a byte, writes
+ * a file into the directory `TMPDIR` names, and reports that file as
+ * `wrote <path>`.
+ */
+const LEFTOVER_PROCESS = `
+const encoder = new TextEncoder();
+await Deno.stdout.write(encoder.encode("ready\\n"));
+if (await Deno.stdin.read(new Uint8Array(1)) === null) {
+  throw new Error("Standard input closed before the cue arrived");
+}
+const directory = Deno.env.get("TMPDIR");
+if (directory === undefined) throw new Error("TMPDIR names no directory");
+const path = directory + "/leftover-process-file";
+await Deno.writeTextFile(path, "");
+await Deno.stdout.write(encoder.encode("wrote " + path + "\\n"));
+`;
+
+/**
+ * Opens a conversation with the process the fixture leaves behind, over the
+ * standard input and standard output that the command it outlived handed down
+ * to it.
+ */
+function openLeftoverProcess(child: Deno.ChildProcess) {
+  const reader = child.stdout.getReader();
+  const writer = child.stdin.getWriter();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let pending = "";
+
+  /**
+   * Helper for `openLeftoverProcess()`, which returns the next line the
+   * leftover process wrote, and throws where standard output ends first.
+   */
+  async function readLine(): Promise<string> {
+    while (!pending.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) {
+        throw new Error(
+          `The leftover process ended after ${JSON.stringify(pending)}`,
+        );
+      }
+      pending += decoder.decode(value, { stream: true });
+    }
+    const end = pending.indexOf("\n");
+    const line = pending.slice(0, end);
+    pending = pending.slice(end + 1);
+    return line;
+  }
+
+  return {
+    /**
+     * Settles once the leftover process is running and has read its
+     * environment.
+     */
+    async started(): Promise<void> {
+      assertEquals(await readLine(), "ready");
+    },
+
+    /**
+     * Has the leftover process write a file into the temporary directory its
+     * environment names, and returns the path it wrote.
+     */
+    async writeIntoTemporaryDirectory(): Promise<string> {
+      await writer.write(encoder.encode("\n"));
+      const line = await readLine();
+      const prefix = "wrote ";
+      if (!line.startsWith(prefix)) {
+        throw new Error(`The leftover process said ${JSON.stringify(line)}`);
+      }
+      return line.slice(prefix.length);
+    },
+
+    /**
+     * Closes the cue, then reads standard output to its end, which the
+     * leftover process reaches as it exits.
+     */
+    async close(): Promise<void> {
+      await writer.close();
+      let done = false;
+      while (!done) ({ done } = await reader.read());
+      reader.releaseLock();
+    },
+  };
+}
+
+Deno.test("dashboard test runner cleans up after a command that leaves a process running", async () => {
+  const scratch = await Deno.makeTempDir({
+    prefix: "commontools-dashboard-runner-test-",
+  });
+  const cacheDirectory = join(scratch, "cache");
+  const temporaryDirectory = join(scratch, "temp");
+  await Deno.mkdir(cacheDirectory);
+  await Deno.mkdir(temporaryDirectory);
+  let leftover: ReturnType<typeof openLeftoverProcess> | undefined;
+  let written: string | undefined;
+  let caches = 0;
+
+  try {
+    const code = await runDashboardTests({
+      interrupts: [],
+      makeTempDirectory: () => Promise.resolve(cacheDirectory),
+      spawn: (args, env) => {
+        if (!args.includes("test-browser")) {
+          // A suite that runs no browser leaves a cache file behind, and
+          // nothing else.
+          const path = join(env.DASHBOARD_CACHE_DIR, `cache-${++caches}.json`);
+          return {
+            status: Deno.writeTextFile(path, "{}").then(() => ({ code: 0 })),
+            kill: () => {},
+          };
+        }
+        const child = new Deno.Command(Deno.execPath(), {
+          args: ["eval", START_LEFTOVER_PROCESS, LEFTOVER_PROCESS],
+          // The machine's own temporary directory sits underneath, and the
+          // runner's environment goes on top of it, which is how `Deno.Command`
+          // layers the two for the real commands.
+          env: { TMPDIR: temporaryDirectory, ...env },
+          stdin: "piped",
+          stdout: "piped",
+          stderr: "inherit",
+        }).spawn();
+        leftover = openLeftoverProcess(child);
+        return child;
+      },
+      removeDirectory: async (directory) => {
+        const leftoverProcess = leftover;
+        if (!leftoverProcess) throw new Error("The browser command never ran");
+        await leftoverProcess.started();
+        // `Deno.remove(directory, { recursive: true })`, the removal the runner
+        // performs, empties the directory and then removes it. Taking those two
+        // steps apart here holds open the window between them that CI reaches
+        // by chance, and gives the leftover process its turn inside it.
+        for await (const entry of Deno.readDir(directory)) {
+          await Deno.remove(join(directory, entry.name), { recursive: true });
+        }
+        written = await leftoverProcess.writeIntoTemporaryDirectory();
+        await Deno.remove(directory);
+      },
+    });
+
+    assertEquals(code, 0);
+    assertEquals(dirname(written!), temporaryDirectory);
+  } finally {
+    await leftover?.close();
+    await Deno.remove(scratch, { recursive: true });
   }
 });

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -70,7 +70,13 @@ export async function runDashboardTests(options: {
     (() => Deno.makeTempDir({ prefix: "commontools-dashboard-tests-" })))();
   const removeDirectory = options.removeDirectory ??
     ((path) => Deno.remove(path, { recursive: true }));
-  const env = { TMPDIR: directory, DASHBOARD_CACHE_DIR: directory };
+  // The dashboard's own caches are the only thing this directory holds. The
+  // runner removes it once the last command has finished, and what it waits
+  // for is the commands themselves. The browser command leaves Chrome's crash
+  // handler, zygote, and GPU processes running after it exits, and those write
+  // into whatever directory `TMPDIR` names, so `TMPDIR` keeps naming the
+  // machine's own temporary directory.
+  const env = { DASHBOARD_CACHE_DIR: directory };
   const interrupts = options.interrupts ?? INTERRUPTS;
   const addSignalListener = options.addSignalListener ?? Deno.addSignalListener;
   const removeSignalListener = options.removeSignalListener ??


### PR DESCRIPTION
The dashboard test runner makes one temporary directory, hands it to each of its three test commands, and removes it when the last one has finished. It handed that directory over twice: once as DASHBOARD_CACHE_DIR, and once as TMPDIR. The second of those is the one the browser reads. Chrome puts its profile and its crash-handler files under the directory TMPDIR names, and Chrome's crash handler, zygote, and GPU processes keep running after the Deno process that launched Chrome has exited, because they are re-parented rather than waited for. The runner has no way to wait for them: what it waits for is the command, and the command has already gone.

So the teardown ran against a directory those processes were still writing into. Removing a directory tree walks it, removing what it finds, and then removes the root. When one of those processes wrote during the walk, the root was no longer empty by the time the walk reached it, and the whole package was reported as failed with every test in it passing:

    error: Uncaught (in promise) Error: Directory not empty
    (os error 39): remove
    '/tmp/commontools-dashboard-tests-ad5ec7d59b498c49'
        at async runDashboardTests
        (packages/dashboard/test/runner.ts:120:5)

Only DASHBOARD_CACHE_DIR was ever needed. `dashboardCacheDirectory()` reads that variable first and falls back to TMPDIR only where it is absent, so the dashboard's caches were already following the one the runner set on purpose, and nothing else in the package reads TMPDIR. Dropping the TMPDIR entry leaves the runner's directory holding the dashboard's own caches and nothing else. Every process that writes there is one the runner waits for, which is what makes removing the directory safe. Chrome's files go to the machine's temporary directory instead, where the rest of the repository's browser tests already put theirs.

The test that covers this drives the runner with a stand-in for the browser command: a process that starts a second process and exits without waiting for it, the way the browser task exits while Chrome's helpers are still running. The second process inherits the environment the first one was given, which is how Chrome's helpers come by the runner's directory.

Hitting the window between the walk and the removal of the root by chance would be a flaky test, so the test takes the removal apart into the two steps it is made of. It empties the directory, gives the leftover process its turn, and then removes the root. The leftover process writes one file into whatever directory TMPDIR names it and reports the path back, so the test also says where that file landed.

Verified by running that test against the runner as it stood, where it failed with the error above ten times out of ten, and against the runner as it stands, where it passes unaltered twenty times out of twenty. The dashboard's own suite passes in full: all three commands, the browser one included, and the runner exits zero.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

