### PR TITLE
CT-2153: attach trusted pattern refs to delegations

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -123,7 +123,8 @@ What works today:
     [Running patterns against a Fabric space](#running-patterns-against-a-fabric-space))
   - `search_patterns` (present only when the run configures a pattern index with
     `--pattern-index-url`; finds published patterns by hashtag or free text and
-    reports each one's declared shapes and import specifier, never its source)
+    reports each one's kind, evidence quality, declared shapes, and import
+    specifier, never its source)
   - `record_feedback` (under the same pattern-index gate; votes a pattern up or
     down so the index learns which ones were worth offering)
   - `search_skills` (present only on the parent surface when the run configures
@@ -726,13 +727,14 @@ bound for model context carries tokens, while the persisted tool-output artifact
 keeps the raw addresses. Model-authored tool arguments resolve tokens back to
 canonical references before policy evaluation, summarization, and dispatch —
 except for `delegate_task`, whose `goal` and `context` reach the child verbatim,
-so a token there is inert text to the parent boundary (its `skillHandle` is the
-one delegate argument the parent boundary resolves itself: trusted-side
-materialization is that parameter's whole point — see "Skill by handle" below).
-And a sealed subagent structured-return string whose raw value names an address
-comes back as a token rather than an opaque `@link` object; the return's
-`linkedStringCount` counts only the positions still sealed. Denial-path tool
-messages are not swapped; that coverage, value handles, and an explicit
+so a token there is inert text to the parent boundary. Its `skillHandle` and
+`patternRefs` fields are resolved separately on the trusted side: materializing
+stored skill text and rebuilding selected pattern-search records are those
+parameters' whole point (see "Skill by handle" and "Pattern references by search
+record" below). And a sealed subagent structured-return string whose raw value
+names an address comes back as a token rather than an opaque `@link` object; the
+return's `linkedStringCount` counts only the positions still sealed. Denial-path
+tool messages are not swapped; that coverage, value handles, and an explicit
 release/readback mechanism are listed in [docs/ROADMAP.md](docs/ROADMAP.md).
 
 #### Well-known grants
@@ -967,6 +969,24 @@ preamble that keeps a skill from authorizing tools applies to it unchanged. The
 child's activation record carries `source: "skill-handle"`, the token, and the
 digest of the exact text injected, so the artifacts say which reference supplied
 the skill and what it said.
+
+#### Pattern references by search record
+
+`delegate_task` also takes up to eight optional `patternRefs`, each containing a
+`patternId` and an optional bounded parent note. The harness resolves an id only
+from successful `search_patterns` results retained by that parent prompt loop;
+it neither trusts model-retyped metadata nor fetches the index during
+delegation. A known id gives the child a neutral generated block with the
+record's kind, quality, description, match evidence, import hint, argument
+shape, result shape, and the note verbatim. An id absent from the parent's
+record is omitted from child context and returned by name in
+`patternRefRefusals` with reason `not-searched-by-parent`.
+
+Cell handles passed as tokens, `skillHandle`, and `patternRefs` are sibling
+channels of one conceptual kind: an id names hashed information stored
+somewhere, attached metadata accompanies it, and trusted-side code resolves it.
+They deliberately remain separate until experience supplies a concrete reason to
+unify them.
 
 ### Running patterns against a Fabric space
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -974,13 +974,14 @@ the skill and what it said.
 
 `delegate_task` also takes up to eight optional `patternRefs`, each containing a
 `patternId` and an optional bounded parent note. The harness resolves an id only
-from successful `search_patterns` results retained by that parent prompt loop;
-it neither trusts model-retyped metadata nor fetches the index during
-delegation. A known id gives the child a neutral generated block with the
-record's kind, quality, description, match evidence, import hint, argument
-shape, result shape, and the note verbatim. An id absent from the parent's
-record is omitted from child context and returned by name in
-`patternRefRefusals` with reason `not-searched-by-parent`.
+from successful `search_patterns` results retained by that parent run and
+restored from its persisted transcript on resume; it neither trusts
+model-retyped metadata nor fetches the index during delegation. A known id gives
+the child a neutral generated block with the record's kind, quality,
+description, match evidence, import hint, argument shape, result shape, and the
+note verbatim. An id absent from the parent's record is omitted from child
+context and returned by name in `patternRefRefusals` with reason
+`not-searched-by-parent`.
 
 Cell handles passed as tokens, `skillHandle`, and `patternRefs` are sibling
 channels of one conceptual kind: an id names hashed information stored

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -104,6 +104,14 @@ The current package provides:
   name-based selection retired for the delegated path — and the child's
   activation records `source: "skill-handle"` with the token and the digest of
   the injected text;
+- pattern references by search record: `delegate_task` takes up to eight
+  optional `{ patternId, note? }` entries and resolves each id only from
+  successful `search_patterns` results retained by that parent prompt loop. A
+  known id contributes a neutral child-context block containing the trusted
+  record's kind, quality, description, match evidence, import hint, argument
+  shape, result shape, and the parent note verbatim; an unknown id is omitted
+  and named in `patternRefRefusals` as `not-searched-by-parent`. Delegation does
+  not refetch the index;
 - shape captured where it is free and read back by token: a handle entry may
   carry the schema of its referent — a `run_pattern` result reference records
   the compiled pattern's result schema, marked `schemaSource: "harness"` — while
@@ -180,24 +188,28 @@ The current package provides:
   session configuration: index requests are signed with the session identity
   under the CF1 first-party scheme, and an indexed pattern runs in the session's
   space. It adds the `search_patterns` tool, which finds published patterns by
-  hashtag or free text and reports each hit's description, hashtags, usage
-  signals, declared argument and result shapes, and the `cf:pattern:<patternId>`
-  import specifier that composes it. It also extends `run_pattern`, which takes
-  exactly one of `sourceText` and `patternId`: with a `patternId` the published
-  program is fetched host-side and compiled down the same path, and neither its
-  source nor a compile diagnostic quoting it reaches model context — the
-  diagnostic is retained in the run artifact instead. The run reports
-  `instantiated` and then `run_succeeded` or `run_failed` back to the index,
-  best-effort, so a reporting failure never bears on the tool result. It adds
-  the `record_feedback` tool, which votes a pattern up or down with an optional
-  note, so the index learns which of the patterns it holds were worth offering.
-  And it closes the loop the other way: source the model authored and ran
-  successfully is recorded under the identity the compile recorded for it,
-  carrying the `description` and `hashtags` the call named, the run's own task
-  as the request the pattern answers, the compiled argument and result schemas,
-  and the published patterns the source imports. Automatic publication records
-  the entry without offering it to search; discoverability is earned from later
-  evidence. Curated seeding may offer a passing run immediately by setting
+  hashtag or free text and reports each hit's kind, evidence quality,
+  description, hashtags, usage signals, declared argument and result shapes, and
+  the `cf:pattern:<patternId>` import specifier that composes it. Free-text
+  search removes stopwords, matches whole words plus light suffix variants, and
+  is disjunctive: one content term may return a hit, so extra terms can admit
+  generic matches. `matchedTerms` and `queryTerms` count the stopword-free
+  terms. It also extends `run_pattern`, which takes exactly one of `sourceText`
+  and `patternId`: with a `patternId` the published program is fetched host-side
+  and compiled down the same path, and neither its source nor a compile
+  diagnostic quoting it reaches model context — the diagnostic is retained in
+  the run artifact instead. The run reports `instantiated` and then
+  `run_succeeded` or `run_failed` back to the index, best-effort, so a reporting
+  failure never bears on the tool result. It adds the `record_feedback` tool,
+  which votes a pattern up or down with an optional note, so the index learns
+  which of the patterns it holds were worth offering. And it closes the loop the
+  other way: source the model authored and ran successfully is recorded under
+  the identity the compile recorded for it, carrying the `description` and
+  `hashtags` the call named, the run's own task as the request the pattern
+  answers, the compiled argument and result schemas, and the published patterns
+  the source imports. Automatic publication records the entry without offering
+  it to search; discoverability is earned from later evidence. Curated seeding
+  may offer a passing run immediately by setting
   `CF_HARNESS_PATTERN_INDEX_PUBLISH_DISCOVERABLE=1`, while a render-gate failure
   remains recorded and non-discoverable with the gate's reason. Publication is
   best-effort in the same way — never awaited, never a failure of a run that

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -106,12 +106,13 @@ The current package provides:
   the injected text;
 - pattern references by search record: `delegate_task` takes up to eight
   optional `{ patternId, note? }` entries and resolves each id only from
-  successful `search_patterns` results retained by that parent prompt loop. A
-  known id contributes a neutral child-context block containing the trusted
-  record's kind, quality, description, match evidence, import hint, argument
-  shape, result shape, and the parent note verbatim; an unknown id is omitted
-  and named in `patternRefRefusals` as `not-searched-by-parent`. Delegation does
-  not refetch the index;
+  successful `search_patterns` results retained by that parent run and restored
+  from its persisted transcript on resume. A known id contributes a neutral
+  child-context block containing the trusted record's kind, quality,
+  description, match evidence, import hint, argument shape, result shape, and
+  the parent note verbatim; an unknown id is omitted and named in
+  `patternRefRefusals` as `not-searched-by-parent`. Delegation does not refetch
+  the index;
 - shape captured where it is free and read back by token: a handle entry may
   carry the schema of its referent — a `run_pattern` result reference records
   the compiled pattern's result schema, marked `schemaSource: "harness"` — while

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -24,6 +24,8 @@ export const PATTERN_AUTHOR_SUBAGENT_PROFILE = "pattern-author" as const;
 export const WEB_SEARCH_SUBAGENT_MODEL = "gemini-3.5-flash" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
 export const MAX_SUBAGENT_MAX_MODEL_TURNS = 64;
+export const MAX_DELEGATE_PATTERN_REFS = 8;
+export const MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH = 500;
 
 /**
  * Turn budget of the `pattern-author` profile. Authoring is a write,
@@ -581,12 +583,30 @@ export type HarnessSubagentRunRef =
   | HarnessRunningSubagentRunRef
   | HarnessTerminalSubagentRunRef;
 
+/** One published pattern the parent selected from its prior search results. */
+export interface DelegateTaskPatternRef {
+  /** Content-addressed id exactly as `search_patterns` returned it. */
+  patternId: string;
+
+  /** Parent-authored context for this selection, passed to the child verbatim. */
+  note?: string;
+}
+
+/** An inert refusal for a selected id absent from the parent's search record. */
+export interface DelegateTaskPatternRefRefusal {
+  patternId: string;
+  reason: "not-searched-by-parent";
+}
+
 export interface DelegateTaskToolInput {
   goal: string;
   profile: HarnessSubagentProfile;
   context?: string;
   maxModelTurns?: number;
   returnSchema?: JSONSchema;
+
+  /** Published patterns selected from this parent's prior search results. */
+  patternRefs?: readonly DelegateTaskPatternRef[];
 
   /**
    * A handle the PARENT holds, naming a cell whose string value is skill
@@ -602,4 +622,5 @@ export interface DelegateTaskToolOutput {
   type: "cf-harness.delegate-task-output";
   outputId: string;
   subagent: HarnessSubagentResult;
+  patternRefRefusals?: readonly DelegateTaskPatternRefRefusal[];
 }

--- a/packages/cf-harness/src/pattern-index/client.ts
+++ b/packages/cf-harness/src/pattern-index/client.ts
@@ -28,6 +28,12 @@ export interface PatternIndexSignals {
   score: number;
 }
 
+/** Whether a published argument schema classifies a hit as reusable or whole. */
+export type PatternIndexPatternKind = "part" | "app";
+
+/** Evidence tier the deployed index computed from recorded run outcomes. */
+export type PatternIndexQuality = "penalized" | "unproven" | "proven";
+
 /** One hit from `searchPatterns`. Carries metadata and never source. */
 export interface PatternIndexSearchResult {
   patternId: string;
@@ -38,8 +44,14 @@ export interface PatternIndexSearchResult {
   dependencies: readonly string[];
   signals?: PatternIndexSignals;
 
+  /** Whether the published argument schema classifies this as a part or app. */
+  kind: PatternIndexPatternKind;
+
+  /** Evidence tier computed by the index from recorded run outcomes. */
+  quality: PatternIndexQuality;
+
   /**
-   * With a text query: how many of its terms this hit carries, out of
+   * With a text query: how many stopword-free terms this hit carries, out of
    * `queryTerms`. Text matching is disjunctive and ranked, so a hit is not a
    * claim that everything matched — the ratio is what says how close.
    */

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -59,6 +59,8 @@ import {
   asHarnessSubagentFailureReport,
   BROWSER_SUBAGENT_PROFILE,
   DEFAULT_SUBAGENT_PROFILE,
+  type DelegateTaskPatternRef,
+  type DelegateTaskPatternRefRefusal,
   type DelegateTaskToolInput,
   type DelegateTaskToolOutput,
   getHarnessSubagentProfileConfig,
@@ -72,6 +74,8 @@ import {
   type HarnessSubagentRunStateSummary,
   type HarnessSubagentStructuredReturn,
   isHarnessSubagentProfile,
+  MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH,
+  MAX_DELEGATE_PATTERN_REFS,
   MAX_SUBAGENT_MAX_MODEL_TURNS,
   PATTERN_AUTHOR_SUBAGENT_PROFILE,
   SUBAGENT_FAILURE_REASON_CODES,
@@ -136,6 +140,10 @@ import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
 import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
+import {
+  isSearchPatternsToolSuccessOutput,
+  type SearchPatternsToolResult,
+} from "./tools/search-patterns.ts";
 import {
   isRunPatternToolSuccessOutput,
   scrubBareFabricIdentifiers,
@@ -737,6 +745,47 @@ const parseDelegateTaskInput = (
       invalid: { field: "context", expected: "a string, or omit it" },
     };
   }
+  let patternRefs: readonly DelegateTaskPatternRef[] | undefined;
+  if (input.patternRefs !== undefined) {
+    if (
+      !Array.isArray(input.patternRefs) ||
+      input.patternRefs.length > MAX_DELEGATE_PATTERN_REFS
+    ) {
+      return {
+        invalid: {
+          field: "patternRefs",
+          expected:
+            `an array of at most ${MAX_DELEGATE_PATTERN_REFS} pattern references`,
+        },
+      };
+    }
+    const parsed: DelegateTaskPatternRef[] = [];
+    for (const patternRef of input.patternRefs) {
+      if (
+        !isObjectNotArray(patternRef) ||
+        typeof patternRef.patternId !== "string" ||
+        patternRef.patternId.trim().length === 0 ||
+        (patternRef.note !== undefined &&
+          (typeof patternRef.note !== "string" ||
+            patternRef.note.length > MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH))
+      ) {
+        return {
+          invalid: {
+            field: "patternRefs",
+            expected:
+              `entries with a non-empty patternId and an optional note of at most ${MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH} characters`,
+          },
+        };
+      }
+      parsed.push({
+        patternId: patternRef.patternId,
+        ...(typeof patternRef.note === "string"
+          ? { note: patternRef.note }
+          : {}),
+      });
+    }
+    patternRefs = parsed;
+  }
   const profile = input.profile === undefined
     ? DEFAULT_SUBAGENT_PROFILE
     : typeof input.profile === "string" &&
@@ -822,6 +871,7 @@ const parseDelegateTaskInput = (
         : {}),
       ...(typeof maxModelTurns === "number" ? { maxModelTurns } : {}),
       ...(returnSchema !== undefined ? { returnSchema } : {}),
+      ...(patternRefs !== undefined ? { patternRefs } : {}),
       ...(typeof input.skillHandle === "string"
         ? { skillHandle: input.skillHandle.trim() }
         : {}),
@@ -1219,7 +1269,7 @@ const buildSubagentSystemPrompt = (
           ]
           : []),
         "Pass pattern source inline as the run_pattern `sourceText` argument. You have no write_file or edit_file; do not try to author patterns as workspace files.",
-        "The pattern factory must return its result object literal directly — `return { count, $UI: <div>…</div> }` — with computed() wrapping individual derived fields at most. Never return a computed(), lift, or other derived wrapper as the whole result: the piece it creates exists only in this session's runtime, and the browser link handed to the user will fail to load it.",
+        "Return a durable result object directly — `return { count, $UI: <div>…</div> }`. A whole-result derived wrapper is a known smell, but not a deterministic failure: after instantiation run_pattern checks the actual pattern pointer and refuses a piece materialized under a session-only identity.",
         "You own the write, compile-error, fix loop. A `compile-error` result is normal iteration material: read the diagnostic, correct the source, and call run_pattern again. Do not hand a compile error back to the parent as the answer.",
         "Use read_file and bash to read existing patterns and pattern documentation in the workspace when the compiler or the preloaded skills leave a question open.",
         "Every reference in your task is an address, not a value. Wire it into the pattern as a run_pattern `inputs` entry so the pattern reads it live; never try to read, print, or transcribe the data behind it yourself.",
@@ -1269,11 +1319,56 @@ const buildSubagentSystemPrompt = (
       ]),
   ].join("\n");
 
-const buildSubagentUserPrompt = (input: DelegateTaskToolInput): string =>
+/** One selected pattern rebuilt from the parent's trusted search record. */
+interface RehydratedDelegatePatternRef {
+  record: SearchPatternsToolResult;
+  note?: string;
+}
+
+/**
+ * Experimental neutral wording for pattern-reference child context. The
+ * committed suites measure this variable; advisory and directive variants
+ * remain empirically undecided, so this one presents available material and
+ * mandates nothing.
+ */
+const PATTERN_REFS_CHILD_CONTEXT = (
+  patternRefs: readonly RehydratedDelegatePatternRef[],
+): string =>
+  [
+    "Published pattern references selected by the parent:",
+    "These records from the parent's earlier searches are available for this delegated task.",
+    ...patternRefs.flatMap(({ record, note }, index) => [
+      "",
+      `Pattern ${index + 1}: ${record.patternId}`,
+      `Kind: ${record.kind}`,
+      `Quality: ${record.quality}`,
+      `Description: ${record.description}`,
+      ...(record.matchedTerms !== undefined &&
+          record.queryTerms !== undefined
+        ? [
+          `Match: ${record.matchedTerms} of ${record.queryTerms} stopword-free query terms`,
+        ]
+        : []),
+      `Import: ${record.importHint}`,
+      "Argument shape:",
+      record.argumentType ?? "Not available.",
+      "Result shape:",
+      record.resultType ?? "Not available.",
+      ...(note !== undefined ? ["Parent note:", note] : []),
+    ]),
+  ].join("\n");
+
+const buildSubagentUserPrompt = (
+  input: DelegateTaskToolInput,
+  patternRefs: readonly RehydratedDelegatePatternRef[] = [],
+): string =>
   [
     "Task:",
     input.goal,
     ...(input.context !== undefined ? ["", "Context:", input.context] : []),
+    ...(patternRefs.length > 0
+      ? ["", PATTERN_REFS_CHILD_CONTEXT(patternRefs)]
+      : []),
     ...(input.returnSchema !== undefined
       ? [
         "",
@@ -2320,6 +2415,10 @@ export class CfHarnessPromptLoop {
   readonly #reasoningEffort?: string;
   readonly #compactThreshold?: number;
   readonly #subagentCompositionGuidance: boolean;
+  readonly #trustedPatternSearchRecords = new Map<
+    string,
+    SearchPatternsToolResult
+  >();
 
   constructor(options: CreateHarnessPromptLoopOptions = {}) {
     this.engine = options.engine ?? new CfHarnessEngine(options);
@@ -2893,6 +2992,53 @@ export class CfHarnessPromptLoop {
     }
   }
 
+  /** Retains successful search hits for this parent prompt loop. */
+  #recordPatternSearchResult(toolId: BuiltinToolId, output: unknown): void {
+    if (
+      toolId !== "search_patterns" ||
+      !isSearchPatternsToolSuccessOutput(output)
+    ) {
+      return;
+    }
+    for (const record of output.results) {
+      this.#trustedPatternSearchRecords.set(
+        record.patternId,
+        structuredClone(record),
+      );
+    }
+  }
+
+  /** Rehydrates selected ids from this parent's prior search results only. */
+  #rehydrateDelegatePatternRefs(
+    patternRefs: readonly DelegateTaskPatternRef[] | undefined,
+  ): {
+    records: readonly RehydratedDelegatePatternRef[];
+    refusals: readonly DelegateTaskPatternRefRefusal[];
+  } {
+    const records: RehydratedDelegatePatternRef[] = [];
+    const refusals: DelegateTaskPatternRefRefusal[] = [];
+    for (const patternRef of patternRefs ?? []) {
+      const record = this.#trustedPatternSearchRecords.get(
+        patternRef.patternId,
+      );
+      if (record === undefined) {
+        refusals.push({
+          patternId: patternRef.patternId,
+          reason: "not-searched-by-parent",
+        });
+        continue;
+      }
+      // No new CFC boundary is crossed here: every search field could already
+      // travel in `goal` or `context`, and `note` is parent-authored prose like
+      // those fields. Trusted-side rehydration replaces lossy retyping.
+      records.push({
+        record: structuredClone(record),
+        ...(patternRef.note !== undefined ? { note: patternRef.note } : {}),
+      });
+    }
+    return { records, refusals };
+  }
+
   /**
    * Helper for `#invokeToolCall()`, which applies the outbound handle swap
    * to a model-bound value, recording the table when minting extended it.
@@ -3415,6 +3561,7 @@ export class CfHarnessPromptLoop {
       // what lets it stay run-fatal without matching error-message strings.
       throw error;
     }
+    this.#recordPatternSearchResult(toolId, result.output);
     // Before the outbound swap, so the token it mints for the result cell
     // already carries the shape the compiler knew.
     await this.#recordRunPatternResultShape(
@@ -3758,6 +3905,9 @@ export class CfHarnessPromptLoop {
     resultRef: ToolResultRef;
   }> {
     const delegateInput = options.input;
+    const patternRefResolution = this.#rehydrateDelegatePatternRefs(
+      delegateInput.patternRefs,
+    );
     const profileConfig = subagentProfileConfigForRun(
       delegateInput.profile,
       this.#toolBackingAvailability(),
@@ -4032,7 +4182,10 @@ export class CfHarnessPromptLoop {
               : {}),
           },
         ),
-        prompt: buildSubagentUserPrompt(delegateInput),
+        prompt: buildSubagentUserPrompt(
+          delegateInput,
+          patternRefResolution.records,
+        ),
         contextMessages: childSkillContextMessages,
         model: childModel.model,
         maxModelTurns,
@@ -4134,6 +4287,9 @@ export class CfHarnessPromptLoop {
       type: "cf-harness.delegate-task-output",
       outputId: this.engine.nextToolOutputId("delegate_task"),
       subagent,
+      ...(patternRefResolution.refusals.length > 0
+        ? { patternRefRefusals: patternRefResolution.refusals }
+        : {}),
     };
     const result = await this.engine.recordBuiltinToolOutput(
       "delegate_task",

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2664,6 +2664,7 @@ export class CfHarnessPromptLoop {
     }
     this.engine.bindRunModel(model);
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
+    this.#restorePatternSearchRecords(transcript);
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
     const toolActivity: HarnessToolActivity[] = [];
     const modelAttempts: HarnessModelAttempt[] = [];
@@ -2989,6 +2990,25 @@ export class CfHarnessPromptLoop {
     });
     if (minted.table !== table) {
       await this.engine.recordHandleTable(minted.table);
+    }
+  }
+
+  /** Restores successful search hits already present in parent history. */
+  #restorePatternSearchRecords(
+    transcript: readonly HarnessTranscriptMessage[],
+  ): void {
+    for (const message of transcript) {
+      if (message.role !== "tool" || message.toolName !== "search_patterns") {
+        continue;
+      }
+      try {
+        this.#recordPatternSearchResult(
+          "search_patterns",
+          JSON.parse(message.content),
+        );
+      } catch {
+        // A malformed persisted result grants no pattern reference.
+      }
     }
   }
 

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -3,7 +3,11 @@ import type {
   DelegateTaskToolOutput,
   HarnessSubagentProfile,
 } from "../contracts/subagent.ts";
-import { HARNESS_SUBAGENT_PROFILES } from "../contracts/subagent.ts";
+import {
+  HARNESS_SUBAGENT_PROFILES,
+  MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH,
+  MAX_DELEGATE_PATTERN_REFS,
+} from "../contracts/subagent.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 import { createUnimplementedToolError } from "./types.ts";
 
@@ -25,7 +29,7 @@ export const delegateTaskTool: HarnessToolDefinition<
         goal: {
           type: "string",
           description:
-            'Specific task for the child run. Include all context the child needs; it will not see the parent transcript. Delegate one buildable piece at a time: a "pattern-author" child that is asked for one small component returns a working result reference, where one asked for a whole application spends its turns on a compile loop that does not converge. Name the words the capability should be findable under, so a later delegation can search the pattern index for the same component instead of asking for it again.',
+            'Specific task for the child run. Include all context the child needs; it will not see the parent transcript. Keep a "pattern-author" delegation focused on one buildable piece so its compile/fix loop fits the child turn budget. Name the words the capability should be findable under, so a later delegation can search the pattern index for the same component instead of asking for it again.',
         },
         profile: {
           type: "string",
@@ -33,12 +37,37 @@ export const delegateTaskTool: HarnessToolDefinition<
             ...HARNESS_SUBAGENT_PROFILES,
           ] satisfies HarnessSubagentProfile[],
           description:
-            'Named subagent profile to spawn. Defaults to the harness default profile. Authoring or running a Common Fabric pattern goes through "pattern-author": it is the one profile preloaded with the pattern authoring skills, which neither the default profile nor the parent run carries — authoring anywhere else means guessing the pattern API. A "pattern-author" child runs what it wrote and answers with a reference to the result cell, never with source: you get something to assign_slug or wire into a run_pattern input, and you never compile anything yourself.',
+            'Named subagent profile to spawn. Defaults to the harness default profile. Authoring or running a Common Fabric pattern goes through "pattern-author": when the configured skill registry carries the pattern skills, this profile preloads them; the default profile does not. A "pattern-author" child runs what it wrote and answers with a reference to the result cell, never with source: you get something to assign_slug or wire into a run_pattern input, and you never compile anything yourself.',
         },
         context: {
           type: "string",
           description:
             "Optional supporting context, paths, constraints, or expected output for the child run.",
+        },
+        patternRefs: {
+          type: "array",
+          maxItems: MAX_DELEGATE_PATTERN_REFS,
+          items: {
+            type: "object",
+            properties: {
+              patternId: {
+                type: "string",
+                minLength: 1,
+                description:
+                  "Pattern id exactly as this parent received it from search_patterns.",
+              },
+              note: {
+                type: "string",
+                maxLength: MAX_DELEGATE_PATTERN_REF_NOTE_LENGTH,
+                description:
+                  "Optional parent-authored context for this pattern selection. It reaches the child verbatim.",
+              },
+            },
+            required: ["patternId"],
+            additionalProperties: false,
+          },
+          description:
+            "Optional published patterns selected from this parent's earlier search_patterns results. The harness attaches their trusted metadata to the child; supply ids and optional notes only.",
         },
         maxModelTurns: {
           type: "integer",

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -296,7 +296,7 @@ export const runPatternToolDescriptor: HarnessToolDescriptor = {
       sourceText: {
         type: "string",
         description:
-          "Pattern source (TypeScript/TSX). At most 256 KiB. The pattern factory must return its result object literal directly (computed() wrapping individual fields at most); a factory that returns a computed() or other derived wrapper as the whole result creates a piece no other runtime can load.",
+          "Pattern source (TypeScript/TSX). At most 256 KiB. Return a durable result object directly. A whole-result derived wrapper is a known smell, but not a deterministic failure: after the run the harness checks the actual pattern pointer and refuses any piece materialized under a session-only identity.",
       },
       patternId: {
         type: "string",
@@ -1303,7 +1303,7 @@ export const runPatternTool: HarnessToolDefinition<
       return {
         ...errorOutput(
           "error",
-          `the pattern ran, but the piece it created can only be opened by this session, so the run is reported as a failure. This is the shape a factory takes when it returns a derived wrapper — a computed() or a lift() over the whole result — instead of the result itself: the wrapper becomes the piece's own body, and nothing durable names it. Return the result object literal directly and put computed() on the individual fields that derive from an input`,
+          `the pattern ran, but the harness detected a session-only pattern pointer in the created piece's graph, so the run is reported as a failure. The detected pointer cannot be opened by another runtime. Return a durable result object directly`,
         ),
         pieceId: piece.id,
         rawCauseMessage:

--- a/packages/cf-harness/src/tools/search-patterns.ts
+++ b/packages/cf-harness/src/tools/search-patterns.ts
@@ -15,6 +15,8 @@ import { schemaToTypeString } from "@commonfabric/runner";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type {
   PatternIndexClient,
+  PatternIndexPatternKind,
+  PatternIndexQuality,
   PatternIndexSignals,
 } from "../pattern-index/client.ts";
 import type { HarnessToolDefinition } from "./types.ts";
@@ -40,10 +42,16 @@ export interface SearchPatternsToolResult {
   hashtags: readonly string[];
   signals?: PatternIndexSignals;
 
+  /** Whether its published argument schema classifies it as a part or app. */
+  kind: PatternIndexPatternKind;
+
+  /** Evidence tier the index computed from recorded run outcomes. */
+  quality: PatternIndexQuality;
+
   /**
-   * With a text query: how many of its terms this hit carries, out of
-   * `queryTerms`. Matching is disjunctive and ranked — a hit with a low
-   * ratio is a distant cousin, not an answer.
+   * With a text query: how many stopword-free terms this hit carries, out of
+   * `queryTerms`. Matching is disjunctive and ranked — a hit with a low ratio
+   * is a distant cousin, not an answer.
    */
   matchedTerms?: number;
 
@@ -78,11 +86,19 @@ export type SearchPatternsToolOutput =
   | SearchPatternsToolSuccessOutput
   | SearchPatternsToolErrorOutput;
 
+/** Narrows a raw tool result to a successful search response. */
+export const isSearchPatternsToolSuccessOutput = (
+  output: unknown,
+): output is SearchPatternsToolSuccessOutput =>
+  typeof output === "object" && output !== null &&
+  "status" in output && output.status === "ok" &&
+  "results" in output && Array.isArray(output.results);
+
 export const searchPatternsToolDescriptor: HarnessToolDescriptor = {
   toolId: "search_patterns",
   title: "Search Patterns",
   description:
-    "Search the pattern index for published Common Fabric patterns by hashtag or free text. Answers with each pattern's id, description, declared argument and result shapes, and the import specifier that composes it — never its source. Run one with run_pattern's patternId argument.",
+    "Search the pattern index for published Common Fabric patterns by hashtag or free text. Answers with each pattern's id, kind, evidence quality, description, import specifier, and stopword-free match ratio; the leading results also carry declared argument and result shapes — never source. Run one with run_pattern's patternId argument.",
   effectClass: "read",
   inputSchema: {
     type: "object",
@@ -91,12 +107,12 @@ export const searchPatternsToolDescriptor: HarnessToolDescriptor = {
         type: "array",
         items: { type: "string" },
         description:
-          "Hashtags a pattern must carry. Omit to search on text alone.",
+          "Hashtags to match. Any supplied hashtag can surface a result. Omit to search on text alone.",
       },
       text: {
         type: "string",
         description:
-          "Free text matched against pattern descriptions, keywords, and tags. Matching is disjunctive and ranked: results carry matchedTerms out of queryTerms, so more words widen the net rather than narrowing it. Omit to search on tags alone.",
+          "A short set of distinctive capability words. English stopwords are removed, then whole words are matched with light suffix handling against pattern descriptions, keywords, and hashtags. One content term can surface a result; adding generic words adds distant OR matches. Results carry matchedTerms out of the stopword-free queryTerms. Omit to search on tags alone.",
       },
     },
     additionalProperties: false,
@@ -124,13 +140,32 @@ export const searchPatternsToolDescriptor: HarnessToolDescriptor = {
                 required: ["uses", "score"],
                 additionalProperties: false,
               },
+              kind: {
+                type: "string",
+                enum: ["part", "app"],
+                description:
+                  "Whether the published argument schema classifies the pattern as a reusable part or whole app.",
+              },
+              quality: {
+                type: "string",
+                enum: ["penalized", "unproven", "proven"],
+                description:
+                  "Evidence tier from recorded outcomes: penalized is net-negative, unproven has no recorded success, and proven has at least one recorded success or positive rating without a net-negative score.",
+              },
               matchedTerms: { type: "number" },
               queryTerms: { type: "number" },
               importHint: { type: "string" },
               argumentType: { type: "string" },
               resultType: { type: "string" },
             },
-            required: ["patternId", "description", "hashtags", "importHint"],
+            required: [
+              "patternId",
+              "description",
+              "hashtags",
+              "kind",
+              "quality",
+              "importHint",
+            ],
             additionalProperties: false,
           },
         },
@@ -243,6 +278,8 @@ export const searchPatternsTool: HarnessToolDefinition<
         description: hit.description,
         hashtags: hit.hashtags,
         ...(hit.signals !== undefined ? { signals: hit.signals } : {}),
+        kind: hit.kind,
+        quality: hit.quality,
         ...(hit.matchedTerms !== undefined && hit.queryTerms !== undefined
           ? { matchedTerms: hit.matchedTerms, queryTerms: hit.queryTerms }
           : {}),

--- a/packages/cf-harness/src/tools/search-patterns.ts
+++ b/packages/cf-harness/src/tools/search-patterns.ts
@@ -86,13 +86,48 @@ export type SearchPatternsToolOutput =
   | SearchPatternsToolSuccessOutput
   | SearchPatternsToolErrorOutput;
 
+const isSearchPatternsToolResult = (
+  result: unknown,
+): result is SearchPatternsToolResult => {
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    return false;
+  }
+  const record = result as Record<string, unknown>;
+  const signals = record.signals;
+  return typeof record.patternId === "string" &&
+    typeof record.description === "string" &&
+    Array.isArray(record.hashtags) &&
+    record.hashtags.every((hashtag) => typeof hashtag === "string") &&
+    (signals === undefined ||
+      (typeof signals === "object" && signals !== null &&
+        !Array.isArray(signals) && "uses" in signals &&
+        typeof signals.uses === "number" && "score" in signals &&
+        typeof signals.score === "number")) &&
+    (record.kind === "part" || record.kind === "app") &&
+    (record.quality === "penalized" || record.quality === "unproven" ||
+      record.quality === "proven") &&
+    (record.matchedTerms === undefined ||
+      typeof record.matchedTerms === "number") &&
+    (record.queryTerms === undefined ||
+      typeof record.queryTerms === "number") &&
+    typeof record.importHint === "string" &&
+    (record.argumentType === undefined ||
+      typeof record.argumentType === "string") &&
+    (record.resultType === undefined || typeof record.resultType === "string");
+};
+
 /** Narrows a raw tool result to a successful search response. */
 export const isSearchPatternsToolSuccessOutput = (
   output: unknown,
-): output is SearchPatternsToolSuccessOutput =>
-  typeof output === "object" && output !== null &&
-  "status" in output && output.status === "ok" &&
-  "results" in output && Array.isArray(output.results);
+): output is SearchPatternsToolSuccessOutput => {
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return false;
+  }
+  const record = output as Record<string, unknown>;
+  return typeof record.outputId === "string" && record.status === "ok" &&
+    Array.isArray(record.results) &&
+    record.results.every(isSearchPatternsToolResult);
+};
 
 export const searchPatternsToolDescriptor: HarnessToolDescriptor = {
   toolId: "search_patterns",

--- a/packages/cf-harness/test/console/index-inspector.test.ts
+++ b/packages/cf-harness/test/console/index-inspector.test.ts
@@ -157,6 +157,8 @@ describe("console/index-inspector", () => {
       ownerDid: "did:key:zOwner",
       createdAt: "2026-08-01T00:00:00.000Z",
       dependencies: [],
+      kind: "part",
+      quality: "proven",
       ...overrides,
     });
 

--- a/packages/cf-harness/test/delegate-task.test.ts
+++ b/packages/cf-harness/test/delegate-task.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The `delegate_task` model-facing contract, including bounded pattern
+ * references selected from prior search results.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { JSONSchema } from "@commonfabric/api";
+
+import { delegateTaskTool } from "../src/tools/delegate-task.ts";
+
+const objectProperties = (
+  schema: JSONSchema,
+): Readonly<Record<string, JSONSchema>> => {
+  if (
+    typeof schema !== "object" || schema === null ||
+    schema.type !== "object" || schema.properties === undefined
+  ) {
+    throw new Error("expected an object schema with properties");
+  }
+  return schema.properties;
+};
+
+describe("delegate-task", () => {
+  it("caps `patternRefs` at eight entries", () => {
+    const patternRefs = objectProperties(
+      delegateTaskTool.descriptor.inputSchema,
+    ).patternRefs;
+
+    expect(patternRefs).toBeDefined();
+    expect(
+      typeof patternRefs === "object" && patternRefs !== null
+        ? patternRefs.maxItems
+        : undefined,
+    ).toBe(8);
+  });
+
+  it("caps each `patternRefs` note at 500 characters", () => {
+    const patternRefs = objectProperties(
+      delegateTaskTool.descriptor.inputSchema,
+    ).patternRefs;
+    if (
+      typeof patternRefs !== "object" || patternRefs === null ||
+      typeof patternRefs.items !== "object" || patternRefs.items === null
+    ) {
+      throw new Error("expected `patternRefs` item schema");
+    }
+    const note = objectProperties(patternRefs.items).note;
+
+    expect(note).toBeDefined();
+    expect(
+      typeof note === "object" && note !== null ? note.maxLength : undefined,
+    ).toBe(500);
+  });
+});

--- a/packages/cf-harness/test/prompt-loop-invalid-tool-calls.test.ts
+++ b/packages/cf-harness/test/prompt-loop-invalid-tool-calls.test.ts
@@ -227,6 +227,24 @@ describe("prompt-loop invalid tool calls", () => {
         field: "maxModelTurns",
       },
       {
+        name: "too-many-pattern-refs",
+        arguments: {
+          goal: "Inspect",
+          patternRefs: Array.from({ length: 9 }, (_, index) => ({
+            patternId: `pattern-${index}`,
+          })),
+        },
+        field: "patternRefs",
+      },
+      {
+        name: "pattern-ref-note-too-long",
+        arguments: {
+          goal: "Inspect",
+          patternRefs: [{ patternId: "pattern-1", note: "x".repeat(501) }],
+        },
+        field: "patternRefs",
+      },
+      {
         name: "unknown-profile",
         arguments: { goal: "Inspect", profile: "unknown" },
         field: "profile",

--- a/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
+++ b/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
@@ -223,7 +223,9 @@ const runDelegation = async (
 };
 
 /** Starts a fresh parent loop over a transcript whose earlier loop searched. */
-const runResumedDelegation = async (): Promise<DelegationFixture> => {
+const runResumedDelegation = async (
+  includeMalformedSearchResult = false,
+): Promise<DelegationFixture> => {
   const index = stubIndex();
   const firstRequests: unknown[] = [];
   const firstTurns = [
@@ -298,6 +300,14 @@ const runResumedDelegation = async (): Promise<DelegationFixture> => {
   const result = await resumedLoop.runTranscript({
     transcript: [
       ...firstResult.transcript,
+      ...(includeMalformedSearchResult
+        ? [{
+          role: "tool" as const,
+          toolCallId: "malformed-search",
+          toolName: "search_patterns",
+          content: "not JSON",
+        }]
+        : []),
       { role: "user", content: "Delegate using the earlier search." },
     ],
   });
@@ -384,6 +394,15 @@ Use this as available evidence; do not assume it is mandatory.`,
 
   it("rehydrates an earlier search after the parent loop resumes", async () => {
     const result = await runResumedDelegation();
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.delegateOutput.patternRefRefusals).toBeUndefined();
+    expect(result.indexCalls).toEqual(["searchPatterns", "getPattern"]);
+  });
+
+  it("ignores malformed persisted search output while restoring later hits", async () => {
+    const result = await runResumedDelegation(true);
 
     expect(result.subagentRuns).toBe(1);
     expect(result.childPrompt).toContain(SEARCH_HIT.patternId);

--- a/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
+++ b/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
@@ -1,0 +1,288 @@
+/**
+ * A parent's selected pattern references cross delegation from the trusted
+ * search record, not from model-retyped metadata or a delegation-time fetch.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { normalize } from "@std/path/posix";
+
+import { Identity } from "@commonfabric/identity";
+
+import { CfHarnessEngine } from "../src/engine.ts";
+import { PatternIndexClient } from "../src/pattern-index/client.ts";
+import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+import {
+  chatViewOfRequest,
+  responsesBodyFromChatFixture,
+} from "./support/responses-fixture.ts";
+
+const signer = await Identity.fromPassphrase(
+  "cf-harness prompt-loop pattern refs",
+);
+
+const SEARCH_HIT = {
+  patternId: "pat-expenses",
+  description: "Totals an expense list",
+  hashtags: ["expenses", "money"],
+  ownerDid: "did:key:zOwner",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  dependencies: [],
+  signals: { uses: 12, score: 2 },
+  quality: "proven",
+  kind: "part",
+  matchedTerms: 2,
+  queryTerms: 3,
+};
+
+const PATTERN_RECORD = {
+  patternId: SEARCH_HIT.patternId,
+  ownerDid: SEARCH_HIT.ownerDid,
+  createdAt: SEARCH_HIT.createdAt,
+  description: SEARCH_HIT.description,
+  hashtags: SEARCH_HIT.hashtags,
+  dependencies: [],
+  argumentSchema: {
+    type: "object",
+    properties: {
+      amounts: { type: "array", items: { type: "number" } },
+    },
+    required: ["amounts"],
+  },
+  resultSchema: {
+    type: "object",
+    properties: { total: { type: "number" } },
+    required: ["total"],
+  },
+};
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(_request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+}
+
+const toolCallTurn = (
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+) => ({
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: "",
+      tool_calls: [{
+        id,
+        type: "function",
+        function: { name, arguments: JSON.stringify(input) },
+      }],
+    },
+  }],
+});
+
+const assistantTurn = (content: string) => ({
+  choices: [{ index: 0, message: { role: "assistant", content } }],
+});
+
+interface IndexStub {
+  fetchFn: HarnessFetch;
+  calls: string[];
+}
+
+/** Index fixture which records every endpoint call. */
+const stubIndex = (): IndexStub => {
+  const calls: string[] = [];
+  const fetchFn: HarnessFetch = (input) => {
+    const fn = String(input).split("/").pop() ?? "";
+    calls.push(fn);
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(
+          fn === "searchPatterns" ? { results: [SEARCH_HIT] } : PATTERN_RECORD,
+        ),
+        { status: 200 },
+      ),
+    );
+  };
+  return { fetchFn, calls };
+};
+
+interface DelegationFixture {
+  childPrompt: string;
+  indexCalls: readonly string[];
+  delegateOutput: Record<string, unknown>;
+  subagentRuns: number;
+}
+
+/** Runs one parent search followed by one pattern-reference delegation. */
+const runDelegation = async (
+  patternRefs: readonly Record<string, unknown>[],
+): Promise<DelegationFixture> => {
+  const index = stubIndex();
+  const modelRequests: unknown[] = [];
+  const modelTurns = [
+    toolCallTurn("call-search", "search_patterns", {
+      text: "expense list totals",
+    }),
+    toolCallTurn("call-delegate", "delegate_task", {
+      goal: "Use the selected pattern metadata to plan the focused task.",
+      context: "Keep the answer concise.",
+      patternRefs,
+    }),
+    assistantTurn("Child completed the focused task."),
+    assistantTurn("Parent received the delegation result."),
+  ];
+  const fetchFn: typeof fetch = (_input, init) => {
+    modelRequests.push(JSON.parse(String(init?.body)));
+    const turn = modelTurns[modelRequests.length - 1];
+    if (turn === undefined) {
+      throw new Error("scripted model ran out of turns");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(turn)), {
+        status: 200,
+      }),
+    );
+  };
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: `run-pattern-refs-${crypto.randomUUID()}`,
+    model: "gpt-5.4",
+    cfcEnforcementMode: "disabled",
+    patternIndexClientFactory: () =>
+      Promise.resolve(
+        new PatternIndexClient({
+          baseUrl: "https://index.test",
+          fetchFn: index.fetchFn,
+          signer,
+        }),
+      ),
+  });
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    allowedToolIds: ["search_patterns", "delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    fetchFn,
+  });
+
+  const result = await loop.runPrompt({ prompt: "Search, then delegate." });
+  const delegateMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "delegate_task"
+  );
+  if (delegateMessage?.role !== "tool") {
+    throw new Error("expected a `delegate_task` tool result");
+  }
+  const childRequest = modelRequests[2] === undefined
+    ? undefined
+    : chatViewOfRequest(modelRequests[2]);
+
+  return {
+    childPrompt: childRequest?.messages.at(-1)?.content ?? "",
+    indexCalls: index.calls,
+    delegateOutput: JSON.parse(delegateMessage.content),
+    subagentRuns: result.runState.subagentRuns?.length ?? 0,
+  };
+};
+
+describe("prompt-loop pattern references", () => {
+  it("rehydrates a selected hit into neutral child context", async () => {
+    const result = await runDelegation([{
+      patternId: SEARCH_HIT.patternId,
+      note: "Use this as available evidence; do not assume it is mandatory.",
+    }]);
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toBe(
+      `Task:
+Use the selected pattern metadata to plan the focused task.
+
+Context:
+Keep the answer concise.
+
+Published pattern references selected by the parent:
+These records from the parent's earlier searches are available for this delegated task.
+
+Pattern 1: pat-expenses
+Kind: part
+Quality: proven
+Description: Totals an expense list
+Match: 2 of 3 stopword-free query terms
+Import: import X from "cf:pattern:pat-expenses"
+Argument shape:
+{
+  amounts: number[]
+}
+Result shape:
+{
+  total: number
+}
+Parent note:
+Use this as available evidence; do not assume it is mandatory.`,
+    );
+  });
+
+  it("names each unseen id as an inert refusal and omits it from child context", async () => {
+    const result = await runDelegation([{
+      patternId: SEARCH_HIT.patternId,
+    }, {
+      patternId: "pat-never-searched",
+      note: "This note must not make an unseen id trusted.",
+    }]);
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.childPrompt).not.toContain("pat-never-searched");
+    expect(result.delegateOutput.patternRefRefusals).toEqual([{
+      patternId: "pat-never-searched",
+      reason: "not-searched-by-parent",
+    }]);
+  });
+
+  it("performs no index call while resolving a delegation", async () => {
+    const result = await runDelegation([{
+      patternId: SEARCH_HIT.patternId,
+    }]);
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.indexCalls).toEqual(["searchPatterns", "getPattern"]);
+  });
+});

--- a/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
+++ b/packages/cf-harness/test/prompt-loop-pattern-refs.test.ts
@@ -222,6 +222,102 @@ const runDelegation = async (
   };
 };
 
+/** Starts a fresh parent loop over a transcript whose earlier loop searched. */
+const runResumedDelegation = async (): Promise<DelegationFixture> => {
+  const index = stubIndex();
+  const firstRequests: unknown[] = [];
+  const firstTurns = [
+    toolCallTurn("call-search", "search_patterns", {
+      text: "expense list totals",
+    }),
+    assistantTurn("Search complete."),
+  ];
+  const firstFetch: typeof fetch = (_input, init) => {
+    firstRequests.push(JSON.parse(String(init?.body)));
+    const turn = firstTurns[firstRequests.length - 1];
+    if (turn === undefined) {
+      throw new Error("first scripted model ran out of turns");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(turn)), {
+        status: 200,
+      }),
+    );
+  };
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: `run-pattern-refs-resume-${crypto.randomUUID()}`,
+    model: "gpt-5.4",
+    cfcEnforcementMode: "disabled",
+    patternIndexClientFactory: () =>
+      Promise.resolve(
+        new PatternIndexClient({
+          baseUrl: "https://index.test",
+          fetchFn: index.fetchFn,
+          signer,
+        }),
+      ),
+  });
+  const firstLoop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    allowedToolIds: ["search_patterns", "delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    fetchFn: firstFetch,
+  });
+  const firstResult = await firstLoop.runPrompt({ prompt: "Search first." });
+
+  const resumedRequests: unknown[] = [];
+  const resumedTurns = [
+    toolCallTurn("call-delegate", "delegate_task", {
+      goal: "Use the pattern searched before this parent loop resumed.",
+      patternRefs: [{ patternId: SEARCH_HIT.patternId }],
+    }),
+    assistantTurn("Child completed the resumed task."),
+    assistantTurn("Parent received the resumed delegation result."),
+  ];
+  const resumedFetch: typeof fetch = (_input, init) => {
+    resumedRequests.push(JSON.parse(String(init?.body)));
+    const turn = resumedTurns[resumedRequests.length - 1];
+    if (turn === undefined) {
+      throw new Error("resumed scripted model ran out of turns");
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(responsesBodyFromChatFixture(turn)), {
+        status: 200,
+      }),
+    );
+  };
+  const resumedLoop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine,
+    allowedToolIds: ["search_patterns", "delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    fetchFn: resumedFetch,
+  });
+  const result = await resumedLoop.runTranscript({
+    transcript: [
+      ...firstResult.transcript,
+      { role: "user", content: "Delegate using the earlier search." },
+    ],
+  });
+  const delegateMessage = result.transcript.findLast((message) =>
+    message.role === "tool" && message.toolName === "delegate_task"
+  );
+  if (delegateMessage?.role !== "tool") {
+    throw new Error("expected a resumed `delegate_task` tool result");
+  }
+  const childRequest = resumedRequests[1] === undefined
+    ? undefined
+    : chatViewOfRequest(resumedRequests[1]);
+  return {
+    childPrompt: childRequest?.messages.at(-1)?.content ?? "",
+    indexCalls: index.calls,
+    delegateOutput: JSON.parse(delegateMessage.content),
+    subagentRuns: result.runState.subagentRuns?.length ?? 0,
+  };
+};
+
 describe("prompt-loop pattern references", () => {
   it("rehydrates a selected hit into neutral child context", async () => {
     const result = await runDelegation([{
@@ -283,6 +379,15 @@ Use this as available evidence; do not assume it is mandatory.`,
 
     expect(result.subagentRuns).toBe(1);
     expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.indexCalls).toEqual(["searchPatterns", "getPattern"]);
+  });
+
+  it("rehydrates an earlier search after the parent loop resumes", async () => {
+    const result = await runResumedDelegation();
+
+    expect(result.subagentRuns).toBe(1);
+    expect(result.childPrompt).toContain(SEARCH_HIT.patternId);
+    expect(result.delegateOutput.patternRefRefusals).toBeUndefined();
     expect(result.indexCalls).toEqual(["searchPatterns", "getPattern"]);
   });
 });

--- a/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
+++ b/packages/cf-harness/test/prompt-loop-subagent-handles.test.ts
@@ -671,6 +671,15 @@ describe("prompt-loop cross-agent address handles", () => {
     expect(childSystemPrompt).toContain(
       "Build up in atoms rather than in one leap.",
     );
+    expect(childSystemPrompt).toContain(
+      "A whole-result derived wrapper is a known smell",
+    );
+    expect(childSystemPrompt).toContain(
+      "run_pattern checks the actual pattern pointer",
+    );
+    expect(childSystemPrompt).not.toContain(
+      "Never return a computed(), lift, or other derived wrapper",
+    );
   });
 
   it("runs a `pattern-author` child on the profile's own turn budget rather than the run default", async () => {

--- a/packages/cf-harness/test/run-pattern-description.test.ts
+++ b/packages/cf-harness/test/run-pattern-description.test.ts
@@ -1,0 +1,29 @@
+/** Model-facing `run_pattern` guidance stays within what the harness detects. */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { JSONSchema } from "@commonfabric/api";
+
+import { runPatternToolDescriptor } from "../src/tools/run-pattern.ts";
+
+describe("run-pattern description", () => {
+  it("states that the post-run pointer check is authoritative", () => {
+    const schema = runPatternToolDescriptor.inputSchema;
+    if (
+      typeof schema !== "object" || schema === null ||
+      schema.type !== "object" || schema.properties === undefined
+    ) {
+      throw new Error("expected `run_pattern` object input schema");
+    }
+    const sourceText = schema.properties.sourceText as JSONSchema;
+    const description = typeof sourceText === "object" && sourceText !== null
+      ? sourceText.description
+      : undefined;
+
+    expect(description).toContain("known smell");
+    expect(description).toContain("checks the actual pattern pointer");
+    expect(description).toContain("session-only identity");
+    expect(description).not.toContain("creates a piece no other runtime");
+  });
+});

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -650,8 +650,9 @@ describe("run-pattern", () => {
       );
       const output = result.output as RunPatternToolErrorOutput;
       expect(output.status).toBe("error");
-      expect(output.message).toContain("only be opened by this session");
-      expect(output.message).toContain("computed()");
+      expect(output.message).toContain("detected");
+      expect(output.message).toContain("session-only pattern pointer");
+      expect(output.message).not.toContain("computed()");
       expect(output.message).not.toContain("keyless:zStranded");
       expect(output.rawCauseMessage).toContain("keyless:zStranded");
     });

--- a/packages/cf-harness/test/search-patterns.test.ts
+++ b/packages/cf-harness/test/search-patterns.test.ts
@@ -62,6 +62,8 @@ const SEARCH_HIT = {
   createdAt: "2026-08-01T00:00:00.000Z",
   dependencies: [],
   signals: { uses: 12, score: 0.9 },
+  quality: "proven",
+  kind: "part",
 };
 
 const PATTERN_RECORD = {
@@ -150,6 +152,8 @@ describe("search-patterns", () => {
     expect(output.results[0].description).toBe("Totals an expense list");
     expect(output.results[0].hashtags).toEqual(["expenses", "money"]);
     expect(output.results[0].signals).toEqual({ uses: 12, score: 0.9 });
+    expect(output.results[0].quality).toBe("proven");
+    expect(output.results[0].kind).toBe("part");
     expect(output.results[0].importHint).toBe(
       'import X from "cf:pattern:pat-expenses"',
     );
@@ -214,6 +218,25 @@ describe("search-patterns", () => {
 
   it("declares itself a read, since a search alters nothing", () => {
     expect(searchPatternsTool.descriptor.effectClass).toBe("read");
+  });
+
+  it("describes deployed stopword-free disjunctive matching", () => {
+    const schema = searchPatternsTool.descriptor.inputSchema;
+    if (
+      typeof schema !== "object" || schema === null ||
+      schema.type !== "object" || schema.properties === undefined
+    ) {
+      throw new Error("expected `search_patterns` object input schema");
+    }
+    const text = schema.properties.text;
+    const description = typeof text === "object" && text !== null
+      ? text.description
+      : undefined;
+
+    expect(description).toContain("stopword-free");
+    expect(description).toContain("whole words");
+    expect(description).toContain("suffix");
+    expect(description).not.toContain("more words widen the net");
   });
 
   it("reports what the index answered when a search fails", async () => {

--- a/packages/cf-harness/test/search-patterns.test.ts
+++ b/packages/cf-harness/test/search-patterns.test.ts
@@ -6,6 +6,7 @@ import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessFetch } from "../src/contracts/http-fetch.ts";
 import { PatternIndexClient } from "../src/pattern-index/client.ts";
 import {
+  isSearchPatternsToolSuccessOutput,
   searchPatternsTool,
   type SearchPatternsToolErrorOutput,
   type SearchPatternsToolSuccessOutput,
@@ -218,6 +219,14 @@ describe("search-patterns", () => {
 
   it("declares itself a read, since a search alters nothing", () => {
     expect(searchPatternsTool.descriptor.effectClass).toBe("read");
+  });
+
+  it("does not trust a persisted success whose hit is incomplete", () => {
+    expect(isSearchPatternsToolSuccessOutput({
+      outputId: "search_patterns-1",
+      status: "ok",
+      results: [{ patternId: "pat-incomplete" }],
+    })).toBe(false);
   });
 
   it("describes deployed stopword-free disjunctive matching", () => {

--- a/packages/cf-harness/test/search-patterns.test.ts
+++ b/packages/cf-harness/test/search-patterns.test.ts
@@ -229,6 +229,15 @@ describe("search-patterns", () => {
     })).toBe(false);
   });
 
+  it("does not trust non-object persisted successes or hits", () => {
+    expect(isSearchPatternsToolSuccessOutput(null)).toBe(false);
+    expect(isSearchPatternsToolSuccessOutput({
+      outputId: "search_patterns-1",
+      status: "ok",
+      results: [null],
+    })).toBe(false);
+  });
+
   it("describes deployed stopword-free disjunctive matching", () => {
     const schema = searchPatternsTool.descriptor.inputSchema;
     if (


### PR DESCRIPTION
## Summary

- add a bounded `delegate_task.patternRefs` channel that rehydrates selected pattern ids only from the parent's successful `search_patterns` records
- render trusted kind, quality, description, match evidence, import hint, argument/result shapes, and verbatim parent notes in one neutral child-context block
- return named inert refusals for unseen ids without refetching the index
- align `search_patterns` with the deployed stopword-free matcher and surface `kind`/`quality`
- replace the CT-2123 derived-wrapper hypothesis with wording about the pointer the harness actually detects
- document cell-handle tokens, `skillHandle`, and `patternRefs` as sibling channels deliberately left separate

Linear: [CT-2153](https://linear.app/common-tools/issue/CT-2153/attach-trusted-pattern-references-to-delegate-task)

## Verification

- pinned cf-harness suite: 905 tests / 1464 steps
- pinned repo-wide `deno fmt --check`
- pinned repo-wide `deno lint`
- pinned `deno task check`: 605 paths / 46 package groups
- pinned `deno task check-docs`: 595 code blocks
- pinned `deno task check-no-waitfor`
- pinned `deno task check-conflict-markers`
- pinned `deno task check-control-characters`
- focused channel/rider suite: 113 steps
- tools-registry/CLI/config/client suite: 205 tests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

