### PR TITLE
docs(runner): three comments that also covered the declarations beneath them

### DIFF
--- a/packages/runner/src/executor/engine-wave-sink.ts
+++ b/packages/runner/src/executor/engine-wave-sink.ts
@@ -143,6 +143,7 @@ export class EngineWaveCommitSink implements WaveCommitSink {
      * The SpaceServer passes the DR1 holder identity. */
     sessionId: string;
 
+    /** The identity that session acts as, where the caller names one. */
     principal?: string;
 
     /** The shared, process-lifetime localSeq counter (see the

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1035,7 +1035,10 @@ export interface CachedCompiledModule {
    */
   exportNames?: readonly string[];
 
+  /** The `export *` target specifiers of that same surface. */
   starTargetSpecs?: readonly string[];
+
+  /** The runtime import specifiers of that same surface. */
   importSpecs?: readonly string[];
 
   /**

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -105,11 +105,16 @@ export type ReplayLatencySample = {
   selector: number;
   docId: string;
 
-  /** Counter deltas for this single invocation. */
+  /** Schema-call delta for this single invocation. */
   schemaCalls: number;
 
+  /** `anyOf`-branch delta over the same invocation. */
   anyOfBranches: number;
+
+  /** DAG-call delta over the same invocation. */
   dagCalls: number;
+
+  /** Pointer-call delta over the same invocation. */
   pointerCalls: number;
 };
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Three comments in `packages/runner` that describe several declarations while
binding to one — the same class @danfuzz caught on #6650's `cf-render.ts`, here
in work already landed by #6639. Bounding such a comment is right as far as it
goes and incomplete: the members it also covered are left bare.

- **`module-record-compiler.ts`** names all three parts of the precomputed
  record surface — "the module's direct export names, `export *` target
  specifiers, and runtime import specifiers ... written all-or-nothing (all
  three present, or none)" — from above `exportNames` alone.
- **`replay.ts`** said "Counter deltas for this single invocation" over four
  counters.
- **`engine-wave-sink.ts`** ends its session comment on "the DR1 holder
  identity" the SpaceServer passes, which is the `principal` beneath it.

### How they were found

The wording net used for the earlier batches looks for a plural at the *head* of
a comment, and the run-length net wants two or more undocumented followers.
Neither sees "Client coordinates of the click" over `x` and `y`. The net that
does: a plural or conjunction anywhere in the comment's **first sentence**, plus
a following declaration that is undocumented and **shares its type** — which is
what a pair usually has in common. Run over the whole tree it cut 328 raw
candidates to 44 worth reading; these three are `runner`'s.

### Checks

`deno fmt --check` and `deno lint` clean. `deno task test` in `packages/runner`
passes. Every change is comment-only, verified by diffing both revisions with
comments and blank lines stripped: no file's code differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

