### PR TITLE
feat(runner): the conversion's answer is deeply frozen

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -4,6 +4,7 @@ import {
   entityRefFromString,
   linkRefFrom,
 } from "@commonfabric/data-model/cell-rep";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
   assertValidFabricValueLayer,
   cloneIfNecessary,
@@ -4122,8 +4123,8 @@ type CellLinkOptions = {
 };
 
 /**
- * Helper for `convertCellsToLinks()`, which returns the link that reaches a
- * cell, carrying the cell's CFC label view onto it when asked.
+ * Helper for `convertCellsToLinks()`, which returns the frozen link that
+ * reaches a cell, carrying the cell's CFC label view onto it when asked.
  */
 function linkToCell(cell: Cell<any>, options: CellLinkOptions): SigilLink {
   const link = cell.getAsLink(options);
@@ -4135,12 +4136,12 @@ function linkToCell(cell: Cell<any>, options: CellLinkOptions): SigilLink {
     }
   }
 
-  return link;
+  return deepFreeze(link);
 }
 
 /**
  * Converts cells and objects that can be turned to cells to links. What comes
- * back is a `FabricValue` with a link wherever a cell sat.
+ * back is a deeply frozen `FabricValue` with a link wherever a cell sat.
  *
  * @param value - The value to convert.
  * @returns The converted value.
@@ -4171,6 +4172,9 @@ export function convertCellsToLinks(
  * cut is correct because an entry sits in `ancestors` only while the walk is
  * inside it, which is exactly while the stack still holds its own path as a
  * prefix.
+ *
+ * Each container is frozen as the walk returns it, and each link as it is
+ * minted, which is what makes the whole answer deeply frozen.
  */
 function convertOneToLinks(
   value: CellLinkInput,
@@ -4182,7 +4186,7 @@ function convertOneToLinks(
     const depth = ancestors.get(value);
 
     if (depth !== undefined) {
-      return linkRefFrom({ path: stack.slice(0, depth) });
+      return deepFreeze(linkRefFrom({ path: stack.slice(0, depth) }));
     }
   }
 
@@ -4277,7 +4281,7 @@ function convertOneToLinks(
       // where filling `new Array(n)` by index returns a holey one, which
       // costs its consumers -- about a fifth of what structured-cloning the
       // result takes, paid on every crossing to the client.
-      return container.map((element: unknown, index: number) => {
+      return Object.freeze(container.map((element: unknown, index: number) => {
         stack.push(String(index));
 
         const converted = convertOneToLinks(
@@ -4290,7 +4294,7 @@ function convertOneToLinks(
         stack.pop();
 
         return converted;
-      });
+      }));
     }
 
     // Built through `fromEntries()` rather than by assigning member by member.
@@ -4298,7 +4302,7 @@ function convertOneToLinks(
     // filled by assignment costs about half again as much to structured-clone
     // as the same object built from entries, and every consumer of a converted
     // value pays that, the crossing to the client included.
-    return Object.fromEntries(
+    return Object.freeze(Object.fromEntries(
       Object.entries(container).map(([key, member]) => {
         stack.push(key);
 
@@ -4313,7 +4317,7 @@ function convertOneToLinks(
 
         return [key, converted];
       }),
-    );
+    ));
   } finally {
     ancestors.delete(original);
   }

--- a/packages/runner/test/convert-cells-to-links-frozenness.test.ts
+++ b/packages/runner/test/convert-cells-to-links-frozenness.test.ts
@@ -4,10 +4,11 @@
  * handed rather than one it controls, and this file pins what it may and may
  * not change about the answer: nothing about which values are refused, nothing
  * about what a converted value holds, and nothing about the input itself. What
- * comes back is a fresh container, mutable, whichever way the input went in.
+ * comes back is a fresh container, deeply frozen, whichever way the input went
+ * in.
  */
 
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
@@ -15,8 +16,15 @@ import {
   FabricBytes,
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-primitives";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { type CellLinkInput, convertCellsToLinks } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
 
 /** The subject: a record with a nested array and a nested record. */
 type Subject = {
@@ -55,6 +63,25 @@ function reachableObjects(
 }
 
 describe("convert-cells-to-links-frozenness", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
   it("returns the same value for a frozen input as for an unfrozen one", () => {
     const unfrozen = convertCellsToLinks(makeSubject());
     const frozen = convertCellsToLinks(deepFreeze(makeSubject()));
@@ -62,20 +89,51 @@ describe("convert-cells-to-links-frozenness", () => {
     expect(frozen).toEqual(unfrozen);
   });
 
-  it("returns a container the caller may still write into, given a frozen input", () => {
+  it("returns a deeply frozen container, given a frozen input", () => {
     const result = convertCellsToLinks(deepFreeze(makeSubject())) as Subject;
 
-    expect(Object.isFrozen(result)).toBe(false);
-    expect(Object.isFrozen(result.list)).toBe(false);
-    expect(Object.isFrozen(result.inner)).toBe(false);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.list)).toBe(true);
+    expect(Object.isFrozen(result.inner)).toBe(true);
   });
 
-  it("returns a container the caller may still write into, given an unfrozen input", () => {
+  it("returns a deeply frozen container, given an unfrozen input", () => {
     const result = convertCellsToLinks(makeSubject()) as Subject;
 
-    expect(Object.isFrozen(result)).toBe(false);
-    expect(Object.isFrozen(result.list)).toBe(false);
-    expect(Object.isFrozen(result.inner)).toBe(false);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.list)).toBe(true);
+    expect(Object.isFrozen(result.inner)).toBe(true);
+  });
+
+  it("returns a frozen link where a cell sat", () => {
+    // The link a cell becomes is minted by the walk rather than rebuilt by it,
+    // so it takes its freeze in `linkToCell()` and not from either container
+    // arm. Its payload is nested, which is why the check reaches past the
+    // outer object.
+    const cell = runtime.getCell(space, "frozen-link", undefined, tx);
+    cell.set({ n: 1 });
+
+    const result = convertCellsToLinks({ ref: cell }) as { ref: object };
+    const payload = Object.values(Object.values(result.ref)[0] as object)[0];
+
+    expect(Object.isFrozen(result.ref)).toBe(true);
+    expect(Object.isFrozen(payload)).toBe(true);
+    expect(Object.isFrozen((payload as { path: unknown[] }).path)).toBe(true);
+  });
+
+  it("returns a frozen back-link where a cycle was", () => {
+    // A cycle's back-link is the walk's other minted value, and it carries a
+    // `path` array of its own.
+    const cyclic: Record<string, unknown> = { inner: {} };
+    (cyclic.inner as Record<string, unknown>).back = cyclic;
+
+    const result = convertCellsToLinks(cyclic) as { inner: { back: object } };
+    const back = result.inner.back;
+    const payload = Object.values(Object.values(back)[0] as object)[0];
+
+    expect(Object.isFrozen(back)).toBe(true);
+    expect(Object.isFrozen(payload)).toBe(true);
+    expect(Object.isFrozen((payload as { path: unknown[] }).path)).toBe(true);
   });
 
   it("returns containers that are none of the input's, given an unfrozen input", () => {

--- a/packages/runner/test/convert-cells-to-links-frozenness.test.ts
+++ b/packages/runner/test/convert-cells-to-links-frozenness.test.ts
@@ -11,7 +11,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
+import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import type { FabricConvertibleValue } from "@commonfabric/data-model/fabric-value";
 import {
   FabricBytes,
   FabricEpochNsec,
@@ -21,6 +23,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { type CellLinkInput, convertCellsToLinks } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { CellLinkRefPayload } from "../src/sigil-types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -60,6 +63,17 @@ function reachableObjects(
   for (const member of Object.values(value)) reachableObjects(member, found);
 
   return found;
+}
+
+/**
+ * The payload riding a link, read through the accessor rather than by reaching
+ * into an envelope shape: which shape a link has is the cell-representation
+ * regime's business, and these assertions are about frozenness in either.
+ */
+function payloadOf(link: unknown): CellLinkRefPayload {
+  return linkRefPayload(
+    link as Parameters<typeof linkRefPayload>[0],
+  ) as CellLinkRefPayload;
 }
 
 describe("convert-cells-to-links-frozenness", () => {
@@ -113,27 +127,30 @@ describe("convert-cells-to-links-frozenness", () => {
     const cell = runtime.getCell(space, "frozen-link", undefined, tx);
     cell.set({ n: 1 });
 
-    const result = convertCellsToLinks({ ref: cell }) as { ref: object };
-    const payload = Object.values(Object.values(result.ref)[0] as object)[0];
+    const result = convertCellsToLinks({ ref: cell }) as { ref: unknown };
+    const link = result.ref;
 
-    expect(Object.isFrozen(result.ref)).toBe(true);
-    expect(Object.isFrozen(payload)).toBe(true);
-    expect(Object.isFrozen((payload as { path: unknown[] }).path)).toBe(true);
+    expect(isLinkRef(link)).toBe(true);
+    expect(Object.isFrozen(link)).toBe(true);
+    expect(Object.isFrozen(payloadOf(link))).toBe(true);
+    expect(Object.isFrozen(payloadOf(link).path)).toBe(true);
   });
 
   it("returns a frozen back-link where a cycle was", () => {
     // A cycle's back-link is the walk's other minted value, and it carries a
     // `path` array of its own.
-    const cyclic: Record<string, unknown> = { inner: {} };
-    (cyclic.inner as Record<string, unknown>).back = cyclic;
+    const inner: Record<string, FabricConvertibleValue> = {};
+    const cyclic: Record<string, FabricConvertibleValue> = { inner };
 
-    const result = convertCellsToLinks(cyclic) as { inner: { back: object } };
+    inner.back = cyclic;
+
+    const result = convertCellsToLinks(cyclic) as { inner: { back: unknown } };
     const back = result.inner.back;
-    const payload = Object.values(Object.values(back)[0] as object)[0];
 
+    expect(isLinkRef(back)).toBe(true);
     expect(Object.isFrozen(back)).toBe(true);
-    expect(Object.isFrozen(payload)).toBe(true);
-    expect(Object.isFrozen((payload as { path: unknown[] }).path)).toBe(true);
+    expect(Object.isFrozen(payloadOf(back))).toBe(true);
+    expect(Object.isFrozen(payloadOf(back).path)).toBe(true);
   });
 
   it("returns containers that are none of the input's, given an unfrozen input", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`convertCellsToLinks()` returned a mutable value. Nothing wrote into one, so
what the mutability offered was an opening rather than a capability: a value on
its way across the IPC boundary could be reached and changed by anything
holding it. It comes back deeply frozen now.

## What the old contract rested on

`convert-cells-to-links-frozenness.test.ts` pinned "returns a container the
caller may still write into". That file arrived as a characterization test and
says so in its own terms — it records what the walk does, not what a consumer
asks of it — so the pin is the thing being renegotiated here rather than an
obstacle to route around.

Nothing writes into the answer, and the control says so rather than a reading
of the call sites: with the conversion's output deep-frozen, the whole `runner`
suite comes back **1335 passed with exactly two failures, both of them the two
characterization assertions above**, and nothing else in the package. A writer
anywhere would have thrown under strict mode. `runtime-client` (16 passed) and
`html` (26 passed) are green under the same probe, and the probe is reached
there: made to throw instead of freeze, it turns 3 and 6 of those tests red.

The one call site that looks like a writer is not one. `propagateRendererTrusted
Event()` adds the converted object to a `WeakSet`, which frozenness does not
touch.

## Where the freeze goes, and why it is not one pass

Each container is frozen as the walk returns it, each link deep-frozen as it is
minted. The alternative — one `deepFreeze()` over the finished answer — costs
several times as much, because it walks the whole tree a second time and
carries its own cycle set and cache bookkeeping per node:

| 1000-record subject | main | one pass at the end | frozen in the walk |
| --- | --- | --- | --- |
| labelless | 1375.1 | 2085.7 (1.52x) | 1458.5 (1.06x) |
| links carrying label views | 2954.6 | 10060.0 (3.40x) | 3183.6 (1.08x) |

`bench/ipc-crossing-steps.bench.ts`, p75, median of 3 runs, microseconds.

## What it costs, and which part of it is ours

Per step on the 1000-record labelless subject, same benchmark and method:

| step | main | here | |
| --- | --- | --- | --- |
| convert | 1375.1 | 1458.5 | 1.06x |
| redact | 134.0 | 146.2 | 1.09x |
| encode | 422.2 | 446.6 | 1.06x |
| transport | 984.6 | 1152.3 | **1.17x** |
| decode | 363.8 | 358.4 | 0.99x |
| hydrate | 150.2 | 146.6 | 0.98x |

The transport row is the largest of these and is not this change's doing.
Structured-cloning a frozen tree costs more than cloning the same tree
unfrozen, which a standalone probe isolates away from this repository
altogether: two 6002-container trees from one builder, differing only in the
freeze, clone at **891 us against 1078 us, 1.21x**. That is about +170 us on a
~4200 us crossing, and every message pays it from here on.

The decode and hydrate rows read an arrival built once, so they report a lower
bound; the benchmark's own header carries the detail. The bound holds on both
sides of this comparison, which is the only use the table is put to.

## What a whole message costs

`bench/ipc-crossing.bench.ts`, unchanged, run at this branch and at its base.
The benchmark, its far-side fixture and `BenchWorker` are byte-identical at
both, verified by hash, so this is one measurement rather than two. p75 per
run, median of 12 interleaved runs, microseconds.

| subject | base | here | |
| --- | --- | --- | --- |
| small record | 13.8 | 13.9 | 1.01x |
| flat, 100 members | 41.1 | 41.4 | 1.01x |
| 100 records with links | 400.4 | 416.9 | 1.04x |
| 1000 records with links | 3834.9 | 3995.8 | 1.04x |

So a message costs about 4% more once its value is frozen, which is what the
freeze is bought with. The status-quo arm moves by the same 1.04x, correctly:
the conversion sits on both arms, and only the envelope arm is absent from one.

The two small subjects are dominated by `postMessage()` scheduling rather than
by any walk and are reported for completeness rather than read. Run-to-run
spread is 2-5% on the 100-record rows and reaches 19% on the 1000-record
status-quo arm, which is why the 100-record row is the one to weigh.

## Tests

Two flipped, two added, and each addition has a differential run against it:

- `returns a frozen link where a cell sat` — the link a cell becomes is minted
  rather than rebuilt, so it takes its freeze somewhere neither container arm
  reaches. The file gains a `Runtime` for it.
- `returns a frozen back-link where a cycle was` — the walk's other minted
  value, carrying a `path` array of its own.

Ablating the two link freezes fails exactly those two tests and nothing else.
Ablating the two container freezes fails exactly the two flipped container
tests and nothing else.

`returns nothing mutable that the input also holds` keeps its grip: the walk
freezes only what it built, so an input container that leaked into the answer
would still arrive unfrozen and still be caught.

## Gates

`deno fmt --check`, `deno lint` and `deno task check` green. `runner` 1337
passed (7987 steps), `runtime-client` 16 passed, `html` 26 passed,
`data-model` 48 passed — the four new and flipped assertions confirmed present
in that `runner` run by name rather than assumed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


