### PR TITLE
Read the compactor's key as the key it is

### DIFF
--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -59,7 +59,7 @@ import {
 } from "@commonfabric/test-support/records";
 import {
   ciSubmissionsPrefix,
-  parsePersonalKeyFile,
+  parseServiceAccountKey,
   storeBucket,
   storePrefix,
 } from "./test-records-config.ts";
@@ -586,7 +586,7 @@ async function main(): Promise<void> {
       );
       Deno.exit(2);
     }
-    const key = parsePersonalKeyFile(await Deno.readTextFile(keyPath));
+    const key = parseServiceAccountKey(await Deno.readTextFile(keyPath));
     if (key === undefined) {
       console.error(`${keyPath} is not a service-account key file`);
       Deno.exit(2);

--- a/tasks/test-records-config.test.ts
+++ b/tasks/test-records-config.test.ts
@@ -5,6 +5,7 @@ import {
   ciSubmissionsPrefix,
   localSubmissionsPrefix,
   parsePersonalKeyFile,
+  parseServiceAccountKey,
   storeBucket,
   storePrefix,
 } from "./test-records-config.ts";
@@ -45,6 +46,47 @@ describe("test-records-config", () => {
       expect(localSubmissionsPrefix("octocat", () => undefined)).toBe(
         "labs/test-records/submissions/local/octocat",
       );
+    });
+  });
+
+  describe("parseServiceAccountKey()", () => {
+    it("returns the key of an account that names no person", () => {
+      // The compactor writes on its own behalf, so its account carries no
+      // username to derive and its key file carries no field naming one.
+      const parsed = parseServiceAccountKey(JSON.stringify({
+        ...KEY,
+        client_email: "test-records-compactor@proj.iam.gserviceaccount.com",
+      }));
+      expect(parsed?.client_email).toBe(
+        "test-records-compactor@proj.iam.gserviceaccount.com",
+      );
+      expect(parsed?.private_key).toBe(KEY.private_key);
+    });
+
+    it("returns undefined for malformed JSON", () => {
+      expect(parseServiceAccountKey("{nope")).toBeUndefined();
+    });
+
+    it("returns undefined for a key missing a field it signs with", () => {
+      expect(parseServiceAccountKey(JSON.stringify({
+        client_email: KEY.client_email,
+        token_uri: KEY.token_uri,
+      }))).toBeUndefined();
+      expect(
+        parseServiceAccountKey(JSON.stringify({ ...KEY, private_key: "" })),
+      )
+        .toBeUndefined();
+      expect(
+        parseServiceAccountKey(JSON.stringify({ ...KEY, client_email: "" })),
+      )
+        .toBeUndefined();
+    });
+
+    it("returns undefined for any token endpoint but Google's", () => {
+      expect(parseServiceAccountKey(JSON.stringify({
+        ...KEY,
+        token_uri: "https://oauth2.example/token",
+      }))).toBeUndefined();
     });
   });
 

--- a/tasks/test-records-config.ts
+++ b/tasks/test-records-config.ts
@@ -7,7 +7,11 @@
  * infra-managed Actions variables.
  */
 
-import { type Environment, readEnv } from "@commonfabric/test-support/records";
+import {
+  type Environment,
+  readEnv,
+  type ServiceAccountKey,
+} from "@commonfabric/test-support/records";
 
 /** Canonical name of this repository in every record context. */
 export const REPO = "commontoolsinc/labs";
@@ -57,29 +61,25 @@ export function localSubmissionsPrefix(
 }
 
 /**
- * A personal key file is the service-account key JSON with one extra
- * field: the GitHub username the minting workflow issued it for, which
- * names the holder's own submissions folder.
+ * A personal key file is a service-account key with one extra field: the
+ * GitHub username the minting workflow issued it for, which names the
+ * holder's own submissions folder. The accounts that write on their own
+ * behalf rather than a person's — the compactor among them — hold a key
+ * with no such field, and are read as the service-account key they are.
  */
-export interface PersonalKeyFile {
-  client_email: string;
-  private_key: string;
-  token_uri: string;
+export interface PersonalKeyFile extends ServiceAccountKey {
   cf_username: string;
 }
 
 /**
- * The one token endpoint a personal key may name. The uploader sends a
- * signed assertion wherever this field points, so the parser accepts
- * exactly Google's HTTPS endpoint — the value every minted key carries —
- * and nothing else.
+ * The one token endpoint a key may name. A holder sends a signed
+ * assertion wherever this field points, so the parser accepts exactly
+ * Google's HTTPS endpoint — the value every minted key carries — and
+ * nothing else.
  */
 export const KEY_TOKEN_URI = "https://oauth2.googleapis.com/token";
 
-/** Parses a personal key file, returning undefined when it is not one. */
-export function parsePersonalKeyFile(
-  text: string,
-): PersonalKeyFile | undefined {
+function parsedObject(text: string): Record<string, unknown> | undefined {
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -87,24 +87,46 @@ export function parsePersonalKeyFile(
     return undefined;
   }
   if (typeof value !== "object" || value === null) return undefined;
-  const key = value as Record<string, unknown>;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Parses a service-account key file, returning undefined when it is not
+ * one.
+ */
+export function parseServiceAccountKey(
+  text: string,
+): ServiceAccountKey | undefined {
+  const key = parsedObject(text);
+  if (key === undefined) return undefined;
   if (
-    typeof key.client_email !== "string" ||
-    typeof key.private_key !== "string" ||
+    typeof key.client_email !== "string" || key.client_email.length === 0 ||
+    typeof key.private_key !== "string" || key.private_key.length === 0 ||
     key.token_uri !== KEY_TOKEN_URI
   ) {
     return undefined;
-  }
-  let username = key.cf_username;
-  if (typeof username !== "string" || username.length === 0) {
-    const match = key.client_email.match(/^test-records-gh-([^@]+)@/);
-    if (!match) return undefined;
-    username = match[1]!;
   }
   return {
     client_email: key.client_email,
     private_key: key.private_key,
     token_uri: KEY_TOKEN_URI,
-    cf_username: username as string,
   };
+}
+
+/** Parses a personal key file, returning undefined when it is not one. */
+export function parsePersonalKeyFile(
+  text: string,
+): PersonalKeyFile | undefined {
+  const key = parseServiceAccountKey(text);
+  if (key === undefined) return undefined;
+  const named = parsedObject(text)!.cf_username;
+  let username: string;
+  if (typeof named === "string" && named.length > 0) {
+    username = named;
+  } else {
+    const match = key.client_email.match(/^test-records-gh-([^@]+)@/);
+    if (!match) return undefined;
+    username = match[1]!;
+  }
+  return { ...key, cf_username: username };
 }


### PR DESCRIPTION
The compactor could not authenticate with its own credential. It read its key file with `parsePersonalKeyFile`, which is for the keys the minting workflow issues to people: it wants either a `cf_username` field, which the workflow adds and Google does not, or an account email of the form `test-records-gh-<username>@`, so that a key names the holder whose submissions folder it may write. The compactor writes on its own behalf, into an area no person owns, and its account is `test-records-compactor@`. A key minted for it therefore satisfies neither test, and every run ended at "is not a service-account key file" before reaching the store.

Nothing had caught this because the compactor has never been given a credential: the account and its grant are provisioned on an infra branch that has not landed, and the key that branch expects is minted by hand afterwards. So the failure was waiting on the first operator to try.

A personal key file is a service-account key with a field naming its holder, and the parsers now say so: `parseServiceAccountKey` reads the three fields a signed assertion needs, `parsePersonalKeyFile` is that plus the username, and the compactor uses the former. A key that names no person is now read as what it is rather than refused for not naming one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

