### PR TITLE
style: the last two sites, and the arc is conformed

### DIFF
--- a/packages/connectors/agents/connector/src/types.ts
+++ b/packages/connectors/agents/connector/src/types.ts
@@ -36,6 +36,7 @@ export interface SourceDescriptor {
   /** Trimmed, lowercase source identity used by commands and by the records
    * stored in the fabric. */
   id: string;
+
   driver: DriverKind;
   version?: string;
   capabilities: DriverCapabilities;

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -13,6 +13,7 @@ export interface Mentionable {
    * what a mention stores is the piece and never the row.
    */
   piece?: unknown;
+
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The last two sites of "The blank line below" (#6633). With this and #6650, the
rule is conformed everywhere the sweep reaches.

**`ui/src/v2/core/mentionable.ts`** arrived with #6637 while the sweep was
running, after its package had already been measured — the same accrual
`verb-section.ts` was in #6665. New code lands unconformed while a sweep is in
flight, and only the last census finds it.

**`connectors/agents/connector/src/types.ts`** was dropped from #6655
deliberately: one blank line pulls the whole `connectors` group into the coverage
ratchet, and that group carries an inconsistently-covered line in a file this
change does not touch — `codex-jsonl-client.ts:172`, the closing brace of the
`catch { /* Child already exited */ }` around `child.kill("SIGTERM")`, which runs
or not depending on whether the child had already exited. It comes back now that
an override is the agreed disposition for a flake, rather than something to route
the sweep around. If the gate trips on it, the marker goes in this description
with that reasoning.

### Checks

`deno fmt --check` and `deno lint` clean. `packages/ui` non-browser tests: 175
passed, 0 failed (the browser half covers four files this does not touch). Both
changes are comment-only — one blank line each — verified by diffing both
revisions with comments and blank lines stripped.

### Where the arc lands

`packages/patterns` stays carved out by standing decision, at 223 sites. Two
test defects found along the way are filed rather than fixed, since neither is
this change's work: BL-075 (`topic-board-pivot-contract` asserts a pivot it never
waits for) and BL-076 (`SpaceSession.ack()`'s early-return branch is
inconsistently covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3aX1oKmL5zxsDNjSX7BaM


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

