### PR TITLE
test(runner): pin what the conversion does with holes and with a cycle's path

### DIFF
--- a/packages/runner/test/convert-cells-to-links-arrays.test.ts
+++ b/packages/runner/test/convert-cells-to-links-arrays.test.ts
@@ -52,6 +52,7 @@ describe("convert-cells-to-links-arrays", () => {
   it("returns an explicit `undefined` member as a member, not a hole", () => {
     // The other side of the distinction. Without this, a conversion that
     // turned every `undefined` into a hole would satisfy the tests above.
+
     const dense: unknown[] = [1, undefined, 3];
     const result = convertCellsToLinks(dense as never) as unknown[];
 

--- a/packages/runner/test/convert-cells-to-links-arrays.test.ts
+++ b/packages/runner/test/convert-cells-to-links-arrays.test.ts
@@ -1,0 +1,61 @@
+/**
+ * A sparse array stays sparse across the conversion. A hole is not a member
+ * holding `undefined`, and the two are different values in this system: the
+ * conversion rebuilds every container it walks, so the rebuild is where the
+ * distinction is at risk of being flattened away.
+ *
+ * The assertions count own keys rather than comparing shapes, because
+ * `toEqual()` reads a hole and an `undefined` member as the same thing, and a
+ * test written that way would pass against a conversion that filled every
+ * hole.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { convertCellsToLinks } from "../src/cell.ts";
+
+/** Own index keys of `array`, which a hole does not contribute. */
+function presentIndexes(array: readonly unknown[]): number[] {
+  return Object.keys(array).map(Number);
+}
+
+describe("convert-cells-to-links-arrays", () => {
+  it("returns an array whose holes are still holes", () => {
+    const sparse: unknown[] = [1, , 3];
+
+    sparse[6] = "far";
+
+    const result = convertCellsToLinks(sparse as never) as unknown[];
+
+    expect(result.length).toBe(7);
+    expect(presentIndexes(result)).toEqual([0, 2, 6]);
+    expect(1 in result).toBe(false);
+  });
+
+  it("returns the members a sparse array does have, converted", () => {
+    const sparse: unknown[] = [{ n: 1 }, , { n: 3 }];
+
+    const result = convertCellsToLinks(sparse as never) as unknown[];
+
+    expect(result[0]).toEqual({ n: 1 });
+    expect(result[2]).toEqual({ n: 3 });
+  });
+
+  it("returns a hole for a hole nested inside a record", () => {
+    const nested = { list: [1, , 3] as unknown[] };
+    const result = convertCellsToLinks(nested as never) as { list: unknown[] };
+
+    expect(presentIndexes(result.list)).toEqual([0, 2]);
+  });
+
+  it("returns an explicit `undefined` member as a member, not a hole", () => {
+    // The other side of the distinction. Without this, a conversion that
+    // turned every `undefined` into a hole would satisfy the tests above.
+    const dense: unknown[] = [1, undefined, 3];
+    const result = convertCellsToLinks(dense as never) as unknown[];
+
+    expect(presentIndexes(result)).toEqual([0, 1, 2]);
+    expect(1 in result).toBe(true);
+  });
+});

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -76,6 +76,7 @@ describe("convert-cells-to-links-sharing", () => {
   it("returns a back-link naming the ancestor's own path, not the root's", () => {
     // The root case above cannot tell a path that was computed from one that
     // was assumed, its answer being the empty path either way.
+
     const inner: Record<string, FabricConvertibleValue> = { depth: 2 };
     const cyclic = { outer: { inner }, sibling: "untouched" };
 
@@ -112,6 +113,7 @@ describe("convert-cells-to-links-sharing", () => {
     // What this pins is that walking out of a subtree leaves the path as it
     // was found. A walk that carried the first branch's segments into the
     // second would name `left` somewhere under `right`.
+
     const left: Record<string, FabricConvertibleValue> = { side: "left" };
     const right: Record<string, FabricConvertibleValue> = { side: "right" };
 
@@ -136,6 +138,7 @@ describe("convert-cells-to-links-sharing", () => {
     // descended through behind would carry `items` into the path taken for a
     // cycle in the following member, where the object branch's sibling case
     // cannot reach.
+
     const inner: Record<string, FabricConvertibleValue> = { kind: "inner" };
     const cyclic = { items: ["x"], inner };
 
@@ -150,10 +153,31 @@ describe("convert-cells-to-links-sharing", () => {
     });
   });
 
+  it("returns a back-link at its own path after a conversion that threw", () => {
+    // Each call walks with state of its own. A conversion that throws part
+    // way leaves none of it behind for the next one, whose back-link paths
+    // are taken from where its own walk has reached.
+
+    expect(() => convertCellsToLinks({ bad: () => {} } as never)).toThrow();
+
+    const cyclic: Record<string, FabricConvertibleValue> = { kind: "after" };
+
+    cyclic.loop = cyclic;
+
+    const result = convertCellsToLinks({ outer: cyclic }) as {
+      outer: Record<string, unknown>;
+    };
+
+    expect(result.outer.loop).toEqual({
+      "/": { "link@1": { path: ["outer"] } },
+    });
+  });
+
   it("returns a back-link at its own depth after a deeper subtree was walked", () => {
     // The deep branch is walked first and must be fully unwound before the
     // shallow cycle's path is taken, so this fails where the first one does
     // not.
+
     const shallow: Record<string, FabricConvertibleValue> = { kind: "shallow" };
     const deep = { a: { b: { c: { d: "bottom" } } } };
 

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -72,4 +72,99 @@ describe("convert-cells-to-links-sharing", () => {
     // including a link naming the wrong path -- is a different answer.
     expect(result.self).toEqual({ "/": { "link@1": { path: [] } } });
   });
+
+  it("returns a back-link naming the ancestor's own path, not the root's", () => {
+    // The root case above cannot tell a path that was computed from one that
+    // was assumed, its answer being the empty path either way.
+    const inner: Record<string, FabricConvertibleValue> = { depth: 2 };
+    const cyclic = { outer: { inner }, sibling: "untouched" };
+
+    inner.back = inner;
+
+    const result = convertCellsToLinks(cyclic) as {
+      outer: { inner: Record<string, unknown> };
+      sibling: unknown;
+    };
+
+    expect(result.outer.inner.depth).toBe(2);
+    expect(result.outer.inner.back).toEqual({
+      "/": { "link@1": { path: ["outer", "inner"] } },
+    });
+    expect(result.sibling).toBe("untouched");
+  });
+
+  it("returns a back-link whose path names the array index it was reached through", () => {
+    const element: Record<string, FabricConvertibleValue> = { tag: "first" };
+    const cyclic = { items: [element] };
+
+    element.owner = element;
+
+    const result = convertCellsToLinks(cyclic) as {
+      items: Record<string, unknown>[];
+    };
+
+    expect(result.items[0]!.owner).toEqual({
+      "/": { "link@1": { path: ["items", "0"] } },
+    });
+  });
+
+  it("returns each of two sibling cycles at its own path", () => {
+    // What this pins is that walking out of a subtree leaves the path as it
+    // was found. A walk that carried the first branch's segments into the
+    // second would name `left` somewhere under `right`.
+    const left: Record<string, FabricConvertibleValue> = { side: "left" };
+    const right: Record<string, FabricConvertibleValue> = { side: "right" };
+
+    left.loop = left;
+    right.loop = right;
+
+    const result = convertCellsToLinks({ left, right }) as {
+      left: Record<string, unknown>;
+      right: Record<string, unknown>;
+    };
+
+    expect(result.left.loop).toEqual({
+      "/": { "link@1": { path: ["left"] } },
+    });
+    expect(result.right.loop).toEqual({
+      "/": { "link@1": { path: ["right"] } },
+    });
+  });
+
+  it("returns a back-link at its own depth after an array sibling was walked", () => {
+    // The array branch's own bookkeeping. A walk that left the index it
+    // descended through behind would carry `items` into the path taken for a
+    // cycle in the following member, where the object branch's sibling case
+    // cannot reach.
+    const inner: Record<string, FabricConvertibleValue> = { kind: "inner" };
+    const cyclic = { items: ["x"], inner };
+
+    inner.loop = inner;
+
+    const result = convertCellsToLinks(cyclic) as {
+      inner: Record<string, unknown>;
+    };
+
+    expect(result.inner.loop).toEqual({
+      "/": { "link@1": { path: ["inner"] } },
+    });
+  });
+
+  it("returns a back-link at its own depth after a deeper subtree was walked", () => {
+    // The deep branch is walked first and must be fully unwound before the
+    // shallow cycle's path is taken, so this fails where the first one does
+    // not.
+    const shallow: Record<string, FabricConvertibleValue> = { kind: "shallow" };
+    const deep = { a: { b: { c: { d: "bottom" } } } };
+
+    shallow.loop = shallow;
+
+    const result = convertCellsToLinks({ deep, shallow }) as {
+      shallow: Record<string, unknown>;
+    };
+
+    expect(result.shallow.loop).toEqual({
+      "/": { "link@1": { path: ["shallow"] } },
+    });
+  });
 });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`convertCellsToLinks()` rebuilds every container it walks. Two properties of
that rebuild had no test, and both are ones a change to how the walk carries
its state can break without any suite noticing.

**A sparse array's holes.** A hole is not a member holding `undefined`, and the
two are different values in this system. Nothing pinned that the conversion
keeps them apart.

**A back-link's path.** The one existing cycle test uses a root self-cycle,
whose answer is the empty path however the path was arrived at, so it cannot
tell a computed path from an assumed one. Nor did anything cover a path formed
through an array index, or a cycle reached after a sibling subtree had already
been walked.

## The gap, measured

Each row is a deliberately broken `convertCellsToLinks()` on this branch's
base, and the tests that catch it. **No pre-existing test in either file fails
under any of them** — that is the gap, rather than an impression of one.

| breakage | tests that catch it |
| --- | --- |
| the array branch fills holes with `undefined` | holes are still holes; hole nested inside a record |
| the array branch converts nothing | all four array tests |
| an `undefined` member becomes a hole | explicit `undefined` is a member |
| an ancestor records the root path | all five back-link path tests |
| the array recursion drops the index | back-link path names the array index |

Two of the path tests — sibling cycles, and a back-link after a deeper subtree
— pin a property this base holds structurally, since it copies a fresh path per
position and so cannot fail to restore one. They are written against a walk
that carries the path some other way, where restoring it is a thing that can be
got wrong.

## Assertions

The array tests count own index keys rather than comparing shapes. `toEqual()`
reads a hole and an `undefined` member as the same thing, so a test written
that way would pass against a conversion that filled every hole.

## Checks

`deno fmt --check`, `deno lint` and `deno task check` all clean, and the
`runner` suite passes.


## Coverage

The ratchet reports `packages/runner` above its baseline, and its own
attribution says why that is not this change: "Regression not attributable to
this PR's added lines: 9 line(s) across 2 unchanged file(s) that the baseline
run covered." Nothing here adds a source line, so no source line can have
become uncovered.

Two runs place it. The count this branch produces is the same both times, 5521,
and the baseline moved under it -- 5516, then 5514, as main advanced. Main's own
two runs therefore disagree by 2 on identical source, and this branch sits 5 to
7 above that, which is more than that jitter accounts for. The mechanism that
does account for it is the one the ratchet is known to be sensitive to: a new
test file repartitions the shards, so which shard reaches which line changes.
That moves attribution rather than coverage, and it does not settle on a
re-run.

Accepted rather than reset, so the debt stays named and scoped to one group:

ACCEPT_COVERAGE_DEBT: packages/runner +7 lines

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


