### PR TITLE
docs: eight doc comments that described more than they sat on

### DIFF
--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -135,8 +135,10 @@ export interface ConsoleCellLabelsSummary {
   detail?: string;
   space?: { configured: string; did?: string; dbPath?: string };
 
-  /** How many cells the snapshot read, and how many of them carry a label. */
+  /** How many cells the snapshot read. */
   cellsRead: number;
+
+  /** How many of those cells carry a label. */
   cellsLabelled: number;
 
   /**

--- a/packages/cf-harness/console/flow.ts
+++ b/packages/cf-harness/console/flow.ts
@@ -71,8 +71,10 @@ export interface ConsoleFlowNode {
   policyDenied?: boolean;
   policyDetail?: string;
 
-  /** Cells this call read, and cells it produced. */
+  /** Cells this call read. */
   reads: readonly ConsoleFlowCell[];
+
+  /** Cells this call produced. */
   produces: readonly ConsoleFlowCell[];
 
   /**

--- a/packages/cf-harness/console/graph.ts
+++ b/packages/cf-harness/console/graph.ts
@@ -39,8 +39,10 @@ export interface ConsoleGraphNode {
   /** For a pattern run from the index rather than from fresh source. */
   patternId?: string;
 
-  /** For a cell: the handle that named it, and the address it stands for. */
+  /** For a cell: the handle that named it. */
   token?: string;
+
+  /** For a cell: the address that handle stands for. */
   address?: string;
 
   /** For a cell: the slug `assign_slug` gave it, once it has one. */

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -451,7 +451,7 @@ describe("console/cell-labels", () => {
   });
 
   describe("foldCellLabels()", () => {
-    /** Three readings of one cell, no two of them stating the same thing. */
+    /** A reading that saw the whole cell, and found a label on it. */
     const whole: ConsoleCellLabels = {
       confidentiality: ["Secret"],
       integrity: [],
@@ -459,6 +459,8 @@ describe("console/cell-labels", () => {
       transformedBy: [],
       entries: [{ path: [], confidentiality: ["Secret"], integrity: [] }],
     };
+
+    /** A reading that ran out of node budget before it finished. */
     const truncated: ConsoleCellLabels = {
       confidentiality: [],
       integrity: [],
@@ -467,6 +469,8 @@ describe("console/cell-labels", () => {
       entries: [],
       truncationReason: "node-budget-exhausted",
     };
+
+    /** A reading that declined a path, so left part of the cell unread. */
     const unread: ConsoleCellLabels = {
       confidentiality: [],
       integrity: [],

--- a/packages/data-model-schema/src/schema-intern.ts
+++ b/packages/data-model-schema/src/schema-intern.ts
@@ -11,25 +11,22 @@ import { SchemaAndHash } from "./SchemaAndHash.ts";
 import { toDeepFrozenSchema } from "./schema-copy.ts";
 
 /**
- * Bidirectional intern cache for schemas.
- *
- * The cache is split into two maps to avoid strong retention:
- *
- * - `schemaToSah`: `WeakMap<JSONSchemaObj, SchemaAndHash>` — forward lookup.
- *   When the schema object is GC'd, the entry (and with it the
- *   `SchemaAndHash`) becomes unreachable.
- * - `hashToRef`: `Map<string, WeakRef<JSONSchemaObj>>` — reverse lookup
- *   (hash string → schema). Stores only a `WeakRef`, so the schema is not
- *   retained. Dead refs are cleaned up by `schemaFinalizer` and on lookup.
- *
- * To look up by hash: deref the `WeakRef` from `hashToRef`, then look up
- * the `SchemaAndHash` from `schemaToSah`. This ensures `SchemaAndHash` is
- * only reachable while the schema object itself is alive.
- *
- * - `booleanInterns`: prefab `SchemaAndHash` for `true` and `false` (boolean
- *   schemas are primitives and can't be `WeakMap`/`WeakRef` targets).
+ * Forward half of the bidirectional schema intern cache: schema object to its
+ * `SchemaAndHash`. A `WeakMap`, so that when the schema object is collected
+ * the entry — and with it the `SchemaAndHash` — becomes unreachable.
  */
 const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
+
+/**
+ * Reverse half of that cache: hash string to schema. Holds only a `WeakRef`,
+ * so the schema is not retained; dead refs are cleaned up by
+ * `schemaFinalizer` and on lookup.
+ *
+ * Splitting the cache in two is what avoids strong retention, and it is why a
+ * lookup by hash takes both halves: deref the `WeakRef` from here, then read
+ * the `SchemaAndHash` out of `schemaToSah`. A `SchemaAndHash` is thereby
+ * reachable only while its own schema object is alive.
+ */
 const hashToRef = new Map<
   string,
   WeakRef<JSONSchemaObj> | boolean | undefined

--- a/packages/data-model-schema/src/schema-intern.ts
+++ b/packages/data-model-schema/src/schema-intern.ts
@@ -18,14 +18,18 @@ import { toDeepFrozenSchema } from "./schema-copy.ts";
 const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
 
 /**
- * Reverse half of that cache: hash string to schema. Holds only a `WeakRef`,
- * so the schema is not retained; dead refs are cleaned up by
- * `schemaFinalizer` and on lookup.
+ * Reverse half of that cache: hash string to schema. An object schema is held
+ * as a `WeakRef`, so it is not retained; dead refs are cleaned up by
+ * `schemaFinalizer` and on lookup. A primitive schema — `true`, `false`, or
+ * `undefined` — is stored as itself instead, a primitive being no possible
+ * `WeakRef` target and having nothing to retain. Consumers tell the two apart
+ * by `typeof`.
  *
- * Splitting the cache in two is what avoids strong retention, and it is why a
- * lookup by hash takes both halves: deref the `WeakRef` from here, then read
- * the `SchemaAndHash` out of `schemaToSah`. A `SchemaAndHash` is thereby
- * reachable only while its own schema object is alive.
+ * Splitting the cache in two is what avoids strong retention, and it is why an
+ * object schema's lookup by hash takes both halves: deref the `WeakRef` from
+ * here, then read the `SchemaAndHash` out of `schemaToSah`. A `SchemaAndHash`
+ * is thereby reachable only while its own schema object is alive. A primitive
+ * hash is answered from `primInterns` and reaches neither half.
  */
 const hashToRef = new Map<
   string,

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -423,8 +423,13 @@ export interface VerifyResult {
      */
     reclassifiedGenerated: number;
 
-    /** Counts per entity kind, so "74 pieces" reads differently from "74 cells". */
+    /**
+     * `changed` broken out per entity kind, so that "74 pieces" reads
+     * differently from "74 cells".
+     */
     changedByKind: Record<string, number>;
+
+    /** `removed` broken out the same way. */
     removedByKind: Record<string, number>;
   };
 

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -545,11 +545,13 @@ describe("scan-extent", () => {
   });
 
   describe("a module that ranks below the pieces pointing at it", () => {
-    /** Three busy pieces; their module written once, so it sorts last. */
+    /** The document all three busy pieces share. */
     const PIECE_DOC = {
       value: { $NAME: "Topic" },
       patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
     };
+
+    /** Three busy pieces, and their module written once, so it sorts last. */
     const quietModule = (run: (space: SpaceDb) => void) =>
       withSeeded(
         [

--- a/tasks/lint-bench-console.test.ts
+++ b/tasks/lint-bench-console.test.ts
@@ -15,8 +15,10 @@ function diagnose(source: string, fileName = "sample.bench.ts"): string[] {
   return Deno.lint.runPlugin(plugin, fileName, source).map((d) => d.message);
 }
 
-/** The distinguishing phrase of each of the rule's two messages. */
+/** Distinguishing phrase of the message for a write that never lands. */
 const LOST = "never reaches stderr";
+
+/** Distinguishing phrase of the message for a disallowed `console` method. */
 const STDOUT = "may use only the `console` methods that write to stderr";
 
 describe("lint-bench-console", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Eight doc comments that claim several declarations and bind to one. They came up
while censusing for "The blank line below" (#6633), and they are the half of
that sweep a blank line cannot fix: bounding one of these where it sits would
freeze the false claim rather than correct it. So they are separated out and
rewritten, in their own PR, ahead of the mechanical batches.

### Five covered a pair

Each splits into two comments that say what their own member is:
`cellsRead`/`cellsLabelled`, `reads`/`produces`, `token`/`address`,
`changedByKind`/`removedByKind`, `LOST`/`STDOUT`.

### Three covered a group

- **`cell-labels.test.ts`** — "three readings of one cell, no two of them
  stating the same thing" sat over three fixtures. Each now names the reading it
  is, which is the very distinction the comment asserted and could not locate.
- **`scan-extent.test.ts`** — the comment described a scenario the const under it
  does not build. The three busy pieces are `quietModule`'s, not `PIECE_DOC`'s.
- **`schema-intern.ts`** — a bulleted description of a two-map cache, written
  above both maps. Each map now carries its own half, and the reason the split
  exists rides with the lookup that needs both.

### A stale name found on the way

`schema-intern.ts`'s third bullet named `booleanInterns`. The file holds no such
const: it is `primInterns`, it carries `undefined` as well as the two booleans,
and it already has an accurate doc comment sitting directly on it. That bullet
had outlived both the rename and the widening. No gate detects this — it took
reading a comment against the code it claims to describe.

### How these were found

Two high-recall passes over the 1058 census sites: plural or group language in
the comment text (318 candidates, 52 of which also had a same-kind declaration
following — only that combination is reachable), and comments that *name* the
declaration below them (44, mostly cross-references rather than coverage).
**6 genuine of the 52, 2 of the 44.** The heuristics narrowed the reading; they
decided nothing.

### Not folded in

These 8 files carry about 20 ordinary blank-line sites as well. Those are left
to their packages' sweep PRs, so this one stays a single reviewable idea.

### Checks

`deno fmt --check`, `deno lint`, and `deno check` clean on all 8 files. Tests:
`data-model-schema` 9 passed, `state-inspector` 111 passed, plus
`lint-bench-console`, `console/cell-labels`, and `scan-extent` run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

