### PR TITLE
docs(development): answer the review findings on the staging-copy procedure

### DIFF
--- a/docs/development/staging-space-copy.md
+++ b/docs/development/staging-space-copy.md
@@ -107,9 +107,16 @@ directory mode the file is:
 
 The doubling is real and every existing store depends on it. Single-file mode
 (`DB_PATH`) composes the same two functions to a different shape: one directory
-beside the database file rather than a nested pair, carrying the doubling in its
-name instead (`<stem>..engine-v3/`), and holding filenames that keep their
+beside the database file rather than a nested pair, and the doubling lands in
+that directory's name. `DB_PATH=/data/cf.sqlite` puts the per-space files in
+`/data/cf..engine-v3/` — two dots — holding filenames that keep their
 percent-encoding rather than reading as literal DIDs.
+
+Reading either function on its own gives a different answer than the server
+gets. The server is constructed with the root the first one returns
+(`packages/toolshed/routes/storage/memory.ts` passes it as `store`), so the
+second composes on `<stem>.engine-v3/` rather than on `DB_PATH`, which is where
+the second dot comes from. Check the composition, not the parts.
 
 Do not compose either path from memory. **List the store directory on the host
 and put your file beside the space files already there** — the neighbors are
@@ -129,11 +136,15 @@ catches is one you do not debug on a shared host.
 sqlite3 <store>/engine-v3/engine-v3/<did>.sqlite "VACUUM INTO '/tmp/<did>.sqlite'"
 sha256sum /tmp/<did>.sqlite
 ```
-Two notes: 
-- \<store\> is currently /data/memory on estuary.
-- estuary does not have enough free space in /tmp (as of 2026/08/31) to host
-  new snapshots, so put them into the same /data/memory directory for now and
-  clean them up as you go.
+
+Two notes, both specific to estuary:
+
+- `<store>` is currently `/data/memory` there.
+- `/tmp` does not have room for a new snapshot (as of 2026-08-31), so put them
+  into that same `/data/memory` directory for now and clean them up as you go.
+  Substitute that path for `/tmp` everywhere above — the `VACUUM INTO` target,
+  the checksum, and the source of the copy down. The `/tmp` in step 3 is your
+  own machine's and stays as it is.
 
 **2. Rehearse it locally first**, following
 [`space-clone-rehearsal.md`](space-clone-rehearsal.md): clone, serve, run


### PR DESCRIPTION
## Why

Two findings on #6648, which merged before they could be worked off. One is a
defect in the merged document; the other is a place where the document is right
but does not show its work, which is why a careful reviewer read it as wrong.

**The estuary note contradicted the commands it annotates.** Step 1 writes and
checksums `/tmp/<did>.sqlite`, and the note added beneath it says estuary has no
room in `/tmp` and that snapshots go to `/data/memory`. An operator following
both writes the snapshot to one path and checksums another, which does not
error — `sha256sum` simply reports on whatever `/tmp` happens to hold, or
nothing. The note now says to substitute the path in the commands above it, and
names the one `/tmp` that stays as it is (step 3's, which is the operator's own
machine).

**The single-file store path is stated without the composition that produces
it.** `resolveMemoryEngineStoreRootUrl` and `resolveSpaceStoreUrl` each build
`<stem>.engine-v3`, so reading them separately says the directory is
`<stem>.engine-v3/`. The server does not compose them that way: it is
constructed with the root the first returns (`store: memoryEngineStoreUrl`,
`packages/toolshed/routes/storage/memory.ts`), so the second sees `.engine-v3`
as *that root's* extension and appends its own. For `DB_PATH=/data/cf.sqlite`
the per-space files land in `/data/cf..engine-v3/`, two dots:

```
server store root : /data/cf.engine-v3/
per-space dir     : /data/cf..engine-v3/
per-space file    : /data/cf..engine-v3/did%3Akey%3Az6MkTest.sqlite
```

The document keeps the two dots and now names the composition, so a reader who
checks the parts and gets a different answer knows why.

## What Changed

- The estuary note tells the reader which paths to substitute, and which not to.
- The single-file paragraph gains the worked path and the reason the second dot
  is there.

## Test plan

Documentation only. `check-docs`, `docs-links --orphan` and
`check-control-characters` pass locally; the path shapes above are the output of
running the two resolvers as `memory.ts` composes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9AuQyGnkkGPPnt4DQWnpc

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

