### PR TITLE
fix(navigation): compare views by their fields, not their key order

### DIFF
--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -299,12 +299,12 @@ export class ShellIntegration {
     await this.#disposePageRuntime();
   }
 
-  // Wait for the app state to match all properties
-  // provided here. Throws if timeout is reached.
+  // Wait for the shell's app state to hold this view, and this identity where
+  // one is given. Throws if the wait runs out.
   //
-  // If waiting for only `spaceName`, for example,
-  // the function returns successfully once state
-  // has a matching `spaceName`, ignoring all other properties.
+  // The view is matched whole, field for field: a state matches when its view
+  // holds the same fields this one holds. A view naming only a space is
+  // matched by the state of a space with no piece open.
   async waitForState(
     params: {
       view: AppView;

--- a/packages/navigation/src/view.ts
+++ b/packages/navigation/src/view.ts
@@ -73,9 +73,21 @@ function isAppViewModeRef(view: object): view is AppViewModeRef {
   return !("mode" in view) || view.mode === "embed";
 }
 
+/**
+ * Whether two views address the same thing. Two views are equal when they hold
+ * the same fields with the same values, whatever order the route or control
+ * that built them wrote those fields in. Every value a view holds is a string,
+ * so the values compare by their contents. A field holding `undefined` counts
+ * as absent, which is what a URL or a history entry keeps of one.
+ */
 export function isAppViewEqual(a: AppView, b: AppView): boolean {
   if (a === b) return true;
-  return JSON.stringify(a) === JSON.stringify(b);
+  const held = (view: AppView) =>
+    new Map(Object.entries(view).filter(([, value]) => value !== undefined));
+  const fields = held(a);
+  const other = held(b);
+  return fields.size === other.size &&
+    [...fields].every(([name, value]) => other.get(name) === value);
 }
 
 export function isEmbeddedView(view: AppView): boolean {

--- a/packages/navigation/test/view.test.ts
+++ b/packages/navigation/test/view.test.ts
@@ -158,6 +158,42 @@ describe("view", () => {
     expect(isAppViewEqual(view, { builtin: "home" })).toBe(false);
   });
 
+  it("compares two views holding the same fields in a different order", () => {
+    // A route parsed from a URL names the space first; a navigation mapped
+    // from a space DID back onto the current space name rebuilds the view
+    // with the piece first.
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: "fid1:abc" },
+      { pieceId: "fid1:abc", spaceName: "space" },
+    )).toBe(true);
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: "fid1:abc" },
+      { pieceId: "fid1:abc", spaceName: "other" },
+    )).toBe(false);
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: "fid1:abc" },
+      { spaceName: "space" },
+    )).toBe(false);
+  });
+
+  it("counts a field holding undefined as absent", () => {
+    // The shell rebuilds a navigated view field by field, carrying a key
+    // through whenever the view has it, so a key present with no value
+    // reaches this comparison.
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: undefined },
+      { spaceName: "space" },
+    )).toBe(true);
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: undefined, mode: undefined },
+      { spaceName: "space" },
+    )).toBe(true);
+    expect(isAppViewEqual(
+      { spaceName: "space", pieceId: undefined },
+      { spaceName: "space", pieceId: "fid1:abc" },
+    )).toBe(false);
+  });
+
   it("treats slug piece routes as non-default pattern views", () => {
     expect(isViewingDefaultPatternView({ spaceName: "space" })).toBe(true);
     expect(

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -2,6 +2,7 @@ import { type DID, type Identity, KeyStore } from "@commonfabric/identity";
 import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
 import {
   AppView,
+  isAppViewEqual,
   isViewingDefaultPatternView,
   navigate,
 } from "@commonfabric/navigation";
@@ -379,8 +380,8 @@ export class XRootView extends BaseView implements ShellApp {
   // and treats a space name that disagrees with a space DID as an error.
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("app")) {
-      const previous = changedProperties.get("app");
-      if (JSON.stringify(previous?.view) !== JSON.stringify(this.app?.view)) {
+      const previousView = changedProperties.get("app")?.view;
+      if (!previousView || !isAppViewEqual(previousView, this.app.view)) {
         if (!this.#preserveRuntimeErrorsForNextViewChange) {
           this._runtimeLoadErrors = [];
         }

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -288,6 +288,46 @@ describe("XRootView", () => {
     }
   });
 
+  it("keeps runtime load errors across a view rebuilt in another key order", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const root = new XRootView();
+      const internals = root as unknown as {
+        _runtimeLoadErrors: readonly ErrorNotification[];
+        willUpdate(changed: Map<string, unknown>): void;
+      };
+      const error: ErrorNotification = {
+        type: NotificationType.ErrorReport,
+        message: "the piece failed to load",
+      };
+      const stateAt = (next: unknown) => ({
+        ...root.app,
+        view: next as typeof root.app.view,
+      });
+
+      // A route parsed from a URL names the space first; a navigation mapped
+      // from a space DID back onto the current space name rebuilds the view
+      // with the piece first. Both address the same piece, so an error that
+      // piece raised is still the error of the piece on screen.
+      root.app = stateAt({ pieceId: "piece-1", spaceName: "atlas" });
+      internals._runtimeLoadErrors = [error];
+      internals.willUpdate(
+        new Map([["app", stateAt({ spaceName: "atlas", pieceId: "piece-1" })]]),
+      );
+      expect(internals._runtimeLoadErrors).toEqual([error]);
+
+      // Another piece is another view, and its errors are not this one's.
+      root.app = stateAt({ spaceName: "atlas", pieceId: "piece-2" });
+      internals.willUpdate(
+        new Map([["app", stateAt({ spaceName: "atlas", pieceId: "piece-1" })]]),
+      );
+      expect(internals._runtimeLoadErrors).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
   it("starts one lookup per name, whatever else changes in the app state", async () => {
     const restore = installBrowserGlobals();
     try {


### PR DESCRIPTION
`isAppViewEqual` serialized both views and compared the strings, so two views holding the same fields compared unequal whenever they were built in a different order. That is not a hypothetical ordering. A route parsed out of a URL names the space first: `urlToAppView` returns `{ spaceName, pieceId }`. A navigation carrying a space DID is rebuilt with the piece first: when the DID names the space already open, `mapNavigationView` returns `{ pieceId, pieceSlug, mode, spaceName }`. Those two spellings of one destination never compared equal, and `packages/shell/test/navigation.test.ts` already pins the shell producing the second of them at `/my-space/fid1:abc`, which is the URL that parses back into the first.

The comparison now reads the fields. Every value an `AppView` holds is a string, so a shallow comparison says exactly what the function claims to. A field holding `undefined` counts as absent, which is what a URL or a history entry keeps of one, and what `mapNavigationView` can produce: it carries a key through whenever the view has that key, whether or not the key has a value.

Two callers were reading the wrong answer.

`RootView.willUpdate` clears the runtime load errors on screen when the view changes, so that an error raised while loading one piece does not outlast the user's move to another. It decided the view had changed by comparing serializations, so navigating to the piece already open read as a change and wiped the errors of the piece still displayed. An in-piece link does exactly that: a cell reference names its space by DID, so following one back to the open piece routes through `mapNavigationView`. Nothing reloads afterwards, so the banner does not return.

`ShellIntegration.waitForState` compares the awaited view against the shell's state the same way. A test that navigated by DID and then awaited the name-first spelling of that destination polls until it gives up, against a shell that has already arrived, and reports a failure naming two views that read identically.

That function's comment also said a caller waiting on only a space name would be answered by any state carrying that space name, whatever else the state held. The comparison is an equality over every field, so a wait on a space alone is answered only by a space with no piece open. No caller reads it the way the comment described.

The guards in `willUpdate` against a missing application state go with the change. `app` is a `@state()` accessor initialized to `createDefaultAppState()` and assigned only in `#commit`, which takes an `AppState`, and `AppState.view` is not optional. Only the previous state can be absent, and only on the first update, where Lit reports every initialized property as changed with no old value.

Three cases cover the comparison: two views holding the same fields in a different order, a field holding `undefined`, and the shell keeping the errors of a piece across a view rebuilt the other way round. The first and third were run against the serializing comparison and fail there for the reason each names. The second passes either way, because serializing also drops a field holding `undefined`; it guards the filter that keeps that behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

