### PR TITLE
perf(runner): locality syncs load documents, not open-schema closures

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3270,8 +3270,15 @@ export class CellImpl<T extends FabricValue>
   ): void {
     if (!this.tx) throw new Error("Transaction required for setMetaRaw");
     // No await for the sync, just kicking this off, so we have the data to
-    // retry on conflict.
-    if (!this.#synced) this.sync();
+    // retry on conflict. The kick loads the DOCUMENT, not the cell's schema
+    // closure: a conflict retry needs the doc it rewrites local, while a
+    // cell here routinely carries an open schema (`true`), and a sync
+    // honoring one loads the cell's entire reachable graph — thousands of
+    // documents on a populated space — to protect one meta write.
+    if (!this.#synced) {
+      this.#synced = true;
+      this.asSchema(false).sync();
+    }
     const metaAddr = {
       space: this.#link.space,
       id: this.#link.id,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3270,14 +3270,26 @@ export class CellImpl<T extends FabricValue>
   ): void {
     if (!this.tx) throw new Error("Transaction required for setMetaRaw");
     // No await for the sync, just kicking this off, so we have the data to
-    // retry on conflict. The kick loads the DOCUMENT, not the cell's schema
-    // closure: a conflict retry needs the doc it rewrites local, while a
-    // cell here routinely carries an open schema (`true`), and a sync
+    // retry on conflict. A cell carrying a trivially-permissive schema
+    // (`true`/`{}`) kicks a DOCUMENT sync: a conflict retry needs the doc it
+    // rewrites local, such a schema is the absence of a bound, and a sync
     // honoring one loads the cell's entire reachable graph — thousands of
-    // documents on a populated space — to protect one meta write.
+    // documents on a populated space — to protect one meta write. Setup's
+    // derived-cell materialization reaches this with exactly those cells.
+    // A shaped schema keeps its own sync: its closure is a bounded
+    // declaration something reads through — a pattern's local `$ref`
+    // resolution rides it — and marking the cell synced without loading it
+    // starves that read.
     if (!this.#synced) {
-      this.#synced = true;
-      this.asSchema(false).sync();
+      if (
+        this.#link.schema !== undefined &&
+        ContextualFlowControl.isTrueSchema(this.#link.schema)
+      ) {
+        this.#synced = true;
+        this.asSchema(false).sync();
+      } else {
+        this.sync();
+      }
     }
     const metaAddr = {
       space: this.#link.space,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5352,7 +5352,22 @@ export class Runner {
     // Per-cell spans: `n` in the timing stats is the number of cells this
     // resume pre-synced, total/max its round-trip cost (spans overlap, so the
     // wall cost is bounded by the enclosing syncCellsForRunningPattern span).
-    await Promise.all(cells.map((c) => {
+    //
+    // A cell whose link carries a trivially-permissive schema (`true`/`{}`)
+    // is synced as the DOCUMENT it names, not as a declaration: such a
+    // schema is the absence of a bound, and a sync honoring one walks the
+    // target's whole reachable graph — on a populated space, thousands of
+    // documents to resume one piece. The pre-sync's job is locality: the
+    // values instantiation reads must be local so their reads do not enter
+    // the commit basis cold, and the doc itself provides that. The deep
+    // reach belongs to the argument link-target wave below, which follows
+    // declared schemas.
+    await Promise.all(cells.map((cell) => {
+      const link = cell.getAsNormalizedFullLink();
+      const c = link.schema !== undefined &&
+          ContextualFlowControl.isTrueSchema(link.schema)
+        ? cell.asSchema(false)
+        : cell;
       const cellSyncStart = performance.now();
       return Promise.resolve(c.sync()).finally(() =>
         logger.time(cellSyncStart, "start", "resumeCellSync")

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -342,6 +342,32 @@ function isReferenceOnlySchema(
   return false;
 }
 
+/**
+ * The form a resume pre-sync's cell wave syncs a cell in.
+ *
+ * A cell whose link carries a trivially-permissive schema (`true`/`{}`) is
+ * synced as the DOCUMENT it names, not as a declaration: such a schema is
+ * the absence of a bound, and a sync honoring one walks the target's whole
+ * reachable graph — on a populated space, thousands of documents to resume
+ * one piece. The pre-sync's job is locality: the values instantiation reads
+ * must be local so their reads do not enter the commit basis cold, and the
+ * doc itself provides that. A shaped or undeclared cell keeps its own sync —
+ * the deep reach belongs to the argument link-target wave, which follows
+ * declared schemas.
+ *
+ * Exported for its test: current authoring stamps declared schemas on every
+ * link it writes, so a wave carrying a trivially-permissive link is vintage
+ * data — deployed pieces wired by older writers — which a test cannot author
+ * through the current stack.
+ */
+export function documentBoundedResumeCell(cell: Cell<any>): Cell<any> {
+  const link = cell.getAsNormalizedFullLink();
+  return link.schema !== undefined &&
+      ContextualFlowControl.isTrueSchema(link.schema)
+    ? cell.asSchema(false)
+    : cell;
+}
+
 // The debug-name builders reuse the action's already-computed
 // `schedulerActionInstanceKey` as their uniquifying suffix instead of hashing
 // the same links a second time (one hashOf per action creation, not two). The
@@ -5352,22 +5378,8 @@ export class Runner {
     // Per-cell spans: `n` in the timing stats is the number of cells this
     // resume pre-synced, total/max its round-trip cost (spans overlap, so the
     // wall cost is bounded by the enclosing syncCellsForRunningPattern span).
-    //
-    // A cell whose link carries a trivially-permissive schema (`true`/`{}`)
-    // is synced as the DOCUMENT it names, not as a declaration: such a
-    // schema is the absence of a bound, and a sync honoring one walks the
-    // target's whole reachable graph — on a populated space, thousands of
-    // documents to resume one piece. The pre-sync's job is locality: the
-    // values instantiation reads must be local so their reads do not enter
-    // the commit basis cold, and the doc itself provides that. The deep
-    // reach belongs to the argument link-target wave below, which follows
-    // declared schemas.
     await Promise.all(cells.map((cell) => {
-      const link = cell.getAsNormalizedFullLink();
-      const c = link.schema !== undefined &&
-          ContextualFlowControl.isTrueSchema(link.schema)
-        ? cell.asSchema(false)
-        : cell;
+      const c = documentBoundedResumeCell(cell);
       const cellSyncStart = performance.now();
       return Promise.resolve(c.sync()).finally(() =>
         logger.time(cellSyncStart, "start", "resumeCellSync")

--- a/packages/runner/test/resume-presync-demand.test.ts
+++ b/packages/runner/test/resume-presync-demand.test.ts
@@ -65,4 +65,81 @@ describe("resume-presync-demand", () => {
 
     expect(syncedSchemas.filter((schema) => schema === false).length).toBe(1);
   });
+
+  it("derives from a linked document's real value under a document-bounded warm", async () => {
+    // The residual a document-bounded pre-sync accepts: a run may read a
+    // document the pre-sync did not warm. The commit machinery owns
+    // correctness there — a genuinely cold read of an existing document
+    // enters the commit basis at sequence zero and the engine rejects the
+    // commit, which compile-cache-writeback-conflict.test.ts pins on a
+    // cold replica end to end. This test pins the outcome from this side:
+    // with only the holder warmed as a document, the committed derivation
+    // is over the target's real value.
+    const otherSm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const otherRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: otherSm,
+    });
+    try {
+      // Another client authors a target document and a holder whose value
+      // links to it, settled server-side before this replica looks.
+      const authorTx = otherRuntime.edit();
+      const target = otherRuntime.getCell<{ value: number }>(
+        space,
+        "unwarmed-link-target",
+        undefined,
+        authorTx,
+      );
+      target.set({ value: 42 });
+      otherRuntime.getCell<{ value: number }>(
+        space,
+        "unwarmed-link-holder",
+        undefined,
+        authorTx,
+      ).set(target);
+      await authorTx.commit();
+      await otherSm.synced();
+
+      // This replica warms the holder as a document only — what the clamped
+      // pre-sync provides — so the link target is genuinely cold.
+      const holder = runtime.getCell<{ value: number }>(
+        space,
+        "unwarmed-link-holder",
+      );
+      await holder.asSchema(false).sync();
+
+      let runs = 0;
+      const result = await runtime.editWithRetry((tx) => {
+        runs++;
+        // The holder is local (the document-bounded sync above); the target
+        // its value links to is not, and this read observes that absence.
+        const seen = runtime.getCell<{ value: number }>(
+          space,
+          "unwarmed-link-target",
+          undefined,
+          tx,
+        ).get()?.value;
+        runtime.getCell<{ doubled: number }>(
+          space,
+          "derived-output",
+          undefined,
+          tx,
+        ).set({ doubled: (seen ?? 0) * 2 });
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(runs).toBeGreaterThan(0);
+      // The committed derivation is over the target's real value, not the
+      // absence the first run observed.
+      const committed = runtime.getCell<{ doubled: number }>(
+        space,
+        "derived-output",
+      );
+      await committed.sync();
+      expect(committed.get()).toEqual({ doubled: 84 });
+    } finally {
+      await otherRuntime.dispose();
+      await otherSm.close();
+    }
+  });
 });

--- a/packages/runner/test/resume-presync-demand.test.ts
+++ b/packages/runner/test/resume-presync-demand.test.ts
@@ -4,11 +4,43 @@ import { Identity } from "@commonfabric/identity";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
 import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { documentBoundedResumeCell } from "../src/runner.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 import type { JSONSchema } from "@commonfabric/api";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
 
 const signer = await Identity.fromPassphrase("resume presync demand");
 const space = signer.did();
+
+// A pattern whose resume wave carries both demand kinds. The lift mints a
+// derived cell per element — the topics board's pivot-table shape, whose
+// one derived cell owned every trivially-permissive selector the census
+// found — and the declared argument and result schemas put shaped reads on
+// the same wave.
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { lift, pattern, Writable } from 'commonfabric';",
+      "interface Row { anchor: unknown; doubled: number }",
+      "const rows = lift(({ items }: { items: { n: number }[] }): Row[] => {",
+      "  const out: unknown[] = [];",
+      "  for (const item of items) {",
+      "    if (!item) continue;",
+      "    out.push(Writable.for<Row>(item).set({ anchor: item, doubled: item.n * 2 }));",
+      "  }",
+      "  return out as Row[];",
+      "});",
+      "export default pattern<{ items: { n: number }[] }, { rows: Row[] }>(",
+      "  ({ items }) => {",
+      "    return { rows: rows({ items }) };",
+      "  },",
+      ");",
+    ].join("\n"),
+  }],
+};
 
 describe("resume-presync-demand", () => {
   // A sync honoring a trivially-permissive schema asks the server for the
@@ -48,6 +80,9 @@ describe("resume-presync-demand", () => {
     const tx = runtime.edit();
     cell.withTx(tx).setMetaRaw("slug", "kick", rawMetaWriteAuthorization);
     tx.abort("inspection only");
+    // The kick is deliberately unawaited in production; the test drains it
+    // so the pull is not still in flight when teardown closes the replica.
+    await sm.synced();
 
     // The kick fired for the document alone: the open schema the cell
     // carries never reaches a sync.
@@ -62,6 +97,8 @@ describe("resume-presync-demand", () => {
     bound.setMetaRaw("slug", "first", rawMetaWriteAuthorization);
     bound.setMetaRaw("slug", "second", rawMetaWriteAuthorization);
     tx.abort("inspection only");
+    // Same drain as above: the unawaited kick must settle before teardown.
+    await sm.synced();
 
     expect(syncedSchemas.filter((schema) => schema === false).length).toBe(1);
   });
@@ -141,5 +178,110 @@ describe("resume-presync-demand", () => {
       await otherRuntime.dispose();
       await otherSm.close();
     }
+  });
+
+  it("resumes trivially-permissive cells as documents and shaped cells as declared", async () => {
+    // Author a running pattern on a sibling replica, so this replica's
+    // start() is a genuine cold resume through the pre-sync cell wave —
+    // the second production site, in runner.ts.
+    const otherSm = EmulatedStorageManager.connectTo(server, { as: signer });
+    const otherRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: otherSm,
+    });
+    try {
+      const compiled = await otherRuntime.patternManager.compilePattern(
+        PROGRAM,
+        { space },
+      );
+      const authorTx = otherRuntime.edit();
+      const authored = otherRuntime.getCell<Record<string, unknown>>(
+        space,
+        "resume-wave-target",
+        compiled.resultSchema,
+        authorTx,
+      );
+      otherRuntime.run(authorTx, compiled, {
+        items: [{ n: 1 }, { n: 2 }, { n: 3 }],
+      }, authored);
+      await authorTx.commit();
+      await authored.pull();
+      await otherRuntime.settled();
+      await otherRuntime.patternManager.flushCompileCacheWrites();
+      await otherSm.synced();
+    } finally {
+      await otherRuntime.dispose({ closeStorage: false });
+    }
+
+    const resumed = await runtime.patternManager.compilePattern(PROGRAM, {
+      space,
+    });
+    const tx = runtime.edit();
+    const rc = runtime.getCell<Record<string, unknown>>(
+      space,
+      "resume-wave-target",
+      resumed.resultSchema,
+      tx,
+    );
+    await tx.commit();
+
+    // Only the resume's own syncs are under judgment.
+    syncedSchemas.length = 0;
+    await runtime.start(rc);
+    await runtime.idle();
+
+    // The guard the clamp holds: no sync the resume issues carries a
+    // trivially-permissive schema. Current authoring stamps declared
+    // schemas on every link, so nothing here rides the clamp itself — the
+    // unit case below pins that decision — and this pins the wave's whole
+    // demand staying bounded if some authoring path starts writing wide
+    // links again.
+    const trivial = syncedSchemas.filter((schema) =>
+      schema !== undefined && schema !== false &&
+      ContextualFlowControl.isTrueSchema(schema)
+    );
+    expect(trivial).toEqual([]);
+    // And the declared reads genuinely happened and kept their shapes.
+    expect(
+      syncedSchemas.some((schema) =>
+        typeof schema === "object" && schema !== null &&
+        !ContextualFlowControl.isTrueSchema(schema)
+      ),
+    ).toBe(true);
+  });
+
+  it("bounds a resume cell to its document exactly when its schema is trivially permissive", () => {
+    // The wave's per-cell decision, on the seam the wave maps every cell
+    // through. A trivially-permissive link is vintage data — deployed
+    // pieces wired by older writers — which the current authoring stack
+    // cannot be made to produce, so the decision is pinned here directly:
+    // `true` and `{}` are sent as the document, a shaped or undeclared
+    // cell keeps the sync its link declares.
+    const open = runtime.getCell(space, "clamp-open", true);
+    expect(documentBoundedResumeCell(open).getAsNormalizedFullLink().schema)
+      .toBe(false);
+
+    const empty = runtime.getCell(space, "clamp-empty", {});
+    expect(documentBoundedResumeCell(empty).getAsNormalizedFullLink().schema)
+      .toBe(false);
+
+    const shaped = runtime.getCell(
+      space,
+      "clamp-shaped",
+      {
+        type: "object",
+        properties: { n: { type: "number" } },
+      } as const,
+    );
+    expect(documentBoundedResumeCell(shaped).getAsNormalizedFullLink().schema)
+      .toEqual({
+        type: "object",
+        properties: { n: { type: "number" } },
+      });
+
+    const undeclared = runtime.getCell(space, "clamp-undeclared");
+    expect(
+      documentBoundedResumeCell(undeclared).getAsNormalizedFullLink().schema,
+    ).toBe(undefined);
   });
 });

--- a/packages/runner/test/resume-presync-demand.test.ts
+++ b/packages/runner/test/resume-presync-demand.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+import type { JSONSchema } from "@commonfabric/api";
+
+const signer = await Identity.fromPassphrase("resume presync demand");
+const space = signer.did();
+
+describe("resume-presync-demand", () => {
+  // A sync honoring a trivially-permissive schema asks the server for the
+  // cell's whole reachable graph. The two sites here exist for LOCALITY —
+  // having a document present before something writes or reads it — so each
+  // must ask for the document, never the closure. The spy records the schema
+  // every cell sync actually carries; the assertions are on what was asked,
+  // which is what decides the server's walk and the wire.
+  let server: ReturnType<typeof newSharedServer>;
+  let sm: EmulatedStorageManager;
+  let runtime: Runtime;
+  let syncedSchemas: (JSONSchema | undefined)[];
+
+  beforeEach(() => {
+    server = newSharedServer();
+    sm = EmulatedStorageManager.connectTo(server, { as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+    });
+    syncedSchemas = [];
+    const original = sm.syncCell.bind(sm);
+    sm.syncCell = ((cell, options) => {
+      syncedSchemas.push(cell.getAsNormalizedFullLink().schema);
+      return original(cell, options);
+    }) as typeof sm.syncCell;
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await sm.close();
+    await server.close();
+  });
+
+  it("kicks a document sync for a meta write, never the cell's open schema", async () => {
+    const cell = runtime.getCell(space, "meta-write-target", true);
+    const tx = runtime.edit();
+    cell.withTx(tx).setMetaRaw("slug", "kick", rawMetaWriteAuthorization);
+    tx.abort("inspection only");
+
+    // The kick fired for the document alone: the open schema the cell
+    // carries never reaches a sync.
+    expect(syncedSchemas).toContain(false);
+    expect(syncedSchemas).not.toContain(true);
+  });
+
+  it("kicks one document sync for repeated meta writes on one cell", async () => {
+    const cell = runtime.getCell(space, "meta-write-once", true);
+    const tx = runtime.edit();
+    const bound = cell.withTx(tx);
+    bound.setMetaRaw("slug", "first", rawMetaWriteAuthorization);
+    bound.setMetaRaw("slug", "second", rawMetaWriteAuthorization);
+    tx.abort("inspection only");
+
+    expect(syncedSchemas.filter((schema) => schema === false).length).toBe(1);
+  });
+});

--- a/packages/runner/test/resume-presync-demand.test.ts
+++ b/packages/runner/test/resume-presync-demand.test.ts
@@ -108,10 +108,12 @@ describe("resume-presync-demand", () => {
     // document the pre-sync did not warm. The commit machinery owns
     // correctness there — a genuinely cold read of an existing document
     // enters the commit basis at sequence zero and the engine rejects the
-    // commit, which compile-cache-writeback-conflict.test.ts pins on a
-    // cold replica end to end. This test pins the outcome from this side:
-    // with only the holder warmed as a document, the committed derivation
-    // is over the target's real value.
+    // commit, which compile-cache-writeback-conflict.test.ts pins on a cold
+    // replica end to end. The in-process loopback may deliver the target sync
+    // kicked by get() before that read returns, so retry count is deliberately
+    // not an assertion here. This test pins the outcome from this side: with
+    // only the holder explicitly warmed, the committed derivation is over the
+    // target's real value.
     const otherSm = EmulatedStorageManager.connectTo(server, { as: signer });
     const otherRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
@@ -137,43 +139,55 @@ describe("resume-presync-demand", () => {
       await authorTx.commit();
       await otherSm.synced();
 
-      // This replica warms the holder as a document only — what the clamped
-      // pre-sync provides — so the link target is genuinely cold.
-      const holder = runtime.getCell<{ value: number }>(
-        space,
-        "unwarmed-link-holder",
-      );
-      await holder.asSchema(false).sync();
-
-      let runs = 0;
-      const result = await runtime.editWithRetry((tx) => {
-        runs++;
-        // The holder is local (the document-bounded sync above); the target
-        // its value links to is not, and this read observes that absence.
-        const seen = runtime.getCell<{ value: number }>(
+      // Connect the reader only after the authoring commit has settled. The
+      // suite's primary replica is already connected in beforeEach and may
+      // receive the target through unrelated session activity, which would
+      // make the purported cold-read retry vacuous.
+      const coldSm = EmulatedStorageManager.connectTo(server, { as: signer });
+      const coldRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: coldSm,
+      });
+      try {
+        // This fresh replica warms the holder as a document only — what the
+        // clamped pre-sync provides — so the link target is genuinely cold.
+        const holder = coldRuntime.getCell<{ value: number }>(
           space,
-          "unwarmed-link-target",
-          undefined,
-          tx,
-        ).get()?.value;
-        runtime.getCell<{ doubled: number }>(
+          "unwarmed-link-holder",
+        );
+        await holder.asSchema(false).sync();
+
+        const result = await coldRuntime.editWithRetry((tx) => {
+          // The holder is local (the document-bounded sync above); the target
+          // its value links to was not part of that warm. This read kicks the
+          // target's own load, which loopback may deliver immediately.
+          const seen = coldRuntime.getCell<{ value: number }>(
+            space,
+            "unwarmed-link-target",
+            undefined,
+            tx,
+          ).get()?.value;
+          coldRuntime.getCell<{ doubled: number }>(
+            space,
+            "derived-output",
+            undefined,
+            tx,
+          ).set({ doubled: (seen ?? 0) * 2 });
+        });
+
+        expect(result.error).toBeUndefined();
+        // The committed derivation is over the target's real value, not the
+        // optimistic fallback used if the target had not arrived yet.
+        const committed = coldRuntime.getCell<{ doubled: number }>(
           space,
           "derived-output",
-          undefined,
-          tx,
-        ).set({ doubled: (seen ?? 0) * 2 });
-      });
-
-      expect(result.error).toBeUndefined();
-      expect(runs).toBeGreaterThan(0);
-      // The committed derivation is over the target's real value, not the
-      // absence the first run observed.
-      const committed = runtime.getCell<{ doubled: number }>(
-        space,
-        "derived-output",
-      );
-      await committed.sync();
-      expect(committed.get()).toEqual({ doubled: 84 });
+        );
+        await committed.sync();
+        expect(committed.get()).toEqual({ doubled: 84 });
+      } finally {
+        await coldRuntime.dispose({ closeStorage: false });
+        await coldSm.close();
+      }
     } finally {
       await otherRuntime.dispose();
       await otherSm.close();
@@ -211,6 +225,7 @@ describe("resume-presync-demand", () => {
       await otherSm.synced();
     } finally {
       await otherRuntime.dispose({ closeStorage: false });
+      await otherSm.close();
     }
 
     const resumed = await runtime.patternManager.compilePattern(PROGRAM, {


### PR DESCRIPTION
A piece resume issues a handful of syncs whose cells carry a trivially-permissive schema (`true`), and a sync honoring one asks the server to walk and ship the cell's entire reachable graph. Censusing every selector one `cf piece setsrc` of a topics-board piece puts on the wire: 5 × `schema:true` — all of one derived crossref cell — against 1,098 × `false` and 3,123 × shaped. That one cell's open sync walks 7,327 documents (9.08 MB payload) on a 106-topic board; the equivalent read on the current production board is the 8,379-document / 10.5 MB single read measured in the setsrc wire-budget investigation.

Two sites ask for the closure while needing only the document, and this PR clamps both:

1. **`setMetaRaw`'s locality kick** (`cell.ts`). The kick exists so the document is local for a conflict retry of the meta write. It honored the cell's schema — and setup's `#materializeDerivedInternalCells` reaches it with derived cells that carry `true`, three times per resume. The kick now syncs the document (`asSchema(false)`) and marks the cell synced.
2. **The resume pre-sync's cell wave** (`runner.ts`). Node input/output and owned cells whose links carry `true`/`{}` were synced wide, twice per resume. The wave now syncs such cells as the documents they name; the deep reach belongs to the argument link-target wave, which follows declared schemas (#6280).

After both, the census reports zero `schema:true` selectors for a full apply.

## What this does and does not buy

It removes the wide demand class and the server-side walk it triggers (thousands of documents visited and tracked per open sync). It does **not** reduce the apply's wire bytes on the measured board: the same documents remain legitimately demanded by the shaped reads — the declared recursive topic schema spans the board by design, and delivery is document-granular — so the transfer is over-determined. Byte reduction requires the structural follow-ups (reference-semantic `mentionable`-class declarations; splitting persisted `$UI` from data documents), for which this is groundwork: after this change the shaped demand is the *only* demand, so those follow-ups' effects become measurable in isolation.

Tests pin both clamps at the sync boundary (the schema each cell sync actually carries), mutation-verified: reverting the kick clamp flips the first assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why `false` at these sites is safe

`false` here is the rejecting selector: it delivers the **root document whole** and registers a document-level watch — it skips only the link-following walk. It is the same `{path: [], schema: false}` pull the conflict-retry machinery itself uses to fetch a document it needs.

Three arguments, from mechanics to semantics:

1. **The clamp is confined to the sync request.** Both sites sync a schema-`false` *sibling* (`asSchema` preserves the transaction binding, so served-instance identity rides along); the cells everything else holds — instantiation, reads, validation, defaults, CFC label views — keep their schemas. Read-time semantics change nowhere; only prefetch width does.
2. **Each site's contract is met exactly.** The `setMetaRaw` kick is unawaited, so nothing can deterministically depend on its completion; its stated contract — the document is local for a conflict retry of this meta write — is precisely what root-document delivery provides. The resume wave clamps only trivially-permissive schemas (`true`/`{}`); shaped cells sync as before, and schemaless cells already synced as `false` (`schema ?? false` in `syncCell`). A `true` schema is the absence of a declaration — its closure was never a declared read surface.
3. **Correctness is owned by the commit machinery, not by pre-syncs.** A first run that reads a genuinely cold document cannot commit a wrong result over an existing one: the cold read enters the commit basis at sequence zero and the engine rejects the commit (`stale confirmed read`), re-running against caught-up state. `compile-cache-writeback-conflict.test.ts` pins that end to end on a cold replica (CT-1824); the new test here pins the outcome from this side. The worst case of under-prefetching is a retry round, never wrong committed data.

The honest residual is latency, not correctness: a first run reading wide through *undeclared* links loses incidental warming and may pay a retry round. The declared reach stays warmed by the argument link-target wave (#6280), and on the measured workload commit attempts and upload were unchanged after the clamp.



ACCEPT_COVERAGE_DEBT: packages/runner +8 lines