### PR TITLE
fix(runner,cf-harness): gate a derivation's answer, not its write

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -279,6 +279,55 @@ The strict-only delta is:
   piece is then un-updatable under strict because the pattern updater,
   `setsrc`, and setup over an existing piece all stamp meta.
 
+  Computed cells are outside the check at every rung too, and it is the same
+  rule over a document rather than over a path. A computed cell is the
+  derived internal cell the runtime materializes to hold a derivation's
+  result, under its own URI scheme (`computed:fid1:<hash>`; see
+  [`computed-cell-identity.md`](./computed-cell-identity.md)). A pattern
+  names the data it declares policy on, and it does not name the
+  intermediates the reactive graph materializes for it, so their ceiling is
+  the empty one and measuring them refuses every derivation that reads
+  labeled data and writes its result — ordinary reactive computation, not an
+  edge case. One predicate covers both surfaces (`isDeclarablePolicyPath` in
+  `prepare.ts`), because they answer one question: could a schema have
+  declared a policy here.
+
+  The skip is scoped to a join the target's own space produced. Every clause
+  the join carries comes from a document some read resolved, and the join
+  records which space each of those lived in; where any of them lived
+  elsewhere, a computed target is measured like any other document. So the
+  residency half of the ceiling still holds for the direction it was written
+  for — a derivation cannot carry another space's labeled value into a local
+  document by materializing it — while a derivation over its own space's data
+  proceeds. Within one space the source and the computed cell share a replica
+  set, so the value reaches no reader it had not reached already, and what
+  follows it is the stamp.
+
+  A declared entry can still reach a computed document, from a
+  schema-carrying write to it, and the skip is unconditional over that route
+  as it is over the meta seam's document-root route. Honoring it would make a
+  derivation admit its own inputs' taint or refuse it according to whether
+  the schema behind it happens to carry an `ifc`, while the atoms arriving in
+  the join come from what the transaction read rather than from anything that
+  schema describes. The residual is that a declaration which did reach such a
+  document stops being a write ceiling; it stays a read floor, and the
+  persisted stamp is unaffected.
+
+  What the skip does NOT do is release the value. A derivation's result
+  leaves the fabric only through a sink, and a sink measures the join it is
+  handed. Where the host is the one releasing — the `run_pattern` tool
+  answering a model with what a piece computed — there is no request to
+  record and no commit to gate, so that tool measures the release itself,
+  against a public ceiling, through `describeSinkReleaseRefusal`
+  ([run-pattern.ts](../../packages/cf-harness/src/tools/run-pattern.ts)).
+  The two routes fit their joins with one membership predicate, so a clause
+  outside a ceiling on one is outside it on the other. They differ in what
+  reaches the join: the host route measures what releasing the answer
+  resolved, and applies no exchange-rule rewriting to it, so a clause a
+  policy evaluation would have discharged is refused there. The ladder
+  governs it like any other gate — at `disabled` and `observe` it records
+  nothing that rejects.
+
   The exemption is not a hole. A path counts as meta only while no payload
   write landed on it too, so a transaction writing both leaves the path
   measured. The collapse of a deeper path against a covering ancestor runs

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -334,6 +334,43 @@ logical path past what that field declares. That is over-taint, so reads stay
 protected, and giving the envelope seam its own path space is the fix. Shares
 the meta-seam predicate with the schema write-policy requirement (#6077).
 
+A second narrowing follows the same rule over a document rather than a path.
+A computed cell is the derived internal cell the runtime materializes to hold
+a derivation's result, addressed under its own URI scheme
+(`computed:fid1:<hash>`). No author declares a store policy on one — a
+pattern names the data it declares policy on, and does not name the
+intermediates the reactive graph materializes for it — so its ceiling is the
+empty one, and measuring it refuses every derivation that reads labeled data
+and writes its result. That is ordinary reactive computation, so the refusal
+reaches product flows and not only tests. The id class is outside the check
+at every rung, through the same predicate the meta seam uses, and the skip is
+scoped to a join the target's own space produced: the join records the space
+each contributing document lived in, and a computed target whose join drew a
+clause from elsewhere is measured like any other document. The residency half
+of the ceiling therefore still holds for the direction it was written for,
+while a derivation over its own space's data proceeds — within one space the
+source and the computed cell share a replica set.
+
+Nothing is laundered here either. The join still lands on the computed
+document as its `derived` component, so a later read of it is tainted and a
+later write of what it read misfits on the original clause. What the
+exemption gives up is a refusal that was doing an egress gate's work by
+accident: a value derived from labeled data now lands, and whether it may
+LEAVE is the sink's question. Where the host is the one releasing — a tool
+answering a model with what a piece computed — there is no sink request to
+record and no commit to gate, so the release is measured directly: read what
+is about to be released through a transaction, and fit that transaction's
+consumed join to the destination's ceiling, which for a model's context is
+the empty one. `describeSinkReleaseRefusal` (runner `cfc/prepare.ts`) is that
+measurement, and it shares `atomsOutsideCeiling` and the refusal-detail
+construction with the in-commit sink gate, so a clause outside a ceiling on
+one route is outside it on the other. Two differences are worth recording:
+the host route measures what releasing the answer resolved rather than what a
+whole transaction consumed, and it applies no exchange-rule rewriting, so it
+refuses a clause a policy evaluation would have discharged. A residual stands where a declared entry did reach a
+computed document, from a schema-carrying write: it stops being a write
+ceiling there, and stays a read floor.
+
 (d) **[normative] Residency fit — the ceiling a document carries by living
 where it lives.** The fit measurement joins the target's declared policy with
 one RESIDENCY clause, `Space(<the space the document resides in>)`. A flow

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -3858,6 +3858,7 @@ export class CfHarnessPromptLoop {
         rawCauseMessage: _rawCauseMessage,
         pieceId: _pieceId,
         resultRefSchema: _resultRefSchema,
+        releaseObservation: _releaseObservation,
         ...publicOutput
       } = output;
       const scrubbed: Record<string, unknown> = { ...publicOutput };

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema } from "@commonfabric/api";
 import {
   type Cell,
+  cellWithScopedLinkRequiredsRelaxed,
   compileAndSavePattern,
   getPatternIdentityRef,
   PatternManager,
@@ -8,9 +9,11 @@ import {
 } from "@commonfabric/runner";
 import {
   type CfcAddress,
+  type CfcConfClause,
   type CfcRefusalAttribution,
   type CfcRefusalDetail,
   type CfcRefusalGate,
+  describeSinkReleaseRefusal,
   selectReferencedCfcSchemaDefs,
   validateAgainstSchema,
 } from "@commonfabric/runner/cfc";
@@ -97,6 +100,15 @@ export interface RunPatternToolSuccessOutput {
 
   /** Canonical LLM-friendly link to the piece's result cell. */
   resultRef: string;
+
+  /**
+   * What the release measurement refused, on a run the enforcement ladder did
+   * not reject it on. Artifact-only, like the other fields the prompt loop
+   * strips: the answer went out, so the model has nothing to act on, while an
+   * operator staging the ladder has the population that raising it would
+   * start refusing.
+   */
+  releaseObservation?: RunPatternPolicyRefusal;
 
   /**
    * The compiled pattern's result schema — the shape of whatever
@@ -186,8 +198,8 @@ export interface RunPatternPublicationReport {
 }
 
 /**
- * What the commit boundary refused, in terms the caller can act on: the
- * boundary that refused, the label atoms outside it, and the keys of this
+ * What a boundary refused, in terms the caller can act on: the boundary that
+ * refused, the label atoms outside it, and the keys of this
  * call's own `inputs` that carried those atoms in. When `attribution` is
  * `complete`, a run without those keys meets the boundary.
  *
@@ -266,8 +278,10 @@ export interface RunPatternToolErrorOutput {
   rawCauseMessage?: string;
 
   /**
-   * What the commit boundary refused and which of this call's own inputs
-   * carried it, when a policy refusal is what stopped the run.
+   * What a boundary refused and which of this call's own inputs carried it,
+   * when a policy refusal is what stopped the run. A refused commit landed no
+   * result; a refused release landed one, which stays in the space under its
+   * own labels while the answer is withheld.
    */
   policyRefusal?: RunPatternPolicyRefusal;
 }
@@ -510,6 +524,21 @@ const RUN_PATTERN_REFUSAL_ARTIFACT_NOTE =
   "The refusal reason is retained in the run artifact and withheld here, " +
   "since it names the labels and documents involved";
 
+/** The sink this tool's own answer is, as a refusal names it. */
+const RUN_PATTERN_ANSWER_SINK = "run_pattern";
+
+/**
+ * What that sink admits: nothing. A model's context is outside every space,
+ * so no confidentiality clause names an audience it belongs to, and an empty
+ * ceiling — "public only", per `sink-inventory.ts` — is the one that says so.
+ *
+ * Empty rather than absent, and the difference is the point. A sink absent
+ * from the inventory goes ungated because a deployment has not decided about
+ * it; this sink is not one a deployment declares, since the audience on the
+ * far side of it is fixed by what the tool does rather than by where it runs.
+ */
+const RUN_PATTERN_ANSWER_CEILING: readonly CfcConfClause[] = [];
+
 /** What a refusal the commit boundary described only in prose is told. */
 const RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE =
   "the pattern ran but the space's policy refused to commit its result: " +
@@ -542,37 +571,47 @@ const pathStartsWith = (
   prefix.every((segment, index) => segment === path[index]);
 
 /**
- * The key of `inputs` a refused read belongs to, or `undefined` when none
- * does.
+ * The keys of `inputs` a refused read belongs to, empty when none does.
  *
  * A read reaches an input two ways. It reads the document the caller's link
  * addressed, which the retained addresses match. Or it reads the piece's
  * argument document, where every input — link or plain JSON — sits under its
  * own key, so the first path segment is the key. Both are matched, because
  * one refusal commonly reports the same input through both.
+ *
+ * Every match is returned. One document handed in under two keys is reached
+ * by dropping either alias alone, and a remedy naming one of them would
+ * leave the other carrying the label.
  */
-const refusalReadInputKey = (
+const refusalReadInputKeys = (
   read: CfcAddress,
   addresses: readonly RunPatternInputAddress[],
   argumentHash: string | undefined,
   suppliedKeys: readonly string[],
-): string | undefined => {
+): readonly string[] => {
   const readHash = comparableEntityHash(read.id);
   if (readHash === undefined) {
-    return undefined;
+    return [];
   }
+  const keys: string[] = [];
   for (const address of addresses) {
-    if (address.hash === readHash && pathStartsWith(read.path, address.path)) {
-      return address.key;
+    if (
+      address.hash === readHash && pathStartsWith(read.path, address.path) &&
+      !keys.includes(address.key)
+    ) {
+      keys.push(address.key);
     }
   }
   if (argumentHash !== undefined && readHash === argumentHash) {
     const first = read.path[0];
-    if (first !== undefined && suppliedKeys.includes(first)) {
-      return first;
+    if (
+      first !== undefined && suppliedKeys.includes(first) &&
+      !keys.includes(first)
+    ) {
+      keys.push(first);
     }
   }
-  return undefined;
+  return keys;
 };
 
 /**
@@ -607,7 +646,7 @@ const namableRefusalAtom = (rendered: string): boolean => {
  */
 export const runPatternPolicyRefusal = (
   refusals: readonly CfcRefusalDetail[],
-  inputKeyFor: (read: CfcAddress) => string | undefined,
+  inputKeysFor: (read: CfcAddress) => readonly string[],
 ): RunPatternPolicyRefusal | undefined => {
   if (refusals.length === 0) {
     return undefined;
@@ -633,13 +672,15 @@ export const runPatternPolicyRefusal = (
       else withheldAtomCount += 1;
     }
     for (const input of detail.inputs) {
-      const key = inputKeyFor(input.read);
-      if (key === undefined) {
+      const keys = inputKeysFor(input.read);
+      if (keys.length === 0) {
         // Counted by document, so one document read at three paths is one
         // input the caller cannot name rather than three.
         unattributed.add(comparableEntityHash(input.read.id) ?? "");
-      } else if (!inputKeys.includes(key)) {
-        inputKeys.push(key);
+        continue;
+      }
+      for (const key of keys) {
+        if (!inputKeys.includes(key)) inputKeys.push(key);
       }
     }
   }
@@ -665,12 +706,20 @@ const quoteAll = (values: readonly string[]): string =>
   values.map((value) => `"${value}"`).join(", ");
 
 /**
+ * Which boundary a refusal came from, which decides what the caller is told
+ * became of the result: a refused commit landed no result, while a refused
+ * release has one, in the space under its own labels.
+ */
+export type RunPatternRefusalBoundary = "commit" | "release";
+
+/**
  * The refusal stated as an instruction: what refused, which of the caller's
  * inputs carried what it refused, and whether dropping those inputs is the
  * whole remedy or only narrows the flow.
  */
 export const policyRefusalMessage = (
   refusal: RunPatternPolicyRefusal,
+  boundaryRefused: RunPatternRefusalBoundary,
 ): string => {
   const boundary = refusal.sinks.length > 0
     ? `the sink${refusal.sinks.length > 1 ? "s" : ""} ${
@@ -680,10 +729,16 @@ export const policyRefusalMessage = (
   const atoms = refusal.offendingAtoms.length > 0
     ? ` (${refusal.offendingAtoms.join(", ")})`
     : "";
+  const refused = boundaryRefused === "commit"
+    ? "commit its result"
+    : "release its result";
+  const became = boundaryRefused === "commit"
+    ? "the result never landed"
+    : "the result stays in the space and is withheld here";
   const opening =
-    "the pattern ran but the space's policy refused to commit its result: " +
+    `the pattern ran but the space's policy refused to ${refused}: ` +
     `${boundary} does not admit the confidentiality${atoms} this run ` +
-    "carries, so the result never landed";
+    `carries, so ${became}`;
   const plural = refusal.inputKeys.length > 1;
   const keys = `input${plural ? "s" : ""} ${quoteAll(refusal.inputKeys)}`;
   const remedy = refusal.attribution === "complete"
@@ -1314,7 +1369,132 @@ export const runPatternTool: HarnessToolDefinition<
       resultCell.getAsNormalizedFullLink(),
       space,
     );
-    const rawValue = asSerializableValue(await piece.result.get());
+    /**
+     * The report a policy refusal produces, whichever boundary stated it.
+     *
+     * The refusal reason stays out of the model-facing message the same way
+     * thrown text does: it names the documents and label atoms involved —
+     * fabric identifiers and policy detail the model does not read — so the
+     * artifact keeps it and the model gets the fact of the refusal.
+     */
+    const policyRefusalOutput = async (
+      details: readonly CfcRefusalDetail[],
+      boundaryRefused: RunPatternRefusalBoundary,
+      rawCauseMessage: string,
+    ) => {
+      recordOutcome("run_failed");
+      // The piece's argument document is where every input reaches the
+      // pattern under its own key, so a refused read of it names an input
+      // by its first path segment. Its address is resolved here rather than
+      // kept from creation because only a refusal asks for it.
+      let argumentHash: string | undefined;
+      try {
+        argumentHash = comparableEntityHash(
+          (await piece.input.getCell()).getAsNormalizedFullLink().id,
+        );
+      } catch {
+        argumentHash = undefined;
+      }
+      const policyRefusal = runPatternPolicyRefusal(
+        details,
+        (read) =>
+          refusalReadInputKeys(
+            read,
+            inputAddresses,
+            argumentHash,
+            suppliedInputKeys,
+          ),
+      );
+      return {
+        ...errorOutput(
+          "error",
+          policyRefusal === undefined
+            ? RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE
+            : policyRefusalMessage(policyRefusal, boundaryRefused),
+        ),
+        pieceId: piece.id,
+        rawCauseMessage,
+        ...(policyRefusal !== undefined ? { policyRefusal } : {}),
+      };
+    };
+
+    // The answer is an egress: what this tool returns is read by a model,
+    // outside every space the fabric labels. A pattern's own egresses are
+    // sink requests the commit boundary gates, and this one records none, so
+    // it is measured here. The measurement is a transaction that reads what
+    // the answer stands for, and its consumed join is what the answer
+    // carries — the result document, and every computed cell the result links
+    // to. Nothing is committed.
+    //
+    // A second transaction reads the piece's argument document, and only that
+    // transaction does. Every input reaches the pattern through that document
+    // under its own key, so a clause it carries names an input the caller can
+    // drop; a clause reaching the answer by another route is reported as
+    // unattributed.
+    //
+    // The ladder decides whether a recorded reason REJECTS, not whether it is
+    // taken: the measurement runs at every rung, so an observe-stage rollout
+    // can size what turning the rung up would refuse, which is what the sink
+    // gate beside it does with the same reason.
+    const releaseGateRejects =
+      pieces.runtime.cfcEnforcementMode !== "disabled" &&
+      pieces.runtime.cfcEnforcementMode !== "observe";
+    let releaseRefusal: CfcRefusalDetail | undefined;
+    let rawValue: unknown;
+    const measureRelease = async () => {
+      const releaseTx = pieces.runtime.edit();
+      const inputsTx = pieces.runtime.edit();
+      try {
+        // The answer the tool returns is read HERE, through the transaction
+        // that measures it, and the value below is that read rather than a
+        // second one. A result the reactive graph advances between two reads
+        // would otherwise let a later clean state answer for an earlier
+        // labeled one. The `required` relaxation is the piece controller's,
+        // so a scoped link the session cannot materialize degrades its member
+        // rather than voiding the whole read.
+        const measuredResult = cellWithScopedLinkRequiredsRelaxed(
+          resultCell.withTx(releaseTx),
+        );
+        await measuredResult.pull();
+        rawValue = asSerializableValue(measuredResult.get());
+        try {
+          const measuredArgument = (await piece.input.getCell())
+            .withTx(inputsTx);
+          await measuredArgument.pull();
+          asSerializableValue(measuredArgument.get());
+        } catch {
+          // An argument cell that will not resolve leaves the caller's own
+          // addresses as the route from a clause back to an input key.
+        }
+        for (const { cell } of liveCellInputs) {
+          const measuredInput = cell.withTx(inputsTx);
+          await measuredInput.pull();
+          asSerializableValue(measuredInput.get());
+        }
+        return describeSinkReleaseRefusal(
+          releaseTx,
+          inputsTx,
+          RUN_PATTERN_ANSWER_SINK,
+          RUN_PATTERN_ANSWER_CEILING,
+        );
+      } finally {
+        releaseTx.abort("run_pattern release measurement");
+        inputsTx.abort("run_pattern release attribution");
+      }
+    };
+    // Raced with the signal like every other wait this tool performs: the
+    // reads resolve a graph, and a caller that gave up while they were in
+    // flight is told it was cancelled rather than handed an answer it stopped
+    // waiting for. The measurement abandons its own transactions whichever
+    // way the race goes.
+    const measuring = (async () => {
+      releaseRefusal = await measureRelease();
+    })();
+    if (await raceWithAbort(measuring, signal) === "aborted") {
+      stopPiece(piece.getCell());
+      return cancelledOutput();
+    }
+
     let value: unknown;
     let linkedStringCount: number | undefined;
     let valueError: string | undefined;
@@ -1367,51 +1547,16 @@ export const runPatternTool: HarnessToolDefinition<
       (inertResultKeys !== undefined && inertResultKeys.length === 0);
     if (valueError !== undefined || resultAbsent) {
       const pieceErrors = observations.errorsSince(observationStart, piece.id);
-      // A policy refusal is named as what it is. The refusal reason stays
-      // out of the model-facing message the same way thrown text does: it
-      // names the documents and label atoms involved — fabric identifiers
-      // and policy detail the model does not read — so the artifact keeps it
-      // and the model gets the fact of the refusal.
+      // A policy refusal is named as what it is.
       const refusal = pieceErrors.find((record) =>
         record.name === "CfcCommitRefusalError"
       );
       if (refusal !== undefined) {
-        recordOutcome("run_failed");
-        // The piece's argument document is where every input reaches the
-        // pattern under its own key, so a refused read of it names an input
-        // by its first path segment. Its address is resolved here rather
-        // than kept from creation because only a refusal asks for it, and an
-        // argument cell that will not resolve costs that second route to a
-        // key while the caller's own resolved addresses still answer.
-        let argumentHash: string | undefined;
-        try {
-          argumentHash = comparableEntityHash(
-            (await piece.input.getCell()).getAsNormalizedFullLink().id,
-          );
-        } catch {
-          argumentHash = undefined;
-        }
-        const policyRefusal = runPatternPolicyRefusal(
+        return await policyRefusalOutput(
           refusal.refusals ?? [],
-          (read) =>
-            refusalReadInputKey(
-              read,
-              inputAddresses,
-              argumentHash,
-              suppliedInputKeys,
-            ),
+          "commit",
+          refusal.message,
         );
-        return {
-          ...errorOutput(
-            "error",
-            policyRefusal === undefined
-              ? RUN_PATTERN_OPAQUE_REFUSAL_MESSAGE
-              : policyRefusalMessage(policyRefusal),
-          ),
-          pieceId: piece.id,
-          rawCauseMessage: refusal.message,
-          ...(policyRefusal !== undefined ? { policyRefusal } : {}),
-        };
       }
       if (pieceErrors.length > 0) {
         // The thrown text stays out of the model-facing message: a
@@ -1468,6 +1613,28 @@ export const runPatternTool: HarnessToolDefinition<
           pieceId: piece.id,
         };
       }
+    }
+    // A measurement the ladder does not reject on is still an answer about
+    // this run, and the only place it can be read from is the artifact.
+    const releaseObservation =
+      releaseRefusal === undefined || releaseGateRejects
+        ? undefined
+        : runPatternPolicyRefusal(
+          [releaseRefusal],
+          (read) =>
+            refusalReadInputKeys(
+              read,
+              inputAddresses,
+              undefined,
+              suppliedInputKeys,
+            ),
+        );
+    if (releaseRefusal !== undefined && releaseGateRejects) {
+      return await policyRefusalOutput(
+        [releaseRefusal],
+        "release",
+        releaseRefusal.reason,
+      );
     }
     // A result the caller's own `resultSchema` refused is reported as neither
     // outcome: the pattern ran and landed a result, and the schema it did not
@@ -1724,6 +1891,7 @@ export const runPatternTool: HarnessToolDefinition<
       ...(linkedStringCount !== undefined ? { linkedStringCount } : {}),
       ...(valueError !== undefined ? { valueError } : {}),
       ...(rawValue !== undefined ? { rawValue } : {}),
+      ...(releaseObservation !== undefined ? { releaseObservation } : {}),
       ...(publication !== undefined ? { patternPublication: publication } : {}),
       ...(probeThrown !== undefined ? { rawCauseMessage: probeThrown } : {}),
     };

--- a/packages/cf-harness/test/run-pattern.test.ts
+++ b/packages/cf-harness/test/run-pattern.test.ts
@@ -224,21 +224,25 @@ const EXPENSE_SCHEMA = {
 } as const;
 
 /**
- * A fabric session at enforce-strict with persisted flow labels, for the
- * tests that pin what a pattern over labelled data leaves in the store.
+ * A fabric session with persisted flow labels, at the enforcement posture the
+ * caller names: `enforce-strict` for the tests that pin what a pattern over
+ * labelled data leaves in the store and what its answer may release, and
+ * `observe` for the one that pins that nothing rejects there.
  */
-async function createStrictFabric() {
+async function createFabric(
+  cfcEnforcementMode: "observe" | "enforce-strict" = "enforce-strict",
+) {
   const storage = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({
     apiUrl: new URL("http://toolshed.test"),
     storageManager: storage,
-    cfcEnforcementMode: "enforce-strict",
+    cfcEnforcementMode,
     cfcFlowLabels: "persist",
   });
   const pieces = new PiecesController(
     await createSession({
       identity: signer,
-      spaceName: `run-pattern-strict-${crypto.randomUUID()}`,
+      spaceName: `run-pattern-${cfcEnforcementMode}-${crypto.randomUUID()}`,
     }),
     runtime,
   );
@@ -253,6 +257,8 @@ async function createStrictFabric() {
     },
   };
 }
+
+const createStrictFabric = () => createFabric("enforce-strict");
 
 /**
  * A pattern over one plain input and one optional referenced input, where the
@@ -385,10 +391,13 @@ function refusalDetail(
 }
 
 /** Resolves a refused read to an input key by the document it names. */
-function inputKeyByDocument(
-  owned: Readonly<Record<string, string>>,
-): (read: CfcAddress) => string | undefined {
-  return (read) => owned[read.id];
+function inputKeysByDocument(
+  owned: Readonly<Record<string, string | string[]>>,
+): (read: CfcAddress) => readonly string[] {
+  return (read) => {
+    const keys = owned[read.id];
+    return keys === undefined ? [] : typeof keys === "string" ? [keys] : keys;
+  };
 }
 
 /**
@@ -943,13 +952,13 @@ describe("run-pattern", () => {
       expect(result.runState.status).toBe("completed");
     });
 
-    it("returns an error naming the policy refusal when the commit boundary refuses the result write", async () => {
-      // A strict flow-label runtime over a labelled source: the pattern's
-      // secret-derived write is refused at the commit boundary. The refusal
-      // is terminal — the scheduler surfaces it on its error channel rather
-      // than retrying — and the tool reports it as a policy refusal, with
-      // the reason (which names the labels and documents involved) kept in
-      // the artifact channel rather than the model-facing message.
+    it("returns an error naming the policy refusal when the answer carries a label the model may not read", async () => {
+      // A strict flow-label runtime over a labelled source: the pattern
+      // derives from the secret, and its result carries the secret's label.
+      // The answer is an egress, so the tool measures what it would release
+      // and refuses, with the reason (which names the labels and documents
+      // involved) kept in the artifact channel rather than the model-facing
+      // message.
       const strictStorage = StorageManager.emulate({ as: signer });
       const strictRuntime = new Runtime({
         apiUrl: new URL("http://toolshed.test"),
@@ -1023,14 +1032,14 @@ describe("run-pattern", () => {
         });
         const output = result.output as RunPatternToolErrorOutput;
         expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to commit");
-        expect(output.message).toContain("result never landed");
+        expect(output.message).toContain("policy refused to release");
+        expect(output.message).toContain("withheld here");
         // The refusal reason is a data channel: it stays in the artifact
         // field the prompt loop strips from model context, never in the
         // message.
-        expect(output.message).not.toContain("CFC enforcement rejected");
+        expect(output.message).not.toContain("exceeds ceiling");
         expect(output.rawCauseMessage).toContain(
-          "CFC enforcement rejected commit",
+          'confidentiality exceeds ceiling for run_pattern: "secret"',
         );
         expect(output.pieceId).toBeDefined();
       } finally {
@@ -1057,13 +1066,13 @@ describe("run-pattern", () => {
         );
         const output = result.output as RunPatternToolErrorOutput;
         expect(output.status).toBe("error");
-        expect(output.message).toContain("policy refused to commit");
+        expect(output.message).toContain("policy refused to release");
         expect(output.message).toContain('input "source"');
         expect(output.message).toContain("without it proceeds");
         expect(output.message).not.toContain('"amount"');
         expect(output.policyRefusal).toEqual({
-          gates: ["writer-fit"],
-          sinks: [],
+          gates: ["sink-ceiling"],
+          sinks: ["run_pattern"],
           offendingAtoms: ['"secret"'],
           inputKeys: ["source"],
           attribution: "complete",
@@ -1142,12 +1151,203 @@ describe("run-pattern", () => {
       }
     });
 
-    it("counts the reads only the argument document accounted for when the piece's argument cell will not resolve", async () => {
-      // The argument document is the second of the two routes from a refused
-      // read back to an input key. With it gone the report stands on the
-      // addresses the caller's own links resolved to, and states the gap
-      // rather than closing over it: what those addresses do not reach is
-      // counted, and the remedy drops to `partial`.
+    it("refuses an answer whose label sits on a field of the document it passes through", async () => {
+      // Resolving a value reads the links it holds; a label on a field is
+      // consumed where that field is read. This answer is the labelled
+      // document itself, passed through by reference, and its label sits one
+      // level down — so the measurement has to walk what it releases.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-field-label",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { pattern, Reactive } from 'commonfabric';",
+              "interface Source { secret: string; }",
+              "interface Input { source: Reactive<Source>; }",
+              "interface Output { copy: Reactive<Source>; }",
+              "export default pattern<Input, Output>(({ source }) => ({",
+              "  copy: source,",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { source: sourceRef },
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("policy refused to release");
+        expect(output.policyRefusal?.offendingAtoms).toEqual(['"secret"']);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("names both keys when one labelled document is supplied under two", async () => {
+      // The remedy has to name every alias: dropping one of them leaves the
+      // other handing the same document to the pattern. With the argument
+      // document gone, one read of the shared document is all there is to
+      // trace, and both aliases resolve from the addresses the caller's own
+      // links reached.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-aliased-input",
+        );
+        const result = await createStrictEngine(
+          piecesWithUnresolvableArgument(pieces),
+        ).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { computed, pattern, Reactive } from 'commonfabric';",
+              "interface Source { secret: string; }",
+              "interface Input {",
+              "  amount: number;",
+              "  source?: Reactive<Source>;",
+              "  alsoSource?: Reactive<Source>;",
+              "}",
+              "interface Output { total: number; }",
+              "export default pattern<Input, Output>(({ amount, source }) => ({",
+              "  total: computed(() => {",
+              "    const secret = source?.secret;",
+              "    return amount + (typeof secret === 'string'",
+              "      ? secret.length",
+              "      : 0);",
+              "  }),",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { amount: 2, source: sourceRef, alsoSource: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.policyRefusal?.inputKeys).toEqual(
+          expect.arrayContaining(["source", "alsoSource"]),
+        );
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("refuses an answer whose label is two links down", async () => {
+      // The leaf the answer carries sits inside a nested object, behind a
+      // computed cell, behind the result document. Resolving the result is
+      // not the same as reading what it resolves to, so this is what says
+      // the measurement reaches the whole answer rather than its first hop.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-nested-label",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { computed, pattern, Reactive } from 'commonfabric';",
+              "interface Source { secret: string; }",
+              "interface Input { source: Reactive<Source>; }",
+              "interface Output { wrapper: { note: string } }",
+              "export default pattern<Input, Output>(({ source }) => ({",
+              "  wrapper: { note: computed(() => `${source.secret}!`) },",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { source: sourceRef },
+          },
+        );
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("policy refused to release");
+        expect(output.policyRefusal?.offendingAtoms).toEqual(['"secret"']);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("answers at the observe posture, where no gate rejects", async () => {
+      // The enforcement ladder decides whether a recorded reason rejects, and
+      // at `observe` none of them do. The answer carries the label either
+      // way; what changes is that nothing refuses over it.
+      const { runtime, pieces, space, dispose } = await createFabric("observe");
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-observe",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect((output.value as { total: number }).total).toBe(8);
+        // Nothing rejects here, and the measurement still ran: what raising
+        // the rung would refuse is recorded for whoever is staging it.
+        expect(output.releaseObservation?.offendingAtoms).toEqual(['"secret"']);
+        expect(output.releaseObservation?.inputKeys).toEqual(["source"]);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("answers when a labelled input reaches the argument document and not the result", async () => {
+      // What the answer carries is what releasing it resolves, not what the
+      // caller handed over. This pattern names the labelled input and never
+      // reads it, so the total it returns derives from the plain one alone.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-unread-input",
+        );
+        const result = await createStrictEngine(pieces).invokeBuiltinTool(
+          "run_pattern",
+          {
+            sourceText: [
+              "import { computed, pattern, Reactive } from 'commonfabric';",
+              "interface Source { secret: string; }",
+              "interface Input { amount: number; source?: Reactive<Source>; }",
+              "interface Output { total: number; }",
+              "export default pattern<Input, Output>(({ amount }) => ({",
+              "  total: computed(() => amount + 1),",
+              "}));",
+              "",
+            ].join("\n"),
+            inputs: { amount: 2, source: sourceRef },
+            resultSchema: TOTAL_RESULT_SCHEMA,
+          },
+        );
+        const output = result.output as RunPatternToolSuccessOutput;
+        expect(output.status).toBe("ok");
+        expect((output.value as { total: number }).total).toBe(3);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it("names the input from the caller's own addresses when the piece's argument cell will not resolve", async () => {
+      // The argument document is one of the two routes from a released clause
+      // back to an input key. With it gone the report stands on the addresses
+      // the caller's own links resolved to, which account for this clause on
+      // their own.
       const { runtime, pieces, space, dispose } = await createStrictFabric();
       try {
         const sourceRef = await seedLabelledSecret(
@@ -1165,9 +1365,8 @@ describe("run-pattern", () => {
         const output = result.output as RunPatternToolErrorOutput;
         expect(output.status).toBe("error");
         expect(output.policyRefusal?.inputKeys).toEqual(["source"]);
-        expect(output.policyRefusal?.unattributedInputCount).toBe(1);
-        expect(output.policyRefusal?.attribution).toBe("partial");
-        expect(output.message).toContain("narrows the flow");
+        expect(output.policyRefusal?.attribution).toBe("complete");
+        expect(output.message).toContain("without it proceeds");
       } finally {
         await dispose();
       }
@@ -1204,10 +1403,11 @@ describe("run-pattern", () => {
       // A pattern-body `.map()` runs as the built-in map, whose coordinator
       // reads the list raw. With the labelled values inline in that list, the
       // read carries their confidentiality, so under enforce-strict the
-      // output write is refused and nothing lands: the labelled text exists
-      // at rest only in the seeded source document, and the tool reports the
-      // refusal — the coordinator carries the piece's observation identity,
-      // which is what attributes a `raw:map` action's refusal to its piece.
+      // coordinator's own container write into an ordinary document is
+      // refused and nothing lands: the labelled text exists at rest only in
+      // the seeded source document, and the tool reports the commit refusal —
+      // the coordinator carries the piece's observation identity, which is
+      // what attributes a `raw:map` action's refusal to its piece.
       const { runtime, pieces, space, dispose } = await createStrictFabric();
       try {
         const seed = runtime.edit();
@@ -1272,6 +1472,9 @@ describe("run-pattern", () => {
         const output = result.output as RunPatternToolErrorOutput;
         expect(output.status).toBe("error");
         expect(output.message).toContain("policy refused to commit");
+        expect(output.rawCauseMessage).toContain(
+          "writer-fit confidentiality misfit",
+        );
         const pieceId = output.pieceId;
         expect(pieceId).toBeDefined();
         await runtime.idle();
@@ -1290,9 +1493,10 @@ describe("run-pattern", () => {
       // With each labelled value in its own document behind a link, the
       // built-in map's coordinator reads only links, and each element result
       // is itself a link into the labelled source path. The result reads
-      // back as the values, but no document at rest holds an unlabelled
-      // copy: a reader reaching the text does so through the source's own
-      // label map.
+      // back as the values, but no document at rest holds a copy at all: a
+      // reader reaching the text does so through the source's own label map.
+      // The answer still leaves the fabric for a model, so it is refused on
+      // the labels those links reach.
       const { runtime, pieces, space, dispose } = await createStrictFabric();
       try {
         const expenseIds: string[] = [];
@@ -1375,12 +1579,13 @@ describe("run-pattern", () => {
             ),
           },
         });
-        const output = result.output as RunPatternToolSuccessOutput;
-        expect(output.status).toBe("ok");
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("error");
+        expect(output.message).toContain("policy refused to release");
         await runtime.idle();
         await pieces.synced();
 
-        const piece = await pieces.get(output.pieceId);
+        const piece = await pieces.get(output.pieceId!);
         expect(await piece.result.get(["notes"])).toEqual([
           "alpha-secret",
           "beta-secret",
@@ -1816,6 +2021,59 @@ describe("run-pattern", () => {
       expect(result.runState.status).toBe("completed");
     });
 
+    it("returns a `cancelled` output when the signal aborts during the release measurement", async () => {
+      // The measurement opens its transactions before it awaits anything, so
+      // aborting on that call lands the signal while the phase is in flight.
+      const { runtime, pieces, space, dispose } = await createStrictFabric();
+      try {
+        const sourceRef = await seedLabelledSecret(
+          runtime,
+          space,
+          "release-cancelled",
+        );
+        const controller = new AbortController();
+        const pristineEdit = runtime.edit.bind(runtime);
+        let measurementReached = false;
+        const runtimeWithEdit = runtime as unknown as {
+          edit: () => ReturnType<typeof pristineEdit>;
+        };
+        runtimeWithEdit.edit = () => {
+          // Every earlier transaction belongs to setup; the release
+          // measurement is what opens one after the piece has settled.
+          if (measurementReached) controller.abort();
+          return pristineEdit();
+        };
+        const stopped: unknown[] = [];
+        const runner = runtime.runner as unknown as {
+          stop: (cell: unknown) => unknown;
+        };
+        const originalStop = runner.stop.bind(runtime.runner);
+        runner.stop = (cell) => {
+          stopped.push(cell);
+          return originalStop(cell);
+        };
+        const engine = createStrictEngine(pieces);
+        const settledBefore = pieces.synced.bind(pieces);
+        (pieces as unknown as { synced: () => Promise<void> }).synced =
+          async () => {
+            await settledBefore();
+            measurementReached = true;
+          };
+
+        const result = await engine.invokeBuiltinTool("run_pattern", {
+          sourceText: OPTIONAL_SECRET_PATTERN_SOURCE,
+          inputs: { amount: 2, source: sourceRef },
+          resultSchema: TOTAL_RESULT_SCHEMA,
+        }, { signal: controller.signal });
+
+        const output = result.output as RunPatternToolErrorOutput;
+        expect(output.status).toBe("cancelled");
+        expect(stopped.length).toBe(1);
+      } finally {
+        await dispose();
+      }
+    });
+
     it("surfaces a rejected session construction as a structured error and invokes the factory again on the next call", async () => {
       let factoryCalls = 0;
       const engine = new CfHarnessEngine({
@@ -2071,7 +2329,7 @@ describe("run-pattern", () => {
 
   describe("runPatternPolicyRefusal()", () => {
     it("returns `undefined` for an empty refusal list", () => {
-      expect(runPatternPolicyRefusal([], () => undefined)).toBeUndefined();
+      expect(runPatternPolicyRefusal([], () => [])).toBeUndefined();
     });
 
     it("names the sink whose ceiling refused for a `sink-ceiling` detail", () => {
@@ -2082,7 +2340,7 @@ describe("run-pattern", () => {
             sink: "fetchText",
             inputs: [refusalInput("source-doc")],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["sink-ceiling"],
         sinks: ["fetchText"],
@@ -2113,7 +2371,7 @@ describe("run-pattern", () => {
               inputs: [refusalInput("other-doc")],
             }),
           ],
-          inputKeyByDocument({
+          inputKeysByDocument({
             "source-doc": "source",
             "other-doc": "notes",
           }),
@@ -2139,7 +2397,7 @@ describe("run-pattern", () => {
             ],
             inputs: [refusalInput("source-doc")],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2160,7 +2418,7 @@ describe("run-pattern", () => {
             offendingAtoms: ['"secret"', "undefined"],
             inputs: [refusalInput("source-doc")],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2171,13 +2429,30 @@ describe("run-pattern", () => {
       });
     });
 
+    it("names every input key one refused document was supplied under", () => {
+      // One document handed in under two keys is reached by dropping either
+      // alias alone, so a remedy naming one of them leaves the other
+      // carrying the label.
+      expect(
+        runPatternPolicyRefusal([
+          refusalDetail({ inputs: [refusalInput("source-doc")] }),
+        ], inputKeysByDocument({ "source-doc": ["source", "alsoSource"] })),
+      ).toEqual({
+        gates: ["writer-fit"],
+        sinks: [],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source", "alsoSource"],
+        attribution: "complete",
+      });
+    });
+
     it("returns `partial` with the unowned read counted when one offending read belongs to no input key", () => {
       expect(
         runPatternPolicyRefusal([
           refusalDetail({
             inputs: [refusalInput("source-doc"), refusalInput("hidden-doc")],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2198,7 +2473,7 @@ describe("run-pattern", () => {
               refusalInput("source-doc"),
             ],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2218,7 +2493,7 @@ describe("run-pattern", () => {
               refusalInput("other-hidden-doc"),
             ],
           }),
-        ], () => undefined),
+        ], () => []),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2236,7 +2511,7 @@ describe("run-pattern", () => {
             attribution: "partial",
             inputs: [refusalInput("source-doc")],
           }),
-        ], inputKeyByDocument({ "source-doc": "source" })),
+        ], inputKeysByDocument({ "source-doc": "source" })),
       ).toEqual({
         gates: ["writer-fit"],
         sinks: [],
@@ -2255,13 +2530,31 @@ describe("run-pattern", () => {
         offendingAtoms: ['"secret"'],
         inputKeys: ["source"],
         attribution: "complete",
-      });
+      }, "commit");
       expect(message).toContain(
         'the sink "fetchText" does not admit the confidentiality ("secret")',
       );
       expect(message).toContain(
         'Every label refused here came in through input "source", so the same run without it proceeds',
       );
+    });
+
+    it("says the result is withheld when the release boundary refused", () => {
+      // The answer's own sink refuses what the run already landed, so what
+      // the caller is told became of the result differs from a refused
+      // commit: it exists, in the space, under its own labels.
+      const message = policyRefusalMessage({
+        gates: ["sink-ceiling"],
+        sinks: ["run_pattern"],
+        offendingAtoms: ['"secret"'],
+        inputKeys: ["source"],
+        attribution: "complete",
+      }, "release");
+      expect(message).toContain("policy refused to release its result");
+      expect(message).toContain(
+        "the result stays in the space and is withheld here",
+      );
+      expect(message).not.toContain("never landed");
     });
 
     it("names both sinks when two ceilings refused", () => {
@@ -2271,7 +2564,9 @@ describe("run-pattern", () => {
         offendingAtoms: ['"secret"'],
         inputKeys: ["source"],
         attribution: "complete",
-      })).toContain('the sinks "fetchText", "postMessage" does not admit');
+      }, "commit")).toContain(
+        'the sinks "fetchText", "postMessage" does not admit',
+      );
     });
 
     it("names the write it attempted and both inputs to drop when no sink refused", () => {
@@ -2281,7 +2576,7 @@ describe("run-pattern", () => {
         offendingAtoms: ['"secret"', '"medical"'],
         inputKeys: ["source", "notes"],
         attribution: "complete",
-      });
+      }, "commit");
       expect(message).toContain(
         'the write it attempted does not admit the confidentiality ("secret", "medical")',
       );
@@ -2298,7 +2593,7 @@ describe("run-pattern", () => {
         withheldAtomCount: 2,
         inputKeys: ["source"],
         attribution: "complete",
-      });
+      }, "commit");
       expect(message).toContain(
         "the write it attempted does not admit the confidentiality this run carries",
       );
@@ -2312,7 +2607,7 @@ describe("run-pattern", () => {
         inputKeys: ["source", "notes"],
         unattributedInputCount: 1,
         attribution: "partial",
-      })).toContain(
+      }, "commit")).toContain(
         'Some of what was refused came in through inputs "source", "notes"; dropping them narrows the flow without necessarily clearing it, since reads this call does not own carry refused labels too',
       );
     });
@@ -2325,7 +2620,7 @@ describe("run-pattern", () => {
         inputKeys: ["source"],
         unattributedInputCount: 1,
         attribution: "partial",
-      })).toContain(
+      }, "commit")).toContain(
         'came in through input "source"; dropping it narrows the flow',
       );
     });
@@ -2338,7 +2633,7 @@ describe("run-pattern", () => {
         inputKeys: [],
         unattributedInputCount: 1,
         attribution: "none",
-      })).toContain(
+      }, "commit")).toContain(
         "No input of this call accounts for what was refused, so dropping an input will not clear it",
       );
     });

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -222,6 +222,7 @@ export {
 } from "./space-membership.ts";
 export {
   CFC_PREFIX_PROVENANCE_MAX_WRITES,
+  describeSinkReleaseRefusal,
   flowLabelWorkExists,
   flowReadExcluded,
   gatedSinkRequestExists,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -28,6 +28,7 @@ import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
+import { entityKindOfIdString } from "../entity-kind.ts";
 import { refuseFabricInstance } from "../fabric-special-object.ts";
 import {
   containsExternalSchemaRef,
@@ -101,6 +102,7 @@ import {
 } from "./migration-reason.ts";
 import { verdictReason } from "./verdict-reason.ts";
 import {
+  type CfcRefusalDetail,
   type ConsumedAtomSource,
   describeRefusalInputs,
   renderCfcAtom,
@@ -1580,6 +1582,35 @@ const isMetaSeamPath = (
   path: readonly string[],
 ): boolean => metaOnlyByPath?.get(pathKey(path)) === true;
 
+/**
+ * Whether a schema could have declared a store policy for a write at `path`
+ * on `id` — the surfaces the §8.12.4 writer-fit measurement quantifies over.
+ *
+ * Two are outside it. The raw meta seam is one, per {@link isMetaSeamPath}:
+ * no value schema describes the document-root siblings of `value`. A computed
+ * cell is the other: the derived internal cell the runtime materializes to
+ * hold a derivation's result, addressed under its own URI scheme
+ * (`computed:fid1:<hash>`; see `entity-kind.ts` and
+ * `docs/specs/computed-cell-identity.md`). A pattern declares policy on the
+ * data it names, and it names neither.
+ *
+ * Both stay flow stamp targets: the join lands on them as the `derived`
+ * component, so a later read of one is tainted and a later egress of one is
+ * gated on that label. The residency clause is part of the ceiling this
+ * skips, so a derivation's result may land in a space whose name none of the
+ * label's clauses carry.
+ *
+ * `docs/specs/cfc-enforcement-matrix.md` §4 carries the reasoning.
+ */
+const isDeclarablePolicyPath = (
+  id: string,
+  joinIsLocal: boolean,
+  metaOnlyByPath: ReadonlyMap<string, boolean> | undefined,
+  path: readonly string[],
+): boolean =>
+  (entityKindOfIdString(id) !== "computed" || !joinIsLocal) &&
+  !isMetaSeamPath(metaOnlyByPath, path);
+
 // S16 flow labels (default transition): one conservative confidentiality join
 // per transaction — everything the transaction observed taints everything it
 // wrote (§8.9.2/§8.9.3 collapsed to tx granularity). Reads of runtime-internal
@@ -1931,11 +1962,9 @@ export const deriveFlowJoin = (
   options?: {
     /**
      * Collect the spaces of observations that contributed label content to
-     * the join (inv-12 Stage 1): the per-target cross-space predicate in
-     * `prepareBoundaryCommit` tests whether any labeled contribution
-     * originated outside the destination space. Opt-in so the default path
-     * — every prepare with `cfcLabelMetadataProtection: "off"` — allocates
-     * nothing for it.
+     * the join (inv-12 Stage 1). The per-target predicates in
+     * `prepareBoundaryCommit` test whether any labeled contribution
+     * originated outside the destination space.
      */
     collectLabeledSpaces?: boolean;
   },
@@ -5020,6 +5049,78 @@ const collectConsumedLabel = (
 };
 
 /**
+ * The refusal a sink's ceiling states about `offending`, with the reads that
+ * carried each clause.
+ *
+ * The reason text is the pairing key between a recorded detail and the reason
+ * that refused, so the two are built together rather than assembled twice.
+ */
+const sinkCeilingRefusal = (
+  sink: string,
+  offending: readonly unknown[],
+  sources: readonly ConsumedAtomSource[],
+): CfcRefusalDetail => {
+  // Name the offending atom(s) so an observe-mode diagnostic identifies the
+  // exact (sink, atom) pair that needs a ceiling entry (review on #3993).
+  const offendingAtoms = offending.map(renderCfcAtom);
+  return {
+    gate: "sink-ceiling",
+    sink,
+    offendingAtoms,
+    ...describeRefusalInputs(offending, sources),
+    reason: `sink-request confidentiality exceeds ceiling for ${sink}: ` +
+      offendingAtoms.join(", "),
+  };
+};
+
+/**
+ * What `ceiling` refuses about everything `released` has read, as the §8.12.4
+ * sink gate would state it, or `undefined` when it refuses nothing.
+ *
+ * The commit boundary answers this question for the sink requests a
+ * transaction records, which covers an egress a pattern performs. An egress
+ * the HOST performs — a tool answering a model with what a piece computed —
+ * has no request to record and no commit to gate, so it asks here instead:
+ * read what it is about to release through a transaction, and measure that
+ * transaction's consumed join against the ceiling the destination carries.
+ * Both routes measure the same join against the same membership predicate,
+ * so a host gate cannot admit a flow the boundary refuses.
+ *
+ * `attributedTo` is the read set the refusal is EXPLAINED in terms of, which
+ * a host narrows to the reads its caller can act on. A clause carried by no
+ * read of `attributedTo` is reported as unattributed. Passing one transaction
+ * for both asks the boundary's own question.
+ *
+ * The join is what `released` has read, and a label on a field is consumed
+ * where that field is read: a read that resolves a document root and stops
+ * there counts entries at or above it only. A caller measuring a release
+ * therefore walks the value it is about to hand over.
+ *
+ * The membership predicate is the one `verifySinkRequestCeilings` fits with,
+ * so a clause outside a ceiling here is outside it there. The join is what
+ * `released` read, with no exchange-rule rewriting applied to it, so a clause
+ * a policy evaluation would have discharged is refused here.
+ *
+ * Neither transaction is committed, written, or recorded against.
+ */
+export const describeSinkReleaseRefusal = (
+  released: IExtendedStorageTransaction,
+  attributedTo: IExtendedStorageTransaction,
+  sink: string,
+  ceiling: readonly CfcConfClause[],
+): CfcRefusalDetail | undefined => {
+  const offending = atomsOutsideCeiling(
+    collectConsumedLabel(released).confidentiality,
+    ceiling,
+  );
+  return offending.length === 0 ? undefined : sinkCeilingRefusal(
+    sink,
+    offending,
+    collectConsumedLabel(attributedTo).sources,
+  );
+};
+
+/**
  * Runs the exchange-rule evaluator over one gated confidentiality set under
  * the transaction's policy snapshot + trust config (Epic B5). Pure wiring:
  * the snapshot/trust/acting-principal come from tx CFC state; `boundary` is
@@ -5254,24 +5355,13 @@ const verifySinkRequestCeilings = (
     // so the egress gate and the observation fits-test cannot drift.
     const offending = atomsOutsideCeiling(effective, ceiling);
     if (offending.length > 0) {
-      // Name the offending atom(s) so an observe-mode diagnostic identifies the
-      // exact (sink, atom) pair that needs a ceiling entry (review on #3993).
-      const offendingAtoms = offending.map(renderCfcAtom);
-      const reason = `sink-request confidentiality exceeds ceiling for ` +
-        `${sink}: ` +
-        offendingAtoms.join(", ");
-      reasons.push(verdict ? verdictReason(reason) : reason);
+      const detail = sinkCeilingRefusal(sink, offending, consumed.sources);
+      reasons.push(verdict ? verdictReason(detail.reason) : detail.reason);
       // The remedy channel (cfc/refusal-detail.ts): which reads carried the
       // clauses this ceiling refused. Recorded for every mode — an observe-mode
       // rollout wants the same answer a refusal does, and the commit boundary
       // keeps only the details whose reason actually refused.
-      tx.recordCfcRefusalDetail?.({
-        gate: "sink-ceiling",
-        sink,
-        offendingAtoms,
-        ...describeRefusalInputs(offending, consumed.sources),
-        reason,
-      });
+      tx.recordCfcRefusalDetail?.(detail);
     }
   }
   return reasons;
@@ -5582,20 +5672,16 @@ export const prepareBoundaryCommit = (
   const flowMode = state.flowLabelsMode;
   const flowPersist = flowMode === "persist";
   // Inv-12 Stage 1 (SC-25): the cross-space label-metadata representation
-  // dial. When active (observe/enforce), the flow join additionally collects
-  // which spaces contributed label content, so the per-target predicate
-  // below can tell a same-space join from one that consumed foreign labels.
-  // `off` pays nothing — no space collection, no eligibility tracking.
+  // dial. The flow join collects which spaces contributed label content, so
+  // the per-target predicates below can tell a same-space join from one that
+  // consumed foreign labels: the label-metadata protection dial reads it for
+  // its cross-space eligibility, and the writer-fit measurement reads it to
+  // decide whether a computed target's exemption applies.
   const labelProtectionMode = state.labelMetadataProtectionMode;
   const flowTargets = flowMode === "off" ? undefined : valueWriteTargets(tx);
   const flowJoin = flowMode === "off"
     ? { confidentiality: [], integrity: [] }
-    : deriveFlowJoin(
-      tx,
-      labelProtectionMode !== "off"
-        ? { collectLabeledSpaces: true }
-        : undefined,
-    );
+    : deriveFlowJoin(tx, { collectLabeledSpaces: true });
   const flowConfidentiality = flowJoin.confidentiality;
   // Read provenance for a refusal's remedy channel, computed only if a gate
   // below actually refuses. `collectConsumedLabel` walks every read against
@@ -5790,6 +5876,12 @@ export const prepareBoundaryCommit = (
       : undefined;
     const flowJoinIsCrossSpace = flowLabeledSpaces !== undefined &&
       [...flowLabeledSpaces].some((labeled) => labeled !== space);
+    // Every document that contributed a clause to the join belongs to this
+    // target's own space. An unknown provenance is not local: the spaces are
+    // collected on every prepare that derives a join, so their absence means
+    // there was no join to collect them from.
+    const flowJoinIsLocal = flowLabeledSpaces !== undefined &&
+      !flowJoinIsCrossSpace;
     const markFlowStampEntry = (entry: LabelMapEntry): LabelMapEntry => {
       if (flowJoinIsCrossSpace) crossSpaceEligible?.add(entry);
       return entry;
@@ -6663,10 +6755,10 @@ export const prepareBoundaryCommit = (
           structureStampPaths.push(structureContainerPath);
         }
       }
-      // Writer-fit measures the paths a schema could have declared a policy
-      // at, and the raw meta seam is not one: no value schema describes the
-      // document-root siblings of `value`. The measurement is skipped there
-      // at every rung, so a meta path raises neither a strict reject nor a
+      // Writer-fit measures the surfaces a schema could have declared a
+      // policy at, which leaves out the raw meta seam and computed cells
+      // alike (`isDeclarablePolicyPath`). The measurement is skipped on both
+      // at every rung, so neither raises a strict reject nor a
       // persist-and-flag diagnostic.
       //
       // A ceiling can still resolve at a meta path, from a document-root
@@ -6674,7 +6766,7 @@ export const prepareBoundaryCommit = (
       // that entry sits at logical `[]`, the PAYLOAD root, and reaches the
       // seam only because canonicalization strips a leading `"value"`.
       //
-      // Meta paths stay flow stamp targets in the loop below, so the join
+      // Exempt paths stay flow stamp targets in the loop below, so the join
       // still lands on them as the `derived` component. Where a payload
       // field carries a `MetaField` name the two share one logical path, so
       // an exempt meta write can raise the stored derived label there past
@@ -6682,7 +6774,12 @@ export const prepareBoundaryCommit = (
       // entry untouched and reads protected.
       if (flowConfidentiality.length > 0) {
         const measuredPaths = derivedStampPaths.filter((path) =>
-          !isMetaSeamPath(flowTarget?.metaOnlyByPath, path)
+          isDeclarablePolicyPath(
+            id,
+            flowJoinIsLocal,
+            flowTarget?.metaOnlyByPath,
+            path,
+          )
         );
         for (const path of measuredPaths) {
           // Deeper paths are covered by the write at a measured ancestor;

--- a/packages/runner/test/builtin-abandoned-request.test.ts
+++ b/packages/runner/test/builtin-abandoned-request.test.ts
@@ -8,10 +8,23 @@
  * property is the same everywhere: the result cells the pattern reads are
  * announced and say the request will not be answered, rather than staying as
  * they were with nothing coming.
+ *
+ * The last block is the control the rest of the file rests on: the same
+ * builtins over an input the result store admits, where the staging
+ * transaction commits and the request is sent. Without it the cases above
+ * would hold of a builtin that never sends anything at all.
  */
 
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import {
+  addMockObjectResponse,
+  addMockResponse,
+  clearMockResponses,
+  enableMockMode,
+  resetMockMode,
+} from "@commonfabric/llm/client";
 
 import type { BuiltInLLMMessage, JSONSchema } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
@@ -136,6 +149,59 @@ describe("a builtin whose staged request is abandoned", () => {
     const resultCell = runtime.getCell(
       space,
       "generateObject-direct-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("reports the refusal on generateObject's error cell with tools", async () => {
+    // The tools path stages its own request, separately from the direct one
+    // the case above reaches, and settles through its own ending.
+    const { pattern, generateObject, Cell: BuilderCell } = commonfabric;
+    const dummyPattern = pattern<Record<string, never>, { ok: boolean }>(
+      () => ({
+        ok: true,
+      }),
+    );
+    const testPattern = pattern<Record<string, never>>(() => {
+      const messages = BuilderCell.of([{
+        role: "user",
+        content: "a briefing the result store does not declare",
+      }], {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      return generateObject({
+        messages,
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+        tools: {
+          dummy: {
+            description: "a tool, so the request takes the tool-calling path",
+            pattern: dummyPattern,
+          },
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "generateObject-tools-abandoned",
       testPattern.resultSchema,
       tx,
     );
@@ -385,5 +451,136 @@ describe("a builtin whose staged request is abandoned", () => {
     // rode the abandoned transaction, so the ending has no turn to answer and
     // writes no assistant message.
     expect(result.withTx().key("messages").get()).toEqual([]);
+  });
+  describe("and the same builtins when the transaction commits", () => {
+    // An unlabelled input leaves the result store's ceiling nothing to
+    // refuse, so the staging transaction commits and the work starts. The
+    // mock client answers in place of a model.
+
+    beforeEach(() => {
+      enableMockMode();
+      clearMockResponses();
+    });
+
+    afterEach(() => {
+      resetMockMode();
+    });
+
+    it("sends llm's request and lands its result", async () => {
+      const { pattern, llm, Cell: BuilderCell } = commonfabric;
+      addMockResponse(() => true, {
+        role: "assistant",
+        content: "an answer",
+        id: "abandoned-control-llm",
+      });
+      const testPattern = pattern<Record<string, never>>(() => {
+        const messages = BuilderCell.of([{
+          role: "user",
+          content: "a briefing nothing labels",
+        }], {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        });
+        // deno-lint-ignore no-explicit-any
+        return llm({ messages } as any);
+      });
+      const resultCell = runtime.getCell(
+        space,
+        "llm-sent",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+
+      const settled = await waitForCellValue<{ pending?: boolean }>(
+        runtime,
+        result,
+        (value) => value?.pending === false,
+      );
+      await runtime.settled();
+
+      expect(settled.pending).toBe(false);
+      expect(result.withTx().key("error").get()).toBeUndefined();
+    });
+
+    it("sends generateObject's request and lands its result", async () => {
+      const { pattern, generateObject, Cell: BuilderCell } = commonfabric;
+      addMockObjectResponse(() => true, {
+        object: { ok: true },
+        id: "abandoned-control-generate-object",
+      });
+      const testPattern = pattern<Record<string, never>>(() => {
+        const messages = BuilderCell.of([{
+          role: "user",
+          content: "a briefing nothing labels",
+        }], {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        });
+        return generateObject({
+          messages,
+          schema: {
+            type: "object",
+            properties: { ok: { type: "boolean" } },
+            required: ["ok"],
+            additionalProperties: false,
+          },
+          // deno-lint-ignore no-explicit-any
+        } as any);
+      });
+      const resultCell = runtime.getCell(
+        space,
+        "generateObject-sent",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+
+      const settled = await waitForCellValue<{ pending?: boolean }>(
+        runtime,
+        result,
+        (value) => value?.pending === false,
+      );
+      await runtime.settled();
+
+      expect(settled.pending).toBe(false);
+      expect(result.withTx().key("error").get()).toBeUndefined();
+    });
+
+    it("sends generateText's request and lands its result", async () => {
+      const { pattern, generateText } = commonfabric;
+      addMockResponse(() => true, {
+        role: "assistant",
+        content: "an answer",
+        id: "abandoned-control-generate-text",
+      });
+      const testPattern = pattern<Record<string, never>>(() =>
+        // deno-lint-ignore no-explicit-any
+        generateText({ prompt: "a briefing nothing labels" } as any)
+      );
+      const resultCell = runtime.getCell(
+        space,
+        "generateText-sent",
+        testPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+
+      const settled = await waitForCellValue<{ pending?: boolean }>(
+        runtime,
+        result,
+        (value) => value?.pending === false,
+      );
+      await runtime.settled();
+
+      expect(settled.pending).toBe(false);
+      expect(result.withTx().key("error").get()).toBeUndefined();
+    });
   });
 });

--- a/packages/runner/test/cfc-computed-cell-derivation.test.ts
+++ b/packages/runner/test/cfc-computed-cell-derivation.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { Identity } from "@commonfabric/identity";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-computed-derivation");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: string[]; integrity?: unknown[] };
+  origin?: string;
+};
+
+//
+// Reactive derivation over labeled data at the strict posture
+//
+// A derivation's result lands in a computed cell: a document the runtime
+// materializes under `computed:fid1:<hash>`, which no author declares a store
+// policy on. The §8.12.4 writer-fit quantifies over the surfaces a schema
+// could have declared a policy at, and that id class is not one of them, so
+// the measurement skips it and a derivation over labeled data commits at
+// every rung.
+//
+// What follows the value is the label. The cases below are what a derivation
+// has to satisfy together: it runs, it runs again when its input changes, and
+// the value it produced carries the taint it came from. A derived value that
+// landed unlabeled would have escaped its label, which is worse than a
+// refusal, so the last case reads the stamp off the computed document the
+// result links to rather than reading the value back. The second is where a
+// recompute is covered: it writes a computed document the first write left
+// CFC metadata on, which is a different question from the first write's.
+//
+// `cfc-writer-fit.test.ts` holds the measurement's own cases, including the
+// control that an ordinary document takes the same join and still misfits.
+// The egress this exemption leaves to another gate is the host's: a tool
+// answering a model measures what it is about to release, in
+// `packages/cf-harness/src/tools/run-pattern.ts`.
+//
+
+describe("CFC derivation into a computed cell", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const seedLabeledDoc = async (
+    rt: Runtime,
+    cause: string,
+    value: FabricValue,
+    atom: string,
+  ): Promise<string> => {
+    const seed = rt.edit();
+    const cell = rt.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    writeSeedEnvelopeDoc(seed, space);
+    seed.writeOrThrow({
+      space,
+      scope: "space",
+      id,
+      path: [],
+    }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+        labelMap: {
+          version: 1,
+          entries: [{ path: [], label: { confidentiality: [atom] } }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (id: string): StoredEntry[] => {
+    const replica = storageManager!.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  /**
+   * The document id a result field's link points at, read through the
+   * link-sigil accessors so the case does not depend on which cell
+   * representation is in force.
+   */
+  const linkTargetId = (result: unknown, field: string): string => {
+    const raw = (result as { getRaw(): Record<string, unknown> }).getRaw();
+    const link = raw[field];
+    if (!isLinkRef(link)) {
+      throw new Error(`result field ${field} does not hold a link`);
+    }
+    return (linkRefPayload(link) as { id: string }).id;
+  };
+
+  const derivedConfidentiality = (id: string): string[] =>
+    entriesOf(id)
+      .filter((e) => e.origin === "derived")
+      .flatMap((e) => e.label.confidentiality ?? []);
+
+  const strictRuntime = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
+    });
+    return runtime;
+  };
+
+  /** Every CFC refusal the scheduler reports while a derivation runs. */
+  const collectRefusals = (rt: Runtime): string[] => {
+    const refusals: string[] = [];
+    rt.scheduler.onError((error: Error) => {
+      if (error.message.includes("CFC enforcement rejected commit")) {
+        refusals.push(error.message);
+      }
+    });
+    return refusals;
+  };
+
+  it("commits a lift that reads a labeled document", async () => {
+    // The smallest reactive derivation there is: one lift, one labeled input,
+    // one derived output. Nothing here is unusual — no cross-space link, no
+    // policy record, no declassification — so a posture that refused this
+    // would refuse ordinary reactive computation over labeled data.
+    const rt = strictRuntime();
+    await seedLabeledDoc(rt, "derivation-input", { n: 21 }, "alice-secret");
+    const refusals = collectRefusals(rt);
+
+    const { commonfabric } = createTrustedBuilder(rt);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    const double = lift((value: { n: number }) => ({ doubled: value.n * 2 }));
+
+    const tx = rt.edit();
+    const input = rt.getCell(space, "derivation-input", undefined, tx);
+    const resultCell = rt.getCell(space, "derivation-result", undefined, tx);
+    const doubling = pattern<{ value: unknown }>(({ value }) => ({
+      out: double(value),
+    }));
+    const result = rt.run(tx, doubling, { value: input }, resultCell);
+
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await result.pull();
+    await rt.idle();
+
+    // A computed cell is not a surface a schema could declare a policy at,
+    // so the derivation's own transaction has nothing measured against it.
+    expect(refusals).toEqual([]);
+    expect(
+      (result.get() as { out?: { doubled?: number } }).out?.doubled,
+    ).toBe(42);
+  });
+
+  it("commits the same lift again when its input changes", async () => {
+    // The first derivation leaves a stamp on the computed document, so the
+    // second one writes a document that already carries CFC metadata. That is
+    // a different gate's question from the first write's, and a derivation
+    // that ran once has to keep running.
+    const rt = strictRuntime();
+    await seedLabeledDoc(rt, "recompute-input", { n: 21 }, "alice-secret");
+    const refusals = collectRefusals(rt);
+
+    const { commonfabric } = createTrustedBuilder(rt);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    const double = lift((value: { n: number }) => ({ doubled: value.n * 2 }));
+
+    const tx = rt.edit();
+    const input = rt.getCell(space, "recompute-input", undefined, tx);
+    const resultCell = rt.getCell(space, "recompute-result", undefined, tx);
+    const doubling = pattern<{ value: unknown }>(({ value }) => ({
+      out: double(value),
+    }));
+    const result = rt.run(tx, doubling, { value: input }, resultCell);
+
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await result.pull();
+    await rt.idle();
+    expect((result.get() as { out?: { doubled?: number } }).out?.doubled)
+      .toBe(42);
+
+    const update = rt.edit();
+    input.withTx(update).set({ n: 50 });
+    rt.prepareTxForCommit(update);
+    expect((await update.commit()).error).toBeUndefined();
+    await result.pull();
+    await rt.idle();
+
+    expect(refusals).toEqual([]);
+    expect((result.get() as { out?: { doubled?: number } }).out?.doubled)
+      .toBe(100);
+    expect(derivedConfidentiality(linkTargetId(result, "out")))
+      .toContain("alice-secret");
+  });
+
+  it("carries the input's taint onto the value it derived", async () => {
+    // The exemption is only sound while the taint survives it, so this is
+    // checked by what the derived document ends up carrying rather than by
+    // the derivation running. A derived value that lands unlabeled has
+    // escaped the label.
+    const rt = strictRuntime();
+    await seedLabeledDoc(rt, "taint-input", { n: 3 }, "bob-secret");
+    const refusals = collectRefusals(rt);
+
+    const { commonfabric } = createTrustedBuilder(rt);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    const describeIt = lift((value: { n: number }) => ({
+      text: `n is ${value.n}`,
+    }));
+
+    const tx = rt.edit();
+    const input = rt.getCell(space, "taint-input", undefined, tx);
+    const resultCell = rt.getCell(space, "taint-result", undefined, tx);
+    const describing = pattern<{ value: unknown }>(({ value }) => ({
+      out: describeIt(value),
+    }));
+    const result = rt.run(tx, describing, { value: input }, resultCell);
+
+    rt.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await result.pull();
+    await rt.idle();
+
+    expect(refusals).toEqual([]);
+    expect((result.get() as { out?: { text?: string } }).out?.text)
+      .toBe("n is 3");
+
+    // The result document holds a link; the derived value itself lives in the
+    // computed document that link names.
+    const computedId = linkTargetId(result, "out");
+    expect(computedId.startsWith("computed:")).toBe(true);
+    expect(derivedConfidentiality(computedId)).toContain("bob-secret");
+  });
+});

--- a/packages/runner/test/cfc-sink-release.test.ts
+++ b/packages/runner/test/cfc-sink-release.test.ts
@@ -1,0 +1,188 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { describeSinkReleaseRefusal } from "../src/cfc/prepare.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-sink-release");
+const space = signer.did();
+
+//
+// The release measurement
+//
+// The commit boundary answers what a ceiling refuses for the sink requests a
+// transaction records. A host releasing a value of its own — a tool answering
+// a model with what a piece computed — records no request and commits
+// nothing, so it reads what it is about to release through a transaction and
+// asks the same question of that transaction's consumed join.
+//
+
+describe("describeSinkReleaseRefusal", () => {
+  const newRuntime = (
+    storageManager: ReturnType<typeof StorageManager.emulate>,
+  ) =>
+    new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
+    });
+
+  /** A document carrying `atom` on its `secret` field. */
+  const seedLabeled = async (runtime: Runtime, cause: string, atom: string) => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell(
+      space,
+      cause,
+      { type: "object", properties: { secret: { type: "string" } } },
+      seed,
+    );
+    const id = cell.getAsNormalizedFullLink().id;
+    writeSeedEnvelopeDoc(seed, space);
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value: { secret: "s3cr3t" },
+      cfc: {
+        version: 1,
+        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+        labelMap: {
+          version: 1,
+          entries: [{ path: ["secret"], label: { confidentiality: [atom] } }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return { id, path: [] as string[], space, scope: "space" as const };
+  };
+
+  it("refuses nothing for a transaction that read no labeled document", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const seed = runtime.edit();
+      const plain = runtime.getCell(space, "release-plain", undefined, seed);
+      plain.set({ note: "public" });
+      expect((await seed.commit()).error).toBeUndefined();
+
+      const tx = runtime.edit();
+      const cell = runtime.getCellFromLink(
+        plain.getAsNormalizedFullLink(),
+      ).withTx(tx);
+      await cell.pull();
+      JSON.stringify(cell.get());
+      expect(describeSinkReleaseRefusal(tx, tx, "answer", [])).toBeUndefined();
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("names the clause a walked read carried, and the read that carried it", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const link = await seedLabeled(runtime, "release-walked", "alice-secret");
+      const tx = runtime.edit();
+      const cell = runtime.getCellFromLink(link).withTx(tx);
+      await cell.pull();
+      JSON.stringify(cell.get());
+
+      const refusal = describeSinkReleaseRefusal(tx, tx, "answer", []);
+      expect(refusal?.gate).toBe("sink-ceiling");
+      expect(refusal?.sink).toBe("answer");
+      expect(refusal?.offendingAtoms).toEqual(['"alice-secret"']);
+      expect(refusal?.attribution).toBe("complete");
+      expect(refusal?.inputs.map((input) => input.read.id)).toContain(link.id);
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("refuses nothing for a read that stopped above the labeled field", async () => {
+    // A label on a field is consumed where that field is read: a read of the
+    // document root is recorded as non-recursive, and counts entries at or
+    // above it only. A caller measuring a release therefore has to walk the
+    // value it is about to hand over, not merely resolve it.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const link = await seedLabeled(runtime, "release-unwalked", "bob-secret");
+      const tx = runtime.edit();
+      const cell = runtime.getCellFromLink(link).withTx(tx);
+      await cell.pull();
+      cell.get();
+      expect(describeSinkReleaseRefusal(tx, tx, "answer", [])).toBeUndefined();
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("reports a clause no attribution read carried as unattributed", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const released = await seedLabeled(
+        runtime,
+        "release-released",
+        "carol-secret",
+      );
+      const attributed = await seedLabeled(
+        runtime,
+        "release-attributed",
+        "dave-secret",
+      );
+      const releasedTx = runtime.edit();
+      const releasedCell = runtime.getCellFromLink(released).withTx(releasedTx);
+      await releasedCell.pull();
+      JSON.stringify(releasedCell.get());
+
+      const attributedTx = runtime.edit();
+      const attributedCell = runtime.getCellFromLink(attributed)
+        .withTx(attributedTx);
+      await attributedCell.pull();
+      JSON.stringify(attributedCell.get());
+
+      const refusal = describeSinkReleaseRefusal(
+        releasedTx,
+        attributedTx,
+        "answer",
+        [],
+      );
+      expect(refusal?.offendingAtoms).toEqual(['"carol-secret"']);
+      expect(refusal?.inputs).toEqual([]);
+      expect(refusal?.attribution).toBe("none");
+      releasedTx.abort();
+      attributedTx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("admits a clause the ceiling names", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      const link = await seedLabeled(runtime, "release-admitted", "erin-ok");
+      const tx = runtime.edit();
+      const cell = runtime.getCellFromLink(link).withTx(tx);
+      await cell.pull();
+      JSON.stringify(cell.get());
+      expect(describeSinkReleaseRefusal(tx, tx, "answer", ["erin-ok"]))
+        .toBeUndefined();
+      tx.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -56,6 +56,21 @@ const newRuntime = (
     cfcFlowLabels: "persist",
   });
 
+/**
+ * A runtime at the strictness where a writer-fit misfit rejects. The blocks
+ * below pin it rather than inheriting the file's `enforce-explicit` default,
+ * because that is where the exemptions they cover are observable.
+ */
+const strictRuntime = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+) =>
+  new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcEnforcementMode: "enforce-strict",
+    cfcFlowLabels: "persist",
+  });
+
 // The space principal of the space every doc in this file lives in — the
 // clause residency admits (§8.12.4).
 const ownSpacePrincipal = {
@@ -723,6 +738,244 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
     });
   });
 
+  describe("computed-cell exemption", () => {
+    // The measurement quantifies over surfaces a schema could have declared a
+    // policy at, and a computed cell is not one. It is the derived internal
+    // cell the runtime materializes to hold a derivation's result, under its
+    // own URI scheme (`computed:fid1:<hash>`; see `entity-kind.ts` and
+    // `docs/specs/computed-cell-identity.md`). A pattern names the data it
+    // declares policy on, and it does not name the intermediates the reactive
+    // graph materializes for it, so measuring them refuses every derivation
+    // that reads labeled data and writes its result.
+    //
+    // The exemption decides which store a value may land in, not whether it
+    // stays labeled: the join still lands on the computed document as its
+    // `derived` component, which is what the cases below pin alongside it.
+
+    /**
+     * The `computed:` id over the same hash as the `of:` id `cause` mints. The
+     * two name different entities, so a case can write the same join to both
+     * and hold everything but the scheme fixed.
+     */
+    const computedIdFor = (
+      runtime: Runtime,
+      cause: string,
+    ): `${string}:${string}` => {
+      const plain = runtime.getCell(signer.did(), cause)
+        .getAsNormalizedFullLink().id;
+      return `computed:${plain.slice("of:".length)}`;
+    };
+
+    it("admits a tainted write into a computed document", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-computed-source");
+        const computedId = computedIdFor(runtime, "wf-computed-target");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-computed-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: computedId,
+          path: ["value", "copied"],
+        }, `${raw.secret}!`);
+        tx.prepareCfc();
+
+        expect((await tx.commit()).error).toBeUndefined();
+
+        // The value landed, and it landed carrying what it derived from.
+        expect(
+          (storedDocument(storageManager, computedId)?.value as {
+            copied?: string;
+          })?.copied,
+        ).toBe("s3cr3t!");
+        expect(
+          replicaEntries(storageManager, computedId)
+            .filter((entry) => entry.origin === "derived")
+            .flatMap((entry) => entry.label.confidentiality ?? []),
+        ).toContain("secret");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("still rejects the same join written into the state cell beside it", async () => {
+      // The control: the exemption is about the surface, not about this
+      // transaction's join. The source and the target cause are the ones the
+      // case above used, so the target here is the `of:` id over the very
+      // hash that case wrote through `computed:` — a different entity,
+      // differing from it in its URI scheme alone — and the misfit is back.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-computed-source");
+        const plainId = runtime
+          .getCell(signer.did(), "wf-computed-target")
+          .getAsNormalizedFullLink().id;
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-computed-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: plainId,
+          path: ["value", "copied"],
+        }, `${raw.secret}!`);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${plainId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps measuring a computed target whose join came from another space", async () => {
+      // The exemption is scoped to a join this target's own space produced.
+      // A clause that reached the join from a document in another space is
+      // measured wherever it lands, so a derivation cannot carry a foreign
+      // space's labeled value into a local document by materializing it.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      const foreign = (await Identity.fromPassphrase("wf-computed-foreign"))
+        .did();
+      try {
+        const seed = runtime.edit();
+        const foreignCell = runtime.getCell(
+          foreign,
+          "wf-computed-foreign-source",
+          { type: "object", properties: { secret: { type: "string" } } },
+          seed,
+        );
+        const foreignId = foreignCell.getAsNormalizedFullLink().id;
+        writeSeedEnvelopeDoc(seed, foreign);
+        seed.writeOrThrow({
+          space: foreign,
+          scope: "space",
+          id: foreignId,
+          path: [],
+        }, {
+          value: { secret: "s3cr3t" },
+          cfc: {
+            version: 1,
+            schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: ["secret"],
+                label: { confidentiality: ["secret"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const computedId = computedIdFor(runtime, "wf-computed-foreign-target");
+        const tx = runtime.edit();
+        const source = runtime.getCellFromLink(
+          { id: foreignId, path: [], space: foreign, scope: "space" },
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: computedId,
+          path: ["value", "copied"],
+        }, `${raw.secret}!`);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${computedId} at /`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("carries the admitted taint into a later transaction that reads it back", async () => {
+      // What the exemption rests on: the stamp the admitted write left is a
+      // read floor like any other, so the value cannot be laundered by
+      // routing it through a computed document. A second transaction reads it
+      // back and writes it into an ordinary undeclared store, and that write
+      // misfits on the clause the first transaction's source carried.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-computed-launder-source");
+        const computedId = computedIdFor(runtime, "wf-computed-launder-target");
+
+        const first = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-computed-launder-source",
+          undefined,
+          first,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        first.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: computedId,
+          path: ["value", "copied"],
+        }, `${raw.secret}!`);
+        first.prepareCfc();
+        expect((await first.commit()).error).toBeUndefined();
+
+        const second = runtime.edit();
+        const derived = runtime.getCellFromLink(
+          { id: computedId, path: [], space: signer.did(), scope: "space" },
+          undefined,
+          second,
+        );
+        const carried = (derived.getRaw() as { copied?: string }).copied;
+        expect(carried).toBe("s3cr3t!");
+        const plainId = runtime.getCell(signer.did(), "wf-computed-launder-out")
+          .getAsNormalizedFullLink().id;
+        second.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: plainId,
+          path: ["value", "copied"],
+        }, carried as string);
+        second.prepareCfc();
+
+        const result = await second.commit();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain('"secret"');
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
   describe("meta-seam exemption", () => {
     // The measurement quantifies over paths a schema could have declared a
     // policy at, and the raw meta seam is not one: `setMetaRaw` lands on a
@@ -738,18 +991,6 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
     //
     // The seam is outside the check at every rung, so these cases assert on
     // both the strict reject and the persist-and-flag diagnostic below it.
-
-    // Pinned rather than inherited: this exemption is only observable at the
-    // strictness where the misfit rejects.
-    const strictRuntime = (
-      storageManager: ReturnType<typeof StorageManager.emulate>,
-    ) =>
-      new Runtime({
-        apiUrl: new URL("https://example.com"),
-        storageManager,
-        cfcEnforcementMode: "enforce-strict",
-        cfcFlowLabels: "persist",
-      });
 
     /** Seed `cause` as a plain document declaring no store policy. */
     const seedUndeclaredTarget = async (


### PR DESCRIPTION
Under `enforce-strict` the §8.12.4 writer-fit measures a transaction's flow join against the target document's declared store policy, and reads an absent declaration as the empty "public" ceiling. A derivation's result lands in a computed cell, a document the runtime materializes under `computed:fid1:<hash>` to hold what a derivation computed, and no author declares a policy on one. Every derivation that read labeled data and wrote its result was therefore refused:

    writer-fit confidentiality misfit for computed:fid1:… at /doubled
    (canWrite, §8.12.4): "alice-secret"

That is ordinary reactive computation, so the refusal reached product flows rather than tests alone. It also arrived where a caller would not look for it: setup commits, the derivation runs afterwards in a transaction of its own, and that one is refused, so a reader saw a hole where the computation should be rather than an error.

The measurement quantifies over the surfaces a schema could have declared a policy at, and a computed cell is not one: a pattern names the data it declares policy on, and it does not name the intermediates the reactive graph materializes for it. The raw meta seam is already outside the check for the same reason, so both now go through one predicate, `isDeclarablePolicyPath`. The join still lands on the computed document as its `derived` component, so what the skip decides is which store a value may land in, not whether it stays labeled.

The skip is scoped to a join the target's own space produced. Skipping the measurement skips the residency clause with it, and residency is what refuses a value whose audience is another space. The join already records which space each contributing document lived in, so a computed target whose join drew a clause from elsewhere is measured like any other document. Within one space the source and the computed cell share a replica set, so the value reaches no reader it had reached already; across spaces it would, and that is the case the guard keeps. The flow join collects those spaces on every prepare now, rather than only under the label-metadata protection dial that first asked for them.

The refusal was also doing an egress gate's work by accident. The `run_pattern` tool answers a model with what a piece computed, and it had no gate of its own — it reported a policy refusal when the result came back empty, which it did because the derivation had been refused. Measured: with the exemption alone, that tool answers with the value a pattern derived from a labeled input.

So the gate moves to where the release happens. Once the run has an answer to return, the tool reads the result through a transaction and fits that transaction's consumed join to the ceiling its own answer carries, which is the empty one — a model's context is outside every space, so no confidentiality clause names an audience it belongs to. `describeSinkReleaseRefusal` is that measurement. It shares `atomsOutsideCeiling` and the refusal-detail construction with the sink gate the commit boundary runs, both now through `sinkCeilingRefusal`, so a clause outside a ceiling on one route is outside it on the other. The two do not measure the same join: the host route measures what releasing the answer resolved, and applies no exchange-rule rewriting, so it refuses a clause a policy evaluation would have discharged. The ladder governs it like any other gate, so at `disabled` and `observe` it measures nothing.

Each read is walked rather than taken. A transaction consumes a label where the labeled path is read: resolving a value reads the links it holds, so a label at or above a link the answer follows is consumed, while a label on a FIELD of a document the answer merely resolves is not. The walk is `asSerializableValue`, which is what the tool does to the answer a few lines later, so the measurement and the value measured are one traversal.

A refusal still names the input to drop. It takes two transactions: one holding what the answer resolved, which is what the ceiling measures, and one holding what the caller can act on — the piece's argument document, where every input sits under its own key, and the document each input's own link addressed. A clause reaching the answer by neither route is reported as unattributed. The caller's documents stay out of the measurement for the dual reason: an input the pattern never read is not in the answer.

What a caller sees changes in two ways. A refusal at the release names the `sink-ceiling` gate against the `run_pattern` sink and says the result is withheld, where a refused commit still says it never landed. And a run whose answer reaches labeled data only through links used to succeed — the pattern-body map over labeled documents, whose element results are links into the labeled sources — because nothing tainted was written; it is refused now, since what the model would read is the labeled text either way.

New cases cover the derivation on the reactive path a pattern actually takes — one lift, one labeled input, one derived output, no cross-space link, policy record, or declassification — and the taint surviving the exemption, which is what makes it sound: the lift stamps the clause onto the computed cell it derived into; the same join written into the state cell beside it, the `of:` id over the same hash, still misfits; a transaction that reads the computed cell back and writes what it read into an ordinary store is refused on the original clause; and a join drawn from another space is measured on a computed target too. `describeSinkReleaseRefusal` gets its own cases: what it refuses and admits, where attribution comes from, and the read-depth property its callers depend on — a read that stops at a document root refuses nothing, and the same read walked refuses the clause on the field below. On the tool: an answer carrying a label is refused and names the input that carried it, the observe posture answers, and a labeled input the pattern never read does not refuse the answer.

Contract text in `docs/specs/cfc-enforcement-matrix.md` §4 and the SC-18b notes in `docs/specs/cfc-spec-changes.md`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

ACCEPT_COVERAGE_DEBT: packages/runner +1 line