### PR TITLE
style: the six files held back so #6635 could land first

### DIFF
--- a/packages/cf-harness/console/cell-labels.ts
+++ b/packages/cf-harness/console/cell-labels.ts
@@ -53,6 +53,7 @@ export interface ConsoleCellLabelEntry {
    * for showing, and belongs to whoever shows it.
    */
   path: readonly string[];
+
   confidentiality: readonly string[];
   integrity: readonly string[];
   origin?: string;

--- a/packages/cf-harness/console/flow.ts
+++ b/packages/cf-harness/console/flow.ts
@@ -30,17 +30,22 @@ export type ConsoleFlowKind =
 export interface ConsoleFlowCell {
   /** Stable identity — the address where known, the token otherwise. */
   id: string;
+
   token?: string;
   ref?: string;
   slug?: string;
   /** The step whose result minted it. */
   producedByStep?: number;
+
   /** The shape the pattern that made it declared, for the chip's card. */
   schema?: unknown;
+
   /** Confidentiality atoms the invocation context put where it was used. */
   confidentiality: readonly string[];
+
   /** The labels the space holds for the cell itself, where the run read them. */
   labels?: ConsoleCellLabels;
+
   /** The argument name it came in as, for a cell a call read. */
   as?: string;
 }
@@ -66,9 +71,13 @@ export interface ConsoleFlowNode {
 
   status: ConsoleStepStatus;
 
-  /** What CFC decided, and whether it refused the observation. */
+  /** What CFC decided about the observation. */
   policyDecision?: string;
+
+  /** Whether that decision refused it. */
   policyDenied?: boolean;
+
+  /** What the decision said, where it said more than its verdict. */
   policyDetail?: string;
 
   /** Cells this call read. */
@@ -90,6 +99,7 @@ export interface ConsoleFlowNode {
    * carried one. A long numeric run is the shape of a channel.
    */
   valueBytes?: number;
+
   longestNumericRun?: number;
 
   /** The child run this call delegated to, drawn beneath it. */
@@ -103,8 +113,10 @@ export interface ConsoleFlowNode {
 export interface ConsoleFlowTurn {
   /** The step of the parent run that opened it. */
   step: number;
+
   /** What the person asked, elided. */
   text?: string;
+
   nodes: readonly ConsoleFlowNode[];
 }
 
@@ -132,10 +144,13 @@ export interface ConsoleFlow {
    * run whose space could not be read.
    */
   cellLabels?: ConsoleCellLabelsSummary;
+
   /** Calls that failed, across the whole family. */
   failures: number;
+
   /** Calls CFC refused, across the whole family. */
   denials: number;
+
   /** Patterns that read no cell — work built from literals. */
   unwiredPatterns: number;
 }

--- a/packages/cf-harness/console/graph.ts
+++ b/packages/cf-harness/console/graph.ts
@@ -31,9 +31,12 @@ export interface ConsoleGraphNode {
   /** The step this node first appeared at. */
   atStep: number;
 
-  /** For a pattern: how the call turned out, and what CFC said about it. */
+  /** For a pattern: how the call turned out. */
   status?: ConsoleStep["status"];
+
+  /** For a pattern: what CFC said about it. */
   policyDecision?: string;
+
   disclosure?: ConsoleDisclosure;
 
   /** For a pattern run from the index rather than from fresh source. */

--- a/packages/cf-harness/test/console/cell-labels.test.ts
+++ b/packages/cf-harness/test/console/cell-labels.test.ts
@@ -25,8 +25,10 @@ const entity = (name: string) => `of:fid1:${name.padEnd(44, "0")}`;
 const LABELLED = entity("labelled");
 const BARE = entity("bare");
 
-/** The space a snapshot is taken in, and one it is not. */
+/** The space a snapshot is taken in. */
 const OWN_DID = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
+
+/** A space it is not taken in. */
 const FOREIGN_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
 const atom = (name: string) => ({ type: name, name });

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -57,6 +57,7 @@ const MANIFEST = "clone.json";
  * Kept out of `clone.json` so that file stays small enough to read by eye.
  */
 const BASELINE = "baseline-entities.json";
+
 const MARKER = ".cf-clone";
 const PRISTINE_DIR = "pristine";
 
@@ -87,6 +88,7 @@ export interface CloneManifest {
    * sidecar existed, which fall back to recomputing.
    */
   baselineHash?: string;
+
   snapshotBytes: number;
 
   /** Durable counts at clone time — the cheap half of "did content survive?". */
@@ -142,6 +144,7 @@ export interface ClonePaths {
 
   /** Per-entity baseline hashes (see {@link BASELINE}). */
   baselinePath: string;
+
   pristinePath: string;
   workingPath: string;
 }

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -64,6 +64,7 @@ interface SeedEntity {
 
   /** The stored document, written once per revision. */
   document: Record<string, unknown>;
+
   revisions: number;
 
   /** Branch the revisions are written on. Defaults to the space branch. */


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The four `console/` files #6652 held back, now that #6635 has landed: **12 blank
lines**, plus three comments that described more than the declaration they sat
on.

- **`flow.ts`** — "what CFC decided, **and** whether it refused the observation"
  over `policyDecision`, `policyDenied`, and `policyDetail`.
- **`graph.ts`** — "how the call turned out, **and** what CFC said about it"
  over `status` and `policyDecision`.
- **`cell-labels.test.ts`** — "the space a snapshot is taken in, **and one it is
  not**" over the two DIDs that are exactly those two things.

### A correction to #6652

The first two fixes were written for #6652 and did **not** land there. Excluding
those files meant reverting them whole, which took the comment fixes out along
with the blank lines. #6652's message claimed the excluded sites were "a
different site in each file" from the ones it fixed; that was wrong, and this PR
is where those two fixes actually arrive.

### Checks

`deno fmt --check` and `deno lint` clean. `deno task test` in
`packages/cf-harness`: **902 passed, 0 failed**. The detector reports zero
remaining sites in all four files. Every change is comment or whitespace only,
verified by diffing both revisions with comments and blank lines stripped.

### And the two files #6655 held back for the same reason

`state-inspector/clone.ts` and `state-inspector/test/scan-extent.test.ts` were
excluded from #6655 on identical grounds. Four blank lines, no comment
rewriting: each of those comments describes the one declaration it sits on.
`tasks/lint-bench-console.test.ts` and `data-model-schema/src/schema-intern.ts`
were held back too and turn out to need nothing — the detector reports zero
sites in both. `state-inspector` tests: 111 passed, 0 failed.

With this and #6650, the sweep is complete outside `packages/patterns`, which is
carved out by standing decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM
