### PR TITLE
style: bound each doc comment below as well as above, across the remainder

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -312,6 +312,7 @@ export interface IWritable<T, C extends AnyBrandedCell<any>> {
    * concurrent increments sum against durable state rather than clobber.
    */
   increment(this: IsThisNumber, by?: number): void;
+
   remove(
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
@@ -326,6 +327,7 @@ export interface IWritable<T, C extends AnyBrandedCell<any>> {
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
   ): void;
+
   removeAll(
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
@@ -469,6 +471,7 @@ export interface IKeyable<out T, Wrap extends HKT> {
     k1: K1,
     k2: K2,
   ): Apply<Wrap, T[K1][K2]>;
+
   // Three keys
   key<
     K1 extends keyof T,
@@ -691,6 +694,7 @@ export interface IKeyableOpaque<T> {
     k1: K1,
     k2: K2,
   ): OpaqueCell<UnwrapCell<T>[K1][K2]>;
+
   key<
     K1 extends keyof UnwrapCell<T>,
     K2 extends keyof UnwrapCell<T>[K1],
@@ -1110,6 +1114,7 @@ export declare const Cell: CellTypeConstructor<AsCell>;
  * all data in patterns is reactive by default, whether wrapped or not.
  */
 export type Writable<T = unknown> = Cell<T>;
+
 export declare const Writable: CellTypeConstructor<AsCell>;
 
 /**
@@ -1256,6 +1261,7 @@ export type Reactive<T> = T;
 type CellWrappedValue<T> = AnyBrandedCell<CellWrappedData<T>> & {
   [CELL_LIKE]?: unknown;
 };
+
 export type CellLike<T> = CellWrappedValue<T> | T;
 type CellWrappedData<T> =
   | T
@@ -1995,6 +2001,7 @@ export type BuiltInGenerateObjectParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   }
   | {
@@ -2024,6 +2031,7 @@ export type BuiltInGenerateObjectParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   };
 
@@ -2050,6 +2058,7 @@ export type BuiltInGenerateTextParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   }
   | {
@@ -2074,6 +2083,7 @@ export type BuiltInGenerateTextParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   };
 
@@ -2097,6 +2107,7 @@ export interface BuiltInCompileAndRunParams<T> {
    * reads one with `dataFile()`; nothing compiles, imports, or transforms it.
    */
   dataFiles?: string[];
+
   input?: T;
 }
 
@@ -2898,12 +2909,14 @@ export interface CfSqliteHelpers {
 
   /** The db's owner (fixed, from the db ref — never the acting reader). */
   dbOwner(): unknown;
+
   endorsedBy(p: unknown): unknown;
   authoredBy(p: unknown): unknown;
 
   /** A literal atom (escape hatch). */
   constant(atom: unknown): unknown;
 }
+
 export type SqliteCfLinkFunction = <_T = unknown>() => JSONSchema;
 
 export type WishTag = `/${string}` | `#${string}`;
@@ -3301,6 +3314,7 @@ export declare const uiVariant: UIVariantFunction;
 
 /** @deprecated Use generateText() or generateObject() instead */
 export declare const llm: LLMFunction;
+
 export declare const llmDialog: LLMDialogFunction;
 export declare const generateObject: GenerateObjectFunction;
 export declare const generateText: GenerateTextFunction;
@@ -3330,10 +3344,12 @@ export declare const wish: WishFunction;
 export declare const multiUserTest: <T extends MultiUserTestDescriptor>(
   descriptor: T,
 ) => T;
+
 export declare const createNodeFactory: CreateNodeFactoryFunction;
 
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];
+
 export declare const equals: EqualsFunction;
 export declare const valueEqual: ValueEqualFunction;
 export declare const byRef: ByRefFunction;
@@ -3379,6 +3395,7 @@ export declare function UiDisclosure(props: UiDisclosureProps): JSXElement;
 export type GetEntityIdFunction = (
   value: any,
 ) => { "/": string } | FabricHash | undefined;
+
 export declare const getEntityId: GetEntityIdFunction;
 
 /**
@@ -3389,6 +3406,7 @@ export declare const getEntityId: GetEntityIdFunction;
 export type EntityRefToStringFunction = (
   value: { "/": string } | FabricHash,
 ) => string;
+
 export declare const entityRefToString: EntityRefToStringFunction;
 
 export declare const schema: SchemaFunction;

--- a/packages/background-piece-service/src/space-manager.ts
+++ b/packages/background-piece-service/src/space-manager.ts
@@ -35,6 +35,7 @@ export class SpaceManager {
    * drives this member directly.
    */
   private activePiece: Cell<BGPieceEntry> | null = null;
+
   #deactivationTimeoutMs: number;
 
   /**
@@ -42,6 +43,7 @@ export class SpaceManager {
    * drives this member directly.
    */
   private workerController!: WorkerController;
+
   #rerunIntervalMs: number;
 
   /**
@@ -55,6 +57,7 @@ export class SpaceManager {
    * drives this member directly.
    */
   private failureTracking = new Map<string, number>();
+
   #workerOptions: WorkerOptions;
 
   /**

--- a/packages/background-piece-service/src/worker-controller.ts
+++ b/packages/background-piece-service/src/worker-controller.ts
@@ -69,6 +69,7 @@ export class WorkerController extends EventTarget {
 
   /** Promise that resolves when the worker is fully initialized. */
   public initializeResolve = this.#initializeDeferred.promise;
+
   #state = WorkerState.Uninitialized;
 
   constructor(options: WorkerOptions) {

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -21,6 +21,7 @@ export type InitializationData = {
    * out of everything it logs, and it redacts by name.
    */
   encodedIdentity: RealmEncodedValue;
+
   experimental?: {
     modernCellRep?: boolean;
   };

--- a/packages/connectors/agents/connector/src/types.ts
+++ b/packages/connectors/agents/connector/src/types.ts
@@ -36,6 +36,7 @@ export interface SourceDescriptor {
   /** Trimmed, lowercase source identity used by commands and by the records
    * stored in the fabric. */
   id: string;
+
   driver: DriverKind;
   version?: string;
   capabilities: DriverCapabilities;

--- a/packages/connectors/agents/connector/src/types.ts
+++ b/packages/connectors/agents/connector/src/types.ts
@@ -36,7 +36,6 @@ export interface SourceDescriptor {
   /** Trimmed, lowercase source identity used by commands and by the records
    * stored in the fabric. */
   id: string;
-
   driver: DriverKind;
   version?: string;
   capabilities: DriverCapabilities;

--- a/packages/dashboard/test-records-history.ts
+++ b/packages/dashboard/test-records-history.ts
@@ -40,6 +40,7 @@ export interface DayAggregate {
 
   /** "yyyy/mm/dd". */
   day: string;
+
   runs: number;
   failures: number;
   skips: number;

--- a/packages/dashboard/test/stream-client.test.ts
+++ b/packages/dashboard/test/stream-client.test.ts
@@ -13,6 +13,7 @@ interface FakeStream extends UpdateStream {
 interface Fixture {
   /** Every stream the page has opened, oldest first. */
   opened: FakeStream[];
+
   current(): FakeStream;
   heard(now: number): void;
   lost(): void;

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -67,6 +67,7 @@ export interface ProxyStream {
   write(buffer: Uint8Array): Promise<number>;
   close(): void;
 }
+
 type OpenProxyStream = (
   options: Deno.ConnectOptions,
 ) => Promise<ProxyStream>;

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -254,6 +254,7 @@ export interface SourceWritePath {
 
   /** Relative path within .src/, e.g. "main.tsx" or "utils/helper.tsx". */
   relPath: string;
+
   piece: PieceController;
 
   /** Inode of the .src/ directory (for error.log lookups). */
@@ -288,6 +289,7 @@ export interface SpaceState {
 
   /** Per-piece subscription cancellers, keyed by piece name. */
   pieceSubs: Map<string, Cancel[]>;
+
   did: string;
   unsubscribes: Cancel[];
 
@@ -371,6 +373,7 @@ export class CellBridge {
 
   /** Callback for kernel cache invalidation (set by mod.ts after mount). */
   onInvalidate: InvalidateCallback | null = null;
+
   onInvalidateInode: InvalidateInodeCallback | null = null;
   #identity: string = "";
   #apiUrl: string = "";
@@ -446,6 +449,7 @@ export class CellBridge {
 
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
   #pendingHydrations = new Map<string, Promise<boolean>>();
+
   #pendingPropRebuildQueues = new Map<string, Promise<void>>();
 
   /** Monotonic invalidation epoch per hydration key. */
@@ -456,6 +460,7 @@ export class CellBridge {
    * cleared when the result switches back to the default result/ tree.
    */
   #fsProjectionEntries: Map<bigint, Set<string>> = new Map();
+
   #cfcAnnotationsEnabled = false;
   #explicitCfcProjectionGeneration: string | undefined;
   #statusProvider: (() => Record<string, unknown>) | undefined;
@@ -473,6 +478,7 @@ export class CellBridge {
    * Reconnection is attempted automatically with exponential backoff.
    */
   private _disconnected = false;
+
   #disconnectCount = 0;
   #lastDisconnectReason: string | null = null;
 

--- a/packages/fuse/mount-options.ts
+++ b/packages/fuse/mount-options.ts
@@ -10,6 +10,7 @@ import type { FuseProvider } from "./platform.ts";
  * caching untouched) or one second to one day.
  */
 export const ATTRCACHE_TIMEOUT_MIN_SECONDS = 0;
+
 export const ATTRCACHE_TIMEOUT_MAX_SECONDS = 86_400;
 
 /**

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -299,6 +299,7 @@ interface JsonTreeBuild {
    * waiting rather than every node it has passed.
    */
   readonly queue: (BuildJsonTreeTask | undefined)[];
+
   nextIndex: number;
   rootIno?: bigint;
 }

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -81,6 +81,7 @@ export class FsTree {
    * member directly.
    */
   private cfcEntryIndexes = new Map<bigint, Map<string, number>>();
+
   #unsortedCfcEntryDirectories = new Set<bigint>();
   #nextIno = 2n;
   #now: () => number;

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -84,6 +84,7 @@ export class DomApplicator {
 
   /** Children tracking: parentId → Set<childId> for O(n) descendant cleanup */
   readonly #nodeChildren = new Map<number, Set<number>>();
+
   readonly #document: Document;
   readonly #onEvent: (message: DomEventMessage) => void;
   readonly #runtimeClient?: RuntimeClient;

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -82,6 +82,7 @@ import {
 
 /** Sentinel key in propSubscriptions for the Cell<Props> subscription itself. */
 const CELL_PROPS_KEY = "__cellProps__";
+
 const CFC_RENDER_BOUNDARY_TAG = "cf-cfc-render-boundary";
 const CFC_AUTHORSHIP_TAG = "cf-cfc-authorship";
 const CFC_BLOCKED_PLACEHOLDER_TAG = "cf-cfc-blocked";

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -174,6 +174,7 @@ export type BridgeResolvedCell = {
   hasValue: true;
   /** Operations the host authorizes on this resolved capability. */
   operations?: string[];
+
   identity?: BridgeCellIdentity;
   value?: FabricValue;
 };

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -299,6 +299,7 @@ export interface TypeScriptCompilerOptions {
    * directive.
    */
   storedSource?: boolean;
+
   // Optional mapping of runtime module name e.g. `"@commonfabric/framework"`,
   // and its corresponding type definitions.
   runtimeModules?: string[];
@@ -309,6 +310,7 @@ export interface TypeScriptCompilerOptions {
    * cannot resolve. The target must be a file in the program.
    */
   specifierAliases?: ReadonlyMap<string, string>;
+
   // Transformations to run before JS transforms.
   // Can return either an array of transformer factories (simple case)
   // or a TransformerPipelineResult with factories and getDiagnostics.

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -127,6 +127,7 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * worker. Spaces absent from the map resolve to `apiUrl`, the default host.
    */
   spaceHostMap?: Record<string, string>;
+
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
 
@@ -146,6 +147,7 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * (H3b) is not implemented.
    */
   cfcRenderCeiling?: boolean;
+
   trustSnapshot?: RuntimeTrustSnapshot | null;
 
   /**
@@ -182,6 +184,7 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * fall back to `/scripts/worker-runtime.js`.
    */
   workerUrl?: URL;
+
   getBuildHash?: () => Promise<string | undefined>;
 
   /**
@@ -199,6 +202,7 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
  * Cached at module level — the hash doesn't change within a page session.
  */
 let buildHashPromise: Promise<string | undefined> | undefined;
+
 export function fetchBuildHash(): Promise<string | undefined> {
   if (!buildHashPromise) {
     buildHashPromise = (async () => {

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -90,6 +90,7 @@ export type LLMToolResult = {
  * drops such a key, so it never crosses the boundary and is not checked.
  */
 export type LLMRequestMetadata = Record<string, JSONValue | undefined>;
+
 export type LLMRequest = {
   cache?: boolean;
   messages: readonly BuiltInLLMMessage[];

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -270,6 +270,7 @@ export function subscribeEventAttentionNotifications(
  * value that survives is smaller than the number here.
  */
 const MAX_CONSOLE_DEBUG_DEPTH = 7;
+
 const blobUploadCodec = newDefaultJsonCodecEngine();
 
 /** Each registered logger's enabled state and level. */

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -134,6 +134,7 @@ export interface InitializedRuntimeConnection extends RuntimeConnection {}
 export interface VDomConnection {
   /** The connection's lifetime signal; aborts on disposal. */
   readonly signal: AbortSignal;
+
   mount(
     mountId: number,
     cellRef: CellRef,

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -484,6 +484,7 @@ export enum NotificationType {
 
   /** Reports a new operation-backed snapshot for a subscription. */
   OperationUpdate = "operation:update",
+
   /** Reports one authoritative terminal event-delivery notice. */
   EventNeedsAttention = "callback:event-needs-attention",
 }
@@ -897,6 +898,7 @@ export type CellSetRequest = BaseRequest & {
    * The value to store, whole and already resolved.
    */
   value: FabricValue;
+
   /** Wait for commit confirmation and return a refusal to the caller. */
   awaitCommit?: boolean;
 };
@@ -937,6 +939,7 @@ export type CellSendRequest = BaseRequest & {
    * The event to deliver.
    */
   event: FabricValue;
+
   /** Wait for commit confirmation and return a refusal to the caller. */
   awaitCommit?: boolean;
 };
@@ -1238,6 +1241,7 @@ export type SqliteExecRequest = BaseRequest & {
   /** What to bind the statement's placeholders to. Absent binds nothing. */
   params?: SqliteParams;
 };
+
 /**
  * The {@link RequestType.GetCell} request. `cause` is what derives the
  * cell: the same space and cause always name the same one.
@@ -2605,6 +2609,7 @@ import type {
   SerializedEvent as SerializedDomEvent,
   SerializedEventTarget,
 } from "@commonfabric/html/events";
+
 export type { SerializedDomEvent, SerializedEventTarget };
 
 /**
@@ -2909,6 +2914,7 @@ export type CellUpdateNotification = {
    * The cell that changed.
    */
   cell: CellRef;
+
   /** Its new value, as {@link CellValueResponse} carries the pulled form. */
   value: FabricValue;
 
@@ -3138,6 +3144,7 @@ export type WorkerConsoleNotification = {
  * different things.
  */
 import type { VDomOp } from "@commonfabric/html/vdom-ops";
+
 export type { VDomOp };
 
 /**

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -35,6 +35,7 @@ const CELL_LIKE_WRAPPER_NAMES = spellingsWhere({
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });
+
 const OPAQUE_WRAPPER_NAMES = spellingsWhere({
   OpaqueCell: true,
   Cell: false,

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -60,6 +60,7 @@ type CalculatorRequest = {
   /** The mathematical expression to evaluate. */
   expression: string;
 };`;
+
       const { type, checker, typeNode } = await getTypeFromCode(
         code,
         "CalculatorRequest",

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -8,6 +8,7 @@ declare global {
     detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
     /** Changes memory-message compression for live and later connections. */
     setMemoryMessageCompression?: (enabled: boolean) => Promise<void>;
+
     watchWrites?: (
       options?:
         | {

--- a/packages/shell/src/lib/device-link-login.ts
+++ b/packages/shell/src/lib/device-link-login.ts
@@ -174,6 +174,7 @@ export async function handleDeviceLink(
      * and picks the new key up directly.
      */
     reloadOnReplace?: boolean;
+
     reload?: () => void;
     report?: (reason: DeviceLinkFailure) => Promise<void>;
     login?: (entropy: Uint8Array) => Promise<DeviceLinkOutcome>;

--- a/packages/shell/src/lib/device-link.ts
+++ b/packages/shell/src/lib/device-link.ts
@@ -42,6 +42,7 @@ const DEVICE_LINK_PREFIX = "#k=";
 
 /** 32 bytes of BIP39 entropy is exactly 43 unpadded base64url characters. */
 const ENCODED_LENGTH = 43;
+
 const ENTROPY_BYTES = 32;
 
 const ENCODED_PATTERN = new RegExp(`^[A-Za-z0-9_-]{${ENCODED_LENGTH}}$`);

--- a/packages/shell/src/lib/otel.ts
+++ b/packages/shell/src/lib/otel.ts
@@ -27,6 +27,7 @@ const SERVICE_VERSION = "1.0.0";
 export interface InitBrowserOtelOptions {
   /** Same-origin (by default) toolshed API base; the OTLP proxy lives under it. */
   apiUrl: URL | string;
+
   userDid: string;
   spaceDid: string;
   environment: string;

--- a/packages/spec-model/server-execution/model.ts
+++ b/packages/spec-model/server-execution/model.ts
@@ -34,19 +34,25 @@ export interface Acting {
 }
 
 /**
- * Scope-key constructors — RESTATED from the real wire vocabulary
- * (`packages/memory/v2.ts`: `resolveScopeKey` /
- * `resolvePrincipalSessionKey`), never imported (model.ts stays
- * import-free). The real constructor encodeURIComponent-encodes each
- * component, so the literal `:` separators split segments exactly and
- * construction is INJECTIVE for `:`-bearing principals (DIDs) and
- * arbitrary session ids — un-encoded interpolation would collide
- * `("a:b","c")` with `("a","b:c")`. The conformance bridge test in
- * properties.test.ts asserts byte-agreement with the real vocabulary.
+ * Encodes one component of the scope keys constructed below — RESTATED from
+ * the real wire vocabulary (`packages/memory/v2.ts`: `resolveScopeKey` /
+ * `resolvePrincipalSessionKey`), never imported (model.ts stays import-free).
+ * The real constructor encodeURIComponent-encodes each component, so the
+ * literal `:` separators split segments exactly and construction is INJECTIVE
+ * for `:`-bearing principals (DIDs) and arbitrary session ids — un-encoded
+ * interpolation would collide `("a:b","c")` with `("a","b:c")`. The
+ * conformance bridge test in properties.test.ts asserts byte-agreement with
+ * the real vocabulary.
  */
 const encodeKeyPart = (value: string): string => encodeURIComponent(value);
+
+/** The space scope's key, which takes no component. */
 export const SPACE_KEY = "space";
+
+/** The per-user scope's key constructor. */
 export const userKey = (u: UserId): string => `user:${encodeKeyPart(u)}`;
+
+/** The per-session scope's key constructor. */
 export const sessionKey = (u: UserId, s: SessionId): string =>
   `session:${encodeKeyPart(u)}:${encodeKeyPart(s)}`;
 
@@ -144,6 +150,7 @@ export interface CommitRecord {
 
   /** "session:<u>:<s>" for client commits; "service:<space>" else. */
   envelope: string;
+
   holder?: string;
   derivedThrough?: number;
   consequenceOf?: EventId[];
@@ -180,6 +187,7 @@ export interface SpaceState {
 
   /** sessionKey -> intents (the effects doc's per-session instance). */
   effects: Record<string, Intent[]>;
+
   W: number;
   commits: CommitRecord[];
   leaseHolder: string | null;
@@ -191,6 +199,7 @@ export interface SpaceState {
   /** per-doc-instance head seq — what the wave commit CASes
    * against (serving-loop §3d). */
   docHeads: Record<string, number>;
+
   derivations: DerivationSpec[];
 
   /** FP1 (RULED): pending cross-space appends as DURABLE rows,
@@ -239,6 +248,7 @@ export interface EventContribution {
 
   /** null for cascade entries minted this wave (seq at commit). */
   entrySeq: number | null;
+
   parent?: EventId;
   writes: WriteRow[];
   cascadesSame: Array<{
@@ -265,10 +275,12 @@ export interface PendingWave {
 
   /** store seq at compute start — the wave's read basis. */
   basisSeq: number;
+
   contributions: EventContribution[];
 
   /** re-derivable derivation outputs (drop class, §3d). */
   pureWrites: WriteRow[];
+
   exhausted: boolean;
 }
 
@@ -291,11 +303,13 @@ export interface World {
 
   /** chain root per event (audit-only; inheritance ground truth). */
   rootOf: Record<EventId, Acting>;
+
   nextEvent: number;
   nextNonce: number;
 
   /** spec-breach detections (must stay empty on legal schedules). */
   violations: string[];
+
   trace: string[];
 
   /** config: split every wave commit in two (serving-loop §3). */
@@ -1227,6 +1241,7 @@ export interface FanoutState {
   /** Every run, as `action × instance` (serving-loop §3c): one entry
    * per RUN with the single instance it ran as and wrote. */
   runs: Array<{ instanceKey: string; wrote: string }>;
+
   violations: string[];
 }
 

--- a/packages/state-inspector/churn.ts
+++ b/packages/state-inspector/churn.ts
@@ -27,6 +27,7 @@ export interface ChurnBucket {
 
   /** Unix seconds for the bucket start — for plotting without re-parsing. */
   startEpoch: number;
+
   commits: number;
   revisions: number;
 }
@@ -43,8 +44,10 @@ export interface ChurnReport {
   bucketSeconds: number;
   branch: string;
 
-  /** First and last bucket start the curve covers (null on an empty window). */
+  /** First bucket start the curve covers; null on an empty window. */
   from: string | null;
+
+  /** Last such bucket start, null under the same condition. */
   to: string | null;
 
   /**
@@ -56,6 +59,7 @@ export interface ChurnReport {
    * without this they render identically.
    */
   lastCommit: string | null;
+
   totals: { commits: number; revisions: number };
 
   /**

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -50,6 +50,7 @@ export interface Writer {
 
   /** The writer's identity (principal DID parsed from the session). */
   principal?: string;
+
   op: string;
   createdAt: string;
 }
@@ -66,6 +67,7 @@ export interface ContendedEntity {
 
   /** True when ≥2 distinct identities wrote it (multi-user, not multi-session). */
   multiUser: boolean;
+
   writes: number;
 
   /** Writer timeline, seq-ordered. */
@@ -187,6 +189,7 @@ export function contendedEntities(
 export interface StaleRead {
   /** The commit that read the entity. */
   readerCommitSeq: number;
+
   readerSession: string;
 
   /** The seq the reader saw the entity at. */
@@ -203,6 +206,7 @@ export interface StaleRead {
 
   /** A conflicting write the engine's own check would have rejected. */
   missedWriteSeq: number;
+
   missedWriteSession: string;
 
   /** The op of the conflicting write (`set`/`delete` always conflict; `patch`
@@ -220,6 +224,7 @@ export interface EntityConflicts {
 
   /** Distinct writer identities — `>=2` is real cross-user contention. */
   writerPrincipals: number;
+
   multiUser: boolean;
   interleaved: boolean;
 

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -45,10 +45,12 @@ export interface LinkRef {
 
   /** Resolved label of the target (if in this space). */
   label?: string;
+
   kind?: EntityKind;
 
   /** Cross-space target space DID. */
   space?: string;
+
   path?: string[];
 
   /** True when the target is in another space (not resolvable locally). */
@@ -93,15 +95,18 @@ export interface EntityDetail {
 
   /** Top-level document paths present (the control plane). */
   paths: string[];
+
   valueShape: string;
 
   /** The annotated value (links/streams normalized; depth-bounded). */
   value: unknown;
+
   valuePreview: string;
 
   /** The result JSONSchema (annotated), if the entity carries one. Streams and
    * named owned cells get their DECLARED schema resolved from the owner piece. */
   schema?: unknown;
+
   schemaKeys?: string[];
 
   /** Where `schema` came from when it isn't the entity's own (e.g. owner piece). */
@@ -115,6 +120,7 @@ export interface EntityDetail {
 
   /** Parsed CFC labels from the `cfc` meta path, if present. */
   cfc?: CfcSummary;
+
   revisions: number;
   headSeq: number | null;
   firstSeq: number | null;
@@ -289,6 +295,7 @@ interface DetailContext {
 
   /** entityId → { ownerId, key } naming it in its owner piece's value. */
   nameOf: Map<string, { owner: string; key: string }>;
+
   moduleIndex: Map<string, ModuleEntry>;
   docs: Map<string, EntityDocument>;
 }
@@ -475,6 +482,7 @@ function roleFor(kind: EntityKind, owned: boolean): string {
 export interface DetailListing {
   /** The entities detailed, at most `extent.limit` of them. */
   details: EntityDetail[];
+
   extent: ScanExtent;
 }
 

--- a/packages/state-inspector/discover.ts
+++ b/packages/state-inspector/discover.ts
@@ -30,6 +30,7 @@ export async function deriveSpaceDid(name: string): Promise<string> {
 export interface DiscoveredSpace {
   /** Space DID (DB file basename without `.sqlite`). */
   did: string;
+
   path: string;
   sizeBytes: number;
   mtimeMs: number;

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -39,6 +39,7 @@ export interface GraphNode {
 
   /** The bare entity id (for display / navigation); equals `id` for local nodes. */
   entityId: string;
+
   kind: EntityKind;
   label: string;
 

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -51,6 +51,7 @@ export interface SpaceSignals {
 
   /** All cross-space link target space DIDs (space ≠ self). */
   crossSpaceDids: string[];
+
   commits: number;
   entities: number;
 }
@@ -209,6 +210,7 @@ export interface GroupedSpace {
 
   /** Present but with zero commits — a pre-created placeholder. */
   empty: boolean;
+
   commits?: number;
   entities?: number;
 
@@ -222,6 +224,7 @@ export interface SpaceGroup {
 
   /** A non-empty home space was found locally for the principal. */
   homePresent: boolean;
+
   spaces: GroupedSpace[];
 }
 

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -38,11 +38,13 @@ export interface InspectorBundle {
 
   /** Base origin of the live shell, for deep links (`<base>/<space>/<id>`). */
   liveBase: string;
+
   summary: SpaceSummary;
   details: EntityDetail[];
 
   /** How far the entity scan behind `details` and `graph` reached. */
   extent: ScanExtent;
+
   graph: SpaceGraph;
   timeline: SpaceTimelineEntry[];
 

--- a/packages/state-inspector/identity.ts
+++ b/packages/state-inspector/identity.ts
@@ -31,6 +31,7 @@ export interface IdentitySpace {
 
   /** Total per-user + per-session entities this identity has here. */
   scopedEntities: number;
+
   evidence: string[];
 }
 
@@ -39,6 +40,7 @@ export interface IdentityWorld {
 
   /** A non-empty home space exists locally for this identity. */
   homePresent: boolean;
+
   spaces: IdentitySpace[];
   totals: {
     spaces: number;
@@ -46,6 +48,7 @@ export interface IdentityWorld {
 
     /** Spaces where this identity has per-user/session state. */
     spacesWithScopedState: number;
+
     scopedEntities: number;
   };
 }

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -165,6 +165,7 @@ export interface EntityModel {
 
   /** Top-level paths present in the document (the control plane, sorted). */
   paths: string[];
+
   valueShape: ValueShape;
   lineage: Lineage;
   revisions?: number;
@@ -722,6 +723,7 @@ function patternIdentityOf(
 export interface EntityListing {
   /** The entities modeled, at most `extent.limit` of them. */
   entities: EntityModel[];
+
   extent: ScanExtent;
 }
 
@@ -933,6 +935,7 @@ export interface PieceCellRef {
 
   /** Classified kind of the owned cell (stream / schema / owned-cell / …). */
   kind: EntityKind;
+
   label: string;
   summary: string;
 }

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -41,6 +41,7 @@ import {
 export interface SpaceRef {
   /** Display label — usually the space DID (DB file basename). */
   label: string;
+
   space: SpaceDb;
 }
 
@@ -120,6 +121,7 @@ export interface CrossSpaceLinkIndex {
 
   /** `${toSpace} ${toId}` for every entity referenced cross-space. */
   targets: Set<string>;
+
   examinedEntities: number;
 }
 
@@ -443,6 +445,7 @@ export interface ScanOptions {
 export interface ScanResult {
   /** Entity ids present in >= 2 spaces. */
   sharedEntities: number;
+
   examined: number;
   examineCapped: boolean;
 
@@ -454,6 +457,7 @@ export interface ScanResult {
 
   /** Findings labeled no-cross-space-link (likely independent instances). */
   unlinkedFindings: number;
+
   findings: ConvergenceResult[];
 }
 
@@ -461,6 +465,7 @@ export interface ScanResult {
 export interface ExactScanResult extends Omit<ScanResult, "findings"> {
   /** Findings whose values could not all be reconstructed. */
   unknownFindings: number;
+
   findings: ExactConvergenceResult[];
 }
 

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -15,6 +15,7 @@ export interface SpaceSummary {
 
   /** Scheduler basis rows (0 even when the table exists empty). */
   schedulerBasisRows: number;
+
   commits: number;
   commitSeqRange: [number, number] | null;
   sessions: number;

--- a/packages/state-inspector/remote.ts
+++ b/packages/state-inspector/remote.ts
@@ -14,6 +14,7 @@ const DUMP_PATH = "/api/storage/memory/dump";
 export interface RemoteSpace {
   /** Canonical space DID. */
   space: string;
+
   sizeBytes: number;
   mtimeMs: number;
 }

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -41,6 +41,7 @@ export type ScopeKind = "space" | "user" | "session" | "other";
 export interface Scope {
   /** The raw scope_key as stored (often %-encoded). */
   raw: string;
+
   kind: ScopeKind;
 
   /** Owning principal DID (user/session scopes). */
@@ -48,6 +49,7 @@ export interface Scope {
 
   /** Session uuid (session scopes). */
   sessionId?: string;
+
   entities: number;
   revisions: number;
 }
@@ -154,6 +156,7 @@ export interface IdentityValue {
 
   /** The scope the value resolved from (the most specific that held the id). */
   resolvedScope?: string;
+
   resolvedKind?: ScopeKind;
   value?: unknown;
 

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -35,6 +35,7 @@ import {
 
 /** Annotation depth used for values included in diff output. */
 const COMPARE_DEPTH = 32;
+
 const DEFAULT_DIFF_DEPTH = 12;
 
 export type ChangeKind = "added" | "removed" | "changed";
@@ -60,6 +61,7 @@ export interface ValueChange {
 
   /** Exact path segments, e.g. `["value", "items", "0"]`. */
   pathSegments?: string[];
+
   kind: ChangeKind;
   before?: unknown;
   after?: unknown;

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -734,6 +734,7 @@ export interface IWritable<T, C extends AnyBrandedCell<any>> {
    * concurrent increments sum against durable state rather than clobber.
    */
   increment(this: IsThisNumber, by?: number): void;
+
   remove(
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
@@ -748,6 +749,7 @@ export interface IWritable<T, C extends AnyBrandedCell<any>> {
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
   ): void;
+
   removeAll(
     this: IsThisArray,
     ref: T extends (infer U)[] ? (U | AnyBrandedCell<U>) : never,
@@ -891,6 +893,7 @@ export interface IKeyable<out T, Wrap extends HKT> {
     k1: K1,
     k2: K2,
   ): Apply<Wrap, T[K1][K2]>;
+
   // Three keys
   key<
     K1 extends keyof T,
@@ -1113,6 +1116,7 @@ export interface IKeyableOpaque<T> {
     k1: K1,
     k2: K2,
   ): OpaqueCell<UnwrapCell<T>[K1][K2]>;
+
   key<
     K1 extends keyof UnwrapCell<T>,
     K2 extends keyof UnwrapCell<T>[K1],
@@ -1532,6 +1536,7 @@ export declare const Cell: CellTypeConstructor<AsCell>;
  * all data in patterns is reactive by default, whether wrapped or not.
  */
 export type Writable<T = unknown> = Cell<T>;
+
 export declare const Writable: CellTypeConstructor<AsCell>;
 
 /**
@@ -1678,6 +1683,7 @@ export type Reactive<T> = T;
 type CellWrappedValue<T> = AnyBrandedCell<CellWrappedData<T>> & {
   [CELL_LIKE]?: unknown;
 };
+
 export type CellLike<T> = CellWrappedValue<T> | T;
 type CellWrappedData<T> =
   | T
@@ -2417,6 +2423,7 @@ export type BuiltInGenerateObjectParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   }
   | {
@@ -2446,6 +2453,7 @@ export type BuiltInGenerateObjectParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   };
 
@@ -2472,6 +2480,7 @@ export type BuiltInGenerateTextParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   }
   | {
@@ -2496,6 +2505,7 @@ export type BuiltInGenerateTextParams =
      * `search: true` is the friendly shorthand for `["google_search"]`.
      */
     nativeModelToolIds?: readonly string[];
+
     queue?: string;
   };
 
@@ -2519,6 +2529,7 @@ export interface BuiltInCompileAndRunParams<T> {
    * reads one with `dataFile()`; nothing compiles, imports, or transforms it.
    */
   dataFiles?: string[];
+
   input?: T;
 }
 
@@ -3320,12 +3331,14 @@ export interface CfSqliteHelpers {
 
   /** The db's owner (fixed, from the db ref — never the acting reader). */
   dbOwner(): unknown;
+
   endorsedBy(p: unknown): unknown;
   authoredBy(p: unknown): unknown;
 
   /** A literal atom (escape hatch). */
   constant(atom: unknown): unknown;
 }
+
 export type SqliteCfLinkFunction = <_T = unknown>() => JSONSchema;
 
 export type WishTag = `/${string}` | `#${string}`;
@@ -3723,6 +3736,7 @@ export declare const uiVariant: UIVariantFunction;
 
 /** @deprecated Use generateText() or generateObject() instead */
 export declare const llm: LLMFunction;
+
 export declare const llmDialog: LLMDialogFunction;
 export declare const generateObject: GenerateObjectFunction;
 export declare const generateText: GenerateTextFunction;
@@ -3752,10 +3766,12 @@ export declare const wish: WishFunction;
 export declare const multiUserTest: <T extends MultiUserTestDescriptor>(
   descriptor: T,
 ) => T;
+
 export declare const createNodeFactory: CreateNodeFactoryFunction;
 
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];
+
 export declare const equals: EqualsFunction;
 export declare const valueEqual: ValueEqualFunction;
 export declare const byRef: ByRefFunction;
@@ -3801,6 +3817,7 @@ export declare function UiDisclosure(props: UiDisclosureProps): JSXElement;
 export type GetEntityIdFunction = (
   value: any,
 ) => { "/": string } | FabricHash | undefined;
+
 export declare const getEntityId: GetEntityIdFunction;
 
 /**
@@ -3811,6 +3828,7 @@ export declare const getEntityId: GetEntityIdFunction;
 export type EntityRefToStringFunction = (
   value: { "/": string } | FabricHash,
 ) => string;
+
 export declare const entityRefToString: EntityRefToStringFunction;
 
 export declare const schema: SchemaFunction;

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -77,6 +77,7 @@ export function serverExecutionPolicyFromEnv(
    * prefixes of those). */
   const strictNonNegativeInt = (raw: string): number | undefined =>
     /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : undefined;
+
   const readRaw = (name: string): string | undefined => {
     const raw = envGet(name);
     return raw === undefined || raw === "" ? undefined : raw;
@@ -96,6 +97,7 @@ export function serverExecutionPolicyFromEnv(
     }
     return value;
   };
+
   const flushDeadlineMs = positiveOrDefault(
     "SERVER_EXECUTION_FLUSH_DEADLINE_MS",
   );
@@ -167,6 +169,7 @@ export function startServerExecutionHost(options: {
 
   /** The patterns/compile base — the serving runtimes' `apiUrl`. */
   apiUrl: URL;
+
   envGet?: EnvReader;
 }): ExecutorHost | undefined {
   const envGet = options.envGet ?? Deno.env.get;

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.utils.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.utils.ts
@@ -103,6 +103,7 @@ export interface ControlDeps {
 
   /** The toolshed's own space — where registrations live. */
   serviceSpace: string;
+
   operatorDid: string;
   serviceDids: readonly string[];
   hostsSpace: (space: string) => boolean;
@@ -112,6 +113,7 @@ export interface ControlDeps {
 
   /** Overridable so a test can reach the cap without minting the whole limit. */
   maxChannelsPerOwner?: number;
+
   maxLifetimeChannelsPerOwner?: number;
   maxLifetimeChannelsPerSpace?: number;
   apiUrl: string;

--- a/packages/toolshed/routes/ingest/ingest.utils.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.ts
@@ -93,6 +93,7 @@ export const containsLink = (value: unknown): boolean => {
   }
   return false;
 };
+
 export const isValidPartition = isValidSegment;
 
 export interface IngestRegistration {
@@ -115,6 +116,7 @@ export interface IngestRegistration {
    * stream-channel id can never silently be given journal semantics here.
    */
   sink: "journal";
+
   secretHash: string;
 
   /**
@@ -129,6 +131,7 @@ export interface IngestRegistration {
    * proof-of-possession, so nothing leaks to a guesser.
    */
   previousSecretHash?: string;
+
   createdBy: string;
   createdAt: string;
   enabled: boolean;

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.types.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.types.ts
@@ -7,6 +7,7 @@ import type { JSONSchema } from "@commonfabric/runner";
 export interface OAuth2ProviderConfig {
   /** Short lowercase name: "google", "airtable" */
   name: string;
+
   clientId: string;
   clientSecret: string;
   authorizationEndpointUri: string;

--- a/scripts/ab-harness.ts
+++ b/scripts/ab-harness.ts
@@ -30,6 +30,7 @@
  * is the comparison, not any single run.
  */
 const ROOT = Deno.env.get("CF_ROOT");
+
 if (!ROOT) {
   console.error("set CF_ROOT to a checkout root");
   Deno.exit(2);
@@ -73,6 +74,7 @@ const { dataUriFromValue } = await import(
 
 /** Identity on a tree with no preflight, so the same probe runs on both. */
 let flatten: (v: unknown) => unknown = (v) => v;
+
 try {
   flatten = (await import(`${R}/storage-preflight.ts`)).flattenBuilderArtifacts;
 } catch { /* baseline */ }

--- a/scripts/topics-export.test.ts
+++ b/scripts/topics-export.test.ts
@@ -67,6 +67,7 @@ const COMMENT = "of:fid1:comment";
 
 /** A stored link, in the sigil form the engine writes. */
 const link = (id: string) => ({ "/": { "link@1": { id } } });
+
 const stream = { $stream: true };
 
 /** The comment body an element of `comments` points at, never inlines. */

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -2,6 +2,7 @@
  * live halves are exercised by the rehearsal drill
  * (`packages/cli/integration/topics-restore-drill.sh`). */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import {
   buildRestoreDocument,

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -265,6 +265,7 @@ export const STRUCTURAL_LINK_SOURCES: Record<string, string> = {
   mentionable: "topics",
   boardCrossrefs: "crossrefs",
 };
+
 export const STRUCTURAL_LINK_FIELDS = Object.keys(STRUCTURAL_LINK_SOURCES);
 export const LEGACY_LINK_FIELDS = ["myName"] as const;
 

--- a/scripts/topics-snapshot-lib.test.ts
+++ b/scripts/topics-snapshot-lib.test.ts
@@ -4,6 +4,7 @@
  * out of the shared lib's test file makes the boundary visible where someone
  * would otherwise reintroduce it. */
 import { describe, it } from "@std/testing/bdd";
+
 import { expect } from "@std/expect";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { argumentIdOf } from "./topics-snapshot-lib.ts";

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -41,13 +41,19 @@ interface Bucket {
   path: string;
   depth: number;
 
-  /** Spans recorded at this exact path. */
+  /** How many spans were recorded at this exact path. */
   own: number;
+
+  /** How long those spans took, summed. */
   ownTime: number;
 
-  /** Spans recorded at this path or anywhere beneath it. */
+  /** How many spans were recorded at this path or anywhere beneath it. */
   calls: number;
+
+  /** How long those spans took, summed. */
   time: number;
+
+  /** The buckets one level beneath this one, by path segment. */
   children: Map<string, Bucket>;
 }
 
@@ -57,6 +63,7 @@ interface Bucket {
  * away — see `attribute-measures.ts --detail` for reading it.
  */
 const MEASURE_PREFIX = "cf:";
+
 function keyOf(name: string): string {
   const body = name.startsWith(MEASURE_PREFIX)
     ? name.slice(MEASURE_PREFIX.length)

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -27,6 +27,7 @@ export interface MeasureEntry {
 export interface Span {
   /** The logger key, with the uniquifying suffix removed. */
   key: string;
+
   start: number;
   end: number;
   parent: number;

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -216,6 +216,7 @@ export async function documentedCommands(
 export interface CommandDocReport {
   /** Commands no live document names and no allowance covers. */
   readonly undocumented: string[];
+
   /** Allowances naming a command the tree no longer accepts. */
   readonly staleAllowance: string[];
 }

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -53,6 +53,7 @@ function twoMeaningsTree() {
 function reportFor(known: {
   /** Option name -> the commands its provider answers on, `null` for all. */
   providerOptions?: Record<string, readonly string[] | null>;
+
   providerArguments?: string[];
   enumerated?: string[];
   allowedOptions?: string[];

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -220,6 +220,7 @@ export function reportSlots(
      * where it answers on every command declaring the option.
      */
     readonly providerOptions: ReadonlyMap<string, readonly string[] | null>;
+
     readonly providerArguments: ReadonlySet<string>;
     readonly enumerated: ReadonlySet<string>;
     readonly allowedOptions: ReadonlySet<string>;

--- a/tasks/check-package-cycles.ts
+++ b/tasks/check-package-cycles.ts
@@ -392,6 +392,7 @@ export interface ScanResult {
 
   /** Allowlist entries that no longer describe a cycle in the tree. */
   readonly resolved: AllowedCycle[];
+
   readonly edges: readonly Edge[];
 }
 

--- a/tasks/check-skill-facts.ts
+++ b/tasks/check-skill-facts.ts
@@ -236,6 +236,7 @@ function resolvesExport(exports: unknown, key: string): boolean {
 export interface SkillDoc {
   /** Repo-relative path, e.g. "skills/cf-review/SKILL.md". */
   path: string;
+
   text: string;
 }
 
@@ -246,6 +247,7 @@ export interface Drift {
 
   /** 1-based line within that doc. */
   line: number;
+
   message: string;
 }
 
@@ -277,6 +279,7 @@ export function skillDirOf(docPath: string): string {
  * PascalCase and dots (e.g. data-model/SchemaAndHash).
  */
 const SPECIFIER_RE = /(@commonfabric\/[a-z0-9-]+)((?:\/[\w.-]+)*)/g;
+
 const BACKTICKED_RE = /`([^`\n]+)`/g;
 
 /**

--- a/tasks/check-unused-deps.ts
+++ b/tasks/check-unused-deps.ts
@@ -181,6 +181,7 @@ export function parseWorkspaceMembers(rootConfigText: string): string[] {
 interface SourceFile {
   /** The owning workspace member, or undefined when under none. */
   owner: string | undefined;
+
   content: string;
 }
 
@@ -261,6 +262,7 @@ interface Entry {
 
   /** The declaring member, or undefined for the root config. */
   member: string | undefined;
+
   alias: string;
   specifier: string;
 }

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -15,6 +15,7 @@ export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
 /** Where the repository is hosted; a workflow run names it. */
 export const SERVER_URL = Deno.env.get("GITHUB_SERVER_URL") ??
   "https://github.com";
+
 export const TOKEN = Deno.env.get("GITHUB_TOKEN");
 export const WORKFLOW_FILE = "deno.yml";
 
@@ -29,6 +30,8 @@ export const WORKFLOW_FILE = "deno.yml";
  * in the identical JSON shape, so it reads as a valid baseline unchanged.
  */
 export const PERF_METRICS_ARTIFACT_NAME = "perf-metrics";
+
+/** The file inside that artifact. */
 export const PERF_METRICS_FILE = "perf-metrics.json";
 
 /**
@@ -37,6 +40,7 @@ export const PERF_METRICS_FILE = "perf-metrics.json";
  * contains one JSON file matching {@link CacheStateRecord}.
  */
 export const CACHE_STATE_ARTIFACT_PREFIX = "cache-state-";
+
 export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
 export const COVERAGE_BASELINE_RESET_MARKER = "NEW_COVERAGE_BASELINE";
 
@@ -53,6 +57,8 @@ export const COVERAGE_SUGGESTION_MARKER = "<!-- coverage-debt-suggestion -->";
  * up and posts it with a write token from the base-repo context.
  */
 export const COVERAGE_COMMENT_ARTIFACT_NAME = "coverage-comment";
+
+/** The file inside that artifact. */
 export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
 
 /**
@@ -86,6 +92,7 @@ export interface CoverageCommentPayload {
    * changed group's debt was accepted with a per-group acceptance or the reset
    * marker, not because the new code is covered. */
   overridden?: boolean;
+
   /** Present when `overridden` is set: the files holding the uncovered lines
    * the acceptance covers for. */
   files?: CoverageSuggestionFileLines[];

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -1492,9 +1492,13 @@ async function walk(
   return { lines, read };
 }
 
-/** Three `main` runs, newest first, along the ancestry `RANKS` describes. */
+/** The newest of three `main` runs along the ancestry `RANKS` describes. */
 const RUN_AT_BASE = makeRun(3, SHA_C, "2026-08-04T10:40:00Z");
+
+/** The one before it. */
 const RUN_ONE_BACK = makeRun(2, SHA_B, "2026-08-04T10:20:00Z");
+
+/** The one before that. */
 const RUN_TWO_BACK = makeRun(1, SHA_A, "2026-08-04T10:00:00Z");
 
 Deno.test("walkBaselineRuns prefers the base-branch commit's own run", async () => {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -564,6 +564,7 @@ export interface SelectBaselinesOptions {
 
   /** Reads one baseline run; called only for the runs the walk reaches. */
   readRun: (run: WorkflowRun) => Promise<BaselineRunReading>;
+
   isPullRequest: boolean;
   readBaseSha?: () => Promise<string | null>;
   fetchRanks?: (baseSha: string) => Promise<Map<string, number>>;
@@ -574,6 +575,7 @@ export interface SelectBaselinesOptions {
 
   /** Wraps the GitHub calls made here so a rate limit skips the check. */
   guard?: <T>(description: string, operation: () => Promise<T>) => Promise<T>;
+
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }
@@ -1171,6 +1173,7 @@ export interface Row {
    * `main` commit whose code the measurement covers.
    */
   baseSha?: string;
+
   pctIncrease?: number;
 }
 
@@ -1513,12 +1516,14 @@ function measurementFromFailures(failures: Row[]): CoverageMeasurement {
 export interface UnattributedRegressionOptions {
   /** Repository checkout whose source files the LCOV reports describe. */
   rootDir: string;
+
   groups: CoverageSuggestionGroup[];
   coverageFailures: Row[];
   prFiles: PRFile[];
 
   /** LCOV from this run. */
   lcov: string;
+
   readBaselineLcov: (runId: number) => Promise<string | null>;
 }
 

--- a/tasks/pattern-files.ts
+++ b/tasks/pattern-files.ts
@@ -15,8 +15,10 @@ export const PATTERNS_DIR = "packages/patterns";
 export interface PatternTree {
   /** Repository-relative directory containing the source modules. */
   readonly directory: string;
+
   /** Baseline-key prefix when the source tree is outside `PATTERNS_DIR`. */
   readonly keyPrefix?: string;
+
   /** Program root allowed to resolve the tree's local imports. */
   readonly programRoot?: string;
 }

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -479,6 +479,7 @@ export interface ReplayFailure {
 
   /** Repo-relative fixture path. */
   path: string;
+
   detail: string;
 }
 

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -104,6 +104,7 @@ const MOVED_KEY = HEALTHY.replace(".for('items')", ".for('itemList')");
  * only the default export.
  */
 const NESTED_KEY = "vintage-gate-nested.tsx";
+
 const NESTED_TEST_KEY = NESTED_KEY.replace(/\.tsx$/, ".test.tsx");
 
 const nestedSource = (extra: { field?: string; line?: string } = {}) =>
@@ -256,6 +257,7 @@ const NESTED_ROW_ARGS_TIGHTENED = nestedSource()
  * witness a moved storage key.
  */
 const UNDECLARED_KEY = "vintage-gate-undeclared.tsx";
+
 const UNDECLARED_TEST_KEY = UNDECLARED_KEY.replace(/\.tsx$/, ".test.tsx");
 
 const undeclaredSource = (storageKey: string, trailer = "") =>
@@ -326,6 +328,7 @@ const undeclaredTest = [
  * required result without a default (the compatible output-evolution case).
  */
 const CROSS_KEY = "vintage-gate-crossspace.tsx";
+
 const CROSS_TEST_KEY = CROSS_KEY.replace(/\.tsx$/, ".test.tsx");
 
 /**

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -311,6 +311,7 @@ export interface ReplayReport {
    * cell's cause-stability (the moved-`.for()` class) gated.
    */
   capturesSuperseded: string[];
+
   failures: ReplayFailure[];
 }
 
@@ -360,6 +361,7 @@ export async function replayVintage(
         .map((e) => patternKeyFromMain(e.main, patternsPrefix(roots)))
         .filter((key): key is string => key !== undefined),
     );
+
   // Stated once, because every "this fixture is not usable" message needs it and
   // the obvious remedy is WRONG: `--update` skips a key that already has a
   // pinned vintage and the capture refuses to overwrite one, so "recapture it"
@@ -992,6 +994,7 @@ export async function replayAll(
      * it — a superseded stored argument, or a hoist no longer emitted.
      */
     capturesSuperseded: string[];
+
     failures: ReplayFailure[];
   }
 > {

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -286,6 +286,7 @@ export interface CompactOptions {
 
   /** Required unless plan is set. */
   token?: string;
+
   fetchImpl?: typeof fetch;
   now?: number;
 }

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -170,10 +170,12 @@ interface StubOptions {
 
   /** One page of runs per listing call; the last repeats. */
   runPages?: Record<string, unknown>[][];
+
   runsStatus?: number;
 
   /** GitHub's clock, as the runs listing reports it. */
   listDate?: string;
+
   artifacts?: { id: number; name: string; expired?: boolean }[];
   artifactStatus?: number;
   zip?: Uint8Array;

--- a/tasks/vintage-adopt.ts
+++ b/tasks/vintage-adopt.ts
@@ -86,10 +86,12 @@ export interface AdoptOptions {
    * `patternIdentity`; each `main` is validated like the root's.
    */
   children?: readonly { cellId: string; main: string }[];
+
   roots: AdoptRoots;
 
   /** Capture stamp; injectable so a test is deterministic. */
   now?: Date;
+
   log?: (line: string) => void;
 }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Finishes "The blank line below" (#6633) outside `packages/patterns`: **193 blank
lines across 69 files** in `state-inspector`, `tasks`, `toolshed`, `spec-model`,
`fuse`, `shell`, `runtime-client`, `api`, `scripts`, `skills`, and the rest of
the tail.

### Seven comments described more than they sat on

- **`ci-check-lib.ts`, twice** — "the per-run artifact **and file**" and
  "artifact **and file** the coverage gate writes", each over the two constants
  naming them.
- **`coverage-check.test.ts`** — "Three `main` runs, newest first" over three
  constants.
- **`churn.ts`** — "First and last bucket start the curve covers" over `from`
  and `to`.
- **`aggregate-measures.ts`, twice** — "Spans recorded at this exact path" over
  the count and the time alike, and the same again for the subtree pair.
- **`spec-model/model.ts`** — headed the scope-key *constructors* from above
  `encodeKeyPart`, the helper they share. Read closely, the comment is about the
  encoding and its injectivity, so it stays on `encodeKeyPart` and now says so;
  the three constructors take their own.

### Two more detector bugs, both caught by the formatter

`deno fmt --check` refused two insertions, and both were real defects in the
tool rather than in the rule:

- A **conditional expression's arms**. `cond ? {...} : {...}` returns bracket
  depth to zero at the end of the first arm, so a blank line went in before the
  `:`.
- A **type parameter list opened by `async <`**. The angle counter deliberately
  requires `<` to sit directly against an identifier, which is what tells a type
  argument list from a comparison — and `async <T,>(...)` has a space there. The
  list is now recognized from its members instead.

Worth noting as a property of this sweep: the formatter is a real safety net
here. Every earlier batch passed `deno fmt --check`, so no batch carries a
mis-insertion of this kind.

### Two pre-existing failures, verified as such

- `packages/iframe-sandbox` — a `deno-web-test` browser-harness timeout.
- `tasks/demo.test.ts` — "default demo dependencies provide time, preflight, and
  subprocess".

Both fail identically on clean `main` with these changes stashed, and this PR
touches neither file's code. Everything else is green: `state-inspector` 111,
`toolshed` 146, `fuse` 372, `spec-model` 23, `shell` 57, `schema-generator` 57,
`html` 26, `runtime-client` 16, `js-compiler` 15, `api` 27,
`background-piece-service` 14, `llm` 7, `lib-shell` 5, and `tasks` 646 passed
with only the pre-existing failure above.

### Excluded

Four files that #6635 also rewrites (`state-inspector/clone.ts`,
`state-inspector/test/scan-extent.test.ts`, `tasks/lint-bench-console.test.ts`,
`data-model-schema/src/schema-intern.ts`). They get a follow-up once it lands.

Every change is comment or whitespace only, verified by diffing both revisions
with comments and blank lines stripped: no file's code differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

