### PR TITLE
test: await speculation setup quiescence

### DIFF
--- a/packages/patterns/integration/sx2-speculation.test.ts
+++ b/packages/patterns/integration/sx2-speculation.test.ts
@@ -115,6 +115,15 @@ describe("sx2 speculation (Phase 2 gates)", () => {
     // PR's Flags.
     const resultCell = cc.getResult(piece.getCell());
     await resultCell.pull();
+    const overlay = runtime.speculationOverlay;
+
+    // Creation itself can leave speculative derivation entries live until
+    // the serving side's authoritative values arrive. Starting the measured
+    // edit on those process-local layers makes the authored commit read a
+    // speculative basis and correctly fail admission. Wait on the entries'
+    // settlement events so this test begins its edit from the store-backed
+    // state it means to measure.
+    await overlay?.waitForSpaceQuiescence(space);
 
     // The ECHO: the authored edit's local render does not gate on the
     // serving round trip. The result sink observes the value through
@@ -180,14 +189,7 @@ describe("sx2 speculation (Phase 2 gates)", () => {
     await waitForSettled(runtime, space, watermarkBefore + 1, {
       timeoutMs: 30_000,
     });
-    const overlay = runtime.speculationOverlay;
-    const drainDeadline = Date.now() + 20_000;
-    while (
-      overlay !== undefined && overlay.entryCount(space) > 0 &&
-      Date.now() < drainDeadline
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
+    await overlay?.waitForSpaceQuiescence(space);
     assertEquals(
       overlay === undefined ? 0 : overlay.entryCount(space),
       0,

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -406,6 +406,20 @@ export class SpeculationOverlayDestination
     return this.#entries.get(space)?.size ?? 0;
   }
 
+  /** DIAGNOSTIC (tests): await every live overlay entry in `space`
+   * settling, including entries registered while the wait is in flight.
+   * Event-driven: each pass sleeps on the entries' own settlement
+   * promises and rechecks after they resolve, rather than polling
+   * `entryCount`. Resolves immediately when the space is already empty
+   * and when the overlay closes. */
+  async waitForSpaceQuiescence(space: MemorySpace): Promise<void> {
+    while (!this.#closed) {
+      const entries = this.#entries.get(space);
+      if (entries === undefined || entries.size === 0) return;
+      await Promise.all([...entries.values()].map((entry) => entry.settled));
+    }
+  }
+
   /** DIAGNOSTIC (tests): cumulative EVENT-HANDLER-kind seals this
    * overlay diverted — never decremented by retirement, so it
    * witnesses transient echoes deterministically. The Phase-4

--- a/packages/runner/test/speculation-overlay.test.ts
+++ b/packages/runner/test/speculation-overlay.test.ts
@@ -303,11 +303,8 @@ describe("Phase 2 speculation overlay", () => {
 
     // Retirement (speculation.md §4): the covering watermark retires
     // every entry; the STORE value renders through the same path.
-    await waitUntil(
-      () => overlay!.entryCount(space) === 0,
-      "overlay retirement after settle",
-      30_000,
-    );
+    await overlay!.waitForSpaceQuiescence(space);
+    expect(overlay!.entryCount(space)).toBe(0);
     await waitUntil(
       () => clientResult.key("total").get() === 56,
       "the authoritative value to render",
@@ -2467,12 +2464,10 @@ describe("Phase 2 speculation overlay", () => {
     // promotes off the pending stack. NO further watermark event.
     ackedSeq = 5;
     pendingLocalSeqs.splice(0, pendingLocalSeqs.length, 30);
+    const quiescence = destination.waitForSpaceQuiescence(space);
     replica.speculationAckObserver?.();
-    await waitUntil(
-      () => destination.entryCount(space) === 0,
-      "the verdict-raced entry to retire on the ack wake",
-      5_000,
-    );
+    await quiescence;
+    expect(destination.entryCount(space)).toBe(0);
     destination.close();
   });
 


### PR DESCRIPTION
## Summary
- add an event-driven diagnostic that waits for all live overlay entries in a space to settle
- begin the sx2 speculation edit only after creation-time derivations have retired
- replace overlay retirement polling with the same settlement-based wait

## Context
PR #6535 exposed an intermittent SpeculativeBasisError in sx2-speculation.test.ts. The first authored edit sometimes ran while speculative derivation layers from piece creation were still live, so admission correctly refused a commit whose read basis included those layers. The identical failure appeared in two runs, while six subsequent branch runs and the failed-job rerun passed, which is consistent with a real setup race rather than a product regression.

This remains a standalone PR so the already-green flag-flip PR stays unchanged.

## Test plan
- runner speculation-overlay test: 21 steps passed
- live server-execution-ON sx2 integration test against local toolshed passed
- deno task check-no-waitfor
- deno task check
- deno fmt --check
- deno lint

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

