### PR TITLE
Give compaction a workflow instead of a person with a key

### DIFF
--- a/.github/workflows/test-records-compact.yml
+++ b/.github/workflows/test-records-compact.yml
@@ -1,0 +1,92 @@
+# Rewrites each closed day of raw test records as a handful of rollup
+# shards under the dataset's aggregated/ area, so a full-history reader
+# fetches a few objects per day instead of every object written that day.
+# Its Google Cloud identity comes from a Workload Identity Federation
+# provider pinned to exactly this workflow file on main, so no other
+# workflow, ref, or repository can mint it, and no key for it exists
+# anywhere (infra: tofu/test-records). Compaction is a read optimization:
+# the raw area stays the full-fidelity record, nothing gates on a rollup,
+# and a failed run is completed by the next one.
+
+name: Test Records Compaction
+
+on:
+  schedule:
+    # Daily. The compactor only touches days that closed a week ago, so
+    # the hour carries no meaning beyond staying off the top of it.
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: How far back to look, in days (at least 7; default 14)
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+# A second run would write shards the first is already writing. They
+# would collide rather than corrupt — every name is deterministic and the
+# credential cannot overwrite — but the work would be wasted. The running
+# one is left alone rather than cancelled, because what it has already
+# written stands.
+concurrency:
+  group: test-records-compaction
+  cancel-in-progress: false
+
+jobs:
+  compact:
+    name: "Compact Test Records"
+    # The provider variable gates the job. Where test records are not
+    # provisioned there is no identity to assume and nothing to compact.
+    if: vars.TEST_RECORDS_COMPACTOR_WIF_PROVIDER != ''
+    runs-on: ubuntu-latest
+    steps:
+      # Every third-party action in this credentialed workflow is pinned
+      # to an immutable commit, so a moved tag cannot alter the one
+      # privileged write path.
+      - name: 📥 Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+        with:
+          cache: false
+
+      - name: 🔑 Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: commontools-core
+          workload_identity_provider: ${{ vars.TEST_RECORDS_COMPACTOR_WIF_PROVIDER }}
+          service_account: ${{ vars.TEST_RECORDS_COMPACTOR_SERVICE_ACCOUNT }}
+          token_format: access_token
+          create_credentials_file: false
+
+      # The dispatch input reaches the shell through the environment
+      # rather than through expansion into the script. An expansion is
+      # substituted before the shell parses the line, so a crafted value
+      # would run as part of this step — which is the step holding the
+      # access token. The window is quoted, then checked against the one
+      # shape it may take before it becomes an argument.
+      - name: 📊 Compact closed days
+        env:
+          TEST_RECORDS_GCS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          TEST_RECORDS_BUCKET: ${{ vars.TEST_RECORDS_BUCKET }}
+          TEST_RECORDS_PREFIX: ${{ vars.TEST_RECORDS_PREFIX }}
+          COMPACT_DAYS: ${{ inputs.days }}
+        run: |
+          set -euo pipefail
+          if [ -n "${COMPACT_DAYS}" ]; then
+            case "${COMPACT_DAYS}" in
+              ''|*[!0-9]*)
+                echo "days must be a whole number of days" >&2
+                exit 1
+                ;;
+            esac
+            deno run --allow-read --allow-env --allow-net \
+              tasks/test-records-compact.ts --days "${COMPACT_DAYS}"
+          else
+            deno run --allow-read --allow-env --allow-net \
+              tasks/test-records-compact.ts
+          fi

--- a/.github/workflows/test-records-compact.yml
+++ b/.github/workflows/test-records-compact.yml
@@ -42,9 +42,12 @@ jobs:
     if: vars.TEST_RECORDS_COMPACTOR_WIF_PROVIDER != ''
     runs-on: ubuntu-latest
     steps:
-      # Every third-party action in this credentialed workflow is pinned
-      # to an immutable commit, so a moved tag cannot alter the one
-      # privileged write path.
+      # The third-party actions named here are pinned to immutable
+      # commits, so a moved tag cannot alter the one privileged write
+      # path. The local deno-setup action this job also uses pulls
+      # actions/cache and denoland/setup-deno by tag, which is the
+      # repository's arrangement for every workflow rather than something
+      # this one sets.
       - name: 📥 Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -251,7 +251,10 @@ validating reader; `deno task` scripts built on it:
   records as a manifest and a few tens of rollup shards under
   `aggregated/`, sized so that a shard is a string a reader can hold;
   `--plan` reads the listing alone and shows what it would do without
-  credentials.
+  credentials. It writes from `.github/workflows/test-records-compact.yml`
+  on a daily schedule, which is the only place its identity can be
+  assumed; there is no key for it and no way to run the writing half by
+  hand.
 - `packages/dashboard/test-records-history.ts` — the dashboard's collector:
   cached per-identity daily series shaped for `trend.ts`.
 

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -171,10 +171,10 @@ which cannot read, list, overwrite, or delete; nothing already stored can
 be modified by any append credential. An incompatible schema writes under
 `v2/` and readers migrate at their own pace.
 
-Three writer principals exist. The **relay** — the only CI principal —
-holds create on `submissions/ci/` through a Workload Identity provider
-pinned to one workflow file on the default branch, with the impersonation
-binding keyed to that exact workflow ref. **People** hold per-person
+Four writer principals exist. The **relay** — the only one that writes
+what CI produced — holds create on `submissions/ci/` through a Workload
+Identity provider pinned to one workflow file on the default branch, with
+the impersonation binding keyed to that exact workflow ref. **People** hold per-person
 service accounts (`test-records-gh-<username>`, the login lowercased)
 with create on their own `submissions/local/<username>/` folders, minted
 by a dispatch-gated workflow and delivered sealed to a
@@ -183,8 +183,9 @@ previous keys before the new one exists — a person holds one live key,
 never two, and re-requesting is how a lost or compromised key is
 rotated — and a daily
 janitor disables accounts after a month without pull-request activity
-and re-enables them on return. The **compactor**, when provisioned,
-holds create on `aggregated/` and rewrites each closed day of raw
+and re-enables them on return. The **compactor** holds create on
+`aggregated/` through a provider pinned to its own daily workflow file,
+the relay's arrangement again, and rewrites each closed day of raw
 records — after a seven-day late-arrival lag — as validated rollup shards
 that keep each report's context line ahead of its records; a day with
 no records stays open, since a write-once rollup would permanently

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -171,11 +171,11 @@ which cannot read, list, overwrite, or delete; nothing already stored can
 be modified by any append credential. An incompatible schema writes under
 `v2/` and readers migrate at their own pace.
 
-Four writer principals exist. The **relay** — the only one that writes
+Three writer principals exist. The **relay** — the only one that writes
 what CI produced — holds create on `submissions/ci/` through a Workload
 Identity provider pinned to one workflow file on the default branch, with
-the impersonation binding keyed to that exact workflow ref. **People** hold per-person
-service accounts (`test-records-gh-<username>`, the login lowercased)
+the impersonation binding keyed to that exact workflow ref. **People**
+hold per-person service accounts (`test-records-gh-<username>`, the login lowercased)
 with create on their own `submissions/local/<username>/` folders, minted
 by a dispatch-gated workflow and delivered sealed to a
 requester-generated X25519 identity. Minting revokes the account's

--- a/tasks/test-records-compact.test.ts
+++ b/tasks/test-records-compact.test.ts
@@ -16,6 +16,7 @@ import {
   SHARD_TARGET_BYTES,
   shardCount,
   shardOf,
+  writeToken,
 } from "./test-records-compact.ts";
 import {
   buildObjectBody,
@@ -634,6 +635,28 @@ describe("test-records-compact", () => {
       await compactDays({ ...OPTIONS, plan: true, fetchImpl: watched });
       expect(Object.keys(store.created)).toEqual([]);
       expect(reads).toEqual([]);
+    });
+  });
+
+  describe("writeToken()", () => {
+    it("reads the federated token the workflow supplies", () => {
+      expect(
+        writeToken((name) =>
+          name === "TEST_RECORDS_GCS_TOKEN" ? "token-1" : undefined
+        ),
+      ).toBe("token-1");
+    });
+
+    it("has no token to offer anywhere else", () => {
+      // The compactor's identity exists as no key, so there is nothing to
+      // fall back to and a run outside the workflow must say so rather
+      // than reach the store with a credential meant for something else.
+      expect(writeToken(() => undefined)).toBeUndefined();
+      expect(
+        writeToken((name) =>
+          name === "TEST_RECORDS_GCS_TOKEN" ? "" : "other-value"
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -36,16 +36,20 @@
  * contents; a day of records-free objects shows as compactable and is then
  * left open by the run that reads it.
  *
- * The writer credential comes from CF_TEST_RECORDS_COMPACTOR_KEY_FILE, a
- * service-account key with create-only access to the aggregated/ area;
- * that principal is provisioned in the infra repository when compaction
- * is turned on. Until then the compactor runs read-only with --plan.
+ * The writer credential is a federated access token in
+ * TEST_RECORDS_GCS_TOKEN, the variable the relay and the publisher read
+ * too. Only the compaction workflow holds one: the compactor's identity is
+ * pinned to that workflow file on main and is the sole principal with
+ * create on the aggregated/ area (infra: tofu/test-records). No key exists
+ * for it, so there is no credential a person could run this with, and
+ * --plan is how a person sees what a run would do.
  */
 
 import {
   buildObjectBody,
   createObject,
   datePartition,
+  type Environment,
   gzipChunks,
   type ListedObject,
   listObjectSizes,
@@ -53,13 +57,10 @@ import {
   readEnv,
   readObject,
   RECORD_SCHEMA_VERSION,
-  STORE_WRITE_SCOPE,
   type StoredReport,
-  tokenFromKey,
 } from "@commonfabric/test-support/records";
 import {
   ciSubmissionsPrefix,
-  parsePersonalKeyFile,
   storeBucket,
   storePrefix,
 } from "./test-records-config.ts";
@@ -566,6 +567,22 @@ export function parseCompactArgs(
   return { days, plan };
 }
 
+/**
+ * The access token for writing shards, when one is reachable. Only the
+ * compaction workflow has one, and there is no fallback to offer: the
+ * compactor's identity exists as no key, and a person's own reporting key
+ * is scoped to their submissions/local/<username>/ folder and cannot write
+ * a rollup. --plan is how a person sees what a run would do.
+ */
+export function writeToken(
+  env: Environment = Deno.env.get,
+): string | undefined {
+  const federated = readEnv("TEST_RECORDS_GCS_TOKEN", env);
+  return federated !== undefined && federated.length > 0
+    ? federated
+    : undefined;
+}
+
 async function main(): Promise<void> {
   const parsed = parseCompactArgs(Deno.args);
   if (parsed === undefined) Deno.exit(2);
@@ -578,20 +595,16 @@ async function main(): Promise<void> {
     rawPrefix: ciSubmissionsPrefix(),
   };
   if (!plan) {
-    const keyPath = readEnv("CF_TEST_RECORDS_COMPACTOR_KEY_FILE");
-    if (keyPath === undefined || keyPath.length === 0) {
+    const token = writeToken();
+    if (token === undefined) {
       console.error(
-        "CF_TEST_RECORDS_COMPACTOR_KEY_FILE is not set; run with --plan " +
-          "to see what would be compacted.",
+        "TEST_RECORDS_GCS_TOKEN is not set. The compactor's identity is " +
+          "held by the compaction workflow alone; run with --plan to see " +
+          "what would be compacted.",
       );
       Deno.exit(2);
     }
-    const key = parsePersonalKeyFile(await Deno.readTextFile(keyPath));
-    if (key === undefined) {
-      console.error(`${keyPath} is not a service-account key file`);
-      Deno.exit(2);
-    }
-    options.token = await tokenFromKey(key, STORE_WRITE_SCOPE);
+    options.token = token;
   }
 
   await compactDays(options);


### PR DESCRIPTION
The compactor was the one writer in the test-record store that authenticated with a downloaded service-account key, read from CF_TEST_RECORDS_COMPACTOR_KEY_FILE. The relay and the publisher each trade a GitHub OIDC token from one workflow file pinned on main and hold no credential at rest. The compactor was different only because nothing had been written to run it, so there was no workflow ref to pin an identity to and a key was what remained.

A key is a long-lived credential on somebody's disk. It needs an operator holding serviceAccountKeyAdmin to mint, a discipline to rotate, and it makes compaction something a person has to remember to do. It also gives a rollup weaker provenance than the records it summarizes, which the infra README had to warn readers about.

So compaction gets .github/workflows/test-records-compact.yml, daily, with the auth step the relay and publisher already use: token_format access_token, no credentials file, the token handed to the task in TEST_RECORDS_GCS_TOKEN. The task reads that variable and nothing else. There is no fallback to offer — a person's own reporting key is scoped to their submissions/local/<username>/ folder and cannot write a rollup — so a run outside the workflow says so and exits rather than reaching the store with a credential meant for something else. --plan still needs no credential at all, and is how a person sees what a run would do.

The dispatch input for a wider window reaches the shell through the environment and is checked against the one shape it may take before it becomes an argument, the same handling the publisher's inputs get: an expansion is substituted before the shell parses the line, and this is the step holding the access token.

Two runs would write shards the other is already writing. They would collide rather than corrupt, because every name is deterministic and the credential cannot overwrite, but the work would be wasted, so the workflow takes a concurrency group. A run in progress is left alone rather than cancelled: what it has already written stands, and the next run completes the rest.

The identity itself is an infra change, and the two Actions variables the workflow reads are installed from there. Until that lands and is applied, TEST_RECORDS_COMPACTOR_WIF_PROVIDER is unset and the job's own condition skips it, so this workflow does nothing rather than failing daily.

This supersedes the fix in commontoolsinc/labs#6624, which taught the key parser to accept a key that names no person. That path is deleted here, so the parser split it adds has no caller left.

Verified with deno fmt, deno lint, deno check, deno task check-docs, the compactor's own tests including two new ones for the token reader, and tasks/ci-workflow.test.ts, which holds every workflow to valid YAML and every named step to a phase marker.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

