### PR TITLE
fix(ui): an index row's piece is reached by address, never through its value

### DIFF
--- a/docs/common/conventions/mentionable.md
+++ b/docs/common/conventions/mentionable.md
@@ -48,6 +48,23 @@ Mentionables are one deliberate way to make an unregistered child discoverable.
 They do not provide a complete piece listing and cannot expose an orphan. See
 [Finding Pieces](../concepts/piece-discovery.md).
 
+### Index rows, and the reserved `piece` key
+
+A `mentionable` list may hold the pieces themselves — the examples above —
+or derived INDEX ROWS standing for them: entries shaped `{ [NAME], piece }`,
+where the strings are the row's own copies and `piece` holds the actual
+piece as a reference. A board-sized producer reaches for rows so that every
+reader of the universe loads one document instead of every listed piece;
+the Topics board's `mentionable` is the worked example
+(`TopicMentionableRow` in `packages/patterns/topics/main.tsx`).
+
+`piece` is therefore a RESERVED key on this contract: an entry carrying one
+IS a row, and the editors store what `piece` names — never the entry — as
+the mention's destination. A producer must not publish an unrelated
+property named `piece` on its mentionable entries; doing so silently
+redirects every mention of that entry. How consumers resolve rows is in
+[`mentionable-internals.md`](../../../packages/ui/docs/mentionable-internals.md).
+
 ## Wishing for Mentionables
 
 Patterns can discover mentionables in the current space using `wish()`:

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -285,8 +285,9 @@ const crossrefTable = lift(
 
 /**
  * One row of the board's mention index: the display name the editor's
- * autocomplete lists, the title it matches on, and the topic itself held as
- * a reference.
+ * autocomplete lists and matches on, the title for readers that select it
+ * (the editors do not — their schema reads `[NAME]` and `piece` alone),
+ * and the topic itself held as a reference.
  *
  * The two strings are COPIES, and the copies are the design rather than a
  * shortcut. The autocomplete needs every row's strings just to open, so a
@@ -466,8 +467,8 @@ export interface TopicsOutput {
 export const submitProfileTopic = handler<void, {
   topics: Writable<TopicDemand[] | Default<[]>>;
 
-  /** Declared at the child's own demand — the two strings its editor lists
-   * and matches on — so the board's index rows and a plain list of pieces
+  /** Declared at the child's own demand — the two strings a universe
+   * entry carries — so the board's index rows and a plain list of pieces
    * both satisfy it. */
   mentionable: Writable<TopicMentionable[] | Default<[]>>;
 

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -332,7 +332,9 @@ export interface TopicCrossrefRow {
 
 /**
  * What the body editor's `@`-mention autocomplete needs of a mention
- * universe entry: the display name it lists, and the title it matches on.
+ * universe entry: the display name it lists and matches on, and the title
+ * — the persisted scalar other readers of the universe select, though the
+ * editor's own schema does not.
  *
  * `[NAME]` is not decoration here. `cf-code-editor` declares its entries as
  * `Mentionable`, whose schema carries `required: [NAME]`

--- a/packages/ui/docs/mentionable-internals.md
+++ b/packages/ui/docs/mentionable-internals.md
@@ -59,6 +59,34 @@ pieceIds, and `mentionIdFromCellId` (`src/v2/utils/mention-id.ts`) for wiki-link
 embeds — the latter throws on `computed:` ids, which the bare embed format
 cannot represent.
 
+For an index row, the resolution goes through `key("piece")` instead of the
+entry itself — the sub-cell names the row. See the next section.
+
+### Index rows: the `piece` indirection
+
+An entry may be a derived index ROW standing for its piece rather than the piece
+itself: `{ [NAME]: string, piece: <reference> }`. `piece` is a reserved key on
+the open `Mentionable` contract — the producer-facing rule is in
+[`docs/common/conventions/mentionable.md`](../../../docs/common/conventions/mentionable.md).
+The row's own strings serve display and matching; `piece` names the destination
+a mention stores.
+
+Two rules govern reaching it, and both come from the client boundary:
+
+- **Detect by KEY, never by value.** An `asCell` position crosses the
+  runtime-client boundary as an empty object, so `entry.piece` in a `.get()`
+  value is `{}` — it carries no handle and no data. The presence of the key is
+  what marks a row.
+- **Reach by ADDRESS, asynchronously.** `entry.key("piece").resolveAsCell()`
+  follows the stored link to the piece's own cell. There is no synchronous road
+  to a row's piece, so the completion surfaces WITHHOLD an unresolved row rather
+  than mint an id that names the row; resolution starts when the list binds, so
+  the window is the resolve round trips.
+
+Both consumers route destinations this way: `cf-code-editor`'s
+`_resolvePieceIds` (cached per index, generation-guarded against late passes)
+and `MentionController`'s `_destinationOf` (per encode and decode).
+
 ## Link Formats
 
 The system uses three link formats for mentions, depending on context:

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -354,30 +354,40 @@ describe("CFCodeEditor pasted-mention decision", () => {
 describe("CFCodeEditor mention-piece resolution", () => {
   // The private resolution surface under test. `piece`-bearing entries are
   // index rows standing for their piece; entries without one ARE the piece.
+  // A row's piece is stored as a LINK, and its value crosses the client
+  // boundary as an empty object — so the fixtures store raw `$link`
+  // sigils, and the mock network's resolveAsCell follows them, exactly as
+  // the runtime does. Nothing here reaches a piece through a value.
   type ResolutionInternals = {
     mentionable: CellHandle<MentionableArray> | null;
     _resolvePieceIds(): Promise<void>;
     _resolvedPieceCells: Map<number, CellHandle<Mentionable>>;
     _getPieceId(index: number): string;
     findPieceById(id: string): CellHandle<Mentionable> | null;
+    getFilteredMentionable(query: string): Array<[unknown, number]>;
   };
 
   const internals = (element: CFCodeEditor): ResolutionInternals =>
     element as unknown as ResolutionInternals;
 
-  const pieceRef = { id: "of:target-piece" } as Partial<CellRef>;
+  const pieceLink = {
+    "$link": { id: "of:target-piece", path: [] },
+  };
 
   it("resolves a piece-bearing entry to its piece", async () => {
     const element = internals(new CFCodeEditor());
-    const piece = createMockCellHandle({ title: "Target" }, pieceRef);
+    const target = createMockCellHandle(
+      { title: "Target" },
+      { id: "of:target-piece" } as Partial<CellRef>,
+    );
     element.mentionable = createMockCellHandle([
-      { [NAME]: "Row", title: "Row", piece },
+      { [NAME]: "Row", title: "Row", piece: pieceLink },
     ]) as unknown as CellHandle<MentionableArray>;
 
     await element._resolvePieceIds();
 
     const resolved = element._resolvedPieceCells.get(0);
-    expect(resolved?.id()).toBe(piece.id());
+    expect(resolved?.id()).toBe(target.id());
   });
 
   it("resolves an entry without a piece to the entry itself", async () => {
@@ -391,61 +401,66 @@ describe("CFCodeEditor mention-piece resolution", () => {
     expect(resolved?.id()).toBe(list.key(0).id());
   });
 
-  it("finds a row's piece before resolution lands", () => {
-    // Nothing resolved yet: the id and the returned cell both come from the
-    // row's hydrated piece, never from the row's own sub-cell.
+  it("withholds an index row until its piece resolves", async () => {
+    // Before resolution a row has no usable identity — its sub-cell names
+    // the row, and no id beats a wrong one — so the completion surfaces
+    // exclude it and its id is empty. Resolution restores all three.
     const element = internals(new CFCodeEditor());
-    const piece = createMockCellHandle({ title: "Target" }, pieceRef);
+    const target = createMockCellHandle(
+      { title: "Target" },
+      { id: "of:target-piece" } as Partial<CellRef>,
+    );
     element.mentionable = createMockCellHandle([
-      { [NAME]: "Row", title: "Row", piece },
+      { [NAME]: "Row", title: "Row", piece: pieceLink },
     ]) as unknown as CellHandle<MentionableArray>;
 
+    expect(element.getFilteredMentionable("")).toEqual([]);
+    expect(element._getPieceId(0)).toBe("");
+
+    await element._resolvePieceIds();
+
+    expect(element.getFilteredMentionable("").length).toBe(1);
     const found = element.findPieceById(element._getPieceId(0));
-    expect(found?.id()).toBe(piece.id());
+    expect(found?.id()).toBe(target.id());
   });
 
   it("keeps the newer resolution when an older pass finishes late", async () => {
     // The mentionable HANDLE stays identical when its contents change, so an
     // older pass that resolves slowly can finish after a newer one. The
-    // slow pass here is gated open only once the fast pass has published;
-    // what the caches hold at the end decides the race.
+    // slow pass is gated open only once the fast pass has published; what
+    // the caches hold at the end decides the race. Plain entries, so the
+    // gate can ride the sub-cell the pass resolves.
     const element = internals(new CFCodeEditor());
-    const slow = createMockCellHandle(
-      { title: "Slow" },
-      { id: "of:slow-piece" } as Partial<CellRef>,
-    );
-    const fast = createMockCellHandle(
-      { title: "Fast" },
-      { id: "of:fast-piece" } as Partial<CellRef>,
-    );
+    const list = createMockCellHandle([{ [NAME]: "Slow" }], {
+      id: "of:race-list" as CellRef["id"],
+    });
     let release!: () => void;
     const gate = new Promise<void>((resolve) => (release = resolve));
-    // The resolution path reads the piece through an `asSchema` copy, so the
-    // gate has to ride the copy: an override on `slow` itself would be left
-    // behind by the copy and the "slow" pass would resolve instantly.
-    const realResolve = slow.resolveAsCell.bind(slow);
-    const realAsSchema = slow.asSchema.bind(slow);
-    slow.asSchema = ((schema: never) => {
-      const copy = realAsSchema(schema);
-      copy.resolveAsCell = (async () => {
-        await gate;
-        return await realResolve();
-      }) as typeof copy.resolveAsCell;
-      return copy;
-    }) as typeof slow.asSchema;
+    let armed = true;
+    const realKey = list.key.bind(list);
+    list.key = ((k: PropertyKey) => {
+      const child = realKey(k as never);
+      if (armed && String(k) === "0") {
+        const realResolve = child.resolveAsCell.bind(child);
+        child.resolveAsCell = (async () => {
+          await gate;
+          return await realResolve();
+        }) as typeof child.resolveAsCell;
+      }
+      return child;
+    }) as typeof list.key;
 
-    const list = createMockCellHandle([
-      { [NAME]: "Row", title: "Row", piece: slow },
-    ]);
     element.mentionable = list as unknown as CellHandle<MentionableArray>;
     const older = element._resolvePieceIds();
 
-    list.set([{ [NAME]: "Row", title: "Row", piece: fast }]);
+    armed = false;
+    list.set([{ [NAME]: "Fast" }]);
     await element._resolvePieceIds();
-    expect(element._resolvedPieceCells.get(0)?.id()).toBe(fast.id());
+    const fastId = element._resolvedPieceCells.get(0)?.id();
+    expect(fastId).toBeDefined();
 
     release();
     await older;
-    expect(element._resolvedPieceCells.get(0)?.id()).toBe(fast.id());
+    expect(element._resolvedPieceCells.get(0)?.id()).toBe(fastId);
   });
 });

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -581,6 +581,11 @@ export class CFCodeEditor extends BaseElement {
 
     for (let i = 0; i < mentionableData.length; i++) {
       const mention = mentionableData[i];
+      // An index row is withheld until its piece resolves: a completion
+      // taken from it before then could only persist an id naming the row.
+      // Resolution starts when the list binds, so the window is the round
+      // trips of `_resolvePieceIds`, not something a user waits on.
+      if (this._isIndexRow(i) && !this._resolvedPieceIds.has(i)) continue;
       if (
         mention &&
         mention[NAME]
@@ -609,6 +614,9 @@ export class CFCodeEditor extends BaseElement {
     const queryLower = query.toLowerCase();
 
     for (let i = 0; i < mentionableData.length; i++) {
+      // Same withholding rule as the filtered list: an unresolved index
+      // row cannot be completed against, exactly or otherwise.
+      if (this._isIndexRow(i) && !this._resolvedPieceIds.has(i)) continue;
       const mention = mentionableData[i];
       const name = mention?.[NAME] ?? "";
       if (name.toLowerCase() === queryLower) {
@@ -1168,13 +1176,14 @@ export class CFCodeEditor extends BaseElement {
         // The resolved cell IS the piece. For an index row the sub-cell is
         // the row rather than the topic behind it, and every caller here
         // wants the piece — to navigate to it, subscribe to its title, or
-        // write its name back. Before resolution completes, a row's own
-        // hydrated piece is the piece by a shorter road; only an entry
-        // that IS the piece falls through to the sub-cell, with exactly
-        // _getPieceId's instability caveat.
+        // write its name back — so an unresolved row answers "not found"
+        // rather than the row. Only an entry that IS the piece falls
+        // through to the sub-cell, with exactly _getPieceId's instability
+        // caveat.
         return this._resolvedPieceCells.get(i) ??
-          this._hydratedPiece(i) ??
-          (handle.key(i) as CellHandle<Mentionable>);
+          (this._isIndexRow(i)
+            ? null
+            : (handle.key(i) as CellHandle<Mentionable>));
       }
     }
 
@@ -1182,31 +1191,33 @@ export class CFCodeEditor extends BaseElement {
   }
 
   /**
-   * The piece handle an index row carries, hydrated by the client — the
-   * synchronous stand-in until resolution lands, and null for an entry that
-   * is the piece itself. Bound to the mentionable schema so field reads on
-   * it materialize, as `_refDestination` binds a stored destination.
+   * Whether the entry at `index` is an index row standing for a piece — it
+   * carries a `piece` property. The property's VALUE is no use for
+   * reaching the piece: an `asCell` position crosses the client boundary
+   * as an empty object, so a row's piece is reachable only by ADDRESS
+   * (`key(index).key("piece")`), and only asynchronously. Until that
+   * resolution lands a row has no usable identity, so the completion
+   * surfaces withhold it rather than mint an id naming the row.
    */
-  private _hydratedPiece(index: number): CellHandle<Mentionable> | null {
+  private _isIndexRow(index: number): boolean {
     const item = ((this.mentionable?.get() ?? []) as MentionableArray)[index];
-    return item && isCellHandle(item.piece)
-      ? item.piece.asSchema<Mentionable>(MentionableSchema)
-      : null;
+    return item != null && item.piece !== undefined;
   }
 
   /**
    * Get the stable piece cell ID for a mentionable item at the given index,
    * in the BARE embed form wiki-link text persists (see mentionIdFromCellId
    * — CellHandle.id() is the full schemed URI; renderers add `/of:` back).
-   * Returns the pre-resolved ID if available, then an index row's own
-   * hydrated piece, and only then the sub-cell ID (which may be unstable
-   * across recomputations, and for an index row names the row rather than
-   * the piece).
+   * Returns the pre-resolved ID if available. An entry that IS the piece
+   * falls back to the sub-cell ID (which may be unstable across
+   * recomputations); an unresolved index row yields the empty id instead —
+   * the sub-cell names the row, and no id beats a wrong one.
    */
   private _getPieceId(index: number): string {
     const id = this._resolvedPieceIds.get(index) ??
-      this._hydratedPiece(index)?.id() ??
-      (this.mentionable?.key(index)?.id() ?? "");
+      (this._isIndexRow(index)
+        ? ""
+        : (this.mentionable?.key(index)?.id() ?? ""));
     return id ? mentionIdFromCellId(id) : id;
   }
 
@@ -1239,14 +1250,14 @@ export class CFCodeEditor extends BaseElement {
     const promises = mentionableData.map(async (item, i) => {
       if (!item) return;
       try {
-        const hydrated = this._hydratedPiece(i);
-        const source = hydrated ?? handle.key(i);
+        const viaPiece = this._isIndexRow(i);
+        const source = viaPiece ? handle.key(i).key("piece") : handle.key(i);
         const resolved = await source.resolveAsCell();
         // Resolution answers with the canonical cell under its own schema,
         // so a piece reached through a row is rebound to the mentionable
         // schema — the `_refDestination` shape — for the field reads its
         // consumers make (the title subscription, the name write-back).
-        const pieceCell = hydrated !== null
+        const pieceCell = viaPiece
           ? resolved.asSchema<Mentionable>(MentionableSchema)
           : (resolved as CellHandle<Mentionable>);
         newCells.set(i, pieceCell);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -730,7 +730,9 @@ export class CFCodeEditor extends BaseElement {
    * persisted against that path would later name whatever had moved into the
    * slot. `_resolvePieceIds` follows the indirection; until it has, this
    * returns null and the caller mints a wiki-link instead — the older form,
-   * but one whose id comes from the same resolution.
+   * but one whose id comes from the same resolution. An index row cannot
+   * reach either fallback: the completion surfaces withhold it until it is
+   * resolved, so a row arriving here always finds its piece in the cache.
    */
   private _createRefEntry(index: number): string | null {
     const destination = this._resolvedPieceCells.get(index);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1203,7 +1203,7 @@ export class CFCodeEditor extends BaseElement {
    */
   private _isIndexRow(index: number): boolean {
     const item = ((this.mentionable?.get() ?? []) as MentionableArray)[index];
-    return item != null && item.piece !== undefined;
+    return item != null && Object.hasOwn(item, "piece");
   }
 
   /**
@@ -1268,7 +1268,8 @@ export class CFCodeEditor extends BaseElement {
           newResolved.set(i, resolvedId);
         }
       } catch {
-        // If resolution fails, we'll fall back to the sub-cell ID
+        // If resolution fails, a direct entry falls back to the sub-cell
+        // ID; an index row stays withheld (its sub-cell names the row).
       }
     });
 
@@ -1866,11 +1867,14 @@ export class CFCodeEditor extends BaseElement {
     // delivering values to subscribers.
     const unsubscribe = this.mentionable
       .subscribe((_value) => {
-        // Clear stale resolved IDs and re-resolve asynchronously
+        // Clear stale resolved IDs and re-resolve asynchronously. The
+        // $mentioned reconciliation waits for the resolution pass (which
+        // runs it on publish): against cleared maps an index-row backlink
+        // has no id, and reconciling in that window would transiently drop
+        // its edge only to re-add it moments later.
         this._resolvedPieceIds.clear();
         this._resolvedPieceCells.clear();
         this._resolvePieceIds();
-        this._updateMentionedFromContent();
       });
     this._mentionableUnsub = unsubscribe;
   }

--- a/packages/ui/src/v2/core/mention-controller.test.ts
+++ b/packages/ui/src/v2/core/mention-controller.test.ts
@@ -274,22 +274,21 @@ describe("MentionController — mention insertion", () => {
 //
 
 describe("MentionController — indexed rows", () => {
-  /** An index-row list: each entry is bookkeeping standing for its piece. */
+  /** An index-row list: each entry is bookkeeping standing for its piece,
+   * held as the stored `$link` an `asCell` position actually carries — the
+   * value never holds a handle, and the mock network follows the link at
+   * resolution exactly as the runtime does. */
   function createIndexedCell(entries: { name: string; pieceId: string }[]) {
-    const pieces = entries.map(({ name, pieceId }) =>
-      createMockCellHandle({ [NAME]: name }, { id: pieceId as any })
-    );
-    const rows: MentionableArray = entries.map(({ name }, i) => ({
+    const rows: MentionableArray = entries.map(({ name, pieceId }) => ({
       [NAME]: name,
       title: name,
-      piece: pieces[i],
+      piece: { "$link": { id: pieceId, path: [] } },
     }));
     return {
       cell: createMockCellHandle(rows, {
         id: "of:mention-index" as any,
         schema: { type: "array", items: { type: "object" } },
       }),
-      pieces,
     };
   }
 

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -302,7 +302,8 @@ export class MentionController implements ReactiveController {
   private _destinationOf(
     mention: CellHandle<Mentionable>,
   ): CellHandle<Mentionable> {
-    return mention.get()?.piece !== undefined
+    const value = mention.get();
+    return value != null && Object.hasOwn(value, "piece")
       ? mention.key("piece").asSchema<Mentionable>(MentionableSchema)
       : mention;
   }
@@ -323,7 +324,11 @@ export class MentionController implements ReactiveController {
       const resolved = await destination.resolveAsCell();
       return `[${name}](/${resolved.ref().id})`;
     } catch {
-      return `[${name}](${this._buildHref(destination.ref())})`;
+      // The ENTRY's href, not the destination's: decode's raw first pass
+      // matches entry refs, so this round-trips even for an index row
+      // whose piece failed to resolve — a `/…/piece` path would match
+      // neither pass.
+      return `[${name}](${this._buildHref(piece.ref())})`;
     }
   }
 

--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -290,18 +290,20 @@ export class MentionController implements ReactiveController {
   }
 
   /**
-   * The entry's destination: a row's hydrated `piece` when it carries one,
-   * the entry itself otherwise. An entry with `piece` is a derived index
-   * row standing for the piece — encoding the entry would make every
-   * mention name a row of somebody's bookkeeping. Bound to the mentionable
-   * schema so field reads on the destination materialize.
+   * The entry's destination: a row's `piece` when it carries one, the
+   * entry itself otherwise. An entry with `piece` is a derived index row
+   * standing for the piece — encoding the entry would make every mention
+   * name a row of somebody's bookkeeping. The row is detected by the KEY's
+   * presence and its piece reached by ADDRESS: an `asCell` value crosses
+   * the client boundary as an empty object, so the value itself can carry
+   * no handle. Bound to the mentionable schema so field reads on the
+   * destination materialize.
    */
   private _destinationOf(
     mention: CellHandle<Mentionable>,
   ): CellHandle<Mentionable> {
-    const piece = mention.get()?.piece;
-    return isCellHandle(piece)
-      ? piece.asSchema<Mentionable>(MentionableSchema)
+    return mention.get()?.piece !== undefined
+      ? mention.key("piece").asSchema<Mentionable>(MentionableSchema)
       : mention;
   }
 

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -9,7 +9,7 @@ export interface Mentionable {
    * Optional, and its absence changes what an entry IS. Without one, the
    * entry is the piece itself, listed directly. With one, the entry is a
    * derived row standing for `piece` — the editor lists and matches on the
-   * row's own strings and resolves `piece` when a completion is picked, so
+   * row's own name and resolves `piece` when a completion is picked, so
    * what a mention stores is the piece and never the row.
    *
    * The VALUE at this position never carries a usable handle: an `asCell`

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -11,6 +11,11 @@ export interface Mentionable {
    * derived row standing for `piece` — the editor lists and matches on the
    * row's own strings and resolves `piece` when a completion is picked, so
    * what a mention stores is the piece and never the row.
+   *
+   * The VALUE at this position never carries a usable handle: an `asCell`
+   * position crosses the client boundary as an empty object. A reader
+   * detects a row by this key's presence and reaches the piece by ADDRESS
+   * — `entry.key("piece").resolveAsCell()` — never through the value.
    */
   piece?: unknown;
 

--- a/packages/ui/src/v2/test-utils/mock-cell-handle.ts
+++ b/packages/ui/src/v2/test-utils/mock-cell-handle.ts
@@ -52,6 +52,34 @@ class MockCellNetwork {
   }
 
   /**
+   * Resolve a ref the way the runtime does: if the value at the ref's path
+   * is a stored `$link`, the resolution answers with the LINKED ref;
+   * otherwise the asking ref is already canonical and echoes back. This is
+   * what lets a test model an index row whose `piece` field holds a link —
+   * the value an `asCell` position actually stores.
+   */
+  resolveRef(ref: CellRef): CellRef {
+    const root = this.#roots.get(this.#rootKey(ref));
+    let value: unknown = root?.get();
+    for (const seg of ref.path ?? []) {
+      if (value == null || typeof value !== "object") break;
+      value = (value as Record<string, unknown>)[seg as string];
+    }
+    const link = value != null && typeof value === "object" &&
+      (value as Record<string, unknown>)["$link"];
+    if (link != null && typeof link === "object") {
+      return {
+        scope: "space",
+        path: [],
+        schema: undefined,
+        space: ref.space,
+        ...(link as Partial<CellRef>),
+      } as CellRef;
+    }
+    return ref;
+  }
+
+  /**
    * Handle a CellSet request: propagate child writes to the root handle.
    */
   handleCellSet(
@@ -103,9 +131,9 @@ function deepSet(
  * Create a mock InitializedRuntimeConnection backed by a MockCellNetwork.
  *
  * - `request()` intercepts CellSet to propagate child→parent writes,
- *   answers CellResolveAsCell with the asking ref (a mock cell is already
- *   canonical — there is no link indirection to follow), and resolves
- *   everything else with `{}`.
+ *   answers CellResolveAsCell by following a stored `$link` at the asked
+ *   path (echoing the asking ref when there is none to follow — already
+ *   canonical), and resolves everything else with `{}`.
  * - `subscribe()` / `unsubscribe()` are no-ops.
  * - Includes EventEmitter stubs (`on`, `off`, `emit`) to satisfy the type.
  */
@@ -118,7 +146,7 @@ function createMockConnection(
         network.handleCellSet(data.cell, data.value);
       }
       if (data.type === "cell:resolveAsCell" && data.cell) {
-        return Promise.resolve({ cell: data.cell } as any);
+        return Promise.resolve({ cell: network.resolveRef(data.cell) } as any);
       }
       return Promise.resolve({} as any);
     },

--- a/packages/ui/src/v2/utils/mention-id.test.ts
+++ b/packages/ui/src/v2/utils/mention-id.test.ts
@@ -24,15 +24,15 @@ Deno.test("cf-code-editor derives mention pieceIds in the bare embed form", () =
   // Pre-resolved id (the stable piece cell id) is stripped to the bare form.
   const withResolved = {
     _resolvedPieceIds: new Map([[0, "of:fid1:abc"]]),
-    _hydratedPiece: () => null,
+    _isIndexRow: () => false,
     mentionable: undefined,
   };
   assertEquals(proto._getPieceId.call(withResolved, 0), "fid1:abc");
-  // Fallback: no resolved id, no hydrated row piece, and no mentionable
+  // Fallback: no resolved id, not an index row, and no mentionable
   // yields the empty id untouched (nothing to strip).
   const empty = {
     _resolvedPieceIds: new Map(),
-    _hydratedPiece: () => null,
+    _isIndexRow: () => false,
     mentionable: undefined,
   };
   assertEquals(proto._getPieceId.call(empty, 0), "");

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -63,11 +63,13 @@ export interface AcceptedContractBreak {
 
 export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
   {
-    // ONE entry per pattern, and that is a requirement rather than tidiness:
-    // the gate keys accepted pairs into a Map, so a second entry naming a
-    // baseline this one also names REPLACES its path set rather than adding to
-    // it. Two breaks on one pattern therefore share an entry, and share its
-    // single `record`; the other is named in the reason.
+    // One entry per (pattern, BASELINE) pair, and that is a requirement
+    // rather than tidiness: the gate keys accepted pairs into a Map, so a
+    // second entry naming a baseline this one also names REPLACES its path
+    // set rather than adding to it. Breaks that share baselines therefore
+    // share an entry — and its single `record`, the other break named in
+    // the reason — while a later break against baselines no earlier entry
+    // names gets its own entry, with the pairs kept disjoint.
     //
     // Carried here: the reference graph rebuilt on cell identity, and the
     // board's demand narrowed to the eight members it reads — which narrows
@@ -140,11 +142,13 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
     record: "docs/history/topics-mentionable-index-break.md",
   },
   {
-    // ONE entry per pattern, and that is a requirement rather than tidiness:
-    // the gate keys accepted pairs into a Map, so a second entry naming a
-    // baseline this one also names REPLACES its path set rather than adding to
-    // it. Two breaks on one pattern therefore share an entry, and share its
-    // single `record`; the other is named in the reason.
+    // One entry per (pattern, BASELINE) pair, and that is a requirement
+    // rather than tidiness: the gate keys accepted pairs into a Map, so a
+    // second entry naming a baseline this one also names REPLACES its path
+    // set rather than adding to it. Breaks that share baselines therefore
+    // share an entry — and its single `record`, the other break named in
+    // the reason — while a later break against baselines no earlier entry
+    // names gets its own entry, with the pairs kept disjoint.
     //
     // Carried here: the reference graph rebuilt on cell identity, and the
     // board's demand narrowed to the eight members it reads — which narrows


### PR DESCRIPTION
## What

Follow-up to #6637, found by exercising the editors in a real browser against the migrated board clone: the index-row destination routing that #6637 added **never fired at runtime**. An `asCell` position crosses the runtime-client boundary as an empty object, so `isCellHandle(item.piece)` was false everywhere, both editors fell back to resolving the row itself, and a saved mention's destination was an inline copy of the bookkeeping row — the exact failure the routing exists to prevent. The value-hydration mocks modeled a world the IPC boundary doesn't permit, which is why the unit tests passed while the browser disagreed.

The same in-page probe that caught it proved the fix: `key(i).key("piece").resolveAsCell()` follows the stored link straight to the piece.

## Changes

- `cf-code-editor` and `MentionController` detect a row by the `piece` KEY's presence and reach the piece **by address**, never through the value. `Mentionable.piece`'s doc now states the boundary rule.
- Completion surfaces **withhold an unresolved index row** rather than mint an id naming it (sol's option from the #6637 review, now load-bearing since no synchronous piece handle can exist). Resolution starts at bind, so the window is the resolve round trips.
- The mock cell network's `resolveAsCell` now **follows a stored `$link`** at the asked path, exactly as the runtime does, and all indexed fixtures store raw sigils — tests now model the real world.

## Verified end to end on the board-clone rig

Autocomplete offers rows by their copied labels; accepting stores `destination: {$link: <topic piece fid>}` (confirmed by offline read of the saved map — the actual target topic's fid); the editor's collection swept the two row-shaped entries earlier rounds had persisted; the topic's `mentions` output carries the reference edge. Mutation-checked: bypassing `_destinationOf` fails both indexed controller tests; the race and withholding pins discriminate.

## Sequencing note

The deployed build carries #6637 as merged (rounds 1–3): safe for boards wired to raw lists (the fallback path is unchanged behavior), but **the board migration must not run until this lands and deploys** — against index rows, the merged editors persist row-copy destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

