### PR TITLE
feat(cli): thread an injectable connection through the write path

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -35,8 +35,9 @@ and `lib/piece-render.ts`, plus the `lib/acl.ts` loaders, beside
 `stepPiece`, whose seam (#6556) the rest are modeled on. `withAcl`
 disposes only a runtime it opened itself, so an ACL call over a held
 connection leaves it open. Each carries the unit test the seam makes
-possible — a controller stub driving the function's body with no runtime,
-no socket, and no server behind it — which is the PR's standalone value.
+possible — a controller stub driving the function's body against a doubled
+piece, with no socket and no server behind it — which is the PR's
+standalone value.
 
 **A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
 and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -26,10 +26,10 @@ contract, and the short list is the record of which internals have a
 second caller. (The view substrate's entries wait for B3, which is when
 they earn their place on that record.)
 
-**A2 — connection injection for the write path.** Done. The write path
-takes the connection as a parameter, so a held `PiecesController` serves
-every call rather than each opening a runtime, a storage manager, and a
-socket of its own: `setCellValue`, `removePiece`, `linkPieces`,
+**A2 — connection injection for the write path.** Done (#6646). The write
+path takes the connection as a parameter, so a held `PiecesController`
+serves every call rather than each opening a runtime, a storage manager,
+and a socket of its own: `setCellValue`, `removePiece`, `linkPieces`,
 `renderPiece`, `callPieceHandler`, and `getPieceView` in `lib/piece.ts`
 and `lib/piece-render.ts`, plus the `lib/acl.ts` loaders, beside
 `stepPiece`, whose seam (#6556) the rest are modeled on. `withAcl`

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -26,19 +26,17 @@ contract, and the short list is the record of which internals have a
 second caller. (The view substrate's entries wait for B3, which is when
 they earn their place on that record.)
 
-**A2 — connection injection for the write path.** Three shapes of work,
-not one. `stepPiece` is already done — it gained the
-`PieceResolutionDeps` seam with its write receipt (#6556), and its unit
-test is the template. `callPieceHandler` and `getPieceView` are
-forwarding gaps: each delegates to an already-injectable function
-(`resolvePieceCallable`, `inspectPiece`) without passing deps through, so
-the fix is a threaded parameter. The genuine conversions — the functions
-that call `loadPieces(config)` directly — are `setCellValue` first (a v1
-verb), then `removePiece`, `renderPiece`, and the `lib/acl.ts` loaders.
-Each change carries the unit test the seam makes possible; that is the
-PR's standalone value. Re-verify this inventory against the tree when A2
-starts: it churned three times during the design, once against its own
-prerequisite landing (#6556).
+**A2 — connection injection for the write path.** Done. The write path
+takes the connection as a parameter, so a held `PiecesController` serves
+every call rather than each opening a runtime, a storage manager, and a
+socket of its own: `setCellValue`, `removePiece`, `linkPieces`,
+`renderPiece`, `callPieceHandler`, and `getPieceView` in `lib/piece.ts`
+and `lib/piece-render.ts`, plus the `lib/acl.ts` loaders, beside
+`stepPiece`, whose seam (#6556) the rest are modeled on. `withAcl`
+disposes only a runtime it opened itself, so an ACL call over a held
+connection leaves it open. Each carries the unit test the seam makes
+possible — a controller stub driving the function's body with no runtime,
+no socket, and no server behind it — which is the PR's standalone value.
 
 **A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
 and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -100,8 +100,9 @@ half.
 write must surface as a value, never reach `Deno.exit`). `set` with
 inline values,
 `edit` over `$EDITOR`, and `link` — the one spelling that writes a
-reference instead of copying a value (decision 14), and the only write of
-the three that has no `cf` equivalent to lean on. `call` through
+reference instead of copying a value (decision 14), which leans on
+`cf piece link`. `edit` is the only write of the three with no `cf`
+equivalent behind it. `call` through
 `callFromCommand`, with `verbs` and `describe` beside it, since listing a
 piece's callables is what makes `call` usable without leaving the shell.
 Numbered handles from listings land here, and `more` with them: `more`

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -161,16 +161,17 @@ injection point that lets a lib function reuse a held controller:
 - **Accept it:** `getCellValue`, `listPieces`, `listSpaceSlugs`,
   `searchPieces`, `inspectPiece`, `executePieceCallable` (via
   `PieceCallableDependencies`), `readWish`, `runExec`, all of
-  `lib/bulk.ts` — and `stepPiece`, seamed when it gained its write receipt
-  (#6556), whose unit test is the template the rest of this list follows.
-- **Forwarding gaps:** `callPieceHandler` and `getPieceView` hardcode
-  nothing themselves — each delegates to an already-injectable function
-  (`resolvePieceCallable` via `PieceCallableDependencies`; `inspectPiece`)
-  without forwarding a deps argument. The fix is a parameter threaded
-  through, not a conversion.
-- **Hardcode `loadPieces`:** `setCellValue`, `removePiece`, `renderPiece`,
-  the `lib/acl.ts` loaders. Each opens a fresh runtime and WebSocket per
-  call; these are the genuine conversions.
+  `lib/bulk.ts` — and the write path: `stepPiece`, `setCellValue`,
+  `removePiece`, `linkPieces`, `renderPiece`, `callPieceHandler`,
+  `getPieceView`, and the `lib/acl.ts` loaders. `stepPiece` gained the seam
+  with its write receipt (#6556), and its unit test is the template the
+  rest of the list follows. A supplied connection is the caller's to close,
+  so `withAcl` disposes only a runtime it opened itself.
+- **Hardcode `loadPieces`:** `setPieceSlug`, `savePiecePattern`,
+  `applyPieceInput`, `linkSqliteDiskSource`, `resetHomePattern`, and
+  `commands/deps.ts`. Each opens a fresh runtime and WebSocket per call. No
+  v1 verb reaches one, so each is a conversion for the milestone that first
+  calls it.
 
 `call` is the one verb with no seam at all: `buildCallCommand`'s action is
 inline and bound to Cliffy's `this` (`getLiteralArgs`). Its constituents are
@@ -188,9 +189,10 @@ Each of these is small and lands on its own; together they are what decision
 1. **Export entries.** Done. `@commonfabric/cli` carries an entry for each
    lib module a sibling calls, beside `.` → `mod.ts`, whose import runs CLI
    startup.
-2. **Thread `deps.loadPieces` through the hardcoded functions** —
-   `setCellValue` first; `set` is a v1 verb and today cannot share a
-   connection.
+2. **Thread `deps.loadPieces` through the functions that still hardcode
+   it.** Everything a v1 verb reaches takes it; what is left is the set the
+   inventory above names, each converting for the milestone that first
+   calls it.
 3. **Extract `callFromCommand`** from `buildCallCommand`'s inline action.
 4. **Exit discipline.** `exitWithDataError` and `exitPieceCallFailure` call
    `Deno.exit(1)` (typed `never`); `getCellValueFromCommand` reaches the

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -170,8 +170,8 @@ injection point that lets a lib function reuse a held controller:
 - **Hardcode `loadPieces`:** `setPieceSlug`, `savePiecePattern`,
   `applyPieceInput`, `linkSqliteDiskSource`, `resetHomePattern`, and
   `commands/deps.ts`. Each opens a fresh runtime and WebSocket per call. No
-  v1 verb reaches one, so each is a conversion for the milestone that first
-  calls it.
+  shuttle-v1 verb reaches one, so each is a conversion for the milestone
+  that first calls it.
 
 `call` is the one verb with no seam at all: `buildCallCommand`'s action is
 inline and bound to Cliffy's `this` (`getLiteralArgs`). Its constituents are

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -13,6 +13,14 @@ import {
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import { noteWroteTo } from "./write-receipt.ts";
 
+/**
+ * The connection an ACL operation runs over. It carries the loader alone: an
+ * ACL document is addressed by the space DID, so nothing here resolves a
+ * piece address and a `resolvePieceAddress` accepted alongside would be a
+ * promise no function keeps.
+ */
+export type AclConnectionDeps = Pick<PieceResolutionDeps, "loadPieces">;
+
 // Open the space and hand an ACLManager to `run`. The ACL document is
 // addressed by the space DID and read through the ACLManager, so the space
 // cell's contents are never needed here and their sync is deferred.
@@ -20,7 +28,7 @@ async function withAcl<T>(
   config: SpaceConfig,
   run: (acl: ACLManager) => Promise<T>,
   options: { writes?: boolean } = {},
-  deps: PieceResolutionDeps = {},
+  deps: AclConnectionDeps = {},
 ): Promise<T> {
   const pieces = await (deps.loadPieces ?? loadPieces)({
     ...config,
@@ -48,7 +56,7 @@ export async function setAclEntry(
   config: SpaceConfig,
   user: string,
   capability: Capability,
-  deps: PieceResolutionDeps = {},
+  deps: AclConnectionDeps = {},
 ): Promise<void> {
   const userDid = userToACLUser(user);
   await withAcl(config, (acl) => acl.set(userDid, capability), {
@@ -60,7 +68,7 @@ export async function setAclEntry(
 export async function removeAclEntry(
   config: SpaceConfig,
   user: string,
-  deps: PieceResolutionDeps = {},
+  deps: AclConnectionDeps = {},
 ): Promise<void> {
   const userDid = userToACLUser(user);
   await withAcl(config, (acl) => acl.remove(userDid), { writes: true }, deps);
@@ -69,7 +77,7 @@ export async function removeAclEntry(
 // Get the current ACL for a space
 export async function getAcl(
   config: SpaceConfig,
-  deps: PieceResolutionDeps = {},
+  deps: AclConnectionDeps = {},
 ): Promise<ACL | null> {
   return await withAcl(config, (acl) => acl.get(), {}, deps);
 }

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -5,7 +5,11 @@ import {
   type Capability,
   isACLUser,
 } from "@commonfabric/memory/acl";
-import { loadPieces, type SpaceConfig } from "./piece.ts";
+import {
+  loadPieces,
+  type PieceResolutionDeps,
+  type SpaceConfig,
+} from "./piece.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import { noteWroteTo } from "./write-receipt.ts";
 
@@ -16,9 +20,16 @@ async function withAcl<T>(
   config: SpaceConfig,
   run: (acl: ACLManager) => Promise<T>,
   options: { writes?: boolean } = {},
+  deps: PieceResolutionDeps = {},
 ): Promise<T> {
-  const pieces = await loadPieces({ ...config, deferSpaceCellSync: true });
-  await using runtime = pieces.runtime;
+  const pieces = await (deps.loadPieces ?? loadPieces)({
+    ...config,
+    deferSpaceCellSync: true,
+  });
+  const runtime = pieces.runtime;
+  // A connection opened here is closed here. One the caller supplied outlives
+  // the call, and closing its runtime would take down a socket still in use.
+  await using _opened = deps.loadPieces ? undefined : runtime;
   const space = pieces.getSpace();
   const result = await run(new ACLManager(runtime, space));
   // Before the authorization check below, which throws on a denial recorded
@@ -37,27 +48,30 @@ export async function setAclEntry(
   config: SpaceConfig,
   user: string,
   capability: Capability,
+  deps: PieceResolutionDeps = {},
 ): Promise<void> {
   const userDid = userToACLUser(user);
   await withAcl(config, (acl) => acl.set(userDid, capability), {
     writes: true,
-  });
+  }, deps);
 }
 
 // Remove an ACL entry for a DID
 export async function removeAclEntry(
   config: SpaceConfig,
   user: string,
+  deps: PieceResolutionDeps = {},
 ): Promise<void> {
   const userDid = userToACLUser(user);
-  await withAcl(config, (acl) => acl.remove(userDid), { writes: true });
+  await withAcl(config, (acl) => acl.remove(userDid), { writes: true }, deps);
 }
 
 // Get the current ACL for a space
 export async function getAcl(
   config: SpaceConfig,
+  deps: PieceResolutionDeps = {},
 ): Promise<ACL | null> {
-  return await withAcl(config, (acl) => acl.get());
+  return await withAcl(config, (acl) => acl.get(), {}, deps);
 }
 
 // Use "ANYONE" on the command line to map to "*"

--- a/packages/cli/lib/piece-render.ts
+++ b/packages/cli/lib/piece-render.ts
@@ -119,7 +119,7 @@ export function renderVDomToHtml(
 export async function renderPiece(
   config: PieceConfig,
   options: RenderOptions = {},
-  deps: PieceResolutionDeps = {},
+  deps: Pick<PieceResolutionDeps, "loadPieces"> = {},
 ): Promise<string | (() => void)> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const piece = await pieces.get(

--- a/packages/cli/lib/piece-render.ts
+++ b/packages/cli/lib/piece-render.ts
@@ -5,7 +5,7 @@ import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import { loadPieces } from "./piece.ts";
-import type { PieceConfig } from "./piece.ts";
+import type { PieceConfig, PieceResolutionDeps } from "./piece.ts";
 
 const logger = getLogger("piece-render", { level: "info", enabled: false });
 
@@ -119,8 +119,9 @@ export function renderVDomToHtml(
 export async function renderPiece(
   config: PieceConfig,
   options: RenderOptions = {},
+  deps: PieceResolutionDeps = {},
 ): Promise<string | (() => void)> {
-  const pieces = await loadPieces(config);
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const piece = await pieces.get(
     config.piece,
     options.start ?? true,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -3417,6 +3417,14 @@ export async function executePieceCallable(
   });
 }
 
+/**
+ * Points the target piece's `targetPath` at the value `sourcePath` names on
+ * the source piece, so the target reads the source rather than holding a copy
+ * of what it said.
+ *
+ * Both endpoints are read back first, and the link is refused when either the
+ * piece or the path is missing; `options.allowNonExisting` links anyway.
+ */
 export async function linkPieces(
   config: SpaceConfig,
   sourcePieceId: string,
@@ -3429,21 +3437,30 @@ export async function linkPieces(
     sourceScope?: PieceConfig["pieceScope"];
     targetScope?: PieceConfig["pieceScope"];
   },
+  deps: PieceResolutionDeps = {},
 ): Promise<void> {
   const pieces = await timeCliPhase(
     "linkPieces.loadPieces",
-    () => loadPieces(config),
+    () => (deps.loadPieces ?? loadPieces)(config),
   );
   const resolvedSourcePieceId = await timeCliPhase(
     "linkPieces.resolveSource",
     () =>
-      resolveLinkEndpointAddress(pieces, sourcePieceId, undefined, {
-        allowMissingSlugFallback: true,
-      }),
+      resolveLinkEndpointAddress(
+        pieces,
+        sourcePieceId,
+        deps.resolvePieceAddress,
+        { allowMissingSlugFallback: true },
+      ),
   );
   const resolvedTargetPieceId = await timeCliPhase(
     "linkPieces.resolveTarget",
-    () => resolveLinkEndpointAddress(pieces, targetPieceId),
+    () =>
+      resolveLinkEndpointAddress(
+        pieces,
+        targetPieceId,
+        deps.resolvePieceAddress,
+      ),
   );
 
   // Validate that source and target pieces/paths exist by reading them
@@ -4006,8 +4023,15 @@ async function inspectSlugTargetCell(
   };
 }
 
-export async function getPieceView(config: PieceConfig): Promise<unknown> {
-  const data = (await inspectPiece(config)) as any;
+/**
+ * Returns the view a piece publishes — the `[UI]` node on its result cell —
+ * or `undefined` where the piece publishes none.
+ */
+export async function getPieceView(
+  config: PieceConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<unknown> {
+  const data = (await inspectPiece(config, deps)) as any;
   return data.result?.[UI] as VNode;
 }
 
@@ -4413,14 +4437,23 @@ export async function getCellValue(
   }
 }
 
+/**
+ * Writes `value` at `path` on a piece's result cell, or on its arguments cell
+ * under `options.input`, and receipts the space the write landed in.
+ */
 export async function setCellValue(
   config: PieceConfig,
   path: (string | number)[],
   value: unknown,
   options?: { input?: boolean },
+  deps: PieceResolutionDeps = {},
 ): Promise<void> {
-  const pieces = await loadPieces(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,
@@ -4442,10 +4475,11 @@ export async function callPieceHandler<T = any>(
   config: PieceConfig,
   handlerName: string,
   args: T,
+  deps: PieceCallableDependencies = {},
 ): Promise<void> {
   const resolved = await timeCliPhase(
     "callPieceHandler.resolve",
-    () => resolvePieceCallable(config, handlerName),
+    () => resolvePieceCallable(config, handlerName, deps),
   );
   if (resolved.callableKind !== "handler") {
     throw new Error(`Callable "${handlerName}" is not a handler`);
@@ -4493,9 +4527,16 @@ export async function stepPiece(
 /**
  * Removes a piece from the space.
  */
-export async function removePiece(config: PieceConfig): Promise<void> {
-  const pieces = await loadPieces(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
+export async function removePiece(
+  config: PieceConfig,
+  deps: PieceResolutionDeps = {},
+): Promise<void> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
   const removed = await pieces.remove(resolvedConfig.piece);
 
   if (!removed) {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4029,7 +4029,7 @@ async function inspectSlugTargetCell(
  */
 export async function getPieceView(
   config: PieceConfig,
-  deps: PieceOperationDependencies = {},
+  deps: PieceResolutionDeps = {},
 ): Promise<unknown> {
   const data = (await inspectPiece(config, deps)) as any;
   return data.result?.[UI] as VNode;
@@ -4469,13 +4469,29 @@ export async function setCellValue(
 }
 
 /**
+ * What a {@link callPieceHandler} call supplies: the connection its
+ * resolution runs over, and the execution deps its dispatch reads.
+ *
+ * Narrower than {@link PieceCallableDependencies} by the fields that have no
+ * bearing here — the stdin readers, because the payload arrives decoded as an
+ * argument, and the help prefix, because nothing on this path renders a page.
+ */
+export type PieceHandlerCallDeps =
+  & CallableExecutionDeps
+  & Pick<PieceCallableDependencies, "loadPieces" | "loadPiece">;
+
+/**
  * Calls a named handler within a piece with a decoded JSON payload.
+ *
+ * A `deps.invocation` names the id and session the handling files its receipt
+ * under; without one the dispatch takes a runtime-minted event id, and there
+ * is no receipt to come back for.
  */
 export async function callPieceHandler<T = any>(
   config: PieceConfig,
   handlerName: string,
   args: T,
-  deps: PieceCallableDependencies = {},
+  deps: PieceHandlerCallDeps = {},
 ): Promise<void> {
   const resolved = await timeCliPhase(
     "callPieceHandler.resolve",
@@ -4486,7 +4502,7 @@ export async function callPieceHandler<T = any>(
   }
   await timeCliPhase(
     "callPieceHandler.execute",
-    () => executeResolvedCallable(resolved, args),
+    () => executeResolvedCallable(resolved, args, deps),
   );
 }
 

--- a/packages/cli/test/acl.test.ts
+++ b/packages/cli/test/acl.test.ts
@@ -1,8 +1,8 @@
 /**
  * Unit tests for the ACL library functions. Each takes the connection as a
  * parameter, so a stub controller carrying a stub runtime is enough to drive
- * the whole read-mutate-write cycle with no runtime, no socket, and no server
- * behind it.
+ * the whole read-mutate-write cycle: nothing here builds a runtime, opens a
+ * socket, or reaches a server.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/cli/test/acl.test.ts
+++ b/packages/cli/test/acl.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the ACL library functions. Each takes the connection as a
+ * parameter, so a stub controller carrying a stub runtime is enough to drive
+ * the whole read-mutate-write cycle with no runtime, no socket, and no server
+ * behind it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { ACL } from "@commonfabric/memory/acl";
+import type { PiecesController } from "@commonfabric/piece/ops";
+
+import { getAcl, removeAclEntry, setAclEntry } from "../lib/acl.ts";
+import type { SpaceConfig } from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+
+const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+const OWNER = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const GUEST = "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
+
+const config: SpaceConfig = {
+  apiUrl: "http://localhost:8000",
+  space: SPACE,
+  identity: "/nonexistent/keyfile",
+};
+
+const stored: ACL = { [OWNER]: "OWNER" };
+
+/** What a call did to the connection it was handed. */
+interface Connection {
+  /** The configuration the loader was asked for a session with. */
+  requested?: SpaceConfig & { deferSpaceCellSync?: boolean };
+
+  /** Every ACL document written, in the order they were written. */
+  written: ACL[];
+
+  /** Whether the runtime behind the connection was disposed. */
+  disposed: boolean;
+
+  /** The `PiecesController` seam a call is given. */
+  pieces: PiecesController;
+}
+
+/**
+ * A connection over `acl`, or over a space with no ACL document where that is
+ * `undefined`. `authorizationError` is what the space reports once the ACL
+ * access has pulled it.
+ */
+function connection(
+  acl: ACL | undefined,
+  authorizationError?: Error,
+): Connection {
+  const result: Connection = {
+    written: [],
+    disposed: false,
+    pieces: undefined as unknown as PiecesController,
+  };
+  const runtime = {
+    getCellFromLink: () => ({
+      sync: () => Promise.resolve(),
+      get: () => acl,
+    }),
+    storageManager: {
+      synced: () => Promise.resolve(),
+      authorizationError: () => authorizationError,
+    },
+    editWithRetry: (body: (tx: unknown) => ACL) => {
+      const tx = {
+        readOrThrow: () => acl === undefined ? undefined : { value: acl },
+        writeOrThrow: (_address: unknown, envelope: { value: ACL }) => {
+          result.written.push(envelope.value);
+        },
+      };
+      return Promise.resolve({ ok: body(tx) });
+    },
+    idle: () => Promise.resolve(),
+    [Symbol.asyncDispose]: () => {
+      result.disposed = true;
+      return Promise.resolve();
+    },
+  };
+  result.pieces = {
+    runtime,
+    getSpace: () => SPACE,
+  } as unknown as PiecesController;
+  return result;
+}
+
+/** The seam under test: a held connection, recording what it was asked for. */
+function over(held: Connection) {
+  return {
+    loadPieces: (requested: SpaceConfig) => {
+      held.requested = requested;
+      return Promise.resolve(held.pieces);
+    },
+  };
+}
+
+/** Collects what a receipt writes, and restores the console afterwards. */
+async function captureStderr(body: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await body();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
+describe("acl", () => {
+  describe("getAcl()", () => {
+    it("returns the ACL the space holds", async () => {
+      const held = connection(stored);
+      expect(await getAcl(config, over(held))).toEqual(stored);
+    });
+
+    it("returns `null` for a space with no ACL document", async () => {
+      const held = connection(undefined);
+      expect(await getAcl(config, over(held))).toBeNull();
+    });
+
+    it("opens the space with the space cell's sync deferred", async () => {
+      // The ACL document is addressed by the space DID and read through the
+      // `ACLManager`, so the space cell's contents are never needed.
+
+      const held = connection(stored);
+      await getAcl(config, over(held));
+      expect(held.requested).toEqual({ ...config, deferSpaceCellSync: true });
+    });
+
+    it("leaves the connection it was handed open", async () => {
+      // Disposing here would close a runtime, a storage manager and a socket
+      // that the caller holds for its next call.
+
+      const held = connection(stored);
+      await getAcl(config, over(held));
+      expect(held.disposed).toBe(false);
+    });
+
+    it("raises the denial the space recorded during the read", async () => {
+      const denied = new Error("not authorized for this space");
+      const held = connection(stored, denied);
+      await expect(getAcl(config, over(held))).rejects.toThrow(denied);
+    });
+
+    it("names no write for a read", async () => {
+      // A receipt is a claim that the space changed, and reading an ACL
+      // changes nothing in it.
+
+      resetWriteReceipts();
+      const held = connection(stored);
+      const lines = await captureStderr(async () => {
+        await getAcl(config, over(held));
+      });
+      expect(lines).toEqual([]);
+    });
+  });
+
+  describe("setAclEntry()", () => {
+    it("writes the ACL with the new entry beside the existing ones", async () => {
+      resetWriteReceipts();
+      const held = connection(stored);
+      const lines = await captureStderr(() =>
+        setAclEntry(config, GUEST, "READ", over(held))
+      );
+      expect(held.written).toEqual([{ [OWNER]: "OWNER", [GUEST]: "READ" }]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("maps `ANYONE` to the wildcard principal", async () => {
+      resetWriteReceipts();
+      const held = connection(stored);
+      await captureStderr(() =>
+        setAclEntry(config, "ANYONE", "READ", over(held))
+      );
+      expect(held.written).toEqual([{ [OWNER]: "OWNER", "*": "READ" }]);
+    });
+
+    it("throws for a principal that is neither `ANYONE` nor a DID", async () => {
+      const held = connection(stored);
+      await expect(setAclEntry(config, "mike", "READ", over(held)))
+        .rejects.toThrow('mike is not "ANYONE" or a valid DID.');
+      expect(held.written).toEqual([]);
+    });
+  });
+
+  describe("removeAclEntry()", () => {
+    it("writes the ACL without the entry", async () => {
+      resetWriteReceipts();
+      const held = connection({ ...stored, [GUEST]: "READ" });
+      const lines = await captureStderr(() =>
+        removeAclEntry(config, GUEST, over(held))
+      );
+      expect(held.written).toEqual([{ [OWNER]: "OWNER" }]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("throws for a space with no ACL document", async () => {
+      const held = connection(undefined);
+      await expect(removeAclEntry(config, GUEST, over(held)))
+        .rejects.toThrow("No ACL initialized for space.");
+      expect(held.written).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/test/acl.test.ts
+++ b/packages/cli/test/acl.test.ts
@@ -14,6 +14,7 @@ import type { PiecesController } from "@commonfabric/piece/ops";
 import { getAcl, removeAclEntry, setAclEntry } from "../lib/acl.ts";
 import type { SpaceConfig } from "../lib/piece.ts";
 import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
 
 const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
 const OWNER = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
@@ -97,21 +98,6 @@ function over(held: Connection) {
   };
 }
 
-/** Collects what a receipt writes, and restores the console afterwards. */
-async function captureStderr(body: () => Promise<void>): Promise<string[]> {
-  const lines: string[] = [];
-  const original = console.error;
-  console.error = (...args: unknown[]) => {
-    lines.push(args.map(String).join(" "));
-  };
-  try {
-    await body();
-  } finally {
-    console.error = original;
-  }
-  return lines;
-}
-
 describe("acl", () => {
   describe("getAcl()", () => {
     it("returns the ACL the space holds", async () => {
@@ -142,7 +128,7 @@ describe("acl", () => {
       expect(held.disposed).toBe(false);
     });
 
-    it("raises the denial the space recorded during the read", async () => {
+    it("throws the denial the space recorded during the read", async () => {
       const denied = new Error("not authorized for this space");
       const held = connection(stored, denied);
       await expect(getAcl(config, over(held))).rejects.toThrow(denied);

--- a/packages/cli/test/piece-connection.test.ts
+++ b/packages/cli/test/piece-connection.test.ts
@@ -29,9 +29,13 @@ import {
   setCellValue,
 } from "../lib/piece.ts";
 import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
 
 const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
 const PIECE = "fid1:connection-piece";
+
+/** What a resolver in these tests maps {@link PIECE} to. */
+const RESOLVED_PIECE = "fid1:resolved";
 
 const config: PieceConfig = {
   apiUrl: "http://localhost:8000",
@@ -48,49 +52,51 @@ function over(pieces: PiecesController): PieceResolutionDeps {
   };
 }
 
-/** Collects what a receipt writes, and restores the console afterwards. */
-async function captureStderr(body: () => Promise<void>): Promise<string[]> {
-  const lines: string[] = [];
-  const original = console.error;
-  console.error = (...args: unknown[]) => {
-    lines.push(args.map(String).join(" "));
-  };
-  try {
-    await body();
-  } finally {
-    console.error = original;
-  }
-  return lines;
-}
-
 describe("piece-connection", () => {
   describe("setCellValue()", () => {
-    // One write per case, so the recorded write is the whole assertion: which
-    // of the piece's two cells it landed on, at what path, with what value.
+    // One write per case, so the recorded write is the whole assertion: the
+    // piece it was asked for, which of that piece's two cells it landed on,
+    // at what path, with what value.
 
     interface CellWrite {
+      piece: string;
       cell: "input" | "result";
       value: unknown;
       path: (string | number)[];
     }
 
     function stubController(writes: CellWrite[]): PiecesController {
-      const setter = (cell: "input" | "result") => ({
-        set: (value: unknown, path: (string | number)[]) => {
-          writes.push({ cell, value, path });
-          return Promise.resolve();
-        },
-      });
       return {
-        get: () =>
-          Promise.resolve({
+        get: (piece: string) => {
+          const setter = (cell: "input" | "result") => ({
+            set: (value: unknown, path: (string | number)[]) => {
+              writes.push({ piece, cell, value, path });
+              return Promise.resolve();
+            },
+          });
+          return Promise.resolve({
             input: setter("input"),
             result: setter("result"),
-          }),
+          });
+        },
       } as unknown as PiecesController;
     }
 
-    it("writes the value at the path on the result cell", async () => {
+    /**
+     * A held connection whose resolver maps the configured address to a
+     * different id. Reaching the piece under that id is what says the write
+     * went through the resolution rather than around it: the address in
+     * `config` already carries a scheme, which the stored resolver hands back
+     * untouched, so an identity resolver here would agree with skipping it.
+     */
+    function overResolving(pieces: PiecesController): PieceResolutionDeps {
+      return {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceAddress: () => Promise.resolve(RESOLVED_PIECE),
+      };
+    }
+
+    it("writes the value at the path on the resolved piece's result cell", async () => {
       resetWriteReceipts();
       const writes: CellWrite[] = [];
       const lines = await captureStderr(() =>
@@ -99,12 +105,15 @@ describe("piece-connection", () => {
           ["items", 0, "title"],
           "Milk",
           undefined,
-          over(stubController(writes)),
+          overResolving(stubController(writes)),
         )
       );
-      expect(writes).toEqual([
-        { cell: "result", value: "Milk", path: ["items", 0, "title"] },
-      ]);
+      expect(writes).toEqual([{
+        piece: RESOLVED_PIECE,
+        cell: "result",
+        value: "Milk",
+        path: ["items", 0, "title"],
+      }]);
       expect(lines).toContain(`wrote to space ${SPACE}`);
     });
 
@@ -117,12 +126,15 @@ describe("piece-connection", () => {
           ["title"],
           "Bread",
           { input: true },
-          over(stubController(writes)),
+          overResolving(stubController(writes)),
         )
       );
-      expect(writes).toEqual([
-        { cell: "input", value: "Bread", path: ["title"] },
-      ]);
+      expect(writes).toEqual([{
+        piece: RESOLVED_PIECE,
+        cell: "input",
+        value: "Bread",
+        path: ["title"],
+      }]);
     });
   });
 
@@ -145,10 +157,10 @@ describe("piece-connection", () => {
       const lines = await captureStderr(() =>
         removePiece(config, {
           loadPieces: () => Promise.resolve(stubController(true, calls)),
-          resolvePieceAddress: () => Promise.resolve("fid1:resolved"),
+          resolvePieceAddress: () => Promise.resolve(RESOLVED_PIECE),
         })
       );
-      expect(calls).toEqual(["fid1:resolved"]);
+      expect(calls).toEqual([RESOLVED_PIECE]);
       expect(lines).toContain(`wrote to space ${SPACE}`);
     });
 
@@ -158,7 +170,8 @@ describe("piece-connection", () => {
         await expect(removePiece(config, over(stubController(false))))
           .rejects.toThrow(`Piece "${PIECE}" not found`);
       });
-      // A receipt claims the space changed, and nothing was removed.
+      // A receipt is a claim that the space changed, and a refused removal
+      // changes nothing in it.
       expect(lines).toEqual([]);
     });
   });
@@ -240,7 +253,7 @@ describe("piece-connection", () => {
       expect(lines).toContain(`wrote to space ${SPACE}`);
     });
 
-    it("refuses a path neither endpoint holds, and links nothing", async () => {
+    it("throws for a path neither endpoint holds, and links nothing", async () => {
       const links: LinkCall[] = [];
       await expect(
         linkPieces(

--- a/packages/cli/test/piece-connection.test.ts
+++ b/packages/cli/test/piece-connection.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Unit tests for the `lib/piece.ts` functions that take the connection as a
+ * parameter. Each drives its whole body against an injected controller stub,
+ * so what the function does with a piece — the value it writes, the piece it
+ * removes, the link it makes, the payload it dispatches, the view it returns
+ * — is asserted with no runtime, no socket, and no server behind it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import type { PiecesController } from "@commonfabric/piece/ops";
+import { Runtime, UI } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  callPieceHandler,
+  getPieceView,
+  linkPieces,
+  LinkValidationError,
+  type PieceConfig,
+  type PieceResolutionDeps,
+  removePiece,
+  setCellValue,
+} from "../lib/piece.ts";
+import { resetWriteReceipts } from "../lib/write-receipt.ts";
+
+const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+const PIECE = "fid1:connection-piece";
+
+const config: PieceConfig = {
+  apiUrl: "http://localhost:8000",
+  space: SPACE,
+  identity: "/nonexistent/keyfile",
+  piece: PIECE,
+};
+
+/** The seam under test: a held connection, and no address lookup behind it. */
+function over(pieces: PiecesController): PieceResolutionDeps {
+  return {
+    loadPieces: () => Promise.resolve(pieces),
+    resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+  };
+}
+
+/** Collects what a receipt writes, and restores the console afterwards. */
+async function captureStderr(body: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await body();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
+describe("piece-connection", () => {
+  describe("setCellValue()", () => {
+    // One write per case, so the recorded write is the whole assertion: which
+    // of the piece's two cells it landed on, at what path, with what value.
+
+    interface CellWrite {
+      cell: "input" | "result";
+      value: unknown;
+      path: (string | number)[];
+    }
+
+    function stubController(writes: CellWrite[]): PiecesController {
+      const setter = (cell: "input" | "result") => ({
+        set: (value: unknown, path: (string | number)[]) => {
+          writes.push({ cell, value, path });
+          return Promise.resolve();
+        },
+      });
+      return {
+        get: () =>
+          Promise.resolve({
+            input: setter("input"),
+            result: setter("result"),
+          }),
+      } as unknown as PiecesController;
+    }
+
+    it("writes the value at the path on the result cell", async () => {
+      resetWriteReceipts();
+      const writes: CellWrite[] = [];
+      const lines = await captureStderr(() =>
+        setCellValue(
+          config,
+          ["items", 0, "title"],
+          "Milk",
+          undefined,
+          over(stubController(writes)),
+        )
+      );
+      expect(writes).toEqual([
+        { cell: "result", value: "Milk", path: ["items", 0, "title"] },
+      ]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("writes to the arguments cell given `input`", async () => {
+      resetWriteReceipts();
+      const writes: CellWrite[] = [];
+      await captureStderr(() =>
+        setCellValue(
+          config,
+          ["title"],
+          "Bread",
+          { input: true },
+          over(stubController(writes)),
+        )
+      );
+      expect(writes).toEqual([
+        { cell: "input", value: "Bread", path: ["title"] },
+      ]);
+    });
+  });
+
+  describe("removePiece()", () => {
+    function stubController(
+      removed: boolean,
+      calls: string[] = [],
+    ): PiecesController {
+      return {
+        remove: (id: string) => {
+          calls.push(id);
+          return Promise.resolve(removed);
+        },
+      } as unknown as PiecesController;
+    }
+
+    it("removes the piece the address resolved to", async () => {
+      resetWriteReceipts();
+      const calls: string[] = [];
+      const lines = await captureStderr(() =>
+        removePiece(config, {
+          loadPieces: () => Promise.resolve(stubController(true, calls)),
+          resolvePieceAddress: () => Promise.resolve("fid1:resolved"),
+        })
+      );
+      expect(calls).toEqual(["fid1:resolved"]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("throws naming the piece when the space held none", async () => {
+      resetWriteReceipts();
+      const lines = await captureStderr(async () => {
+        await expect(removePiece(config, over(stubController(false))))
+          .rejects.toThrow(`Piece "${PIECE}" not found`);
+      });
+      // A receipt claims the space changed, and nothing was removed.
+      expect(lines).toEqual([]);
+    });
+  });
+
+  describe("linkPieces()", () => {
+    interface LinkCall {
+      source: string;
+      sourcePath: (string | number)[];
+      target: string;
+      targetPath: (string | number)[];
+    }
+
+    /**
+     * Both endpoints carry a pattern identity, which is what the validation
+     * reads to tell a piece from a cell that was merely written to, and hold
+     * the values the paths are checked against.
+     */
+    function stubController(
+      links: LinkCall[],
+      cells: { source: unknown; target: unknown },
+    ): PiecesController {
+      const piece = (result: unknown, input: unknown) => ({
+        getCell: () => ({
+          getMetaRaw: () => ({ identity: "id-a", symbol: "default" }),
+        }),
+        result: { get: () => Promise.resolve(result) },
+        input: { get: () => Promise.resolve(input) },
+      });
+      return {
+        get: (id: string) =>
+          Promise.resolve(
+            id === "fid1:source"
+              ? piece(cells.source, undefined)
+              : piece(undefined, cells.target),
+          ),
+        link: (
+          source: string,
+          sourcePath: (string | number)[],
+          target: string,
+          targetPath: (string | number)[],
+        ) => {
+          links.push({ source, sourcePath, target, targetPath });
+          return Promise.resolve();
+        },
+      } as unknown as PiecesController;
+    }
+
+    const endpoints = {
+      source: { items: ["a"] },
+      target: { feed: null },
+    };
+
+    it("links the resolved endpoints at the paths it checked", async () => {
+      resetWriteReceipts();
+      const links: LinkCall[] = [];
+      const lines = await captureStderr(() =>
+        linkPieces(
+          config,
+          "source-slug",
+          ["items"],
+          "target-slug",
+          ["feed"],
+          undefined,
+          {
+            loadPieces: () => Promise.resolve(stubController(links, endpoints)),
+            resolvePieceAddress: (_pieces, token) =>
+              Promise.resolve(
+                token === "source-slug" ? "fid1:source" : "fid1:target",
+              ),
+          },
+        )
+      );
+      expect(links).toEqual([{
+        source: "fid1:source",
+        sourcePath: ["items"],
+        target: "fid1:target",
+        targetPath: ["feed"],
+      }]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("refuses a path neither endpoint holds, and links nothing", async () => {
+      const links: LinkCall[] = [];
+      await expect(
+        linkPieces(
+          config,
+          "fid1:source",
+          ["missing"],
+          "fid1:target",
+          ["feed"],
+          undefined,
+          over(stubController(links, endpoints)),
+        ),
+      ).rejects.toThrow(LinkValidationError);
+      expect(links).toEqual([]);
+    });
+
+    it("links a path neither endpoint holds under `allowNonExisting`", async () => {
+      resetWriteReceipts();
+      const links: LinkCall[] = [];
+      await captureStderr(() =>
+        linkPieces(
+          config,
+          "fid1:source",
+          ["missing"],
+          "fid1:target",
+          ["feed"],
+          { allowNonExisting: true },
+          over(stubController(links, endpoints)),
+        )
+      );
+      expect(links).toEqual([{
+        source: "fid1:source",
+        sourcePath: ["missing"],
+        target: "fid1:target",
+        targetPath: ["feed"],
+      }]);
+    });
+  });
+
+  describe("callPieceHandler()", () => {
+    /**
+     * The stream marker on the raw cell value is what classifies a name as a
+     * handler, so `addItem` resolves and every other name reaches the end of
+     * the resolution walk with nothing.
+     */
+    function stubController(sent: unknown[]): PiecesController {
+      const handlerCell = {
+        getRaw: () => ({ $stream: true }),
+        get: () => ({ $stream: true }),
+        send: (input: unknown, resolve: (tx: unknown) => void) => {
+          sent.push(input);
+          resolve({ status: () => ({ status: "done" }) });
+        },
+      };
+      const plainCell = { getRaw: () => "Milk", get: () => "Milk" };
+      const rootCell = {
+        key: (name: string) => ({
+          asSchemaFromLinks: () => name === "addItem" ? handlerCell : plainCell,
+        }),
+      };
+      return {
+        getSpace: () => SPACE,
+        get: () =>
+          Promise.resolve({
+            getCell: () => ({}),
+            input: { getCell: () => Promise.resolve(rootCell) },
+            result: { getCell: () => Promise.resolve(rootCell) },
+          }),
+      } as unknown as PiecesController;
+    }
+
+    it("dispatches the payload to the named handler", async () => {
+      resetWriteReceipts();
+      const sent: unknown[] = [];
+      const lines = await captureStderr(() =>
+        callPieceHandler(
+          config,
+          "addItem",
+          { title: "Milk" },
+          {
+            loadPieces: () => Promise.resolve(stubController(sent)),
+            loadPiece: (pieces) => pieces.get(),
+          },
+        )
+      );
+      expect(sent).toEqual([{ title: "Milk" }]);
+      expect(lines).toContain(`wrote to space ${SPACE}`);
+    });
+
+    it("throws naming a verb the piece does not expose", async () => {
+      const sent: unknown[] = [];
+      await expect(
+        callPieceHandler(config, "title", {}, {
+          loadPieces: () => Promise.resolve(stubController(sent)),
+          loadPiece: (pieces) => pieces.get(),
+        }),
+      ).rejects.toThrow(`Callable "title" not found on piece ${PIECE}`);
+      expect(sent).toEqual([]);
+    });
+  });
+
+  describe("getPieceView()", () => {
+    const view = { type: "vnode", name: "div", props: {}, children: [] };
+
+    /**
+     * An inspection reads both cells and their runtime, so the stub hands out
+     * real cells from an emulated storage manager; only the piece around them
+     * is a double.
+     */
+    async function withStub(
+      result: unknown,
+      body: (deps: PieceResolutionDeps) => Promise<void>,
+    ): Promise<void> {
+      const signer = await Identity.fromPassphrase("cli piece view test");
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+      });
+      try {
+        const space = signer.did();
+        await body({
+          resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+          loadPieces: () =>
+            Promise.resolve({
+              get: () =>
+                Promise.resolve({
+                  id: PIECE,
+                  name: () => "Notes",
+                  getPatternRef: () => Promise.resolve(undefined),
+                  input: {
+                    get: () => Promise.resolve({}),
+                    getCell: () =>
+                      Promise.resolve(runtime.getCell(space, "argument")),
+                  },
+                  result: {
+                    get: () => Promise.resolve(result),
+                    getCell: () =>
+                      Promise.resolve(runtime.getCell(space, "result")),
+                  },
+                  readingFrom: () => Promise.resolve([]),
+                  readBy: () => Promise.resolve([]),
+                }),
+            } as any),
+        });
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    }
+
+    it("returns the view node on the piece's result cell", async () => {
+      await withStub({ title: "Notes", [UI]: view }, async (deps) => {
+        expect(await getPieceView(config, deps)).toEqual(view);
+      });
+    });
+
+    it("returns `undefined` for a piece that publishes no view", async () => {
+      await withStub({ title: "Notes" }, async (deps) => {
+        expect(await getPieceView(config, deps)).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/cli/test/piece-connection.test.ts
+++ b/packages/cli/test/piece-connection.test.ts
@@ -293,17 +293,32 @@ describe("piece-connection", () => {
   });
 
   describe("callPieceHandler()", () => {
+    /** One dispatch onto the handler cell. */
+    interface Dispatch {
+      input: unknown;
+
+      /**
+       * What the send was told to file the handling under, where the call
+       * named an invocation, and `undefined` where it named none.
+       */
+      options?: { eventId: string; session: string };
+    }
+
     /**
      * The stream marker on the raw cell value is what classifies a name as a
      * handler, so `addItem` resolves and every other name reaches the end of
      * the resolution walk with nothing.
      */
-    function stubController(sent: unknown[]): PiecesController {
+    function stubController(sent: Dispatch[]): PiecesController {
       const handlerCell = {
         getRaw: () => ({ $stream: true }),
         get: () => ({ $stream: true }),
-        send: (input: unknown, resolve: (tx: unknown) => void) => {
-          sent.push(input);
+        send: (
+          input: unknown,
+          resolve: (tx: unknown) => void,
+          options?: { eventId: string; session: string },
+        ) => {
+          sent.push({ input, ...(options !== undefined ? { options } : {}) });
           resolve({ status: () => ({ status: "done" }) });
         },
       };
@@ -326,7 +341,7 @@ describe("piece-connection", () => {
 
     it("dispatches the payload to the named handler", async () => {
       resetWriteReceipts();
-      const sent: unknown[] = [];
+      const sent: Dispatch[] = [];
       const lines = await captureStderr(() =>
         callPieceHandler(
           config,
@@ -338,12 +353,51 @@ describe("piece-connection", () => {
           },
         )
       );
-      expect(sent).toEqual([{ title: "Milk" }]);
+      expect(sent).toEqual([{ input: { title: "Milk" } }]);
       expect(lines).toContain(`wrote to space ${SPACE}`);
     });
 
+    it("files the handling under the invocation the caller named", async () => {
+      // The id and the session decide which receipt this handling files
+      // under, so a call that names one and dispatches without it has spent
+      // an invocation nobody can collect.
+
+      resetWriteReceipts();
+      const sent: Dispatch[] = [];
+      await captureStderr(() =>
+        callPieceHandler(config, "addItem", { title: "Milk" }, {
+          loadPieces: () => Promise.resolve(stubController(sent)),
+          loadPiece: (pieces) => pieces.get(),
+          invocation: { id: "inv-7", session: "sess-3" },
+        })
+      );
+      expect(sent).toEqual([{
+        input: { title: "Milk" },
+        options: { eventId: "inv-7", session: "sess-3" },
+      }]);
+    });
+
+    it("reports each dispatch phase to the observer it was given", async () => {
+      resetWriteReceipts();
+      const sent: Dispatch[] = [];
+      const phases: string[] = [];
+      await captureStderr(() =>
+        callPieceHandler(config, "addItem", { title: "Milk" }, {
+          loadPieces: () => Promise.resolve(stubController(sent)),
+          loadPiece: (pieces) => pieces.get(),
+          invocation: { id: "inv-7", session: "sess-3" },
+          // The readback reads an outcome back off the receipt, which this
+          // stub does not mint; skipping it ends the call at the commit, and
+          // is itself a dep that has to arrive to be honored.
+          skipReadback: true,
+          onPhase: (phase) => phases.push(phase),
+        })
+      );
+      expect(phases).toEqual(["dispatched", "committed"]);
+    });
+
     it("throws naming a verb the piece does not expose", async () => {
-      const sent: unknown[] = [];
+      const sent: Dispatch[] = [];
       await expect(
         callPieceHandler(config, "title", {}, {
           loadPieces: () => Promise.resolve(stubController(sent)),

--- a/packages/cli/test/piece-connection.test.ts
+++ b/packages/cli/test/piece-connection.test.ts
@@ -1,9 +1,13 @@
 /**
  * Unit tests for the `lib/piece.ts` functions that take the connection as a
- * parameter. Each drives its whole body against an injected controller stub,
- * so what the function does with a piece — the value it writes, the piece it
- * removes, the link it makes, the payload it dispatches, the view it returns
- * — is asserted with no runtime, no socket, and no server behind it.
+ * parameter. The piece behind the connection is a double throughout, so what
+ * each function does with one — the value it writes, the piece it removes,
+ * the link it makes, the payload it dispatches, the view it returns — is what
+ * the assertions turn on, and no socket and no server stand behind any of it.
+ *
+ * Most of it needs no runtime either. `getPieceView()` is the exception: the
+ * inspection it delegates to reads a cell's runtime, so that block builds one
+ * over an emulated storage manager and doubles only the piece around it.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/cli/test/piece-render.test.ts
+++ b/packages/cli/test/piece-render.test.ts
@@ -10,10 +10,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { type Cell, Runtime } from "@commonfabric/runner";
+import type { PiecesController } from "@commonfabric/piece/ops";
+import { type Cell, Runtime, UI } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { defer } from "@commonfabric/utils/defer";
-import { renderVDomToHtml } from "../lib/piece-render.ts";
+import { renderPiece, renderVDomToHtml } from "../lib/piece-render.ts";
+import type { PieceConfig } from "../lib/piece.ts";
 
 const signer = await Identity.fromPassphrase("cli piece render test");
 const space = signer.did();
@@ -267,6 +269,92 @@ describe("piece-render", () => {
           await runtime.dispose();
         }
       });
+    });
+  });
+
+  describe("renderPiece()", () => {
+    // The connection is a parameter, so the piece around the cell is a stub
+    // and only the runtime under it is real: what is asserted is the tree the
+    // render read off the piece the caller's connection holds.
+
+    const config: PieceConfig = {
+      apiUrl: "http://localhost:8000",
+      space,
+      identity: "/nonexistent/keyfile",
+      piece: "fid1:render-piece",
+    };
+
+    /** A controller over `cell`, collecting the arguments of every `get`. */
+    function stubController(
+      runtime: Runtime,
+      cell: Cell<unknown>,
+      gets: unknown[][] = [],
+    ): PiecesController {
+      return {
+        runtime,
+        get: (...args: unknown[]) => {
+          gets.push(args);
+          return Promise.resolve({ getCell: () => cell });
+        },
+      } as unknown as PiecesController;
+    }
+
+    it("returns the piece's UI as HTML", async () => {
+      const runtime = makeRuntime();
+      try {
+        const cell = await cellHolding(runtime, "render-piece-ui", {
+          [UI]: vnode("div", { id: "hello" }, [vnode("p", {}, ["Hi"])]),
+        });
+
+        const html = await renderPiece(config, {}, {
+          loadPieces: () => Promise.resolve(stubController(runtime, cell)),
+        });
+
+        expect(html).toBe('<div id="hello"><p>Hi</p></div>');
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("throws naming a piece that publishes no UI", async () => {
+      const runtime = makeRuntime();
+      try {
+        const cell = await cellHolding(runtime, "render-piece-bare", {
+          title: "Notes",
+        });
+
+        await expect(
+          renderPiece(config, {}, {
+            loadPieces: () => Promise.resolve(stubController(runtime, cell)),
+          }),
+        ).rejects.toThrow(`Piece ${config.piece} has no UI`);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("starts the piece unless `start` says otherwise", async () => {
+      // Computed state is only fresh while the pattern runs, so a render
+      // starts the piece by default and reads stored state when told not to.
+
+      const runtime = makeRuntime();
+      try {
+        const cell = await cellHolding(runtime, "render-piece-start", {
+          [UI]: vnode("div", {}, []),
+        });
+        const gets: unknown[][] = [];
+        const deps = {
+          loadPieces: () =>
+            Promise.resolve(stubController(runtime, cell, gets)),
+        };
+
+        await renderPiece(config, {}, deps);
+        await renderPiece(config, { start: false }, deps);
+
+        expect(gets.map((args) => args[1])).toEqual([true, false]);
+      } finally {
+        await runtime.dispose();
+      }
     });
   });
 });

--- a/packages/cli/test/piece-step.test.ts
+++ b/packages/cli/test/piece-step.test.ts
@@ -13,6 +13,7 @@ import type { PiecesController } from "@commonfabric/piece/ops";
 
 import { type PieceConfig, stepPiece } from "../lib/piece.ts";
 import { resetWriteReceipts } from "../lib/write-receipt.ts";
+import { captureStderr } from "./utils.ts";
 
 const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
 
@@ -42,21 +43,6 @@ function stubController(calls: string[]): PiecesController {
       return Promise.resolve();
     },
   } as unknown as PiecesController;
-}
-
-// Collects what a receipt writes, and restores the console afterwards.
-async function captureStderr(body: () => Promise<void>): Promise<string[]> {
-  const lines: string[] = [];
-  const original = console.error;
-  console.error = (...args: unknown[]) => {
-    lines.push(args.map(String).join(" "));
-  };
-  try {
-    await body();
-  } finally {
-    console.error = original;
-  }
-  return lines;
 }
 
 describe("stepPiece", () => {

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -41,6 +41,30 @@ export function checkStderr(stderr: string[]) {
   expect(relevant[0]).toMatch(/deno run /);
 }
 
+/**
+ * Collects what `body` writes to `console.error`, restoring the console
+ * afterwards even where `body` throws.
+ *
+ * Every argument is stringified, so a `null` or an `undefined` among them
+ * reads as its own name rather than as the empty string `join` alone would
+ * give it.
+ */
+export async function captureStderr(
+  body: () => Promise<void>,
+): Promise<string[]> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    await body();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
 export interface CliResult {
   code: number;
   stdout: string[];

--- a/packages/cli/test/wish-command.test.ts
+++ b/packages/cli/test/wish-command.test.ts
@@ -12,7 +12,7 @@ import {
 import { setQuietMode } from "../commands/piece.ts";
 import type { WishReadConfig, WishReadResult } from "../lib/wish.ts";
 import { CellSelectionError } from "../lib/cell-selection.ts";
-import { withEnv } from "./utils.ts";
+import { captureStderr, withEnv } from "./utils.ts";
 
 // Drives the `cf wish` action body in-process with a stubbed readWish/exit
 // (same idiom as test/inspect-remote.test.ts), so flag handling, config
@@ -61,20 +61,6 @@ async function captureStdout(fn: () => Promise<void>): Promise<string> {
     Deno.stdout.writeSync = original;
   }
   return captured;
-}
-
-async function captureStderr(fn: () => Promise<void>): Promise<string[]> {
-  const errors: string[] = [];
-  const original = console.error;
-  console.error = (...args: unknown[]) => {
-    errors.push(args.join(" "));
-  };
-  try {
-    await fn();
-  } finally {
-    console.error = original;
-  }
-  return errors;
 }
 
 async function makeTempKeyFile(): Promise<{ path: string; did: string }> {


### PR DESCRIPTION
## Why

Every write in `packages/cli` opens its own fabric connection. `setCellValue`,
`removePiece`, `linkPieces`, `renderPiece`, and the `lib/acl.ts` loaders each
call `loadPieces(config)` directly, so each one builds a runtime, a storage
manager, and a WebSocket, uses them once, and leaves them for process exit to
clean up. `callPieceHandler` and `getPieceView` are a milder version of the
same thing: each delegates to a function that already accepts an injected
connection, and drops the dependencies on the floor on the way.

For one-shot `cf` that is merely wasteful. For any caller that outlives a
single command it is a correctness problem — `withRuntimeCleanupOnFailure`
disposes only on throw, so every successful call leaks, and the process exit
that currently covers for it is not available to a host that keeps running.

The independent value here is the same one the `*FromCommand` family was
factored for: none of these functions had a unit test, because there was no
way to run one without a live server. Now there is. This PR adds 22 cases
that drive the write path with no runtime, no socket, and no server.

Second of the stage-A seam PRs behind the merged shuttle design (#6537,
`docs/plans/shuttle/build-sequence.md`), after #6626.

## What Changed

Every seamed function takes `deps` as a trailing optional parameter defaulting
to `{}` and reads `(deps.loadPieces ?? loadPieces)(config)` — the shape
`stepPiece` established with its write receipt (#6556). **No call site
changed**; all nine pass no deps and take the default.

- **Conversions**: `setCellValue`, `removePiece`, `linkPieces` (`lib/piece.ts`),
  `renderPiece` (`lib/piece-render.ts`), and the `lib/acl.ts` loaders.
- **Forwarding gaps closed**: `callPieceHandler` and `getPieceView` now pass
  their deps to `resolvePieceCallable` and `inspectPiece`.
- `linkPieces` is not in the design's written list. The stage text orders a
  re-verification of its inventory against the tree; that turned it up, and
  `cf piece link` already calls it.

**One trap worth naming.** `withAcl` opened with
`await using runtime = pieces.runtime`, which would have disposed an *injected*
caller's runtime at the end of every ACL call — the seam would have worked once
and then closed the caller's socket. It now disposes only a runtime it opened
itself. A test pins that an injected connection is left open.

The ACL functions and `renderPiece` take `Pick<PieceResolutionDeps,
"loadPieces">` rather than the whole bag, because a type that advertises a
field the function ignores is a suggestion rather than a contract:
`PiecesController.get` does not resolve slugs, so a caller passing one deps
object to every seam would get resolution everywhere except `render`, silently.

`captureStderr` had been copied into three test files and was about to become
four; it moves to `packages/cli/test/utils.ts` beside `stripAnsi` and `withEnv`.
The surviving form is the `args.map(String)` one, so a `null` reads as its own
name rather than as the empty string `join` alone gives.

## Test plan

Gates run on this diff: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, and `deno task test` in `packages/cli` (1741 parallel +
210 serial, 0 failed).

Two new files — `test/piece-connection.test.ts` and `test/acl.test.ts` — plus
new cases in `test/piece-render.test.ts`. Each drives a seamed function over an
injected stub controller. The piece behind the connection is a double
throughout; where cells have to be real (`getPieceView`, which reaches
`resultCell.runtime`, and the render cases) they come from an emulated storage
manager, and the file headers say which is which rather than claiming more
hermeticity than they have.

The assertions turn on what each function did with the connection — the value
written and to which cell, the resolved address it removed, the link it made,
the payload dispatched, the rendered HTML, the ACL entry, and that
`deferSpaceCellSync` survives to the loader. Every case was checked
non-vacuously by mutating the implementation, observing the failure, and
restoring the file byte-identically.

Two known limits, recorded rather than papered over. The "closes what it
opened" half of the `withAcl` fix is not directly testable while the
discriminator is `deps.loadPieces`, since reaching that branch means opening a
real connection. And rendering `cell` versus `cell.key(UI)` produces identical
HTML — the reconciler walks the `[UI]` chain itself — so no assertion can
separate them; `cell.key(UI)` stays because it says what is being rendered.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

