### PR TITLE
Reorder dashboard tiles and add metric slots

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -303,6 +303,7 @@ surveillance tool.
 
 | tile | source | needs |
 |---|---|---|
+| YOUR METRIC HERE (three slots) | static green placeholders reserved for future metrics | none |
 | labs ci, labs ci trust, labs ci duration | GitHub Actions (`deno.yml` on main in `commontoolsinc/labs`), via the REST API | `GH_TOKEN` (or `GITHUB_TOKEN`) |
 | loom ci, loom ci trust, loom ci duration | the same three tiles for `commontoolsinc/loom` (`test-fast.yml` on main) | `GH_TOKEN` (read access to loom); optional `DASHBOARD_LOOM_REPO` |
 | recent main runs | Labs and Loom main-run snapshots, refreshed independently and merged chronologically whenever either arrives; each row is tagged with its repo | `GH_TOKEN` |

--- a/packages/dashboard/registry.test.ts
+++ b/packages/dashboard/registry.test.ts
@@ -1,0 +1,57 @@
+/** Verifies the dashboard's registered tile sequence and reserved slots. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { TILES } from "./registry.ts";
+import type { Ctx } from "./types.ts";
+
+const context: Ctx = {
+  runs: () => Promise.resolve([]),
+  runsFor: () => Promise.resolve([]),
+  env: () => undefined,
+};
+
+describe("registry", () => {
+  it("registers tiles in dashboard display order", () => {
+    expect(TILES.map((tile) => tile.id)).toEqual([
+      "labs-ci",
+      "ci-trust",
+      "ci-duration",
+      "benchmark",
+      "loom-ci",
+      "loom-ci-trust",
+      "loom-ci-duration",
+      "loom-metric-placeholder",
+      "test-flakes",
+      "test-selection",
+      "testing-metric-placeholder",
+      "prod-errors",
+      "dau",
+      "discord-online",
+      "github-members",
+      "prod-uptime",
+      "gcp-spend",
+      "github-ci-spend",
+      "model-spend",
+      "spend-metric-placeholder",
+      "recent-runs",
+    ]);
+  });
+
+  it("returns the empty metric view for each reserved slot", async () => {
+    const placeholders = TILES.filter((tile) =>
+      tile.id.endsWith("metric-placeholder")
+    );
+    const views = await Promise.all(
+      placeholders.map((tile) => tile.collect(context)),
+    );
+
+    expect(views).toEqual(Array(3).fill({
+      label: "YOUR METRIC HERE",
+      status: "good",
+      value: "–",
+      sub: "no metric selected for this tile",
+    }));
+  });
+});

--- a/packages/dashboard/registry.ts
+++ b/packages/dashboard/registry.ts
@@ -6,46 +6,49 @@
 
 import type { Tile } from "./types.ts";
 
-import { labsCi, loomCi } from "./tiles/main-build.ts";
-import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
+import { benchmark } from "./tiles/benchmark.ts";
 import { labsCiDuration, loomCiDuration } from "./tiles/ci-duration.ts";
-import { prodUptime } from "./tiles/prod-uptime.ts";
-import { prodErrors } from "./tiles/prod-errors.ts";
+import { labsCiTrust, loomCiTrust } from "./tiles/ci-trust.ts";
+import { dau } from "./tiles/dau.ts";
+import { discordOnline } from "./tiles/discord-online.ts";
 import { gcpSpend } from "./tiles/gcp-spend.ts";
 import { githubCiSpend } from "./tiles/github-ci-spend.ts";
-import { modelSpend } from "./tiles/model-spend.ts";
-import { discordOnline } from "./tiles/discord-online.ts";
-import { benchmark } from "./tiles/benchmark.ts";
-import { dau } from "./tiles/dau.ts";
 import { githubMembers } from "./tiles/github-members.ts";
+import { labsCi, loomCi } from "./tiles/main-build.ts";
+import { makeMetricPlaceholder } from "./tiles/metric-placeholder.ts";
+import { modelSpend } from "./tiles/model-spend.ts";
+import { prodErrors } from "./tiles/prod-errors.ts";
+import { prodUptime } from "./tiles/prod-uptime.ts";
 import { recentRuns } from "./tiles/recent-runs.ts";
 import { testFlakes } from "./tiles/test-flakes.ts";
 import { testSelection } from "./tiles/test-selection.ts";
 
-// Order controls placement: a normal tile takes the next slot in the grid, and
-// a wide tile renders full-width below the grid, in this same order.
+/** Tiles in grid order, followed by full-width tiles in display order. */
 export const TILES: Tile[] = [
-  // Row 1: labs CI family + benchmark
   labsCi,
   labsCiTrust,
   labsCiDuration,
   benchmark,
-  // Row 2: loom CI family + github spend
+
   loomCi,
   loomCiTrust,
   loomCiDuration,
-  githubCiSpend,
-  // Row 3: production health and flaky tests
-  prodUptime,
-  prodErrors,
-  dau,
+  makeMetricPlaceholder("loom-metric-placeholder"),
+
   testFlakes,
-  // Row 4: test selection, spend, and community
   testSelection,
-  modelSpend,
-  gcpSpend,
+  makeMetricPlaceholder("testing-metric-placeholder"),
+  prodErrors,
+
+  dau,
   discordOnline,
-  // Row 5: the remaining community tiles
   githubMembers,
-  recentRuns, // wide — renders full-width below the grid
+  prodUptime,
+
+  gcpSpend,
+  githubCiSpend,
+  modelSpend,
+  makeMetricPlaceholder("spend-metric-placeholder"),
+
+  recentRuns,
 ];

--- a/packages/dashboard/tiles/metric-placeholder.ts
+++ b/packages/dashboard/tiles/metric-placeholder.ts
@@ -5,9 +5,7 @@ export function makeMetricPlaceholder(id: string): Tile {
   return {
     id,
     intervalMs: 24 * 60 * 60_000,
-    // This static tile implements the asynchronous collector contract.
-    // deno-lint-ignore require-await
-    collect: async () => ({
+    collect: () => Promise.resolve({
       label: "YOUR METRIC HERE",
       status: "good",
       value: "–",

--- a/packages/dashboard/tiles/metric-placeholder.ts
+++ b/packages/dashboard/tiles/metric-placeholder.ts
@@ -1,0 +1,17 @@
+import type { Tile } from "../types.ts";
+
+/** Builds a green slot for a dashboard metric that has not been selected. */
+export function makeMetricPlaceholder(id: string): Tile {
+  return {
+    id,
+    intervalMs: 24 * 60 * 60_000,
+    // This static tile implements the asynchronous collector contract.
+    // deno-lint-ignore require-await
+    collect: async () => ({
+      label: "YOUR METRIC HERE",
+      status: "good",
+      value: "–",
+      sub: "no metric selected for this tile",
+    }),
+  };
+}


### PR DESCRIPTION
Arrange the dashboard's normal tiles into five complete rows. Keep the Labs and Loom CI families together, group testing and production signals, and finish with spend metrics.

Fill the three unused positions with green placeholder tiles. Each placeholder uses a distinct stable identifier and renders the shared prompt, dash, and subtitle. Add registry coverage for the exact order and placeholder content, and document the reserved slots in the dashboard tile inventory.

Verified with the dashboard package test task, including 699 Deno tests, four favicon tests, and six browser tests. Also passed repo-wide formatting, lint, type checking, and documentation code-block checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

