### PR TITLE
fix(dashboard): align sparkline heights

### DIFF
--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -174,6 +174,21 @@ Deno.test("durationTag renders an auto-formatted span; sparkline itself has no l
   assert([...svg.matchAll(/<polyline/g)].length === 2, "the line + highlight are still drawn");
 });
 
+Deno.test("sparklines share one rendered height", () => {
+  const single = sparkline([1, 2], "#111");
+  const multi = multiSparkline([{ vals: [1, 2], color: "#111" }]);
+  const labeled = multiSparkline([{
+    vals: [1, 2],
+    color: "#111",
+    label: "2",
+  }]);
+
+  assert(single.includes('height="28"'));
+  assert(multi.includes('height="28"'));
+  assert(labeled.includes('height="28"'));
+  assert(labeled.includes("height:28px"));
+});
+
 Deno.test("sparkline: fadeFrom makes the base line a gradient to color at the highlight edge", () => {
   const svg = sparkline([30, 20, 10, 11, 12, 13], "#727882", { count: 3, color: "#c7ccd4" }, "#101010");
   assert(/<linearGradient id="[^"]+" x1="0" y1="0" x2="1" y2="0"/.test(svg), "horizontal gradient defined");
@@ -276,8 +291,25 @@ Deno.test("multiSparkline: overlapping end-labels are spread apart, not stacked"
   const tops = [...svg.matchAll(/top:([0-9.]+)px;transform/g)].map((m) => parseFloat(m[1]));
   assertEquals(tops.length, 2);
   assert(Math.abs(tops[0] - tops[1]) >= 11, `labels should stay ~12px apart, got ${tops}`);
-  // And they stay within the 32px-tall label band.
-  for (const t of tops) assert(t >= 0 && t <= 32, `label ${t} within band`);
+  // And they stay within the 28px-tall label band.
+  for (const t of tops) assert(t >= 0 && t <= 28, `label ${t} within band`);
+
+  const crowded = multiSparkline([
+    { vals: [5, 5, 0], color: "#0a0", label: "$100" },
+    { vals: [3, 3, 0], color: "#00a", label: "$75" },
+    { vals: [1, 1, 0], color: "#a00", label: "$50" },
+  ]);
+  const crowdedTops = [...crowded.matchAll(/top:([0-9.]+)px;transform/g)]
+    .map((match) => parseFloat(match[1]));
+  assertEquals(crowdedTops.length, 3);
+  for (const top of crowdedTops) {
+    assert(top >= 6 && top <= 22, `label ${top} inside the chart`);
+  }
+  assert(
+    crowdedTops[1] - crowdedTops[0] >= 8 &&
+      crowdedTops[2] - crowdedTops[1] >= 8,
+    `crowded labels use the available height: ${crowdedTops}`,
+  );
 });
 
 Deno.test("lighten: blends a color toward white; non-hex is left alone", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -586,6 +586,9 @@ export function durationTag(ms: number): string {
   return `<span style="position:absolute;left:1px;bottom:0;font-size:9px;line-height:1;color:${CHART_HIGHLIGHT};pointer-events:none">${escapeHtml(humanSpan(ms))}</span>`;
 }
 
+// All sparkline variants and their duration labels occupy this rendered height.
+const SPARKLINE_HEIGHT = 28;
+
 function scaleValues(
   vals: number[],
   scale: { trim?: number; minValues?: number } | undefined,
@@ -662,7 +665,7 @@ export function sparkline(
   // The svg is a block, so the chart's box is the height it draws: an inline svg
   // sits on a text baseline, and the line box around it reserves descender space
   // underneath.
-  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="24" preserveAspectRatio="none" style="display:block;margin-top:9px">${defs}${lines.join("")}</svg>`;
+  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="${SPARKLINE_HEIGHT}" preserveAspectRatio="none" style="display:block;margin-top:9px">${defs}${lines.join("")}</svg>`;
 }
 
 // Overlaid trend lines (each oldest -> newest) sharing one vertical scale, each
@@ -848,21 +851,30 @@ export function multiSparkline(
 
   const labeled = drawable.filter((s) => s.label !== undefined);
   if (labeled.length === 0) {
-    return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="32" preserveAspectRatio="none" style="display:block;margin-top:9px">${defsBlock}${lines}</svg>`;
+    return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="${SPARKLINE_HEIGHT}" preserveAspectRatio="none" style="display:block;margin-top:9px">${defsBlock}${lines}</svg>`;
   }
-  const RH = 32; // rendered svg height, px
+  const RH = SPARKLINE_HEIGHT;
+  const LABEL_INSET = 6;
+  const LABEL_GAP = 12;
+  const labelEdge = RH - LABEL_INSET;
   // Each label sits at its line's end height; when a chart is drawn its value
-  // appears only here, so spread any labels that would overlap into one unreadable
-  // stack — sort by height and push each down to at least MIN_GAP below the last.
-  const MIN_GAP = 12;
+  // appears only here. Sort the labels by height and spread close labels apart.
+  // A crowded chart divides the available band evenly between every label.
   const placed = labeled
-    .map((s) => ({ s, py: Math.max(6, Math.min(26, (yv(s.vals[s.vals.length - 1]) / h) * RH)) }))
+    .map((s) => ({ s, py: Math.max(LABEL_INSET, Math.min(labelEdge, (yv(s.vals[s.vals.length - 1]) / h) * RH)) }))
     .sort((a, b) => a.py - b.py);
+  const gap = placed.length > 1
+    ? Math.min(LABEL_GAP, (labelEdge - LABEL_INSET) / (placed.length - 1))
+    : 0;
   for (let i = 1; i < placed.length; i++) {
-    if (placed[i].py - placed[i - 1].py < MIN_GAP) placed[i].py = placed[i - 1].py + MIN_GAP;
+    placed[i].py = Math.max(placed[i].py, placed[i - 1].py + gap);
   }
-  const overflow = placed.length ? placed[placed.length - 1].py - 26 : 0;
-  if (overflow > 0) for (const p of placed) p.py -= overflow;
+  if (placed[placed.length - 1].py > labelEdge) {
+    placed[placed.length - 1].py = labelEdge;
+    for (let i = placed.length - 2; i >= 0; i--) {
+      placed[i].py = Math.min(placed[i].py, placed[i + 1].py - gap);
+    }
+  }
   const tags = placed.map(({ s, py }) =>
     `<span style="position:absolute;right:0;top:${py.toFixed(1)}px;transform:translateY(-50%);font-size:11px;line-height:1;color:${s.color};font-variant-numeric:tabular-nums;pointer-events:none">${escapeHtml(s.label!)}</span>`
   ).join("");


### PR DESCRIPTION
Single-line and multi-line sparklines rendered at 24 and 32 pixels. Their duration labels are pinned to each chart's bottom, so labels in neighboring tiles landed at different heights.

Use one 28-pixel rendered height for every sparkline variant. Derive labeled chart bounds from that height, and reduce label spacing when several end labels must share the smaller band. Tests cover simple, multi-line, labeled, and crowded-label charts.

Verified with the dashboard test runner (694 tests), favicon raster tests (4), headless browser tests (6), `deno fmt --check`, and `deno lint`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

