### PR TITLE
docs(topics): use canonical per-user identity key

### DIFF
--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -23,12 +23,21 @@ Run from the Labs repository root so `cf` uses that checkout:
 export CF_API_URL='https://estuary.saga-castor.ts.net'
 export CF_SPACE='topics-dev-476ea34f'
 export TOPICS_BOARD='/of:fid1:jtdD-DSmuGrLGSt_6sJ3DS_7jmerrkKTEnW3fZV9e34'
-export CF_IDENTITY='<exact path to the key your human user uses>'
+export CF_IDENTITY="${CF_IDENTITY:-$HOME/.config/commonfabric/identity.key}"
+test -r "$CF_IDENTITY" || {
+  printf 'Topics identity key is not readable: %s\n' "$CF_IDENTITY" >&2
+  exit 1
+}
 ```
 
-Use the same Estuary identity key as your human user. Do not mint an agent key,
-guess a key path, use another human's key, or use the publicly derivable
-`implicit trust` identity. If the exact path is not already explicit, ask.
+An already-set `CF_IDENTITY` is the explicit override. Otherwise use the team's
+stable per-user default at `~/.config/commonfabric/identity.key`; the path is
+common while its contents belong to that teammate. Use the same Estuary identity
+key as your human user. If the readability check fails, stop and ask the human
+to provision that default or export the correct path. Do not search for keys,
+mint an agent key, use another human's key, or use the publicly derivable
+`implicit trust` identity. Never print or inspect key material; use
+`cf id did "$CF_IDENTITY"` when the public DID is needed for verification.
 
 Every authored-content mutation carries `agentName` in the same event. Use one
 stable agent name, without decorating titles, labels, bodies, or comments with a


### PR DESCRIPTION
## Summary

- preserve an explicit `CF_IDENTITY` override
- otherwise resolve the human user's key from Loom's canonical per-user path at `~/.config/commonfabric/identity.key`
- stop on a missing or unreadable key while retaining the existing no-search, no-mint, and no-key-inspection guardrails

## Validation

- `deno task check-skill-facts`
- `deno task check-docs`
- `deno fmt --check`
- `deno lint`
- verified that the canonical local key is readable by `cf id did`

— Sol


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

