### PR TITLE
The harness defaults to gpt-5.6-sol

### DIFF
--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -206,7 +206,7 @@ const DEFAULT_FABRIC_API_URL = "http://localhost:8000";
 const DEFAULT_FABRIC_CFC_POSTURE: CfcPosture = "max-enforcement";
 
 /** The CLI's own default model, so both entrypoints bill the same route. */
-const DEFAULT_MODEL = "gpt-5.6-terra";
+const DEFAULT_MODEL = "gpt-5.6-sol";
 
 /** How often the stream publishes a liveness tick, in milliseconds. */
 const PING_INTERVAL_MS = 15_000;

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -144,7 +144,7 @@ import {
   type HarnessControlErrorCode,
 } from "./control-errors.ts";
 
-const DEFAULT_MODEL = "gpt-5.6-terra";
+const DEFAULT_MODEL = "gpt-5.6-sol";
 const DEFAULT_MAX_MODEL_TURNS = 8;
 const DEFAULT_ARTIFACT_DIRNAME = ".cf-harness-artifacts";
 const CLI_OUTPUT_MODES = ["operator", "batch"] as const;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -97,7 +97,7 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   }
   assertEquals(parsed.workspace, "/tmp/project");
   assertEquals(parsed.prompt, "Summarize this workspace");
-  assertEquals(parsed.model, "gpt-5.6-terra");
+  assertEquals(parsed.model, "gpt-5.6-sol");
   assertEquals(parsed.gatewayAuthMode, "bearer");
   assertEquals(parsed.outputMode, "operator");
   assertEquals(parsed.streamEvents, false);
@@ -917,7 +917,7 @@ Deno.test("parseCfHarnessCliArgs ignores blank gateway environment values", asyn
   }
   assertEquals(parsed.gatewayBaseUrl, "https://llm.stage.commontools.dev/");
   assertEquals(parsed.gatewayAuthMode, "bearer");
-  assertEquals(parsed.model, "gpt-5.6-terra");
+  assertEquals(parsed.model, "gpt-5.6-sol");
 });
 
 Deno.test("parseCfHarnessCliArgs supports batch output mode override", async () => {


### PR DESCRIPTION
Two-line default flip plus the two test assertions that pin it. Rationale in the commit: the 2026-08-31 grid found tier changes cost rather than occurrence, and the operator wants the higher tier's dynamics as the default while we keep testing a spread. `--model` / `CF_HARNESS_MODEL` unchanged as per-run overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

