### PR TITLE
fix(runner): a personal space's owner is one of its readers

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -220,10 +220,11 @@ The strict-only delta is:
   instead of the join and are outside the check, as is the pure-link-structure
   shape channel; grown existence atoms (SC-4) are historical and deliberately
   never measured — only the current join is; `Space` is the only principal
-  form residency admits, because `PersonalSpace`, `User`, and the bare
-  DID-string spelling all gate by equality against one acting reader, making
-  their audience a person rather than the container and so narrower than the
-  set of principals a space grants reader roles to; and the ungrantable
+  form residency admits, because `User` and the bare DID-string spelling gate
+  by equality against one acting reader, making their audience narrower than
+  the set of principals a space grants reader roles to, while
+  `PersonalSpace(<owner>)` names a space whose clause the measurement cannot
+  build from a target address (SC-39); and the ungrantable
   read-failed marker sits outside every ceiling, the residency clause
   included, so a poisoned measurement never proves fit. The reserved policy
   namespaces are outside the check too: the durable policy manifests
@@ -247,6 +248,21 @@ The strict-only delta is:
   transaction with recorded reasons CFC-relevant (`prepare-reasons`), so a
   reasoned tx whose reads never tripped an eager relevance mark cannot slip the
   ladder ([extended-storage-transaction.ts](../../packages/runner/src/storage/extended-storage-transaction.ts)).
+
+  One of the forms residency excludes is readable in the DECLARED half of the
+  ceiling, in one direction. A `PersonalSpace(owner)` LABEL clause answers a
+  declared ceiling naming that owner, because §3.6.2's role order makes an
+  owner a reader and §3.6.4 makes that principal the space's sole owner, and
+  the fit test asks only that everyone the ceiling admits is entitled to the
+  data. The reverse does not hold: a store DECLARING the atom is not read by
+  that person alone, because adding a member converts the space and §3.6.5
+  rewrites no labels, so a stamped clause outlives the conversion. `Space` gains nothing either way, for the reason residency lets
+  it in — its readers are derived through verified `HasRole` exchange, and
+  residency already joins the target's own space onto every ceiling, so
+  covering it here would admit that data space-wide. The kernel owns the
+  reading, so it holds at the egress, display, observation, and
+  declared-monotonicity gates too. Recorded in
+  [`cfc-spec-changes.md`](./cfc-spec-changes.md) SC-39.
 
   The raw meta seam is outside the check at EVERY rung, so a meta path
   raises neither a strict reject nor a persist-and-flag diagnostic. The

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -347,18 +347,21 @@ names, and the write reaches no reader the data had not already reached. The
 guarantee is therefore exactly as strong as the deployment's ACL posture, the
 same bound the §4.9.3 membership lookup carries.
 
-The rule is confined to `Space` deliberately. §3.6.4 gives a personal space
-fixed membership — its owner alone — and says sharing happens by moving the
-data to a shared space or by converting the personal space into one, so
-`PersonalSpace(<owner>)` names a single principal rather than a container with
-a reader set. The runtime agrees: no exchange rule maps a space reader onto a
-`PersonalSpace` clause, the display ceiling admits it only by exact match
-against the acting user, and the deployment's §4.6.4.2 field classification
-commits `PersonalSpace.owner` alongside `User.subject` while keeping
-`Space.id` public precisely so §4.9.3's point query can dereference it. A
-space grants reader roles its owner does not hold in person, so admitting
-those forms would place data readable by one principal into a store its
-co-readers sync.
+The rule is confined to `Space` deliberately, and for two different reasons.
+`User(<subject>)` and the bare DID spelling name a person: a space grants
+reader roles that person does not hold, so admitting them would place data
+readable by one principal into a store its co-readers sync. That argument
+does not reach `PersonalSpace(<owner>)`, which names a space rather than a
+person (SC-39). What keeps that form out is narrower and mechanical: the
+residency clause is built from the target's address alone — `Space(<the space
+this document is stored in>)` — and the runtime cannot form
+`PersonalSpace(<owner>)` from an address, because nothing marks a space as
+personal (§3.6.4 has one stop being personal with no marker changing) or
+names its owner without resolving its ACL. The clause is
+unavailable rather than unsound. A deployment that did resolve ownership
+could admit it on the same footing as `Space`, since the two atoms would then
+name one space and so one audience; the limit is what the measurement can
+construct, not what it may admit.
 
 One spec question this exposes and should settle: §4.9.4 describes
 `HasRole(user, PersonalSpace(User), reader)` as minted by a §4.9.3 point query
@@ -366,10 +369,13 @@ against that space's own ACL record, and calls it one of "the two `Space(...)`
 atoms", which reads `PersonalSpace` as an ACL-dereferenced container atom. That
 sits in tension with §3.6.4's fixed membership, and with a deployment
 classification that commits the very field such a point query would have to
-read. If `PersonalSpace` is genuinely ACL-dereferenced, its audience is the
-space's reader set and residency admits it on the same footing as `Space`;
-if membership is fixed, it names one principal and residency must not. The
-implementation takes the second reading, which is the fail-closed one. Reading
+read. SC-39 settles it: §3.6.5 has a member added to a space gain access to
+all data in it with no labels rewritten, so a personal space's audience grows
+after the fact and the atom is an ACL-dereferenced container. The
+fixed-membership reading recorded here is therefore wrong, and the rationale
+above has been rewritten accordingly. Residency's behavior is unchanged, but
+its ground moves: the atom stays out because the measurement cannot construct
+it from an address, not because its audience is one person. Reading
 back is unaffected in every case: the derived stamp persists the full join, so
 the egress and display ceilings fit the unchanged label, and the space
 principal there resolves to a reader only through the §4.3.3
@@ -889,3 +895,99 @@ actually carrying that user's acting identity. Proposed edit: when the
 audit-3.5 chain is written into §6/§8.15, state the snapshot's per-run
 binding and the acting-principal resolution as the normative reading for
 serving hosts, citing serving-loop.md §3c.
+
+## From the strict-defaults prerequisites (2026-08-31)
+
+**SC-39 [normative] A personal space's owner is one of its readers —
+§8.12.1's `atomLe`.** `open`. §8.12.1 defines the alternative-level relation
+`atomLe` as structural equality for every atom type but `Expires`, and
+§8.12.4's `canWrite` restates it that way. Under that relation a store
+declaring `User(P)` refuses a value labeled `PersonalSpace(P)`, even though
+P is an owner of that space and therefore one of its readers. Under
+`enforce-strict` that is a refused write. The runtime adds one case to the
+relation, on the LABEL side only: a `PersonalSpace(owner)` alternative also
+answers a ceiling alternative naming that owner.
+
+The criterion is the one §8.12.1 gives for `atomLe` itself — satisfying the
+more restrictive side implies satisfying the other. The guarantee comes from
+the role order rather than from any ACL configuration: §3.6.2 states `owner
+⊃ writer ⊃ reader` — "owners are implicitly writers; writers are implicitly
+readers" — and §3.6.4 makes the named principal the space's sole owner, so
+that principal is one of its readers normatively. A ceiling whose audience
+is that owner is therefore inside the label's audience however the
+membership has since changed, which is the containment the fit test asks
+for. Grounding this in §3.6.4's `readers: {Alice}` would not do: that is a
+starting configuration, and this entry declines to treat it as an invariant
+when it refuses the reverse rule.
+
+The reverse does not hold, and the reverse is the tempting rule. A ceiling
+declaring `PersonalSpace(P)` would have to be read by P ALONE for it to admit
+a `User(P)` label. §3.6.4's fixed membership does not deliver that, and the
+reason is not that a personal space's membership grows — its own sharing
+bullet has adding a member CONVERT the space into a shared one, so
+membership is fixed exactly as long as the space stays personal. What
+defeats the one-person reading is that the label outlives the conversion:
+§3.6.5 rewrites **no labels** when a member is added, so a
+`PersonalSpace(P)` clause stamped beforehand goes on naming a space that has
+stopped being personal. §4.9.4 agrees
+from the other side: it generates `HasRole(user, PersonalSpace(User), reader)`
+by a §4.9.3 point query against that space's own ACL record and calls the
+form one of "the two `Space(...)` atoms", and §15.2 and §4.1.2 both call it a
+convenience form for a per-user space principal. A store declaring it would
+take data labeled for the owner alone and replicate it to a member added
+later.
+
+This corrects the framing SC-18(d) recorded. That note treated §3.6.4's fixed
+membership and §4.9.4's point query as an unsettled tension and took the
+fixed-membership reading as the fail-closed one. The tension dissolves rather
+than resolving against §3.6.4: membership is fixed while the space is
+personal, adding a member converts it, and §3.6.5 rewrites no labels when it
+does — so a stamped clause outlives the conversion and the atom is an
+ACL-dereferenced container. That leaves SC-18(d)'s behavior intact but
+replaces its reason. Residency excludes the atom because its clause is built
+from the target's address and nothing there names a space's owner or marks it
+as personal — not because the atom names one principal, which it does not.
+SC-18(d)'s rationale is rewritten there to say so.
+
+`Space(id)` gains no case. §15.2 derives its access through verified `HasRole`
+exchange, which the fit kernel cannot run, and SC-18(d) already joins
+`Space(<the space the document resides in>)` onto every document's write
+ceiling, so covering it here would admit a person's data into every store in
+that space.
+
+The bare DID string gains no case either, and the runtime's use of one should
+be retired rather than taught. §4.1.1 states that an atom is "not a simple
+string but a structured value with a type and parameters", and §15.2 lists no
+string form. The shell's default display ceiling nonetheless carries a raw
+acting-user DID beside `User` and `PersonalSpace`; §8.10.6's illustrative
+profile lists only the latter two, and its tighten-only rule forbids
+admitting an additional atom family without a release judgment. That entry is
+a pre-existing loosening and wants removing, not generalizing.
+
+Only canonical shapes participate, the discipline §8.12.1 already applies to
+`Expires`: a two-field `PersonalSpace` whose `owner` is a plaintext DID or
+its §4.6.4.1 `{digestOf}` commitment. A record carrying further fields is not
+the atom it resembles. The owner value carries across untouched, so a
+committed field still meets its plaintext twin under the same-form
+comparison.
+
+Clause IDENTITY is untouched: `clausesEqual`, the canonical clause digest,
+and the ceiling meet all still tell the two atoms apart, so a
+mutually-subsuming pair can carry different digests. Every place that shows
+is fail-closed — a §8.12.7 route-2b exemption naming one does not exempt the
+other, and a meet keeps both alternatives rather than collapsing them.
+
+Spec home: §8.12.1's `atomLe`, with the restatement in §8.12.4's `canWrite`
+comment following it. Three points the spec should settle. Whether the case
+belongs in `atomLe` or in a normalization ahead of it — the runtime takes the
+second, so the relation keeps its "equality except `Expires`" shape and the
+integrity floor, which shares the relation, is untouched. Whether the
+one-sided form is permanent, which turns on whether a `PersonalSpace` clause
+may outlive its space's conversion at all: if §3.6.4's conversion re-spelled
+the clause, or §3.6.5 rewrote it, the atom's audience would stay its owner's
+and the relation could be symmetric. And whether a §4.6.4.1 commitment should
+carry its field's type. It does not today, so a well-formedness test on a
+committed field is unenforceable — the plaintext arm of this rule rejects a
+malformed owner and the committed arm cannot, which is a general property of
+every check that validates a commitment-classified field rather than
+something particular to this one.

--- a/packages/runner/src/cfc/clause.ts
+++ b/packages/runner/src/cfc/clause.ts
@@ -1,8 +1,10 @@
 import { CFC_ATOM_TYPE, type CfcAtom } from "@commonfabric/api/cfc";
+import { isDID } from "@commonfabric/identity";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { atomEntails } from "./atom-pattern.ts";
+import { isCfcFieldCommitment } from "./label-representation.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
 
 /**
@@ -79,6 +81,76 @@ export const clausesEqual = (
 ): boolean => deepEqual(normalizeClause(left), normalizeClause(right));
 
 /**
+ * A `PersonalSpace(owner)` label alternative, restated as the one principal
+ * every reading of the atom puts inside its audience: its owner.
+ *
+ * The atom is a SPACE principal, not a person. §15.2 and §4.1.2 both call it
+ * a convenience form for a per-user space principal, and §4.9.4 generates its
+ * reader fact by a §4.9.3 point query against that space's own ACL record,
+ * calling it one of "the two `Space(...)` atoms". §3.6.4 does give a personal
+ * space fixed membership, but only while it stays personal: its own sharing
+ * bullet has adding a member CONVERT the space into a shared one, and §3.6.5
+ * rewrites no labels when that happens. A `PersonalSpace(P)` clause stamped
+ * beforehand therefore goes on naming a space that has stopped being
+ * personal, which is what defeats reading its audience as one person.
+ *
+ * What holds regardless is the role hierarchy. §3.6.2 states `owner ⊃ writer
+ * ⊃ reader` — "owners are implicitly writers; writers are implicitly readers"
+ * — and §3.6.4 makes the named principal the space's sole owner, so the owner
+ * is one of its readers by the role order rather than by any particular ACL
+ * configuration. A ceiling whose audience is that owner is therefore inside
+ * the label's audience however the membership has since changed, which is
+ * what the fit test asks. This is a fact about space membership, not a
+ * spelling equivalence, and it runs on the LABEL side only. In a ceiling the
+ * same rewrite would claim a store declaring the atom is read by that person
+ * ALONE — the reverse containment, which nothing establishes.
+ *
+ * Only the canonical two-field shape participates, and only when its `owner`
+ * is a DID — the type §15.2 gives the field, tested with the identity
+ * package's `isDID` rather than a `did:` prefix, so a truncated or
+ * method-only string gets no reading — or the §4.6.4.1 `{digestOf}`
+ * commitment the cross-space seam persists that field as. A record carrying
+ * further fields, or an `owner` that is neither, is not the atom it resembles
+ * and gets no reading either. `isDID` refuses a third colon, so a
+ * method-specific id containing one is refused too; that is over-refusal,
+ * which is the direction a well-formedness gate should fail in.
+ *
+ * Both fields are checked as OWN properties, which the sibling recognizers
+ * here do not bother with because they only gate a comparison. This one
+ * builds an atom out of the field it reads, so a value arriving from a
+ * prototype would end up inside the manufactured `User`. Label atoms come
+ * from `JSON.parse` and from module source, neither of which produces one,
+ * so this is closing a shape the input cannot currently take rather than a
+ * live hole.
+ *
+ * The well-formedness test reaches the plaintext form only. A commitment is a
+ * digest of whatever the field held, and the transform that produces one
+ * commits every classified field without inspecting it, so a malformed owner
+ * digests exactly as a DID does and this predicate cannot tell them apart.
+ * The committed form of a malformed owner is therefore admitted where its
+ * plaintext twin is refused. What it can be admitted AGAINST is the bound:
+ * the ceiling has to name that same malformed subject, in plaintext or under
+ * the same digest, and §15.2 types `User.subject` as a DID too — so reaching
+ * it takes a store whose declared policy is already malformed in the matching
+ * way. Closing the gap properly means validating at the commit seam or
+ * carrying the field's type into the marker, neither of which belongs in a
+ * fit predicate.
+ */
+const personalSpaceOwnerAsReader = (atom: CfcAtom): CfcAtom => {
+  if (!isObjectNotArray(atom)) return atom;
+  const record = atom as Record<string, CfcAtom>;
+  if (
+    !Object.hasOwn(record, "type") || !Object.hasOwn(record, "owner") ||
+    Object.keys(record).length !== 2 ||
+    record.type !== CFC_ATOM_TYPE.PersonalSpace ||
+    !(isDID(record.owner) || isCfcFieldCommitment(record.owner))
+  ) {
+    return atom;
+  }
+  return { type: CFC_ATOM_TYPE.User, subject: record.owner };
+};
+
+/**
  * Clause subsumption — the ceiling-fit kernel (spec §8.10.3):
  * a ceiling clause `c` subsumes a label clause `l` when every alternative of
  * `c` appears among `l`'s alternatives (`alts(c) ⊆ alts(l)`) — then any
@@ -102,6 +174,26 @@ export const clausesEqual = (
  * for disjunctions iff EVERY alternative of `c` entails SOME alternative of
  * `l` — so the subset check becomes an entailment-witness check, reducing to
  * the previous deepEqual membership on order-free families.
+ *
+ * One case is added to that relation, on the LABEL side only: a
+ * `PersonalSpace(owner)` alternative also answers a ceiling alternative
+ * naming that owner, because the owner is always among their own space's
+ * readers (`personalSpaceOwnerAsReader` above). Each comparison tries the
+ * atoms as written first, so a clause carrying no such alternative costs
+ * exactly what it did before.
+ *
+ * §8.12.1 states `atomLe` as structural equality plus the `Expires` order,
+ * so this is a deviation from that text. It preserves the semantic criterion
+ * the same section gives for the relation — satisfying the more restrictive
+ * side implies satisfying the other — which is what makes it safe; the spec
+ * edit it owes is recorded as SC-39.
+ *
+ * Clause IDENTITY is left untouched: `clausesEqual`, `normalizeClause`, and
+ * `cfcCanonicalClauseDigest` still tell the two atoms apart, so a
+ * mutually-subsuming pair can carry different digests. That direction is
+ * fail-closed everywhere it shows — a §8.12.7 route-2b exemption naming one
+ * does not exempt the other, and a ceiling meet keeps both alternatives
+ * rather than collapsing them.
  */
 export const clauseSubsumes = (
   ceilingClause: CfcConfClause,
@@ -110,9 +202,13 @@ export const clauseSubsumes = (
   const ceilingAlternatives = clauseAlternatives(ceilingClause);
   if (ceilingAlternatives.length === 0) return false;
   const labelAlternatives = clauseAlternatives(labelClause);
-  return ceilingAlternatives.every((ceilingAtom) =>
-    labelAlternatives.some((labelAtom) => atomEntails(ceilingAtom, labelAtom))
-  );
+  return ceilingAlternatives.every((ceilingAtom) => {
+    return labelAlternatives.some((labelAtom) => {
+      if (atomEntails(ceilingAtom, labelAtom)) return true;
+      const owner = personalSpaceOwnerAsReader(labelAtom);
+      return owner !== labelAtom && atomEntails(ceilingAtom, owner);
+    });
+  });
 };
 
 // Atom types forbidden as alternatives of an AUTHORED OR-clause (spec §3.1.8):

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -334,10 +334,14 @@ export const cfcIntegritySatisfiesFloorCoherently = (
  * iff SOME ceiling clause `c` subsumes it — `alts(c) ⊆ alts(l)` — so a reader
  * the ceiling admits (satisfying `c`) is entitled to data guarded by `l`.
  *
- * On flat labels (every clause a singleton) this is byte-for-byte the previous
- * membership check: `clauseSubsumes(a, l)` reduces to `deepEqual(a, l)`, so
- * `∃ c ∈ ceiling: deepEqual(c, l)` ≡ "the atom is in the allowlist". The
- * clause form additionally makes a **reader-enumeration** ceiling clause
+ * On flat labels (every clause a singleton) this is the previous membership
+ * check on every atom but one: `clauseSubsumes(a, l)` reduces to
+ * `deepEqual(a, l)`, so `∃ c ∈ ceiling: deepEqual(c, l)` ≡ "the atom is in
+ * the allowlist". The exception is a `PersonalSpace(owner)` LABEL, which also
+ * meets a ceiling naming that owner — the owner is one of the space's
+ * readers (`clause.ts`).
+ *
+ * The clause form additionally makes a **reader-enumeration** ceiling clause
  * `{anyOf:[r₁,…,rₖ]}` require EVERY listed reader to satisfy each label clause
  * (`∀reader ∀clause`) — closing the quantifier hole where a multi-party label
  * `[User(A),User(B)]` (nobody alone may read) wrongly fit a flat `[A,B]`

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -6561,11 +6561,13 @@ export const prepareBoundaryCommit = (
       // stamp below persists the full join, leaving the egress and display
       // gates the unchanged label.
       //
-      // `Space` is the only form admitted here. `PersonalSpace` and the bare
-      // DID-string spelling gate by equality against one acting reader
-      // (`label-field-classification.ts` classes their subject fields with
-      // `User.subject`), so they name a person rather than the container and
-      // reach a narrower audience than the space's readers.
+      // `Space` is the only form admitted here, for two reasons. The bare
+      // DID-string spelling gates by equality against one acting reader, so
+      // it reaches a narrower audience than the space's readers.
+      // `PersonalSpace(<owner>)` names a space rather than a person (SC-39),
+      // and what keeps it out is that this clause is built from the target's
+      // address alone: nothing in an address names a space's owner or marks
+      // the space as personal, so the atom cannot be constructed here.
       const residencyCeiling: readonly CfcConfClause[] = [cfcAtom.space(space)];
       const declaredPolicyEntries = flowConfidentiality.length > 0
         ? persistedLabelEntries.filter((entry) =>

--- a/packages/runner/test/cfc-clause-ceiling-fit.test.ts
+++ b/packages/runner/test/cfc-clause-ceiling-fit.test.ts
@@ -7,6 +7,7 @@ import {
   meetCfcObservationCeilings,
 } from "../src/cfc/observation.ts";
 import { normalizeClause } from "../src/cfc/clause.ts";
+import { commitCfcFieldValue } from "../src/cfc/label-representation.ts";
 
 // Epic A2 (docs/history/plans/cfc-future-work-implementation.md): the ceiling-fit
 // check becomes CNF clause subsumption (spec §8.10.3). The load-bearing case
@@ -16,6 +17,23 @@ import { normalizeClause } from "../src/cfc/clause.ts";
 const A = { type: "https://commonfabric.org/cfc/atom/User", subject: "A" };
 const B = { type: "https://commonfabric.org/cfc/atom/User", subject: "B" };
 const C = { type: "https://commonfabric.org/cfc/atom/User", subject: "C" };
+
+// The three spellings of one principal (§15.2), and the container atom that
+// carries the same DID without naming a person.
+const ALICE = "did:key:zAlice";
+const BOB = "did:key:zBob";
+const aliceUser = {
+  type: "https://commonfabric.org/cfc/atom/User",
+  subject: ALICE,
+};
+const alicePersonalSpace = {
+  type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+  owner: ALICE,
+};
+const aliceSpace = {
+  type: "https://commonfabric.org/cfc/atom/Space",
+  id: ALICE,
+};
 
 describe("CFC clause-aware ceiling fit", () => {
   describe("flat labels/ceilings behave exactly as before (golden)", () => {
@@ -107,6 +125,171 @@ describe("CFC clause-aware ceiling fit", () => {
       expect(
         cfcObservationFitsCeiling([{ anyOf: [A, C] }], [{ anyOf: [A, B] }]),
       ).toBe(false);
+    });
+  });
+
+  describe("a personal space's owner is one of its readers", () => {
+    // §3.6.4: the owner owns the space, so the owner is always among its
+    // readers. A ceiling whose audience is that owner is therefore inside a
+    // `PersonalSpace(owner)` label's audience however wide the space's
+    // membership has grown. The reverse containment does not hold: §3.6.5
+    // gives a newly added member access to all data in the space with no
+    // label rewriting, so the atom's audience is not the owner alone.
+
+    it("a personal-space LABEL fits a ceiling naming its owner", () => {
+      expect(cfcObservationFitsCeiling([alicePersonalSpace], [aliceUser]))
+        .toBe(true);
+    });
+
+    it("a personal-space CEILING does not admit its owner's label", () => {
+      expect(cfcObservationFitsCeiling([aliceUser], [alicePersonalSpace]))
+        .toBe(false);
+    });
+
+    it("names one person: another owner's space stays outside", () => {
+      const bobPersonalSpace = {
+        type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+        owner: BOB,
+      };
+      expect(cfcObservationFitsCeiling([bobPersonalSpace], [aliceUser]))
+        .toBe(false);
+    });
+
+    it("a Space atom carrying the same DID is not covered", () => {
+      // §15.2: a `Space(id)` reader is derived through verified `HasRole`
+      // exchange, which the kernel cannot run. Writer-fit also joins the
+      // target's own `Space(...)` onto every ceiling as the residency
+      // clause, so covering it here would admit that data space-wide.
+      expect(cfcObservationFitsCeiling([aliceSpace], [aliceUser])).toBe(false);
+      expect(cfcObservationFitsCeiling([aliceUser], [aliceSpace])).toBe(false);
+      expect(cfcObservationFitsCeiling([aliceSpace], [alicePersonalSpace]))
+        .toBe(false);
+    });
+
+    it("the bare DID string is not an atom and gets no reading", () => {
+      // §4.1.1: an atom is a structured value, not a simple string. The
+      // legacy bare form stays opaque in both positions.
+      expect(cfcObservationFitsCeiling([ALICE], [aliceUser])).toBe(false);
+      expect(cfcObservationFitsCeiling([aliceUser], [ALICE])).toBe(false);
+      expect(cfcObservationFitsCeiling([alicePersonalSpace], [ALICE]))
+        .toBe(false);
+    });
+
+    it("only a canonical two-field personal space with a DID owner", () => {
+      const scoped = { ...alicePersonalSpace, scope: "drafts" };
+      expect(cfcObservationFitsCeiling([scoped], [aliceUser])).toBe(false);
+      const numeric = {
+        type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+        owner: 42,
+      };
+      expect(cfcObservationFitsCeiling([numeric], [{
+        type: "https://commonfabric.org/cfc/atom/User",
+        subject: 42,
+      }])).toBe(false);
+      // §15.2 types the field as a DID; a string that is not one is a
+      // malformed atom and gets no reading, so two degenerate atoms do not
+      // meet each other through it.
+      // `isDID` and not a `did:` prefix: a truncated or method-only string
+      // is not a DID, and a method-specific id carrying a third colon is
+      // refused too — over-refusal, the safe way for this gate to be wrong.
+      for (const owner of ["", "alice", "did:", "did:key", "did:web:h:p"]) {
+        expect(cfcObservationFitsCeiling([{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner,
+        }], [{
+          type: "https://commonfabric.org/cfc/atom/User",
+          subject: owner,
+        }])).toBe(false);
+      }
+    });
+
+    it("reaches into an OR-clause on the label side", () => {
+      expect(
+        cfcObservationFitsCeiling([{ anyOf: [alicePersonalSpace, C] }], [
+          aliceUser,
+        ]),
+      ).toBe(true);
+      // A ceiling enumeration still demands every alternative it names.
+      expect(
+        cfcObservationFitsCeiling([alicePersonalSpace], [{
+          anyOf: [aliceUser, C],
+        }]),
+      ).toBe(false);
+    });
+
+    it("meets a committed owner field against its plaintext twin", () => {
+      // `label-field-classification.ts` commits `PersonalSpace.owner` and
+      // `User.subject` alike, and the digest is of the field value, so a
+      // label persisted at a cross-space seam still meets a ceiling naming
+      // the same owner in plaintext.
+      const committedOwner = {
+        type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+        owner: commitCfcFieldValue(ALICE),
+      };
+      expect(cfcObservationFitsCeiling([committedOwner], [aliceUser]))
+        .toBe(true);
+      expect(
+        cfcObservationFitsCeiling([{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: commitCfcFieldValue(BOB),
+        }], [aliceUser]),
+      ).toBe(false);
+    });
+
+    it("reads own properties only", () => {
+      // The rewrite builds an atom out of the field it reads, so a prototype
+      // supplying `type`/`owner` must not reach it. Two own enumerable keys
+      // make `Object.keys` report the canonical arity without the canonical
+      // shape.
+      const inherited = Object.create(alicePersonalSpace) as Record<
+        string,
+        unknown
+      >;
+      inherited.a = 1;
+      inherited.b = 2;
+      expect(cfcObservationFitsCeiling([inherited as never], [aliceUser]))
+        .toBe(false);
+    });
+
+    it("a committed owner is admitted where its plaintext twin is refused", () => {
+      // A commitment is a digest of whatever the field held, so the
+      // well-formedness test cannot reach it: a malformed owner digests
+      // exactly as a DID does. Pinned so the asymmetry is explicit rather
+      // than a surprise — and pinned with what bounds it, that reaching the
+      // committed form takes a ceiling naming the same malformed subject.
+      const malformed = "alice";
+      expect(
+        cfcObservationFitsCeiling([{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: malformed,
+        }], [{
+          type: "https://commonfabric.org/cfc/atom/User",
+          subject: malformed,
+        }]),
+      ).toBe(false);
+      expect(
+        cfcObservationFitsCeiling([{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: commitCfcFieldValue(malformed),
+        }], [{
+          type: "https://commonfabric.org/cfc/atom/User",
+          subject: malformed,
+        }]),
+      ).toBe(true);
+      // A well-formed ceiling is unreachable from the malformed committed
+      // label, which is the bound that makes the gap tolerable.
+      expect(
+        cfcObservationFitsCeiling([{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: commitCfcFieldValue(malformed),
+        }], [aliceUser]),
+      ).toBe(false);
+    });
+
+    it("does not admit a label the ceiling omits entirely", () => {
+      expect(cfcObservationFitsCeiling([alicePersonalSpace], [])).toBe(false);
+      expect(atomsOutsideCeiling([alicePersonalSpace], [C]))
+        .toEqual([alicePersonalSpace]);
     });
   });
 

--- a/packages/runner/test/cfc-clause-meet.test.ts
+++ b/packages/runner/test/cfc-clause-meet.test.ts
@@ -24,6 +24,17 @@ const A = { type: "https://commonfabric.org/cfc/atom/User", subject: "A" };
 const B = { type: "https://commonfabric.org/cfc/atom/User", subject: "B" };
 const C = { type: "https://commonfabric.org/cfc/atom/User", subject: "C" };
 
+// A personal space and its owner, which the fit kernel relates on the label
+// side (the owner is one of the space's readers). The property below has to
+// hold across them: a ceiling naming the owner and one naming something else
+// meet to a ceiling admitting exactly what both admit.
+const DID = "did:key:zD";
+const D = { type: "https://commonfabric.org/cfc/atom/User", subject: DID };
+const DPersonalSpace = {
+  type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+  owner: DID,
+};
+
 const clauseSetsEqual = (
   left: readonly unknown[],
   right: readonly unknown[],
@@ -130,6 +141,31 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
     });
   });
 
+  describe("the personal-space containment across a meet", () => {
+    // The property test below cannot see this rule: both its sides call the
+    // same `clauseSubsumes`, so the equivalence holds whether or not the
+    // containment is wired in. These pin the containment directly, at the
+    // seam where a meet puts the two spellings in one clause.
+
+    it("a meet of the two spellings still admits the personal-space label", () => {
+      // The meet unions the alternatives (no collapse — `clausesEqual` tells
+      // the atoms apart), so every ceiling alternative must answer the label.
+      // `PersonalSpace(P)` answers itself, and `User(P)` answers it only
+      // through the containment.
+      const met = meetCfcObservationCeilings([D], [DPersonalSpace]);
+      expect(met).toHaveLength(1);
+      expect(cfcObservationFitsCeiling([DPersonalSpace], met)).toBe(true);
+    });
+
+    it("that meet does not admit the owner label — the one-sidedness", () => {
+      // `PersonalSpace(P)` sitting in the ceiling gets no reading, so the
+      // meet refuses a `User(P)` label even though one parent admits it.
+      const met = meetCfcObservationCeilings([D], [DPersonalSpace]);
+      expect(cfcObservationFitsCeiling([D], [D])).toBe(true);
+      expect(cfcObservationFitsCeiling([D], met)).toBe(false);
+    });
+  });
+
   describe("both-direction property: fits(L, meet(C1,C2)) ⟺ fits(L,C1) ∧ fits(L,C2)", () => {
     // Exhaustive enumeration over a small clause universe, including flat
     // atoms, OR-clauses (with an order-differing spelling), the malformed
@@ -145,6 +181,8 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
       { anyOf: [A, B, C] },
       { anyOf: [] },
       CFC_LABEL_READ_FAILED_ATOM,
+      D,
+      DPersonalSpace,
     ];
     const labelClausePool: readonly CfcConfClause[] = [
       A,
@@ -156,6 +194,9 @@ describe("CFC ceiling meet (pairwise alternative-set union)", () => {
       { anyOf: [] },
       CFC_LABEL_READ_FAILED_ATOM,
       { anyOf: [CFC_LABEL_READ_FAILED_ATOM, A] },
+      D,
+      DPersonalSpace,
+      { anyOf: [DPersonalSpace, C] },
     ];
 
     const subsetsUpToSize2 = (

--- a/packages/runner/test/cfc-declared-monotonicity.test.ts
+++ b/packages/runner/test/cfc-declared-monotonicity.test.ts
@@ -8,6 +8,7 @@ import type { JSONSchema } from "../src/builder/types.ts";
 import { stampExternalIngest } from "../src/cfc/external-ingest.ts";
 import {
   cfcCanonicalClauseDigest,
+  type CfcConfClause,
   type CfcDeclaredMonotonicityMode,
   collectDeclaredMonotonicityViolations,
 } from "../src/cfc/mod.ts";
@@ -1644,6 +1645,75 @@ describe("CFC declared-component monotonicity (WP5, §8.12.1/§8.12.8)", () => {
       expect(
         violations.filter((v) => v.includes("integrity violation")),
       ).toHaveLength(1);
+    });
+  });
+
+  describe("a personal space's owner (the §8.10.3 witness relation)", () => {
+    // The gate's witness is `clauseSubsumes(proposed, stored)`, the same
+    // §8.10.3 kernel the ceiling gates use, so the personal-space reading
+    // reaches here too — proposed sits in the CEILING position and stored in
+    // the LABEL position. Pinned because a change to that kernel changes
+    // what this gate calls monotone.
+
+    const OWNER = "did:key:zMonoOwner";
+    const userAtom = {
+      type: "https://commonfabric.org/cfc/atom/User",
+      subject: OWNER,
+    };
+    const personalSpaceAtom = {
+      type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+      owner: OWNER,
+    };
+    const confidentialityViolations = (
+      stored: CfcConfClause,
+      proposed: CfcConfClause,
+    ): string[] =>
+      collectDeclaredMonotonicityViolations({
+        space: signer.did(),
+        docId: "of:spelling-doc",
+        storedEntries: [{
+          path: ["out"],
+          origin: "declared",
+          label: { confidentiality: [stored] },
+        }],
+        proposedEntries: [{
+          path: ["out"],
+          origin: "declared",
+          label: { confidentiality: [proposed] },
+        }],
+      }).filter((v) => v.includes("confidentiality violation"));
+
+    it("narrowing a declared personal space to its owner is monotone", () => {
+      // The owner is one of the space's readers, so naming the owner alone
+      // is the tightening direction.
+      expect(confidentialityViolations(personalSpaceAtom, userAtom))
+        .toEqual([]);
+    });
+
+    it("widening a declared owner to their personal space is a violation", () => {
+      // The direction the gate exists to catch: a declared policy naming one
+      // person re-minted as an atom whose audience is the space's readers.
+      expect(confidentialityViolations(userAtom, personalSpaceAtom))
+        .toHaveLength(1);
+    });
+
+    it("re-spelling a declared owner as a space principal is a violation", () => {
+      const spaceAtom = {
+        type: "https://commonfabric.org/cfc/atom/Space",
+        id: OWNER,
+      };
+      expect(confidentialityViolations(userAtom, spaceAtom)).toHaveLength(1);
+      expect(confidentialityViolations(personalSpaceAtom, spaceAtom))
+        .toHaveLength(1);
+    });
+
+    it("a different owner is a violation", () => {
+      const otherUser = {
+        type: "https://commonfabric.org/cfc/atom/User",
+        subject: "did:key:zMonoOther",
+      };
+      expect(confidentialityViolations(personalSpaceAtom, otherUser))
+        .toHaveLength(1);
     });
   });
 

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -63,6 +63,29 @@ const ownSpacePrincipal = {
   id: signer.did(),
 };
 
+// A second person, who is neither this space's DID nor its acting signer.
+const OTHER_PRINCIPAL = "did:key:zOtherPerson";
+
+// The three spellings of one principal (§15.2): the identity atom, the
+// personal-space atom naming its owner, and the legacy bare DID string.
+const userPrincipal = (subject: string) => ({
+  type: "https://commonfabric.org/cfc/atom/User",
+  subject,
+});
+const personalSpacePrincipal = (owner: string) => ({
+  type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+  owner,
+});
+
+// A target schema whose store policy is exactly `confidentiality`.
+const declaring = (
+  ...confidentiality: readonly FabricValue[]
+): JSONSchema => ({
+  type: "object",
+  properties: { copied: { type: "string" } },
+  ifc: { confidentiality: [...confidentiality] },
+} as JSONSchema);
+
 // Seed a source doc whose `secret` field carries `confidentiality`, so a
 // transaction reading it takes those clauses into the per-tx flow join.
 const seedSecretSource = async (
@@ -559,6 +582,145 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       await runtime.dispose();
       await storageManager.close();
     }
+  });
+
+  describe("a personal space's owner is one of its readers", () => {
+    // §8.10.3 fit kernel: a `PersonalSpace(P)` LABEL fits a store declaring
+    // `User(P)`, because §3.6.4 makes P an owner and so a reader of that
+    // space. The reverse does not hold — §3.6.5 gives a member added later
+    // access to all data in the space with no label rewriting, so a store
+    // declaring the atom is not read by P alone.
+
+    it("admits a personal-space clause into a store declaring that owner", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-owner-source", [
+          personalSpacePrincipal(OTHER_PRINCIPAL),
+        ]);
+        const { tx, targetId, result } = await deriveIntoTarget(
+          runtime,
+          "wf-owner-source",
+          "wf-owner-derived",
+          "enforce-strict",
+          declaring(userPrincipal(OTHER_PRINCIPAL)),
+        );
+        expect(result.error?.message).toBeUndefined();
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+
+        // A write admission, not a relabeling: the derived stamp still
+        // carries the atom the flow measured, so the egress and display
+        // gates read the unchanged label.
+        const flowEntry = replicaEntries(storageManager, targetId)
+          .find((e) => e.origin === "derived");
+        expect(flowEntry!.label.confidentiality).toContainEqual(
+          personalSpacePrincipal(OTHER_PRINCIPAL),
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("admits a clause carrying the personal space as one alternative", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-owner-alt-source", [{
+          anyOf: [personalSpacePrincipal(OTHER_PRINCIPAL), "internal"],
+        }]);
+        const { result } = await deriveIntoTarget(
+          runtime,
+          "wf-owner-alt-source",
+          "wf-owner-alt-derived",
+          "enforce-strict",
+          declaring(userPrincipal(OTHER_PRINCIPAL)),
+        );
+        expect(result.error?.message).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a User clause into a store declaring that person's personal space", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        // The direction §3.6.5 denies: the store's audience is the space's
+        // readers, which a later membership change widens without touching
+        // any label.
+        await seedSecretSource(runtime, "wf-owner-ceiling-source", [
+          userPrincipal(OTHER_PRINCIPAL),
+        ]);
+        const { result } = await deriveIntoTarget(
+          runtime,
+          "wf-owner-ceiling-source",
+          "wf-owner-ceiling-derived",
+          "enforce-strict",
+          declaring(personalSpacePrincipal(OTHER_PRINCIPAL)),
+        );
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(OTHER_PRINCIPAL);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a personal space the declared owner does not name", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        // The neighbouring case: the same rule, one DID apart.
+        await seedSecretSource(runtime, "wf-owner-mismatch-source", [
+          personalSpacePrincipal(OTHER_PRINCIPAL),
+        ]);
+        const { result } = await deriveIntoTarget(
+          runtime,
+          "wf-owner-mismatch-source",
+          "wf-owner-mismatch-derived",
+          "enforce-strict",
+          declaring(userPrincipal(signer.did())),
+        );
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(OTHER_PRINCIPAL);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a User clause naming the acting principal into an undeclared store", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        // No self exemption. The acting principal signs this transaction and
+        // its DID is this space's, so residency contributes `Space(<that
+        // DID>)` — and the store is still public, which is what refuses the
+        // write. A person writing their own secret to a world-readable store
+        // is the disclosure the ceiling exists to catch.
+        await seedSecretSource(runtime, "wf-owner-self-source", [
+          userPrincipal(signer.did()),
+        ]);
+        const { result } = await deriveIntoTarget(
+          runtime,
+          "wf-owner-self-source",
+          "wf-owner-self-derived",
+        );
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(signer.did());
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
   });
 
   describe("meta-seam exemption", () => {


### PR DESCRIPTION
The §8.12.4 writer-fit check measures a transaction's confidentiality flow join against the target document's declared store policy, and the fit test is clause subsumption over §8.12.1's `atomLe` — structural equality for every atom type but `Expires`. Under that relation a store declaring `User(P)` refuses a value labelled `PersonalSpace(P)`, even though P is an owner of that space and so one of its readers. Under `enforce-strict` that is a refused write.

The fit kernel gains one case, on the LABEL side only: a `PersonalSpace(owner)` alternative also answers a ceiling alternative naming that owner. The criterion is the one §8.12.1 states for `atomLe` itself — satisfying the more restrictive side implies satisfying the other. §3.6.4 makes the owner an owner of their personal space, so the owner is among its readers whatever else the membership holds, and a ceiling whose audience is that owner is inside the label's audience. That is the containment the fit test asks for. It is a fact about space membership rather than a claim that two atoms name one thing, which is why it does not generalize.

The reverse does not hold, and the reverse is the tempting rule. A ceiling declaring `PersonalSpace(P)` would have to be read by P ALONE to admit a `User(P)` label. §3.6.4 has a user share by "adding members to their personal space (converting it to a shared space)", and §3.6.5 then gives the new member access to all data in the space with no labels rewritten. The atom's audience grows after the fact, so §3.6.4's `readers: {Alice}` is a starting configuration and not an invariant. §4.9.4 agrees from the other side, generating `HasRole(user, PersonalSpace(User), reader)` by a §4.9.3 point query against that space's own ACL record and calling the form one of "the two `Space(...)` atoms"; §15.2 and §4.1.2 both call it a convenience form for a per-user space principal. A store declaring it would take data labelled for its owner alone and replicate it to a member added later.

`Space(id)` gains no case. §15.2 derives its access through verified `HasRole` exchange, which this kernel cannot run, and writer-fit already joins `Space(<the space the document lives in>)` onto every document's ceiling as its residency clause, so covering it here would admit a person's data into every document in that space — the blanket exemption the ceiling exists to refuse, reached by a second route.

Nor does any atom naming the acting principal. Alice signing the transaction says nothing about who reads the store she writes to, and an undeclared store is world-readable, so alice writing her own secret there is the disclosure. A test pins that refusal in the shape most likely to be mistaken for a rule landing here: the acting principal's DID is also the space's, so residency contributes a `Space` clause carrying that very DID, and the write is still refused.

The bare DID string gains no case either. §4.1.1 states that an atom is "not a simple string but a structured value with a type and parameters", and §15.2 lists no string form, so there is nothing here to read. The shell's default display ceiling nonetheless carries a raw acting-user DID beside `User` and `PersonalSpace`; §8.10.6's profile lists only the latter two and forbids admitting an additional atom family without a release judgment, so that entry is a loosening that wants removing rather than generalizing. No runtime code mints one; it appears only there and in tests.

This is a deviation from §8.12.1's stated `atomLe`, which is equality plus the `Expires` order, and from the restatement in §8.12.4's `canWrite`. The spec edit it owes is recorded as SC-39, along with the question of whether the case belongs in the relation or in a normalization ahead of it — the runtime takes the second, so the relation keeps its shape and the integrity floor, which shares it, is untouched.

The reading reaches every caller of the kernel, the §8.12.1 declared-monotonicity gate among them, where `clauseSubsumes(proposed, stored)` puts the proposal in the ceiling position and the stored clause in the label position. The one-sidedness lands the right way round there: narrowing a declared `PersonalSpace(P)` to `User(P)` is monotone, while re-minting a declared `User(P)` as `PersonalSpace(P)` is the widening the gate exists to catch and stays a violation. That gate gets its own cases rather than inheriting the ceiling gates' coverage.

Clause IDENTITY is untouched. `clausesEqual`, the canonical clause digest, and the ceiling meet all still tell the two atoms apart, so a mutually-subsuming pair can carry different digests. Every place that shows is fail-closed: a §8.12.7 route-2b exemption naming one does not exempt the other, and a meet keeps both alternatives rather than collapsing them. Nothing is relabelled and no envelope is rewritten — the derived stamp still persists the whole join, so the egress and display gates read the unchanged label.

Only the canonical two-field shape participates, the discipline `atomEntails` already applies to `Expires`, and only when its `owner` is a plaintext DID or the §4.6.4.1 `{digestOf}` commitment the cross-space seam persists that field as. A record carrying further fields is not the atom it resembles. The owner value carries across untouched, so a committed field still meets its plaintext twin under the same-form comparison.

One gate keeps its own comparison and so keeps the old reading: the schema `maxConfidentiality` input-requirement check falls back to a flat structural comparison when `cfcPolicyEvaluation` is `off`, which is already blind to clause subsumption and to the `Expires` order. It consults the kernel at the dial's higher rungs, and writer-fit consults it at every rung.

Of the two candidate fixes this branch was scoped around, this is a piece of the first: a document declares a ceiling, and the fit rule lets a label sit inside it. Only the part that holds is here. Reading a declared `Space(S)` as covering the space's members, and reading a declared `PersonalSpace(P)` as covering P, are the two rules just refused. The second candidate, an exemption for the piece-instantiation seam alongside the meta-seam and reserved-document exemptions in `cfc/prepare.ts`, is wrong for the reason those exemptions are right: they cover surfaces no value schema describes, whereas a piece's `/title` and `/description` are ordinary piece data with an ordinary declaration route. An exemption there is a hole in the ceiling, not a boundary of it.

The strict defaults this is a prerequisite for stay blocked on other gaps, and this does not move them. Run with the dials raised, the agents host's debug-view replacement test meets the same refusals before and after: 132 on computed cells and 122 on piece documents, the same count and the same bare `User` atom either way. Computed cells are the separately tracked gap the strict-defaults change already names as the reason the pattern-test harnesses hold a rung below the fleet pin. The piece documents want a declaration naming the owner on the document holding the owner's data, which is §8.12.5's per-write route and belongs to whichever writer puts the data there.

Measured at `enforce-strict` with flow labels persisting, reading a labelled source and writing a derivation into a target whose declared policy varied: an undeclared target is refused, a `Space(<this space>)` target is refused, a `PersonalSpace(P)` target refuses a `User(P)` join, and a `User(P)` target admits a `PersonalSpace(P)` join. Every admission fails against a reverted rule with the writer-fit misfit naming the offending atom, and adding the ceiling-side reading breaks a refusal in each of the three gates.

The enforcement matrix records the reading in the writer-fit ceiling's scope note, and the spec change list gains SC-39. SC-18(d)'s note that §3.6.4 and §4.9.4 leave the atom's membership unsettled is corrected there: §3.6.5 settles it, and residency's exclusion of the atom is unaffected and better grounded for it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

