### PR TITLE
docs(development): a doc comment is bounded below as well as above

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -529,6 +529,61 @@ export type FryerState =
 Object types, tuple types, array literals, and class and interface bodies all
 keep their blank lines, so the rule holds in full there.
 
+### The blank line below
+
+A documented declaration takes a blank line after it as well. The rule above
+separates a doc comment from what precedes it; this one bounds what it covers.
+
+Without that blank line a doc comment reads as a header over everything down to
+the next one, and whatever sits under the declaration it was written for looks
+documented when it is not:
+
+```ts
+// Shown as alternative snippets.
+
+// Wrong: `humidity` reads as covered by the comment above `temperature`.
+
+interface Reading {
+  /** Fryer temperature, in Kelvin. */
+  readonly temperature: number;
+  readonly humidity: number;
+}
+```
+
+```ts
+// Shown as alternative snippets.
+
+// Right: the blank line ends the doc comment's reach.
+
+interface Reading {
+  /** Fryer temperature, in Kelvin. */
+  readonly temperature: number;
+
+  readonly humidity: number;
+}
+```
+
+Anything following takes the blank line, not only another declaration. A
+statement under a documented local is the same shape and gets the same
+treatment.
+
+The exemptions mirror the ones above. A declaration with nothing after it in
+its file or bracketed block takes no blank line: the closing bracket, or the
+end of the file, is the separator, exactly as the opening bracket is on the
+other side. And the two constructs `deno fmt` will not keep a blank line in are
+exempt here for the reason they are exempt there — the formatter strips one
+after a documented parameter or union arm just as it strips one before.
+
+The rule reaches documented declarations only. Two adjacent members carrying no
+doc comment between them leave no comment's scope in doubt, and stay as they
+are.
+
+For this rule an overload set is one declaration. Its signatures and the
+implementation carrying the code are a single thing to a caller and a single
+thing to the doc comment above them, so no blank line falls between them; the
+one that closes the set goes after the implementation. `deno fmt` keeps a blank
+line between two signatures, so this is a convention no gate will raise.
+
 ### What gets one
 
 - Every file, as a header, except for the kinds listed under

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -211,6 +211,15 @@ is allowed. Two doc comments in a row are the loudest tell — only the nearer o
 survives into rendered documentation. See
 `docs/development/code-comment-style.md`, "Where one goes".
 
+**A documented declaration with nothing blank after it** is that same defect
+read downward, and it is quieter, because the comment is still next to the thing
+it was written for. The comment reaches on past it, so the members added under
+it look documented when they are not — which is exactly the shape a diff
+appending one member to a run of them puts in front of you. See the same
+document, "The blank line below". An overload set counts as one declaration
+here, so the blank line falls after the implementation and not between the
+signatures.
+
 **A missing or misplaced file header** is that same defect one level up, and is
 equally a thing a diff shows you. A file header is a doc comment at the very
 top, above the first `import` and the first `export`; a new file carrying none,

--- a/skills/writing-code/SKILL.md
+++ b/skills/writing-code/SKILL.md
@@ -19,7 +19,8 @@ All paths are relative to the repo root.
   Principles is the part a reviewer will hold a new abstraction to.
 - `docs/development/code-comment-style.md` — how a comment is written, `//` and
   JSDoc alike. A comment describes the system as it stands, and nothing comes
-  between a doc comment and the declaration it documents.
+  between a doc comment and the declaration it documents. Blank lines bound that
+  pairing on both sides: one above the comment, one below the declaration.
 
 Everything below this line is read-when-it-applies. Reach for it by what you are
 doing, not by reading the list through.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`code-comment-style.md` bounds a doc comment on the top side only. Nothing stops
the reader's eye at the bottom, so a documented one-line member reads as a header
over everything down to the next blank line, and the declarations under the one
it was written for look documented when they are not.

This adds **"The blank line below"** as a sibling of "The blank line above".

### What the rule says

- Anything following a documented declaration takes the blank line, not only
  another declaration.
- It reaches **documented** declarations alone. Two adjacent members carrying no
  doc comment leave no comment's scope in doubt, and stay as they are.
- An **overload set counts as one declaration** — its signatures and the
  implementation carrying the code are a single thing to a caller and a single
  thing to the doc comment above them — so the blank line falls after the
  implementation rather than between the signatures.

### The exemptions were checked, not assumed

They mirror the ones above, and `deno fmt` was run on a probe to confirm it:
the formatter strips a blank line after a documented parameter or union arm
exactly as it strips one before, and it collapses two blank lines to one, so the
above-rule and the below-rule cannot together ask for two. It *does* keep a blank
line between two overload signatures, which is why that clause is noted as a
convention no gate will raise.

`skills/writing-code` and `skills/cf-review` pick the rule up, the latter as a
thing a diff shows plainly when a member is appended to a documented run.

### Conformance is not in this PR

A census of the tree finds **1058 sites in 530 files**, in four populations:

| sites | files | class |
| ---: | ---: | --- |
| 720 | 337 | next thing is undocumented code |
| 180 | 180 | file header glued to what follows |
| 136 | 35 | next thing is itself documented |
| 22 | 19 | next thing is a `//` comment |

Two of those are pre-existing debt rather than new: the 180 file headers already
violate "File headers" (which says the blank line there is load-bearing), and the
136 already violate "The blank line above". One blank line satisfies both rules
at once, so they are the same edit under two justifications. Vendored and
generated files were excluded first — `packages/html/src/jsx.d.ts` and its
byte-identical copy under `packages/static/assets/types/` are 580 sites each of
upstream `lib.dom.d.ts` CSS properties.

The 180 file headers are not a fresh regression, and worth knowing about before
reviewing that batch: #5865/#5867/#5868 swept 219 of these on 2026-08-15, and of
today's 180, **124 predate that sweep — 122 of them in `packages/patterns`**, the
package it excluded. Only 56 are new files since.

The sweep follows in separate PRs, read site by site rather than applied
mechanically. Ten sites carry a doc comment that describes more than the
declaration it sits on, where inserting a blank line would freeze a false claim
instead of fixing it; those are separated out and rewritten rather than bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

