### PR TITLE
style(utils,data-model): bound each doc comment below as well as above

### DIFF
--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -37,6 +37,7 @@ import {
 const SINGLES_JSON = SINGLES.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );
+
 const ARRAYS_JSON = ARRAYS.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );

--- a/packages/data-model/bench/codec-realm.bench.ts
+++ b/packages/data-model/bench/codec-realm.bench.ts
@@ -77,6 +77,7 @@ const SINGLE_SHOT = new Set(["bytes"]);
 const SINGLES_REALM = SINGLES
   .filter(([name]) => !SINGLE_SHOT.has(name))
   .map(([n, v]) => [n, realmFromFabricValue(v)] as const);
+
 const ARRAYS_REALM = ARRAYS.map(([n, v]) =>
   [n, realmFromFabricValue(v)] as const
 );

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -54,6 +54,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
    * unshared `ArrayBuffer`.
    */
   readonly #hash: Uint8Array<ArrayBuffer>;
+
   readonly #tag: string;
   readonly #justHashString: string;
   readonly #fullStringForm: string;

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -443,11 +443,19 @@ function computeHashAsString(value: unknown): string {
 // Caches
 //
 
-/** Pre-computed constant hashes (these values never change). */
+/** Pre-computed hash of `null`. */
 const NULL_HASH = computeHash(null);
+
+/** Pre-computed hash of `undefined`. */
 const UNDEFINED_HASH = computeHash(undefined);
+
+/** Pre-computed hash of `true`. */
 const TRUE_HASH = computeHash(true);
+
+/** Pre-computed hash of `false`. */
 const FALSE_HASH = computeHash(false);
+
+/** Pre-computed hash of negative zero. */
 const NEGATIVE_ZERO_HASH = computeHash(-0);
 
 /**

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -42,6 +42,7 @@ import {
 
 /** A fixed 32-byte hash for deterministic tests. */
 const SAMPLE_HASH = new Uint8Array(32);
+
 for (let i = 0; i < 32; i++) SAMPLE_HASH[i] = i;
 
 const HASH = new FabricHash(SAMPLE_HASH, "fid1");

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -40,6 +40,7 @@ class MockRuntime extends BaseLiveEnvironment {
     throw new Error("getCell not implemented in test runtime");
   }
 }
+
 const mockRuntime = new MockRuntime();
 
 /** Encodes and then decodes a value, per the current dispatch configuration. */

--- a/packages/data-model/test/fabric-instances/fixtures.ts
+++ b/packages/data-model/test/fabric-instances/fixtures.ts
@@ -22,11 +22,12 @@ export class DummyLiveEnvironment extends BaseLiveEnvironment {
 export const dummyEnv = new DummyLiveEnvironment(true);
 
 /**
- * Recursion-callback helpers for exercising the `[DEEP_FREEZE]` /
- * `[IS_DEEP_FROZEN]` protocol members directly (invoking them on an instance
- * with a recursion callback). They use `deepFreeze` / `isDeepFrozen` only as
- * recursion helpers on the nested (plain) sub-values -- never as the entry
- * point for the instance itself.
+ * Recursion-callback helper for exercising the `[DEEP_FREEZE]` protocol member
+ * directly (invoking it on an instance with a recursion callback). It uses
+ * `deepFreeze` only as a recursion helper on the nested (plain) sub-values --
+ * never as the entry point for the instance itself.
  */
 export const subFreeze = (v: FabricValue): FabricValue => deepFreeze(v);
+
+/** Like `subFreeze`, except for `[IS_DEEP_FROZEN]` and `isDeepFrozen`. */
 export const subIsDeepFrozen = (v: FabricValue): boolean => isDeepFrozen(v);

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -22,10 +22,12 @@ import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 
 /** A fixed 32-byte hash for deterministic tests. */
 const SAMPLE_HASH = new Uint8Array(32);
+
 for (let i = 0; i < 32; i++) SAMPLE_HASH[i] = i;
 
 /** A fixed 17-byte hash for deterministic tests. */
 const SAMPLE_HASH_17 = new Uint8Array(17);
+
 for (let i = 0; i < 17; i++) SAMPLE_HASH_17[i] = ((i * 17) + 177) & 0xff;
 
 describe("FabricHash", () => {

--- a/packages/utils/src/arrays.bench.ts
+++ b/packages/utils/src/arrays.bench.ts
@@ -83,6 +83,7 @@ for (const size of SIZES) {
 
 /** Sparse, to track the cost of extent as distinct from element count. */
 const sparse: unknown[] = [];
+
 sparse.length = 100_000;
 sparse[0] = "first";
 sparse[99_999] = "last";
@@ -94,6 +95,7 @@ const compact: unknown[] = ["first", "last"];
 
 /** Rejected for a named property, which short-circuits on the last key. */
 const named = [1, 2, 3] as unknown[] & { foo?: string };
+
 named.foo = "bar";
 
 /**
@@ -102,6 +104,7 @@ named.foo = "bar";
  * check accepts this array, so its row doubles as an accepting-case measure.)
  */
 const getterIndexed = [1, 2, 3];
+
 Object.defineProperty(getterIndexed, 2, {
   get: () => 33,
   enumerable: true,

--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -107,6 +107,7 @@ const B64_PADDING_CHAR = "=";
 
 /** Reverse lookup: base64 char -> 6-bit value. */
 const B64_DECODE = new Uint8Array(128).fill(B64_INVALID);
+
 for (let i = 0; i < B64_CHARS.length; i++) {
   B64_DECODE[B64_CHARS.charCodeAt(i)] = i;
 }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -497,6 +497,7 @@ let _emitTimingMeasures = false;
  * silently continuing to grow or silently dropping.
  */
 let _timingMeasureCap = 200_000;
+
 let _timingMeasuresEmitted = 0;
 let _timingMeasureCapReported = false;
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms the guinea-pig packages to "The blank line below" (#6633). Three of the
five — `leb128`, `pure-json`, `content-hash` — hold no sites at all.

Twelve of the fourteen are the plain shape: a documented declaration with the
next one glued to it, so the comment reads as a header over both.

### The two that a blank line alone would have made worse

Both are comments whose text describes several declarations while binding to
one. Bounding them where they sit would have frozen the false claim:

- **`value-hash.ts`** had one comment over five constant hashes. Each now
  carries its own, so no comment claims more than it sits on.
- **`fixtures.ts`** had one comment over `subFreeze` and `subIsDeepFrozen`. The
  first keeps the explanation; the second takes the `Like <baseline>, except
  <difference>.` form `code-comment-style.md` gives for a variation on a theme.

**2 of 14 needed judgment rather than insertion** — close to the ~1/5 the
comment arc measured in `data-model`, and the reason this sweep is read rather
than run.

### What the pilot bought

Reading all the candidates by hand found three bugs in the detector that built
the census, none of which a tree-wide count would have surfaced. The worst
applied the name-matching regex to a declaration's *last* line, where the name
is on its *first*, so no multi-line overload set was ever absorbed — **8 of the
22 original candidates here, 36%, against 1% tree-wide.** A pilot's error rate
is not the tree's.

After the fixes the census predicted exactly 14 sites in these packages against
a blind hand-read of 14.

### Checks

`deno fmt --check` passes over every touched file, so the formatter keeps all
twelve insertions rather than undoing them. `deno lint` clean. Tests: `utils`
99 passed, `data-model` 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

