### PR TITLE
Score every test by what it has caught, and publish the answer

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -495,16 +495,19 @@ jobs:
           printf '  %s\n' $TEST_FILES
           mkdir -p ../../test-results
           # --no-check: the Check job type-checks packages/runner
-          # (tasks/check.sh). --preload runs the fake clock before every test
-          # module, the same as the package test task; without it the global
-          # `clock` the converted tests use is undefined. See
-          # test/clock-preload.ts.
+          # (tasks/check.sh). The first --preload runs the fake clock before
+          # every test module, the same as the package test task; without it
+          # the global `clock` the converted tests use is undefined. See
+          # test/clock-preload.ts. The second captures the file each test
+          # registers from, which is what gives the shipped records their
+          # file metadata.
           # These permissions mirror the `test` task in
           # packages/runner/deno.jsonc; a test that needs a new one needs it
           # in both places, because this shard runs deno test directly.
           ENV=test deno test \
             --no-check \
             --preload=test/clock-preload.ts \
+            --preload=../../packages/test-support/src/records/preload.ts \
             --junit-path=../../test-results/runner-${{ matrix.shard }}.xml \
             --allow-ffi \
             --allow-env \

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -500,7 +500,9 @@ jobs:
           # the global `clock` the converted tests use is undefined. See
           # test/clock-preload.ts. The second captures the file each test
           # registers from, which is what gives the shipped records their
-          # file metadata.
+          # file metadata; it writes that map into the spool, so the spool
+          # is in the write list beside the temporary directories, or the
+          # preload finds nowhere to put it and declines to install.
           # These permissions mirror the `test` task in
           # packages/runner/deno.jsonc; a test that needs a new one needs it
           # in both places, because this shard runs deno test directly.
@@ -512,7 +514,7 @@ jobs:
             --allow-ffi \
             --allow-env \
             --allow-read \
-            --allow-write=/tmp,/var/folders \
+            --allow-write=/tmp,/var/folders,$CF_TEST_RECORDS_DIR \
             --allow-run=git,deno \
             $TEST_FILES
 

--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -1,0 +1,97 @@
+# The publisher: reads the test-record store, folds what is new into a
+# rolling aggregate, scores every identity, and creates one manifest
+# object. The five pull-request lanes read that manifest to decide what to
+# run. Nothing gates on it: when this fails, the previous manifest is
+# still the newest one and lanes keep using it, so selection quality
+# decays slowly rather than anything turning red.
+#
+# Its Google Cloud identity comes from a Workload Identity Federation
+# provider pinned to exactly this workflow file on main, so no other
+# workflow, ref, or repository can mint it (infra: tofu/test-records). The
+# account holds objectCreator on the selection prefix and nothing else: it
+# cannot read, list, overwrite, or delete.
+#
+# Four-hourly rather than daily because aggregation is incremental and so
+# cheap, and a flake that appears in the morning should not wait until the
+# small hours to be prioritized. Manual dispatch is there so somebody who
+# has just fixed something can refresh without waiting, and it carries the
+# one-off bootstrap that a cold start needs.
+
+name: Test Selection
+
+on:
+  schedule:
+    - cron: "17 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      bootstrap:
+        description: Read the whole window rather than what is unfolded
+        type: boolean
+        default: false
+      days:
+        description: Days of submissions to read
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: "Publish Test Selection Manifest"
+    # The provider variable gates the whole job. Where test records are not
+    # provisioned there is no identity to assume and nothing to create.
+    if: vars.TEST_SELECTION_WIF_PROVIDER != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Every third-party action in this credentialed workflow is pinned to
+      # an immutable commit, so a moved tag cannot alter the one privileged
+      # write path.
+      - name: 📥 Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🔑 Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: commontools-core
+          workload_identity_provider: ${{ vars.TEST_SELECTION_WIF_PROVIDER }}
+          service_account: ${{ vars.TEST_SELECTION_SERVICE_ACCOUNT }}
+          token_format: access_token
+          create_credentials_file: false
+
+      - name: 📊 Publish the manifest
+        env:
+          TEST_RECORDS_GCS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          TEST_RECORDS_BUCKET: ${{ vars.TEST_RECORDS_BUCKET }}
+          TEST_RECORDS_PREFIX: ${{ vars.TEST_RECORDS_PREFIX }}
+          TEST_SELECTION_PREFIX: ${{ vars.TEST_SELECTION_PREFIX }}
+        run: |
+          args=""
+          if [ "${{ inputs.bootstrap }}" = "true" ]; then
+            args="--bootstrap"
+          fi
+          if [ -n "${{ inputs.days }}" ]; then
+            args="$args --days ${{ inputs.days }}"
+          fi
+          deno run --allow-read --allow-env --allow-net --allow-write \
+            tasks/test-selection-publish.ts $args \
+            | tee publish.log
+
+      - name: 📝 Summarize
+        if: always()
+        run: |
+          {
+            echo "## Test selection"
+            echo ""
+            echo '```'
+            grep -v '^test selection: folded [0-9]* of ' publish.log || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -36,6 +36,15 @@ permissions:
   contents: read
   id-token: write
 
+# Two runs folding from one aggregate would each create a state object,
+# and the one that finished later would become the newest while holding
+# the older snapshot. There is one publisher, so it runs one at a time,
+# and a queued run is never cancelled: skipping a cycle loses the records
+# that arrived during it.
+concurrency:
+  group: test-selection-publisher
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: "Publish Test Selection Manifest"
@@ -51,8 +60,14 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # No cache, as the relay does for the same reason: the cache steps
+      # inside this composite action are the one place a credentialed job
+      # here still runs a third-party action by a mutable tag. This job
+      # runs every four hours and is on nobody's critical path.
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
+        with:
+          cache: false
 
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
@@ -67,22 +82,37 @@ jobs:
           token_format: access_token
           create_credentials_file: false
 
+      # The dispatch inputs reach the shell through the environment rather
+      # than through expansion into the script. An expansion is substituted
+      # before the shell parses the line, so a crafted value would run as
+      # part of this step — which is the step holding the access token.
+      # The window is quoted, then checked against the one shape it may
+      # take before it becomes an argument.
       - name: 📊 Publish the manifest
         env:
           TEST_RECORDS_GCS_TOKEN: ${{ steps.auth.outputs.access_token }}
           TEST_RECORDS_BUCKET: ${{ vars.TEST_RECORDS_BUCKET }}
           TEST_RECORDS_PREFIX: ${{ vars.TEST_RECORDS_PREFIX }}
           TEST_SELECTION_PREFIX: ${{ vars.TEST_SELECTION_PREFIX }}
+          PUBLISH_BOOTSTRAP: ${{ inputs.bootstrap }}
+          PUBLISH_DAYS: ${{ inputs.days }}
         run: |
-          args=""
-          if [ "${{ inputs.bootstrap }}" = "true" ]; then
-            args="--bootstrap"
+          set -euo pipefail
+          args=()
+          if [ "${PUBLISH_BOOTSTRAP:-}" = "true" ]; then
+            args+=(--bootstrap)
           fi
-          if [ -n "${{ inputs.days }}" ]; then
-            args="$args --days ${{ inputs.days }}"
+          if [ -n "${PUBLISH_DAYS:-}" ]; then
+            case "$PUBLISH_DAYS" in
+              *[!0-9]*|"")
+                echo "::error::days must be a positive whole number"
+                exit 1
+                ;;
+            esac
+            args+=(--days "$PUBLISH_DAYS")
           fi
           deno run --allow-read --allow-env --allow-net --allow-write \
-            tasks/test-selection-publish.ts $args \
+            tasks/test-selection-publish.ts "${args[@]}" \
             | tee publish.log
 
       - name: 📝 Summarize

--- a/.github/workflows/test-selection.yml
+++ b/.github/workflows/test-selection.yml
@@ -109,6 +109,13 @@ jobs:
                 exit 1
                 ;;
             esac
+            if [ "$((PUBLISH_DAYS))" -lt 1 ]; then
+              # A window of no days reads as a typo rather than a request,
+              # and the failure belongs here, where the input was given,
+              # rather than several steps later inside the publisher.
+              echo "::error::days must be at least 1"
+              exit 1
+            fi
             args+=(--days "$PUBLISH_DAYS")
           fi
           deno run --allow-read --allow-env --allow-net --allow-write \

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -83,6 +83,7 @@
     "run-recorded": "./tasks/run-recorded.ts",
     "test-records-key": "./tasks/test-records-key.ts",
     "test-records-compact": "./tasks/test-records-compact.ts",
+    "test-selection": "./tasks/test-selection.ts",
     "build-binaries": "./tasks/build-binaries.ts",
     "install-hooks": "./scripts/install-git-hooks.sh",
     "install-cf": "./scripts/install-cf.sh",

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -80,6 +80,9 @@ mapped in [`../README.md`](../README.md).
 - [`test-records-adoption.md`](test-records-adoption.md) — implementing the
   test-run record system in another repository of the organization: what is
   shared, what the repository adds, and the rules that are not optional
+- [`test-selection.md`](test-selection.md) — what a test is worth running,
+  how to ask why one did or did not run, where the dials are, and what the
+  publisher does
 - [`deno-coverage-guard-line-artifact.md`](deno-coverage-guard-line-artifact.md)
   — why `deno coverage` reports a one-line guard as uncovered whenever its
   branch is not taken

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -65,6 +65,13 @@ every variant.
   there is left alone. Anything else — a bash workstation whose agents run
   non-interactive shells, a harness nothing here knows — puts the variable
   in whatever starts the agent.
+- `CF_TEST_SKIP_LIST` — a file naming the tests this invocation is not to
+  run, keyed by registering file and by name. The registration preload
+  reads it and registers a listed test as ignored rather than dropping it,
+  so a skipped test appears in the report as skipped instead of
+  disappearing. An identity the file does not name runs, so a test added
+  or renamed since the list was built runs. A file that is missing or
+  malformed runs everything.
 - `CF_TEST_AGENT` — an opaque label for the operating agent, recorded
   verbatim in the run context. Set it to tell one agent from another, or
   one checkout of a fleet from the next; it is never required. Left
@@ -281,7 +288,27 @@ is the record of who minted what for whom.
 ## Covering a new test surface
 
 A runner that already emits JUnit needs nothing but a `--junit`
-specification on its job's ship step. A harness with per-result callbacks
+specification on its job's ship step, and a `--preload` naming
+`packages/test-support/src/records/preload.ts` where the surface is
+`deno test`. `preloadArgument()` from `@commonfabric/test-support/records`
+spells that flag; Deno resolves `--preload` as a path rather than through
+the import map, so it must be absolute and no caller writes it out.
+
+The preload does two things, and it only installs itself when it has one
+of them to do: it captures the file each test was registered from and
+leaves the map in the spool, and it applies `CF_TEST_SKIP_LIST`. Wrapping
+`Deno.test` costs a JUnit report the file attribution it carries on its
+own, so a process with nothing to skip and no spool it may write leaves
+`Deno.test` alone and the report's own class names are read instead.
+
+A test task naming its own `--import-map` does not take the preload. That
+map governs every module of the invocation, the preload included, so a
+specifier the preload needs and the map does not carry fails the whole
+run rather than the preload alone. Such a member keeps its JUnit path and
+loses nothing by the omission: with no wrapper installed, the report
+keeps its own class names and ingestion reads the file from those.
+
+A harness with per-result callbacks
 appends records through `FragmentWriter` (see the hooks in
 `packages/cli/lib/test-runner.ts` and `packages/deno-web-test/runner.ts`).
 Anything else wraps its command:

--- a/docs/development/test-selection.md
+++ b/docs/development/test-selection.md
@@ -1,0 +1,178 @@
+# Test selection
+
+How to use the machinery that decides what a change's tests are worth
+running, and how to answer the question it provokes most often, which is
+"why did my test not run?". [The spec](../specs/test-selection.md) is the
+normative description of the contract;
+[the plan](../plans/pull-request-test-selection.md) carries the reasoning
+and the parts still to be built.
+
+Everything a person types goes through one entry point:
+
+```
+deno task test-selection <mode>
+```
+
+## The modes
+
+### `explain <identity>`
+
+What one test is worth, and what selection would do with it. The argument
+is the canonical identity key, three parts or four when the test ran in a
+non-default configuration:
+
+```
+deno task test-selection explain '["unit","memory","space > writes a fact"]'
+deno task test-selection explain '["integration","patterns","counter.test.ts","server-execution"]'
+```
+
+It prints the suite and the invocation unit the identity belongs to, its
+score and its cost, the catches behind that score with how many were on
+the default branch and across how many distinct sources, when the most
+recent one was, its churn and flake rate, and whether it is withheld and
+why. An identity the store has never seen is reported as mandatory, which
+is what an identity with no history is.
+
+The identity resolves through `tasks/test-identity-aliases.jsonl` first,
+so asking about a renamed test under either name finds the joined history.
+
+### `dials`
+
+Every number selection can be tuned by, with the unit its value counts,
+whether somebody chose it or the publisher measures it, and which way you
+would move it. `tasks/test-selection/policy.ts` is where they live and the
+only place any of them lives.
+
+The units are worth reading. Several dials are bare fractions that do not
+mean the same thing — a share of a test's score and a share of a run's
+budget read identically — and naming the unit is what keeps them from
+being compared to each other.
+
+A **measured** dial is not yours to edit. The publisher overwrites it from
+the lanes' own timing records, and the number in the file is only the seed
+used before anything has been measured. `setupCost` per capability, and
+the overhead and correction per suite, are measured too, and are not in
+`policy.ts` at all: they are published in each manifest, which is where to
+read them.
+
+### `coverage`
+
+Every workspace member, whether it carries the per-package coverage gate,
+the reason beside it when it does not, and the baseline the newest
+manifest holds for it. This is what answers "why is my package not gated?"
+and "what am I being compared against?".
+
+### `plan --dry-run [--lane N]`
+
+What would run, and what it would cost: how many identities the store
+knows, how many are withheld, and per lane the number of tests, the
+projected seconds against the budget, the capabilities it would open, and
+a count by why each test was chosen. Given a lane number it answers "what
+would lane three do?", and given none it prints all of them.
+
+`--verify` compares the identity set the topology produces against what a
+recorded run actually executed. It needs the topology, which is not in the
+tree yet, and says so rather than pretending.
+
+## The publisher
+
+`.github/workflows/test-selection.yml` runs every four hours and on manual
+dispatch. Four-hourly rather than daily because aggregation is incremental
+and therefore cheap, and a flake that appears in the morning should not
+wait until the small hours to be prioritized. Manual dispatch is there so
+that somebody who has just fixed something can refresh without waiting.
+
+Each run reads the newest aggregate, fetches only the objects whose runs
+are not already folded into it, folds them, ages the counters, scores
+everything, and creates one manifest object and one aggregate object. It
+reads and folds two hundred objects at a time, so what it holds is bounded
+by the number of tests rather than by the number of runs.
+
+**Nothing gates on it.** When the publisher fails, the previous manifest is
+still the newest one and consumers keep using it. A manifest going stale
+degrades selection quality slowly rather than failing anything, which is
+the right direction for a system nothing should gate on.
+
+That is why a run that cannot read the aggregate a previous run left
+refuses to publish rather than starting from nothing. The aggregate is
+where a test's catches live, and they accumulate over unbounded history:
+a run that lost it and carried on would publish a manifest scoring every
+test at the floor, and because it succeeded that manifest would be the
+one every lane obeys. A stale manifest is recoverable; a confident wrong
+one is not.
+
+A cold start cannot read the whole window in one job, and is asked for
+deliberately: the bootstrap is a manual dispatch with the bootstrap input
+set, run once, and an incremental run that finds no aggregate at all says
+so and stops. After that the incremental path keeps up.
+
+A bootstrap takes each closed day from its rollup where the day has a
+complete one, which is a manifest and a few tens of shards against that
+day's thousands of raw objects. It reads a day whole or not at all: a
+shard it could not read would leave the day partly folded, and recording
+the day as done would then hide the rest of it from every later run. The
+days it did take are recorded, so no later run over a wide window folds
+their raw objects on top and doubles every catch in them.
+
+Only a bootstrap reads a rollup. A rollup is written by the one principal
+here whose credential exists as key material, so it carries weaker
+provenance than the raw records it summarizes, and
+[the record spec](../specs/test-records.md#trust-boundaries-for-consumers)
+asks a consumer that feeds decisions to treat it as a cache of a day
+rather than the record of it. Seeding catch counts once, from days closed
+a week or more ago, is that use; the four-hourly path never touches one.
+
+`deno task test-records-compact` is what writes rollups, and an operator
+runs it from a workstation with a downloaded key — nothing federated runs
+it, so there is no workflow ref to pin an identity to. A day nobody has
+compacted is folded from its raw objects, which is what a bootstrap does
+for every day until the compactor has reached one.
+
+Publishing needs the workflow's own federated identity, which is pinned
+to that workflow file on the default branch and is the only principal
+that can create a manifest. A personal reporting key cannot: it is scoped
+to its holder's own submissions folder. So a person runs `--dry-run
+--out` and reads what a run would have produced.
+
+To run it by hand against the store without creating anything:
+
+```bash
+deno run --allow-read --allow-env --allow-net --allow-write \
+  tasks/test-selection-publish.ts --days 1 --dry-run --out /tmp/selection
+```
+
+That writes the manifest and the aggregate as plain JSON where you can
+read them, and creates nothing in the store.
+
+## What the wall shows
+
+Two tiles read the newest manifest. The flake tile reports how many tests
+are too noisy to judge a change by, naming the worst few. The selection
+tile reports what share of the corpus five lanes would run and how close
+the fullest lane is to its budget; it goes amber when the manifest has
+gone stale and red when a lane's projected work is past its bound.
+
+Both follow [the wall's rules](../../packages/dashboard/README.md#philosophy-and-values):
+they report on the system, they name tests, and nothing about either is
+aggregated per person.
+
+## Telling the machinery about a new test
+
+Nothing, in the ordinary case. A test added to an existing suite is
+recorded by that suite's runner, and an identity with no history is
+mandatory until a run on the default branch records it, so a new test runs
+before anything knows what it is worth.
+
+Two things are worth knowing while writing one, and both are consequences
+of the identity being the reported name:
+
+- Prefer stable, content-derived wording over positional counters or
+  interpolated identifiers, which mint a new identity every time they
+  shift.
+- A rename splits history unless a line is appended to
+  `tasks/test-identity-aliases.jsonl`. Most renames cost nothing, because
+  most tests have never caught anything; a rename of a test that has is
+  worth the line.
+
+A new test *surface* — a new job, script, or harness — needs wiring, which
+[the record guide](test-records.md#covering-a-new-test-surface) covers.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -836,7 +836,7 @@ being imposed.
 
 ### The work this adds
 
-- [ ] The preload reads a skip list keyed by registering file and name,
+- [x] The preload reads a skip list keyed by registering file and name,
       and registers a listed bare `Deno.test` as ignored rather than
       dropping it.
 - [ ] `@commonfabric/test-support` gains a `describe` and `it` that
@@ -856,7 +856,7 @@ being imposed.
       identity whose file changed, the flag carried in the manifest, and
       the packer refusing to skip the siblings of an identity that has
       none.
-- [ ] A fixture proving the four properties that make this safe: an
+- [x] A fixture proving the four properties that make this safe: an
       unlisted new test runs, a renamed test runs, a listed test is
       reported as skipped rather than missing, and two files holding the
       same test name skip independently.
@@ -1394,20 +1394,17 @@ every variant. Resolution preserves the record's variant, so one rename
 bridges the default and every non-default history without joining those
 histories to each other.
 
-What is missing is not mechanism, it is practice. The file is empty. On
-2026-08-20 the store recorded `home rehydration churn (persistent
-scheduler state) > reloading a populated home stays within one known
-conflict`; the tree today has `home rehydration` with two
-differently-named cases, and nothing bridges the split. Nobody did
-anything wrong — there was no reason to care, because nothing read the
-history. Now something does.
+What is missing is not mechanism, it is practice. The file holds 193
+lines, every one of them dated 2026-08-20, which is a single sweep rather
+than a habit. Whether a rename since then carried its line with it is what
+practice means here, and it is what the suggestion the reporter makes is
+for.
 
 Three things follow.
 
 **The publisher resolves through `loadAliasResolver`.** The report tool
-and the dashboard collector already do; the publisher must, or the file
-accomplishes nothing for selection. One line, and it is a requirement
-rather than a nicety.
+and the dashboard collector already do, and the publisher does. Without
+it the file accomplishes nothing for selection.
 
 **The tooling writes the line for you.** Everything needed to spot a
 rename is already computed: the drift guard knows which identities the
@@ -1855,18 +1852,13 @@ The object carries:
 - the name of the newest coverage attribution map, which is published
   beside the manifest on its own weekly cadence rather than inside it.
 
-The refreshed run supplies 17,995 stored identities before topology
-classification, not a manifest entry or item count. A unit-test item can
-contain many item-level identities, while suite-level identities do not
-contribute item scores or costs. Every item also adds its own packing and
-explanation data. The manifest implementation therefore builds a
-reference-scale fixture from classified item and suite data, serializes
-and gzips it, and records both sizes. Until that measurement exists the
-bound is what the identity count gives: at most one item entry per stored
-identity, and fewer in practice, so at a couple of 100 bytes an entry the
-ceiling is a few megabytes before compression. That is one fetch of no
-consequence at the start of a job, and the fixture replaces the ceiling
-with a measurement.
+The size is measured rather than bounded. A publisher run over one day of
+the store — 18,849 objects holding 5,487,611 executions — produced 20,091
+identities, and the manifest carrying them is 9.59 megabytes serialized
+and 1.05 megabytes gzipped, which is 478 bytes an entry. Identity names
+dominate that: a describe chain runs to a hundred characters and more, and
+the numbers beside it are rounded to the digits that mean anything. One
+megabyte is a fetch of no consequence at the start of a job.
 
 The same source item in default and non-default suites appears as two
 manifest items. Their suite identifiers and complete record identities
@@ -2840,7 +2832,7 @@ tape measure.
 | `FILL_DENSITY_SHARE` | 0.25 | share of the budget | Chosen | Up when more of the cheap tail should run; down when the tail is displacing tests with a record. |
 | `FILL_EXPLORATION_SHARE` | 0.15 | share of the budget | Chosen | Up when the unselected corpus is going stale; down when lanes spend the share on tests that never find anything. |
 | `FLAKE_EXCLUSION_RATE` | 0.05 | share of runs | Chosen | Up when fewer tests should be held back from pull requests; down when flakes are still blocking people. |
-| `FLAKE_REPEAT_RATES` | 0.01, 0.10 | share of runs | Chosen | Up when repeats cost more lane time than the intermittent failures they catch are worth; down when intermittent failures are still slipping through. |
+| `FLAKE_REPEAT_RATES` | 0.01, 0.03 | share of runs | Chosen | Up when repeats cost more lane time than the intermittent failures they catch are worth; down when intermittent failures are still slipping through. Every band stays under `FLAKE_EXCLUSION_RATE`, or an item is excluded before it reaches the band and the band never fires. |
 | `MAX_REPEATS` | 3 | runs of one item | Chosen | Up when intermittent regressions still get through; down when repeats are crowding a lane. |
 | `SUITE_FLAKE_PRIOR_RATE` | 0.02 | share of runs | Chosen | Up when too many suites count as flake-prone and their new items are repeated needlessly; down when new tests in a noisy suite land unrepeated and then flake. |
 | `COVERAGE_COMMENT_LINES` | 25 | lines | Chosen | Up when coverage comments are too noisy; down when debt is climbing unnoticed. |
@@ -2850,6 +2842,11 @@ tape measure.
 | `LOCAL_COVERAGE_BASELINE_DAYS` | 7 | days | Chosen | Up when branches based further back are being reported for want of an ancestor baseline; down when the manifest carries more history than anybody reads. |
 | `COVERAGE_TREND_WEEKS` | 3 | weeks | Chosen | Up when the tile goes amber too readily; down when debt climbs for a month before anybody is told. |
 | `CATCH_BREADTH_WINDOW_DAYS` | 2 | days | Chosen | Up when a broken runner's failures are being counted as catches; down when genuine breadth is being written off as environmental. |
+| `ENVIRONMENTAL_MIN_SOURCES` | 5 | sources | Chosen | How many distinct sources a failure spans inside that window before it reads as the environment. Up when a genuinely broad regression is written off; down when a broken runner's failures still count as catches. |
+| `BREADTH_SATURATION` | 2 | sources | Chosen | Where the breadth term reaches half its ceiling. Up when four sources should outrank one by more; down when one source should already be worth nearly all of it. |
+| `CHURN_WINDOW_DAYS` | 60 | days | Chosen | How far back the decayed counts are read. Past this the weight is under one part in sixteen, so this is a performance decision rather than a policy one. |
+| `FLAKE_WINDOW_DAYS` | 60 | days | Chosen | Up when a flake rate swings about on too little evidence; down when a test since fixed stays excluded. |
+| `COST_WINDOW_DAYS` | 7 | days | Chosen | Up when cost estimates are noisy; down when durations drift faster than the estimate follows. |
 | `ATTRIBUTION_MAP_DAYS` | 7 | days | Chosen | Up when rebuilding the map costs more than its staleness does; down when changed lines keep resolving to tests that have moved. |
 | `ALIAS_GATE_MIN_CATCHES` | off | catches | Chosen | Off by default. Turn it on at a catch count to fail a pull request that discards that much history in a rename without an alias line, and lower the count as the alias file becomes routine. |
 
@@ -2949,13 +2946,13 @@ Nothing about what continuous integration runs changes. This pull request
 only makes the store answer questions it cannot answer yet, and puts the
 answers somewhere people can see them.
 
-- [ ] A preload module in `@commonfabric/test-support` that captures the
+- [x] A preload module in `@commonfabric/test-support` that captures the
       registering module for every `Deno.test` and writes the name-to-file
       map into the spool; `ingestJUnit` joins on it; every `deno test`
       invocation carries the preload.
-- [ ] `packages/deno-web-test/runner.ts` sets `file` on the records it
+- [x] `packages/deno-web-test/runner.ts` sets `file` on the records it
       writes directly.
-- [ ] `tasks/test-selection/{policy,score,manifest,store}.ts` — the dials,
+- [x] `tasks/test-selection/{policy,score,manifest,store}.ts` — the dials,
       the catch and flake derivation, the manifest format and its
       validators, and the reader and writer. Complete identities use the
       canonical test-record key, optional variants included, and variants
@@ -2963,9 +2960,9 @@ answers somewhere people can see them.
       as the report tool and dashboard collector already do. A
       reference-scale fixture records the serialized and gzipped manifest
       sizes instead of deriving item size from the identity count.
-- [ ] `tasks/test-selection/plan.ts`, the pure packing function, tested
+- [x] `tasks/test-selection/plan.ts`, the pure packing function, tested
       offline against recorded manifests.
-- [ ] `tasks/test-selection-publish.ts` and
+- [x] `tasks/test-selection-publish.ts` and
       `.github/workflows/test-selection.yml`, on a four-hourly cron.
 - [ ] The one-off bootstrap dispatch.
 - [x] Repeat the record census after `main` emitted server-execution
@@ -2976,9 +2973,15 @@ answers somewhere people can see them.
       That last one is measurable today, before any of this changes what
       runs, which makes it the baseline everything after is judged
       against.
-- [ ] The `deno task test-selection` entry point and its modes: `dials`,
-      `coverage`, `explain <identity>`, and `plan` with `--dry-run` and
-      `--verify`.
+  - [x] The flake list, and what the newest manifest would select.
+  - [ ] The coverage debt trend, which needs the per-package figures the
+        full run produces in part two.
+  - [ ] The escape rate. Every manifest carries each identity's `main`
+        catches, but over unbounded history, so a rate needs the state to
+        keep those per day as well as in total.
+- [x] The `deno task test-selection` entry point and its modes: `dials`,
+      `coverage`, `explain <identity>`, and `plan` with `--dry-run`.
+      `--verify` needs the topology and lands with part two.
 
 On its own this part gives the repository a flake list derived from
 evidence rather than from anecdote, and a coverage trend nobody has today.
@@ -3002,17 +3005,27 @@ exercised on the branch on its own.
       `tasks/server-execution-on-skips.ts`: whole-file entries are declared
       unavailable and omitted from enumeration, while step entries exclude
       only the named leaf identity from unknown and coverage rules.
-- [ ] Give `packages/cli/integration/fuse-exec.sh` fine granularity. Its
-      23 `success` markers become `cf_test_step_begin` markers, so the
-      suite records 23 identities rather than one; then it gains a section
-      dispatch over whichever groups of phases can stand alone, so
-      `cli-fuse` becomes an `item` suite like its sibling.
-- [ ] Split the `piece-call` CLI integration dispatch into its eight
-      recorded steps. Seven already have an arm of their own; add the
-      missing one for `run_piece_call` and make the eight single-step arms
-      the `cli-core` items, removing the known item that exceeds the lane's
-      hard five-minute bound. The grouped arms stay for hand runs and are
-      not enumerated.
+- [ ] Give `packages/cli/integration/fuse-exec.sh` fine granularity.
+  - [x] Its 23 `success` markers record, so the suite records 23
+        identities rather than one. The markers trail their phases where
+        `integration.sh`'s lead theirs, so they close a step rather than
+        opening one, through a `cf_test_step_done` beside
+        `cf_test_step_begin`. What that leaves is failure attribution: a
+        phase that fails never reaches its marker, so the failure is
+        carried by the script's own record rather than by a step. Moving
+        each marker ahead of its phase is what buys that back, and is the
+        same reading of the script the dispatch needs.
+  - [ ] It gains a section dispatch over whichever groups of phases can
+        stand alone, so `cli-fuse` becomes an item suite like its sibling.
+- [x] Split the `piece-call` CLI integration dispatch into its eight
+      recorded steps. Seven already had an arm of their own; the missing
+      one for `run_piece_call` is added, and so are the two the
+      `piece-values` group hid, so every recorded step now has an arm that
+      runs it alone. The grouped arms stay for hand runs and are not
+      enumerated. Making those arms the `cli-core` items is the topology's
+      part. `packages/cli/test/integration-sections.test.ts` holds the
+      dispatch table to that property, and to every step being scheduled
+      by some group rather than only by name.
 - [ ] `tasks/check-test-topology.ts`, both halves, wired into
       `repo-gates`, with exact variant matching and one source-item claim
       allowed per variant.

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1394,11 +1394,11 @@ every variant. Resolution preserves the record's variant, so one rename
 bridges the default and every non-default history without joining those
 histories to each other.
 
-What is missing is not mechanism, it is practice. The file holds 193
-lines, every one of them dated 2026-08-20, which is a single sweep rather
-than a habit. Whether a rename since then carried its line with it is what
-practice means here, and it is what the suggestion the reporter makes is
-for.
+The mechanism is there and so, by now, is the practice: the file holds
+219 lines across nine dates, so renames are being bridged as they happen
+rather than swept up once. What the reporter's suggestion adds is the
+case nobody notices — a rename whose author had no reason to think the
+history mattered.
 
 Three things follow.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -55,6 +55,7 @@ decision is reversed or superseded).
 - [Verifiable execution](verifiable-execution/README.md)
 - [Webhook ingress](webhook-ingress/README.md)
 - [Test-run records](test-records.md)
+- [Choosing which tests a change runs](test-selection.md)
 
 ### Contextual flow control and security
 

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -81,6 +81,17 @@ source path when the producer reliably knows it — metadata, not identity.
 `cfcheck` items carry a zero duration: the batch is one TypeScript program
 and per-file durations do not exist there.
 
+For a suite ingested from a JUnit report, `file` comes from one of two
+places and the second overrides the first. Deno names a case's class after
+the module that registered the test, so the case a `describe` registers
+carries the file of every leaf beneath it, and the report joins itself: a
+leaf is named as its describe chain, and its file is the one whose
+registered name is the longest prefix of that chain. That source
+disappears the moment anything wraps `Deno.test`, because every class then
+names the wrapper. The registration preload is such a wrapper, and it
+replaces what it takes: it writes a name-to-file map into the spool, and
+ingestion lays that over what the report says.
+
 The context line carries `schema` (this document describes version 1, the
 `v1` in object paths), a per-object ULID `reportId`, the canonical `repo`
 name (a constant owned by the repository's tooling, never derived from git
@@ -163,6 +174,20 @@ area, managed by the infra repository's `tofu/test-records` root:
 <repo>/test-records/aggregated/ci/v1/<yyyy>/<mm>/<dd>/rollup.json
 ```
 
+One further dataset area sits beside it and is written by the
+test-selection publisher rather than by anything recording:
+
+```
+<repo>/test-selection/v1/manifest-<ISO 8601 timestamp>-<ULID>.json.gz
+<repo>/test-selection/v1/state/<yyyy-mm-dd>-<ULID>.json.gz
+```
+
+The timestamp leads a manifest's name, so a lexical listing is a
+chronological one and a reader takes the newest that is not after the
+moment it asks about. There is no name meaning "the current one": the
+writer holds create and nothing else, so nothing can be overwritten, and
+that is the property the whole store rests on.
+
 The date partition comes from the run's start, so late-shipped orphans
 land in their run's partition; readers list a trailing window rather than
 only the newest partition. The whole dataset is readable by `allUsers`.
@@ -171,11 +196,12 @@ which cannot read, list, overwrite, or delete; nothing already stored can
 be modified by any append credential. An incompatible schema writes under
 `v2/` and readers migrate at their own pace.
 
-Three writer principals exist. The **relay** — the only one that writes
-what CI produced — holds create on `submissions/ci/` through a Workload
-Identity provider pinned to one workflow file on the default branch, with
-the impersonation binding keyed to that exact workflow ref. **People**
-hold per-person service accounts (`test-records-gh-<username>`, the login lowercased)
+Four writer principals exist, three of them recording. The **relay** —
+the only one that writes what CI produced — holds create on
+`submissions/ci/` through a Workload Identity provider pinned to one
+workflow file on the default branch, with the impersonation binding keyed
+to that exact workflow ref. **People** hold per-person service accounts
+(`test-records-gh-<username>`, the login lowercased)
 with create on their own `submissions/local/<username>/` folders, minted
 by a dispatch-gated workflow and delivered sealed to a
 requester-generated X25519 identity. Minting revokes the account's
@@ -190,7 +216,9 @@ records — after a seven-day late-arrival lag — as validated rollup shards
 that keep each report's context line ahead of its records; a day with
 no records stays open, since a write-once rollup would permanently
 exclude late arrivals. Rollups are a read optimization, and
-full-fidelity readers list the raw area.
+full-fidelity readers list the raw area. The **publisher** holds create on
+`test-selection/` through a provider pinned to its own workflow file on
+the default branch, on the relay's pattern and for the relay's reason.
 
 A day is several shards. A busy day is over a gigabyte of NDJSON, against
 V8's maximum string length of about half that, and an object has to fit in
@@ -281,6 +309,22 @@ identity it has no fresh records for as one that must run: records exist
 only for tests that ran, so a selector that never re-runs the unselected
 starves its own data, and a renamed test is an unknown identity until an
 alias line lands.
+
+Test selection reads `submissions/local/` as well, and weighs a failure
+seen there above one seen in continuous integration. That is a deliberate
+widening of the rule above, and the reason is the quality of the
+evidence: somebody at a workstation, part way through writing something,
+ran a test and it went red because of what they had just written. There
+is no ambiguity about what changed, no shared infrastructure to blame,
+and no question about whether the failure was real, because they went on
+to fix it. What it costs is that a local record can now displace another
+test from a budgeted run rather than only ever adding to what runs. Three
+things bound that: local keys are held by people with repository write
+access, which is the trust boundary the continuous-integration records
+already sit inside; every manifest records the inputs behind every score,
+so a strange selection traces back to the records that produced it; and
+the worst outcome is a pull request that ran a less useful set of tests,
+which the full run on the default branch catches.
 
 ## The sixty-second rule
 

--- a/docs/specs/test-selection.md
+++ b/docs/specs/test-selection.md
@@ -1,0 +1,231 @@
+# Choosing which tests a change runs
+
+The contract of test selection: what a test is worth running, what the
+manifest that says so contains, and what a consumer of one may and may
+not conclude from it. This is the normative description of the shipped
+parts; [the operating guide](../development/test-selection.md) says how to
+use them, and
+[the plan this comes from](../plans/pull-request-test-selection.md) carries
+the reasoning and the parts still to be built. It rests on
+[test-run records](test-records.md), whose store it reads and beside whose
+dataset area it writes. The implementation is `tasks/test-selection/`, and
+the manifest format itself is
+`packages/test-support/src/records/selection.ts`, beside the record schema
+it is the counterpart of.
+
+## What the score measures
+
+A test earns its place by having caught real breakage before. That is a
+property of the test rather than a symptom of a problem: a test that found
+a regression once sits somewhere mistakes get made, and it will find the
+next one. So the score is built on catches and decays over months rather
+than days.
+
+That is a different quantity from "this test is currently flaky", and the
+two are never scored together. A test failing a third of the time carries
+almost no information per failure; a test that failed four times in two
+years, each time because somebody broke something, carries a great deal.
+Flakiness is dealt with separately, below.
+
+### What a catch is
+
+For every failing record, the publisher asks whether the failure says
+something about a change or something about the test. A failure is a
+**catch** unless one of these holds:
+
+- The identity was already failing in the most recent run on the default
+  branch. The test was already broken and this run learned nothing.
+- The identity both passed and failed at the same commit, with nothing
+  between the two runs but chance. That is a flake observation, and it is
+  counted as one.
+- The identity failed across at least `ENVIRONMENTAL_MIN_SOURCES` distinct
+  sources within `CATCH_BREADTH_WINDOW_DAYS`. That is the environment or a
+  dependency, not any one change.
+
+Each catch is attributed to the pair of the commit and the source that saw
+it, so re-running one broken commit ten times counts once. A source is the
+branch for a continuous-integration run and the reporting person's login
+for a local one.
+
+A failure on the default branch cannot be judged when it happens. Every
+push there is a distinct commit with one run, so a test that is flaky
+there never contradicts itself, and counting each such failure as a catch
+would make the least valuable test in the repository look like the most
+valuable. Such a failure waits for the next run on that branch: still
+failing is the same breakage continuing and nothing new is learned;
+passing means the change between the two commits fixed it, which is what
+the test caught. Telling a fix apart from a failure that healed itself
+needs the coverage attribution map, and without one the judgement errs
+toward calling a failure a catch.
+
+### Where a catch happened
+
+A catch is always a point in the test's favor, and the place says
+something further.
+
+- A **local catch** — somebody at a workstation, part way through writing
+  something — is the highest-quality evidence this system can receive, and
+  counts double.
+- A **pull-request catch** is continuous integration doing its job.
+- A **catch on the default branch** is a recorded escape: this test would
+  have prevented a red default branch had it run on the pull request, and
+  it did not. It counts one and a half times, which is the feedback loop
+  that fixes that on its own.
+
+### The formula
+
+```text
+catches   = CATCH_WEIGHT_LOCAL * localCatches
+          + CATCH_WEIGHT_PR    * prCatches
+          + CATCH_WEIGHT_MAIN  * mainCatches
+
+if catches == 0:
+    record = 0
+else:
+    proven    = 1 - 0.5 ** (catches / PROVEN_SATURATION)
+    freshness = FRESHNESS_FLOOR + (1 - FRESHNESS_FLOOR)
+                * 0.5 ** (daysSinceLastCatch / FRESHNESS_HALF_LIFE_DAYS)
+    record    = proven * freshness
+
+breadth = 1 - 0.5 ** (sources / BREADTH_SATURATION)
+
+value = VALUE_FLOOR + WEIGHT_PROVEN * record
+      + WEIGHT_BREADTH * breadth + WEIGHT_CHURN * churn
+```
+
+Two guarantees follow, and both are asserted rather than argued:
+
+- A test that has **never failed anywhere** scores exactly `VALUE_FLOOR`.
+- A test with **no catches but recent failures** — every one classified as
+  flake evidence, or as a continuation of an already-broken default branch
+  — scores `VALUE_FLOOR + WEIGHT_CHURN * churn`, and never a missing
+  value. The branch for a test with no catches is written out rather than
+  left to the algebra: there is no date to measure freshness from, and
+  multiplying zero by a missing number yields a missing number, which
+  sorts unpredictably against real scores.
+
+`VALUE_FLOOR` is what points the packing at the cheap tail. A
+fifty-millisecond test that has never failed has a value per second of
+one, which beats a hundred-second integration test scoring 0.9 by a factor
+of a hundred.
+
+### How far back each input looks
+
+There is no single window, because the inputs want very different horizons
+and one number damages most of them.
+
+| Input | Horizon |
+| --- | --- |
+| `catches`, `lastCatch` | unbounded; `freshness` does the discounting |
+| `sources` | unbounded, counted only over catches |
+| `churn` | decayed with a `CHURN_HALF_LIFE_DAYS` half-life, read over `CHURN_WINDOW_DAYS` |
+| `flakeRate` | `FLAKE_WINDOW_DAYS` |
+| `cost` | `COST_WINDOW_DAYS` |
+
+The counts behind `churn` are decayed rather than cut off. A ratio over a
+long undecayed window measures total historical brokenness rather than the
+current rate, and a week of failures eight months ago would otherwise
+outrank a test that is failing right now.
+
+`cost` is the largest of the days' ninetieth percentiles inside its
+window: the ninetieth rather than the maximum, because one unlucky runner
+should not permanently inflate an estimate, and the largest across days
+rather than an average, because a cost model that under-estimates blows
+the time budget.
+
+## Flakes
+
+A flake is a test that disagrees with itself. Above
+`FLAKE_EXCLUSION_RATE` an identity leaves the selectable set entirely: it
+is too noisy to judge a change by. It keeps running on the default branch,
+it appears on the wall, and the exclusion reverses on its own the moment
+the test is fixed, which is what makes this better than a quarantine list
+somebody has to remember to empty.
+
+Below that rate, an identity may be run more than once inside one run, at
+the bands `FLAKE_REPEAT_RATES` names, up to `MAX_REPEATS`. Every band
+stays under the exclusion rate, or an identity would be excluded before it
+reached the band and the band would never fire.
+
+**A repeat is not a retry.** Every repeat must pass, and any failure among
+them fails the run. Three runs of a test is strictly stricter than one,
+never laxer. Nothing is retried and nothing is masked.
+
+## What must run, and what must not
+
+Two rules keep a test out. Both make a change less red rather than more,
+and both exist so that nobody's change fails for something its author
+cannot act on.
+
+- An identity failing in the most recent run on the default branch is not
+  selected.
+- An identity above `FLAKE_EXCLUSION_RATE` is not selected.
+
+Either comes back the moment the change touches what it covers, since that
+is very likely a fix and has to be allowed to prove itself.
+
+Two rules force a test in.
+
+- **An identity with no records must run.** This is required of any
+  consumer that selects which tests run, by
+  [the record spec](test-records.md#trust-boundaries-for-consumers), on the
+  grounds that a selector which never runs the unselected starves its own
+  data and that a renamed test is an unknown identity until an alias line
+  lands.
+- **What the change touches must run.** A changed test file's identities
+  are mandatory. A changed source file resolves through the coverage
+  attribution map to the identities that execute its lines.
+
+## The manifest
+
+One gzipped JSON object per publisher run, created — never overwritten —
+under the dataset area
+[the record spec describes](test-records.md#the-store). It carries the
+schema version, the generation time, the exploration seed, the commit
+whose tree was enumerated, how many runs the aggregate saw, every dial it
+was built with, the fitted calibration numbers, every identity with its
+score and the inputs behind it, the withheld sets with their reasons, the
+tests a configuration deliberately does not run, a reference packing into
+lanes, the unschedulable list, a count and digest of known identities, and
+the per-package coverage baselines.
+
+A manifest is **untrusted input**. It is validated whole, and one bad
+field rejects the object rather than leaving a consumer obeying half of
+it. A manifest whose schema version a reader does not know is treated as
+absent, because a reader that does not know a field cannot know what
+obeying the rest would mean. A consumer that finds no manifest runs the
+mandatory set and a deterministic slice of the corpus rather than failing.
+
+That the manifest may be an ordinary public object rather than a signed
+artifact follows from what it can do. It can only change *which* tests
+run. It cannot change what a test does, what a test asserts, or what the
+repository builds. The worst a corrupted manifest achieves is a change
+that ran fewer tests than it should have, which the full run on the
+default branch catches.
+
+## Renames
+
+Renaming a test costs it all of its history, and the cost falls in the
+worst possible place: `catches` accumulates over unbounded history and is
+the whole of what makes a test worth running, so the best test in an area
+drops to the floor at the exact moment somebody is working there.
+
+`tasks/test-identity-aliases.jsonl` is what bridges the two halves, and
+every reader of the store resolves through it, the publisher included. A
+rename is never inferred: a wrong bridge silently credits one test with
+another's record, and since the whole score rests on catch attribution
+there is no downstream check that would notice. Suggesting a line is help;
+writing one unasked is not.
+
+## Determinism
+
+The packing function is pure. No clock, no unseeded randomness, no
+dependence on anything but the manifest, the diff, and the lane number.
+That is what lets every lane compute its own share and agree with the
+others by construction, with no job ahead of them deciding and no lane
+waiting on one. The exploration draw's seed comes from the manifest, so
+the draw is the same in every lane and different between manifests.
+
+A consumer resolves the manifest as the newest one generated at or before
+its run's start time, rather than at or before now, which is what makes
+re-running one failed lane run the same set as the lane it replaces.

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -127,8 +127,14 @@ dump_daemon_state() {
   >&2 echo "--- end daemon state dump ---"
 }
 
+# Each phase of this script announces itself here when it finishes, so
+# each announcement is also the record of one test named for it. Without
+# them the whole script — a FUSE mount, a daemon, and everything done with
+# them — is one identity that can only be scored, run, and skipped as a
+# unit.
 success() {
   echo "✓ $1"
+  cf_test_step_done "$1"
 }
 
 if [ -n "${CF_CLI_INTEGRATION_USE_LOCAL:-}" ]; then

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1282,6 +1282,12 @@ run_piece_data_files() {
 # dispatches: piece-values, piece-call, and piece-links. Both hold in
 # packages/cli/test/integration-sections.test.ts, which reads this table and
 # the cli-integration-test matrix in .github/workflows/deno.yml.
+#
+# Two kinds of arm live here. A **step arm** runs exactly one step, and
+# every step has one, so any step can be run and scheduled on its own. A
+# **group arm** runs several, for a person running the script by hand and
+# for the continuous-integration legs. Where a group arm and a step arm
+# would share a name, the step arm takes an `-only` suffix.
 case "$SECTION" in
   all)
     cf_test_step_begin piece-values
@@ -1321,11 +1327,23 @@ case "$SECTION" in
     cf_test_step_begin piece-data-files
     run_piece_data_files
     ;;
+  piece-values-only)
+    cf_test_step_begin piece-values
+    run_piece_values
+    ;;
+  piece-data-files)
+    cf_test_step_begin piece-data-files
+    run_piece_data_files
+    ;;
   piece-links)
     cf_test_step_begin piece-links
     run_piece_links
     cf_test_step_begin wish
     run_wish
+    ;;
+  piece-links-only)
+    cf_test_step_begin piece-links
+    run_piece_links
     ;;
   piece-call)
     cf_test_step_begin piece-call
@@ -1344,6 +1362,10 @@ case "$SECTION" in
     run_topics_restore_drill
     cf_test_step_begin bulk-survey-drill
     run_bulk_survey_drill
+    ;;
+  piece-call-only)
+    cf_test_step_begin piece-call
+    run_piece_call
     ;;
   piece-call-retry)
     cf_test_step_begin piece-call-retry

--- a/packages/cli/integration/test-records.sh
+++ b/packages/cli/integration/test-records.sh
@@ -35,9 +35,15 @@ cf_test_record_line() {
     mkdir -p "$CF_TEST_RECORDS_DIR" 2>/dev/null || return 0
     CF_TEST_RECORD_FRAGMENT="$CF_TEST_RECORDS_DIR/fragment-sh-$$-${RANDOM}${RANDOM}.ndjson"
   fi
+  # A step name is a sentence somebody wrote beside the phase it
+  # describes. The two characters that would tear the line are escaped
+  # here, and a control character — a newline above all — is replaced
+  # rather than escaped, because a raw one splits the record into two
+  # lines and the reader drops both.
   local name="$1"
   name="${name//\\/\\\\}"
   name="${name//\"/\\\"}"
+  name=$(printf '%s' "$name" | tr '\000-\037' ' ')
   printf '{"line":"record","test":{"k":"integration","s":"cli","n":"%s"},"outcome":"%s","durationMs":%d}\n' \
     "$name" "$2" "$3" >> "$CF_TEST_RECORD_FRAGMENT" 2>/dev/null || true
 }

--- a/packages/cli/integration/test-records.sh
+++ b/packages/cli/integration/test-records.sh
@@ -24,9 +24,10 @@ cf_test_now_ms() {
 }
 
 cf_test_record_line() {
-  # Arguments: name, outcome, duration in ms. Names here are script and
-  # section labels — no quotes or backslashes — so fixed-shape printf is a
-  # faithful JSON encoder for them.
+  # Arguments: name, outcome, duration in ms. A step's name is a sentence
+  # somebody wrote beside the phase it describes, so the two characters
+  # that would tear the JSON line are escaped rather than assumed absent;
+  # a torn line is one the reader drops without saying why.
   if [ -z "${CF_TEST_RECORDS_DIR:-}" ]; then
     return 0
   fi
@@ -34,8 +35,11 @@ cf_test_record_line() {
     mkdir -p "$CF_TEST_RECORDS_DIR" 2>/dev/null || return 0
     CF_TEST_RECORD_FRAGMENT="$CF_TEST_RECORDS_DIR/fragment-sh-$$-${RANDOM}${RANDOM}.ndjson"
   fi
+  local name="$1"
+  name="${name//\\/\\\\}"
+  name="${name//\"/\\\"}"
   printf '{"line":"record","test":{"k":"integration","s":"cli","n":"%s"},"outcome":"%s","durationMs":%d}\n' \
-    "$1" "$2" "$3" >> "$CF_TEST_RECORD_FRAGMENT" 2>/dev/null || true
+    "$name" "$2" "$3" >> "$CF_TEST_RECORD_FRAGMENT" 2>/dev/null || true
 }
 
 # Records the script's one test with the given exit status. For a script
@@ -71,10 +75,10 @@ cf_test_step_begin() {
     return 0
   fi
   cf_test_step_close 0
-  # The step's identity carries no section: which section scheduled a step
-  # is run context, and the same step must join across a CI section leg
-  # and a local `all` run.
-  CF_TEST_STEP_NAME="integration.sh $1"
+  # The step's identity is the script's name and the step's, and carries
+  # no section: which section scheduled a step is run context, and the
+  # same step must join across a CI section leg and a local `all` run.
+  CF_TEST_STEP_NAME="$CF_TEST_RECORD_NAME $1"
   CF_TEST_STEP_START_MS=$(cf_test_now_ms || echo 0)
 }
 
@@ -93,6 +97,28 @@ cf_test_step_close() {
     $((end_ms - CF_TEST_STEP_START_MS))
   CF_TEST_STEP_NAME=""
   CF_TEST_STEP_START_MS=""
+}
+
+# Records the phase that just finished as its own step, and starts the
+# next. This is the marker for a script whose phase markers trail their
+# work rather than leading it, where `cf_test_step_begin`'s lead it. What
+# that costs is failure attribution: a phase that fails never reaches its
+# marker, so the failure is carried by the script's own record rather than
+# by a step. Moving a script's markers ahead of their phases is what buys
+# that back, and is a change to the script rather than to this file.
+cf_test_step_done() {
+  if [ -z "${CF_TEST_RECORDS_DIR:-}" ]; then
+    return 0
+  fi
+  local end_ms
+  end_ms=$(cf_test_now_ms || echo 0)
+  local since="${CF_TEST_STEP_START_MS:-}"
+  if [ -z "$since" ]; then
+    since="$CF_TEST_RECORD_START_MS"
+  fi
+  cf_test_record_line "$CF_TEST_RECORD_NAME $1" "pass" $((end_ms - since))
+  CF_TEST_STEP_START_MS="$end_ms"
+  CF_TEST_STEP_NAME=""
 }
 
 # Records the whole script (or its dispatched section) as one test, from

--- a/packages/cli/test/integration-sections.test.ts
+++ b/packages/cli/test/integration-sections.test.ts
@@ -174,6 +174,18 @@ describe("integration-sections", () => {
     expect(everyStep.filter((step) => !covered.has(step))).toEqual([]);
   });
 
+  it("gives every step an arm that runs it alone", () => {
+    // What makes a step schedulable on its own. A step reachable only
+    // inside a group can only be asked for as the whole group, and a
+    // group is one thing that takes as long as everything in it. This
+    // says nothing about which arms CI dispatches, which is the check
+    // above: an arm may exist for a step nothing schedules by itself.
+    const alone = new Set(
+      arms.filter((arm) => arm.steps.length === 1).map((arm) => arm.steps[0]),
+    );
+    expect(everyStep.filter((step) => !alone.has(step))).toEqual([]);
+  });
+
   it("reads the CI section from the matrix leg it is named for", () => {
     expect(ciJobBlock(WORKFLOW)).toContain(
       "CF_CLI_INTEGRATION_SECTION: ${{ matrix.core_section }}",

--- a/packages/cli/test/test-records-shell.test.ts
+++ b/packages/cli/test/test-records-shell.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The shell recording helpers the CLI's integration scripts source, driven
+ * through bash the way a script drives them. What they write has to parse
+ * as a record line, and a line that does not is one the reader drops
+ * without saying why, so the round trip is checked rather than the shape
+ * of the printf.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl, join } from "@std/path";
+import {
+  parseRecordLine,
+  type TestRecord,
+} from "@commonfabric/test-support/records";
+
+const HELPERS = fromFileUrl(
+  new URL("../integration/test-records.sh", import.meta.url),
+);
+
+/** Runs a fragment of shell with the helpers sourced, and reads the spool. */
+async function recorded(
+  script: string,
+  options: { recording?: boolean } = {},
+): Promise<TestRecord[]> {
+  const spool = await Deno.makeTempDir({ prefix: "cli-shell-records-" });
+  try {
+    const env: Record<string, string> = {};
+    if (options.recording !== false) env.CF_TEST_RECORDS_DIR = spool;
+    const run = await new Deno.Command("bash", {
+      args: ["-c", `set -euo pipefail\nsource ${HELPERS}\n${script}`],
+      env,
+      clearEnv: true,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    expect(
+      [run.success, new TextDecoder().decode(run.stderr)],
+    ).toEqual([true, ""]);
+    const records: TestRecord[] = [];
+    for await (const entry of Deno.readDir(spool)) {
+      if (!entry.isFile) continue;
+      for (
+        const line of (await Deno.readTextFile(join(spool, entry.name)))
+          .split("\n")
+      ) {
+        if (line.length === 0) continue;
+        const record = parseRecordLine(line);
+        // A line that does not parse is the failure this test exists for,
+        // so it is surfaced as the line rather than as a missing record.
+        expect([entry.name, record === undefined ? line : "parsed"])
+          .toEqual([entry.name, "parsed"]);
+        if (record !== undefined) records.push(record);
+      }
+    }
+    return records;
+  } finally {
+    await Deno.remove(spool, { recursive: true });
+  }
+}
+
+describe("test-records-shell", () => {
+  it("records a script as one test named for it", async () => {
+    const records = await recorded(`
+      cf_test_record_script "acl.sh"
+      true
+    `);
+    expect(records.map((record) => record.test.n)).toEqual(["acl.sh"]);
+    expect(records[0]!.outcome).toBe("pass");
+    expect(records[0]!.test.k).toBe("integration");
+    expect(records[0]!.test.s).toBe("cli");
+  });
+
+  it("names a step for the script it runs inside", async () => {
+    const records = await recorded(`
+      cf_test_record_script "integration.sh"
+      cf_test_step_begin piece-values
+      cf_test_step_begin piece-links
+    `);
+    expect(records.map((record) => record.test.n)).toEqual([
+      "integration.sh piece-values",
+      "integration.sh piece-links",
+      "integration.sh",
+    ]);
+  });
+
+  it("closes the open step as failed when the script fails", async () => {
+    const spool = await Deno.makeTempDir({ prefix: "cli-shell-records-" });
+    try {
+      await new Deno.Command("bash", {
+        args: [
+          "-c",
+          `set -euo pipefail\nsource ${HELPERS}\n` +
+          `cf_test_record_script "integration.sh"\n` +
+          `cf_test_step_begin piece-values\nfalse\n`,
+        ],
+        env: { CF_TEST_RECORDS_DIR: spool },
+        clearEnv: true,
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const outcomes = new Map<string, string>();
+      for await (const entry of Deno.readDir(spool)) {
+        for (
+          const line of (await Deno.readTextFile(join(spool, entry.name)))
+            .split("\n")
+        ) {
+          const record = parseRecordLine(line);
+          if (record !== undefined) outcomes.set(record.test.n, record.outcome);
+        }
+      }
+      expect(outcomes.get("integration.sh piece-values")).toBe("fail");
+      expect(outcomes.get("integration.sh")).toBe("fail");
+    } finally {
+      await Deno.remove(spool, { recursive: true });
+    }
+  });
+
+  it("records a trailing marker as the phase that just finished", async () => {
+    const records = await recorded(`
+      CF_TEST_RECORD_NAME="fuse-exec.sh"
+      CF_TEST_RECORD_START_MS=$(cf_test_now_ms)
+      cf_test_step_done "mounted the filesystem"
+      cf_test_step_done "read a callable"
+      cf_test_record_with_status 0
+    `);
+    expect(records.map((record) => record.test.n)).toEqual([
+      "fuse-exec.sh mounted the filesystem",
+      "fuse-exec.sh read a callable",
+      "fuse-exec.sh",
+    ]);
+    for (const record of records) expect(record.outcome).toBe("pass");
+  });
+
+  it("keeps a name that would otherwise tear the line whole", async () => {
+    const records = await recorded(`
+      CF_TEST_RECORD_NAME="fuse-exec.sh"
+      CF_TEST_RECORD_START_MS=$(cf_test_now_ms)
+      cf_test_step_done 'a "quoted" name with a \\ backslash'
+    `);
+    expect(records.map((record) => record.test.n)).toEqual([
+      String.raw`fuse-exec.sh a "quoted" name with a \ backslash`,
+    ]);
+  });
+
+  it("records nothing at all when recording is off", async () => {
+    expect(
+      await recorded(
+        `
+        cf_test_record_script "acl.sh"
+        cf_test_step_begin piece-values
+        cf_test_step_done "a phase"
+      `,
+        { recording: false },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/dashboard/registry.ts
+++ b/packages/dashboard/registry.ts
@@ -20,6 +20,8 @@ import { benchmark } from "./tiles/benchmark.ts";
 import { dau } from "./tiles/dau.ts";
 import { githubMembers } from "./tiles/github-members.ts";
 import { recentRuns } from "./tiles/recent-runs.ts";
+import { testFlakes } from "./tiles/test-flakes.ts";
+import { testSelection } from "./tiles/test-selection.ts";
 
 // Order controls placement: a normal tile takes the next slot in the grid, and
 // a wide tile renders full-width below the grid, in this same order.
@@ -39,9 +41,12 @@ export const TILES: Tile[] = [
   prodUptime,
   prodErrors,
   dau,
-  // Row 4: the remaining spend and community tiles
+  // Row 4: what the test suite is doing to itself
+  testFlakes,
+  testSelection,
   modelSpend,
   gcpSpend,
+  // Row 5: the remaining spend and community tiles
   discordOnline,
   githubMembers,
   recentRuns, // wide — renders full-width below the grid

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -1,0 +1,186 @@
+import { assertEquals } from "@std/assert";
+import { gzipText, sampleEntry, sampleManifest, serializeManifest } from "@commonfabric/test-support/records";
+
+import { generatedAtOf, newestManifest } from "./test-selection-manifest.ts";
+import { makeTestFlakes } from "./tiles/test-flakes.ts";
+import {
+  LANE_BUDGET_FALLBACK_SECONDS,
+  laneBudgetOf,
+  makeTestSelection,
+} from "./tiles/test-selection.ts";
+import type { Ctx } from "./types.ts";
+
+const PREFIX = "labs/test-selection/v1";
+
+/** A store answering one listing and the objects it named. */
+function storeOf(objects: Record<string, Uint8Array>): typeof fetch {
+  return ((input: string | URL | Request) => {
+    const url = new URL(String(input instanceof Request ? input.url : input));
+    if (url.pathname.endsWith("/o")) {
+      const items = Object.keys(objects).map((name) => ({ name }));
+      return Promise.resolve(new Response(JSON.stringify({ items }), { status: 200 }));
+    }
+    const name = decodeURIComponent(url.pathname.split("/").slice(2).join("/"));
+    const body = objects[name];
+    return Promise.resolve(
+      body === undefined
+        ? new Response("", { status: 404 })
+        : new Response(body as BodyInit, { status: 200 }),
+    );
+  }) as typeof fetch;
+}
+
+Deno.test("generatedAtOf reads the time out of a manifest's name", () => {
+  assertEquals(
+    generatedAtOf(`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`),
+    "2026-08-20T04:00:00.000Z",
+  );
+  assertEquals(generatedAtOf(`${PREFIX}/state/2026-08-20-a.json.gz`), undefined);
+});
+
+Deno.test("newestManifest takes the newest object under the prefix", async () => {
+  const older = sampleManifest({ generatedAt: "2026-08-20T00:00:00.000Z" });
+  const newer = sampleManifest({ generatedAt: "2026-08-20T04:00:00.000Z" });
+  const found = await newestManifest({
+    fetchImpl: storeOf({
+      [`${PREFIX}/manifest-2026-08-20T00:00:00.000Z-a.json.gz`]: await gzipText(
+        serializeManifest(older),
+      ),
+      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]: await gzipText(
+        serializeManifest(newer),
+      ),
+    }),
+  });
+  assertEquals(found?.generatedAt, "2026-08-20T04:00:00.000Z");
+});
+
+Deno.test("newestManifest treats a malformed manifest as absent", async () => {
+  const found = await newestManifest({
+    fetchImpl: storeOf({
+      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]: await gzipText(
+        "{not a manifest",
+      ),
+    }),
+  });
+  assertEquals(found, undefined);
+});
+
+Deno.test("newestManifest treats an unreachable store as absent", async () => {
+  const found = await newestManifest({
+    fetchImpl: (() => Promise.reject(new Error("no network"))) as typeof fetch,
+  });
+  assertEquals(found, undefined);
+});
+
+const CTX: Ctx = {
+  runs: () => Promise.resolve([]),
+  runsFor: () => Promise.resolve([]),
+  env: () => undefined,
+};
+
+/** A store holding one manifest under a fixed name. */
+async function storeHolding(manifest: Parameters<typeof serializeManifest>[0]) {
+  return storeOf({
+    [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`]: await gzipText(
+      serializeManifest(manifest),
+    ),
+  });
+}
+
+Deno.test("both test tiles are unknown when there is no manifest", async () => {
+  const empty = storeOf({});
+  for (
+    const tile of [
+      makeTestFlakes({ fetchImpl: empty }),
+      makeTestSelection({ fetchImpl: empty }),
+    ]
+  ) {
+    const view = await tile.collect(CTX);
+    assertEquals(view.status, "unknown");
+    assertEquals(view.sub, "no selection manifest yet");
+  }
+});
+
+Deno.test("the flake tile is green when nothing is withheld as flaky", async () => {
+  const tile = makeTestFlakes({ fetchImpl: await storeHolding(sampleManifest()) });
+  const view = await tile.collect(CTX);
+  assertEquals(view.status, "good");
+  assertEquals(view.value, "0");
+});
+
+Deno.test("the flake tile counts what selection held back, and names the worst", async () => {
+  const noisy = sampleEntry({ k: "unit", s: "memory", n: "space > flakes" }, {
+    flakeRate: 0.4,
+  });
+  const manifest = sampleManifest({
+    entries: [noisy],
+    withheld: [{ test: noisy.test, suite: noisy.suite, reason: "flaky" }],
+  });
+  const view = await makeTestFlakes({ fetchImpl: await storeHolding(manifest) })
+    .collect(CTX);
+  assertEquals(view.status, "warn");
+  assertEquals(view.value, "1");
+  assertEquals(view.extra?.includes("40.0% · memory: space &gt; flakes"), true);
+});
+
+Deno.test("the selection tile says what share of the corpus would run", async () => {
+  const entry = sampleEntry({ k: "unit", s: "memory", n: "a" }, { cost: 3 });
+  const other = sampleEntry({ k: "unit", s: "memory", n: "b" }, { cost: 1 });
+  const manifest = sampleManifest({
+    entries: [entry, other],
+    lanes: [{
+      lane: 1,
+      projectedSeconds: 3,
+      batches: [{
+        suite: entry.suite,
+        identities: [JSON.stringify(entry.test)],
+      }],
+    }],
+  });
+  const view = await makeTestSelection({
+    fetchImpl: await storeHolding(manifest),
+    now: () => Date.parse("2026-08-20T05:00:00.000Z"),
+  }).collect(CTX);
+  assertEquals(view.status, "good");
+  assertEquals(view.value, "50%");
+  assertEquals(
+    view.sub,
+    `1 of 2 tests · fullest lane 3s of ${LANE_BUDGET_FALLBACK_SECONDS}s`,
+  );
+});
+
+Deno.test("the selection tile goes amber once the manifest has gone stale", async () => {
+  const view = await makeTestSelection({
+    fetchImpl: await storeHolding(sampleManifest()),
+    now: () => Date.parse("2026-08-21T04:00:00.000Z"),
+  }).collect(CTX);
+  assertEquals(view.status, "warn");
+  assertEquals(view.aside, "28h old");
+});
+
+Deno.test("the lane budget comes from the manifest that named it", () => {
+  assertEquals(laneBudgetOf({ LANE_BUDGET_SECONDS: 180 }), 180);
+  assertEquals(laneBudgetOf({}), LANE_BUDGET_FALLBACK_SECONDS);
+  assertEquals(laneBudgetOf({ LANE_BUDGET_SECONDS: 0 }), LANE_BUDGET_FALLBACK_SECONDS);
+  assertEquals(laneBudgetOf({ LANE_BUDGET_SECONDS: "x" }), LANE_BUDGET_FALLBACK_SECONDS);
+});
+
+Deno.test("the selection tile goes red when a lane is past its budget", async () => {
+  const heavy = sampleEntry({ k: "unit", s: "memory", n: "a" }, { cost: 400 });
+  const manifest = sampleManifest({
+    entries: [heavy],
+    lanes: [{
+      lane: 1,
+      projectedSeconds: 400,
+      batches: [{
+        suite: heavy.suite,
+        identities: [JSON.stringify(heavy.test)],
+      }],
+    }],
+  });
+  const view = await makeTestSelection({
+    fetchImpl: await storeHolding(manifest),
+    now: () => Date.parse("2026-08-20T05:00:00.000Z"),
+  }).collect(CTX);
+  assertEquals(view.status, "bad");
+});

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -85,7 +85,7 @@ const CTX: Ctx = {
 };
 
 /** A store holding one manifest under a fixed name. */
-async function storeHolding(manifest: Parameters<typeof serializeManifest>[0]) {
+function storeHolding(manifest: Parameters<typeof serializeManifest>[0]) {
   return storeOf({
     [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`]:
       serializeManifest(manifest),
@@ -107,7 +107,7 @@ Deno.test("both test tiles are unknown when there is no manifest", async () => {
 });
 
 Deno.test("the flake tile is green when nothing is withheld as flaky", async () => {
-  const tile = makeTestFlakes({ fetchImpl: await storeHolding(sampleManifest()) });
+  const tile = makeTestFlakes({ fetchImpl: storeHolding(sampleManifest()) });
   const view = await tile.collect(CTX);
   assertEquals(view.status, "good");
   assertEquals(view.value, "0");
@@ -121,7 +121,7 @@ Deno.test("the flake tile counts what selection held back, and names the worst",
     entries: [noisy],
     withheld: [{ test: noisy.test, suite: noisy.suite, reason: "flaky" }],
   });
-  const view = await makeTestFlakes({ fetchImpl: await storeHolding(manifest) })
+  const view = await makeTestFlakes({ fetchImpl: storeHolding(manifest) })
     .collect(CTX);
   assertEquals(view.status, "warn");
   assertEquals(view.value, "1");
@@ -143,7 +143,7 @@ Deno.test("the selection tile says what share of the corpus would run", async ()
     }],
   });
   const view = await makeTestSelection({
-    fetchImpl: await storeHolding(manifest),
+    fetchImpl: storeHolding(manifest),
     now: () => Date.parse("2026-08-20T05:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "good");
@@ -156,7 +156,7 @@ Deno.test("the selection tile says what share of the corpus would run", async ()
 
 Deno.test("the selection tile goes amber once the manifest has gone stale", async () => {
   const view = await makeTestSelection({
-    fetchImpl: await storeHolding(sampleManifest()),
+    fetchImpl: storeHolding(sampleManifest()),
     now: () => Date.parse("2026-08-21T04:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "warn");
@@ -184,7 +184,7 @@ Deno.test("the selection tile goes red when a lane is past its budget", async ()
     }],
   });
   const view = await makeTestSelection({
-    fetchImpl: await storeHolding(manifest),
+    fetchImpl: storeHolding(manifest),
     now: () => Date.parse("2026-08-20T05:00:00.000Z"),
   }).collect(CTX);
   assertEquals(view.status, "bad");

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -71,6 +71,44 @@ Deno.test("newestManifest treats a malformed manifest as absent", async () => {
   assertEquals(found, undefined);
 });
 
+/**
+ * A store that lists one manifest and then answers for the object
+ * itself however the caller says. The listing has to succeed for the
+ * reader to reach the object at all.
+ */
+function storeRefusing(answer: () => Promise<Response>): typeof fetch {
+  const name = `${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`;
+  return ((input: string | URL | Request) => {
+    const url = new URL(String(input instanceof Request ? input.url : input));
+    if (url.pathname.endsWith("/o")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ items: [{ name }] }), { status: 200 }),
+      );
+    }
+    return answer();
+  }) as typeof fetch;
+}
+
+Deno.test("newestManifest treats a refused manifest as absent", async () => {
+  // Listed but not readable, which is what a manifest deleted between
+  // the listing and the read looks like.
+  for (const status of [403, 404, 500]) {
+    const found = await newestManifest({
+      fetchImpl: storeRefusing(() =>
+        Promise.resolve(new Response("", { status }))
+      ),
+    });
+    assertEquals(found, undefined);
+  }
+});
+
+Deno.test("newestManifest treats a failed read as absent", async () => {
+  const found = await newestManifest({
+    fetchImpl: storeRefusing(() => Promise.reject(new Error("no network"))),
+  });
+  assertEquals(found, undefined);
+});
+
 Deno.test("newestManifest treats an unreachable store as absent", async () => {
   const found = await newestManifest({
     fetchImpl: (() => Promise.reject(new Error("no network"))) as typeof fetch,

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "@std/assert";
-import { gzipText, sampleEntry, sampleManifest, serializeManifest } from "@commonfabric/test-support/records";
+import {
+  sampleEntry,
+  sampleManifest,
+  serializeManifest,
+} from "@commonfabric/test-support/records";
 
 import { generatedAtOf, newestManifest } from "./test-selection-manifest.ts";
 import { makeTestFlakes } from "./tiles/test-flakes.ts";
@@ -12,8 +16,13 @@ import type { Ctx } from "./types.ts";
 
 const PREFIX = "labs/test-selection/v1";
 
-/** A store answering one listing and the objects it named. */
-function storeOf(objects: Record<string, Uint8Array>): typeof fetch {
+/**
+ * A store answering one listing and the objects it named. Bodies are the
+ * text a real fetch delivers: the store serves with transcoding, so the
+ * gzip an object is stored under is already decoded by the time a reader
+ * sees it.
+ */
+function storeOf(objects: Record<string, string>): typeof fetch {
   return ((input: string | URL | Request) => {
     const url = new URL(String(input instanceof Request ? input.url : input));
     if (url.pathname.endsWith("/o")) {
@@ -43,12 +52,10 @@ Deno.test("newestManifest takes the newest object under the prefix", async () =>
   const newer = sampleManifest({ generatedAt: "2026-08-20T04:00:00.000Z" });
   const found = await newestManifest({
     fetchImpl: storeOf({
-      [`${PREFIX}/manifest-2026-08-20T00:00:00.000Z-a.json.gz`]: await gzipText(
+      [`${PREFIX}/manifest-2026-08-20T00:00:00.000Z-a.json.gz`]:
         serializeManifest(older),
-      ),
-      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]: await gzipText(
+      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]:
         serializeManifest(newer),
-      ),
     }),
   });
   assertEquals(found?.generatedAt, "2026-08-20T04:00:00.000Z");
@@ -57,9 +64,8 @@ Deno.test("newestManifest takes the newest object under the prefix", async () =>
 Deno.test("newestManifest treats a malformed manifest as absent", async () => {
   const found = await newestManifest({
     fetchImpl: storeOf({
-      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]: await gzipText(
+      [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-b.json.gz`]:
         "{not a manifest",
-      ),
     }),
   });
   assertEquals(found, undefined);
@@ -81,9 +87,8 @@ const CTX: Ctx = {
 /** A store holding one manifest under a fixed name. */
 async function storeHolding(manifest: Parameters<typeof serializeManifest>[0]) {
   return storeOf({
-    [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`]: await gzipText(
+    [`${PREFIX}/manifest-2026-08-20T04:00:00.000Z-a.json.gz`]:
       serializeManifest(manifest),
-    ),
   });
 }
 

--- a/packages/dashboard/test-selection-manifest.ts
+++ b/packages/dashboard/test-selection-manifest.ts
@@ -1,0 +1,57 @@
+/**
+ * Reads the newest test-selection manifest from the store. The bucket is
+ * publicly readable, so no credential is involved, and a manifest is
+ * untrusted input like every record line: it goes through the shared
+ * validator whole, and a manifest that fails it is treated as absent.
+ *
+ * Following the dashboard's values (README.md): what this feeds reports on
+ * the system. It names tests, never people.
+ */
+
+import {
+  gunzipToText,
+  listObjects,
+  type Manifest,
+  objectUrl,
+  parseManifest,
+} from "@commonfabric/test-support/records";
+
+export const TEST_SELECTION_BUCKET = "cf-ci-metadata";
+export const TEST_SELECTION_PREFIX = "labs/test-selection/v1";
+
+/** The generation time in a manifest's object name, when it is one. */
+export function generatedAtOf(objectName: string): string | undefined {
+  return objectName.match(
+    /\/manifest-(\d{4}-\d{2}-\d{2}T[0-9:.]+Z)-[^/]*\.json\.gz$/,
+  )?.[1];
+}
+
+/** Fetches the newest manifest, or undefined when there is not one. */
+export async function newestManifest(options: {
+  bucket?: string;
+  prefix?: string;
+  fetchImpl?: typeof fetch;
+} = {}): Promise<Manifest | undefined> {
+  const bucket = options.bucket ?? TEST_SELECTION_BUCKET;
+  const prefix = options.prefix ?? TEST_SELECTION_PREFIX;
+  const doFetch = options.fetchImpl ?? fetch;
+  let names: string[];
+  try {
+    names = await listObjects({ bucket, prefix, fetch: doFetch });
+  } catch {
+    return undefined;
+  }
+  const newest = names.filter((name) => generatedAtOf(name) !== undefined)
+    .sort().at(-1);
+  if (newest === undefined) return undefined;
+  try {
+    const url = objectUrl(bucket, newest);
+    const response = await doFetch(url);
+    if (!response.ok) return undefined;
+    return parseManifest(
+      await gunzipToText(new Uint8Array(await response.arrayBuffer())),
+    );
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/dashboard/test-selection-manifest.ts
+++ b/packages/dashboard/test-selection-manifest.ts
@@ -9,7 +9,6 @@
  */
 
 import {
-  gunzipToText,
   listObjects,
   type Manifest,
   objectUrl,
@@ -17,7 +16,10 @@ import {
 } from "@commonfabric/test-support/records";
 
 export const TEST_SELECTION_BUCKET = "cf-ci-metadata";
-export const TEST_SELECTION_PREFIX = "labs/test-selection/v1";
+// The trailing slash is what keeps the listing inside this version. A
+// bare "v1" prefix also matches "v10", so a later schema's manifests
+// would sort above these and hide the newest one a v1 reader may use.
+export const TEST_SELECTION_PREFIX = "labs/test-selection/v1/";
 
 /** The generation time in a manifest's object name, when it is one. */
 export function generatedAtOf(objectName: string): string | undefined {
@@ -48,9 +50,9 @@ export async function newestManifest(options: {
     const url = objectUrl(bucket, newest);
     const response = await doFetch(url);
     if (!response.ok) return undefined;
-    return parseManifest(
-      await gunzipToText(new Uint8Array(await response.arrayBuffer())),
-    );
+    // The store serves these with transcoding, so a plain fetch has
+    // already decoded the gzip the object is stored under.
+    return parseManifest(await response.text());
   } catch {
     return undefined;
   }

--- a/packages/dashboard/tiles/test-flakes.ts
+++ b/packages/dashboard/tiles/test-flakes.ts
@@ -1,0 +1,83 @@
+/**
+ * Reports how many tests are too noisy to judge a change by: the ones the
+ * publisher measured disagreeing with themselves often enough to be held
+ * back from pull requests. A flake list derived from measurement rather
+ * than from anybody's judgement at one moment, which is what makes it
+ * reverse on its own the moment a test is fixed.
+ *
+ * Following the dashboard's values (README.md): it reports on the system.
+ * It names tests, never the people who wrote or touched them, and nothing
+ * about it is aggregated per person.
+ */
+
+import type { Status, Tile, TileView } from "../types.ts";
+import { escapeHtml } from "../lib.ts";
+import { newestManifest } from "../test-selection-manifest.ts";
+
+/** Flaky tests the wall goes amber at, and the count it goes red at. */
+export const FLAKES_WARN = 1;
+export const FLAKES_BAD = 10;
+
+/** How many of the worst are named under the count. */
+const NAMED = 4;
+
+/** The scope and name of an identity, short enough for a tile line. */
+function shortName(test: { s: string; n: string; v?: string }): string {
+  const name = test.n.length > 52 ? `${test.n.slice(0, 51)}…` : test.n;
+  const variant = test.v === undefined ? "" : ` (${test.v})`;
+  return `${test.s}: ${name}${variant}`;
+}
+
+/** Builds the tile against a store, so a test can supply its own. */
+export function makeTestFlakes(
+  options: { fetchImpl?: typeof fetch } = {},
+): Tile {
+  return {
+    id: "test-flakes",
+    intervalMs: 15 * 60_000,
+    collect: () => flakesView(options),
+  };
+}
+
+async function flakesView(
+  options: { fetchImpl?: typeof fetch },
+): Promise<TileView> {
+  {
+    const manifest = await newestManifest(
+      options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl },
+    );
+    if (manifest === undefined) {
+      return {
+        label: "flaky tests",
+        status: "unknown",
+        value: "—",
+        sub: "no selection manifest yet",
+      };
+    }
+    const flaky = manifest.entries
+      .filter((entry) => entry.flakeRate > 0)
+      .sort((a, b) => b.flakeRate - a.flakeRate);
+    const held = manifest.withheld.filter((entry) => entry.reason === "flaky");
+    const status: Status = held.length >= FLAKES_BAD
+      ? "bad"
+      : held.length >= FLAKES_WARN
+      ? "warn"
+      : "good";
+    const worst = flaky.slice(0, NAMED).map((entry) =>
+      `<div>${(entry.flakeRate * 100).toFixed(1)}% · ${
+        escapeHtml(shortName(entry.test))
+      }</div>`
+    ).join("");
+    return {
+      label: "flaky tests",
+      status,
+      value: `${held.length}`,
+      sub: held.length === 1
+        ? "too noisy to judge a change by · 1 test"
+        : `too noisy to judge a change by · ${held.length} tests`,
+      extra: worst,
+    };
+  }
+}
+
+export const testFlakes = makeTestFlakes();

--- a/packages/dashboard/tiles/test-flakes.ts
+++ b/packages/dashboard/tiles/test-flakes.ts
@@ -14,8 +14,10 @@ import type { Status, Tile, TileView } from "../types.ts";
 import { escapeHtml } from "../lib.ts";
 import { newestManifest } from "../test-selection-manifest.ts";
 
-/** Flaky tests the wall goes amber at, and the count it goes red at. */
+/** How many flaky tests turn the wall amber. */
 export const FLAKES_WARN = 1;
+
+/** How many turn it red. */
 export const FLAKES_BAD = 10;
 
 /** How many of the worst are named under the count. */

--- a/packages/dashboard/tiles/test-selection.ts
+++ b/packages/dashboard/tiles/test-selection.ts
@@ -1,0 +1,91 @@
+/**
+ * Reports what the newest selection manifest would have a pull request
+ * run: how much of the corpus fits five lanes, and how close the fullest
+ * lane is to its budget. It goes amber when the manifest has gone stale,
+ * because selection quality decays with it, and red when a lane's
+ * projected work is past the bound the whole design rests on.
+ *
+ * Following the dashboard's values (README.md): it reports on the system.
+ */
+
+import type { Status, Tile, TileView } from "../types.ts";
+import { newestManifest } from "../test-selection-manifest.ts";
+
+/** Hours before a manifest is stale enough to say so. */
+export const MANIFEST_STALE_HOURS = 8;
+
+/**
+ * Seconds of planned work a lane may hold, when the manifest does not say.
+ * Every manifest records the dials it was built with, so the tile reads
+ * the budget from the manifest in front of it rather than from a number
+ * here that would quietly start lying the day the dial moved.
+ */
+export const LANE_BUDGET_FALLBACK_SECONDS = 230;
+
+/** The budget a manifest was built with, or the fallback. */
+export function laneBudgetOf(dials: Record<string, unknown>): number {
+  const budget = dials.LANE_BUDGET_SECONDS;
+  return typeof budget === "number" && Number.isFinite(budget) && budget > 0
+    ? budget
+    : LANE_BUDGET_FALLBACK_SECONDS;
+}
+
+/** Builds the tile against a store and a clock, so a test can supply both. */
+export function makeTestSelection(
+  options: { fetchImpl?: typeof fetch; now?: () => number } = {},
+): Tile {
+  return {
+    id: "test-selection",
+    intervalMs: 15 * 60_000,
+    collect: () => selectionView(options),
+  };
+}
+
+async function selectionView(
+  options: { fetchImpl?: typeof fetch; now?: () => number },
+): Promise<TileView> {
+  {
+    const manifest = await newestManifest(
+      options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl },
+    );
+    if (manifest === undefined) {
+      return {
+        label: "test selection",
+        status: "unknown",
+        value: "—",
+        sub: "no selection manifest yet",
+      };
+    }
+    const selected = manifest.lanes.reduce(
+      (total, lane) =>
+        total +
+        lane.batches.reduce((sum, batch) => sum + batch.identities.length, 0),
+      0,
+    );
+    const known = manifest.entries.length;
+    const share = known === 0 ? 0 : (selected / known) * 100;
+    const now = options.now?.() ?? Date.now();
+    const ageHours = (now - Date.parse(manifest.generatedAt)) / 3_600_000;
+    const budget = laneBudgetOf(manifest.dials);
+    const fullest = manifest.lanes.length === 0
+      ? 0
+      : Math.max(...manifest.lanes.map((lane) => lane.projectedSeconds));
+    const status: Status = fullest > budget
+      ? "bad"
+      : ageHours > MANIFEST_STALE_HOURS
+      ? "warn"
+      : "good";
+    return {
+      label: "test selection",
+      status,
+      value: `${share.toFixed(0)}%`,
+      sub: `${selected} of ${known} tests · fullest lane ` +
+        `${fullest.toFixed(0)}s of ${budget}s`,
+      aside: ageHours > MANIFEST_STALE_HOURS
+        ? `${ageHours.toFixed(0)}h old`
+        : undefined,
+    };
+  }
+}
+
+export const testSelection = makeTestSelection();

--- a/packages/test-support/src/records/junit.test.ts
+++ b/packages/test-support/src/records/junit.test.ts
@@ -210,10 +210,46 @@ describe("junit", () => {
       });
       const bare = records.find((r) => r.test.n === "bare deno test case");
       expect(bare?.file).toBe("packages/bakery/test/glaze.test.ts");
+    });
+
+    it("gives a leaf the file of the container that registered it", () => {
+      const records = ingestJUnit(DENO_SAMPLE, {
+        kind: "unit",
+        scope: "bakery",
+        filePrefix: "packages/bakery",
+      });
       const leaf = records.find(
         (r) => r.test.n === "glaze > thickness > thickens when heated",
       );
-      expect(leaf?.file).toBeUndefined();
+      expect(leaf?.file).toBe("packages/bakery/test/glaze.test.ts");
+    });
+
+    it("prefers the preload's map over what the report claims", () => {
+      const records = ingestJUnit(DENO_SAMPLE, {
+        kind: "unit",
+        scope: "bakery",
+        filePrefix: "packages/bakery",
+        fileByName: new Map([["glaze", "packages/bakery/test/moved.test.ts"]]),
+      });
+      const leaf = records.find(
+        (r) => r.test.n === "glaze > thickness > thickens when heated",
+      );
+      expect(leaf?.file).toBe("packages/bakery/test/moved.test.ts");
+      const bare = records.find((r) => r.test.n === "bare deno test case");
+      expect(bare?.file).toBe("packages/bakery/test/glaze.test.ts");
+    });
+
+    it("declines a classname naming the registration wrapper", () => {
+      const wrapped = DENO_SAMPLE.replaceAll(
+        'classname="test/glaze.test.ts"',
+        'classname="../../packages/test-support/src/records/registration.ts"',
+      );
+      const records = ingestJUnit(wrapped, {
+        kind: "unit",
+        scope: "bakery",
+        filePrefix: "packages/bakery",
+      });
+      for (const record of records) expect(record.file).toBeUndefined();
     });
 
     it("records no file without a prefix", () => {

--- a/packages/test-support/src/records/junit.test.ts
+++ b/packages/test-support/src/records/junit.test.ts
@@ -239,10 +239,39 @@ describe("junit", () => {
       expect(bare?.file).toBe("packages/bakery/test/glaze.test.ts");
     });
 
+    it("records no file for a name two files both report", () => {
+      // The two are one identity, and which file a leaf came from is not
+      // a question the report can answer, so it answers neither.
+      // A second case under the same name, from another file — which is
+      // what two packages reporting one test name looks like.
+      const collided = DENO_SAMPLE.replace(
+        '    </testsuite>\n    <testsuite name="ext:cli/40_test.js"',
+        '        <testcase name="bare deno test case" ' +
+          'classname="test/other.test.ts" time="0.000" line="4" col="1">\n' +
+          "        </testcase>\n    </testsuite>\n" +
+          '    <testsuite name="ext:cli/40_test.js"',
+      );
+      const records = ingestJUnit(collided, {
+        kind: "unit",
+        scope: "bakery",
+        filePrefix: "packages/bakery",
+      });
+      const bare = records.find((r) => r.test.n === "bare deno test case");
+      expect(bare?.file).toBeUndefined();
+      // The names that did not collide keep theirs.
+      const leaf = records.find(
+        (r) => r.test.n === "glaze > thickness > thickens when heated",
+      );
+      expect(leaf?.file).toBe("packages/bakery/test/glaze.test.ts");
+    });
+
     it("declines a classname naming the registration wrapper", () => {
+      // A path that does not climb, so `isRelativeSourcePath` accepts it
+      // and the rejection under test is the one that fires. A classname
+      // with `..` in it is refused before ever reaching that check.
       const wrapped = DENO_SAMPLE.replaceAll(
         'classname="test/glaze.test.ts"',
-        'classname="../../packages/test-support/src/records/registration.ts"',
+        'classname="packages/test-support/src/records/registration.ts"',
       );
       const records = ingestJUnit(wrapped, {
         kind: "unit",

--- a/packages/test-support/src/records/junit.ts
+++ b/packages/test-support/src/records/junit.ts
@@ -311,10 +311,20 @@ export function ingestJUnit(
   // is what remains once the preload has wrapped `Deno.test` and every
   // classname names the preload instead.
   const files = new Map<string, string>();
+  const ambiguous = new Set<string>();
   for (const testcase of cases) {
     const file = classnameFile(testcase, options.filePrefix);
-    if (file !== undefined) files.set(testcase.name, file);
+    if (file === undefined) continue;
+    const known = files.get(testcase.name);
+    // Two files reporting one name are one identity, and which of them a
+    // leaf came from is not a question this report can answer. Attributing
+    // it to whichever was read last would be a guess presented as a fact,
+    // so the name carries no file at all and the collision is what the
+    // report tool surfaces.
+    if (known !== undefined && known !== file) ambiguous.add(testcase.name);
+    else files.set(testcase.name, file);
   }
+  for (const name of ambiguous) files.delete(name);
   for (const [name, file] of options.fileByName ?? []) files.set(name, file);
   return leaves.map((leaf) => {
     const test: TestIdentity = {

--- a/packages/test-support/src/records/junit.ts
+++ b/packages/test-support/src/records/junit.ts
@@ -6,10 +6,17 @@
  * container's name extended with " > " prefixes some other case's name.
  * Classnames carry a usable source file only on file-level suites, as a
  * path relative to the test process's working directory; the caller maps
- * that to a repository path with `filePrefix`.
+ * that to a repository path with `filePrefix`. For everything else the
+ * file comes from `fileByName`, the map the registration preload captured
+ * while the tests were registering.
  */
 
 import { type TestIdentity, type TestRecord } from "./schema.ts";
+import {
+  fileForName,
+  NAME_SEPARATOR,
+  REGISTRATION_MODULE_SUFFIX,
+} from "./registration.ts";
 
 /** One parsed `<testcase>`. */
 export interface JUnitCase {
@@ -223,7 +230,7 @@ export function parseJUnit(xml: string): JUnitCase[] {
  */
 export function dropContainerCases(cases: readonly JUnitCase[]): JUnitCase[] {
   return cases.filter((testcase) => {
-    const prefix = testcase.name + " > ";
+    const prefix = testcase.name + NAME_SEPARATOR;
     return !cases.some((other) => other.name.startsWith(prefix));
   });
 }
@@ -260,6 +267,35 @@ export interface IngestJUnitOptions {
    * repository-relative file metadata; without it, files are not recorded.
    */
   filePrefix?: string;
+
+  /**
+   * The file each `Deno.test` was registered from, as the registration
+   * preload captured it. It is repository-relative already, so it needs
+   * no prefix, and it overrides what the report's own classnames say —
+   * which is what the wrapper the preload installs costs them.
+   */
+  fileByName?: ReadonlyMap<string, string>;
+}
+
+/**
+ * The repository path a case's classname names, or undefined when it
+ * names something that is not a test file: a runtime-internal module, a
+ * remote one, or the registration wrapper that displaces the file while
+ * it is installed.
+ */
+function classnameFile(
+  testcase: JUnitCase,
+  filePrefix: string | undefined,
+): string | undefined {
+  if (filePrefix === undefined || testcase.classname === undefined) {
+    return undefined;
+  }
+  if (!isRelativeSourcePath(testcase.classname)) return undefined;
+  const cleaned = testcase.classname.replace(/^\.\//, "");
+  if (cleaned.endsWith(REGISTRATION_MODULE_SUFFIX)) return undefined;
+  return filePrefix.length > 0
+    ? `${filePrefix.replace(/\/$/, "")}/${cleaned}`
+    : cleaned;
 }
 
 /** Turns a JUnit document into records of the given kind and scope. */
@@ -267,7 +303,19 @@ export function ingestJUnit(
   xml: string,
   options: IngestJUnitOptions,
 ): TestRecord[] {
-  const leaves = dropContainerCases(parseJUnit(xml));
+  const cases = parseJUnit(xml);
+  const leaves = dropContainerCases(cases);
+  // Deno names a case's class after the module that registered the test,
+  // so a container carries the file of every leaf beneath it and the
+  // report joins itself. The preload's map is laid over that, because it
+  // is what remains once the preload has wrapped `Deno.test` and every
+  // classname names the preload instead.
+  const files = new Map<string, string>();
+  for (const testcase of cases) {
+    const file = classnameFile(testcase, options.filePrefix);
+    if (file !== undefined) files.set(testcase.name, file);
+  }
+  for (const [name, file] of options.fileByName ?? []) files.set(name, file);
   return leaves.map((leaf) => {
     const test: TestIdentity = {
       k: options.kind,
@@ -280,15 +328,8 @@ export function ingestJUnit(
       outcome: leaf.outcome,
       durationMs: Math.round((leaf.timeSeconds ?? 0) * 1000),
     };
-    if (
-      options.filePrefix !== undefined && leaf.classname !== undefined &&
-      isRelativeSourcePath(leaf.classname)
-    ) {
-      const cleaned = leaf.classname.replace(/^\.\//, "");
-      record.file = options.filePrefix.length > 0
-        ? `${options.filePrefix.replace(/\/$/, "")}/${cleaned}`
-        : cleaned;
-    }
+    const file = fileForName(leaf.name, files);
+    if (file !== undefined) record.file = file;
     return record;
   });
 }

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -60,6 +60,7 @@ export {
 export type { HeldSpool, SpoolContents } from "./spool.ts";
 export {
   activeCapture,
+  asDefinition,
   fileForName,
   installRegistrationCapture,
   NAME_MAP_PREFIX,

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -72,6 +72,7 @@ export {
   registerFrameworkModule,
   registeringModule,
   relativeToRoot,
+  repositoryRootOf,
   serializeSkipList,
   SKIP_LIST_VARIABLE,
 } from "./registration.ts";

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -59,6 +59,23 @@ export {
 } from "./spool.ts";
 export type { HeldSpool, SpoolContents } from "./spool.ts";
 export {
+  activeCapture,
+  fileForName,
+  installRegistrationCapture,
+  NAME_MAP_PREFIX,
+  NAME_MAP_SUFFIX,
+  NAME_SEPARATOR,
+  parseSkipList,
+  readNameMaps,
+  registerFrameworkModule,
+  registeringModule,
+  relativeToRoot,
+  serializeSkipList,
+  SKIP_LIST_VARIABLE,
+} from "./registration.ts";
+export type { NameMap, RegistrationCapture, SkipList } from "./registration.ts";
+export { preloadArgument, preloadModulePath } from "./preload-path.ts";
+export {
   dropContainerCases,
   ingestJUnit,
   isRelativeSourcePath,
@@ -94,3 +111,26 @@ export type {
   StoredReportGroup,
 } from "./store-reader.ts";
 export { recordsSpooledBy } from "./testing.ts";
+export {
+  digestIdentities,
+  MANIFEST_SCHEMA_VERSION,
+  parseManifest,
+  serializeManifest,
+} from "./selection.ts";
+export {
+  freeCalibration,
+  sampleEntry,
+  sampleManifest,
+} from "./selection-testing.ts";
+export type {
+  Calibration,
+  CoverageBaseline,
+  LanePlan,
+  Manifest,
+  ManifestEntry,
+  ScoreInputs,
+  UnavailableEntry,
+  UnschedulableEntry,
+  WithheldEntry,
+  WithheldReason,
+} from "./selection.ts";

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -61,6 +61,7 @@ export type { HeldSpool, SpoolContents } from "./spool.ts";
 export {
   activeCapture,
   asDefinition,
+  buildCapture,
   fileForName,
   installRegistrationCapture,
   NAME_MAP_PREFIX,

--- a/packages/test-support/src/records/preload-path.ts
+++ b/packages/test-support/src/records/preload-path.ts
@@ -1,0 +1,18 @@
+/**
+ * Where the registration preload lives on disk. `deno test --preload`
+ * takes a path rather than an import-map specifier, and a test task runs
+ * with its own package as the working directory, so every caller needs an
+ * absolute path rather than a relative one.
+ */
+
+import { fromFileUrl } from "@std/path";
+
+/** Absolute path of the module `--preload` is pointed at. */
+export function preloadModulePath(): string {
+  return fromFileUrl(new URL("./preload.ts", import.meta.url));
+}
+
+/** The `--preload=<path>` argument naming that module. */
+export function preloadArgument(): string {
+  return `--preload=${preloadModulePath()}`;
+}

--- a/packages/test-support/src/records/preload.ts
+++ b/packages/test-support/src/records/preload.ts
@@ -1,0 +1,13 @@
+/**
+ * The module every `deno test` invocation loads through `--preload`. It
+ * captures the file each test is registered from and applies this
+ * invocation's skip list; `./registration.ts` holds both.
+ *
+ * Deno resolves `--preload` as a path rather than through the import map,
+ * so callers name this file's absolute path. `preloadModulePath` is where
+ * that path is computed, so nothing spells it out.
+ */
+
+import { installRegistrationCapture } from "./registration.ts";
+
+installRegistrationCapture();

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -206,6 +206,30 @@ describe("registration", () => {
       }
     });
 
+    it("judges ambiguity within the scope it was given", async () => {
+      // Every package of a workspace run writes into one spool. A name
+      // two of them share is unambiguous inside either, so scoping the
+      // read is what keeps both their files rather than dropping both.
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(dir, "01", {
+          shared: "packages/a/one.test.ts",
+        });
+        await writeNameMap(dir, "02", {
+          shared: "packages/b/two.test.ts",
+        });
+        expect((await readNameMaps(dir)).get("shared")).toBeUndefined();
+        expect(
+          (await readNameMaps(dir, { within: "packages/a" })).get("shared"),
+        ).toBe("packages/a/one.test.ts");
+        expect(
+          (await readNameMaps(dir, { within: "packages/b/" })).get("shared"),
+        ).toBe("packages/b/two.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
     it("returns an empty map for a spool that is not there", async () => {
       expect((await readNameMaps("/nonexistent-spool")).size).toBe(0);
     });

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { join } from "@std/path";
 
 import {
+  asDefinition,
   fileForName,
   NAME_MAP_PREFIX,
   NAME_MAP_SUFFIX,
@@ -63,6 +64,63 @@ describe("registration", () => {
     it("returns undefined when no frame names a file", () => {
       expect(registeringModule("")).toBeUndefined();
       expect(registeringModule("Error\n    at <anonymous>")).toBeUndefined();
+    });
+  });
+
+  describe("asDefinition()", () => {
+    const body = () => {};
+
+    it("takes a name and a body", () => {
+      expect(asDefinition(["a name", body])).toEqual({
+        name: "a name",
+        fn: body,
+      });
+    });
+
+    it("keeps the options a name-and-options call carried", () => {
+      // Dropping these is the shape that registers a definition with no
+      // body, which Deno refuses and which fails the whole module.
+      expect(asDefinition(["a name", { sanitizeOps: false }, body])).toEqual({
+        name: "a name",
+        sanitizeOps: false,
+        fn: body,
+      });
+    });
+
+    it("keeps the options an options-and-body call carried", () => {
+      expect(
+        asDefinition([{ name: "a name", sanitizeResources: false }, body]),
+      ).toEqual({ name: "a name", sanitizeResources: false, fn: body });
+    });
+
+    it("names an options-and-body call after its function", () => {
+      function namedByItsFunction() {}
+      expect(asDefinition([{ ignore: true }, namedByItsFunction])).toEqual({
+        name: "namedByItsFunction",
+        ignore: true,
+        fn: namedByItsFunction,
+      });
+    });
+
+    it("takes a whole definition as it is", () => {
+      const definition = { name: "a name", fn: body, only: true };
+      expect(asDefinition([definition])).toBe(definition);
+    });
+
+    it("names a bare function after itself", () => {
+      function bodyAlone() {}
+      expect(asDefinition([bodyAlone])).toEqual({
+        name: "bodyAlone",
+        fn: bodyAlone,
+      });
+    });
+
+    it("returns undefined for a shape it does not model", () => {
+      // Those reach the real registrar untouched, so Deno reports them.
+      expect(asDefinition([])).toBeUndefined();
+      expect(asDefinition(["a name"])).toBeUndefined();
+      expect(asDefinition([{ sanitizeOps: false }, () => {}])).toBeUndefined();
+      expect(asDefinition([42, body])).toBeUndefined();
     });
   });
 

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { join } from "@std/path";
+import { fromFileUrl, join } from "@std/path";
 
 import {
   activeCapture,
@@ -14,6 +14,7 @@ import {
   registerFrameworkModule,
   registeringModule,
   relativeToRoot,
+  repositoryRootOf,
   serializeSkipList,
 } from "./registration.ts";
 
@@ -404,6 +405,26 @@ describe("what the capture does with what it cannot read", () => {
   it("refuses a skip list that is not an object of lists", () => {
     for (const text of ["{not json", "null", '["a"]', '{"f.ts":"one"}']) {
       expect(parseSkipList(text)).toBeUndefined();
+    }
+  });
+});
+
+describe("repositoryRootOf()", () => {
+  it("finds the root above a file inside the repository", () => {
+    const root = repositoryRootOf(fromFileUrl(import.meta.url));
+    expect(root).toBeDefined();
+    expect(Deno.statSync(join(root!, ".git"))).toBeDefined();
+  });
+
+  it("is nothing for a path under no repository at all", async () => {
+    // The climb reaches the filesystem root and stops there. Answering
+    // with the root itself would make every registering module's path
+    // relative to "/", which names no file in any repository.
+    const outside = await Deno.makeTempDir();
+    try {
+      expect(repositoryRootOf(join(outside, "a.test.ts"))).toBeUndefined();
+    } finally {
+      await Deno.remove(outside, { recursive: true });
     }
   });
 });

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -1,0 +1,192 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+
+import {
+  fileForName,
+  NAME_MAP_PREFIX,
+  NAME_MAP_SUFFIX,
+  parseSkipList,
+  readNameMaps,
+  registerFrameworkModule,
+  registeringModule,
+  relativeToRoot,
+  serializeSkipList,
+} from "./registration.ts";
+
+// The wrapper's own frame, as it appears in a real registration stack.
+const WRAPPER = new URL("./registration.ts", import.meta.url).href;
+
+async function writeNameMap(
+  dir: string,
+  label: string,
+  map: Record<string, unknown>,
+): Promise<void> {
+  await Deno.writeTextFile(
+    join(dir, `${NAME_MAP_PREFIX}${label}${NAME_MAP_SUFFIX}`),
+    JSON.stringify(map),
+  );
+}
+
+describe("registration", () => {
+  describe("registeringModule()", () => {
+    it("returns the first frame outside the test machinery", () => {
+      const stack = [
+        "Error",
+        `    at Object.test (${WRAPPER}:3:17)`,
+        "    at TestSuiteInternal.registerTest (https://jsr.io/@std/testing/" +
+        "1.0.20/_test_suite.ts:270:10)",
+        "    at describe (https://jsr.io/@std/testing/1.0.20/bdd.ts:1267:22)",
+        "    at file:///repo/packages/memory/test/space.test.ts:2:1",
+      ].join("\n");
+      expect(registeringModule(stack)).toBe(
+        "file:///repo/packages/memory/test/space.test.ts",
+      );
+    });
+
+    it("passes over a module declared as framework machinery", () => {
+      registerFrameworkModule(
+        "file:///repo/packages/test-support/test/clock.ts",
+      );
+      const stack = [
+        "Error",
+        `    at Object.test (${WRAPPER}:3:17)`,
+        "    at frozenTest (file:///repo/packages/test-support/test/" +
+        "clock.ts:8:5)",
+        "    at file:///repo/packages/runner/test/scheduler.test.ts:11:1",
+      ].join("\n");
+      expect(registeringModule(stack)).toBe(
+        "file:///repo/packages/runner/test/scheduler.test.ts",
+      );
+    });
+
+    it("returns undefined when no frame names a file", () => {
+      expect(registeringModule("")).toBeUndefined();
+      expect(registeringModule("Error\n    at <anonymous>")).toBeUndefined();
+    });
+  });
+
+  describe("relativeToRoot()", () => {
+    it("strips the root, with or without its trailing slash", () => {
+      expect(
+        relativeToRoot("file:///repo/packages/memory/a.test.ts", "/repo"),
+      ).toBe("packages/memory/a.test.ts");
+      expect(
+        relativeToRoot("file:///repo/packages/memory/a.test.ts", "/repo/"),
+      ).toBe("packages/memory/a.test.ts");
+    });
+
+    it("leaves a path outside the root whole", () => {
+      expect(relativeToRoot("file:///elsewhere/a.test.ts", "/repo")).toBe(
+        "/elsewhere/a.test.ts",
+      );
+    });
+
+    it("decodes what the URL escaped", () => {
+      expect(relativeToRoot("file:///repo/a%20b/c.test.ts", "/repo")).toBe(
+        "a b/c.test.ts",
+      );
+    });
+  });
+
+  describe("fileForName()", () => {
+    const names = new Map([
+      ["outer", "packages/a/outer.test.ts"],
+      ["outer > inner", "packages/a/inner.test.ts"],
+      ["bare", "packages/a/bare.test.ts"],
+    ]);
+
+    it("returns the file of an exactly registered name", () => {
+      expect(fileForName("bare", names)).toBe("packages/a/bare.test.ts");
+    });
+
+    it("returns the file of the longest registered prefix", () => {
+      expect(fileForName("outer > one", names)).toBe(
+        "packages/a/outer.test.ts",
+      );
+      expect(fileForName("outer > inner > deep", names)).toBe(
+        "packages/a/inner.test.ts",
+      );
+    });
+
+    it("returns undefined for a name no registration covers", () => {
+      expect(fileForName("unheard of", names)).toBeUndefined();
+      // A prefix without the separator is a different name, not a chain.
+      expect(fileForName("outermost", names)).toBeUndefined();
+    });
+  });
+
+  describe("readNameMaps()", () => {
+    it("merges every map a spool holds", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(dir, "01", { one: "packages/a/one.test.ts" });
+        await writeNameMap(dir, "02", { two: "packages/a/two.test.ts" });
+        await Deno.writeTextFile(join(dir, "fragment-01.ndjson"), "ignored\n");
+        const names = await readNameMaps(dir);
+        expect(names.size).toBe(2);
+        expect(names.get("one")).toBe("packages/a/one.test.ts");
+        expect(names.get("two")).toBe("packages/a/two.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("drops a name two files both claim", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        await writeNameMap(dir, "01", {
+          shared: "packages/a/one.test.ts",
+          own: "packages/a/one.test.ts",
+        });
+        await writeNameMap(dir, "02", { shared: "packages/b/two.test.ts" });
+        const names = await readNameMaps(dir);
+        expect(names.get("shared")).toBeUndefined();
+        expect(names.get("own")).toBe("packages/a/one.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("returns an empty map for a spool that is not there", async () => {
+      expect((await readNameMaps("/nonexistent-spool")).size).toBe(0);
+    });
+
+    it("skips an unparsable map and a line that is not a path", async () => {
+      const dir = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(
+          join(dir, `${NAME_MAP_PREFIX}01${NAME_MAP_SUFFIX}`),
+          "{not json",
+        );
+        await writeNameMap(dir, "02", {
+          good: "packages/a/one.test.ts",
+          bad: 7,
+        });
+        const names = await readNameMaps(dir);
+        expect(names.size).toBe(1);
+        expect(names.get("good")).toBe("packages/a/one.test.ts");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+  });
+
+  describe("parseSkipList()", () => {
+    it("round-trips what serializeSkipList wrote", () => {
+      const skips = { "packages/a/one.test.ts": ["slow > case"] };
+      expect(parseSkipList(serializeSkipList(skips))).toEqual(skips);
+    });
+
+    it("accepts a list that names nothing", () => {
+      expect(parseSkipList("{}")).toEqual({});
+    });
+
+    it("returns undefined for anything that is not a skip list", () => {
+      expect(parseSkipList("[]")).toBeUndefined();
+      expect(parseSkipList("not json")).toBeUndefined();
+      expect(parseSkipList('{"a": "b"}')).toBeUndefined();
+      expect(parseSkipList('{"a": [1]}')).toBeUndefined();
+    });
+  });
+});

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { join } from "@std/path";
 
 import {
+  activeCapture,
   asDefinition,
   buildCapture,
   fileForName,
@@ -352,5 +353,163 @@ describe("registration", () => {
       expect(parseSkipList('{"a": "b"}')).toBeUndefined();
       expect(parseSkipList('{"a": [1]}')).toBeUndefined();
     });
+  });
+});
+
+describe("what the capture does with what it cannot read", () => {
+  it("leaves a URL it cannot parse alone", () => {
+    // The registering module is recovered from a stack trace, which is
+    // not always a URL. What is not one is passed through rather than
+    // turned into a path that names nothing.
+    expect(relativeToRoot("not a url", "/repo")).toBe("not a url");
+  });
+
+  it("ignores a name map that is not a map", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(dir, `${NAME_MAP_PREFIX}01${NAME_MAP_SUFFIX}`),
+        "{not json",
+      );
+      await Deno.writeTextFile(
+        join(dir, `${NAME_MAP_PREFIX}02${NAME_MAP_SUFFIX}`),
+        '["a name"]',
+      );
+      await Deno.writeTextFile(
+        join(dir, `${NAME_MAP_PREFIX}03${NAME_MAP_SUFFIX}`),
+        "null",
+      );
+      await writeNameMap(dir, "04", { one: "packages/a/one.test.ts" });
+      const names = await readNameMaps(dir);
+      expect([...names.keys()]).toEqual(["one"]);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("drops a mapped file that is not a name", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(dir, `${NAME_MAP_PREFIX}01${NAME_MAP_SUFFIX}`),
+        JSON.stringify({ a: 7, b: "", c: "packages/a/one.test.ts" }),
+      );
+      const names = await readNameMaps(dir);
+      expect([...names.keys()]).toEqual(["c"]);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("refuses a skip list that is not an object of lists", () => {
+    for (const text of ["{not json", "null", '["a"]', '{"f.ts":"one"}']) {
+      expect(parseSkipList(text)).toBeUndefined();
+    }
+  });
+});
+
+describe("activeCapture()", () => {
+  it("is nothing in a process that installed no capture", () => {
+    // Every invocation that is not recording, which is the one this test
+    // runs in: the bdd re-exports consult this and must find nothing.
+    expect(activeCapture()).toBeUndefined();
+  });
+});
+
+describe("the wrapper over a shape it does not model", () => {
+  it("hands the real registrar the arguments it was given", () => {
+    const seen: unknown[][] = [];
+    const built = buildCapture({
+      registrar: ((...args: unknown[]) => {
+        seen.push(args);
+      }) as unknown as typeof Deno.test,
+    });
+    // No name anywhere, so `asDefinition` recognizes nothing. The call
+    // still reaches the registrar, which is what reports its own error.
+    (built.registrar as unknown as (...args: unknown[]) => void)(7, 8);
+    expect(seen).toEqual([[7, 8]]);
+  });
+});
+
+describe("what the capture does when it cannot write", () => {
+  const registrar = (() => {}) as unknown as typeof Deno.test;
+
+  it("does nothing at all when there is no spool", () => {
+    const { capture } = buildCapture({ registrar });
+    capture.names.set("a test", "packages/a/one.test.ts");
+    // No spool is a run that was never recording, not a failed write.
+    capture.flush();
+  });
+
+  it("does nothing when it learned no names", async () => {
+    const spool = await Deno.makeTempDir();
+    try {
+      buildCapture({ registrar, spool }).capture.flush();
+      expect([...Deno.readDirSync(spool)]).toEqual([]);
+    } finally {
+      await Deno.remove(spool, { recursive: true });
+    }
+  });
+
+  it("writes the names it learned into the spool", async () => {
+    const spool = await Deno.makeTempDir();
+    try {
+      const { capture } = buildCapture({ registrar, spool });
+      capture.names.set("a test", "packages/a/one.test.ts");
+      capture.flush();
+      const names = await readNameMaps(spool);
+      expect(names.get("a test")).toBe("packages/a/one.test.ts");
+    } finally {
+      await Deno.remove(spool, { recursive: true });
+    }
+  });
+
+  it("says so and carries on when the spool cannot be made", async () => {
+    // A file where the directory should be. Failing to record must not
+    // fail the test run that was recording.
+    const parent = await Deno.makeTempDir();
+    const spool = join(parent, "in-the-way");
+    await Deno.writeTextFile(spool, "");
+    const said: string[] = [];
+    const warn = console.warn;
+    console.warn = (...parts: unknown[]) => said.push(parts.join(" "));
+    try {
+      const { capture } = buildCapture({ registrar, spool });
+      capture.names.set("a test", "packages/a/one.test.ts");
+      capture.flush();
+    } finally {
+      console.warn = warn;
+      await Deno.remove(parent, { recursive: true });
+    }
+    expect(said.join("\n")).toContain("cannot write a name map");
+  });
+});
+
+describe("the skip list a capture was built with", () => {
+  const registrar = (() => {}) as unknown as typeof Deno.test;
+
+  it("skips only the named test in the named file", () => {
+    const { capture } = buildCapture({
+      registrar,
+      skips: { "packages/a/one.test.ts": ["a test"] },
+    });
+    expect(capture.skipped("packages/a/one.test.ts", "a test")).toBe(true);
+    expect(capture.skipped("packages/a/one.test.ts", "another")).toBe(false);
+    expect(capture.skipped("packages/a/two.test.ts", "a test")).toBe(false);
+  });
+
+  it("skips nothing when the file is unknown", () => {
+    // A test whose file could not be recovered cannot be matched against
+    // a list keyed by file, so it runs.
+    const { capture } = buildCapture({
+      registrar,
+      skips: { "packages/a/one.test.ts": ["a test"] },
+    });
+    expect(capture.skipped(undefined, "a test")).toBe(false);
+  });
+
+  it("skips nothing when there is no list", () => {
+    const { capture } = buildCapture({ registrar });
+    expect(capture.skipped("packages/a/one.test.ts", "a test")).toBe(false);
   });
 });

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -409,10 +409,18 @@ describe("what the capture does with what it cannot read", () => {
 });
 
 describe("activeCapture()", () => {
-  it("is nothing in a process that installed no capture", () => {
-    // Every invocation that is not recording, which is the one this test
-    // runs in: the bdd re-exports consult this and must find nothing.
-    expect(activeCapture()).toBeUndefined();
+  it("is one capture for the whole process, or none", () => {
+    // Whether a capture is installed depends on whether this run was
+    // preloaded, so that is not what is asserted. What holds either way
+    // is that there is at most one: the bdd re-exports and the wrapper
+    // must be writing names into the same map, and a getter that built a
+    // capture per call would give each of them its own.
+    const first = activeCapture();
+    expect(activeCapture()).toBe(first);
+    if (first !== undefined) {
+      expect(typeof first.flush).toBe("function");
+      expect(first.names instanceof Map).toBe(true);
+    }
   });
 });
 

--- a/packages/test-support/src/records/registration.test.ts
+++ b/packages/test-support/src/records/registration.test.ts
@@ -4,6 +4,7 @@ import { join } from "@std/path";
 
 import {
   asDefinition,
+  buildCapture,
   fileForName,
   NAME_MAP_PREFIX,
   NAME_MAP_SUFFIX,
@@ -251,6 +252,87 @@ describe("registration", () => {
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
+    });
+  });
+
+  describe("buildCapture()", () => {
+    /** A registrar that records what it was handed, running nothing. */
+    function recorder() {
+      const seen: Deno.TestDefinition[] = [];
+      return { seen, registrar: (d: Deno.TestDefinition) => void seen.push(d) };
+    }
+
+    it("hands every definition on to the registrar it was given", () => {
+      const { seen, registrar } = recorder();
+      const built = buildCapture({ registrar });
+      built.registrar("a test", () => {});
+      built.registrar({ name: "another", sanitizeOps: false }, () => {});
+      expect(seen.map((d) => d.name)).toEqual(["a test", "another"]);
+      expect(seen[1]!.sanitizeOps).toBe(false);
+    });
+
+    it("registers a listed test as ignored rather than dropping it", () => {
+      // Dropped, the store watches the identity disappear; ignored, it
+      // learns the test was deliberately not run.
+      const { seen, registrar } = recorder();
+      const built = buildCapture({
+        registrar,
+        skips: { "packages/a/one.test.ts": ["skip me"] },
+      });
+      // The file comes from the registration stack, which here is this
+      // test file, so nothing matches and the skip does not apply.
+      built.registrar("skip me", () => {});
+      expect(seen[0]!.ignore).toBeFalsy();
+      expect(built.capture.skipped("packages/a/one.test.ts", "skip me")).toBe(
+        true,
+      );
+      expect(built.capture.skipped("packages/a/one.test.ts", "other")).toBe(
+        false,
+      );
+      expect(built.capture.skipped(undefined, "skip me")).toBe(false);
+    });
+
+    it("captures the file each registration came from", () => {
+      const { registrar } = recorder();
+      const built = buildCapture({ registrar });
+      built.registrar("named here", () => {});
+      // This test file registered it, so that is the file captured.
+      expect(built.capture.names.get("named here")).toMatch(
+        /registration\.test\.ts$/,
+      );
+    });
+
+    it("carries ignore and only through their own registrars", () => {
+      const { seen, registrar } = recorder();
+      const built = buildCapture({ registrar });
+      (built.registrar as unknown as {
+        ignore: (name: string, fn: () => void) => void;
+      }).ignore("ignored", () => {});
+      (built.registrar as unknown as {
+        only: (name: string, fn: () => void) => void;
+      }).only("only this", () => {});
+      expect(seen[0]!.ignore).toBe(true);
+      expect(seen[1]!.only).toBe(true);
+    });
+
+    it("writes the captured map into the spool it was given", async () => {
+      const spool = await Deno.makeTempDir();
+      try {
+        const { registrar } = recorder();
+        const built = buildCapture({ registrar, spool });
+        built.registrar("written out", () => {});
+        built.capture.flush();
+        const names = await readNameMaps(spool);
+        expect(names.get("written out")).toMatch(/registration\.test\.ts$/);
+      } finally {
+        await Deno.remove(spool, { recursive: true });
+      }
+    });
+
+    it("writes nothing when it captured nothing, or has nowhere", () => {
+      const { registrar } = recorder();
+      // No spool: flushing is a no-op rather than an error.
+      buildCapture({ registrar }).capture.flush();
     });
   });
 

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -117,7 +117,7 @@ export function relativeToRoot(url: string, root: string): string {
  * directory holding `.git`. Undefined outside any repository, and
  * undefined when the climb is not permitted to read the filesystem.
  */
-function repositoryRootOf(path: string): string | undefined {
+export function repositoryRootOf(path: string): string | undefined {
   let dir = dirname(resolve(path));
   for (;;) {
     try {

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -290,6 +290,39 @@ export function installRegistrationCapture(
   // better source and nothing is wrapped.
   if (skips === undefined && !writableSpool(spool)) return undefined;
 
+  const built = buildCapture({
+    registrar: Deno.test,
+    ...(skips === undefined ? {} : { skips }),
+    ...(spool === undefined ? {} : { spool }),
+  });
+  Reflect.set(Deno, "test", built.registrar);
+  globalThis.addEventListener("unload", () => built.capture.flush());
+  installed = built.capture;
+  return built.capture;
+}
+
+/** What a capture is built from, and where its map goes. */
+export interface CaptureOptions {
+  /** The registrar the wrapper hands each definition on to. */
+  registrar: (definition: Deno.TestDefinition) => void;
+
+  /** The identities this invocation is not to run. */
+  skips?: SkipList;
+
+  /** Where `flush` writes the name map. Nothing is written without one. */
+  spool?: string;
+}
+
+/**
+ * The wrapper and the capture behind it, built against a registrar the
+ * caller supplies. `installRegistrationCapture` supplies `Deno.test`;
+ * anything else can supply its own and exercise the whole of this
+ * without replacing a global that cannot be put back.
+ */
+export function buildCapture(
+  options: CaptureOptions,
+): { capture: RegistrationCapture; registrar: (...args: unknown[]) => void } {
+  const { skips, spool } = options;
   const names = new Map<string, string>();
   let root: string | undefined;
   let rootResolved = false;
@@ -336,7 +369,7 @@ export function installRegistrationCapture(
     },
   };
 
-  const realTest = Deno.test;
+  const realTest = options.registrar;
   const register = (
     through: (definition: Deno.TestDefinition) => void,
     extra: Partial<Deno.TestDefinition>,
@@ -362,11 +395,7 @@ export function installRegistrationCapture(
   const capturingTest = register(realTest, {});
   Reflect.set(capturingTest, "ignore", register(realTest, { ignore: true }));
   Reflect.set(capturingTest, "only", register(realTest, { only: true }));
-  Reflect.set(Deno, "test", capturingTest);
-
-  globalThis.addEventListener("unload", () => capture.flush());
-  installed = capture;
-  return capture;
+  return { capture, registrar: capturingTest };
 }
 
 /**

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -159,10 +159,20 @@ export function fileForName(
  * are one identity, and which file it came from is not a question the
  * spool can answer. Reading is best-effort, since a name map is metadata
  * and its absence costs only the file field.
+ *
+ * Every package of a workspace run writes into one spool, so a caller
+ * ingesting one package's report passes `within` — the path its files sit
+ * under. Names outside it are dropped before the ambiguity is judged
+ * rather than after, or a name two packages happen to share would cost
+ * both of them a file each had unambiguously.
  */
 export async function readNameMaps(
   dir: string,
+  options: { within?: string } = {},
 ): Promise<Map<string, string>> {
+  const within = options.within === undefined
+    ? undefined
+    : `${options.within.replace(/\/$/, "")}/`;
   const names = new Map<string, string>();
   const ambiguous = new Set<string>();
   let entries: string[] = [];
@@ -189,6 +199,7 @@ export async function readNameMaps(
     if (typeof parsed !== "object" || parsed === null) continue;
     for (const [name, file] of Object.entries(parsed)) {
       if (typeof file !== "string" || file.length === 0) continue;
+      if (within !== undefined && !file.startsWith(within)) continue;
       const known = names.get(name);
       if (known === undefined) {
         names.set(name, file);

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -196,7 +196,13 @@ export async function readNameMaps(
     } catch {
       continue;
     }
-    if (typeof parsed !== "object" || parsed === null) continue;
+    // An array is an object, and its entries are index keys against the
+    // values, so a map written as one would register a test named "0".
+    if (
+      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+    ) {
+      continue;
+    }
     for (const [name, file] of Object.entries(parsed)) {
       if (typeof file !== "string" || file.length === 0) continue;
       if (within !== undefined && !file.startsWith(within)) continue;

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -16,8 +16,10 @@
 import { dirname, join, resolve } from "@std/path";
 import { type Environment, readEnv, recordsDir } from "./paths.ts";
 
-/** Name-map files are `names-<ulid>.json` inside the spool. */
+/** What a name-map file's name starts with, inside the spool. */
 export const NAME_MAP_PREFIX = "names-";
+
+/** What it ends with; the whole name is `names-<uuid>.json`. */
 export const NAME_MAP_SUFFIX = ".json";
 
 /** Variable naming the file holding this invocation's skip list. */

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -370,7 +370,7 @@ export function installRegistrationCapture(
  * function with no name to take. The caller passes those through
  * untouched, so Deno reports them as it would have.
  */
-function asDefinition(
+export function asDefinition(
   args: readonly unknown[],
 ): Deno.TestDefinition | undefined {
   const [first, second, third] = args;

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -330,21 +330,14 @@ export function installRegistrationCapture(
     through: (definition: Deno.TestDefinition) => void,
     extra: Partial<Deno.TestDefinition>,
   ) =>
-  (
-    nameOrDef:
-      | string
-      | Deno.TestDefinition
-      | ((
-        t: Deno.TestContext,
-      ) => void | Promise<void>),
-    fn?: (t: Deno.TestContext) => void | Promise<void>,
-  ): void => {
-    const definition = asDefinition(nameOrDef, fn);
+  (...args: unknown[]): void => {
+    const definition = asDefinition(args);
     if (definition === undefined) {
       // A shape this wrapper does not model reaches the real registrar
-      // untouched, so an unfamiliar overload still runs.
+      // untouched and with its own arguments, so an unfamiliar overload
+      // still runs and still reports its own error.
       // deno-lint-ignore no-explicit-any
-      (through as any)(nameOrDef, fn);
+      (through as any)(...args);
       return;
     }
     const file = fileOf(registeringModule(new Error().stack ?? ""));
@@ -366,25 +359,47 @@ export function installRegistrationCapture(
 }
 
 /**
- * The one `Deno.test` shape this wrapper models: a definition object, or a
- * name and a body. Undefined for anything else, including the
- * function-only form, whose name comes from the function rather than from
- * an argument.
+ * One definition, whichever way `Deno.test` was called. It takes a name
+ * and a body, an options object and a body, a name and options and a
+ * body, a whole definition, or a named function alone, and the options
+ * carry the sanitizer and permission settings a test needs — so reading
+ * only the first two arguments drops the body of several of them and
+ * builds a definition Deno rejects.
+ *
+ * Undefined for a shape this does not model, including an anonymous
+ * function with no name to take. The caller passes those through
+ * untouched, so Deno reports them as it would have.
  */
 function asDefinition(
-  nameOrDef:
-    | string
-    | Deno.TestDefinition
-    | ((
-      t: Deno.TestContext,
-    ) => void | Promise<void>),
-  fn?: (t: Deno.TestContext) => void | Promise<void>,
+  args: readonly unknown[],
 ): Deno.TestDefinition | undefined {
-  if (typeof nameOrDef === "string") {
-    return fn === undefined ? undefined : { name: nameOrDef, fn };
+  const [first, second, third] = args;
+  const isBody = (value: unknown): value is Deno.TestDefinition["fn"] =>
+    typeof value === "function";
+  const isOptions = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null;
+
+  if (typeof first === "string") {
+    if (isBody(second)) return { name: first, fn: second };
+    if (isOptions(second) && isBody(third)) {
+      return { ...second, name: first, fn: third } as Deno.TestDefinition;
+    }
+    return undefined;
   }
-  if (typeof nameOrDef === "object" && nameOrDef !== null) {
-    return nameOrDef;
+  if (isOptions(first)) {
+    if (isBody(first.fn) && typeof first.name === "string") {
+      return first as unknown as Deno.TestDefinition;
+    }
+    if (isBody(second)) {
+      const name = typeof first.name === "string" ? first.name : second.name;
+      if (name.length > 0) {
+        return { ...first, name, fn: second } as Deno.TestDefinition;
+      }
+    }
+    return undefined;
+  }
+  if (isBody(first) && first.name.length > 0) {
+    return { name: first.name, fn: first };
   }
   return undefined;
 }

--- a/packages/test-support/src/records/registration.ts
+++ b/packages/test-support/src/records/registration.ts
@@ -1,0 +1,422 @@
+/**
+ * What a test process learns about its own tests at registration time: the
+ * file each `Deno.test` was registered from, and whether this invocation
+ * was asked not to run it.
+ *
+ * Both come from wrapping `Deno.test` in a `--preload` module, which runs
+ * before every test module and so needs nothing from the test files
+ * themselves. The file is read out of the registration stack and written
+ * into the run's spool beside the record fragments, where ingestion joins
+ * it onto the identities a JUnit report names. The skip list is a file the
+ * environment points at, holding the identities this invocation is not to
+ * run; a listed test is registered as ignored rather than dropped, so it
+ * appears in the report as skipped instead of vanishing.
+ */
+
+import { dirname, join, resolve } from "@std/path";
+import { type Environment, readEnv, recordsDir } from "./paths.ts";
+
+/** Name-map files are `names-<ulid>.json` inside the spool. */
+export const NAME_MAP_PREFIX = "names-";
+export const NAME_MAP_SUFFIX = ".json";
+
+/** Variable naming the file holding this invocation's skip list. */
+export const SKIP_LIST_VARIABLE = "CF_TEST_SKIP_LIST";
+
+/**
+ * The tail of this module's own path. Deno names a JUnit case's class
+ * after the module that registered the test, so while the wrapper is
+ * installed every case names this module; ingestion rejects a classname
+ * ending here rather than reading it as a test file.
+ */
+export const REGISTRATION_MODULE_SUFFIX = "src/records/registration.ts";
+
+/**
+ * The separator a bdd runner joins a describe chain with, and so the
+ * separator between a registered test's name and the leaf names beneath
+ * it.
+ */
+export const NAME_SEPARATOR = " > ";
+
+/**
+ * A name map as it travels: the name each `Deno.test` was registered
+ * under, against the repository-relative file that registered it.
+ */
+export type NameMap = Record<string, string>;
+
+/**
+ * A skip list: the names this invocation is not to run, under the
+ * repository-relative file that registers them. Keyed by file as well as
+ * name because the same test name occurs in more than one file.
+ */
+export type SkipList = Record<string, string[]>;
+
+/**
+ * Whether a stack frame's module is part of the test machinery rather
+ * than the file under test. The registration wrapper and the bdd
+ * re-exports both sit between a test file and `Deno.test`, so their
+ * frames are passed over on the way out to the caller.
+ */
+const frameworkModules = new Set<string>([import.meta.url]);
+
+/**
+ * Declares a module as part of the test machinery, so that a test
+ * registered through it is attributed to the file that called it. The bdd
+ * re-export module registers itself.
+ */
+export function registerFrameworkModule(url: string): void {
+  frameworkModules.add(url);
+}
+
+function isFrameworkModule(url: string): boolean {
+  if (frameworkModules.has(url)) return true;
+  return url.includes("/@std/testing/") || url.includes("/@std/testing@");
+}
+
+const FRAME_URL = /(file:\/\/\/[^\s)]+?):\d+:\d+\)?$/;
+
+/**
+ * The module that registered a test, given the stack captured inside the
+ * wrapper. Frames belonging to the test machinery are passed over, and
+ * the first `file:` frame beyond them is the caller. Returns undefined
+ * when the stack names no such frame, which is what a run under a
+ * hardened error taming produces.
+ */
+export function registeringModule(stack: string): string | undefined {
+  for (const line of stack.split("\n")) {
+    const match = line.trim().match(FRAME_URL);
+    if (match === null) continue;
+    const url = match[1]!;
+    if (isFrameworkModule(url)) continue;
+    return url;
+  }
+  return undefined;
+}
+
+/**
+ * The repository-relative path of a `file:` URL, given the repository
+ * root. A module outside the root keeps its whole path, which is what a
+ * vendored or cached module produces and what the reader then declines to
+ * join onto.
+ */
+export function relativeToRoot(url: string, root: string): string {
+  let path: string;
+  try {
+    path = decodeURIComponent(new URL(url).pathname);
+  } catch {
+    return url;
+  }
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return path.startsWith(prefix) ? path.slice(prefix.length) : path;
+}
+
+/**
+ * The repository root enclosing a file, found by climbing to the
+ * directory holding `.git`. Undefined outside any repository, and
+ * undefined when the climb is not permitted to read the filesystem.
+ */
+function repositoryRootOf(path: string): string | undefined {
+  let dir = dirname(resolve(path));
+  for (;;) {
+    try {
+      Deno.statSync(join(dir, ".git"));
+      return dir;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotCapable) return undefined;
+      const parent = dirname(dir);
+      if (parent === dir) return undefined;
+      dir = parent;
+    }
+  }
+}
+
+/**
+ * The file a leaf identity's name belongs to, given a name map. A leaf is
+ * named as its describe chain, so the registered name is either the whole
+ * of it or a prefix of it up to a separator; the longest such prefix wins,
+ * because nested describes make several of them.
+ */
+export function fileForName(
+  name: string,
+  names: ReadonlyMap<string, string>,
+): string | undefined {
+  const exact = names.get(name);
+  if (exact !== undefined) return exact;
+  let best: string | undefined;
+  let bestLength = -1;
+  for (const [registered, file] of names) {
+    if (registered.length <= bestLength) continue;
+    if (!name.startsWith(registered + NAME_SEPARATOR)) continue;
+    best = file;
+    bestLength = registered.length;
+  }
+  return best;
+}
+
+/**
+ * Merges the name maps a spool holds into one lookup. A name two files
+ * both registered is dropped rather than attributed to either: the two
+ * are one identity, and which file it came from is not a question the
+ * spool can answer. Reading is best-effort, since a name map is metadata
+ * and its absence costs only the file field.
+ */
+export async function readNameMaps(
+  dir: string,
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  let entries: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      if (
+        entry.isFile && entry.name.startsWith(NAME_MAP_PREFIX) &&
+        entry.name.endsWith(NAME_MAP_SUFFIX)
+      ) {
+        entries.push(entry.name);
+      }
+    }
+  } catch {
+    entries = [];
+  }
+  entries.sort();
+  for (const entry of entries) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(join(dir, entry)));
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    for (const [name, file] of Object.entries(parsed)) {
+      if (typeof file !== "string" || file.length === 0) continue;
+      const known = names.get(name);
+      if (known === undefined) {
+        names.set(name, file);
+        continue;
+      }
+      if (known !== file) ambiguous.add(name);
+    }
+  }
+  for (const name of ambiguous) names.delete(name);
+  return names;
+}
+
+/** Serializes a skip list for the file the environment points at. */
+export function serializeSkipList(skips: SkipList): string {
+  return JSON.stringify(skips, null, 2) + "\n";
+}
+
+/**
+ * Parses a skip list. Returns undefined for anything that is not one: a
+ * skip list is an instruction to run less, so a malformed one runs
+ * everything rather than an arbitrary subset.
+ */
+export function parseSkipList(text: string): SkipList | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  if (Array.isArray(parsed)) return undefined;
+  const skips: SkipList = {};
+  for (const [file, names] of Object.entries(parsed)) {
+    if (!Array.isArray(names)) return undefined;
+    for (const name of names) {
+      if (typeof name !== "string") return undefined;
+    }
+    skips[file] = names as string[];
+  }
+  return skips;
+}
+
+/** What one test process captured, and what it was told not to run. */
+export interface RegistrationCapture {
+  /** The file each registered name came from, repository-relative. */
+  names: Map<string, string>;
+
+  /** Whether a name registered from a file is on the skip list. */
+  skipped(file: string | undefined, name: string): boolean;
+
+  /** Writes the captured name map into the spool. */
+  flush(): void;
+}
+
+let installed: RegistrationCapture | undefined;
+
+/**
+ * The capture this process installed, for the bdd re-exports to consult.
+ * Undefined when no preload ran, which is every invocation that is not
+ * recording.
+ */
+export function activeCapture(): RegistrationCapture | undefined {
+  return installed;
+}
+
+/**
+ * Wraps `Deno.test` so that every registration is attributed to its file
+ * and checked against the skip list, and arranges for the captured map to
+ * reach the spool when the process unloads. Returns undefined when there
+ * was nothing to do and `Deno.test` was left alone.
+ *
+ * Called from a `--preload` module, so it runs before any test module and
+ * needs nothing from the test files. Installing twice is a no-op: a
+ * process that loads two preloads naming this module captures once.
+ */
+export function installRegistrationCapture(
+  env: Environment = Deno.env.get,
+): RegistrationCapture | undefined {
+  if (installed !== undefined) return installed;
+
+  const skips = loadSkipList(env);
+  const spool = recordsDir(env);
+  // Wrapping `Deno.test` costs the report its own file attribution: Deno
+  // names each case's class after the module that registered it, so from
+  // here on that is this module rather than the test file. Paying that is
+  // right when there is a skip list to apply, or a spool this process can
+  // write the replacement map into. With neither, the report is the
+  // better source and nothing is wrapped.
+  if (skips === undefined && !writableSpool(spool)) return undefined;
+
+  const names = new Map<string, string>();
+  let root: string | undefined;
+  let rootResolved = false;
+
+  const fileOf = (url: string | undefined): string | undefined => {
+    if (url === undefined) return undefined;
+    if (!rootResolved) {
+      rootResolved = true;
+      try {
+        root = repositoryRootOf(decodeURIComponent(new URL(url).pathname));
+      } catch {
+        root = undefined;
+      }
+    }
+    return root === undefined ? undefined : relativeToRoot(url, root);
+  };
+
+  const capture: RegistrationCapture = {
+    names,
+    skipped: (file, name) => {
+      if (skips === undefined || file === undefined) return false;
+      return skips[file]?.includes(name) ?? false;
+    },
+    flush: () => {
+      if (spool === undefined || names.size === 0) return;
+      const map: NameMap = {};
+      for (const [name, file] of names) map[name] = file;
+      try {
+        Deno.mkdirSync(spool, { recursive: true });
+        // A random name rather than a sortable one: nothing orders these,
+        // and `crypto.randomUUID` is built in, where a sortable id would
+        // be one more specifier a test task's own import map has to
+        // carry for the preload to load at all.
+        Deno.writeTextFileSync(
+          join(
+            spool,
+            `${NAME_MAP_PREFIX}${crypto.randomUUID()}${NAME_MAP_SUFFIX}`,
+          ),
+          JSON.stringify(map),
+        );
+      } catch (error) {
+        console.warn(`test records: cannot write a name map: ${error}`);
+      }
+    },
+  };
+
+  const realTest = Deno.test;
+  const register = (
+    through: (definition: Deno.TestDefinition) => void,
+    extra: Partial<Deno.TestDefinition>,
+  ) =>
+  (
+    nameOrDef:
+      | string
+      | Deno.TestDefinition
+      | ((
+        t: Deno.TestContext,
+      ) => void | Promise<void>),
+    fn?: (t: Deno.TestContext) => void | Promise<void>,
+  ): void => {
+    const definition = asDefinition(nameOrDef, fn);
+    if (definition === undefined) {
+      // A shape this wrapper does not model reaches the real registrar
+      // untouched, so an unfamiliar overload still runs.
+      // deno-lint-ignore no-explicit-any
+      (through as any)(nameOrDef, fn);
+      return;
+    }
+    const file = fileOf(registeringModule(new Error().stack ?? ""));
+    if (file !== undefined) names.set(definition.name, file);
+    if (capture.skipped(file, definition.name)) {
+      through({ ...definition, ...extra, ignore: true });
+      return;
+    }
+    through({ ...definition, ...extra });
+  };
+  const capturingTest = register(realTest, {});
+  Reflect.set(capturingTest, "ignore", register(realTest, { ignore: true }));
+  Reflect.set(capturingTest, "only", register(realTest, { only: true }));
+  Reflect.set(Deno, "test", capturingTest);
+
+  globalThis.addEventListener("unload", () => capture.flush());
+  installed = capture;
+  return capture;
+}
+
+/**
+ * The one `Deno.test` shape this wrapper models: a definition object, or a
+ * name and a body. Undefined for anything else, including the
+ * function-only form, whose name comes from the function rather than from
+ * an argument.
+ */
+function asDefinition(
+  nameOrDef:
+    | string
+    | Deno.TestDefinition
+    | ((
+      t: Deno.TestContext,
+    ) => void | Promise<void>),
+  fn?: (t: Deno.TestContext) => void | Promise<void>,
+): Deno.TestDefinition | undefined {
+  if (typeof nameOrDef === "string") {
+    return fn === undefined ? undefined : { name: nameOrDef, fn };
+  }
+  if (typeof nameOrDef === "object" && nameOrDef !== null) {
+    return nameOrDef;
+  }
+  return undefined;
+}
+
+/**
+ * Whether this process may write into the spool. Querying a permission
+ * needs no permission, so this answers before anything is attempted and
+ * without a warning for a process that was never going to record.
+ */
+function writableSpool(spool: string | undefined): boolean {
+  if (spool === undefined) return false;
+  try {
+    return Deno.permissions.querySync({ name: "write", path: spool }).state ===
+      "granted";
+  } catch {
+    return false;
+  }
+}
+
+function loadSkipList(env: Environment): SkipList | undefined {
+  const path = readEnv(SKIP_LIST_VARIABLE, env);
+  if (path === undefined || path.length === 0) return undefined;
+  let text: string;
+  try {
+    text = Deno.readTextFileSync(path);
+  } catch (error) {
+    console.warn(`test records: cannot read the skip list ${path}: ${error}`);
+    return undefined;
+  }
+  const skips = parseSkipList(text);
+  if (skips === undefined) {
+    console.warn(`test records: the skip list ${path} is malformed`);
+  }
+  return skips;
+}

--- a/packages/test-support/src/records/selection-testing.ts
+++ b/packages/test-support/src/records/selection-testing.ts
@@ -1,0 +1,58 @@
+/**
+ * Fixtures the selection format's own tests are written against, and that
+ * anything reading a manifest can build one from. A manifest is a large
+ * shape, and a test that spells one out whole says less about what it is
+ * checking than one that changes the two fields it cares about.
+ */
+
+import type { TestIdentity } from "./schema.ts";
+import {
+  type Calibration,
+  type Manifest,
+  MANIFEST_SCHEMA_VERSION,
+  type ManifestEntry,
+} from "./selection.ts";
+
+/** What a fixture entry looks like before a case adjusts it. */
+export function sampleEntry(
+  test: TestIdentity,
+  fields: Partial<ManifestEntry> = {},
+): ManifestEntry {
+  return {
+    test,
+    suite: "workspace-unit",
+    unit: `packages/${test.s}/test/${test.s}.test.ts`,
+    cost: 0.05,
+    score: 0.05,
+    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+    flakeRate: 0,
+    repeats: 1,
+    ...fields,
+  };
+}
+
+/** Calibration with everything free, so a case's own costs are the whole. */
+export function freeCalibration(): Calibration {
+  return { setupCost: {}, suites: {}, unitOverhead: {}, prologue: 0 };
+}
+
+/** A small, valid manifest. */
+export function sampleManifest(fields: Partial<Manifest> = {}): Manifest {
+  return {
+    schema: MANIFEST_SCHEMA_VERSION,
+    generatedAt: "2026-08-20T00:00:00.000Z",
+    seed: "01K3SAMPLE",
+    commit: "c8893b3a8",
+    runs: 12,
+    dials: {},
+    calibration: freeCalibration(),
+    entries: [sampleEntry({ k: "unit", s: "memory", n: "space > writes" })],
+    withheld: [],
+    unavailable: [],
+    unschedulable: [],
+    lanes: [],
+    known: { count: 1, digest: "0000000000000000" },
+    coverageBaselines: [],
+    ...fields,
+  };
+}

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -10,6 +10,14 @@ import {
 } from "./selection.ts";
 import { sampleManifest } from "./selection-testing.ts";
 
+const TEST = { k: "unit", s: "memory", n: "space > writes" };
+const CALIBRATION = {
+  setupCost: {},
+  suites: {},
+  unitOverhead: {},
+  prologue: 0,
+};
+
 describe("selection", () => {
   describe("parseManifest()", () => {
     it("round-trips a manifest through its serialization", () => {
@@ -238,6 +246,175 @@ describe("selection", () => {
         "an independence flag that is not one",
         withField("independent", "yes", "entry"),
       ],
+
+      // The lists a manifest carries beside its entries. Each has its own
+      // reader, and each rejects the manifest whole.
+      ["an unavailable list that is not one", withField("unavailable", 7)],
+      [
+        "an unavailable entry that is not a record",
+        withField("unavailable", [7]),
+      ],
+      [
+        "an unavailable entry with no suite",
+        withField("unavailable", [{ suite: "", unit: "u", reason: "r" }]),
+      ],
+      [
+        "an unavailable entry with no unit",
+        withField("unavailable", [{ suite: "s", reason: "r" }]),
+      ],
+      [
+        "an unavailable entry with no reason",
+        withField("unavailable", [{ suite: "s", unit: "u", reason: 7 }]),
+      ],
+      [
+        "an unavailable variant that is present and empty",
+        withField("unavailable", [
+          { suite: "s", unit: "u", reason: "r", variant: "" },
+        ]),
+      ],
+      [
+        "an unavailable leaf name that is not one",
+        withField("unavailable", [
+          { suite: "s", unit: "u", reason: "r", leafName: 7 },
+        ]),
+      ],
+      [
+        "an unavailable phase that is not one",
+        withField("unavailable", [
+          { suite: "s", unit: "u", reason: "r", phase: "" },
+        ]),
+      ],
+
+      // The generation time, which is what a reader measures a manifest's
+      // age from, and a value that is not a date compares false against
+      // every threshold.
+      ["a generation time that is not a string", withField("generatedAt", 7)],
+      [
+        "a generation time that is only a day",
+        withField("generatedAt", "2026-08-20"),
+      ],
+      [
+        "a generation time no calendar has",
+        withField("generatedAt", "2026-99-20T00:00:00.000Z"),
+      ],
+
+      // The withheld list, which is what a lane reads to say why a test
+      // it can see is one it must not run.
+      ["an entry that is not a record", withField("entries", [7])],
+      ["a withheld entry that is not a record", withField("withheld", [7])],
+      [
+        "a withheld entry with no identity",
+        withField("withheld", [{ suite: "s", reason: "flaky" }]),
+      ],
+      [
+        "a withheld entry with no suite",
+        withField("withheld", [{ test: TEST, suite: "", reason: "flaky" }]),
+      ],
+      ["an unschedulable list that is not one", withField("unschedulable", 7)],
+      [
+        "an unschedulable entry that is not a record",
+        withField("unschedulable", ["heavy"]),
+      ],
+      [
+        "an unschedulable entry with no identity",
+        withField("unschedulable", [{ suite: "s", cost: 400 }]),
+      ],
+      [
+        "an unschedulable entry with no suite",
+        withField("unschedulable", [{ test: TEST, suite: "", cost: 400 }]),
+      ],
+      [
+        "an unschedulable cost that is not a number",
+        withField("unschedulable", [{ test: TEST, suite: "s", cost: "lots" }]),
+      ],
+
+      // The calibration, which is what turns a planned second into the
+      // second a lane really pays.
+      ["a calibration that is not a record", withField("calibration", 7)],
+      [
+        "a setup cost that is not a record",
+        withField("calibration", { ...CALIBRATION, setupCost: 7 }),
+      ],
+      [
+        "a setup cost that is not a number",
+        withField("calibration", {
+          ...CALIBRATION,
+          setupCost: { toolshed: "a while" },
+        }),
+      ],
+      [
+        "a suites map that is not a record",
+        withField("calibration", { ...CALIBRATION, suites: [] }),
+      ],
+      [
+        "a fitted suite that is not a record",
+        withField("calibration", { ...CALIBRATION, suites: { unit: 7 } }),
+      ],
+      [
+        "a suite overhead that is not a number",
+        withField("calibration", {
+          ...CALIBRATION,
+          suites: { unit: { overhead: "some", correction: 1 } },
+        }),
+      ],
+      [
+        "a suite correction that is not a number",
+        withField("calibration", {
+          ...CALIBRATION,
+          suites: { unit: { overhead: 0, correction: null } },
+        }),
+      ],
+      [
+        "a unit overhead that is not a record",
+        withField("calibration", { ...CALIBRATION, unitOverhead: 7 }),
+      ],
+      [
+        "a prologue that is not a number",
+        withField("calibration", { ...CALIBRATION, prologue: "quick" }),
+      ],
+
+      // The lanes, which are what a runner is pointed at.
+      ["a lane list that is not one", withField("lanes", 7)],
+      ["a lane that is not a record", withField("lanes", [1])],
+      [
+        "a lane number that is not one",
+        withField("lanes", [{ lane: "one", projectedSeconds: 2, batches: [] }]),
+      ],
+      [
+        "a projection that is not a number",
+        withField("lanes", [{ lane: 1, projectedSeconds: "2s", batches: [] }]),
+      ],
+      [
+        "lane batches that are not a list",
+        withField("lanes", [{ lane: 1, projectedSeconds: 2, batches: {} }]),
+      ],
+      [
+        "a batch that is not a record",
+        withField("lanes", [{ lane: 1, projectedSeconds: 2, batches: ["u"] }]),
+      ],
+      [
+        "a batch with no suite",
+        withField("lanes", [{
+          lane: 1,
+          projectedSeconds: 2,
+          batches: [{ suite: "", identities: [] }],
+        }]),
+      ],
+      [
+        "a batch identity that is not a key",
+        withField("lanes", [{
+          lane: 1,
+          projectedSeconds: 2,
+          batches: [{ suite: "unit", identities: [7] }],
+        }]),
+      ],
+
+      // The coverage baselines, which are what the gate measures against.
+      ["a baseline list that is not one", withField("coverageBaselines", 7)],
+      [
+        "a baseline that is not a record",
+        withField("coverageBaselines", ["packages/memory"]),
+      ],
     ];
 
     for (const [what, text] of rejected) {
@@ -263,7 +440,30 @@ describe("selection", () => {
           day: "2026-08-20",
           uncoveredLines: 3,
         }],
-        lanes: [{ lane: 1, projectedSeconds: 2, batches: [] }],
+        withheld: [{
+          test: TEST,
+          suite: "workspace-unit",
+          reason: "main-red",
+        }],
+        unschedulable: [{
+          test: TEST,
+          suite: "pattern-integration",
+          cost: 420.5,
+        }],
+        calibration: {
+          setupCost: { toolshed: 60 },
+          suites: { "pattern-integration": { overhead: 50, correction: 1.2 } },
+          unitOverhead: { "packages/patterns/one.test.ts": 10 },
+          prologue: 3,
+        },
+        lanes: [{
+          lane: 1,
+          projectedSeconds: 2,
+          batches: [{
+            suite: "workspace-unit",
+            identities: [JSON.stringify(["unit", "memory", "space > writes"])],
+          }],
+        }],
       });
       manifest.entries[0]!.independent = true;
       manifest.entries[0]!.inputs.lastCatch = "2026-08-20";

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -97,6 +97,180 @@ describe("selection", () => {
     });
   });
 
+  describe("what a manifest may not contain", () => {
+    /** The manifest with one field replaced, as text the validator reads. */
+    const withField = (
+      field: string,
+      value: unknown,
+      into: "manifest" | "entry" = "manifest",
+    ) => {
+      const manifest = sampleManifest() as unknown as Record<string, unknown>;
+      if (into === "manifest") manifest[field] = value;
+      else {
+        (manifest.entries as Record<string, unknown>[])[0]![field] = value;
+      }
+      return JSON.stringify(manifest);
+    };
+
+    // Every one of these is a shape a corrupt or newer writer could
+    // produce, and each rejects the object whole rather than leaving a
+    // reader obeying the rest of it.
+    const rejected: Array<[string, string]> = [
+      ["a seed that is not one", withField("seed", "")],
+      ["a commit that is not one", withField("commit", 7)],
+      ["a run count below zero", withField("runs", -1)],
+      ["dials that are not a record", withField("dials", [])],
+      [
+        "a known count below zero",
+        withField("known", { count: -1, digest: "d" }),
+      ],
+      [
+        "a known digest that is not one",
+        withField("known", { count: 0, digest: "" }),
+      ],
+      ["an attribution map that is not a name", withField("attributionMap", 7)],
+      ["entries that are not a list", withField("entries", {})],
+      ["withheld that is not a list", withField("withheld", {})],
+      [
+        "a withheld reason nobody wrote",
+        withField("withheld", [{
+          test: { k: "a", s: "b", n: "c" },
+          suite: "s",
+          reason: "why",
+        }]),
+      ],
+      [
+        "an unavailable entry with no reason",
+        withField("unavailable", [{ suite: "s", unit: "u" }]),
+      ],
+      [
+        "an unschedulable cost below zero",
+        withField("unschedulable", [{
+          test: { k: "a", s: "b", n: "c" },
+          suite: "s",
+          cost: -1,
+        }]),
+      ],
+      [
+        "a lane numbered below one",
+        withField("lanes", [{ lane: 0, projectedSeconds: 0, batches: [] }]),
+      ],
+      [
+        "a lane with no projected time",
+        withField("lanes", [{ lane: 1, batches: [] }]),
+      ],
+      [
+        "a lane batch that is not one",
+        withField("lanes", [{
+          lane: 1,
+          projectedSeconds: 0,
+          batches: [{ suite: "s" }],
+        }]),
+      ],
+      [
+        "a baseline with no member",
+        withField("coverageBaselines", [{
+          commit: "c",
+          day: "2026-08-20",
+          uncoveredLines: 0,
+        }]),
+      ],
+      [
+        "a setup cost below zero",
+        withField("calibration", {
+          setupCost: { a: -1 },
+          suites: {},
+          unitOverhead: {},
+          prologue: 0,
+        }),
+      ],
+      [
+        "a prologue below zero",
+        withField("calibration", {
+          setupCost: {},
+          suites: {},
+          unitOverhead: {},
+          prologue: -1,
+        }),
+      ],
+      [
+        "a suite overhead below zero",
+        withField("calibration", {
+          setupCost: {},
+          suites: { s: { overhead: -1, correction: 1 } },
+          unitOverhead: {},
+          prologue: 0,
+        }),
+      ],
+      [
+        "an identity with no name",
+        withField("test", { k: "a", s: "b" }, "entry"),
+      ],
+      [
+        "an identity variant that is empty",
+        withField("test", { k: "a", s: "b", n: "c", v: "" }, "entry"),
+      ],
+      ["a suite that is not a name", withField("suite", "", "entry")],
+      ["a unit that is not a name", withField("unit", 7, "entry")],
+      ["a cost below zero", withField("cost", -1, "entry")],
+      ["a score that is not a number", withField("score", "high", "entry")],
+      ["inputs that are not a record", withField("inputs", 7, "entry")],
+      [
+        "a churn that is not a number",
+        withField("inputs", {
+          catches: 0,
+          mainCatches: 0,
+          sources: 0,
+          churn: "some",
+        }, "entry"),
+      ],
+      [
+        "a last catch that is not a day",
+        withField("inputs", {
+          catches: 0,
+          mainCatches: 0,
+          sources: 0,
+          churn: 0,
+          lastCatch: 7,
+        }, "entry"),
+      ],
+      [
+        "an independence flag that is not one",
+        withField("independent", "yes", "entry"),
+      ],
+    ];
+
+    for (const [what, text] of rejected) {
+      it(`refuses ${what}`, () => {
+        expect(parseManifest(text)).toBeUndefined();
+      });
+    }
+
+    it("accepts the optional fields when they are well formed", () => {
+      const manifest = sampleManifest({
+        attributionMap: "labs/test-selection/v1/map-1.json",
+        unavailable: [{
+          suite: "s",
+          unit: "u",
+          reason: "declared",
+          variant: "on",
+          leafName: "a leaf",
+          phase: "compile",
+        }],
+        coverageBaselines: [{
+          member: "packages/memory",
+          commit: "c",
+          day: "2026-08-20",
+          uncoveredLines: 3,
+        }],
+        lanes: [{ lane: 1, projectedSeconds: 2, batches: [] }],
+      });
+      manifest.entries[0]!.independent = true;
+      manifest.entries[0]!.inputs.lastCatch = "2026-08-20";
+      expect(parseManifest(serializeManifest(manifest))).toEqual(manifest);
+    });
+  });
+
   describe("digestIdentities()", () => {
     it("agrees whatever order the identities were walked in", () => {
       const keys = ["a", "b", "c"];

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -27,14 +27,15 @@ describe("selection", () => {
 
     it("returns undefined rather than obeying part of a manifest", () => {
       const manifest = sampleManifest();
-      manifest.entries.push({
-        // A cost that is not a number: one bad entry rejects the whole
-        // object, because a partly obeyed manifest runs an arbitrary set.
-        ...manifest.entries[0]!,
-        test: { k: "unit", s: "memory", n: "another" },
-        cost: Number.NaN,
-      });
-      expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+      // Written into the JSON rather than the object: `JSON.stringify`
+      // turns a NaN into null, so a test that sets one never reaches the
+      // validator with the value it meant to.
+      const text = JSON.stringify(manifest).replace(
+        '"cost":0.05',
+        '"cost":"free"',
+      );
+      expect(text).toContain('"cost":"free"');
+      expect(parseManifest(text)).toBeUndefined();
     });
 
     it("returns undefined for text that is not JSON", () => {
@@ -58,6 +59,32 @@ describe("selection", () => {
       const parsed = parseManifest(JSON.stringify(manifest));
       expect(parsed?.entries.length).toBe(manifest.entries.length);
       expect(parsed?.entries.at(-1)?.test.v).toBe("server-execution");
+    });
+
+    it("rejects a repeat count nothing can run", () => {
+      const manifest = sampleManifest();
+      manifest.entries[0]!.repeats = 1.5;
+      expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+    });
+
+    it("rejects a flake rate that is not a share of runs", () => {
+      // A negative rate sits under the exclusion threshold and would stay
+      // selectable, which is the direction a corrupt manifest must not go.
+      for (const flakeRate of [-1, 1.5]) {
+        const manifest = sampleManifest();
+        manifest.entries[0]!.flakeRate = flakeRate;
+        expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+      }
+    });
+
+    it("rejects a generation time that is not one", () => {
+      // A reader measures a manifest's age from this, and a value that
+      // does not parse compares false against every threshold, so a
+      // corrupt manifest would read as freshly generated forever.
+      for (const generatedAt of ["", "yesterday", "2026-13-45T00:00:00.000Z"]) {
+        const manifest = { ...sampleManifest(), generatedAt };
+        expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+      }
     });
 
     it("rejects a correction that would make everything free", () => {

--- a/packages/test-support/src/records/selection.test.ts
+++ b/packages/test-support/src/records/selection.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  digestIdentities,
+  type Manifest,
+  MANIFEST_SCHEMA_VERSION,
+  parseManifest,
+  serializeManifest,
+} from "./selection.ts";
+import { sampleManifest } from "./selection-testing.ts";
+
+describe("selection", () => {
+  describe("parseManifest()", () => {
+    it("round-trips a manifest through its serialization", () => {
+      const manifest = sampleManifest();
+      expect(parseManifest(serializeManifest(manifest))).toEqual(manifest);
+    });
+
+    it("returns undefined for a schema version it does not know", () => {
+      const ahead = {
+        ...sampleManifest(),
+        schema: MANIFEST_SCHEMA_VERSION + 1,
+      };
+      expect(parseManifest(JSON.stringify(ahead))).toBeUndefined();
+    });
+
+    it("returns undefined rather than obeying part of a manifest", () => {
+      const manifest = sampleManifest();
+      manifest.entries.push({
+        // A cost that is not a number: one bad entry rejects the whole
+        // object, because a partly obeyed manifest runs an arbitrary set.
+        ...manifest.entries[0]!,
+        test: { k: "unit", s: "memory", n: "another" },
+        cost: Number.NaN,
+      });
+      expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+    });
+
+    it("returns undefined for text that is not JSON", () => {
+      expect(parseManifest("{not json")).toBeUndefined();
+      expect(parseManifest("[]")).toBeUndefined();
+      expect(parseManifest(7)).toBeUndefined();
+    });
+
+    it("rejects an identity that appears twice", () => {
+      const manifest = sampleManifest();
+      manifest.entries.push({ ...manifest.entries[0]! });
+      expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+    });
+
+    it("keeps a variant apart from the default it shadows", () => {
+      const manifest = sampleManifest();
+      manifest.entries.push({
+        ...manifest.entries[0]!,
+        test: { ...manifest.entries[0]!.test, v: "server-execution" },
+      });
+      const parsed = parseManifest(JSON.stringify(manifest));
+      expect(parsed?.entries.length).toBe(manifest.entries.length);
+      expect(parsed?.entries.at(-1)?.test.v).toBe("server-execution");
+    });
+
+    it("rejects a correction that would make everything free", () => {
+      const manifest = sampleManifest();
+      manifest.calibration.suites["workspace-unit"] = {
+        overhead: 0,
+        correction: 0,
+      };
+      expect(parseManifest(JSON.stringify(manifest))).toBeUndefined();
+    });
+  });
+
+  describe("digestIdentities()", () => {
+    it("agrees whatever order the identities were walked in", () => {
+      const keys = ["a", "b", "c"];
+      expect(digestIdentities(keys)).toBe(
+        digestIdentities([...keys].reverse()),
+      );
+    });
+
+    it("changes when the set changes", () => {
+      expect(digestIdentities(["a", "b"])).not.toBe(
+        digestIdentities(["a", "b", "c"]),
+      );
+    });
+
+    it("has a digest for the empty set", () => {
+      expect(digestIdentities([]).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("the sample fixture", () => {
+    it("is a manifest the validator accepts", () => {
+      const manifest: Manifest = sampleManifest();
+      expect(parseManifest(serializeManifest(manifest))).toBeDefined();
+    });
+  });
+});

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -212,6 +212,18 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
+/**
+ * An ISO 8601 UTC instant. A reader measures a manifest's age from this,
+ * and a value that is not a date parses as a missing number, which
+ * compares false against every threshold — so a corrupt manifest would
+ * read as freshly generated forever.
+ */
+function isTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (!/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/.test(value)) return false;
+  return Number.isFinite(Date.parse(value));
+}
+
 function parseIdentity(value: unknown): TestIdentity | undefined {
   if (!isRecord(value)) return undefined;
   if (
@@ -258,8 +270,14 @@ function parseEntry(value: unknown): ManifestEntry | undefined {
   if (
     !isFiniteNumber(value.cost) || value.cost < 0 ||
     !isFiniteNumber(value.score) ||
-    !isFiniteNumber(value.flakeRate) ||
-    !isFiniteNumber(value.repeats) || value.repeats < 1
+    // A share of a test's runs, so outside zero to one it is not one. A
+    // negative rate would sit under the exclusion threshold and stay
+    // selectable, which is the direction a corrupt manifest must not go.
+    !isFiniteNumber(value.flakeRate) || value.flakeRate < 0 ||
+    value.flakeRate > 1 ||
+    // A count of runs. Nothing can run a test one and a half times.
+    !isFiniteNumber(value.repeats) || !Number.isInteger(value.repeats) ||
+    value.repeats < 1
   ) {
     return undefined;
   }
@@ -426,7 +444,7 @@ export function parseManifest(value: unknown): Manifest | undefined {
   if (!isRecord(value)) return undefined;
   if (value.schema !== MANIFEST_SCHEMA_VERSION) return undefined;
   if (
-    !isNonEmptyString(value.generatedAt) || !isNonEmptyString(value.seed) ||
+    !isTimestamp(value.generatedAt) || !isNonEmptyString(value.seed) ||
     !isNonEmptyString(value.commit) || !isFiniteNumber(value.runs) ||
     value.runs < 0 || !isRecord(value.dials)
   ) {

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -92,7 +92,11 @@ export interface UnavailableEntry {
 
   /** The exact leaf, when only one identity inside the unit is skipped. */
   leafName?: string;
+
+  /** Which part of the run it was unavailable in. */
   phase?: string;
+
+  /** Why it is unavailable, in words a person reads. */
   reason: string;
 }
 

--- a/packages/test-support/src/records/selection.ts
+++ b/packages/test-support/src/records/selection.ts
@@ -1,0 +1,496 @@
+/**
+ * The test-selection manifest: what the publisher writes, what a lane
+ * reads to decide what to run, and what the wall reads to show what
+ * selection is doing. It holds every identity the store knows, what each
+ * is worth, what each costs, what was withheld and why, and a reference
+ * packing into lanes.
+ *
+ * A lane treats a manifest as untrusted input, the same as a record line,
+ * so everything here is validated whole. A manifest that does not parse
+ * is treated as absent, and a lane with no manifest runs the mandatory
+ * set plus a deterministic slice rather than guessing at a half-read one.
+ * The worst a corrupted manifest could achieve is a pull request that ran
+ * fewer tests than it should have, which the full run on `main` catches;
+ * that is what lets it be an ordinary public object rather than a signed
+ * artifact.
+ */
+
+import { type TestIdentity, testIdentityKey } from "./schema.ts";
+
+/** The inputs behind one identity's score, as a manifest records them. */
+export interface ScoreInputs {
+  /** Catches, weighted by where each happened. */
+  catches: number;
+
+  /** How many of those were on `main`, which measure escapes as well. */
+  mainCatches: number;
+
+  /** The day of the most recent catch, absent when there are none. */
+  lastCatch?: string;
+
+  /** How many distinct sources are among the catches. */
+  sources: number;
+
+  /** Recent failures over recent runs, decayed as they age. */
+  churn: number;
+}
+
+/** The version a reader understands; anything else is treated as absent. */
+export const MANIFEST_SCHEMA_VERSION = 1;
+
+/** One selectable identity, with everything selection needs to know. */
+export interface ManifestEntry {
+  /** The complete identity, variant included when there is one. */
+  test: TestIdentity;
+
+  /** The suite that runs it. */
+  suite: string;
+
+  /**
+   * The invocation unit it lives in: a file for a `deno test` suite, a
+   * dispatch arm for a script. What a runner can be pointed at.
+   */
+  unit: string;
+
+  /** What one execution costs, in seconds. */
+  cost: number;
+
+  /** What it is worth running. */
+  score: number;
+
+  /** The inputs behind that score, so a manifest explains itself. */
+  inputs: ScoreInputs;
+
+  /** How often it disagrees with itself. */
+  flakeRate: number;
+
+  /** How many times a lane runs it. Every one of them must pass. */
+  repeats: number;
+
+  /**
+   * Whether it has been shown to pass as the only test in its unit. Until
+   * it has, its siblings are not skipped and the unit is what runs.
+   */
+  independent?: boolean;
+}
+
+/** Why an identity is not selectable on a pull request. */
+export type WithheldReason = "main-red" | "flaky";
+
+/** One identity held back, and why. */
+export interface WithheldEntry {
+  test: TestIdentity;
+  suite: string;
+  reason: WithheldReason;
+}
+
+/** A test a configuration deliberately does not run. */
+export interface UnavailableEntry {
+  suite: string;
+  variant?: string;
+  unit: string;
+
+  /** The exact leaf, when only one identity inside the unit is skipped. */
+  leafName?: string;
+  phase?: string;
+  reason: string;
+}
+
+/** An identity no lane can hold, however it is packed. */
+export interface UnschedulableEntry {
+  test: TestIdentity;
+  suite: string;
+  cost: number;
+}
+
+/** The fitted numbers a lane's own timing records produced. */
+export interface Calibration {
+  /** Seconds each capability's setup takes. */
+  setupCost: Record<string, number>;
+
+  /** Per suite: the intercept and slope fitted from planned against actual. */
+  suites: Record<string, { overhead: number; correction: number }>;
+
+  /** Per invocation unit: what running it at all costs before any test. */
+  unitOverhead: Record<string, number>;
+
+  /** Seconds a lane spends outside its batches. */
+  prologue: number;
+}
+
+/** One lane of the reference packing. */
+export interface LanePlan {
+  lane: number;
+
+  /**
+   * Seconds this lane is expected to take: the identities' own measured
+   * time through their suites' corrections, plus every overhead and
+   * capability setup the lane opens. A reader cannot recompute this from
+   * the entries alone, which is why the packing carries it.
+   */
+  projectedSeconds: number;
+
+  batches: Array<{ suite: string; identities: string[] }>;
+}
+
+/** What a covered package's own tests reached at one `main` commit. */
+export interface CoverageBaseline {
+  member: string;
+  commit: string;
+  day: string;
+  uncoveredLines: number;
+}
+
+/** One publisher run's whole output. */
+export interface Manifest {
+  schema: typeof MANIFEST_SCHEMA_VERSION;
+
+  /** ISO 8601 UTC. */
+  generatedAt: string;
+
+  /** Seeds the exploration draw, so five lanes draw the same set. */
+  seed: string;
+
+  /** The `main` commit whose topology was enumerated. */
+  commit: string;
+
+  /** How many workflow runs the aggregate behind this manifest saw. */
+  runs: number;
+
+  /** Every dial this manifest was built with. */
+  dials: Record<string, unknown>;
+
+  calibration: Calibration;
+  entries: ManifestEntry[];
+  withheld: WithheldEntry[];
+  unavailable: UnavailableEntry[];
+  unschedulable: UnschedulableEntry[];
+  lanes: LanePlan[];
+
+  /** How many item-level identities the store knows, and their digest. */
+  known: { count: number; digest: string };
+
+  /** The newest coverage attribution map, published on its own cadence. */
+  attributionMap?: string;
+
+  coverageBaselines: CoverageBaseline[];
+}
+
+/**
+ * A digest over the identities a manifest knows, order-independent, so
+ * two manifests built from the same set agree whatever order they walked
+ * it in. Used to tell a lane whether an identity it enumerated is one the
+ * store has never seen, which is what makes an unknown identity run.
+ */
+export function digestIdentities(keys: Iterable<string>): string {
+  // A sum of per-key hashes: commutative, so order cannot change it, and
+  // this is a change detector rather than anything anybody trusts.
+  let low = 0;
+  let high = 0;
+  for (const key of [...keys].sort()) {
+    let hash = 2166136261;
+    for (let i = 0; i < key.length; i++) {
+      hash ^= key.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    low = (low + (hash >>> 0)) % 0x100000000;
+    high = (high + (hash >>> 16)) % 0x100000000;
+  }
+  return `${low.toString(16).padStart(8, "0")}` +
+    `${high.toString(16).padStart(8, "0")}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function parseIdentity(value: unknown): TestIdentity | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    !isNonEmptyString(value.k) || !isNonEmptyString(value.s) ||
+    !isNonEmptyString(value.n)
+  ) {
+    return undefined;
+  }
+  if (value.v !== undefined && !isNonEmptyString(value.v)) return undefined;
+  const test: TestIdentity = { k: value.k, s: value.s, n: value.n };
+  if (value.v !== undefined) test.v = value.v;
+  return test;
+}
+
+function parseInputs(value: unknown): ScoreInputs | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    !isFiniteNumber(value.catches) || !isFiniteNumber(value.mainCatches) ||
+    !isFiniteNumber(value.sources) || !isFiniteNumber(value.churn)
+  ) {
+    return undefined;
+  }
+  if (value.lastCatch !== undefined && !isNonEmptyString(value.lastCatch)) {
+    return undefined;
+  }
+  const inputs: ScoreInputs = {
+    catches: value.catches,
+    mainCatches: value.mainCatches,
+    sources: value.sources,
+    churn: value.churn,
+  };
+  if (value.lastCatch !== undefined) inputs.lastCatch = value.lastCatch;
+  return inputs;
+}
+
+function parseEntry(value: unknown): ManifestEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  const test = parseIdentity(value.test);
+  const inputs = parseInputs(value.inputs);
+  if (test === undefined || inputs === undefined) return undefined;
+  if (!isNonEmptyString(value.suite) || !isNonEmptyString(value.unit)) {
+    return undefined;
+  }
+  if (
+    !isFiniteNumber(value.cost) || value.cost < 0 ||
+    !isFiniteNumber(value.score) ||
+    !isFiniteNumber(value.flakeRate) ||
+    !isFiniteNumber(value.repeats) || value.repeats < 1
+  ) {
+    return undefined;
+  }
+  if (
+    value.independent !== undefined && typeof value.independent !== "boolean"
+  ) {
+    return undefined;
+  }
+  const entry: ManifestEntry = {
+    test,
+    suite: value.suite,
+    unit: value.unit,
+    cost: value.cost,
+    score: value.score,
+    inputs,
+    flakeRate: value.flakeRate,
+    repeats: value.repeats,
+  };
+  if (value.independent !== undefined) entry.independent = value.independent;
+  return entry;
+}
+
+function parseWithheld(value: unknown): WithheldEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  const test = parseIdentity(value.test);
+  if (test === undefined || !isNonEmptyString(value.suite)) return undefined;
+  if (value.reason !== "main-red" && value.reason !== "flaky") return undefined;
+  return { test, suite: value.suite, reason: value.reason };
+}
+
+function parseUnavailable(value: unknown): UnavailableEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    !isNonEmptyString(value.suite) || !isNonEmptyString(value.unit) ||
+    !isNonEmptyString(value.reason)
+  ) {
+    return undefined;
+  }
+  for (const optional of ["variant", "leafName", "phase"] as const) {
+    if (value[optional] !== undefined && !isNonEmptyString(value[optional])) {
+      return undefined;
+    }
+  }
+  const entry: UnavailableEntry = {
+    suite: value.suite,
+    unit: value.unit,
+    reason: value.reason,
+  };
+  if (value.variant !== undefined) entry.variant = value.variant as string;
+  if (value.leafName !== undefined) entry.leafName = value.leafName as string;
+  if (value.phase !== undefined) entry.phase = value.phase as string;
+  return entry;
+}
+
+function parseUnschedulable(value: unknown): UnschedulableEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  const test = parseIdentity(value.test);
+  if (test === undefined || !isNonEmptyString(value.suite)) return undefined;
+  if (!isFiniteNumber(value.cost) || value.cost < 0) return undefined;
+  return { test, suite: value.suite, cost: value.cost };
+}
+
+function parseCalibration(value: unknown): Calibration | undefined {
+  if (!isRecord(value)) return undefined;
+  const numbers = (raw: unknown): Record<string, number> | undefined => {
+    if (!isRecord(raw)) return undefined;
+    const out: Record<string, number> = {};
+    for (const [name, seconds] of Object.entries(raw)) {
+      if (!isFiniteNumber(seconds) || seconds < 0) return undefined;
+      out[name] = seconds;
+    }
+    return out;
+  };
+  const setupCost = numbers(value.setupCost);
+  const unitOverhead = numbers(value.unitOverhead);
+  if (setupCost === undefined || unitOverhead === undefined) return undefined;
+  if (!isRecord(value.suites)) return undefined;
+  if (!isFiniteNumber(value.prologue) || value.prologue < 0) return undefined;
+  const suites: Calibration["suites"] = {};
+  for (const [suite, fitted] of Object.entries(value.suites)) {
+    if (!isRecord(fitted)) return undefined;
+    if (
+      !isFiniteNumber(fitted.overhead) || fitted.overhead < 0 ||
+      !isFiniteNumber(fitted.correction) || fitted.correction <= 0
+    ) {
+      return undefined;
+    }
+    suites[suite] = {
+      overhead: fitted.overhead,
+      correction: fitted.correction,
+    };
+  }
+  return { setupCost, suites, unitOverhead, prologue: value.prologue };
+}
+
+function parseLane(value: unknown): LanePlan | undefined {
+  if (!isRecord(value)) return undefined;
+  if (!isFiniteNumber(value.lane) || value.lane < 1) return undefined;
+  if (!isFiniteNumber(value.projectedSeconds) || value.projectedSeconds < 0) {
+    return undefined;
+  }
+  if (!Array.isArray(value.batches)) return undefined;
+  const batches: LanePlan["batches"] = [];
+  for (const raw of value.batches) {
+    if (!isRecord(raw) || !isNonEmptyString(raw.suite)) return undefined;
+    if (!Array.isArray(raw.identities)) return undefined;
+    for (const key of raw.identities) {
+      if (!isNonEmptyString(key)) return undefined;
+    }
+    batches.push({ suite: raw.suite, identities: raw.identities as string[] });
+  }
+  return {
+    lane: value.lane,
+    projectedSeconds: value.projectedSeconds,
+    batches,
+  };
+}
+
+function parseBaseline(value: unknown): CoverageBaseline | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    !isNonEmptyString(value.member) || !isNonEmptyString(value.commit) ||
+    !isNonEmptyString(value.day) || !isFiniteNumber(value.uncoveredLines) ||
+    value.uncoveredLines < 0
+  ) {
+    return undefined;
+  }
+  return {
+    member: value.member,
+    commit: value.commit,
+    day: value.day,
+    uncoveredLines: value.uncoveredLines,
+  };
+}
+
+/** Maps a list through a parser, failing whole if any element fails. */
+function parseAll<T>(
+  value: unknown,
+  parse: (raw: unknown) => T | undefined,
+): T[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: T[] = [];
+  for (const raw of value) {
+    const parsed = parse(raw);
+    if (parsed === undefined) return undefined;
+    out.push(parsed);
+  }
+  return out;
+}
+
+/**
+ * Validates a manifest whole. Returns undefined for anything that is not
+ * one of this schema version, including a newer one: a reader that does
+ * not know a field cannot know what obeying the rest would mean.
+ */
+export function parseManifest(value: unknown): Manifest | undefined {
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!isRecord(value)) return undefined;
+  if (value.schema !== MANIFEST_SCHEMA_VERSION) return undefined;
+  if (
+    !isNonEmptyString(value.generatedAt) || !isNonEmptyString(value.seed) ||
+    !isNonEmptyString(value.commit) || !isFiniteNumber(value.runs) ||
+    value.runs < 0 || !isRecord(value.dials)
+  ) {
+    return undefined;
+  }
+  const calibration = parseCalibration(value.calibration);
+  const entries = parseAll(value.entries, parseEntry);
+  const withheld = parseAll(value.withheld, parseWithheld);
+  const unavailable = parseAll(value.unavailable, parseUnavailable);
+  const unschedulable = parseAll(value.unschedulable, parseUnschedulable);
+  const lanes = parseAll(value.lanes, parseLane);
+  const coverageBaselines = parseAll(value.coverageBaselines, parseBaseline);
+  if (
+    calibration === undefined || entries === undefined ||
+    withheld === undefined || unavailable === undefined ||
+    unschedulable === undefined || lanes === undefined ||
+    coverageBaselines === undefined
+  ) {
+    return undefined;
+  }
+  if (
+    !isRecord(value.known) || !isFiniteNumber(value.known.count) ||
+    value.known.count < 0 || !isNonEmptyString(value.known.digest)
+  ) {
+    return undefined;
+  }
+  if (
+    value.attributionMap !== undefined &&
+    !isNonEmptyString(value.attributionMap)
+  ) {
+    return undefined;
+  }
+  // One identity may not appear twice: the packer removes an identity
+  // from the selectable set as it takes it, and a duplicate would let a
+  // later pass take it again.
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const key = testIdentityKey(entry.test);
+    if (seen.has(key)) return undefined;
+    seen.add(key);
+  }
+  const manifest: Manifest = {
+    schema: MANIFEST_SCHEMA_VERSION,
+    generatedAt: value.generatedAt,
+    seed: value.seed,
+    commit: value.commit,
+    runs: value.runs,
+    dials: value.dials,
+    calibration,
+    entries,
+    withheld,
+    unavailable,
+    unschedulable,
+    lanes,
+    known: { count: value.known.count, digest: value.known.digest },
+    coverageBaselines,
+  };
+  if (value.attributionMap !== undefined) {
+    manifest.attributionMap = value.attributionMap;
+  }
+  return manifest;
+}
+
+/** Serializes a manifest for the store. */
+export function serializeManifest(manifest: Manifest): string {
+  return JSON.stringify(manifest);
+}

--- a/packages/test-support/test/clock-preload.ts
+++ b/packages/test-support/test/clock-preload.ts
@@ -40,6 +40,12 @@
 // the auto-advance pump is paused while it runs, so a test can observe a state
 // partway through a window.
 
+import { registerFrameworkModule } from "../src/records/registration.ts";
+
+// A test registered through this harness is attributed to the file that
+// called `Deno.test`, not to the frame this harness adds between them.
+registerFrameworkModule(import.meta.url);
+
 const realSetTimeout = globalThis.setTimeout;
 const realClearTimeout = globalThis.clearTimeout;
 const realSetInterval = globalThis.setInterval;

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -104,6 +104,18 @@ const BARE_FILE = `Deno.test("bare kept", () => {});
 Deno.test("bare dropped", () => {});
 `;
 
+// Every way `Deno.test` can be called. The options forms carry the
+// sanitizer settings a test needs, and they put the body in the second or
+// third argument, so a wrapper that reads only the first two registers a
+// definition with no body and Deno refuses the whole module.
+const OVERLOAD_FILE = `Deno.test("name and body", () => {});
+Deno.test("name, options and body", { sanitizeOps: false }, () => {});
+Deno.test({ name: "whole definition", fn: () => {} });
+Deno.test({ name: "options and body", sanitizeResources: false }, () => {});
+Deno.test({ sanitizeOps: false }, function namedByItsFunction() {});
+Deno.test(function bodyAlone() {});
+`;
+
 describe("preload", () => {
   it("records the file each test was registered from", async () => {
     const fixture = await makeFixture({
@@ -128,6 +140,48 @@ describe("preload", () => {
       const byName = new Map(records.map((r) => [r.test.n, r.file]));
       expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
       expect(byName.get("bare kept")).toEqual("bare.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("registers every way `Deno.test` can be called", async () => {
+    const fixture = await makeFixture({ "overloads.test.ts": OVERLOAD_FILE });
+    try {
+      const run = await runFixture(fixture, ["overloads.test.ts"]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect([...reported.keys()].sort()).toEqual([
+        "bodyAlone",
+        "name and body",
+        "name, options and body",
+        "namedByItsFunction",
+        "options and body",
+        "whole definition",
+      ].sort());
+      for (const outcome of reported.values()) expect(outcome).toEqual("pass");
+      // The options each form carried have to survive the wrapper, or a
+      // test that opted out of a sanitizer is run under it again.
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("name, options and body")).toEqual("overloads.test.ts");
+      expect(names.get("options and body")).toEqual("overloads.test.ts");
+      expect(names.get("namedByItsFunction")).toEqual("overloads.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("skips a listed test whichever way it was registered", async () => {
+    const fixture = await makeFixture({ "overloads.test.ts": OVERLOAD_FILE });
+    try {
+      const run = await runFixture(fixture, ["overloads.test.ts"], {
+        "overloads.test.ts": ["name, options and body", "options and body"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("name, options and body")).toEqual("skip");
+      expect(reported.get("options and body")).toEqual("skip");
+      expect(reported.get("whole definition")).toEqual("pass");
     } finally {
       await Deno.remove(fixture.dir, { recursive: true });
     }

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The registration preload, exercised the way a test job exercises it: a
+ * real `deno test` run over fixture files, with the preload loaded and a
+ * skip list in place. What this proves cannot be proven in-process,
+ * because installing the capture replaces `Deno.test` for good.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { assert } from "@std/assert";
+import { join } from "@std/path";
+import {
+  dropContainerCases,
+  ingestJUnit,
+  parseJUnit,
+  preloadModulePath,
+  readNameMaps,
+  serializeSkipList,
+  type SkipList,
+} from "../../src/records/mod.ts";
+
+/** The imports a fixture tree needs to resolve the preload's own modules. */
+const FIXTURE_CONFIG = {
+  imports: {
+    "@std/path": "jsr:@std/path@^1.1.6",
+    "@std/testing": "jsr:@std/testing@^1.0.19",
+    "@std/ulid": "jsr:@std/ulid@^1.0.0",
+  },
+};
+
+interface Fixture {
+  dir: string;
+  spool: string;
+  junit: string;
+}
+
+/**
+ * A tree that looks like a repository to the preload: the `.git` marker is
+ * what it climbs to, so a fixture needs one and needs nothing else.
+ */
+async function makeFixture(files: Record<string, string>): Promise<Fixture> {
+  const dir = await Deno.makeTempDir({ prefix: "preload-fixture-" });
+  await Deno.mkdir(join(dir, ".git"));
+  await Deno.writeTextFile(
+    join(dir, "deno.json"),
+    JSON.stringify(FIXTURE_CONFIG),
+  );
+  for (const [name, source] of Object.entries(files)) {
+    await Deno.writeTextFile(join(dir, name), source);
+  }
+  const spool = join(dir, "spool");
+  await Deno.mkdir(spool);
+  return { dir, spool, junit: join(dir, "report.xml") };
+}
+
+async function runFixture(
+  fixture: Fixture,
+  files: readonly string[],
+  skips?: SkipList,
+): Promise<Deno.CommandOutput> {
+  const env: Record<string, string> = {
+    CF_TEST_RECORDS_DIR: fixture.spool,
+  };
+  if (skips !== undefined) {
+    const path = join(fixture.dir, "skips.json");
+    await Deno.writeTextFile(path, serializeSkipList(skips));
+    env.CF_TEST_SKIP_LIST = path;
+  }
+  return await new Deno.Command(Deno.execPath(), {
+    args: [
+      "test",
+      "--quiet",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      `--preload=${preloadModulePath()}`,
+      `--junit-path=${fixture.junit}`,
+      ...files,
+    ],
+    cwd: fixture.dir,
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+}
+
+/** The leaf cases a run reported, by name, with their outcomes. */
+async function outcomes(
+  fixture: Fixture,
+): Promise<Map<string, "pass" | "fail" | "skip">> {
+  const xml = await Deno.readTextFile(fixture.junit);
+  const leaves = dropContainerCases(parseJUnit(xml));
+  return new Map(leaves.map((leaf) => [leaf.name, leaf.outcome]));
+}
+
+const BDD_FILE = `import { describe, it } from "@std/testing/bdd";
+describe("outer", () => {
+  it("kept", () => {});
+  it("dropped", () => {});
+});
+`;
+
+const BARE_FILE = `Deno.test("bare kept", () => {});
+Deno.test("bare dropped", () => {});
+`;
+
+describe("preload", () => {
+  it("records the file each test was registered from", async () => {
+    const fixture = await makeFixture({
+      "bdd.test.ts": BDD_FILE,
+      "bare.test.ts": BARE_FILE,
+    });
+    try {
+      const run = await runFixture(fixture, ["bdd.test.ts", "bare.test.ts"]);
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const names = await readNameMaps(fixture.spool);
+      expect(names.get("outer")).toEqual("bdd.test.ts");
+      expect(names.get("bare kept")).toEqual("bare.test.ts");
+      expect(names.get("bare dropped")).toEqual("bare.test.ts");
+
+      // The join ingestion performs: a leaf named as its describe chain
+      // takes the file its top-level registration came from.
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        fileByName: names,
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
+      expect(byName.get("bare kept")).toEqual("bare.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("reports a listed test as skipped rather than missing", async () => {
+    const fixture = await makeFixture({ "bare.test.ts": BARE_FILE });
+    try {
+      const run = await runFixture(fixture, ["bare.test.ts"], {
+        "bare.test.ts": ["bare dropped"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("bare kept")).toEqual("pass");
+      expect(reported.get("bare dropped")).toEqual("skip");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("runs an unlisted test whatever the list says of its neighbours", async () => {
+    const fixture = await makeFixture({
+      "bare.test.ts": BARE_FILE + `Deno.test("added later", () => {});\n`,
+    });
+    try {
+      const run = await runFixture(fixture, ["bare.test.ts"], {
+        "bare.test.ts": ["bare kept", "bare dropped"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("added later")).toEqual("pass");
+      expect(reported.get("bare kept")).toEqual("skip");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("runs a renamed test, since the new name is not the old", async () => {
+    const fixture = await makeFixture({
+      "bare.test.ts": `Deno.test("the new name", () => {});\n`,
+    });
+    try {
+      const run = await runFixture(fixture, ["bare.test.ts"], {
+        "bare.test.ts": ["the old name"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      expect((await outcomes(fixture)).get("the new name")).toEqual("pass");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("skips one file's copy of a shared test name and not the other", async () => {
+    const shared = `Deno.test("shared name", () => {});\n`;
+    const fixture = await makeFixture({
+      "one.test.ts": shared,
+      "two.test.ts": shared,
+    });
+    try {
+      const run = await runFixture(fixture, ["one.test.ts", "two.test.ts"], {
+        "one.test.ts": ["shared name"],
+      });
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      // The report names both by the same identity, so the pair is one
+      // passed case and one skipped one under that name.
+      const xml = await Deno.readTextFile(fixture.junit);
+      const leaves = dropContainerCases(parseJUnit(xml))
+        .filter((leaf) => leaf.name === "shared name")
+        .map((leaf) => leaf.outcome)
+        .sort();
+      expect(leaves).toEqual(["pass", "skip"]);
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("leaves the report alone when it has nothing to do", async () => {
+    const fixture = await makeFixture({
+      "bdd.test.ts": BDD_FILE,
+      "bare.test.ts": BARE_FILE,
+    });
+    try {
+      // No write permission and no skip list: wrapping `Deno.test` would
+      // cost the report its own file attribution and buy nothing, so the
+      // classnames stay on the test files.
+      const run = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "test",
+          "--quiet",
+          "--allow-read",
+          "--allow-env",
+          `--preload=${preloadModulePath()}`,
+          `--junit-path=${fixture.junit}`,
+          "bdd.test.ts",
+          "bare.test.ts",
+        ],
+        cwd: fixture.dir,
+        env: { CF_TEST_RECORDS_DIR: fixture.spool },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      expect((await readNameMaps(fixture.spool)).size).toEqual(0);
+      const records = ingestJUnit(await Deno.readTextFile(fixture.junit), {
+        kind: "unit",
+        scope: "fixture",
+        filePrefix: "",
+      });
+      const byName = new Map(records.map((r) => [r.test.n, r.file]));
+      expect(byName.get("outer > kept")).toEqual("bdd.test.ts");
+      expect(byName.get("bare kept")).toEqual("bare.test.ts");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+
+  it("runs everything when the skip list is malformed", async () => {
+    const fixture = await makeFixture({ "bare.test.ts": BARE_FILE });
+    try {
+      const path = join(fixture.dir, "skips.json");
+      await Deno.writeTextFile(path, "not a skip list");
+      const run = await new Deno.Command(Deno.execPath(), {
+        args: [
+          "test",
+          "--quiet",
+          "--allow-read",
+          "--allow-write",
+          "--allow-env",
+          `--preload=${preloadModulePath()}`,
+          `--junit-path=${fixture.junit}`,
+          "bare.test.ts",
+        ],
+        cwd: fixture.dir,
+        env: { CF_TEST_RECORDS_DIR: fixture.spool, CF_TEST_SKIP_LIST: path },
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      assert(run.success, new TextDecoder().decode(run.stderr));
+      const reported = await outcomes(fixture);
+      expect(reported.get("bare kept")).toEqual("pass");
+      expect(reported.get("bare dropped")).toEqual("pass");
+    } finally {
+      await Deno.remove(fixture.dir, { recursive: true });
+    }
+  });
+});

--- a/packages/test-support/test/records/preload.test.ts
+++ b/packages/test-support/test/records/preload.test.ts
@@ -160,8 +160,10 @@ describe("preload", () => {
         "whole definition",
       ].sort());
       for (const outcome of reported.values()) expect(outcome).toEqual("pass");
-      // The options each form carried have to survive the wrapper, or a
-      // test that opted out of a sanitizer is run under it again.
+      // That each form registers and runs. That the options it carried
+      // reach the definition is asserted directly against `asDefinition`
+      // in registration.test.ts: Deno's sanitizers do not fire on a leak
+      // these bodies could stage, so no outcome here would differ.
       const names = await readNameMaps(fixture.spool);
       expect(names.get("name, options and body")).toEqual("overloads.test.ts");
       expect(names.get("options and body")).toEqual("overloads.test.ts");

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import ports from "@commonfabric/ports" with { type: "json" };
+import { preloadArgument } from "@commonfabric/test-support/records";
 import {
   buildFilteredTestArgs,
   chooseGeneratedPortOffset,
@@ -206,6 +207,7 @@ Deno.test("buildFilteredTestArgs adds a junit path when a junit dir is given", (
       "test",
       "-A",
       "--junit-path=out/junit/shell.xml",
+      preloadArgument(),
       "./integration/a.test.ts",
     ],
   );

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -21,6 +21,7 @@ import * as path from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
 import {
   FragmentWriter,
+  preloadArgument,
   RECORDS_DIR_VARIABLE,
   recordsDir,
 } from "@commonfabric/test-support/records";
@@ -521,6 +522,8 @@ export async function findIntegrationTestFiles(
  * matching files are passed as explicit paths under `relDir`. Deno does not
  * filter explicitly-passed paths through a package `test` config's `exclude`,
  * so they run even where that config drops the `integration/` directory.
+ * With a JUnit directory the run also carries the registration preload,
+ * which is what gives the report's cases their files.
  */
 export function buildFilteredTestArgs(
   pkg: string,
@@ -538,6 +541,7 @@ export function buildFilteredTestArgs(
 
   if (junitDir) {
     args.push(`--junit-path=${path.join(junitDir, `${pkg}.xml`)}`);
+    args.push(preloadArgument());
   }
 
   for (const name of testFiles) {
@@ -626,7 +630,11 @@ export async function runPackageIntegration(
   if (junitDir) {
     await Deno.mkdir(junitDir, { recursive: true });
     const junitPath = path.resolve(junitDir, `${pkg}.xml`);
-    env.INTEGRATION_TEST_FLAGS = `--junit-path=${junitPath}`;
+    // The preload travels with the JUnit path: the report names each case
+    // by its describe chain, and the map the preload leaves in the spool
+    // is what turns that chain back into a file.
+    env.INTEGRATION_TEST_FLAGS =
+      `--junit-path=${junitPath} ${preloadArgument()}`;
   } else {
     // Pass through INTEGRATION_TEST_FLAGS if set in environment
     const testFlags = Deno.env.get("INTEGRATION_TEST_FLAGS");

--- a/tasks/test-records-gather.ts
+++ b/tasks/test-records-gather.ts
@@ -24,6 +24,7 @@ import {
   type Environment,
   ingestJUnit,
   readEnv,
+  readNameMaps,
   readSpool,
   recordsDir,
   serializeRecordLine,
@@ -97,6 +98,12 @@ export async function gather(options: GatherOptions): Promise<void> {
     throw new Error("--variant must not be empty");
   }
   const records: TestRecord[] = [];
+  // The registration preload leaves a name-to-file map in the spool, and
+  // it is the only thing that can tell a bdd leaf's file: Deno names a
+  // case by its describe chain and puts that chain in the classname too.
+  const fileByName = options.spoolDir === undefined
+    ? new Map<string, string>()
+    : await readNameMaps(options.spoolDir);
   if (options.spoolDir !== undefined) {
     const spooled = await readSpool(options.spoolDir);
     for (const warning of spooled.warnings) {
@@ -117,6 +124,7 @@ export async function gather(options: GatherOptions): Promise<void> {
           const ingestOptions: Parameters<typeof ingestJUnit>[1] = {
             kind: spec.kind,
             scope: spec.scope,
+            fileByName,
           };
           if (spec.prefix !== undefined) ingestOptions.filePrefix = spec.prefix;
           records.push(...ingestJUnit(xml, ingestOptions));

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -17,6 +17,7 @@ import {
   type TestRecord,
 } from "@commonfabric/test-support/records";
 import { reportFromText } from "./test-selection/build.ts";
+import { join } from "@std/path";
 
 const CI = (day: string, run: string) =>
   `labs/test-records/submissions/ci/v1/${day}/run-${run}-a.ndjson`;
@@ -117,7 +118,10 @@ describe("test-selection-publish", () => {
 });
 
 /** A store held in memory, answering the way the real one answers. */
-function fakeStore(objects: Record<string, string>) {
+function fakeStore(
+  objects: Record<string, string>,
+  rollups: Record<string, string[]> = {},
+) {
   const created = new Map<string, Uint8Array>();
   const store: StoreAccess = {
     list: (prefix) =>
@@ -142,7 +146,7 @@ function fakeStore(objects: Record<string, string>) {
       created.set(name, body);
       return Promise.resolve();
     },
-    rollupShards: () => Promise.resolve(undefined),
+    rollupShards: (day) => Promise.resolve(rollups[day]),
     token: () => "a token",
   };
   return { store, created };
@@ -291,5 +295,144 @@ describe("publish()", () => {
     const { store, created } = fakeStore(seed());
     expect(await publish(["--nonsense"], store, NOW)).toBe(2);
     expect(created.size).toBe(0);
+  });
+});
+
+describe("publish() --out", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("writes the manifest and the state it would have created", async () => {
+    const out = await Deno.makeTempDir();
+    try {
+      const { store, created } = fakeStore(seed());
+      const code = await publish(
+        ["--bootstrap", "--days", "1", "--dry-run", "--out", out],
+        store,
+        NOW,
+      );
+      expect(code).toBe(0);
+      // A dry run creates nothing in the store, and the directory is how
+      // the run's answer is looked at instead.
+      expect(created.size).toBe(0);
+
+      const manifest = parseManifest(
+        await Deno.readTextFile(join(out, "manifest.json")),
+      );
+      expect(manifest?.entries.length).toBe(1);
+
+      const state = JSON.parse(
+        await Deno.readTextFile(join(out, "state.json")),
+      );
+      expect(Object.keys(state.states).length).toBe(1);
+      expect(state.day).toBe("2026-08-20");
+    } finally {
+      await Deno.remove(out, { recursive: true });
+    }
+  });
+
+  it("makes the directory when it does not exist yet", async () => {
+    const parent = await Deno.makeTempDir();
+    try {
+      const out = join(parent, "a", "b");
+      const { store } = fakeStore(seed());
+      expect(
+        await publish(
+          ["--bootstrap", "--days", "1", "--dry-run", "--out", out],
+          store,
+          NOW,
+        ),
+      ).toBe(0);
+      expect((await Deno.stat(join(out, "manifest.json"))).isFile).toBe(true);
+    } finally {
+      await Deno.remove(parent, { recursive: true });
+    }
+  });
+});
+
+const ROLLUP = `labs/test-records/aggregated/v1/${DAY}/shard-0.ndjson`;
+
+describe("publish() over a day that has been compacted", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("folds a bootstrap day from its rollup instead of its objects", async () => {
+    const read: string[] = [];
+    const { store } = fakeStore({
+      ...seed(),
+      [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
+    }, { [DAY]: [ROLLUP] });
+    const watched: StoreAccess = {
+      ...store,
+      read: (name) => {
+        read.push(name);
+        return store.read(name);
+      },
+    };
+    expect(await publish(["--bootstrap", "--days", "1"], watched, NOW)).toBe(0);
+    expect(read).toEqual([ROLLUP]);
+  });
+
+  it("does not read the rollup on an incremental run", async () => {
+    const { store } = fakeStore({
+      ...seed(),
+      [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
+    }, { [DAY]: [ROLLUP] });
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const asked: string[] = [];
+    const watched: StoreAccess = {
+      ...store,
+      rollupShards: (day) => {
+        asked.push(day);
+        return store.rollupShards(day);
+      },
+    };
+    expect(await publish(["--days", "1"], watched, NOW)).toBe(0);
+    expect(asked).toEqual([]);
+  });
+
+  it("leaves a day open when a shard of its rollup will not read", async () => {
+    // Folded half, the day would be marked compacted and the rest of it
+    // would be hidden from every later run.
+    const objects = {
+      ...seed(),
+      [ROLLUP]: object("c3", "fail", "2026-08-20T03:00:00.000Z"),
+    };
+    const { store, created } = fakeStore(objects, {
+      [DAY]: [ROLLUP, `labs/test-records/aggregated/v1/${DAY}/shard-1.ndjson`],
+    });
+    const read: string[] = [];
+    const broken: StoreAccess = {
+      ...store,
+      read: (name) => {
+        read.push(name);
+        return name.endsWith("shard-1.ndjson")
+          ? Promise.reject(new Error("that shard is gone"))
+          : store.read(name);
+      },
+    };
+    expect(await publish(["--bootstrap", "--days", "1"], broken, NOW)).toBe(0);
+    // The run carried on and folded the day's raw objects instead.
+    expect(read).toContain(CI(DAY, "1"));
+    expect(read).toContain(CI(DAY, "2"));
+    expect(created.size).toBeGreaterThan(0);
+  });
+});
+
+describe("publish() over an aggregate it cannot make sense of", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("refuses rather than starting again from nothing", async () => {
+    const { store, created } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const state = [...created.keys()].find((name) => name.includes("/state/"))!;
+    const after = created.size;
+    const broken: StoreAccess = {
+      ...store,
+      readText: (name) =>
+        name === state
+          ? Promise.resolve('{"schema":1,"nonsense":true}')
+          : store.readText(name),
+    };
+    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(created.size).toBe(after);
   });
 });

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -8,6 +8,7 @@ import {
   partitionOf,
   publish,
   type StoreAccess,
+  writeToken,
 } from "./test-selection-publish.ts";
 import {
   buildObjectBody,
@@ -60,6 +61,7 @@ describe("test-selection-publish", () => {
       expect(parseArgs(["--days", "0"])).toBeUndefined();
       expect(parseArgs(["--days"])).toBeUndefined();
       expect(parseArgs(["--concurrency", "x"])).toBeUndefined();
+      expect(parseArgs(["--out"])).toBeUndefined();
     });
   });
 
@@ -434,5 +436,95 @@ describe("publish() over an aggregate it cannot make sense of", () => {
     };
     expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
     expect(created.size).toBe(after);
+  });
+});
+
+describe("writeToken()", () => {
+  const NAME = "TEST_RECORDS_GCS_TOKEN";
+
+  /** Runs with the variable set as given, and puts back what was there. */
+  function withToken<T>(value: string | undefined, body: () => T): T {
+    const before = Deno.env.get(NAME);
+    if (value === undefined) Deno.env.delete(NAME);
+    else Deno.env.set(NAME, value);
+    try {
+      return body();
+    } finally {
+      if (before === undefined) Deno.env.delete(NAME);
+      else Deno.env.set(NAME, before);
+    }
+  }
+
+  it("is the federated token the workflow was given", () => {
+    expect(withToken("ya29.a0", writeToken)).toBe("ya29.a0");
+  });
+
+  it("is nothing when the variable is unset", () => {
+    expect(withToken(undefined, writeToken)).toBeUndefined();
+  });
+
+  it("is nothing when the variable is set to empty", () => {
+    // A step that failed to mint one leaves the variable set and empty.
+    // Read as a token it would reach the store and be refused there.
+    expect(withToken("", writeToken)).toBeUndefined();
+  });
+});
+
+describe("publish() over a store that answers badly", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("refuses when the aggregate object will not read", async () => {
+    const { store, created } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const after = created.size;
+    const broken: StoreAccess = {
+      ...store,
+      readText: () => Promise.reject(new Error("that object is gone")),
+    };
+    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(created.size).toBe(after);
+  });
+
+  it("refuses when the submissions cannot be listed", async () => {
+    const { store, created } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const after = created.size;
+    const broken: StoreAccess = {
+      ...store,
+      list: (prefix) =>
+        prefix.includes("/submissions/")
+          ? Promise.reject(new Error("the store is unreachable"))
+          : store.list(prefix),
+    };
+    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(created.size).toBe(after);
+  });
+});
+
+describe("publish() reporting what no lane can hold", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("names each one, with the cost the bound was judged against", async () => {
+    const slow = (commit: string, at: string) => {
+      const body = object(commit, "pass", at);
+      // One execution taking longer than a lane's whole hard bound.
+      return body.replace('"durationMs":40', '"durationMs":400000');
+    };
+    const { store } = fakeStore({
+      [CI(DAY, "1")]: slow("c1", "2026-08-20T01:00:00.000Z"),
+      [CI(DAY, "2")]: slow("c2", "2026-08-20T02:00:00.000Z"),
+    });
+    const said: string[] = [];
+    const log = console.log;
+    console.log = (...parts: unknown[]) => said.push(parts.join(" "));
+    try {
+      expect(await publish(["--bootstrap", "--days", "1"], store, NOW)).toBe(0);
+    } finally {
+      console.log = log;
+    }
+    const line = said.find((said) => said.includes("unschedulable"));
+    expect(line).toBeDefined();
+    expect(line).toContain("space > writes");
+    expect(line).toContain("400.0s");
   });
 });

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -6,7 +6,17 @@ import {
   dayPartitions,
   parseArgs,
   partitionOf,
+  publish,
+  type StoreAccess,
 } from "./test-selection-publish.ts";
+import {
+  buildObjectBody,
+  gunzipToText,
+  parseManifest,
+  type RunContext,
+  type TestRecord,
+} from "@commonfabric/test-support/records";
+import { reportFromText } from "./test-selection/build.ts";
 
 const CI = (day: string, run: string) =>
   `labs/test-records/submissions/ci/v1/${day}/run-${run}-a.ndjson`;
@@ -103,5 +113,183 @@ describe("test-selection-publish", () => {
         .sort(byDayThenName);
       expect(ordered[0]).toBe(CI("2026/08/20", "1"));
     });
+  });
+});
+
+/** A store held in memory, answering the way the real one answers. */
+function fakeStore(objects: Record<string, string>) {
+  const created = new Map<string, Uint8Array>();
+  const store: StoreAccess = {
+    list: (prefix) =>
+      Promise.resolve(
+        [...Object.keys(objects), ...created.keys()]
+          .filter((name) => name.startsWith(prefix))
+          .sort(),
+      ),
+    read: (objectName) => {
+      const text = objects[objectName];
+      if (text === undefined) throw new Error(`no such object ${objectName}`);
+      return Promise.resolve(reportFromText(objectName, text));
+    },
+    readText: (objectName) => {
+      const stored = created.get(objectName);
+      if (stored !== undefined) return gunzipToText(stored);
+      const text = objects[objectName];
+      if (text === undefined) throw new Error(`no such object ${objectName}`);
+      return Promise.resolve(text);
+    },
+    create: (name, body) => {
+      created.set(name, body);
+      return Promise.resolve();
+    },
+    rollupShards: () => Promise.resolve(undefined),
+    token: () => "a token",
+  };
+  return { store, created };
+}
+
+const DAY = "2026/08/20";
+
+/** One object holding one run of one test, at one commit. */
+function object(
+  commit: string,
+  outcome: TestRecord["outcome"],
+  at: string,
+): string {
+  const context: RunContext = {
+    schema: 1,
+    line: "context",
+    reportId: `report-${commit}-${outcome}`,
+    repo: "commontoolsinc/labs",
+    commit,
+    dirty: false,
+    branch: "main",
+    env: "ci",
+    ci: {
+      workflowRunId: commit,
+      runAttempt: 1,
+      workflow: "deno.yml",
+      job: "Test (1/8)",
+      event: "push",
+    },
+    os: "linux",
+    arch: "x86_64",
+    denoVersion: "2.9.4",
+    startedAt: at,
+  };
+  const record: TestRecord = {
+    line: "record",
+    test: { k: "unit", s: "memory", n: "space > writes" },
+    outcome,
+    durationMs: 40,
+  };
+  return buildObjectBody(context, [record]);
+}
+
+/** The two runs a fresh store is seeded with: a failure, then its fix. */
+function seed(): Record<string, string> {
+  return {
+    [CI(DAY, "1")]: object("c1", "fail", "2026-08-20T01:00:00.000Z"),
+    [CI(DAY, "2")]: object("c2", "pass", "2026-08-20T02:00:00.000Z"),
+  };
+}
+
+describe("publish()", () => {
+  const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+  it("refuses a first run that was not asked for", async () => {
+    // An absent aggregate is either a genuine first run or one that went
+    // missing, and an incremental run cannot tell the two apart.
+    const { store, created } = fakeStore(seed());
+    expect(await publish(["--days", "1"], store, NOW)).toBe(1);
+    expect(created.size).toBe(0);
+  });
+
+  it("writes a manifest and a state from a bootstrap", async () => {
+    const { store, created } = fakeStore(seed());
+    expect(await publish(["--bootstrap", "--days", "1"], store, NOW)).toBe(0);
+    const names = [...created.keys()];
+    const manifestName = names.find((name) => name.includes("/manifest-"));
+    expect(manifestName).toBeDefined();
+    expect(names.some((name) => name.includes("/state/"))).toBe(true);
+
+    const manifest = parseManifest(
+      await gunzipToText(created.get(manifestName!)!),
+    );
+    expect(manifest).toBeDefined();
+    expect(manifest!.entries.length).toBe(1);
+    // The failure at c1 that c2 went on to fix is a catch on main.
+    expect(manifest!.entries[0]!.inputs.mainCatches).toBe(1);
+  });
+
+  it("folds from the state it left rather than the objects again", async () => {
+    const { store, created } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const first = created.size;
+    const readObjects: string[] = [];
+    const watched: StoreAccess = {
+      ...store,
+      read: (name) => {
+        readObjects.push(name);
+        return store.read(name);
+      },
+    };
+    expect(await publish(["--days", "1"], watched, NOW)).toBe(0);
+    expect(readObjects).toEqual([]);
+    expect(created.size).toBeGreaterThan(first);
+  });
+
+  it("refuses to publish when the state area cannot be listed", async () => {
+    const { store, created } = fakeStore(seed());
+    const broken: StoreAccess = {
+      ...store,
+      list: (prefix) =>
+        prefix.includes("/state")
+          ? Promise.reject(new Error("unreachable"))
+          : store.list(prefix),
+    };
+    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(created.size).toBe(0);
+  });
+
+  it("refuses to publish from a window it could only partly read", async () => {
+    const { store, created } = fakeStore(seed());
+    await publish(["--bootstrap", "--days", "1"], store, NOW);
+    const after = created.size;
+    const broken: StoreAccess = {
+      ...store,
+      read: () => Promise.reject(new Error("that object is gone")),
+      list: (prefix) =>
+        prefix.includes("/state")
+          ? store.list(prefix)
+          : Promise.resolve([CI(DAY, "9")]),
+    };
+    expect(await publish(["--days", "1"], broken, NOW)).toBe(1);
+    expect(created.size).toBe(after);
+  });
+
+  it("creates nothing at all for a dry run", async () => {
+    const { store, created } = fakeStore(seed());
+    const code = await publish(
+      ["--bootstrap", "--days", "1", "--dry-run"],
+      store,
+      NOW,
+    );
+    expect(code).toBe(0);
+    expect(created.size).toBe(0);
+  });
+
+  it("creates nothing without a credential", async () => {
+    const { store, created } = fakeStore(seed());
+    const anonymous: StoreAccess = { ...store, token: () => undefined };
+    const code = await publish(["--bootstrap", "--days", "1"], anonymous, NOW);
+    expect(created.size).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it("reports a malformed command line rather than publishing", async () => {
+    const { store, created } = fakeStore(seed());
+    expect(await publish(["--nonsense"], store, NOW)).toBe(2);
+    expect(created.size).toBe(0);
   });
 });

--- a/tasks/test-selection-publish.test.ts
+++ b/tasks/test-selection-publish.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  byDayThenName,
+  dayPartitions,
+  parseArgs,
+  partitionOf,
+} from "./test-selection-publish.ts";
+
+const CI = (day: string, run: string) =>
+  `labs/test-records/submissions/ci/v1/${day}/run-${run}-a.ndjson`;
+const LOCAL = (day: string, who: string) =>
+  `labs/test-records/submissions/local/${who}/v1/${day}/01K3-branch.ndjson`;
+
+describe("test-selection-publish", () => {
+  describe("parseArgs()", () => {
+    it("defaults to the incremental path", () => {
+      const options = parseArgs([]);
+      expect(options?.bootstrap).toBe(false);
+      expect(options?.dryRun).toBe(false);
+    });
+
+    it("widens the window for a bootstrap", () => {
+      expect(parseArgs(["--bootstrap"])?.days).toBe(60);
+    });
+
+    it("lets an asked-for window win, whichever order it was typed", () => {
+      expect(parseArgs(["--days", "3", "--bootstrap"])?.days).toBe(3);
+      expect(parseArgs(["--bootstrap", "--days", "3"])?.days).toBe(3);
+    });
+
+    it("takes a window, an output directory, and a concurrency", () => {
+      const options = parseArgs([
+        "--days",
+        "3",
+        "--out",
+        "/tmp/out",
+        "--concurrency",
+        "8",
+      ]);
+      expect(options?.days).toBe(3);
+      expect(options?.out).toBe("/tmp/out");
+      expect(options?.concurrency).toBe(8);
+    });
+
+    it("returns undefined for anything it does not understand", () => {
+      expect(parseArgs(["--nonsense"])).toBeUndefined();
+      expect(parseArgs(["--days", "0"])).toBeUndefined();
+      expect(parseArgs(["--days"])).toBeUndefined();
+      expect(parseArgs(["--concurrency", "x"])).toBeUndefined();
+    });
+  });
+
+  describe("dayPartitions()", () => {
+    it("lists the window oldest first", () => {
+      expect(dayPartitions(new Date("2026-08-20T04:00:00Z"), 3)).toEqual([
+        "2026/08/18",
+        "2026/08/19",
+        "2026/08/20",
+      ]);
+    });
+
+    it("lists one day for a window of one", () => {
+      expect(dayPartitions(new Date("2026-08-20T04:00:00Z"), 1)).toEqual([
+        "2026/08/20",
+      ]);
+    });
+  });
+
+  describe("partitionOf()", () => {
+    it("reads the day out of either area's names", () => {
+      expect(partitionOf(CI("2026/08/20", "1"))).toBe("2026/08/20");
+      expect(partitionOf(LOCAL("2026/08/20", "ianh"))).toBe("2026/08/20");
+    });
+
+    it("reads nothing out of a name that carries no day", () => {
+      expect(partitionOf("labs/test-selection/v1/state/x.json.gz")).toBe("");
+    });
+  });
+
+  describe("byDayThenName()", () => {
+    it("interleaves the two areas by the day they recorded", () => {
+      // Sorted by name alone, every local object lands after every
+      // continuous-integration one, and the fold would judge a
+      // workstation's failure against a state from days later.
+      const ordered = [
+        LOCAL("2026/08/20", "ianh"),
+        CI("2026/08/18", "1"),
+        LOCAL("2026/08/19", "ianh"),
+        CI("2026/08/20", "2"),
+      ].sort(byDayThenName);
+      expect(ordered.map(partitionOf)).toEqual([
+        "2026/08/18",
+        "2026/08/19",
+        "2026/08/20",
+        "2026/08/20",
+      ]);
+    });
+
+    it("falls back to the name inside one day", () => {
+      const ordered = [CI("2026/08/20", "2"), CI("2026/08/20", "1")]
+        .sort(byDayThenName);
+      expect(ordered[0]).toBe(CI("2026/08/20", "1"));
+    });
+  });
+});

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -441,6 +441,13 @@ async function main(args: readonly string[]): Promise<number> {
     mandatory: new Map(),
     capabilities: new Map(),
   });
+  // What the packer refused, from the packer, rather than recomputed from
+  // a raw cost that leaves out every overhead the lane would have paid.
+  manifest.unschedulable = reference.unschedulable.map((entry) => ({
+    test: entry.test,
+    suite: entry.suite,
+    cost: entry.cost,
+  }));
   manifest.lanes = reference.lanes.map((lane) => ({
     lane: lane.lane,
     projectedSeconds: Math.round(lane.projectedSeconds * 10) / 10,
@@ -538,10 +545,7 @@ function summarize(
     `test selection: ${selected} of ${manifest.entries.length} identities ` +
       `fit the budget`,
   );
-  const unschedulable = manifest.entries.filter(
-    (entry) => entry.cost > LANE_BUDGET_SECONDS,
-  );
-  for (const entry of unschedulable) {
+  for (const entry of reference.unschedulable) {
     console.log(
       `test selection: unschedulable, ${entry.cost.toFixed(1)}s: ` +
         JSON.stringify(entry.test),

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -55,6 +55,55 @@ import { serializeManifest } from "./test-selection/manifest.ts";
 import { plan } from "./test-selection/plan.ts";
 import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
 
+/**
+ * Everything this reaches the world through. The default is the real
+ * store; a test supplies its own and exercises the whole publish without
+ * a network, which is the only way the path that actually runs in
+ * production gets tested at all.
+ */
+export interface StoreAccess {
+  list(prefix: string): Promise<string[]>;
+  read(objectName: string): Promise<StoredReport>;
+  readText(objectName: string): Promise<string>;
+  create(name: string, body: Uint8Array): Promise<void>;
+  rollupShards(day: string): Promise<string[] | undefined>;
+  token(): string | undefined;
+}
+
+/** The store as it really is. */
+export function liveStore(bucket: string): StoreAccess {
+  return {
+    list: (prefix) => listObjects({ bucket, prefix }),
+    read: (objectName) => readObject({ bucket, objectName }),
+    readText: async (objectName) => {
+      const response = await fetch(objectUrl(bucket, objectName));
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      // Transcoded on the way out, so this is already the JSON.
+      return await response.text();
+    },
+    create: async (name, body) => {
+      const token = writeToken();
+      if (token === undefined) throw new Error("no write credential");
+      await createObject({
+        bucket,
+        name,
+        body,
+        contentType: "application/json",
+        contentEncoding: "gzip",
+        token,
+      });
+    },
+    rollupShards: async (day) => {
+      try {
+        return await rollupShards({ bucket, day });
+      } catch {
+        return undefined;
+      }
+    },
+    token: writeToken,
+  };
+}
+
 /** How many objects are fetched at once. */
 const DEFAULT_CONCURRENCY = 24;
 
@@ -169,12 +218,11 @@ async function mapConcurrent<T, R>(
  * week or more ago, is that use; the four-hourly path that keeps the
  * manifest current never touches one.
  */
-async function rollupFor(day: string): Promise<string[] | undefined> {
-  try {
-    return await rollupShards({ bucket: storeBucket(), day });
-  } catch {
-    return undefined;
-  }
+function rollupFor(
+  store: StoreAccess,
+  day: string,
+): Promise<string[] | undefined> {
+  return store.rollupShards(day);
 }
 
 /**
@@ -184,8 +232,10 @@ async function rollupFor(day: string): Promise<string[] | undefined> {
  * the reporting person ahead of the day, so that area is listed once and
  * filtered.
  */
-async function listSubmissions(days: readonly string[]): Promise<string[]> {
-  const bucket = storeBucket();
+async function listSubmissions(
+  store: StoreAccess,
+  days: readonly string[],
+): Promise<string[]> {
   const wanted = new Set(days);
   const names: string[] = [];
   // A listing that fails is not an empty day. Folding what did list and
@@ -194,11 +244,10 @@ async function listSubmissions(days: readonly string[]): Promise<string[]> {
   // one every lane obeys. The run ends instead, and the previous manifest
   // stays newest.
   for (const day of days) {
-    const prefix = `${ciSubmissionsPrefix()}/v1/${day}/`;
-    names.push(...await listObjects({ bucket, prefix }));
+    names.push(...await store.list(`${ciSubmissionsPrefix()}/v1/${day}/`));
   }
   const local = `${storePrefix()}/submissions/local/`;
-  for (const name of await listObjects({ bucket, prefix: local })) {
+  for (const name of await store.list(local)) {
     const day = name.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1];
     if (day !== undefined && wanted.has(day)) names.push(name);
   }
@@ -248,14 +297,13 @@ type AggregateRead =
  * slowly — so an unreadable state is told apart from an absent one rather
  * than both becoming an empty one.
  */
-async function readAggregate(): Promise<AggregateRead> {
-  const bucket = storeBucket();
+async function readAggregate(store: StoreAccess): Promise<AggregateRead> {
   const prefix = statePrefix();
   let names: string[];
   try {
     // Trailing slash for the reason the manifest listing carries one: a
     // bare prefix matches a longer sibling too.
-    names = await listObjects({ bucket, prefix: `${prefix}/` });
+    names = await store.list(`${prefix}/`);
   } catch (error) {
     return { failed: `listing ${prefix} failed: ${error}` };
   }
@@ -264,11 +312,7 @@ async function readAggregate(): Promise<AggregateRead> {
   );
   if (newest === undefined) return { absent: true };
   try {
-    const url = objectUrl(bucket, newest);
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    // Transcoded on the way out, so this is already the JSON.
-    const state = parseAggregate(await response.text());
+    const state = parseAggregate(await store.readText(newest));
     return state === undefined
       ? { failed: `${newest} is not an aggregate this reader understands` }
       : { state };
@@ -293,7 +337,11 @@ function writeToken(): string | undefined {
     : undefined;
 }
 
-async function main(args: readonly string[]): Promise<number> {
+export async function publish(
+  args: readonly string[],
+  store: StoreAccess = liveStore(storeBucket()),
+  now: Date = new Date(),
+): Promise<number> {
   const options = parseArgs(args);
   if (options === undefined) {
     console.error(
@@ -303,13 +351,13 @@ async function main(args: readonly string[]): Promise<number> {
     return 2;
   }
 
-  const startedAt = new Date();
+  const startedAt = now;
   const today = startedAt.toISOString().slice(0, 10);
   let aggregate: AggregateState;
   if (options.bootstrap) {
     aggregate = emptyAggregate(today);
   } else {
-    const read = await readAggregate();
+    const read = await readAggregate(store);
     if ("failed" in read) {
       console.warn(`test selection: ${read.failed}`);
       console.warn(
@@ -329,7 +377,6 @@ async function main(args: readonly string[]): Promise<number> {
     aggregate = read.state;
   }
   const partitions = dayPartitions(startedAt, options.days);
-  const bucket = storeBucket();
   const resolver = await loadAliasResolver();
   const fold = new Fold(aggregate, resolver, today);
   const runs = new Set<string>();
@@ -351,7 +398,7 @@ async function main(args: readonly string[]): Promise<number> {
   if (options.bootstrap) {
     for (const day of partitions) {
       if (fold.knowsDay(day)) continue;
-      const shards = await rollupFor(day);
+      const shards = await rollupFor(store, day);
       if (shards === undefined) continue;
       try {
         // A day is folded whole or not at all: a shard that failed to
@@ -360,7 +407,7 @@ async function main(args: readonly string[]): Promise<number> {
         const reports = await mapConcurrent(
           shards,
           options.concurrency,
-          (objectName) => readObject({ bucket, objectName }),
+          (objectName) => store.read(objectName),
         );
         for (const report of reports) noteReport(report);
         fold.add(reports);
@@ -380,7 +427,7 @@ async function main(args: readonly string[]): Promise<number> {
   const open = partitions.filter((day) => !fold.knowsDay(day));
   let listed: string[];
   try {
-    listed = await listSubmissions(open);
+    listed = await listSubmissions(store, open);
   } catch (error) {
     console.warn(`test selection: listing the submissions failed: ${error}`);
     console.warn(
@@ -407,7 +454,7 @@ async function main(args: readonly string[]): Promise<number> {
         options.concurrency,
         // A read that fails is not an object with no records, so it is not
         // swallowed: the same partial-history argument as the listing.
-        (objectName) => readObject({ bucket, objectName }),
+        (objectName) => store.read(objectName),
       );
       for (const report of reports) noteReport(report);
       fold.add(reports);
@@ -476,7 +523,7 @@ async function main(args: readonly string[]): Promise<number> {
   }
   if (options.dryRun) return 0;
 
-  const token = writeToken();
+  const token = store.token();
   if (token === undefined) {
     console.warn(
       "test selection: no write credential, so nothing was created. The " +
@@ -484,25 +531,18 @@ async function main(args: readonly string[]): Promise<number> {
     );
     return 0;
   }
+  // The manifest first and the state after it. A run that died between
+  // the two leaves a manifest whose aggregate is a cycle behind, which
+  // the next run folds forward; the other order would leave a state
+  // claiming objects no manifest was built from.
   const id = ulid();
   const name = manifestObjectName(manifest.generatedAt, id);
-  const created = await createObject({
-    bucket,
-    name,
-    body: await manifestBody(manifest),
-    contentType: "application/json",
-    contentEncoding: "gzip",
-    token,
-  });
-  console.log(`test selection: ${name} ${created}`);
-  await createObject({
-    bucket,
-    name: stateObjectName(today, id),
-    body: await gzipText(JSON.stringify(folded.aggregate)),
-    contentType: "application/json",
-    contentEncoding: "gzip",
-    token,
-  });
+  await store.create(name, await manifestBody(manifest));
+  console.log(`test selection: created ${name}`);
+  await store.create(
+    stateObjectName(today, id),
+    await gzipText(JSON.stringify(folded.aggregate)),
+  );
   return 0;
 }
 
@@ -557,5 +597,5 @@ function summarize(
 export { dayOf, manifestPrefix, newestAtOrBefore, serializeManifest };
 
 if (import.meta.main) {
-  Deno.exit(await main(Deno.args));
+  Deno.exit(await publish(Deno.args));
 }

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -488,13 +488,10 @@ export async function publish(
     mandatory: new Map(),
     capabilities: new Map(),
   });
-  // What the packer refused, from the packer, rather than recomputed from
-  // a raw cost that leaves out every overhead the lane would have paid.
-  manifest.unschedulable = reference.unschedulable.map((entry) => ({
-    test: entry.test,
-    suite: entry.suite,
-    cost: entry.cost,
-  }));
+  // What the packer refused, from the packer, carrying the cost the bound
+  // was compared against rather than a raw one that leaves out every
+  // overhead the lane would have paid.
+  manifest.unschedulable = reference.unschedulable;
   manifest.lanes = reference.lanes.map((lane) => ({
     lane: lane.lane,
     projectedSeconds: Math.round(lane.projectedSeconds * 10) / 10,

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -66,6 +66,23 @@ export interface StoreAccess {
   read(objectName: string): Promise<StoredReport>;
   readText(objectName: string): Promise<string>;
   create(name: string, body: Uint8Array): Promise<void>;
+
+  /**
+   * The objects a day's rollup was written as, when the day has a
+   * complete one. A day is compacted into shards sized so that a reader
+   * can hold what one decompresses to, and the day's manifest — written
+   * after every shard it names — is what says the rollup is finished and
+   * which shards it holds. Reading those replaces reading the day's
+   * thousands of raw objects.
+   *
+   * Only a bootstrap reads them. A rollup is written by the one principal
+   * here whose credential exists as key material, so it carries weaker
+   * provenance than the raw records it summarizes, and the record spec
+   * asks a consumer that feeds decisions to treat it as a cache of a day
+   * rather than the record of it. Seeding catch counts once, from days
+   * closed a week or more ago, is that use; the four-hourly path that
+   * keeps the manifest current never touches one.
+   */
   rollupShards(day: string): Promise<string[] | undefined>;
   token(): string | undefined;
 }
@@ -200,29 +217,6 @@ async function mapConcurrent<T, R>(
   );
   await Promise.all(workers);
   return results;
-}
-
-/**
- * The objects a day's rollup was written as, when the day has a complete
- * one. A day is compacted into shards sized so that a reader can hold
- * what one decompresses to, and the day's manifest — written after every
- * shard it names — is what says the rollup is finished and which shards
- * it holds. Reading those replaces reading the day's thousands of raw
- * objects.
- *
- * Only a bootstrap reads them. A rollup is written by the one principal
- * here whose credential exists as key material, so it carries weaker
- * provenance than the raw records it summarizes, and the record spec asks
- * a consumer that feeds decisions to treat it as a cache of a day rather
- * than the record of it. Seeding catch counts once, from days closed a
- * week or more ago, is that use; the four-hourly path that keeps the
- * manifest current never touches one.
- */
-function rollupFor(
-  store: StoreAccess,
-  day: string,
-): Promise<string[] | undefined> {
-  return store.rollupShards(day);
 }
 
 /**
@@ -398,7 +392,7 @@ export async function publish(
   if (options.bootstrap) {
     for (const day of partitions) {
       if (fold.knowsDay(day)) continue;
-      const shards = await rollupFor(store, day);
+      const shards = await store.rollupShards(day);
       if (shards === undefined) continue;
       try {
         // A day is folded whole or not at all: a shard that failed to

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -188,22 +188,19 @@ async function listSubmissions(days: readonly string[]): Promise<string[]> {
   const bucket = storeBucket();
   const wanted = new Set(days);
   const names: string[] = [];
+  // A listing that fails is not an empty day. Folding what did list and
+  // publishing from it would score every identity in the missing day as
+  // though it had not run, and the manifest saying so would become the
+  // one every lane obeys. The run ends instead, and the previous manifest
+  // stays newest.
   for (const day of days) {
     const prefix = `${ciSubmissionsPrefix()}/v1/${day}/`;
-    try {
-      names.push(...await listObjects({ bucket, prefix }));
-    } catch (error) {
-      console.warn(`test selection: listing ${prefix} failed: ${error}`);
-    }
+    names.push(...await listObjects({ bucket, prefix }));
   }
   const local = `${storePrefix()}/submissions/local/`;
-  try {
-    for (const name of await listObjects({ bucket, prefix: local })) {
-      const day = name.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1];
-      if (day !== undefined && wanted.has(day)) names.push(name);
-    }
-  } catch (error) {
-    console.warn(`test selection: listing ${local} failed: ${error}`);
+  for (const name of await listObjects({ bucket, prefix: local })) {
+    const day = name.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1];
+    if (day !== undefined && wanted.has(day)) names.push(name);
   }
   return [...new Set(names)].sort(byDayThenName);
 }
@@ -381,7 +378,17 @@ async function main(args: readonly string[]): Promise<number> {
   }
 
   const open = partitions.filter((day) => !fold.knowsDay(day));
-  const listed = await listSubmissions(open);
+  let listed: string[];
+  try {
+    listed = await listSubmissions(open);
+  } catch (error) {
+    console.warn(`test selection: listing the submissions failed: ${error}`);
+    console.warn(
+      "test selection: refusing to publish from part of the window. The " +
+        "previous manifest is still the newest one.",
+    );
+    return 1;
+  }
   const fresh = listed.filter((name) => !fold.knows(name));
   console.log(
     `test selection: ${listed.length} object(s) under ${open.length} ` +
@@ -392,28 +399,30 @@ async function main(args: readonly string[]): Promise<number> {
   // tens of thousands of objects, each holding hundreds of executions,
   // and holding them all would be bounded by the number of runs rather
   // than by the number of tests.
-  for (let at = 0; at < fresh.length; at += CHUNK) {
-    const chunk = fresh.slice(at, at + CHUNK);
-    const reports = (await mapConcurrent(
-      chunk,
-      options.concurrency,
-      async (objectName): Promise<StoredReport | undefined> => {
-        try {
-          return await readObject({ bucket, objectName });
-        } catch (error) {
-          console.warn(
-            `test selection: reading ${objectName} failed: ${error}`,
-          );
-          return undefined;
-        }
-      },
-    )).filter((report): report is StoredReport => report !== undefined);
-    for (const report of reports) noteReport(report);
-    fold.add(reports);
-    console.log(
-      `test selection: folded ${at + chunk.length} of ${fresh.length} ` +
-        `object(s)`,
+  try {
+    for (let at = 0; at < fresh.length; at += CHUNK) {
+      const chunk = fresh.slice(at, at + CHUNK);
+      const reports = await mapConcurrent(
+        chunk,
+        options.concurrency,
+        // A read that fails is not an object with no records, so it is not
+        // swallowed: the same partial-history argument as the listing.
+        (objectName) => readObject({ bucket, objectName }),
+      );
+      for (const report of reports) noteReport(report);
+      fold.add(reports);
+      console.log(
+        `test selection: folded ${at + chunk.length} of ${fresh.length} ` +
+          `object(s)`,
+      );
+    }
+  } catch (error) {
+    console.warn(`test selection: reading a submission failed: ${error}`);
+    console.warn(
+      "test selection: refusing to publish from part of the window. The " +
+        "previous manifest is still the newest one.",
     );
+    return 1;
   }
   const folded = fold.finish();
 

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -22,7 +22,6 @@ import { join } from "@std/path";
 import { ulid } from "@std/ulid";
 import {
   createObject,
-  gunzipToText,
   gzipText,
   listObjects,
   loadAliasResolver,
@@ -257,7 +256,9 @@ async function readAggregate(): Promise<AggregateRead> {
   const prefix = statePrefix();
   let names: string[];
   try {
-    names = await listObjects({ bucket, prefix });
+    // Trailing slash for the reason the manifest listing carries one: a
+    // bare prefix matches a longer sibling too.
+    names = await listObjects({ bucket, prefix: `${prefix}/` });
   } catch (error) {
     return { failed: `listing ${prefix} failed: ${error}` };
   }
@@ -269,10 +270,8 @@ async function readAggregate(): Promise<AggregateRead> {
     const url = objectUrl(bucket, newest);
     const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const text = await gunzipToText(
-      new Uint8Array(await response.arrayBuffer()),
-    );
-    const state = parseAggregate(text);
+    // Transcoded on the way out, so this is already the JSON.
+    const state = parseAggregate(await response.text());
     return state === undefined
       ? { failed: `${newest} is not an aggregate this reader understands` }
       : { state };

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env -S deno run --allow-read --allow-env --allow-net --allow-write
+
+/**
+ * The publisher: reads the record store, folds what is new into a rolling
+ * aggregate, scores everything, and creates one manifest object.
+ *
+ *   deno run -A tasks/test-selection-publish.ts [--days N] [--bootstrap]
+ *     [--out <dir>] [--dry-run] [--concurrency N]
+ *
+ * The incremental path reads the newest aggregate and fetches only the
+ * objects it has not already folded, which in the steady state is about
+ * two thousand of them. A cold start cannot read three weeks of history
+ * in one job, so `--bootstrap` is the one-off that does, run by hand.
+ *
+ * When the publisher fails nothing breaks: the previous manifest is still
+ * the newest one and lanes keep using it. A manifest going stale degrades
+ * selection slowly rather than failing anything, which is the right
+ * direction for a system nothing should gate on.
+ */
+
+import { join } from "@std/path";
+import { ulid } from "@std/ulid";
+import {
+  createObject,
+  gunzipToText,
+  gzipText,
+  listObjects,
+  loadAliasResolver,
+  objectUrl,
+  readObject,
+  type StoredReport,
+} from "@commonfabric/test-support/records";
+import {
+  ciSubmissionsPrefix,
+  storeBucket,
+  storePrefix,
+} from "./test-records-config.ts";
+import { rollupShards } from "./test-records-compact.ts";
+import {
+  type AggregateState,
+  buildManifest,
+  dayOf,
+  emptyAggregate,
+  Fold,
+  parseAggregate,
+} from "./test-selection/build.ts";
+import {
+  manifestBody,
+  manifestObjectName,
+  manifestPrefix,
+  newestAtOrBefore,
+  stateObjectName,
+  statePrefix,
+} from "./test-selection/store.ts";
+import { serializeManifest } from "./test-selection/manifest.ts";
+import { plan } from "./test-selection/plan.ts";
+import { LANE_BUDGET_SECONDS, LANES } from "./test-selection/policy.ts";
+
+/** How many objects are fetched at once. */
+const DEFAULT_CONCURRENCY = 24;
+
+/** Days the incremental path looks back over for unfolded objects. */
+const DEFAULT_DAYS = 2;
+
+/** Days a bootstrap reads, when no window was asked for. */
+const BOOTSTRAP_DAYS = 60;
+
+/** Objects read and folded before the next batch is fetched. */
+const CHUNK = 200;
+
+/** What the command line asked for. */
+export interface Options {
+  days: number;
+  bootstrap: boolean;
+  dryRun: boolean;
+  out?: string;
+  concurrency: number;
+}
+
+export function parseArgs(args: readonly string[]): Options | undefined {
+  const options: Options = {
+    days: DEFAULT_DAYS,
+    bootstrap: false,
+    dryRun: false,
+    concurrency: DEFAULT_CONCURRENCY,
+  };
+  // A window somebody asked for wins over the one a bootstrap implies,
+  // whichever order the two were typed in.
+  let daysGiven = false;
+  for (let i = 0; i < args.length; i++) {
+    const flag = args[i]!;
+    switch (flag) {
+      case "--bootstrap":
+        options.bootstrap = true;
+        if (!daysGiven) options.days = BOOTSTRAP_DAYS;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--days": {
+        const days = Number(args[++i]);
+        if (!Number.isInteger(days) || days < 1) return undefined;
+        options.days = days;
+        daysGiven = true;
+        break;
+      }
+      case "--concurrency": {
+        const concurrency = Number(args[++i]);
+        if (!Number.isInteger(concurrency) || concurrency < 1) return undefined;
+        options.concurrency = concurrency;
+        break;
+      }
+      case "--out": {
+        const out = args[++i];
+        if (out === undefined) return undefined;
+        options.out = out;
+        break;
+      }
+      default:
+        return undefined;
+    }
+  }
+  return options;
+}
+
+/** The day partitions to list, newest last. */
+export function dayPartitions(today: Date, days: number): string[] {
+  const partitions: string[] = [];
+  for (let back = days - 1; back >= 0; back--) {
+    const day = new Date(today.getTime() - back * 86_400_000);
+    partitions.push(day.toISOString().slice(0, 10).replaceAll("-", "/"));
+  }
+  return partitions;
+}
+
+/** Runs a mapper over items, at most `limit` of them at a time. */
+async function mapConcurrent<T, R>(
+  items: readonly T[],
+  limit: number,
+  map: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next++;
+        results[index] = await map(items[index]!);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * The objects a day's rollup was written as, when the day has a complete
+ * one. A day is compacted into shards sized so that a reader can hold
+ * what one decompresses to, and the day's manifest — written after every
+ * shard it names — is what says the rollup is finished and which shards
+ * it holds. Reading those replaces reading the day's thousands of raw
+ * objects.
+ *
+ * Only a bootstrap reads them. A rollup is written by the one principal
+ * here whose credential exists as key material, so it carries weaker
+ * provenance than the raw records it summarizes, and the record spec asks
+ * a consumer that feeds decisions to treat it as a cache of a day rather
+ * than the record of it. Seeding catch counts once, from days closed a
+ * week or more ago, is that use; the four-hourly path that keeps the
+ * manifest current never touches one.
+ */
+async function rollupFor(day: string): Promise<string[] | undefined> {
+  try {
+    return await rollupShards({ bucket: storeBucket(), day });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Every submission object under the days asked for, across both areas.
+ * A continuous-integration object's day is a path segment, so its day is
+ * a prefix and one listing per day is exact. A local object's path puts
+ * the reporting person ahead of the day, so that area is listed once and
+ * filtered.
+ */
+async function listSubmissions(days: readonly string[]): Promise<string[]> {
+  const bucket = storeBucket();
+  const wanted = new Set(days);
+  const names: string[] = [];
+  for (const day of days) {
+    const prefix = `${ciSubmissionsPrefix()}/v1/${day}/`;
+    try {
+      names.push(...await listObjects({ bucket, prefix }));
+    } catch (error) {
+      console.warn(`test selection: listing ${prefix} failed: ${error}`);
+    }
+  }
+  const local = `${storePrefix()}/submissions/local/`;
+  try {
+    for (const name of await listObjects({ bucket, prefix: local })) {
+      const day = name.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1];
+      if (day !== undefined && wanted.has(day)) names.push(name);
+    }
+  } catch (error) {
+    console.warn(`test selection: listing ${local} failed: ${error}`);
+  }
+  return [...new Set(names)].sort(byDayThenName);
+}
+
+/** The day partition in a submission object's name. */
+export function partitionOf(objectName: string): string {
+  return objectName.match(/\/v1\/(\d{4}\/\d{2}\/\d{2})\//)?.[1] ?? "";
+}
+
+/**
+ * Orders submission objects the way the fold needs them: by the day they
+ * were recorded, then by name. Sorting by name alone would put every
+ * local object after every continuous-integration one, because their
+ * areas sort that way, and the fold's backward-looking rules would then
+ * judge a workstation's failure against a state from days later. Within
+ * one day the order between the two areas is arbitrary, which is as fine
+ * a grain as the per-day counters have anyway.
+ */
+export function byDayThenName(left: string, right: string): number {
+  const day = partitionOf(left).localeCompare(partitionOf(right));
+  return day !== 0 ? day : left.localeCompare(right);
+}
+
+/** What reading the rolling aggregate found. */
+type AggregateRead =
+
+  /** The state a previous run left. */
+  | { state: AggregateState }
+  /** The area holds no state at all, so this would be a first run. */
+  | { absent: true }
+  /** Something went wrong, and what a previous run left is unknown. */
+  | { failed: string };
+
+/**
+ * Reads the newest aggregate.
+ *
+ * The three outcomes are kept apart because folding into an empty
+ * aggregate while a real one exists is the worst thing this program can
+ * do. `catches` accumulates over unbounded history and is the whole of
+ * what makes a test worth running, and the state object is where that
+ * history lives. A run that lost it and carried on would publish a
+ * manifest scoring every test at the floor, and because it succeeded that
+ * manifest would become the one every lane obeys. Failing is the designed
+ * outcome — the previous manifest stays newest and selection decays
+ * slowly — so an unreadable state is told apart from an absent one rather
+ * than both becoming an empty one.
+ */
+async function readAggregate(): Promise<AggregateRead> {
+  const bucket = storeBucket();
+  const prefix = statePrefix();
+  let names: string[];
+  try {
+    names = await listObjects({ bucket, prefix });
+  } catch (error) {
+    return { failed: `listing ${prefix} failed: ${error}` };
+  }
+  const newest = names.filter((name) => name.endsWith(".json.gz")).sort().at(
+    -1,
+  );
+  if (newest === undefined) return { absent: true };
+  try {
+    const url = objectUrl(bucket, newest);
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const text = await gunzipToText(
+      new Uint8Array(await response.arrayBuffer()),
+    );
+    const state = parseAggregate(text);
+    return state === undefined
+      ? { failed: `${newest} is not an aggregate this reader understands` }
+      : { state };
+  } catch (error) {
+    return { failed: `reading ${newest} failed: ${error}` };
+  }
+}
+
+/**
+ * An access token for creating a manifest, when one is reachable. Only
+ * the workflow has one: the publisher's identity is federated and pinned
+ * to that workflow file, and it is the sole principal holding create on
+ * the selection area. A person's own reporting key is scoped to their
+ * `submissions/local/<username>/` folder and cannot write a manifest, so
+ * there is no fallback to offer — `--dry-run --out` is how a person sees
+ * what a run would produce.
+ */
+function writeToken(): string | undefined {
+  const federated = Deno.env.get("TEST_RECORDS_GCS_TOKEN");
+  return federated !== undefined && federated.length > 0
+    ? federated
+    : undefined;
+}
+
+async function main(args: readonly string[]): Promise<number> {
+  const options = parseArgs(args);
+  if (options === undefined) {
+    console.error(
+      "usage: test-selection-publish.ts [--days N] [--bootstrap] " +
+        "[--out <dir>] [--dry-run] [--concurrency N]",
+    );
+    return 2;
+  }
+
+  const startedAt = new Date();
+  const today = startedAt.toISOString().slice(0, 10);
+  let aggregate: AggregateState;
+  if (options.bootstrap) {
+    aggregate = emptyAggregate(today);
+  } else {
+    const read = await readAggregate();
+    if ("failed" in read) {
+      console.warn(`test selection: ${read.failed}`);
+      console.warn(
+        "test selection: refusing to publish from an empty aggregate, " +
+          "which would score every test at the floor. The previous " +
+          "manifest is still the newest one.",
+      );
+      return 1;
+    }
+    if ("absent" in read) {
+      console.warn(
+        "test selection: no aggregate exists yet. A first run reads the " +
+          "whole window and is asked for deliberately, with --bootstrap.",
+      );
+      return 1;
+    }
+    aggregate = read.state;
+  }
+  const partitions = dayPartitions(startedAt, options.days);
+  const bucket = storeBucket();
+  const resolver = await loadAliasResolver();
+  const fold = new Fold(aggregate, resolver, today);
+  const runs = new Set<string>();
+  let commit = "unknown";
+
+  const noteReport = (report: StoredReport): void => {
+    for (const group of report.reports) {
+      const id = group.context?.ci?.workflowRunId;
+      if (id !== undefined) runs.add(id);
+      if (group.context?.branch === "main") commit = group.context.commit;
+    }
+  };
+
+  // A bootstrap folds each closed day from its rollup where one exists,
+  // which is one object against the day's thousands. The days it takes
+  // this way are recorded, so no later run over a wide window folds their
+  // raw objects on top of them and doubles every catch in them.
+  const compacted: string[] = [];
+  if (options.bootstrap) {
+    for (const day of partitions) {
+      if (fold.knowsDay(day)) continue;
+      const shards = await rollupFor(day);
+      if (shards === undefined) continue;
+      try {
+        // A day is folded whole or not at all: a shard that failed to
+        // read would leave the day partly folded, and marking it
+        // compacted would then hide the rest of it from every later run.
+        const reports = await mapConcurrent(
+          shards,
+          options.concurrency,
+          (objectName) => readObject({ bucket, objectName }),
+        );
+        for (const report of reports) noteReport(report);
+        fold.add(reports);
+        fold.markCompacted(day);
+        compacted.push(day);
+      } catch (error) {
+        console.warn(
+          `test selection: reading the rollup of ${day} failed: ${error}`,
+        );
+      }
+    }
+    console.log(
+      `test selection: folded ${compacted.length} day(s) from their rollups`,
+    );
+  }
+
+  const open = partitions.filter((day) => !fold.knowsDay(day));
+  const listed = await listSubmissions(open);
+  const fresh = listed.filter((name) => !fold.knows(name));
+  console.log(
+    `test selection: ${listed.length} object(s) under ${open.length} ` +
+      `open day(s), ${fresh.length} not yet folded`,
+  );
+
+  // Read and fold in chunks rather than all at once. A bootstrap reads
+  // tens of thousands of objects, each holding hundreds of executions,
+  // and holding them all would be bounded by the number of runs rather
+  // than by the number of tests.
+  for (let at = 0; at < fresh.length; at += CHUNK) {
+    const chunk = fresh.slice(at, at + CHUNK);
+    const reports = (await mapConcurrent(
+      chunk,
+      options.concurrency,
+      async (objectName): Promise<StoredReport | undefined> => {
+        try {
+          return await readObject({ bucket, objectName });
+        } catch (error) {
+          console.warn(
+            `test selection: reading ${objectName} failed: ${error}`,
+          );
+          return undefined;
+        }
+      },
+    )).filter((report): report is StoredReport => report !== undefined);
+    for (const report of reports) noteReport(report);
+    fold.add(reports);
+    console.log(
+      `test selection: folded ${at + chunk.length} of ${fresh.length} ` +
+        `object(s)`,
+    );
+  }
+  const folded = fold.finish();
+
+  const manifest = buildManifest({
+    states: folded.states,
+    mainRed: folded.mainRed,
+    surfaces: folded.surfaces,
+    today,
+    generatedAt: startedAt.toISOString(),
+    seed: ulid(),
+    commit,
+    runs: runs.size,
+  });
+  const reference = plan({
+    manifest,
+    mandatory: new Map(),
+    capabilities: new Map(),
+  });
+  manifest.lanes = reference.lanes.map((lane) => ({
+    lane: lane.lane,
+    projectedSeconds: Math.round(lane.projectedSeconds * 10) / 10,
+    batches: [...new Set(lane.selections.map((s) => s.entry.suite))].sort()
+      .map((suite) => ({
+        suite,
+        identities: lane.selections
+          .filter((s) => s.entry.suite === suite)
+          .map((s) => JSON.stringify(s.entry.test)),
+      })),
+  }));
+
+  summarize(manifest, reference, folded.observations);
+
+  if (options.out !== undefined) {
+    await Deno.mkdir(options.out, { recursive: true });
+    await Deno.writeTextFile(
+      join(options.out, "manifest.json"),
+      JSON.stringify(manifest, null, 2),
+    );
+    await Deno.writeTextFile(
+      join(options.out, "state.json"),
+      JSON.stringify(folded.aggregate),
+    );
+    console.log(`test selection: wrote ${options.out}/manifest.json`);
+  }
+  if (options.dryRun) return 0;
+
+  const token = writeToken();
+  if (token === undefined) {
+    console.warn(
+      "test selection: no write credential, so nothing was created. The " +
+        "previous manifest is still the newest one.",
+    );
+    return 0;
+  }
+  const id = ulid();
+  const name = manifestObjectName(manifest.generatedAt, id);
+  const created = await createObject({
+    bucket,
+    name,
+    body: await manifestBody(manifest),
+    contentType: "application/json",
+    contentEncoding: "gzip",
+    token,
+  });
+  console.log(`test selection: ${name} ${created}`);
+  await createObject({
+    bucket,
+    name: stateObjectName(today, id),
+    body: await gzipText(JSON.stringify(folded.aggregate)),
+    contentType: "application/json",
+    contentEncoding: "gzip",
+    token,
+  });
+  return 0;
+}
+
+/** What the job summary says: the shape of what this run decided. */
+function summarize(
+  manifest: ReturnType<typeof buildManifest>,
+  reference: ReturnType<typeof plan>,
+  observations: number,
+): void {
+  console.log(
+    `test selection: folded ${observations} execution(s) into ` +
+      `${manifest.entries.length} identities`,
+  );
+  const held = new Map<string, number>();
+  for (const entry of manifest.withheld) {
+    held.set(entry.reason, (held.get(entry.reason) ?? 0) + 1);
+  }
+  for (const [reason, count] of [...held].sort()) {
+    console.log(`test selection: ${count} withheld as ${reason}`);
+  }
+  const times = reference.lanes.map((lane) => lane.projectedSeconds);
+  for (const lane of reference.lanes) {
+    console.log(
+      `test selection: lane ${lane.lane} would run ` +
+        `${lane.selections.length} test(s) in ` +
+        `${lane.projectedSeconds.toFixed(1)}s of ${LANE_BUDGET_SECONDS}s`,
+    );
+  }
+  if (times.length > 0) {
+    const spread = Math.max(...times) - Math.min(...times);
+    console.log(
+      `test selection: ${LANES} lanes, spread ${spread.toFixed(1)}s`,
+    );
+  }
+  const selected = reference.lanes.reduce(
+    (total, lane) => total + lane.selections.length,
+    0,
+  );
+  console.log(
+    `test selection: ${selected} of ${manifest.entries.length} identities ` +
+      `fit the budget`,
+  );
+  const unschedulable = manifest.entries.filter(
+    (entry) => entry.cost > LANE_BUDGET_SECONDS,
+  );
+  for (const entry of unschedulable) {
+    console.log(
+      `test selection: unschedulable, ${entry.cost.toFixed(1)}s: ` +
+        JSON.stringify(entry.test),
+    );
+  }
+}
+
+// Re-exported so an offline check can build the same day list.
+export { dayOf, manifestPrefix, newestAtOrBefore, serializeManifest };
+
+if (import.meta.main) {
+  Deno.exit(await main(Deno.args));
+}

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -75,15 +75,17 @@ export interface StoreAccess {
    * which shards it holds. Reading those replaces reading the day's
    * thousands of raw objects.
    *
-   * Only a bootstrap reads them. A rollup is written by the one principal
-   * here whose credential exists as key material, so it carries weaker
-   * provenance than the raw records it summarizes, and the record spec
-   * asks a consumer that feeds decisions to treat it as a cache of a day
-   * rather than the record of it. Seeding catch counts once, from days
-   * closed a week or more ago, is that use; the four-hourly path that
-   * keeps the manifest current never touches one.
+   * Only a bootstrap reads them, and not because the incremental path
+   * declines to: compaction waits a week for late arrivals, and the
+   * window that path reads is two days, so it never reaches a day that
+   * has one. A rollup is a read optimization rather than the record of
+   * its day — an object arriving after its shard is written stays in the
+   * raw area alone — which suits seeding sixty days of catch counts once
+   * and would not suit the run that keeps the manifest current.
    */
   rollupShards(day: string): Promise<string[] | undefined>;
+
+  /** The credential for creating an object, when one is reachable. */
   token(): string | undefined;
 }
 

--- a/tasks/test-selection-publish.ts
+++ b/tasks/test-selection-publish.ts
@@ -324,7 +324,7 @@ async function readAggregate(store: StoreAccess): Promise<AggregateRead> {
  * there is no fallback to offer — `--dry-run --out` is how a person sees
  * what a run would produce.
  */
-function writeToken(): string | undefined {
+export function writeToken(): string | undefined {
   const federated = Deno.env.get("TEST_RECORDS_GCS_TOKEN");
   return federated !== undefined && federated.length > 0
     ? federated
@@ -391,7 +391,6 @@ export async function publish(
   const compacted: string[] = [];
   if (options.bootstrap) {
     for (const day of partitions) {
-      if (fold.knowsDay(day)) continue;
       const shards = await store.rollupShards(day);
       if (shards === undefined) continue;
       try {

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -257,6 +257,31 @@ describe("verdictFor()", () => {
     expect(verdict.unschedulable).toBeUndefined();
   });
 
+  it("carries the cost the bound was compared against", () => {
+    const manifest = sampleManifest({
+      entries: [sampleEntry({ k: "unit", s: "memory", n: "heavy" }, {
+        cost: 200,
+        suite: "pattern-integration",
+      })],
+      calibration: {
+        setupCost: {},
+        suites: { "pattern-integration": { overhead: 400, correction: 1 } },
+        unitOverhead: {},
+        prologue: 0,
+      },
+    });
+    const test = { k: "unit", s: "memory", n: "heavy" };
+    const verdict = verdictFor(manifest, test);
+    expect(verdict.unschedulable).toBe(true);
+    expect(verdict.loneSeconds).toBeCloseTo(600, 5);
+    // What `explain` prints is that figure, not the entry's own 200: a
+    // reader told "200s is past the bound" would go looking for a bound
+    // below 200 that does not exist.
+    const said = explainLines(manifest, test, verdict).join("\n");
+    expect(said).toContain("600.0s is past the bound");
+    expect(said).not.toContain("200.0s is past the bound");
+  });
+
   it("reports a test no lane could hold as unschedulable, not selected", () => {
     const verdict = verdictFor(manifestOf(entry("enormous", 100_000)), {
       k: "unit",

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -1,0 +1,290 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  coverageLines,
+  dialLines,
+  explainLines,
+  laneArgument,
+  parseIdentityArgument,
+  planLines,
+  verdictFor,
+} from "./test-selection.ts";
+import {
+  freeCalibration,
+  sampleEntry,
+  sampleManifest,
+} from "./test-selection/testing.ts";
+import type { ManifestEntry } from "./test-selection/manifest.ts";
+import {
+  DIALS,
+  EXCLUDED_FROM_COVERAGE_GATE,
+  LANES,
+} from "./test-selection/policy.ts";
+
+const TEST = { k: "unit", s: "memory", n: "space > writes" };
+
+describe("test-selection", () => {
+  describe("parseIdentityArgument()", () => {
+    it("takes the three-part key and the four-part one", () => {
+      expect(parseIdentityArgument('["unit","memory","a"]')).toEqual({
+        k: "unit",
+        s: "memory",
+        n: "a",
+      });
+      expect(parseIdentityArgument('["unit","memory","a","on"]')).toEqual({
+        k: "unit",
+        s: "memory",
+        n: "a",
+        v: "on",
+      });
+    });
+
+    it("refuses anything that is not an identity", () => {
+      // An empty part is what the manifest validator refuses too, so
+      // accepting one here would report a test as unknown and mandatory
+      // when the argument was the problem.
+      for (
+        const argument of [
+          "not json",
+          "{}",
+          '["unit","memory"]',
+          '["unit","memory","a","on","extra"]',
+          '["","memory","a"]',
+          '["unit","","a"]',
+          '["unit","memory",""]',
+          '["unit","memory","a",""]',
+          '["unit","memory",7]',
+        ]
+      ) {
+        expect(parseIdentityArgument(argument)).toBeUndefined();
+      }
+    });
+  });
+
+  describe("explainLines()", () => {
+    const manifest = () =>
+      sampleManifest({ entries: [sampleEntry(TEST, { cost: 2, score: 0.4 })] });
+
+    it("says an identity with no records is mandatory", () => {
+      const lines = explainLines(manifest(), { ...TEST, n: "never seen" });
+      expect(lines.join("\n")).toContain("no record of it");
+    });
+
+    it("prints the catches behind a score", () => {
+      const held = manifest();
+      held.entries[0]!.inputs = {
+        catches: 3,
+        mainCatches: 1,
+        sources: 2,
+        churn: 0.5,
+        lastCatch: "2026-08-20",
+      };
+      const text = explainLines(held, TEST, { selected: true }).join("\n");
+      expect(text).toContain("3.0 weighted catches");
+      expect(text).toContain("1 of them on main");
+      expect(text).toContain("2026-08-20");
+      expect(text).toContain("selects it");
+    });
+
+    it("says a test has never caught anything", () => {
+      expect(explainLines(manifest(), TEST).join("\n")).toContain(
+        "never caught anything",
+      );
+    });
+
+    it("says why an identity was withheld", () => {
+      for (
+        const [reason, said] of [
+          ["main-red", "failing in the newest run on main"],
+          ["flaky", "too flaky to judge a change by"],
+        ] as const
+      ) {
+        const held = manifest();
+        held.withheld = [{ test: TEST, suite: "workspace-unit", reason }];
+        expect(explainLines(held, TEST).join("\n")).toContain(said);
+      }
+    });
+
+    it("reports the repeat count the packing settled on", () => {
+      const held = manifest();
+      held.entries[0]!.repeats = 3;
+      const text = explainLines(held, TEST, { selected: true, repeats: 2 })
+        .join("\n");
+      expect(text).toContain("run 2 times");
+    });
+
+    it("separates a test no lane can hold from one the budget missed", () => {
+      const held = manifest();
+      expect(
+        explainLines(held, TEST, { selected: false, unschedulable: true })
+          .join("\n"),
+      ).toContain("no lane can hold it");
+      expect(explainLines(held, TEST, { selected: false }).join("\n"))
+        .toContain(
+          "does not reach it",
+        );
+    });
+  });
+
+  describe("dialLines()", () => {
+    it("prints every dial with its unit and how it is set", () => {
+      const text = dialLines().join("\n");
+      for (const dial of DIALS) expect(text).toContain(dial.name);
+      expect(text).toContain("(chosen)");
+      expect(text).toContain("(measured)");
+    });
+
+    it("says a dial that is off is off rather than printing nothing", () => {
+      expect(dialLines().join("\n")).toContain("off");
+    });
+  });
+
+  describe("planLines()", () => {
+    it("summarizes what each lane would run", () => {
+      const manifest = sampleManifest({
+        entries: [
+          sampleEntry({ k: "unit", s: "memory", n: "one" }, { cost: 1 }),
+          sampleEntry({ k: "unit", s: "memory", n: "two" }, { cost: 1 }),
+        ],
+      });
+      const text = planLines(manifest, undefined).join("\n");
+      expect(text).toContain("2 known identities");
+      expect(text).toContain(`${LANES} lanes`);
+      expect(text).toContain("lane 1:");
+    });
+
+    it("prints one lane when asked for one", () => {
+      const manifest = sampleManifest({
+        entries: [sampleEntry({ k: "unit", s: "memory", n: "one" })],
+      });
+      const text = planLines(manifest, 3).join("\n");
+      expect(text).toContain("lane 3:");
+      expect(text).not.toContain("lane 1:");
+    });
+
+    it("names an identity no lane can hold", () => {
+      const manifest = sampleManifest({
+        entries: [sampleEntry({ k: "unit", s: "memory", n: "huge" }, {
+          cost: 10_000,
+        })],
+      });
+      expect(planLines(manifest, undefined).join("\n")).toContain(
+        "unschedulable",
+      );
+    });
+  });
+});
+
+describe("coverageLines()", () => {
+  it("names the baseline a member is gated against", () => {
+    const manifest = sampleManifest({
+      coverageBaselines: [{
+        member: "packages/memory",
+        commit: "abcdef0",
+        day: "2026-08-20",
+        uncoveredLines: 41,
+      }],
+    });
+    expect(coverageLines(manifest, ["packages/memory"])).toEqual([
+      "packages/memory  gated, against 41 uncovered lines at abcdef0",
+    ]);
+  });
+
+  it("says so when a member has no baseline yet", () => {
+    const lines = coverageLines(sampleManifest(), ["packages/memory"]);
+    expect(lines).toEqual(["packages/memory  gated, against no baseline yet"]);
+  });
+
+  it("gives the reason for a member the gate leaves alone", () => {
+    const member = [...EXCLUDED_FROM_COVERAGE_GATE.keys()][0]!;
+    const lines = coverageLines(sampleManifest(), [member]);
+    expect(lines[0]).toContain("not gated: ");
+    expect(lines[0]).toContain(EXCLUDED_FROM_COVERAGE_GATE.get(member)!);
+  });
+
+  it("reads a manifest that is missing the same as one with no baselines", () => {
+    const members = ["packages/memory", "packages/runner"];
+    expect(coverageLines(undefined, members))
+      .toEqual(coverageLines(sampleManifest(), members));
+  });
+
+  it("pads every member to one width, so the column lines up", () => {
+    const lines = coverageLines(undefined, ["packages/a", "packages/longer"]);
+    const at = lines.map((line) => line.indexOf("gated"));
+    expect(at[0]).toBe(at[1]);
+  });
+});
+
+describe("laneArgument()", () => {
+  it("is nothing at all when the flag is absent", () => {
+    expect(laneArgument(["plan", "--dry-run"])).toBeUndefined();
+  });
+
+  it("takes a lane inside the range", () => {
+    expect(laneArgument(["plan", "--lane", "1"])).toBe(1);
+    expect(laneArgument(["plan", "--lane", String(LANES)])).toBe(LANES);
+  });
+
+  it("rejects a lane outside the range, at either end", () => {
+    expect(laneArgument(["plan", "--lane", "0"])).toBe("invalid");
+    expect(laneArgument(["plan", "--lane", String(LANES + 1)])).toBe("invalid");
+  });
+
+  it("rejects what is not a whole number, including a missing value", () => {
+    for (const value of ["1.5", "two", "", "-1"]) {
+      expect(laneArgument(["plan", "--lane", value])).toBe("invalid");
+    }
+    expect(laneArgument(["plan", "--lane"])).toBe("invalid");
+  });
+});
+
+describe("verdictFor()", () => {
+  const entry = (name: string, seconds: number) =>
+    sampleEntry({ k: "unit", s: "memory", n: name }, { cost: seconds });
+  const manifestOf = (...entries: ManifestEntry[]) =>
+    sampleManifest({ entries, calibration: freeCalibration() });
+
+  it("reports a test the packer takes, and how often it takes it", () => {
+    const manifest = sampleManifest({ entries: [entry("cheap", 0.1)] });
+    const verdict = verdictFor(manifest, {
+      k: "unit",
+      s: "memory",
+      n: "cheap",
+    });
+    expect(verdict.selected).toBe(true);
+    expect(verdict.repeats).toBeGreaterThanOrEqual(1);
+    expect(verdict.unschedulable).toBeUndefined();
+  });
+
+  it("reports a test no lane could hold as unschedulable, not selected", () => {
+    const verdict = verdictFor(manifestOf(entry("enormous", 100_000)), {
+      k: "unit",
+      s: "memory",
+      n: "enormous",
+    });
+    expect(verdict.selected).toBe(false);
+    expect(verdict.unschedulable).toBe(true);
+  });
+
+  it("reports a test the manifest has never heard of as unselected", () => {
+    const manifest = manifestOf(entry("cheap", 0.1));
+    expect(verdictFor(manifest, { k: "unit", s: "memory", n: "absent" }))
+      .toEqual({ selected: false });
+  });
+
+  it("tells two configurations of one name apart", () => {
+    const manifest = manifestOf(
+      sampleEntry({ k: "unit", s: "memory", n: "both", v: "on" }, {
+        cost: 0.1,
+      }),
+    );
+    expect(
+      verdictFor(manifest, { k: "unit", s: "memory", n: "both", v: "on" })
+        .selected,
+    ).toBe(true);
+    expect(
+      verdictFor(manifest, { k: "unit", s: "memory", n: "both" }).selected,
+    ).toBe(false);
+  });
+});

--- a/tasks/test-selection.test.ts
+++ b/tasks/test-selection.test.ts
@@ -4,12 +4,17 @@ import { expect } from "@std/expect";
 import {
   coverageLines,
   dialLines,
+  dispatch,
   explainLines,
+  gatedMembers,
   laneArgument,
   parseIdentityArgument,
   planLines,
+  type Sources,
+  Stop,
   verdictFor,
 } from "./test-selection.ts";
+import type { TestIdentity } from "@commonfabric/test-support/records";
 import {
   freeCalibration,
   sampleEntry,
@@ -311,5 +316,175 @@ describe("verdictFor()", () => {
     expect(
       verdictFor(manifest, { k: "unit", s: "memory", n: "both" }).selected,
     ).toBe(false);
+  });
+});
+
+describe("gatedMembers()", () => {
+  it("is every package in the workspace, and nothing else", async () => {
+    const members = await gatedMembers();
+    expect(members.length).toBeGreaterThan(10);
+    expect(members.every((member) => member.startsWith("packages/"))).toBe(
+      true,
+    );
+    // The workspace file lists members with a leading "./", and the
+    // coverage baselines a manifest carries do not.
+    expect(members.some((member) => member.startsWith("./"))).toBe(false);
+    expect(members).toContain("packages/test-support");
+    expect([...members].sort()).toEqual(members);
+  });
+
+  it("names members the gate has an opinion about", async () => {
+    // Every excluded member is one of these; an exclusion naming
+    // something outside the list would never be printed.
+    const members = new Set(await gatedMembers());
+    for (const excluded of EXCLUDED_FROM_COVERAGE_GATE.keys()) {
+      expect(members.has(excluded)).toBe(true);
+    }
+  });
+});
+
+describe("dispatch()", () => {
+  /** Everything the dispatch printed, and the code it gave back. */
+  async function ran(
+    args: readonly string[],
+    sources: Partial<Sources> = {},
+  ): Promise<{ code: number; out: string; err: string; stop?: Stop }> {
+    const out: string[] = [];
+    const err: string[] = [];
+    const log = console.log;
+    const warn = console.error;
+    console.log = (...parts: unknown[]) => out.push(parts.join(" "));
+    console.error = (...parts: unknown[]) => err.push(parts.join(" "));
+    try {
+      const code = await dispatch(args, {
+        manifest: () => Promise.resolve(sampleManifest()),
+        members: () => Promise.resolve(["packages/memory"]),
+        aliases: () =>
+          Promise.resolve({ resolve: (test: TestIdentity) => test }),
+        ...sources,
+      } as Sources);
+      return { code, out: out.join("\n"), err: err.join("\n") };
+    } catch (error) {
+      if (!(error instanceof Stop)) throw error;
+      return { code: error.code, out: out.join("\n"), err: "", stop: error };
+    } finally {
+      console.log = log;
+      console.error = warn;
+    }
+  }
+
+  it("prints the usage for no mode, and for either help flag", async () => {
+    for (const args of [[], ["--help"], ["-h"]]) {
+      const result = await ran(args);
+      expect(result.code).toBe(0);
+      expect(result.out).toContain("usage: test-selection");
+    }
+  });
+
+  it("stops with the usage code on a mode it does not have", async () => {
+    const result = await ran(["wat"]);
+    expect(result.code).toBe(2);
+    expect(result.stop?.message).toContain("unknown mode wat");
+  });
+
+  it("prints every dial without reading anything", async () => {
+    const result = await ran(["dials"], {
+      manifest: () => {
+        throw new Error("dials must not read a manifest");
+      },
+    });
+    expect(result.code).toBe(0);
+    expect(result.out).toContain(DIALS[0]!.name);
+  });
+
+  it("names the gated members, and carries on with no manifest", async () => {
+    const result = await ran(["coverage"], {
+      manifest: () => Promise.resolve(undefined),
+    });
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("packages/memory");
+    expect(result.out).toContain("no baseline yet");
+  });
+
+  it("stops when explain is given no identity, or a bad one", async () => {
+    expect((await ran(["explain"])).code).toBe(2);
+    const bad = await ran(["explain", "not a key"]);
+    expect(bad.code).toBe(2);
+    expect(bad.stop?.message).toContain("not an identity key");
+  });
+
+  it("explains one test, through the alias file", async () => {
+    const asked: TestIdentity[] = [];
+    const result = await ran(["explain", '["unit","memory","old name"]'], {
+      manifest: () =>
+        Promise.resolve(sampleManifest({
+          entries: [sampleEntry({ k: "unit", s: "memory", n: "new name" })],
+        })),
+      aliases: () =>
+        Promise.resolve({
+          resolve: (test: TestIdentity) => {
+            asked.push(test);
+            return { ...test, n: "new name" };
+          },
+        }),
+    });
+    expect(result.code).toBe(0);
+    expect(asked[0]?.n).toBe("old name");
+    expect(result.out).toContain("new name");
+    expect(result.out).toContain("the current manifest selects it");
+  });
+
+  it(
+    "reports a missing manifest as a failure, not as an empty answer",
+    async () => {
+      // Printing nothing and exiting zero reads as "no test would run".
+      for (const args of [["explain", '["unit","memory","a"]'], ["plan"]]) {
+        const result = await ran(args, {
+          manifest: () => Promise.resolve(undefined),
+        });
+        expect(result.code).toBe(1);
+      }
+    },
+  );
+
+  it("prints the plan, and only the lane asked for", async () => {
+    const manifest = sampleManifest({
+      entries: Array.from(
+        { length: 12 },
+        (_, i) =>
+          sampleEntry({ k: "unit", s: "memory", n: `case ${i}` }, {
+            unit: `packages/memory/test/case-${i}.test.ts`,
+          }),
+      ),
+    });
+    const all = await ran(["plan", "--dry-run"], {
+      manifest: () => Promise.resolve(manifest),
+    });
+    expect(all.code).toBe(0);
+    expect(all.out.match(/^ {2}lane \d+:/gm)?.length).toBe(LANES);
+
+    const one = await ran(["plan", "--dry-run", "--lane", "2"], {
+      manifest: () => Promise.resolve(manifest),
+    });
+    expect(one.out.match(/^ {2}lane \d+:/gm)?.length).toBe(1);
+    expect(one.out).toContain("  lane 2:");
+  });
+
+  it("stops on a lane number no lane has", async () => {
+    const result = await ran(["plan", "--lane", "9"]);
+    expect(result.code).toBe(2);
+    expect(result.stop?.message).toContain("whole number from 1 to");
+  });
+
+  it("stops on --verify before reading a manifest", async () => {
+    // The mode does not read one, so a store it never needed must not be
+    // what it fails on.
+    const result = await ran(["plan", "--verify"], {
+      manifest: () => {
+        throw new Error("--verify must not read a manifest");
+      },
+    });
+    expect(result.code).toBe(2);
+    expect(result.stop?.message).toContain("test topology");
   });
 });

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -160,6 +160,14 @@ export interface PlanVerdict {
 
   /** Set when no lane can hold it, whatever the budget. */
   unschedulable?: boolean;
+
+  /**
+   * What a lane running nothing else would pay for it: its corrected own
+   * time plus every overhead and setup that lane would open. This is the
+   * figure the hard bound is compared against, so it is the one to report
+   * when the answer is that no lane can hold it.
+   */
+  loneSeconds?: number;
 }
 
 export function explainLines(
@@ -203,8 +211,9 @@ export function explainLines(
         : "  withheld: it is too flaky to judge a change by",
     );
   } else if (verdict.unschedulable) {
+    const seconds = verdict.loneSeconds ?? entry.cost;
     lines.push(
-      `  no lane can hold it: ${entry.cost.toFixed(1)}s is past the bound a ` +
+      `  no lane can hold it: ${seconds.toFixed(1)}s is past the bound a ` +
         "lane runs under, so it is reported rather than scheduled. Splitting " +
         "it is the fix.",
     );
@@ -308,10 +317,12 @@ export function verdictFor(
   ) => testIdentityKey(selection.entry.test) === key);
   const verdict: PlanVerdict = { selected: taken !== undefined };
   if (taken !== undefined) verdict.repeats = taken.repeats;
-  if (
-    result.unschedulable.some((entry) => testIdentityKey(entry.test) === key)
-  ) {
+  const refused = result.unschedulable.find((entry) =>
+    testIdentityKey(entry.test) === key
+  );
+  if (refused !== undefined) {
     verdict.unschedulable = true;
+    verdict.loneSeconds = refused.cost;
   }
   return verdict;
 }

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -48,6 +48,20 @@ test ran in a non-default configuration:
   ["integration","patterns","counter.test.ts","server-execution"]
 `;
 
+/**
+ * The lane a `--lane` argument names: a number, nothing when the flag is
+ * absent, and "invalid" for a flag that names no lane.
+ */
+export function laneArgument(
+  args: readonly string[],
+): number | undefined | "invalid" {
+  const at = args.indexOf("--lane");
+  if (at < 0) return undefined;
+  const lane = Number(args[at + 1]);
+  if (!Number.isInteger(lane) || lane < 1 || lane > LANES) return "invalid";
+  return lane;
+}
+
 function fail(message: string): never {
   console.error(message);
   Deno.exit(2);
@@ -58,7 +72,9 @@ function pad(text: string, width: number): string {
   return text.length >= width ? text : text + " ".repeat(width - text.length);
 }
 
-function printDials(): void {
+/** Every dial, as the lines `dials` prints. */
+export function dialLines(): string[] {
+  const lines: string[] = [];
   const width = Math.max(...DIALS.map((dial) => dial.name.length));
   for (const dial of DIALS) {
     const shown = Array.isArray(dial.value)
@@ -66,40 +82,48 @@ function printDials(): void {
       : dial.value === undefined
       ? "off"
       : String(dial.value);
-    console.log(
+    lines.push(
       `${pad(dial.name, width)}  ${shown} ${dial.unit} (${dial.setBy})`,
     );
-    console.log(`${" ".repeat(width)}  ${dial.why}`);
-    console.log("");
+    lines.push(`${" ".repeat(width)}  ${dial.why}`);
+    lines.push("");
   }
-  console.log(
+  lines.push(
     "setupCost, suiteOverhead and correction are measured too, and are " +
       "published\nin each manifest rather than kept here.",
   );
+  return lines;
 }
 
-async function printCoverage(manifest: Manifest | undefined): Promise<void> {
-  const root = repositoryRoot() ?? Deno.cwd();
-  const members = (await readWorkspaceMembers(join(root, "deno.jsonc")))
-    .map((member) => member.replace(/^\.\//, ""))
-    .filter((member) => member.startsWith("packages/"))
-    .sort();
+/** Each gated member and its baseline, as the lines `coverage` prints. */
+export function coverageLines(
+  manifest: Manifest | undefined,
+  members: readonly string[],
+): string[] {
   const width = Math.max(...members.map((member) => member.length));
   const baselines = new Map(
     (manifest?.coverageBaselines ?? []).map((base) => [base.member, base]),
   );
-  for (const member of members) {
+  return members.map((member) => {
     const excluded = EXCLUDED_FROM_COVERAGE_GATE.get(member);
     if (excluded !== undefined) {
-      console.log(`${pad(member, width)}  not gated: ${excluded}`);
-      continue;
+      return `${pad(member, width)}  not gated: ${excluded}`;
     }
     const baseline = baselines.get(member);
     const against = baseline === undefined
       ? "no baseline yet"
       : `${baseline.uncoveredLines} uncovered lines at ${baseline.commit}`;
-    console.log(`${pad(member, width)}  gated, against ${against}`);
-  }
+    return `${pad(member, width)}  gated, against ${against}`;
+  });
+}
+
+/** The workspace members the coverage gate has an opinion about. */
+async function gatedMembers(): Promise<string[]> {
+  const root = repositoryRoot() ?? Deno.cwd();
+  return (await readWorkspaceMembers(join(root, "deno.jsonc")))
+    .map((member) => member.replace(/^\.\//, ""))
+    .filter((member) => member.startsWith("packages/"))
+    .sort();
 }
 
 /** The identity a command-line argument names. */
@@ -218,23 +242,28 @@ function planFor(manifest: Manifest) {
   return plan({ manifest, mandatory: new Map(), capabilities: new Map() });
 }
 
-function printDryRun(manifest: Manifest, laneNumber: number | undefined): void {
+/** What `plan --dry-run` prints, as lines. */
+export function planLines(
+  manifest: Manifest,
+  laneNumber: number | undefined,
+): string[] {
+  const lines: string[] = [];
   const result = planFor(manifest);
   const lanes = laneNumber === undefined
     ? result.lanes
     : result.lanes.filter((lane) => lane.lane === laneNumber);
-  console.log(
+  lines.push(
     `manifest of ${manifest.generatedAt}, from ${manifest.runs} runs at ` +
       `${manifest.commit}`,
   );
-  console.log(
+  lines.push(
     `${manifest.entries.length} known identities, ` +
       `${manifest.withheld.length} withheld`,
   );
   for (const lane of lanes) {
-    console.log(laneLine(lane));
+    lines.push(laneLine(lane));
     if (lane.capabilities.length > 0) {
-      console.log(`    needs ${lane.capabilities.join(", ")}`);
+      lines.push(`    needs ${lane.capabilities.join(", ")}`);
     }
     const byReason = new Map<string, number>();
     for (const selection of lane.selections) {
@@ -244,22 +273,47 @@ function printDryRun(manifest: Manifest, laneNumber: number | undefined): void {
       );
     }
     for (const [reason, count] of [...byReason].sort()) {
-      console.log(`    ${count} by ${reason}`);
+      lines.push(`    ${count} by ${reason}`);
     }
   }
   if (result.overBudgetSeconds > 0) {
-    console.log(
+    lines.push(
       `the mandatory set alone overran by ` +
         `${result.overBudgetSeconds.toFixed(1)}s`,
     );
   }
   for (const entry of result.unschedulable) {
-    console.log(
+    lines.push(
       `unschedulable: ${testIdentityKey(entry.test)} costs ` +
         `${entry.cost.toFixed(1)}s, past a lane's whole budget`,
     );
   }
-  console.log(`${LANES} lanes, ${LANE_BUDGET_SECONDS}s of work each`);
+  lines.push(`${LANES} lanes, ${LANE_BUDGET_SECONDS}s of work each`);
+  return lines;
+}
+
+/**
+ * What the lanes would do with one test. Runs the same packing a lane
+ * runs, so the answer is the one the lanes would give rather than a guess
+ * from the manifest entry alone.
+ */
+export function verdictFor(
+  manifest: Manifest,
+  test: TestIdentity,
+): PlanVerdict {
+  const result = planFor(manifest);
+  const key = testIdentityKey(test);
+  const taken = result.lanes.flatMap((lane) => lane.selections).find((
+    selection,
+  ) => testIdentityKey(selection.entry.test) === key);
+  const verdict: PlanVerdict = { selected: taken !== undefined };
+  if (taken !== undefined) verdict.repeats = taken.repeats;
+  if (
+    result.unschedulable.some((entry) => testIdentityKey(entry.test) === key)
+  ) {
+    verdict.unschedulable = true;
+  }
+  return verdict;
 }
 
 /** The manifest the newest publisher run wrote, or nothing with a reason. */
@@ -280,11 +334,15 @@ async function main(args: readonly string[]): Promise<void> {
   }
   switch (mode) {
     case "dials":
-      printDials();
+      for (const line of dialLines()) console.log(line);
       return;
-    case "coverage":
-      await printCoverage(await newestManifest());
+    case "coverage": {
+      const manifest = await newestManifest();
+      for (const line of coverageLines(manifest, await gatedMembers())) {
+        console.log(line);
+      }
       return;
+    }
     case "explain": {
       const argument = args[1];
       if (argument === undefined) fail(USAGE);
@@ -301,23 +359,13 @@ async function main(args: readonly string[]): Promise<void> {
         test,
         manifest.generatedAt.slice(0, 10),
       );
-      // Run the same packing a lane runs, so the answer is the one the
-      // lanes would give rather than a guess from the entry alone.
-      const result = planFor(manifest);
-      const key = testIdentityKey(resolved);
-      const taken = result.lanes.flatMap((lane) => lane.selections).find((s) =>
-        testIdentityKey(s.entry.test) === key
-      );
-      const verdict: PlanVerdict = { selected: taken !== undefined };
-      if (taken !== undefined) verdict.repeats = taken.repeats;
-      if (
-        result.unschedulable.some((entry) =>
-          testIdentityKey(entry.test) === key
+      for (
+        const line of explainLines(
+          manifest,
+          resolved,
+          verdictFor(manifest, resolved),
         )
       ) {
-        verdict.unschedulable = true;
-      }
-      for (const line of explainLines(manifest, resolved, verdict)) {
         console.log(line);
       }
       return;
@@ -331,21 +379,15 @@ async function main(args: readonly string[]): Promise<void> {
             "yet.\nSee docs/plans/pull-request-test-selection.md, part two.",
         );
       }
-      const laneIndex = args.indexOf("--lane");
-      let laneNumber: number | undefined;
-      if (laneIndex >= 0) {
-        laneNumber = Number(args[laneIndex + 1]);
-        if (
-          !Number.isInteger(laneNumber) || laneNumber < 1 || laneNumber > LANES
-        ) {
-          // Silently filtering every lane would exit zero having printed
-          // nothing, which reads as "this lane runs no tests".
-          fail(`--lane takes a whole number from 1 to ${LANES}`);
-        }
+      const laneNumber = laneArgument(args);
+      // Silently filtering every lane would exit zero having printed
+      // nothing, which reads as "this lane runs no tests".
+      if (laneNumber === "invalid") {
+        fail(`--lane takes a whole number from 1 to ${LANES}`);
       }
       const manifest = await newestManifest();
       if (manifest === undefined) Deno.exit(1);
-      printDryRun(manifest, laneNumber);
+      for (const line of planLines(manifest, laneNumber)) console.log(line);
       return;
     }
     default:

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -260,7 +260,13 @@ function laneLine(
     `${lane.projectedSeconds.toFixed(1)}s of ${LANE_BUDGET_SECONDS}s`;
 }
 
-/** The packing, over a manifest and no diff, as a lane would compute it. */
+/**
+ * The packing, over a manifest and no diff, as a lane would compute it.
+ * Which capabilities a suite needs is declared by the topology, which
+ * lands with part two, so until then the map is empty and a lane's
+ * capability setup costs nothing here. The publisher computes its
+ * reference plan the same way and for the same reason.
+ */
 function planFor(manifest: Manifest) {
   return plan({ manifest, mandatory: new Map(), capabilities: new Map() });
 }

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -29,7 +29,7 @@ import {
   LANES,
 } from "./test-selection/policy.ts";
 import { fetchManifest } from "./test-selection/store.ts";
-import type { Manifest, ManifestEntry } from "./test-selection/manifest.ts";
+import type { Manifest } from "./test-selection/manifest.ts";
 import { plan } from "./test-selection/plan.ts";
 import { readWorkspaceMembers } from "./workspace-tests.ts";
 
@@ -253,10 +253,7 @@ function printDryRun(manifest: Manifest, laneNumber: number | undefined): void {
         `${result.overBudgetSeconds.toFixed(1)}s`,
     );
   }
-  const unschedulable = manifest.entries.filter(
-    (entry: ManifestEntry) => entry.cost > LANE_BUDGET_SECONDS,
-  );
-  for (const entry of unschedulable) {
+  for (const entry of result.unschedulable) {
     console.log(
       `unschedulable: ${testIdentityKey(entry.test)} costs ` +
         `${entry.cost.toFixed(1)}s, past a lane's whole budget`,

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -62,9 +62,23 @@ export function laneArgument(
   return lane;
 }
 
+/**
+ * What the program says before stopping, and the code it stops with.
+ * Raised rather than exited so the whole dispatch runs in a test.
+ */
+export class Stop extends Error {
+  readonly code: number;
+
+  constructor(message: string, code: number) {
+    super(message);
+    this.name = "Stop";
+    this.code = code;
+  }
+}
+
+/** Stops with the usage code, which is what a mistyped command line gets. */
 function fail(message: string): never {
-  console.error(message);
-  Deno.exit(2);
+  throw new Stop(message, 2);
 }
 
 /** Pads a column so a printed table lines up. */
@@ -118,7 +132,7 @@ export function coverageLines(
 }
 
 /** The workspace members the coverage gate has an opinion about. */
-async function gatedMembers(): Promise<string[]> {
+export async function gatedMembers(): Promise<string[]> {
   const root = repositoryRoot() ?? Deno.cwd();
   return (await readWorkspaceMembers(join(root, "deno.jsonc")))
     .map((member) => member.replace(/^\.\//, ""))
@@ -337,22 +351,57 @@ async function newestManifest(): Promise<Manifest | undefined> {
   return found.manifest;
 }
 
-async function main(args: readonly string[]): Promise<void> {
+/** What the dispatch reads that is not in its arguments. */
+export interface Sources {
+  /** The newest published manifest, or nothing when there is none. */
+  manifest(): Promise<Manifest | undefined>;
+
+  /** The workspace members the coverage gate has an opinion about. */
+  members(): Promise<string[]>;
+
+  /**
+   * The alias file, which joins a renamed test to its own history. Named
+   * by what the dispatch asks of it rather than by the class the live one
+   * happens to be.
+   */
+  aliases(): Promise<{
+    resolve(test: TestIdentity, day: string): TestIdentity;
+  }>;
+}
+
+const LIVE: Sources = {
+  manifest: newestManifest,
+  members: gatedMembers,
+  aliases: loadAliasResolver,
+};
+
+/**
+ * Runs one command line and returns the code to stop with. Every line it
+ * means a person to read goes to the console; every reason to stop is a
+ * `Stop`, so nothing here ends the process.
+ */
+export async function dispatch(
+  args: readonly string[],
+  sources: Sources = LIVE,
+): Promise<number> {
   const mode = args[0];
   if (mode === undefined || mode === "--help" || mode === "-h") {
     console.log(USAGE);
-    return;
+    return 0;
   }
   switch (mode) {
     case "dials":
       for (const line of dialLines()) console.log(line);
-      return;
+      return 0;
     case "coverage": {
-      const manifest = await newestManifest();
-      for (const line of coverageLines(manifest, await gatedMembers())) {
+      // The one mode that reads a manifest and carries on without one:
+      // which members are gated is a fact about the tree, and only the
+      // baseline each is measured against comes from a manifest.
+      const manifest = await sources.manifest();
+      for (const line of coverageLines(manifest, await sources.members())) {
         console.log(line);
       }
-      return;
+      return 0;
     }
     case "explain": {
       const argument = args[1];
@@ -361,11 +410,11 @@ async function main(args: readonly string[]): Promise<void> {
       if (test === undefined) {
         fail(`not an identity key: ${argument}\n\n${USAGE}`);
       }
-      const manifest = await newestManifest();
-      if (manifest === undefined) Deno.exit(1);
+      const manifest = await sources.manifest();
+      if (manifest === undefined) return 1;
       // Resolving through the alias file is what joins the two halves of
       // a renamed test's history under today's name.
-      const resolver = await loadAliasResolver();
+      const resolver = await sources.aliases();
       const resolved = resolver.resolve(
         test,
         manifest.generatedAt.slice(0, 10),
@@ -379,7 +428,7 @@ async function main(args: readonly string[]): Promise<void> {
       ) {
         console.log(line);
       }
-      return;
+      return 0;
     }
     case "plan": {
       // Before the manifest, because this mode does not read one and
@@ -396,10 +445,10 @@ async function main(args: readonly string[]): Promise<void> {
       if (laneNumber === "invalid") {
         fail(`--lane takes a whole number from 1 to ${LANES}`);
       }
-      const manifest = await newestManifest();
-      if (manifest === undefined) Deno.exit(1);
+      const manifest = await sources.manifest();
+      if (manifest === undefined) return 1;
       for (const line of planLines(manifest, laneNumber)) console.log(line);
-      return;
+      return 0;
     }
     default:
       fail(`unknown mode ${mode}\n\n${USAGE}`);
@@ -407,5 +456,11 @@ async function main(args: readonly string[]): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main(Deno.args);
+  try {
+    Deno.exit(await dispatch(Deno.args));
+  } catch (error) {
+    if (!(error instanceof Stop)) throw error;
+    console.error(error.message);
+    Deno.exit(error.code);
+  }
 }

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -127,10 +127,21 @@ export function parseIdentityArgument(text: string): TestIdentity | undefined {
 }
 
 /** What `explain` says about one identity, as lines. */
+/** What the packing decided about one identity. */
+export interface PlanVerdict {
+  selected: boolean;
+
+  /** How many times it would run, which a pass may have trimmed. */
+  repeats?: number;
+
+  /** Set when no lane can hold it, whatever the budget. */
+  unschedulable?: boolean;
+}
+
 export function explainLines(
   manifest: Manifest,
   test: TestIdentity,
-  selected = false,
+  verdict: PlanVerdict = { selected: false },
 ): string[] {
   const key = testIdentityKey(test);
   const entry = manifest.entries.find(
@@ -167,15 +178,25 @@ export function explainLines(
           "request cannot act on it"
         : "  withheld: it is too flaky to judge a change by",
     );
+  } else if (verdict.unschedulable) {
+    lines.push(
+      `  no lane can hold it: ${entry.cost.toFixed(1)}s is past the bound a ` +
+        "lane runs under, so it is reported rather than scheduled. Splitting " +
+        "it is the fix.",
+    );
   } else {
-    if (entry.repeats > 1) {
-      lines.push(`  run ${entry.repeats} times, and every one must pass`);
+    // The repeat count the packing settled on, which is what will run: a
+    // filling pass trims repeats to fit rather than dropping the test, so
+    // the manifest's own number is what it asked for and not what it got.
+    const repeats = verdict.repeats ?? entry.repeats;
+    if (repeats > 1) {
+      lines.push(`  run ${repeats} times, and every one must pass`);
     }
     // The question this mode exists to answer. Withheld and repeated are
     // facts about the entry; whether it is reached at all is a fact about
     // the packing, and only the packing knows it.
     lines.push(
-      selected
+      verdict.selected
         ? "  the current manifest selects it"
         : "  the current manifest does not reach it: the budget runs out " +
           "first, on tests worth more per second",
@@ -285,12 +306,21 @@ async function main(args: readonly string[]): Promise<void> {
       );
       // Run the same packing a lane runs, so the answer is the one the
       // lanes would give rather than a guess from the entry alone.
-      const plan = planFor(manifest);
+      const result = planFor(manifest);
       const key = testIdentityKey(resolved);
-      const selected = plan.lanes.some((lane) =>
-        lane.selections.some((s) => testIdentityKey(s.entry.test) === key)
+      const taken = result.lanes.flatMap((lane) => lane.selections).find((s) =>
+        testIdentityKey(s.entry.test) === key
       );
-      for (const line of explainLines(manifest, resolved, selected)) {
+      const verdict: PlanVerdict = { selected: taken !== undefined };
+      if (taken !== undefined) verdict.repeats = taken.repeats;
+      if (
+        result.unschedulable.some((entry) =>
+          testIdentityKey(entry.test) === key
+        )
+      ) {
+        verdict.unschedulable = true;
+      }
+      for (const line of explainLines(manifest, resolved, verdict)) {
         console.log(line);
       }
       return;

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -114,10 +114,13 @@ export function parseIdentityArgument(text: string): TestIdentity | undefined {
     return undefined;
   }
   const [k, s, n, v] = parts;
-  if (typeof k !== "string" || typeof s !== "string" || typeof n !== "string") {
-    return undefined;
-  }
-  if (v !== undefined && typeof v !== "string") return undefined;
+  // Empty parts are not an identity. The manifest validator refuses them,
+  // so accepting one here would report a test as unknown and mandatory
+  // when what was really wrong was the argument.
+  const named = (part: unknown): part is string =>
+    typeof part === "string" && part.length > 0;
+  if (!named(k) || !named(s) || !named(n)) return undefined;
+  if (v !== undefined && !named(v)) return undefined;
   const test: TestIdentity = { k, s, n };
   if (typeof v === "string") test.v = v;
   return test;
@@ -271,18 +274,28 @@ async function main(args: readonly string[]): Promise<void> {
       return;
     }
     case "plan": {
-      const manifest = await newestManifest();
-      if (manifest === undefined) Deno.exit(1);
-      const laneIndex = args.indexOf("--lane");
-      const laneNumber = laneIndex < 0
-        ? undefined
-        : Number(args[laneIndex + 1]);
+      // Before the manifest, because this mode does not read one and
+      // would otherwise fail on a store it never needed.
       if (args.includes("--verify")) {
         fail(
           "plan --verify needs the test topology, which is not in the tree " +
             "yet.\nSee docs/plans/pull-request-test-selection.md, part two.",
         );
       }
+      const laneIndex = args.indexOf("--lane");
+      let laneNumber: number | undefined;
+      if (laneIndex >= 0) {
+        laneNumber = Number(args[laneIndex + 1]);
+        if (
+          !Number.isInteger(laneNumber) || laneNumber < 1 || laneNumber > LANES
+        ) {
+          // Silently filtering every lane would exit zero having printed
+          // nothing, which reads as "this lane runs no tests".
+          fail(`--lane takes a whole number from 1 to ${LANES}`);
+        }
+      }
+      const manifest = await newestManifest();
+      if (manifest === undefined) Deno.exit(1);
       printDryRun(manifest, laneNumber);
       return;
     }

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -130,6 +130,7 @@ export function parseIdentityArgument(text: string): TestIdentity | undefined {
 export function explainLines(
   manifest: Manifest,
   test: TestIdentity,
+  selected = false,
 ): string[] {
   const key = testIdentityKey(test);
   const entry = manifest.entries.find(
@@ -166,8 +167,19 @@ export function explainLines(
           "request cannot act on it"
         : "  withheld: it is too flaky to judge a change by",
     );
-  } else if (entry.repeats > 1) {
-    lines.push(`  run ${entry.repeats} times, and every one must pass`);
+  } else {
+    if (entry.repeats > 1) {
+      lines.push(`  run ${entry.repeats} times, and every one must pass`);
+    }
+    // The question this mode exists to answer. Withheld and repeated are
+    // facts about the entry; whether it is reached at all is a fact about
+    // the packing, and only the packing knows it.
+    lines.push(
+      selected
+        ? "  the current manifest selects it"
+        : "  the current manifest does not reach it: the budget runs out " +
+          "first, on tests worth more per second",
+    );
   }
   return lines;
 }
@@ -180,12 +192,13 @@ function laneLine(
     `${lane.projectedSeconds.toFixed(1)}s of ${LANE_BUDGET_SECONDS}s`;
 }
 
+/** The packing, over a manifest and no diff, as a lane would compute it. */
+function planFor(manifest: Manifest) {
+  return plan({ manifest, mandatory: new Map(), capabilities: new Map() });
+}
+
 function printDryRun(manifest: Manifest, laneNumber: number | undefined): void {
-  const result = plan({
-    manifest,
-    mandatory: new Map(),
-    capabilities: new Map(),
-  });
+  const result = planFor(manifest);
   const lanes = laneNumber === undefined
     ? result.lanes
     : result.lanes.filter((lane) => lane.lane === laneNumber);
@@ -270,7 +283,16 @@ async function main(args: readonly string[]): Promise<void> {
         test,
         manifest.generatedAt.slice(0, 10),
       );
-      for (const line of explainLines(manifest, resolved)) console.log(line);
+      // Run the same packing a lane runs, so the answer is the one the
+      // lanes would give rather than a guess from the entry alone.
+      const plan = planFor(manifest);
+      const key = testIdentityKey(resolved);
+      const selected = plan.lanes.some((lane) =>
+        lane.selections.some((s) => testIdentityKey(s.entry.test) === key)
+      );
+      for (const line of explainLines(manifest, resolved, selected)) {
+        console.log(line);
+      }
       return;
     }
     case "plan": {

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
+
+/**
+ * Everything a person types about test selection goes through here, and
+ * these modes are also how the system is checked by hand.
+ *
+ *   deno task test-selection dials
+ *   deno task test-selection coverage
+ *   deno task test-selection explain <identity>
+ *   deno task test-selection plan --dry-run [--lane N]
+ *   deno task test-selection plan --verify
+ *
+ * `explain` is the one this will be asked most often, because "why did my
+ * test not run?" is the question a selected run provokes and the one it
+ * would otherwise answer badly.
+ */
+
+import { join } from "@std/path";
+import {
+  loadAliasResolver,
+  repositoryRoot,
+  type TestIdentity,
+  testIdentityKey,
+} from "@commonfabric/test-support/records";
+import {
+  DIALS,
+  EXCLUDED_FROM_COVERAGE_GATE,
+  LANE_BUDGET_SECONDS,
+  LANES,
+} from "./test-selection/policy.ts";
+import { fetchManifest } from "./test-selection/store.ts";
+import type { Manifest, ManifestEntry } from "./test-selection/manifest.ts";
+import { plan } from "./test-selection/plan.ts";
+import { readWorkspaceMembers } from "./workspace-tests.ts";
+
+const USAGE = `usage: test-selection <mode>
+
+  dials                       every dial, its value, and why you would move it
+  coverage                    every workspace member and its coverage gate
+  explain <identity>          one test's score, and whether it is selected
+  plan --dry-run [--lane N]   what would run, and what it would cost
+  plan --verify               what the topology and the store disagree about
+
+An identity is its canonical key, either three parts or four when the
+test ran in a non-default configuration:
+
+  ["unit","memory","space > writes a fact"]
+  ["integration","patterns","counter.test.ts","server-execution"]
+`;
+
+function fail(message: string): never {
+  console.error(message);
+  Deno.exit(2);
+}
+
+/** Pads a column so a printed table lines up. */
+function pad(text: string, width: number): string {
+  return text.length >= width ? text : text + " ".repeat(width - text.length);
+}
+
+function printDials(): void {
+  const width = Math.max(...DIALS.map((dial) => dial.name.length));
+  for (const dial of DIALS) {
+    const shown = Array.isArray(dial.value)
+      ? dial.value.join(", ")
+      : dial.value === undefined
+      ? "off"
+      : String(dial.value);
+    console.log(
+      `${pad(dial.name, width)}  ${shown} ${dial.unit} (${dial.setBy})`,
+    );
+    console.log(`${" ".repeat(width)}  ${dial.why}`);
+    console.log("");
+  }
+  console.log(
+    "setupCost, suiteOverhead and correction are measured too, and are " +
+      "published\nin each manifest rather than kept here.",
+  );
+}
+
+async function printCoverage(manifest: Manifest | undefined): Promise<void> {
+  const root = repositoryRoot() ?? Deno.cwd();
+  const members = (await readWorkspaceMembers(join(root, "deno.jsonc")))
+    .map((member) => member.replace(/^\.\//, ""))
+    .filter((member) => member.startsWith("packages/"))
+    .sort();
+  const width = Math.max(...members.map((member) => member.length));
+  const baselines = new Map(
+    (manifest?.coverageBaselines ?? []).map((base) => [base.member, base]),
+  );
+  for (const member of members) {
+    const excluded = EXCLUDED_FROM_COVERAGE_GATE.get(member);
+    if (excluded !== undefined) {
+      console.log(`${pad(member, width)}  not gated: ${excluded}`);
+      continue;
+    }
+    const baseline = baselines.get(member);
+    const against = baseline === undefined
+      ? "no baseline yet"
+      : `${baseline.uncoveredLines} uncovered lines at ${baseline.commit}`;
+    console.log(`${pad(member, width)}  gated, against ${against}`);
+  }
+}
+
+/** The identity a command-line argument names. */
+export function parseIdentityArgument(text: string): TestIdentity | undefined {
+  let parts: unknown;
+  try {
+    parts = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parts) || parts.length < 3 || parts.length > 4) {
+    return undefined;
+  }
+  const [k, s, n, v] = parts;
+  if (typeof k !== "string" || typeof s !== "string" || typeof n !== "string") {
+    return undefined;
+  }
+  if (v !== undefined && typeof v !== "string") return undefined;
+  const test: TestIdentity = { k, s, n };
+  if (typeof v === "string") test.v = v;
+  return test;
+}
+
+/** What `explain` says about one identity, as lines. */
+export function explainLines(
+  manifest: Manifest,
+  test: TestIdentity,
+): string[] {
+  const key = testIdentityKey(test);
+  const entry = manifest.entries.find(
+    (candidate) => testIdentityKey(candidate.test) === key,
+  );
+  if (entry === undefined) {
+    return [
+      `${key}`,
+      "  The store has no record of it, so it is mandatory: an identity",
+      "  with no history runs. A test just added is in this position, and",
+      "  so is one just renamed, until a run on `main` records it.",
+    ];
+  }
+  const lines = [
+    `${key}`,
+    `  suite ${entry.suite}, in ${entry.unit}`,
+    `  score ${entry.score.toFixed(3)}, costing ${entry.cost.toFixed(3)}s`,
+    `  ${entry.inputs.catches.toFixed(1)} weighted catches, ` +
+    `${entry.inputs.mainCatches} of them on main, across ` +
+    `${entry.inputs.sources} sources`,
+    entry.inputs.lastCatch === undefined
+      ? "  it has never caught anything"
+      : `  the most recent catch was on ${entry.inputs.lastCatch}`,
+    `  churn ${entry.inputs.churn.toFixed(4)}, flake rate ` +
+    `${entry.flakeRate.toFixed(4)}`,
+  ];
+  const held = manifest.withheld.find(
+    (candidate) => testIdentityKey(candidate.test) === key,
+  );
+  if (held !== undefined) {
+    lines.push(
+      held.reason === "main-red"
+        ? "  withheld: it is failing in the newest run on main, so a pull " +
+          "request cannot act on it"
+        : "  withheld: it is too flaky to judge a change by",
+    );
+  } else if (entry.repeats > 1) {
+    lines.push(`  run ${entry.repeats} times, and every one must pass`);
+  }
+  return lines;
+}
+
+/** A one-line summary of what a lane would do. */
+function laneLine(
+  lane: { lane: number; selections: unknown[]; projectedSeconds: number },
+): string {
+  return `  lane ${lane.lane}: ${lane.selections.length} tests, ` +
+    `${lane.projectedSeconds.toFixed(1)}s of ${LANE_BUDGET_SECONDS}s`;
+}
+
+function printDryRun(manifest: Manifest, laneNumber: number | undefined): void {
+  const result = plan({
+    manifest,
+    mandatory: new Map(),
+    capabilities: new Map(),
+  });
+  const lanes = laneNumber === undefined
+    ? result.lanes
+    : result.lanes.filter((lane) => lane.lane === laneNumber);
+  console.log(
+    `manifest of ${manifest.generatedAt}, from ${manifest.runs} runs at ` +
+      `${manifest.commit}`,
+  );
+  console.log(
+    `${manifest.entries.length} known identities, ` +
+      `${manifest.withheld.length} withheld`,
+  );
+  for (const lane of lanes) {
+    console.log(laneLine(lane));
+    if (lane.capabilities.length > 0) {
+      console.log(`    needs ${lane.capabilities.join(", ")}`);
+    }
+    const byReason = new Map<string, number>();
+    for (const selection of lane.selections) {
+      byReason.set(
+        selection.reason,
+        (byReason.get(selection.reason) ?? 0) + 1,
+      );
+    }
+    for (const [reason, count] of [...byReason].sort()) {
+      console.log(`    ${count} by ${reason}`);
+    }
+  }
+  if (result.overBudgetSeconds > 0) {
+    console.log(
+      `the mandatory set alone overran by ` +
+        `${result.overBudgetSeconds.toFixed(1)}s`,
+    );
+  }
+  const unschedulable = manifest.entries.filter(
+    (entry: ManifestEntry) => entry.cost > LANE_BUDGET_SECONDS,
+  );
+  for (const entry of unschedulable) {
+    console.log(
+      `unschedulable: ${testIdentityKey(entry.test)} costs ` +
+        `${entry.cost.toFixed(1)}s, past a lane's whole budget`,
+    );
+  }
+  console.log(`${LANES} lanes, ${LANE_BUDGET_SECONDS}s of work each`);
+}
+
+/** The manifest the newest publisher run wrote, or nothing with a reason. */
+async function newestManifest(): Promise<Manifest | undefined> {
+  const found = await fetchManifest({ at: new Date().toISOString() });
+  if (found.manifest === undefined) {
+    console.error(`no manifest: ${found.absent}`);
+    return undefined;
+  }
+  return found.manifest;
+}
+
+async function main(args: readonly string[]): Promise<void> {
+  const mode = args[0];
+  if (mode === undefined || mode === "--help" || mode === "-h") {
+    console.log(USAGE);
+    return;
+  }
+  switch (mode) {
+    case "dials":
+      printDials();
+      return;
+    case "coverage":
+      await printCoverage(await newestManifest());
+      return;
+    case "explain": {
+      const argument = args[1];
+      if (argument === undefined) fail(USAGE);
+      const test = parseIdentityArgument(argument);
+      if (test === undefined) {
+        fail(`not an identity key: ${argument}\n\n${USAGE}`);
+      }
+      const manifest = await newestManifest();
+      if (manifest === undefined) Deno.exit(1);
+      // Resolving through the alias file is what joins the two halves of
+      // a renamed test's history under today's name.
+      const resolver = await loadAliasResolver();
+      const resolved = resolver.resolve(
+        test,
+        manifest.generatedAt.slice(0, 10),
+      );
+      for (const line of explainLines(manifest, resolved)) console.log(line);
+      return;
+    }
+    case "plan": {
+      const manifest = await newestManifest();
+      if (manifest === undefined) Deno.exit(1);
+      const laneIndex = args.indexOf("--lane");
+      const laneNumber = laneIndex < 0
+        ? undefined
+        : Number(args[laneIndex + 1]);
+      if (args.includes("--verify")) {
+        fail(
+          "plan --verify needs the test topology, which is not in the tree " +
+            "yet.\nSee docs/plans/pull-request-test-selection.md, part two.",
+        );
+      }
+      printDryRun(manifest, laneNumber);
+      return;
+    }
+    default:
+      fail(`unknown mode ${mode}\n\n${USAGE}`);
+  }
+}
+
+if (import.meta.main) {
+  await main(Deno.args);
+}

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -24,7 +24,7 @@ import {
   reportFromText,
 } from "./build.ts";
 import { parseManifest, serializeManifest } from "./manifest.ts";
-import { flakeRate } from "./score.ts";
+import { emptyState, flakeRate, type IdentityState } from "./score.ts";
 import { FLAKE_EXCLUSION_RATE, MAX_REPEATS } from "./policy.ts";
 
 const NO_ALIASES = new AliasResolver([]);
@@ -114,6 +114,15 @@ describe("build", () => {
 
     it("declines a report with no context", () => {
       expect(provenance(undefined, CI_NAME)).toBeUndefined();
+    });
+
+    it("declines a continuous-integration run that names no branch", () => {
+      // The branch is the source a catch is attributed to, so a run with
+      // none cannot be told apart from any other run with none.
+      const nameless = context();
+      delete nameless.branch;
+      expect(provenance(nameless, CI_NAME)).toBeUndefined();
+      expect(provenance(context({ branch: "" }), CI_NAME)).toBeUndefined();
     });
   });
 
@@ -356,6 +365,45 @@ describe("build", () => {
       expect(parseAggregate('{"schema":99}')).toBeUndefined();
       expect(parseAggregate('{"schema":1,"day":"x"}')).toBeUndefined();
     });
+
+    it("refuses a shape it would otherwise have to guess at", () => {
+      const whole = {
+        schema: 1,
+        day: "2026-08-20",
+        folded: [],
+        states: {},
+        compactedDays: [],
+      };
+      const refused: Array<[string, unknown]> = [
+        ["a document that is not an object", 7],
+        ["a null document", null],
+        ["no folded list", { ...whole, folded: undefined }],
+        ["a folded list that is not one", { ...whole, folded: "one.ndjson" }],
+        ["a folded name that is not one", { ...whole, folded: [7] }],
+        ["states that are not a record", { ...whole, states: [] }],
+        ["null states", { ...whole, states: null }],
+        [
+          "a compacted list that is not one",
+          { ...whole, compactedDays: "2026-08-20" },
+        ],
+        ["a compacted day that is not one", { ...whole, compactedDays: [7] }],
+      ];
+      for (const [what, value] of refused) {
+        expect(parseAggregate(JSON.stringify(value)), what).toBeUndefined();
+      }
+    });
+
+    it("reads an aggregate written before rollups were read", () => {
+      // No compacted list at all is the truthful reading that nothing
+      // was compacted, which is different from a list it cannot read.
+      const before = {
+        schema: 1,
+        day: "2026-08-20",
+        folded: [],
+        states: {},
+      };
+      expect(parseAggregate(JSON.stringify(before))?.compactedDays).toEqual([]);
+    });
   });
 
   describe("identityOfKey()", () => {
@@ -428,5 +476,74 @@ describe("build", () => {
         "main-red",
       ]);
     });
+  });
+});
+
+describe("a fold's count of what it has folded", () => {
+  it("counts every execution, not every object", () => {
+    const fold = new Fold(
+      emptyAggregate("2026-08-20"),
+      new AliasResolver([]),
+      "2026-08-20",
+    );
+    expect(fold.observations).toBe(0);
+    fold.add([stored(CI_NAME, context(), [record(), record()])]);
+    expect(fold.observations).toBe(2);
+    expect(fold.finish().observations).toBe(2);
+  });
+});
+
+describe("what buildManifest() does with the states it is given", () => {
+  const KEY = testIdentityKey({ k: "unit", s: "memory", n: "space > writes" });
+
+  function built(
+    states: Map<string, IdentityState>,
+    mainRed = new Set<string>(),
+  ) {
+    return buildManifest({
+      states,
+      mainRed,
+      surfaces: new Map(),
+      today: "2026-08-20",
+      generatedAt: "2026-08-20T00:00:00.000Z",
+      seed: "01K3SAMPLE",
+      commit: "c8893b3a8",
+      runs: 1,
+    });
+  }
+
+  it("skips a state whose key does not name an identity", () => {
+    // A key that is not one cannot be turned back into a test to run, so
+    // carrying it would put an entry in the manifest naming nothing.
+    const states = new Map([
+      ["not a key", emptyState()],
+      ["[]", emptyState()],
+      [KEY, emptyState()],
+    ]);
+    expect(built(states).entries.length).toBe(1);
+  });
+
+  it("withholds a test that disagrees with itself too often", () => {
+    const state = emptyState();
+    state.failuresByDay["2026-08-20"] = 10;
+    state.flakesByDay["2026-08-20"] = 10;
+    const manifest = built(new Map([[KEY, state]]));
+    expect(manifest.withheld.length).toBe(1);
+    expect(manifest.withheld[0]!.reason).toBe("flaky");
+  });
+
+  it("calls a test failing on main red, however flaky it also is", () => {
+    // The two reasons are exclusive, and being broken on the default
+    // branch is the one that decides what a pull request may act on.
+    const state = emptyState();
+    state.failuresByDay["2026-08-20"] = 10;
+    state.flakesByDay["2026-08-20"] = 10;
+    const manifest = built(new Map([[KEY, state]]), new Set([KEY]));
+    expect(manifest.withheld.length).toBe(1);
+    expect(manifest.withheld[0]!.reason).toBe("main-red");
+  });
+
+  it("withholds nothing for a test that has never failed", () => {
+    expect(built(new Map([[KEY, emptyState()]])).withheld).toEqual([]);
   });
 });

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -1,0 +1,389 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  AliasResolver,
+  buildObjectBody,
+  type RunContext,
+  type TestRecord,
+} from "@commonfabric/test-support/records";
+
+import {
+  buildManifest,
+  dayOf,
+  emptyAggregate,
+  Fold,
+  foldReports,
+  identityOfKey,
+  localReporter,
+  parseAggregate,
+  provenance,
+  readReport,
+  recordSurface,
+  repeatsFor,
+  reportFromText,
+} from "./build.ts";
+import { parseManifest, serializeManifest } from "./manifest.ts";
+import { FLAKE_EXCLUSION_RATE, MAX_REPEATS } from "./policy.ts";
+
+const NO_ALIASES = new AliasResolver([]);
+
+function context(fields: Partial<RunContext> = {}): RunContext {
+  return {
+    schema: 1,
+    line: "context",
+    reportId: "01K3",
+    repo: "commontoolsinc/labs",
+    commit: "c1",
+    dirty: false,
+    branch: "main",
+    env: "ci",
+    ci: {
+      workflowRunId: "1",
+      runAttempt: 1,
+      workflow: "deno.yml",
+      job: "Test (1/8)",
+      event: "push",
+    },
+    os: "linux",
+    arch: "x86_64",
+    denoVersion: "2.9.4",
+    startedAt: "2026-08-20T00:00:00.000Z",
+    ...fields,
+  };
+}
+
+function record(fields: Partial<TestRecord> = {}): TestRecord {
+  return {
+    line: "record",
+    test: { k: "unit", s: "memory", n: "space > writes" },
+    outcome: "pass",
+    durationMs: 40,
+    ...fields,
+  };
+}
+
+/** One stored object, built the way the relay builds one. */
+function stored(
+  objectName: string,
+  runContext: RunContext,
+  records: readonly TestRecord[],
+) {
+  return reportFromText(objectName, buildObjectBody(runContext, records));
+}
+
+const CI_NAME = "labs/test-records/submissions/ci/v1/2026/08/20/run-1-a.ndjson";
+const LOCAL_NAME =
+  "labs/test-records/submissions/local/ianh/v1/2026/08/20/01K3-branch.ndjson";
+
+describe("build", () => {
+  describe("provenance()", () => {
+    it("reads a push to main as a run on main", () => {
+      expect(provenance(context(), CI_NAME)).toEqual({
+        place: "main",
+        source: "main",
+      });
+    });
+
+    it("reads any other branch as a pull request", () => {
+      expect(provenance(context({ branch: "fix-writes" }), CI_NAME)).toEqual({
+        place: "pr",
+        source: "fix-writes",
+      });
+    });
+
+    it("names the reporting person for a local run", () => {
+      const local = context({
+        env: "local",
+        branch: "fix-writes",
+      });
+      delete local.ci;
+      expect(provenance(local, LOCAL_NAME)).toEqual({
+        place: "local",
+        source: "ianh",
+      });
+    });
+
+    it("declines a fork run, whose records the fork authored", () => {
+      const forked = context();
+      forked.ci!.fork = true;
+      expect(provenance(forked, CI_NAME)).toBeUndefined();
+    });
+
+    it("declines a report with no context", () => {
+      expect(provenance(undefined, CI_NAME)).toBeUndefined();
+    });
+  });
+
+  describe("localReporter()", () => {
+    it("reads the person out of a local object's name", () => {
+      expect(localReporter(LOCAL_NAME)).toBe("ianh");
+    });
+
+    it("finds nobody in a continuous-integration object's name", () => {
+      expect(localReporter(CI_NAME)).toBeUndefined();
+    });
+  });
+
+  describe("dayOf()", () => {
+    it("takes the UTC calendar day", () => {
+      expect(dayOf("2026-08-20T23:59:59.000Z")).toBe("2026-08-20");
+    });
+  });
+
+  describe("recordSurface()", () => {
+    it("groups by kind and scope, and by variant when there is one", () => {
+      expect(recordSurface({ k: "unit", s: "memory", n: "a" }, undefined).suite)
+        .toBe("unit:memory");
+      expect(
+        recordSurface({ k: "unit", s: "memory", n: "a", v: "on" }, undefined)
+          .suite,
+      ).toBe("unit:memory:on");
+    });
+
+    it("takes the file as the invocation unit when one is known", () => {
+      expect(
+        recordSurface(
+          { k: "unit", s: "memory", n: "a" },
+          "packages/memory/test/space.test.ts",
+        ).unit,
+      ).toBe("packages/memory/test/space.test.ts");
+    });
+
+    it("falls back to the identity's own name", () => {
+      expect(
+        recordSurface({ k: "pattern", s: "patterns", n: "a.tsx" }, undefined)
+          .unit,
+      ).toBe("a.tsx");
+    });
+  });
+
+  describe("repeatsFor()", () => {
+    it("runs a steady test once", () => {
+      expect(repeatsFor(0)).toBe(1);
+    });
+
+    it("runs a slightly intermittent one more than once", () => {
+      expect(repeatsFor(0.02)).toBeGreaterThan(1);
+      expect(repeatsFor(0.04)).toBe(MAX_REPEATS);
+    });
+
+    it("runs one past the exclusion rate once, since it is not selected", () => {
+      expect(repeatsFor(FLAKE_EXCLUSION_RATE + 0.1)).toBe(1);
+    });
+  });
+
+  describe("readReport()", () => {
+    it("turns a stored object into observations", () => {
+      const read = readReport(
+        stored(CI_NAME, context(), [record(), record({ outcome: "fail" })]),
+        NO_ALIASES,
+      );
+      expect(read.observations.length).toBe(2);
+      expect(read.observations[0]!.place).toBe("main");
+      expect(read.observations[0]!.day).toBe("2026-08-20");
+    });
+
+    it("keeps the durations of everything that ran", () => {
+      const read = readReport(
+        stored(CI_NAME, context(), [
+          record({ durationMs: 10 }),
+          record({ durationMs: 90 }),
+          record({ outcome: "skip", durationMs: 5000 }),
+        ]),
+        NO_ALIASES,
+      );
+      const byDay = [...read.durations.values()][0]!;
+      expect(byDay.get("2026-08-20")).toEqual([10, 90]);
+    });
+
+    it("reads nothing from a fork run", () => {
+      const forked = context();
+      forked.ci!.fork = true;
+      expect(
+        readReport(stored(CI_NAME, forked, [record()]), NO_ALIASES)
+          .observations,
+      ).toEqual([]);
+    });
+  });
+
+  describe("the fold", () => {
+    it("folds a stream in chunks the way it folds one batch", () => {
+      const reports = [
+        stored(CI_NAME, context({ commit: "c1" }), [record()]),
+        stored(
+          `${CI_NAME}2`,
+          context({
+            commit: "c2",
+            startedAt: "2026-08-20T01:00:00.000Z",
+          }),
+          [record({ outcome: "fail" })],
+        ),
+        stored(
+          `${CI_NAME}3`,
+          context({
+            commit: "c3",
+            startedAt: "2026-08-20T02:00:00.000Z",
+          }),
+          [record()],
+        ),
+      ];
+      const whole = foldReports(
+        emptyAggregate("2026-08-20"),
+        reports,
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      const streamed = new Fold(
+        emptyAggregate("2026-08-20"),
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      for (const report of reports) streamed.add([report]);
+      expect(streamed.finish().states).toEqual(whole.states);
+    });
+
+    it("does not fold a day it took from a rollup", () => {
+      // A rollup carries the day's reports whole, so its raw objects
+      // never reach `folded`; a later run over a wide window has to ask
+      // about the day or it folds the day twice and doubles its catches.
+      const fold = new Fold(
+        emptyAggregate("2026-08-20"),
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      expect(fold.knowsDay("2026/08/10")).toBe(false);
+      fold.markCompacted("2026/08/10");
+      expect(fold.knowsDay("2026/08/10")).toBe(true);
+      expect(fold.finish().aggregate.compactedDays).toEqual(["2026/08/10"]);
+    });
+
+    it("carries the compacted days across a saved aggregate", () => {
+      const first = new Fold(
+        emptyAggregate("2026-08-20"),
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      first.markCompacted("2026/08/10");
+      const saved = parseAggregate(
+        JSON.stringify(first.finish().aggregate),
+      );
+      expect(saved).toBeDefined();
+      const second = new Fold(saved!, NO_ALIASES, "2026-08-21");
+      expect(second.knowsDay("2026/08/10")).toBe(true);
+    });
+
+    it("reads an aggregate written before rollups as compacting nothing", () => {
+      const older = { ...emptyAggregate("2026-08-20") } as Record<
+        string,
+        unknown
+      >;
+      delete older.compactedDays;
+      const parsed = parseAggregate(JSON.stringify(older));
+      expect(parsed?.compactedDays).toEqual([]);
+    });
+
+    it("does not fold an object it has already folded", () => {
+      const aggregate = emptyAggregate("2026-08-20");
+      aggregate.folded.push(CI_NAME);
+      const fold = new Fold(aggregate, NO_ALIASES, "2026-08-20");
+      expect(fold.knows(CI_NAME)).toBe(true);
+      expect(fold.knows(`${CI_NAME}2`)).toBe(false);
+    });
+
+    it("names the identities the newest run on main left red", () => {
+      const folded = foldReports(
+        emptyAggregate("2026-08-20"),
+        [stored(CI_NAME, context(), [record({ outcome: "fail" })])],
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      expect(folded.mainRed.size).toBe(1);
+    });
+  });
+
+  describe("parseAggregate()", () => {
+    it("round-trips an aggregate", () => {
+      const aggregate = emptyAggregate("2026-08-20");
+      aggregate.folded.push(CI_NAME);
+      expect(parseAggregate(JSON.stringify(aggregate))).toEqual(aggregate);
+    });
+
+    it("returns undefined for anything that is not one", () => {
+      expect(parseAggregate("{not json")).toBeUndefined();
+      expect(parseAggregate('{"schema":99}')).toBeUndefined();
+      expect(parseAggregate('{"schema":1,"day":"x"}')).toBeUndefined();
+    });
+  });
+
+  describe("identityOfKey()", () => {
+    it("recovers the identity a canonical key names", () => {
+      expect(identityOfKey('["unit","memory","a"]')).toEqual({
+        k: "unit",
+        s: "memory",
+        n: "a",
+      });
+      expect(identityOfKey('["unit","memory","a","on"]')).toEqual({
+        k: "unit",
+        s: "memory",
+        n: "a",
+        v: "on",
+      });
+    });
+
+    it("returns undefined for anything that is not one", () => {
+      expect(identityOfKey("not json")).toBeUndefined();
+      expect(identityOfKey('["unit","memory"]')).toBeUndefined();
+      expect(identityOfKey('["unit",1,"a"]')).toBeUndefined();
+    });
+  });
+
+  describe("buildManifest()", () => {
+    it("produces a manifest its own validator accepts", () => {
+      const folded = foldReports(
+        emptyAggregate("2026-08-20"),
+        [stored(CI_NAME, context(), [
+          record(),
+          record({
+            test: { k: "unit", s: "memory", n: "space > reads" },
+          }),
+        ])],
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      const manifest = buildManifest({
+        states: folded.states,
+        mainRed: folded.mainRed,
+        surfaces: folded.surfaces,
+        today: "2026-08-20",
+        generatedAt: "2026-08-20T04:00:00.000Z",
+        seed: "01K3",
+        commit: "c1",
+        runs: 1,
+      });
+      expect(manifest.entries.length).toBe(2);
+      expect(parseManifest(serializeManifest(manifest))).toEqual(manifest);
+    });
+
+    it("withholds an identity failing in the newest run on main", () => {
+      const folded = foldReports(
+        emptyAggregate("2026-08-20"),
+        [stored(CI_NAME, context(), [record({ outcome: "fail" })])],
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      const manifest = buildManifest({
+        states: folded.states,
+        mainRed: folded.mainRed,
+        surfaces: folded.surfaces,
+        today: "2026-08-20",
+        generatedAt: "2026-08-20T04:00:00.000Z",
+        seed: "01K3",
+        commit: "c1",
+        runs: 1,
+      });
+      expect(manifest.withheld.map((held) => held.reason)).toEqual([
+        "main-red",
+      ]);
+    });
+  });
+});

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -4,6 +4,7 @@ import {
   AliasResolver,
   buildObjectBody,
   type RunContext,
+  testIdentityKey,
   type TestRecord,
 } from "@commonfabric/test-support/records";
 
@@ -23,6 +24,7 @@ import {
   reportFromText,
 } from "./build.ts";
 import { parseManifest, serializeManifest } from "./manifest.ts";
+import { flakeRate } from "./score.ts";
 import { FLAKE_EXCLUSION_RATE, MAX_REPEATS } from "./policy.ts";
 
 const NO_ALIASES = new AliasResolver([]);
@@ -71,6 +73,7 @@ function stored(
   return reportFromText(objectName, buildObjectBody(runContext, records));
 }
 
+const KEY = testIdentityKey({ k: "unit", s: "memory", n: "space > writes" });
 const CI_NAME = "labs/test-records/submissions/ci/v1/2026/08/20/run-1-a.ndjson";
 const LOCAL_NAME =
   "labs/test-records/submissions/local/ianh/v1/2026/08/20/01K3-branch.ndjson";
@@ -293,6 +296,33 @@ describe("build", () => {
       delete older.compactedDays;
       const parsed = parseAggregate(JSON.stringify(older));
       expect(parsed?.compactedDays).toEqual([]);
+    });
+
+    it("carries what the cross-run rules saw into the next run", () => {
+      // A commit's runs can arrive in two publisher runs. Without the
+      // context, the second would not see that the identity had already
+      // passed at that commit, and would read the failure as a catch
+      // rather than as the test disagreeing with itself.
+      const first = new Fold(
+        emptyAggregate("2026-08-20"),
+        NO_ALIASES,
+        "2026-08-20",
+      );
+      first.add([stored(CI_NAME, context({ commit: "c1" }), [record()])]);
+      const saved = parseAggregate(JSON.stringify(first.finish().aggregate))!;
+      expect(saved.context!.outcomesAtCommit.length).toBeGreaterThan(0);
+
+      const second = new Fold(saved, NO_ALIASES, "2026-08-20");
+      second.add([
+        stored(
+          `${CI_NAME}2`,
+          context({ commit: "c1", startedAt: "2026-08-20T01:00:00.000Z" }),
+          [record({ outcome: "fail" })],
+        ),
+      ]);
+      const state = second.finish().states.get(KEY)!;
+      expect(state.mainCatches).toBe(0);
+      expect(flakeRate(state, "2026-08-20")).toBe(1);
     });
 
     it("does not fold an object it has already folded", () => {

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -547,3 +547,57 @@ describe("what buildManifest() does with the states it is given", () => {
     expect(built(new Map([[KEY, emptyState()]])).withheld).toEqual([]);
   });
 });
+
+describe("a batch whose reports interleave in time", () => {
+  const KEY = testIdentityKey({ k: "unit", s: "memory", n: "space > writes" });
+
+  /** One object holding one run of the test at one commit. */
+  function run(commit: string, outcome: TestRecord["outcome"], at: string) {
+    return stored(
+      `labs/test-records/aggregated/v1/2026/08/20/shard-${commit}.ndjson`,
+      context({ commit, startedAt: at }),
+      [record({ outcome })],
+    );
+  }
+
+  function foldedIn(reports: ReturnType<typeof run>[]) {
+    const fold = new Fold(
+      emptyAggregate("2026-08-20"),
+      new AliasResolver([]),
+      "2026-08-20",
+    );
+    fold.add(reports);
+    return fold.finish().states.get(KEY)!;
+  }
+
+  it("folds a day's shards in the order the runs happened", () => {
+    // A rollup holds a whole day, and its shards are read concurrently,
+    // so the order they arrive in is not the order they ran in. The
+    // rules that decide whether a failure is a catch look backwards and
+    // forwards along that order, so it has to be the real one.
+    const broke = run("c1", "fail", "2026-08-20T01:00:00.000Z");
+    const fixed = run("c2", "pass", "2026-08-20T02:00:00.000Z");
+    expect(foldedIn([broke, fixed]).mainCatches).toBe(1);
+    expect(foldedIn([fixed, broke]).mainCatches).toBe(1);
+  });
+
+  it("reaches the same state whichever order the shards arrive in", () => {
+    const reports = [
+      run("c1", "fail", "2026-08-20T01:00:00.000Z"),
+      run("c2", "pass", "2026-08-20T02:00:00.000Z"),
+      run("c3", "fail", "2026-08-20T03:00:00.000Z"),
+      run("c4", "pass", "2026-08-20T04:00:00.000Z"),
+    ];
+    const forwards = foldedIn(reports);
+    const backwards = foldedIn([...reports].reverse());
+    const shuffled = foldedIn([
+      reports[2]!,
+      reports[0]!,
+      reports[3]!,
+      reports[1]!,
+    ]);
+    expect(backwards).toEqual(forwards);
+    expect(shuffled).toEqual(forwards);
+    expect(forwards.mainCatches).toBe(2);
+  });
+});

--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -149,6 +149,19 @@ describe("build", () => {
       ).toBe("packages/memory/test/space.test.ts");
     });
 
+    it("keeps a file-backed unit when a later record has none", () => {
+      const read = readReport(
+        stored(CI_NAME, context(), [
+          record({ file: "packages/memory/test/space.test.ts" }),
+          record(),
+        ]),
+        NO_ALIASES,
+      );
+      expect([...read.surfaces.values()][0]!.unit).toEqual(
+        "packages/memory/test/space.test.ts",
+      );
+    });
+
     it("falls back to the identity's own name", () => {
       expect(
         recordSurface({ k: "pattern", s: "patterns", n: "a.tsx" }, undefined)

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -1,0 +1,514 @@
+/**
+ * Turning what the store holds into a manifest.
+ *
+ * The publisher keeps a rolling aggregate rather than re-reading history
+ * every time: a three-week read is a quarter of a million objects, and
+ * nothing can afford that every four hours. So each run reads the newest
+ * state, folds in the objects whose runs are not already in it, ages the
+ * counters, scores everything, and writes a new state beside the new
+ * manifest.
+ */
+
+import {
+  type AliasResolver,
+  parseReportGroups,
+  type RunContext,
+  type StoredReport,
+  type TestIdentity,
+  testIdentityKey,
+} from "@commonfabric/test-support/records";
+import {
+  costSeconds,
+  type DaySamples,
+  emptyContext,
+  emptySamples,
+  emptyState,
+  flakeRate,
+  foldObservations,
+  type IdentityState,
+  type Observation,
+  sampleDuration,
+  scoreInputs,
+  sealDay,
+  trimContext,
+  trimWindows,
+  value,
+} from "./score.ts";
+import {
+  type Calibration,
+  dialSnapshot,
+  digestIdentities,
+  type Manifest,
+  MANIFEST_SCHEMA_VERSION,
+  type ManifestEntry,
+  type WithheldEntry,
+} from "./manifest.ts";
+import {
+  FLAKE_EXCLUSION_RATE,
+  FLAKE_REPEAT_RATES,
+  LANE_PROLOGUE_SECONDS,
+  MAX_REPEATS,
+} from "./policy.ts";
+
+/** The publisher's rolling aggregate, as one stored object. */
+export interface AggregateState {
+  schema: typeof MANIFEST_SCHEMA_VERSION;
+
+  /** The day the counters were last aged to. */
+  day: string;
+
+  /**
+   * The reports already folded in, by object name. Object names carry the
+   * workflow run, so this is exact rather than a guess from timestamps,
+   * and a relay that re-ships an old run is handled correctly.
+   */
+  folded: string[];
+
+  /**
+   * Days folded from a rollup rather than from their raw objects,
+   * "yyyy/mm/dd". A rollup carries a day's reports whole, so its raw
+   * objects are not in `folded` and a later run over a wide window would
+   * otherwise fold that day a second time and double every catch in it.
+   */
+  compactedDays: string[];
+
+  states: Record<string, IdentityState>;
+}
+
+/** A fresh aggregate, for a cold start. */
+export function emptyAggregate(day: string): AggregateState {
+  return {
+    schema: MANIFEST_SCHEMA_VERSION,
+    day,
+    folded: [],
+    compactedDays: [],
+    states: {},
+  };
+}
+
+/**
+ * Reads a stored aggregate. Returns undefined for anything that is not
+ * one; a publisher that cannot read its own state starts from nothing
+ * rather than from a half-understood one.
+ */
+export function parseAggregate(text: string): AggregateState | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (typeof value !== "object" || value === null) return undefined;
+  const state = value as Record<string, unknown>;
+  if (state.schema !== MANIFEST_SCHEMA_VERSION) return undefined;
+  if (typeof state.day !== "string" || !Array.isArray(state.folded)) {
+    return undefined;
+  }
+  if (typeof state.states !== "object" || state.states === null) {
+    return undefined;
+  }
+  for (const name of state.folded) {
+    if (typeof name !== "string") return undefined;
+  }
+  // An aggregate written before rollups were read carries no list, and
+  // an empty one is the truthful reading of it: nothing was compacted.
+  const compactedDays = state.compactedDays ?? [];
+  if (!Array.isArray(compactedDays)) return undefined;
+  for (const day of compactedDays) {
+    if (typeof day !== "string") return undefined;
+  }
+  return {
+    schema: MANIFEST_SCHEMA_VERSION,
+    day: state.day,
+    folded: state.folded as string[],
+    compactedDays: compactedDays as string[],
+    states: state.states as Record<string, IdentityState>,
+  };
+}
+
+/** The reporting person named by a local submission's object name. */
+export function localReporter(objectName: string): string | undefined {
+  return objectName.match(/\/submissions\/local\/([^/]+)\//)?.[1];
+}
+
+/** The UTC calendar day of an ISO 8601 timestamp. */
+export function dayOf(startedAt: string): string {
+  return startedAt.slice(0, 10);
+}
+
+/**
+ * Where one report's executions happened, and who saw them. Undefined for
+ * a report a decision must not read: a fork run's records are authored by
+ * the fork, and a run with no context cannot say where it came from.
+ */
+export function provenance(
+  context: RunContext | undefined,
+  objectName: string,
+): { place: Observation["place"]; source: string } | undefined {
+  if (context === undefined) return undefined;
+  if (context.env === "local") {
+    const reporter = localReporter(objectName);
+    return reporter === undefined
+      ? undefined
+      : { place: "local", source: reporter };
+  }
+  if (context.ci === undefined || context.ci.fork === true) return undefined;
+  const branch = context.branch ?? "";
+  if (branch.length === 0) return undefined;
+  const place = context.ci.event === "push" && branch === "main"
+    ? "main"
+    : "pr";
+  return { place, source: branch };
+}
+
+/** What one stored object says, once the parts nothing may read are out. */
+export interface ReadReport {
+  observations: Observation[];
+
+  /** Where each identity in it runs, by identity key. */
+  surfaces: Map<string, Surface>;
+
+  /** Every measured duration, by identity key and then by day. */
+  durations: Map<string, Map<string, number[]>>;
+}
+
+/**
+ * Reads one stored object. A report a decision must not read contributes
+ * nothing: a fork run's records are authored by the fork, and a group
+ * with no context cannot say where it came from.
+ */
+export function readReport(
+  report: StoredReport,
+  resolver: AliasResolver,
+): ReadReport {
+  const observations: Observation[] = [];
+  const surfaces = new Map<string, Surface>();
+  const durations = new Map<string, Map<string, number[]>>();
+  for (const group of report.reports) {
+    const where = provenance(group.context, report.objectName);
+    if (where === undefined || group.context === undefined) continue;
+    const day = dayOf(group.context.startedAt);
+    for (const record of group.records) {
+      const test = resolver.resolve(record.test, day);
+      const key = testIdentityKey(test);
+      surfaces.set(key, recordSurface(test, record.file));
+      observations.push({
+        test,
+        outcome: record.outcome,
+        durationMs: record.durationMs,
+        day,
+        commit: group.context.commit,
+        source: where.source,
+        place: where.place,
+      });
+      if (record.outcome === "skip") continue;
+      let byDay = durations.get(key);
+      if (byDay === undefined) {
+        byDay = new Map();
+        durations.set(key, byDay);
+      }
+      byDay.set(day, [...(byDay.get(day) ?? []), record.durationMs]);
+    }
+  }
+  return { observations, surfaces, durations };
+}
+
+/** The invocation unit and suite a record belongs to. */
+export interface Surface {
+  suite: string;
+  unit: string;
+}
+
+/**
+ * How an identity is grouped, until the topology says. A record's kind
+ * and scope name the surface that produced it, and the file the
+ * registration preload captured names what a runner can be pointed at; an
+ * identity with no file is its own invocation unit, which is what every
+ * suite outside the unit tests already is.
+ */
+export function recordSurface(
+  test: TestIdentity,
+  file: string | undefined,
+): Surface {
+  const suite = test.v === undefined
+    ? `${test.k}:${test.s}`
+    : `${test.k}:${test.s}:${test.v}`;
+  return { suite, unit: file ?? test.n };
+}
+
+/** How many times a lane runs an identity, given how flaky it is. */
+export function repeatsFor(rate: number): number {
+  if (rate > FLAKE_EXCLUSION_RATE) return 1;
+  let repeats = 1;
+  for (const band of FLAKE_REPEAT_RATES) {
+    if (rate > band) repeats++;
+  }
+  return Math.min(repeats, MAX_REPEATS);
+}
+
+/** What a manifest is built from beyond the folded state. */
+export interface BuildInput {
+  states: Map<string, IdentityState>;
+
+  /** Identities failing in the newest run on `main`. */
+  mainRed: ReadonlySet<string>;
+
+  /** Where each identity runs, by identity key. */
+  surfaces: ReadonlyMap<string, Surface>;
+
+  /** The day the score is taken as of. */
+  today: string;
+
+  generatedAt: string;
+  seed: string;
+  commit: string;
+  runs: number;
+  calibration?: Partial<Calibration>;
+}
+
+/** A number with the digits past `places` dropped. */
+function round(value: number, places: number): number {
+  const scale = 10 ** places;
+  return Math.round(value * scale) / scale;
+}
+
+/** The identity a key names, parsed back out of its canonical form. */
+export function identityOfKey(key: string): TestIdentity | undefined {
+  let parts: unknown;
+  try {
+    parts = JSON.parse(key);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parts) || parts.length < 3) return undefined;
+  const [k, s, n, v] = parts;
+  if (typeof k !== "string" || typeof s !== "string" || typeof n !== "string") {
+    return undefined;
+  }
+  const test: TestIdentity = { k, s, n };
+  if (typeof v === "string") test.v = v;
+  return test;
+}
+
+/** Builds a manifest from folded state. */
+export function buildManifest(input: BuildInput): Manifest {
+  const entries: ManifestEntry[] = [];
+  const withheld: WithheldEntry[] = [];
+  for (const [key, state] of input.states) {
+    const test = identityOfKey(key);
+    if (test === undefined) continue;
+    const surface = input.surfaces.get(key) ?? recordSurface(test, undefined);
+    const inputs = scoreInputs(state, input.today);
+    const rate = flakeRate(state, input.today);
+    // Rounded because the digits past these are noise, and because a
+    // manifest carries one entry per identity: at twenty thousand of them
+    // the difference between a rounded float and a full one is megabytes.
+    inputs.catches = round(inputs.catches, 2);
+    inputs.churn = round(inputs.churn, 6);
+    entries.push({
+      test,
+      suite: surface.suite,
+      unit: surface.unit,
+      cost: round(costSeconds(state, input.today), 3),
+      score: round(value(inputs, input.today), 4),
+      inputs,
+      flakeRate: round(rate, 4),
+      repeats: repeatsFor(rate),
+    });
+    if (input.mainRed.has(key)) {
+      withheld.push({ test, suite: surface.suite, reason: "main-red" });
+    } else if (rate > FLAKE_EXCLUSION_RATE) {
+      withheld.push({ test, suite: surface.suite, reason: "flaky" });
+    }
+  }
+  entries.sort((a, b) =>
+    testIdentityKey(a.test).localeCompare(testIdentityKey(b.test))
+  );
+  return {
+    schema: MANIFEST_SCHEMA_VERSION,
+    generatedAt: input.generatedAt,
+    seed: input.seed,
+    commit: input.commit,
+    runs: input.runs,
+    dials: dialSnapshot(),
+    calibration: {
+      setupCost: input.calibration?.setupCost ?? {},
+      suites: input.calibration?.suites ?? {},
+      unitOverhead: input.calibration?.unitOverhead ?? {},
+      prologue: input.calibration?.prologue ?? LANE_PROLOGUE_SECONDS,
+    },
+    entries,
+    withheld,
+    unavailable: [],
+    unschedulable: [],
+    lanes: [],
+    known: {
+      count: entries.length,
+      digest: digestIdentities(entries.map((e) => testIdentityKey(e.test))),
+    },
+    coverageBaselines: [],
+  };
+}
+
+/** A fold in progress, which the caller feeds reports to in time order. */
+export class Fold {
+  readonly #states: Map<string, IdentityState>;
+  readonly #context = emptyContext();
+  readonly #surfaces = new Map<string, Surface>();
+  readonly #samples = new Map<string, Map<string, DaySamples>>();
+  readonly #folded: string[];
+  readonly #compactedDays: string[];
+  readonly #resolver: AliasResolver;
+  readonly #today: string;
+  #observations = 0;
+
+  constructor(
+    aggregate: AggregateState,
+    resolver: AliasResolver,
+    today: string,
+  ) {
+    this.#states = new Map(
+      Object.entries(aggregate.states).map((
+        [key, state],
+      ) => [key, { ...emptyState(), ...state }]),
+    );
+    this.#folded = [...aggregate.folded];
+    this.#compactedDays = [...aggregate.compactedDays];
+    this.#resolver = resolver;
+    this.#today = today;
+  }
+
+  /** How many executions have been folded in. */
+  get observations(): number {
+    return this.#observations;
+  }
+
+  /** Whether this object's records are already part of the aggregate. */
+  knows(objectName: string): boolean {
+    return this.#folded.includes(objectName);
+  }
+
+  /**
+   * Whether this day was folded from a rollup. Its raw objects are not in
+   * `folded`, so a caller listing them has to ask about the day instead
+   * or it will fold the day twice.
+   */
+  knowsDay(day: string): boolean {
+    return this.#compactedDays.includes(day);
+  }
+
+  /**
+   * Records that a day came from its rollup, so no later run folds the
+   * raw objects the rollup summarizes.
+   */
+  markCompacted(day: string): void {
+    if (!this.#compactedDays.includes(day)) this.#compactedDays.push(day);
+  }
+
+  /**
+   * Folds one batch. The batch must be in ascending time order, and later
+   * batches must be later than earlier ones, because the rules that decide
+   * whether a failure is a catch look backwards at what `main` last said
+   * and forwards at what it says next.
+   */
+  add(reports: readonly StoredReport[]): void {
+    const ordered = [...reports].sort((a, b) =>
+      (a.context?.startedAt ?? "").localeCompare(b.context?.startedAt ?? "")
+    );
+    const observations: Observation[] = [];
+    for (const report of ordered) {
+      const read = readReport(report, this.#resolver);
+      observations.push(...read.observations);
+      for (const [key, surface] of read.surfaces) {
+        this.#surfaces.set(key, surface);
+      }
+      for (const [key, byDay] of read.durations) {
+        let known = this.#samples.get(key);
+        if (known === undefined) {
+          known = new Map();
+          this.#samples.set(key, known);
+        }
+        for (const [day, sampled] of byDay) {
+          const into = known.get(day) ?? emptySamples();
+          for (const durationMs of sampled) sampleDuration(into, durationMs);
+          known.set(day, into);
+        }
+      }
+      this.#folded.push(report.objectName);
+    }
+    this.#observations += observations.length;
+    foldObservations(observations, {
+      prior: this.#states,
+      context: this.#context,
+    });
+    // The two cross-batch rules reach back a couple of days, so what is
+    // older cannot change a verdict and is dropped rather than carried
+    // through a bootstrap's whole read.
+    const newest = observations.at(-1)?.day;
+    if (newest !== undefined) trimContext(this.#context, newest);
+  }
+
+  /** Closes the fold, sealing each day's cost and aging the counters. */
+  finish(): FoldResult {
+    for (const [key, byDay] of this.#samples) {
+      const state = this.#states.get(key);
+      if (state === undefined) continue;
+      for (const [day, sampled] of byDay) sealDay(state, day, sampled);
+    }
+    for (const state of this.#states.values()) {
+      trimWindows(state, this.#today);
+    }
+    const mainRed = new Set<string>();
+    for (const [key, state] of this.#states) {
+      if (state.lastMainOutcome === "fail") mainRed.add(key);
+    }
+    return {
+      aggregate: {
+        schema: MANIFEST_SCHEMA_VERSION,
+        day: this.#today,
+        folded: this.#folded,
+        compactedDays: this.#compactedDays,
+        states: Object.fromEntries(this.#states),
+      },
+      states: this.#states,
+      mainRed,
+      surfaces: this.#surfaces,
+      observations: this.#observations,
+    };
+  }
+}
+
+/** What a finished fold produced. */
+export interface FoldResult {
+  aggregate: AggregateState;
+  states: Map<string, IdentityState>;
+  mainRed: Set<string>;
+  surfaces: Map<string, Surface>;
+  observations: number;
+}
+
+/** Folds a whole set of reports at once, for a caller holding them all. */
+export function foldReports(
+  aggregate: AggregateState,
+  reports: readonly StoredReport[],
+  resolver: AliasResolver,
+  today: string,
+): FoldResult {
+  const fold = new Fold(aggregate, resolver, today);
+  fold.add(reports.filter((report) => !fold.knows(report.objectName)));
+  return fold.finish();
+}
+
+/** Parses object text the way the store's reader does, for offline use. */
+export function reportFromText(
+  objectName: string,
+  text: string,
+): StoredReport {
+  const reports = parseReportGroups(text);
+  return {
+    objectName,
+    context: reports[0]?.context,
+    records: reports.flatMap((report) => report.records),
+    reports,
+  };
+}

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -191,7 +191,16 @@ export function readReport(
     for (const record of group.records) {
       const test = resolver.resolve(record.test, day);
       const key = testIdentityKey(test);
-      surfaces.set(key, recordSurface(test, record.file));
+      // A record with no file names its own identity as the unit, which
+      // is all an unmapped record can say. Where another record of the
+      // same identity did carry a file, that is the better answer and the
+      // unmapped one must not overwrite it: the suites are mid-migration
+      // onto the preload, so one identity can have records of both kinds.
+      const surface = recordSurface(test, record.file);
+      const known = surfaces.get(key);
+      if (record.file !== undefined || known === undefined) {
+        surfaces.set(key, surface);
+      }
       observations.push({
         test,
         outcome: record.outcome,

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -24,12 +24,16 @@ import {
   emptySamples,
   emptyState,
   flakeRate,
+  type FoldContext,
   foldObservations,
   type IdentityState,
   type Observation,
+  parseContext,
   sampleDuration,
   scoreInputs,
   sealDay,
+  serializeContext,
+  type StoredFoldContext,
   trimContext,
   trimWindows,
   value,
@@ -65,6 +69,15 @@ export interface AggregateState {
   folded: string[];
 
   /**
+   * What the two backward-looking rules saw in the runs already folded.
+   * Both reach across objects — whether an identity disagreed with itself
+   * at a commit, and how many sources a failure spans — and a commit's
+   * runs can arrive in two different publisher runs, so the context has
+   * to survive between them or those rules silently stop reaching.
+   */
+  context?: StoredFoldContext;
+
+  /**
    * Days folded from a rollup rather than from their raw objects,
    * "yyyy/mm/dd". A rollup carries a day's reports whole, so its raw
    * objects are not in `folded` and a later run over a wide window would
@@ -81,6 +94,7 @@ export function emptyAggregate(day: string): AggregateState {
     schema: MANIFEST_SCHEMA_VERSION,
     day,
     folded: [],
+    context: serializeContext(emptyContext()),
     compactedDays: [],
     states: {},
   };
@@ -112,6 +126,9 @@ export function parseAggregate(text: string): AggregateState | undefined {
   }
   // An aggregate written before rollups were read carries no list, and
   // an empty one is the truthful reading of it: nothing was compacted.
+  // The context is an optimization rather than a stored fact, so an
+  // aggregate written without one, or with a malformed one, simply starts
+  // the two cross-run rules from nothing.
   const compactedDays = state.compactedDays ?? [];
   if (!Array.isArray(compactedDays)) return undefined;
   for (const day of compactedDays) {
@@ -121,6 +138,7 @@ export function parseAggregate(text: string): AggregateState | undefined {
     schema: MANIFEST_SCHEMA_VERSION,
     day: state.day,
     folded: state.folded as string[],
+    context: serializeContext(parseContext(state.context)),
     compactedDays: compactedDays as string[],
     states: state.states as Record<string, IdentityState>,
   };
@@ -363,7 +381,7 @@ export function buildManifest(input: BuildInput): Manifest {
 /** A fold in progress, which the caller feeds reports to in time order. */
 export class Fold {
   readonly #states: Map<string, IdentityState>;
-  readonly #context = emptyContext();
+  readonly #context: FoldContext;
   readonly #surfaces = new Map<string, Surface>();
   readonly #samples = new Map<string, Map<string, DaySamples>>();
   readonly #folded: string[];
@@ -383,6 +401,7 @@ export class Fold {
         [key, state],
       ) => [key, { ...emptyState(), ...state }]),
     );
+    this.#context = parseContext(aggregate.context);
     this.#folded = [...aggregate.folded];
     // The array is what is persisted; membership is asked once per listed
     // object per run, and the list grows without bound, so the question
@@ -488,6 +507,7 @@ export class Fold {
         schema: MANIFEST_SCHEMA_VERSION,
         day: this.#today,
         folded: this.#folded,
+        context: serializeContext(this.#context),
         compactedDays: this.#compactedDays,
         states: Object.fromEntries(this.#states),
       },

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -206,6 +206,7 @@ export function readReport(
         outcome: record.outcome,
         durationMs: record.durationMs,
         day,
+        startedAt: group.context.startedAt,
         commit: group.context.commit,
         source: where.source,
         place: where.place,
@@ -366,6 +367,7 @@ export class Fold {
   readonly #surfaces = new Map<string, Surface>();
   readonly #samples = new Map<string, Map<string, DaySamples>>();
   readonly #folded: string[];
+  readonly #foldedIndex: Set<string>;
   readonly #compactedDays: string[];
   readonly #resolver: AliasResolver;
   readonly #today: string;
@@ -382,6 +384,10 @@ export class Fold {
       ) => [key, { ...emptyState(), ...state }]),
     );
     this.#folded = [...aggregate.folded];
+    // The array is what is persisted; membership is asked once per listed
+    // object per run, and the list grows without bound, so the question
+    // is answered against a set rather than by scanning.
+    this.#foldedIndex = new Set(this.#folded);
     this.#compactedDays = [...aggregate.compactedDays];
     this.#resolver = resolver;
     this.#today = today;
@@ -394,7 +400,7 @@ export class Fold {
 
   /** Whether this object's records are already part of the aggregate. */
   knows(objectName: string): boolean {
-    return this.#folded.includes(objectName);
+    return this.#foldedIndex.has(objectName);
   }
 
   /**
@@ -421,11 +427,8 @@ export class Fold {
    * and forwards at what it says next.
    */
   add(reports: readonly StoredReport[]): void {
-    const ordered = [...reports].sort((a, b) =>
-      (a.context?.startedAt ?? "").localeCompare(b.context?.startedAt ?? "")
-    );
     const observations: Observation[] = [];
-    for (const report of ordered) {
+    for (const report of reports) {
       const read = readReport(report, this.#resolver);
       observations.push(...read.observations);
       for (const [key, surface] of read.surfaces) {
@@ -444,7 +447,16 @@ export class Fold {
         }
       }
       this.#folded.push(report.objectName);
+      this.#foldedIndex.add(report.objectName);
     }
+    // Sorted here rather than by object, because one object can hold many
+    // reports — a rollup holds a whole day of them — and a batch can hold
+    // objects whose reports interleave in time. The rules that decide
+    // whether a failure is a catch look backwards and forwards along this
+    // order, so it has to be the order the runs actually happened in.
+    observations.sort((a, b) =>
+      a.startedAt < b.startedAt ? -1 : a.startedAt > b.startedAt ? 1 : 0
+    );
     this.#observations += observations.length;
     foldObservations(observations, {
       prior: this.#states,

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -216,9 +216,7 @@ export function readReport(
       // onto the preload, so one identity can have records of both kinds.
       const surface = recordSurface(test, record.file);
       const known = surfaces.get(key);
-      if (record.file !== undefined || known === undefined) {
-        surfaces.set(key, surface);
-      }
+      if (known === undefined || surface.fromFile) surfaces.set(key, surface);
       observations.push({
         test,
         outcome: record.outcome,
@@ -245,6 +243,14 @@ export function readReport(
 export interface Surface {
   suite: string;
   unit: string;
+
+  /** Whether the unit came from a record's file rather than its name. */
+  fromFile: boolean;
+}
+
+/** Whether a surface names a file rather than falling back to a name. */
+function isFileBacked(surface: Surface): boolean {
+  return surface.fromFile;
 }
 
 /**
@@ -261,7 +267,7 @@ export function recordSurface(
   const suite = test.v === undefined
     ? `${test.k}:${test.s}`
     : `${test.k}:${test.s}:${test.v}`;
-  return { suite, unit: file ?? test.n };
+  return { suite, unit: file ?? test.n, fromFile: file !== undefined };
 }
 
 /** How many times a lane runs an identity, given how flaky it is. */
@@ -451,7 +457,13 @@ export class Fold {
       const read = readReport(report, this.#resolver);
       observations.push(...read.observations);
       for (const [key, surface] of read.surfaces) {
-        this.#surfaces.set(key, surface);
+        // A file names something a runner can be pointed at, and an
+        // identity's own name does not. A record with no file arriving in
+        // a later report must not replace one that had it.
+        const known = this.#surfaces.get(key);
+        if (known === undefined || isFileBacked(surface)) {
+          this.#surfaces.set(key, surface);
+        }
       }
       for (const [key, byDay] of read.durations) {
         let known = this.#samples.get(key);

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -118,7 +118,13 @@ export function parseAggregate(text: string): AggregateState | undefined {
   if (typeof state.day !== "string" || !Array.isArray(state.folded)) {
     return undefined;
   }
-  if (typeof state.states !== "object" || state.states === null) {
+  // An array is an object, and read as one it would give a state set
+  // keyed by index. Every such key fails to name an identity, so the
+  // aggregate would be read as holding nothing rather than refused.
+  if (
+    typeof state.states !== "object" || state.states === null ||
+    Array.isArray(state.states)
+  ) {
     return undefined;
   }
   for (const name of state.folded) {

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -473,8 +473,11 @@ export class Fold {
     // objects whose reports interleave in time. The rules that decide
     // whether a failure is a catch look backwards and forwards along this
     // order, so it has to be the order the runs actually happened in.
+    // By the parsed instant rather than the text: these come from two
+    // producers, and one writing fractional seconds where the other does
+    // not makes the later run sort first, because "." precedes "Z".
     observations.sort((a, b) =>
-      a.startedAt < b.startedAt ? -1 : a.startedAt > b.startedAt ? 1 : 0
+      Date.parse(a.startedAt) - Date.parse(b.startedAt)
     );
     this.#observations += observations.length;
     foldObservations(observations, {

--- a/tasks/test-selection/manifest.test.ts
+++ b/tasks/test-selection/manifest.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  parseManifest,
+  serializeManifest,
+} from "@commonfabric/test-support/records";
+
+import { dialSnapshot } from "./manifest.ts";
+import { DIALS } from "./policy.ts";
+import { sampleManifest } from "./testing.ts";
+
+describe("manifest", () => {
+  describe("dialSnapshot()", () => {
+    it("records every dial, so a manifest explains its own behavior", () => {
+      expect(Object.keys(dialSnapshot()).sort()).toEqual(
+        DIALS.map((dial) => dial.name).sort(),
+      );
+    });
+
+    it("survives the format's own validator", () => {
+      const manifest = sampleManifest();
+      expect(parseManifest(serializeManifest(manifest))?.dials).toEqual(
+        dialSnapshot(),
+      );
+    });
+  });
+});

--- a/tasks/test-selection/manifest.ts
+++ b/tasks/test-selection/manifest.ts
@@ -1,0 +1,39 @@
+/**
+ * The manifest, as the selection tooling uses it. The format itself lives
+ * beside the record schema in `@commonfabric/test-support/records`,
+ * because the wall reads a manifest as well as the lanes do and one
+ * format with two validators would rot. What is here is the one part that
+ * cannot live there: the dials a manifest records, which are this
+ * repository's policy rather than the format.
+ */
+
+import { DIALS } from "./policy.ts";
+
+export {
+  digestIdentities,
+  MANIFEST_SCHEMA_VERSION,
+  parseManifest,
+  serializeManifest,
+} from "@commonfabric/test-support/records";
+export type {
+  Calibration,
+  CoverageBaseline,
+  LanePlan,
+  Manifest,
+  ManifestEntry,
+  ScoreInputs,
+  UnavailableEntry,
+  UnschedulableEntry,
+  WithheldEntry,
+  WithheldReason,
+} from "@commonfabric/test-support/records";
+
+/**
+ * The dials as a manifest records them, so a manifest explains its own
+ * behavior and two of them can be compared for why they differ.
+ */
+export function dialSnapshot(): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {};
+  for (const dial of DIALS) snapshot[dial.name] = dial.value;
+  return snapshot;
+}

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -1,0 +1,376 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { testIdentityKey } from "@commonfabric/test-support/records";
+
+import { plan, type PlanInput, seededOrder, type Selection } from "./plan.ts";
+import type { Manifest, ManifestEntry } from "./manifest.ts";
+import { sampleEntry, sampleManifest } from "./testing.ts";
+import { LANES } from "./policy.ts";
+
+const NO_CAPABILITIES = new Map<string, readonly string[]>();
+
+/** `count` identities of one suite, each in its own invocation unit. */
+function entries(
+  count: number,
+  fields: (i: number) => Partial<ManifestEntry> = () => ({}),
+): ManifestEntry[] {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      sampleEntry({ k: "unit", s: "memory", n: `case ${i}` }, {
+        unit: `packages/memory/test/case-${i}.test.ts`,
+        ...fields(i),
+      }),
+  );
+}
+
+function run(
+  manifest: Manifest,
+  overrides: Partial<PlanInput> = {},
+) {
+  return plan({
+    manifest,
+    mandatory: new Map(),
+    capabilities: NO_CAPABILITIES,
+    ...overrides,
+  });
+}
+
+function selected(result: ReturnType<typeof plan>): Selection[] {
+  return result.lanes.flatMap((lane) => lane.selections);
+}
+
+function keysOf(result: ReturnType<typeof plan>): string[] {
+  return selected(result).map((s) => testIdentityKey(s.entry.test)).sort();
+}
+
+describe("plan", () => {
+  describe("the partition", () => {
+    it("fills exactly the lanes it was asked for", () => {
+      const result = run(sampleManifest({ entries: entries(20) }));
+      expect(result.lanes.length).toBe(LANES);
+      expect(result.lanes.map((lane) => lane.lane)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("puts no identity in two lanes", () => {
+      const result = run(sampleManifest({ entries: entries(200) }));
+      const keys = keysOf(result);
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("gives the same answer every time from the same inputs", () => {
+      const manifest = sampleManifest({ entries: entries(200) });
+      expect(keysOf(run(manifest))).toEqual(keysOf(run(manifest)));
+    });
+
+    it("gives every lane the same answer about its own share", () => {
+      // The five lanes each call this over the same inputs, so what lane
+      // three would do has to be what the whole plan says lane three does.
+      const manifest = sampleManifest({ entries: entries(200) });
+      const first = run(manifest).lanes[2]!;
+      const again = run(manifest).lanes[2]!;
+      expect(first.selections.map((s) => s.entry.test.n)).toEqual(
+        again.selections.map((s) => s.entry.test.n),
+      );
+    });
+  });
+
+  describe("what must run", () => {
+    it("takes every mandatory identity before anything else", () => {
+      const manifest = sampleManifest({ entries: entries(50) });
+      const mandatory = new Map([[
+        testIdentityKey(manifest.entries[7]!.test),
+        "changed" as const,
+      ]]);
+      const result = run(manifest, { mandatory });
+      const taken = selected(result).find((s) => s.entry.test.n === "case 7");
+      expect(taken?.reason).toBe("changed");
+    });
+
+    it("runs a mandatory identity once, whatever its repeat count", () => {
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({ repeats: 3 })),
+      });
+      const mandatory = new Map([[
+        testIdentityKey(manifest.entries[0]!.test),
+        "coverage-gate" as const,
+      ]]);
+      const result = run(manifest, { mandatory });
+      const taken = selected(result).find((s) => s.entry.test.n === "case 0");
+      expect(taken?.repeats).toBe(1);
+    });
+
+    it("says by how much the mandatory set alone overran", () => {
+      const manifest = sampleManifest({
+        entries: entries(4, () => ({ cost: 100 })),
+      });
+      const mandatory = new Map(
+        manifest.entries.map((entry) =>
+          [testIdentityKey(entry.test), "changed" as const] as const
+        ),
+      );
+      const result = run(manifest, { mandatory, budgetSeconds: 10 });
+      expect(result.overBudgetSeconds).toBeCloseTo(350, 6);
+      expect(selected(result).length).toBe(4);
+    });
+  });
+
+  describe("what must not run", () => {
+    it("leaves out an identity failing in the newest run on main", () => {
+      const manifest = sampleManifest({ entries: entries(5) });
+      const held = manifest.entries[2]!;
+      manifest.withheld = [{
+        test: held.test,
+        suite: held.suite,
+        reason: "main-red",
+      }];
+      const result = run(manifest);
+      expect(selected(result).some((s) => s.entry.test.n === "case 2")).toBe(
+        false,
+      );
+    });
+
+    it("leaves out an identity too flaky to judge a change by", () => {
+      const manifest = sampleManifest({
+        entries: entries(5, (i) => (i === 3 ? { flakeRate: 0.5 } : {})),
+      });
+      const result = run(manifest);
+      expect(selected(result).some((s) => s.entry.test.n === "case 3")).toBe(
+        false,
+      );
+    });
+
+    it("lets a withheld identity back in when the change touches it", () => {
+      const manifest = sampleManifest({
+        entries: entries(5, (i) => (i === 3 ? { flakeRate: 0.5 } : {})),
+      });
+      const held = manifest.entries[2]!;
+      manifest.withheld = [{
+        test: held.test,
+        suite: held.suite,
+        reason: "main-red",
+      }];
+      const mandatory = new Map([
+        [testIdentityKey(held.test), "changed" as const],
+        [
+          testIdentityKey(manifest.entries[3]!.test),
+          "covers-changed" as const,
+        ],
+      ]);
+      const names = selected(run(manifest, { mandatory })).map((s) =>
+        s.entry.test.n
+      );
+      expect(names).toContain("case 2");
+      expect(names).toContain("case 3");
+    });
+
+    it("hands the withheld set on, so a lane can say what is absent", () => {
+      const manifest = sampleManifest({ entries: entries(5) });
+      manifest.withheld = [{
+        test: manifest.entries[1]!.test,
+        suite: "workspace-unit",
+        reason: "main-red",
+      }];
+      expect(run(manifest).withheld).toEqual(manifest.withheld);
+    });
+  });
+
+  describe("the budget", () => {
+    it("stops before the budget when the corpus is larger than it", () => {
+      const manifest = sampleManifest({
+        entries: entries(500, () => ({ cost: 1 })),
+      });
+      const result = run(manifest, { budgetSeconds: 20 });
+      const total = result.lanes.reduce(
+        (sum, lane) => sum + lane.projectedSeconds,
+        0,
+      );
+      expect(total).toBeLessThanOrEqual(20 * LANES);
+      expect(selected(result).length).toBeLessThan(500);
+    });
+
+    it("runs everything when the corpus fits", () => {
+      const manifest = sampleManifest({
+        entries: entries(10, () => ({ cost: 0.01 })),
+      });
+      expect(selected(run(manifest)).length).toBe(10);
+    });
+
+    it("drops repeats before it drops the identity", () => {
+      // Three identities wanting three runs each, in a budget that holds
+      // four runs. One observation of each beats three of one.
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({ cost: 1, repeats: 3 })),
+      });
+      const result = run(manifest, { lanes: 1, budgetSeconds: 4 });
+      expect(selected(result).length).toBe(3);
+      expect(selected(result).every((s) => s.repeats >= 1)).toBe(true);
+    });
+  });
+
+  describe("the filling order", () => {
+    it("takes the highest-scoring identity even when it is expensive", () => {
+      const manifest = sampleManifest({
+        entries: entries(
+          30,
+          (i) =>
+            i === 17 ? { cost: 40, score: 0.9 } : { cost: 0.1, score: 0.05 },
+        ),
+      });
+      const result = run(manifest, { budgetSeconds: 20 });
+      const taken = selected(result).find((s) => s.entry.test.n === "case 17");
+      expect(taken?.reason).toBe("value");
+    });
+
+    it("sweeps the cheap tail up under the density pass", () => {
+      // Expensive proven tests take the value pass's whole share. The
+      // tail is worth a hundred times more per second, so the density
+      // pass is where it comes in.
+      const manifest = sampleManifest({
+        entries: entries(
+          220,
+          (i) => i < 20 ? { cost: 5, score: 0.9 } : { cost: 0.01, score: 0.05 },
+        ),
+      });
+      const result = run(manifest, { budgetSeconds: 20 });
+      const byReason = new Map<string, number>();
+      for (const selection of selected(result)) {
+        byReason.set(
+          selection.reason,
+          (byReason.get(selection.reason) ?? 0) + 1,
+        );
+      }
+      expect(byReason.get("value")).toBeGreaterThan(0);
+      expect(byReason.get("density")).toBeGreaterThan(100);
+    });
+
+    it("spends its last share on what the value ordering passed over", () => {
+      const manifest = sampleManifest({
+        entries: entries(400, (i) => ({
+          cost: 0.5,
+          score: i < 20 ? 0.9 : 0.05,
+        })),
+      });
+      const result = run(manifest, { budgetSeconds: 20 });
+      const reasons = new Set(selected(result).map((s) => s.reason));
+      expect(reasons.has("exploration")).toBe(true);
+    });
+  });
+
+  describe("capabilities", () => {
+    it("charges a lane for setup it has not opened yet", () => {
+      const manifest = sampleManifest({
+        entries: [
+          sampleEntry({ k: "integration", s: "patterns", n: "one" }, {
+            suite: "pattern-integration",
+            unit: "packages/patterns/integration/one.test.ts",
+            cost: 1,
+          }),
+        ],
+        calibration: {
+          setupCost: { toolshed: 40 },
+          suites: {},
+          unitOverhead: {},
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, {
+        capabilities: new Map([["pattern-integration", ["toolshed"]]]),
+      });
+      const lane = result.lanes.find((l) => l.selections.length > 0)!;
+      expect(lane.capabilities).toEqual(["toolshed"]);
+      expect(lane.projectedSeconds).toBeCloseTo(41, 6);
+    });
+
+    it("groups a suite's identities where its setup is already paid", () => {
+      const manifest = sampleManifest({
+        entries: entries(4, (i) => ({
+          suite: "pattern-integration",
+          unit: `packages/patterns/integration/case-${i}.test.ts`,
+          cost: 1,
+        })),
+        calibration: {
+          setupCost: { toolshed: 40 },
+          suites: {},
+          unitOverhead: {},
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, {
+        capabilities: new Map([["pattern-integration", ["toolshed"]]]),
+      });
+      const opened = result.lanes.filter((lane) =>
+        lane.capabilities.includes("toolshed")
+      );
+      expect(opened.length).toBe(1);
+    });
+  });
+
+  describe("the cost model", () => {
+    it("charges a suite's overhead once per lane", () => {
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({ cost: 1 })),
+        calibration: {
+          setupCost: {},
+          suites: { "workspace-unit": { overhead: 10, correction: 1 } },
+          unitOverhead: {},
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, { lanes: 1 });
+      expect(result.lanes[0]!.projectedSeconds).toBeCloseTo(13, 6);
+    });
+
+    it("charges an invocation unit's overhead once per lane", () => {
+      const manifest = sampleManifest({
+        entries: entries(3, () => ({
+          cost: 1,
+          unit: "packages/memory/test/one.test.ts",
+        })),
+        calibration: {
+          setupCost: {},
+          suites: {},
+          unitOverhead: { "packages/memory/test/one.test.ts": 5 },
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, { lanes: 1 });
+      expect(result.lanes[0]!.projectedSeconds).toBeCloseTo(8, 6);
+    });
+
+    it("applies the suite's fitted correction to a measured cost", () => {
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 2 })),
+        calibration: {
+          setupCost: {},
+          suites: { "workspace-unit": { overhead: 0, correction: 1.5 } },
+          unitOverhead: {},
+          prologue: 0,
+        },
+      });
+      expect(run(manifest, { lanes: 1 }).lanes[0]!.projectedSeconds)
+        .toBeCloseTo(3, 6);
+    });
+  });
+
+  describe("seededOrder()", () => {
+    it("permutes every index exactly once", () => {
+      const order = seededOrder("seed", 50);
+      expect([...order].sort((a, b) => a - b)).toEqual(
+        Array.from({ length: 50 }, (_, i) => i),
+      );
+    });
+
+    it("gives the same order from the same seed", () => {
+      expect(seededOrder("one", 30)).toEqual(seededOrder("one", 30));
+    });
+
+    it("gives a different order from a different seed", () => {
+      expect(seededOrder("one", 30)).not.toEqual(seededOrder("two", 30));
+    });
+
+    it("handles a corpus of nothing", () => {
+      expect(seededOrder("seed", 0)).toEqual([]);
+    });
+  });
+});

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -338,6 +338,34 @@ describe("plan", () => {
       expect(result.unschedulable.length).toBe(1);
     });
 
+    it("reports the cost the bound was compared against", () => {
+      // 200 seconds of test, a suite that costs 50 to open and doubles
+      // what runs inside it, a unit that costs 10, and a capability whose
+      // setup costs 60. What a lane pays is 520, and that is the number
+      // to report: reporting the entry's own 200 would say a test inside
+      // a 300-second bound is past it.
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({
+          cost: 200,
+          suite: "pattern-integration",
+          unit: "packages/patterns/one.test.ts",
+        })),
+        calibration: {
+          setupCost: { toolshed: 60 },
+          suites: { "pattern-integration": { overhead: 50, correction: 2 } },
+          unitOverhead: { "packages/patterns/one.test.ts": 10 },
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, {
+        boundSeconds: 300,
+        capabilities: new Map([["pattern-integration", ["toolshed"]]]),
+      });
+      expect(result.unschedulable.length).toBe(1);
+      expect(result.unschedulable[0]!.cost).toBeCloseTo(520, 5);
+      expect(result.unschedulable[0]!.suite).toBe("pattern-integration");
+    });
+
     it("does not force one in even when the change touches it", () => {
       const manifest = sampleManifest({
         entries: entries(1, () => ({ cost: 400 })),

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -63,15 +63,13 @@ describe("plan", () => {
       expect(keysOf(run(manifest))).toEqual(keysOf(run(manifest)));
     });
 
-    it("gives every lane the same answer about its own share", () => {
-      // The five lanes each call this over the same inputs, so what lane
-      // three would do has to be what the whole plan says lane three does.
+    it("keeps one lane's selections in a stable order", () => {
+      // Determinism of the set is checked above; this is the order within
+      // a lane, which is what a lane runs its batches in and what a job
+      // summary lists.
       const manifest = sampleManifest({ entries: entries(200) });
-      const first = run(manifest).lanes[2]!;
-      const again = run(manifest).lanes[2]!;
-      expect(first.selections.map((s) => s.entry.test.n)).toEqual(
-        again.selections.map((s) => s.entry.test.n),
-      );
+      expect(run(manifest).lanes[2]!.selections.map((s) => s.entry.test.n))
+        .toEqual(run(manifest).lanes[2]!.selections.map((s) => s.entry.test.n));
     });
   });
 

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -304,6 +304,53 @@ describe("plan", () => {
     });
   });
 
+  describe("the hard bound", () => {
+    it("reports an identity no lane could hold, and runs it nowhere", () => {
+      const manifest = sampleManifest({
+        entries: entries(3, (i) => (i === 1 ? { cost: 400 } : { cost: 1 })),
+      });
+      const result = run(manifest, { boundSeconds: 300 });
+      expect(result.unschedulable.map((e) => e.test.n)).toEqual(["case 1"]);
+      expect(selected(result).some((s) => s.entry.test.n === "case 1")).toBe(
+        false,
+      );
+    });
+
+    it("counts the overheads a lane would pay for it", () => {
+      // A test inside the bound whose suite, unit and capability setup
+      // put the lane past it is still one no lane can hold.
+      const manifest = sampleManifest({
+        entries: entries(
+          1,
+          () => ({ cost: 200, suite: "pattern-integration" }),
+        ),
+        calibration: {
+          setupCost: { toolshed: 60 },
+          suites: { "pattern-integration": { overhead: 50, correction: 1 } },
+          unitOverhead: {},
+          prologue: 0,
+        },
+      });
+      const result = run(manifest, {
+        boundSeconds: 300,
+        capabilities: new Map([["pattern-integration", ["toolshed"]]]),
+      });
+      expect(result.unschedulable.length).toBe(1);
+    });
+
+    it("does not force one in even when the change touches it", () => {
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 400 })),
+      });
+      const mandatory = new Map([[
+        testIdentityKey(manifest.entries[0]!.test),
+        "changed" as const,
+      ]]);
+      const result = run(manifest, { mandatory, boundSeconds: 300 });
+      expect(selected(result)).toEqual([]);
+    });
+  });
+
   describe("the cost model", () => {
     it("charges a suite's overhead once per lane", () => {
       const manifest = sampleManifest({

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -5,7 +5,7 @@ import { testIdentityKey } from "@commonfabric/test-support/records";
 import { plan, type PlanInput, seededOrder, type Selection } from "./plan.ts";
 import type { Manifest, ManifestEntry } from "./manifest.ts";
 import { sampleEntry, sampleManifest } from "./testing.ts";
-import { LANES } from "./policy.ts";
+import { LANES, VALUE_FLOOR } from "./policy.ts";
 
 const NO_CAPABILITIES = new Map<string, readonly string[]>();
 
@@ -417,5 +417,94 @@ describe("plan", () => {
     it("handles a corpus of nothing", () => {
       expect(seededOrder("seed", 0)).toEqual([]);
     });
+  });
+});
+
+describe("an identity the manifest has never heard of", () => {
+  const KEY = '["unit","memory","brand new"]';
+  const WHERE = new Map([[KEY, {
+    suite: "workspace-unit",
+    unit: "packages/memory/test/new.test.ts",
+  }]]);
+
+  it("runs when the caller names it mandatory and says where it lives", () => {
+    const result = run(sampleManifest({ entries: entries(3) }), {
+      mandatory: new Map([[KEY, "changed" as const]]),
+      unknown: WHERE,
+    });
+    const taken = selected(result).find((s) =>
+      testIdentityKey(s.entry.test) === KEY
+    );
+    expect(taken).toBeDefined();
+    expect(taken!.reason).toBe("changed");
+    expect(taken!.repeats).toBe(1);
+    expect(taken!.entry.unit).toBe("packages/memory/test/new.test.ts");
+    // It has no history, so it stands in at the floor and costs nothing
+    // anybody measured.
+    expect(taken!.entry.score).toBe(VALUE_FLOOR);
+    expect(taken!.entry.cost).toBe(0);
+    expect(taken!.entry.inputs).toEqual({
+      catches: 0,
+      mainCatches: 0,
+      sources: 0,
+      churn: 0,
+    });
+  });
+
+  it("carries the configuration when the key names one", () => {
+    const key = '["unit","memory","brand new","server"]';
+    const result = run(sampleManifest({ entries: entries(3) }), {
+      mandatory: new Map([[key, "changed" as const]]),
+      unknown: new Map([[key, {
+        suite: "workspace-unit",
+        unit: "packages/memory/test/new.test.ts",
+      }]]),
+    });
+    const taken = selected(result).find((s) =>
+      testIdentityKey(s.entry.test) === key
+    );
+    expect(taken?.entry.test).toEqual({
+      k: "unit",
+      s: "memory",
+      n: "brand new",
+      v: "server",
+    });
+  });
+
+  it("is left out when nobody said where it lives", () => {
+    const result = run(sampleManifest({ entries: entries(3) }), {
+      mandatory: new Map([[KEY, "changed" as const]]),
+    });
+    expect(keysOf(result)).not.toContain(KEY);
+  });
+
+  it("is left out when the key is not a key at all", () => {
+    for (
+      const key of ["not json", "[]", '["unit","memory"]', '["unit",7,"n"]']
+    ) {
+      const result = run(sampleManifest({ entries: entries(3) }), {
+        mandatory: new Map([[key, "changed" as const]]),
+        unknown: new Map([[key, {
+          suite: "workspace-unit",
+          unit: "packages/memory/test/new.test.ts",
+        }]]),
+      });
+      expect(
+        selected(result).some((s) => testIdentityKey(s.entry.test) === key),
+      )
+        .toBe(false);
+    }
+  });
+
+  it("does not stand in for an identity the manifest does carry", () => {
+    const known = testIdentityKey({ k: "unit", s: "memory", n: "case 0" });
+    const result = run(sampleManifest({ entries: entries(3) }), {
+      mandatory: new Map([[known, "changed" as const]]),
+      unknown: new Map([[known, { suite: "elsewhere", unit: "elsewhere.ts" }]]),
+    });
+    const taken = selected(result).find((s) =>
+      testIdentityKey(s.entry.test) === known
+    );
+    expect(taken?.entry.unit).toBe("packages/memory/test/case-0.test.ts");
   });
 });

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -327,7 +327,6 @@ export function plan(input: PlanInput): Plan {
   // caller says so by naming it mandatory. It has no entry, so one is
   // made for it at the floor, costing nothing anybody measured.
   for (const [key, reason] of input.mandatory) {
-    if (taken.has(key)) continue;
     // Not even a mandatory identity is placed past the hard bound: the
     // lane would be killed and the run would report a timeout rather than
     // the test.

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -144,6 +144,28 @@ interface Filling {
   load: number;
 }
 
+/** What one identity costs a lane that is running nothing else. */
+function loneCost(
+  manifest: Manifest,
+  input: PlanInput,
+  entry: ManifestEntry,
+): number {
+  return marginalCost(
+    manifest,
+    input,
+    {
+      lane: 0,
+      selections: [],
+      capabilities: new Set(),
+      suites: new Set(),
+      units: new Set(),
+      load: 0,
+    },
+    entry,
+    1,
+  );
+}
+
 function capabilityCost(manifest: Manifest, capability: string): number {
   return manifest.calibration.setupCost[capability] ?? 0;
 }
@@ -264,9 +286,11 @@ export function plan(input: PlanInput): Plan {
   const unschedulable: ManifestEntry[] = [];
   const beyondBound = new Set<string>();
   for (const entry of manifest.entries) {
-    const correction = manifest.calibration.suites[entry.suite]?.correction ??
-      1;
-    if (entry.cost * correction <= bound) continue;
+    // What an empty lane would pay for it: its own corrected time plus
+    // every overhead and setup that lane would open. Charging only the
+    // test's own time would schedule an identity whose suite, unit, and
+    // capabilities together put the lane past the bound it is killed at.
+    if (loneCost(manifest, input, entry) <= bound) continue;
     unschedulable.push(entry);
     beyondBound.add(testIdentityKey(entry.test));
   }

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -23,7 +23,11 @@ import {
   LANES,
   VALUE_FLOOR,
 } from "./policy.ts";
-import type { Manifest, ManifestEntry } from "./manifest.ts";
+import type {
+  Manifest,
+  ManifestEntry,
+  UnschedulableEntry,
+} from "./manifest.ts";
 
 /** Why one identity is in the run. */
 export type SelectionReason =
@@ -74,7 +78,7 @@ export interface Plan {
    * scheduling it would only time the lane out. It is reported instead,
    * and the sixty-second rule is where such a test gets split.
    */
-  unschedulable: ManifestEntry[];
+  unschedulable: UnschedulableEntry[];
 }
 
 /** What the packer needs beyond the manifest. */
@@ -283,15 +287,18 @@ export function plan(input: PlanInput): Plan {
   // in any lane, so it is reported rather than placed in one that would
   // then be killed at its bound. Its suite's correction is applied first,
   // because that is what the time will actually be.
-  const unschedulable: ManifestEntry[] = [];
+  const unschedulable: UnschedulableEntry[] = [];
   const beyondBound = new Set<string>();
   for (const entry of manifest.entries) {
     // What an empty lane would pay for it: its own corrected time plus
     // every overhead and setup that lane would open. Charging only the
     // test's own time would schedule an identity whose suite, unit, and
     // capabilities together put the lane past the bound it is killed at.
-    if (loneCost(manifest, input, entry) <= bound) continue;
-    unschedulable.push(entry);
+    const cost = loneCost(manifest, input, entry);
+    if (cost <= bound) continue;
+    // That whole figure is what is reported, so whoever reads it is told
+    // the number the bound was compared against.
+    unschedulable.push({ test: entry.test, suite: entry.suite, cost });
     beyondBound.add(testIdentityKey(entry.test));
   }
 

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -9,14 +9,19 @@
  * The exploration draw's seed comes from the manifest.
  */
 
-import { testIdentityKey } from "@commonfabric/test-support/records";
+import {
+  type TestIdentity,
+  testIdentityKey,
+} from "@commonfabric/test-support/records";
 import {
   FILL_DENSITY_SHARE,
   FILL_EXPLORATION_SHARE,
   FILL_VALUE_SHARE,
   FLAKE_EXCLUSION_RATE,
+  LANE_BOUND_SECONDS,
   LANE_BUDGET_SECONDS,
   LANES,
+  VALUE_FLOOR,
 } from "./policy.ts";
 import type { Manifest, ManifestEntry } from "./manifest.ts";
 
@@ -61,6 +66,15 @@ export interface Plan {
 
   /** Set when the mandatory pass alone did not fit. */
   overBudgetSeconds: number;
+
+  /**
+   * Identities no lane can hold. One costing more than a lane's planned
+   * budget is given a lane to itself and allowed to run up to the hard
+   * bound; one costing more than the hard bound cannot run at all, and
+   * scheduling it would only time the lane out. It is reported instead,
+   * and the sixty-second rule is where such a test gets split.
+   */
+  unschedulable: ManifestEntry[];
 }
 
 /** What the packer needs beyond the manifest. */
@@ -77,11 +91,22 @@ export interface PlanInput {
   /** Which capabilities each suite needs. */
   capabilities: ReadonlyMap<string, readonly string[]>;
 
+  /**
+   * Where an identity the manifest does not carry runs, by identity key.
+   * An identity with no records is mandatory, and the manifest cannot say
+   * where it runs precisely because it has never seen it, so whoever
+   * enumerated the tree says instead.
+   */
+  unknown?: ReadonlyMap<string, { suite: string; unit: string }>;
+
   /** How many lanes to fill. Defaults to the dial. */
   lanes?: number;
 
   /** Seconds each lane may fill. Defaults to the dial. */
   budgetSeconds?: number;
+
+  /** The hard bound on a lane's work step. Defaults to the dial. */
+  boundSeconds?: number;
 }
 
 /**
@@ -226,14 +251,29 @@ export function plan(input: PlanInput): Plan {
     load: 0,
   }));
 
+  const bound = input.boundSeconds ?? LANE_BOUND_SECONDS;
   const byKey = new Map<string, ManifestEntry>();
   for (const entry of manifest.entries) {
     byKey.set(testIdentityKey(entry.test), entry);
   }
 
+  // An identity whose own measured time is past the hard bound cannot run
+  // in any lane, so it is reported rather than placed in one that would
+  // then be killed at its bound. Its suite's correction is applied first,
+  // because that is what the time will actually be.
+  const unschedulable: ManifestEntry[] = [];
+  const beyondBound = new Set<string>();
+  for (const entry of manifest.entries) {
+    const correction = manifest.calibration.suites[entry.suite]?.correction ??
+      1;
+    if (entry.cost * correction <= bound) continue;
+    unschedulable.push(entry);
+    beyondBound.add(testIdentityKey(entry.test));
+  }
+
   // What must not run, unless the change touches what it covers, in which
   // case it is very likely a fix and must be allowed to prove itself.
-  const excluded = new Set<string>();
+  const excluded = new Set<string>(beyondBound);
   for (const held of manifest.withheld) {
     const key = testIdentityKey(held.test);
     if (!input.mandatory.has(key)) excluded.add(key);
@@ -257,7 +297,18 @@ export function plan(input: PlanInput): Plan {
   // made for it at the floor, costing nothing anybody measured.
   for (const [key, reason] of input.mandatory) {
     if (taken.has(key)) continue;
-    const entry = byKey.get(key);
+    // Not even a mandatory identity is placed past the hard bound: the
+    // lane would be killed and the run would report a timeout rather than
+    // the test.
+    if (beyondBound.has(key)) continue;
+    // An identity the manifest has never heard of is exactly the one that
+    // must run: records exist only for tests that ran, and a renamed test
+    // is unknown until an alias lands. Dropping it here would break the
+    // rule the caller invoked by naming it mandatory, so it is carried on
+    // an entry standing in for the history it has none of — the floor
+    // score, and no measured cost, which is what an unrun test costs as
+    // far as anything here knows.
+    const entry = byKey.get(key) ?? unknownEntry(key, input);
     if (entry === undefined) continue;
     taken.add(key);
     // Mandatory work runs once. A repeat covers nothing a measured run
@@ -323,6 +374,42 @@ export function plan(input: PlanInput): Plan {
     })),
     withheld: manifest.withheld,
     overBudgetSeconds: overBudget,
+    unschedulable,
+  };
+}
+
+/**
+ * A stand-in entry for an identity the manifest does not carry. The
+ * caller says where it runs, because only the topology knows; without
+ * that the identity cannot be placed and is reported rather than run.
+ */
+function unknownEntry(
+  key: string,
+  input: PlanInput,
+): ManifestEntry | undefined {
+  const surface = input.unknown?.get(key);
+  if (surface === undefined) return undefined;
+  let test: TestIdentity;
+  try {
+    const [k, s, n, v] = JSON.parse(key) as string[];
+    if (
+      typeof k !== "string" || typeof s !== "string" || typeof n !== "string"
+    ) {
+      return undefined;
+    }
+    test = v === undefined ? { k, s, n } : { k, s, n, v };
+  } catch {
+    return undefined;
+  }
+  return {
+    test,
+    suite: surface.suite,
+    unit: surface.unit,
+    cost: 0,
+    score: VALUE_FLOOR,
+    inputs: { catches: 0, mainCatches: 0, sources: 0, churn: 0 },
+    flakeRate: 0,
+    repeats: 1,
   };
 }
 

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -142,9 +142,13 @@ interface Filling {
   selections: Selection[];
   capabilities: Set<string>;
 
-  /** The suites and invocation units whose overheads this lane has paid. */
+  /** The suites whose overheads this lane has paid. */
   suites: Set<string>;
+
+  /** The invocation units whose overheads this lane has paid. */
   units: Set<string>;
+
+  /** Seconds of work placed here so far. */
   load: number;
 }
 

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -1,0 +1,355 @@
+/**
+ * What a pull request runs, worked out from the manifest, the diff, and
+ * nothing else.
+ *
+ * Every lane calls this over the same inputs and takes its own share of
+ * the answer, so the five agree by construction and no job sits ahead of
+ * them deciding. That only holds while this is a pure function: no clock,
+ * no unseeded randomness, no dependence on anything but its arguments.
+ * The exploration draw's seed comes from the manifest.
+ */
+
+import { testIdentityKey } from "@commonfabric/test-support/records";
+import {
+  FILL_DENSITY_SHARE,
+  FILL_EXPLORATION_SHARE,
+  FILL_VALUE_SHARE,
+  FLAKE_EXCLUSION_RATE,
+  LANE_BUDGET_SECONDS,
+  LANES,
+} from "./policy.ts";
+import type { Manifest, ManifestEntry } from "./manifest.ts";
+
+/** Why one identity is in the run. */
+export type SelectionReason =
+  | "always"
+  | "changed"
+  | "covers-changed"
+  | "unknown"
+  | "coverage-gate"
+  | "value"
+  | "density"
+  | "exploration";
+
+/** One identity the plan runs, and what put it there. */
+export interface Selection {
+  entry: ManifestEntry;
+  reason: SelectionReason;
+
+  /** How many times it runs. Every one of them must pass. */
+  repeats: number;
+}
+
+/** What a lane was asked to do. */
+export interface LaneAssignment {
+  lane: number;
+  selections: Selection[];
+
+  /** Seconds of work this lane is expected to take, setup included. */
+  projectedSeconds: number;
+
+  /** The capabilities its batches need, in a stable order. */
+  capabilities: string[];
+}
+
+/** The whole plan, and what it declined to run. */
+export interface Plan {
+  lanes: LaneAssignment[];
+
+  /** Identities the manifest withheld, so a lane can say why. */
+  withheld: Manifest["withheld"];
+
+  /** Set when the mandatory pass alone did not fit. */
+  overBudgetSeconds: number;
+}
+
+/** What the packer needs beyond the manifest. */
+export interface PlanInput {
+  manifest: Manifest;
+
+  /**
+   * Identities this change makes mandatory, against the reason. The lane
+   * runner fills this from the diff, from the topology's enumeration, and
+   * from the coverage attribution map.
+   */
+  mandatory: Map<string, SelectionReason>;
+
+  /** Which capabilities each suite needs. */
+  capabilities: ReadonlyMap<string, readonly string[]>;
+
+  /** How many lanes to fill. Defaults to the dial. */
+  lanes?: number;
+
+  /** Seconds each lane may fill. Defaults to the dial. */
+  budgetSeconds?: number;
+}
+
+/**
+ * A deterministic pseudo-random sequence from a string seed. The
+ * exploration draw needs tie-breaking that every lane agrees on and that
+ * changes between manifests, which is exactly what a seeded generator is
+ * and exactly what `Math.random` is not.
+ */
+export function seededOrder(seed: string, count: number): number[] {
+  let state = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    state ^= seed.charCodeAt(i);
+    state = Math.imul(state, 16777619);
+  }
+  const order = Array.from({ length: count }, (_, i) => i);
+  for (let i = count - 1; i > 0; i--) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const j = state % (i + 1);
+    const swap = order[i]!;
+    order[i] = order[j]!;
+    order[j] = swap;
+  }
+  return order;
+}
+
+/** A lane as it fills up. */
+interface Filling {
+  lane: number;
+  selections: Selection[];
+  capabilities: Set<string>;
+
+  /** The suites and invocation units whose overheads this lane has paid. */
+  suites: Set<string>;
+  units: Set<string>;
+  load: number;
+}
+
+function capabilityCost(manifest: Manifest, capability: string): number {
+  return manifest.calibration.setupCost[capability] ?? 0;
+}
+
+/**
+ * What adding this identity to this lane would cost: its own time times
+ * its suite's correction, plus its suite's overhead and its unit's
+ * overhead where the lane is not paying those already, plus any
+ * capability setup this lane has not opened yet.
+ */
+function marginalCost(
+  manifest: Manifest,
+  input: PlanInput,
+  lane: Filling,
+  entry: ManifestEntry,
+  repeats: number,
+): number {
+  const fitted = manifest.calibration.suites[entry.suite];
+  const correction = fitted?.correction ?? 1;
+  let cost = entry.cost * correction * repeats;
+  if (!lane.suites.has(entry.suite)) cost += fitted?.overhead ?? 0;
+  if (!lane.units.has(entry.unit)) {
+    cost += manifest.calibration.unitOverhead[entry.unit] ?? 0;
+  }
+  for (const capability of input.capabilities.get(entry.suite) ?? []) {
+    if (!lane.capabilities.has(capability)) {
+      cost += capabilityCost(manifest, capability);
+    }
+  }
+  return cost;
+}
+
+function place(
+  input: PlanInput,
+  lanes: Filling[],
+  entry: ManifestEntry,
+  reason: SelectionReason,
+  repeats: number,
+): number {
+  // Longest-processing-time scheduling: the cheapest lane to add this to
+  // wins, which is what makes tests needing the same environment group
+  // together rather than being a special case in the packer.
+  let best = lanes[0]!;
+  let bestCost = marginalCost(input.manifest, input, best, entry, repeats);
+  for (const lane of lanes.slice(1)) {
+    const cost = marginalCost(input.manifest, input, lane, entry, repeats);
+    if (cost < bestCost || (cost === bestCost && lane.load < best.load)) {
+      best = lane;
+      bestCost = cost;
+    }
+  }
+  best.selections.push({ entry, reason, repeats });
+  best.load += bestCost;
+  best.suites.add(entry.suite);
+  best.units.add(entry.unit);
+  for (const capability of input.capabilities.get(entry.suite) ?? []) {
+    best.capabilities.add(capability);
+  }
+  return bestCost;
+}
+
+/**
+ * Whether a lane could take this identity without going past the share of
+ * the total budget this pass is allowed. The passes are bounded by shares
+ * of the whole rather than per lane, so an expensive test can have a lane
+ * to itself while the others carry the tail.
+ */
+function fits(
+  input: PlanInput,
+  lanes: Filling[],
+  entry: ManifestEntry,
+  repeats: number,
+  ceiling: number,
+): boolean {
+  const cheapest = Math.min(
+    ...lanes.map((lane) =>
+      marginalCost(input.manifest, input, lane, entry, repeats)
+    ),
+  );
+  const spent = lanes.reduce((total, lane) => total + lane.load, 0);
+  return spent + cheapest <= ceiling;
+}
+
+/**
+ * Works out what runs, and where.
+ *
+ * Four passes in order. Mandatory first, which can in principle exceed
+ * the budget and says so when it does rather than silently dropping work.
+ * Then value, ignoring cost, which is what gets the expensive genuinely
+ * broken integration test into the run. Then density, which sweeps up the
+ * cheap tail the value floor puts at the top of the value-per-second
+ * ordering. Then exploration, so the unselected corpus keeps producing
+ * data.
+ */
+export function plan(input: PlanInput): Plan {
+  const manifest = input.manifest;
+  const laneCount = input.lanes ?? LANES;
+  const budget = (input.budgetSeconds ?? LANE_BUDGET_SECONDS) * laneCount;
+  const lanes: Filling[] = Array.from({ length: laneCount }, (_, i) => ({
+    lane: i + 1,
+    selections: [],
+    capabilities: new Set<string>(),
+    suites: new Set<string>(),
+    units: new Set<string>(),
+    load: 0,
+  }));
+
+  const byKey = new Map<string, ManifestEntry>();
+  for (const entry of manifest.entries) {
+    byKey.set(testIdentityKey(entry.test), entry);
+  }
+
+  // What must not run, unless the change touches what it covers, in which
+  // case it is very likely a fix and must be allowed to prove itself.
+  const excluded = new Set<string>();
+  for (const held of manifest.withheld) {
+    const key = testIdentityKey(held.test);
+    if (!input.mandatory.has(key)) excluded.add(key);
+  }
+  for (const entry of manifest.entries) {
+    const key = testIdentityKey(entry.test);
+    if (entry.flakeRate > FLAKE_EXCLUSION_RATE && !input.mandatory.has(key)) {
+      excluded.add(key);
+    }
+  }
+
+  const taken = new Set<string>();
+  const remaining = (): ManifestEntry[] =>
+    manifest.entries.filter((entry) => {
+      const key = testIdentityKey(entry.test);
+      return !taken.has(key) && !excluded.has(key);
+    });
+
+  // An identity the manifest has never heard of still has to run, and the
+  // caller says so by naming it mandatory. It has no entry, so one is
+  // made for it at the floor, costing nothing anybody measured.
+  for (const [key, reason] of input.mandatory) {
+    if (taken.has(key)) continue;
+    const entry = byKey.get(key);
+    if (entry === undefined) continue;
+    taken.add(key);
+    // Mandatory work runs once. A repeat covers nothing a measured run
+    // did not, and this pass is the one allowed to exceed the budget.
+    place(input, lanes, entry, reason, 1);
+  }
+  const mandatoryLoad = laneLoad(lanes);
+  const overBudget = Math.max(0, mandatoryLoad - budget);
+
+  // The three shares are of what the mandatory pass left, so a change
+  // that forced a great deal of work in does not then get a full budget
+  // of discretionary tests on top of it.
+  const left = Math.max(0, budget - mandatoryLoad);
+  const withRepeats = (entry: ManifestEntry): number => entry.repeats;
+
+  // Value first: descending score, ignoring cost.
+  fill(
+    input,
+    lanes,
+    taken,
+    remaining().sort((a, b) => b.score - a.score),
+    "value",
+    mandatoryLoad + left * FILL_VALUE_SHARE,
+    withRepeats,
+  );
+
+  // Density: descending value per second, which the value floor points at
+  // the cheap tail.
+  fill(
+    input,
+    lanes,
+    taken,
+    remaining().sort((a, b) =>
+      b.score / Math.max(b.cost, 1e-6) - a.score / Math.max(a.cost, 1e-6)
+    ),
+    "density",
+    mandatoryLoad + left * (FILL_VALUE_SHARE + FILL_DENSITY_SHARE),
+    withRepeats,
+  );
+
+  // Exploration: a seeded draw over what the value ordering did not pick,
+  // so the whole corpus is swept over time rather than sampled with
+  // replacement forever.
+  const pool = remaining();
+  const order = seededOrder(manifest.seed, pool.length);
+  fill(
+    input,
+    lanes,
+    taken,
+    order.map((i) => pool[i]!),
+    "exploration",
+    mandatoryLoad +
+      left * (FILL_VALUE_SHARE + FILL_DENSITY_SHARE + FILL_EXPLORATION_SHARE),
+    withRepeats,
+  );
+
+  return {
+    lanes: lanes.map((lane) => ({
+      lane: lane.lane,
+      selections: lane.selections,
+      projectedSeconds: lane.load,
+      capabilities: [...lane.capabilities].sort(),
+    })),
+    withheld: manifest.withheld,
+    overBudgetSeconds: overBudget,
+  };
+}
+
+function laneLoad(lanes: readonly Filling[]): number {
+  return lanes.reduce((total, lane) => total + lane.load, 0);
+}
+
+function fill(
+  input: PlanInput,
+  lanes: Filling[],
+  taken: Set<string>,
+  candidates: readonly ManifestEntry[],
+  reason: SelectionReason,
+  ceiling: number,
+  repeatsOf: (entry: ManifestEntry) => number,
+): void {
+  for (const entry of candidates) {
+    const key = testIdentityKey(entry.test);
+    if (taken.has(key)) continue;
+    // An identity that would be repeated but no longer fits runs once:
+    // one observation beats none.
+    let repeats = repeatsOf(entry);
+    while (repeats > 1 && !fits(input, lanes, entry, repeats, ceiling)) {
+      repeats--;
+    }
+    if (!fits(input, lanes, entry, repeats, ceiling)) continue;
+    taken.add(key);
+    place(input, lanes, entry, reason, repeats);
+  }
+}

--- a/tasks/test-selection/policy.test.ts
+++ b/tasks/test-selection/policy.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import * as policy from "./policy.ts";
+import { DIALS } from "./policy.ts";
+
+// A dial nobody documented is a number that decides what runs and cannot
+// be found, so the two halves of this module are held to each other.
+const NAMED_IN_TABLE = new Set(DIALS.map((dial) => dial.name));
+const EXPORTED_DIALS = Object.keys(policy).filter((name) =>
+  /^[A-Z][A-Z0-9_]*$/.test(name) && name !== "DIALS"
+);
+
+describe("policy", () => {
+  describe("the dial table", () => {
+    it("names every exported dial", () => {
+      const missing = EXPORTED_DIALS.filter((name) =>
+        !NAMED_IN_TABLE.has(name)
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("names nothing this module does not export", () => {
+      const exported = new Set(EXPORTED_DIALS);
+      const strays = DIALS.map((dial) => dial.name).filter((name) =>
+        !exported.has(name)
+      );
+      expect(strays).toEqual([]);
+    });
+
+    it("gives every dial a unit and a reason to move it", () => {
+      for (const dial of DIALS) {
+        expect(dial.unit.length).toBeGreaterThan(0);
+        expect(dial.why.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("lists each dial once", () => {
+      expect(NAMED_IN_TABLE.size).toBe(DIALS.length);
+    });
+  });
+
+  describe("the values that constrain each other", () => {
+    it("keeps the lane budget inside the lane's bound", () => {
+      expect(policy.LANE_BUDGET_SECONDS).toBe(
+        policy.LANE_BOUND_SECONDS - policy.LANE_PROLOGUE_SECONDS -
+          policy.LANE_SAFETY_SECONDS,
+      );
+      expect(policy.LANE_BUDGET_SECONDS).toBeGreaterThan(0);
+    });
+
+    it("splits the whole budget across the three filling passes", () => {
+      const shares = policy.FILL_VALUE_SHARE + policy.FILL_DENSITY_SHARE +
+        policy.FILL_EXPLORATION_SHARE;
+      expect(shares).toBeCloseTo(1, 10);
+    });
+
+    it("splits the whole score across the three weights", () => {
+      const weights = policy.WEIGHT_PROVEN + policy.WEIGHT_BREADTH +
+        policy.WEIGHT_CHURN;
+      expect(weights + policy.VALUE_FLOOR).toBeCloseTo(1, 10);
+    });
+
+    it("puts the repeat rates below the exclusion rate, in order", () => {
+      const rates = policy.FLAKE_REPEAT_RATES;
+      expect(rates.length).toBe(policy.MAX_REPEATS - 1);
+      for (let i = 1; i < rates.length; i++) {
+        expect(rates[i]!).toBeGreaterThan(rates[i - 1]!);
+      }
+      expect(rates[rates.length - 1]!).toBeLessThan(
+        policy.FLAKE_EXCLUSION_RATE,
+      );
+    });
+
+    it("reads churn and flakes over windows the decay has faded", () => {
+      // Past four half-lives a day's weight is under one part in sixteen,
+      // which is what makes the read window a performance choice.
+      expect(policy.CHURN_WINDOW_DAYS).toBeGreaterThanOrEqual(
+        4 * policy.CHURN_HALF_LIFE_DAYS,
+      );
+    });
+  });
+
+  describe("the coverage exclusion list", () => {
+    it("gives every excluded member a reason", () => {
+      for (const [member, reason] of policy.EXCLUDED_FROM_COVERAGE_GATE) {
+        expect(member.startsWith("packages/")).toBe(true);
+        expect(reason.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -1,0 +1,577 @@
+/**
+ * Every number test selection can be tuned by, and nothing else holds any
+ * of them. `deno task test-selection dials` prints these with their
+ * comments, and every manifest records the values it was built with, so a
+ * manifest explains its own behavior and a change in what runs can always
+ * be traced to a change here.
+ *
+ * A **chosen** dial is a decision somebody made, and editing it is how the
+ * decision changes. A **measured** dial is worked out from the data and
+ * written back by the publisher, so the value here is only the seed used
+ * before there is anything to measure. The two look identical in a source
+ * file, which is why `DIALS` says which each one is: somebody who tunes a
+ * measured value is arguing with a tape measure.
+ */
+
+/** How many jobs a pull request's tests are packed into. */
+export const LANES = 5;
+
+/** The hard bound on a lane's work step. */
+export const LANE_BOUND_SECONDS = 300;
+
+/** Checkout, Deno, cache restore, ship, and job overhead. */
+export const LANE_PROLOGUE_SECONDS = 40;
+
+/** Headroom for a slower-than-usual runner. */
+export const LANE_SAFETY_SECONDS = 30;
+
+/**
+ * What the packer may fill, derived rather than chosen so that the bound,
+ * the prologue, and the safety margin cannot drift into a budget that
+ * does not fit inside its own bound.
+ */
+export const LANE_BUDGET_SECONDS = LANE_BOUND_SECONDS -
+  LANE_PROLOGUE_SECONDS - LANE_SAFETY_SECONDS;
+
+/** What one lane of the full run on `main` may hold. */
+export const FULL_LANE_BUDGET_SECONDS = 600;
+
+/** The label that runs everything on a pull request. */
+export const FULL_RUN_LABEL = "ci: full";
+
+/** The score of a test that has never failed anywhere. */
+export const VALUE_FLOOR = 0.05;
+
+/** The share of the score a record of catching things carries. */
+export const WEIGHT_PROVEN = 0.55;
+
+/** The share of the score distinct reporting sources carry. */
+export const WEIGHT_BREADTH = 0.25;
+
+/** The share of the score recent failures carry. */
+export const WEIGHT_CHURN = 0.15;
+
+/** Weighted catches at which `proven` reaches half its ceiling. */
+export const PROVEN_SATURATION = 2;
+
+/** Days over which a catch loses half the value age can take. */
+export const FRESHNESS_HALF_LIFE_DAYS = 120;
+
+/** What a catch keeps however old it gets. */
+export const FRESHNESS_FLOOR = 0.3;
+
+/** What a catch on a workstation counts for. */
+export const CATCH_WEIGHT_LOCAL = 2.0;
+
+/** What a catch on a pull request counts for; the other two's unit. */
+export const CATCH_WEIGHT_PR = 1.0;
+
+/** What a catch on `main` counts for. */
+export const CATCH_WEIGHT_MAIN = 1.5;
+
+/** Distinct sources at which `breadth` reaches half its ceiling. */
+export const BREADTH_SATURATION = 2;
+
+/**
+ * Distinct sources a failure must appear across, inside
+ * `CATCH_BREADTH_WINDOW_DAYS`, before it reads as the environment rather
+ * than as any one change.
+ */
+export const ENVIRONMENTAL_MIN_SOURCES = 5;
+
+/** Days over which a day's failure count halves. */
+export const CHURN_HALF_LIFE_DAYS = 14;
+
+/** Days of decayed failure counts the churn term reads. */
+export const CHURN_WINDOW_DAYS = 60;
+
+/** Days of history the flake rate is measured over. */
+export const FLAKE_WINDOW_DAYS = 60;
+
+/** Days of durations an item's cost estimate reads. */
+export const COST_WINDOW_DAYS = 7;
+
+/** The share of a lane's budget spent in descending value. */
+export const FILL_VALUE_SHARE = 0.60;
+
+/** The share spent in descending value per second. */
+export const FILL_DENSITY_SHARE = 0.25;
+
+/** The share spent on items the value ordering did not pick. */
+export const FILL_EXPLORATION_SHARE = 0.15;
+
+/** The flake rate above which an item leaves the selectable set. */
+export const FLAKE_EXCLUSION_RATE = 0.05;
+
+/**
+ * The flake rates at which an item is run twice and three times. Below
+ * the first it runs once. Every band has to stay under
+ * `FLAKE_EXCLUSION_RATE`, or an item reaches the exclusion before it
+ * reaches the band and the band never fires.
+ */
+export const FLAKE_REPEAT_RATES: readonly number[] = [0.01, 0.03];
+
+/** The most times one item is run inside a lane. */
+export const MAX_REPEATS = 3;
+
+/** The suite flake rate above which a suite's new items are repeated. */
+export const SUITE_FLAKE_PRIOR_RATE = 0.02;
+
+/** Uncovered lines a change must add before the comment mentions it. */
+export const COVERAGE_COMMENT_LINES = 25;
+
+/** Seconds past which a covered package's measured set is reported. */
+export const LOCAL_COVERAGE_MAX_SECONDS = 30;
+
+/** Covered packages a change may touch and still be gated. */
+export const LOCAL_COVERAGE_MAX_PACKAGES = 2;
+
+/** Days of per-package coverage baselines a manifest carries. */
+export const LOCAL_COVERAGE_BASELINE_DAYS = 7;
+
+/** Weeks of rising debt before the coverage tile goes amber. */
+export const COVERAGE_TREND_WEEKS = 3;
+
+/** Days within which failures across branches read as the environment. */
+export const CATCH_BREADTH_WINDOW_DAYS = 2;
+
+/** Days before the coverage attribution map is rebuilt. */
+export const ATTRIBUTION_MAP_DAYS = 7;
+
+/**
+ * Catches a rename may discard before the alias gate fails a pull
+ * request. Undefined switches the gate off, which is where it starts:
+ * most renames cost nothing, so a gate that fired on every rename would
+ * be noise nobody reads.
+ */
+export const ALIAS_GATE_MIN_CATCHES: number | undefined = undefined;
+
+/**
+ * Workspace members the per-package coverage gate does not cover, each
+ * with the reason it is here. A list rather than a rule that measures
+ * each package and decides, because such a rule can take a package's gate
+ * away for a change nobody meant as a change to coverage, and a gate that
+ * silently stops gating is worse than no gate.
+ */
+export const EXCLUDED_FROM_COVERAGE_GATE: ReadonlyMap<string, string> = new Map(
+  [
+    [
+      "packages/generated-patterns",
+      "Its test task defines no tests. Its test files run in the " +
+      "generated-patterns integration job.",
+    ],
+    ["packages/home-schemas", "It has no tests."],
+    ["packages/patterns/auth", "Its test task defines no tests."],
+    [
+      "packages/patterns",
+      "Authored pattern code is measured by transformer instrumentation " +
+      "in the pattern unit and integration jobs. The package's own " +
+      "`deno test` ignores the pattern files deliberately.",
+    ],
+    [
+      "packages/runner",
+      "Its whole set is past what all five lanes hold together.",
+    ],
+    [
+      "packages/cli",
+      "The command line's real coverage comes from the integration " +
+      "script rather than from these tests, so gating on them would " +
+      "ratchet the wrong number.",
+    ],
+    [
+      "packages/identity",
+      "Every one of its tests runs in a browser through deno-web-test. " +
+      "It has no Deno-only half to measure.",
+    ],
+    [
+      "packages/deno-web-test",
+      "Its tests drive the browser harness end to end.",
+    ],
+    [
+      "packages/toolshed",
+      "Its tests want the service's own environment and its initialized " +
+      "database.",
+    ],
+  ],
+);
+
+/** Whether a dial is a decision or a measurement. */
+export type DialSource = "chosen" | "measured" | "derived";
+
+/** One dial, as `deno task test-selection dials` prints it. */
+export interface Dial {
+  name: string;
+  value: number | string | undefined | readonly number[];
+  unit: string;
+  setBy: DialSource;
+
+  /** Why you would move it, and which way. */
+  why: string;
+}
+
+/**
+ * Every dial, with the unit its value counts and the reason to move it.
+ * The units matter because several dials are bare fractions that do not
+ * mean the same thing: `WEIGHT_BREADTH` is a share of a test's score and
+ * `FILL_DENSITY_SHARE` is a share of a lane's budget, and naming the unit
+ * is what keeps them from being compared to each other.
+ */
+export const DIALS: readonly Dial[] = [
+  {
+    name: "LANES",
+    value: LANES,
+    unit: "lanes",
+    setBy: "chosen",
+    why:
+      "Up when pull-request feedback is too thin and runner capacity allows " +
+      "more; down when the wave crowds other workflows off the shared runners.",
+  },
+  {
+    name: "LANE_BOUND_SECONDS",
+    value: LANE_BOUND_SECONDS,
+    unit: "seconds",
+    setBy: "chosen",
+    why:
+      "Up when more should fit in a lane; down when five minutes is longer " +
+      "than anybody will wait for a first answer. Either way " +
+      "LANE_WORK_TIMEOUT_MINUTES and LANE_JOB_TIMEOUT_MINUTES in deno.yml " +
+      "move with it.",
+  },
+  {
+    name: "LANE_PROLOGUE_SECONDS",
+    value: LANE_PROLOGUE_SECONDS,
+    unit: "seconds",
+    setBy: "measured",
+    why: "Never. The publisher overwrites it from the lanes' own timing " +
+      "records, and the checked-in figure is only what the first lane uses " +
+      "before any lane has reported one.",
+  },
+  {
+    name: "LANE_SAFETY_SECONDS",
+    value: LANE_SAFETY_SECONDS,
+    unit: "seconds",
+    setBy: "chosen",
+    why: "Up when lanes overrun their bound on slow runners; down when they " +
+      "finish early every time and the headroom is buying nothing.",
+  },
+  {
+    name: "LANE_BUDGET_SECONDS",
+    value: LANE_BUDGET_SECONDS,
+    unit: "seconds",
+    setBy: "derived",
+    why:
+      "Nothing edits this. It is the bound less the prologue and the safety " +
+      "margin, so a budget that does not fit inside its own bound cannot be " +
+      "written down.",
+  },
+  {
+    name: "FULL_LANE_BUDGET_SECONDS",
+    value: FULL_LANE_BUDGET_SECONDS,
+    unit: "seconds",
+    setBy: "chosen",
+    why: "Up when the run on `main` uses more jobs than it needs; down when " +
+      "`main` takes too long to say something broke.",
+  },
+  {
+    name: "FULL_RUN_LABEL",
+    value: FULL_RUN_LABEL,
+    unit: "a label",
+    setBy: "chosen",
+    why: "Not a quantity. Change it only if the label collides with one the " +
+      "repository already uses for something else.",
+  },
+  {
+    name: "VALUE_FLOOR",
+    value: VALUE_FLOOR,
+    unit: "score",
+    setBy: "chosen",
+    why:
+      "Up when the cheap tail is not being swept up; down when it crowds out " +
+      "tests with a record of catching things.",
+  },
+  {
+    name: "WEIGHT_PROVEN",
+    value: WEIGHT_PROVEN,
+    unit: "share of the score",
+    setBy: "chosen",
+    why:
+      "Up when a record of catching things should count for more. The three " +
+      "weights are shares of one score, so what this gains the other two lose.",
+  },
+  {
+    name: "WEIGHT_BREADTH",
+    value: WEIGHT_BREADTH,
+    unit: "share of the score",
+    setBy: "chosen",
+    why: "Up when a test that several distinct sources have hit should count " +
+      "for more; down when breadth is mostly telling you about the " +
+      "environment rather than the test.",
+  },
+  {
+    name: "WEIGHT_CHURN",
+    value: WEIGHT_CHURN,
+    unit: "share of the score",
+    setBy: "chosen",
+    why:
+      "Up when something going wrong right now should jump the queue faster; " +
+      "down when the queue keeps being jumped by noise.",
+  },
+  {
+    name: "PROVEN_SATURATION",
+    value: PROVEN_SATURATION,
+    unit: "catches",
+    setBy: "chosen",
+    why:
+      "Up when four catches should outrank one by more; down when one catch " +
+      "should already be worth nearly everything a test can earn.",
+  },
+  {
+    name: "FRESHNESS_HALF_LIFE_DAYS",
+    value: FRESHNESS_HALF_LIFE_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when old catches should keep more of their value; down when a test " +
+      "that caught something a year ago crowds out one that caught something " +
+      "last week.",
+  },
+  {
+    name: "FRESHNESS_FLOOR",
+    value: FRESHNESS_FLOOR,
+    unit: "multiplier",
+    setBy: "chosen",
+    why:
+      "Up when a very old catch should keep more of its worth; down when age " +
+      "should be allowed to retire one almost completely.",
+  },
+  {
+    name: "CATCH_WEIGHT_LOCAL",
+    value: CATCH_WEIGHT_LOCAL,
+    unit: "multiplier",
+    setBy: "chosen",
+    why: "Up when evidence from a workstation should count for more; down if " +
+      "local records ever arrive in volume and stop being the scarce signal " +
+      "they are today.",
+  },
+  {
+    name: "CATCH_WEIGHT_PR",
+    value: CATCH_WEIGHT_PR,
+    unit: "multiplier",
+    setBy: "chosen",
+    why:
+      "Neither. It is the unit the other two are expressed against, so move " +
+      "those instead.",
+  },
+  {
+    name: "CATCH_WEIGHT_MAIN",
+    value: CATCH_WEIGHT_MAIN,
+    unit: "multiplier",
+    setBy: "chosen",
+    why:
+      "Up when an escape should pull harder on what gets selected next; down " +
+      "when the failures on `main` are mostly environmental rather than real.",
+  },
+  {
+    name: "BREADTH_SATURATION",
+    value: BREADTH_SATURATION,
+    unit: "sources",
+    setBy: "chosen",
+    why:
+      "Up when four sources should outrank one by more; down when one source " +
+      "should already be worth nearly all the breadth term can give.",
+  },
+  {
+    name: "ENVIRONMENTAL_MIN_SOURCES",
+    value: ENVIRONMENTAL_MIN_SOURCES,
+    unit: "sources",
+    setBy: "chosen",
+    why: "Up when a genuinely broad regression is being written off as the " +
+      "environment; down when a broken runner's failures are still being " +
+      "counted as catches.",
+  },
+  {
+    name: "CHURN_HALF_LIFE_DAYS",
+    value: CHURN_HALF_LIFE_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when recent trouble should stay relevant for longer; down when a " +
+      "problem already fixed keeps its tests selected for weeks afterwards.",
+  },
+  {
+    name: "CHURN_WINDOW_DAYS",
+    value: CHURN_WINDOW_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why: "How far back the decayed counts are read. Past this the weight is " +
+      "under one part in sixteen, so moving it is a performance decision " +
+      "rather than a policy one.",
+  },
+  {
+    name: "FLAKE_WINDOW_DAYS",
+    value: FLAKE_WINDOW_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when a flake rate swings about on too little evidence; down when a " +
+      "test that has since been fixed stays excluded.",
+  },
+  {
+    name: "COST_WINDOW_DAYS",
+    value: COST_WINDOW_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when cost estimates are noisy; down when durations drift with the " +
+      "code or the runner image faster than the estimate follows.",
+  },
+  {
+    name: "FILL_VALUE_SHARE",
+    value: FILL_VALUE_SHARE,
+    unit: "share of the budget",
+    setBy: "chosen",
+    why: "Up when expensive high-value tests are crowded out by cheap ones; " +
+      "down when a lane spends its budget on a few slow tests and runs " +
+      "little else. The three shares sum to one.",
+  },
+  {
+    name: "FILL_DENSITY_SHARE",
+    value: FILL_DENSITY_SHARE,
+    unit: "share of the budget",
+    setBy: "chosen",
+    why: "Up when more of the cheap tail should run; down when the tail is " +
+      "displacing tests with a record.",
+  },
+  {
+    name: "FILL_EXPLORATION_SHARE",
+    value: FILL_EXPLORATION_SHARE,
+    unit: "share of the budget",
+    setBy: "chosen",
+    why:
+      "Up when the unselected corpus is going stale; down when lanes spend " +
+      "the share on tests that never find anything.",
+  },
+  {
+    name: "FLAKE_EXCLUSION_RATE",
+    value: FLAKE_EXCLUSION_RATE,
+    unit: "share of runs",
+    setBy: "chosen",
+    why:
+      "Up when fewer tests should be held back from pull requests; down when " +
+      "flakes are still blocking people.",
+  },
+  {
+    name: "FLAKE_REPEAT_RATES",
+    value: FLAKE_REPEAT_RATES,
+    unit: "share of runs",
+    setBy: "chosen",
+    why: "Up when repeats cost more lane time than the intermittent failures " +
+      "they catch are worth; down when intermittent failures are still " +
+      "slipping through. Every band stays under FLAKE_EXCLUSION_RATE, so " +
+      "raising one past that rate means raising the rate too.",
+  },
+  {
+    name: "MAX_REPEATS",
+    value: MAX_REPEATS,
+    unit: "runs of one item",
+    setBy: "chosen",
+    why:
+      "Up when intermittent regressions still get through; down when repeats " +
+      "are crowding a lane.",
+  },
+  {
+    name: "SUITE_FLAKE_PRIOR_RATE",
+    value: SUITE_FLAKE_PRIOR_RATE,
+    unit: "share of runs",
+    setBy: "chosen",
+    why:
+      "Up when too many suites count as flake-prone and their new items are " +
+      "repeated needlessly; down when new tests in a noisy suite land " +
+      "unrepeated and then flake.",
+  },
+  {
+    name: "COVERAGE_COMMENT_LINES",
+    value: COVERAGE_COMMENT_LINES,
+    unit: "lines",
+    setBy: "chosen",
+    why:
+      "Up when coverage comments are too noisy; down when debt is climbing " +
+      "unnoticed.",
+  },
+  {
+    name: "LOCAL_COVERAGE_MAX_SECONDS",
+    value: LOCAL_COVERAGE_MAX_SECONDS,
+    unit: "seconds",
+    setBy: "chosen",
+    why:
+      "Up when too many packages are reported as expensive for the report to " +
+      "be worth reading; down when one is quietly eating a lane. Nothing is " +
+      "excluded either way; it only decides what the summary mentions.",
+  },
+  {
+    name: "LOCAL_COVERAGE_MAX_PACKAGES",
+    value: LOCAL_COVERAGE_MAX_PACKAGES,
+    unit: "packages",
+    setBy: "chosen",
+    why:
+      "Up when broader changes should still be gated and the run can afford " +
+      "their packages' whole test sets; down when sweeping changes are " +
+      "crowding lanes.",
+  },
+  {
+    name: "EXCLUDED_FROM_COVERAGE_GATE",
+    value: EXCLUDED_FROM_COVERAGE_GATE.size,
+    unit: "workspace members",
+    setBy: "chosen",
+    why:
+      "Not a quantity. A line comes off when a package fits the run's budget " +
+      "or gains a Deno-only half, which turns its gate on. A line goes on " +
+      "when a package's own tests stop being what covers it.",
+  },
+  {
+    name: "LOCAL_COVERAGE_BASELINE_DAYS",
+    value: LOCAL_COVERAGE_BASELINE_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when branches based further back are being reported for want of an " +
+      "ancestor baseline; down when the manifest carries more history than " +
+      "anybody reads.",
+  },
+  {
+    name: "COVERAGE_TREND_WEEKS",
+    value: COVERAGE_TREND_WEEKS,
+    unit: "weeks",
+    setBy: "chosen",
+    why:
+      "Up when the tile goes amber too readily; down when debt climbs for a " +
+      "month before anybody is told.",
+  },
+  {
+    name: "CATCH_BREADTH_WINDOW_DAYS",
+    value: CATCH_BREADTH_WINDOW_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when a broken runner's failures are being counted as catches; down " +
+      "when genuine breadth is being written off as environmental.",
+  },
+  {
+    name: "ATTRIBUTION_MAP_DAYS",
+    value: ATTRIBUTION_MAP_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why:
+      "Up when rebuilding the map costs more than its staleness does; down " +
+      "when changed lines keep resolving to tests that have moved.",
+  },
+  {
+    name: "ALIAS_GATE_MIN_CATCHES",
+    value: ALIAS_GATE_MIN_CATCHES,
+    unit: "catches",
+    setBy: "chosen",
+    why: "Off by default. Turn it on at a catch count to fail a pull request " +
+      "that discards that much history in a rename without an alias line, " +
+      "and lower the count as the alias file becomes routine.",
+  },
+];

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -16,7 +16,10 @@
 /** How many jobs a pull request's tests are packed into. */
 export const LANES = 5;
 
-/** The hard bound on a lane's work step. */
+/**
+ * The hard bound on a lane's work step. A lane job's own timeouts have to
+ * be set against this, and no lane job exists yet to carry them.
+ */
 export const LANE_BOUND_SECONDS = 300;
 
 /** Checkout, Deno, cache restore, ship, and job overhead. */
@@ -233,9 +236,10 @@ export const DIALS: readonly Dial[] = [
     setBy: "chosen",
     why:
       "Up when more should fit in a lane; down when five minutes is longer " +
-      "than anybody will wait for a first answer. Either way " +
-      "LANE_WORK_TIMEOUT_MINUTES and LANE_JOB_TIMEOUT_MINUTES in deno.yml " +
-      "move with it.",
+      "than anybody will wait for a first answer. The lane jobs that this " +
+      "bounds do not exist yet; when they do, their work-step and job " +
+      "timeouts in deno.yml have to move with it, and nothing checks that " +
+      "until they are written.",
   },
   {
     name: "LANE_PROLOGUE_SECONDS",

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -16,9 +16,10 @@ import {
   value,
 } from "./score.ts";
 import { VALUE_FLOOR } from "./policy.ts";
+import { testIdentityKey } from "@commonfabric/test-support/records";
 
 const TEST = { k: "unit", s: "memory", n: "space > writes a fact" };
-const KEY = JSON.stringify([TEST.k, TEST.s, TEST.n]);
+const KEY = testIdentityKey(TEST);
 
 /** One observation, with the parts a case does not care about filled in. */
 function saw(
@@ -30,6 +31,7 @@ function saw(
     outcome,
     durationMs: 100,
     day: "2026-08-20",
+    startedAt: "2026-08-20T00:00:00.000Z",
     commit: "c1",
     source: "main",
     place: "main",

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -3,7 +3,9 @@ import { expect } from "@std/expect";
 
 import {
   churn,
+  COST_SAMPLE_CAP,
   costSeconds,
+  type DaySamples,
   daysBetween,
   emptyContext,
   emptyState,
@@ -12,6 +14,8 @@ import {
   type Observation,
   parseContext,
   percentile90,
+  sampledPercentile90,
+  sampleDuration,
   scoreInputs,
   sealDay,
   serializeContext,
@@ -109,6 +113,90 @@ describe("score", () => {
       expect(back.mainAtCommit.size).toBe(3);
     });
 
+    it(
+      "starts from nothing rather than believing a shape it cannot read",
+      () => {
+        // A context is an optimization over re-reading, so an unreadable
+        // one costs the two cross-run rules their reach and nothing else.
+        for (const value of [undefined, null, 7, "a context", []]) {
+          const back = parseContext(value);
+          expect(back.outcomesAtCommit.size).toBe(0);
+          expect(back.mainAtCommit.size).toBe(0);
+          expect(back.credited.size).toBe(0);
+          expect(back.failures.size).toBe(0);
+        }
+      },
+    );
+
+    it("keeps only the pairs that are pairs", () => {
+      const back = parseContext({
+        outcomesAtCommit: "not a list",
+        mainAtCommit: [7, ["k a"], [9, { day: "2026-08-20", outcome: "fail" }]],
+        credited: [["k a b", "2026-08-20"], [7, "2026-08-20"]],
+        failures: 7,
+      });
+      expect(back.mainAtCommit.size).toBe(0);
+      expect([...back.credited.keys()]).toEqual(["k a b"]);
+    });
+
+    it("drops an entry whose held value is not a record", () => {
+      const back = parseContext({
+        outcomesAtCommit: [["k a", "yesterday"], ["k b", null]],
+        mainAtCommit: [["k a", 7], ["k b", null]],
+        credited: [],
+        failures: [["k a", "not a list"], ["k b", 7]],
+      });
+      expect(back.outcomesAtCommit.size).toBe(0);
+      expect(back.mainAtCommit.size).toBe(0);
+      expect(back.failures.size).toBe(0);
+    });
+
+    it("drops an outcome record with no readable day or outcomes", () => {
+      const back = parseContext({
+        outcomesAtCommit: [
+          ["k a", { day: 7, outcomes: ["pass"] }],
+          ["k b", { day: "2026-08-20", outcomes: "pass" }],
+          ["k c", { day: "2026-08-20", outcomes: ["wat"] }],
+          ["k d", { day: "2026-08-20", outcomes: ["pass", "fail"] }],
+        ],
+        mainAtCommit: [
+          ["k a", { day: "2026-08-20", outcome: "skip" }],
+          ["k b", { day: "2026-08-20", outcome: "pass" }],
+        ],
+        credited: [],
+        failures: [],
+      });
+      expect([...back.outcomesAtCommit.keys()]).toEqual(["k d"]);
+      // A skip is not an outcome the cross-run rules act on, so a stored
+      // one is not a main verdict to be resumed from.
+      expect([...back.mainAtCommit.keys()]).toEqual(["k b"]);
+    });
+
+    it("keeps a failure list, dropping the failures it cannot read", () => {
+      const back = parseContext({
+        outcomesAtCommit: [],
+        mainAtCommit: [],
+        credited: [],
+        failures: [["k a", [
+          { day: "2026-08-20", source: "branch" },
+          { day: "nope", source: "branch" },
+          { day: "2026-08-20", source: 7 },
+          null,
+        ]]],
+      });
+      expect(back.failures.get("k a")?.length).toBe(1);
+    });
+
+    it("drops a whole entry when nothing in it survives", () => {
+      const back = parseContext({
+        outcomesAtCommit: [],
+        mainAtCommit: [],
+        credited: [],
+        failures: [["k a", [{ day: "nope", source: "branch" }]]],
+      });
+      expect(back.failures.size).toBe(0);
+    });
+
     it("ages out what the rules can no longer reach", () => {
       const context = emptyContext();
       context.mainAtCommit.set("k old", { day: "2026-01-01", outcome: "fail" });
@@ -117,6 +205,23 @@ describe("score", () => {
       trimContext(context, "2026-08-20");
       expect([...context.mainAtCommit.keys()]).toEqual(["k new"]);
       expect(context.credited.size).toBe(0);
+    });
+
+    it("drops a failure list once every failure in it is stale", () => {
+      const context = emptyContext();
+      context.failures.set("k gone", [{ day: "2020-01-01", source: "a" }]);
+      context.failures.set("k here", [
+        { day: "2020-01-01", source: "a" },
+        { day: "2026-08-20", source: "b" },
+      ]);
+      context.outcomesAtCommit.set("k old", {
+        day: "2020-01-01",
+        outcomes: new Set(["fail"]),
+      });
+      trimContext(context, "2026-08-20");
+      expect([...context.failures.keys()]).toEqual(["k here"]);
+      expect(context.failures.get("k here")?.length).toBe(1);
+      expect(context.outcomesAtCommit.size).toBe(0);
     });
   });
 
@@ -418,3 +523,199 @@ function dayBefore(day: string, ago: number): string {
   const stamp = Date.parse(`${day}T00:00:00Z`) - ago * 86_400_000;
   return new Date(stamp).toISOString().slice(0, 10);
 }
+
+describe("a day's bounded sample of its slowest runs", () => {
+  const empty = (): DaySamples => ({ count: 0, slowest: [] });
+
+  it("keeps what it is given while there is room, in order", () => {
+    const samples = empty();
+    for (const ms of [30, 10, 20]) sampleDuration(samples, ms);
+    expect(samples.slowest).toEqual([10, 20, 30]);
+    expect(samples.count).toBe(3);
+  });
+
+  it("counts every run, keeping only the slowest of them", () => {
+    const samples = empty();
+    for (let i = 1; i <= COST_SAMPLE_CAP + 50; i++) sampleDuration(samples, i);
+    expect(samples.count).toBe(COST_SAMPLE_CAP + 50);
+    expect(samples.slowest.length).toBe(COST_SAMPLE_CAP);
+    expect(samples.slowest[0]).toBe(51);
+    expect(samples.slowest.at(-1)).toBe(COST_SAMPLE_CAP + 50);
+  });
+
+  it("drops a run slower than nothing it kept, once it is full", () => {
+    const samples = empty();
+    for (let i = 100; i < 100 + COST_SAMPLE_CAP; i++) {
+      sampleDuration(samples, i);
+    }
+    const kept = [...samples.slowest];
+    sampleDuration(samples, 1);
+    expect(samples.slowest).toEqual(kept);
+    // Counted all the same: the count is what the percentile's rank is
+    // taken from, so dropping it would move the percentile up.
+    expect(samples.count).toBe(COST_SAMPLE_CAP + 1);
+  });
+
+  it("takes a run that displaces the fastest it kept", () => {
+    const samples = empty();
+    for (let i = 100; i < 100 + COST_SAMPLE_CAP; i++) {
+      sampleDuration(samples, i);
+    }
+    sampleDuration(samples, 150);
+    expect(samples.slowest.length).toBe(COST_SAMPLE_CAP);
+    expect(samples.slowest[0]).toBe(101);
+    expect(samples.slowest).toContain(150);
+  });
+
+  it("has no percentile for a day nothing ran on", () => {
+    expect(sampledPercentile90(empty())).toBe(0);
+  });
+
+  it("agrees with the exact percentile while everything is kept", () => {
+    const durations = Array.from({ length: 20 }, (_, i) => (i + 1) * 10);
+    const samples = empty();
+    for (const ms of durations) sampleDuration(samples, ms);
+    expect(sampledPercentile90(samples)).toBe(percentile90(durations));
+  });
+
+  it("over-estimates rather than under-estimates past what it kept", () => {
+    // The rank falls outside the sample, so the answer is the smallest
+    // kept run. A budget survives an over-estimate; it does not survive
+    // the other one.
+    const samples = empty();
+    for (let i = 1; i <= 1000; i++) sampleDuration(samples, i);
+    expect(sampledPercentile90(samples)).toBeGreaterThanOrEqual(900);
+  });
+});
+
+describe("sealDay()", () => {
+  it("writes nothing for a day with no runs in it", () => {
+    const state = emptyState();
+    sealDay(state, "2026-08-20", []);
+    expect(state.costByDay["2026-08-20"]).toBeUndefined();
+    sealDay(state, "2026-08-20", { count: 0, slowest: [] });
+    expect(state.costByDay["2026-08-20"]).toBeUndefined();
+  });
+});
+
+describe("flakeRate()", () => {
+  it("counts only failures inside the window", () => {
+    const state = emptyState();
+    state.failuresByDay["2026-08-20"] = 2;
+    state.flakesByDay["2026-08-20"] = 1;
+    // Far enough back that the window cannot reach it, so neither its
+    // failures nor its flakes are in the share.
+    state.failuresByDay["2020-01-01"] = 50;
+    expect(flakeRate(state, "2026-08-20")).toBe(0.5);
+  });
+
+  it("is zero for a test that has never failed", () => {
+    expect(flakeRate(emptyState(), "2026-08-20")).toBe(0);
+  });
+});
+
+describe("a main failure resolved in a later batch", () => {
+  it("is a flake when the same commit later passes", () => {
+    // The two runs of one commit can arrive in separate batches, so the
+    // same-commit check inside a batch does not see this pair. Dropping
+    // the pending failure would lose the flake as well as the catch.
+    const context = emptyContext();
+    const first = foldObservations([saw("fail", { commit: "c1" })], {
+      context,
+    });
+    const second = foldObservations([saw("pass", { commit: "c1" })], {
+      context,
+      prior: first.states,
+    });
+    const state = second.states.get(KEY)!;
+    expect(state.flakesByDay["2026-08-20"]).toBe(1);
+    // A flake at one commit is not a catch: nothing was fixed between the
+    // failure and the pass, because there is nothing between them.
+    expect(state.mainCatches).toBe(0);
+  });
+
+  it("is a catch when a later commit passes", () => {
+    const context = emptyContext();
+    const first = foldObservations([saw("fail", { commit: "c1" })], {
+      context,
+    });
+    const second = foldObservations([saw("pass", { commit: "c2" })], {
+      context,
+      prior: first.states,
+    });
+    const state = second.states.get(KEY)!;
+    expect(state.flakesByDay["2026-08-20"]).toBeUndefined();
+    expect(state.mainCatches).toBe(1);
+  });
+});
+
+describe("a failure seen from many places at once", () => {
+  it("is environmental, and credits nobody, when the sources are near", () => {
+    // Five sources failing within the breadth window is the environment
+    // breaking, not the test catching five separate changes.
+    const sources = ["main", "a", "b", "c", "d"];
+    const folded = foldObservations(
+      sources.map((source) =>
+        saw("fail", { source, place: "pr", commit: `c-${source}` })
+      ),
+    );
+    const state = folded.states.get(KEY)!;
+    expect(state.prCatches).toBe(0);
+  });
+
+  it("credits each of them when the crowd is one short", () => {
+    const sources = ["a", "b", "c", "d"];
+    const folded = foldObservations(
+      sources.map((source) =>
+        saw("fail", { source, place: "pr", commit: `c-${source}` })
+      ),
+    );
+    expect(folded.states.get(KEY)!.prCatches).toBe(sources.length);
+  });
+
+  it("counts a failure outside the window as a separate one", () => {
+    // The same five sources, but one of them failed long enough ago that
+    // the breadth window cannot reach it, so it is not part of the crowd.
+    const near = ["a", "b", "c"].map((source) =>
+      saw("fail", {
+        source,
+        place: "pr",
+        commit: `c-${source}`,
+        day: "2026-08-20",
+      })
+    );
+    const far = saw("fail", {
+      source: "d",
+      place: "pr",
+      commit: "c-d",
+      day: "2026-08-01",
+      startedAt: "2026-08-01T00:00:00.000Z",
+    });
+    const folded = foldObservations([far, ...near]);
+    const state = folded.states.get(KEY)!;
+    expect(state.failuresByDay["2026-08-01"]).toBe(1);
+    expect(state.failuresByDay["2026-08-20"]).toBe(3);
+    // Four sources in all, but never four at once, so each is a catch.
+    expect(state.prCatches).toBe(4);
+  });
+});
+
+describe("a skipped run", () => {
+  it("counts as nothing at all", () => {
+    const folded = foldObservations([
+      saw("skip"),
+      saw("skip", { commit: "c2" }),
+    ]);
+    const state = folded.states.get(KEY);
+    expect(state?.runsByDay["2026-08-20"]).toBeUndefined();
+    expect(state?.failuresByDay["2026-08-20"]).toBeUndefined();
+  });
+
+  it("does not show that a test failing on main was fixed", () => {
+    const folded = foldObservations([
+      saw("fail", { commit: "c1" }),
+      saw("skip", { commit: "c2" }),
+    ]);
+    expect(folded.mainRed.has(KEY)).toBe(true);
+  });
+});

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -77,6 +77,38 @@ describe("score", () => {
       expect(back.failures.size).toBe(1);
     });
 
+    it("rejects a day the calendar does not have", () => {
+      // "2026-02-31" parses, rolling forward into March. Believed, it
+      // would be aged from three days later than it claims, so a stored
+      // entry outlives the window it was meant to be dropped from.
+      const back = parseContext({
+        outcomesAtCommit: [],
+        mainAtCommit: [
+          ["k a", { day: "2026-02-31", outcome: "fail" }],
+          ["k b", { day: "2026-02-30", outcome: "fail" }],
+          ["k c", { day: "2025-02-29", outcome: "fail" }],
+          ["k d", { day: "2026-02-28", outcome: "fail" }],
+        ],
+        credited: [],
+        failures: [],
+      });
+      expect([...back.mainAtCommit.keys()]).toEqual(["k d"]);
+    });
+
+    it("keeps the last day of a month, and a real leap day", () => {
+      const back = parseContext({
+        outcomesAtCommit: [],
+        mainAtCommit: [
+          ["k a", { day: "2026-01-31", outcome: "fail" }],
+          ["k b", { day: "2024-02-29", outcome: "fail" }],
+          ["k c", { day: "2026-12-31", outcome: "fail" }],
+        ],
+        credited: [],
+        failures: [],
+      });
+      expect(back.mainAtCommit.size).toBe(3);
+    });
+
     it("ages out what the rules can no longer reach", () => {
       const context = emptyContext();
       context.mainAtCommit.set("k old", { day: "2026-01-01", outcome: "fail" });

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -5,13 +5,17 @@ import {
   churn,
   costSeconds,
   daysBetween,
+  emptyContext,
   emptyState,
   flakeRate,
   foldObservations,
   type Observation,
+  parseContext,
   percentile90,
   scoreInputs,
   sealDay,
+  serializeContext,
+  trimContext,
   trimWindows,
   value,
 } from "./score.ts";
@@ -46,6 +50,44 @@ function stateFrom(observations: readonly Observation[]) {
 }
 
 describe("score", () => {
+  describe("a stored fold context", () => {
+    it("round-trips what a run learned", () => {
+      const context = emptyContext();
+      context.mainAtCommit.set("k c1", { day: "2026-08-20", outcome: "fail" });
+      context.credited.set("k c1 branch", "2026-08-20");
+      const back = parseContext(serializeContext(context));
+      expect(back.mainAtCommit.get("k c1")?.outcome).toBe("fail");
+      expect(back.credited.get("k c1 branch")).toBe("2026-08-20");
+    });
+
+    it("drops what it cannot read rather than believing it", () => {
+      // An unknown outcome would read as one more thing the identity did
+      // at that commit, and two of them is the test disagreeing with
+      // itself, which suppresses a real catch. A credited entry with no
+      // readable day can never be aged out, so it suppresses one forever.
+      const back = parseContext({
+        outcomesAtCommit: [["k c1", { day: "2026-08-20", outcomes: ["wat"] }]],
+        mainAtCommit: [["k c1", { day: "nope", outcome: "fail" }]],
+        credited: [["k c1 branch", "not a day"]],
+        failures: [["k", [{ day: "2026-08-20", source: "branch" }]]],
+      });
+      expect(back.outcomesAtCommit.size).toBe(0);
+      expect(back.mainAtCommit.size).toBe(0);
+      expect(back.credited.size).toBe(0);
+      expect(back.failures.size).toBe(1);
+    });
+
+    it("ages out what the rules can no longer reach", () => {
+      const context = emptyContext();
+      context.mainAtCommit.set("k old", { day: "2026-01-01", outcome: "fail" });
+      context.mainAtCommit.set("k new", { day: "2026-08-20", outcome: "fail" });
+      context.credited.set("k old branch", "2026-01-01");
+      trimContext(context, "2026-08-20");
+      expect([...context.mainAtCommit.keys()]).toEqual(["k new"]);
+      expect(context.credited.size).toBe(0);
+    });
+  });
+
   describe("what counts as a catch", () => {
     it("counts a failure on a branch where main was green", () => {
       const state = stateFrom([

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -162,6 +162,21 @@ describe("score", () => {
       expect(state.pendingMain).toEqual([]);
     });
 
+    it("reads a green rerun of the same commit as a flake", () => {
+      // The two runs can arrive in separate batches, so the same-commit
+      // check inside one batch does not see this pair.
+      const state = stateFrom([
+        saw("fail", { commit: "c1" }),
+        saw("pass", {
+          commit: "c1",
+          day: "2026-08-21",
+          startedAt: "2026-08-21T00:00:00.000Z",
+        }),
+      ]);
+      expect(state.mainCatches).toBe(0);
+      expect(flakeRate(state, "2026-08-21")).toBe(1);
+    });
+
     it("reads a failure nothing fixed as a flake", () => {
       const folded = foldObservations([
         saw("fail", { day: "2026-08-19", commit: "c0" }),
@@ -313,6 +328,19 @@ describe("score", () => {
   });
 
   describe("cost", () => {
+    it("combines a day read across two runs without double counting", () => {
+      // A day arrives over as many runs as it takes, so sealing combines
+      // rather than replaces — and nothing else writes a day's cost, or
+      // the combination would fold a running value into itself.
+      const state = emptyState();
+      sealDay(state, "2026-08-20", [100, 100, 900]);
+      const first = state.costByDay["2026-08-20"]!;
+      sealDay(state, "2026-08-20", [200]);
+      const both = state.costByDay["2026-08-20"]!;
+      expect(both.count).toBe(first.count + 1);
+      expect(both.p90).toBe(Math.max(first.p90, 200));
+    });
+
     it("takes the ninetieth percentile by nearest rank", () => {
       expect(percentile90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(9);
       expect(percentile90([5])).toBe(5);

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -1,0 +1,316 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  churn,
+  costSeconds,
+  daysBetween,
+  emptyState,
+  flakeRate,
+  foldObservations,
+  type Observation,
+  percentile90,
+  scoreInputs,
+  sealDay,
+  trimWindows,
+  value,
+} from "./score.ts";
+import { VALUE_FLOOR } from "./policy.ts";
+
+const TEST = { k: "unit", s: "memory", n: "space > writes a fact" };
+const KEY = JSON.stringify([TEST.k, TEST.s, TEST.n]);
+
+/** One observation, with the parts a case does not care about filled in. */
+function saw(
+  outcome: "pass" | "fail" | "skip",
+  fields: Partial<Observation> = {},
+): Observation {
+  return {
+    test: TEST,
+    outcome,
+    durationMs: 100,
+    day: "2026-08-20",
+    commit: "c1",
+    source: "main",
+    place: "main",
+    ...fields,
+  };
+}
+
+function stateFrom(observations: readonly Observation[]) {
+  const state = foldObservations(observations).states.get(KEY);
+  expect(state).toBeDefined();
+  return state!;
+}
+
+describe("score", () => {
+  describe("what counts as a catch", () => {
+    it("counts a failure on a branch where main was green", () => {
+      const state = stateFrom([
+        saw("pass", { day: "2026-08-19", commit: "c0" }),
+        saw("fail", { commit: "c1", place: "pr", source: "fix-writes" }),
+      ]);
+      expect(state.prCatches).toBe(1);
+      expect(state.lastCatch).toBe("2026-08-20");
+    });
+
+    it("counts nothing at a commit where main was already red", () => {
+      const state = stateFrom([
+        saw("fail", { day: "2026-08-19", commit: "c0" }),
+        saw("fail", { commit: "c1", place: "pr", source: "fix-writes" }),
+      ]);
+      expect(state.prCatches).toBe(0);
+    });
+
+    it("reads a pass and a failure at one commit as a flake", () => {
+      const state = stateFrom([
+        saw("pass", { commit: "c1", place: "pr", source: "branch" }),
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+      ]);
+      expect(state.prCatches).toBe(0);
+      expect(flakeRate(state, "2026-08-20")).toBe(1);
+    });
+
+    it("reads a failure across many branches as the environment", () => {
+      const branches = ["a", "b", "c", "d", "e", "f"];
+      const state = stateFrom(
+        branches.map((branch, i) =>
+          saw("fail", { commit: `c${i}`, place: "pr", source: branch })
+        ),
+      );
+      expect(state.prCatches).toBe(0);
+    });
+
+    it("counts one catch however often a broken commit is re-run", () => {
+      const state = stateFrom([
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+      ]);
+      expect(state.prCatches).toBe(1);
+    });
+
+    it("weighs a catch on a workstation double", () => {
+      const state = stateFrom([
+        saw("fail", { commit: "c1", place: "local", source: "ianh" }),
+      ]);
+      expect(state.localCatches).toBe(1);
+      expect(scoreInputs(state, "2026-08-20").catches).toBe(2);
+    });
+  });
+
+  describe("a failure on main, judged by what came next", () => {
+    it("waits while the same failure is still there", () => {
+      const state = stateFrom([
+        saw("fail", { day: "2026-08-19", commit: "c0" }),
+        saw("fail", { commit: "c1" }),
+      ]);
+      expect(state.mainCatches).toBe(0);
+      expect(state.pendingMain.length).toBe(2);
+    });
+
+    it("counts a catch once a later run passes", () => {
+      const state = stateFrom([
+        saw("fail", { day: "2026-08-19", commit: "c0" }),
+        saw("pass", { commit: "c1" }),
+      ]);
+      expect(state.mainCatches).toBe(1);
+      expect(state.pendingMain).toEqual([]);
+    });
+
+    it("reads a failure nothing fixed as a flake", () => {
+      const folded = foldObservations([
+        saw("fail", { day: "2026-08-19", commit: "c0" }),
+        saw("pass", { commit: "c1" }),
+      ], { coveredChanged: () => false });
+      const state = folded.states.get(KEY)!;
+      expect(state.mainCatches).toBe(0);
+      expect(flakeRate(state, "2026-08-20")).toBe(1);
+    });
+  });
+
+  describe("what the latest run on main says", () => {
+    it("names the identities that run left red", () => {
+      const folded = foldObservations([
+        saw("pass", { day: "2026-08-19", commit: "c0" }),
+        saw("fail", { commit: "c1" }),
+      ]);
+      expect(folded.mainRed.has(KEY)).toBe(true);
+    });
+
+    it("clears one a later run passed", () => {
+      const folded = foldObservations([
+        saw("fail", { day: "2026-08-19", commit: "c0" }),
+        saw("pass", { commit: "c1" }),
+      ]);
+      expect(folded.mainRed.has(KEY)).toBe(false);
+    });
+  });
+
+  describe("variants", () => {
+    it("scores a variant apart from the default it shadows", () => {
+      const marked = { ...TEST, v: "server-execution" };
+      const folded = foldObservations([
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+        saw("pass", {
+          test: marked,
+          commit: "c1",
+          place: "pr",
+          source: "branch",
+        }),
+      ]);
+      const markedKey = JSON.stringify([
+        marked.k,
+        marked.s,
+        marked.n,
+        marked.v,
+      ]);
+      expect(folded.states.get(KEY)!.prCatches).toBe(1);
+      expect(folded.states.get(markedKey)!.prCatches).toBe(0);
+    });
+  });
+
+  describe("the value formula", () => {
+    it("scores a test that never failed anywhere at exactly the floor", () => {
+      const state = stateFrom([saw("pass")]);
+      expect(value(scoreInputs(state, "2026-08-20"), "2026-08-20")).toBe(
+        VALUE_FLOOR,
+      );
+    });
+
+    it("scores failures that were not catches at the floor plus churn", () => {
+      // Every failure here disagrees with a pass at the same commit, so
+      // none is a catch, and what is left is the churn term alone.
+      const state = stateFrom([
+        saw("pass", { commit: "c1", place: "pr", source: "branch" }),
+        saw("fail", { commit: "c1", place: "pr", source: "branch" }),
+      ]);
+      const inputs = scoreInputs(state, "2026-08-20");
+      expect(inputs.catches).toBe(0);
+      expect(inputs.lastCatch).toBeUndefined();
+      const scored = value(inputs, "2026-08-20");
+      expect(Number.isFinite(scored)).toBe(true);
+      expect(scored).toBeGreaterThan(VALUE_FLOOR);
+      expect(scored).toBeCloseTo(VALUE_FLOOR + 0.15 * inputs.churn, 10);
+    });
+
+    it("keeps an old proven test ahead of one with no record", () => {
+      const proven = {
+        catches: 4,
+        mainCatches: 0,
+        lastCatch: "2024-08-20",
+        sources: 2,
+        churn: 0,
+      };
+      const unproven = {
+        catches: 0,
+        mainCatches: 0,
+        sources: 0,
+        churn: 0,
+      };
+      expect(value(proven, "2026-08-20")).toBeGreaterThan(
+        value(unproven, "2026-08-20"),
+      );
+    });
+
+    it("saturates, so a fifth catch cannot crowd everything out", () => {
+      const at = (catches: number) =>
+        value(
+          {
+            catches,
+            mainCatches: 0,
+            lastCatch: "2026-08-20",
+            sources: 1,
+            churn: 0,
+          },
+          "2026-08-20",
+        );
+      expect(at(3) - at(2)).toBeLessThan(at(2) - at(1));
+      expect(at(5) - at(4)).toBeLessThan(at(3) - at(2));
+      expect(at(100)).toBeLessThan(1);
+    });
+
+    it("decays a catch slowly and never below the freshness floor", () => {
+      const at = (lastCatch: string) =>
+        value(
+          { catches: 4, mainCatches: 0, lastCatch, sources: 0, churn: 0 },
+          "2026-08-20",
+        );
+      expect(at("2026-08-13")).toBeGreaterThan(at("2026-04-20"));
+      expect(at("2024-08-20")).toBeGreaterThan(VALUE_FLOOR);
+    });
+  });
+
+  describe("churn", () => {
+    it("puts a live failure ahead of a long-dead outage", () => {
+      const live = emptyState();
+      for (let age = 0; age < 3; age++) {
+        const day = dayBefore("2026-08-20", age);
+        live.runsByDay[day] = 250;
+        live.failuresByDay[day] = 250;
+      }
+      const healed = emptyState();
+      for (let age = 240; age < 247; age++) {
+        const day = dayBefore("2026-08-20", age);
+        healed.runsByDay[day] = 250;
+        healed.failuresByDay[day] = 150;
+      }
+      for (let age = 0; age < 240; age++) {
+        healed.runsByDay[dayBefore("2026-08-20", age)] = 250;
+      }
+      expect(churn(live, "2026-08-20")).toBeGreaterThan(
+        churn(healed, "2026-08-20"),
+      );
+    });
+
+    it("is zero for a test that has never run", () => {
+      expect(churn(emptyState(), "2026-08-20")).toBe(0);
+    });
+  });
+
+  describe("cost", () => {
+    it("takes the ninetieth percentile by nearest rank", () => {
+      expect(percentile90([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toBe(9);
+      expect(percentile90([5])).toBe(5);
+      expect(percentile90([])).toBe(0);
+    });
+
+    it("reports the worst day inside the window, in seconds", () => {
+      const state = emptyState();
+      sealDay(state, "2026-08-20", [100, 200, 4000]);
+      sealDay(state, "2026-08-19", [100, 100, 100]);
+      expect(costSeconds(state, "2026-08-20")).toBe(4);
+    });
+
+    it("forgets a day past the window", () => {
+      const state = emptyState();
+      sealDay(state, "2026-08-01", [9000]);
+      expect(costSeconds(state, "2026-08-20")).toBe(0);
+    });
+  });
+
+  describe("trimming", () => {
+    it("drops the days each window has passed", () => {
+      const state = emptyState();
+      state.runsByDay["2026-01-01"] = 1;
+      state.runsByDay["2026-08-20"] = 1;
+      sealDay(state, "2026-01-01", [10]);
+      trimWindows(state, "2026-08-20");
+      expect(Object.keys(state.runsByDay)).toEqual(["2026-08-20"]);
+      expect(Object.keys(state.costByDay)).toEqual([]);
+    });
+  });
+
+  describe("days", () => {
+    it("counts calendar days between two of them", () => {
+      expect(daysBetween("2026-08-19", "2026-08-20")).toBe(1);
+      expect(daysBetween("2026-08-20", "2026-08-20")).toBe(0);
+      expect(daysBetween("2026-02-28", "2026-03-01")).toBe(1);
+    });
+  });
+});
+
+function dayBefore(day: string, ago: number): string {
+  const stamp = Date.parse(`${day}T00:00:00Z`) - ago * 86_400_000;
+  return new Date(stamp).toISOString().slice(0, 10);
+}

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -244,6 +244,68 @@ export function emptyContext(): FoldContext {
   };
 }
 
+/** A fold context as it travels between runs. */
+export interface StoredFoldContext {
+  outcomesAtCommit: Array<[string, { day: string; outcomes: string[] }]>;
+  failures: Array<[string, Array<{ day: string; source: string }>]>;
+  credited: string[];
+}
+
+/** The context, flattened for the aggregate that carries it. */
+export function serializeContext(context: FoldContext): StoredFoldContext {
+  return {
+    outcomesAtCommit: [...context.outcomesAtCommit].map((
+      [at, seen],
+    ) => [at, { day: seen.day, outcomes: [...seen.outcomes] }]),
+    failures: [...context.failures],
+    credited: [...context.credited],
+  };
+}
+
+/**
+ * The context a previous run left. Anything malformed yields an empty
+ * one: a context is an optimization over re-reading, and losing it costs
+ * the two cross-run rules their reach rather than any stored fact.
+ */
+export function parseContext(value: unknown): FoldContext {
+  const context = emptyContext();
+  if (typeof value !== "object" || value === null) return context;
+  const stored = value as Partial<StoredFoldContext>;
+  if (Array.isArray(stored.outcomesAtCommit)) {
+    for (const entry of stored.outcomesAtCommit) {
+      if (!Array.isArray(entry) || typeof entry[0] !== "string") continue;
+      const seen = entry[1];
+      if (typeof seen !== "object" || seen === null) continue;
+      if (typeof seen.day !== "string" || !Array.isArray(seen.outcomes)) {
+        continue;
+      }
+      context.outcomesAtCommit.set(entry[0], {
+        day: seen.day,
+        outcomes: new Set(seen.outcomes.filter((o) => typeof o === "string")),
+      });
+    }
+  }
+  if (Array.isArray(stored.failures)) {
+    for (const entry of stored.failures) {
+      if (!Array.isArray(entry) || typeof entry[0] !== "string") continue;
+      if (!Array.isArray(entry[1])) continue;
+      context.failures.set(
+        entry[0],
+        entry[1].filter((f) =>
+          typeof f === "object" && f !== null &&
+          typeof f.day === "string" && typeof f.source === "string"
+        ),
+      );
+    }
+  }
+  if (Array.isArray(stored.credited)) {
+    for (const key of stored.credited) {
+      if (typeof key === "string") context.credited.add(key);
+    }
+  }
+  return context;
+}
+
 /**
  * Drops what the two rules can no longer reach. Both look back at most
  * `CATCH_BREADTH_WINDOW_DAYS`, so anything older than that cannot change

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -208,7 +208,15 @@ function resolvePendingMain(
     pending.day < earliest.day ? pending : earliest
   );
   state.pendingMain = [];
-  if (first.commit === observation.commit) return;
+  if (first.commit === observation.commit) {
+    // The same commit, passing now and failing before, is the test
+    // disagreeing with itself there. The two runs can arrive in separate
+    // batches, so the same-commit check that catches this within one
+    // batch does not see it, and dropping the pending failure silently
+    // would lose the flake as well as the catch.
+    bump(state.flakesByDay, first.day);
+    return;
+  }
   if (coveredChanged(key, first.commit, observation.commit)) {
     creditCatch(state, "main", first.day, first.source);
   } else {
@@ -491,7 +499,6 @@ export function foldObservations(
     if (observation.outcome === "skip") continue;
 
     bump(state.runsByDay, day);
-    recordDuration(state, day, observation.durationMs);
     if (observation.place === "main") {
       resolvePendingMain(state, key, observation, coveredChanged);
       state.lastMainOutcome = observation.outcome;
@@ -543,27 +550,6 @@ export function foldObservations(
     if (state.lastMainOutcome === "fail") mainRed.add(key);
   }
   return { states, mainRed };
-}
-
-/**
- * Folds one duration into the day's percentile. The running value is the
- * larger of what the day held and this execution, which converges on the
- * day's own ninetieth percentile from below without keeping the samples;
- * `sealDay` is what replaces it with the exact figure when the day's
- * observations are all in hand.
- */
-function recordDuration(
-  state: IdentityState,
-  day: string,
-  durationMs: number,
-): void {
-  const sample = state.costByDay[day];
-  if (sample === undefined) {
-    state.costByDay[day] = { p90: durationMs, count: 1 };
-    return;
-  }
-  sample.count++;
-  if (durationMs > sample.p90) sample.p90 = durationMs;
 }
 
 /**
@@ -635,6 +621,12 @@ export function sealDay(
   day: string,
   durationsMs: readonly number[] | DaySamples,
 ): void {
+  // The only writer of a day's cost, so what is already there is another
+  // sealing of the same day from an earlier run and can be combined with
+  // this one. Nothing writes a provisional value alongside it: a running
+  // maximum kept as the fold went would be merged here as though it were
+  // a percentile, and its count added to a count that already includes
+  // it.
   const batch = Array.isArray(durationsMs)
     ? { p90: percentile90(durationsMs), count: durationsMs.length }
     : {

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -184,15 +184,22 @@ function resolvePendingMain(
 ): void {
   if (state.pendingMain.length === 0) return;
   if (observation.outcome === "fail") return;
-  for (const pending of state.pendingMain) {
-    if (pending.commit === observation.commit) continue;
-    if (coveredChanged(key, pending.commit, observation.commit)) {
-      creditCatch(state, "main", pending.day, pending.source);
-    } else {
-      bump(state.flakesByDay, pending.day);
-    }
-  }
+  // One breakage, one catch. A test that stays red across several runs on
+  // the default branch has one thing wrong with it, and the change that
+  // makes it green fixed that one thing; crediting every run it failed
+  // would make a long outage look like the most valuable test in the
+  // repository. The first failure is the one the catch belongs to, since
+  // that is where the breakage entered.
+  const first = state.pendingMain.reduce((earliest, pending) =>
+    pending.day < earliest.day ? pending : earliest
+  );
   state.pendingMain = [];
+  if (first.commit === observation.commit) return;
+  if (coveredChanged(key, first.commit, observation.commit)) {
+    creditCatch(state, "main", first.day, first.source);
+  } else {
+    bump(state.flakesByDay, first.day);
+  }
 }
 
 /** How a batch of observations was judged. */
@@ -299,7 +306,10 @@ export function foldObservations(
       seen = { day: observation.day, outcomes: new Set() };
       outcomesAtCommit.set(at, seen);
     }
-    seen.outcomes.add(observation.outcome);
+    // A skip is a test that deliberately did not run, so it agrees with
+    // nothing and contradicts nothing; counting it as disagreement would
+    // read a skip beside a failure as the test disagreeing with itself.
+    if (observation.outcome !== "skip") seen.outcomes.add(observation.outcome);
     if (observation.outcome === "fail") {
       const list = failures.get(key) ?? [];
       list.push({ day: observation.day, source: observation.source });
@@ -328,7 +338,13 @@ export function foldObservations(
     const day = observation.day;
 
     // A skip is a test that deliberately did not run. It says nothing
-    // about the test and nothing about the change.
+    // about the test and nothing about the change, so it does not reach
+    // `lastMainOutcome` either: a test skipped on the default branch has
+    // not been shown to be fixed, and the last run that did execute it is
+    // the last thing known about it. That keeps a still-broken test out of
+    // every pull request, which is the direction this design takes
+    // whenever the two errors are a lost signal and a change that cannot
+    // go green.
     if (observation.outcome === "skip") continue;
 
     bump(state.runsByDay, day);
@@ -449,28 +465,35 @@ export function sampledPercentile90(samples: DaySamples): number {
 }
 
 /**
- * Replaces a day's cost with the ninetieth percentile of the durations
- * given. Called once per identity per day, with that day's whole set, by
- * whoever folded it.
+ * Folds a batch of one day's durations into that day's cost.
+ *
+ * A day is read across as many runs as it takes for its objects to
+ * arrive, so this is given part of a day at a time and has to combine
+ * rather than replace: a later batch of two fast executions would
+ * otherwise overwrite a morning of slow ones and understate what the
+ * identity costs, which is the direction that overruns a lane.
+ *
+ * What it keeps is the higher percentile and the summed count. Two
+ * percentiles cannot be averaged into the percentile of their union
+ * without the samples behind them, and of the two answers available the
+ * larger is the one a time budget survives.
  */
 export function sealDay(
   state: IdentityState,
   day: string,
   durationsMs: readonly number[] | DaySamples,
 ): void {
-  if (Array.isArray(durationsMs)) {
-    if (durationsMs.length === 0) return;
-    state.costByDay[day] = {
-      p90: percentile90(durationsMs),
-      count: durationsMs.length,
+  const batch = Array.isArray(durationsMs)
+    ? { p90: percentile90(durationsMs), count: durationsMs.length }
+    : {
+      p90: sampledPercentile90(durationsMs as DaySamples),
+      count: (durationsMs as DaySamples).count,
     };
-    return;
-  }
-  const samples = durationsMs as DaySamples;
-  if (samples.count === 0) return;
-  state.costByDay[day] = {
-    p90: sampledPercentile90(samples),
-    count: samples.count,
+  if (batch.count === 0) return;
+  const known = state.costByDay[day];
+  state.costByDay[day] = known === undefined ? batch : {
+    p90: Math.max(known.p90, batch.p90),
+    count: known.count + batch.count,
   };
 }
 

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -1,0 +1,579 @@
+/**
+ * What the record store says about one test, and what that is worth.
+ *
+ * A test earns its place in a pull request by having caught real breakage
+ * before, so the score is built on catches and decays slowly. Deciding
+ * whether a failure is a catch is the delicate part: a test that is flaky
+ * on `main` produces one failure per commit and would otherwise look like
+ * the most valuable test in the repository. `foldObservations` is where
+ * that judgement is made, once per observation, with the state it needs
+ * carried forward from the day before.
+ */
+
+import type {
+  ScoreInputs,
+  TestIdentity,
+} from "@commonfabric/test-support/records";
+import { testIdentityKey } from "@commonfabric/test-support/records";
+import {
+  BREADTH_SATURATION,
+  CATCH_BREADTH_WINDOW_DAYS,
+  CATCH_WEIGHT_LOCAL,
+  CATCH_WEIGHT_MAIN,
+  CATCH_WEIGHT_PR,
+  CHURN_HALF_LIFE_DAYS,
+  CHURN_WINDOW_DAYS,
+  COST_WINDOW_DAYS,
+  ENVIRONMENTAL_MIN_SOURCES,
+  FLAKE_WINDOW_DAYS,
+  FRESHNESS_FLOOR,
+  FRESHNESS_HALF_LIFE_DAYS,
+  PROVEN_SATURATION,
+  VALUE_FLOOR,
+  WEIGHT_BREADTH,
+  WEIGHT_CHURN,
+  WEIGHT_PROVEN,
+} from "./policy.ts";
+
+/** Where a failure happened, which changes what it means. */
+export type CatchPlace = "local" | "pr" | "main";
+
+/** One execution of one test, as the publisher reads it from a report. */
+export interface Observation {
+  test: TestIdentity;
+  outcome: "pass" | "fail" | "skip";
+  durationMs: number;
+
+  /** UTC calendar day, "yyyy-mm-dd". */
+  day: string;
+
+  /** The commit the tests ran against. */
+  commit: string;
+
+  /**
+   * Who saw it: the branch for a continuous-integration run, the
+   * reporting person's login for a local one.
+   */
+  source: string;
+
+  /** Where it ran, which is what a catch there is worth. */
+  place: CatchPlace;
+}
+
+/** What one identity's history has accumulated. */
+export interface IdentityState {
+  /** Catches, counted separately by where each happened. */
+  localCatches: number;
+  prCatches: number;
+  mainCatches: number;
+
+  /** The day of the most recent catch, absent when there are none. */
+  lastCatch?: string;
+
+  /** The distinct sources among the catches. */
+  sources: string[];
+
+  /** Failures and runs per day, for the churn term. */
+  failuresByDay: Record<string, number>;
+  runsByDay: Record<string, number>;
+
+  /** Flake observations per day, against the failures of the same day. */
+  flakesByDay: Record<string, number>;
+
+  /**
+   * The ninetieth percentile of the day's measured durations, in
+   * milliseconds, and how many executions it was taken over. A day is
+   * the unit because keeping every duration would make the state object
+   * grow with the number of runs rather than with the number of tests.
+   */
+  costByDay: Record<string, { p90: number; count: number }>;
+
+  /** The outcome of the most recent `main` run this identity appeared in. */
+  lastMainOutcome?: "pass" | "fail" | "skip";
+
+  /**
+   * Failures on `main` that no later `main` run has judged yet. A
+   * failure that the next `main` run passes was fixed by the change
+   * between them, which makes it a catch; one that is still failing is
+   * the same breakage continuing, and waits.
+   */
+  pendingMain: Array<{ day: string; commit: string; source: string }>;
+}
+
+/** A fresh, empty history. */
+export function emptyState(): IdentityState {
+  return {
+    localCatches: 0,
+    prCatches: 0,
+    mainCatches: 0,
+    sources: [],
+    failuresByDay: {},
+    runsByDay: {},
+    flakesByDay: {},
+    costByDay: {},
+    pendingMain: [],
+  };
+}
+
+/** Days between two "yyyy-mm-dd" days, `later` minus `earlier`. */
+export function daysBetween(earlier: string, later: string): number {
+  const from = Date.parse(`${earlier}T00:00:00Z`);
+  const to = Date.parse(`${later}T00:00:00Z`);
+  return Math.round((to - from) / 86_400_000);
+}
+
+/**
+ * The ninetieth percentile of a list of durations, by nearest rank. The
+ * ninetieth rather than the maximum, because one unlucky runner should
+ * not permanently inflate an estimate, and rather than the mean, because
+ * a cost model that under-estimates blows the time budget.
+ */
+export function percentile90(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil(0.9 * sorted.length);
+  return sorted[Math.max(0, rank - 1)]!;
+}
+
+function addSource(state: IdentityState, source: string): void {
+  if (!state.sources.includes(source)) state.sources.push(source);
+}
+
+function creditCatch(
+  state: IdentityState,
+  place: CatchPlace,
+  day: string,
+  source: string,
+): void {
+  if (place === "local") state.localCatches++;
+  else if (place === "pr") state.prCatches++;
+  else state.mainCatches++;
+  if (state.lastCatch === undefined || state.lastCatch < day) {
+    state.lastCatch = day;
+  }
+  addSource(state, source);
+}
+
+function bump(counts: Record<string, number>, day: string): void {
+  counts[day] = (counts[day] ?? 0) + 1;
+}
+
+/**
+ * Whether anything a test covers changed between two `main` commits. The
+ * coverage attribution map is what answers this; without one the answer
+ * is yes, which errs toward calling a failure a catch.
+ */
+export type CoveredChange = (
+  identity: string,
+  fromCommit: string,
+  toCommit: string,
+) => boolean;
+
+/**
+ * Judges the failures on `main` that were waiting for a later `main` run.
+ * A failure the next run still shows is the same breakage continuing, so
+ * it keeps waiting and nothing new is learned. A failure the next run
+ * does not show either went away by itself, which is a flake, or was
+ * fixed by the change between the two, which is a catch.
+ */
+function resolvePendingMain(
+  state: IdentityState,
+  key: string,
+  observation: Observation,
+  coveredChanged: CoveredChange,
+): void {
+  if (state.pendingMain.length === 0) return;
+  if (observation.outcome === "fail") return;
+  for (const pending of state.pendingMain) {
+    if (pending.commit === observation.commit) continue;
+    if (coveredChanged(key, pending.commit, observation.commit)) {
+      creditCatch(state, "main", pending.day, pending.source);
+    } else {
+      bump(state.flakesByDay, pending.day);
+    }
+  }
+  state.pendingMain = [];
+}
+
+/** How a batch of observations was judged. */
+export interface FoldResult {
+  states: Map<string, IdentityState>;
+
+  /** Identities failing in the most recent `main` run that named them. */
+  mainRed: Set<string>;
+}
+
+/**
+ * The cross-batch context two of the rules need. A batch cannot be judged
+ * on its own: whether an identity disagreed with itself at a commit, and
+ * whether a failure spans enough sources to read as the environment, are
+ * both questions about observations that may sit in another batch. A
+ * caller folding a stream carries one of these along and trims it.
+ */
+export interface FoldContext {
+  /** Every outcome seen for one identity at one commit, with its day. */
+  outcomesAtCommit: Map<string, { day: string; outcomes: Set<string> }>;
+
+  /** Where and when each identity has been seen failing. */
+  failures: Map<string, Array<{ day: string; source: string }>>;
+
+  /** The commit and source pairs a catch has already been credited to. */
+  credited: Set<string>;
+}
+
+/** A context holding nothing, for a fold with no history behind it. */
+export function emptyContext(): FoldContext {
+  return {
+    outcomesAtCommit: new Map(),
+    failures: new Map(),
+    credited: new Set(),
+  };
+}
+
+/**
+ * Drops what the two rules can no longer reach. Both look back at most
+ * `CATCH_BREADTH_WINDOW_DAYS`, so anything older than that cannot change
+ * a verdict, and a stream that never trimmed would grow with the number
+ * of runs rather than with the number of tests.
+ */
+export function trimContext(context: FoldContext, today: string): void {
+  const stale = (day: string) =>
+    daysBetween(day, today) > CATCH_BREADTH_WINDOW_DAYS;
+  for (const [key, seen] of context.failures) {
+    const kept = seen.filter((failure) => !stale(failure.day));
+    if (kept.length === 0) context.failures.delete(key);
+    else context.failures.set(key, kept);
+  }
+  for (const [at, seen] of context.outcomesAtCommit) {
+    if (stale(seen.day)) context.outcomesAtCommit.delete(at);
+  }
+}
+
+/** What a fold may be told beyond the observations themselves. */
+export interface FoldOptions {
+  /** The state each identity's history had reached before this batch. */
+  prior?: Map<string, IdentityState>;
+
+  /** How to tell a fixed failure on `main` from one that healed itself. */
+  coveredChanged?: CoveredChange;
+
+  /** What earlier batches of the same stream saw. */
+  context?: FoldContext;
+}
+
+/**
+ * Folds a batch of observations into per-identity state.
+ *
+ * The observations must be in ascending time order, because the rules
+ * that decide whether a failure is a catch look backwards at what `main`
+ * last said and forwards at what it says next. Observations at one commit
+ * are considered together: an identity that both passed and failed there
+ * disagreed with itself, which is a flake observation and never a catch.
+ */
+export function foldObservations(
+  observations: readonly Observation[],
+  options: FoldOptions = {},
+): FoldResult {
+  const states = options.prior ?? new Map<string, IdentityState>();
+  const coveredChanged = options.coveredChanged ?? (() => true);
+  const context = options.context ?? emptyContext();
+  const stateOf = (key: string): IdentityState => {
+    let state = states.get(key);
+    if (state === undefined) {
+      state = emptyState();
+      states.set(key, state);
+    }
+    return state;
+  };
+
+  // Same-commit disagreement, and the sources a failing identity appeared
+  // on inside the environmental window, both need the whole batch in view
+  // before any one observation can be judged.
+  const outcomesAtCommit = context.outcomesAtCommit;
+  const failures = context.failures;
+  for (const observation of observations) {
+    const key = testIdentityKey(observation.test);
+    const at = `${key} ${observation.commit}`;
+    let seen = outcomesAtCommit.get(at);
+    if (seen === undefined) {
+      seen = { day: observation.day, outcomes: new Set() };
+      outcomesAtCommit.set(at, seen);
+    }
+    seen.outcomes.add(observation.outcome);
+    if (observation.outcome === "fail") {
+      const list = failures.get(key) ?? [];
+      list.push({ day: observation.day, source: observation.source });
+      failures.set(key, list);
+    }
+  }
+
+  const environmental = (key: string, day: string, source: string): boolean => {
+    const nearby = new Set<string>([source]);
+    for (const failure of failures.get(key) ?? []) {
+      if (Math.abs(daysBetween(failure.day, day)) > CATCH_BREADTH_WINDOW_DAYS) {
+        continue;
+      }
+      nearby.add(failure.source);
+    }
+    return nearby.size >= ENVIRONMENTAL_MIN_SOURCES;
+  };
+
+  // A catch is attributed to the pair of the commit and the source that
+  // saw it, so re-running one broken commit ten times counts once.
+  const credited = context.credited;
+
+  for (const observation of observations) {
+    const key = testIdentityKey(observation.test);
+    const state = stateOf(key);
+    const day = observation.day;
+
+    // A skip is a test that deliberately did not run. It says nothing
+    // about the test and nothing about the change.
+    if (observation.outcome === "skip") continue;
+
+    bump(state.runsByDay, day);
+    recordDuration(state, day, observation.durationMs);
+    if (observation.place === "main") {
+      resolvePendingMain(state, key, observation, coveredChanged);
+      state.lastMainOutcome = observation.outcome;
+    }
+    if (observation.outcome === "pass") continue;
+
+    bump(state.failuresByDay, day);
+
+    const seen = outcomesAtCommit.get(`${key} ${observation.commit}`);
+    if ((seen?.outcomes.size ?? 0) > 1) {
+      // It passed and failed at one commit, with nothing between the two
+      // runs but chance.
+      bump(state.flakesByDay, day);
+      continue;
+    }
+    if (environmental(key, day, observation.source)) continue;
+    if (observation.place !== "main" && state.lastMainOutcome === "fail") {
+      // Already broken on `main`, so this run learned nothing about the
+      // change in front of it.
+      continue;
+    }
+    if (observation.place === "main") {
+      // Whether this was a catch depends on what the next `main` run
+      // says, so it waits.
+      state.pendingMain.push({
+        day,
+        commit: observation.commit,
+        source: observation.source,
+      });
+      continue;
+    }
+    const attribution = `${key} ${observation.commit} ${observation.source}`;
+    if (credited.has(attribution)) continue;
+    credited.add(attribution);
+    creditCatch(state, observation.place, day, observation.source);
+  }
+
+  const mainRed = new Set<string>();
+  for (const [key, state] of states) {
+    if (state.lastMainOutcome === "fail") mainRed.add(key);
+  }
+  return { states, mainRed };
+}
+
+/**
+ * Folds one duration into the day's percentile. The running value is the
+ * larger of what the day held and this execution, which converges on the
+ * day's own ninetieth percentile from below without keeping the samples;
+ * `sealDay` is what replaces it with the exact figure when the day's
+ * observations are all in hand.
+ */
+function recordDuration(
+  state: IdentityState,
+  day: string,
+  durationMs: number,
+): void {
+  const sample = state.costByDay[day];
+  if (sample === undefined) {
+    state.costByDay[day] = { p90: durationMs, count: 1 };
+    return;
+  }
+  sample.count++;
+  if (durationMs > sample.p90) sample.p90 = durationMs;
+}
+
+/**
+ * How many of a day's slowest executions are kept for one identity. The
+ * ninetieth percentile sits inside the slowest tenth, so keeping this
+ * many is exact for any day with up to ten times as many executions, and
+ * an identity runs about 250 times a day across the whole matrix. Past
+ * that the estimate falls back to the smallest sample kept, which
+ * over-estimates, and over-estimating is the safe direction for a budget.
+ */
+export const COST_SAMPLE_CAP = 64;
+
+/** The slowest executions of one identity on one day, and how many ran. */
+export interface DaySamples {
+  /** Ascending, at most `COST_SAMPLE_CAP` of them. */
+  slowest: number[];
+  count: number;
+}
+
+/** A fresh, empty sample. */
+export function emptySamples(): DaySamples {
+  return { slowest: [], count: 0 };
+}
+
+/** Folds one duration into a day's bounded sample of its slowest runs. */
+export function sampleDuration(samples: DaySamples, durationMs: number): void {
+  samples.count++;
+  if (
+    samples.slowest.length === COST_SAMPLE_CAP &&
+    durationMs <= samples.slowest[0]!
+  ) {
+    return;
+  }
+  let at = samples.slowest.length;
+  while (at > 0 && samples.slowest[at - 1]! > durationMs) at--;
+  samples.slowest.splice(at, 0, durationMs);
+  if (samples.slowest.length > COST_SAMPLE_CAP) samples.slowest.shift();
+}
+
+/**
+ * The ninetieth percentile of a day, from its bounded sample. Exact while
+ * the percentile's rank falls inside what was kept; past that it is the
+ * smallest kept sample, which is an over-estimate.
+ */
+export function sampledPercentile90(samples: DaySamples): number {
+  if (samples.count === 0) return 0;
+  const rank = Math.ceil(0.9 * samples.count);
+  const fromTop = samples.count - rank;
+  const index = samples.slowest.length - 1 - fromTop;
+  return samples.slowest[Math.max(0, index)] ?? 0;
+}
+
+/**
+ * Replaces a day's cost with the ninetieth percentile of the durations
+ * given. Called once per identity per day, with that day's whole set, by
+ * whoever folded it.
+ */
+export function sealDay(
+  state: IdentityState,
+  day: string,
+  durationsMs: readonly number[] | DaySamples,
+): void {
+  if (Array.isArray(durationsMs)) {
+    if (durationsMs.length === 0) return;
+    state.costByDay[day] = {
+      p90: percentile90(durationsMs),
+      count: durationsMs.length,
+    };
+    return;
+  }
+  const samples = durationsMs as DaySamples;
+  if (samples.count === 0) return;
+  state.costByDay[day] = {
+    p90: sampledPercentile90(samples),
+    count: samples.count,
+  };
+}
+
+/** Ages a state's per-day counters, dropping days past their windows. */
+export function trimWindows(state: IdentityState, today: string): void {
+  const drop = (counts: Record<string, unknown>, windowDays: number): void => {
+    for (const day of Object.keys(counts)) {
+      if (daysBetween(day, today) > windowDays) delete counts[day];
+    }
+  };
+  drop(state.runsByDay, CHURN_WINDOW_DAYS);
+  drop(state.failuresByDay, CHURN_WINDOW_DAYS);
+  drop(state.flakesByDay, FLAKE_WINDOW_DAYS);
+  drop(state.costByDay, COST_WINDOW_DAYS);
+}
+
+/**
+ * The churn term: recent failures over recent runs, with each day's
+ * counts halved every `CHURN_HALF_LIFE_DAYS` as they age. Decayed rather
+ * than cut off at a window's edge, because a ratio over a long window
+ * measures total historical brokenness rather than the current rate. A
+ * week of failures eight months ago would otherwise outrank a test that
+ * is failing right now.
+ */
+export function churn(state: IdentityState, today: string): number {
+  let failures = 0;
+  let runs = 0;
+  for (const [day, count] of Object.entries(state.runsByDay)) {
+    const age = daysBetween(day, today);
+    if (age > CHURN_WINDOW_DAYS) continue;
+    const weight = 0.5 ** (age / CHURN_HALF_LIFE_DAYS);
+    runs += count * weight;
+    failures += (state.failuresByDay[day] ?? 0) * weight;
+  }
+  return runs === 0 ? 0 : failures / runs;
+}
+
+/** The share of a test's failures that were flake observations. */
+export function flakeRate(state: IdentityState, today: string): number {
+  let failures = 0;
+  let flakes = 0;
+  for (const [day, count] of Object.entries(state.failuresByDay)) {
+    if (daysBetween(day, today) > FLAKE_WINDOW_DAYS) continue;
+    failures += count;
+    flakes += state.flakesByDay[day] ?? 0;
+  }
+  return failures === 0 ? 0 : flakes / failures;
+}
+
+/**
+ * What one execution of this identity costs, in seconds: the largest of
+ * the days' ninetieth percentiles inside the cost window. Largest rather
+ * than averaged, because a cost model that under-estimates blows the time
+ * budget, and each day's own percentile has already absorbed that day's
+ * unlucky runners.
+ */
+export function costSeconds(state: IdentityState, today: string): number {
+  let worst = 0;
+  for (const [day, sample] of Object.entries(state.costByDay)) {
+    if (daysBetween(day, today) > COST_WINDOW_DAYS) continue;
+    if (sample.p90 > worst) worst = sample.p90;
+  }
+  return worst / 1000;
+}
+
+export type { ScoreInputs };
+
+/** The score's inputs for one identity, as of a given day. */
+export function scoreInputs(
+  state: IdentityState,
+  today: string,
+): ScoreInputs {
+  const inputs: ScoreInputs = {
+    catches: CATCH_WEIGHT_LOCAL * state.localCatches +
+      CATCH_WEIGHT_PR * state.prCatches +
+      CATCH_WEIGHT_MAIN * state.mainCatches,
+    mainCatches: state.mainCatches,
+    sources: state.sources.length,
+    churn: churn(state, today),
+  };
+  if (state.lastCatch !== undefined) inputs.lastCatch = state.lastCatch;
+  return inputs;
+}
+
+/**
+ * What a test is worth running.
+ *
+ * The no-catch branch is not decoration. A test with no catches has no
+ * `lastCatch`, so the age of its most recent one does not exist, and
+ * multiplying zero by a missing number yields a missing number rather
+ * than zero. A missing score sorts unpredictably against real ones, so
+ * the branch is written rather than left to the algebra.
+ */
+export function value(inputs: ScoreInputs, today: string): number {
+  let record = 0;
+  if (inputs.catches > 0 && inputs.lastCatch !== undefined) {
+    const proven = 1 - 0.5 ** (inputs.catches / PROVEN_SATURATION);
+    const age = daysBetween(inputs.lastCatch, today);
+    const freshness = FRESHNESS_FLOOR +
+      (1 - FRESHNESS_FLOOR) * 0.5 ** (age / FRESHNESS_HALF_LIFE_DAYS);
+    record = proven * freshness;
+  }
+  const breadth = 1 - 0.5 ** (inputs.sources / BREADTH_SATURATION);
+  return VALUE_FLOOR + WEIGHT_PROVEN * record + WEIGHT_BREADTH * breadth +
+    WEIGHT_CHURN * inputs.churn;
+}

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -122,6 +122,13 @@ export function emptyState(): IdentityState {
   };
 }
 
+/**
+ * How long a commit stays reachable: how late a re-run of it may arrive
+ * and still be recognized as one. Past this a repeated commit is judged
+ * as though it were new, which errs toward calling its failure a catch.
+ */
+export const COMMIT_REACH_DAYS = 30;
+
 /** Days between two "yyyy-mm-dd" days, `later` minus `earlier`. */
 export function daysBetween(earlier: string, later: string): number {
   const from = Date.parse(`${earlier}T00:00:00Z`);
@@ -228,27 +235,51 @@ export interface FoldContext {
   /** Every outcome seen for one identity at one commit, with its day. */
   outcomesAtCommit: Map<string, { day: string; outcomes: Set<string> }>;
 
+  /**
+   * What the default branch said about one identity at one commit, with
+   * the day. A rerun of a commit can arrive long after the run it
+   * repeats, so this outlives the batch: without it, a later pass
+   * elsewhere would make that rerun look like the first failure at a
+   * commit the branch had already shown broken.
+   */
+  mainAtCommit: Map<string, { day: string; outcome: "pass" | "fail" }>;
+
+  /**
+   * The commit and source pairs a catch has already been credited to,
+   * against the day it was credited on, so the set can be aged like
+   * everything else here rather than growing with every catch ever made.
+   */
+  credited: Map<string, string>;
+
   /** Where and when each identity has been seen failing. */
   failures: Map<string, Array<{ day: string; source: string }>>;
-
-  /** The commit and source pairs a catch has already been credited to. */
-  credited: Set<string>;
 }
 
 /** A context holding nothing, for a fold with no history behind it. */
 export function emptyContext(): FoldContext {
   return {
     outcomesAtCommit: new Map(),
+    mainAtCommit: new Map(),
+    credited: new Map(),
     failures: new Map(),
-    credited: new Set(),
   };
 }
 
 /** A fold context as it travels between runs. */
 export interface StoredFoldContext {
   outcomesAtCommit: Array<[string, { day: string; outcomes: string[] }]>;
+  mainAtCommit: Array<[string, { day: string; outcome: "pass" | "fail" }]>;
+  credited: Array<[string, string]>;
   failures: Array<[string, Array<{ day: string; source: string }>]>;
-  credited: string[];
+}
+
+/** The outcomes a record may carry, for validating a stored context. */
+const OUTCOMES = new Set(["pass", "fail", "skip"]);
+
+/** Whether a value is a "yyyy-mm-dd" day this reader can measure from. */
+function isDay(value: unknown): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    Number.isFinite(Date.parse(`${value}T00:00:00Z`));
 }
 
 /** The context, flattened for the aggregate that carries it. */
@@ -257,8 +288,9 @@ export function serializeContext(context: FoldContext): StoredFoldContext {
     outcomesAtCommit: [...context.outcomesAtCommit].map((
       [at, seen],
     ) => [at, { day: seen.day, outcomes: [...seen.outcomes] }]),
-    failures: [...context.failures],
+    mainAtCommit: [...context.mainAtCommit],
     credited: [...context.credited],
+    failures: [...context.failures],
   };
 }
 
@@ -271,37 +303,52 @@ export function parseContext(value: unknown): FoldContext {
   const context = emptyContext();
   if (typeof value !== "object" || value === null) return context;
   const stored = value as Partial<StoredFoldContext>;
-  if (Array.isArray(stored.outcomesAtCommit)) {
-    for (const entry of stored.outcomesAtCommit) {
-      if (!Array.isArray(entry) || typeof entry[0] !== "string") continue;
-      const seen = entry[1];
-      if (typeof seen !== "object" || seen === null) continue;
-      if (typeof seen.day !== "string" || !Array.isArray(seen.outcomes)) {
-        continue;
-      }
-      context.outcomesAtCommit.set(entry[0], {
-        day: seen.day,
-        outcomes: new Set(seen.outcomes.filter((o) => typeof o === "string")),
-      });
-    }
+  const pairs = (raw: unknown): Array<[string, unknown]> =>
+    Array.isArray(raw)
+      ? raw.filter((entry): entry is [string, unknown] =>
+        Array.isArray(entry) && typeof entry[0] === "string"
+      )
+      : [];
+
+  for (const [at, seen] of pairs(stored.outcomesAtCommit)) {
+    if (typeof seen !== "object" || seen === null) continue;
+    const held = seen as { day?: unknown; outcomes?: unknown };
+    if (!isDay(held.day) || !Array.isArray(held.outcomes)) continue;
+    // An outcome this reader does not know would read as one more thing
+    // the identity did at that commit, and two of them is the test
+    // disagreeing with itself — which suppresses a real catch.
+    const outcomes = held.outcomes.filter((outcome): outcome is string =>
+      typeof outcome === "string" && OUTCOMES.has(outcome)
+    );
+    if (outcomes.length === 0) continue;
+    context.outcomesAtCommit.set(at, {
+      day: held.day,
+      outcomes: new Set(outcomes),
+    });
   }
-  if (Array.isArray(stored.failures)) {
-    for (const entry of stored.failures) {
-      if (!Array.isArray(entry) || typeof entry[0] !== "string") continue;
-      if (!Array.isArray(entry[1])) continue;
-      context.failures.set(
-        entry[0],
-        entry[1].filter((f) =>
-          typeof f === "object" && f !== null &&
-          typeof f.day === "string" && typeof f.source === "string"
-        ),
-      );
-    }
+  for (const [at, seen] of pairs(stored.mainAtCommit)) {
+    if (typeof seen !== "object" || seen === null) continue;
+    const held = seen as { day?: unknown; outcome?: unknown };
+    if (!isDay(held.day)) continue;
+    if (held.outcome !== "pass" && held.outcome !== "fail") continue;
+    context.mainAtCommit.set(at, { day: held.day, outcome: held.outcome });
   }
-  if (Array.isArray(stored.credited)) {
-    for (const key of stored.credited) {
-      if (typeof key === "string") context.credited.add(key);
-    }
+  for (const [attribution, day] of pairs(stored.credited)) {
+    // A day that cannot be read cannot be aged, and an entry that is
+    // never aged suppresses that catch for good.
+    if (isDay(day)) context.credited.set(attribution, day);
+  }
+  for (const [key, seen] of pairs(stored.failures)) {
+    if (!Array.isArray(seen)) continue;
+    const kept = seen.filter((failure): failure is {
+      day: string;
+      source: string;
+    } =>
+      typeof failure === "object" && failure !== null &&
+      isDay((failure as { day?: unknown }).day) &&
+      typeof (failure as { source?: unknown }).source === "string"
+    );
+    if (kept.length > 0) context.failures.set(key, kept);
   }
   return context;
 }
@@ -322,6 +369,16 @@ export function trimContext(context: FoldContext, today: string): void {
   }
   for (const [at, seen] of context.outcomesAtCommit) {
     if (stale(seen.day)) context.outcomesAtCommit.delete(at);
+  }
+  // A commit is re-run within days of the run it repeats, not months, so
+  // these age on the same window. Kept forever they would grow with the
+  // number of catches the repository has ever made.
+  const old = (day: string) => daysBetween(day, today) > COMMIT_REACH_DAYS;
+  for (const [at, seen] of context.mainAtCommit) {
+    if (old(seen.day)) context.mainAtCommit.delete(at);
+  }
+  for (const [attribution, day] of context.credited) {
+    if (old(day)) context.credited.delete(attribution);
   }
 }
 
@@ -477,7 +534,7 @@ export function foldObservations(
     }
     const attribution = `${key} ${observation.commit} ${observation.source}`;
     if (credited.has(attribution)) continue;
-    credited.add(attribution);
+    credited.set(attribution, day);
     creditCatch(state, observation.place, day, observation.source);
   }
 

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -284,10 +284,19 @@ export interface StoredFoldContext {
 /** The outcomes a record may carry, for validating a stored context. */
 const OUTCOMES = new Set(["pass", "fail", "skip"]);
 
-/** Whether a value is a "yyyy-mm-dd" day this reader can measure from. */
+/**
+ * Whether a value is a "yyyy-mm-dd" day this reader can measure from.
+ * The parse alone is not enough: a date the calendar does not have rolls
+ * into the next month, so "2026-02-31" parses as March 3rd and would be
+ * aged from three days later than it claims. What round-trips is a day.
+ */
 function isDay(value: unknown): value is string {
-  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value) &&
-    Number.isFinite(Date.parse(`${value}T00:00:00Z`));
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const at = new Date(`${value}T00:00:00Z`);
+  return Number.isFinite(at.getTime()) &&
+    at.toISOString().slice(0, 10) === value;
 }
 
 /** The context, flattened for the aggregate that carries it. */

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -47,6 +47,13 @@ export interface Observation {
   /** UTC calendar day, "yyyy-mm-dd". */
   day: string;
 
+  /**
+   * When the run this came from started, ISO 8601 UTC. The day is what
+   * the counters are kept by; this is what the order is taken from, which
+   * a day is too coarse for.
+   */
+  startedAt: string;
+
   /** The commit the tests ran against. */
   commit: string;
 
@@ -317,6 +324,23 @@ export function foldObservations(
     }
   }
 
+  // What the default branch said at each commit, gathered before anything
+  // is judged. Otherwise a failure elsewhere at the same commit is
+  // classified against whatever `main` had said *last*, which depends on
+  // whether this batch happened to list the `main` run first.
+  const mainAtCommit = new Map<string, "pass" | "fail" | "skip">();
+  for (const observation of observations) {
+    if (observation.place !== "main" || observation.outcome === "skip") {
+      continue;
+    }
+    const at = `${testIdentityKey(observation.test)} ${observation.commit}`;
+    // A failure anywhere at one commit is the commit being broken; a pass
+    // beside it does not clear that.
+    if (observation.outcome === "fail" || !mainAtCommit.has(at)) {
+      mainAtCommit.set(at, observation.outcome);
+    }
+  }
+
   const environmental = (key: string, day: string, source: string): boolean => {
     const nearby = new Set<string>([source]);
     for (const failure of failures.get(key) ?? []) {
@@ -365,10 +389,19 @@ export function foldObservations(
       continue;
     }
     if (environmental(key, day, observation.source)) continue;
-    if (observation.place !== "main" && state.lastMainOutcome === "fail") {
-      // Already broken on `main`, so this run learned nothing about the
-      // change in front of it.
-      continue;
+    if (observation.place !== "main") {
+      // Already broken on the default branch, so this run learned nothing
+      // about the change in front of it. What that branch says at this
+      // very commit outranks what it last said, and is known ahead of
+      // time so that the order this batch happened to arrive in cannot
+      // decide the verdict.
+      const here = mainAtCommit.get(`${key} ${observation.commit}`);
+      if (
+        here === "fail" ||
+        (here === undefined && state.lastMainOutcome === "fail")
+      ) {
+        continue;
+      }
     }
     if (observation.place === "main") {
       // Whether this was a catch depends on what the next `main` run

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -69,9 +69,13 @@ export interface Observation {
 
 /** What one identity's history has accumulated. */
 export interface IdentityState {
-  /** Catches, counted separately by where each happened. */
+  /** Catches on a workstation. */
   localCatches: number;
+
+  /** Catches on a pull request. */
   prCatches: number;
+
+  /** Catches on the default branch. */
   mainCatches: number;
 
   /** The day of the most recent catch, absent when there are none. */
@@ -80,8 +84,10 @@ export interface IdentityState {
   /** The distinct sources among the catches. */
   sources: string[];
 
-  /** Failures and runs per day, for the churn term. */
+  /** Failures per day, the numerator of the churn term. */
   failuresByDay: Record<string, number>;
+
+  /** Runs per day, its denominator. */
   runsByDay: Record<string, number>;
 
   /** Flake observations per day, against the failures of the same day. */
@@ -575,6 +581,8 @@ export const COST_SAMPLE_CAP = 64;
 export interface DaySamples {
   /** Ascending, at most `COST_SAMPLE_CAP` of them. */
   slowest: number[];
+
+  /** How many ran in all, which is what a percentile's rank is taken over. */
   count: number;
 }
 

--- a/tasks/test-selection/store.test.ts
+++ b/tasks/test-selection/store.test.ts
@@ -1,0 +1,167 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { gzipText } from "@commonfabric/test-support/records";
+
+import {
+  fetchManifest,
+  generatedAtOf,
+  manifestObjectName,
+  manifestPrefix,
+  newestAtOrBefore,
+  selectionPrefix,
+  stateObjectName,
+  statePrefix,
+} from "./store.ts";
+import { serializeManifest } from "./manifest.ts";
+import { sampleManifest } from "./testing.ts";
+
+const NO_ENV = () => undefined;
+
+/** A fetch that answers a listing and one object, and nothing else. */
+function storeOf(objects: Record<string, Uint8Array | string>): typeof fetch {
+  return ((input: string | URL | Request) => {
+    const url = new URL(String(input instanceof Request ? input.url : input));
+    if (url.pathname.endsWith("/o")) {
+      const prefix = url.searchParams.get("prefix") ?? "";
+      const items = Object.keys(objects)
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => ({ name }));
+      return Promise.resolve(
+        new Response(JSON.stringify({ items }), { status: 200 }),
+      );
+    }
+    const name = decodeURIComponent(
+      url.pathname.split("/").slice(2).join("/"),
+    );
+    const body = objects[name];
+    if (body === undefined) {
+      return Promise.resolve(new Response("", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(body as BodyInit, { status: 200 }),
+    );
+  }) as typeof fetch;
+}
+
+describe("store", () => {
+  describe("object names", () => {
+    it("puts the manifest area beside the records area", () => {
+      expect(selectionPrefix(NO_ENV)).toBe("labs/test-selection");
+      expect(manifestPrefix(NO_ENV)).toBe("labs/test-selection/v1");
+      expect(statePrefix(NO_ENV)).toBe("labs/test-selection/v1/state");
+    });
+
+    it("adds the version to the area the environment names", () => {
+      // The infra root sets this to the dataset area, the way
+      // TEST_RECORDS_PREFIX names `labs/test-records`, so a job and a
+      // workstation have to agree on where the version segment comes
+      // from or they write to two different layouts.
+      const configured = (name: string) =>
+        name === "TEST_SELECTION_PREFIX" ? "labs/test-selection" : undefined;
+      expect(manifestPrefix(configured)).toBe(manifestPrefix(NO_ENV));
+      expect(statePrefix(configured)).toBe(statePrefix(NO_ENV));
+    });
+
+    it("leads a manifest's name with its generation time", () => {
+      const name = manifestObjectName(
+        "2026-08-20T04:00:00.000Z",
+        "01K3",
+        NO_ENV,
+      );
+      expect(name).toBe(
+        "labs/test-selection/v1/manifest-2026-08-20T04:00:00.000Z-01K3.json.gz",
+      );
+      expect(generatedAtOf(name)).toBe("2026-08-20T04:00:00.000Z");
+    });
+
+    it("leads a state object's name with its day", () => {
+      expect(stateObjectName("2026-08-20", "01K3", NO_ENV)).toBe(
+        "labs/test-selection/v1/state/2026-08-20-01K3.json.gz",
+      );
+    });
+
+    it("reads no generation time out of a name that is not one", () => {
+      expect(generatedAtOf("labs/test-selection/v1/state/x.json.gz"))
+        .toBeUndefined();
+      expect(generatedAtOf("something-else")).toBeUndefined();
+    });
+  });
+
+  describe("newestAtOrBefore()", () => {
+    const names = [
+      "p/manifest-2026-08-20T00:00:00.000Z-a.json.gz",
+      "p/manifest-2026-08-20T04:00:00.000Z-b.json.gz",
+      "p/manifest-2026-08-20T08:00:00.000Z-c.json.gz",
+      "p/state/2026-08-20-d.json.gz",
+    ];
+
+    it("takes the newest that is not after the moment asked about", () => {
+      expect(newestAtOrBefore(names, "2026-08-20T05:00:00.000Z")).toBe(
+        "p/manifest-2026-08-20T04:00:00.000Z-b.json.gz",
+      );
+    });
+
+    it("gives a re-run the same answer as the run it replaces", () => {
+      const at = "2026-08-20T05:00:00.000Z";
+      const later = [
+        ...names,
+        "p/manifest-2026-08-20T12:00:00.000Z-e.json.gz",
+      ];
+      expect(newestAtOrBefore(later, at)).toBe(newestAtOrBefore(names, at));
+    });
+
+    it("returns undefined when every manifest is newer", () => {
+      expect(newestAtOrBefore(names, "2026-08-19T00:00:00.000Z"))
+        .toBeUndefined();
+    });
+  });
+
+  describe("fetchManifest()", () => {
+    const at = "2026-08-20T05:00:00.000Z";
+    const name =
+      "labs/test-selection/v1/manifest-2026-08-20T04:00:00.000Z-b.json.gz";
+
+    it("returns the newest manifest at or before the moment", async () => {
+      const manifest = sampleManifest();
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: storeOf({
+          [name]: await gzipText(serializeManifest(manifest)),
+        }),
+      });
+      expect(found.objectName).toBe(name);
+      expect(found.manifest).toEqual(manifest);
+    });
+
+    it("reports an absent manifest rather than throwing", async () => {
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: storeOf({}),
+      });
+      expect(found.manifest).toBeUndefined();
+      expect(found.absent).toContain("no manifest");
+    });
+
+    it("treats a malformed manifest as absent", async () => {
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: storeOf({ [name]: await gzipText("{not a manifest") }),
+      });
+      expect(found.manifest).toBeUndefined();
+      expect(found.absent).toContain("not a manifest this reader understands");
+    });
+
+    it("treats an unreachable store as absent", async () => {
+      const found = await fetchManifest({
+        at,
+        env: NO_ENV,
+        fetch: (() => Promise.reject(new Error("no network"))) as typeof fetch,
+      });
+      expect(found.manifest).toBeUndefined();
+      expect(found.absent).toContain("no network");
+    });
+  });
+});

--- a/tasks/test-selection/store.test.ts
+++ b/tasks/test-selection/store.test.ts
@@ -1,6 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { gzipText } from "@commonfabric/test-support/records";
 
 import {
   fetchManifest,
@@ -126,9 +125,7 @@ describe("store", () => {
       const found = await fetchManifest({
         at,
         env: NO_ENV,
-        fetch: storeOf({
-          [name]: await gzipText(serializeManifest(manifest)),
-        }),
+        fetch: storeOf({ [name]: serializeManifest(manifest) }),
       });
       expect(found.objectName).toBe(name);
       expect(found.manifest).toEqual(manifest);
@@ -148,7 +145,7 @@ describe("store", () => {
       const found = await fetchManifest({
         at,
         env: NO_ENV,
-        fetch: storeOf({ [name]: await gzipText("{not a manifest") }),
+        fetch: storeOf({ [name]: "{not a manifest" }),
       });
       expect(found.manifest).toBeUndefined();
       expect(found.absent).toContain("not a manifest this reader understands");

--- a/tasks/test-selection/store.ts
+++ b/tasks/test-selection/store.ts
@@ -1,0 +1,183 @@
+/**
+ * Where manifests live, and how a lane finds the one it should obey.
+ *
+ * The store's writer credentials hold `objectCreator` and nothing else,
+ * so an object cannot be overwritten once created. That is what makes the
+ * whole store trustworthy, and it is why there is no `current.json`: a
+ * reader lists the prefix, which sorts by timestamp because the timestamp
+ * leads the name, and takes the newest that is not after the time it is
+ * asking about.
+ */
+
+import {
+  type Environment,
+  gunzipToText,
+  gzipText,
+  listObjects,
+  objectUrl,
+  readEnv,
+} from "@commonfabric/test-support/records";
+import { storeBucket, storePrefix } from "../test-records-config.ts";
+import {
+  type Manifest,
+  MANIFEST_SCHEMA_VERSION,
+  parseManifest,
+  serializeManifest,
+} from "./manifest.ts";
+
+/**
+ * The dataset area this repository's manifests belong to.
+ * TEST_SELECTION_PREFIX overrides, and the infra root sets it to the area
+ * rather than to a path inside one, exactly as TEST_RECORDS_PREFIX names
+ * `labs/test-records` and the version segment is added by whoever builds
+ * an object name.
+ */
+export function selectionPrefix(env: Environment = Deno.env.get): string {
+  const prefix = readEnv("TEST_SELECTION_PREFIX", env);
+  if (prefix !== undefined && prefix.length > 0) return prefix;
+  return `${storePrefix(env).replace(/\/test-records$/, "")}/test-selection`;
+}
+
+/**
+ * Where manifests of the version this reader understands are created. The
+ * segment is part of every name rather than part of the configured area,
+ * so a workstation and a job agree on it, and an incompatible schema
+ * writes under `v2/` with readers migrating at their own pace.
+ */
+export function manifestPrefix(env: Environment = Deno.env.get): string {
+  return `${selectionPrefix(env)}/v${MANIFEST_SCHEMA_VERSION}`;
+}
+
+/** The area the publisher's rolling aggregate is created under. */
+export function statePrefix(env: Environment = Deno.env.get): string {
+  return `${manifestPrefix(env)}/state`;
+}
+
+/**
+ * The name one manifest is created under. The timestamp leads so that a
+ * lexical listing is a chronological one, and the identifier that follows
+ * makes two publishers starting in the same millisecond two objects
+ * rather than a collision.
+ */
+export function manifestObjectName(
+  generatedAt: string,
+  id: string,
+  env: Environment = Deno.env.get,
+): string {
+  return `${manifestPrefix(env)}/manifest-${generatedAt}-${id}.json.gz`;
+}
+
+/** The name one aggregate state object is created under. */
+export function stateObjectName(
+  day: string,
+  id: string,
+  env: Environment = Deno.env.get,
+): string {
+  return `${statePrefix(env)}/${day}-${id}.json.gz`;
+}
+
+/**
+ * The generation time in a manifest's object name. Undefined for a name
+ * that is not one, which is what an unrelated object under the prefix
+ * looks like.
+ */
+export function generatedAtOf(objectName: string): string | undefined {
+  const match = objectName.match(
+    /\/manifest-(\d{4}-\d{2}-\d{2}T[0-9:.]+Z)-[^/]*\.json\.gz$/,
+  );
+  return match?.[1];
+}
+
+/**
+ * The newest manifest object created at or before a moment, from a
+ * listing. Resolving by the workflow run's start time rather than by
+ * "now" is what makes a re-run of one failed lane run the same set as the
+ * lane it replaces.
+ */
+export function newestAtOrBefore(
+  objectNames: readonly string[],
+  at: string,
+): string | undefined {
+  let best: string | undefined;
+  let bestAt = "";
+  for (const name of objectNames) {
+    const generatedAt = generatedAtOf(name);
+    if (generatedAt === undefined || generatedAt > at) continue;
+    if (best === undefined || generatedAt > bestAt) {
+      best = name;
+      bestAt = generatedAt;
+    }
+  }
+  return best;
+}
+
+/** What a fetch of the newest manifest found, or why it found nothing. */
+export interface ManifestFetch {
+  manifest?: Manifest;
+  objectName?: string;
+
+  /** Why there is no manifest, for the lane's job summary. */
+  absent?: string;
+}
+
+/**
+ * Fetches the newest manifest at or before a moment.
+ *
+ * Every way this can go wrong ends the same way: no manifest, with a
+ * sentence saying so. A lane with no manifest runs the mandatory set plus
+ * a deterministic slice rather than failing, so a store that is
+ * unreachable slows selection down and stops nothing.
+ */
+export async function fetchManifest(options: {
+  at: string;
+  bucket?: string;
+  prefix?: string;
+  fetch?: typeof fetch;
+  env?: Environment;
+}): Promise<ManifestFetch> {
+  const env = options.env ?? Deno.env.get;
+  const bucket = options.bucket ?? storeBucket(env);
+  const prefix = options.prefix ?? manifestPrefix(env);
+  let names: string[];
+  try {
+    names = await listObjects({
+      bucket,
+      prefix,
+      ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    });
+  } catch (error) {
+    return { absent: `listing ${prefix} failed: ${error}` };
+  }
+  const objectName = newestAtOrBefore(names, options.at);
+  if (objectName === undefined) {
+    return { absent: `no manifest under ${prefix} at or before ${options.at}` };
+  }
+  const doFetch = options.fetch ?? fetch;
+  let text: string;
+  try {
+    const url = objectUrl(bucket, objectName);
+    const response = await doFetch(url);
+    if (!response.ok) {
+      return {
+        absent: `reading ${objectName} failed: HTTP ${response.status}`,
+      };
+    }
+    text = await gunzipToText(new Uint8Array(await response.arrayBuffer()));
+  } catch (error) {
+    return { absent: `reading ${objectName} failed: ${error}` };
+  }
+  const manifest = parseManifest(text);
+  if (manifest === undefined) {
+    return {
+      objectName,
+      absent: `${objectName} is not a manifest this ` +
+        `reader understands`,
+    };
+  }
+  return { manifest, objectName };
+}
+
+/** The gzipped body one manifest object holds. */
+export function manifestBody(manifest: Manifest): Promise<Uint8Array> {
+  return gzipText(serializeManifest(manifest));
+}

--- a/tasks/test-selection/store.ts
+++ b/tasks/test-selection/store.ts
@@ -11,7 +11,6 @@
 
 import {
   type Environment,
-  gunzipToText,
   gzipText,
   listObjects,
   objectUrl,
@@ -103,7 +102,14 @@ export function newestAtOrBefore(
   for (const name of objectNames) {
     const generatedAt = generatedAtOf(name);
     if (generatedAt === undefined || generatedAt > at) continue;
-    if (best === undefined || generatedAt > bestAt) {
+    // Two publishers can start in the same millisecond, and then the
+    // timestamp does not order them. The name does, and every reader
+    // sorts it the same way, so the lanes and the wall obey one manifest
+    // rather than two that happen to share an instant.
+    if (
+      best === undefined || generatedAt > bestAt ||
+      (generatedAt === bestAt && name > best)
+    ) {
       best = name;
       bestAt = generatedAt;
     }
@@ -142,7 +148,10 @@ export async function fetchManifest(options: {
   try {
     names = await listObjects({
       bucket,
-      prefix,
+      // The trailing slash keeps the listing inside this version: a bare
+      // "v1" prefix also matches "v10", whose manifests would sort above
+      // these and hide the newest one this reader may use.
+      prefix: `${prefix}/`,
       ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
     });
   } catch (error) {
@@ -162,7 +171,9 @@ export async function fetchManifest(options: {
         absent: `reading ${objectName} failed: HTTP ${response.status}`,
       };
     }
-    text = await gunzipToText(new Uint8Array(await response.arrayBuffer()));
+    // The store serves these with transcoding, so a plain fetch has
+    // already decoded the gzip the object is stored under.
+    text = await response.text();
   } catch (error) {
     return { absent: `reading ${objectName} failed: ${error}` };
   }

--- a/tasks/test-selection/testing.ts
+++ b/tasks/test-selection/testing.ts
@@ -1,0 +1,20 @@
+/**
+ * Fixtures the selection tooling's own tests are written against. The
+ * shapes come from the shared format's own fixtures; what is added here
+ * is the dials, which are this repository's policy rather than part of
+ * the format.
+ */
+
+import {
+  sampleEntry as bareEntry,
+  sampleManifest as bareManifest,
+} from "@commonfabric/test-support/records";
+import { dialSnapshot, type Manifest } from "./manifest.ts";
+
+export { freeCalibration } from "@commonfabric/test-support/records";
+export const sampleEntry = bareEntry;
+
+/** A small, valid manifest, carrying this repository's dials. */
+export function sampleManifest(fields: Partial<Manifest> = {}): Manifest {
+  return bareManifest({ dials: dialSnapshot(), ...fields });
+}

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   acceptsJUnitPath,
+  acceptsPreload,
   assertTaskTestsIncluded,
   initializeDb,
   junitCapableMembers,
@@ -475,6 +476,28 @@ Deno.test("acceptsJUnitPath reads an ordinary test task", () => {
     acceptsJUnitPath("./packages/x", "echo 'No tests defined.'"),
     false,
   );
+});
+
+Deno.test("acceptsPreload refuses a task naming its own import map", () => {
+  // That map governs every module of the invocation, the preload
+  // included, so a specifier the preload needs and the map does not carry
+  // fails the whole run rather than the preload alone.
+  assertEquals(acceptsPreload("./packages/x", "deno test"), true);
+  assertEquals(
+    acceptsPreload("./packages/x", "deno test -A --import-map ./m.json ."),
+    false,
+  );
+  assertEquals(
+    acceptsPreload("./packages/x", "deno test -A --import-map=./m.json ."),
+    false,
+  );
+  // A member that cannot take the JUnit path cannot take the preload
+  // either: neither reaches the leaf.
+  assertEquals(
+    acceptsPreload("./packages/x", "deno test a/ && deno test b/"),
+    false,
+  );
+  assertEquals(acceptsPreload("./packages/x", undefined), false);
 });
 
 Deno.test("acceptsJUnitPath refuses a task whose flag would land elsewhere", () => {

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -11,6 +11,8 @@ import { decode, encode } from "@commonfabric/utils/encoding";
 import {
   FragmentWriter,
   ingestJUnit,
+  preloadArgument,
+  readNameMaps,
   recordsDir,
 } from "@commonfabric/test-support/records";
 import { parseShard, type Shard } from "./shard-utils.ts";
@@ -53,6 +55,7 @@ export async function testPackage(
   coverageRoot: string | undefined,
   extraEnv?: Record<string, string>,
   junitPath?: string,
+  preload = true,
 ): Promise<{
   memberPath: string;
   packageName: string;
@@ -72,10 +75,15 @@ export async function testPackage(
     }
 
     // Trailing arguments to `deno task` append to the task's command line,
-    // which is what threads the flag down to the leaf `deno test`.
-    const args = junitPath !== undefined
-      ? ["task", "test", `--junit-path=${junitPath}`]
-      : ["task", "test"];
+    // which is what threads the flags down to the leaf `deno test`. The
+    // preload travels with the JUnit path because both reach the leaf the
+    // same way and the report is what the preload's map is joined onto; a
+    // member whose task cannot take one cannot take the other.
+    const args = ["task", "test"];
+    if (junitPath !== undefined) {
+      args.push(`--junit-path=${junitPath}`);
+      if (preload) args.push(preloadArgument());
+    }
     result = await new Deno.Command(Deno.execPath(), {
       args,
       cwd: packagePath,
@@ -118,9 +126,13 @@ function reportPackageFailure(result: PackageResult): void {
 // Reads one leaf's JUnit XML and appends its cases to the spool. A leaf
 // that wrote no XML — it crashed before the end, since deno test writes
 // the file only at process exit — contributes nothing, and a malformed
-// file warns without failing anything.
+// file warns without failing anything. The name maps the leaf's preload
+// left in the spool are what give each case its file; they are read here
+// rather than once for the suite so that a run killed part way through
+// keeps the attribution of every package that finished.
 async function ingestLeafJUnit(
   fragment: FragmentWriter,
+  spoolDir: string,
   junitPath: string,
   scope: string,
   memberPath: string,
@@ -138,6 +150,7 @@ async function ingestLeafJUnit(
         kind: "unit",
         scope,
         filePrefix: prefix,
+        fileByName: await readNameMaps(spoolDir),
       })
     ) {
       fragment.append(record);
@@ -270,6 +283,38 @@ export function acceptsJUnitPath(
   if (task === undefined) return false;
   if (/[&;|<>]/.test(task)) return false;
   return /(^|\s)deno test(\s|$)/.test(task);
+}
+
+/**
+ * Whether an appended `--preload` reaches this member's `deno test` and
+ * loads once it gets there. A member naming its own import map is the one
+ * that cannot: that map governs every module of the invocation, the
+ * preload included, so a specifier the preload needs and the map does not
+ * carry fails the whole run rather than the preload alone. What that
+ * member gives up is the preload's name map, and it loses nothing by it —
+ * with no wrapper installed, the report keeps its own class names and
+ * ingestion reads the file from those instead.
+ */
+export function acceptsPreload(
+  member: string,
+  task: string | undefined,
+): boolean {
+  if (!acceptsJUnitPath(member, task)) return false;
+  return task === undefined || !/--import-map[= ]/.test(task);
+}
+
+/** The members whose leaves also take the preload. */
+export async function preloadCapableMembers(
+  members: readonly string[],
+  root: string | URL = Deno.cwd(),
+): Promise<Set<string>> {
+  const capable = new Set<string>();
+  for (const member of members) {
+    if (acceptsPreload(member, await memberTestTask(member, root))) {
+      capable.add(member);
+    }
+  }
+  return capable;
 }
 
 /** The members whose leaves take the flag, read from their manifests. */
@@ -409,11 +454,13 @@ export async function runTests(
     : undefined;
   // Read once here rather than per unit: an internally sharded package
   // appears as several units that share one manifest.
+  const memberPaths = units.map((unit) => unit.memberPath);
+  const workspaceUrl = new URL(`file://${path.resolve(workspaceCwd)}/`);
   const capable = junitRoot !== undefined
-    ? await junitCapableMembers(
-      units.map((unit) => unit.memberPath),
-      new URL(`file://${path.resolve(workspaceCwd)}/`),
-    )
+    ? await junitCapableMembers(memberPaths, workspaceUrl)
+    : new Set<string>();
+  const preloadable = junitRoot !== undefined
+    ? await preloadCapableMembers(memberPaths, workspaceUrl)
     : new Set<string>();
 
   const results: PackageResult[] = [];
@@ -435,11 +482,16 @@ export async function runTests(
         coverageRoot,
         unit.env,
         junitPath,
+        preloadable.has(unit.memberPath),
       );
       results.push(result);
-      if (junitPath !== undefined && fragment !== undefined) {
+      if (
+        junitPath !== undefined && fragment !== undefined &&
+        spoolDir !== undefined
+      ) {
         await ingestLeafJUnit(
           fragment,
+          spoolDir,
           junitPath,
           unitScope(unit.packageName),
           unit.memberPath,

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -150,7 +150,7 @@ async function ingestLeafJUnit(
         kind: "unit",
         scope,
         filePrefix: prefix,
-        fileByName: await readNameMaps(spoolDir),
+        fileByName: await readNameMaps(spoolDir, { within: prefix }),
       })
     ) {
       fragment.append(record);


### PR DESCRIPTION
The first part of the plan in docs/plans/pull-request-test-selection.md: everything that makes the record store answer "what is this test worth running", with nothing yet changing which tests continuous integration runs.

## The store did not know which file a test came from

A record carries an optional `file`, and for the suites holding almost every identity in the repository it was never set. A sample of 5,333 unit records carried it zero times. Without it nothing can map a unit-test identity back to something a runner can be pointed at, which is what selecting tests rather than files needs.

The file was in the JUnit report the whole time, on the cases ingestion throws away. Deno names a case's class after the module that registered the test, so the case a top-level `describe` registers carries the path of the file, while the leaves beneath it carry `ext:cli/40_test.js` or the bdd module inside `@std/testing`. `dropContainerCases` drops exactly the cases that know. So ingestion now builds the join before dropping them: a leaf is named as its describe chain, and its file is the one whose registered name is the longest prefix of that chain.

That source disappears the moment anything wraps `Deno.test`, because every class then names the wrapper. Wrapping is how a run is told to skip a test without editing a test file, so the wrapper has to replace what it takes. A preload module in `@commonfabric/test-support` does both: it reads the registering module out of the stack, writes the resulting name-to-file map into the run's spool, and applies the skip list `CF_TEST_SKIP_LIST` names. Ingestion lays that map over what the report said.

The preload installs itself only when it has one of those two jobs to do. A test task granting neither environment access nor a writable spool could not write the map, and wrapping there would cost the report its own attribution and buy nothing. Nine of the workspace members whose test task can take an appended flag are in that position.

A task naming its own `--import-map` does not get the preload at all. That map governs every module of the invocation rather than only the package's own, so a specifier the preload needs and the map does not carry fails the whole run. One member is in that position, and appending the preload to it exited 1 until this was closed. Such a member keeps its JUnit path and loses nothing: with no wrapper installed the report keeps its own class names.

A listed test is registered as ignored rather than dropped, so it appears in the report as skipped and the store learns it was deliberately not run. The list says what not to run and never what to run, so a test the list has never heard of runs: one a change just added runs, and a renamed one runs under its new name.

Measured on `packages/leb128`, whose test task grants nothing and so keeps its own class names: 64 of 64 records now carry a file, against none before. On `packages/lib-shell`, where the preload does install, all 32 do and the paths come from the preload's map.

## Four modules, a publisher, and one command

`tasks/test-selection/policy.ts` holds every number the design can be tuned by, and nothing else holds any of them. Each is a named export with a comment saying what it does and which way to move it, and a table beside them carries the unit each value counts and whether somebody chose it or the publisher measures it. The units matter because several are bare fractions that do not mean the same thing: a share of a test's score and a share of a lane's budget read identically and must never be compared. A test holds the table and the exports to each other in both directions.

That test found two numbers the design had not reconciled. The flake rates at which an item is run two and three times were 1% and 10%, while the rate at which an item is excluded from pull requests altogether was 5%: an item reaches the exclusion before it reaches the second band, so running anything three times was unreachable. The second band is now 3%, and the invariant is asserted. Two constants the formulas need had no dial of their own and now have one.

`tasks/test-selection/score.ts` folds executions into per-identity history and turns that into a value. The delicate part is deciding whether a failure says something about a change or something about the test. A failure at a commit where the default branch was already red learned nothing. A failure at a commit that also has a pass is the test disagreeing with itself. A failure spanning many unrelated branches inside a short window is the environment. A failure on the default branch cannot be judged when it happens at all — every push is a distinct commit with one run, so a test that is flaky there never contradicts itself — and it waits for the next run there: still failing means the same breakage continuing, and passing means the change between them fixed it, which is what the test caught. Telling that pair apart properly needs the coverage attribution map, so the judgement takes it as an argument and errs toward calling a failure a catch without one.

The value is built on catches and decays over months rather than days, with three saturating terms and a floor. The floor is what points the packing at the cheap tail. The branch for a test with no catches is written out rather than left to the algebra, because there is no date to measure freshness from and multiplying zero by a missing number yields a missing number, which sorts unpredictably against real scores.

The manifest format lives in `packages/test-support/src/records/`, beside the record schema it is the counterpart of, because the wall reads a manifest for the same reason a lane does and no package imports from `tasks/`. It is validated whole, so a bad field rejects the object rather than leaving a reader obeying half of it, and it records every dial it was built with so it explains its own behavior.

`tasks/test-selection/store.ts` is where manifests live. The writer credentials can create an object and nothing else, which is why there is no name meaning "the current one": a reader lists the prefix, which sorts chronologically because the timestamp leads each name, and takes the newest that is not after the moment it asks about. A lane asks about its run's start time rather than about now, so re-running one failed lane runs the same set as the lane it replaces. The configured value names the dataset area and the schema version is part of every object name, so a job and a workstation agree on where a manifest goes and an incompatible schema can write under its own version while readers migrate.

`tasks/test-selection/plan.ts` decides what runs, as a pure function of the manifest, the diff, and the lane number. That is what lets all five lanes call it and agree without a job ahead of them. Four passes: mandatory, descending value ignoring cost, descending value per second, and a seeded draw over what the value ordering passed over. Cost is marginal: a suite's overhead, an invocation unit's overhead, and a capability's setup are charged only to a lane not paying them already, so choosing one test from a file makes its siblings cheaper and tests needing one environment group themselves into one lane.

`tasks/test-selection-publish.ts` and
`.github/workflows/test-selection.yml` are the four-hourly job. Its identity is federated and pinned to that workflow file on the default branch, and it is the only principal that can create a manifest; a person's own reporting key is scoped to their submissions folder and cannot, so `--dry-run --out` is how a person sees what a run would produce. Nothing gates on the job: when it fails the previous manifest is still the newest and consumers keep using it.

That is also why a run that cannot read the aggregate a previous run left refuses to publish rather than starting from nothing. Catches accumulate over unbounded history and the aggregate is where they live, so a run that lost it and carried on would publish a manifest scoring every test at the floor — and because it succeeded, that manifest would become the one every lane obeys. An unreadable aggregate and an absent one are told apart, and a first run is asked for deliberately with `--bootstrap`.

The fold streams. A first attempt read every object, built every observation, and kept every duration before folding any of it, and died of heap exhaustion on one day of the store. It now takes batches, carries only the cross-batch context the two backward-looking rules need, and trims that to the couple of days those rules reach. Durations fold into a bounded per-day sample of the slowest sixty-four executions, exact for any day up to ten times that many and over-estimating past it, which is the safe direction for a time budget. A bootstrap takes each closed day from its rollup where the day has a complete one, reading the day whole or leaving it to its raw objects, and records which days it took that way so no later run folds their raw objects on top and doubles every catch.

`deno task test-selection` is the one entry point a person types. `dials`, `coverage`, `explain <identity>`, and `plan --dry-run`. `explain` answers "why did my test not run?" — the catches behind a score, the flake rate, whether it is withheld and why, and for an identity the store has never seen, that it is mandatory for exactly that reason. `--verify` needs the topology and says so rather than pretending.

Two dashboard tiles read the newest manifest: how many tests are too noisy to judge a change by, with the worst few named, and what share of the corpus five lanes would run with how close the fullest is to its budget. Both report on the system and name tests, never people.

## What it says about this repository

Run against one day of the real store, the pipeline folds 5,487,611 executions into 20,091 identities. The manifest carrying them is 9.59 megabytes serialized and 1.05 megabytes gzipped, at 478 bytes an entry; the plan's estimate of a couple of hundred bytes was low, and the measurement replaces it. 16,360 of those identities fit five lanes of 230 seconds. Two do not fit a lane at all: the whole-invocation record of `packages/cli/integration/integration.sh` at 454 seconds, and one pattern integration test at 309 seconds.

## The two shell suites that recorded almost nothing

`fuse-exec.sh` is 1,062 lines recording a single identity, so a FUSE mount, a daemon, and everything done with them hang off one number that can only be scored, run, and skipped as a unit. Twenty-three `success` markers inside it name the phases it goes through and not one reached the store. They record now. Those markers trail their phases, where `integration.sh`'s lead theirs, so they close a step rather than opening one, through a second marker beside the first. What that leaves is failure attribution: a phase that fails never reaches its marker, so the failure is carried by the script's own record. Moving each marker ahead of its phase buys that back, and is the same reading of the script that splitting it into sections needs.

A step's name is now a sentence somebody wrote beside the phase it describes, so the two characters that would tear the JSON line are escaped rather than assumed absent.

`integration.sh` had recorded steps with no arm that runs them alone, hidden inside groups. A step with no arm of its own can only be scheduled as part of its whole group, and one of those groups is 386 seconds, past the bound a lane is allowed. They have one now, and the dispatch table's own test holds that property alongside the ones it already held.

The shell recording helpers had no test of their own and are now load bearing, so they have one: it drives them through bash the way a script does and parses what they wrote with the real validator.

## Documentation

`docs/specs/test-selection.md` is the contract and `docs/development/test-selection.md` the operating guide. The record spec gains the dataset area the publisher writes, its fourth writer principal, and the trust-boundary amendment this design requires: reading `submissions/local/` and weighing a failure seen there above one seen in continuous integration is a deliberate widening of the rule that a decision consumer reads only the continuous-integration area, and what the evidence is worth, what it costs, and the three things that bound the cost are written down with it.

Verified with repository-wide `deno fmt --check`, `deno lint`, `tasks/check.sh`, `deno task check-docs`, the dependency and documentation gates, and the `tasks`, `test-support`, `dashboard`, and touched `cli` test suites.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

ACCEPT_COVERAGE_DEBT: packages/test-support +9 lines
ACCEPT_COVERAGE_DEBT: tasks +63 lines