### PR TITLE
style(cli): bound each doc comment below as well as above

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3040,6 +3040,7 @@ export interface PieceCLIOptions {
    * directly states it.
    */
   explicitSpace?: boolean;
+
   url?: string;
   mainExport?: string;
   repository?: string;
@@ -3322,6 +3323,7 @@ export interface SurveyCLIOptions extends BulkSelectionOptions {
 
   /** A plan this survey is reported against rather than emitted beside. */
   diff?: string;
+
   out?: string;
 }
 
@@ -3405,6 +3407,7 @@ export function planDiffConverged(diff: PlanDiff): boolean {
 export interface BulkSelectionOptions extends PieceCLIOptions {
   /** Inherited from the `piece` mount's global target options. */
   quiet?: boolean;
+
   path?: string;
   side?: string;
   list?: string[];
@@ -3772,6 +3775,7 @@ export async function repairFromCommand(
 export interface RetargetCLIOptions extends PieceCLIOptions {
   /** Inherited from the `piece` mount's global target options. */
   quiet?: boolean;
+
   plan: string;
   acceptUnretained?: string[];
   apply?: boolean;
@@ -4101,6 +4105,7 @@ async function reportApplyRun(
 export interface RollbackCLIOptions extends PieceCLIOptions {
   /** Inherited from the `piece` mount's global target options. */
   quiet?: boolean;
+
   plan: string;
   acceptUnretained?: string[];
   apply?: boolean;
@@ -4200,6 +4205,7 @@ export async function rollbackFromCommand(
 export interface RestoreCLIOptions extends PieceCLIOptions {
   /** Inherited from the `piece` mount's global target options. */
   quiet?: boolean;
+
   revision?: string;
   apply?: boolean;
 }

--- a/packages/cli/integration/pattern/topic-graph.tsx
+++ b/packages/cli/integration/pattern/topic-graph.tsx
@@ -33,6 +33,7 @@ interface CreateTopicEvent {
 
   /** The topic's initial body, part of the create's atomic unit. */
   body: string;
+
   agentName: string;
 
   /** Ids the body references, recorded as explicit edges. */
@@ -75,6 +76,7 @@ interface TopicGraphOutput {
    * ids of the topics whose `references` name it. A derived result over a list
    * of children, which is what this fixture exercises the CLI against. */
   referencedBy: Record<string, string[]>;
+
   createTopic: Stream<CreateTopicEvent, CreateTopicResult>;
   reviseBody: Stream<ReviseBodyEvent, ReviseBodyResult>;
 }

--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -46,6 +46,7 @@ export interface ItemOutput {
 
   /** Mark this item archived. Declares no result — the value-less shape. */
   archive: Stream<void>;
+
   [NAME]: string;
   title: string;
 

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -247,6 +247,7 @@ export interface RetargetRunRequest {
    * any such row is refused without them; a dry run needs none.
    */
   accept?: readonly string[];
+
   /** Write each row's source; absent, the run is the classification alone. */
   apply?: boolean;
 
@@ -358,6 +359,7 @@ export interface RollbackRunRequest {
    * precondition being the reference that row produced.
    */
   planPath: string;
+
   /**
    * Pieces the operator accepts, by name, as ones this rollback cannot
    * return — their prior source is not retained. Every other unretained row
@@ -365,12 +367,16 @@ export interface RollbackRunRequest {
    * refuses it too.
    */
   accept?: readonly string[];
+
   /** Restore each row's revision; absent, the run is the classification. */
   apply?: boolean;
+
   /** Pieces one session serves before it is replaced. */
   groupSize?: number;
+
   /** Called as each row settles, for reporting as the run proceeds. */
   onRow?: (row: ApplyRow) => void;
+
   /** The derived plan's `takenAt`; defaults to now. A seam so tests can pin it. */
   takenAt?: string;
 }
@@ -425,6 +431,7 @@ export interface RestoreRunRequest {
    * returned to and writes nothing.
    */
   revisionId?: string;
+
   /** Perform the restore; absent, the run reads and writes nothing. */
   apply?: boolean;
 }

--- a/packages/cli/lib/callable-command.ts
+++ b/packages/cli/lib/callable-command.ts
@@ -22,6 +22,7 @@ export interface CallableCommandExecutionResult<TResolved> {
 
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
+
   parsed: ParsedExecArgs;
   resolved: TResolved;
 }
@@ -46,6 +47,7 @@ export interface CallableCommandExecutionOptions<
     commandSpec: ExecCommandSpec,
     parsed: ParsedExecArgs,
   ) => string | Promise<string>;
+
   validateRawArgs?: (
     rawArgs: string[],
     commandSpec: ExecCommandSpec,

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -110,6 +110,7 @@ export interface RenderedLinkAddress {
 export interface LinkMarkers {
   /** The address at this position was asked for. */
   marked?: true;
+
   properties?: Record<string, LinkMarkers>;
   items?: LinkMarkers;
 }
@@ -595,9 +596,10 @@ const UNSUPPORTED_PROJECTION_KEYS = new Set([
 ]);
 
 /**
- * The keywords that apply to exactly one container. Naming one says which
- * container the position describes, so the traversal that reads the projection
- * back needs no separate `type` from the caller.
+ * The keywords that apply to an object and to nothing else. Naming one says
+ * which container the position describes, so the traversal that reads the
+ * projection back needs no separate `type` from the caller; the array half is
+ * `ARRAY_PROJECTION_KEYS` below.
  */
 const OBJECT_PROJECTION_KEYS = [
   "properties",
@@ -606,6 +608,8 @@ const OBJECT_PROJECTION_KEYS = [
   "minProperties",
   "maxProperties",
 ];
+
+/** The keywords that apply to an array and to nothing else. */
 const ARRAY_PROJECTION_KEYS = [
   "items",
   "minItems",
@@ -1665,6 +1669,7 @@ type ProjectionMask =
   | false
   | ArrayProjectionMask
   | ObjectProjectionMask;
+
 interface ObjectPredicateMask extends ObjectMask<PredicateMask> {}
 type PredicateMask = true | ObjectPredicateMask;
 
@@ -2785,6 +2790,7 @@ interface WalkedPosition {
    * path that crosses a link can land the source elsewhere.
    */
   contextSpace: MemorySpace | undefined;
+
   stored?: { value: unknown };
 }
 

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -100,6 +100,7 @@ export interface CompletionLine {
 
   /** Command path below the program name, e.g. `["piece", "ls"]`. */
   readonly path: readonly string[];
+
   readonly slot: CompletionSlot | null;
 
   /** The partial word under the cursor; `""` at a fresh position. */
@@ -571,6 +572,7 @@ export interface DeclaredPositional {
 export interface DeclaredSlots {
   /** Option long name -> the command paths declaring it. */
   readonly options: ReadonlyMap<string, readonly string[]>;
+
   readonly positionals: readonly DeclaredPositional[];
 
   /**

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -93,6 +93,7 @@ export interface ExecutedMountedCallableFile {
 
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
+
   parsed: ParsedExecArgs;
   resolved: ResolvedMountedCallableFile;
 }

--- a/packages/cli/lib/fuse-mount-flags.ts
+++ b/packages/cli/lib/fuse-mount-flags.ts
@@ -57,6 +57,7 @@ interface FlagSpec {
 
   /** Placeholder for the value in help output. */
   valueLabel?: string;
+
   help: string;
 }
 

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -86,6 +86,7 @@ export interface StepMeta {
 
   /** Marker name for label/await steps. */
   marker?: string;
+
   skip?: boolean;
 }
 
@@ -125,6 +126,7 @@ let engine: Engine | undefined;
 
 /** Every participant's marker document, keyed by participant name. */
 const markersCells = new Map<string, Cell<Record<string, boolean>>>();
+
 let selfParticipant: string | undefined;
 let stepCells: Cell<unknown>[] = [];
 let patternCoverage: PatternCoverageCollector | undefined;
@@ -134,6 +136,7 @@ const runtimeErrors: string[] = [];
 
 /** Channel 1: console.error/warn captured via the harness console event. */
 const consoleErrors: string[] = [];
+
 const consoleWarnings: string[] = [];
 const continuousUiErrors: Error[] = [];
 let continuousUiCancel: (() => void) | undefined;

--- a/packages/cli/lib/piece-describe.ts
+++ b/packages/cli/lib/piece-describe.ts
@@ -58,6 +58,7 @@ export interface PieceDescription {
   /** The piece's display name — its NAME cell. Advisory the way the pattern
    * identity is: absent when the piece is unnamed or the cell unreadable. */
   name?: string;
+
   pattern: PiecePatternRef | null;
 
   /** What the pattern is FOR: the result schema's root description. */
@@ -75,6 +76,7 @@ export interface PieceDescription {
 
   /** The callable surface, exactly as `listPieceCallables` returned it. */
   verbs: PieceCallableListing[];
+
   incomplete?: "pattern-unavailable";
 }
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -394,6 +394,7 @@ export interface ExecutedPieceCallable {
 
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
+
   parsed: ParsedExecArgs;
   resolved: ResolvedPieceCallable;
 }
@@ -1984,6 +1985,7 @@ export interface PieceCallablesListing {
    * `probeForcedStreamCell`, whose cast is the only thing that finds one and
    * finds every data field with it. */
   incomplete?: "pattern-unavailable";
+
   verbs: PieceCallableListing[];
 }
 
@@ -2315,6 +2317,7 @@ export function declaredVerbProse(
 interface DescriptionEdit {
   /** Keys from the served document's root down to the `description` slot. */
   readonly path: readonly string[];
+
   readonly description: string;
 }
 
@@ -3899,6 +3902,7 @@ export interface PieceInspection {
 
   /** The fields of `result` whose resolution crosses a computed-cell cache. */
   cachedResultFields: CachedResultField[];
+
   readingFrom: Array<{ id: string; name?: string }>;
   readBy: Array<{ id: string; name?: string }>;
 }

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -24,6 +24,7 @@ export const CSI = `${ESC}[`;
 
 /** Operating System Command introducer and its BEL terminator. */
 const OSC = `${ESC}]`;
+
 const BEL = "\x07";
 export const RESET = `${CSI}0m`;
 

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -37,6 +37,7 @@ export interface CardTarget {
 
   /** Destination line/column in the main document. */
   readonly destLine: number;
+
   readonly destCol: number;
 
   /** Char offset of the declaration to select, when the target is a definition. */

--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -54,6 +54,7 @@ export interface CommitMessage {
 
   /** First and last (inclusive) 0-based line indices of the indented message. */
   readonly start: number;
+
   readonly end: number;
 }
 

--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -52,9 +52,10 @@ export interface CommitMessage {
   /** The commit hash, as printed after `commit `. */
   readonly sha: string;
 
-  /** First and last (inclusive) 0-based line indices of the indented message. */
+  /** First 0-based line index of the indented message. */
   readonly start: number;
 
+  /** Last such index, inclusive. */
   readonly end: number;
 }
 

--- a/packages/cli/lib/view/diff.ts
+++ b/packages/cli/lib/view/diff.ts
@@ -38,10 +38,12 @@ export interface DiffHunk {
 
   /** 1-based start line in the old file (from the `@@` header). */
   readonly oldStart: number;
+
   readonly oldCount: number;
 
   /** 1-based start line in the new file (from the `@@` header). */
   readonly newStart: number;
+
   readonly newCount: number;
 
   /** Trailing context from the header (the enclosing function), if any. */
@@ -63,6 +65,7 @@ export interface DiffFile {
 
   /** 0-based diff-text line index of the file's last line. */
   readonly endLine: number;
+
   readonly hunks: readonly DiffHunk[];
 }
 

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -328,6 +328,7 @@ export interface DiffEdit {
 export interface DiffHunkInfo {
   /** The workspace file the hunk maps to, or null when it resolves to none. */
   readonly absPath: string | null;
+
   readonly newStart: number;
   readonly newCount: number;
   readonly verified: boolean;
@@ -1048,15 +1049,20 @@ interface HunkCtx {
   definitions: Map<string, Definition[]>;
   hunks: DiffHunkInfo[];
 
-  /** The languages of the new and old sides (they differ across a rename that
-   * changes the extension); each colors its side's fragments and, for the new
-   * side, projects the hunk's structure. */
+  /** The new side's language. It colors that side's fragments, and it is the
+   * one that projects the hunk's structure. */
   newLanguage: Language;
+
+  /** The old side's language, which colors its own fragments. Differs from
+   * `newLanguage` across a rename that changes the extension. */
   oldLanguage: Language;
 
-  /** Paths whose extensions the parsers use to pick a script variant. */
+  /** New-side path, whose extension the parsers use to pick a script variant. */
   newFileName: string | undefined;
+
+  /** Old-side path, read the same way. */
   oldFileName: string | undefined;
+
   viewMode: ViewMode;
 }
 

--- a/packages/cli/lib/view/diffremap.ts
+++ b/packages/cli/lib/view/diffremap.ts
@@ -39,11 +39,13 @@ export function remapStructure(ctx: HunkStructureContext): StructureNode[] {
 export interface RemapCtx {
   /** Source line (file or fragment) → diff line, for visible lines. */
   newToDiff: Map<number, number>;
+
   diffLineStarts: number[];
   rawLines: string[];
 
   /** Line starts of the source text the nodes were parsed from. */
   sourceLineStarts: number[];
+
   sourceOmitsUtf8Bom: boolean;
   definitions: Map<string, Definition[]>;
 }

--- a/packages/cli/lib/view/display.ts
+++ b/packages/cli/lib/view/display.ts
@@ -53,6 +53,7 @@ export interface DisplayCell {
 
   /** Exclusive source column represented by this display cell. */
   readonly sourceEnd: number;
+
   readonly syntax: Style;
   readonly ansi?: Style;
 }

--- a/packages/cli/lib/view/editbuffer.ts
+++ b/packages/cli/lib/view/editbuffer.ts
@@ -45,6 +45,7 @@ export class EditBuffer {
   #lastYank:
     | { row: number; col: number; endRow: number; endCol: number }
     | null = null;
+
   #lastKill: LastKill = "none";
 
   #original: string;

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -54,6 +54,7 @@ export interface ExpandResult {
 
   /** Exact workspace endings for the rows inserted into `text`. */
   insertedLineEndings: readonly (LineEndingProvenance | undefined)[];
+
   up: boolean;
   removedAt: number | null;
 
@@ -92,6 +93,7 @@ export interface EditableSource {
    * is read-only. `reason` is shown when a cursor move is attempted on a
    * non-editable view. */
   readonly editable: boolean;
+
   readonly reason?: string;
 
   /** Representation used when the caller did not choose one explicitly. */

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -19,15 +19,18 @@ export interface DiffFileRange {
   /** First and last (inclusive) diff-text line of the file (header … last
    * hunk line). */
   readonly headerLine: number;
+
   readonly endLine: number;
 
   /** The path used for file-category detection (new side, else old side). */
   readonly path: string;
+
   readonly isTest: boolean;
   readonly isMarkdown: boolean;
 
   /** Added and removed line counts within the file's range. */
   readonly adds: number;
+
   readonly dels: number;
 
   /** The one-line summary shown when the file is collapsed. */

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -16,10 +16,10 @@ export interface DiffFileRange {
   /** 0-based index in document order — the stable key for the fold set. */
   readonly index: number;
 
-  /** First and last (inclusive) diff-text line of the file (header … last
-   * hunk line). */
+  /** First diff-text line of the file, which is its header line. */
   readonly headerLine: number;
 
+  /** Last such line, inclusive — the file's last hunk line. */
   readonly endLine: number;
 
   /** The path used for file-category detection (new side, else old side). */
@@ -28,9 +28,10 @@ export interface DiffFileRange {
   readonly isTest: boolean;
   readonly isMarkdown: boolean;
 
-  /** Added and removed line counts within the file's range. */
+  /** Added line count within the file's range. */
   readonly adds: number;
 
+  /** Removed line count over the same range. */
   readonly dels: number;
 
   /** The one-line summary shown when the file is collapsed. */

--- a/packages/cli/lib/view/keys.ts
+++ b/packages/cli/lib/view/keys.ts
@@ -19,11 +19,13 @@ export interface Key {
    * printable key ("a", "/", "?").
    */
   readonly name: string;
+
   readonly ctrl?: boolean;
 
   /** Alt/Meta modifier (from `ESC <key>` or a CSI modifier param). For an
    * Alt+letter, `name` is the letter and `char` is unset. */
   readonly alt?: boolean;
+
   readonly shift?: boolean;
 
   /** The printable character, when the key produced one. */

--- a/packages/cli/lib/view/languages/decoder.ts
+++ b/packages/cli/lib/view/languages/decoder.ts
@@ -4,6 +4,7 @@ export interface DecodedLanguageSource {
 
   /** Whether the decoded source began with a UTF-8 byte-order mark. */
   readonly hasUtf8Bom: boolean;
+
   encode(text: string): Uint8Array;
 }
 

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -180,6 +180,7 @@ export interface HunkStructureContext {
 
   /** Last diff line of the hunk (its extent). */
   readonly hunkEnd: number;
+
   readonly diffLineStarts: number[];
   readonly rawLines: string[];
 
@@ -378,6 +379,9 @@ export function readOnlyReasonFor(language: Language): string | undefined {
 // selection
 //
 
+/** Memo for {@link allLanguages}, filled on its first call. */
+let languages: readonly Language[] | undefined;
+
 /**
  * Every language the pager knows, most specific first, built on first use.
  * Plain text comes last and remains the fallback after metadata selection.
@@ -388,7 +392,6 @@ export function readOnlyReasonFor(language: Language): string | undefined {
  * building the array eagerly would read a singleton that a cycle-first load had
  * not yet initialized. By first use every module has finished evaluating.
  */
-let languages: readonly Language[] | undefined;
 function allLanguages(): readonly Language[] {
   return languages ??= [
     typeScriptLanguage,

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -1206,6 +1206,7 @@ interface Desc {
 
   /** Char offset of the declared identifier, when the node names one. */
   nameOffset?: number;
+
   recurseInto: readonly ts.Node[];
   meta?: NodeMeta;
 }
@@ -2101,6 +2102,7 @@ interface SchemaProps {
 
   /** True when the literal spells `items: false` (a closed tuple). */
   itemsFalse?: boolean;
+
   prefixItems?: ts.ArrayLiteralExpression;
 }
 

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -44,6 +44,7 @@ interface SectionFile {
 
   /** Global offset of the section's first character in the blob. */
   start: number;
+
   end: number;
   text: string;
 }

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -36,6 +36,7 @@ interface ExplicitKeyState {
 interface HighlightState {
   /** Logical indentation of each open flow collection. */
   readonly flow: number[];
+
   readonly explicitKeys: ExplicitKeyState[];
   documentPrefix: boolean;
   quote?: QuoteState;

--- a/packages/cli/lib/view/loadinput.ts
+++ b/packages/cli/lib/view/loadinput.ts
@@ -18,6 +18,7 @@ export interface BufferedViewInput {
   /** The streamed detector consumed all bytes without selecting a byte
    * language. Later decoding can proceed directly as text. */
   readonly byteLanguageDetectionComplete?: boolean;
+
   readonly extent: RenderInputExtent;
 }
 

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -54,6 +54,7 @@ export interface ViewOptions {
 
   /** Start in the rendered representation when one is available. */
   rendered?: boolean;
+
   file?: string;
 
   /** Select piped source with this stable language identifier. */

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -68,11 +68,16 @@ export interface Span {
   /** Single-line spelling used when displaying an exact definition target. */
   readonly exactDefinitionDisplayName?: string;
 
-  /** Rich-text modifiers used by rendered document views. */
+  /** Bold, one of the rich-text modifiers rendered document views use. */
   readonly bold?: boolean;
 
+  /** Italic, likewise. */
   readonly italic?: boolean;
+
+  /** Underline, likewise. */
   readonly underline?: boolean;
+
+  /** Strikethrough, likewise. */
   readonly strikethrough?: boolean;
 }
 
@@ -229,6 +234,7 @@ export interface StructureNode {
   /** Character offset of the node start, for definition peeks. */
   readonly startOffset: number;
 
+  /** Character offset of the node end, read the same way. */
   readonly endOffset: number;
   readonly depth: number;
   readonly children: StructureNode[];

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -55,6 +55,7 @@ export type ViewMode = "source" | "rendered";
 export interface Span {
   /** 0-based column where this span starts on its line. */
   readonly col: number;
+
   readonly text: string;
   readonly cls: TokenClass;
 
@@ -69,6 +70,7 @@ export interface Span {
 
   /** Rich-text modifiers used by rendered document views. */
   readonly bold?: boolean;
+
   readonly italic?: boolean;
   readonly underline?: boolean;
   readonly strikethrough?: boolean;
@@ -115,6 +117,7 @@ export interface SchemaField {
 
   /** Compact type, e.g. `string`, `string[]`, `object`, `boolean`. */
   readonly type: string;
+
   readonly required: boolean;
 
   /** Nested fields for object types / array-of-object item types. */
@@ -147,10 +150,12 @@ export type NodeMeta =
 
     /** Builder family: `pattern`, `lift`, `handler`, `computed`, … */
     readonly builder: string;
+
     readonly synthetic: boolean;
 
     /** Callback parameters — the captured input cells, e.g. `{ token }`. */
     readonly captures: readonly string[];
+
     readonly input?: SchemaMeta;
     readonly output?: SchemaMeta;
 
@@ -211,6 +216,7 @@ export interface StructureNode {
   /** Char offset of the declared identifier (the `name`), for semantic queries
    * (type-at / definition-at). Absent when the node declares no single name. */
   readonly nameOffset?: number;
+
   readonly startLine: number;
   readonly endLine: number;
 
@@ -222,6 +228,7 @@ export interface StructureNode {
 
   /** Character offset of the node start, for definition peeks. */
   readonly startOffset: number;
+
   readonly endOffset: number;
   readonly depth: number;
   readonly children: StructureNode[];
@@ -271,6 +278,7 @@ export function flattenStructure(
 export interface Document {
   /** Verbatim source text exactly as piped in, in either view mode. */
   readonly text: string;
+
   readonly lines: readonly Line[];
 
   /** Root-level structure nodes (sections, or top-level statements). */

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -53,10 +53,12 @@ export interface PagerTty {
 export interface PagerDeps {
   /** Open the controlling terminal for reading; throws when there is none. */
   openTty(): PagerTty;
+
   write(text: string): void;
 
   /** The terminal size; may throw when there is no console. */
   consoleSize(): { columns: number; rows: number };
+
   env(key: string): string | undefined;
   addSignalListener(signal: Deno.Signal, handler: () => void): void;
   removeSignalListener(signal: Deno.Signal, handler: () => void): void;

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -61,6 +61,7 @@ export type DiffAnnotationKind =
 export interface DiffAnnotation {
   /** Folded logical line carrying the annotation. */
   readonly line: number;
+
   readonly kind: DiffAnnotationKind;
 }
 
@@ -189,6 +190,7 @@ export interface ViewState {
 
   /** Whether the source is a diff. */
   isDiff?: boolean;
+
   showLineNumbers: boolean;
 
   /** How long logical lines continue on later screen rows. */
@@ -219,6 +221,7 @@ export interface ViewState {
 
   /** Command/search input line, e.g. "/token"; null in normal mode. */
   inputLine: string | null;
+
   overlay: OverlayState | null;
 
   /** A modal prompt drawn as a centered Turbo Vision dialog (the save, revert and

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -178,6 +178,7 @@ interface ExpandOffer {
 
   /** Document line passed to the context expander. */
   readonly line: number;
+
   readonly up: boolean;
 }
 
@@ -218,6 +219,7 @@ export class Session {
 
   /** The parsed source document used for editing, offsets, and source cards. */
   #sourceDoc: Document;
+
   #currentDoc: Document;
   #viewMode: ViewMode = "source";
   #color: boolean;
@@ -236,6 +238,7 @@ export class Session {
 
   /** Bumped whenever `collapsed` changes, to invalidate the fold-plan cache. */
   #foldVersion = 0;
+
   #foldFileCache?: { doc: Document; files: DiffFileRange[] };
   #foldPlanCache?: { doc: Document; version: number; plan: FoldPlan };
   #wrapPlanCache?: {
@@ -293,6 +296,7 @@ export class Session {
    * first at or after the cursor and Enter lands the cursor there. Null for a
    * normal-mode `/` search. */
   #searchAnchor: { row: number; col: number } | null = null;
+
   #message = "";
   #mode: Mode = "normal";
   #input = "";
@@ -303,6 +307,7 @@ export class Session {
    * the chain of cards and file peeks. Empty when the current overlay is the
    * first one opened from the main view. */
   #overlayStack: Array<{ overlay: PeekOverlay; scroll: number }> = [];
+
   #semantics?: Semantics;
   quit = false;
 
@@ -349,6 +354,7 @@ export class Session {
    * editing an author-written -/+ pair to match does not. Overwritten by the
    * next split, cleared on a collapse or when the buffer text is replaced. */
   #splitRow: number | null = null;
+
   #cursorOn = false;
 
   /** Pending C-x prefix (Emacs chord), reset by the next key. */
@@ -383,6 +389,7 @@ export class Session {
   /** Every file and commit in the diff, in document order; the filter narrows
    * this into the shown `#jumpEntries`. */
   #jumpAll: JumpEntry[] = [];
+
   #jumpEntries: JumpEntry[] = [];
   #jumpFilter = "";
   #jumpSel = 0;

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -148,16 +148,19 @@ export const ui = {
 
   /** End-of-document ornament. */
   endMark: { fg: C.fgDim } as Style,
+
   statusBar: { fg: C.fg, bg: C.panel } as Style,
   statusKey: { fg: C.red, bg: C.panel, bold: true } as Style,
 
   /** The current file name on the status bar. */
   statusFile: { fg: C.fgBright, bg: C.panel, bold: true } as Style,
+
   statusDim: { fg: C.fgDim, bg: C.panel } as Style,
 
   /** The notice region above the status bar (e.g. the files a save would
    * write), tinted to read as a callout rather than ordinary content. */
   noticeBar: { fg: C.ink, bg: C.cyan } as Style,
+
   lineNumber: { fg: C.fgDim, bg: C.editorBg } as Style,
   lineNumberCurrent: { fg: C.yellow, bg: C.editorBg } as Style,
   searchMatch: { fg: C.ink, bg: C.cyan } as Style,
@@ -166,6 +169,7 @@ export const ui = {
   /** A dialog is a panel a shade lighter than the editor, with a bright frame
    * and a drop shadow, distinct from the content behind it. */
   overlayBg: C.panel,
+
   overlayBorder: { fg: C.white, bold: true } as Style,
 
   /** Border of an overlay that shows source (an editor window). */
@@ -177,6 +181,7 @@ export const ui = {
   /** The drop shadow cast to the right of and below a dialog: the content behind
    * shows through, darkened. */
   overlayShadow: { fg: C.fgDim, bg: C.shadow } as Style,
+
   overlayTitle: { fg: C.fgBright, bold: true } as Style,
 
   /** Body text inside a modal prompt dialog. */
@@ -194,6 +199,7 @@ export const ui = {
   /** The drop shadow cast below and right of a button, painted with half-block
    * glyphs so it reads as a thin edge rather than a full cell. */
   buttonShadow: { fg: C.shadow } as Style,
+
   scrollbarTrack: { fg: C.fgDim } as Style,
   scrollbarThumb: { fg: C.cyan } as Style,
 };

--- a/packages/cli/test/fixtures/view-language/corpus.ts
+++ b/packages/cli/test/fixtures/view-language/corpus.ts
@@ -27,6 +27,7 @@ export interface ViewLanguageFixture {
 
   /** Other adapters that deliberately share this fixture's token evidence. */
   readonly highlightingPeers?: readonly string[];
+
   readonly surveyRepository: string;
   readonly surveyCommit: string;
   readonly surveyPath: string;

--- a/packages/cli/test/multi-user-step-reading.test.ts
+++ b/packages/cli/test/multi-user-step-reading.test.ts
@@ -9,6 +9,7 @@
  * back to an author named nothing they had written.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -160,6 +160,7 @@ interface Tracker {
   /** How many times a caller reached for the compiled pattern. The declared
    * result is behind it, so this is what a readback pays to bound itself. */
   patternLoads: () => number;
+
   root: Cell<any>;
 }
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1451,6 +1451,7 @@ function createPieceCallableHarness(options: {
    * nothing reaches the runtime error log: the reason on the transaction is
    * the whole signal. */
   abortedWithReason?: string;
+
   callableScope?: "space" | "user" | "session";
 
   /** Value the handling's receipt cell reads back ({} = value-less verb). */
@@ -3142,6 +3143,7 @@ describe("collectInvocationResultLinks", () => {
 
   /** The space the call targeted: an address in it carries no `@did`. */
   const contextSpace = "did:key:test-home" as MemorySpace;
+
   const receiptRef = "/of:receipt-1";
 
   it("yields just the receipt for a plain-JSON-only result", () => {

--- a/packages/cli/test/program-root.test.ts
+++ b/packages/cli/test/program-root.test.ts
@@ -5,6 +5,7 @@
  * and must not capture the walk.
  */
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { inferProgramRoot } from "../lib/program-root.ts";

--- a/packages/cli/test/read-options-four-ways.test.ts
+++ b/packages/cli/test/read-options-four-ways.test.ts
@@ -59,6 +59,7 @@ import { safeStringify } from "../lib/render.ts";
  * every arrival.
  */
 const userIdentity = await Identity.fromPassphrase("cf-four-ways-user");
+
 const profileSpace = (await Identity.fromPassphrase("cf-four-ways-profile"))
   .did();
 

--- a/packages/cli/test/test-runner-action-event.test.ts
+++ b/packages/cli/test/test-runner-action-event.test.ts
@@ -6,6 +6,7 @@
  * every object.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-program-root.test.ts
+++ b/packages/cli/test/test-runner-program-root.test.ts
@@ -6,6 +6,7 @@
  * is refused by name rather than reported as a missing file it never named.
  */
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-step-kinds.test.ts
+++ b/packages/cli/test/test-runner-step-kinds.test.ts
@@ -5,6 +5,7 @@
  * one matched no discriminant and the run reported it as malformed.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-timing-measures.test.ts
+++ b/packages/cli/test/test-runner-timing-measures.test.ts
@@ -9,6 +9,7 @@
  * which is why it is pinned here rather than left to a reading of the code.
  */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/verb-emitted-address.test.ts
+++ b/packages/cli/test/verb-emitted-address.test.ts
@@ -31,6 +31,7 @@ import { executePieceCallable, handlerVerbEvents } from "../lib/piece.ts";
 /** A real-shaped piece id, so the address parser judges the spelling and not
  * a malformed hash. */
 const ID = "of:fid1:d2cuq3cMqJY3oaG3fkalMq4uO7BgLfBFkvI-Dm-Kk94";
+
 const ADDRESS = `/${ID}`;
 const ENVELOPE = { "/": { "link@1": { id: ID } } };
 
@@ -456,6 +457,7 @@ describe("verb-emitted-address", () => {
 
       /** `links[0]` read THROUGH, so it says where the edge landed. */
       linkedLabel: () => string | undefined;
+
       notes: () => string[];
 
       /** How many times the dispatch path loaded the compiled pattern. */

--- a/packages/cli/test/verb-prose-overlay.test.ts
+++ b/packages/cli/test/verb-prose-overlay.test.ts
@@ -35,6 +35,7 @@ function registeredRefTo(schema: JSONSchema): string {
   }
   return rootRef;
 }
+
 import { declaredVerbProse, withDeclaredFieldProse } from "../lib/piece.ts";
 
 /** `withDeclaredFieldProse` with both sides as plain objects. */

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -202,6 +202,7 @@ interface Tracker {
   /** What the handlers recorded, read off the cell rather than through any
    * rendering, so it says what the handler actually received. */
   entries: () => string[];
+
   root: Cell<any>;
 }
 

--- a/packages/cli/test/view-session-gate2.test.ts
+++ b/packages/cli/test/view-session-gate2.test.ts
@@ -35,6 +35,7 @@ type SessionPrivates = {
   openPickedFile(absPath: string): void;
   adjustHunkCounts(oldDelta: number, newDelta: number): void;
 };
+
 const priv = (s: Session) => s as unknown as SessionPrivates;
 
 Deno.test("selectNode: an out-of-range index leaves the selection untouched", () => {

--- a/packages/cli/test/wish-read-options.test.ts
+++ b/packages/cli/test/wish-read-options.test.ts
@@ -16,6 +16,7 @@ import {
  * these shape.
  */
 const userIdentity = await Identity.fromPassphrase("cf-wish-read-options-user");
+
 const profileSpace =
   (await Identity.fromPassphrase("cf-wish-read-options-profile")).did();
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `packages/cli` to "The blank line below" (#6633): **104 blank lines
across 50 files**, plus four comments that claimed more than the declaration
they sat on.

### The four that needed rewriting

- **`diffdoc.ts`** — one comment over `newLanguage`/`oldLanguage`, and another
  over `newFileName`/`oldFileName`. Each side now says what its own side does,
  and the rename case that makes the two languages differ stays on the field it
  actually distinguishes.
- **`cell-selection.ts`** — "the keywords that apply to exactly one container"
  sat over both `OBJECT_PROJECTION_KEYS` and `ARRAY_PROJECTION_KEYS`, so the
  claim covered two lists and bound to one. Each now names its own container.
- **`language.ts`** — the lazy language list is documented with what it holds,
  the order, and a paragraph on why it is built on first use (an import cycle
  with the concrete language singletons). All of that sat above the memo
  variable rather than the function doing the building. The explanation moves to
  `allLanguages()`; the variable says it is that function's memo.

### A detector bug this batch turned up

`commands/space.ts` looked like a site and was not. The scanner that masks
string and regex literals before counting brackets read `/\/[^/]*$/` as ending
at the `/` inside its character class, so `]*$/` leaked through as code and the
stray `]` dropped bracket depth a line early — ending the declaration in the
middle of a function body. A `/` inside `[...]` is a literal, and the scanner
now tracks that. Tree-wide this removed 26 phantom sites, three of them in this
package.

### Checks

`deno fmt --check` and `deno lint` pass over the package, the formatter keeping
every insertion rather than undoing it. `deno task test`: **210 passed, 0
failed**. The detector reports zero remaining sites.

Every change is comment or whitespace only, verified by diffing both revisions
with comments and blank lines stripped: no file's code differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

