### PR TITLE
style(runner): bound each doc comment below as well as above

### DIFF
--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -238,6 +238,7 @@ declare module "@commonfabric/api" {
      * identity (see docs/specs/content-addressed-action-identity.md).
      */
     $implRef?: { identity: string; symbol: string };
+
     wrapper?: "handler";
     argumentSchema?: JSONSchema;
     resultSchema?: JSONSchema;
@@ -377,6 +378,7 @@ export type Frame = {
    * Only meaningful on handler frames.
    */
   eventTime?: number;
+
   unsafe_binding?: UnsafeBinding;
 
   /**

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -61,6 +61,7 @@ type FetchInputs = {
 
   /** fetchJson only. */
   schema?: JSONSchema;
+
   options?: FetchRequestOptions;
 };
 
@@ -325,6 +326,7 @@ function fetchBuiltin(kind: FetchKind) {
      * read as the ending of the second.
      */
     let currentStaging: symbol | undefined = undefined;
+
     let abortController: AbortController | undefined = undefined;
 
     // This is called when the pattern containing this node is being stopped.

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -84,6 +84,7 @@ export interface ResumeRepublisherOptions {
    * lazily on each republish rather than captured once.
    */
   getResult: () => Cell<any[]> | undefined;
+
   inputsCell: Cell<any>;
   inputSchema: JSONSchema;
   resultSchema: JSONSchema;

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -800,6 +800,7 @@ export function sqliteQuery(
   /** Hashes whose RPC this node instance currently has in flight — the
    * in-process half of the memo decision above. */
   const inFlightIssues = new Set<string>();
+
   /**
    * The query this node staged on its most recent run, if that run staged one.
    * A token rather than the request's hash: two stagings of the same statement
@@ -807,6 +808,7 @@ export function sqliteQuery(
    * ending of the second.
    */
   let currentStaging: symbol | undefined;
+
   const space = parentCell.space;
 
   const action: Action = (tx: IExtendedStorageTransaction) => {

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -42,6 +42,7 @@ export interface RowLabelReadArgs {
   /** Per-result-column TRUE origins (`res.columns`); undefined when the
    *  server captured none. */
   columns: readonly ResultColumn[] | undefined;
+
   rows: readonly unknown[];
 
   /** The db's owner (db ref), resolving the rule's `dbOwner()` term. */

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -259,6 +259,7 @@ type WishContext = {
 
   /** The wish node's cause, keying the durable one-shot #now capture cell. */
   nowCause?: Cell<any>[];
+
   usedHomeSpace?: boolean;
 };
 
@@ -1540,6 +1541,7 @@ function releaseSharedHashtagResolver(runtime: Runtime, key: string): void {
 type SidecarSurface = {
   /** The `system:` origin the surface's piece records. */
   readonly origin: string;
+
   /** The file the origin names. Labels errors. */
   readonly name: string;
 };

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -544,6 +544,7 @@ declare module "@commonfabric/api" {
       options: RawCellReadOptions & { frozen: false },
     ): FabricValue;
     getRawUntyped(options?: RawCellReadOptions): FabricValue;
+
     setRaw(value: (NoInfer<T> & FabricValue) | undefined): void;
 
     /**
@@ -574,6 +575,7 @@ declare module "@commonfabric/api" {
      * rewriting that value.
      */
     applyCfcSchemaToExistingValue(): void;
+
     setSchema(newSchema: JSONSchema): void;
     connect(node: NodeRef): void;
     export(): {
@@ -617,6 +619,7 @@ declare module "@commonfabric/api" {
      * consults it.
      */
     toJSON(): SigilLink | null;
+
     runtime: Runtime;
     tx: IExtendedStorageTransaction | undefined;
     schema?: JSONSchema;

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -244,6 +244,7 @@ const symbolicSchemaAtPathPart = (
  * for a default it no longer describes.
  */
 const defaultSchemaTags = new WeakMap<object, string>();
+
 let nextDefaultSchemaTag = 0;
 
 const defaultSchemaTag = (schema: JSONSchema): string | undefined => {

--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -87,6 +87,7 @@ export type RuleFiring = {
 
   /** Index of the rewritten clause in the label AT FIRING TIME. */
   readonly clauseIndex: number;
+
   readonly kind: "add" | "drop";
 
   /** Alternatives added by an `add` firing. */
@@ -167,6 +168,7 @@ export type ExchangeEvalContext = {
 
   /** Trust closure for concept-valued integrity guards (B3). */
   readonly trustResolver?: TrustResolver;
+
   readonly actingPrincipal?: string;
 
   /**

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -108,11 +108,13 @@ export type CfcGrant = CfcGrantIdentity & {
 
   /** Principal-like atoms (§3.1.8-validated) the release extends to. */
   readonly audience: readonly unknown[];
+
   readonly grantedAt: number;
   readonly expiresAt?: number;
 
   /** §6 intent attribution once the intent substrate exists. */
   readonly sourceIntentId?: string;
+
   readonly revoked?: { readonly at: number; readonly by: string };
 
   /**
@@ -142,6 +144,7 @@ export type CfcGrantWriteInput = {
 
   /** Defaults to the runner clock at write time. */
   readonly grantedAt?: number;
+
   readonly expiresAt?: number;
   readonly sourceIntentId?: string;
   readonly revoked?: { readonly at: number; readonly by: string };

--- a/packages/runner/src/cfc/label-field-classification.ts
+++ b/packages/runner/src/cfc/label-field-classification.ts
@@ -49,6 +49,7 @@ export type LabelFieldClassificationEntry = {
    * walks, so nesting needs no extra rows.
    */
   readonly field: readonly string[];
+
   readonly class: LabelFieldRepresentationClass;
 };
 

--- a/packages/runner/src/cfc/observation-classes.ts
+++ b/packages/runner/src/cfc/observation-classes.ts
@@ -40,6 +40,7 @@ export type ReadObservationShape = "value" | "shape" | "followRef";
  */
 export const LABEL_METADATA_OBSERVATION: LabelMetadataObservationClass =
   "labelMetadata";
+
 export type { LabelMetadataObservationClass };
 
 /**

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3365,6 +3365,7 @@ export type CfcPrefixProvenanceWrite = {
    * consumers can recover the exact segments via parsePointer.
    */
   path: string;
+
   boundSource: CfcPrefixBoundSource;
 
   /** Gated reads within this write's D4 prefix (post-S7-exemption). */

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -138,6 +138,7 @@ export function enqueueSinkRequestPostCommitEffect(
      * its cells pending forever (the stage-G round-2 headline). The
      * CFC policy-input `effectId` stays unscoped either way. */
     idempotencyKey?: string;
+
     /** Called once, with an error naming the refusal, when the transaction
      * staging this request is abandoned — no further attempt at it is
      * coming, so the request will never be sent. */

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -388,6 +388,7 @@ export type ImplementationIdentity =
 
     /** Export/`__cfReg` symbol of the registered factory, when module-scope. */
     symbol?: string;
+
     sourceFile?: string;
     bindingPath?: string[];
     codeHash?: string;
@@ -507,6 +508,7 @@ export type PreparedDigestInput = {
    * shape; docs/specs/cfc-write-prefix-provenance.md §6).
    */
   readonly writeAttemptLog: readonly OrderedWriteAttempt[];
+
   readonly dereferenceTraces: readonly CfcDereferenceTrace[];
   readonly triggerReads: readonly CfcAddress[];
   readonly writePolicyInputs: readonly WritePolicyInput[];
@@ -515,6 +517,7 @@ export type PreparedDigestInput = {
 
   /** Update-authority aliases consulted by writeAuthorizedBy verification. */
   readonly moduleDelegations?: readonly ModuleDelegationSnapshotEntry[];
+
   // Digest of the policy snapshot the boundary decisions evaluated under
   // (Epic B5): anything that can change a boundary decision must be in the
   // digest, so a decision made under one rule set cannot be committed under
@@ -545,6 +548,7 @@ export type PostCommitSideEffect = {
    * authoritative intent arrives with, and the effects channel converges
    * on it instead of re-enacting (T2.Q7). Absent everywhere else. */
   nonce?: string;
+
   flush(tx: unknown): void | Promise<void>;
   /**
    * Called instead of {@link flush} when the work this effect stands for will

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -139,6 +139,7 @@ export interface CompiledDoc extends ModuleDocBase {
    * Absent on documents written before the field existed (→ parse fallback).
    */
   readonly exportNames?: readonly string[];
+
   readonly starTargetSpecs?: readonly string[];
   readonly importSpecs?: readonly string[];
   readonly policyManifests?: readonly unknown[];

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -319,6 +319,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
  * reject the missing cell".
  */
 const _toleratesMissingCache = new WeakMap<object, boolean>();
+
 function schemaToleratesMissing(schema: JSONSchema | undefined): boolean {
   if (schema === undefined) return true;
   if (!isObjectOrArray(schema)) return true;

--- a/packages/runner/src/executor/engine-wave-sink.ts
+++ b/packages/runner/src/executor/engine-wave-sink.ts
@@ -142,6 +142,7 @@ export class EngineWaveCommitSink implements WaveCommitSink {
      * under (replay detection keys on it — see the constructor doc).
      * The SpaceServer passes the DR1 holder identity. */
     sessionId: string;
+
     principal?: string;
 
     /** The shared, process-lifetime localSeq counter (see the

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -82,6 +82,7 @@ export type ExecutorHostOptions = {
     runtime: Runtime;
     dispose: () => Promise<void>;
   }>;
+
   policy?: SpaceServerPolicy;
 
   /** The RULED test switch for the tenure's space-root ensure (OW45
@@ -135,6 +136,7 @@ export class ExecutorHost {
   /** Wakers for in-flight backoff sleeps — close() flushes them so a
    * delayed re-activation never stalls shutdown. */
   readonly #backoffWakers = new Set<() => void>();
+
   readonly #stats: ServingLoopStats = emptyServingLoopStats();
   #releaseServerExecution: () => void = () => {};
   #closed = false;

--- a/packages/runner/src/executor/outbox.ts
+++ b/packages/runner/src/executor/outbox.ts
@@ -139,6 +139,7 @@ export class SpaceOutbox {
    * effect (fetch/llm callbacks return synchronously after starting
    * it), and outbox.completed counts only when it settles. */
   #capturing: Array<Promise<unknown>> | undefined;
+
   // Per-space egress budgets (Phase 6, serving-loop.md §5).
   readonly #budget: OutboxBudgetPolicy | undefined;
   readonly #now: () => number;
@@ -153,6 +154,7 @@ export class SpaceOutbox {
 
   /** Token bucket for the egress rate (burst = one second's tokens). */
   #egressTokens = 0;
+
   #egressRefilledAt = 0;
   #closed = false;
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -75,6 +75,7 @@ const EVENT_DEFERRAL_REARM_MS = 250;
  * creation path, while the cost of NO bound is a wedged tenure that
  * keeps its lease. */
 const DEFAULT_ROOT_ENSURE_DEADLINE_MS = 30_000;
+
 import {
   markRuntimeInjectedEventKeys,
   sanitizeRuntimeInjectedEventKeys,
@@ -225,6 +226,7 @@ export type SpaceServerPolicy = {
 
   /** serving-loop.md §1's IDLE_PARK_MS. */
   idleParkMs?: number;
+
   renewIntervalMs?: number;
 
   /** OW54's owner-ratified cumulative confirmed failed-state budget. */
@@ -254,6 +256,7 @@ export type SpaceServerPolicy = {
    * a bounded rate instead of once per admission. A successfully
    * committed wave clears the streak. */
   failureParkBackoffBaseMs?: number;
+
   failureParkBackoffMaxMs?: number;
 };
 
@@ -293,6 +296,7 @@ export type SpaceServerOptions = {
    * DEFERRED by the same ruling — this is a whole-instance switch,
    * never a policy about which spaces deserve roots. */
   ensureSpaceRoots?: boolean;
+
   policy?: SpaceServerPolicy;
   onParked?: (reason: string) => void;
 
@@ -458,6 +462,7 @@ export class SpaceServer implements TransactionSealDestination {
    * quiescence transition — armed only by CONTENT-carrying wave
    * commits, never by its own bookkeeping-only commit. */
   #coverageHead = 0;
+
   #watermark = 0;
 
   /** S1 (RULED 2026-08-19): this loop's own committed wave seqs still
@@ -477,6 +482,7 @@ export class SpaceServer implements TransactionSealDestination {
    * healthy space the prune-at-advance keeps the set near-empty and
    * the bound is never reached. */
   readonly #ownWaveSeqs = new Set<number>();
+
   static readonly #MAX_OWN_WAVE_SEQS = 4096;
 
   /** S1's once-per-quiescence-transition latch: armed when a wave with
@@ -487,6 +493,7 @@ export class SpaceServer implements TransactionSealDestination {
    * #coverageHead comment's commit-storm class stays structurally
    * unreachable. */
   #settleAdvanceOwed = false;
+
   #active = false;
   #loopRunning = false;
   #parkRequested = false;
@@ -556,6 +563,7 @@ export class SpaceServer implements TransactionSealDestination {
    * changed (or a session opened) and the grace elapsed; consumed by the
    * next #waitForInput. */
   #pendingDemandWake = false;
+
   // MINOR-1: a monotonic demand-note generation, bumped on every
   // `noteDemandChanged` (watch OR push-growth). A pass snapshots it at its
   // row read; if a note lands AFTER that snapshot but while the pass is
@@ -650,6 +658,7 @@ export class SpaceServer implements TransactionSealDestination {
    * drained seqs, insertion-ordered, pruned at a bound that far
    * exceeds any realistic in-process reorder window. */
   readonly #drainedLateWindow = new Set<number>();
+
   // (d′): `#demandSinks` (the per-key demand WALK effects,
   // `demand-walk:<space>/<root>`) is DELETED — demand is the tracked-ids
   // closure and its writers are standing demand roots (design §2.7).
@@ -759,6 +768,7 @@ export class SpaceServer implements TransactionSealDestination {
   /** Lease-local mirrors of durable OW54 processing checkpoints. A mirror is
    * installed only from stored state or after a wave confirms its write. */
   readonly #deliveryCheckpoints = new Map<string, DeliveryDeferral>();
+
   readonly #pendingDeliveryCheckpointWrites = new Map<string, {
     sidecarId: string;
     index: number;
@@ -784,10 +794,12 @@ export class SpaceServer implements TransactionSealDestination {
   /** Input frontier at which a processing-state write failed. Only a newer
    * admitted input may serve as the generic storage/input wake. */
   readonly #deliveryWriteBlockedAt = new Map<string, number>();
+
   /** Failed boundary associated with a checkpoint write that did not commit.
    * This is wake correlation only, never an age/checkpoint authority: a retry
    * re-observes the failure and starts from durable state. */
   readonly #uncommittedDeliveryFailureEpochs = new Map<string, string>();
+
   readonly #deliveryLoadRecoveries = new Map<string, string>();
 
   /** The deferral backstop timer (see EVENT_DEFERRAL_REARM_MS): armed
@@ -4103,6 +4115,7 @@ export class SpaceServer implements TransactionSealDestination {
    * is a lookup instead of a full key scan per action run (with the
    * closure as keys the scan would be O(closure) twice per pass). */
   readonly #keysByRootId = new Map<string, Set<string>>();
+
   readonly #keysByResolvedRoot = new Map<string, Set<string>>();
 
   #indexDemandKey(key: string, id: string): void {

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -289,6 +289,7 @@ export type ServingLoopStats = {
        * lands (NIT-1: these growth fields are optional, present only on a
        * promoted entry). */
       class: "value-only" | "structural-growth";
+
       eventAppend: boolean;
 
       /** ms from admission to the structural-growth LANDING (the derived
@@ -329,8 +330,10 @@ export type ServingLoopStats = {
      * quiescence advance, so W4 can split advance-only waves out of
      * the per-input settle timings. */
     series: Array<{ space: string; from: number; to: number; at: number }>;
+
     dropped: number;
   };
+
   events: {
     appended: number;
     processed: number;
@@ -427,6 +430,7 @@ export type ServingLoopStats = {
      * that grows without `processed` settling names a handler whose
      * argument never resolves. */
     handlerNotRunDeferrals: number;
+
     /** The pre-dispatch LOAD-PARK deferrals (verification-coverage.md's
      * OW45 residue member, fixed 2026-08-26): a served event's dispatch
      * preflight parked on an in-flight replica load its closure reads
@@ -449,10 +453,13 @@ export type ServingLoopStats = {
      * followers remain work counted by `loadParkDeferrals` only. */
     loadParkFailures: number;
 
-    /** Durable pending delivery checkpoints, split by whether confirmed
-     * failed-state time is currently accruing. */
+    /** Durable pending delivery checkpoints currently active, all states. */
     deliveryDeferralsActive: number;
+
+    /** How many of those are failed, and so accruing failed-state time. */
     deliveryFailuresActive: number;
+
+    /** The greatest failed-state time any one active checkpoint has accrued. */
     maxAccumulatedDeliveryFailureMs: number;
 
     /** Durable terminal covers, counted only after the carrying wave commits. */
@@ -464,6 +471,7 @@ export type ServingLoopStats = {
         "commit-finalization": number;
       };
     };
+
     needsAttentionSealFailures: number;
     deliveryCheckpointWriteFailures: number;
     explicitRetries: number;

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -114,6 +114,7 @@ export interface WaveRunContext {
   /** Durable action identity for basis rows (serving-loop.md §3b):
    * restart-stable, never per-process. */
   actionId: string;
+
   kind: WaveRunKind;
 
   /** ATTRIBUTION — the acting identity, one per action run, where the run
@@ -415,6 +416,7 @@ export interface WaveSpaceCommit {
    * (§3's sealing-order MUST binds the loop's processing order; this step
    * preserves what it was handed). */
   operations: Operation[];
+
   preconditions: CommitPrecondition[];
 
   /** Owning contribution index per precondition — home batch only; lets a
@@ -426,6 +428,7 @@ export interface WaveSpaceCommit {
    * letting the accumulator identify the one event whose deterministic write
    * was refused without terminalizing unrelated events in the same wave. */
   operationOwners?: number[];
+
   annotations: WaveWriteAnnotation[];
 
   /** Every eventId whose handler consequences ride this commit. */
@@ -527,6 +530,7 @@ export interface WaveCommitSink {
     doc: { id: string; scope?: CellScope; scopeKey: string },
     sinceSeq: number,
   ): Promise<ReadonlyArray<readonly string[]>>;
+
   commitWave(
     batch: WaveSpaceCommit,
   ): Promise<Result<{ seq: number }, WaveCommitRejection>>;
@@ -605,6 +609,7 @@ export interface WaveCommitOutcome {
   /** The home commit's store seq; absent when the wave had nothing to
    * commit or aborted. */
   seq?: number;
+
   aborted?: "lease-lost" | "abandoned" | "foreign-commit-failed" | "rejected";
 
   /** Superseded pure-derivation writes dropped at the per-doc CAS —
@@ -645,6 +650,7 @@ export interface WaveCommitOutcome {
    * NOT reported as requeued (there is no entry to retry); the serving
    * loop's `events.orphanDeliveriesRefused` feeds from this. */
   orphanDeliveriesRefused: number;
+
   dispositions: ContributionDisposition[];
 
   /** Foreign provisioning batches this wave DURABLY COMMITTED, in commit
@@ -754,6 +760,7 @@ interface PendingAssembly {
   /** Undefined until the post-seal emptiness check: a tx with writes and
    * no context is refused; an empty tx needs none. */
   context: WaveRunContext | undefined;
+
   spaces: SealedSpaceContribution[];
   readOnlyReadKeys: Set<string>;
   discoveredScope: CellScope;
@@ -843,6 +850,7 @@ export class WaveAccumulator
    * A post-seal enqueue on the same tx is refused — it could no longer
    * ride this wave's transaction. */
   readonly #pendingAppendsByTx = new WeakMap<object, OutboxAppendRow[]>();
+
   readonly #sealedTxs = new WeakSet<object>();
   readonly #onUnstampedSeal: (() => void) | undefined;
   readonly #onEarlyEmitRefusal: (() => void) | undefined;
@@ -864,6 +872,7 @@ export class WaveAccumulator
      * loop supplies per-run demanded identities when it builds real
      * accumulators. */
     scopeKeyIdentity: ScopeKeyIdentity;
+
     replicaFor: (space: MemorySpace) => ISpaceReplica;
     lease?: WaveLease;
 
@@ -1604,6 +1613,7 @@ export class WaveAccumulator
      * withdrawn foreign write into the withdrawal (the cross-space half
      * of the closure below). */
     const byLocalSeq = new Map<MemorySpace, Map<number, number>>();
+
     for (const contribution of this.#contributions) {
       for (const sealed of contribution.spaces) {
         let perSpace = byLocalSeq.get(sealed.space);
@@ -1632,6 +1642,7 @@ export class WaveAccumulator
      * (`orphanRefusedEvents`), since an orphan-refused copy takes its
      * same-eventId siblings down with it (the sibling fold below). */
     const orphanRefused = new Set<number>();
+
     const orphanRefusedEvents = new Set<string>();
 
     /** eventId → the contribution (and its home sidecar doc-instance

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -323,6 +323,7 @@ export class Engine extends EventTarget {
    * this member directly.
    */
   private sesRuntime: SESRuntime | undefined;
+
   #nextEvalId = 0;
 
   /**
@@ -330,6 +331,7 @@ export class Engine extends EventTarget {
    * this member directly.
    */
   private readonly executableRegistry = new ExecutableRegistry();
+
   readonly #consoleShim = createSafeConsoleGlobal(new Console(this));
   readonly #patternCoverageByGraph = new WeakMap<
     CompiledModuleGraph,

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -39,6 +39,7 @@ export type LastNode = "value" | "writeRedirect" | "top";
  * has any links between the top and the value at `link.path`.
  */
 declare const resolvedFullLinkBrand: unique symbol;
+
 export type ResolvedFullLink = NormalizedFullLink & {
   // type-script only marker, doesn't appear in actual data
   [resolvedFullLinkBrand]: true;
@@ -66,6 +67,7 @@ type LinkHop = {
    * subject is the link as stored.
    */
   storedSchema?: JSONSchema;
+
   link: NormalizedFullLink;
   source: NormalizedFullLink;
   kind: "value" | "write-redirect";

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -64,6 +64,7 @@ export function parseScopedIdSegment(idSegment: string): {
 export type ScopeCapAtDepth = {
   /** Number of leading `path` segments the declaring schema addresses. */
   depth: number;
+
   scope: SchemaScope;
 };
 

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -734,6 +734,7 @@ export function unwrapOneLevelAndBindToDoc<T extends FabricExecValue>(
       return converted;
     } else return binding;
   }
+
   return convert(binding, options?.targetSchema) as T;
 }
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -62,6 +62,7 @@ import type { MemorySpace, Runtime, ServerRunInfo } from "./runtime.ts";
  * and threaded to the writeback stamps, where it applies only to writes
  * FOREIGN to the serving manager's home space. */
 export type WritebackDelegation = NonNullable<ServerRunInfo["delegated"]>;
+
 import {
   isFabricImportSpecifier,
   parseFabricRef,
@@ -651,6 +652,7 @@ export class PatternManager {
       `to=${record.toSpace}`,
     ]);
   }
+
   // Maps each storage slot written during this PatternManager session to its
   // complete module set. One slot can hold only one closure shape at a time.
   private persistedCompileCacheClosures = new Map<string, string>();

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -232,6 +232,7 @@ type InternalCellDescriptor = {
    * re-materialize the cell under its new id rather than reuse the old link.
    */
   kind?: EntityKind;
+
   link: SigilLink;
 };
 
@@ -963,10 +964,12 @@ export interface PieceSourceRevision {
 
   /** Link retaining the exact content-addressed source closure. */
   source: SigilLink;
+
   origin?: string;
 
   /** The legacy origin string, when normalizing it changed its value. */
   recordedOrigin?: string;
+
   operation: PieceSourceRevisionOperation;
   selectedRevisionId?: string;
 }
@@ -1037,6 +1040,7 @@ export interface PieceSourceTransition {
 
   /** The active origin after the transition. Null means detached. */
   origin: string | null;
+
   expected: PieceSourceSnapshot;
   selectedRevisionId?: string;
 }
@@ -1714,6 +1718,7 @@ export class Runner {
   ): { identity: string; symbol: string } | undefined {
     return this.sessionPatternPointers.get(this.getDocKey(resultCell));
   }
+
   // SESSION-side pattern-swap channel for RUNNING pieces, the third stamp
   // stand-in: a re-derived child (a lift returning a pattern) used to reach
   // its running piece's swap machinery THROUGH the durable stamp — setup

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -713,6 +713,7 @@ export interface ProductionServerPresetParams extends CoreParams {
    * `apiUrl` carries MEMORY_URL.
    */
   patternApiUrl?: URL;
+
   consoleHandler?: ConsoleHandler;
   errorHandlers?: ErrorHandler[];
   telemetry?: RuntimeTelemetry;
@@ -745,12 +746,14 @@ export interface RemoteClientPresetParams extends CoreParams {
    * in `coreOptions`.
    */
   cfcEnforcementMode?: CfcEnforcementMode;
+
   cfcFlowLabels?: CfcFlowLabelsMode;
 }
 
 export interface PatternTestPresetParams extends CoreParams {
   /** Mock fetch honoring test-declared `fetchMocks` (CT-1768). */
   fetch?: RuntimeFetch;
+
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
   moduleByteCache?: ModuleByteCache;
@@ -771,6 +774,7 @@ export interface BrowserWorkerPresetParams extends CoreParams {
 
   /** Host-controlled rollout dials, from `InitializationData`. */
   cfcEnforcementMode?: CfcEnforcementMode;
+
   cfcFlowLabels?: CfcFlowLabelsMode;
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
   telemetry?: RuntimeTelemetry;
@@ -786,6 +790,7 @@ export interface BrowserWorkerPresetParams extends CoreParams {
 export interface UnitTestPresetParams extends Omit<CoreParams, "experimental"> {
   /** Optional here (unlike the first-party presets): unit tests default to no flags. */
   experimental?: ExperimentalOptions;
+
   fetch?: RuntimeFetch;
   errorHandlers?: ErrorHandler[];
   moduleByteCache?: ModuleByteCache;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -497,6 +497,7 @@ export interface RuntimeOptions {
    * one. Fixed for the runtime's lifetime.
    */
   spaceHostMap?: Record<string, string>;
+
   storageManager: IStorageManager;
   consoleHandler?: ConsoleHandler;
   errorHandlers?: ErrorHandler[];
@@ -708,6 +709,7 @@ export interface CfcRuntimeStats {
    * (`flowLabelWorkExists`) vs answered from the transaction's memoized
    * negative verdict. Measurement only. */
   flowLabelProbesComputed: number;
+
   flowLabelProbeMemoHits: number;
   cfcPreparedTx: number;
   cfcPrepareRejects: number;
@@ -880,6 +882,7 @@ export class Runtime {
 
   /** See `RuntimeOptions.onPatternInstantiated`. */
   readonly onPatternInstantiated?: PatternInstantiationObserver;
+
   readonly cfcFlowLabels: CfcFlowLabelsMode;
   readonly cfcWriteFloor: CfcWriteFloorMode;
   readonly cfcTriggerReadGating: CfcTriggerReadGating;
@@ -895,6 +898,7 @@ export class Runtime {
 
   /** Frozen deployment trust config; undefined = no trust configured. */
   readonly cfcTrustConfig: CfcTrustConfig | undefined;
+
   readonly staticCache: StaticCache;
   readonly storageManager: IStorageManager;
 
@@ -903,6 +907,7 @@ export class Runtime {
 
   /** Optional pattern statement-coverage collector; see RuntimeOptions. */
   readonly patternCoverage?: PatternCoverageCollector;
+
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
   // The runtime's trust revision — `<runtime id>` with the trust-config
   // digest folded in when one is configured. The ONE composition site for
@@ -917,6 +922,7 @@ export class Runtime {
 
   /** Resolved committed-write backpressure policy (all fields present). */
   readonly commitBackpressure: CommitBackpressurePolicy;
+
   readonly apiUrl: URL;
   readonly spaceHostMap?: Record<string, string>;
 
@@ -929,6 +935,7 @@ export class Runtime {
 
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
+
   // The transaction seal destination (server-execution v2, serving-loop.md
   // §3d): installed only on a serving runtime under
   // EXPERIMENTAL_SERVER_EXECUTION, by the wave machinery around each wave.
@@ -968,6 +975,7 @@ export class Runtime {
    * NOTE-a: R1.dispose after R2's construction must not drop R2's
    * subscriptions). */
   #installedSpaceOpenObserver: ((space: MemorySpace) => void) | undefined;
+
   // Whether THIS runtime explicitly set the serverExecution flag at
   // construction (the only case its dispose participates in the
   // process-global ambient lifecycle — see the constructor's propagation
@@ -985,6 +993,7 @@ export class Runtime {
    * SpaceServer's own runtime. Gates the Phase-2 speculation-overlay
    * default (a serving runtime never speculates). */
   readonly servingPosture: boolean;
+
   readonly userIdentityDID: DID;
 
   /**
@@ -1002,6 +1011,7 @@ export class Runtime {
 
   /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
   readonly #spaceNameToDid = new Map<string, MemorySpace>();
+
   #defaultFrame?: Frame;
   #queues = new Map<string, AsyncSemaphoreQueue>();
   #writeDebugContext = new WriteDebugContextStorage<string>();
@@ -3455,6 +3465,7 @@ export class Runtime {
   get serverGitSha(): string | null {
     return this.#serverGitSha;
   }
+
   #serverGitSha: string | null = null;
   #healthCheckGeneration = 0;
 

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -106,6 +106,7 @@ export const RESERVED_FACTORY_BINDING_SET: ReadonlySet<string> = new Set<
 >(
   RESERVED_FACTORY_BINDINGS,
 );
+
 const DEFAULT_EXPORT_ALLOWED_BINDING_ERROR =
   "Default exports must be trusted builders, direct functions, verified data, or import re-exports";
 

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -12,6 +12,7 @@ export interface FabricRef {
 
   /** Space name or DID; absent = the compiling space. */
   space?: string;
+
   ref:
     | { kind: "slug"; slug: string }
     | { kind: "uri"; scheme: EntityUriScheme | "pattern"; hash: string };

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -56,10 +56,11 @@ export function dataFileSpecifier(path: string): string {
 }
 
 /**
- * Memo of the two pure derivations {@link buildRecordsFromCompiled} extracts
- * from a module's compiled body: its direct export surface (names + `export *`
- * target specifiers) and its runtime `require()` specifiers. **Keyed by the
- * compiled body itself** — both derivations are pure functions of that body.
+ * Memo of one of the two pure derivations {@link buildRecordsFromCompiled}
+ * extracts from a module's compiled body: its direct export surface (names +
+ * `export *` target specifiers). Its partner is `importParseCache` below.
+ * **Keyed by the compiled body itself** — both derivations are pure functions
+ * of that body.
  *
  * At piece boot every system pattern loaded by identity rebuilds its record
  * graph from the SAME shared module closure, so `buildRecordsFromCompiled` runs
@@ -75,7 +76,7 @@ export function dataFileSpecifier(path: string): string {
  * body's parse for another; the body fully determines the parse, so a body key
  * is exact and cross-contamination is impossible.
  *
- * The two maps are process-global and unbounded by design: one small
+ * Both maps are process-global and unbounded by design: one small
  * record-surface entry (export names + import specifiers) per distinct compiled
  * body, retained for the process lifetime and keyed by the body string. Distinct
  * bodies are bounded by the pattern universe a worker serves; a long-lived
@@ -89,6 +90,12 @@ const exportParseCache = new Map<
   string,
   { exportNames: readonly string[]; starTargetSpecs: readonly string[] }
 >();
+
+/**
+ * Memo of the other derivation: the module body's runtime `require()`
+ * specifiers. Same key, same lifetime, and same reasoning as
+ * `exportParseCache` above.
+ */
 const importParseCache = new Map<string, readonly string[]>();
 
 function parseCompiledExports(
@@ -383,6 +390,7 @@ export interface CompileSourcesOptions {
    * `cf:runtime/<specifier>`; the caller must register a matching record.
    */
   runtimeModules?: Record<string, string[]>;
+
   runtimeFingerprint?: string;
 
   /**
@@ -1026,6 +1034,7 @@ export interface CachedCompiledModule {
    * which parses and writes the surface back for later warm loads.
    */
   exportNames?: readonly string[];
+
   starTargetSpecs?: readonly string[];
   importSpecs?: readonly string[];
 

--- a/packages/runner/src/scheduler/dependency-graph.ts
+++ b/packages/runner/src/scheduler/dependency-graph.ts
@@ -15,6 +15,7 @@ import type {
 export interface DependencyGraphState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly triggerIndex: TriggerIndexState;
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;

--- a/packages/runner/src/scheduler/event-preflight-dependencies.ts
+++ b/packages/runner/src/scheduler/event-preflight-dependencies.ts
@@ -23,6 +23,7 @@ import type {
 export interface EventPreflightDependencyState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly getTrace: () => EventPreflightTraceContext | undefined;
   readonly nodes: NodeRegistry;
   readonly pending: ReadonlySet<Action>;

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -763,6 +763,7 @@ export interface SchedulerEventExecutionState {
     deps: ReactivityLog,
     actor: ScopeKeyIdentity,
   ) => Action[];
+
   readonly setEventPassDemandRefresh: (
     refresh: ((demand: Set<Action>) => void) | undefined,
   ) => void;
@@ -817,6 +818,7 @@ export function preflightQueuedEventDependencies(state: {
     deps: ReactivityLog,
     actor: ScopeKeyIdentity,
   ) => Action[];
+
   readonly collectPendingLoadParkKeys: (
     event: QueuedEvent,
     deps: ReactivityLog,

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -151,6 +151,7 @@ export type SchedulerSettleResult = {
 
   /** Actions deferred by convergence backoff in this settle pass. */
   backoffActions: readonly Action[];
+
   backoffUntil?: number;
 
   /** Iterations that actually ran work (excludes the final settled check). */
@@ -161,12 +162,14 @@ export type SchedulerSettleResult = {
 
   /** Number of actions in the final non-empty settle work set. */
   workSetSize: number;
+
   settleStats?: SettleStats;
 };
 
 export interface SchedulerSettleLoopState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly getCollectSettleStats: () => boolean;
   readonly effects: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
@@ -188,6 +191,7 @@ export interface SchedulerSettleLoopState {
 
   /** Refresh transient demand such as a head event's current invalid closure. */
   readonly refreshPassScopedDemand?: (demand: Set<Action>) => void;
+
   readonly getActionId: (action: Action) => string;
   readonly isThrottled: (action: Action) => boolean;
   readonly getNextEligibleRunTime: (action: Action) => number | undefined;
@@ -277,6 +281,7 @@ export function planBudgetBackoff(state: {
 
   /** Transient demand roots, such as a head event's preflight closure. */
   readonly passScopedDemand?: ReadonlySet<Action>;
+
   readonly nodes: NodeRegistry;
   readonly pending: ReadonlySet<Action>;
   readonly isLiveAction: (action: Action) => boolean;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1083,6 +1083,7 @@ export class Scheduler {
    * `stats.demand` accumulators (these reset with the runtime on a
    * reactivation, so they are a per-tenure source, not the total). */
   readonly demandRootCounters = { enters: 0, leaves: 0, notCurrentRearms: 0 };
+
   #demandedWriterHookInstalled = false;
 
   #installDemandedWriterHook(): void {
@@ -2973,6 +2974,7 @@ export class Scheduler {
        * durable entry UNCONSEQUENCED for a later drain (events.md §5);
        * only meaningful for a served event. */
       servedKind?: "dropped" | "deferred";
+
       servedOutcome?: ServedEventFailureOutcome;
     } = {},
   ): void {

--- a/packages/runner/src/scheduler/graph-snapshot.ts
+++ b/packages/runner/src/scheduler/graph-snapshot.ts
@@ -16,6 +16,7 @@ import type { Action, ReactivityLog } from "./types.ts";
 export interface SchedulerGraphSnapshotState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly effects: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
   readonly pending: ReadonlySet<Action>;

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -24,6 +24,7 @@ export class SpeculationLineage {
 
     /** Wake the scheduler (parked cross-space events become ready). */
     queueExecution: () => void;
+
     onError: (error: unknown) => void;
   };
 
@@ -34,6 +35,7 @@ export class SpeculationLineage {
 
       /** Wake the scheduler (parked cross-space events become ready). */
       queueExecution: () => void;
+
       onError: (error: unknown) => void;
     },
   ) {

--- a/packages/runner/src/scheduler/materializers.ts
+++ b/packages/runner/src/scheduler/materializers.ts
@@ -10,6 +10,7 @@ import type { Action, ReactivityLog, SpaceScopeAndURI } from "./types.ts";
 export interface MaterializerIndexState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly materializersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly effects: ReadonlySet<Action>;
   getMaterializerWriteEnvelopes(

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -11,6 +11,7 @@ import type { Action, SpaceScopeAndURI } from "./types.ts";
 export interface WriterIndexState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
   setSurface(action: Action, surface: IMemorySpaceAddress[]): void;

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -18,6 +18,7 @@ import type { Action, ReactivityLog, SpaceScopeAndURI } from "./types.ts";
 export interface TriggerIndexState {
   /** Identity entity keys resolve scoped addresses against (keys.ts). */
   readonly scopeKeyIdentity: () => ScopeKeyIdentity;
+
   readonly triggers: Map<
     SpaceScopeAndURI,
     Map<Action, SortedAndCompactPaths>

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -34,6 +34,7 @@ export type TelemetryAnnotations = {
     materializerWriteEnvelopes: NormalizedFullLink[];
     directOutputs: NormalizedFullLink[];
   };
+
   schedulerObservationIdentity?: SchedulerObservationIdentity;
 };
 
@@ -114,6 +115,7 @@ export type ReactivityLog = {
 
   /** Reads that should not invalidate on child writes unless they add a new key */
   shallowReads: IMemorySpaceAddress[];
+
   writes: IMemorySpaceAddress[];
 };
 
@@ -128,6 +130,7 @@ export type EventPreflightTraceContext = SchedulerEventPreflightStats & {
  * `entityKey` — see `keys.ts` for the identity-threading contract.
  */
 export type SpaceScopeAndURI = `${MemorySpace}/${ScopeKey}/${URI}`;
+
 export type SpaceScopeURIAndType =
   `${MemorySpace}/${ScopeKey}/${URI}/${MediaType}`;
 
@@ -139,6 +142,7 @@ export type SettleIterationStats = {
 
   /** Action IDs in the work set (truncated to top entries) */
   actions: { id: string; type: "effect" | "computation" }[];
+
   durationMs: number;
 };
 
@@ -260,6 +264,7 @@ export type ServedEventFailureOutcome =
      * drain re-delivers it; the deferral threshold hardens a permanently
      * unresolvable argument into the visible §5 DROP notice. */
     kind: "deferred";
+
     cause: "handler-not-run";
     message: string;
   }
@@ -299,6 +304,7 @@ export type ServedEventDispatch = {
    * `streamEntry`-less served copy); absent on the drain's copies and
    * everywhere client-side. */
   lt1?: { emitterTx: IExtendedStorageTransaction };
+
   /** The outcome is discriminated so an arrival-barrier follower can never
    * inherit the failing head's checkpoint or typed failure evidence. */
   onFailure?: (outcome: ServedEventFailureOutcome) => void;
@@ -353,6 +359,7 @@ export type QueuedEvent = {
 
   /** The transaction whose handler sent this event, when transactional. */
   readonly originTx?: IExtendedStorageTransaction;
+
   eventLink: NormalizedFullLink;
   action: Action;
   handler: EventHandler;
@@ -391,6 +398,7 @@ export type QueuedEvent = {
    * previously-unresolved name, and a resolved name never becomes pending again).
    */
   retry: boolean;
+
   onCommit?: (tx: IExtendedStorageTransaction) => void;
 
   /**
@@ -407,6 +415,7 @@ export type QueuedEvent = {
    * callback: the mark rode the tx. Absent on every client-side event.
    */
   served?: ServedEventDispatch;
+
   notBefore?: number;
 
   /**

--- a/packages/runner/src/scheduler/wake-shaping.ts
+++ b/packages/runner/src/scheduler/wake-shaping.ts
@@ -95,6 +95,7 @@ export interface WakeHold {
 
   /** Deliver the leading edge on a fresh macrotask instead of synchronously. */
   defer?: boolean;
+
   deliver: () => void;
 }
 
@@ -106,6 +107,7 @@ interface ThrottleGroup {
 
   /** itemKey -> deliver thunk; unique keys preserve FIFO, shared keys coalesce. */
   pending: Map<string, () => void>;
+
   timer: ReturnType<typeof setTimeout> | undefined;
 
   /** Deferred leading-edge deliveries scheduled but not yet run. */

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1402,6 +1402,7 @@ class TransformObjectCreator
    * drives this member directly.
    */
   private tx: IExtendedStorageTransaction;
+
   #synced: boolean;
   #baseLink: NormalizedFullLink;
   #cfcLabelView: CfcLabelView | undefined;

--- a/packages/runner/src/space-host.ts
+++ b/packages/runner/src/space-host.ts
@@ -46,6 +46,7 @@ export const normalizeSpaceHost = (host: string | URL): URL => {
       "Space host must contain only an origin",
     );
   }
+
   return parsed;
 };
 

--- a/packages/runner/src/speculation/doc-notification-listener.ts
+++ b/packages/runner/src/speculation/doc-notification-listener.ts
@@ -73,6 +73,7 @@ export class CoalescedDocListener {
   /** DIAGNOSTIC: notifications that touched a wanted doc; microtask
    * checks dispatched. */
   #relevantNotifications = 0;
+
   #dispatches = 0;
 
   constructor(

--- a/packages/runner/src/speculation/effects-channel.ts
+++ b/packages/runner/src/speculation/effects-channel.ts
@@ -98,6 +98,7 @@ export class EffectsChannel {
    * nonce at a time; a failed ack retries on the next sink delivery
    * (the entry is still unacked there). */
   readonly #acking = new Set<string>();
+
   #warnedNoNavigate = false;
   #closed = false;
 

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -285,6 +285,7 @@ export class SpeculationOverlayDestination
    * already terminal has no job — the authoritative consequences exist
    * (speculation.md §4 step 2) — and is not registered. */
   readonly #terminalIntents = new Set<string>();
+
   static readonly #MAX_TERMINAL_INTENTS = 4096;
 
   /** The client cascade THREAD (stage C W2.1): cascade child eventId →
@@ -311,6 +312,7 @@ export class SpeculationOverlayDestination
 
   /** DIAGNOSTIC counters (tests). */
   #arrivalSweeps = 0;
+
   #lateEchoDrops = 0;
 
   /** Stage C W2.1: cascade-child echoes retired because an ANCESTOR
@@ -319,6 +321,7 @@ export class SpeculationOverlayDestination
    * wrote had yet moved past their read basis in the replica — the
    * flicker witness (see `retireIntent`). */
   #cascadeEchoRetirements = 0;
+
   #cascadeEchoRetirementsUnarrived = 0;
 
   /** F6 telemetry (combined review 2026-08-19): the silent-strand
@@ -329,6 +332,7 @@ export class SpeculationOverlayDestination
    * posture, with nothing else to see. Zero in every expected
    * workload; nonzero is the signal to look. */
   #cascadeThreadEvictions = 0;
+
   #cascadeWalkDepthCaps = 0;
 
   /** space -> last observed watermark (for registration-time sweeps). */
@@ -369,6 +373,7 @@ export class SpeculationOverlayDestination
   /** DIAGNOSTIC counters (tests; the `commonfabric.*` surface reads the
    * logger keys — `speculation-overlay/intent-*`). */
   #intentCheckCount = 0;
+
   #intentCheckVisits = 0;
   #intentCheckMaxVisits = 0;
   #intentListenerInstalls = 0;
@@ -395,6 +400,7 @@ export class SpeculationOverlayDestination
   /** Resolvers parked by `waitForIntentQuiescence`, flushed by the same
    * untrack step that empties the outstanding-intent set (and by close). */
   #intentQuiescenceWaiters: Array<() => void> = [];
+
   #closed = false;
 
   constructor(runtime: Runtime) {
@@ -431,6 +437,7 @@ export class SpeculationOverlayDestination
    * neutralized start's authored commit usually LOSES its create-only
    * race to the serving side and vanishes whole. */
   #eventEchoSeals = 0;
+
   get eventEchoSealCount(): number {
     return this.#eventEchoSeals;
   }
@@ -1620,6 +1627,7 @@ export class SpeculationOverlayDestination
     /** The mark frame's seq (the sidecar's confirmed seq at this check);
      * 0 = unknown → the witness does not count. */
     let markSeq: number | undefined;
+
     for (const entry of [...entries.values()]) {
       const own = entry.eventId === eventId;
       if (!own && !this.#cascadeReaches(entry, eventId)) continue;

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -70,11 +70,13 @@ export type QueuedEventAppend = {
 
   /** The durable client-minted event id (event-identity). */
   eventId: string;
+
   payload?: FabricValue;
 
   /** The one client-minted firedAt component (events.md §1): orders
    * this session's own appends and steers nothing. */
   clientSeq: number;
+
   runtimeInjectedEventKeys?: string[];
 
   /** See StreamEventEntry.rendererTrusted (fan-out stage B). */
@@ -202,10 +204,12 @@ export class EventAppendQueue {
   /** OW27 pacing: the per-stream token buckets (keyed by sidecar doc id
    * — one per stream), or undefined when pacing is disabled. */
   readonly #pacing: EventAppendPacing | undefined;
+
   readonly #buckets = new Map<string, { tokens: number; refilledAt: number }>();
 
   /** DIAGNOSTIC (tests): sends held by pacing so far. */
   #pacedHolds = 0;
+
   #loaded: Promise<void>;
 
   /** The tail of the save chain — `persisted` awaits it (tests, and
@@ -224,6 +228,7 @@ export class EventAppendQueue {
      * across other commits, and a session-replacement resubmit needs a
      * fresh one anyway. */
     nextLocalSeq: () => number;
+
     store?: EventAppendQueueStore;
     onRefused?: (append: QueuedEventAppend, reason: string) => void;
 

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -157,6 +157,7 @@ type CfcInstrumentationHooks = {
    * answered from the memoized negative verdict (`memo`). Measurement
    * only. */
   onFlowLabelProbe?(outcome: "computed" | "memo"): void;
+
   onPreparedTx?(): void;
   /**
    * CFC prepare refused this transaction. `reasons` are the PLAIN reason
@@ -171,6 +172,7 @@ type CfcInstrumentationHooks = {
     refusals: readonly CfcRefusalDetail[];
     terminal: boolean;
   }): void;
+
   onDigestInvalidation?(reason: string): void;
   onOutboxFlush?(effect: PostCommitSideEffect): void;
   onSinkDedupHit?(key: string): void;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -931,6 +931,7 @@ export interface IWriteOptions {
    * from absent. A root-path delete retracts the document.
    */
   delete?: boolean;
+
   /**
    * Marks the write as one the runtime makes on a document's meta seam. See
    * {@link RAW_META_WRITE}: the write chokepoint accepts a write that reaches
@@ -1097,6 +1098,7 @@ export interface IStorageTransaction {
    * transactions.
    */
   setReadOnly?(reason?: string): void;
+
   clearReadOnly?(): void;
   isReadOnly?(): boolean;
 
@@ -1129,6 +1131,7 @@ export interface IStorageTransaction {
     space: MemorySpace,
     precondition: CommitPrecondition,
   ): void;
+
   getCommitPreconditions?(
     space: MemorySpace,
   ): readonly CommitPrecondition[] | undefined;
@@ -1561,6 +1564,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * a caller writing documents itself.
    */
   stageSchemaDocClosure(space: MemorySpace, rootHash: string): void;
+
   tx: IStorageTransaction;
 
   /**
@@ -1624,6 +1628,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
     space: MemorySpace,
     precondition: CommitPrecondition,
   ): void;
+
   getCommitPreconditions?(
     space: MemorySpace,
   ): readonly CommitPrecondition[] | undefined;
@@ -1728,6 +1733,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * threading metadata through intermediate APIs.
    */
   runWithAmbientReadMeta<T>(meta: Metadata, fn: () => T): T;
+
   markCfcRelevant(reason?: string): void;
   invalidateCfc(reason: string): void;
 
@@ -1751,6 +1757,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * after the transaction it was made against has finished.
    */
   markLazyMaterialize(enabled?: boolean): void;
+
   isLazyMaterialize(): boolean;
 
   /**
@@ -1786,6 +1793,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * of the run the same way either way.
    */
   noteSchemaRefusal(refusal: unknown): void;
+
   takeSchemaRefusal(): unknown;
 
   /**
@@ -2345,6 +2353,7 @@ export interface INotFoundError extends IStorageError {
 
   /** Path to the non-existent key, or `[]` if the document doesn't exist. */
   readonly path: readonly MemoryAddressPathComponent[];
+
   from(space: MemorySpace): INotFoundError;
 }
 
@@ -2495,6 +2504,7 @@ export type EventAppendRequest = {
   /** Client-minted append order within this session; allocated by the
    * queue when absent. */
   clientSeq?: number;
+
   runtimeInjectedEventKeys?: string[];
 
   /** The runtime's attestation that the sent event was renderer-trusted

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -17,6 +17,7 @@ export interface SessionFactory {
    *  by lower-level replica tests omit this because they intentionally model
    *  only the messages under test. */
   readonly supportsAclBootstrap?: boolean;
+
   create(
     space: MemorySpace,
     signer?: Signer,

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -890,6 +890,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   get scopeKeyIdentity(): ScopeKeyIdentity | undefined {
     return this.#scopeKeyIdentity;
   }
+
   set scopeKeyIdentity(identity: ScopeKeyIdentity | undefined) {
     if (identity === undefined) return;
     const current = this.#scopeKeyIdentity;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -454,6 +454,7 @@ type PendingCommitRead = {
    * {@link PendingRead.basisSeq} (memory/v2.ts).
    */
   basisSeq: number;
+
   nonRecursive?: boolean;
 };
 
@@ -621,6 +622,7 @@ export interface Options {
    * stateful operation.
    */
   spaceHostMap?: Record<string, string>;
+
   id?: string;
   settings?: IRemoteStorageProviderSettings;
 
@@ -890,6 +892,7 @@ export class StorageManager implements IStorageManager {
 
   /** Phase 5: the serving manager's home space (Options.servingHomeSpace). */
   #servingHomeSpace?: MemorySpace;
+
   #spaceIdentities = new Map<MemorySpace, Signer>();
 
   /** Genesis ACL owners registered beside a space identity (OW31): the
@@ -2202,6 +2205,7 @@ type ProviderOptions = {
    * differentials resolve scoped change addresses against.
    */
   scopeKeyIdentity: () => ScopeKeyIdentity;
+
   routeState: ProviderRouteState;
   createSession: (
     routeGeneration: number,
@@ -2685,6 +2689,7 @@ type InFlightCommit = {
    * carry the same `localSeq` field, so they contribute here too).
    */
   readonly dependencies: ReadonlySet<number>;
+
   readonly operations: NativeCommitOperation[];
   readonly source?: IStorageTransaction;
   readonly commit: ClientCommit;
@@ -2751,6 +2756,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * own-identity address with a map lookup, never a per-read
    * `resolveScopeKey`. A scope the identity cannot resolve keys by NAME. */
   #ownInstanceKeys: Map<string, string> | undefined;
+
   readonly #createSession: () => Promise<{
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
@@ -2776,6 +2782,7 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    *  Cleared when the owed remount is consumed — or immediately, when there
    *  is no memoized mount to replace. */
   #aclChangedSinceMount = false;
+
   readonly #docs = new Map<string, DocumentRecord>();
   readonly #syncTasks = new Map<string, SyncTask>();
   readonly #commitPromises = new Set<Promise<unknown>>();
@@ -2860,12 +2867,14 @@ class SpaceReplica implements ISpaceReplica, IOperationStorageCapability {
    * duplicate-as-delivered classification; its entries are the client's
    * offline event queue. */
   #eventAppendQueue?: EventAppendQueue;
+
   #eventAppendQueueStore?: EventAppendQueueStore;
   #eventAppendPacing?: EventAppendPacing | false;
 
   /** Phase 5's producer-side foreign-scoped-read refusal (see
    * ProviderOptions.refuseForeignScopedReads). */
   #refuseForeignScopedReads = false;
+
   #closed = false;
   readonly #closeSignal = Promise.withResolvers<void>();
   #getTelemetry: () => TelemetrySink | undefined;

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -76,6 +76,7 @@ export type TraverseFixture = {
 
   /** Full fact values keyed by `space|scope|id|type`. */
   docs: Record<string, FabricValue>;
+
   invocations: TraverseFixtureInvocation[];
 };
 
@@ -97,6 +98,7 @@ export class TraverseCaptureRecorder {
    * `test/traverse-replay/profile.ts` drives this member directly.
    */
   private invocations: TraverseFixtureInvocation[] = [];
+
   #selectors: SchemaPathSelector[] = [];
   #selectorIndex = new Map<string, number>();
   #links: NormalizedFullLink[] = [];

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -398,6 +398,7 @@ function narrowAndCombineSelectorForLink(
 const EMPTY_PROPERTIES_MARKER: JSONSchema = Object.freeze(
   { $comment: "emptyProperties" },
 );
+
 const MISSING_PROPERTY_MARKER: JSONSchema = Object.freeze(
   { $comment: "missingProperty" },
 );
@@ -622,10 +623,12 @@ function combinatorRestSchema(
 type PreparedAnyOfBranch = {
   /** Original option was the `false` schema: counted, never matched. */
   optionIsFalse: boolean;
+
   merged: JSONSchema;
 
   /** Prefilter verdict known statically (boolean merged / unresolved $ref). */
   constant: boolean | undefined;
+
   hasAsCell: boolean;
 
   /** Normalized type list of the resolved merged schema, if constrained. */
@@ -793,6 +796,7 @@ export function traverseDiagnosticsEnabled(): boolean {
  * arrival.
  */
 let _resolvedRefCache = new WeakMap<JSONSchemaObj, JSONSchema | null>();
+
 // Successful resolutions embed registry content; the registry clear (last
 // lease out) swaps the cache so an epoch's successes do not outlive it.
 onSchemaRegistryClear(() => {
@@ -1268,6 +1272,7 @@ export type TraversalContext = {
    * server's query path supplies the querying session's.
    */
   scopeKeyIdentity: ScopeKeyIdentity;
+
   includeMeta: boolean;
   metaDocsVisited: Set<string>;
 

--- a/packages/runner/test/bench-write-accounting.ts
+++ b/packages/runner/test/bench-write-accounting.ts
@@ -63,6 +63,7 @@ export function jsonBytes(value: unknown): number {
 interface PathNode {
   /** True when an attestation named this exact path. */
   written: boolean;
+
   value: unknown;
   children: Map<string, PathNode>;
 }

--- a/packages/runner/test/cfc-refusal-detail.test.ts
+++ b/packages/runner/test/cfc-refusal-detail.test.ts
@@ -17,6 +17,7 @@
  *   than terminal and so never puts it on the error channel at all.
  */
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import {

--- a/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
+++ b/packages/runner/test/cfc-terminal-refusal-rerun.test.ts
@@ -32,6 +32,7 @@
  * is documented here rather than pinned as a test.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";

--- a/packages/runner/test/cfc-verdict-reason.test.ts
+++ b/packages/runner/test/cfc-verdict-reason.test.ts
@@ -8,6 +8,7 @@
  * write, which is the failure OW50 exists to surface rather than reproduce.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import {
   CFC_VERDICT_REASON,

--- a/packages/runner/test/computed-id-e2e.test.ts
+++ b/packages/runner/test/computed-id-e2e.test.ts
@@ -27,6 +27,7 @@ import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
  * like any ordinary stored document.
  */
 const e2eSigner = await Identity.fromPassphrase("computed-id-e2e");
+
 const e2eSpace = e2eSigner.did();
 
 describe("computed-cell id end-to-end (default-on instantiation)", () => {

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -251,6 +251,7 @@ class CountingLoopbackSessionFactory implements SessionFactory {
 
   /** Commits sent for the ACL document, across all sessions. */
   aclCommits = 0;
+
   #aclDocId: string;
 
   readonly #server: MemoryV2Server.Server;
@@ -409,6 +410,7 @@ class SessionErrorSessionFactory implements SessionFactory {
 
   /** transact() calls made after `arm()`. */
   commits = 0;
+
   #armed = false;
 
   readonly #server: MemoryV2Server.Server;

--- a/packages/runner/test/ensure-space-root.test.ts
+++ b/packages/runner/test/ensure-space-root.test.ts
@@ -49,6 +49,7 @@ describe("space-root ensure core", () => {
   /** The served patterns route, in-process: pathname → TSX. Mutable so a
    * test can age the served source under a persisted root. */
   let files: Map<string, string>;
+
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
 

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -146,10 +146,12 @@ class GatedStorageManager extends EmulatedStorageManager {
    * throw seam: the host may rotate runtime tenures, and the seam must
    * hold across every tenure of the pass under test. */
   static loadParkFailDocId: string | undefined;
+
   /** The armed doc's address, reported as pending while armed. */
   static loadParkFailAddress:
     | { space: MemorySpace; scope: "space"; id: string }
     | undefined;
+
   /** How many head-event load parks the seam has failed — a pin's
    * evidence that the park was REACHED, not merely armed. */
   static loadParkFailHits = 0;
@@ -424,6 +426,7 @@ describe("Phase 3 events-down (serving side)", () => {
    * — the C8d raced-cascade test reads sealed state through them and
    * closes the settle gate. */
   let servingRuntime: Runtime | undefined;
+
   let servingManager: GatedStorageManager | undefined;
   let rejectWaveCommitWhen: ((batch: WaveSpaceCommit) => boolean) | undefined;
   let rejectWaveCommitWith:
@@ -3055,6 +3058,7 @@ describe("Phase 3 events-down (serving side)", () => {
       ).all() as Array<{ consequence_of: string }>).filter((row) =>
         row.consequence_of.includes(eventId)
       ).length;
+
     return {
       engine,
       serving,

--- a/packages/runner/test/executor-instance-keyed-replica.test.ts
+++ b/packages/runner/test/executor-instance-keyed-replica.test.ts
@@ -115,6 +115,7 @@ const PER_USER_PATTERN = [
 const PER_USER_PATTERN_HANDLER_ONLY = PER_USER_PATTERN
   .replace("'echo:' + draftText(draftCell)", "'echo:const'")
   .replace("'saved-echo:' + draftText(savedCell)", "'saved-echo:const'");
+
 if (PER_USER_PATTERN_HANDLER_ONLY === PER_USER_PATTERN) {
   throw new Error("handler-only pattern did not derive from the base");
 }

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -108,6 +108,7 @@ describe("stage F serving loop", () => {
   let servingFetch:
     | ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>)
     | undefined;
+
   // serving-loop.md §3e: the pattern-update posture flips server-side.
   const newHost = (
     policy?: ConstructorParameters<typeof ExecutorHost>[0]["policy"],

--- a/packages/runner/test/executor-session-remount.test.ts
+++ b/packages/runner/test/executor-session-remount.test.ts
@@ -262,6 +262,7 @@ describe("the session remount (profile-starvation fifth face)", () => {
    * issued, and a revoked session refuses it exactly as it refuses any
    * other. */
   let probeCounter = 0;
+
   const mintProbeId = (runtime: Runtime, space: MemorySpace): URI => {
     probeCounter += 1;
     return runtime.getCell<string>(

--- a/packages/runner/test/fetch-writeback.test.ts
+++ b/packages/runner/test/fetch-writeback.test.ts
@@ -46,6 +46,7 @@ const space = signer.did();
 
 /** The inputs every case in this file writes back against. */
 const INPUTS = { url: "http://mock-test-server.local/api/writeback" };
+
 const INPUT_HASH = computeInputHashFromValue(INPUTS);
 
 /**

--- a/packages/runner/test/generate-object-cfc-refusal.test.ts
+++ b/packages/runner/test/generate-object-cfc-refusal.test.ts
@@ -9,6 +9,7 @@
  * the request it could not send is staged once rather than once per retry.
  */
 import { expect } from "@std/expect";
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import type { BuiltInLLMTool } from "@commonfabric/api";

--- a/packages/runner/test/list-container-link-reissue.test.ts
+++ b/packages/runner/test/list-container-link-reissue.test.ts
@@ -116,6 +116,7 @@ type ReconcileRecord = {
 
   /** Whether this reconcile called `sendResult`, the container link's only writer. */
   issuedLink: boolean;
+
   outcome: string;
 };
 

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -75,6 +75,7 @@ class ResumeBatchGate {
 
   /** Resolves once a per-element document has been held back. */
   readonly elementsHeld: Promise<void>;
+
   constructor() {
     let resolveTop!: () => void;
     let resolveElements!: () => void;

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -16,6 +16,7 @@
  *   rather than reading as a healthy, quietly empty piece.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model-schema";

--- a/packages/runner/test/memory-v2-reconnect-holdings.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-holdings.test.ts
@@ -8,6 +8,7 @@
  * 09-invariants.md INV-14).
  */
 import { assert } from "@std/assert";
+
 import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -294,6 +294,7 @@ class RecordingWebSocket extends EventTarget {
       RecordingWebSocket.#waiters.push({ count, resolve })
     );
   }
+
   send(_payload: EncodedMemoryMessage): void {}
   close(): void {}
 }

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -133,6 +133,7 @@ type ScriptedOutcome =
 
     /** See {@link RejectionError.retryAfterSeq}. */
     retryAfterSeq?: number;
+
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
     onReceipt?: () => void;

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -207,6 +207,7 @@ export abstract class ScriptedSessionTransport
   protected decode(payload: string): ScriptedTransportMessage {
     return decodeMemoryBoundary(payload) as unknown as ScriptedTransportMessage;
   }
+
   protected encode(message: unknown): string {
     return encodeMemoryBoundary(message as FabricValue);
   }

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -723,6 +723,7 @@ describe("pattern-binding", () => {
         { derivedInternalCells: [{ partialCause: "a" }] },
       ) as T;
     };
+
     const alias = () => ({ $alias: { partialCause: "a", path: [] } });
 
     it("returns a binding with nothing to rebind by identity", () => {

--- a/packages/runner/test/release-vs-stop-link-resolution.test.ts
+++ b/packages/runner/test/release-vs-stop-link-resolution.test.ts
@@ -12,6 +12,7 @@
  * lives here on its own.
  */
 import { expect } from "@std/expect";
+
 import {
   createSchedulerTestRuntime,
   disposeSchedulerTestRuntime,

--- a/packages/runner/test/resume-append-scenario.ts
+++ b/packages/runner/test/resume-append-scenario.ts
@@ -51,6 +51,7 @@ class Gate {
    * the per-element result documents). The test awaits this instead of polling.
    */
   readonly firstHeld: Promise<void>;
+
   readonly #match: RegExp;
 
   constructor(match: RegExp) {

--- a/packages/runner/test/resume-owned-cells-skip-log.test.ts
+++ b/packages/runner/test/resume-owned-cells-skip-log.test.ts
@@ -147,6 +147,7 @@ type SkipCase = {
    * stored root whose argument meta link is already written.
    */
   seedFirst: boolean;
+
   level: "debug" | "warn";
   message: string;
   node: string;

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -85,6 +85,7 @@ class CountingStorageManager extends StorageManager {
    * the relay's own membership is private, and its `hasSubscribers()` would
    * read the same whether teardown was clean or leaked two per runtime. */
   readonly live = new Set<IStorageSubscription>();
+
   static over(server: MemoryV2Server.Server): CountingStorageManager {
     return new CountingStorageManager(
       { as: signer, memoryHost: new URL("memory://") } as Options,
@@ -132,6 +133,7 @@ describe("runtime.dispose({ closeStorage })", () => {
 
   /** An independent view of the same durable state, for witnessing writes. */
   let witness: CountingStorageManager;
+
   let witnessRuntime: Runtime;
 
   /** What the durable store holds for `cause`, read through `witness`. */

--- a/packages/runner/test/scheduler-event-preflight.bench.ts
+++ b/packages/runner/test/scheduler-event-preflight.bench.ts
@@ -28,6 +28,7 @@ import {
  * - Even tiny menu handlers still paid for broad upstream graph traversal.
  */
 const BROAD_FANOUT = 512;
+
 const QUEUED_EVENT_ROUNDS = 30;
 const EVENTS_PER_ROUND = 7;
 const DEEP_READ_COUNT = 660;

--- a/packages/runner/test/schema-ref-helpers.ts
+++ b/packages/runner/test/schema-ref-helpers.ts
@@ -8,6 +8,7 @@
  * consumers resolve at their point of use.
  */
 import type { JSONSchemaObj } from "@commonfabric/api";
+
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -708,6 +708,7 @@ const cascadeDestination = () => {
 
   /** The confirmed read seq the NEXT seal reports (the entry's floor). */
   let nextFloor = 40;
+
   const confirmedSeqs = new Map<string, number>();
   const verdicts = new Map<number, Promise<unknown>>();
   const replica = {
@@ -833,6 +834,7 @@ const cascadeDestination = () => {
       value.entries![index].consequenced = true;
     }, [["value", "entries", String(index), "consequenced"]]);
   };
+
   const markDropped = (index: number, markSeq = 42 + index) => {
     confirmedSeqs.set(W21_SIDECAR, markSeq);
     scripted.deliver(SPACE, W21_SIDECAR, (value) => {

--- a/packages/runner/test/sqlite-served-identity.test.ts
+++ b/packages/runner/test/sqlite-served-identity.test.ts
@@ -405,6 +405,7 @@ describe("sqlite-served-identity", () => {
       );
       return { builtin: b, result: () => cell! };
     };
+
     return { builtin, result: () => resultCell!, makeBuiltin };
   };
 

--- a/packages/runner/test/transaction-abandon-callbacks.test.ts
+++ b/packages/runner/test/transaction-abandon-callbacks.test.ts
@@ -8,6 +8,7 @@
  * and never through a wrapper standing for work whose outcome nobody acts on.
  */
 import { expect } from "@std/expect";
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { Identity } from "@commonfabric/identity";

--- a/packages/runner/test/traverse-recorder.test.ts
+++ b/packages/runner/test/traverse-recorder.test.ts
@@ -7,6 +7,7 @@
  * how much one run may accumulate.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 
 import {

--- a/packages/runner/test/traverse-replay/profile-driver.ts
+++ b/packages/runner/test/traverse-replay/profile-driver.ts
@@ -14,6 +14,7 @@ const outPrefix = Deno.args[2] ?? `/tmp/traverse-${fixtureName}`;
 
 /** Optional: forwarded to profile-target to replay a single invocation. */
 const onlyInvocation = Deno.args[3];
+
 const INSPECT_PORT = 9911;
 
 const target = new Deno.Command(Deno.execPath(), {

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -107,6 +107,7 @@ export type ReplayLatencySample = {
 
   /** Counter deltas for this single invocation. */
   schemaCalls: number;
+
   anyOfBranches: number;
   dagCalls: number;
   pointerCalls: number;

--- a/packages/runner/test/unknown-reference-materialization.test.ts
+++ b/packages/runner/test/unknown-reference-materialization.test.ts
@@ -13,6 +13,7 @@
  * them identically, or the same field means two things.
  */
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `packages/runner` to "The blank line below" (#6633): **211 blank lines
across 93 files**, plus two comments that a blank line alone would have left
saying something false.

### The mechanical sites, by class

Each class was validated by reading a sample before any of it was applied:

| sites | class |
| ---: | --- |
| 121 | multi-line doc comment, undocumented member glued beneath |
| 60 | one-line doc comment on a one-line member, same shape |
| 11 | file header glued to the first `import` |
| 10 | followed by a `//` note |
| 9 | followed by another doc comment |

The `//` group is the one worth naming. A blank line near a `//` note can orphan
it — #5865's sweep found `cli/lib/color-mode.ts`, whose note says "the import
below must resolve to the same `@std/fmt` instance Cliffy uses". All ten here
were read individually: every note describes what comes *after* it, so the blank
line goes above the note and leaves note and subject together.

The 9 followed by another doc comment already violated "The blank line above";
one blank line satisfies both rules.

### Two that were not mechanical

- **`module-record-compiler.ts`** said "the two maps are process-global and
  unbounded by design" from above `exportParseCache` alone, leaving
  `importParseCache` undocumented and the claim bound to half its subject. Each
  map now documents itself, and the shared reasoning stays with the first.
- **`stats.ts`** described three delivery counters as a two-way split, "by
  whether confirmed failed-state time is currently accruing". Read against
  `refreshDeliveryCheckpointStats`, `deliveryDeferralsActive` is `rows.size` —
  **every** active checkpoint, not one side of a split. So the comment was
  inaccurate as well as misplaced. All three now say what the code computes.

That second one is the case for reading this sweep rather than running it: no
gate reads a comment against its code, and the blank line would have made a
wrong claim look deliberate.

### Checks

`deno fmt --check` passes over the package, so the formatter keeps every
insertion rather than undoing it. `deno lint` clean. `deno task test` in
`packages/runner`: **1327 passed, 0 failed**. The detector reports zero
remaining sites in the package.

Every change is comment or whitespace only, verified by diffing both revisions
with comment and blank lines stripped: no file's code differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

