### PR TITLE
test(cf-harness): await pattern index event

### DIFF
--- a/packages/cf-harness/test/run-pattern-pattern-index.test.ts
+++ b/packages/cf-harness/test/run-pattern-pattern-index.test.ts
@@ -546,6 +546,7 @@ describe("run-pattern over the pattern index", () => {
         patternId: "pat-doubler",
         inputs: { n: 1 },
       });
+      await index.settled("recordEvent", 1);
       const events = index.calls.filter((call) => call.fn === "recordEvent");
       expect(events.map((event) => event.body.eventType)).toContain(
         "instantiated",


### PR DESCRIPTION
## Summary

- wait for the first pattern-index `recordEvent` response before inspecting the test stub's call log
- use the stub's existing event-driven completion signal to avoid racing the production fire-and-forget event path

## Why

`run_pattern` records pattern-index events best-effort from a detached async task. The test previously inspected `index.calls` immediately after the tool returned, so it could observe an empty event list even though the event was still in flight.

## Testing

- `deno fmt --check` — 5,446 files checked
- `deno lint` — 5,286 files checked
- `deno task check-no-waitfor`
- `packages/cf-harness/test/run-pattern-pattern-index.test.ts` — 47 steps passed in six consecutive runs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

