### PR TITLE
fix(dashboard): show 160 trust runs in four rows

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -953,8 +953,8 @@ Notes:
 Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
-- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the newest `TRUST_RUNS_MAX=150` fetched runs. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
-- **ci-trust cell grid:** `TRUST_COLS=30` sets the column count. The grid has up to `TRUST_RUNS_MAX=150` cells, one for every run in the trust window. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
+- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the newest `TRUST_RUNS_MAX=160` fetched runs. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
+- **ci-trust cell grid:** `TRUST_COLS=40` sets the column count. The grid has up to `TRUST_RUNS_MAX=160` cells, one for every run in the four-row trust window. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development
 

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -27,8 +27,8 @@ export const CI_RUNS_MAX_AGE_DAYS = 60; // ~2 months
 
 // Tile display windows and status thresholds (tune here).
 export const TRUST_GOOD = 90, TRUST_WARN = 75; // first-try-green %
-export const TRUST_RUNS_MAX = 150; // newest runs scored and shown by ci-trust
-export const TRUST_COLS = 30; // columns in the ci-trust cell grid (more = smaller cells)
+export const TRUST_RUNS_MAX = 160; // newest runs scored and shown by ci-trust
+export const TRUST_COLS = 40; // columns in the ci-trust cell grid (more = smaller cells)
 export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
 // ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -100,27 +100,27 @@ Deno.test("labs ci trust: only first-attempt success counts as green", async () 
 });
 
 Deno.test(
-  "labs ci trust grid: every run in the latest 150-run window has a cell",
+  "labs ci trust grid: every run in the latest 160-run window has a cell",
   async () => {
     const runs = [
       run({ status: "in_progress", conclusion: null }),
-      ...Array.from({ length: 149 }, () => run({ conclusion: "success" })),
+      ...Array.from({ length: 159 }, () => run({ conclusion: "success" })),
       run({ conclusion: "failure" }),
     ];
     const view = await labsCiTrust.collect(ctx(runs));
     const cells = (view.extra ?? "").match(/class="cell"/g)?.length ?? 0;
-    assertEquals(cells, 150);
+    assertEquals(cells, 160);
     assertStringIncludes(
       view.extra ?? "",
-      "grid-template-columns:repeat(30,1fr)",
+      "grid-template-columns:repeat(40,1fr)",
     );
     assertEquals(
       view.sub,
-      "first-try green · 149 of last 150 runs",
+      "first-try green · 159 of last 160 runs",
     );
     assert(
       !(view.extra ?? "").includes("var(--status-bad)"),
-      "the 151st run must be outside the grid and percentage window",
+      "the 161st run must be outside the grid and percentage window",
     );
   },
 );


### PR DESCRIPTION
Increase the shared CI trust window to 160 workflow runs and render its grid with 40 columns. Both the labs and loom trust tiles therefore show four complete rows while scoring the same runs they display.

Update the trust-grid test and dashboard configuration guide to pin the new window and layout. The focused tile test, the dashboard unit and favicon suites, repository formatting and lint, and repository type checking pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

