### PR TITLE
fix(cli): a handler call accepts only the deps it can honor

### DIFF
--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -190,9 +190,9 @@ Each of these is small and lands on its own; together they are what decision
    lib module a sibling calls, beside `.` → `mod.ts`, whose import runs CLI
    startup.
 2. **Thread `deps.loadPieces` through the functions that still hardcode
-   it.** Everything a v1 verb reaches takes it; what is left is the set the
-   inventory above names, each converting for the milestone that first
-   calls it.
+   it.** Everything a shuttle-v1 verb reaches takes it; what is left is the
+   set the inventory above names, each converting for the milestone that
+   first calls it.
 3. **Extract `callFromCommand`** from `buildCallCommand`'s inline action.
 4. **Exit discipline.** `exitWithDataError` and `exitPieceCallFailure` call
    `Deno.exit(1)` (typed `never`); `getCellValueFromCommand` reaches the

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4477,14 +4477,21 @@ export async function setCellValue(
 
 /**
  * What a {@link callPieceHandler} call supplies: the connection its
- * resolution runs over, and the execution deps its dispatch reads.
+ * resolution runs over, and the three execution deps a handling can observe
+ * through a call that returns nothing.
  *
- * Narrower than {@link PieceCallableDependencies} by the fields that have no
- * bearing here — the stdin readers, because the payload arrives decoded as an
- * argument, and the help prefix, because nothing on this path renders a page.
+ * Narrower than {@link PieceCallableDependencies} by the fields this path
+ * cannot keep. The input readers and the help prefix have no bearing on it —
+ * the payload arrives decoded as an argument, and nothing here renders a
+ * page. The result-shaping deps are excluded for a sharper reason: a
+ * selection makes the dispatch derive a value that this signature then
+ * discards, so admitting one would spend a settle and a sync on an answer
+ * nobody receives, and could raise where the handling itself committed
+ * cleanly. A call that wants a result wants
+ * {@link executePieceCallable}, which returns one.
  */
 export type PieceHandlerCallDeps =
-  & CallableExecutionDeps
+  & Pick<CallableExecutionDeps, "invocation" | "onPhase" | "skipReadback">
   & Pick<PieceCallableDependencies, "loadPieces" | "loadPiece">;
 
 /**


### PR DESCRIPTION
## Why

#6646 gave `callPieceHandler` a `deps` parameter typed
`CallableExecutionDeps & Pick<PieceCallableDependencies, …>`. Of the seven
fields `CallableExecutionDeps` carries, that function can observe three.
`callPieceHandler` returns `Promise<void>` and discards the
`ExecutedCallable`, so the four result-shaping deps have nowhere to land:

- `uuid` is read only in `executeResolvedCallable`'s **tool** branch
  (`callable.ts:1798`), and `callPieceHandler` throws
  `Callable "…" is not a handler` before dispatch, so it is unreachable by
  construction.
- `selection`, `showLinks`, and `deriveSelectedValue` exist to shape
  `ExecutedCallable.invocation.{result,links}` — the value this signature
  throws away.

`selection` is the one with teeth. Passing it makes the dispatch run
`selectCallResult` (`callable.ts:1719`), which awaits the runtime's global
idle plus a storage sync and can raise `CyclicResultError` out of
`boundCyclicResult`. So a handler call that committed cleanly and returned
can now throw, and the caller gets nothing back either way. No caller passes
it today, so this is latent rather than a live regression — but `./lib/piece`
is an export entry, and shuttle is the caller these seams exist for.

This is the principle #6646's own commit message states — *"a type that
carries a field its function ignores promises a caller something the code
does not keep"* — applied one level below where that PR applied it.

## What Changed

`PieceHandlerCallDeps` narrows to the set this signature keeps:

```ts
export type PieceHandlerCallDeps =
  & Pick<CallableExecutionDeps, "invocation" | "onPhase" | "skipReadback">
  & Pick<PieceCallableDependencies, "loadPieces" | "loadPiece">;
```

Its doc comment now says why the result-shaping deps are excluded, and points
a caller that wants a result at `executePieceCallable`, which returns one.

Also in `runtime-integration.md`: #6646 disambiguated "no v1 verb reaches one"
to "no shuttle-v1 verb" in the seam inventory, but left the same claim
unqualified twelve lines below in the prerequisite list. One spelling in each
place invited a reader to think they named different sets; both now say
shuttle-v1.

## Test plan

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`,
and `deno task test` in `packages/cli` (210 passed, 0 failed), plus
`test/piece-connection.test.ts` directly — 18 steps, unchanged, including the
two cases #6646 added for `invocation` and phase reporting. Those still pass
because `invocation`, `onPhase`, and `skipReadback` are exactly the three
fields the narrowed type keeps.

No test changes, and none needed: this removes the ability to pass fields no
caller passes and no assertion observes. The type-checker is the guard, and
every call site in the tree was enumerated — `scripts/bench-setup.ts` (×3) and
`test/piece-integration.test.ts` (×2) pass no deps at all; only
`test/piece-connection.test.ts` passes any, and it passes only admitted ones.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

