### PR TITLE
fix(dashboard): align tile history layouts

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -954,7 +954,7 @@ Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
 - **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the newest `TRUST_RUNS_MAX=160` fetched runs. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
-- **ci-trust cell grid:** `TRUST_COLS=40` sets the column count. The grid has up to `TRUST_RUNS_MAX=160` cells, one for every run in the four-row trust window. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
+- **ci-trust cell grid:** The grid has up to `TRUST_RUNS_MAX=160` square cells. Its responsive columns keep every cell at least 4 px wide and add columns when a tile grows, so the history remains inside the fixed chart height. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development
 

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -954,7 +954,7 @@ Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
 - **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the newest `TRUST_RUNS_MAX=160` fetched runs. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
-- **ci-trust cell grid:** The grid has up to `TRUST_RUNS_MAX=160` square cells. Its responsive columns keep every cell at least 4 px wide and add columns when a tile grows, so the history remains inside the fixed chart height. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
+- **ci-trust cell grid:** The grid has up to `TRUST_RUNS_MAX=160` square cells in rows of `TRUST_COLS=40`. On wide tiles, the squares stop growing and the columns spread out to keep the grid clear of the subheading while preserving its equal left, right, and bottom insets. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development
 

--- a/packages/dashboard/chart-layout.ts
+++ b/packages/dashboard/chart-layout.ts
@@ -6,6 +6,7 @@ export const TILE_BOX_RULE =
   `.tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}`;
 export const BOTTOM_CHART_RULES =
   `.tile.bottom-chart{display:flex;flex-direction:column}
+  a.tile.link.bottom-chart{display:flex}
   .tile.bottom-chart .chart{margin-top:auto}`;
 export const TILE_LABEL_RULE =
   `.lbl{font-size:11px;line-height:15px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin:0 0 7px;display:flex;align-items:center;gap:7px;white-space:nowrap}`;

--- a/packages/dashboard/chart-layout.ts
+++ b/packages/dashboard/chart-layout.ts
@@ -1,5 +1,6 @@
-export const LABELED_CELL_GRID_SHIFT = 2;
 export const LABELED_CELL_GRID_MARGIN_TOP = 9;
+export const CHART_BOTTOM_INSET = 2;
+export const CELL_GRID_MIN_SIZE = 4;
 export const DASHBOARD_GRID_RULE =
   `.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}`;
 export const TILE_BOX_RULE =
@@ -13,14 +14,12 @@ export const TILE_LABEL_RULE =
 
 export function labeledCellGridRule(
   chartHeight: number,
-  labelHeight: number,
 ): string {
-  return `.cells.labeled{margin-top:${LABELED_CELL_GRID_MARGIN_TOP}px;height:${chartHeight}px;box-sizing:border-box;padding-bottom:${labelHeight}px;align-content:start;transform:translateY(-${LABELED_CELL_GRID_SHIFT}px)}`;
+  return `.cells.labeled{margin-top:${LABELED_CELL_GRID_MARGIN_TOP}px;height:${chartHeight}px;align-content:end;align-items:start;transform:translateY(-${CHART_BOTTOM_INSET}px)}`;
 }
 
 export function tileContentRules(
   chartHeight: number,
-  labelHeight: number,
 ): string {
   return `${TILE_LABEL_RULE}
   .lbl .spacer{flex:1}
@@ -35,9 +34,11 @@ export function tileContentRules(
     chartHeight + 9
   }px;overflow-y:auto;overflow-x:hidden;scrollbar-gutter:stable}
   .tile-detail-list>div{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .cells{display:grid;gap:1px;margin-top:10px}
-  ${labeledCellGridRule(chartHeight, labelHeight)}
-  .cells.labeled .cell{aspect-ratio:auto;height:4px}
+  .chart>span:last-child{bottom:${CHART_BOTTOM_INSET}px!important}
+  .cells{display:grid;grid-template-columns:repeat(auto-fill,minmax(${CELL_GRID_MIN_SIZE}px,1fr));gap:1px;margin-top:10px}
+  ${labeledCellGridRule(chartHeight)}
+  .cells.labeled .cell{width:100%}
+  .cells.labeled+span{font-weight:700;text-shadow:-1px -1px 0 var(--surface),1px -1px 0 var(--surface),-1px 1px 0 var(--surface),1px 1px 0 var(--surface),0 0 4px var(--surface);z-index:1}
   .cell{aspect-ratio:1;border-radius:1px}
   .dot{width:10px;height:10px;display:inline-block;flex:none;position:relative}
   .dot::before{content:"";position:absolute;inset:0}

--- a/packages/dashboard/chart-layout.ts
+++ b/packages/dashboard/chart-layout.ts
@@ -1,6 +1,9 @@
+import { TRUST_COLS } from "./ci-trust-layout.ts";
+
 export const LABELED_CELL_GRID_MARGIN_TOP = 9;
 export const CHART_BOTTOM_INSET = 2;
-export const CELL_GRID_MIN_SIZE = 4;
+const CELL_GRID_GAP = 1;
+const CELL_GRID_MAX_SIZE = 7.5;
 export const DASHBOARD_GRID_RULE =
   `.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}`;
 export const TILE_BOX_RULE =
@@ -35,7 +38,9 @@ export function tileContentRules(
   }px;overflow-y:auto;overflow-x:hidden;scrollbar-gutter:stable}
   .tile-detail-list>div{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .chart>span:last-child{bottom:${CHART_BOTTOM_INSET}px!important}
-  .cells{display:grid;grid-template-columns:repeat(auto-fill,minmax(${CELL_GRID_MIN_SIZE}px,1fr));gap:1px;margin-top:10px}
+  .cells{display:grid;grid-template-columns:repeat(${TRUST_COLS},min(${CELL_GRID_MAX_SIZE}px,calc((100% - ${
+    (TRUST_COLS - 1) * CELL_GRID_GAP
+  }px)/${TRUST_COLS})));column-gap:${CELL_GRID_GAP}px;row-gap:${CELL_GRID_GAP}px;justify-content:space-between;margin-top:10px}
   ${labeledCellGridRule(chartHeight)}
   .cells.labeled .cell{width:100%}
   .cells.labeled+span{font-weight:700;text-shadow:-1px -1px 0 var(--surface),1px -1px 0 var(--surface),-1px 1px 0 var(--surface),1px 1px 0 var(--surface),0 0 4px var(--surface);z-index:1}

--- a/packages/dashboard/chart-layout.ts
+++ b/packages/dashboard/chart-layout.ts
@@ -1,0 +1,45 @@
+export const LABELED_CELL_GRID_SHIFT = 2;
+export const LABELED_CELL_GRID_MARGIN_TOP = 9;
+export const DASHBOARD_GRID_RULE =
+  `.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}`;
+export const TILE_BOX_RULE =
+  `.tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}`;
+export const BOTTOM_CHART_RULES =
+  `.tile.bottom-chart{display:flex;flex-direction:column}
+  .tile.bottom-chart .chart{margin-top:auto}`;
+export const TILE_LABEL_RULE =
+  `.lbl{font-size:11px;line-height:15px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin:0 0 7px;display:flex;align-items:center;gap:7px;white-space:nowrap}`;
+
+export function labeledCellGridRule(
+  chartHeight: number,
+  labelHeight: number,
+): string {
+  return `.cells.labeled{margin-top:${LABELED_CELL_GRID_MARGIN_TOP}px;height:${chartHeight}px;box-sizing:border-box;padding-bottom:${labelHeight}px;align-content:start;transform:translateY(-${LABELED_CELL_GRID_SHIFT}px)}`;
+}
+
+export function tileContentRules(
+  chartHeight: number,
+  labelHeight: number,
+): string {
+  return `${TILE_LABEL_RULE}
+  .lbl .spacer{flex:1}
+  .drill{min-width:0;overflow:hidden;text-overflow:ellipsis;font-size:10px;color:var(--text-muted);letter-spacing:0;text-transform:none}
+  .hmtd{min-width:0;overflow:hidden;text-overflow:ellipsis;font-size:11px;color:var(--text-muted);letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
+  .big{font-size:30px;font-weight:600;margin:0;line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .sub{font-size:13px;color:var(--text-muted);margin:5px 0 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:var(--text-muted);letter-spacing:.02em;text-transform:none;margin-top:10px}
+  .lbl .running{margin-top:0;margin-right:8px}
+  .rdot{width:7px;height:7px;border-radius:50%;background:var(--running);flex:none}
+  .tile-detail-list{max-height:${
+    chartHeight + 9
+  }px;overflow-y:auto;overflow-x:hidden;scrollbar-gutter:stable}
+  .tile-detail-list>div{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .cells{display:grid;gap:1px;margin-top:10px}
+  ${labeledCellGridRule(chartHeight, labelHeight)}
+  .cells.labeled .cell{aspect-ratio:auto;height:4px}
+  .cell{aspect-ratio:1;border-radius:1px}
+  .dot{width:10px;height:10px;display:inline-block;flex:none;position:relative}
+  .dot::before{content:"";position:absolute;inset:0}
+  .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
+  a.tile.link{display:block;text-decoration:none;color:inherit;cursor:pointer;transition:border-color .12s}`;
+}

--- a/packages/dashboard/ci-trust-layout.ts
+++ b/packages/dashboard/ci-trust-layout.ts
@@ -1,0 +1,2 @@
+export const TRUST_COLS = 40;
+export const TRUST_RUNS_MAX = 160;

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -5,6 +5,8 @@
  * threshold is tuned here rather than in the tile that applies it.
  */
 
+export { TRUST_RUNS_MAX } from "./ci-trust-layout.ts";
+
 export const PORT = Number(Deno.env.get("DASHBOARD_PORT") ?? "8731");
 export const REPO = Deno.env.get("DASHBOARD_REPO") ?? "commontoolsinc/labs";
 export const CI_WORKFLOW = "deno.yml";
@@ -27,7 +29,6 @@ export const CI_RUNS_MAX_AGE_DAYS = 60; // ~2 months
 
 // Tile display windows and status thresholds (tune here).
 export const TRUST_GOOD = 90, TRUST_WARN = 75; // first-try-green %
-export const TRUST_RUNS_MAX = 160; // newest runs scored and shown by ci-trust
 export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
 // ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -28,7 +28,6 @@ export const CI_RUNS_MAX_AGE_DAYS = 60; // ~2 months
 // Tile display windows and status thresholds (tune here).
 export const TRUST_GOOD = 90, TRUST_WARN = 75; // first-try-green %
 export const TRUST_RUNS_MAX = 160; // newest runs scored and shown by ci-trust
-export const TRUST_COLS = 40; // columns in the ci-trust cell grid (more = smaller cells)
 export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
 // ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -14,7 +14,7 @@
     // A task line runs the Deno running the task, so asking that Deno for its
     // own path allows exactly the one binary the tests start.
     "test-favicon-raster": "deno test --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") --allow-ffi --allow-sys=cpus,networkInterfaces,hostname favicon-raster.test.ts regenerate-favicons.test.ts",
-    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts dashboard-message-client.browser.test.ts favicon-client.browser.test.ts theme.browser.test.ts",
+    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts dashboard-message-client.browser.test.ts favicon-client.browser.test.ts render.browser.test.ts theme.browser.test.ts",
     "regenerate-favicons": "deno run --allow-read --allow-write=favicon-png.generated.ts --allow-ffi --allow-sys=cpus,networkInterfaces,hostname regenerate-favicons.ts"
   }
 }

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the pure helpers. No network, subprocess, or filesystem.
  */
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { budgetStatus, clampInt, concDot, daysLabel, durationTag, escapeHtml, friendlyError, humanDur, humanSpan, landingHref, lighten, multiSparkline, readBudget, sparkline, strip, thin, usd } from "./lib.ts";
 
 Deno.test("landingHref: squash-merge trailing (#N) -> the PR", () => {
@@ -541,6 +541,10 @@ Deno.test("strip: each cell links to that run's CI results in a new tab", () => 
   assert(html.includes('href="https://github.com/o/r/actions/runs/1"'), "first run link");
   assert(html.includes('href="https://github.com/o/r/actions/runs/2"'), "second run link");
   assert(html.includes('target="_blank"'), "opens in a new tab");
+  assertStringIncludes(
+    strip([{ outcome: "green", href: "" }], 40, true),
+    'class="cells labeled"',
+  );
   assertEquals(strip([], 40), ""); // empty -> nothing
 });
 

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -536,16 +536,16 @@ Deno.test("strip: each cell links to that run's CI results in a new tab", () => 
   const html = strip([
     { outcome: "green", href: "https://github.com/o/r/actions/runs/1" },
     { outcome: "red", href: "https://github.com/o/r/actions/runs/2" },
-  ], 40);
+  ]);
   assertEquals([...html.matchAll(/<a class="cell"/g)].length, 2);
   assert(html.includes('href="https://github.com/o/r/actions/runs/1"'), "first run link");
   assert(html.includes('href="https://github.com/o/r/actions/runs/2"'), "second run link");
   assert(html.includes('target="_blank"'), "opens in a new tab");
   assertStringIncludes(
-    strip([{ outcome: "green", href: "" }], 40, true),
+    strip([{ outcome: "green", href: "" }], true),
     'class="cells labeled"',
   );
-  assertEquals(strip([], 40), ""); // empty -> nothing
+  assertEquals(strip([]), ""); // empty -> nothing
 });
 
 Deno.test("sparkline: no highlight is a single line; a short series is empty", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -8,11 +8,29 @@
 
 import type { Status } from "./types.ts";
 import { PROD_SERVICE } from "./config.ts";
-import { CHART_HIGHLIGHT } from "./theme.ts";
 import {
   type GitHubPrimaryRateLimit,
   performanceGitHubRateLimit,
 } from "./github-rate-limit.ts";
+import {
+  daysLabel,
+  DURATION_LABEL_HEIGHT,
+  durationTag,
+  escapeHtml,
+  humanSpan,
+  SPARKLINE_HEIGHT,
+  STATUS_DOT,
+} from "./tile-render-values.ts";
+
+export {
+  daysLabel,
+  DURATION_LABEL_HEIGHT,
+  durationTag,
+  escapeHtml,
+  humanSpan,
+  SPARKLINE_HEIGHT,
+  STATUS_DOT,
+};
 
 // The service.name to scope a SigNoz query to. The name lands inside a query
 // expression, so anything outside the shape a service name has falls back to the
@@ -481,31 +499,7 @@ export function memo<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
   };
 }
 
-// good/warn/bad/unknown -> the dot color class the renderer uses.
-export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber", bad: "red", unknown: "gray" };
-
-export const escapeHtml = (s: string) =>
-  s.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
-
 export { SPARK_FADE_CSS as SPARK_FADE } from "./palette.ts";
-
-// How a sparkline caption spells a day span, consistently across tiles:
-// "5 days", "1 day", "<1 day".
-export function daysLabel(days: number): string {
-  if (days < 1) return "<1 day";
-  return `${days} day${days === 1 ? "" : "s"}`;
-}
-
-// A time span for sparkline captions: "5 days" (>= 1 day, via daysLabel), else a
-// finer "8 hours", else "30 min".
-export function humanSpan(ms: number): string {
-  if (ms >= 86_400_000) return daysLabel(Math.round(ms / 86_400_000));
-  if (ms >= 3_600_000) {
-    const hr = Math.round(ms / 3_600_000);
-    return `${hr} hour${hr === 1 ? "" : "s"}`;
-  }
-  return `${Math.max(1, Math.round(ms / 60_000))} min`;
-}
 
 export function humanDur(ms: number): string {
   const m = Math.floor(ms / 60000);
@@ -577,17 +571,6 @@ export function lighten(hex: string, amount = 0.6): string {
   const [r, g, b] = [mix((n >> 16) & 255), mix((n >> 8) & 255), mix(n & 255)];
   return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
 }
-
-// The span the line covers, formatted with humanSpan for the bottom-left corner
-// of a chart, absolutely positioned. The renderer draws it for a tile's `duration`
-// slot; standalone chart pages (the bench drill-down) reuse it directly. Its
-// container must be position:relative.
-export function durationTag(ms: number): string {
-  return `<span style="position:absolute;left:1px;bottom:0;font-size:9px;line-height:1;color:${CHART_HIGHLIGHT};pointer-events:none">${escapeHtml(humanSpan(ms))}</span>`;
-}
-
-// All sparkline variants and their duration labels occupy this rendered height.
-const SPARKLINE_HEIGHT = 28;
 
 function scaleValues(
   vals: number[],
@@ -895,7 +878,11 @@ export function thin<T>(arr: T[], max: number): T[] {
 // A grid of small run-outcome cells (one per run, oldest first) laid out in
 // `cols` fixed columns. Each cell links to that run's CI results. Cells shrink
 // to fit width.
-export function strip(cells: { outcome: string; href: string }[], cols: number): string {
+export function strip(
+  cells: { outcome: string; href: string }[],
+  cols: number,
+  labelSpace = false,
+): string {
   if (!cells.length) return "";
   const col = (d: string) =>
     d === "green"
@@ -908,7 +895,8 @@ export function strip(cells: { outcome: string; href: string }[], cols: number):
   const html = cells.map((c) =>
     `<a class="cell" href="${escapeHtml(c.href)}" target="_blank" rel="noopener" style="background:${col(c.outcome)}"></a>`
   ).join("");
-  return `<div class="cells" style="grid-template-columns:repeat(${cols},1fr)">${html}</div>`;
+  const className = labelSpace ? "cells labeled" : "cells";
+  return `<div class="${className}" style="grid-template-columns:repeat(${cols},1fr)">${html}</div>`;
 }
 
 // The PR that landed a commit: squash titles end "(#123)", merge commits start

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -876,11 +876,9 @@ export function thin<T>(arr: T[], max: number): T[] {
 }
 
 // A grid of small run-outcome cells (one per run, oldest first) laid out in
-// `cols` fixed columns. Each cell links to that run's CI results. Cells shrink
-// to fit width.
+// responsive columns. Each cell links to that run's CI results.
 export function strip(
   cells: { outcome: string; href: string }[],
-  cols: number,
   labelSpace = false,
 ): string {
   if (!cells.length) return "";
@@ -896,7 +894,7 @@ export function strip(
     `<a class="cell" href="${escapeHtml(c.href)}" target="_blank" rel="noopener" style="background:${col(c.outcome)}"></a>`
   ).join("");
   const className = labelSpace ? "cells labeled" : "cells";
-  return `<div class="${className}" style="grid-template-columns:repeat(${cols},1fr)">${html}</div>`;
+  return `<div class="${className}">${html}</div>`;
 }
 
 // The PR that landed a commit: squash titles end "(#123)", merge commits start

--- a/packages/dashboard/render.browser.test.ts
+++ b/packages/dashboard/render.browser.test.ts
@@ -165,6 +165,36 @@ Deno.test("every standard tile shares text baselines and fits under benchmarks",
   }
 });
 
+Deno.test("a linked bottom-chart tile keeps its flex layout", async () => {
+  const fixture = document.createElement("div");
+  fixture.innerHTML = `<style>
+    ${TILE_BOX_RULE}
+    ${BOTTOM_CHART_RULES}
+    ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+  </style>${
+    renderTile({
+      label: "linked history",
+      status: "good",
+      value: "42",
+      sub: "representative linked tile",
+      extra: `<div style="height:${SPARKLINE_HEIGHT}px"></div>`,
+      duration: 30 * 86_400_000,
+      href: "/details",
+      alignChartBottom: true,
+    })
+  }`;
+  document.body.append(fixture);
+
+  try {
+    await new Promise(requestAnimationFrame);
+    const tile = fixture.querySelector<HTMLElement>(".tile");
+    assertExists(tile);
+    assertEquals(getComputedStyle(tile).display, "flex");
+  } finally {
+    fixture.remove();
+  }
+});
+
 Deno.test("the trust grid preserves tile text and moves above its duration label", async () => {
   const cells = Array.from(
     { length: 160 },

--- a/packages/dashboard/render.browser.test.ts
+++ b/packages/dashboard/render.browser.test.ts
@@ -143,9 +143,11 @@ function assertStandardTileLayout(
       const grid = tile.querySelector<HTMLElement>(".cells.labeled");
       const firstCell = grid?.querySelector<HTMLElement>(".cell");
       const lastCell = grid?.querySelector<HTMLElement>(".cell:last-child");
+      const trustSub = tile.querySelector<HTMLElement>(".sub");
       assertExists(grid);
       assertExists(firstCell);
       assertExists(lastCell);
+      assertExists(trustSub);
       assertExists(duration);
       const gridRect = grid.getBoundingClientRect();
       const firstCellRect = firstCell.getBoundingClientRect();
@@ -162,12 +164,15 @@ function assertStandardTileLayout(
         `${id} commit grid must align to its bottom edge at ${width}px`,
       );
       assert(
-        firstCellRect.top >= gridRect.top - 0.05,
-        `${id} commit grid must stay inside its top edge at ${width}px`,
+        firstCellRect.top >= trustSub.getBoundingClientRect().bottom,
+        `${id} commit grid must not overlap its subheading at ${width}px: ${
+          pixel(firstCellRect.top)
+        }px vs ${pixel(trustSub.getBoundingClientRect().bottom)}px`,
       );
       const leftInset = gridRect.left - tileRect.left;
+      const rightInset = tileRect.right - gridRect.right;
       assertPixelAligned(
-        tileRect.right - gridRect.right,
+        rightInset,
         leftInset,
         `${id} commit grid must have equal side insets at ${width}px`,
       );
@@ -188,6 +193,30 @@ function assertStandardTileLayout(
         getComputedStyle(duration).textShadow,
         "none",
         `${id} duration must carry a readable grid outline at ${width}px`,
+      );
+      const cells = [...grid.querySelectorAll<HTMLElement>(".cell")];
+      assertEquals(cells.length, 160);
+      const fortiethRect = cells[39].getBoundingClientRect();
+      const fortyFirstRect = cells[40].getBoundingClientRect();
+      assertPixelAligned(
+        firstCellRect.left,
+        gridRect.left,
+        `${id} first cell must reach the grid's left edge at ${width}px`,
+      );
+      assert(
+        Math.abs(fortiethRect.right - gridRect.right) < 0.5,
+        `${id} fortieth cell must reach the grid's right edge at ${width}px: ${
+          pixel(fortiethRect.right)
+        }px vs ${pixel(gridRect.right)}px`,
+      );
+      assertPixelAligned(
+        fortiethRect.top,
+        firstCellRect.top,
+        `${id} first row must contain 40 cells at ${width}px`,
+      );
+      assert(
+        fortyFirstRect.top > firstCellRect.top,
+        `${id} forty-first cell must start the second row at ${width}px`,
       );
     }
     assert(

--- a/packages/dashboard/render.browser.test.ts
+++ b/packages/dashboard/render.browser.test.ts
@@ -1,0 +1,285 @@
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertNotEquals,
+} from "@std/assert";
+import { renderTile } from "./tile-render.ts";
+import {
+  BOTTOM_CHART_RULES,
+  DASHBOARD_GRID_RULE,
+  LABELED_CELL_GRID_SHIFT,
+  labeledCellGridRule,
+  TILE_BOX_RULE,
+  TILE_LABEL_RULE,
+  tileContentRules,
+} from "./chart-layout.ts";
+import {
+  TILE_LAYOUT_FIXTURES,
+  type TileLayoutFixture,
+} from "./tile-layout-fixtures.ts";
+import {
+  DURATION_LABEL_HEIGHT,
+  SPARKLINE_HEIGHT,
+} from "./tile-render-values.ts";
+
+const pixel = (value: number): number => Math.round(value * 1000) / 1000;
+
+function assertStandardTileLayout(
+  root: HTMLElement,
+  standard: readonly TileLayoutFixture[],
+): void {
+  const width = pixel(root.getBoundingClientRect().width);
+  const tiles = new Map(
+    [...root.querySelectorAll<HTMLElement>("[data-tile-id]")].map((tile) => [
+      tile.dataset.tileId!,
+      tile,
+    ]),
+  );
+  assertEquals(tiles.size, standard.length);
+  const benchmark = tiles.get("benchmark");
+  assertExists(benchmark);
+  const benchmarkHeadline = benchmark.querySelector<HTMLElement>(".big");
+  const benchmarkSub = benchmark.querySelector<HTMLElement>(
+    ".benchmark-count",
+  );
+  const benchmarkDuration = benchmark.querySelector<HTMLElement>(
+    ".chart > span:last-child",
+  );
+  assertExists(benchmarkHeadline);
+  assertExists(benchmarkSub);
+  assertExists(benchmarkDuration);
+  const benchmarkRect = benchmark.getBoundingClientRect();
+  const headlineTop = pixel(
+    benchmarkHeadline.getBoundingClientRect().top - benchmarkRect.top,
+  );
+  const subTop = pixel(
+    benchmarkSub.getBoundingClientRect().top - benchmarkRect.top,
+  );
+  const durationTop = pixel(
+    benchmarkDuration.getBoundingClientRect().top - benchmarkRect.top,
+  );
+
+  for (const { id, subSelector, view } of standard) {
+    const tile = tiles.get(id);
+    assertExists(tile);
+    if (view.href) {
+      assert(tile instanceof HTMLAnchorElement, `${id} must render as a link`);
+      assertEquals(
+        getComputedStyle(tile).display,
+        "block",
+        `${id} linked tile must retain block layout`,
+      );
+    }
+    const tileRect = tile.getBoundingClientRect();
+    const headline = tile.querySelector<HTMLElement>(".big");
+    assertExists(headline);
+    if (view.valueLabel !== undefined) {
+      assertEquals(
+        headline.title,
+        view.valueLabel,
+        `${id} truncated headline must expose its full text at ${width}px`,
+      );
+    }
+    const header = tile.querySelector<HTMLElement>(".lbl");
+    assertExists(header);
+    assert(
+      header.scrollWidth <= header.clientWidth,
+      `${id} header overflows at ${width}px`,
+    );
+    const mtd = header.querySelector<HTMLElement>(".hmtd");
+    if (mtd) {
+      assertEquals(
+        mtd.title,
+        mtd.textContent,
+        `${id} truncated MTD value must expose its full text at ${width}px`,
+      );
+    }
+    assertEquals(
+      pixel(headline.getBoundingClientRect().top - tileRect.top),
+      headlineTop,
+      `${id} headline must share the benchmark offset at ${width}px`,
+    );
+    const sub = tile.querySelector<HTMLElement>(subSelector ?? ".sub");
+    if (view.sub !== undefined || subSelector !== undefined) {
+      assertExists(sub, `${id} must render its subheading at ${width}px`);
+      assertEquals(
+        pixel(sub.getBoundingClientRect().top - tileRect.top),
+        subTop,
+        `${id} subheading must share the benchmark offset at ${width}px`,
+      );
+      if (sub.matches(".sub")) {
+        assertEquals(
+          sub.title,
+          sub.textContent?.trim(),
+          `${id} truncated subheading must expose its full text at ${width}px`,
+        );
+      }
+    }
+    const duration = tile.querySelector<HTMLElement>(
+      ".chart > span:last-child",
+    );
+    if (view.duration !== undefined) {
+      assertExists(duration, `${id} must render its duration at ${width}px`);
+      assertEquals(
+        pixel(duration.getBoundingClientRect().top - tileRect.top),
+        durationTop,
+        `${id} duration must share the benchmark offset at ${width}px`,
+      );
+    }
+    assert(
+      pixel(tileRect.height) <= pixel(benchmarkRect.height),
+      `${id} is ${pixel(tileRect.height)}px tall at ${width}px; benchmarks is ${
+        pixel(benchmarkRect.height)
+      }px`,
+    );
+  }
+}
+
+Deno.test("every standard tile shares text baselines and fits under benchmarks", async () => {
+  const standard = TILE_LAYOUT_FIXTURES.filter(({ wide }) => !wide);
+  const tiles = standard.map(({ id, view }) => renderTile(view, id)).join("");
+  const fixture = document.createElement("div");
+  fixture.innerHTML = `<style>
+    .layout-wall{width:1100px;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
+    .layout-minimum{width:220px;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
+    ${DASHBOARD_GRID_RULE}
+    ${TILE_BOX_RULE}
+    ${BOTTOM_CHART_RULES}
+    ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+    .cells.labeled .cell{display:block}
+  </style><div class="grid layout-wall">${tiles}</div>
+  <div class="grid layout-minimum">${tiles}</div>`;
+  document.body.append(fixture);
+
+  try {
+    await new Promise(requestAnimationFrame);
+    const wall = fixture.querySelector<HTMLElement>(".layout-wall");
+    const minimum = fixture.querySelector<HTMLElement>(".layout-minimum");
+    assertExists(wall);
+    assertExists(minimum);
+    assertStandardTileLayout(wall, standard);
+    assertStandardTileLayout(minimum, standard);
+  } finally {
+    fixture.remove();
+  }
+});
+
+Deno.test("the trust grid preserves tile text and moves above its duration label", async () => {
+  const cells = Array.from(
+    { length: 160 },
+    () => `<span class="cell" style="background:#fff"></span>`,
+  ).join("");
+  const fixture = document.createElement("div");
+  fixture.innerHTML = `<style>
+    .row-test{display:flex;gap:10px}
+    .tile{width:220px;height:115px}
+    ${BOTTOM_CHART_RULES}
+    ${TILE_LABEL_RULE}
+    .height-control{height:15px}
+    .big{height:36px;font:30px/36px sans-serif}
+    .sub{height:15px;margin:5px 0 0;font:10px/15px sans-serif}
+    .chart{position:relative;width:220px}
+    .control-chart{position:relative;height:28px;margin-top:9px}
+    .cells{display:grid;grid-template-columns:repeat(40,1fr);gap:1px}
+    ${labeledCellGridRule(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+    .cells.labeled .cell{display:block;height:4px}
+    .duration-test{position:absolute;bottom:0;height:9px}
+  </style>
+  <div class="row-test">
+    <div class="tile bottom-chart trust-test">
+      <div class="lbl">labs ci trust</div>
+      <div class="big">90%</div>
+      <div class="sub">first-try green</div>
+      <div class="chart">
+        <div class="cells labeled">${cells}</div>
+        <span class="duration-test">3 days</span>
+      </div>
+    </div>
+    <div class="tile control-test">
+      <div class="lbl">labs ci duration<span class="height-control"></span></div>
+      <div class="big">15m</div>
+      <div class="sub">median</div>
+      <div class="control-chart"><span class="duration-test">4 days</span></div>
+    </div>
+  </div>`;
+  document.body.append(fixture);
+
+  try {
+    await new Promise(requestAnimationFrame);
+    const grid = fixture.querySelector<HTMLElement>(".cells.labeled");
+    const cell = grid?.querySelector<HTMLElement>(".cell");
+    const lastCell = grid?.querySelector<HTMLElement>(".cell:last-child");
+    const trust = fixture.querySelector<HTMLElement>(".trust-test");
+    const control = fixture.querySelector<HTMLElement>(".control-test");
+    const durationLabel = trust?.querySelector<HTMLElement>(".duration-test");
+    assertExists(grid);
+    assertExists(cell);
+    assertExists(lastCell);
+    assertExists(durationLabel);
+    assertExists(trust);
+    assertExists(control);
+    const controlDurationLabel = control.querySelector<HTMLElement>(
+      ".duration-test",
+    );
+    assertExists(controlDurationLabel);
+
+    for (const selector of [".lbl", ".big", ".sub"]) {
+      const trustText: HTMLElement | null = trust.querySelector(selector);
+      const controlText: HTMLElement | null = control.querySelector(selector);
+      assertExists(trustText);
+      assertExists(controlText);
+      assertEquals(
+        trustText.getBoundingClientRect().top,
+        controlText.getBoundingClientRect().top,
+      );
+      assertEquals(
+        trustText.getBoundingClientRect().bottom,
+        controlText.getBoundingClientRect().bottom,
+      );
+    }
+    assertEquals(
+      durationLabel.getBoundingClientRect().bottom,
+      controlDurationLabel.getBoundingClientRect().bottom,
+    );
+
+    const trustLabel = trust.querySelector<HTMLElement>(".lbl");
+    const trustHeadline = trust.querySelector<HTMLElement>(".big");
+    const controlHeadline = control.querySelector<HTMLElement>(".big");
+    assertExists(trustLabel);
+    assertExists(trustHeadline);
+    assertExists(controlHeadline);
+    trustLabel.style.lineHeight = "normal";
+    assertNotEquals(
+      trustHeadline.getBoundingClientRect().top,
+      controlHeadline.getBoundingClientRect().top,
+    );
+    trustLabel.style.removeProperty("line-height");
+
+    grid.style.marginTop = "11.5px";
+    assertNotEquals(
+      durationLabel.getBoundingClientRect().bottom,
+      controlDurationLabel.getBoundingClientRect().bottom,
+    );
+    grid.style.removeProperty("margin-top");
+
+    const shiftedCellTop = cell.getBoundingClientRect().top;
+    const shiftedGapBelow = durationLabel.getBoundingClientRect().top -
+      lastCell.getBoundingClientRect().bottom;
+    const labelBottom = durationLabel.getBoundingClientRect().bottom;
+
+    grid.style.transform = "none";
+    assertEquals(
+      shiftedCellTop,
+      cell.getBoundingClientRect().top - LABELED_CELL_GRID_SHIFT,
+    );
+    assertEquals(
+      shiftedGapBelow,
+      durationLabel.getBoundingClientRect().top -
+        lastCell.getBoundingClientRect().bottom + LABELED_CELL_GRID_SHIFT,
+    );
+    assertEquals(labelBottom, durationLabel.getBoundingClientRect().bottom);
+  } finally {
+    fixture.remove();
+  }
+});

--- a/packages/dashboard/render.browser.test.ts
+++ b/packages/dashboard/render.browser.test.ts
@@ -8,22 +8,26 @@ import { renderTile } from "./tile-render.ts";
 import {
   BOTTOM_CHART_RULES,
   DASHBOARD_GRID_RULE,
-  LABELED_CELL_GRID_SHIFT,
-  labeledCellGridRule,
   TILE_BOX_RULE,
-  TILE_LABEL_RULE,
   tileContentRules,
 } from "./chart-layout.ts";
 import {
   TILE_LAYOUT_FIXTURES,
   type TileLayoutFixture,
 } from "./tile-layout-fixtures.ts";
-import {
-  DURATION_LABEL_HEIGHT,
-  SPARKLINE_HEIGHT,
-} from "./tile-render-values.ts";
+import { SPARKLINE_HEIGHT } from "./tile-render-values.ts";
 
 const pixel = (value: number): number => Math.round(value * 1000) / 1000;
+const assertPixelAligned = (
+  actual: number,
+  expected: number,
+  message: string,
+): void => {
+  assert(
+    Math.abs(actual - expected) <= 0.05,
+    `${message}: ${pixel(actual)}px vs ${pixel(expected)}px`,
+  );
+};
 
 function assertStandardTileLayout(
   root: HTMLElement,
@@ -58,6 +62,9 @@ function assertStandardTileLayout(
   );
   const durationTop = pixel(
     benchmarkDuration.getBoundingClientRect().top - benchmarkRect.top,
+  );
+  const durationLeft = pixel(
+    benchmarkDuration.getBoundingClientRect().left - benchmarkRect.left,
   );
 
   for (const { id, subSelector, view } of standard) {
@@ -126,6 +133,62 @@ function assertStandardTileLayout(
         durationTop,
         `${id} duration must share the benchmark offset at ${width}px`,
       );
+      assertEquals(
+        pixel(duration.getBoundingClientRect().left - tileRect.left),
+        durationLeft,
+        `${id} duration must share the benchmark left offset at ${width}px`,
+      );
+    }
+    if (id === "ci-trust" || id === "loom-ci-trust") {
+      const grid = tile.querySelector<HTMLElement>(".cells.labeled");
+      const firstCell = grid?.querySelector<HTMLElement>(".cell");
+      const lastCell = grid?.querySelector<HTMLElement>(".cell:last-child");
+      assertExists(grid);
+      assertExists(firstCell);
+      assertExists(lastCell);
+      assertExists(duration);
+      const gridRect = grid.getBoundingClientRect();
+      const firstCellRect = firstCell.getBoundingClientRect();
+      const lastCellRect = lastCell.getBoundingClientRect();
+      const durationRect = duration.getBoundingClientRect();
+      assertPixelAligned(
+        firstCellRect.width,
+        firstCellRect.height,
+        `${id} commit cells must be square at ${width}px`,
+      );
+      assertPixelAligned(
+        lastCellRect.bottom,
+        gridRect.bottom,
+        `${id} commit grid must align to its bottom edge at ${width}px`,
+      );
+      assert(
+        firstCellRect.top >= gridRect.top - 0.05,
+        `${id} commit grid must stay inside its top edge at ${width}px`,
+      );
+      const leftInset = gridRect.left - tileRect.left;
+      assertPixelAligned(
+        tileRect.right - gridRect.right,
+        leftInset,
+        `${id} commit grid must have equal side insets at ${width}px`,
+      );
+      assertPixelAligned(
+        tileRect.bottom - gridRect.bottom,
+        leftInset,
+        `${id} commit grid bottom inset must match its sides at ${width}px`,
+      );
+      assert(
+        durationRect.left >= gridRect.left &&
+          durationRect.left < gridRect.right &&
+          durationRect.right > gridRect.left &&
+          durationRect.top < gridRect.bottom &&
+          durationRect.bottom > gridRect.top,
+        `${id} duration must overlap the grid's bottom-left corner at ${width}px`,
+      );
+      assertNotEquals(
+        getComputedStyle(duration).textShadow,
+        "none",
+        `${id} duration must carry a readable grid outline at ${width}px`,
+      );
     }
     assert(
       pixel(tileRect.height) <= pixel(benchmarkRect.height),
@@ -141,24 +204,31 @@ Deno.test("every standard tile shares text baselines and fits under benchmarks",
   const tiles = standard.map(({ id, view }) => renderTile(view, id)).join("");
   const fixture = document.createElement("div");
   fixture.innerHTML = `<style>
-    .layout-wall{width:1100px;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
-    .layout-minimum{width:220px;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
+    .layout-wall{width:1100px;--surface:#111;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
+    .layout-intermediate{width:451px;--surface:#111;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
+    .layout-minimum{width:220px;--surface:#111;font-family:-apple-system,"Segoe UI",Roboto,sans-serif}
     ${DASHBOARD_GRID_RULE}
     ${TILE_BOX_RULE}
     ${BOTTOM_CHART_RULES}
-    ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+    ${tileContentRules(SPARKLINE_HEIGHT)}
     .cells.labeled .cell{display:block}
   </style><div class="grid layout-wall">${tiles}</div>
+  <div class="grid layout-intermediate">${tiles}</div>
   <div class="grid layout-minimum">${tiles}</div>`;
   document.body.append(fixture);
 
   try {
     await new Promise(requestAnimationFrame);
     const wall = fixture.querySelector<HTMLElement>(".layout-wall");
+    const intermediate = fixture.querySelector<HTMLElement>(
+      ".layout-intermediate",
+    );
     const minimum = fixture.querySelector<HTMLElement>(".layout-minimum");
     assertExists(wall);
+    assertExists(intermediate);
     assertExists(minimum);
     assertStandardTileLayout(wall, standard);
+    assertStandardTileLayout(intermediate, standard);
     assertStandardTileLayout(minimum, standard);
   } finally {
     fixture.remove();
@@ -170,7 +240,7 @@ Deno.test("a linked bottom-chart tile keeps its flex layout", async () => {
   fixture.innerHTML = `<style>
     ${TILE_BOX_RULE}
     ${BOTTOM_CHART_RULES}
-    ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+    ${tileContentRules(SPARKLINE_HEIGHT)}
   </style>${
     renderTile({
       label: "linked history",
@@ -190,125 +260,6 @@ Deno.test("a linked bottom-chart tile keeps its flex layout", async () => {
     const tile = fixture.querySelector<HTMLElement>(".tile");
     assertExists(tile);
     assertEquals(getComputedStyle(tile).display, "flex");
-  } finally {
-    fixture.remove();
-  }
-});
-
-Deno.test("the trust grid preserves tile text and moves above its duration label", async () => {
-  const cells = Array.from(
-    { length: 160 },
-    () => `<span class="cell" style="background:#fff"></span>`,
-  ).join("");
-  const fixture = document.createElement("div");
-  fixture.innerHTML = `<style>
-    .row-test{display:flex;gap:10px}
-    .tile{width:220px;height:115px}
-    ${BOTTOM_CHART_RULES}
-    ${TILE_LABEL_RULE}
-    .height-control{height:15px}
-    .big{height:36px;font:30px/36px sans-serif}
-    .sub{height:15px;margin:5px 0 0;font:10px/15px sans-serif}
-    .chart{position:relative;width:220px}
-    .control-chart{position:relative;height:28px;margin-top:9px}
-    .cells{display:grid;grid-template-columns:repeat(40,1fr);gap:1px}
-    ${labeledCellGridRule(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
-    .cells.labeled .cell{display:block;height:4px}
-    .duration-test{position:absolute;bottom:0;height:9px}
-  </style>
-  <div class="row-test">
-    <div class="tile bottom-chart trust-test">
-      <div class="lbl">labs ci trust</div>
-      <div class="big">90%</div>
-      <div class="sub">first-try green</div>
-      <div class="chart">
-        <div class="cells labeled">${cells}</div>
-        <span class="duration-test">3 days</span>
-      </div>
-    </div>
-    <div class="tile control-test">
-      <div class="lbl">labs ci duration<span class="height-control"></span></div>
-      <div class="big">15m</div>
-      <div class="sub">median</div>
-      <div class="control-chart"><span class="duration-test">4 days</span></div>
-    </div>
-  </div>`;
-  document.body.append(fixture);
-
-  try {
-    await new Promise(requestAnimationFrame);
-    const grid = fixture.querySelector<HTMLElement>(".cells.labeled");
-    const cell = grid?.querySelector<HTMLElement>(".cell");
-    const lastCell = grid?.querySelector<HTMLElement>(".cell:last-child");
-    const trust = fixture.querySelector<HTMLElement>(".trust-test");
-    const control = fixture.querySelector<HTMLElement>(".control-test");
-    const durationLabel = trust?.querySelector<HTMLElement>(".duration-test");
-    assertExists(grid);
-    assertExists(cell);
-    assertExists(lastCell);
-    assertExists(durationLabel);
-    assertExists(trust);
-    assertExists(control);
-    const controlDurationLabel = control.querySelector<HTMLElement>(
-      ".duration-test",
-    );
-    assertExists(controlDurationLabel);
-
-    for (const selector of [".lbl", ".big", ".sub"]) {
-      const trustText: HTMLElement | null = trust.querySelector(selector);
-      const controlText: HTMLElement | null = control.querySelector(selector);
-      assertExists(trustText);
-      assertExists(controlText);
-      assertEquals(
-        trustText.getBoundingClientRect().top,
-        controlText.getBoundingClientRect().top,
-      );
-      assertEquals(
-        trustText.getBoundingClientRect().bottom,
-        controlText.getBoundingClientRect().bottom,
-      );
-    }
-    assertEquals(
-      durationLabel.getBoundingClientRect().bottom,
-      controlDurationLabel.getBoundingClientRect().bottom,
-    );
-
-    const trustLabel = trust.querySelector<HTMLElement>(".lbl");
-    const trustHeadline = trust.querySelector<HTMLElement>(".big");
-    const controlHeadline = control.querySelector<HTMLElement>(".big");
-    assertExists(trustLabel);
-    assertExists(trustHeadline);
-    assertExists(controlHeadline);
-    trustLabel.style.lineHeight = "normal";
-    assertNotEquals(
-      trustHeadline.getBoundingClientRect().top,
-      controlHeadline.getBoundingClientRect().top,
-    );
-    trustLabel.style.removeProperty("line-height");
-
-    grid.style.marginTop = "11.5px";
-    assertNotEquals(
-      durationLabel.getBoundingClientRect().bottom,
-      controlDurationLabel.getBoundingClientRect().bottom,
-    );
-    grid.style.removeProperty("margin-top");
-
-    const shiftedCellTop = cell.getBoundingClientRect().top;
-    const shiftedGapBelow = durationLabel.getBoundingClientRect().top -
-      lastCell.getBoundingClientRect().bottom;
-    const labelBottom = durationLabel.getBoundingClientRect().bottom;
-
-    grid.style.transform = "none";
-    assertEquals(
-      shiftedCellTop,
-      cell.getBoundingClientRect().top - LABELED_CELL_GRID_SHIFT,
-    );
-    assertEquals(
-      shiftedGapBelow,
-      durationLabel.getBoundingClientRect().top -
-        lastCell.getBoundingClientRect().bottom + LABELED_CELL_GRID_SHIFT,
-    );
-    assertEquals(labelBottom, durationLabel.getBoundingClientRect().bottom);
   } finally {
     fixture.remove();
   }

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./palette.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
 import { liveUpdateStream } from "./stream-client.ts";
+import { TILE_LABEL_RULE } from "./chart-layout.ts";
 
 const TEST_VERSION = "1".repeat(40);
 
@@ -102,7 +103,7 @@ Deno.test("renderTile: label and sub are escaped — a hostile label cannot inje
   assertStringIncludes(html, "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
   assertStringIncludes(
     html,
-    `<p class="sub">a &amp; b &quot;quoted&quot; &lt;script&gt;</p>`,
+    `<p class="sub" title="a &amp; b &quot;quoted&quot; &lt;script&gt;">a &amp; b &quot;quoted&quot; &lt;script&gt;</p>`,
   );
 });
 
@@ -115,12 +116,24 @@ Deno.test("renderTile: value, extra and aside are trusted html; hint is escaped"
   }));
   // A tile builds these itself, escaping any data it puts in them.
   assertStringIncludes(html, `<p class="big good"><b>42</b></p>`);
+  assert(!html.includes(`title="&lt;b&gt;42&lt;/b&gt;"`));
   assertStringIncludes(html, `<span class="hmtd">$12</span>`);
   assertStringIncludes(html, `<svg viewBox="0 0 1 1"></svg>`);
   // The hint is plain text from the tile, so the renderer escapes it.
   assertStringIncludes(
     html,
-    `<span class="drill">commits ↗ &lt;not a tag&gt;</span>`,
+    `<span class="drill" title="commits ↗ &lt;not a tag&gt;">commits ↗ &lt;not a tag&gt;</span>`,
+  );
+});
+
+Deno.test("renderTile: a plain headline label supplies truncated text", () => {
+  const html = renderTile(view({
+    value: `<b>42</b>`,
+    valueLabel: `42 "requests"`,
+  }));
+  assertStringIncludes(
+    html,
+    `<p class="big good" title="42 &quot;requests&quot;"><b>42</b></p>`,
   );
 });
 
@@ -128,7 +141,7 @@ Deno.test("renderTile: the aside and hint sit after the label, separated by the 
   const html = renderTile(view({ aside: "<i>mtd</i>", hint: "runs" }));
   assertStringIncludes(
     html,
-    `<p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span><i>mtd</i><span class="drill">runs</span></p>`,
+    `<p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span><i>mtd</i><span class="drill" title="runs">runs</span></p>`,
   );
 });
 
@@ -136,7 +149,10 @@ Deno.test("renderTile: a duration wraps the chart so the span can be pinned to i
   const html = renderTile(
     view({ extra: "<svg></svg>", duration: 25 * 86_400_000 }),
   );
-  assertStringIncludes(html, `<div style="position:relative"><svg></svg>`);
+  assertStringIncludes(
+    html,
+    `<div class="chart" style="position:relative"><svg></svg>`,
+  );
   // The corner tag is the auto-formatted span, and it is inside the wrapper.
   assertStringIncludes(html, ">25 days</span></div>");
   assertStringIncludes(html, "position:absolute");
@@ -161,7 +177,7 @@ Deno.test("renderTile: a duration with no chart draws nothing to label", () => {
     "nothing to position, so no wrapper",
   );
   assert(!html.includes(humanSpan(90 * 60_000)), "and no orphaned span label");
-  assertStringIncludes(html, `<p class="sub">things</p>`); // the sub is left alone
+  assertStringIncludes(html, `<p class="sub" title="things">things</p>`); // the sub is left alone
 });
 
 Deno.test("renderTile: the body order is label, headline, sub, chart", () => {
@@ -200,6 +216,31 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
     `href="/favicon.png?status=bad&v=${FAVICON_VERSION}"`,
   );
   assertStringIncludes(html, "</body></html>");
+});
+
+Deno.test("shell: labeled cell grids share the sparkline label baseline", () => {
+  const html = shell("", "", 0, 30_000, TEST_VERSION, "good");
+  assertStringIncludes(
+    html,
+    `.cells.labeled{margin-top:9px;height:28px;box-sizing:border-box;padding-bottom:9px;align-content:start;transform:translateY(-2px)}`,
+  );
+  assertStringIncludes(
+    html,
+    `.cells.labeled .cell{aspect-ratio:auto;height:4px}`,
+  );
+  assertStringIncludes(html, `.tile.bottom-chart{display:flex;flex-direction:column}`);
+  assertStringIncludes(html, `.tile.bottom-chart .chart{margin-top:auto}`);
+  assertStringIncludes(html, TILE_LABEL_RULE);
+});
+
+Deno.test("renderTile: a bottom-aligned chart can absorb a taller grid row", () => {
+  const html = renderTile(view({
+    extra: "<svg></svg>",
+    duration: 86_400_000,
+    alignChartBottom: true,
+  }));
+  assertStringIncludes(html, `class="tile good bottom-chart"`);
+  assertStringIncludes(html, `class="chart"`);
 });
 
 Deno.test("shell: the shared message is directly editable in the header center", () => {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -222,12 +222,18 @@ Deno.test("shell: labeled cell grids share the sparkline label baseline", () => 
   const html = shell("", "", 0, 30_000, TEST_VERSION, "good");
   assertStringIncludes(
     html,
-    `.cells.labeled{margin-top:9px;height:28px;box-sizing:border-box;padding-bottom:9px;align-content:start;transform:translateY(-2px)}`,
+    `.cells.labeled{margin-top:9px;height:28px;align-content:end;align-items:start;transform:translateY(-2px)}`,
   );
   assertStringIncludes(
     html,
-    `.cells.labeled .cell{aspect-ratio:auto;height:4px}`,
+    `.cells.labeled .cell{width:100%}`,
   );
+  assertStringIncludes(
+    html,
+    `.cells{display:grid;grid-template-columns:repeat(auto-fill,minmax(4px,1fr))`,
+  );
+  assertStringIncludes(html, `.chart>span:last-child{bottom:2px!important}`);
+  assertStringIncludes(html, `.cells.labeled+span{font-weight:700;text-shadow:`);
   assertStringIncludes(html, `.tile.bottom-chart{display:flex;flex-direction:column}`);
   assertStringIncludes(html, `.tile.bottom-chart .chart{margin-top:auto}`);
   assertStringIncludes(html, TILE_LABEL_RULE);

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -230,7 +230,7 @@ Deno.test("shell: labeled cell grids share the sparkline label baseline", () => 
   );
   assertStringIncludes(
     html,
-    `.cells{display:grid;grid-template-columns:repeat(auto-fill,minmax(4px,1fr))`,
+    `.cells{display:grid;grid-template-columns:repeat(40,min(7.5px,`,
   );
   assertStringIncludes(html, `.chart>span:last-child{bottom:2px!important}`);
   assertStringIncludes(html, `.cells.labeled+span{font-weight:700;text-shadow:`);

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -13,7 +13,6 @@ import {
   tileContentRules,
 } from "./chart-layout.ts";
 import {
-  DURATION_LABEL_HEIGHT,
   escapeHtml,
   SPARKLINE_HEIGHT,
   STATUS_DOT,
@@ -255,7 +254,7 @@ ${TILE_RULES}
   .tile.unknown .texture::before{${DOT_TEXTURE}}
   .tile.warn .texture::before{${WAVE_TEXTURE};--turn:120deg}
   .tile.bad .texture::before{${ZIGZAG_TEXTURE}}
-  ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
+  ${tileContentRules(SPARKLINE_HEIGHT)}
   ${BIG_RULES}
   a.cell{display:block}
   a.cell:hover{outline:1px solid var(--accent);outline-offset:-1px}

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -4,8 +4,20 @@
  * wide tiles in the page, together with the client that listens for updates.
  */
 
-import type { Status, TileView } from "./types.ts";
-import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
+import type { Status } from "./types.ts";
+export { renderTile } from "./tile-render.ts";
+import {
+  BOTTOM_CHART_RULES,
+  DASHBOARD_GRID_RULE,
+  TILE_BOX_RULE,
+  tileContentRules,
+} from "./chart-layout.ts";
+import {
+  DURATION_LABEL_HEIGHT,
+  escapeHtml,
+  SPARKLINE_HEIGHT,
+  STATUS_DOT,
+} from "./lib.ts";
 import {
   STATUS_EDGE,
   STATUS_WASH,
@@ -187,41 +199,6 @@ export function formatViewerTimes(
   }
 }
 
-export function renderTile(v: TileView, id?: string, wide = false): string {
-  const cls = `tile ${v.status}${v.href ? " link" : ""}${wide ? " wide" : ""}`;
-  const key = id ? ` data-tile-id="${escapeHtml(id)}"` : "";
-  const dot = `<span class="dot ${STATUS_DOT[v.status]}"></span>`;
-  const hint = v.hint ? `<span class="drill">${escapeHtml(v.hint)}</span>` : "";
-  const header = `<p class="lbl">${dot} ${
-    escapeHtml(v.label)
-  }<span class="spacer"></span>${v.aside ?? ""}${hint}</p>`;
-  const big = v.value !== undefined
-    ? `<p class="big ${v.status}">${v.value}</p>`
-    : "";
-  const sub = v.sub ? `<p class="sub">${escapeHtml(v.sub)}</p>` : "";
-  // The chart plus its duration label (bottom-left corner, auto-formatted). The
-  // relative wrapper positions the duration; a tile with no duration renders extra
-  // unwrapped, unchanged. The label describes the chart's span, so it needs a chart
-  // to sit in: drawn without one, the wrapper has no height and the label lands on
-  // top of the sub line. A tile whose series is too short to plot still reports a
-  // span, so this is reachable.
-  const body = v.duration && v.extra
-    ? `<div style="position:relative">${v.extra}${
-      durationTag(v.duration)
-    }</div>`
-    : (v.extra ?? "");
-  // The status texture is painted by this empty layer rather than by the tile,
-  // because the texture is turned on an angle and drawn past every edge, while
-  // the fade that thins it towards the bottom is measured against the tile.
-  // Those are two frames of reference, so they need two boxes.
-  const inner = `<div class="texture"></div>${header}${big}${sub}${body}`;
-  if (!v.href) return `<div class="${cls}"${key}>${inner}</div>`;
-  const tgt = /^https?:/.test(v.href) ? ` target="_blank" rel="noopener"` : "";
-  return `<a class="${cls}"${key} href="${
-    escapeHtml(v.href)
-  }"${tgt}>${inner}</a>`;
-}
-
 function renderShell(
   gridHtml: string,
   wideHtml: string,
@@ -253,8 +230,9 @@ ${DASHBOARD_THEME_STYLES}
   .message-input:focus{outline:none}
   .message-input[aria-invalid="true"]{border-color:var(--status-bad)}
   .message-status{position:absolute;top:100%;left:9px;right:9px;color:var(--status-bad-text);font-size:11px;text-align:center}
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
-  .tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
+  ${DASHBOARD_GRID_RULE}
+  ${TILE_BOX_RULE}
+  ${BOTTOM_CHART_RULES}
   .tile.wide{margin-bottom:12px}
 ${TILE_RULES}
   .tile.unknown,.tile.wide.unknown{border-color:var(--border-strong)}
@@ -277,32 +255,14 @@ ${TILE_RULES}
   .tile.unknown .texture::before{${DOT_TEXTURE}}
   .tile.warn .texture::before{${WAVE_TEXTURE};--turn:120deg}
   .tile.bad .texture::before{${ZIGZAG_TEXTURE}}
-  .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin:0 0 7px;display:flex;align-items:center;gap:7px}
-  .lbl .spacer{flex:1}
-  .drill{font-size:10px;color:var(--text-muted);letter-spacing:0;text-transform:none}
-  .hmtd{font-size:11px;color:var(--text-muted);letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
-  /* Fixed line-height so the headline's line box is the same height regardless of
-     which font the glyph comes from: the ▲/▼ trend arrows fall back to a taller
-     symbol font, and under line-height:normal that stretched the tile. */
-  .big{font-size:30px;font-weight:600;margin:0;line-height:1.2}
+  ${tileContentRules(SPARKLINE_HEIGHT, DURATION_LABEL_HEIGHT)}
   ${BIG_RULES}
-  .sub{font-size:13px;color:var(--text-muted);margin:5px 0 0}
-  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:var(--text-muted);letter-spacing:.02em;text-transform:none;margin-top:10px}
-  /* In the header the badge is a facet of a single line, not a block under the
-     chart, so it takes the line's own vertical rhythm. */
-  .lbl .running{margin-top:0;margin-right:8px}
-  .rdot{width:7px;height:7px;border-radius:50%;background:var(--running);flex:none}
-  .cells{display:grid;gap:1px;margin-top:10px}
-  .cell{aspect-ratio:1;border-radius:1px}
   a.cell{display:block}
   a.cell:hover{outline:1px solid var(--accent);outline-offset:-1px}
   /* The dot is drawn by its own layer so each status can take a shape as well
      as a color. The shape carries the same signal the color does, which is
      what a viewer who cannot separate the hues reads instead. */
-  .dot{width:10px;height:10px;display:inline-block;flex:none;position:relative}
-  .dot::before{content:"";position:absolute;inset:0}
   ${DOT_RULES}
-  a.tile.link{display:block;text-decoration:none;color:inherit;cursor:pointer;transition:border-color .12s}
   a.tile.link:hover{border-color:var(--border-hover)}
   .evscroll{max-height:340px;overflow:auto}
   .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid var(--divider)}.ev:first-child{border-top:0}
@@ -313,7 +273,6 @@ ${TILE_RULES}
   a.evdur:hover{color:var(--accent)}
   .evarrow{color:var(--icon-subtle);text-decoration:none;flex:none;font-size:11px;transition:color .1s}
   .evarrow:hover{color:var(--text-subtle)}
-  .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
   .note{font-size:11px;color:var(--text-faint);margin-top:14px}
   code{background:var(--surface-code);padding:1px 5px;border-radius:4px}
   @media(max-width:560px){.top{grid-template-columns:minmax(0,1fr) max-content;gap:8px 12px}.brand span:last-child{display:none}.top-actions{gap:8px}.message-form{grid-column:1/-1;grid-row:2;width:100%}.message-input{font-size:14px;padding-inline:5px}}

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -324,7 +324,7 @@ Deno.test("a tile stays wide through failures and keeps its last good view", asy
   const firstFailure = tileHtml("recent-runs");
   assert(firstFailure.startsWith(`unknown wide" data-tile-id="recent-runs">`));
   assertStringIncludes(firstFailure, `<p class="big unknown">—</p>`);
-  assertStringIncludes(firstFailure, `<p class="sub">not found</p>`);
+  assertStringIncludes(firstFailure, `<p class="sub" title="not found">not found</p>`);
 
   const good: TileView = { label: "recent main runs", status: "good", value: "passing", sub: "10 runs" };
   await tick([fake("recent-runs", () => good)]);
@@ -335,8 +335,14 @@ Deno.test("a tile stays wide through failures and keeps its last good view", asy
   })]);
   const html = tileHtml("recent main runs");
   assert(html.startsWith(`unknown wide" data-tile-id="recent-runs">`));
-  assertStringIncludes(html, `<p class="big unknown">passing</p>`);
-  assertStringIncludes(html, `<p class="sub">source unreachable</p>`);
+  assertStringIncludes(
+    html,
+    `<p class="big unknown">passing</p>`,
+  );
+  assertStringIncludes(
+    html,
+    `<p class="sub" title="source unreachable">source unreachable</p>`,
+  );
 });
 
 Deno.test("the ticker leaves a tile alone until its interval has elapsed", async () => {

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -152,7 +152,8 @@ Deno.test("the flake tile is green when nothing is withheld as flaky", async () 
 });
 
 Deno.test("the flake tile counts what selection held back, and names the worst", async () => {
-  const noisy = sampleEntry({ k: "unit", s: "memory", n: "space > flakes" }, {
+  const longName = "space > flakes with a name that keeps going past the tile limit";
+  const noisy = sampleEntry({ k: "unit", s: "memory", n: longName }, {
     flakeRate: 0.4,
   });
   const manifest = sampleManifest({
@@ -167,7 +168,13 @@ Deno.test("the flake tile counts what selection held back, and names the worst",
   assertEquals(view.extra?.includes('role="region"'), true);
   assertEquals(view.extra?.includes('tabindex="0"'), true);
   assertEquals(view.extra?.includes("scroll for more"), false);
-  assertEquals(view.extra?.includes("40.0% · memory: space &gt; flakes"), true);
+  assertEquals(
+    view.extra?.includes(
+      `title="40.0% · unit · memory: ${longName.replace(">", "&gt;")}"`,
+    ),
+    true,
+  );
+  assertEquals(view.extra?.includes("…</div>"), true);
 });
 
 Deno.test("the selection tile says what share of the corpus would run", async () => {

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -163,6 +163,10 @@ Deno.test("the flake tile counts what selection held back, and names the worst",
     .collect(CTX);
   assertEquals(view.status, "warn");
   assertEquals(view.value, "1");
+  assertEquals(view.extra?.includes('class="tile-detail-list"'), true);
+  assertEquals(view.extra?.includes('role="region"'), true);
+  assertEquals(view.extra?.includes('tabindex="0"'), true);
+  assertEquals(view.extra?.includes("scroll for more"), false);
   assertEquals(view.extra?.includes("40.0% · memory: space &gt; flakes"), true);
 });
 

--- a/packages/dashboard/test-selection-manifest.test.ts
+++ b/packages/dashboard/test-selection-manifest.test.ts
@@ -153,7 +153,7 @@ Deno.test("the flake tile is green when nothing is withheld as flaky", async () 
 
 Deno.test("the flake tile counts what selection held back, and names the worst", async () => {
   const longName = "space > flakes with a name that keeps going past the tile limit";
-  const noisy = sampleEntry({ k: "unit", s: "memory", n: longName }, {
+  const noisy = sampleEntry({ k: "unit", s: "memory", n: longName, v: "worker" }, {
     flakeRate: 0.4,
   });
   const manifest = sampleManifest({
@@ -170,11 +170,11 @@ Deno.test("the flake tile counts what selection held back, and names the worst",
   assertEquals(view.extra?.includes("scroll for more"), false);
   assertEquals(
     view.extra?.includes(
-      `title="40.0% · unit · memory: ${longName.replace(">", "&gt;")}"`,
+      `title="40.0% · unit · memory: ${longName.replace(">", "&gt;")} (worker)"`,
     ),
     true,
   );
-  assertEquals(view.extra?.includes("…</div>"), true);
+  assertEquals(view.extra?.includes("… (worker)</div>"), true);
 });
 
 Deno.test("the selection tile says what share of the corpus would run", async () => {

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -11,6 +11,7 @@ export const TEST_COMMANDS = [
     `--allow-run=${Deno.execPath()},git`,
     "--ignore=favicon-client.browser.test.ts",
     "--ignore=dashboard-message-client.browser.test.ts",
+    "--ignore=render.browser.test.ts",
     "--ignore=theme.browser.test.ts",
     "--ignore=favicon-raster.test.ts",
     "--ignore=regenerate-favicons.test.ts",

--- a/packages/dashboard/tile-layout-fixtures.ts
+++ b/packages/dashboard/tile-layout-fixtures.ts
@@ -14,7 +14,7 @@ const history = () =>
 const twoLines = () =>
   `<div style="position:relative;margin-top:9px;height:${SPARKLINE_HEIGHT}px"><svg viewBox="0 0 220 34" width="calc(100% - 24px)" height="${SPARKLINE_HEIGHT}" preserveAspectRatio="none" style="display:block"><polyline points="0,20 55,12 110,16 165,4 220,8" fill="none" stroke="#7aa2ff" stroke-width="2"></polyline><polyline points="0,24 55,20 110,16 165,20 220,12" fill="none" stroke="#be95ff" stroke-width="2"></polyline></svg></div>`;
 const trustStrip = (prefix: string, badEvery: number) =>
-  `<div class="cells labeled" style="grid-template-columns:repeat(40,1fr)">${
+  `<div class="cells labeled">${
     Array.from(
       { length: 160 },
       (_, index) =>

--- a/packages/dashboard/tile-layout-fixtures.ts
+++ b/packages/dashboard/tile-layout-fixtures.ts
@@ -1,0 +1,276 @@
+import type { TileView } from "./types.ts";
+import { SPARKLINE_HEIGHT } from "./tile-render-values.ts";
+
+export interface TileLayoutFixture {
+  id: string;
+  view: TileView;
+  wide?: boolean;
+  subSelector?: string;
+}
+
+const DAY = 86_400_000;
+const history = () =>
+  `<svg viewBox="0 0 220 26" width="100%" height="${SPARKLINE_HEIGHT}" preserveAspectRatio="none" style="display:block;margin-top:9px"><polyline points="0,20 55,12 110,16 165,4 220,8" fill="none" stroke="var(--chart-line)" stroke-width="2"></polyline></svg>`;
+const twoLines = () =>
+  `<div style="position:relative;margin-top:9px;height:${SPARKLINE_HEIGHT}px"><svg viewBox="0 0 220 34" width="calc(100% - 24px)" height="${SPARKLINE_HEIGHT}" preserveAspectRatio="none" style="display:block"><polyline points="0,20 55,12 110,16 165,4 220,8" fill="none" stroke="#7aa2ff" stroke-width="2"></polyline><polyline points="0,24 55,20 110,16 165,20 220,12" fill="none" stroke="#be95ff" stroke-width="2"></polyline></svg></div>`;
+const trustStrip = (prefix: string, badEvery: number) =>
+  `<div class="cells labeled" style="grid-template-columns:repeat(40,1fr)">${
+    Array.from(
+      { length: 160 },
+      (_, index) =>
+        `<a class="cell" href="https://example.com/${prefix}/${index}" style="background:var(--status-${
+          index % badEvery === 0 ? "bad" : "good"
+        })"></a>`,
+    ).join("")
+  }</div>`;
+const spendSub = (text: string) =>
+  `<p class="sub" title="${text}"><span class="swatch" style="background:#7aa2ff"></span> ${text}</p>`;
+
+// These are maximum-content loaded states expressed through the renderer's
+// public TileView contract. The registry test keeps the list complete and in
+// dashboard order. The browser test supplies these views to renderTile().
+const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
+  {
+    id: "labs-ci",
+    view: {
+      label: "labs ci",
+      status: "good",
+      value: "passing",
+      valueLabel: "passing",
+      sub: "green for 3h",
+      hint: "commits ↗",
+      href: "https://example.com/labs/commits",
+      extra:
+        `<span class="running"><span class="rdot"></span>next build running</span>`,
+    },
+  },
+  {
+    id: "ci-trust",
+    view: {
+      label: "labs ci trust",
+      status: "good",
+      value: "90.4%",
+      sub: "first-try green · 156 of last 160 runs",
+      extra: trustStrip("runs", 10),
+      duration: 30 * DAY,
+      alignChartBottom: true,
+    },
+  },
+  {
+    id: "ci-duration",
+    view: {
+      label: "labs ci duration",
+      status: "good",
+      value: "17m",
+      sub: "median · 31 passing runs in the last 6h",
+      extra: history(),
+      duration: 30 * DAY,
+      hint: "jobs ↗",
+      href: "/bench?repo=labs",
+    },
+  },
+  {
+    id: "benchmark",
+    subSelector: ".benchmark-count",
+    view: {
+      label: "benchmarks",
+      status: "warn",
+      value: "▲6%",
+      extra:
+        `<div class="benchmark-count" style="font-size:13px;color:var(--text-muted);margin:5px 0 0">544 benchmarks · last 10 days</div>${twoLines()}`,
+      duration: 30 * DAY,
+      hint: "details ↗",
+      href: "/bench",
+    },
+  },
+  {
+    id: "loom-ci",
+    view: {
+      label: "loom ci",
+      status: "good",
+      value: "passing",
+      valueLabel: "passing",
+      sub: "green for 5h",
+      hint: "commits ↗",
+      href: "https://example.com/loom/commits",
+      extra:
+        `<span class="running"><span class="rdot"></span>next build running</span>`,
+    },
+  },
+  {
+    id: "loom-ci-trust",
+    view: {
+      label: "loom ci trust",
+      status: "warn",
+      value: "73.8%",
+      sub: "first-try green · last 160 runs",
+      extra: trustStrip("loom-runs", 4),
+      duration: 30 * DAY,
+      alignChartBottom: true,
+    },
+  },
+  {
+    id: "loom-ci-duration",
+    view: {
+      label: "loom ci duration",
+      status: "good",
+      value: "6m",
+      sub: "median · last 20 passing runs",
+      extra: history(),
+      duration: 30 * DAY,
+      hint: "jobs ↗",
+      href: "/bench?repo=loom",
+    },
+  },
+  {
+    id: "github-ci-spend",
+    subSelector: ".sub",
+    view: {
+      label: "github ci spend",
+      status: "good",
+      value: "~$3059/mo",
+      valueLabel: "~$3059/mo",
+      aside: `<span class="hmtd" title="$1644 MTD">$1644 MTD</span>`,
+      extra: spendSub("GitHub · Budget $3100") + history(),
+      duration: 30 * DAY,
+      hint: "billing ↗",
+      href: "https://example.com/billing",
+    },
+  },
+  {
+    id: "prod-uptime",
+    view: {
+      label: "production",
+      status: "bad",
+      value: "common.tools down",
+      valueLabel: "common.tools down",
+      extra:
+        `<div class="tile-detail-list" tabindex="0" role="region" aria-label="Production target details; scroll for more" title="Scroll for more details" style="display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin-top:11px;font-size:12px;line-height:1.35">${
+          [
+            "common.tools",
+            "estuary",
+            "rapids",
+            "bastion",
+            "prod shell",
+            "stage shell",
+            "LLM",
+            "sandbox",
+          ].map((name) =>
+            `<span style="display:inline-flex;align-items:center;gap:6px;font-weight:600"><span class="dot red"></span>${name}</span><span style="color:var(--text-muted);font-variant-numeric:tabular-nums">connection refused</span>`
+          ).join("")
+        }</div>`,
+    },
+  },
+  {
+    id: "prod-errors",
+    view: {
+      label: "production errors",
+      status: "good",
+      value: "0.24%",
+      sub: "12 err / 5000 spans · last 12h",
+      extra: history(),
+      duration: 30 * DAY,
+      hint: "traces ↗",
+      href: "https://example.com/traces",
+    },
+  },
+  {
+    id: "dau",
+    view: {
+      label: "dau",
+      status: "good",
+      value: "244",
+      sub: "active identities · toolshed-production",
+      extra: history(),
+      duration: 30 * DAY,
+      hint: "traces ↗",
+      href: "https://example.com/identities",
+    },
+  },
+  {
+    id: "test-flakes",
+    view: {
+      label: "flaky tests",
+      status: "warn",
+      value: "4",
+      sub: "too noisy to judge a change by · 4 tests",
+      extra:
+        `<div class="tile-detail-list" tabindex="0" role="region" aria-label="Flaky test details; scroll for more" title="Scroll for more details">${
+          [
+            "4.2% · package alpha: longest representative test name",
+            "3.7% · package beta: another representative test name",
+            "2.9% · package gamma: a third representative test name",
+            "2.1% · package delta: a fourth representative test name",
+          ].map((line) => `<div title="${line}">${line}</div>`).join("")
+        }</div>`,
+    },
+  },
+  {
+    id: "test-selection",
+    view: {
+      label: "test selection",
+      status: "good",
+      value: "64%",
+      sub: "640 of 1000 tests · fullest lane 280s of 300s",
+      aside: "12h old",
+    },
+  },
+  {
+    id: "model-spend",
+    subSelector: ".sub",
+    view: {
+      label: "model spend",
+      status: "good",
+      value: "~$820/mo",
+      valueLabel: "~$820/mo",
+      aside: `<span class="hmtd" title="$440 MTD">$440 MTD</span>`,
+      extra: spendSub("OpenAI • Anthropic • OR $0") + twoLines(),
+      duration: 30 * DAY,
+    },
+  },
+  {
+    id: "gcp-spend",
+    view: {
+      label: "gcp spend",
+      status: "good",
+      value: "~$410/mo",
+      valueLabel: "~$410/mo",
+      aside: `<span class="hmtd" title="$220 MTD">$220 MTD</span>`,
+      sub: "billing account spend",
+      extra: history(),
+      duration: 30 * DAY,
+    },
+  },
+  {
+    id: "discord-online",
+    subSelector: ".sub",
+    view: {
+      label: "discord online",
+      status: "good",
+      value: "37",
+      extra: spendSub("team + visitors") + twoLines(),
+      duration: 30 * DAY,
+    },
+  },
+  {
+    id: "github-members",
+    subSelector: ".sub",
+    view: {
+      label: "github people",
+      status: "good",
+      value: "14",
+      extra: spendSub("members · collaborators") + twoLines(),
+      duration: 30 * DAY,
+      hint: "people ↗",
+      href: "https://example.com/people",
+    },
+  },
+  {
+    id: "recent-runs",
+    wide: true,
+    view: { label: "recent runs", status: "good" },
+  },
+] as const;
+
+export const TILE_LAYOUT_FIXTURES: readonly TileLayoutFixture[] =
+  TILE_LAYOUT_FIXTURE_INPUTS;

--- a/packages/dashboard/tile-layout-fixtures.ts
+++ b/packages/dashboard/tile-layout-fixtures.ts
@@ -123,68 +123,12 @@ const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
     },
   },
   {
-    id: "github-ci-spend",
-    subSelector: ".sub",
+    id: "loom-metric-placeholder",
     view: {
-      label: "github ci spend",
+      label: "YOUR METRIC HERE",
       status: "good",
-      value: "~$3059/mo",
-      valueLabel: "~$3059/mo",
-      aside: `<span class="hmtd" title="$1644 MTD">$1644 MTD</span>`,
-      extra: spendSub("GitHub · Budget $3100") + history(),
-      duration: 30 * DAY,
-      hint: "billing ↗",
-      href: "https://example.com/billing",
-    },
-  },
-  {
-    id: "prod-uptime",
-    view: {
-      label: "production",
-      status: "bad",
-      value: "common.tools down",
-      valueLabel: "common.tools down",
-      extra:
-        `<div class="tile-detail-list" tabindex="0" role="region" aria-label="Production target details; scroll for more" title="Scroll for more details" style="display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin-top:11px;font-size:12px;line-height:1.35">${
-          [
-            "common.tools",
-            "estuary",
-            "rapids",
-            "bastion",
-            "prod shell",
-            "stage shell",
-            "LLM",
-            "sandbox",
-          ].map((name) =>
-            `<span style="display:inline-flex;align-items:center;gap:6px;font-weight:600"><span class="dot red"></span>${name}</span><span style="color:var(--text-muted);font-variant-numeric:tabular-nums">connection refused</span>`
-          ).join("")
-        }</div>`,
-    },
-  },
-  {
-    id: "prod-errors",
-    view: {
-      label: "production errors",
-      status: "good",
-      value: "0.24%",
-      sub: "12 err / 5000 spans · last 12h",
-      extra: history(),
-      duration: 30 * DAY,
-      hint: "traces ↗",
-      href: "https://example.com/traces",
-    },
-  },
-  {
-    id: "dau",
-    view: {
-      label: "dau",
-      status: "good",
-      value: "244",
-      sub: "active identities · toolshed-production",
-      extra: history(),
-      duration: 30 * DAY,
-      hint: "traces ↗",
-      href: "https://example.com/identities",
+      value: "–",
+      sub: "no metric selected for this tile",
     },
   },
   {
@@ -216,29 +160,38 @@ const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
     },
   },
   {
-    id: "model-spend",
-    subSelector: ".sub",
+    id: "testing-metric-placeholder",
     view: {
-      label: "model spend",
+      label: "YOUR METRIC HERE",
       status: "good",
-      value: "~$820/mo",
-      valueLabel: "~$820/mo",
-      aside: `<span class="hmtd" title="$440 MTD">$440 MTD</span>`,
-      extra: spendSub("OpenAI • Anthropic • OR $0") + twoLines(),
-      duration: 30 * DAY,
+      value: "–",
+      sub: "no metric selected for this tile",
     },
   },
   {
-    id: "gcp-spend",
+    id: "prod-errors",
     view: {
-      label: "gcp spend",
+      label: "production errors",
       status: "good",
-      value: "~$410/mo",
-      valueLabel: "~$410/mo",
-      aside: `<span class="hmtd" title="$220 MTD">$220 MTD</span>`,
-      sub: "billing account spend",
+      value: "0.24%",
+      sub: "12 err / 5000 spans · last 12h",
       extra: history(),
       duration: 30 * DAY,
+      hint: "traces ↗",
+      href: "https://example.com/traces",
+    },
+  },
+  {
+    id: "dau",
+    view: {
+      label: "dau",
+      status: "good",
+      value: "244",
+      sub: "active identities · toolshed-production",
+      extra: history(),
+      duration: 30 * DAY,
+      hint: "traces ↗",
+      href: "https://example.com/identities",
     },
   },
   {
@@ -263,6 +216,80 @@ const TILE_LAYOUT_FIXTURE_INPUTS: readonly TileLayoutFixture[] = [
       duration: 30 * DAY,
       hint: "people ↗",
       href: "https://example.com/people",
+    },
+  },
+  {
+    id: "prod-uptime",
+    view: {
+      label: "production",
+      status: "bad",
+      value: "common.tools down",
+      valueLabel: "common.tools down",
+      extra:
+        `<div class="tile-detail-list" tabindex="0" role="region" aria-label="Production target details; scroll for more" title="Scroll for more details" style="display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin-top:11px;font-size:12px;line-height:1.35">${
+          [
+            "common.tools",
+            "estuary",
+            "rapids",
+            "bastion",
+            "prod shell",
+            "stage shell",
+            "LLM",
+            "sandbox",
+          ].map((name) =>
+            `<span style="display:inline-flex;align-items:center;gap:6px;font-weight:600"><span class="dot red"></span>${name}</span><span style="color:var(--text-muted);font-variant-numeric:tabular-nums">connection refused</span>`
+          ).join("")
+        }</div>`,
+    },
+  },
+  {
+    id: "gcp-spend",
+    view: {
+      label: "gcp spend",
+      status: "good",
+      value: "~$410/mo",
+      valueLabel: "~$410/mo",
+      aside: `<span class="hmtd" title="$220 MTD">$220 MTD</span>`,
+      sub: "billing account spend",
+      extra: history(),
+      duration: 30 * DAY,
+    },
+  },
+  {
+    id: "github-ci-spend",
+    subSelector: ".sub",
+    view: {
+      label: "github ci spend",
+      status: "good",
+      value: "~$3059/mo",
+      valueLabel: "~$3059/mo",
+      aside: `<span class="hmtd" title="$1644 MTD">$1644 MTD</span>`,
+      extra: spendSub("GitHub · Budget $3100") + history(),
+      duration: 30 * DAY,
+      hint: "billing ↗",
+      href: "https://example.com/billing",
+    },
+  },
+  {
+    id: "model-spend",
+    subSelector: ".sub",
+    view: {
+      label: "model spend",
+      status: "good",
+      value: "~$820/mo",
+      valueLabel: "~$820/mo",
+      aside: `<span class="hmtd" title="$440 MTD">$440 MTD</span>`,
+      extra: spendSub("OpenAI • Anthropic • OR $0") + twoLines(),
+      duration: 30 * DAY,
+    },
+  },
+  {
+    id: "spend-metric-placeholder",
+    view: {
+      label: "YOUR METRIC HERE",
+      status: "good",
+      value: "–",
+      sub: "no metric selected for this tile",
     },
   },
   {

--- a/packages/dashboard/tile-render-values.ts
+++ b/packages/dashboard/tile-render-values.ts
@@ -1,0 +1,43 @@
+import type { Status } from "./types.ts";
+import { CHART_HIGHLIGHT } from "./theme.ts";
+
+// good/warn/bad/unknown -> the dot color class the renderer uses.
+export const STATUS_DOT: Record<Status, string> = {
+  good: "green",
+  warn: "amber",
+  bad: "red",
+  unknown: "gray",
+};
+
+export const escapeHtml = (s: string) =>
+  s.replace(
+    /[<>&"]/g,
+    (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" })[c]!,
+  );
+
+// How a sparkline caption spells a day span, consistently across tiles.
+export function daysLabel(days: number): string {
+  if (days < 1) return "<1 day";
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+// A time span for sparkline captions: days, then hours, then minutes.
+export function humanSpan(ms: number): string {
+  if (ms >= 86_400_000) return daysLabel(Math.round(ms / 86_400_000));
+  if (ms >= 3_600_000) {
+    const hr = Math.round(ms / 3_600_000);
+    return `${hr} hour${hr === 1 ? "" : "s"}`;
+  }
+  return `${Math.max(1, Math.round(ms / 60_000))} min`;
+}
+
+export const DURATION_LABEL_HEIGHT = 9;
+// All sparkline variants and their duration labels occupy this rendered height.
+export const SPARKLINE_HEIGHT = 28;
+
+// The span sits in the bottom-left corner of its positioned chart container.
+export function durationTag(ms: number): string {
+  return `<span style="position:absolute;left:1px;bottom:0;font-size:${DURATION_LABEL_HEIGHT}px;line-height:1;color:${CHART_HIGHLIGHT};pointer-events:none">${
+    escapeHtml(humanSpan(ms))
+  }</span>`;
+}

--- a/packages/dashboard/tile-render.ts
+++ b/packages/dashboard/tile-render.ts
@@ -1,0 +1,39 @@
+import type { TileView } from "./types.ts";
+import { durationTag, escapeHtml, STATUS_DOT } from "./tile-render-values.ts";
+
+export function renderTile(v: TileView, id?: string, wide = false): string {
+  const cls = `tile ${v.status}${v.href ? " link" : ""}${wide ? " wide" : ""}${
+    v.alignChartBottom ? " bottom-chart" : ""
+  }`;
+  const key = id ? ` data-tile-id="${escapeHtml(id)}"` : "";
+  const dot = `<span class="dot ${STATUS_DOT[v.status]}"></span>`;
+  const hint = v.hint
+    ? `<span class="drill" title="${escapeHtml(v.hint)}">${
+      escapeHtml(v.hint)
+    }</span>`
+    : "";
+  const header = `<p class="lbl">${dot} ${
+    escapeHtml(v.label)
+  }<span class="spacer"></span>${v.aside ?? ""}${hint}</p>`;
+  const big = v.value !== undefined
+    ? `<p class="big ${v.status}"${
+      v.valueLabel === undefined ? "" : ` title="${escapeHtml(v.valueLabel)}"`
+    }>${v.value}</p>`
+    : "";
+  const sub = v.sub
+    ? `<p class="sub" title="${escapeHtml(v.sub)}">${escapeHtml(v.sub)}</p>`
+    : "";
+  // A duration labels the chart in `extra`; without chart markup there is no
+  // positioned box for the label.
+  const body = v.duration && v.extra
+    ? `<div class="chart" style="position:relative">${v.extra}${
+      durationTag(v.duration)
+    }</div>`
+    : (v.extra ?? "");
+  const inner = `<div class="texture"></div>${header}${big}${sub}${body}`;
+  if (!v.href) return `<div class="${cls}"${key}>${inner}</div>`;
+  const tgt = /^https?:/.test(v.href) ? ` target="_blank" rel="noopener"` : "";
+  return `<a class="${cls}"${key} href="${
+    escapeHtml(v.href)
+  }"${tgt}>${inner}</a>`;
+}

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -103,17 +103,26 @@ Deno.test("labs ci trust: only first-attempt success counts as green", async () 
 Deno.test(
   "labs ci trust grid: every run in the latest 160-run window has a cell",
   async () => {
+    const createdAt = (index: number) => new Date(index * 1_000).toISOString();
     const runs = [
-      run({ status: "in_progress", conclusion: null }),
-      ...Array.from({ length: 159 }, () => run({ conclusion: "success" })),
-      run({ conclusion: "failure" }),
+      run({
+        status: "in_progress",
+        conclusion: null,
+        created_at: createdAt(160),
+      }),
+      ...Array.from({ length: 159 }, (_, index) =>
+        run({
+          conclusion: "success",
+          created_at: createdAt(159 - index),
+        })),
+      run({ conclusion: "failure", created_at: createdAt(0) }),
     ];
     const view = await labsCiTrust.collect(ctx(runs));
     const cells = (view.extra ?? "").match(/class="cell"/g)?.length ?? 0;
     assertEquals(cells, 160);
     assertStringIncludes(
       view.extra ?? "",
-      'class="cells"',
+      'class="cells labeled"',
     );
     assertEquals(
       view.sub,

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -113,7 +113,7 @@ Deno.test(
     assertEquals(cells, 160);
     assertStringIncludes(
       view.extra ?? "",
-      "grid-template-columns:repeat(40,1fr)",
+      'class="cells"',
     );
     assertEquals(
       view.sub,

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { TILE_LAYOUT_FIXTURES } from "./tile-layout-fixtures.ts";
 import { runSource, type Ctx, type Run } from "./types.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
 import { labsCi, loomCi } from "./tiles/main-build.ts";
@@ -147,6 +148,32 @@ Deno.test("labs ci trust grid: cell colors match trust scoring", async () => {
     colors.filter((color) => color === "var(--status-unknown)").length,
     2,
   );
+});
+
+Deno.test("labs ci trust grid: duration spans the displayed runs", async () => {
+  const now = Date.now();
+  const runs = [
+    run({ created_at: new Date(now).toISOString() }),
+    run({ created_at: new Date(now - 2 * 86_400_000).toISOString() }),
+    run({ created_at: new Date(now - 5 * 86_400_000).toISOString() }),
+  ];
+  const view = await labsCiTrust.collect(ctx(runs));
+  assertEquals(view.duration, 5 * 86_400_000);
+  assertStringIncludes(view.extra ?? "", 'class="cells labeled"');
+
+  const malformed = await labsCiTrust.collect(ctx([
+    runs[0],
+    run({ created_at: "not a timestamp" }),
+    runs[2],
+  ]));
+  assertEquals(malformed.duration, 0);
+  assert(!(malformed.extra ?? "").includes("cells labeled"));
+
+  const window = Array.from({ length: 161 }, (_, i) =>
+    run({ created_at: new Date(now - i * 86_400_000).toISOString() })
+  );
+  const limited = await labsCiTrust.collect(ctx(window));
+  assertEquals(limited.duration, 159 * 86_400_000);
 });
 
 Deno.test("ci-duration window: the 6h window when it has >= 20 runs, else the most recent 20", async () => {
@@ -341,10 +368,14 @@ Deno.test("recent runs: duration opens every successful run for the commit", asy
 
 Deno.test("tile labels: the labs/loom ci family is renamed and paired", async () => {
   const one = ctx([run({ conclusion: "success" })]);
+  const labsTrust = await labsCiTrust.collect(one);
+  const loomTrust = await loomCiTrust.collect(one);
   assertEquals((await labsCi.collect(one)).label, "labs ci");
   assertEquals((await loomCi.collect(one)).label, "loom ci");
-  assertEquals((await labsCiTrust.collect(one)).label, "labs ci trust");
-  assertEquals((await loomCiTrust.collect(one)).label, "loom ci trust");
+  assertEquals(labsTrust.label, "labs ci trust");
+  assertEquals(loomTrust.label, "loom ci trust");
+  assertEquals(labsTrust.alignChartBottom, true);
+  assertEquals(loomTrust.alignChartBottom, true);
   assertEquals((await labsCiDuration.collect(one)).label, "labs ci duration");
   assertEquals((await loomCiDuration.collect(one)).label, "loom ci duration");
 });
@@ -634,4 +665,15 @@ Deno.test("registry: unique ids and positive intervals", () => {
   for (const t of TILES) {
     assert(t.intervalMs > 0, `${t.id} needs a positive intervalMs`);
   }
+});
+
+Deno.test("layout fixtures cover every registered tile in registry order", () => {
+  assertEquals(
+    TILE_LAYOUT_FIXTURES.map(({ id }) => id),
+    TILES.map(({ id }) => id),
+  );
+  assertEquals(
+    TILE_LAYOUT_FIXTURES.filter(({ wide }) => wide).map(({ id }) => id),
+    TILES.filter(({ wide }) => wide).map(({ id }) => id),
+  );
 });

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -47,12 +47,21 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
         outcome,
         href: run.html_url,
       }));
+      const times = scored.flatMap(({ run }) => {
+        const createdAt = Date.parse(run.created_at);
+        return Number.isFinite(createdAt) ? [createdAt] : [];
+      });
+      const spanMs = times.length === scored.length && times.length >= 2
+        ? Math.max(...times) - Math.min(...times)
+        : 0;
       return {
         label: opts.label,
         status: s,
         value: `${pct.toFixed(1)}%`,
         sub: `first-try green · ${runSummary}`,
-        extra: strip(cells, TRUST_COLS),
+        extra: strip(cells, TRUST_COLS, spanMs > 0),
+        duration: spanMs,
+        alignChartBottom: true,
       };
     },
   };

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -13,7 +13,7 @@ import {
   type TileView,
 } from "../types.ts";
 import { strip } from "../lib.ts";
-import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_RUNS_MAX, TRUST_WARN } from "../config.ts";
+import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_GOOD, TRUST_RUNS_MAX, TRUST_WARN } from "../config.ts";
 
 type TrustOutcome = "green" | "red" | "run" | "gray";
 
@@ -59,7 +59,7 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
         status: s,
         value: `${pct.toFixed(1)}%`,
         sub: `first-try green · ${runSummary}`,
-        extra: strip(cells, TRUST_COLS, spanMs > 0),
+        extra: strip(cells, spanMs > 0),
         duration: spanMs,
         alignChartBottom: true,
       };

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -277,8 +277,8 @@ export const discordOnline: Tile = {
     // With the chart drawn, the counts sit at each line's end; until there are
     // two samples show them inline so the tile is never numberless.
     const subline = chart
-      ? `<p class="sub">${swatch(teamSeries.color)} team + ${swatch(visitorSeries.color)} visitors</p>`
-      : `<p class="sub">${swatch(teamSeries.color)} team ${snap.team} + ${swatch(visitorSeries.color)} visitors ${snap.visitors}</p>`;
+      ? `<p class="sub" title="team + visitors">${swatch(teamSeries.color)} team + ${swatch(visitorSeries.color)} visitors</p>`
+      : `<p class="sub" title="team ${snap.team} + visitors ${snap.visitors}">${swatch(teamSeries.color)} team ${snap.team} + ${swatch(visitorSeries.color)} visitors ${snap.visitors}</p>`;
 
     return {
       label,

--- a/packages/dashboard/tiles/gcp-spend.test.ts
+++ b/packages/dashboard/tiles/gcp-spend.test.ts
@@ -169,9 +169,10 @@ Deno.test(
     // month-to-date total and out of the rate.
     assertEquals(result.status, "good");
     assertEquals(result.value, "~$509/mo");
+    assertEquals(result.valueLabel, result.value);
     assertEquals(
       result.aside,
-      '<span class="hmtd">$185 MTD</span>',
+      '<span class="hmtd" title="$185 MTD">$185 MTD</span>',
     );
     assertEquals(result.sub, "billing account spend");
     assertEquals(result.duration, 45 * DAY);
@@ -242,7 +243,7 @@ Deno.test(
     assertEquals(result.value, "~$382/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$139 MTD</span>',
+      '<span class="hmtd" title="$139 MTD">$139 MTD</span>',
     );
     assertEquals(result.sub, "billing account spend");
     // One line, for what the account pays. The credit is not a figure the tile
@@ -304,7 +305,7 @@ Deno.test(
     assertEquals(result.value, "~$310/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$7 MTD</span>',
+      '<span class="hmtd" title="$7 MTD">$7 MTD</span>',
     );
     assertEquals(result.duration, 45 * DAY);
     const polylines = [
@@ -329,7 +330,7 @@ Deno.test(
     assertEquals(result.value, "~$620/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$40 MTD</span>',
+      '<span class="hmtd" title="$40 MTD">$40 MTD</span>',
     );
     assertEquals(result.duration, 0);
     assertEquals(result.extra, "");
@@ -383,7 +384,7 @@ Deno.test(
     assertEquals(result.value, "~$620/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$150 MTD</span>',
+      '<span class="hmtd" title="$150 MTD">$150 MTD</span>',
     );
     assertEquals(result.duration, 7 * DAY);
   },
@@ -409,7 +410,7 @@ Deno.test(
     // the month-to-date total. Rating every day the export has touched would
     // read the same $620 off days two of which are not all there.
     assertEquals(result.value, "~$620/mo");
-    assertEquals(result.aside, '<span class="hmtd">$180 MTD</span>');
+    assertEquals(result.aside, '<span class="hmtd" title="$180 MTD">$180 MTD</span>');
     assertEquals(result.duration, 7 * DAY);
   },
 );
@@ -438,7 +439,7 @@ Deno.test(
 
     // Four days at $20 and five at $6 rate the month: $110 / 9 * 31 = $379.
     assertEquals(result.value, "~$379/mo");
-    assertEquals(result.aside, '<span class="hmtd">$116 MTD</span>');
+    assertEquals(result.aside, '<span class="hmtd" title="$116 MTD">$116 MTD</span>');
     assertEquals(result.duration, 9 * DAY);
   },
 );

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -321,11 +321,14 @@ export const gcpSpend: Tile = {
       summary.estimateDays,
     );
 
+    const value = `~${usd(summary.projected)}/mo`;
+    const mtd = `${usd(history.paidMtd)} MTD`;
     return {
       label,
       status,
-      value: `~${usd(summary.projected)}/mo`,
-      aside: `<span class="hmtd">${usd(history.paidMtd)} MTD</span>`,
+      value,
+      valueLabel: value,
+      aside: `<span class="hmtd" title="${mtd}">${mtd}</span>`,
       sub: "billing account spend",
       extra: chart.chart,
       duration: chart.duration,

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -168,7 +168,8 @@ Deno.test("github spend: projects the month from the settled daily rate, against
   // lag), carried across all 31 -> $1171. The quiet 11th-18th count; the
   // unsettled 19th-20th do not.
   assertEquals(v.value, "~$1171/mo");
-  assertEquals(v.aside, '<span class="hmtd">$680 MTD</span>');
+  assertEquals(v.valueLabel, v.value);
+  assertEquals(v.aside, '<span class="hmtd" title="$680 MTD">$680 MTD</span>');
   // Both products' budgets, since the figure they are held against covers both.
   assertEquals(v.sub, undefined);
   assertStringIncludes(v.extra ?? "", "Budget $3000");
@@ -243,7 +244,7 @@ Deno.test("github spend: every metered product lands in the one GitHub figure", 
   assertEquals(v.status, "good");
   // $700 over the 18 settled days, carried across all 31.
   assertEquals(v.value, "~$1206/mo");
-  assertEquals(v.aside, '<span class="hmtd">$700 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$700 MTD">$700 MTD</span>');
   assertStringIncludes(v.extra ?? "", "<polyline");
 });
 
@@ -261,7 +262,7 @@ Deno.test("github spend: a quiet week reads as $0 days while the report is writt
   });
   assertEquals(v.status, "good");
   assertEquals(v.value, "~$310/mo"); // $180 over the 18 settled days, across 31
-  assertEquals(v.aside, '<span class="hmtd">$180 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$180 MTD">$180 MTD</span>');
   assertStringIncludes(v.extra ?? "", "<polyline");
 });
 
@@ -385,7 +386,7 @@ Deno.test("github spend: a product with no budget of its own never trips the lig
   // The headline and the month-to-date total still carry every dollar: the
   // Copilot spend is out of the comparison, not out of the figure.
   assertEquals(v.value, "~$3754/mo");
-  assertEquals(v.aside, '<span class="hmtd">$2180 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$2180 MTD">$2180 MTD</span>');
   // The ceiling shown covers what the headline covers: Actions' $400, plus
   // Copilot's own $3444 projection standing in for the budget it lacks. A bare
   // $400 next to a $3754 headline would read as an overrun on a green tile.
@@ -424,7 +425,7 @@ Deno.test("github spend: an undated row weighs on the comparison as it does on t
   // $280 over the 18 settled days across 31, in the headline and against the
   // budget alike. Counting only the dated $180 would project $310 and pass.
   assertEquals(v.value, "~$482/mo");
-  assertEquals(v.aside, '<span class="hmtd">$280 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$280 MTD">$280 MTD</span>');
   assertEquals(v.status, "warn"); // $482 of a $400 Actions budget
   assertStringIncludes(v.extra ?? "", "Budget $400");
 });
@@ -488,7 +489,7 @@ Deno.test("github spend: early in the month the rate comes from last month's tai
   // Window = $40 over 2 days here + $120 over the last 12 of December = $160/14
   // days -> $354 across 31. Rating the two days alone would claim $620.
   assertEquals(v.value, "~$354/mo");
-  assertEquals(v.aside, '<span class="hmtd">$40 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$40 MTD">$40 MTD</span>');
   // November is fetched only to fill the chart, which spans at most 45 days back
   // from the last day with a figure (January 2nd).
   assertEquals(v.duration, 45 * D);
@@ -541,7 +542,7 @@ Deno.test("github spend: an unavailable prior month is not zero-spend history", 
     [budgetsPath()]: { budgets: [productBudget("actions", 400)] },
   });
   assertEquals(v.value, "~$620/mo");
-  assertEquals(v.aside, '<span class="hmtd">$40 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$40 MTD">$40 MTD</span>');
   assertEquals(v.status, "bad");
   assertEquals(v.duration, 2 * D);
 });
@@ -583,7 +584,7 @@ Deno.test("github spend: a row whose date is unreadable leaves the chart out", a
     },
   });
   assertEquals(v.value, "~$344/mo");
-  assertEquals(v.aside, '<span class="hmtd">$200 MTD</span>');
+  assertEquals(v.aside, '<span class="hmtd" title="$200 MTD">$200 MTD</span>');
   assertStringIncludes(v.extra ?? "", "GitHub $200");
   assertEquals(v.extra?.includes("<polyline"), false);
   assertEquals(v.duration, 0);
@@ -651,7 +652,7 @@ Deno.test("github spend: both billing endpoints unreachable -> gray with a calm 
   );
   assertEquals(
     v.extra,
-    `<p class="sub">${themedSwatch("#58a6ff")} GitHub $???</p>`,
+    `<p class="sub" title="GitHub $???">${themedSwatch("#58a6ff")} GitHub $???</p>`,
   );
 });
 

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -29,7 +29,14 @@
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { budgetStatus, daysLabel, friendlyError, github, usd } from "../lib.ts";
+import {
+  budgetStatus,
+  daysLabel,
+  escapeHtml,
+  friendlyError,
+  github,
+  usd,
+} from "../lib.ts";
 import { REPO } from "../config.ts";
 import {
   calendarMonth,
@@ -479,15 +486,19 @@ export const githubCiSpend: Tile = {
       const budgetLabel = Number.isFinite(shownBudget)
         ? ` • Budget ${usd(shownBudget)}`
         : "";
+      const legendText = `GitHub${amount}${budgetLabel}`;
       const legend =
-        `<p class="sub">${GITHUB_SWATCH} GitHub${amount}${budgetLabel}</p>`;
+        `<p class="sub" title="${escapeHtml(legendText)}">${GITHUB_SWATCH} ${legendText}</p>`;
+      const value = `~${usd(spend.projected)}/mo`;
+      const mtd = `${usd(spend.mtd)} MTD`;
 
       return {
         ...drill,
         label,
         status,
-        value: `~${usd(spend.projected)}/mo`,
-        aside: `<span class="hmtd">${usd(spend.mtd)} MTD</span>`,
+        value,
+        valueLabel: value,
+        aside: `<span class="hmtd" title="${mtd}">${mtd}</span>`,
         extra: `${legend}${chart.chart}`,
         duration: chart.duration,
       };
@@ -498,7 +509,8 @@ export const githubCiSpend: Tile = {
         status: "unknown",
         value: "—",
         sub: unavailableMessage(error),
-        extra: `<p class="sub">${GITHUB_SWATCH} GitHub $???</p>`,
+        extra:
+          `<p class="sub" title="GitHub $???">${GITHUB_SWATCH} GitHub $???</p>`,
       };
     }
   },

--- a/packages/dashboard/tiles/github-members.ts
+++ b/packages/dashboard/tiles/github-members.ts
@@ -196,10 +196,10 @@ export function createGithubMembers(): Tile {
       const swatch = (color: string) =>
         `<span class="swatch" style="background:${escapeHtml(color)}"></span>`;
       const subline = chart
-        ? `<p class="sub">${swatch(membersSeries.color)} members · ${
+        ? `<p class="sub" title="members · collaborators">${swatch(membersSeries.color)} members · ${
           swatch(collaboratorsSeries.color)
         } collaborators</p>`
-        : `<p class="sub">${swatch(membersSeries.color)} members ${members} · ${
+        : `<p class="sub" title="members ${members} · collaborators ${collaborators}">${swatch(membersSeries.color)} members ${members} · ${
           swatch(collaboratorsSeries.color)
         } collaborators ${collaborators}</p>`;
 

--- a/packages/dashboard/tiles/main-build.ts
+++ b/packages/dashboard/tiles/main-build.ts
@@ -118,10 +118,16 @@ function makeBuildTile(opts: { id: string; label: string; repo: string; workflow
         ? `<span class="running" title="${escapeHtml((latest.display_title ?? "").slice(0, 90))}"><span class="rdot"></span>${runningLabel}</span>`
         : "";
 
+      const value = s === "unknown"
+        ? "—"
+        : s === "good"
+        ? "passing"
+        : escapeHtml(conclusion);
       return {
         label: opts.label,
         status: s,
-        value: s === "unknown" ? "—" : s === "good" ? "passing" : escapeHtml(conclusion),
+        value,
+        valueLabel: value,
         sub: streak || "no completed runs in window",
         href: commitsUrl,
         hint: "commits ↗",

--- a/packages/dashboard/tiles/model-spend.test.ts
+++ b/packages/dashboard/tiles/model-spend.test.ts
@@ -118,14 +118,15 @@ Deno.test("model spend: all three providers read -> green, combined MTD, a line 
       // $1/day from OpenAI and $2/day from Anthropic for each day of the month so
       // far, plus OpenRouter's running $5. The buckets with no day and no figures
       // are dropped rather than counted, and both pages of each provider land.
-      assertEquals(v.aside, `<span class="hmtd">$${3 * DOM + 5} MTD</span>`);
+      assertEquals(v.valueLabel, v.value);
+      assertEquals(v.aside, `<span class="hmtd" title="$${3 * DOM + 5} MTD">$${3 * DOM + 5} MTD</span>`);
       assert(v.value?.startsWith("~"), `a complete read is a projection, got ${v.value}`);
       assert(v.value?.endsWith("/mo"));
       // The key: a swatch each for the charted providers (their totals sit at the
       // line ends), OpenRouter's total inline since it has no line.
       assertStringIncludes(
         v.extra ?? "",
-        `<p class="sub">${themedSwatch("#10a37f")} OpenAI • ` +
+        `<p class="sub" title="OpenAI • Anthropic • OR $5">${themedSwatch("#10a37f")} OpenAI • ` +
           `${themedSwatch("#d97757")} Anthropic • OR $5</p>`,
       );
       // Each line is drawn in its provider's color and labeled with its own MTD.
@@ -160,11 +161,11 @@ Deno.test("model spend: a provider that errors -> $??? and gray, the rest still 
       // is unknown, so the tile grays out rather than claiming a verdict.
       const v = await modelSpend.collect(ctx({ ...ALL_KEYS, MODEL_MONTHLY_BUDGET: "0" }));
       assertEquals(v.status, "unknown");
-      assertEquals(v.aside, `<span class="hmtd">$${DOM + 5} MTD</span>`); // Anthropic adds nothing
+      assertEquals(v.aside, `<span class="hmtd" title="$${DOM + 5} MTD">$${DOM + 5} MTD</span>`); // Anthropic adds nothing
       assert(v.value?.startsWith("≥"), `the total is a lower bound, got ${v.value}`);
       assertStringIncludes(
         v.extra ?? "",
-        `<p class="sub">${themedSwatch("#10a37f")} OpenAI • Anthropic $??? • OR $5</p>`,
+        `<p class="sub" title="OpenAI • Anthropic $??? • OR $5">${themedSwatch("#10a37f")} OpenAI • Anthropic $??? • OR $5</p>`,
       );
       assertEquals(v.duration, 45 * DAY); // OpenAI's line is still drawn
       assertStringIncludes(v.extra ?? "", "#10a37f");
@@ -192,7 +193,7 @@ Deno.test("model spend: a provider whose report stopped -> $??? and gray, never 
     const v = await modelSpend.collect(ctx({ OPENAI_ADMIN_KEY: "oa", OPENROUTER_KEY: "or" }));
     assertEquals(v.status, "unknown"); // OpenAI's recent days are unknown, not quiet
     assert(v.value?.startsWith("≥"), `the total is a lower bound, got ${v.value}`);
-    assertEquals(v.extra, `<p class="sub">OpenAI $??? • OR $5</p>`); // no line, no total
+    assertEquals(v.extra, `<p class="sub" title="OpenAI $??? • OR $5">OpenAI $??? • OR $5</p>`); // no line, no total
   });
 });
 
@@ -213,7 +214,7 @@ Deno.test("model spend: a provider with no bucket at all draws no line of $0", a
   await withFetch({ "api.openai.com": () => json({ data: [] }), "api.anthropic.com": anthropicPaged }, async () => {
     const v = await modelSpend.collect(ctx({ OPENAI_ADMIN_KEY: "oa", ANTHROPIC_ADMIN_KEY: "an" }));
     assertEquals(v.status, "good");
-    assertEquals(v.aside, `<span class="hmtd">$${2 * DOM} MTD</span>`); // Anthropic's $2/day alone
+    assertEquals(v.aside, `<span class="hmtd" title="$${2 * DOM} MTD">$${2 * DOM} MTD</span>`); // Anthropic's $2/day alone
     // OpenAI's color survives in the key's swatch and nowhere in the chart.
     assertEquals((v.extra ?? "").match(/#10a37f/gi)?.length, 1);
     assertStringIncludes(v.extra ?? "", "#d97757");
@@ -224,10 +225,10 @@ Deno.test("model spend: a one-key deployment still turns green (an unset key doe
   await withFetch({ "openrouter.ai": openrouterFive }, async () => {
     const v = await modelSpend.collect(ctx({ OPENROUTER_KEY: "or" }));
     assertEquals(v.status, "good");
-    assertEquals(v.aside, `<span class="hmtd">$5 MTD</span>`);
+    assertEquals(v.aside, `<span class="hmtd" title="$5 MTD">$5 MTD</span>`);
     assert(v.value?.startsWith("~"), `nothing configured is missing, got ${v.value}`);
     // OpenRouter has no daily series, so there is no chart and nothing to span.
-    assertEquals(v.extra, `<p class="sub">OR $5</p>`);
+    assertEquals(v.extra, `<p class="sub" title="OR $5">OR $5</p>`);
     assertEquals(v.duration, 0);
   });
 });
@@ -237,8 +238,8 @@ Deno.test("model spend: one day of data draws no chart, so the provider's total 
   await withFetch({ "api.openai.com": () => json({ data: [oaBucket(today, 12)] }) }, async () => {
     const v = await modelSpend.collect(ctx({ OPENAI_ADMIN_KEY: "oa" }));
     assertEquals(v.status, "good");
-    assertEquals(v.extra, `<p class="sub">${themedSwatch("#10a37f")} OpenAI $12</p>`);
-    assertEquals(v.aside, `<span class="hmtd">$12 MTD</span>`);
+    assertEquals(v.extra, `<p class="sub" title="OpenAI $12">${themedSwatch("#10a37f")} OpenAI $12</p>`);
+    assertEquals(v.aside, `<span class="hmtd" title="$12 MTD">$12 MTD</span>`);
     assertEquals(v.duration, 0);
   });
 });

--- a/packages/dashboard/tiles/model-spend.ts
+++ b/packages/dashboard/tiles/model-spend.ts
@@ -26,7 +26,7 @@
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { budgetStatus, readBudget, usd } from "../lib.ts";
+import { budgetStatus, escapeHtml, readBudget, usd } from "../lib.ts";
 import {
   DAY_MS,
   newestReportedDay,
@@ -226,15 +226,24 @@ export const modelSpend: Tile = {
     if (oaKey) seg.push(charted(oa, "OpenAI", OPENAI_COLOR));
     if (anKey) seg.push(charted(an, "Anthropic", ANTHROPIC_COLOR));
     if (orKey) seg.push(or ? `OR ${usd(or.mtd)}` : "OR $???");
-    const legend = `<p class="sub">${seg.join(" • ")}</p>`;
+    const legendText = seg.join(" • ").replaceAll(/<[^>]+>/g, "").replaceAll(
+      /\s+/g,
+      " ",
+    ).trim();
+    const legend = `<p class="sub" title="${escapeHtml(legendText)}">${
+      seg.join(" • ")
+    }</p>`;
+    const value = `${complete ? "~" : "≥"}${usd(totalProjected)}/mo`;
+    const mtd = `${usd(totalMtd)} MTD`;
 
     return {
       label,
       status,
       // Complete -> a projection (~); missing a provider -> the total is only a
       // lower bound, since the absent provider would add to it (≥).
-      value: `${complete ? "~" : "≥"}${usd(totalProjected)}/mo`,
-      aside: `<span class="hmtd">${usd(totalMtd)} MTD</span>`,
+      value,
+      valueLabel: value,
+      aside: `<span class="hmtd" title="${mtd}">${mtd}</span>`,
       extra: legend + chart.chart,
       duration: chart.duration,
     };

--- a/packages/dashboard/tiles/prod-uptime.test.ts
+++ b/packages/dashboard/tiles/prod-uptime.test.ts
@@ -452,6 +452,10 @@ Deno.test("prod uptime: several hosts with nothing behind them are counted", asy
     const view = await prodUptime.collect(ctx());
     assertEquals(view.status, "bad");
     assertEquals(view.value, "3 hosts down");
+    assertStringIncludes(view.extra ?? "", 'class="tile-detail-list"');
+    assertStringIncludes(view.extra ?? "", 'role="region"');
+    assertStringIncludes(view.extra ?? "", 'tabindex="0"');
+    assertStringIncludes(view.extra ?? "", "scroll for more");
     assertStringIncludes(view.extra ?? "", "rapids");
     assertStringIncludes(view.extra ?? "", "bastion");
     assertStringIncludes(view.extra ?? "", "stage shell");
@@ -473,6 +477,9 @@ Deno.test("prod uptime: one host down is named rather than counted", async () =>
     const view = await prodUptime.collect(ctx());
     assertEquals(view.status, "bad");
     assertEquals(view.value, "LLM down");
+    assertStringIncludes(view.extra ?? "", 'role="region"');
+    assertStringIncludes(view.extra ?? "", 'tabindex="0"');
+    assert(!(view.extra ?? "").includes("scroll for more"));
     assertStringIncludes(view.extra ?? "", "LLM");
     assertStringIncludes(view.extra ?? "", "DNS down");
   } finally {

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -528,16 +528,21 @@ function view(results: readonly TargetResult[]): TileView {
       (status !== "bad" && result.target.http?.kind === "health"),
   );
   const rows = visible.map(resultRow).join("");
+  const listAttributes = visible.length > 1
+    ? ` aria-label="Production target details; scroll for more" title="Scroll for more details"`
+    : ` aria-label="Production target details"`;
+  const value = headline ??
+    `${
+      results.filter((result) => result.status === "good").length
+    }/${results.length} hosts up`;
   return {
     label: "production",
     status,
-    value: headline ??
-      `${
-        results.filter((result) => result.status === "good").length
-      }/${results.length} hosts up`,
+    value,
+    valueLabel: value,
     extra: rows === ""
       ? undefined
-      : `<div style="display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin-top:11px;font-size:12px;line-height:1.35">${rows}</div>`,
+      : `<div class="tile-detail-list" role="region" tabindex="0"${listAttributes} style="display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin-top:11px;font-size:12px;line-height:1.35">${rows}</div>`,
   };
 }
 

--- a/packages/dashboard/tiles/test-flakes.ts
+++ b/packages/dashboard/tiles/test-flakes.ts
@@ -65,11 +65,20 @@ async function flakesView(
       : held.length >= FLAKES_WARN
       ? "warn"
       : "good";
-    const worst = flaky.slice(0, NAMED).map((entry) =>
-      `<div>${(entry.flakeRate * 100).toFixed(1)}% · ${
-        escapeHtml(shortName(entry.test))
-      }</div>`
-    ).join("");
+    const named = flaky.slice(0, NAMED);
+    const listAttributes = named.length > 2
+      ? ` aria-label="Flaky test details; scroll for more" title="Scroll for more details"`
+      : ` aria-label="Flaky test details"`;
+    const worst = named.length === 0
+      ? ""
+      : `<div class="tile-detail-list" role="region" tabindex="0"${listAttributes}>${
+        named.map((entry) => {
+          const line = `${(entry.flakeRate * 100).toFixed(1)}% · ${
+            shortName(entry.test)
+          }`;
+          return `<div title="${escapeHtml(line)}">${escapeHtml(line)}</div>`;
+        }).join("")
+      }</div>`;
     return {
       label: "flaky tests",
       status,

--- a/packages/dashboard/tiles/test-flakes.ts
+++ b/packages/dashboard/tiles/test-flakes.ts
@@ -30,6 +30,11 @@ function shortName(test: { s: string; n: string; v?: string }): string {
   return `${test.s}: ${name}${variant}`;
 }
 
+function fullName(test: { k: string; s: string; n: string; v?: string }): string {
+  const variant = test.v === undefined ? "" : ` (${test.v})`;
+  return `${test.k} · ${test.s}: ${test.n}${variant}`;
+}
+
 /** Builds the tile against a store, so a test can supply its own. */
 export function makeTestFlakes(
   options: { fetchImpl?: typeof fetch } = {},
@@ -73,10 +78,10 @@ async function flakesView(
       ? ""
       : `<div class="tile-detail-list" role="region" tabindex="0"${listAttributes}>${
         named.map((entry) => {
-          const line = `${(entry.flakeRate * 100).toFixed(1)}% · ${
-            shortName(entry.test)
-          }`;
-          return `<div title="${escapeHtml(line)}">${escapeHtml(line)}</div>`;
+          const rate = `${(entry.flakeRate * 100).toFixed(1)}%`;
+          const line = `${rate} · ${shortName(entry.test)}`;
+          const title = `${rate} · ${fullName(entry.test)}`;
+          return `<div title="${escapeHtml(title)}">${escapeHtml(line)}</div>`;
         }).join("")
       }</div>`;
     return {

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -13,9 +13,11 @@ export interface TileView {
   label: string; // header label (plain text; escaped by the renderer)
   status: Status; // good / warn / bad / unknown -> green / orange / red / gray
   value?: string; // big headline (TRUSTED html — escape in the tile if it holds data)
+  valueLabel?: string; // plain-text headline shown when CSS truncates value
   sub?: string; // sub line (plain text; escaped by the renderer)
   extra?: string; // trusted inline html under sub (sparkline / strip / list)
   duration?: number; // a span in ms; rendered (humanSpan) in the chart's bottom-left corner
+  alignChartBottom?: boolean; // keep the chart at the tile bottom when its grid row grows taller
   aside?: string; // trusted inline html minor header facet (e.g. an MTD or "running" badge)
   href?: string; // if set, the whole tile becomes a link (external opens a new tab)
   hint?: string; // small drill affordance text, e.g. "commits ↗"


### PR DESCRIPTION
CI Trust used a different vertical rhythm from the sparkline tiles. Its headline and subheading began at different offsets, while its history grid left too much space above the cells and no visible label for the time span.

Give CI Trust and Loom CI Trust the same duration label as other history tiles. Share the tile layout rules so headlines, subheadings, charts, and duration labels use the same geometry. Bound long detail lists and preserve truncated values through labels and keyboard-accessible scrolling.

Add maximum-content fixtures for every registered tile. Render each standard tile with production markup and CSS at the dashboard width and its supported minimum. Require expected text and duration labels to exist, compare their vertical offsets with Benchmarks, and reject tiles taller than Benchmarks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

