### PR TITLE
fix(runner): a piece's substrate declares what flowed into it

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -292,6 +292,100 @@ The strict-only delta is:
   label at their shared logical path past what that field declares. The
   direction is over-taint, so reads stay protected; giving the envelope seam
   a path space of its own is what removes the collision.
+
+- **Piece-substrate declaration (§8.12.5 route 2) — implemented.** The
+  runtime writes a small set of documents while it sets a piece up: the
+  piece's argument document, and the internal documents and streams its
+  result projects to. It fills them with whatever the setup transaction
+  read. An author cannot know which atoms a given transaction will carry, so
+  a declaration written into a schema either misses them or over-declares
+  every instance of the pattern. The transaction declares the policy
+  instead, which is §8.12.5's route 2: the write that puts the join on a
+  path also declares, in that same transaction, a policy covering it. What
+  lands is the ceiling that resolved at the path plus exactly the clauses
+  that had nowhere to go, as an ordinary `declared` entry, so the fit test
+  passes and the store's promise becomes the audience of what it holds.
+
+  Declaring is what makes the route sound where an exemption would not be.
+  The atoms persist as store policy, so readers of the substrate consume
+  them, and go on consuming them after an overwrite clears the derived stamp
+  that carried them. The cost is the ratchet §8.12.2 asks for: a substrate
+  document that once held data derived from a labeled read keeps that clause
+  after the read stops. The direction is over-taint.
+
+  The route is the strict rung's, like the reject it replaces. Every rung
+  below keeps its `writer-fit(persist-and-flag)` diagnostic, which is the
+  rollout signal, and stores no declared policy it could never take back —
+  so `enforce-explicit` keeps the shipped posture bit-for-bit here too. At
+  strict, a declaration records a `writer-fit(piece-substrate-declared)`
+  diagnostic naming the document, the path, and the clauses added: a
+  permanent change to a store's policy leaves a trace even at the rung that
+  admits it.
+
+  Five conditions bound it:
+
+  - **The marker.** Only a document the runner named through its
+    piece-substrate write-policy input is reached, and only where that
+    marker's address names the whole document rather than a path inside
+    one. Every other document keeps the ceiling it resolves to, and a
+    misfit there is refused as before, with the §8.12.5 remedy in the
+    reason. The runner records only addresses it MINTS from the piece's
+    result cell: the argument address it would derive, and each derived
+    internal cell's. It reads the argument address back out of the result
+    cell's stored meta on every setup after the first, and where that
+    stored link names some other document — a nested piece's argument lives
+    in its HOST's document — no marker is recorded, so that document keeps
+    its own ceiling. Within a marked document the route reaches every path
+    that transaction writes, not only the paths setup wrote.
+  - **No schema declaration at that path.** A schema that declares at the
+    written path owns the store's policy there. Widening it from the join
+    would make the walk's own re-mint non-monotone on the next write, and
+    would brick the path under the declared-monotonicity gate. That store's
+    route 2 is the author's, in the schema. The reverse order stays
+    reachable, and is §8.12.1 rather than a defect of the route: a pattern
+    that later adds an `ifc` at a path the route already declared has to
+    name what the store already promises, or the monotonicity gate rejects
+    the write for dropping a stored clause. The gate ships `off`, so this is
+    latent until it is turned on.
+  - **No poisoned measurement.** The ungrantable read-failed marker is
+    outside every ceiling, so it is outside what the route may declare: a
+    measurement the runtime could not take proves nothing about the
+    audience, and declaring it would write a clause no reader can satisfy.
+  - **No foreign container clause.** A `Space` clause is honored by a
+    replica set rather than by a reader check — §4.9.3 resolves it against
+    that space's ACL, the document that also decides who holds the bytes —
+    so a store in this space cannot keep a promise made to another space's
+    readers. That is why residency admits only the target's own space
+    clause, and the route declares no `Space` clause naming another.
+  - **Growth only.** Within the walk, the ceiling the declaration starts
+    from resolves over the entries that walk is about to persist,
+    carried-forward stored declared entries among them, so a later
+    transaction carrying a wider join adds its clauses to what the path
+    already declared rather than replacing them. The entry coalesces with
+    the carried-forward stored entry rather than standing in for it. Adding
+    clauses is the restricting direction, so the monotonicity gate that runs
+    earlier in the same walk cannot be contradicted by what this route
+    pushes. Growth is also what reaches a piece whose substrate was written
+    before any labeled read entered a transaction writing it: that substrate
+    declares nothing, and the write that first carries a join is the one
+    that declares it.
+
+  What the route does NOT reach is the piece's running graph. A lift or
+  handler writing in a later transaction records no setup marker, so its
+  target — commonly a `computed:` document — measures against its own
+  ceiling and a misfit there still refuses. Under strict that turns "the
+  piece will not start" into "the piece starts and drops those writes",
+  which is progress on the setup seam and not a working strict rung.
+
+  Implementation in
+  [prepare.ts](../../packages/runner/src/cfc/prepare.ts)
+  (`prepareBoundaryCommit` writer-fit) and
+  [runner.ts](../../packages/runner/src/runner.ts) (`recordPieceSubstrate`),
+  asserted condition by condition in
+  [cfc-writer-fit.test.ts](../../packages/runner/test/cfc-writer-fit.test.ts),
+  and against the cross-space representation transform in
+  [cfc-label-metadata-protection.test.ts](../../packages/runner/test/cfc-label-metadata-protection.test.ts).
+
 - **Future strict-only fail-closed cases.** Any new check that wants a
   persist-and-flag grace under explicit puts its reject at the strict level,
   same shape.

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -307,9 +307,12 @@ The strict-only delta is:
   passes and the store's promise becomes the audience of what it holds.
 
   Declaring is what makes the route sound where an exemption would not be.
-  The atoms persist as store policy, so readers of the substrate consume
-  them, and go on consuming them after an overwrite clears the derived stamp
-  that carried them. The cost is the ratchet §8.12.2 asks for: a substrate
+  The declared clauses persist as store policy, so readers of the substrate
+  consume them, and go on consuming them after an overwrite clears the
+  derived stamp. They are the clauses the ceiling did not already cover
+  rather than the whole join: a clause the residency alternative satisfies
+  lands in the stamp and not in the declaration, because the store already
+  answers for it. The cost is the ratchet §8.12.2 asks for: a substrate
   document that once held data derived from a labeled read keeps that clause
   after the read stops. The direction is over-taint.
 

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -325,30 +325,31 @@ The strict-only delta is:
   permanent change to a store's policy leaves a trace even at the rung that
   admits it.
 
-  Five conditions bound it:
+  What bounds the route, and what it declares once inside:
 
-  - **The marker, and who recorded it.** Only a document the runner named
-    through its piece-substrate write-policy input is reached, and only
-    where the runtime itself recorded that input and its address names the
-    whole document rather than a path inside one. The recording method is
-    on the public transaction interface, and pattern-authored code reaches
-    the transaction its cells are bound to, so an input's own fields say
-    only what its recorder wrote; the runtime passes an authorization
-    alongside, the way `setMetaRaw` marks a meta write, and an unmarked
-    marker naming the same document counts for nothing. That is the
-    difference between a gate that ACTS on an input and one that measures
-    it: the two sibling markers in the same file corroborate against
-    transaction state, which suits a claim about a write that has already
-    happened, while this one is a claim about whose write it is. Every other document keeps the ceiling it resolves to, and a
-    misfit there is refused as before, with the §8.12.5 remedy in the
-    reason. The runner records only addresses it MINTS from the piece's
-    result cell: the argument address it would derive, and each derived
-    internal cell's. It reads the argument address back out of the result
-    cell's stored meta on every setup after the first, and where that
-    stored link names some other document — a nested piece's argument lives
-    in its HOST's document — no marker is recorded, so that document keeps
-    its own ceiling. Within a marked document the route reaches every path
-    that transaction writes, not only the paths setup wrote.
+  - **Who recorded the marker.** The recording method is on the public
+    transaction interface, and pattern-authored code reaches the
+    transaction its cells are bound to, so an input's own fields say only
+    what its recorder wrote. The runtime passes an authorization alongside,
+    the way `setMetaRaw` marks a meta write, and a marker without it counts
+    for nothing however it is addressed. This is the difference between a
+    gate that ACTS on an input and one that measures it: the two sibling
+    markers in the same file corroborate against transaction state, which
+    suits a claim about a write that has already happened, while this one
+    is a claim about whose write it is, and a forger supplies the write.
+  - **Which document it names.** The runner records only addresses it
+    MINTS from the piece's result cell — the argument address it would
+    derive, and each derived internal cell's — and only where the address
+    names a whole document rather than a path inside one. It reads the
+    argument address back out of the result cell's stored meta on every
+    setup after the first, and where that stored link names some other
+    document (a nested piece's argument lives in its HOST's) no marker is
+    recorded, so that document keeps its own ceiling. Every document the
+    route does not reach keeps the ceiling it resolves to, and a misfit
+    there is refused as before, with the §8.12.5 remedy in the reason.
+  - **How far it reaches inside that document.** Every path the
+    transaction writes there, not only the paths setup wrote: the marker
+    names the store, and the declaration is a statement about the store.
   - **No schema declaration at that path.** A schema that declares at the
     written path owns the store's policy there. Widening it from the join
     would make the walk's own re-mint non-monotone on the next write, and

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -351,12 +351,20 @@ The strict-only delta is:
     outside every ceiling, so it is outside what the route may declare: a
     measurement the runtime could not take proves nothing about the
     audience, and declaring it would write a clause no reader can satisfy.
-  - **No foreign container clause.** A `Space` clause is honored by a
+  - **No foreign container clause.** A container clause is honored by a
     replica set rather than by a reader check — §4.9.3 resolves it against
     that space's ACL, the document that also decides who holds the bytes —
     so a store in this space cannot keep a promise made to another space's
     readers. That is why residency admits only the target's own space
-    clause, and the route declares no `Space` clause naming another.
+    clause, and the route declares no container clause naming another.
+    `PersonalSpace(owner)` is the second spelling of one: §4.9.4 calls the
+    two forms "the two `Space(...)` atoms", and §3.6.4 makes the named
+    principal the sole owner of the space whose id it is. The same-space
+    spelling stays admissible, because there the clause names the space the
+    bytes are already in, and if that space stops being personal its
+    audience and its replica set grow together. A person-audience clause is
+    not a container clause: `User(alice)` is honored by the reader check
+    whoever holds the bytes.
   - **Growth only.** Within the walk, the ceiling the declaration starts
     from resolves over the entries that walk is about to persist,
     carried-forward stored declared entries among them, so a later

--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -324,10 +324,19 @@ The strict-only delta is:
 
   Five conditions bound it:
 
-  - **The marker.** Only a document the runner named through its
-    piece-substrate write-policy input is reached, and only where that
-    marker's address names the whole document rather than a path inside
-    one. Every other document keeps the ceiling it resolves to, and a
+  - **The marker, and who recorded it.** Only a document the runner named
+    through its piece-substrate write-policy input is reached, and only
+    where the runtime itself recorded that input and its address names the
+    whole document rather than a path inside one. The recording method is
+    on the public transaction interface, and pattern-authored code reaches
+    the transaction its cells are bound to, so an input's own fields say
+    only what its recorder wrote; the runtime passes an authorization
+    alongside, the way `setMetaRaw` marks a meta write, and an unmarked
+    marker naming the same document counts for nothing. That is the
+    difference between a gate that ACTS on an input and one that measures
+    it: the two sibling markers in the same file corroborate against
+    transaction state, which suits a claim about a write that has already
+    happened, while this one is a claim about whose write it is. Every other document keeps the ceiling it resolves to, and a
     misfit there is refused as before, with the §8.12.5 remedy in the
     reason. The runner records only addresses it MINTS from the piece's
     result cell: the argument address it would derive, and each derived

--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -265,13 +265,21 @@ Not new machinery so much as turning the system on:
   reject: the SC-18b writer-fit misfit. The per-transaction flow join landing on
   a written document must fit that document's declared store policy; under
   strict a misfit rejects the commit, and under every mode below it persists the
-  measurement and flags a diagnostic. Implemented in `prepareBoundaryCommit`
+  measurement and flags a diagnostic. One seam answers a misfit by declaring
+  rather than rejecting: a document the runtime is setting a piece up in
+  takes the §8.12.5 route-2 upgrade, declaring a policy that covers the join
+  in the same transaction that writes it. Implemented in
+  `prepareBoundaryCommit`
   ([`prepare.ts`](../../packages/runner/src/cfc/prepare.ts)), contract in
   [`cfc-enforcement-matrix.md`](./cfc-enforcement-matrix.md) §4, asserted under
   both modes in
   [`cfc-writer-fit.test.ts`](../../packages/runner/test/cfc-writer-fit.test.ts).
   What remains is picking the conforming default deployment states from that
-  matrix's §3 progression and moving the shipped hosts onto them. Strict
+  matrix's §3 progression and moving the shipped hosts onto them. A piece's
+  RUNNING graph is not on that seam: a lift or handler writing in a later
+  transaction records no setup marker, so its target — commonly a `computed:`
+  document — measures against its own ceiling, and strict refuses those
+  writes until they have a route of their own. Strict
   presupposes `cfcFlowLabels: persist`: §18.6.3's conformance matrix marks
   `enforce-strict` without `persist` non-conforming, and the writer-fit
   measurement exists only where the flow join is stamped. §18.6.3 also puts the

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -75,9 +75,11 @@ export type {
   OrderedWriteAttempt,
   PostCommitSideEffect,
   PreparedDigestInput,
+  RuntimeWritePolicyAuthorization,
   TrustSnapshot,
   WritePolicyInput,
 } from "./types.ts";
+export { runtimeWritePolicyAuthorization } from "./types.ts";
 export {
   cfcCanonicalClauseDigest,
   collectDeclaredMonotonicityViolations,

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -79,7 +79,12 @@ export type {
   TrustSnapshot,
   WritePolicyInput,
 } from "./types.ts";
-export { runtimeWritePolicyAuthorization } from "./types.ts";
+// `runtimeWritePolicyAuthorization` is deliberately NOT re-exported here.
+// `./cfc` is a public entry point of this package, and the value is what
+// mints a write-policy input the route-2 declaration acts on; publishing it
+// would let anything that can import the package name it. The type above
+// carries no such risk — it is erased, and names nothing at run time. The
+// runtime passes the value through an in-package import.
 export {
   cfcCanonicalClauseDigest,
   collectDeclaredMonotonicityViolations,

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -47,7 +47,7 @@ export const CFC_LABEL_READ_FAILED_ATOM = "cfc:label-read-failed";
 // `{digestOf: H(marker)}` spelling can only be crafted — and with atom
 // equality now commitment-aware, a marker-naming ceiling would otherwise
 // subsume that spelling. Recognize it here so BOTH forms stay ungrantable.
-const clauseBearsReadFailedMarker = (clause: unknown): boolean =>
+export const clauseBearsReadFailedMarker = (clause: unknown): boolean =>
   clauseAlternatives(clause as CfcConfClause).some((alternative) =>
     deepEqual(alternative, CFC_LABEL_READ_FAILED_ATOM) ||
     commitmentAwareEquals(alternative, CFC_LABEL_READ_FAILED_ATOM)

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -825,11 +825,20 @@ const writeIsPatternSetupInitialization = (
  * each piece's argument document, and the internal documents its result
  * projects to.
  *
+ * The route below ACTS on these markers rather than measuring them, so who
+ * recorded one decides whether it counts. `recordCfcWritePolicyInput` is on
+ * the public transaction interface and pattern-authored code reaches the
+ * transaction its cells are bound to, so an input's own fields say only what
+ * its recorder wrote: a marker without the runtime's mark names nothing here.
+ * The two sibling markers in this file corroborate against transaction state
+ * instead, which suits a claim about a write that has already happened; this
+ * one is a claim about whose write it is.
+ *
  * A marker whose address carries a path names part of a document rather than
- * the document, and is ignored: the route below declares a policy for the
- * whole store, so it may only take a marker that claims the whole store. The
- * setup path records the empty path for every document it mints from a
- * piece's result cell, so this excludes only an argument link that was stored
+ * the document, and is ignored too: the route declares a policy for the whole
+ * store, so it may only take a marker that claims the whole store. The setup
+ * path records the empty path for every document it mints from a piece's
+ * result cell, so this excludes only an argument link that was stored
  * pointing into some other document.
  */
 const pieceSetupSubstrateDocuments = (
@@ -840,7 +849,8 @@ const pieceSetupSubstrateDocuments = (
     if (
       input.kind === "structural-provenance" &&
       input.claim === CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE &&
-      canonicalizeLogicalPath(input.target.path).length === 0
+      canonicalizeLogicalPath(input.target.path).length === 0 &&
+      tx.isRuntimeWritePolicyInput(input)
     ) {
       documents.add(targetKey(input.target));
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -115,6 +115,7 @@ import {
   type CfcFloorTrustContext,
   cfcIntegritySatisfiesFloor,
   cfcIntegritySatisfiesFloorCoherently,
+  clauseBearsReadFailedMarker,
   uniqueCfcAtoms,
 } from "./observation.ts";
 import { CFC_POLICY_MANIFEST_ID_PREFIX } from "./policy.ts";
@@ -123,6 +124,7 @@ import { cfcSchemaEntries } from "./schema-label-view.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import { createTrustResolver } from "./trust.ts";
 import {
+  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type CfcAddress,
@@ -816,6 +818,34 @@ const writeIsPatternSetupInitialization = (
       );
     })
   );
+};
+
+/**
+ * The documents this transaction is setting a piece up in, as target keys —
+ * each piece's argument document, and the internal documents its result
+ * projects to.
+ *
+ * A marker whose address carries a path names part of a document rather than
+ * the document, and is ignored: the route below declares a policy for the
+ * whole store, so it may only take a marker that claims the whole store. The
+ * setup path records the empty path for every document it mints from a
+ * piece's result cell, so this excludes only an argument link that was stored
+ * pointing into some other document.
+ */
+const pieceSetupSubstrateDocuments = (
+  tx: IExtendedStorageTransaction,
+): Set<string> => {
+  const documents = new Set<string>();
+  for (const input of tx.getCfcState().writePolicyInputs) {
+    if (
+      input.kind === "structural-provenance" &&
+      input.claim === CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE &&
+      canonicalizeLogicalPath(input.target.path).length === 0
+    ) {
+      documents.add(targetKey(input.target));
+    }
+  }
+  return documents;
 };
 
 const storedMetadataFor = (
@@ -5678,6 +5708,16 @@ export const prepareBoundaryCommit = (
     );
   }
   const targetKeys = new Set([...candidates.keys(), ...linkWrites.keys()]);
+  // Computed once: the §8.12.5 route-2 seam is a property of the transaction,
+  // and the persist loop below asks about it per target.
+  // The §8.12.5 route-2 seam is a property of the transaction, so it is read
+  // once. Only the strict rung's declaration consults it, and only where the
+  // flow join is stamped, so no other posture pays for the scan — and every
+  // rung below keeps the persist-and-flag diagnostic that is its rollout
+  // signal, storing no declared policy it could never take back.
+  const pieceSubstrateDocuments = flowPersist && writerFitRejects
+    ? pieceSetupSubstrateDocuments(tx)
+    : new Set<string>();
   // A vouched ingest writes its provenance mark even when the payload write
   // carries no schema candidate and flow labels are off, so the ingest target
   // must enter the persist loop on its own. The anchor is the cell the helper
@@ -5777,14 +5817,18 @@ export const prepareBoundaryCommit = (
     //   foreign labeled contribution makes the WHOLE stamped entry eligible
     //   — ambiguous provenance fails toward protection.
     //
-    // NOT eligible (persist verbatim): `declared` entries (authored schema
+    // NOT eligible (persist verbatim): AUTHORED `declared` entries (schema
     // policy — the schema document replicates to the destination anyway, so
     // transforming the mirror entries would protect nothing), carried-
     // forward existing entries (already at rest in this doc; migration
     // never rewrites persisted envelopes), and the local external-ingest
     // mark (minted from this tx's own channel stamp — no cross-space
     // observation feeds it; its atoms commit like any others if they later
-    // flow into a foreign target through the join).
+    // flow into a foreign target through the join). The §8.12.5 route-2
+    // declaration below is the one `declared` entry that IS eligible: its
+    // content is the flow join rather than an author's schema, so leaving
+    // it verbatim beside a committed derived stamp of the same atoms would
+    // publish in one entry what the other protects.
     const crossSpaceEligible = labelProtectionMode !== "off"
       ? new Set<LabelMapEntry>()
       : undefined;
@@ -6052,8 +6096,12 @@ export const prepareBoundaryCommit = (
     // item 3): the declared-component monotonicity gate. Each declared entry
     // this walk is about to persist replaces the stored declared entry at
     // the same path (the carry-forward below skips replaced paths), so this
-    // is the ONE point where the store policy can change — compare against
-    // the stored entries per canUpdateStoreLabel before it does. The stored
+    // is where a schema-minted store policy changes — compare against the
+    // stored entries per canUpdateStoreLabel before it does. The §8.12.5
+    // route-2 declaration in the flow-persist stamping below adds clauses
+    // after this point rather than replacing any, which is the restricting
+    // direction; it coalesces with the carried-forward stored entry instead
+    // of standing in for it. The stored
     // metadata was read above under the internal-verifier meta
     // (storedMetadataFor), so the gate consumes no additional reads. Under
     // `enforce` a violation records fail-closed reasons and skips persisting
@@ -6575,6 +6623,12 @@ export const prepareBoundaryCommit = (
           readConsumesEntry("value", entry)
         )
         : [];
+      // Whether a misfit below is answered by declaring a covering policy
+      // (§8.12.5 route 2) instead of refusing: this document is one the
+      // runner named as a piece's substrate, at a rung that would reject.
+      // `cfc-enforcement-matrix.md` §4 states the route; the rest of the
+      // conditions on it are at the mint below.
+      const pieceSetupSubstrate = pieceSubstrateDocuments.has(key);
       // SC-4, freeze-at-creation form: a path's shape (existence) entry is
       // minted ONCE — at creation, or at the one-time migration of legacy
       // pre-class entries (whose accumulated confidentiality is absorbed
@@ -6716,6 +6770,76 @@ export const prepareBoundaryCommit = (
               ...residencyCeiling,
             ],
           );
+          if (
+            offending.length > 0 && pieceSetupSubstrate &&
+            // A schema that declares at this exact path owns the store's
+            // policy there; widening it from the join would make the walk's
+            // own re-mint non-monotone on the next write and brick the path
+            // under the declared-monotonicity gate. That store's route 2 is
+            // the author's, in the schema.
+            !remintedDeclaredPaths.has(pathKey(path)) &&
+            // The read-failed marker is ungrantable: a measurement the
+            // runtime could not take proves nothing about the audience, so
+            // it is outside every ceiling including one that names it.
+            // Declaring it would both admit a poisoned measurement and
+            // write a clause no reader can ever satisfy.
+            !offending.some(clauseBearsReadFailedMarker) &&
+            // A `Space` clause is honored by a replica set, not by a
+            // reader check: §4.9.3 resolves it against that space's ACL,
+            // the document that also decides who holds the bytes. A store
+            // in THIS space cannot keep a promise made to another space's
+            // readers, which is why residency admits only this space's own
+            // clause. Declaring a foreign one would put the bytes in front
+            // of this space's members under a promise made to somebody
+            // else's, so the route leaves that write to the refusal below.
+            !offending.some((clause) =>
+              clauseAlternatives(clause as CfcConfClause).some((alternative) =>
+                isObjectOrArray(alternative) &&
+                (alternative as { type?: unknown }).type ===
+                  CFC_ATOM_TYPE.Space &&
+                (alternative as { id?: unknown }).id !== space
+              )
+            )
+          ) {
+            // §8.12.5 route 2, the monotone-safe upgrade: the transaction
+            // writing the join onto this path also declares, in that same
+            // transaction, a policy covering it. What lands is the ceiling
+            // resolved above plus exactly the clauses that had nowhere to
+            // go, so the store's promise becomes the audience of what it
+            // holds. A piece's substrate is filled by the runtime out of
+            // what the setup transaction read — the argument document, and
+            // the internal documents and streams its result projects to —
+            // and no value schema can carry that declaration, because the
+            // atoms are a property of the transaction rather than of the
+            // pattern.
+            //
+            // The declaration only ever grows, which is what §8.12.1 asks
+            // of a declared component. `declaredCeiling` resolves over the
+            // entries this walk is about to persist, carried-forward stored
+            // declared entries among them, so the union below contains
+            // every clause the path already declared, and adding clauses is
+            // the restricting direction.
+            //
+            // Marked like a flow stamp rather than like an authored
+            // declaration: the content is the join, so it carries whatever
+            // foreign label metadata the join carries.
+            persistedLabelEntries.push(markFlowStampEntry({
+              path,
+              label: {
+                confidentiality: foldedUnique([
+                  ...declaredCeiling as readonly CfcConfClause[],
+                  ...offending as readonly CfcConfClause[],
+                ]),
+              },
+              origin: "declared",
+            }));
+            tx.noteCfcDiagnostic(
+              `writer-fit(piece-substrate-declared): ${id} at /${
+                path.join("/")
+              } (§8.12.5 route 2): ${offending.map(renderCfcAtom).join(", ")}`,
+            );
+            continue;
+          }
           if (offending.length > 0) {
             // SC-18c error contract: a stable reason naming the rule id and
             // the target path, plus the offending clause(s) so a flag names

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -6617,6 +6617,27 @@ export const prepareBoundaryCommit = (
       // address alone: nothing in an address names a space's owner or marks
       // the space as personal, so the atom cannot be constructed here.
       const residencyCeiling: readonly CfcConfClause[] = [cfcAtom.space(space)];
+      // Whether an alternative names a CONTAINER audience — the readers of
+      // some space, resolved from that space's ACL — other than this
+      // document's own. `PersonalSpace(owner)` is the second spelling
+      // (§4.9.4 calls the two forms "the two `Space(...)` atoms"), and its
+      // space is the owner's: §3.6.4 makes that principal its sole owner,
+      // and the space's id is that principal. A person-audience clause is
+      // not one of these: `User(alice)` is honored by the reader check
+      // whoever holds the bytes, so it needs no replica set to agree.
+      const namesAnotherSpace = (alternative: unknown): boolean => {
+        if (!isObjectOrArray(alternative)) return false;
+        const atom = alternative as {
+          type?: unknown;
+          id?: unknown;
+          owner?: unknown;
+        };
+        if (atom.type === CFC_ATOM_TYPE.Space) return atom.id !== space;
+        if (atom.type === CFC_ATOM_TYPE.PersonalSpace) {
+          return atom.owner !== space;
+        }
+        return false;
+      };
       const declaredPolicyEntries = flowConfidentiality.length > 0
         ? persistedLabelEntries.filter((entry) =>
           (entry.origin === undefined || entry.origin === "declared") &&
@@ -6784,7 +6805,7 @@ export const prepareBoundaryCommit = (
             // Declaring it would both admit a poisoned measurement and
             // write a clause no reader can ever satisfy.
             !offending.some(clauseBearsReadFailedMarker) &&
-            // A `Space` clause is honored by a replica set, not by a
+            // A container clause is honored by a replica set, not by a
             // reader check: §4.9.3 resolves it against that space's ACL,
             // the document that also decides who holds the bytes. A store
             // in THIS space cannot keep a promise made to another space's
@@ -6792,12 +6813,11 @@ export const prepareBoundaryCommit = (
             // clause. Declaring a foreign one would put the bytes in front
             // of this space's members under a promise made to somebody
             // else's, so the route leaves that write to the refusal below.
+            // The space's own clause is not reachable here: residency
+            // covers it, so it is never offending.
             !offending.some((clause) =>
-              clauseAlternatives(clause as CfcConfClause).some((alternative) =>
-                isObjectOrArray(alternative) &&
-                (alternative as { type?: unknown }).type ===
-                  CFC_ATOM_TYPE.Space &&
-                (alternative as { id?: unknown }).id !== space
+              clauseAlternatives(clause as CfcConfClause).some(
+                namesAnotherSpace,
               )
             )
           ) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -5836,9 +5836,9 @@ export const prepareBoundaryCommit = (
     // observation feeds it; its atoms commit like any others if they later
     // flow into a foreign target through the join). The §8.12.5 route-2
     // declaration below is the one `declared` entry that IS eligible: its
-    // content is the flow join rather than an author's schema, so leaving
-    // it verbatim beside a committed derived stamp of the same atoms would
-    // publish in one entry what the other protects.
+    // content comes from the flow join rather than from an author's schema,
+    // so leaving it verbatim beside a committed derived stamp carrying those
+    // same clauses would publish in one entry what the other protects.
     const crossSpaceEligible = labelProtectionMode !== "off"
       ? new Set<LabelMapEntry>()
       : undefined;
@@ -6836,7 +6836,9 @@ export const prepareBoundaryCommit = (
             // transaction, a policy covering it. What lands is the ceiling
             // resolved above plus exactly the clauses that had nowhere to
             // go, so the store's promise becomes the audience of what it
-            // holds. A piece's substrate is filled by the runtime out of
+            // holds. What lands is what the ceiling did not already cover,
+            // so a clause residency satisfies stays in the stamp alone.
+            // A piece's substrate is filled by the runtime out of
             // what the setup transaction read — the argument document, and
             // the internal documents and streams its result projects to —
             // and no value schema can carry that declaration, because the

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -73,6 +73,10 @@ export interface RuntimeWritePolicyAuthorization {
  * It travels as an argument of the one call that carries it, so it marks that
  * input and no other — including no input recorded on the same transaction in
  * the meantime.
+ *
+ * In-package callers only: `cfc/mod.ts` re-exports the type and not this
+ * value, so it stays out of the package's public entry points, and holding it
+ * is what naming a piece's substrate takes.
  */
 export const runtimeWritePolicyAuthorization: RuntimeWritePolicyAuthorization =
   Object.freeze(

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -41,9 +41,50 @@ export const CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION =
 // document, minted from the piece's result cell; `sources` is that result
 // document. The prepare gate reads it for the §8.12.5 route-2 declaration
 // described in `docs/specs/cfc-enforcement-matrix.md` §4, and takes it only
-// where `target` names a whole document.
+// where `target` names a whole document AND the input was recorded under
+// {@link runtimeWritePolicyAuthorization}.
 export const CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE =
   "runtime.setup.piece-substrate";
+
+/**
+ * Marks a write-policy input as one the runtime itself recorded.
+ *
+ * `recordCfcWritePolicyInput` is on the public transaction interface, and
+ * pattern-authored code runs in the runtime's own realm holding runtime cells,
+ * so it reaches `cell.tx` and can record an input naming whatever it likes.
+ * An input a gate ACTS on — rather than one a gate measures — therefore has to
+ * say who recorded it. This is the mark, and it works the way
+ * `rawMetaWriteAuthorization` does: a symbol cannot be named by a module that
+ * did not import it, and the sandbox hands pattern code the builder namespace
+ * rather than the runner's modules.
+ */
+export const RUNTIME_WRITE_POLICY_INPUT: unique symbol = Symbol(
+  "runtime-write-policy-input",
+);
+
+/** The authorization a runtime-recorded write-policy input carries. */
+export interface RuntimeWritePolicyAuthorization {
+  readonly [RUNTIME_WRITE_POLICY_INPUT]: true;
+}
+
+/**
+ * The authorization the runtime passes beside an input a gate acts on.
+ *
+ * It travels as an argument of the one call that carries it, so it marks that
+ * input and no other — including no input recorded on the same transaction in
+ * the meantime.
+ */
+export const runtimeWritePolicyAuthorization: RuntimeWritePolicyAuthorization =
+  Object.freeze(
+    { [RUNTIME_WRITE_POLICY_INPUT]: true } as RuntimeWritePolicyAuthorization,
+  );
+
+/** Whether an authorization argument carries the runtime's mark. */
+export const runtimeWritePolicyAuthorized = (value: unknown): boolean =>
+  typeof value === "object" && value !== null &&
+  (value as Partial<RuntimeWritePolicyAuthorization>)[
+      RUNTIME_WRITE_POLICY_INPUT
+    ] === true;
 
 export type CfcEnforcementMode =
   | "disabled"

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -36,6 +36,15 @@ export const CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION =
 export const CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION =
   "runtime.setup.seed-materialization";
 
+// A document a piece is being set up in: its argument document, or an
+// internal document or stream its result projects to. `target` is the
+// document, minted from the piece's result cell; `sources` is that result
+// document. The prepare gate reads it for the §8.12.5 route-2 declaration
+// described in `docs/specs/cfc-enforcement-matrix.md` §4, and takes it only
+// where `target` names a whole document.
+export const CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE =
+  "runtime.setup.piece-substrate";
+
 export type CfcEnforcementMode =
   | "disabled"
   | "observe"

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -162,6 +162,7 @@ import {
   validateSchemaValue,
 } from "./cfc/schema-sanitization.ts";
 import {
+  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type ImplementationIdentity,
 } from "./cfc/types.ts";
@@ -937,6 +938,55 @@ const recordSetupProjectionPolicyInputs = (
     }
   }
 };
+
+/**
+ * Name `substrate` as a document this transaction is setting `resultCell`'s
+ * piece up in.
+ *
+ * A piece's substrate holds whatever the setup transaction read, and an
+ * author cannot know which atoms a given transaction will carry, so no
+ * confidentiality declaration written into a schema covers it. CFC's
+ * write-side fit check (spec §8.12.4) reads this marker and declares that
+ * policy itself; `docs/specs/cfc-enforcement-matrix.md` §4 states the route.
+ *
+ * `substrate` must be an address MINTED from `resultCell`'s cause, never one
+ * read back out of stored metadata: a stored `argument` link can name another
+ * document, and that document is its owner's store rather than this piece's.
+ * The address goes on verbatim, path included, and the fit check takes the
+ * marker only where it names a whole document.
+ */
+const recordPieceSubstrate = (
+  tx: IExtendedStorageTransaction,
+  resultCell: Cell<any>,
+  substrate: NormalizedFullLink,
+): void => {
+  const result = resultCell.getAsNormalizedFullLink();
+  tx.recordCfcWritePolicyInput({
+    kind: "structural-provenance",
+    target: {
+      space: substrate.space,
+      id: substrate.id,
+      scope: substrate.scope,
+      path: [...substrate.path],
+    },
+    claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+    sources: [{
+      space: result.space,
+      id: result.id,
+      scope: result.scope,
+      path: [...result.path],
+    }],
+  });
+};
+
+/** Whether two links name the same document, each at that document's root. */
+const sameRootDocument = (
+  left: NormalizedFullLink,
+  right: NormalizedFullLink,
+): boolean =>
+  left.space === right.space && left.id === right.id &&
+  left.scope === right.scope && left.path.length === 0 &&
+  right.path.length === 0;
 
 type SetupResult<R> = {
   resultCell: Cell<R>;
@@ -2025,10 +2075,21 @@ export class Runner {
 
   #updateArgument<T>(
     tx: IExtendedStorageTransaction,
+    resultCell: Cell<any>,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema | undefined,
   ): void {
+    // The argument link can come from the result cell's stored `argument`
+    // meta, which need not name the document this result cell's cause mints
+    // — a nested piece's argument lives in its HOST's document. Mark the
+    // substrate only where the two agree, so the marker never claims a store
+    // this piece does not own.
+    const mintedArgument = getMetaCell(resultCell, "argument", tx)
+      .getAsNormalizedFullLink();
+    if (sameRootDocument(argumentLink, mintedArgument)) {
+      recordPieceSubstrate(tx, resultCell, mintedArgument);
+    }
     const argumentCell = this.runtime.getCellFromLink(
       argumentLink,
       undefined,
@@ -2069,12 +2130,19 @@ export class Runner {
    * reject the transaction unless the resulting value satisfies its schema. */
   #updateAndValidateArgument<T>(
     tx: IExtendedStorageTransaction,
+    resultCell: Cell<any>,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema,
     defaults: FabricValue,
   ): void {
-    this.#updateArgument(tx, argumentLink, argument, argumentSchema);
+    this.#updateArgument(
+      tx,
+      resultCell,
+      argumentLink,
+      argument,
+      argumentSchema,
+    );
     this.#validateArgument(
       tx,
       argumentLink,
@@ -2274,6 +2342,7 @@ export class Runner {
       // pattern-changing updates always take the validated path below.
       this.#updateArgument(
         tx,
+        resultCell,
         argumentLink,
         nextArgument,
         pattern.argumentSchema,
@@ -2394,6 +2463,13 @@ export class Runner {
         link: derivedSigilLink,
       });
       setResultCell(derivedCell, resultCell.asSchema(pattern.resultSchema));
+      // Minted from the result cell's cause, so this address is the piece's
+      // own by construction.
+      recordPieceSubstrate(
+        tx,
+        resultCell,
+        getDerivedInternalCellLink(resultCell, descriptor),
+      );
       if (manifestMatch === -1) {
         // Seed the build-time default for the freshly created cell. The
         // manifest entry and this default are written together in one
@@ -2542,6 +2618,7 @@ export class Runner {
         // case — so the merge yields a value.)
         this.#updateAndValidateArgument(
           tx,
+          resultCell,
           argumentLink,
           nextArgument,
           pattern.argumentSchema,
@@ -2557,6 +2634,7 @@ export class Runner {
       // validate their exact supplied value before entering Runner.
       this.#updateArgument(
         tx,
+        resultCell,
         argumentLink,
         nextArgument,
         pattern.argumentSchema,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -165,6 +165,7 @@ import {
   CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type ImplementationIdentity,
+  runtimeWritePolicyAuthorization,
 } from "./cfc/types.ts";
 import {
   prepareSourceClosureVerification,
@@ -954,6 +955,10 @@ const recordSetupProjectionPolicyInputs = (
  * document, and that document is its owner's store rather than this piece's.
  * The address goes on verbatim, path included, and the fit check takes the
  * marker only where it names a whole document.
+ *
+ * The marker carries the runtime's authorization, which is what the fit check
+ * asks for: the method that records it is reachable from anything holding a
+ * cell, so an unmarked marker naming the same document counts for nothing.
  */
 const recordPieceSubstrate = (
   tx: IExtendedStorageTransaction,
@@ -976,7 +981,7 @@ const recordPieceSubstrate = (
       scope: result.scope,
       path: [...result.path],
     }],
-  });
+  }, runtimeWritePolicyAuthorization);
 };
 
 /** Whether two links name the same document, each at that document's root. */

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -97,10 +97,12 @@ import {
   prepareCfcGrantWrite,
   preparedDigestFor,
   type PreparedDigestInput,
+  type RuntimeWritePolicyAuthorization,
   type SinkMaxConfidentiality,
   type TrustSnapshot,
   type WritePolicyInput,
 } from "../cfc/mod.ts";
+import { runtimeWritePolicyAuthorized } from "../cfc/types.ts";
 import { CFC_POLICY_MANIFEST_ID_PREFIX } from "../cfc/policy.ts";
 import { isTerminalRefusal, plainReason } from "../cfc/verdict-reason.ts";
 import {
@@ -431,6 +433,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // ECMAScript-private (#) so handler code reaching cell.tx cannot enter the
   // scope via `(cell.tx as any)` — `as any` cannot touch a `#private` member.
   #privilegedSystemWriteDepth = 0;
+
+  // The write-policy inputs the runtime recorded, by reference to the frozen
+  // record. `#`-private, so nothing outside this class can add to it; the one
+  // writer is `recordCfcWritePolicyInput` handed the runtime's mark.
+  #runtimeWritePolicyInputs = new WeakSet<WritePolicyInput>();
   // Per-transaction cache of `Cell.get()` results, keyed by stable cell view.
   // Replaced wholesale on any write (see `#invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
@@ -1337,7 +1344,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
   }
 
-  recordCfcWritePolicyInput(input: WritePolicyInput): void {
+  recordCfcWritePolicyInput(
+    input: WritePolicyInput,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void {
     // Freeze on entry: from this point on the record is owned by the tx and
     // identity-stable, which lets `hashStringOf()` cache its hash on the
     // existing WeakMap. The within-sort tiebreaker in
@@ -1351,9 +1361,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       frozen,
       this.#cfcState.implementationIdentity,
     );
+    // And remember whether the RUNTIME recorded it. The set is private and
+    // holds the frozen record itself, so `isRuntimeWritePolicyInput` answers
+    // for exactly the records that arrived with the mark.
+    if (runtimeWritePolicyAuthorized(authorization)) {
+      this.#runtimeWritePolicyInputs.add(frozen);
+    }
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-policy-input-added");
     }
+  }
+
+  isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {
+    return this.#runtimeWritePolicyInputs.has(input);
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {
@@ -3050,8 +3070,15 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     this.#wrapped.setCfcImplementationIdentity(identity);
   }
 
-  recordCfcWritePolicyInput(input: WritePolicyInput): void {
-    this.#wrapped.recordCfcWritePolicyInput(input);
+  recordCfcWritePolicyInput(
+    input: WritePolicyInput,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void {
+    this.#wrapped.recordCfcWritePolicyInput(input, authorization);
+  }
+
+  isRuntimeWritePolicyInput(input: WritePolicyInput): boolean {
+    return this.#wrapped.isRuntimeWritePolicyInput(input);
   }
 
   recordCfcConsultedGrant(consulted: ConsultedGrant): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -71,6 +71,7 @@ import type {
   ConsultedPolicyManifest,
   ImplementationIdentity,
   PostCommitSideEffect,
+  RuntimeWritePolicyAuthorization,
   TrustSnapshot,
   WritePolicyInput,
 } from "../cfc/mod.ts";
@@ -1885,7 +1886,21 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * contract and to enable the within-sort tiebreaker cache in
    * `compareWritePolicyInput`.
    */
-  recordCfcWritePolicyInput(input: WritePolicyInput): void;
+  recordCfcWritePolicyInput(
+    input: WritePolicyInput,
+    authorization?: RuntimeWritePolicyAuthorization,
+  ): void;
+
+  /**
+   * Whether `input` was recorded by the runtime, under
+   * `runtimeWritePolicyAuthorization`.
+   *
+   * `recordCfcWritePolicyInput` is on this interface, and pattern-authored
+   * code reaches the transaction its cells are bound to, so an input's own
+   * fields say only what its recorder wrote. A gate that ACTS on an input
+   * asks this; a gate that measures one does not need to.
+   */
+  isRuntimeWritePolicyInput(input: WritePolicyInput): boolean;
 
   /**
    * Records a grant document consulted by policyState-guarded boundary

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -17,6 +17,7 @@ import {
   containsCfcFieldCommitment,
 } from "../src/cfc/label-representation.ts";
 import type { CfcLabelMetadataProtectionMode } from "../src/cfc/mod.ts";
+import { CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE } from "../src/cfc/types.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -450,6 +451,73 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
         // The foreign User clause landed committed; Space-free plaintext
         // DIDs are gone.
         expect(flowEntry!.label.confidentiality).toContainEqual({
+          type: CFC_ATOM_TYPE.User,
+          subject: commitCfcFieldValue("did:key:alice"),
+        });
+        expect(JSON.stringify(entries)).not.toContain("did:key:alice");
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("commits the piece-substrate declaration built from that same join", async () => {
+      // The §8.12.5 route-2 declaration a piece's setup mints carries the
+      // flow join as its content, so it is the one `declared` entry the
+      // transform applies to. Leaving it verbatim beside the committed
+      // derived stamp of the same atoms would publish in one entry what the
+      // other protects.
+
+      const { storageManager, runtime } = makeRuntime("enforce", {
+        cfcFlowLabels: "persist",
+      });
+      try {
+        await seedSource(runtime, spaceA, "substrate-source");
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          spaceA,
+          "substrate-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          spaceB,
+          "substrate-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(spaceB, "substrate", undefined, tx);
+        const resultLink = result.getAsNormalizedFullLink();
+        const substrateLink = substrate.getAsNormalizedFullLink();
+        tx.recordCfcWritePolicyInput({
+          kind: "structural-provenance",
+          target: {
+            space: substrateLink.space,
+            scope: substrateLink.scope,
+            id: substrateLink.id,
+            path: [],
+          },
+          claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+          sources: [{
+            space: resultLink.space,
+            scope: resultLink.scope,
+            id: resultLink.id,
+            path: [],
+          }],
+        });
+        substrate.set({ copied: `${raw.secret}!` });
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        const entries = persistedEntriesFor(
+          storageManager,
+          spaceB,
+          substrateLink.id,
+        );
+        const declared = entries.find((e) => e.origin === "declared");
+        expect(declared).toBeDefined();
+        expect(declared!.label.confidentiality).toContainEqual({
           type: CFC_ATOM_TYPE.User,
           subject: commitCfcFieldValue("did:key:alice"),
         });

--- a/packages/runner/test/cfc-label-metadata-protection.test.ts
+++ b/packages/runner/test/cfc-label-metadata-protection.test.ts
@@ -17,7 +17,10 @@ import {
   containsCfcFieldCommitment,
 } from "../src/cfc/label-representation.ts";
 import type { CfcLabelMetadataProtectionMode } from "../src/cfc/mod.ts";
-import { CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE } from "../src/cfc/types.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+  runtimeWritePolicyAuthorization,
+} from "../src/cfc/types.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
@@ -505,7 +508,7 @@ describe("CFC cross-space label-metadata persist transform (inv-12 Stage 1)", ()
             id: resultLink.id,
             path: [],
           }],
-        });
+        }, runtimeWritePolicyAuthorization);
         substrate.set({ copied: `${raw.secret}!` });
         tx.prepareCfc();
         expect((await tx.commit()).ok).toBeDefined();

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -14,6 +14,7 @@ import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+  runtimeWritePolicyAuthorization,
 } from "../src/cfc/types.ts";
 import type { JSONSchema, Pattern } from "../src/builder/types.ts";
 import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
@@ -162,8 +163,10 @@ const writerFitDiagnostics = (
   tx: { getCfcState(): { diagnostics: string[] } },
 ) => tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit"));
 
-// The marker the runner records for each document it instantiates a piece
-// into, naming the piece's result document as the source.
+// The marker the runner records for each document it sets a piece up in,
+// naming the piece's result document as the source. `authorized` stands for
+// who recorded it: the runtime passes its authorization, and code that merely
+// holds a transaction cannot.
 const recordPieceSubstrate = (
   tx: ReturnType<Runtime["edit"]>,
   resultCell: {
@@ -177,6 +180,7 @@ const recordPieceSubstrate = (
       path: readonly string[];
     };
   },
+  authorized = true,
 ): void => {
   const result = resultCell.getAsNormalizedFullLink();
   const substrate = substrateCell.getAsNormalizedFullLink();
@@ -195,7 +199,7 @@ const recordPieceSubstrate = (
       id: result.id,
       path: [],
     }],
-  });
+  }, authorized ? runtimeWritePolicyAuthorization : undefined);
 };
 
 describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
@@ -1644,6 +1648,55 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
             .filter((entry) => entry.origin === "declared")
             .flatMap((entry) => entry.label.confidentiality ?? []),
         ).toContainEqual(ownPersonalSpace);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a substrate write whose marker the runtime did not record", async () => {
+      // `recordCfcWritePolicyInput` is on the public transaction interface,
+      // and pattern-authored code reaches the transaction its cells are bound
+      // to, so a marker naming any document at all can be recorded by
+      // anything holding one. Without the runtime's authorization the route
+      // does not fire, and the document keeps the ceiling it resolves to.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-forged-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-forged-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-forged-result",
+          undefined,
+          tx,
+        );
+        const bystander = runtime.getCell<{ note?: string }>(
+          signer.did(),
+          "writer-fit-seam-forged-bystander",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, bystander, false);
+        bystander.set({ note: `${raw.secret}!` });
+        const bystanderId = bystander.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(`for ${bystanderId} at /`);
+        expect(storedDocument(storageManager, bystanderId)).toBeUndefined();
       } finally {
         await runtime.dispose();
         await storageManager.close();

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -9,9 +9,13 @@ import {
 } from "./cfc-seed-envelope.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
+import { getDerivedInternalCellLink, parseLink } from "../src/link-utils.ts";
 import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
-import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+  CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+} from "../src/cfc/types.ts";
+import type { JSONSchema, Pattern } from "../src/builder/types.ts";
 import { rawMetaWriteAuthorization } from "../src/meta-seam.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-writer-fit");
@@ -157,6 +161,42 @@ const deriveIntoTarget = async (
 const writerFitDiagnostics = (
   tx: { getCfcState(): { diagnostics: string[] } },
 ) => tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit"));
+
+// The marker the runner records for each document it instantiates a piece
+// into, naming the piece's result document as the source.
+const recordPieceSubstrate = (
+  tx: ReturnType<Runtime["edit"]>,
+  resultCell: {
+    getAsNormalizedFullLink(): { space: string; scope: string; id: string };
+  },
+  substrateCell: {
+    getAsNormalizedFullLink(): {
+      space: string;
+      scope: string;
+      id: string;
+      path: readonly string[];
+    };
+  },
+): void => {
+  const result = resultCell.getAsNormalizedFullLink();
+  const substrate = substrateCell.getAsNormalizedFullLink();
+  tx.recordCfcWritePolicyInput({
+    kind: "structural-provenance",
+    target: {
+      space: substrate.space as `did:${string}:${string}`,
+      scope: substrate.scope as "space",
+      id: substrate.id,
+      path: [...substrate.path],
+    },
+    claim: CFC_STRUCTURAL_PROVENANCE_PIECE_SUBSTRATE,
+    sources: [{
+      space: result.space as `did:${string}:${string}`,
+      scope: result.scope as "space",
+      id: result.id,
+      path: [],
+    }],
+  });
+};
 
 describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
   // H4 writer-fit (SC-18b, spec §8.12.4): a write whose derived flow label does
@@ -1120,5 +1160,824 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       await runtime.dispose();
       await storageManager.close();
     }
+  });
+
+  // The pattern the end-to-end cases set up: one argument field, and one
+  // derived internal cell the result projects to.
+  const seamResultSchema = {
+    type: "object",
+    properties: { savedTitle: { type: "string" } },
+    required: ["savedTitle"],
+  } as const satisfies JSONSchema;
+
+  const seamPattern = {
+    argumentSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+    } as const,
+    resultSchema: seamResultSchema,
+    derivedInternalCells: [{
+      partialCause: "savedTitle",
+      schema: { type: "string", default: "" },
+    }],
+    result: {
+      savedTitle: { $alias: { partialCause: "savedTitle", path: [] } },
+    },
+    nodes: [],
+  } satisfies Pattern;
+
+  describe("the piece-substrate declaration (§8.12.5 route 2)", () => {
+    // A piece's substrate is filled by the runtime out of whatever the setup
+    // transaction read: the argument document, and the internal documents
+    // and streams the result projects to. No value schema can declare a
+    // covering policy for them, because the atoms are a property of the
+    // transaction rather than of the pattern, so the transaction declares
+    // that policy itself. `docs/specs/cfc-enforcement-matrix.md` §4 states
+    // the route and the four conditions on it; one test per condition
+    // follows.
+
+    it("declares the join on a document the substrate marker names", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        const entries = replicaEntries(storageManager, substrateId);
+        expect(entries.some((entry) =>
+          entry.origin === "declared" &&
+          (entry.label.confidentiality ?? []).includes("secret")
+        )).toBe(true);
+
+        // A permanent change to a store's policy leaves a trace even at the
+        // rung that admits it.
+        const flags = writerFitDiagnostics(tx);
+        expect(flags.length).toBe(1);
+        expect(flags[0]).toContain("writer-fit(piece-substrate-declared)");
+        expect(flags[0]).toContain(`${substrateId} at /`);
+        expect(flags[0]).toContain('"secret"');
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects the same write on a document no substrate marker names", async () => {
+      // The negative twin of the test above: one transaction, one marker, and
+      // a second target the marker does not name. The route reaches the seam
+      // and stops there.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-bystander-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-bystander-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-bystander-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-bystander-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        const bystander = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-bystander",
+          undefined,
+          tx,
+        );
+        bystander.set({ copied: `${raw.secret}!` });
+        const bystanderId = bystander.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(`for ${bystanderId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("grows the declaration when a later transaction carries a wider join", async () => {
+      // The declared component only ever tightens (§8.12.1), so a second
+      // atom joins the first rather than replacing it. A piece created
+      // before its inputs were labeled reaches the same path: nothing was
+      // declared at birth, and the write that first carries a join declares
+      // it then.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-grow-first");
+        await seedSecretSource(runtime, "writer-fit-seam-grow-second", [
+          "other",
+        ]);
+
+        const born = runtime.edit();
+        const untainted = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-grow-substrate",
+          undefined,
+          born,
+        );
+        untainted.set({ copied: "public" });
+        const substrateId = untainted.getAsNormalizedFullLink().id;
+        expect((await born.commit()).ok).toBeDefined();
+        expect(replicaEntries(storageManager, substrateId)).toEqual([]);
+
+        const declaredClauses = async (sources: readonly string[]) => {
+          const tx = runtime.edit();
+          tx.setCfcEnforcementMode("enforce-strict");
+          const copied = sources.map((name) =>
+            (runtime.getCell(signer.did(), name, undefined, tx)
+              .getRaw() as { secret?: string }).secret
+          ).join("/");
+          const result = runtime.getCell(
+            signer.did(),
+            "writer-fit-seam-grow-result",
+            undefined,
+            tx,
+          );
+          const substrate = runtime.getCell(
+            signer.did(),
+            "writer-fit-seam-grow-substrate",
+            undefined,
+            tx,
+          );
+          recordPieceSubstrate(tx, result, substrate);
+          substrate.set({ copied });
+          tx.prepareCfc();
+          expect((await tx.commit()).ok).toBeDefined();
+          const declared = replicaEntries(storageManager, substrateId)
+            .filter((entry) => entry.origin === "declared");
+          // One entry per path per component: a second declaration at the
+          // same path would coalesce, and a stored one that failed to
+          // coalesce would rewrite the envelope on every reconcile.
+          expect(declared.length).toBe(1);
+          return declared[0].label.confidentiality ?? [];
+        };
+
+        expect(await declaredClauses(["writer-fit-seam-grow-first"]))
+          .toEqual(["secret"]);
+        // Re-declaring the same join changes nothing.
+        expect(await declaredClauses(["writer-fit-seam-grow-first"]))
+          .toEqual(["secret"]);
+        const grown = await declaredClauses([
+          "writer-fit-seam-grow-first",
+          "writer-fit-seam-grow-second",
+        ]);
+        expect(grown).toContain("secret");
+        expect(grown).toContain("other");
+        // And the wider declaration survives a transaction that carries only
+        // the narrower join: the declared component never shrinks.
+        expect(await declaredClauses(["writer-fit-seam-grow-first"]))
+          .toEqual(grown);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a substrate write at a path its own schema declares", async () => {
+      // A schema that declares at the written path owns the store's policy
+      // there, and widening it from the join would make the walk's own
+      // re-mint non-monotone on the next write. That store's route 2 is the
+      // author's, in the schema.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-declared-source");
+
+        // The field has to exist already: a key write into a document this
+        // transaction is also creating materializes the whole document, and
+        // lands at the root rather than at the declared field.
+        const create = runtime.edit();
+        runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-seam-declared-substrate",
+          undefined,
+          create,
+        ).set({ copied: "public" });
+        expect((await create.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-declared-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-declared-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-seam-declared-substrate",
+          {
+            type: "object",
+            properties: {
+              copied: {
+                type: "string",
+                ifc: { confidentiality: ["policy"] },
+              },
+            },
+          },
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.key("copied").set(`${raw.secret}!`);
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain("at /copied");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a substrate write whose marker names only part of the document", async () => {
+      // The route declares a policy for the whole store, so it takes a
+      // marker only where the marker claims the whole store. Setup records
+      // the empty path for every document it mints from a result cell, so
+      // this excludes a stored argument link that points inside some other
+      // document.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-partial-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-partial-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-partial-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell<{ copied?: string }>(
+          signer.did(),
+          "writer-fit-seam-partial-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate.key("copied"));
+        substrate.set({ copied: `${raw.secret}!` });
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a clause naming a space other than the target's", async () => {
+      // A `Space` clause is honored by a replica set, not by a reader check,
+      // which is why residency admits only the target's own. Declaring a
+      // foreign one would put the bytes in front of this space's members
+      // under a promise made to another space's readers.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-foreign-source", [{
+          type: "https://commonfabric.org/cfc/atom/Space",
+          id: "did:key:z6MkfZ3gV6ZKqmyWLTPYnPYRUYQBqTHTNCJgqbCkNBzYqZ4H",
+        }]);
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-foreign-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-foreign-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-foreign-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(storedDocument(storageManager, substrateId)).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a substrate write named by a different provenance claim", async () => {
+      // The claim discriminates. The seed-materialization marker records a
+      // whole-document address too, so without it that unrelated runtime
+      // marker would carry the route.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-claim-source");
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-claim-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-claim-substrate",
+          undefined,
+          tx,
+        );
+        const link = substrate.getAsNormalizedFullLink();
+        tx.recordCfcWritePolicyInput({
+          kind: "structural-provenance",
+          target: {
+            space: link.space,
+            scope: link.scope,
+            id: link.id,
+            path: [],
+          },
+          claim: CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+          sources: [{
+            space: link.space,
+            scope: link.scope,
+            id: link.id,
+            path: [],
+          }],
+        });
+        substrate.set({ copied: `${raw.secret}!` });
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a poisoned measurement on a substrate document", async () => {
+      // The ungrantable read-failed marker is outside every ceiling, so it
+      // is outside what the route may declare: a measurement the runtime
+      // could not take proves nothing about the audience, and declaring it
+      // would write a clause no reader can ever satisfy.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-poisoned-source", [{
+          anyOf: [CFC_LABEL_READ_FAILED_ATOM, ownSpacePrincipal],
+        }]);
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-poisoned-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-poisoned-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-poisoned-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(committed.error?.message).toContain(CFC_LABEL_READ_FAILED_ATOM);
+        expect(storedDocument(storageManager, substrateId)).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps the clauses an ancestor path already declared", async () => {
+      // The route declares the resolved ceiling as well as the offending
+      // clauses. Reads resolve declared entries by longest prefix, so a mint
+      // that carried only what was offending would shadow the ancestor
+      // declaration at every path below it — lowering the store's promise
+      // through the very entry meant to raise it.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-ancestor-first");
+        await seedSecretSource(runtime, "writer-fit-seam-ancestor-second", [
+          "other",
+        ]);
+
+        const writeUnder = async (sourceName: string, field: string) => {
+          const tx = runtime.edit();
+          tx.setCfcEnforcementMode("enforce-strict");
+          const source = runtime.getCell(
+            signer.did(),
+            sourceName,
+            undefined,
+            tx,
+          );
+          const raw = source.getRaw() as { secret?: string };
+          const result = runtime.getCell(
+            signer.did(),
+            "writer-fit-seam-ancestor-result",
+            undefined,
+            tx,
+          );
+          const substrate = runtime.getCell<Record<string, string>>(
+            signer.did(),
+            "writer-fit-seam-ancestor-substrate",
+            undefined,
+            tx,
+          );
+          recordPieceSubstrate(tx, result, substrate);
+          if (field === "") {
+            substrate.set({ first: `${raw.secret}!` });
+          } else {
+            substrate.key(field).set(`${raw.secret}!`);
+          }
+          const substrateId = substrate.getAsNormalizedFullLink().id;
+          tx.prepareCfc();
+          expect((await tx.commit()).ok).toBeDefined();
+          return replicaEntries(storageManager, substrateId);
+        };
+
+        // The document root declares the first join.
+        expect(
+          (await writeUnder("writer-fit-seam-ancestor-first", ""))
+            .filter((entry) =>
+              entry.origin === "declared" && entry.path.length === 0
+            )
+            .flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toEqual(["secret"]);
+
+        // A later write below it carries a join the root does not cover, so
+        // the route declares at the deeper path — and that declaration is
+        // what a reader of the deeper path resolves, so it has to carry the
+        // root's clause too.
+        const deeper = (await writeUnder(
+          "writer-fit-seam-ancestor-second",
+          "second",
+        ))
+          .filter((entry) =>
+            entry.origin === "declared" && entry.path.join("/") === "second"
+          )
+          .flatMap((entry) => entry.label.confidentiality ?? []);
+        expect(deeper).toContain("secret");
+        expect(deeper).toContain("other");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("leaves the persist-and-flag diagnostic in place under enforce-explicit", async () => {
+      // The route is the strict rung's, like the reject it replaces. Every
+      // rung below keeps the diagnostic that is its rollout signal, and
+      // stores no declared policy it could never take back.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-explicit-source");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-explicit-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-explicit-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-explicit-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        const flags = writerFitDiagnostics(tx);
+        expect(flags.length).toBeGreaterThan(0);
+        expect(flags[0]).toContain("writer-fit(persist-and-flag)");
+        expect(
+          replicaEntries(storageManager, substrateId)
+            .filter((entry) => entry.origin === "declared"),
+        ).toEqual([]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("declares on both documents a real setup writes", async () => {
+      // Drives the production recorder rather than the marker the tests
+      // above hand-record: `setup` marks the argument document and each
+      // internal document its result projects to, and a first setup inside
+      // a labeled transaction writes both.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-both-source");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-both-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const resultCell = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-both",
+          seamResultSchema,
+          tx,
+        );
+        await runtime.setup(
+          tx,
+          seamPattern,
+          { title: `${raw.secret}!` },
+          resultCell,
+        );
+        const argumentId = parseLink(
+          resultCell.getMetaRaw("argument"),
+          resultCell,
+        )!.id!;
+        const internalId = getDerivedInternalCellLink(
+          resultCell,
+          seamPattern.derivedInternalCells[0],
+        ).id;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        for (const id of [argumentId, internalId]) {
+          expect(
+            replicaEntries(storageManager, id).filter((entry) =>
+              entry.origin === "declared" &&
+              (entry.label.confidentiality ?? []).includes("secret")
+            ).length,
+          ).toBe(1);
+        }
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("rejects a setup whose stored argument link names another document", async () => {
+      // `setup` reads the argument address back out of the result cell's
+      // stored meta, where it need not name the document that result cell's
+      // cause mints. The marker follows the minted address, so a stored link
+      // aimed elsewhere carries no route and that document keeps its own
+      // ceiling.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-aimed-source");
+
+        const aim = runtime.edit();
+        const resultCell = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-aimed",
+          seamResultSchema,
+          aim,
+        );
+        const bystander = runtime.getCell<{ note?: string }>(
+          signer.did(),
+          "writer-fit-seam-aimed-bystander",
+          undefined,
+          aim,
+        );
+        bystander.set({ note: "public" });
+        const bystanderId = bystander.getAsNormalizedFullLink().id;
+        resultCell.withTx(aim).setMetaRaw(
+          "argument",
+          bystander.getAsWriteRedirectLink({ base: resultCell }),
+          rawMetaWriteAuthorization,
+        );
+        expect((await aim.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-aimed-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const reused = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-aimed",
+          seamResultSchema,
+          tx,
+        );
+        await runtime.setup(
+          tx,
+          seamPattern,
+          { title: `${raw.secret}!` },
+          reused,
+        );
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(
+          replicaEntries(storageManager, bystanderId)
+            .filter((entry) => entry.origin === "declared"),
+        ).toEqual([]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("commits a piece instantiation whose transaction read labeled data", async () => {
+      // The end-to-end shape the hand-recorded marker above stands in for: a
+      // real `setup` writing a real piece's argument document. The piece is
+      // set up twice — first with nothing labeled in the transaction, then
+      // inside one that read a labeled document — so the second setup
+      // finds an argument document that already exists and declares
+      // nothing, which a create-only route would refuse.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-piece-source");
+
+        const tx = runtime.edit();
+        const resultCell = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-piece",
+          seamResultSchema,
+          tx,
+        );
+        await runtime.setup(
+          tx,
+          seamPattern,
+          { title: "public" },
+          resultCell,
+        );
+        const argumentId = parseLink(
+          resultCell.getMetaRaw("argument"),
+          resultCell,
+        )!.id!;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        const labeled = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-piece-source",
+          undefined,
+          labeled,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const reused = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-piece",
+          seamResultSchema,
+          labeled,
+        );
+        await runtime.setup(
+          labeled,
+          seamPattern,
+          { title: `${raw.secret}!` },
+          reused,
+        );
+        labeled.prepareCfc();
+        expect((await labeled.commit()).ok).toBeDefined();
+
+        const entries = replicaEntries(storageManager, argumentId);
+        expect(entries.some((entry) =>
+          entry.origin === "declared" &&
+          (entry.label.confidentiality ?? []).includes("secret")
+        )).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
   });
 });

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -1239,9 +1239,12 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         // rung that admits it.
         const flags = writerFitDiagnostics(tx);
         expect(flags.length).toBe(1);
-        expect(flags[0]).toContain("writer-fit(piece-substrate-declared)");
-        expect(flags[0]).toContain(`${substrateId} at /`);
-        expect(flags[0]).toContain('"secret"');
+        expect(
+          flags.some((flag) =>
+            flag.includes("writer-fit(piece-substrate-declared)") &&
+            flag.includes(`${substrateId} at /`) && flag.includes('"secret"')
+          ),
+        ).toBe(true);
       } finally {
         await runtime.dispose();
         await storageManager.close();
@@ -1542,6 +1545,111 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       }
     });
 
+    it("rejects a personal-space clause naming a space other than the target's", async () => {
+      // `PersonalSpace(owner)` is the second spelling of a container
+      // audience, so it answers to the same rule: the owner's personal
+      // space is a space of its own, and a store here cannot keep a promise
+      // made to that space's readers.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "writer-fit-seam-personal-source", [{
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: "did:key:z6MkfZ3gV6ZKqmyWLTPYnPYRUYQBqTHTNCJgqbCkNBzYqZ4H",
+        }]);
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-personal-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-personal-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-personal-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        const committed = await tx.commit();
+        expect(committed.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(storedDocument(storageManager, substrateId)).toBeUndefined();
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("declares a personal-space clause naming the target's own space", async () => {
+      // The same-space spelling is keepable, so the route takes it: the
+      // clause names the space the bytes are already in, and if that space
+      // stops being personal the audience and the replica set grow
+      // together.
+
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        const ownPersonalSpace = {
+          type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+          owner: signer.did(),
+        };
+        await seedSecretSource(runtime, "writer-fit-seam-own-personal-source", [
+          ownPersonalSpace,
+        ]);
+
+        const tx = runtime.edit();
+        tx.setCfcEnforcementMode("enforce-strict");
+        const source = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-own-personal-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const result = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-own-personal-result",
+          undefined,
+          tx,
+        );
+        const substrate = runtime.getCell(
+          signer.did(),
+          "writer-fit-seam-own-personal-substrate",
+          undefined,
+          tx,
+        );
+        recordPieceSubstrate(tx, result, substrate);
+        substrate.set({ copied: `${raw.secret}!` });
+        const substrateId = substrate.getAsNormalizedFullLink().id;
+        tx.prepareCfc();
+        expect((await tx.commit()).ok).toBeDefined();
+
+        expect(
+          replicaEntries(storageManager, substrateId)
+            .filter((entry) => entry.origin === "declared")
+            .flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toContainEqual(ownPersonalSpace);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
     it("rejects a substrate write named by a different provenance claim", async () => {
       // The claim discriminates. The seed-materialization marker records a
       // whole-document address too, so without it that unrelated runtime
@@ -1760,9 +1868,12 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         tx.prepareCfc();
         expect((await tx.commit()).ok).toBeDefined();
 
-        const flags = writerFitDiagnostics(tx);
-        expect(flags.length).toBeGreaterThan(0);
-        expect(flags[0]).toContain("writer-fit(persist-and-flag)");
+        expect(
+          writerFitDiagnostics(tx).some((flag) =>
+            flag.includes("writer-fit(persist-and-flag)") &&
+            flag.includes(`${substrateId} at /`)
+          ),
+        ).toBe(true);
         expect(
           replicaEntries(storageManager, substrateId)
             .filter((entry) => entry.origin === "declared"),

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -12,6 +12,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { createNonReactiveTransaction } from "../src/storage/extended-storage-transaction.ts";
+import { runtimeWritePolicyAuthorization } from "../src/cfc/types.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("extended-storage-transaction");
@@ -224,6 +225,88 @@ describe("extended-storage-transaction", () => {
           reason: "sink-request confidentiality exceeds ceiling for " +
             'fetchText: "medical"',
         }]);
+      } finally {
+        await tx.commit();
+      }
+    });
+  });
+
+  describe("a write-policy input's recorder", () => {
+    // A gate that ACTS on a write-policy input asks who recorded it, because
+    // this method is on the public interface and pattern-authored code
+    // reaches the transaction its cells are bound to. The authorization
+    // travels as an argument of the one call that carries it, so the answer
+    // has to be per input rather than per transaction.
+
+    const input = (id: string) =>
+      ({
+        kind: "structural-provenance",
+        target: { space, id, scope: "space", path: [] },
+        claim: "runtime.setup.piece-substrate",
+        sources: [],
+      }) as const;
+
+    it("returns `true` for an input recorded with the authorization", async () => {
+      const tx = runtime.edit();
+      try {
+        tx.recordCfcWritePolicyInput(
+          input("of:authorized"),
+          runtimeWritePolicyAuthorization,
+        );
+        const [recorded] = tx.getCfcState().writePolicyInputs;
+        expect(tx.isRuntimeWritePolicyInput(recorded)).toBe(true);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("returns `false` for an input recorded without it", async () => {
+      const tx = runtime.edit();
+      try {
+        tx.recordCfcWritePolicyInput(input("of:unauthorized"));
+        const [recorded] = tx.getCfcState().writePolicyInputs;
+        expect(tx.isRuntimeWritePolicyInput(recorded)).toBe(false);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("answers per input rather than per transaction", async () => {
+      // The mark reaches the one input its call carried, so recording an
+      // authorized input does not lend the mark to an unauthorized one
+      // beside it — in either order.
+      const tx = runtime.edit();
+      try {
+        tx.recordCfcWritePolicyInput(
+          input("of:first-authorized"),
+          runtimeWritePolicyAuthorization,
+        );
+        tx.recordCfcWritePolicyInput(input("of:then-plain"));
+        tx.recordCfcWritePolicyInput(
+          input("of:then-authorized"),
+          runtimeWritePolicyAuthorization,
+        );
+        expect(
+          tx.getCfcState().writePolicyInputs.map((recorded) =>
+            tx.isRuntimeWritePolicyInput(recorded)
+          ),
+        ).toEqual([true, false, true]);
+      } finally {
+        await tx.commit();
+      }
+    });
+
+    it("returns `false` for an input this transaction never recorded", async () => {
+      // The mark is held by reference to the frozen record the transaction
+      // owns, so a look-alike built outside it answers `false` however
+      // exactly its fields match.
+      const tx = runtime.edit();
+      try {
+        tx.recordCfcWritePolicyInput(
+          input("of:owned"),
+          runtimeWritePolicyAuthorization,
+        );
+        expect(tx.isRuntimeWritePolicyInput(input("of:owned"))).toBe(false);
       } finally {
         await tx.commit();
       }

--- a/packages/runner/test/getCellFromLink.test.ts
+++ b/packages/runner/test/getCellFromLink.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("runner-get-cell-from-link");
+const space = signer.did();
+
+describe("getCellFromLink()", () => {
+  // The entry point every caller holding a link reaches a cell through. It
+  // accepts three shapes — a sigil `CellLink`, a `NormalizedFullLink`, and a
+  // plain object carrying a full link's fields — and turns anything else into
+  // a throw. These cases pin that admission rule from both sides, because
+  // whether the rejecting branches run is otherwise a property of which other
+  // tests happen to share the process rather than of the code.
+
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const fullLink = () => ({
+    space,
+    id: "of:get-cell-from-link" as `${string}:${string}`,
+    path: [] as string[],
+    type: "application/json",
+  });
+
+  describe("the shapes it admits", () => {
+    it("returns a cell for a normalized full link", () => {
+      const cell = runtime.getCellFromLink({ ...fullLink(), scope: "space" });
+      expect(cell.getAsNormalizedFullLink().id).toBe("of:get-cell-from-link");
+      expect(cell.getAsNormalizedFullLink().space).toBe(space);
+    });
+
+    it("returns a cell for a link-shaped object that names no scope", () => {
+      // A plain object carrying the link's fields is admitted, and an absent
+      // scope takes the default rather than travelling as `undefined`. That
+      // is the only scope the shape test lets through besides a cell scope,
+      // so it is the only way the defaulting arm is reached.
+      const cell = runtime.getCellFromLink(fullLink());
+      expect(cell.getAsNormalizedFullLink().scope).toBe("space");
+    });
+
+    it("returns a cell for a sigil link", () => {
+      const source = runtime.getCellFromLink({ ...fullLink(), scope: "space" });
+      const cell = runtime.getCellFromLink(source.getAsLink());
+      expect(cell.getAsNormalizedFullLink().id).toBe("of:get-cell-from-link");
+    });
+  });
+
+  describe("the shapes it refuses", () => {
+    // Each of these reaches the link-shape test with something it cannot
+    // read, so the shape test returns false and no branch produces a link.
+
+    it("throws for a string", () => {
+      expect(() =>
+        runtime.getCellFromLink(
+          "of:get-cell-from-link" as unknown as Parameters<
+            Runtime["getCellFromLink"]
+          >[0],
+        )
+      ).toThrow("Invalid cell link");
+    });
+
+    it("throws for `null`", () => {
+      expect(() =>
+        runtime.getCellFromLink(
+          null as unknown as Parameters<Runtime["getCellFromLink"]>[0],
+        )
+      ).toThrow("Invalid cell link");
+    });
+
+    it("throws for an object carrying none of a link's fields", () => {
+      expect(() =>
+        runtime.getCellFromLink(
+          { nothing: "here" } as unknown as Parameters<
+            Runtime["getCellFromLink"]
+          >[0],
+        )
+      ).toThrow("Invalid cell link");
+    });
+
+    it("throws for a link-shaped object whose scope is not a cell scope", () => {
+      // `any` is a schema scope rather than a cell scope, so the shape test
+      // does not read this as a link at all.
+      expect(() =>
+        runtime.getCellFromLink(
+          { ...fullLink(), scope: "any" } as unknown as Parameters<
+            Runtime["getCellFromLink"]
+          >[0],
+        )
+      ).toThrow("Invalid cell link");
+    });
+
+    it("throws for a link-shaped object whose `path` is not an array", () => {
+      expect(() =>
+        runtime.getCellFromLink(
+          { ...fullLink(), path: "value" } as unknown as Parameters<
+            Runtime["getCellFromLink"]
+          >[0],
+        )
+      ).toThrow("Invalid cell link");
+    });
+
+    it("throws for a link-shaped object whose scope is `inherit`", () => {
+      // Distinct from the refusals above: an unresolved scope is a caller
+      // mistake the shape test names rather than a shape it cannot read, so
+      // it reports what is wrong instead of the generic refusal.
+      expect(() =>
+        runtime.getCellFromLink(
+          { ...fullLink(), scope: "inherit" } as unknown as Parameters<
+            Runtime["getCellFromLink"]
+          >[0],
+        )
+      ).toThrow("resolve scope before creating a full link");
+    });
+  });
+});


### PR DESCRIPTION
Under `cfcEnforcementMode: "enforce-strict"` with `cfcFlowLabels: "persist"`, setting a piece up failed whenever the transaction doing it had read anything a user principal labels. The refusals name the piece's own documents:

  CfcCommitRefusalError: writer-fit confidentiality misfit for
  of:fid1:... at /title (canWrite, §8.12.4):
  {"subject":"did:key:...","type":".../cfc/atom/User"}

repeated at /description, /origin and /processing, and again at the root of each internal document the piece's result projects to.

The write-side fit check of CFC §8.12.4 measures the per-transaction flow join against the target document's declared store policy, and a document that declares nothing resolves to the empty "public" ceiling. The runtime writes a piece's substrate — its argument document, and the internal documents and streams its result projects to — and fills it with whatever the setup transaction read. An author cannot know which atoms a given transaction will carry, so a declaration written into a schema either misses them or over-declares every instance of the pattern. A `User(owner)` clause picked up from an earlier read in the same transaction therefore had nowhere to land, and every piece setup inside a labeled transaction was refused.

This is §8.12.5's route 2, the monotone-safe upgrade: the write that puts the join on a path also declares, in that same transaction, a policy covering it. The runner records a piece-substrate marker on each document it sets a piece up in, and the prepare walk answers a misfit on such a document by minting a `declared` label-map entry carrying the ceiling that resolved at the path plus exactly the clauses that had nowhere to go. The fit test then passes because the store's policy covers the data, not because the check was skipped.

Declaring rather than exempting is what makes the route sound. The atoms persist as store policy, so readers of the substrate consume them, and go on consuming them after an overwrite clears the derived stamp that carried them. The cost is the ratchet §8.12.2 asks for: a substrate document that once held data derived from a labeled read keeps that clause after the read stops, which is the over-taint direction.

Five conditions bound the route, each with a test that fails when it is deleted:

- The document must carry the marker, and the marker must name the whole document. The runner records only addresses it mints from the piece's result cell; it reads the argument address back out of stored meta on every setup after the first, and where that stored link names another document — a nested piece's argument lives in its host's — no marker is recorded and that document keeps its own ceiling.
- No schema may declare at the written path. A schema that does owns the store's policy there, and widening it from the join would make the walk's own re-mint non-monotone on the next write.
- The join must carry no read-failed marker. That marker is ungrantable, so declaring it would both admit a measurement the runtime could not take and write a clause no reader can satisfy.
- No clause may name a space other than the target's. A `Space` clause is honored by a replica set rather than by a reader check, so a store here cannot keep a promise made to another space's readers — which is why residency admits only this space's own clause.
- The declaration only grows. The ceiling it starts from resolves over the entries the walk is about to persist, carried-forward stored declared entries among them, so a wider join later adds clauses rather than replacing them. Growth is also what reaches a piece whose substrate was written before any labeled read entered a transaction writing it — the create-only shape refuses that piece forever, which is the ordinary sequence rather than an edge case.

The route sits at `enforce-strict`, where the reject it replaces sits. Every rung below keeps its `writer-fit(persist-and-flag)` diagnostic and stores no declared policy it could never take back. At strict a declaration records a `writer-fit(piece-substrate-declared)` diagnostic, so a permanent change to a store's policy leaves a trace even at the rung that admits it.

Measured against the agent host's debug-view tests with the strict posture forced on: refusals on `of:` documents fall from 122 to 0 in the replacement test and from 494 to 6 in the pattern test. The six that remain are a different shape — a tainted write to an array that already existed in an ordinary document — which is the misfit the ceiling exists to catch. Refusals on `computed:` documents are unchanged at 132 and
495. Those are the piece's RUNNING graph, writing in later transactions that record no setup marker, so they measure against their own ceilings; the route moves the setup seam and does not by itself make the strict rung work.

Two approaches were measured and rejected before this one. Declaring the space principal at piece creation does not admit ordinary taint at all, because a declared policy is an allowlist keyed on atom identity rather than a sensitivity level. Reading a declared `PersonalSpace(P)` ceiling as admitting a `User(P)` label is unsound, because §3.6.4 lets an owner convert a personal space into a shared one and §3.6.5 then grants new members access with no labels rewritten.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

