### PR TITLE
cf-harness: register skills.sh discovery and pin hits

### DIFF
--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -358,7 +358,7 @@ there.
 - It does not retire the trusted operator `--skills-root` path.
 - It does not build CT-2068's declassification predicate, and nothing here
   should be taken as a precedent for an integrity fact granting permission.
-- It does not close the search-query channel. Stage 6 does; until then a
+- It does not close the search-query channel. Stage 5 does; until then a
   parent that has read a secret and then chooses a query is a channel, and
   that is a known, stated gap rather than a solved problem.
 - It does not make the registry trustworthy. Nothing here is a claim about

--- a/docs/plans/external-skill-acquisition.md
+++ b/docs/plans/external-skill-acquisition.md
@@ -77,6 +77,9 @@ A read-only tool over the registry, shaped on `search_patterns` and holding
 the same boundary that tool's own header states: *a model needs to know what
 something is for, and never what it says.*
 
+Stage 1 registers this metadata-only tool on the configured parent surface, as
+CT-2106 requires; a run with no public skill registry does not offer it.
+
 **Reuses.** `PatternIndexClient`'s shape for a typed client over a remote
 index (`packages/cf-harness/src/pattern-index/client.ts`); `HarnessFetch` from
 `contracts/http-fetch.ts` so the egress is substitutable and testable;
@@ -107,14 +110,17 @@ it above.
 **The ranking signal is not imported.** See below; this is load-bearing enough
 to have its own section.
 
-**Egress.** Discovery reaches the public internet, so it belongs to a child
-with network reach and no secrets, along the decomposition CT-2078 proved:
-the acquirer has web reach and no task data, the user has task data and no
-acquisition surface. `WEB_FETCH_SUBAGENT_PROFILE_CONFIG` is the existing
-shape. The residual channel is real and unclosed: **a search query can encode
-anything the searcher knows**, so a parent that has read a secret and then
-chooses what to search for is a channel by construction. CT-2068 names this;
-this plan does not solve it, and the mirror below is what eventually does.
+**Egress.** Stage 1 discovery runs on the configured parent surface and returns
+metadata only. Stage 3 moves discovery and acquisition together into a
+dedicated child with web reach and no secrets, using
+`WEB_FETCH_SUBAGENT_PROFILE_CONFIG` as its constrained shape rather than adding
+registry search to the existing hostile-web-text profile. The decomposition is
+the one CT-2078 proved: the acquirer has web reach and no task data, the user
+has task data and no acquisition surface. The residual channel is real and
+unclosed: **a search query can encode anything the searcher knows**, so a parent
+that has read a secret and then chooses what to search for is a channel by
+construction. CT-2068 names this; this plan does not solve it, and the mirror
+below is what eventually does.
 
 ## Part 2 — Handle-load: the text never reaches the chooser
 
@@ -161,6 +167,13 @@ A skills.sh id alone is **not** a pinned address. Resolving one into a pinned
 address — reading the source repository, choosing a commit — is a discovery-side
 step whose output is an address, and the acquiring child fetches only the
 address, never the id.
+
+That resolution is host-side machinery rather than a model-facing tool. It
+reads the source repository's default branch through the GitHub API, records
+the full commit SHA at the branch head and the resolution time, and returns
+`{id, owner, repo, slug, commitSha, resolvedAt}`. The registry's served hash is
+never the pin and is not stored in this address; if retained elsewhere, it is
+named only as an unverified change detector.
 
 **Gate on the parse, never on the status.** `https://www.skills.sh/.well-known/agent-skills/index.json`
 returns the site's HTML 404 page with **status 200**. A client that tested
@@ -317,28 +330,21 @@ there.
 
 ## Staging
 
-1. **`search_skills`, read-only, not registered.** The client, the
-   sanitization, the shape refusals, and tests against recorded fixtures. No
-   tool-registry entry, so nothing can call it yet. A first cut of this exists:
-   `packages/cf-harness/src/skills-sh/search-client.ts`, its fixture-driven
-   tests, and `deno task probe-skills-sh` for the hand-run call against the
-   live registry. Running it against live data immediately paid for the
-   refusal counter — a legitimate listing with several thousand reported
-   installs uses `::` in its slug, which one character class shared across all
-   three identifier segments drops silently. The counter is what made the
-   silence visible, and the fix was a character set per segment rather than a
-   looser one for all of them.
-2. **Address resolution.** Turning a discovery hit into a pinned address, or
-   refusing. This is where the honest answer is often "no pinned address
-   exists for this hit", and that refusal is the feature.
-3. **Verified acquisition.** The `.well-known` digest path and the commit-SHA
-   path, both fail-closed, with the single-file payload whitelist and its
-   refusal. Write into a cell, return a handle.
+1. **Registered metadata discovery.** The `search_skills` parent tool, the
+   sanitization, the shape refusals, and tests against recorded fixtures. It is
+   present only when a public skill registry is configured and surfaces the
+   refusal counter; it cannot fetch, read, or load skill content.
+2. **Address resolution.** Host-side conversion of a discovery hit into the
+   source repository's full default-branch commit SHA, or refusal. The output
+   is an immutable pinned address for a later acquisition step, never the
+   registry's unverified hash.
+3. **Isolated verified acquisition.** Move discovery into a dedicated
+   no-secrets child alongside the `.well-known` digest path and commit-SHA
+   acquisition path, both fail-closed, with the single-file payload whitelist
+   and its refusal. Write into a cell, return a handle, and prove with an
+   adversarial canary that skill text never reached the parent's context.
 4. **The provenance mark**, minted split-mint style on the acquiring write.
-5. **Register `search_skills`** and wire the end-to-end path, with an
-   adversarial run: a skill whose text attempts to make the child exfiltrate,
-   and a canary proving the payload never reached the parent's context.
-6. **The mirror.** The registry's terms explicitly encourage it —
+5. **The mirror.** The registry's terms explicitly encourage it —
    *"caching results on your own infrastructure, is encouraged and not
    restricted"* — and CT-2068 already names a mirror as the destination and
    "trusted not to log" as the interim. A mirror removes third-party egress

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -126,6 +126,11 @@ What works today:
     reports each one's declared shapes and import specifier, never its source)
   - `record_feedback` (under the same pattern-index gate; votes a pattern up or
     down so the index learns which ones were worth offering)
+  - `search_skills` (present only on the parent surface when the run configures
+    the public registry with `--skills-registry-url`; returns sanitized
+    identifiers, names, sources, registry-reported install counts, and the
+    number of refused hits, never skill text. Install counts are unauthenticated
+    and unverifiable telemetry, not a trust signal)
 - composing published patterns: source the model authors may
   `import Sub from "cf:pattern:<patternId>"`, and `run_pattern` fetches and
   compiles each named pattern into the space before compiling the source that
@@ -292,8 +297,10 @@ From [packages/cf-harness](.):
   answers with, along with a count of the entries the client refused. It is the
   one thing here that calls the live registry, which is why it is a script you
   run rather than a test that runs itself; the committed tests use a captured
-  response. It prints no skill text, and the client behind it is not registered
-  as a tool, so no model can reach it. The discovery half of
+  response. It uses the same guarded client as the parent-only `search_skills`
+  tool and prints no skill text. Configure that tool with
+  `--skills-registry-url` or `CF_HARNESS_SKILLS_REGISTRY_URL`; without either,
+  the tool is absent. The discovery half of
   [`../../docs/plans/external-skill-acquisition.md`](../../docs/plans/external-skill-acquisition.md)
   is what it exists to exercise.
 

--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -44,6 +44,10 @@ cookie when it loads. Do not put it behind a public address.
   this server unattended and counting what they did with the index is
   [the measurement protocol](../docs/pattern-index-measurement.md), whose runner
   reaches this server over the same routes the page does.
+- **A public skill registry URL**, optionally. With one set, the parent session
+  offers metadata-only `search_skills`; without one, the tool is absent. Its
+  registry-reported install counts are unauthenticated and unverifiable, not a
+  trust signal, and the tool cannot fetch, read, or load skill content.
 
 ## Running it
 
@@ -52,6 +56,7 @@ export CF_HARNESS_FABRIC_API_URL=http://localhost:8000
 export CF_HARNESS_FABRIC_IDENTITY="$HOME/.cf/my-key.pkcs8"
 export CF_HARNESS_FABRIC_SPACE=my-space
 export CF_HARNESS_PATTERN_INDEX_URL=https://index.example/   # optional
+export CF_HARNESS_SKILLS_REGISTRY_URL=https://www.skills.sh/  # optional
 
 deno task --cwd packages/cf-harness console
 open http://127.0.0.1:8100
@@ -69,20 +74,21 @@ the one-shot build on its own.
 
 Every environment variable has a flag, and the flag wins:
 
-| Flag                  | Environment                          | Default                               |
-| --------------------- | ------------------------------------ | ------------------------------------- |
-| `--port`              | `CF_HARNESS_CONSOLE_PORT`            | `8100`                                |
-| `--fabric-api-url`    | `CF_HARNESS_FABRIC_API_URL`          | `http://localhost:8000`               |
-| `--fabric-identity`   | `CF_HARNESS_FABRIC_IDENTITY`         | required                              |
-| `--fabric-space`      | `CF_HARNESS_FABRIC_SPACE`            | required, a name                      |
-| `--pattern-index-url` | `CF_HARNESS_PATTERN_INDEX_URL`       | unset                                 |
-| `--model`             | `CF_HARNESS_MODEL`                   | the CLI's default model               |
-| `--workspace`         | `CF_HARNESS_CONSOLE_WORKSPACE`       | `.cf-harness-console/workspace`       |
-| `--artifact-root`     | `CF_HARNESS_ARTIFACT_ROOT`           | `.cf-harness-console/runs`            |
-| `--session-db`        | `CF_HARNESS_CONSOLE_SESSION_DB`      | `.cf-harness-console/sessions.sqlite` |
-| `--space-db`          | `CF_HARNESS_SPACE_DB`                | the space's own database, discovered  |
-| `--max-model-turns`   | `CF_HARNESS_CONSOLE_MAX_MODEL_TURNS` | the prompt loop's default             |
-| `--skills-root`       | `CF_HARNESS_CONSOLE_SKILLS_ROOT`     | the repository's `skills/` tree       |
+| Flag                    | Environment                          | Default                               |
+| ----------------------- | ------------------------------------ | ------------------------------------- |
+| `--port`                | `CF_HARNESS_CONSOLE_PORT`            | `8100`                                |
+| `--fabric-api-url`      | `CF_HARNESS_FABRIC_API_URL`          | `http://localhost:8000`               |
+| `--fabric-identity`     | `CF_HARNESS_FABRIC_IDENTITY`         | required                              |
+| `--fabric-space`        | `CF_HARNESS_FABRIC_SPACE`            | required, a name                      |
+| `--pattern-index-url`   | `CF_HARNESS_PATTERN_INDEX_URL`       | unset                                 |
+| `--skills-registry-url` | `CF_HARNESS_SKILLS_REGISTRY_URL`     | unset                                 |
+| `--model`               | `CF_HARNESS_MODEL`                   | the CLI's default model               |
+| `--workspace`           | `CF_HARNESS_CONSOLE_WORKSPACE`       | `.cf-harness-console/workspace`       |
+| `--artifact-root`       | `CF_HARNESS_ARTIFACT_ROOT`           | `.cf-harness-console/runs`            |
+| `--session-db`          | `CF_HARNESS_CONSOLE_SESSION_DB`      | `.cf-harness-console/sessions.sqlite` |
+| `--space-db`            | `CF_HARNESS_SPACE_DB`                | the space's own database, discovered  |
+| `--max-model-turns`     | `CF_HARNESS_CONSOLE_MAX_MODEL_TURNS` | the prompt loop's default             |
+| `--skills-root`         | `CF_HARNESS_CONSOLE_SKILLS_ROOT`     | the repository's `skills/` tree       |
 
 Every turn scans the skills root and records the registry on its run before the
 first model call, so `read_skill_resource` can answer and a delegated
@@ -408,13 +414,14 @@ Three panes:
 
 `CreateHarnessPromptLoopOptions` extends the engine's options, which extend the
 config resolver's, and the interactive chat service spreads its
-`basePromptLoopOptions` into every turn. So `fabricSession` and `patternIndex`
-set once at startup hold for the whole session, and the engine builds each
-lazily-cached client factory from them.
+`basePromptLoopOptions` into every turn. So `fabricSession`, `patternIndex`, and
+`skillsSh` set once at startup hold for the whole session, and the engine builds
+each lazily-cached client factory from them.
 
 Configuration alone is not enough: the default chat policy's tool surface does
-not include `run_pattern`, `assign_slug`, `search_patterns`, or
-`record_feedback`. The server names them in the policy it starts each session
+not include `run_pattern`, `assign_slug`, `search_patterns`, `record_feedback`,
+or `search_skills`. The server names them in the policy it starts each session
 with, and the prompt loop withholds each again if its backing is absent — so a
-missing index means the two index tools are simply not offered, rather than
-offered and failing.
+missing index means the two index tools are simply not offered, and a missing
+public skill registry means `search_skills` is not offered, rather than either
+surface being offered and failing.

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -59,6 +59,7 @@ import type {
   HarnessFabricSessionConfig,
   HarnessModelProviderId,
   HarnessPatternIndexConfig,
+  HarnessSkillsShConfig,
 } from "../src/config.ts";
 import type { CfcPosture } from "@commonfabric/runner";
 import {
@@ -309,6 +310,7 @@ interface ConsoleConfig {
   model: string;
   fabricSession: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
+  skillsSh?: HarnessSkillsShConfig;
   sessionDbPath?: string;
 
   /**
@@ -401,6 +403,7 @@ export const resolveConsoleConfig = (
       "fabric-identity",
       "fabric-space",
       "pattern-index-url",
+      "skills-registry-url",
       "session-db",
       "space-db",
       "max-model-turns",
@@ -525,6 +528,8 @@ export const resolveConsoleConfig = (
 
   const patternIndexUrl = flag("pattern-index-url") ??
     nonEmpty(env.CF_HARNESS_PATTERN_INDEX_URL);
+  const skillsRegistryUrl = flag("skills-registry-url") ??
+    nonEmpty(env.CF_HARNESS_SKILLS_REGISTRY_URL);
   const sessionDb = flag("session-db") ??
     nonEmpty(env.CF_HARNESS_CONSOLE_SESSION_DB) ??
     join(dataDir, "sessions.sqlite");
@@ -556,6 +561,16 @@ export const resolveConsoleConfig = (
         },
       }
       : {}),
+    ...(skillsRegistryUrl !== undefined
+      ? {
+        skillsSh: {
+          baseUrl: requiredUrl(
+            skillsRegistryUrl,
+            "--skills-registry-url",
+          ),
+        },
+      }
+      : {}),
     // `none` turns the durable store off and keeps sessions in memory, which
     // is what a throwaway run wants and what a machine without the SQLite
     // native library can still do.
@@ -581,12 +596,14 @@ export const resolveConsoleConfig = (
  */
 export const consoleChatPolicy = (
   patternIndexConfigured: boolean,
+  skillsShConfigured: boolean,
 ): HarnessChatPolicy => ({
   ...DEFAULT_HARNESS_CHAT_POLICY,
   allowedToolIds: [
     ...DEFAULT_HARNESS_CHAT_POLICY.allowedToolIds,
     ...FABRIC_TOOL_IDS,
     ...(patternIndexConfigured ? PATTERN_INDEX_TOOL_IDS : []),
+    ...(skillsShConfigured ? ["search_skills" as const] : []),
   ],
   allowedSubagentProfiles: [
     ...DEFAULT_HARNESS_CHAT_POLICY.allowedSubagentProfiles,
@@ -1104,7 +1121,10 @@ export class ConsoleServer {
         workspace: { hostPath: this.#config.workspacePath },
         model: this.#config.model,
         artifactRoot: this.#config.artifactRoot,
-        policy: consoleChatPolicy(this.#config.patternIndex !== undefined),
+        policy: consoleChatPolicy(
+          this.#config.patternIndex !== undefined,
+          this.#config.skillsSh !== undefined,
+        ),
       });
       if (!session.ok) {
         return chatErrorResponse(session);
@@ -1348,6 +1368,7 @@ export const createConsoleInteractiveServiceOptions = (
     ...(config.patternIndex !== undefined
       ? { patternIndex: config.patternIndex }
       : {}),
+    ...(config.skillsSh !== undefined ? { skillsSh: config.skillsSh } : {}),
     ...(config.maxModelTurns !== undefined
       ? { maxModelTurns: config.maxModelTurns }
       : {}),
@@ -1419,6 +1440,9 @@ export const startConsoleServer = async (
       console.log(`  fabric:     ${config.fabricSession.apiUrl}`);
       console.log(
         `  index:      ${config.patternIndex?.baseUrl ?? "(not configured)"}`,
+      );
+      console.log(
+        `  skills:     ${config.skillsSh?.baseUrl ?? "(not configured)"}`,
       );
       console.log(
         `  cfc:        ${

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -16,6 +16,7 @@ import {
   type HarnessGatewayAuthMode,
   type HarnessModelProviderId,
   type HarnessPatternIndexConfig,
+  type HarnessSkillsShConfig,
   isHarnessModelProviderId,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
@@ -170,6 +171,7 @@ const CLI_STRING_FLAGS = [
   "compact-threshold",
   "prompt-cache-mode",
   "skills-root",
+  "skills-registry-url",
   "skill",
   "skill-script-execution-target",
   "gateway-base-url",
@@ -270,6 +272,7 @@ export interface CfHarnessCliConfig {
   fabricMount?: string;
   fabricSession?: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
+  skillsSh?: HarnessSkillsShConfig;
   hostMounts: readonly CfHarnessHostMountConfig[];
 }
 
@@ -488,9 +491,10 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback);
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | web_fetch | read_skill_resource | run_skill_script | edit_file | write_file | delegate_task | describe_handle | run_pattern | assign_slug | search_patterns | record_feedback | search_skills);
                                 run_pattern and assign_slug additionally require the three --fabric-* session flags,
-                                and search_patterns and record_feedback require --pattern-index-url
+                                search_patterns and record_feedback require --pattern-index-url,
+                                and search_skills requires --skills-registry-url
   --allow-skill-script <spec>   Allow exact skill script execution (repeatable: skill:scripts/path)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser | web_fetch | web_search)
   --output-mode <mode>          operator | batch (default: operator)
@@ -502,6 +506,7 @@ Options:
   --resume-run <path>           Resume from a run root or run-state.json path
   --system-prompt <text>        Optional system prompt
   --skills-root <path>          Skill root containing <name>/SKILL.md
+  --skills-registry-url <url>  Registry origin for metadata-only search_skills discovery
   --skill <name>                Preload a skill for this run (repeatable)
   --skill-script-execution-target <target>
                                 Execute skill scripts in sandbox or host (default: sandbox)
@@ -572,6 +577,7 @@ Environment:
   CF_HARNESS_COMPACT_THRESHOLD  Default value for --compact-threshold
   CF_HARNESS_PROMPT_CACHE_MODE  Default value for --prompt-cache-mode
   CF_HARNESS_HOME               Local cf-harness credential/config directory
+  CF_HARNESS_SKILLS_REGISTRY_URL Default value for --skills-registry-url
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
   CF_HARNESS_FABRIC_API_URL     Default value for --fabric-api-url
   CF_HARNESS_FABRIC_IDENTITY    Default value for --fabric-identity
@@ -641,6 +647,7 @@ const CLI_PARENT_TOOL_IDS = [
   "assign_slug",
   "search_patterns",
   "record_feedback",
+  "search_skills",
 ] as const satisfies readonly BuiltinToolId[];
 
 const uniqueStrings = <T extends string>(
@@ -1372,6 +1379,9 @@ export const parseCfHarnessCliArgs = async (
         "CF_HARNESS_COMPACT_THRESHOLD",
       ),
       CF_HARNESS_HOME: Deno.env.get("CF_HARNESS_HOME"),
+      CF_HARNESS_SKILLS_REGISTRY_URL: Deno.env.get(
+        "CF_HARNESS_SKILLS_REGISTRY_URL",
+      ),
       HOME: Deno.env.get("HOME"),
       CF_HARNESS_CFC_ENFORCEMENT_MODE: Deno.env.get(
         "CF_HARNESS_CFC_ENFORCEMENT_MODE",
@@ -1731,6 +1741,23 @@ export const parseCfHarnessCliArgs = async (
       ...(publishDiscoverable ? { publishDiscoverable: true } : {}),
     };
   }
+  const rawSkillsRegistryUrl = typeof args["skills-registry-url"] === "string"
+    ? args["skills-registry-url"].trim()
+    : nonEmptyEnvValue(env.CF_HARNESS_SKILLS_REGISTRY_URL);
+  if (rawSkillsRegistryUrl === "") {
+    throw new Error("--skills-registry-url requires a non-empty value");
+  }
+  let skillsSh: HarnessSkillsShConfig | undefined;
+  if (rawSkillsRegistryUrl !== undefined) {
+    try {
+      new URL(rawSkillsRegistryUrl);
+    } catch {
+      throw new Error(
+        `--skills-registry-url must be a valid URL: ${rawSkillsRegistryUrl}`,
+      );
+    }
+    skillsSh = { baseUrl: rawSkillsRegistryUrl };
+  }
   // An allowlisted fabric-session tool with no session to run it against is
   // a configuration contradiction, surfaced here rather than as a tool that
   // is silently absent from the run.
@@ -1748,6 +1775,14 @@ export const parseCfHarnessCliArgs = async (
   if (indexTool !== undefined && patternIndex === undefined) {
     throw new Error(
       `--allow-tool ${indexTool} requires a pattern index; missing --pattern-index-url`,
+    );
+  }
+  if (
+    allowedToolIds?.includes("search_skills") === true &&
+    skillsSh === undefined
+  ) {
+    throw new Error(
+      "--allow-tool search_skills requires a skills registry; missing --skills-registry-url",
     );
   }
   const apiKey = env.CF_HARNESS_API_KEY ?? env.OPENAI_API_KEY;
@@ -1818,6 +1853,7 @@ export const parseCfHarnessCliArgs = async (
     ...(fabricMount !== undefined ? { fabricMount } : {}),
     ...(fabricSession !== undefined ? { fabricSession } : {}),
     ...(patternIndex !== undefined ? { patternIndex } : {}),
+    ...(skillsSh !== undefined ? { skillsSh } : {}),
     hostMounts,
   };
 };
@@ -2408,6 +2444,21 @@ const summarizeToolCallArguments = (
           ? `text=${JSON.stringify(parsed.text)}`
           : undefined;
         const joined = [tags, text].filter((value): value is string =>
+          value !== undefined
+        ).join(" ");
+        return joined === "" ? undefined : joined;
+      }
+      case "search_skills": {
+        const query = typeof parsed.query === "string"
+          ? `query=${JSON.stringify(parsed.query)}`
+          : undefined;
+        const owner = typeof parsed.owner === "string"
+          ? `owner=${JSON.stringify(parsed.owner)}`
+          : undefined;
+        const limit = typeof parsed.limit === "number"
+          ? `limit=${parsed.limit}`
+          : undefined;
+        const joined = [query, owner, limit].filter((value): value is string =>
           value !== undefined
         ).join(" ");
         return joined === "" ? undefined : joined;
@@ -3220,6 +3271,7 @@ export const runCfHarnessCli = async (
         ...(parsed.patternIndex !== undefined
           ? { patternIndex: parsed.patternIndex }
           : {}),
+        ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
         // What the run was asked to do, in the operator's words. A pattern
         // the run publishes carries it as the request it answers.
         ...(parsed.prompt !== undefined ? { taskText: parsed.prompt } : {}),
@@ -3399,6 +3451,7 @@ export const runCfHarnessCli = async (
         ...(parsed.patternIndex !== undefined
           ? { patternIndex: parsed.patternIndex }
           : {}),
+        ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
         // What the run was asked to do, in the operator's words. A pattern
         // the run publishes carries it as the request it answers.
         ...(parsed.prompt !== undefined ? { taskText: parsed.prompt } : {}),

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -89,6 +89,9 @@ import {
 import { loadHarnessSkillContext } from "./skills/registry.ts";
 import { persistHarnessRunSkillRegistry } from "./skills/run-registry.ts";
 import {
+  createHarnessSkillsShSearchClientFactory,
+} from "./skills-sh/search-client.ts";
+import {
   parseAllowedSkillScriptSpec,
   uniqueAllowedSkillScripts,
 } from "./skills/scripts.ts";
@@ -3117,6 +3120,13 @@ export const runCfHarnessCli = async (
       }
       : undefined;
     const additionalMounts = createAdditionalMountConfigs(parsed);
+    const skillsShSearchClientFactory = parsed.skillsSh !== undefined &&
+        deps.fetchFn !== undefined
+      ? createHarnessSkillsShSearchClientFactory(
+        parsed.skillsSh.baseUrl,
+        deps.fetchFn,
+      )
+      : undefined;
     const prepareSkillContextMessages = async (
       engine: CfHarnessEngine,
     ): Promise<string[]> => {
@@ -3272,6 +3282,9 @@ export const runCfHarnessCli = async (
           ? { patternIndex: parsed.patternIndex }
           : {}),
         ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
+        ...(skillsShSearchClientFactory !== undefined
+          ? { skillsShSearchClientFactory }
+          : {}),
         // What the run was asked to do, in the operator's words. A pattern
         // the run publishes carries it as the request it answers.
         ...(parsed.prompt !== undefined ? { taskText: parsed.prompt } : {}),
@@ -3452,6 +3465,9 @@ export const runCfHarnessCli = async (
           ? { patternIndex: parsed.patternIndex }
           : {}),
         ...(parsed.skillsSh !== undefined ? { skillsSh: parsed.skillsSh } : {}),
+        ...(skillsShSearchClientFactory !== undefined
+          ? { skillsShSearchClientFactory }
+          : {}),
         // What the run was asked to do, in the operator's words. A pattern
         // the run publishes carries it as the request it answers.
         ...(parsed.prompt !== undefined ? { taskText: parsed.prompt } : {}),

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -80,6 +80,16 @@ export interface HarnessPatternIndexConfig {
    */
   publishDiscoverable?: boolean;
 }
+
+/**
+ * Connection settings for skills.sh metadata discovery. When present, the run
+ * offers `search_skills`; when absent, the tool is unavailable.
+ */
+export interface HarnessSkillsShConfig {
+  /** Registry origin serving the public `/api/search` route. */
+  baseUrl: string;
+}
+
 export type HarnessModelProviderId =
   | "openai-compatible-gateway"
   | "openai-codex";
@@ -114,6 +124,7 @@ interface HarnessCommonConfig {
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
   fabricSession?: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
+  skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -168,6 +179,7 @@ export interface ResolveHarnessConfigOptions {
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
   fabricSession?: HarnessFabricSessionConfig;
   patternIndex?: HarnessPatternIndexConfig;
+  skillsSh?: HarnessSkillsShConfig;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -354,6 +366,7 @@ export const resolveHarnessConfig = (
     ...(options.patternIndex !== undefined
       ? { patternIndex: options.patternIndex }
       : {}),
+    ...(options.skillsSh !== undefined ? { skillsSh: options.skillsSh } : {}),
   };
   if (modelProvider === "openai-codex") {
     return {

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -15,7 +15,8 @@ export type BuiltinToolId =
   | "assign_slug"
   | "describe_handle"
   | "search_patterns"
-  | "record_feedback";
+  | "record_feedback"
+  | "search_skills";
 
 export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -86,6 +86,11 @@ import {
   createPatternIndexPublicationLedger,
   type PatternIndexPublicationLedger,
 } from "./pattern-index/publish-ledger.ts";
+import {
+  cacheHarnessSkillsShSearchClientFactory,
+  createHarnessSkillsShSearchClientFactory,
+  type HarnessSkillsShSearchClientFactory,
+} from "./skills-sh/search-client.ts";
 import type { HandleValueResolutionContext } from "./tools/handle-values.ts";
 import type { HarnessWellKnownGrant } from "./contracts/well-known-grants.ts";
 import {
@@ -165,6 +170,10 @@ import type {
   SearchPatternsToolInput,
   SearchPatternsToolOutput,
 } from "./tools/search-patterns.ts";
+import type {
+  SearchSkillsToolInput,
+  SearchSkillsToolOutput,
+} from "./tools/search-skills.ts";
 import {
   type ViewImageToolInput,
   type ViewImageToolOutput,
@@ -194,6 +203,7 @@ export interface BuiltinToolInputMap {
   describe_handle: DescribeHandleToolInput;
   search_patterns: SearchPatternsToolInput;
   record_feedback: RecordFeedbackToolInput;
+  search_skills: SearchSkillsToolInput;
 }
 
 export interface BuiltinToolOutputMap {
@@ -212,6 +222,7 @@ export interface BuiltinToolOutputMap {
   describe_handle: DescribeHandleToolOutput;
   search_patterns: SearchPatternsToolOutput;
   record_feedback: RecordFeedbackToolOutput;
+  search_skills: SearchSkillsToolOutput;
 }
 
 interface ToolOutputWithId {
@@ -251,6 +262,13 @@ export interface CreateHarnessEngineOptions
    * `run_pattern` refuses a `patternId`.
    */
   patternIndexClientFactory?: HarnessPatternIndexClientFactory;
+
+  /**
+   * Injection seam for skills.sh discovery. When absent, a factory is built
+   * from `skillsSh` in the resolved config; when both are absent,
+   * `search_skills` stays out of the tool surface.
+   */
+  skillsShSearchClientFactory?: HarnessSkillsShSearchClientFactory;
 
   /**
    * What this run was asked to do, in the words it was asked in — the CLI
@@ -396,6 +414,7 @@ export class CfHarnessEngine {
   readonly #now: () => string;
   readonly #fabricSessionFactory?: HarnessFabricSessionFactory;
   readonly #patternIndexClientFactory?: HarnessPatternIndexClientFactory;
+  readonly #skillsShSearchClientFactory?: HarnessSkillsShSearchClientFactory;
   #patternIndexPublications?: PatternIndexPublicationLedger;
   readonly #taskText?: string;
   readonly #inputCells: readonly HarnessInputCellSpec[];
@@ -551,6 +570,16 @@ export class CfHarnessEngine {
     this.#patternIndexClientFactory = patternIndexClientFactory === undefined
       ? undefined
       : cacheHarnessPatternIndexClientFactory(patternIndexClientFactory);
+    const skillsShSearchClientFactory = options.skillsShSearchClientFactory ??
+      (this.config.skillsSh !== undefined
+        ? createHarnessSkillsShSearchClientFactory(
+          this.config.skillsSh.baseUrl,
+        )
+        : undefined);
+    this.#skillsShSearchClientFactory =
+      skillsShSearchClientFactory === undefined
+        ? undefined
+        : cacheHarnessSkillsShSearchClientFactory(skillsShSearchClientFactory);
     this.#taskText = options.taskText;
     this.#inputCells = options.inputCells ?? [];
     this.#spaceDbPath = options.spaceDbPath;
@@ -797,6 +826,18 @@ export class CfHarnessEngine {
     | HarnessPatternIndexClientFactory
     | undefined {
     return this.#patternIndexClientFactory;
+  }
+
+  /** Whether this run can search the configured skills.sh registry. */
+  get skillsShSearchAvailable(): boolean {
+    return this.#skillsShSearchClientFactory !== undefined;
+  }
+
+  /** The run's cached skills.sh search-client factory, when configured. */
+  get skillsShSearchClientFactory():
+    | HarnessSkillsShSearchClientFactory
+    | undefined {
+    return this.#skillsShSearchClientFactory;
   }
 
   bindRunModel(model: string): HarnessRunState {
@@ -1779,6 +1820,9 @@ export class CfHarnessEngine {
           patternIndexPublishDiscoverable: this.patternIndexPublishDiscoverable,
           patternIndexPublications: this.patternIndexPublications,
         }
+        : {}),
+      ...(this.#skillsShSearchClientFactory !== undefined
+        ? { getSkillsShSearchClient: this.#skillsShSearchClientFactory }
         : {}),
       ...(this.#taskText !== undefined ? { taskText: this.#taskText } : {}),
       sandbox: this.sandbox,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -900,6 +900,11 @@ const PATTERN_INDEX_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
   ["search_patterns", "record_feedback"] as const,
 );
 
+/** The metadata-only tool gated on configured skills.sh discovery. */
+const SKILLS_SH_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
+  ["search_skills"] as const,
+);
+
 /**
  * The tools that exist only over a skill registry, gated on the same terms.
  * A run given no skills root scans no registry, so `read_skill_resource`
@@ -915,6 +920,7 @@ const SKILL_REGISTRY_TOOL_IDS: ReadonlySet<BuiltinToolId> = new Set(
 interface HarnessToolBackingAvailability {
   fabricSessionAvailable: boolean;
   patternIndexAvailable: boolean;
+  skillsShSearchAvailable: boolean;
   skillRegistryAvailable: boolean;
 }
 
@@ -925,6 +931,7 @@ const withheldToolIds = (
   new Set([
     ...(availability.fabricSessionAvailable ? [] : FABRIC_SESSION_TOOL_IDS),
     ...(availability.patternIndexAvailable ? [] : PATTERN_INDEX_TOOL_IDS),
+    ...(availability.skillsShSearchAvailable ? [] : SKILLS_SH_TOOL_IDS),
     ...(availability.skillRegistryAvailable ? [] : SKILL_REGISTRY_TOOL_IDS),
   ]);
 
@@ -2378,12 +2385,13 @@ export class CfHarnessPromptLoop {
       ? "all-builtins"
       : "restricted";
     // The gated tools join the tool surface exactly when the run can back
-    // them; see FABRIC_SESSION_TOOL_IDS and PATTERN_INDEX_TOOL_IDS.
+    // them; see the backing-specific tool-id sets above.
     const availability = this.#toolBackingAvailability();
     const requestedToolIds = options.allowedToolIds ?? [
       ...DEFAULT_PROMPT_LOOP_TOOL_IDS,
       ...(availability.fabricSessionAvailable ? FABRIC_SESSION_TOOL_IDS : []),
       ...(availability.patternIndexAvailable ? PATTERN_INDEX_TOOL_IDS : []),
+      ...(availability.skillsShSearchAvailable ? SKILLS_SH_TOOL_IDS : []),
     ];
     const withheld = withheldToolIds(availability);
     this.#allowedToolIds = new Set(
@@ -2420,6 +2428,7 @@ export class CfHarnessPromptLoop {
     return {
       fabricSessionAvailable: this.engine.fabricSessionAvailable,
       patternIndexAvailable: this.engine.patternIndexAvailable,
+      skillsShSearchAvailable: this.engine.skillsShSearchAvailable,
       // A configured skills root is what a run scans into the registry the
       // skill tools read, so its presence is the tools' backing — a run that
       // has yet to scan still knows it will, and one that never will offers

--- a/packages/cf-harness/src/skills-sh/pin.ts
+++ b/packages/cf-harness/src/skills-sh/pin.ts
@@ -1,0 +1,175 @@
+/**
+ * Host-side resolution of a mutable skills.sh discovery hit to the immutable
+ * commit at the source repository's default-branch head. This module is
+ * machinery for the later acquisition step, not a model-facing tool: the
+ * model chooses a candidate, and the host resolves where that candidate
+ * points without exposing the GitHub request or response.
+ */
+
+import {
+  defaultHarnessFetch,
+  type HarnessFetch,
+} from "../contracts/http-fetch.ts";
+import type { SkillsShSearchHit } from "./search-client.ts";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const OWNER_PATTERN = /^[A-Za-z0-9-]{1,39}$/;
+const REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
+const SLUG_PATTERN = /^[A-Za-z0-9._:-]{1,100}$/;
+const DOT_ONLY_SEGMENT = /^\.+$/;
+const FULL_GIT_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export interface SkillsShPinnedAddress {
+  readonly id: string;
+  readonly owner: string;
+  readonly repo: string;
+  readonly slug: string;
+  readonly commitSha: string;
+  readonly resolvedAt: string;
+}
+
+export type SkillsShPinResolutionFailureCode =
+  | "invalid_hit"
+  | "request_failed"
+  | "http_error"
+  | "unparseable_response";
+
+export class SkillsShPinResolutionError extends Error {
+  override readonly name = "SkillsShPinResolutionError";
+  readonly code: SkillsShPinResolutionFailureCode;
+
+  constructor(code: SkillsShPinResolutionFailureCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export interface ResolveSkillsShHitPinOptions {
+  readonly fetch?: HarnessFetch;
+  readonly now?: () => string;
+}
+
+interface ParsedHitId {
+  owner: string;
+  repo: string;
+  slug: string;
+}
+
+/** Returns the three trusted path segments, or refuses before any request. */
+const parseHitId = (hit: SkillsShSearchHit): ParsedHitId => {
+  const [owner, repo, slug, extra] = hit.id.split("/");
+  if (
+    extra !== undefined || owner === undefined || repo === undefined ||
+    slug === undefined || !OWNER_PATTERN.test(owner) ||
+    !REPO_PATTERN.test(repo) || !SLUG_PATTERN.test(slug) ||
+    DOT_ONLY_SEGMENT.test(repo) || DOT_ONLY_SEGMENT.test(slug) ||
+    hit.source !== `${owner}/${repo}`
+  ) {
+    throw new SkillsShPinResolutionError(
+      "invalid_hit",
+      "skills.sh pin resolution requires an id whose owner and repository match its source",
+    );
+  }
+  return { owner, repo, slug };
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+
+/** Fetches one GitHub API object, parsing the body rather than trusting status. */
+const fetchGithubObject = async (
+  fetch: HarnessFetch,
+  url: string,
+): Promise<Record<string, unknown>> => {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    throw new SkillsShPinResolutionError(
+      "request_failed",
+      `GitHub pin resolution could not be reached: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!response.ok) {
+    throw new SkillsShPinResolutionError(
+      "http_error",
+      `GitHub pin resolution answered ${response.status}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new SkillsShPinResolutionError(
+      "unparseable_response",
+      "GitHub pin resolution answered with a body that is not JSON",
+    );
+  }
+  const object = asRecord(body);
+  if (object === undefined) {
+    throw new SkillsShPinResolutionError(
+      "unparseable_response",
+      "GitHub pin resolution answered without an object",
+    );
+  }
+  return object;
+};
+
+/**
+ * Resolves `hit` to the full commit SHA at its source repository's default
+ * branch head. The registry's own served hash is not consulted or stored: it
+ * is an unverified change detector, not a pin.
+ */
+export const resolveSkillsShHitPin = async (
+  hit: SkillsShSearchHit,
+  options: ResolveSkillsShHitPinOptions = {},
+): Promise<SkillsShPinnedAddress> => {
+  const { owner, repo, slug } = parseHitId(hit);
+  const fetch = options.fetch ?? defaultHarnessFetch;
+  const repositoryUrl = `${GITHUB_API_BASE_URL}/repos/${owner}/${repo}`;
+  const repository = await fetchGithubObject(fetch, repositoryUrl);
+  const defaultBranch = repository.default_branch;
+  if (
+    typeof defaultBranch !== "string" || defaultBranch.length === 0 ||
+    defaultBranch.length > 255
+  ) {
+    throw new SkillsShPinResolutionError(
+      "unparseable_response",
+      "GitHub repository metadata carried no usable default branch",
+    );
+  }
+
+  const branchUrl = `${repositoryUrl}/branches/${
+    encodeURIComponent(defaultBranch)
+  }`;
+  const branch = await fetchGithubObject(fetch, branchUrl);
+  const commitSha = asRecord(branch.commit)?.sha;
+  if (
+    typeof commitSha !== "string" ||
+    !FULL_GIT_COMMIT_SHA_PATTERN.test(commitSha)
+  ) {
+    throw new SkillsShPinResolutionError(
+      "unparseable_response",
+      "GitHub default-branch metadata carried no full commit SHA",
+    );
+  }
+
+  return {
+    id: hit.id,
+    owner,
+    repo,
+    slug,
+    commitSha,
+    resolvedAt: (options.now ?? (() => new Date().toISOString()))(),
+  };
+};

--- a/packages/cf-harness/src/skills-sh/search-client.ts
+++ b/packages/cf-harness/src/skills-sh/search-client.ts
@@ -2,10 +2,9 @@
  * A read-only client over the public skills.sh search route: what a candidate
  * skill is called and where it lives, and never a byte of what it says.
  *
- * This is the discovery half of `docs/plans/external-skill-acquisition.md`,
- * and it is deliberately not registered as a tool. Nothing here fetches,
- * materializes, or returns skill text; a hit is an identifier that a later,
- * pinned acquisition step resolves.
+ * This is the discovery half of `docs/plans/external-skill-acquisition.md`.
+ * Nothing here fetches, materializes, or returns skill text; a hit is an
+ * identifier that a later, pinned acquisition step resolves.
  *
  * Two properties are the point, and both are tested:
  *
@@ -58,8 +57,8 @@ const SOURCE_PATTERN = /^[A-Za-z0-9-]{1,39}\/[A-Za-z0-9._-]{1,100}$/;
 const OWNER_PATTERN = /^[A-Za-z0-9-]{1,39}$/;
 
 /**
- * One candidate. There is no field for skill text, and the absence is the
- * boundary this client keeps rather than an omission to fill in later.
+ * One candidate. The hit type has no field for skill text and that absence is
+ * the boundary.
  */
 export interface SkillsShSearchHit {
   /** Registry identifier, `{owner}/{repo}/{slug}`. Not a content address. */
@@ -318,3 +317,41 @@ export class SkillsShSearchClient {
     return { hits, rejected };
   }
 }
+
+/** Builds the skills.sh search client used by a run. */
+export type HarnessSkillsShSearchClientFactory = () => Promise<
+  SkillsShSearchClient
+>;
+
+/** Creates a client factory over one configured registry origin. */
+export const createHarnessSkillsShSearchClientFactory = (
+  baseUrl: string,
+  fetch?: HarnessFetch,
+): HarnessSkillsShSearchClientFactory =>
+() =>
+  Promise.resolve(
+    new SkillsShSearchClient({
+      origin: baseUrl,
+      ...(fetch !== undefined ? { fetch } : {}),
+    }),
+  );
+
+/**
+ * Caches a healthy client for one run. A rejected construction is forgotten
+ * so the next call may retry it.
+ */
+export const cacheHarnessSkillsShSearchClientFactory = (
+  factory: HarnessSkillsShSearchClientFactory,
+): HarnessSkillsShSearchClientFactory => {
+  let client: Promise<SkillsShSearchClient> | undefined;
+  return () => {
+    if (client === undefined) {
+      const attempt = Promise.resolve().then(factory).catch((error) => {
+        if (client === attempt) client = undefined;
+        throw error;
+      });
+      client = attempt;
+    }
+    return client;
+  };
+};

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -11,6 +11,7 @@ import { recordFeedbackTool } from "./record-feedback.ts";
 import { runPatternTool } from "./run-pattern.ts";
 import { runSkillScriptTool } from "./run-skill-script.ts";
 import { searchPatternsTool } from "./search-patterns.ts";
+import { searchSkillsTool } from "./search-skills.ts";
 import { webFetchTool } from "./web-fetch.ts";
 import { viewImageTool } from "./view-image.ts";
 import { writeFileTool } from "./write-file.ts";
@@ -32,6 +33,7 @@ export const BUILTIN_TOOLS = [
   describeHandleTool,
   searchPatternsTool,
   recordFeedbackTool,
+  searchSkillsTool,
 ] as const;
 
 export const BUILTIN_TOOL_REGISTRY = new Map<

--- a/packages/cf-harness/src/tools/search-skills.ts
+++ b/packages/cf-harness/src/tools/search-skills.ts
@@ -1,0 +1,152 @@
+/**
+ * The `search_skills` tool: metadata-only discovery over a configured
+ * skills.sh registry.
+ *
+ * The hit type has no field for skill text and that absence is the boundary.
+ * A hit can be named to the operator or handed to a later pinned acquisition
+ * step; this tool cannot fetch, read, or load the skill itself.
+ */
+
+import type { JSONSchema } from "@commonfabric/api";
+
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import type {
+  SkillsShSearchClient,
+  SkillsShSearchHit,
+} from "../skills-sh/search-client.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+
+export interface SearchSkillsToolInput {
+  query: string;
+  owner?: string;
+  limit?: number;
+}
+
+export interface SearchSkillsToolSuccessOutput {
+  outputId: string;
+  status: "ok";
+  hits: readonly SkillsShSearchHit[];
+  rejected: number;
+}
+
+export interface SearchSkillsToolErrorOutput {
+  outputId: string;
+  status: "error";
+  message: string;
+}
+
+export type SearchSkillsToolOutput =
+  | SearchSkillsToolSuccessOutput
+  | SearchSkillsToolErrorOutput;
+
+export const searchSkillsToolDescriptor: HarnessToolDescriptor = {
+  toolId: "search_skills",
+  title: "Search Skills",
+  description:
+    "Search the configured skills.sh registry for candidate skills. Returns metadata only: id, name, source, installs, and a rejected-entry count. Registry-reported installs are unauthenticated telemetry and unverifiable, not a trust signal. A result can name a skill to the operator or to a later acquisition step; this tool cannot fetch, read, or load skill content.",
+  effectClass: "read",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Search text of at least two characters.",
+      },
+      owner: {
+        type: "string",
+        description: "Optional registry owner to restrict results to.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        description:
+          "Maximum hits to return. Values above the registry client cap return the capped result set.",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["ok"] },
+        hits: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              name: { type: "string" },
+              source: { type: "string" },
+              installs: { type: "number", minimum: 0 },
+            },
+            required: ["id", "name", "source"],
+            additionalProperties: false,
+          },
+        },
+        rejected: { type: "integer", minimum: 0 },
+      },
+      required: ["outputId", "status", "hits", "rejected"],
+      additionalProperties: false,
+    }, {
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        status: { type: "string", enum: ["error"] },
+        message: { type: "string" },
+      },
+      required: ["outputId", "status", "message"],
+      additionalProperties: false,
+    }],
+  } satisfies JSONSchema,
+  tags: ["skill", "search", "registry"],
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+export const searchSkillsTool: HarnessToolDefinition<
+  SearchSkillsToolInput,
+  SearchSkillsToolOutput
+> = {
+  descriptor: searchSkillsToolDescriptor,
+  async invoke(context, input) {
+    const outputId = context.nextOutputId("search_skills");
+    const errorOutput = (message: string): SearchSkillsToolErrorOutput => ({
+      outputId,
+      status: "error",
+      message,
+    });
+    if (context.getSkillsShSearchClient === undefined) {
+      return errorOutput(
+        "search_skills requires a skills registry; configure --skills-registry-url",
+      );
+    }
+
+    let client: SkillsShSearchClient;
+    try {
+      client = await context.getSkillsShSearchClient();
+    } catch (error) {
+      return errorOutput(
+        `skills.sh registry unavailable: ${errorMessage(error)}`,
+      );
+    }
+    try {
+      const result = await client.search({
+        query: input.query,
+        ...(input.owner !== undefined ? { owner: input.owner } : {}),
+        ...(input.limit !== undefined ? { limit: input.limit } : {}),
+      });
+      return {
+        outputId,
+        status: "ok",
+        hits: result.hits,
+        rejected: result.rejected,
+      };
+    } catch (error) {
+      return errorOutput(errorMessage(error));
+    }
+  },
+};

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -20,6 +20,7 @@ import type { HarnessHandleTable } from "../contracts/handle-table.ts";
 import type { HarnessFabricSession } from "../fabric-session.ts";
 import type { PatternIndexClient } from "../pattern-index/client.ts";
 import type { PatternIndexPublicationLedger } from "../pattern-index/publish-ledger.ts";
+import type { SkillsShSearchClient } from "../skills-sh/search-client.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { ToolOutputId } from "../contracts/tool-result.ts";
 import type { ProcessRunner } from "../sandbox/process-runner.ts";
@@ -64,6 +65,13 @@ export interface HarnessToolContext {
    * `run_pattern`'s `patternId` argument unusable.
    */
   getPatternIndexClient?: () => Promise<PatternIndexClient>;
+
+  /**
+   * The run's skills.sh discovery client, lazy and cached by the engine.
+   * Undefined when no remote skill registry is configured, which also keeps
+   * `search_skills` out of the tool surface.
+   */
+  getSkillsShSearchClient?: () => Promise<SkillsShSearchClient>;
 
   /**
    * Whether a pattern the model authored and ran successfully is published

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2096,6 +2096,7 @@ Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   assertEquals(capabilities.parentToolIds.includes("run_pattern"), true);
   assertEquals(capabilities.parentToolIds.includes("browser"), false);
   assertEquals(capabilities.builtinToolIds.includes("run_pattern"), true);
+  assertEquals(capabilities.builtinToolIds.includes("search_skills"), true);
   assertEquals(capabilities.features.runPattern, true);
   assertEquals(capabilities.builtinToolIds.includes("browser"), true);
   assertEquals(capabilities.subagentProfiles.includes("web_search"), true);
@@ -6502,6 +6503,62 @@ Deno.test("parseCfHarnessCliArgs parses --pattern-index-url alongside the fabric
     throw new Error("expected config result");
   }
   assertEquals(parsed.patternIndex, { baseUrl: "https://index.example/api" });
+});
+
+Deno.test("parseCfHarnessCliArgs parses --skills-registry-url", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--skills-registry-url",
+      "https://registry.example",
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.skillsSh, { baseUrl: "https://registry.example" });
+});
+
+Deno.test("parseCfHarnessCliArgs reads the skills registry URL from the environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_SKILLS_REGISTRY_URL: "https://registry.example" },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.skillsSh, { baseUrl: "https://registry.example" });
+});
+
+Deno.test("parseCfHarnessCliArgs rejects a skills registry URL that does not parse", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--skills-registry-url", "not a url"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--skills-registry-url must be a valid URL",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects --allow-tool search_skills without a skills registry", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--allow-tool", "search_skills"],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "missing --skills-registry-url",
+  );
 });
 
 Deno.test("parseCfHarnessCliArgs reads the pattern index URL from the environment", async () => {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -4088,6 +4088,25 @@ Deno.test("formatCfHarnessTranscriptEvent formats assistant tool calls and tool 
         role: "assistant",
         content: "",
         toolCalls: [{
+          id: "call-skills-1",
+          type: "function",
+          function: {
+            name: "search_skills",
+            arguments:
+              '{"query":"react native","owner":"vercel-labs","limit":3}',
+          },
+        }],
+      },
+      transcript: [],
+    }),
+    'assistant -> tools: search_skills(query="react native" owner="vercel-labs" limit=3)\n',
+  );
+  assertEquals(
+    formatCfHarnessTranscriptEvent({
+      message: {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
           id: "call-1",
           type: "function",
           function: { name: "bash", arguments: '{"command":"ls"}' },
@@ -6611,6 +6630,18 @@ Deno.test("parseCfHarnessCliArgs rejects a skills registry URL that does not par
       ),
     Error,
     "--skills-registry-url must be a valid URL",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects an empty skills registry flag", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--skills-registry-url", "   "],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--skills-registry-url requires a non-empty value",
   );
 });
 

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -5177,6 +5177,71 @@ Deno.test("runCfHarnessCli threads sandbox-image into engine sandbox config", as
   );
 });
 
+Deno.test("runCfHarnessCli routes skills.sh discovery through its injected fetch", async () => {
+  const originalFetch = globalThis.fetch;
+  let defaultFetchCalls = 0;
+  const injectedUrls: string[] = [];
+  let toolStatus: string | undefined;
+  globalThis.fetch = (() => {
+    defaultFetchCalls += 1;
+    return Promise.resolve(Response.json({ skills: [] }));
+  }) as typeof globalThis.fetch;
+
+  let exitCode: number;
+  try {
+    exitCode = await runCfHarnessCli(
+      [
+        "--model-provider",
+        "openai-compatible-gateway",
+        "--gateway-auth-mode",
+        "none",
+        "--cfc-enforcement-mode",
+        "disabled",
+        "--workspace",
+        "/tmp/project",
+        "--skills-registry-url",
+        "https://registry.example",
+        "--prompt",
+        "Find a skill",
+      ],
+      {
+        env: {},
+        fetchFn: (input) => {
+          injectedUrls.push(String(input));
+          return Promise.resolve(Response.json({ skills: [] }));
+        },
+        createPromptLoop: (options) => {
+          if (options.engine === undefined) {
+            throw new Error("expected CLI-created engine");
+          }
+          const engine = options.engine;
+          return {
+            runPrompt: async () => {
+              const result = await engine.invokeBuiltinTool(
+                "search_skills",
+                { query: "react native" },
+              );
+              toolStatus = (result.output as { status?: string }).status;
+              return completedCliResult("run-skills-sh-fetch");
+            },
+            runTranscript: () =>
+              Promise.reject(new Error("unexpected resume path")),
+          };
+        },
+      },
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assertEquals(exitCode, 0);
+  assertEquals(defaultFetchCalls, 0);
+  assertEquals(injectedUrls, [
+    "https://registry.example/api/search?q=react+native&limit=20",
+  ]);
+  assertEquals(toolStatus, "ok");
+});
+
 Deno.test("parseCfHarnessCliArgs selects openai-codex without an API key", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--model-provider", "openai-codex", "--prompt", "hello"],

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -332,3 +332,11 @@ Deno.test("resolveHarnessConfig carries a pattern index the run does not publish
     publish: false,
   });
 });
+
+Deno.test("resolveHarnessConfig carries a skills.sh discovery registry", () => {
+  const config = resolveHarnessConfig({
+    skillsSh: { baseUrl: "https://registry.example/" },
+    skillScriptExecutionTarget: "sandbox",
+  });
+  assertEquals(config.skillsSh, { baseUrl: "https://registry.example/" });
+});

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -307,6 +307,25 @@ describe("console/server", () => {
       });
     });
 
+    it("rejects a skills.sh discovery registry that is not a URL", () => {
+      expect(() =>
+        resolveConsoleConfig(
+          [
+            "--fabric-identity",
+            "key.pkcs8",
+            "--fabric-space",
+            "console-test",
+            "--session-db",
+            "none",
+            "--skills-registry-url",
+            "not a url",
+          ],
+          {},
+          "/console",
+        )
+      ).toThrow("--skills-registry-url must be a valid URL");
+    });
+
     it("reads the named prompt and disables child composition guidance", async () => {
       const directory = await Deno.makeTempDir({
         prefix: "cf-harness-console-prompt-",

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -4,6 +4,7 @@ import { join, resolve, toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
+  consoleChatPolicy,
   ConsoleServer,
   createConsoleInteractiveServiceOptions,
   resolveConsoleConfig,
@@ -248,6 +249,64 @@ describe("console/server", () => {
     });
 
   describe("console prompt configuration", () => {
+    it("threads configured skills.sh discovery into the run and policy", () => {
+      const resolved = resolveConsoleConfig(
+        [
+          "--fabric-identity",
+          "key.pkcs8",
+          "--fabric-space",
+          "console-test",
+          "--session-db",
+          "none",
+          "--skills-registry-url",
+          "https://registry.example",
+        ],
+        {},
+        "/console",
+      );
+      const serviceOptions = createConsoleInteractiveServiceOptions(
+        resolved,
+        {
+          modelProvider: "openai-compatible-gateway",
+          modelAuthSource: "none",
+          gatewayAuthMode: "none",
+        },
+        () => {},
+      );
+
+      expect(resolved.skillsSh).toEqual({
+        baseUrl: "https://registry.example",
+      });
+      expect(serviceOptions.basePromptLoopOptions?.skillsSh).toEqual({
+        baseUrl: "https://registry.example",
+      });
+      expect(consoleChatPolicy(false, true).allowedToolIds).toContain(
+        "search_skills",
+      );
+      expect(consoleChatPolicy(false, false).allowedToolIds).not.toContain(
+        "search_skills",
+      );
+    });
+
+    it("reads the skills.sh discovery registry from the environment", () => {
+      const resolved = resolveConsoleConfig(
+        [
+          "--fabric-identity",
+          "key.pkcs8",
+          "--fabric-space",
+          "console-test",
+          "--session-db",
+          "none",
+        ],
+        { CF_HARNESS_SKILLS_REGISTRY_URL: "https://registry.example" },
+        "/console",
+      );
+
+      expect(resolved.skillsSh).toEqual({
+        baseUrl: "https://registry.example",
+      });
+    });
+
     it("reads the named prompt and disables child composition guidance", async () => {
       const directory = await Deno.makeTempDir({
         prefix: "cf-harness-console-prompt-",

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -2215,6 +2215,78 @@ Deno.test("CfHarnessPromptLoop drops the pattern-index tools from an explicit al
   );
 });
 
+Deno.test("CfHarnessPromptLoop advertises search_skills in the default tool surface when configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "skills-sh-default-surface",
+      model: "gpt-5.4",
+      skillsSh: { baseUrl: "https://registry.example" },
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assert(
+    chatViewOfRequest(request).tools.includes("search_skills"),
+  );
+});
+
+Deno.test("CfHarnessPromptLoop advertises search_skills from an explicit allowlist when configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "search_skills"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "skills-sh-allowed-surface",
+      model: "gpt-5.4",
+      skillsSh: { baseUrl: "https://registry.example" },
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools,
+    ["read_file", "search_skills"],
+  );
+});
+
+Deno.test("CfHarnessPromptLoop drops search_skills from an explicit allowlist when no registry is configured", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["read_file", "search_skills"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "skills-sh-absent",
+      model: "gpt-5.4",
+    }),
+    fetchFn: noToolCallFetch(fetchCalls),
+  });
+
+  await loop.runPrompt({ prompt: "Say hi." });
+
+  const request = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  assertEquals(
+    chatViewOfRequest(request).tools.map((name) => name),
+    ["read_file"],
+  );
+});
+
 Deno.test("CfHarnessPromptLoop withholds the pattern-index tools from the pattern-author profile when no index is configured", async () => {
   await using fixture = await createPatternSkillsFixture();
   const fetchCalls: RequestInit[] = [];

--- a/packages/cf-harness/test/search-skills.test.ts
+++ b/packages/cf-harness/test/search-skills.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The model-facing skills.sh discovery tool: metadata returned, refusals
+ * surfaced, and the trust limits stated in its prompt-visible descriptor.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { normalize } from "@std/path/posix";
+
+import { CfHarnessEngine } from "../src/engine.ts";
+import { SkillsShSearchClient } from "../src/skills-sh/search-client.ts";
+import {
+  searchSkillsTool,
+  type SearchSkillsToolErrorOutput,
+  type SearchSkillsToolSuccessOutput,
+} from "../src/tools/search-skills.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(_request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+const capturedResponse = {
+  skills: [{
+    id: "vercel-labs/agent-skills/vercel-react-native-skills",
+    name: "vercel-react-native-skills",
+    installs: 197232,
+    source: "vercel-labs/agent-skills",
+  }, {
+    id: "owner/repo/../../escape",
+    name: "refused",
+    source: "owner/repo",
+  }],
+};
+
+const createEngine = (configured = true): CfHarnessEngine =>
+  new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: `search-skills-test-${crypto.randomUUID()}`,
+    cfcEnforcementMode: "disabled",
+    ...(configured
+      ? {
+        skillsShSearchClientFactory: () =>
+          Promise.resolve(
+            new SkillsShSearchClient({
+              origin: "https://registry.example",
+              fetch: () => Promise.resolve(Response.json(capturedResponse)),
+            }),
+          ),
+      }
+      : {}),
+  });
+
+describe("search-skills", () => {
+  it("returns sanitized metadata and the rejected entry count", async () => {
+    const result = await createEngine().invokeBuiltinTool("search_skills", {
+      query: "react native",
+    });
+    const output = result.output as SearchSkillsToolSuccessOutput;
+
+    expect(output).toEqual({
+      outputId: output.outputId,
+      status: "ok",
+      hits: [{
+        id: "vercel-labs/agent-skills/vercel-react-native-skills",
+        name: "vercel-react-native-skills",
+        source: "vercel-labs/agent-skills",
+        installs: 197232,
+      }],
+      rejected: 1,
+    });
+    expect(Object.keys(output.hits[0]).sort()).toEqual([
+      "id",
+      "installs",
+      "name",
+      "source",
+    ]);
+  });
+
+  it("refuses when the run has no discovery registry configured", async () => {
+    const result = await createEngine(false).invokeBuiltinTool(
+      "search_skills",
+      { query: "react native" },
+    );
+    const output = result.output as SearchSkillsToolErrorOutput;
+
+    expect(output.status).toBe("error");
+    expect(output.message).toContain("--skills-registry-url");
+  });
+
+  it("declares the telemetry and content boundaries to the model", () => {
+    expect(searchSkillsTool.descriptor.effectClass).toBe("read");
+    expect(searchSkillsTool.descriptor.description).toContain("unverifiable");
+    expect(searchSkillsTool.descriptor.description).toContain(
+      "not a trust signal",
+    );
+    expect(searchSkillsTool.descriptor.description).toContain(
+      "cannot fetch, read, or load skill content",
+    );
+  });
+});

--- a/packages/cf-harness/test/search-skills.test.ts
+++ b/packages/cf-harness/test/search-skills.test.ts
@@ -89,7 +89,10 @@ const createEngine = (configured = true): CfHarnessEngine =>
 
 describe("search-skills", () => {
   it("returns sanitized metadata and the rejected entry count", async () => {
-    const result = await createEngine().invokeBuiltinTool("search_skills", {
+    const engine = createEngine();
+    expect(engine.skillsShSearchAvailable).toBe(true);
+    expect(engine.skillsShSearchClientFactory).toBeDefined();
+    const result = await engine.invokeBuiltinTool("search_skills", {
       query: "react native",
     });
     const output = result.output as SearchSkillsToolSuccessOutput;
@@ -122,6 +125,34 @@ describe("search-skills", () => {
 
     expect(output.status).toBe("error");
     expect(output.message).toContain("--skills-registry-url");
+  });
+
+  it("reports a client-construction failure without throwing it", async () => {
+    const engine = new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: `search-skills-test-${crypto.randomUUID()}`,
+      cfcEnforcementMode: "disabled",
+      skillsShSearchClientFactory: () =>
+        Promise.reject(new Error("registry offline")),
+    });
+    const result = await engine.invokeBuiltinTool("search_skills", {
+      query: "react native",
+    });
+    const output = result.output as SearchSkillsToolErrorOutput;
+
+    expect(output.status).toBe("error");
+    expect(output.message).toContain("registry unavailable");
+    expect(output.message).toContain("registry offline");
+  });
+
+  it("reports a refused search as a tool error", async () => {
+    const result = await createEngine().invokeBuiltinTool("search_skills", {
+      query: "x",
+    });
+    const output = result.output as SearchSkillsToolErrorOutput;
+
+    expect(output.status).toBe("error");
+    expect(output.message).toContain("at least two characters");
   });
 
   it("declares the telemetry and content boundaries to the model", () => {

--- a/packages/cf-harness/test/skills-sh/pin.test.ts
+++ b/packages/cf-harness/test/skills-sh/pin.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Resolution of a mutable skills.sh discovery name to the captured default
+ * branch head of its GitHub source repository. The valid responses are
+ * captured fixtures and refusal cases mutate those captured fields; this file
+ * never reaches the network.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { HarnessFetch } from "../../src/contracts/http-fetch.ts";
+import type { SkillsShSearchHit } from "../../src/skills-sh/search-client.ts";
+import {
+  resolveSkillsShHitPin,
+  SkillsShPinResolutionError,
+} from "../../src/skills-sh/pin.ts";
+
+const HIT: SkillsShSearchHit = {
+  id: "vercel-labs/agent-skills/vercel-react-native-skills",
+  name: "vercel-react-native-skills",
+  source: "vercel-labs/agent-skills",
+  installs: 197232,
+};
+
+// Captured from the GitHub REST responses for HIT's source on 2026-09-01.
+const COMMIT_SHA = "063bee94c3f4df8453406c830b0a7df0f2860278";
+
+const CAPTURED_REPOSITORY_RESPONSE = { default_branch: "main" };
+const CAPTURED_BRANCH_RESPONSE = { commit: { sha: COMMIT_SHA } };
+
+const fixtureFetch = (
+  responses: Readonly<Record<string, unknown>> = {
+    "https://api.github.com/repos/vercel-labs/agent-skills":
+      CAPTURED_REPOSITORY_RESPONSE,
+    "https://api.github.com/repos/vercel-labs/agent-skills/branches/main":
+      CAPTURED_BRANCH_RESPONSE,
+  },
+): { fetch: HarnessFetch; urls: string[] } => {
+  const urls: string[] = [];
+  const fetch: HarnessFetch = (input) => {
+    const url = String(input);
+    urls.push(url);
+    const body = responses[url];
+    return Promise.resolve(
+      body === undefined
+        ? Response.json({ message: "Not Found" }, { status: 404 })
+        : Response.json(body),
+    );
+  };
+  return { fetch, urls };
+};
+
+/** Returns the typed refusal from `call`, and fails if it resolves. */
+const refusalOf = async (
+  call: Promise<unknown>,
+): Promise<SkillsShPinResolutionError> => {
+  try {
+    await call;
+  } catch (error) {
+    expect(error).toBeInstanceOf(SkillsShPinResolutionError);
+    return error as SkillsShPinResolutionError;
+  }
+  throw new Error("expected pin resolution to refuse, and it resolved");
+};
+
+describe("skills.sh pin resolution", () => {
+  it("resolves the source repository's default branch head", async () => {
+    const { fetch, urls } = fixtureFetch();
+    const pin = await resolveSkillsShHitPin(HIT, {
+      fetch,
+      now: () => "2026-09-01T02:03:04.000Z",
+    });
+
+    expect(urls).toEqual([
+      "https://api.github.com/repos/vercel-labs/agent-skills",
+      "https://api.github.com/repos/vercel-labs/agent-skills/branches/main",
+    ]);
+    expect(pin).toEqual({
+      id: HIT.id,
+      owner: "vercel-labs",
+      repo: "agent-skills",
+      slug: "vercel-react-native-skills",
+      commitSha: COMMIT_SHA,
+      resolvedAt: "2026-09-01T02:03:04.000Z",
+    });
+    expect(Object.keys(pin).sort()).toEqual([
+      "commitSha",
+      "id",
+      "owner",
+      "repo",
+      "resolvedAt",
+      "slug",
+    ]);
+  });
+
+  it("encodes a default branch name before placing it in the API path", async () => {
+    const { fetch, urls } = fixtureFetch({
+      "https://api.github.com/repos/vercel-labs/agent-skills": {
+        default_branch: "release/next",
+      },
+      "https://api.github.com/repos/vercel-labs/agent-skills/branches/release%2Fnext":
+        {
+          commit: { sha: COMMIT_SHA },
+        },
+    });
+
+    await resolveSkillsShHitPin(HIT, { fetch });
+
+    expect(urls[1]).toBe(
+      "https://api.github.com/repos/vercel-labs/agent-skills/branches/release%2Fnext",
+    );
+  });
+
+  it("refuses malformed ids and source disagreements before any request", async () => {
+    const { fetch, urls } = fixtureFetch();
+    const invalidHits: SkillsShSearchHit[] = [
+      { ...HIT, id: "vercel-labs/agent-skills" },
+      { ...HIT, id: `${HIT.id}/extra` },
+      { ...HIT, id: "owner space/agent-skills/slug" },
+      { ...HIT, id: "vercel-labs/repo space/slug" },
+      { ...HIT, id: "vercel-labs/../slug", source: "vercel-labs/.." },
+      { ...HIT, id: "vercel-labs/agent-skills/slug space" },
+      { ...HIT, id: "vercel-labs/agent-skills/.." },
+      { ...HIT, id: "attacker/repo/vercel-react-native-skills" },
+    ];
+
+    for (const hit of invalidHits) {
+      const refusal = await refusalOf(resolveSkillsShHitPin(hit, { fetch }));
+      expect(refusal.code).toBe("invalid_hit");
+    }
+    expect(urls).toEqual([]);
+  });
+
+  it("refuses an unusable default branch in repository metadata", async () => {
+    for (const defaultBranch of [null, 42, "", "a".repeat(256)]) {
+      const { fetch } = fixtureFetch({
+        "https://api.github.com/repos/vercel-labs/agent-skills": {
+          ...CAPTURED_REPOSITORY_RESPONSE,
+          default_branch: defaultBranch,
+        },
+      });
+      const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+      expect(refusal.code).toBe("unparseable_response");
+      expect(refusal.message).toContain("no usable default branch");
+    }
+  });
+
+  it("refuses branch metadata without a full lowercase commit SHA", async () => {
+    for (
+      const commit of [
+        null,
+        { sha: 42 },
+        { sha: "0123456" },
+        { sha: COMMIT_SHA.toUpperCase() },
+      ]
+    ) {
+      const { fetch } = fixtureFetch({
+        "https://api.github.com/repos/vercel-labs/agent-skills":
+          CAPTURED_REPOSITORY_RESPONSE,
+        "https://api.github.com/repos/vercel-labs/agent-skills/branches/main": {
+          ...CAPTURED_BRANCH_RESPONSE,
+          commit,
+        },
+      });
+      const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+      expect(refusal.code).toBe("unparseable_response");
+      expect(refusal.message).toContain("no full commit SHA");
+    }
+  });
+
+  it("refuses a transport failure as request_failed", async () => {
+    const fetch: HarnessFetch = () =>
+      Promise.reject(new TypeError("connection refused"));
+    const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+
+    expect(refusal.code).toBe("request_failed");
+    expect(refusal.message).toContain("connection refused");
+  });
+
+  it("refuses a non-JSON success body", async () => {
+    const fetch: HarnessFetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify(CAPTURED_REPOSITORY_RESPONSE).slice(0, -1)),
+      );
+    const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+
+    expect(refusal.code).toBe("unparseable_response");
+    expect(refusal.message).toContain("not JSON");
+  });
+
+  it("refuses a JSON success body that is not an object", async () => {
+    const fetch: HarnessFetch = () =>
+      Promise.resolve(Response.json([CAPTURED_REPOSITORY_RESPONSE]));
+    const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+
+    expect(refusal.code).toBe("unparseable_response");
+    expect(refusal.message).toContain("without an object");
+  });
+
+  it("refuses a GitHub API error without reading it as a pin", async () => {
+    const { fetch } = fixtureFetch({});
+    const refusal = await refusalOf(resolveSkillsShHitPin(HIT, { fetch }));
+
+    expect(refusal.code).toBe("http_error");
+    expect(refusal.message).toContain("404");
+  });
+});

--- a/packages/cf-harness/test/skills-sh/search-client.test.ts
+++ b/packages/cf-harness/test/skills-sh/search-client.test.ts
@@ -12,6 +12,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  cacheHarnessSkillsShSearchClientFactory,
+  createHarnessSkillsShSearchClientFactory,
   sanitizeRegistryString,
   SKILLS_SH_MAX_FIELD_CHARS,
   SkillsShSearchClient,
@@ -86,6 +88,46 @@ const refusalOf = async (
 };
 
 describe("skills.sh search client", () => {
+  describe("run client factory", () => {
+    it("uses the supplied transport and caches one healthy client", async () => {
+      const urls: string[] = [];
+      const cached = cacheHarnessSkillsShSearchClientFactory(
+        createHarnessSkillsShSearchClientFactory(
+          "https://registry.example",
+          (input) => {
+            urls.push(String(input));
+            return Promise.resolve(jsonResponse({ skills: [] }));
+          },
+        ),
+      );
+
+      const first = cached();
+      const second = cached();
+      expect(second).toBe(first);
+      await (await first).search({ query: "react native" });
+      expect(urls).toEqual([
+        "https://registry.example/api/search?q=react+native&limit=20",
+      ]);
+    });
+
+    it("forgets a rejected construction so a later call can recover", async () => {
+      let calls = 0;
+      const recovered = new SkillsShSearchClient({
+        origin: "https://registry.example",
+        fetch: () => Promise.resolve(jsonResponse({ skills: [] })),
+      });
+      const cached = cacheHarnessSkillsShSearchClientFactory(() => {
+        calls += 1;
+        if (calls === 1) throw new Error("construction failed");
+        return Promise.resolve(recovered);
+      });
+
+      await expect(cached()).rejects.toThrow("construction failed");
+      expect(await cached()).toBe(recovered);
+      expect(calls).toBe(2);
+    });
+  });
+
   describe("sanitizeRegistryString", () => {
     it("removes escape sequences, control codepoints, and bidirectional marks", () => {
       const hostile =

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -27,8 +27,9 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "describe_handle",
     "search_patterns",
     "record_feedback",
+    "search_skills",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 15);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 16);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [


### PR DESCRIPTION
## Summary

- register parent-only metadata search_skills when a skills.sh registry URL is configured
- resolve mutable discovery hits host-side to the GitHub default-branch head commit SHA
- keep acquisition, loading, and provenance minting out of scope for CT-2148 stages 1 and 2
- align the live acquisition design and cf-harness operator docs with the implemented staging

## Verification

- cf-harness package: 899 tests / 1,451 steps, 0 failures
- focused registration and pin suite: 291 tests / 65 steps, 0 failures
- deno fmt --check
- deno lint
- deno task check
- all independent repository checks, including check-docs, check-command-docs, and check-completion-slots
- every new pin boundary mutation-checked red on removal and green after restore

Linear: CT-2148

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

