### PR TITLE
fix(runner): compare CFC label views structurally, not as JSON text

### DIFF
--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,5 +1,6 @@
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 import { encodePointer } from "../../../memory/v2/path.ts";
 import type { CfcConfClause } from "./clause.ts";
@@ -309,12 +310,25 @@ export const rebaseCfcLabelView = (
   ]);
 };
 
+/**
+ * Whether two label views carry the same labels.
+ *
+ * `cloneCfcLabelView` puts each side into canonical form: logical paths, entry
+ * order, empty labels dropped, and a view left holding nothing reduced to
+ * `undefined`. `deepEqual` then compares what remains property by property, so
+ * an atom written `{type, subject}` equals the same atom written
+ * `{subject, type}`. That is the reading `uniqueCfcAtoms` gives atoms on the
+ * merge path, where a fabric-converted clone of an atom is the same atom.
+ *
+ * The clause list and the integrity set are compared IN ORDER. That matches
+ * `canonicalizeCfcLabel`, which reorders the alternatives inside an OR-clause
+ * and leaves those two lists as they were given, so this answer stays aligned
+ * with the persist-side idempotence check in `prepare.ts` that deep-equals
+ * canonicalized metadata.
+ */
 export const cfcLabelViewsEqual = (
   left: CfcLabelView | undefined,
   right: CfcLabelView | undefined,
-): boolean => {
-  if (left === right) return true;
-  if (left === undefined || right === undefined) return false;
-  return JSON.stringify(cloneCfcLabelView(left)) ===
-    JSON.stringify(cloneCfcLabelView(right));
-};
+): boolean =>
+  left === right ||
+  deepEqual(cloneCfcLabelView(left), cloneCfcLabelView(right));

--- a/packages/runner/test/cfcLabelViewsEqual.test.ts
+++ b/packages/runner/test/cfcLabelViewsEqual.test.ts
@@ -1,0 +1,130 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import type { CfcConfClause } from "../src/cfc/clause.ts";
+import {
+  type CfcLabelView,
+  cfcLabelViewsEqual,
+} from "../src/cfc/label-view-core.ts";
+
+const USER_TYPE = "https://commonfabric.org/cfc/atom/User";
+
+const viewWith = (
+  confidentiality: readonly CfcConfClause[],
+): CfcLabelView => ({
+  version: 1,
+  entries: [{
+    path: ["body"],
+    label: { confidentiality: [...confidentiality] },
+  }],
+});
+
+describe("cfcLabelViewsEqual()", () => {
+  it("returns `true` for one atom written with its properties in either order", () => {
+    // Atoms are plain objects built at many call sites, and a mint that
+    // spreads its optional fields ahead of `type` writes the same atom in a
+    // different property order from one that writes `type` first. Both
+    // spellings name one principal, which is the reading `uniqueCfcAtoms`
+    // gives them when the merge path dedupes.
+
+    const left = viewWith([{ type: USER_TYPE, subject: "did:key:z6Mk" }]);
+    const right = viewWith([{ subject: "did:key:z6Mk", type: USER_TYPE }]);
+    expect(cfcLabelViewsEqual(left, right)).toBe(true);
+  });
+
+  it("returns `true` for one atom nested inside an OR-clause in either property order", () => {
+    const left = viewWith([{
+      anyOf: [{ type: USER_TYPE, subject: "A" }],
+    }]);
+    const right = viewWith([{
+      anyOf: [{ subject: "A", type: USER_TYPE }],
+    }]);
+    expect(cfcLabelViewsEqual(left, right)).toBe(true);
+  });
+
+  it("returns `false` for atoms that differ in a property value", () => {
+    const left = viewWith([{ type: USER_TYPE, subject: "A" }]);
+    const right = viewWith([{ subject: "B", type: USER_TYPE }]);
+    expect(cfcLabelViewsEqual(left, right)).toBe(false);
+  });
+
+  it("returns `false` for atoms that differ in which properties they carry", () => {
+    const left = viewWith([{ type: USER_TYPE, subject: "A" }]);
+    const right = viewWith([{ type: USER_TYPE, subject: "A", scope: "s" }]);
+    expect(cfcLabelViewsEqual(left, right)).toBe(false);
+  });
+
+  it("returns `false` for the same clauses listed in a different order", () => {
+    // The clause list is a conjunction whose order canonicalization leaves
+    // alone (`canonicalizeCfcLabel`), so two orderings are two forms and the
+    // persist-side idempotence check in `prepare.ts` separates them too.
+
+    const a = { type: USER_TYPE, subject: "A" };
+    const b = { type: USER_TYPE, subject: "B" };
+    expect(cfcLabelViewsEqual(viewWith([a, b]), viewWith([b, a]))).toBe(false);
+  });
+
+  it("returns `true` for the same entries listed in a different order", () => {
+    const entryA = {
+      path: ["a"],
+      label: { confidentiality: [{ type: USER_TYPE, subject: "A" }] },
+    };
+    const entryB = {
+      path: ["b"],
+      label: { integrity: [{ type: USER_TYPE, subject: "B" }] },
+    };
+    expect(cfcLabelViewsEqual(
+      { version: 1, entries: [entryA, entryB] },
+      { version: 1, entries: [entryB, entryA] },
+    )).toBe(true);
+  });
+
+  it("returns `true` for a logical path spelled with and without its `value` root", () => {
+    expect(cfcLabelViewsEqual(
+      {
+        version: 1,
+        entries: [{ path: ["value", "body"], label: { integrity: ["t"] } }],
+      },
+      {
+        version: 1,
+        entries: [{ path: ["body"], label: { integrity: ["t"] } }],
+      },
+    )).toBe(true);
+  });
+
+  it("returns `true` for `undefined` and a view whose entries all canonicalize away", () => {
+    expect(cfcLabelViewsEqual(undefined, { version: 1, entries: [] })).toBe(
+      true,
+    );
+    expect(cfcLabelViewsEqual(
+      { version: 1, entries: [{ path: ["body"], label: { integrity: [] } }] },
+      undefined,
+    )).toBe(true);
+  });
+
+  it("returns `false` for a labeled view against no view at all", () => {
+    expect(cfcLabelViewsEqual(viewWith(["prompt-influenced"]), undefined))
+      .toBe(false);
+  });
+
+  it("returns `false` for the same label under different observation classes", () => {
+    expect(cfcLabelViewsEqual(
+      {
+        version: 1,
+        entries: [{
+          path: ["a"],
+          label: { integrity: ["t"] },
+          observes: "value",
+        }],
+      },
+      {
+        version: 1,
+        entries: [{
+          path: ["a"],
+          label: { integrity: ["t"] },
+          observes: "shape",
+        }],
+      },
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
`cfcLabelViewsEqual` decided whether two label views carry the same labels by serializing each side and comparing the two strings. That made the answer depend on the property order inside the CFC atoms held in the label value arrays. Atoms are plain objects built at many call sites: `cfcAtom.user()` writes `type` first, while the mints that spread an options object -- `cfcAtom.caveatScreened()` and its neighbors -- write it last. So two atoms naming one thing can be spelled in two property orders, and the serializing comparison then called the whole view different.

The rest of the CFC subsystem already settles atoms structurally. `uniqueCfcAtoms` dedupes with `deepEqual`, and its comment says why: a fabric-converted clone of an atom is a fresh object, so a reference-keyed dedup would leave duplicates behind. `mergeLabel` and `normalizeClause` both run their atoms through it. This one equality check was the exception.

Compare with the same `deepEqual` instead. `cloneCfcLabelView` keeps its place ahead of the comparison, because it canonicalizes what `deepEqual` does not: it drops the `value` root from each logical path, sorts the entries, drops empty labels, and reduces a view left holding nothing to `undefined`.

The clause list and the integrity set are still compared in order. That matches `canonicalizeCfcLabel`, which reorders the alternatives inside an OR-clause and leaves those two lists as they were given. The persist-side idempotence check in `prepare.ts` deep-equals canonicalized metadata the same way, and sorting here would part the two answers.

One thing changes beyond atom spelling. The guard returning `false` when exactly one side is `undefined` is gone, so a view whose entries all canonicalize away now equals no view at all. That was already the answer for two such views, since both canonicalize to `undefined`; the guard made it depend on how the caller spelled "no labels".

Where this reaches: `CellHandle[$onCellUpdate]` uses the result to decide whether a label-only delivery is a change its subscribers hear about, and `cellRefsEqual` -- reached from `applyValue` and from the public `CellHandle.equals()` -- to decide whether a cell reference names the cell a handle already holds. A false "not equal" costs a redundant subscriber notification in the first, and in the second a discarded handle plus the notification that follows, or two handles on one cell reporting themselves unequal. Both sides of both comparisons come from `cfcLabelViewForCell`, which merges the cell's own stored metadata with a linked document's and with any carried view, so two documents would have to spell one atom two ways for the orders to diverge. I found no case where that happens today, so this is a consistency fix rather than a repair of an observed failure.

The new test file covers the function on its own. Against the serializing comparison, three of its cases fail: an atom spelled in two property orders, the same inside an OR-clause, and `undefined` against a view that canonicalizes away.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

