### PR TITLE
Stop the manifest publisher running out of memory on real data

### DIFF
--- a/tasks/test-selection/build.test.ts
+++ b/tasks/test-selection/build.test.ts
@@ -24,8 +24,17 @@ import {
   reportFromText,
 } from "./build.ts";
 import { parseManifest, serializeManifest } from "./manifest.ts";
-import { emptyState, flakeRate, type IdentityState } from "./score.ts";
-import { FLAKE_EXCLUSION_RATE, MAX_REPEATS } from "./policy.ts";
+import {
+  daysBetween,
+  emptyState,
+  flakeRate,
+  type IdentityState,
+} from "./score.ts";
+import {
+  COST_WINDOW_DAYS,
+  FLAKE_EXCLUSION_RATE,
+  MAX_REPEATS,
+} from "./policy.ts";
 
 const NO_ALIASES = new AliasResolver([]);
 
@@ -599,5 +608,68 @@ describe("a batch whose reports interleave in time", () => {
     expect(backwards).toEqual(forwards);
     expect(shuffled).toEqual(forwards);
     expect(forwards.mainCatches).toBe(2);
+  });
+});
+
+describe("a report holding a whole day", () => {
+  it("folds a rollup shard larger than a call can carry arguments", () => {
+    // A rollup shard is a whole day of records in one object. Appending
+    // its observations by spreading them as arguments overflows the
+    // stack, and the rollup path is the one that reads these.
+    const many = Array.from(
+      { length: 200_000 },
+      (_, i) => record({ test: { k: "unit", s: "memory", n: `case ${i}` } }),
+    );
+    const fold = new Fold(
+      emptyAggregate("2026-08-20"),
+      new AliasResolver([]),
+      "2026-08-20",
+    );
+    fold.add([stored(CI_NAME, context(), many)]);
+    expect(fold.observations).toBe(many.length);
+  });
+});
+
+describe("the days a fold measures cost over", () => {
+  const KEY = testIdentityKey({ k: "unit", s: "memory", n: "space > writes" });
+
+  /** One run of the test on `day`, taking `ms`. */
+  function ranOn(day: string, ms: number) {
+    return stored(
+      `labs/test-records/submissions/ci/v1/${
+        day.replaceAll("-", "/")
+      }/r.ndjson`,
+      context({ startedAt: `${day}T00:00:00.000Z`, commit: `c-${day}` }),
+      [record({ durationMs: ms })],
+    );
+  }
+
+  function costsAfterFolding(days: readonly string[]) {
+    const fold = new Fold(
+      emptyAggregate("2026-08-20"),
+      new AliasResolver([]),
+      "2026-08-20",
+    );
+    for (const day of days) fold.add([ranOn(day, 1000)]);
+    return fold.finish().states.get(KEY)!.costByDay;
+  }
+
+  it("keeps a day inside the window", () => {
+    expect(Object.keys(costsAfterFolding(["2026-08-20"]))).toEqual([
+      "2026-08-20",
+    ]);
+  });
+
+  it("holds no cost for a day the window cannot reach", () => {
+    // This is what makes not sampling such a day safe: `finish` seals a
+    // day's cost and then ages it off in the same call, so a day past
+    // the window has no cost either way, and sampling it only costs the
+    // memory to hold sixty days of samples during a bootstrap.
+    const old = "2026-06-01";
+    expect(daysBetween(old, "2026-08-20")).toBeGreaterThan(COST_WINDOW_DAYS);
+    expect(costsAfterFolding([old])).toEqual({});
+    expect(costsAfterFolding([old, "2026-08-20"])).toEqual(
+      costsAfterFolding(["2026-08-20"]),
+    );
   });
 });

--- a/tasks/test-selection/build.ts
+++ b/tasks/test-selection/build.ts
@@ -20,6 +20,7 @@ import {
 import {
   costSeconds,
   type DaySamples,
+  daysBetween,
   emptyContext,
   emptySamples,
   emptyState,
@@ -48,6 +49,7 @@ import {
   type WithheldEntry,
 } from "./manifest.ts";
 import {
+  COST_WINDOW_DAYS,
   FLAKE_EXCLUSION_RATE,
   FLAKE_REPEAT_RATES,
   LANE_PROLOGUE_SECONDS,
@@ -461,7 +463,12 @@ export class Fold {
     const observations: Observation[] = [];
     for (const report of reports) {
       const read = readReport(report, this.#resolver);
-      observations.push(...read.observations);
+      // Appended one at a time rather than spread: a rollup shard holds a
+      // whole day, and spreading that many arguments onto the stack is
+      // past what a call can carry.
+      for (const observation of read.observations) {
+        observations.push(observation);
+      }
       for (const [key, surface] of read.surfaces) {
         // A file names something a runner can be pointed at, and an
         // identity's own name does not. A record with no file arriving in
@@ -473,11 +480,15 @@ export class Fold {
       }
       for (const [key, byDay] of read.durations) {
         let known = this.#samples.get(key);
-        if (known === undefined) {
-          known = new Map();
-          this.#samples.set(key, known);
-        }
         for (const [day, sampled] of byDay) {
+          // A day past the cost window is sealed and then dropped again
+          // by the same `finish` that sealed it, so sampling it buys
+          // nothing and a bootstrap holds sixty days of it at once.
+          if (daysBetween(day, this.#today) > COST_WINDOW_DAYS) continue;
+          if (known === undefined) {
+            known = new Map();
+            this.#samples.set(key, known);
+          }
           const into = known.get(day) ?? emptySamples();
           for (const durationMs of sampled) sampleDuration(into, durationMs);
           known.set(day, into);

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -138,6 +138,43 @@ export const COVERAGE_TREND_WEEKS = 3;
 /** Days within which failures across branches read as the environment. */
 export const CATCH_BREADTH_WINDOW_DAYS = 2;
 
+/**
+ * Days the fold remembers what an identity did at a commit, which is how
+ * a rerun that disagrees with the run it repeats is read as the test
+ * disagreeing with itself rather than as a catch.
+ *
+ * Its own dial rather than the breadth window's, because the two ask
+ * different questions over different spans. Breadth asks whether many
+ * branches saw one test fail around the same time, which is a question
+ * about weeks. This asks whether a rerun of one commit could still
+ * arrive, which is a question about hours: a commit is superseded long
+ * before a day is out, and nothing reruns a three-week-old one.
+ *
+ * It is also the expensive one. Every identity runs at nearly every
+ * commit, so what is remembered is the corpus times the commits: over 21
+ * days of the store that is 63.8 million pairs, past what a `Map` can
+ * hold at all. Keeping only the identities the failure witness names
+ * brings 21 days to 4.2 million, and two days to 40 thousand.
+ */
+export const SAME_COMMIT_REACH_DAYS = 2;
+
+/**
+ * How many of the most recently observed commits the fold remembers
+ * outcomes at, so that a failure arriving in a later batch than the pass
+ * it disagrees with is still read as the test disagreeing with itself.
+ *
+ * Every identity runs at nearly every commit, so this multiplies by the
+ * whole corpus: one measured day of the store holds 2.6 million
+ * identity-and-commit pairs, of which 23 carry a failure and 13 carry
+ * both a pass and a failure. Remembering all of them costs 442MB for one
+ * day, which is more than a string can hold. What slides out of the
+ * window keeps the identities the failure witness still names, so a test
+ * that has already failed stays exact until the commit itself ages out
+ * at `SAME_COMMIT_REACH_DAYS` — which is the shorter of the two spans
+ * whenever the breadth window is the longer one.
+ */
+export const FLAKE_COMMIT_REACH = 8;
+
 /** Days before the coverage attribution map is rebuilt. */
 export const ATTRIBUTION_MAP_DAYS = 7;
 
@@ -559,6 +596,26 @@ export const DIALS: readonly Dial[] = [
     why:
       "Up when a broken runner's failures are being counted as catches; down " +
       "when genuine breadth is being written off as environmental.",
+  },
+  {
+    name: "SAME_COMMIT_REACH_DAYS",
+    value: SAME_COMMIT_REACH_DAYS,
+    unit: "days",
+    setBy: "chosen",
+    why: "Up when reruns are landing far enough behind the run they repeat " +
+      "that their disagreement is being counted as a catch; down when the " +
+      "fold's memory is the thing that will not fit. It costs the number " +
+      "of identities that have failed times the number of commits, so it " +
+      "is the dial to check first when a run runs out of memory.",
+  },
+  {
+    name: "FLAKE_COMMIT_REACH",
+    value: FLAKE_COMMIT_REACH,
+    unit: "commits",
+    setBy: "chosen",
+    why: "Up when reruns of a commit arrive far enough behind the run they " +
+      "repeat that their disagreement is being counted as a catch; down " +
+      "when the fold's memory is the thing that will not fit.",
   },
   {
     name: "ATTRIBUTION_MAP_DAYS",

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -155,6 +155,13 @@ export const CATCH_BREADTH_WINDOW_DAYS = 2;
  * days of the store that is 63.8 million pairs, past what a `Map` can
  * hold at all. Keeping only the identities the failure witness names
  * brings 21 days to 4.2 million, and two days to 40 thousand.
+ *
+ * A floor rather than an exact span. Aging happens once per batch, after
+ * the batch has been judged, so an entry older than this survives until
+ * the next batch arrives and can still answer for a rerun that lands
+ * late. That is the more accurate answer — a pass and a failure at one
+ * commit is the test disagreeing with itself however far apart they
+ * arrive — so the lateness is left alone rather than tightened.
  */
 export const SAME_COMMIT_REACH_DAYS = 2;
 

--- a/tasks/test-selection/policy.ts
+++ b/tasks/test-selection/policy.ts
@@ -174,11 +174,12 @@ export const SAME_COMMIT_REACH_DAYS = 2;
  * whole corpus: one measured day of the store holds 2.6 million
  * identity-and-commit pairs, of which 23 carry a failure and 13 carry
  * both a pass and a failure. Remembering all of them costs 442MB for one
- * day, which is more than a string can hold. What slides out of the
- * window keeps the identities the failure witness still names, so a test
- * that has already failed stays exact until the commit itself ages out
- * at `SAME_COMMIT_REACH_DAYS` — which is the shorter of the two spans
- * whenever the breadth window is the longer one.
+ * day, which is more than a string can hold.
+ *
+ * What slides out of the window keeps the identities the failure witness
+ * still names. So a test that has already failed goes on being exact,
+ * and stops when `SAME_COMMIT_REACH_DAYS` drops the commit — that span,
+ * not the witness's own, is what bounds it.
  */
 export const FLAKE_COMMIT_REACH = 8;
 

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -23,7 +23,12 @@ import {
   trimWindows,
   value,
 } from "./score.ts";
-import { VALUE_FLOOR } from "./policy.ts";
+import {
+  CATCH_BREADTH_WINDOW_DAYS,
+  FLAKE_COMMIT_REACH,
+  SAME_COMMIT_REACH_DAYS,
+  VALUE_FLOOR,
+} from "./policy.ts";
 import { testIdentityKey } from "@commonfabric/test-support/records";
 
 const TEST = { k: "unit", s: "memory", n: "space > writes a fact" };
@@ -70,7 +75,9 @@ describe("score", () => {
       // itself, which suppresses a real catch. A credited entry with no
       // readable day can never be aged out, so it suppresses one forever.
       const back = parseContext({
-        outcomesAtCommit: [["k c1", { day: "2026-08-20", outcomes: ["wat"] }]],
+        outcomesAtCommit: [
+          ["c1", { day: "2026-08-20", identities: [["k", ["wat"]]] }],
+        ],
         mainAtCommit: [["k c1", { day: "nope", outcome: "fail" }]],
         credited: [["k c1 branch", "not a day"]],
         failures: [["k", [{ day: "2026-08-20", source: "branch" }]]],
@@ -141,7 +148,7 @@ describe("score", () => {
 
     it("drops an entry whose held value is not a record", () => {
       const back = parseContext({
-        outcomesAtCommit: [["k a", "yesterday"], ["k b", null]],
+        outcomesAtCommit: [["c1", "yesterday"], ["c2", null]],
         mainAtCommit: [["k a", 7], ["k b", null]],
         credited: [],
         failures: [["k a", "not a list"], ["k b", 7]],
@@ -154,10 +161,14 @@ describe("score", () => {
     it("drops an outcome record with no readable day or outcomes", () => {
       const back = parseContext({
         outcomesAtCommit: [
-          ["k a", { day: 7, outcomes: ["pass"] }],
-          ["k b", { day: "2026-08-20", outcomes: "pass" }],
-          ["k c", { day: "2026-08-20", outcomes: ["wat"] }],
-          ["k d", { day: "2026-08-20", outcomes: ["pass", "fail"] }],
+          ["ca", { day: 7, identities: [["k", ["pass"]]] }],
+          ["cb", { day: "2026-08-20", identities: "not a list" }],
+          ["cc", { day: "2026-08-20", identities: [["k", ["wat"]]] }],
+          ["cd", { day: "2026-08-20", identities: [["k", "pass"]] }],
+          ["ce", {
+            day: "2026-08-20",
+            identities: [["k", ["pass", "fail"]]],
+          }],
         ],
         mainAtCommit: [
           ["k a", { day: "2026-08-20", outcome: "skip" }],
@@ -166,7 +177,7 @@ describe("score", () => {
         credited: [],
         failures: [],
       });
-      expect([...back.outcomesAtCommit.keys()]).toEqual(["k d"]);
+      expect([...back.outcomesAtCommit.keys()]).toEqual(["ce"]);
       // A skip is not an outcome the cross-run rules act on, so a stored
       // one is not a main verdict to be resumed from.
       expect([...back.mainAtCommit.keys()]).toEqual(["k b"]);
@@ -214,9 +225,9 @@ describe("score", () => {
         { day: "2020-01-01", source: "a" },
         { day: "2026-08-20", source: "b" },
       ]);
-      context.outcomesAtCommit.set("k old", {
+      context.outcomesAtCommit.set("old", {
         day: "2020-01-01",
-        outcomes: new Set(["fail"]),
+        identities: new Map([["k", new Set(["fail"])]]),
       });
       trimContext(context, "2026-08-20");
       expect([...context.failures.keys()]).toEqual(["k here"]);
@@ -717,5 +728,99 @@ describe("a skipped run", () => {
       saw("skip", { commit: "c2" }),
     ]);
     expect(folded.mainRed.has(KEY)).toBe(true);
+  });
+});
+
+describe("how far back the fold remembers where a test passed", () => {
+  /** A pass at each of `count` commits, one after another. */
+  function passesAt(count: number): Observation[] {
+    return Array.from({ length: count }, (_, i) =>
+      saw("pass", {
+        commit: `c${i}`,
+        startedAt: `2026-08-20T${String(i).padStart(2, "0")}:00:00.000Z`,
+      }));
+  }
+
+  it("reads a failure at a remembered commit as disagreement", () => {
+    const context = emptyContext();
+    foldObservations([saw("pass", { commit: "c0" })], { context });
+    const second = foldObservations([
+      saw("pass", { commit: "c1", startedAt: "2026-08-20T01:00:00.000Z" }),
+      saw("fail", { commit: "c0", startedAt: "2026-08-20T02:00:00.000Z" }),
+    ], { context });
+    const state = second.states.get(KEY)!;
+    expect(state.flakesByDay["2026-08-20"]).toBe(1);
+    expect(state.mainCatches).toBe(0);
+  });
+
+  it("keeps at most the reach, so the corpus times commits cannot grow", () => {
+    // Every identity runs at nearly every commit, so an unbounded map is
+    // the whole corpus multiplied by every commit it ever saw.
+    const context = emptyContext();
+    foldObservations(passesAt(FLAKE_COMMIT_REACH + 6), { context });
+    expect(context.recentCommits.length).toBe(FLAKE_COMMIT_REACH);
+    expect(context.outcomesAtCommit.size).toBe(FLAKE_COMMIT_REACH);
+  });
+
+  it("forgets a clean test's pass once the commit falls out of reach", () => {
+    const context = emptyContext();
+    foldObservations(passesAt(FLAKE_COMMIT_REACH + 2), { context });
+    // c0 is past the reach and the test has never failed, so nothing is
+    // held against it and the late failure reads as a first failure.
+    const late = foldObservations([
+      saw("fail", { commit: "c0", startedAt: "2026-08-21T00:00:00.000Z" }),
+    ], { context, prior: new Map() });
+    expect(late.states.get(KEY)!.flakesByDay["2026-08-20"]).toBeUndefined();
+  });
+
+  it("keeps a failed test's passes past the reach", () => {
+    // Once a test has failed it is a flake candidate, and its passes are
+    // what a later disagreement is judged against, so they survive the
+    // window that a clean test's do not.
+    const context = emptyContext();
+    foldObservations([
+      saw("fail", { commit: "c0" }),
+      saw("pass", { commit: "c0", startedAt: "2026-08-20T00:30:00.000Z" }),
+    ], { context });
+    foldObservations(
+      passesAt(FLAKE_COMMIT_REACH + 6).slice(1),
+      { context },
+    );
+    const held = context.outcomesAtCommit.get("c0");
+    expect(held).toBeDefined();
+    expect([...held!.identities.get(KEY)!].sort()).toEqual(["fail", "pass"]);
+  });
+
+  it("drops the window along with the days it aged out", () => {
+    const context = emptyContext();
+    foldObservations(passesAt(3), { context });
+    expect(context.recentCommits.length).toBe(3);
+    trimContext(context, "2027-01-01");
+    expect(context.outcomesAtCommit.size).toBe(0);
+    expect(context.recentCommits).toEqual([]);
+  });
+});
+
+describe("the two windows the context ages on", () => {
+  it("keeps a failure the breadth rule can still reach", () => {
+    // Breadth asks whether many branches saw one test fail around the
+    // same time, and same-commit disagreement asks whether a rerun could
+    // still arrive. One is weeks, the other hours, so a context aged on
+    // a single span must be aged on the longer one and pay for it.
+    const context = emptyContext();
+    context.failures.set("k", [{ day: "2026-08-20", source: "a" }]);
+    context.outcomesAtCommit.set("c1", {
+      day: "2026-08-20",
+      identities: new Map([["k", new Set(["pass"])]]),
+    });
+    const past = new Date(
+      Date.parse("2026-08-20T00:00:00Z") +
+        (SAME_COMMIT_REACH_DAYS + 1) * 86_400_000,
+    ).toISOString().slice(0, 10);
+    trimContext(context, past);
+    expect(context.outcomesAtCommit.size).toBe(0);
+    expect(context.failures.size).toBe(
+      CATCH_BREADTH_WINDOW_DAYS > SAME_COMMIT_REACH_DAYS ? 1 : 0,
+    );
   });
 });

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -876,3 +876,27 @@ describe("a commit the window has already let go of", () => {
     expect(context.outcomesAtCommit.has("gone")).toBe(false);
   });
 });
+
+describe("a rerun that lands after the window would have let go", () => {
+  it("still reads as the test disagreeing with itself", () => {
+    // Aging happens once per batch and after it, so an entry past the
+    // span survives until the next batch arrives. A pass and a failure
+    // at one commit is disagreement however far apart they land, and
+    // there is no change between them for a catch to be about, so the
+    // later answer is the better one and is left as it is.
+    const context = emptyContext();
+    const first = foldObservations([saw("pass", { commit: "c0" })], {
+      context,
+    });
+    const late = foldObservations([
+      saw("fail", {
+        commit: "c0",
+        day: "2026-08-30",
+        startedAt: "2026-08-30T00:00:00.000Z",
+      }),
+    ], { context, prior: first.states });
+    const state = late.states.get(KEY)!;
+    expect(state.flakesByDay["2026-08-30"]).toBe(1);
+    expect(state.mainCatches).toBe(0);
+  });
+});

--- a/tasks/test-selection/score.test.ts
+++ b/tasks/test-selection/score.test.ts
@@ -824,3 +824,55 @@ describe("the two windows the context ages on", () => {
     );
   });
 });
+
+describe("a commit the window has already let go of", () => {
+  const OTHER = { k: "unit", s: "memory", n: "another test" };
+  const OTHER_KEY = testIdentityKey(OTHER);
+
+  /** Passes at `count` commits after `c0`, one after another. */
+  function moveOn(count: number): Observation[] {
+    return Array.from({ length: count }, (_, i) =>
+      saw("pass", {
+        commit: `c${i + 1}`,
+        startedAt: `2026-08-20T${String(i + 1).padStart(2, "0")}:00:00.000Z`,
+      }));
+  }
+
+  it("remembers nothing new there about a test that has not failed", () => {
+    // The commit is held only for the test that failed at it. Another
+    // test arriving there later is not what it is being held for, and
+    // remembering it would put the whole corpus back at that commit.
+    const context = emptyContext();
+    foldObservations([saw("fail", { commit: "c0" })], { context });
+    foldObservations(moveOn(FLAKE_COMMIT_REACH + 1), { context });
+
+    const held = context.outcomesAtCommit.get("c0")!;
+    expect([...held.identities.keys()]).toEqual([KEY]);
+    foldObservations([
+      saw("pass", {
+        test: OTHER,
+        commit: "c0",
+        startedAt: "2026-08-20T20:00:00.000Z",
+      }),
+    ], { context });
+    expect([...held.identities.keys()]).toEqual([KEY]);
+    expect(held.identities.has(OTHER_KEY)).toBe(false);
+  });
+
+  it("lets go of a commit the window names but no longer holds", () => {
+    // A stored window can name a commit whose outcomes did not survive
+    // being read, so the walk that evicts has to tolerate one that is
+    // already gone rather than assume the two agree.
+    const context = parseContext({
+      outcomesAtCommit: [],
+      recentCommits: ["gone"],
+      mainAtCommit: [],
+      credited: [],
+      failures: [],
+    });
+    expect(context.recentCommits).toEqual(["gone"]);
+    foldObservations(moveOn(FLAKE_COMMIT_REACH), { context });
+    expect(context.recentCommits).not.toContain("gone");
+    expect(context.outcomesAtCommit.has("gone")).toBe(false);
+  });
+});

--- a/tasks/test-selection/score.ts
+++ b/tasks/test-selection/score.ts
@@ -25,10 +25,12 @@ import {
   CHURN_WINDOW_DAYS,
   COST_WINDOW_DAYS,
   ENVIRONMENTAL_MIN_SOURCES,
+  FLAKE_COMMIT_REACH,
   FLAKE_WINDOW_DAYS,
   FRESHNESS_FLOOR,
   FRESHNESS_HALF_LIFE_DAYS,
   PROVEN_SATURATION,
+  SAME_COMMIT_REACH_DAYS,
   VALUE_FLOOR,
   WEIGHT_BREADTH,
   WEIGHT_CHURN,
@@ -246,8 +248,24 @@ export interface FoldResult {
  * caller folding a stream carries one of these along and trims it.
  */
 export interface FoldContext {
-  /** Every outcome seen for one identity at one commit, with its day. */
-  outcomesAtCommit: Map<string, { day: string; outcomes: Set<string> }>;
+  /**
+   * The outcomes seen at one commit, by identity, with the commit's day.
+   * Keyed by commit rather than by the pair so that the window below can
+   * drop a whole commit at once, and so that a commit's name is stored
+   * once instead of against every identity that ran at it.
+   */
+  outcomesAtCommit: Map<
+    string,
+    { day: string; identities: Map<string, Set<string>> }
+  >;
+
+  /**
+   * The most recently seen commits, oldest first, at most
+   * `FLAKE_COMMIT_REACH` of them. Outcomes are remembered at a commit
+   * while it is in here, and afterwards only for identities the failure
+   * witness still names.
+   */
+  recentCommits: string[];
 
   /**
    * What the default branch said about one identity at one commit, with
@@ -273,6 +291,7 @@ export interface FoldContext {
 export function emptyContext(): FoldContext {
   return {
     outcomesAtCommit: new Map(),
+    recentCommits: [],
     mainAtCommit: new Map(),
     credited: new Map(),
     failures: new Map(),
@@ -281,7 +300,10 @@ export function emptyContext(): FoldContext {
 
 /** A fold context as it travels between runs. */
 export interface StoredFoldContext {
-  outcomesAtCommit: Array<[string, { day: string; outcomes: string[] }]>;
+  outcomesAtCommit: Array<
+    [string, { day: string; identities: Array<[string, string[]]> }]
+  >;
+  recentCommits: string[];
   mainAtCommit: Array<[string, { day: string; outcome: "pass" | "fail" }]>;
   credited: Array<[string, string]>;
   failures: Array<[string, Array<{ day: string; source: string }>]>;
@@ -308,9 +330,16 @@ function isDay(value: unknown): value is string {
 /** The context, flattened for the aggregate that carries it. */
 export function serializeContext(context: FoldContext): StoredFoldContext {
   return {
-    outcomesAtCommit: [...context.outcomesAtCommit].map((
-      [at, seen],
-    ) => [at, { day: seen.day, outcomes: [...seen.outcomes] }]),
+    outcomesAtCommit: [...context.outcomesAtCommit].map(([commit, seen]) => [
+      commit,
+      {
+        day: seen.day,
+        identities: [...seen.identities].map((
+          [key, outcomes],
+        ) => [key, [...outcomes]] as [string, string[]]),
+      },
+    ]),
+    recentCommits: [...context.recentCommits],
     mainAtCommit: [...context.mainAtCommit],
     credited: [...context.credited],
     failures: [...context.failures],
@@ -333,21 +362,28 @@ export function parseContext(value: unknown): FoldContext {
       )
       : [];
 
-  for (const [at, seen] of pairs(stored.outcomesAtCommit)) {
+  for (const [commit, seen] of pairs(stored.outcomesAtCommit)) {
     if (typeof seen !== "object" || seen === null) continue;
-    const held = seen as { day?: unknown; outcomes?: unknown };
-    if (!isDay(held.day) || !Array.isArray(held.outcomes)) continue;
-    // An outcome this reader does not know would read as one more thing
-    // the identity did at that commit, and two of them is the test
-    // disagreeing with itself — which suppresses a real catch.
-    const outcomes = held.outcomes.filter((outcome): outcome is string =>
-      typeof outcome === "string" && OUTCOMES.has(outcome)
-    );
-    if (outcomes.length === 0) continue;
-    context.outcomesAtCommit.set(at, {
-      day: held.day,
-      outcomes: new Set(outcomes),
-    });
+    const held = seen as { day?: unknown; identities?: unknown };
+    if (!isDay(held.day)) continue;
+    const identities = new Map<string, Set<string>>();
+    for (const [key, raw] of pairs(held.identities)) {
+      if (!Array.isArray(raw)) continue;
+      // An outcome this reader does not know would read as one more
+      // thing the identity did at that commit, and two of them is the
+      // test disagreeing with itself — which suppresses a real catch.
+      const outcomes = raw.filter((outcome): outcome is string =>
+        typeof outcome === "string" && OUTCOMES.has(outcome)
+      );
+      if (outcomes.length > 0) identities.set(key, new Set(outcomes));
+    }
+    if (identities.size === 0) continue;
+    context.outcomesAtCommit.set(commit, { day: held.day, identities });
+  }
+  if (Array.isArray(stored.recentCommits)) {
+    context.recentCommits = stored.recentCommits
+      .filter((commit): commit is string => typeof commit === "string")
+      .slice(-FLAKE_COMMIT_REACH);
   }
   for (const [at, seen] of pairs(stored.mainAtCommit)) {
     if (typeof seen !== "object" || seen === null) continue;
@@ -377,22 +413,26 @@ export function parseContext(value: unknown): FoldContext {
 }
 
 /**
- * Drops what the two rules can no longer reach. Both look back at most
- * `CATCH_BREADTH_WINDOW_DAYS`, so anything older than that cannot change
- * a verdict, and a stream that never trimmed would grow with the number
+ * Drops what the rules can no longer reach, each on the span its own
+ * question needs. A stream that never trimmed would grow with the number
  * of runs rather than with the number of tests.
  */
 export function trimContext(context: FoldContext, today: string): void {
-  const stale = (day: string) =>
+  const beyondBreadth = (day: string) =>
     daysBetween(day, today) > CATCH_BREADTH_WINDOW_DAYS;
   for (const [key, seen] of context.failures) {
-    const kept = seen.filter((failure) => !stale(failure.day));
+    const kept = seen.filter((failure) => !beyondBreadth(failure.day));
     if (kept.length === 0) context.failures.delete(key);
     else context.failures.set(key, kept);
   }
-  for (const [at, seen] of context.outcomesAtCommit) {
-    if (stale(seen.day)) context.outcomesAtCommit.delete(at);
+  for (const [commit, seen] of context.outcomesAtCommit) {
+    if (daysBetween(seen.day, today) > SAME_COMMIT_REACH_DAYS) {
+      context.outcomesAtCommit.delete(commit);
+    }
   }
+  context.recentCommits = context.recentCommits.filter((commit) =>
+    context.outcomesAtCommit.has(commit)
+  );
   // A commit is re-run within days of the run it repeats, not months, so
   // these age on the same window. Kept forever they would grow with the
   // number of catches the repository has ever made.
@@ -447,23 +487,54 @@ export function foldObservations(
   // before any one observation can be judged.
   const outcomesAtCommit = context.outcomesAtCommit;
   const failures = context.failures;
+  const recent = context.recentCommits;
+
+  // The failure witness first, so that the pass below can tell a test
+  // that has failed from one that never has.
   for (const observation of observations) {
+    if (observation.outcome !== "fail") continue;
     const key = testIdentityKey(observation.test);
-    const at = `${key} ${observation.commit}`;
-    let seen = outcomesAtCommit.get(at);
-    if (seen === undefined) {
-      seen = { day: observation.day, outcomes: new Set() };
-      outcomesAtCommit.set(at, seen);
-    }
+    const list = failures.get(key) ?? [];
+    list.push({ day: observation.day, source: observation.source });
+    failures.set(key, list);
+  }
+
+  // Outcomes at a commit, for as long as they can still be asked about.
+  // Every identity runs at nearly every commit, so keeping all of them
+  // costs the corpus times the commits: one measured day is 2.6 million
+  // pairs and 442MB, which is more than a string can hold. A commit is
+  // remembered whole while it is one of the last `FLAKE_COMMIT_REACH`
+  // seen, and once it slides out it keeps only the identities the
+  // failure witness names — so a test that has failed is exact until the
+  // commit ages out at `SAME_COMMIT_REACH_DAYS`, and one that never has
+  // is remembered only as long as its rerun could plausibly still
+  // arrive.
+  for (const observation of observations) {
     // A skip is a test that deliberately did not run, so it agrees with
     // nothing and contradicts nothing; counting it as disagreement would
     // read a skip beside a failure as the test disagreeing with itself.
-    if (observation.outcome !== "skip") seen.outcomes.add(observation.outcome);
-    if (observation.outcome === "fail") {
-      const list = failures.get(key) ?? [];
-      list.push({ day: observation.day, source: observation.source });
-      failures.set(key, list);
+    if (observation.outcome === "skip") continue;
+    const key = testIdentityKey(observation.test);
+    const commit = observation.commit;
+    let seen = outcomesAtCommit.get(commit);
+    if (seen === undefined) {
+      seen = { day: observation.day, identities: new Map() };
+      outcomesAtCommit.set(commit, seen);
+      recent.push(commit);
+      while (recent.length > FLAKE_COMMIT_REACH) {
+        const dropped = recent.shift()!;
+        const held = outcomesAtCommit.get(dropped);
+        if (held === undefined) continue;
+        for (const identity of [...held.identities.keys()]) {
+          if (!failures.has(identity)) held.identities.delete(identity);
+        }
+        if (held.identities.size === 0) outcomesAtCommit.delete(dropped);
+      }
     }
+    if (!recent.includes(commit) && !failures.has(key)) continue;
+    const outcomes = seen.identities.get(key) ?? new Set<string>();
+    outcomes.add(observation.outcome);
+    seen.identities.set(key, outcomes);
   }
 
   // What the default branch said at each commit, gathered before anything
@@ -522,8 +593,8 @@ export function foldObservations(
 
     bump(state.failuresByDay, day);
 
-    const seen = outcomesAtCommit.get(`${key} ${observation.commit}`);
-    if ((seen?.outcomes.size ?? 0) > 1) {
+    const seen = outcomesAtCommit.get(observation.commit)?.identities.get(key);
+    if ((seen?.size ?? 0) > 1) {
       // It passed and failed at one commit, with nothing between the two
       // runs but chance.
       bump(state.flakesByDay, day);


### PR DESCRIPTION
The publisher reads the store of test-run records, works out how often each test has caught a real problem, and writes a manifest saying what a pull request ought to run. Before it can keep that manifest current every four hours, it needs one long first run over sixty days of history. That first run could not finish. Two separate things stopped it, and neither was visible from the tests, which fed the same code a few dozen records at a time.

The first was memory. Reading a single day of history took 442MB and then could not write out what it had learned at all, because the text of it was longer than the longest string the engine will build. Three days ran the process out of memory before it got that far.

The cause was a lookup table holding every outcome of every test at every commit. Nearly every test runs at nearly every commit, so the table grew as the number of tests multiplied by the number of commits. One day of the store is 20,005 tests across 137 commits, which comes to 2.6 million entries.

That table exists to answer one narrow question, and it is only ever asked when a test has just failed: did this same test also pass at this same commit? If it did, the test disagreed with itself, so it is flaky rather than having caught a real problem. In that same day, 23 test-and-commit pairs saw a failure at all, and 13 saw both a pass and a failure. So 2.6 million entries were being kept in order to find 13 answers.

The table is now keyed by commit rather than by test-and-commit, which stores a commit's name once instead of against every test that ran at it. Three rules then limit what it holds:

  - A commit is kept in full while it is one of the last eight seen. That is the `FLAKE_COMMIT_REACH` setting.
  - Once it falls out of those eight, it keeps entries only for tests that have failed recently. A flaky test fails more than once, so this keeps the tests the question is actually asked about.
  - The commit is dropped altogether after two days. That is a new setting, `SAME_COMMIT_REACH_DAYS`.

The new setting exists because one number was controlling how long two different memories were kept, and they had been sharing it by accident of living in the same function. One of them answers whether several branches saw a test fail at around the same time, which is a question about weeks and is cheap to keep: 21 days of the store is 16,551 failing runs across 1,615 tests. The other is the one above, which asks whether a re-run of a commit could still turn up and contradict the run it repeats. That is a question about hours, and it is the expensive one — over 21 days it would be 63.8 million entries, which is more than a `Map` can hold at all, its limit being 16.7 million. Over two days it is 40 thousand. Separating the two lets the first grow without dragging the second along behind it.

Something is given up. If a test has never failed before, and it passed at a commit older than the last eight, and its first failure arrives in a later batch of records than that pass did, then the failure reads as a real catch rather than as the test disagreeing with itself. It reads correctly again the next time that test fails.

The second thing that stopped the first run was that compacted history could not be read. Days older than a week are rewritten into a handful of large files instead of the thousands of small ones they came from. Every attempt to read one of those failed outright, so the run fell back to the small files the compaction exists to replace — 167,126 of them across sixty days. The failure was a day's worth of records being handed to a function as individual arguments, which is far more arguments than a call can take. They are added one at a time now.

One further waste is gone. The publisher measures how long each test takes on each day, and then keeps only the last seven days of those measurements. It had been collecting all sixty days and throwing away fifty-three of them.

With all of that in place, and measured against the real store: the sixty-day first run reads 45,983,577 test executions covering 24,578 tests in 442 seconds, and writes a 15.3MB manifest and a 54.2MB state file. A three-day run, which used to die outright, takes 96 seconds and peaks at 998MB. Its state file is 31.7MB where one day's is 26.3MB, so the size now grows with the number of tests rather than with the number of tests multiplied by the number of commits.

Three tests cover what could not be seen before. One reads a single record file holding 200,000 records, which overflows the stack without the fix above. One walks a commit out of the eight-commit window and checks that a never-failed test's pass is forgotten while a failed test's pass is kept. One pins the reason it is safe to stop measuring an old day: that day's measurements are discarded by the very same step that records them, so the day carries no measurement either way.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

