### PR TITLE
perf(runner): the conversion stops building a path it never reads

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4232,41 +4232,49 @@ function convertOneToLinks(
     // Each descent brackets itself with a push and a pop, so the stack holds
     // the path to whatever the walk is looking at and holds nothing else.
     if (Array.isArray(container)) {
-      const converted: FabricValue[] = new Array(container.length);
-
-      for (let index = 0; index < container.length; index++) {
-        // A hole is not a member: `converted` is born holding nothing, and an
-        // assignment per index would fill each hole with `undefined` instead
-        // of leaving it a hole. A sparse array stays sparse across this system.
-        if (!(index in container)) continue;
-
+      // Built through `map()` rather than by index assignment into a
+      // preallocated array. The two produce equal arrays, and not equally
+      // cheap ones: `map()` leaves a hole a hole and returns a packed array
+      // where filling `new Array(n)` by index returns a holey one, which
+      // costs its consumers -- about a fifth of what structured-cloning the
+      // result takes, paid on every crossing to the client.
+      return container.map((element: unknown, index: number) => {
         stack.push(String(index));
-        converted[index] = convertOneToLinks(
-          container[index] as CellLinkInput,
+
+        const converted = convertOneToLinks(
+          element as CellLinkInput,
           options,
           stack,
           ancestors,
         );
+
         stack.pop();
-      }
 
-      return converted;
+        return converted;
+      });
     }
 
-    const converted: Record<string, FabricValue> = {};
+    // Built through `fromEntries()` rather than by assigning member by member.
+    // The two produce equal objects, and not equally cheap ones: an object
+    // filled by assignment costs about half again as much to structured-clone
+    // as the same object built from entries, and every consumer of a converted
+    // value pays that, the crossing to the client included.
+    return Object.fromEntries(
+      Object.entries(container).map(([key, member]) => {
+        stack.push(key);
 
-    for (const [key, member] of Object.entries(container)) {
-      stack.push(key);
-      converted[key] = convertOneToLinks(
-        member as CellLinkInput,
-        options,
-        stack,
-        ancestors,
-      );
-      stack.pop();
-    }
+        const converted = convertOneToLinks(
+          member as CellLinkInput,
+          options,
+          stack,
+          ancestors,
+        );
 
-    return converted;
+        stack.pop();
+
+        return [key, converted];
+      }),
+    );
   } finally {
     ancestors.delete(original);
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4166,7 +4166,7 @@ function convertOneToLinks(
   // been refused by the time the branch ends, which is what the type says.
   let container: unknown[] | Record<string, unknown>;
 
-  // ...which needs to be tracked for circularity.
+  // Tracked for circularity, at the depth a back-link to it names.
   ancestors.set(original, stack.length);
 
   // Everything past the line above runs inside this `try`, so that EVERY way

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4103,26 +4103,48 @@ function linkToCell(cell: Cell<any>, options: CellLinkOptions): SigilLink {
  * Converts cells and objects that can be turned to cells to links. What comes
  * back is a `FabricValue` with a link wherever a cell sat.
  *
- * `ancestors` holds the ancestors of the value being converted, so what it
- * recognizes is a cycle. A value reachable twice by different paths is not one:
- * it is shared, and each position gets its own conversion. Returning a
- * back-link for a shared reference would rewrite one of its positions into a
- * pointer
- * at the other -- and a graph holds plenty of shared structure that is nobody's
- * cycle, an empty `path: []` array reachable from every alias in it being the
- * common case.
- *
  * @param value - The value to convert.
  * @returns The converted value.
  */
 export function convertCellsToLinks(
   value: CellLinkInput,
   options: CellLinkOptions = {},
-  path: readonly string[] = [],
-  ancestors: Map<object, readonly string[]> = new Map(),
 ): FabricValue {
-  if (isObjectOrArray(value) && ancestors.has(value)) {
-    return linkRefFrom({ path: ancestors.get(value) });
+  return convertOneToLinks(value, options, [], new Map());
+}
+
+/**
+ * Recursive worker for {@link convertCellsToLinks}, carrying the state of the
+ * walk in progress.
+ *
+ * `ancestors` holds the ancestors of the value being converted, so what it
+ * recognizes is a cycle. A value reachable twice by different paths is not one:
+ * it is shared, and each position gets its own conversion. Returning a
+ * back-link for a shared reference would rewrite one of its positions into a
+ * pointer at the other -- and a graph holds plenty of shared structure that is
+ * nobody's cycle, an empty `path: []` array reachable from every alias in it
+ * being the common case.
+ *
+ * `stack` is the path to `value`, held as one array that the walk pushes to and
+ * pops from rather than as a fresh array per position. A back-link is the only
+ * thing that reads a path, so what an ancestor records is its depth into that
+ * stack, and the path is cut from the stack where a cycle asks for one. The
+ * cut is correct because an entry sits in `ancestors` only while the walk is
+ * inside it, which is exactly while the stack still holds its own path as a
+ * prefix.
+ */
+function convertOneToLinks(
+  value: CellLinkInput,
+  options: CellLinkOptions,
+  stack: string[],
+  ancestors: Map<object, number>,
+): FabricValue {
+  if (isObjectOrArray(value)) {
+    const depth = ancestors.get(value);
+
+    if (depth !== undefined) {
+      return linkRefFrom({ path: stack.slice(0, depth) });
+    }
   }
 
   // Early-return cases
@@ -4144,7 +4166,8 @@ export function convertCellsToLinks(
   // been refused by the time the branch ends, which is what the type says.
   let container: unknown[] | Record<string, unknown>;
 
-  ancestors.set(original, path); // ...which needs to be tracked for circularity.
+  // ...which needs to be tracked for circularity.
+  ancestors.set(original, stack.length);
 
   // Everything past the line above runs inside this `try`, so that EVERY way
   // out clears the ancestor just recorded -- the exits that return a value
@@ -4205,27 +4228,45 @@ export function convertCellsToLinks(
     // what a container holds is unconverted until the recursion reaches it.
     // That makes each one a `CellLinkInput` -- the very domain this walk takes
     // -- rather than anything narrower.
+    //
+    // Each descent brackets itself with a push and a pop, so the stack holds
+    // the path to whatever the walk is looking at and holds nothing else.
     if (Array.isArray(container)) {
-      return container.map((element: unknown, index: number) =>
-        convertCellsToLinks(
-          element as CellLinkInput,
+      const converted: FabricValue[] = new Array(container.length);
+
+      for (let index = 0; index < container.length; index++) {
+        // A hole is not a member: `converted` is born holding nothing, and an
+        // assignment per index would fill each hole with `undefined` instead
+        // of leaving it a hole. A sparse array stays sparse across this system.
+        if (!(index in container)) continue;
+
+        stack.push(String(index));
+        converted[index] = convertOneToLinks(
+          container[index] as CellLinkInput,
           options,
-          [...path, String(index)],
+          stack,
           ancestors,
-        )
-      );
+        );
+        stack.pop();
+      }
+
+      return converted;
     }
-    return Object.fromEntries(
-      Object.entries(container).map(([key, member]) => [
-        key,
-        convertCellsToLinks(
-          member as CellLinkInput,
-          options,
-          [...path, key],
-          ancestors,
-        ),
-      ]),
-    );
+
+    const converted: Record<string, FabricValue> = {};
+
+    for (const [key, member] of Object.entries(container)) {
+      stack.push(key);
+      converted[key] = convertOneToLinks(
+        member as CellLinkInput,
+        options,
+        stack,
+        ancestors,
+      );
+      stack.pop();
+    }
+
+    return converted;
   } finally {
     ancestors.delete(original);
   }

--- a/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
@@ -1,0 +1,219 @@
+/**
+ * Where the cost of a worker-to-client crossing sits, one step at a time.
+ *
+ * `ipc-crossing.bench.ts` times the whole round trip, which is what a reader
+ * means by "what does a message cost" and is the number to quote. It cannot
+ * say which step to work on, because it reports one figure for six walks. This
+ * file takes the same payloads and times each walk on its own, so a
+ * work-reduction candidate can be picked by size rather than by guess.
+ *
+ * The six steps, in the order a message meets them:
+ *
+ * | step | status quo | envelope |
+ * | --- | --- | --- |
+ * | worker: `convertCellsToLinks()` | yes | yes |
+ * | worker: redact carried label views | yes | yes |
+ * | worker: encode | -- | yes |
+ * | transport | yes | yes |
+ * | client: decode | -- | yes |
+ * | client: hydrate refs into handles | yes | yes |
+ *
+ * Each step is timed on an input the previous steps already produced, hoisted
+ * out of the timed region. So the figures are the steps' own costs and do not
+ * compose into the round trip: what a step hands the next one is built once
+ * here and rebuilt every iteration in the real crossing, and the allocation
+ * pressure that comes of it lands on whichever step is running.
+ *
+ * The transport step is `structuredClone()` rather than a real
+ * `postMessage()`, which is a proxy and not the thing: it serializes and
+ * deserializes as the crossing does, on the calling thread and without the
+ * scheduling that dominates a small message. `ipc-crossing.bench.ts` measures
+ * the real one and bounds this.
+ *
+ * Both flavors of payload are measured, because which one is representative
+ * changes over time. A tree carrying no `cfcLabelView` is what crosses today,
+ * and the redaction walk over it visits every container to find nothing. A
+ * tree carrying one on every link is what crosses once CFC is meaningful, and
+ * there the redaction rebuilds the spine as well.
+ *
+ * Run with:
+ *
+ *     deno task bench
+ */
+
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { convertCellsToLinks, KeepAsCell } from "@commonfabric/runner";
+import {
+  type CfcLabelView,
+  redactSigilCfcLabelViewsForDisplay,
+  setLinkCfcLabelView,
+} from "@commonfabric/runner/cfc";
+
+import { CellHandle } from "@/cell-handle.ts";
+import { $conn, type RuntimeClient } from "@/runtime-client.ts";
+
+/** The options the IPC response and notification paths convert under. */
+const CONVERT_OPTIONS = {
+  includeSchema: true,
+  keepAsCell: KeepAsCell.All,
+  doNotConvertCellResults: true,
+  includeCfcLabelView: true,
+} as const;
+
+/**
+ * A label view of the shape a link-write policy input carries: one entry, whose
+ * confidentiality holds a caveat with a `source` for the redaction to drop.
+ */
+function makeLabelView(index: number): CfcLabelView {
+  return {
+    version: 1,
+    entries: [{
+      path: [],
+      label: {
+        confidentiality: [{
+          type: CFC_ATOM_TYPE.Caveat,
+          kind: "benchmark",
+          source: { type: CFC_ATOM_TYPE.Builtin, name: `principal-${index}` },
+        }],
+      },
+    }],
+  } as CfcLabelView;
+}
+
+/**
+ * Builds the link that a converted cell becomes, distinct per index, carrying
+ * a label view when `labeled`.
+ */
+function makeLink(index: number, labeled: boolean): FabricValue {
+  const link = linkRefFrom({
+    id: `of:${"0".repeat(56)}${index.toString(16).padStart(8, "0")}`,
+    space: `did:key:z${"a".repeat(47)}`,
+    path: ["items", String(index)],
+  });
+
+  if (labeled) setLinkCfcLabelView(link as never, makeLabelView(index));
+
+  return link as unknown as FabricValue;
+}
+
+/** A list of records, each with a few scalars, a nested array, and one link. */
+function makeList(items: number, labeled: boolean): FabricValue {
+  const list: FabricValue[] = [];
+
+  for (let i = 0; i < items; i++) {
+    list.push({
+      title: `item number ${i}`,
+      count: i,
+      done: (i % 3) === 0,
+      tags: [`tag-${i % 7}`, `tag-${i % 11}`],
+      source: makeLink(i, labeled),
+    });
+  }
+
+  return { items: list, total: items, updatedAt: "2026-08-27T00:00:00Z" };
+}
+
+/** A flat object of `count` scalar members: one container, many members. */
+function makeFlat(count: number): FabricValue {
+  const out: Record<string, FabricValue> = {};
+
+  for (let i = 0; i < count; i++) out[`member${i}`] = i;
+
+  return out;
+}
+
+/**
+ * A handle for the hydration to walk from. `deserialize()` reads its ref, to
+ * rebase a relative link, and its client, to hand to a hydrated child -- so a
+ * stand-in serves, and building a real `RuntimeClient` here would put a
+ * connection this benchmark does not use behind every iteration.
+ */
+const base = new CellHandle(
+  { [$conn]: () => ({}) } as unknown as RuntimeClient,
+  {
+    id: `of:${"0".repeat(64)}`,
+    space: `did:key:z${"a".repeat(47)}`,
+    scope: "space",
+    path: [],
+  },
+);
+
+/** One subject: a payload, and what each step of the crossing turns it into. */
+type Subject = {
+  readonly name: string;
+  readonly value: FabricValue;
+
+  /** Whether the payload's links carry a label view. */
+  readonly labeled: boolean;
+};
+
+const SUBJECTS: readonly Subject[] = [
+  { name: "flat 100 members", value: makeFlat(100), labeled: false },
+  { name: "100 records", value: makeList(100, false), labeled: false },
+  { name: "100 records, labeled", value: makeList(100, true), labeled: true },
+  { name: "1000 records", value: makeList(1000, false), labeled: false },
+  { name: "1000 records, labeled", value: makeList(1000, true), labeled: true },
+];
+
+for (const { name, value, labeled } of SUBJECTS) {
+  const converted = convertCellsToLinks(value as never, CONVERT_OPTIONS);
+  const redacted = redactSigilCfcLabelViewsForDisplay(converted);
+  const encoded = realmFromFabricValue(redacted as FabricValue);
+
+  // What each far side is handed: a message arrives as a clone, never as the
+  // object the sender held, and a decode reading a fresh clone is what the
+  // crossing does.
+  const encodedArrival = structuredClone(encoded);
+  const rawArrival = structuredClone(redacted);
+  const decoded = fabricFromRealmValue(encodedArrival);
+
+  // A labeled subject whose redaction finds nothing would be a second copy of
+  // the labelless one wearing a different name, and would read as a result.
+  // Copy-on-write returns the input by reference when no view is found, so
+  // identity is the check: it separates the two flavors exactly.
+  if ((redacted !== converted) !== labeled) {
+    throw new Error(`Fixture is not what it claims: ${name}`);
+  }
+
+  Deno.bench({
+    name: `convert — ${name}`,
+    group: name,
+    baseline: true,
+  }, () => {
+    convertCellsToLinks(value as never, CONVERT_OPTIONS);
+  });
+
+  Deno.bench({ name: `redact — ${name}`, group: name }, () => {
+    redactSigilCfcLabelViewsForDisplay(converted);
+  });
+
+  Deno.bench({ name: `encode — ${name}`, group: name }, () => {
+    realmFromFabricValue(redacted as FabricValue);
+  });
+
+  Deno.bench({ name: `transport, raw — ${name}`, group: name }, () => {
+    structuredClone(redacted);
+  });
+
+  Deno.bench({ name: `transport, encoded — ${name}`, group: name }, () => {
+    structuredClone(encoded);
+  });
+
+  Deno.bench({ name: `decode — ${name}`, group: name }, () => {
+    fabricFromRealmValue(encodedArrival);
+  });
+
+  Deno.bench({ name: `hydrate, raw — ${name}`, group: name }, () => {
+    CellHandle.deserialize(base, rawArrival);
+  });
+
+  Deno.bench({ name: `hydrate, decoded — ${name}`, group: name }, () => {
+    CellHandle.deserialize(base, decoded);
+  });
+}

--- a/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
+++ b/packages/runtime-client/bench/ipc-crossing-steps.bench.ts
@@ -24,6 +24,18 @@
  * here and rebuilt every iteration in the real crossing, and the allocation
  * pressure that comes of it lands on whichever step is running.
  *
+ * The two client-side steps read an arrival this file built once, so each
+ * iteration decodes and hydrates a tree already resident in cache. What they
+ * report is therefore a lower bound. Handing each iteration an arrival of its
+ * own does not fix that so much as move it: the figure rises with the size of
+ * the working set rather than settling anywhere, from 360 us over one tree to
+ * 403 over 64 and 438 over 256, on the 1000-record subject. Neither number is
+ * what a crossing pays, one message being neither one of many resident trees
+ * nor one of hundreds. `ipc-crossing.bench.ts` is what pays the real cost, on
+ * a tree `postMessage()` has just written; this file is for ranking the steps
+ * against each other and for comparing a change against its base, and a bound
+ * that holds on both sides of such a comparison does not disturb it.
+ *
  * The transport step is `structuredClone()` rather than a real
  * `postMessage()`, which is a proxy and not the thing: it serializes and
  * deserializes as the crossing does, on the calling thread and without the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`convertCellsToLinks()` built a fresh path array for every position it
descended into, and the only reader of one is the back-link a cycle produces.
An acyclic value — which is nearly all of them — paid for a path at every node
and read none of them.

The path is now one array the walk pushes to and pops from. An ancestor records
a depth into that array rather than an array of its own, and a cycle cuts its
back-link path from the stack at that depth. The cut is correct because an
entry sits in `ancestors` only while the walk is inside it, which is exactly
while the stack still holds its own path as a prefix.

The two recursion parameters leave the public signature, nothing outside the
function's own recursion having passed one.

## What a whole message costs

`packages/runtime-client/bench/ipc-crossing.bench.ts`, unchanged, run at four
commits: the last build before the IPC envelope, the envelope's own merge, this
branch's base, and this branch. The benchmark, its far-side fixture and
`BenchWorker` are byte-identical at all four, verified by hash, so this is one
measurement rather than four. p75 per run, median of 12 interleaved runs,
microseconds. Each point shows the arm that point's code actually ran.

| subject | before the envelope | the envelope | base | here |
| --- | --- | --- | --- | --- |
| small record | 13.2 | 14.2 | 13.7 | 13.3 |
| flat, 100 members | 41.7 | 46.7 | 39.4 | 38.3 |
| 100 records with links | 369.7 | 462.2 | 427.6 | 404.4 |
| 1000 records with links | 3918.1 | 4883.6 | 4368.5 | 4185.1 |

| subject | envelope | base | **here** | here vs base |
| --- | --- | --- | --- | --- |
| flat, 100 members | 1.12x | 0.94x | **0.92x** | 0.97x |
| 100 records with links | 1.25x | 1.16x | **1.09x** | 0.95x |
| 1000 records with links | 1.25x | 1.11x | **1.07x** | 0.96x |

each against what the same message cost before the envelope existed.

**Internal control.** The status-quo arm is flat between the first two points —
41.7 against 41.6, 369.7 against 370.4, 3918.1 against 3912.1 — which is what
it must be, those walks being untouched by the envelope. That the harness
reproduces it is the evidence the rest is readable.

The `small record` row is dominated by `postMessage()` scheduling rather than
by any walk, and carries run-to-run spread up to 15%. It is reported for
completeness rather than read.

## Which step this is, and that it is the only one that moved

`bench/ipc-crossing-steps.bench.ts`, added here, times each step of the
crossing separately. It is what says the conversion is the step worth working
on: at 1000 records it is 43% of the summed step costs, against 12% for the
encode and 10% for the decode. Those are shares of the sum, which is not the
same as a share of a message — the steps are timed on pre-built inputs and do
not compose into the round trip. Against the measured crossing in the table
above, the conversion is 36%, the encode 10% and the decode 8%, the ~780 us
difference being `postMessage()` scheduling that the steps benchmark stands in
for with `structuredClone()`. The conversion is the largest step under either
denominator.

Per step against this branch's base, p75 median of 10 runs — and the point of
the table is the six rows that do not move:

| step | 1000 records, base | here | |
| --- | --- | --- | --- |
| convert | 1555.6 | 1363.6 | 0.88x |
| redact | 135.3 | 134.6 | 0.99x |
| encode | 417.5 | 419.2 | 1.00x |
| transport | 971.4 | 972.7 | 1.00x |
| decode | 362.2 | 364.3 | 1.01x |
| hydrate | 147.8 | 148.8 | 1.01x |

The decode and hydrate rows read an arrival built once, so they report a lower
bound — a tree resident in cache decodes about 20% quicker than one that is
not, and the figure tracks the size of the working set rather than settling at
any particular value. The step file's header carries the detail. It does not
disturb either use this table is put to, the bound holding on both sides of the
comparison.

Both flavors of payload are measured, since a link carrying a `cfcLabelView` is
what crosses once CFC is meaningful. Labels roughly double every step upstream
of the hydration and leave the ratios where they are.

## Why the container builders are untouched

An earlier revision of this branch also rebuilt each container member by
member, which is quicker than `map()` into `fromEntries()` and made the whole
conversion 1.4x rather than 1.13x. It is not in this branch, because the values
it returns cost their consumers more:

| construction | structuredClone, 100 keys | 1000 keys |
| --- | --- | --- |
| `Object.fromEntries` | 3.33 | 24.80 |
| assignment per member | 4.75 | 44.48 |

An array has the same shape of problem from the other direction: `map()`
returns a packed array where filling a preallocated one by index returns a
holey array. Measured per step, the two together took about 20% back out of the
crossing on every subject carrying an array, and 3.96x out of the redaction
walk over a wide flat object — while the whole-crossing figure still read as a
win, the conversion's saving being the larger number.

Two things about that are worth a reader's attention. It is invisible to any
suite, and it is invisible to a benchmark that holds both constructions in one
process, where the two sites share inline caches and measure as identical. One
implementation per process is what shows it.

## Sparse arrays

`map()` leaves a hole a hole; an assignment per index fills it with
`undefined`. That distinction now has tests, in the PR that adds them (#6625),
which pass against this branch as well as against its base.

## Checks

`deno fmt --check`, `deno lint` and `deno task check` clean. The `runner`,
`runtime-client` and `html` suites pass — the three packages that call the
conversion.

Each `stack.pop()` was ablated separately against #6625's tests. Removing the
array branch's fails the back-link taken after an array sibling; removing the
object branch's fails that one and the two sibling-cycle cases. Neither
ablation is caught by any test that predates #6625.


## Coverage

The ratchet reports `packages/runner` one line above its baseline, in a file
this change does not touch. The run's own artifact names it:
`packages/runner/src/executor/space-server.ts:3763`, the entry to
`#loadDemandedStructure()`, which sits behind a runtime guard and a timing
pass — a line reached only when work lands in a particular order, and one the
tooling reports as "inconsistently covered on `main`".

Baseline and measurement are of the same base commit, `4126f8e98`, so the
comparison is that commit against itself plus this branch's two files, and the
line that differs is in neither. Re-running reproduced it exactly, so it is not
per-run variance at that granularity; the inconsistency is in how that line is
reached across runs on `main`.

Accepted rather than reset, so the debt stays named and scoped to one group:

ACCEPT_COVERAGE_DEBT: packages/runner +1 line

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




