### PR TITLE
perf(runner): reuse externalized link schemas

### DIFF
--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -225,6 +225,17 @@ export function areMaybeLinkAndNormalizedLinkSame(
 // ./link-types.ts — one canonical implementation — and reaches importers of
 // this module through the `export *` above.
 
+// Successful externalization depends on schema documents registered during
+// the current lease epoch. Frozen source schemas keep stable identity, so the
+// external reference can be reused until that registry clears.
+let externalizedLinkSchemaCache = new WeakMap<
+  object,
+  Map<KeepAsCell, JSONSchema>
+>();
+onSchemaRegistryClear(() => {
+  externalizedLinkSchemaCache = new WeakMap();
+});
+
 /**
  * Replaces an inline schema with a reference to content-addressed schema
  * documents (`docs/specs/content-addressed-schemas.md`, Phases 1 and 2;
@@ -329,14 +340,12 @@ export function createSigilLinkFromParsedLink(
   // permissive and should not turn links into schema-bearing links.
   if (options.includeSchema && link.schema !== undefined) {
     // Default to keeping streams unless a broader mode was requested.
-    const schema = sanitizeSchemaForLinks(
-      link.schema,
-      options.keepAsCell ?? KeepAsCell.OnlyStream,
-    );
+    const keepAsCell = options.keepAsCell ?? KeepAsCell.OnlyStream;
+    const schema = getContentAddressedSchemasConfig()
+      ? externalizeLinkSchema(link.schema, keepAsCell)
+      : sanitizeSchemaForLinks(link.schema, keepAsCell);
     if (isNontrivialSchema(schema)) {
-      reference.schema = getContentAddressedSchemasConfig()
-        ? externalizeSchema(schema as JSONSchemaObj)
-        : schema;
+      reference.schema = schema;
     }
   }
 
@@ -482,6 +491,36 @@ export function sanitizeSchemaForLinks(
   }
 
   return output;
+}
+
+/** Sanitizes and externalizes a link schema, memoizing frozen inputs. */
+function externalizeLinkSchema(
+  schema: JSONSchema,
+  keepAsCell: KeepAsCell,
+): JSONSchema {
+  const cacheable = isObjectOrArray(schema) && isDeepFrozen(schema);
+  const cached = cacheable
+    ? externalizedLinkSchemaCache.get(schema)?.get(keepAsCell)
+    : undefined;
+  if (cached !== undefined) return cached;
+  const sanitized = sanitizeSchemaForLinks(schema, keepAsCell);
+  if (!isObjectNotArray(sanitized) || !isNontrivialSchema(sanitized)) {
+    return sanitized;
+  }
+  const externalized = externalizeSchema(sanitized);
+  if (
+    cacheable && isObjectNotArray(externalized) &&
+    typeof externalized.$ref === "string" &&
+    isExternalSchemaRef(externalized.$ref)
+  ) {
+    let byMode = externalizedLinkSchemaCache.get(schema);
+    if (byMode === undefined) {
+      byMode = new Map();
+      externalizedLinkSchemaCache.set(schema, byMode);
+    }
+    byMode.set(keepAsCell, externalized);
+  }
+  return externalized;
 }
 
 interface SanitizeContext {

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -5,6 +5,7 @@ import {
   FabricPrimitive,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
+import { deepFrozenCloneAndInternSchema } from "@commonfabric/data-model-schema";
 import {
   type FabricExecValue,
   isPattern,
@@ -110,7 +111,11 @@ const foldDeclaredScopeIntoLinkSchema = (
   if (authoredRootSchema === undefined || !isObjectOrArray(link.schema)) {
     return link;
   }
-  if (ContextualFlowControl.getSchemaScopeCap(link.schema) !== undefined) {
+  const emittedSchema = sanitizeAliasSchemaForBinding(link.schema);
+  if (
+    !isObjectOrArray(emittedSchema) ||
+    ContextualFlowControl.getSchemaScopeCap(emittedSchema) !== undefined
+  ) {
     return link;
   }
   const authoredSlotSchema = path.length > 0
@@ -125,7 +130,13 @@ const foldDeclaredScopeIntoLinkSchema = (
   ) {
     return link;
   }
-  return { ...link, schema: { ...link.schema, scope: declaredCap } };
+  return {
+    ...link,
+    schema: deepFrozenCloneAndInternSchema({
+      ...emittedSchema,
+      scope: declaredCap,
+    }),
+  };
 };
 
 const scopedLinkForPath = (
@@ -153,9 +164,7 @@ const scopedLinkForPath = (
   }
 
   const finalSchema = schemaOverride ?? childSchema;
-  const linkSchema = finalSchema === undefined
-    ? undefined
-    : sanitizeAliasSchemaForBinding(finalSchema);
+  const linkSchema = finalSchema;
   scope = declaredScope(linkSchema) ?? scope;
 
   return {
@@ -171,6 +180,19 @@ const sanitizeAliasSchemaForBinding = (schema: JSONSchema): JSONSchema =>
   // schemas without cell wrappers so scoped asCell entries do not stamp the
   // redirect link's own scope and bypass stored argument links.
   sanitizeSchemaForLinks(schema, KeepAsCell.OnlyStream);
+
+/**
+ * Returns a link with a canonical schema without freezing the caller's input.
+ */
+const canonicalSchemaLink = (
+  link: NormalizedFullLink | undefined,
+): NormalizedFullLink | undefined => {
+  if (link === undefined || !isObjectOrArray(link.schema)) return link;
+  const schema = deepFrozenCloneAndInternSchema(
+    sanitizeSchemaForLinks(link.schema, KeepAsCell.All),
+  );
+  return schema === link.schema ? link : { ...link, schema };
+};
 
 const descriptorForPartialCauseAlias = (
   partialCause: JSONValue,
@@ -544,7 +566,10 @@ export function unwrapOneLevelAndBindToDoc<T extends FabricExecValue>(
   resultCell: AnyCell<unknown>,
   options?: UnwrapOneLevelOptions,
 ): T {
-  const resultCellLink = resultCell.getAsNormalizedFullLink();
+  const resultCellLink = canonicalSchemaLink(
+    resultCell.getAsNormalizedFullLink(),
+  )!;
+  argumentCellLink = canonicalSchemaLink(argumentCellLink);
 
   /**
    * Rebinds one value, returning it unchanged when nothing under it rebound.

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -549,16 +549,19 @@ describe("stage G SpaceServer recovery seams", () => {
       getLogger("space-server").countsByKey["watermark-seal-failed"]?.warn ??
         0;
     const failuresBefore = watermarkFailureCount();
-    let failedWatermarkCommits = 0;
+    const retryCommitGate = Promise.withResolvers<void>();
+    let watermarkCommitAttempts = 0;
     runtime.edit = (options) => {
       const tx = edit(options);
       const commit = tx.commit.bind(tx);
       tx.commit = () => {
         if (
-          failedWatermarkCommits === 0 &&
-          waveRunContextOf(tx)?.actionId === "server-execution/watermark"
+          waveRunContextOf(tx)?.actionId !== "server-execution/watermark"
         ) {
-          failedWatermarkCommits += 1;
+          return commit();
+        }
+        watermarkCommitAttempts += 1;
+        if (watermarkCommitAttempts === 1) {
           const reason = new Error("injected watermark commit failure");
           return Promise.resolve({
             error: {
@@ -567,6 +570,9 @@ describe("stage G SpaceServer recovery seams", () => {
               reason,
             },
           });
+        }
+        if (watermarkCommitAttempts === 2) {
+          return retryCommitGate.promise.then(() => commit());
         }
         return commit();
       };
@@ -589,24 +595,32 @@ describe("stage G SpaceServer recovery seams", () => {
       () => watermarkFailureCount() > failuresBefore,
       "the failed watermark transaction to be reported",
     );
-    expect(failedWatermarkCommits).toBe(1);
-    expect(created.watermark).toBeLessThan(first.seq);
+    expect(watermarkCommitAttempts).toBe(1);
 
     const second = await server.writeDocument(
       space,
       "of:watermark-failure-second",
       { n: 2 },
     );
-    created.enqueueCommit({
-      space,
-      seq: second.seq,
-      class: "authored",
-      sessionId: "session:watermark-failure",
-      writes: [{ id: "of:watermark-failure-second", scopeKey: "space" }],
-    });
+    try {
+      created.enqueueCommit({
+        space,
+        seq: second.seq,
+        class: "authored",
+        sessionId: "session:watermark-failure",
+        writes: [{ id: "of:watermark-failure-second", scopeKey: "space" }],
+      });
+      await waitUntil(
+        () => watermarkCommitAttempts === 2,
+        "the fresh input to start the retry transaction",
+      );
+      expect(created.watermark).toBeLessThan(first.seq);
+    } finally {
+      retryCommitGate.resolve();
+    }
     await waitUntil(
       () => created.watermark >= second.seq,
-      "the watermark to advance after fresh input",
+      "the watermark to advance after the retry commits",
     );
   });
 

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -19,6 +19,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import {
@@ -49,7 +50,7 @@ import {
   SpaceServer,
   STRUCTURE_LOAD_STUCK_AFTER,
 } from "../src/executor/space-server.ts";
-import { stampWaveRunContext } from "../src/executor/wave.ts";
+import { stampWaveRunContext, waveRunContextOf } from "../src/executor/wave.ts";
 import {
   emptyServingLoopStats,
   type ServingLoopStats,
@@ -536,6 +537,77 @@ describe("stage G SpaceServer recovery seams", () => {
       15_000,
     );
     expect(stats.watermarkClamped).toBe(3);
+  });
+
+  it("holds the watermark when its bookkeeping transaction fails, then advances on fresh input", async () => {
+    const created = newSpaceServer();
+    expect(await created.activate()).toBe(true);
+
+    const runtime = servingRuntime!;
+    const edit = runtime.edit.bind(runtime);
+    const watermarkFailureCount = () =>
+      getLogger("space-server").countsByKey["watermark-seal-failed"]?.warn ??
+        0;
+    const failuresBefore = watermarkFailureCount();
+    let failedWatermarkCommits = 0;
+    runtime.edit = (options) => {
+      const tx = edit(options);
+      const commit = tx.commit.bind(tx);
+      tx.commit = () => {
+        if (
+          failedWatermarkCommits === 0 &&
+          waveRunContextOf(tx)?.actionId === "server-execution/watermark"
+        ) {
+          failedWatermarkCommits += 1;
+          const reason = new Error("injected watermark commit failure");
+          return Promise.resolve({
+            error: {
+              name: "StorageTransactionAborted" as const,
+              message: reason.message,
+              reason,
+            },
+          });
+        }
+        return commit();
+      };
+      return tx;
+    };
+
+    const first = await server.writeDocument(
+      space,
+      "of:watermark-failure-first",
+      { n: 1 },
+    );
+    created.enqueueCommit({
+      space,
+      seq: first.seq,
+      class: "authored",
+      sessionId: "session:watermark-failure",
+      writes: [{ id: "of:watermark-failure-first", scopeKey: "space" }],
+    });
+    await waitUntil(
+      () => watermarkFailureCount() > failuresBefore,
+      "the failed watermark transaction to be reported",
+    );
+    expect(failedWatermarkCommits).toBe(1);
+    expect(created.watermark).toBeLessThan(first.seq);
+
+    const second = await server.writeDocument(
+      space,
+      "of:watermark-failure-second",
+      { n: 2 },
+    );
+    created.enqueueCommit({
+      space,
+      seq: second.seq,
+      class: "authored",
+      sessionId: "session:watermark-failure",
+      writes: [{ id: "of:watermark-failure-second", scopeKey: "space" }],
+    });
+    await waitUntil(
+      () => created.watermark >= second.seq,
+      "the watermark to advance after fresh input",
+    );
   });
 
   it("fires an EFFECT-ONLY batch on a quiet space: an all-no-op tx's deferred effects close a vacuous wave instead of starving until park (round-2 thread 1)", async () => {

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -57,6 +57,7 @@ describe("link-utils", () => {
   });
 
   afterEach(async () => {
+    resetContentAddressedSchemasConfig();
     tx.abort();
     await runtime?.dispose();
     await storageManager?.close();

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -761,6 +761,82 @@ describe("link-utils", () => {
         required: ["title"],
       });
     });
+
+    it("externalizes each sanitization mode for one frozen schema", () => {
+      setContentAddressedSchemasConfig(true);
+      const schema = deepFreeze(
+        {
+          type: "object",
+          properties: {
+            send: {
+              type: "string",
+              asCell: ["stream"],
+            },
+          },
+          required: ["send"],
+        } as const satisfies JSONSchema,
+      );
+      const link = {
+        id: "of:cached-schema",
+        path: [],
+        space,
+        schema,
+      } as const;
+
+      const kept = createSigilLinkFromParsedLink(link, {
+        includeSchema: true,
+      });
+      const stripped = createSigilLinkFromParsedLink(link, {
+        includeSchema: true,
+        keepAsCell: KeepAsCell.None,
+      });
+
+      expect(resolvedSchema(linkRefPayload(kept).schema)).toEqual(schema);
+      expect(resolvedSchema(linkRefPayload(stripped).schema)).toEqual({
+        type: "object",
+        properties: {
+          send: { type: "string" },
+        },
+      });
+    });
+
+    it("re-registers cached schema documents after an epoch change", async () => {
+      setContentAddressedSchemasConfig(true);
+      const schema = deepFreeze(
+        {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+          },
+        } as const satisfies JSONSchema,
+      );
+      const link = {
+        id: "of:cached-schema-epoch",
+        path: [],
+        space,
+        schema,
+      } as const;
+
+      const first = createSigilLinkFromParsedLink(link, {
+        includeSchema: true,
+      });
+      expect(resolvedSchema(linkRefPayload(first).schema)).toEqual(schema);
+
+      tx.abort();
+      await runtime.dispose();
+      await storageManager.close();
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      tx = runtime.edit();
+
+      const second = createSigilLinkFromParsedLink(link, {
+        includeSchema: true,
+      });
+      expect(resolvedSchema(linkRefPayload(second).schema)).toEqual(schema);
+    });
   });
 
   describe("inlineExternalSchemaRefsInValue", () => {

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -41,6 +41,7 @@ import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -600,6 +601,53 @@ describe("pattern-binding", () => {
         overwrite: "redirect",
         // parseLink of a sigil stamps the read-side data-derived mark (OW51).
         viaLinkHop: true,
+      });
+    });
+
+    it("binds aliases from a caller-owned circular schema", () => {
+      const circularSchema: JSONSchema & {
+        properties: Record<string, JSONSchema>;
+      } = {
+        type: "object",
+        properties: {},
+      };
+      circularSchema.properties.self = circularSchema;
+      const resultCell = runtime.getCell(
+        space,
+        "circular schema result cell",
+        undefined,
+        tx,
+      );
+      const argumentCell = runtime.getCell(
+        space,
+        "circular schema argument cell",
+        undefined,
+        tx,
+      );
+      const argumentLink = {
+        ...argumentCell.getAsNormalizedFullLink(),
+        schema: circularSchema,
+      };
+
+      const result = unwrapOneLevelAndBindToDoc(
+        { self: { $alias: { cell: "argument", path: ["self"] } } },
+        argumentLink,
+        resultCell,
+      );
+
+      const parsed = parseLink(result.self, resultCell)!;
+      expect(Object.isFrozen(circularSchema)).toBe(false);
+      expect(parsed.path).toEqual(["self"]);
+      expect(resolvedSchema(parsed.schema)).toEqual({
+        $ref: "#/$defs/CircularSchema_0",
+        $defs: {
+          CircularSchema_0: {
+            type: "object",
+            properties: {
+              self: { $ref: "#/$defs/CircularSchema_0" },
+            },
+          },
+        },
       });
     });
 


### PR DESCRIPTION
Enabling content-addressed schemas made each bound alias sanitize, hash, decompose, and register the same schema. Mutable input schemas also bypassed the schema traversal identity cache, so the pattern-binding benchmark paid that work once per alias.

Canonicalize input link schemas once per binding operation without freezing caller-owned objects. Use cycle-aware sanitization so circular schemas continue to become local definitions and cell annotations remain intact.

Keep the canonical identity until link emission. Cache each successful external reference by sanitization mode for the current schema registry lease epoch. Do not cache inline fallback results because a missing schema document can arrive later.

Five alternating runs of the 100-alias benchmark reduced median p75 from 1.775 ms to 0.200 ms. Add coverage for circular caller-owned schemas and for re-registering cached schema documents after the registry is cleared.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

