### PR TITLE
style(memory,piece,ui,ts-transformers,test-support): bound doc comments below

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -146,6 +146,7 @@ export interface ConflictError extends Error {
 
   /** The commit that was rejected. */
   transaction: ClientCommit;
+
   conflict: Conflict;
   retryAfterSeq?: number;
   readyToRetry?: () => Promise<void>;

--- a/packages/memory/test/v2-client-holdings.test.ts
+++ b/packages/memory/test/v2-client-holdings.test.ts
@@ -7,6 +7,7 @@
  * statement is the consumer's, through `holdingsProvider`.
  */
 import { assert } from "@std/assert";
+
 import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { defer } from "@commonfabric/utils/defer";

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -120,10 +120,12 @@ interface ScheduleStats {
   rejected: number;
   pendingReadAccepts: number;
 
-  /** Commits whose pending read was sparsely mutated, split by verdict —
-   * both sides must stay exercised for the declared-set exclusion to keep
+  /** Sparsely-mutated pending reads the schedule accepted. Both this and
+   * `sparseRejects` must stay non-zero for the declared-set exclusion to keep
    * differential coverage (see the vacuity guard). */
   sparseAccepts: number;
+
+  /** The same, for the ones it rejected. */
   sparseRejects: number;
 }
 

--- a/packages/memory/test/v2-schema-doc-closure-delivery.test.ts
+++ b/packages/memory/test/v2-schema-doc-closure-delivery.test.ts
@@ -32,6 +32,7 @@
  * assertion here passes with the closure pass entirely disabled.
  */
 import { assert } from "@std/assert";
+
 import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import type { JSONSchema } from "@commonfabric/api";

--- a/packages/memory/test/v2-session-holdings.test.ts
+++ b/packages/memory/test/v2-session-holdings.test.ts
@@ -10,6 +10,7 @@
  * closure-delivery pins do: raw connections, raw messages.
  */
 import { assert } from "@std/assert";
+
 import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
@@ -119,6 +120,7 @@ describe("session holdings", () => {
   /** The union every reader watches: two roots, one of which mentions
    * the leaf schema, so the closure joins `cid:<leaf>`. */
   const roots = ["of:holdings-a", "of:holdings-b"];
+
   const watches = [
     watchOn("of:holdings-a", "w-a"),
     watchOn("of:holdings-b", "w-b"),

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -295,6 +295,8 @@ export class EventAppendDuplicateError extends ProtocolError {
  * defined once here in the wire-shape module (protocol.md §7).
  */
 export type CommitClass = "authored" | "derived" | "system";
+
+/** The same closed set, enumerable at run time. */
 export const COMMIT_CLASSES: readonly CommitClass[] = [
   "authored",
   "derived",
@@ -492,6 +494,7 @@ export type StreamEventEntry = {
   /** The stream this entry targets — self-describing so the drain, the
    * dropped-notice reader, and compaction never need a reverse map. */
   stream: StreamLinkRef;
+
   payload?: FabricValue;
   firedAt?: StreamEventFiredAt;
 
@@ -529,6 +532,7 @@ export type StreamEventEntry = {
   /** Processing-side: the dropped-event notice (events.md §5 T7) —
    * `{ status: "dropped", reason }` on the entry itself. */
   status?: "dropped" | "needs-attention";
+
   reason?: string;
 
   /** Processing-side checkpoint. It is not a consequence and advances no
@@ -580,6 +584,7 @@ export type StreamEventsDocValue = {
 export type EventAppendDecl = {
   /** The stream's sidecar doc ({@link streamEntriesDocId}). */
   id: EntityId;
+
   scope?: CellScope;
   eventId: string;
 };
@@ -740,10 +745,12 @@ export const identityOfScopeKey = (
 export type DerivedWriteAnnotation = {
   /** Index into the commit's operations array. */
   op: number;
+
   scopeKey?: string;
   actingUser?: string;
   actingSession?: string;
 };
+
 export type Reference = string & {
   readonly __memoryV2Reference: unique symbol;
 };
@@ -915,6 +922,7 @@ export type OperationFieldSnapshot = OperationFieldAddress & {
   operations: IntegratedOperation[];
   /** Lowest cursor from which the retained integrated suffix is contiguous. */
   retainedFrom?: OpCursor;
+
   /** Replace local codec state from `materialized` before continuing. */
   reset?: boolean;
 };
@@ -1021,8 +1029,8 @@ export type CommitPrecondition =
     id: EntityId;
     scope?: CellScope;
   }
+  /** Security-critical exact value pin, including null for absent/deleted. */
   | {
-    /** Security-critical exact value pin, including null for absent/deleted. */
     kind: "entity-value-hash";
     id: EntityId;
     scope?: CellScope;
@@ -1070,12 +1078,16 @@ export type MemoryProtocolFlags = {
 
   /** The server integrates durable collaborative operation streams. */
   applyOp: boolean;
+
   /** Versioned operation codecs registered by this server build. */
   operationCodecs?: readonly string[];
+
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
+
   /** The peer can exchange versioned binary gzip message envelopes. */
   messageCompressionV1: boolean;
+
   /**
    * Server capability (CFC Phase 3.c): commit-folded `sqlite` writes to
    * rule-bearing tables are re-derived through the shared row-label evaluator
@@ -1271,6 +1283,7 @@ export type GraphQueryRoot = {
    * error (the silent-empty-instance trap).
    */
   entityScopeKey?: ScopeKey;
+
   selector: SchemaPathSelector;
 };
 
@@ -1297,6 +1310,7 @@ export type EntitySnapshot = {
    * byte-identical.
    */
   scopeKey?: ScopeKey;
+
   seq: number;
   document: EntityDocument | null;
 
@@ -1374,6 +1388,7 @@ export type SessionSyncUpsert = {
    * (protocol.md §1, §3); the OFF-arm wire is byte-identical.
    */
   scopeKey?: ScopeKey;
+
   seq: number;
   doc?: EntityDocument;
   deleted?: true;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -49,6 +49,7 @@ import { type ArmedTurn, armTurn } from "./turn.ts";
 export type Transport = {
   /** Whether this transport can exchange negotiated compression envelopes. */
   readonly supportsMessageCompression?: boolean;
+
   send(payload: string): Promise<void>;
   close(): Promise<void>;
   setReceiver(receiver: (payload: string) => void): void;
@@ -96,6 +97,7 @@ export type WatchMutationResult = {
 
   /** Effects delivered before the first watch response, in wire order. */
   precedingSyncs: SessionSync[];
+
   sync: SessionSync;
 };
 
@@ -681,6 +683,7 @@ export class SpaceSession {
    * cannot take it (`sessionHoldings` unadvertised) terminates the
    * session at restore rather than silently degrading (see `restore`). */
   holdingsProvider: (() => SessionHolding[] | undefined) | undefined;
+
   // Highest caughtUpLocalSeq already pushed into the WatchView (via a real sync
   // or a synthetic forward). Subscribers such as runner storage only advance
   // their own caught-up seq from emitted syncs, so a resume that promotes

--- a/packages/memory/v2/dump.ts
+++ b/packages/memory/v2/dump.ts
@@ -32,6 +32,7 @@ const SQLITE_SUFFIX = ".sqlite";
 export type SpaceStoreInfo = {
   /** Canonical space DID (decoded from the on-disk filename). */
   space: string;
+
   sizeBytes: number;
   mtimeMs: number;
 };

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -983,6 +983,7 @@ export type Engine = {
 export class ConflictError extends Error {
   /** Entity whose confirmed read went stale (stale-read conflicts only). */
   readonly of?: string;
+
   readonly seq?: number;
   readonly conflictSeq?: number;
   constructor(
@@ -1201,6 +1202,7 @@ export type AppliedCommit = {
    * The commit itself still records and advances the space log.
    */
   elidedOpIndexes?: number[];
+
   operationResolutions?: ApplyOpResolution[];
 };
 
@@ -2428,6 +2430,7 @@ type EventAppendStamp = {
   /** Index into the patch's `values` array (append/add-unique) or the
    * written array value (add/replace/set). */
   valueIndex: number;
+
   firedAt: StreamEventFiredAt;
 };
 

--- a/packages/memory/v2/execution-lease.ts
+++ b/packages/memory/v2/execution-lease.ts
@@ -89,6 +89,7 @@ export type ExecutionLeaseWrite = {
    *  judges liveness by. Injectable so tests can construct expiry without
    *  waiting on real time. */
   now?: number;
+
   ttlMs?: number;
 };
 
@@ -183,6 +184,7 @@ export type ExecutionLeaseCycleOptions = {
 
   /** The DR1 per-process holder identity (`executionLeaseHolder`). */
   holder: string;
+
   ttlMs?: number;
 
   /** The cycle's clock; injectable for tests. Defaults to `Date.now`. */

--- a/packages/memory/v2/execution-outbox.ts
+++ b/packages/memory/v2/execution-outbox.ts
@@ -61,6 +61,7 @@ export type OutboxAppendRow = {
   /** The ORIGINATING chain actor (events.md §2): absent only for a
    * chain with no acting user (a space-scope derivation's emission). */
   actingPrincipal?: string;
+
   actingSession?: string;
 
   /** The OW15 declaration (protocol.md §2's Phase-3 floor carve-out,

--- a/packages/memory/v2/execution-outbox.ts
+++ b/packages/memory/v2/execution-outbox.ts
@@ -62,6 +62,7 @@ export type OutboxAppendRow = {
    * chain with no acting user (a space-scope derivation's emission). */
   actingPrincipal?: string;
 
+  /** The session that actor was acting in. */
   actingSession?: string;
 
   /** The OW15 declaration (protocol.md §2's Phase-3 floor carve-out,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -79,6 +79,7 @@ export type TrackedGraphState = {
   /** referrerKey → the miss keys it attributed (the reverse index the
    * re-walk clears by). */
   missesOf: Map<string, Set<string>>;
+
   entities: Map<QueryDocKey, EntitySnapshot>;
   memo: SchemaMemo;
   manager: EngineObjectManager;
@@ -118,6 +119,7 @@ export type SlowestQueryRoot = {
    * declares none. The hash rather than the schema itself: a board root's
    * schema runs to kilobytes, and the hash is how the registry names it. */
   schema?: string;
+
   elapsedMs: number;
 
   /** Engine documents read while visiting this root. */
@@ -431,6 +433,7 @@ export type QueryGraphReuseContext = {
  * that costs a cache miss, never a wrong hit.
  */
 let nextCanonicalSelectorId = 0;
+
 const canonicalSelectorIds = new WeakMap<SchemaPathSelector, number>();
 const canonicalSelectorId = (selector: SchemaPathSelector): number => {
   const interned = internPathSelector(selector);
@@ -473,26 +476,36 @@ export type QueryEvaluationCacheDiagnostics = {
   weight: number;
   /** Total serves: the sum of the three per-class hit counters. */
   hits: number;
+
   misses: number;
   rotations: number;
   /** Serves of a scope-pure entry (identical for every identity). */
   hitsPure: number;
+
   /** Serves of an absent-residue entry — the recording identity's own
    * re-ask included (its keys need no rewrite, but the entry is the
    * same class). */
   hitsAbsentResidue: number;
+
   /** Serves of a tainted entry to the identity it is keyed to. */
   hitsIdentity: number;
+
   /** Absent-residue shares refused because a residue doc is PRESENT
    * for the requester. A refusal is not a miss by itself: the call
    * then serves from the identity entry (an identity hit) or
    * evaluates in full (a miss). */
   residueRefusals: number;
-  /** Live entries by share class. Together with the hit split, this
-   * is the production measure of how often scoped reach actually
-   * forecloses cross-identity sharing. */
+
+  /** Live scope-pure entries. This count and the two below it are the live
+   * entries by share class; together with the hit split they are the
+   * production measure of how often scoped reach actually forecloses
+   * cross-identity sharing. */
   entriesPure: number;
+
+  /** Live absent-residue entries. */
   entriesAbsentResidue: number;
+
+  /** Live tainted entries, each keyed to one identity. */
   entriesTainted: number;
 };
 
@@ -540,6 +553,7 @@ export type QueryEvaluationCache = {
    * for the same space rotates the cache exactly as a seq advance does —
    * both entry points accept a caller-supplied engine. */
   engine: Engine.Engine | null;
+
   seq: number;
   entries: Map<
     string,
@@ -549,13 +563,25 @@ export type QueryEvaluationCache = {
    * parsed documents an entry keeps alive). The server enforces its
    * cross-space budget against this. */
   weight: number;
-  /** Per-class serve counters ({@link QueryEvaluationCacheDiagnostics}
-   * defines each class); diagnostics report their sum as `hits`. */
+
+  /** Serves of a scope-pure entry. This counter and the two below it are the
+   * per-class serve counters, which diagnostics report summed as `hits`;
+   * {@link QueryEvaluationCacheDiagnostics} defines each class. */
   hitsPure: number;
+
+  /** Serves of an absent-residue entry. */
   hitsAbsentResidue: number;
+
+  /** Serves of a tainted entry to the identity it is keyed to. */
   hitsIdentity: number;
+
+  /** Absent-residue shares refused because a residue doc is present. */
   residueRefusals: number;
+
+  /** Evaluations that found no usable entry. */
   misses: number;
+
+  /** Times the cache was rotated out for a newer engine seq. */
   rotations: number;
 };
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -239,12 +239,16 @@ export type SlowQuery = {
    * lock, so a large value is head-of-line blocking behind fan-out rather
    * than the commit's own cost. */
   lockWaitMs?: number;
+
   /** transact only: the commit's operation count. */
   operations?: number;
+
   /** transact only: the commit's confirmed read count. */
   readsConfirmed?: number;
+
   /** transact only: the commit's pending read count. */
   readsPending?: number;
+
   /** transact only: "ok", the response error's name (a rejected commit
    * that took this long is at least as interesting as an applied one), or
    * "threw" when evaluation raised instead of responding. */
@@ -1339,6 +1343,7 @@ export class Server {
    * query.ts for the sharing, purity, and seq-rotation rules), held for at
    * most QUERY_EVALUATION_CACHE_MAX_SPACES spaces in LRU order. */
   #queryEvaluationCaches = new Map<string, QueryEvaluationCache>();
+
   #engines = new Map<string, Promise<Engine.Engine>>();
   // The resolved-engine index for the SYNC cross-engine lease lookup
   // (server-execution v2 Phase 5; see openEngine / #liveCoHostedLeaseSpaceFor).
@@ -1426,6 +1431,7 @@ export class Server {
       operationCodecs?: OperationCodecRegistry;
       /** Engine-owned interval for operation checkpoints and bounded retention. */
       operationCheckpointInterval?: number;
+
       /**
        * Coalescing delay for the batched subscription fan-out, in
        * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
@@ -1438,6 +1444,7 @@ export class Server {
        * dirty spaces held for the next explicit call.
        */
       subscriptionRefreshDelayMs?: number | "manual";
+
       /** Cross-space retained-entity budget for the query evaluation
        * caches (default QUERY_EVALUATION_CACHE_BUDGET). An entry's weight
        * is the entity count of the evaluation it retains — the proxy for
@@ -1446,6 +1453,7 @@ export class Server {
        * fits. A single evaluation heavier than the whole budget is not
        * retained at all. */
       queryEvaluationCacheBudget?: number;
+
       authorizeSessionOpen: (
         message: SessionOpenRequest,
         context: SessionOpenAuthContext,
@@ -2520,6 +2528,7 @@ export class Server {
      * `stream` field; stage-G-era rows fall back to a path-less link
      * at the sidecar id. */
     targetStreamLink?: StreamLinkRef;
+
     eventId: string;
     payload: unknown;
     actingPrincipal?: string;
@@ -2529,6 +2538,7 @@ export class Server {
      * Phase-3 floor carve-out): admits an ABSENT acting principal;
      * the entry stamps `firedAt = { session: "server" }`. */
     sessionlessSpaceScope?: boolean;
+
     capabilityRef: string;
 
     /** The delivering SpaceServer's service session — the commit's

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -50,6 +50,7 @@ export type SessionState = {
    * a renewal blip the SpaceServer survives in-process must not leave
    * its serving replica silently stale. Cleared by that pass. */
   leaseHolderReadsLapsed?: boolean;
+
   expiresAt: number | null;
   ownerConnectionId: string | null;
   principal?: string;

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -19,6 +19,7 @@ export type ColumnSchema = {
 
   /** Marks a `_cf_link` column (stored TEXT, surfaced as a Cell). */
   cfLink?: true;
+
   [key: string]: FabricValue;
 };
 

--- a/packages/piece/src/ops/bulk-apply.ts
+++ b/packages/piece/src/ops/bulk-apply.ts
@@ -78,6 +78,7 @@ export interface ApplyRow {
   piece: string;
   /** The plan row's phase label, carried as the plan stamped it. */
   phase?: string;
+
   verdict: ApplyVerdict;
   /**
    * What a moved, refused, or failed row broke; absent otherwise. A row
@@ -85,6 +86,7 @@ export interface ApplyRow {
    * would not open or close, is the report's `stopReason`.
    */
   problem?: string;
+
   /**
    * What the runtime warned about a write that DID land — the source was
    * saved and something after it complained. Distinct from `problem`, which
@@ -93,6 +95,7 @@ export interface ApplyRow {
    * only a console nobody keeps.
    */
   warning?: string;
+
   /**
    * The origin the plan recorded for this piece, absent when the plan
    * recorded none. A survey's reading, carried verbatim: it says what the
@@ -106,6 +109,7 @@ export interface ApplyRow {
    * [docs/features/piece-bulk-operations.md](../../../../docs/features/piece-bulk-operations.md).
    */
   origin?: string;
+
   /**
    * The origin this run's write actually detached, present only on a row
    * this run wrote and only when that write detached one.
@@ -125,6 +129,7 @@ export interface ApplyRow {
    * exactly the case a substitution would have hidden.
    */
   detachedOrigin?: string;
+
   /**
    * The row's wall-clock cost in milliseconds, present on every row an
    * apply session began work on: a row reclassified as landed, moved, or
@@ -142,6 +147,7 @@ export interface ApplyReport {
   rows: readonly ApplyRow[];
   /** Operations applied. Zero on a dry run and on a fully landed re-run. */
   applied: number;
+
   /**
    * True when every row reached what this run was for and no session
    * boundary failed: under `apply`, every row is `landed` or `applied`;
@@ -152,6 +158,7 @@ export interface ApplyReport {
    * `warning` is still complete: the write happened.
    */
   complete: boolean;
+
   /**
    * Why the run stopped when no piece is at fault: a session that could not
    * be opened, could not be released, or opened onto a space other than the
@@ -185,6 +192,7 @@ export interface WorkRow<Op extends ReferenceOp> {
    * refuse.
    */
   origin?: string;
+
   expect: { patternIdentity: string; symbol: string };
   op: Op;
 }
@@ -196,8 +204,10 @@ export interface WorkRow<Op extends ReferenceOp> {
 export interface WriteOutcome {
   /** Why this row must not apply. Nothing was written. */
   refused?: string;
+
   /** What the runtime warned about a write that landed anyway. */
   warning?: string;
+
   /**
    * The origin the write detached, when it detached one. The write step is
    * the only place this can be observed honestly — the detach happens
@@ -215,6 +225,7 @@ export interface WriteOutcome {
 export interface PlanOperation<Op extends ReferenceOp> {
   /** The op kind this run applies; a plan carrying any other is refused. */
   kind: Op["kind"];
+
   /**
    * The word a refusal uses for one of this run's rows — "retarget",
    * "restore" — pluralized by the engine where a message needs it. Both
@@ -222,6 +233,7 @@ export interface PlanOperation<Op extends ReferenceOp> {
    * operation this vocabulary does not hold.
    */
   noun: string;
+
   /**
    * Write one outstanding row, in the session in hand, immediately after
    * its precondition was proved. Returns `undefined` when the write landed
@@ -251,6 +263,7 @@ export interface ApplyOptions<Op extends ReferenceOp> {
    * classification alone — where every piece stands, and no write at all.
    */
   apply?: boolean;
+
   /**
    * Pieces the operator has accepted, by name, as ones no reversal can
    * return — their prior source is not retained. Only a run that writes
@@ -258,12 +271,14 @@ export interface ApplyOptions<Op extends ReferenceOp> {
    * moves nothing. See {@link acceptUnretained}.
    */
   accepted?: readonly string[];
+
   /**
    * Pieces served by one session before it is replaced. The knob the
    * design requires: warm-up amortizes across a group while the pieces
    * live at once stay bounded by it.
    */
   groupSize?: number;
+
   /**
    * Called as each row settles, for reporting as the run proceeds. A throw
    * from it is the caller's error rather than the run's: it reaches the
@@ -272,6 +287,7 @@ export interface ApplyOptions<Op extends ReferenceOp> {
    * `failed`.
    */
   onRow?: (row: ApplyRow) => void;
+
   /** The clock behind `elapsedMs`, injectable for deterministic tests. */
   now?: () => number;
 }
@@ -446,6 +462,7 @@ export async function applyPlan<Op extends ReferenceOp>(
   let startBlocked = false;
   /** The run's own trouble, as opposed to any piece's: see `stopReason`. */
   let sessionProblem: string | undefined;
+
   {
     const pieces = await sessions.open();
     try {

--- a/packages/piece/src/ops/bulk-diff.ts
+++ b/packages/piece/src/ops/bulk-diff.ts
@@ -57,6 +57,7 @@ export interface PlanDiff {
 
   /** Pieces the after-survey holds that the plan does not. */
   unplanned: readonly string[];
+
   counts: Readonly<Record<PieceDiffStatus, number>>;
 }
 

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -233,6 +233,7 @@ export interface PiecePlanRow {
 
   /** A grouping label for reports and for stopping between groups; not a sort key. */
   phase?: string;
+
   expect: PieceExpect;
   op?: PieceOp;
 }
@@ -266,6 +267,7 @@ export interface PiecePlanHeader {
 
   /** Which selector produced the rows: a holder's collection, or a list. */
   selector: "collection" | "list";
+
   enumerated: PlanEnumeration;
 
   /**

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -81,6 +81,7 @@ export interface DocumentChange {
    * escaped `~0`.
    */
   path: string;
+
   kind: "changed" | "added" | "removed";
   before?: unknown;
   after?: unknown;
@@ -110,6 +111,7 @@ export interface RepairRow {
 
   /** The plan row's phase label, carried as the survey stamped it. */
   phase?: string;
+
   verdict: RepairVerdict;
 
   /** What a refused, moved, or failed row broke; absent otherwise. */
@@ -570,6 +572,7 @@ type RowDecision =
      * the report and the write cannot describe two different evaluations
      * of a fixer that lied to the purity probe. */
     document: Record<string, unknown>;
+
     changes: readonly DocumentChange[];
   }
   | { kind: "refused"; documentHash: string; problem: string };
@@ -770,6 +773,7 @@ export async function repairPieces(
   // piece in the report twice, under two verdicts, the second contradicting
   // what the caller was just told.
   let reporterThrew = false;
+
   const report = (row: RepairRow) => {
     rows.push(row);
     if (options.onRow === undefined) return;

--- a/packages/piece/src/ops/bulk-survey.ts
+++ b/packages/piece/src/ops/bulk-survey.ts
@@ -55,6 +55,7 @@ export type PieceSelector =
 
     /** The path to the collection within the chosen document. */
     path: readonly (string | number)[];
+
     side?: "input" | "result";
   }
   | { kind: "list"; pieces: readonly string[] };
@@ -370,6 +371,7 @@ export async function surveyPieces(
 export interface PiecePin {
   /** The piece's canonical address. */
   piece: string;
+
   patternIdentity: string;
 
   /** The entry export the identity runs. */

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -504,6 +504,7 @@ export interface PatternCompatibilityReport {
 
   /** Every issue joined, or `undefined` when compatible. */
   message?: string;
+
   candidate: { identity: string; symbol: string };
 }
 

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -51,6 +51,7 @@ export type PieceOriginKind = "system" | "fabric-piece" | "fabric-pattern";
 export interface PieceOrigin {
   /** The canonical origin URL. */
   url: string;
+
   kind: PieceOriginKind;
 
   /**
@@ -106,6 +107,7 @@ export interface PieceSourceState {
 
   /** Ordered, append-only source and origin states accepted by the piece. */
   history: PieceSourceRevisionState[];
+
   currentRevisionId?: string;
 }
 

--- a/packages/piece/src/ops/piece-restore.ts
+++ b/packages/piece/src/ops/piece-restore.ts
@@ -35,11 +35,14 @@ export interface RestorableRevision {
   revisionId: string;
   /** When the piece accepted this source state, as an epoch millisecond. */
   timestamp: number;
+
   patternIdentity: string;
   /** The export the revision runs — the executable pointer's other half. */
   symbol: string;
+
   /** The transition that recorded it: a baseline, an edit, a revert. */
   operation: PieceSourceRevisionState["operation"];
+
   /**
    * Whether the source behind `patternIdentity` is verifiably retained in
    * the space — the canonical loader can produce its closure. A revision
@@ -48,6 +51,7 @@ export interface RestorableRevision {
    * incident.
    */
   retained: boolean;
+
   /**
    * Whether the piece runs this revision's reference right now. A fact
    * about the reference alone: a piece that runs it while still following
@@ -62,8 +66,10 @@ export interface RestorableRevision {
 export interface RestoreOutcome {
   /** The piece's canonical address. */
   piece: string;
+
   /** Every revision the piece's log holds, oldest first. */
   revisions: readonly RestorableRevision[];
+
   /**
    * The revision this run named, when it named one that exists. A copy of
    * the matching `revisions` entry rather than that entry itself: the CLI's
@@ -72,6 +78,7 @@ export interface RestoreOutcome {
    * instead of the revision, in exactly the mode a script reads.
    */
   selected?: RestorableRevision;
+
   /**
    * The origin the piece follows, when it follows one; absent when it is
    * detached. A restore severs it, so this is what tells a piece that is
@@ -79,8 +86,10 @@ export interface RestoreOutcome {
    * reference and would still take the origin's next update.
    */
   origin?: string;
+
   /** Whether this run wrote the restore. False on every dry run. */
   restored: boolean;
+
   /**
    * Why the named revision was not restored: no such revision in this
    * piece's log, a source no longer retained, or a compatibility verdict
@@ -93,6 +102,7 @@ export interface RestoreOutcome {
    * rather than settling into an outcome.
    */
   problem?: string;
+
   /**
    * What the runtime warned about a transition that committed anyway — the
    * restored source ran and something in its execution complained. The
@@ -109,8 +119,10 @@ export interface RestoreOptions {
    * could actually load.
    */
   revisionId?: string;
+
   /** Perform the restore. Absent, the run reads and writes nothing. */
   apply?: boolean;
+
   /**
    * The piece scope to read and write under, when the caller named one. A
    * scoped reference names a different cell from the default-scope one, so a
@@ -130,6 +142,7 @@ export interface RestorableSource {
    * pattern identity at all.
    */
   pattern?: { identity: string; symbol: string };
+
   /**
    * The origin the piece follows as THIS read observed it, and null when it
    * follows none — the same fact the runtime's own source snapshot carries,
@@ -139,6 +152,7 @@ export interface RestorableSource {
    * reference cannot answer.
    */
   origin: string | null;
+
   /** Every revision the log holds, oldest first. */
   revisions: RestorableRevision[];
 }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -195,6 +195,7 @@ function filterOutCell(
  */
 const FRAMED_MIGRATION_REASON =
   `: ${CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON}: `;
+
 const isCfcMigrationRejection = (error: unknown): boolean =>
   error instanceof Error &&
   error.message.startsWith("CFC enforcement rejected commit") &&
@@ -297,6 +298,7 @@ export class PiecesController<T = unknown> {
        * does not need those contents.
        */
       deferSpaceCellSync?: boolean;
+
       // Optional compiled-module-byte cache to share across controllers. Supplied
       // only by test code (see the integration suite's compile-byte-cache helper);
       // unset in production, so no cache is installed.

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -166,6 +166,7 @@ export interface VintageRuntime {
    * reader to work out why a root was not there.
    */
   restoredSpaces: readonly string[];
+
   storeDir: string;
 
   /**
@@ -177,6 +178,7 @@ export interface VintageRuntime {
    * write itself (`captureVintage` does).
    */
   snapshot(destPath: string): Promise<void>;
+
   dispose(): Promise<void>;
 }
 
@@ -487,6 +489,7 @@ export interface VintageManifestEntry {
 
   /** Entity id of the result cell the pattern was materialized onto. */
   cellId: string;
+
   space: string;
 }
 

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -16,6 +16,7 @@ export interface DenoCheckWithTemporaryConfigOptions {
    * Compiler options may differ for the check.
    */
   config: unknown;
+
   files: string[];
   tempConfigPrefix: string;
 }

--- a/packages/test-support/src/records/aliases.ts
+++ b/packages/test-support/src/records/aliases.ts
@@ -20,6 +20,7 @@ export const ALIAS_FILE = "tasks/test-identity-aliases.jsonl";
 export interface AliasLine {
   /** ISO date of the rename; readers apply the alias to older records. */
   date: string;
+
   from: { k: string; s: string; n?: string };
   to: { k: string; s: string; n?: string };
 }

--- a/packages/test-support/src/records/fragment.ts
+++ b/packages/test-support/src/records/fragment.ts
@@ -14,6 +14,7 @@ import { type Environment, recordsDir } from "./paths.ts";
 
 /** Fragment files are `fragment-<ulid>.ndjson` inside the spool. */
 export const FRAGMENT_PREFIX = "fragment-";
+
 export const FRAGMENT_SUFFIX = ".ndjson";
 
 const encoder = new TextEncoder();

--- a/packages/test-support/src/records/gcp-auth.ts
+++ b/packages/test-support/src/records/gcp-auth.ts
@@ -11,6 +11,7 @@ export interface ServiceAccountKey {
 
   /** PEM, PKCS#8. */
   private_key: string;
+
   token_uri: string;
 }
 

--- a/packages/test-support/src/records/schema.ts
+++ b/packages/test-support/src/records/schema.ts
@@ -54,6 +54,7 @@ export interface TestRecord {
 export interface CiContext {
   /** GitHub workflow run id; spans every job of the workflow run. */
   workflowRunId: string;
+
   runAttempt: number;
   workflow: string;
 
@@ -94,6 +95,7 @@ export interface RunContext {
 
   /** True when the working tree had uncommitted changes. */
   dirty: boolean;
+
   branch?: string;
   env: "ci" | "local";
   ci?: CiContext;
@@ -103,6 +105,7 @@ export interface RunContext {
    * harness a run was started under when that variable is unset.
    */
   agent?: string;
+
   os: string;
   arch: string;
   denoVersion: string;

--- a/packages/test-support/src/records/store.ts
+++ b/packages/test-support/src/records/store.ts
@@ -41,6 +41,7 @@ export interface CreateObjectOptions {
 
   /** Full object name, prefix included. */
   name: string;
+
   body: Uint8Array;
   token: string;
   contentType?: string;

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -49,6 +49,7 @@ export class TransformationContext {
    * `TransformationContext` built from these options joins the same run.
    */
   readonly state: CrossStageState;
+
   readonly cfHelpers: CFHelpers;
   readonly diagnostics: TransformationDiagnostic[] = [];
   readonly tsContext: ts.TransformationContext;

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -115,11 +115,14 @@ export class CrossStageState {
   }
 
   /**
-   * Bare cross-package channels (the published boundary contract). Read
-   * directly by the schema-generator package as plain WeakMaps; they must NOT
-   * be folded into `nodeLinks`. See `core/mod.ts`.
+   * One of the two bare cross-package channels making up the published
+   * boundary contract, `schemaHints` below being the other. Both are read
+   * directly by the schema-generator package as plain WeakMaps, and so must
+   * NOT be folded into `nodeLinks`. See `core/mod.ts`.
    */
   readonly typeRegistry: TypeRegistry = new WeakMap();
+
+  /** The other such channel, held to the same contract. */
   readonly schemaHints: SchemaHints = new WeakMap();
 
   /**
@@ -137,6 +140,7 @@ export class CrossStageState {
 
   /** Marker family — keyed by node/symbol identity; cache-coupled via context. */
   readonly mapCallbackRegistry = new WeakSet<ts.Node>();
+
   readonly syntheticComputeCallbackRegistry = new WeakSet<ts.Node>();
   readonly syntheticComputeOwnedNodeRegistry = new WeakSet<ts.Node>();
   readonly syntheticReactiveCollectionRegistry:

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -199,6 +199,7 @@
  *      public accessors, the table never handed out.
  */
 export { TransformationContext } from "./context.ts";
+
 export { CrossStageState } from "./cross-stage-state.ts";
 export type {
   BuilderSourceSiteOptions,

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -11,6 +11,7 @@ import type { BuilderSourceSite } from "./runtime-contract.ts";
 export type SchemaHint = {
   /** Override for array items schema (e.g., false for items: false) */
   readonly items?: unknown;
+
   readonly cfcUiContract?: {
     readonly helper: "UiAction" | "UiPromptSlot" | "UiDisclosure";
     readonly action?: string;
@@ -55,6 +56,7 @@ export type CapabilityParamSummary = {
    * (`const f = cell.send; f(x)`) are outside the contract.
    */
   readonly hasUnverifiedCellUse?: boolean;
+
   readonly identityOnly?: boolean;
   readonly identityPaths?: readonly (readonly string[])[];
   readonly identityCellPaths?: readonly (readonly string[])[];
@@ -127,6 +129,7 @@ export interface BuilderSourceSiteOptions {
  * Type is used in multiple places with different access patterns.
  */
 export type SchemaHints = WeakMap<ts.Node, SchemaHint>;
+
 export type SyntheticReactiveCollectionRegistry = WeakSet<ts.Symbol>;
 
 export type TransformationOptions = {
@@ -146,6 +149,7 @@ export type TransformationOptions = {
    * If provided, diagnostics are pushed to this array in addition to the local context.
    */
   readonly diagnosticsCollector?: TransformationDiagnostic[];
+
   readonly patternCoverage?: PatternCoverageOptions;
   readonly builderSourceSites?: BuilderSourceSiteOptions;
 

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -87,6 +87,7 @@ interface MutableCapabilityState {
    * identity paths the unknown access can actually cover, instead of
    * blanket-erasing every capture sharing this root state (#4714). */
   readonly wildcardPaths: Set<string>;
+
   hasIdentityUse: boolean;
   hasNonIdentityUse: boolean;
   hasNonIdentityRootUse: boolean;

--- a/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
@@ -26,6 +26,7 @@ export interface RewriteParams {
    * Effective reactive context at the rewrite site.
    */
   readonly reactiveContextKind?: ReactiveContextKind;
+
   readonly containerKind?: ExpressionContainerKind;
 
   /**

--- a/packages/ts-transformers/test/commonfabric-test-types.ts
+++ b/packages/ts-transformers/test/commonfabric-test-types.ts
@@ -16,6 +16,7 @@ const staticCache = StaticCache.fromFileSystem();
 export const commonfabricTypes = await staticCache.getText(
   "types/commonfabric.d.ts",
 );
+
 export const cfcTypes = await staticCache.getText("types/cfc.ts");
 
 /**

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -162,6 +162,7 @@ interface BuilderSite {
    * hoisted `const __cfLift_N = __cfHelpers.lift(...)` this is the INNER
    * call; for a top-level authored builder it is the call itself. */
   readonly call: ts.CallExpression;
+
   readonly callback: ts.ArrowFunction | ts.FunctionExpression | undefined;
 }
 

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -24,6 +24,7 @@ export interface TransformOptions {
 
   /** If provided, pipeline diagnostics will be pushed into this array after transformation. */
   pipelineDiagnostics?: TransformationDiagnostic[];
+
   moduleIdentities?: ReadonlyMap<string, string>;
   policyManifests?: unknown[];
   state?: CrossStageState;

--- a/packages/ui/src/v2/components/cf-chart/lib/scales.ts
+++ b/packages/ui/src/v2/components/cf-chart/lib/scales.ts
@@ -14,6 +14,7 @@ import {
   type ScaleTime,
   scaleTime,
 } from "d3-scale";
+
 // @ts-types="@types/d3-array"
 import { extent } from "d3-array";
 import type {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -303,6 +303,7 @@ export class CFCodeEditor extends BaseElement {
    * Mentionable items for @ completion.
    */
   declare mentionable?: CellHandle<MentionableArray> | null;
+
   declare mentioned?: CellHandle<MentionableArray>;
 
   /**
@@ -317,6 +318,7 @@ export class CFCodeEditor extends BaseElement {
    * URL from anywhere else is a link to a web page.
    */
   declare fabricHosts: string[];
+
   declare pattern: CellHandle<string>;
   declare wordWrap: boolean;
   declare lineNumbers: boolean;

--- a/packages/ui/src/v2/components/cf-code-editor/copresence-client.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/copresence-client.ts
@@ -36,12 +36,16 @@ export type PresenceFailureCategory =
 export type PresencePublication = {
   /** Plain-text participant label. */
   name: string;
+
   /** Whether the editor currently owns browser focus. */
   focused: boolean;
+
   /** Confirmed Memory coordinate used by the selection. */
   cursor: PresenceCursor;
+
   /** Selection in confirmed coordinates, or `null` until one is established. */
   selection: PresenceSelection;
+
   /** Whether local pending changes were involved in deriving the selection. */
   basis: ParticipantPresence["basis"];
 };
@@ -50,6 +54,7 @@ export type PresencePublication = {
 export type PresenceSnapshot = {
   /** Participant id assigned to this WebSocket by the room. */
   selfParticipantId: string;
+
   /** Latest states for the room's other live participants. */
   participants: ParticipantPresence[];
 };
@@ -64,19 +69,25 @@ export type PresenceServerMessage =
 export interface PresenceSocket {
   /** Current WebSocket ready-state value. */
   readonly readyState: number;
+
   /** Sends one UTF-8 JSON protocol frame. */
   send(data: string): void;
+
   /** Closes the socket with an optional protocol code and public reason. */
   close(code?: number, reason?: string): void;
+
   /** Registers an open-event listener. */
   addEventListener(type: "open", listener: (event: Event) => void): void;
+
   /** Registers a message-event listener. */
   addEventListener(
     type: "message",
     listener: (event: MessageEvent) => void,
   ): void;
+
   /** Registers an error-event listener. */
   addEventListener(type: "error", listener: (event: Event) => void): void;
+
   /** Registers a close-event listener. */
   addEventListener(type: "close", listener: (event: CloseEvent) => void): void;
 }
@@ -85,16 +96,22 @@ export interface PresenceSocket {
 export type CopresenceSessionOptions = {
   /** WebSocket origin or base URL for the co-presence service. */
   serviceUrl: string;
+
   /** Opaque high-entropy room identifier. */
   room: string;
+
   /** Optional WebSocket factory used by tests and alternate browser hosts. */
   createSocket?: (url: string) => PresenceSocket;
+
   /** Optional animation-frame scheduler used to coalesce publications. */
   scheduleFrame?: (callback: FrameRequestCallback) => number;
+
   /** Cancels a frame scheduled through `scheduleFrame`. */
   cancelFrame?: (handle: number) => void;
+
   /** Receives one strictly validated server message. */
   onMessage: (message: PresenceServerMessage) => void;
+
   /** Receives the first terminal failure category for this session. */
   onFailure: (category: PresenceFailureCategory) => void;
 };

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -52,6 +52,7 @@ export interface MarkdownCallbacks {
  * comes back is the single text node the parser built.
  */
 let scratch: HTMLElement | undefined;
+
 function decodeEntities(text: string): string {
   if (!text.includes("&")) return text;
   scratch ??= document.createElement("div");

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -2900,10 +2900,12 @@ function statefulPiece(
 
     /** When set, the argument read also returns this schema-bearing ref. */
     argumentRef?: CellRef;
+
     getPageFails?: boolean;
 
     /** When true, getPage stays pending until `resolveGetPage()` is called. */
     deferGetPage?: boolean;
+
     sendFails?: boolean;
     pieceSchema?: Record<string, unknown>;
   } = {},

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -54,6 +54,7 @@ interface MenuEntry {
 
   /** Stable hook for tests, exposed as the entry's `test-id`. */
   testId: string;
+
   panel: Panel;
 }
 
@@ -215,6 +216,7 @@ export interface PieceAction {
 
   /** Which side of the piece carries it. */
   source: "result" | "argument";
+
   handle: CellHandle;
 
   /**
@@ -869,6 +871,7 @@ export class CFPieceMenu extends BaseElement {
 
   /** Where the click landed, in client coordinates. */
   declare x: number;
+
   declare y: number;
 
   static override properties = {

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -58,9 +58,10 @@ export interface PieceContextMenuDetail {
   /** The piece's full schemed id. */
   pieceId: string;
 
-  /** Client coordinates of the click, for placing the menu. */
+  /** Client X coordinate of the click, for placing the menu. */
   x: number;
 
+  /** Client Y coordinate of the click, read the same way. */
   y: number;
 
   /** The variant the piece was rendered at. */

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -60,6 +60,7 @@ export interface PieceContextMenuDetail {
 
   /** Client coordinates of the click, for placing the menu. */
   x: number;
+
   y: number;
 
   /** The variant the piece was rendered at. */

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -309,6 +309,7 @@ export class CFToolsChip extends BaseElement {
     | ToolsChipTool[]
     | ToolsRecord
     | undefined = undefined;
+
   /** Delay in ms before closing on hover-out. */
   declare closeDelay: number;
 

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -86,11 +86,10 @@ export function endDrag(): void {
   notifyListeners(null);
 }
 
-/**
- * Callbacks for when drag is ending (before cleanup).
- * Used by drop zones to emit drop events.
- */
+/** A callback run when a drag is ending, before cleanup. */
 type DragEndListener = (state: DragState) => void;
+
+/** The registered such callbacks; drop zones use them to emit drop events. */
 const endListeners: Set<DragEndListener> = new Set();
 
 /**

--- a/packages/ui/src/v2/core/mention-refs.ts
+++ b/packages/ui/src/v2/core/mention-refs.ts
@@ -47,6 +47,7 @@ const KEY_LENGTH = 6;
 
 /** Longest key {@link mintRefKey} widens to before it gives up. */
 const MAX_KEY_LENGTH = 10;
+
 const KEY_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 /** Samples drawn at one length before widening. */

--- a/packages/ui/src/v2/utils/file-cell-storage.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.ts
@@ -23,6 +23,7 @@ export interface StoreFileOptions {
 
   /** The space the file's blob belongs to — part of its address. */
   space: DID;
+
   width?: number;
   height?: number;
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Conforms `memory`, `piece`, `ui`, `ts-transformers`, and `test-support` to
"The blank line below" (#6633): **148 blank lines across 49 files**, plus seven
comments that described more than the declaration they sat on.

### The seven

- **`query.ts`, twice.** "Per-class serve counters" sat over five fields, only
  three of which are per-class serve counters; "Live entries by share class" sat
  over three. Each field now says what it counts, and `misses`, `rotations`, and
  `residueRefusals` — never part of either claim, merely adjacent to one — are
  documented rather than left inside its reach.
- **`v2-differential-consistency.test.ts`** described "both sides" of a verdict
  split from above one of them.
- **`cross-stage-state.ts`** said "channels ... they must NOT be folded into
  `nodeLinks`" from above `typeRegistry` alone, leaving `schemaHints` outside a
  contract it is equally bound by.
- **`drag-state.ts`** covered both a callback type and the set holding them.
- **`v2.ts`, twice.** A union arm's comment sat on the arm's `kind`
  discriminator instead of above the arm; and `COMMIT_CLASSES` inherited the
  comment written for the `CommitClass` type above it.

The union-arm case is one **no blank line could have fixed**: the rule exempts
arms precisely because `deno fmt` will not keep a blank line between them, so
the comment had to move rather than be bounded.

### How these were found, after the wording heuristic missed one

The plural/group-word heuristic that found the earlier batches' cases missed
`query.ts`'s "Live entries by share class" — "Live" is not a plural and
"Together" is not a group word. So this batch added a signal that does not
depend on prose: **count the undocumented same-kind declarations that follow a
documented one.** A comment describing a group is usually followed by more than
one member of it, whatever words it uses. That found 36 candidates here, read
individually, of which the genuine ones are listed above.

### Checks

`deno fmt --check` and `deno lint` clean on every touched file. Tests: `memory`
592, `piece` 51, `ts-transformers` 1164, `test-support` 19, and `ui` 172 — that
last being `ui`'s non-browser half; its browser half covers four files this
change does not touch.

Every change is comment or whitespace only, verified by diffing both revisions
with comments and blank lines stripped: no file's code differs.

### Unrelated, noticed in passing

`packages/ui/src/v2/components/cf-fab/cf-fab.ts` is unformatted under Deno
2.9.6 and formatted under the 2.9.4 in `mise.toml` — the two disagree on a Lit
template's `></div>`. Both are inside the range `tasks/check.sh` accepts, so a
local `deno fmt --check` can fail on a clean tree. Untouched here and left
alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



### Coverage acceptance

ACCEPT_COVERAGE_DEBT: packages/memory +3 lines

The three lines are the early-return branch of `SpaceSession.ack()` in
`packages/memory/v2/client.ts`:

```ts
if (!this.#client.isConnected() || seenSeq <= this.#ackedSeq) {
  this.#ackedSeq = Math.max(this.#ackedSeq, seenSeq);
  return;
}
```

They are inconsistently covered, and nothing in this PR can reach them.
`client.ts` differs from `main` by exactly three blank lines, at 52, 100, and
686 — all far above `ack()`. Comparing the LCOV artifacts of three CI runs, with
line numbers mapped through those insertions:

| run | zero-hit lines near `ack()` |
| --- | --- |
| baseline main `b67a107f` | 1070, 1071 |
| another main `3beb8146` | 1070, 1071 |
| this PR | 1073, 1074 (the same two, shifted) **plus 1076, 1077, 1078** |

Both `main` runs execute the branch; this run did not. Whether it runs depends on
whether a test happens to call `ack()` while disconnected or with a stale seq —
the environment-dependent coverage `COVERAGE.md` describes, filed as BL-075's
sibling rather than fixed here, since a settle race in someone else's test is not
this change's work.

`packages/memory` did not change between the baseline commit and this PR's base,
so the rise is not base-branch drift either.
