### PR TITLE
style(cli): two sites the package's own sweep left behind

### DIFF
--- a/packages/cli/lib/verb-section.ts
+++ b/packages/cli/lib/verb-section.ts
@@ -103,6 +103,7 @@ export const EVERY_FLAG_TAKES_A_VALUE: SpendsNextWord = () => true;
 export interface SectionUnit {
   /** The flag's name without its `--`, or `undefined` for a bare word. */
   readonly flag?: string;
+
   /** The unit's words, in the order they were written. */
   readonly tokens: readonly string[];
 }

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -236,6 +236,7 @@ export interface StructureNode {
 
   /** Character offset of the node end, read the same way. */
   readonly endOffset: number;
+
   readonly depth: number;
   readonly children: StructureNode[];
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two sites in `packages/cli` that appeared after its sweep (#6645) landed, for
different reasons.

**`view/model.ts` is mine.** #6645's last commit gave `endOffset` a doc comment
of its own — fixing a comment that had covered both offsets — and that made it a
newly *documented* declaration, with `depth` sitting directly beneath it. Adding
a doc comment creates a blank-line-below obligation just as surely as finding
one does, so **the detector has to run again after the comment work, not only
before it**. I checked the three sweep branches still in flight the same way;
all three are clean.

**`verb-section.ts` arrived with #6622**, after the sweep had measured the
package.

`deno fmt --check` clean; `deno task test` in `packages/cli`: 210 passed, 0
failed. The detector reports zero remaining sites in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

