### PR TITLE
feat(cli): make diff jump lists browsable

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,20 @@ A diff shows its whole-diff change totals at the top right corner of its first
 line: the added line count and the removed line count, colored like additions
 and removals.
 
+Press `i` in a diff to open its file and commit list. The list starts in browse
+mode. Press `/` to filter it by file name, commit hash, or commit subject. The
+usual `f`, `F`, `E`, `T`, and `M` file-visibility keys remain active while the
+list is in browse mode, and Space pages through the entries. Its summary reports
+added and removed lines for the complete diff and for the files that are
+currently shown.
+
+Press `D` in that list to cycle its line-count policy. Normal counts include
+every added and removed line. The second policy removes pairs within one file
+whose text differs only in whitespace. The third also removes lines containing
+only whitespace or comments. It compares the remaining lines without comments or
+whitespace across the complete diff, so code moved between files does not count
+as an addition and a removal.
+
 Markdown files can switch between the source and a rendered terminal view with
 `V`. The rendered view formats headings, emphasis, links, quotes, lists, task
 markers, tables, rules, and code. The same view is available for Markdown files

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -229,7 +229,7 @@ interface CommentState {
   heredoc?: { readonly end: string; readonly stripTabs: boolean };
 }
 
-/** Scans each hunk side so block comments carry across changed lines. */
+/** Scans each file side so multiline syntax carries across diff hunks. */
 function fallbackCommentLines(
   raw: readonly string[],
   diffLines: readonly DiffLine[],
@@ -241,9 +241,9 @@ function fallbackCommentLines(
   if (!oldSyntax && !newSyntax) return new Map();
 
   const result = new Map<number, string>();
+  const oldState: CommentState = {};
+  const newState: CommentState = {};
   for (const hunk of file.hunks) {
-    const oldState: CommentState = {};
-    const newState: CommentState = {};
     for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
       const kind = diffLines[i]?.kind;
       const text = (raw[i] ?? "").slice(1);
@@ -334,6 +334,7 @@ function stripCommonComments(
   }
 
   let quote = "";
+  let heredoc: CommentState["heredoc"];
   for (let i = start; i < text.length;) {
     if (state.block) {
       if (state.block.nested && text.startsWith(state.block.open, i)) {
@@ -381,6 +382,12 @@ function stripCommonComments(
       i = after;
       continue;
     }
+    if (syntax.heredocs && !heredoc) {
+      const match = /^<<(-)?\s*(['"]?)([A-Za-z_]\w*)\2/u.exec(text.slice(i));
+      if (match) {
+        heredoc = { end: match[3], stripTabs: match[1] === "-" };
+      }
+    }
     const block = syntax.blocks.find(([open]) => text.startsWith(open, i));
     if (block) {
       state.block = {
@@ -398,12 +405,7 @@ function stripCommonComments(
     result += ch;
     i++;
   }
-  if (syntax.heredocs && !state.heredoc) {
-    const heredoc = /<<(-)?\s*(['"]?)([A-Za-z_]\w*)\2/.exec(result);
-    if (heredoc) {
-      state.heredoc = { end: heredoc[3], stripTabs: heredoc[1] === "-" };
-    }
-  }
+  if (heredoc) state.heredoc = heredoc;
   return result;
 }
 

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -218,6 +218,11 @@ interface CommentSyntax {
   readonly heredocs: boolean;
 }
 
+interface HeredocState {
+  readonly end: string;
+  readonly stripTabs: boolean;
+}
+
 interface CommentState {
   block?: {
     readonly open: string;
@@ -226,7 +231,7 @@ interface CommentState {
     readonly nested: boolean;
   };
   literalClose?: string;
-  heredoc?: { readonly end: string; readonly stripTabs: boolean };
+  heredocs?: HeredocState[];
 }
 
 /** Scans each file side so multiline syntax carries across diff hunks. */
@@ -245,8 +250,24 @@ function fallbackCommentLines(
   const newState: CommentState = {};
   for (const [hunkIndex, hunk] of file.hunks.entries()) {
     if (hunkIndex > 0) {
-      reconcileStateAfterGap(raw, diffLines, hunk, oldState, "old");
-      reconcileStateAfterGap(raw, diffLines, hunk, newState, "new");
+      const previous = file.hunks[hunkIndex - 1];
+      const remaining = file.hunks.slice(hunkIndex);
+      reconcileStateAfterGap(
+        raw,
+        diffLines,
+        previous,
+        remaining,
+        oldState,
+        "old",
+      );
+      reconcileStateAfterGap(
+        raw,
+        diffLines,
+        previous,
+        remaining,
+        newState,
+        "new",
+      );
     }
     for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
       const kind = diffLines[i]?.kind;
@@ -280,37 +301,84 @@ function fallbackCommentLines(
 function reconcileStateAfterGap(
   raw: readonly string[],
   diffLines: readonly DiffLine[],
-  hunk: DiffFile["hunks"][number],
+  previous: DiffFile["hunks"][number],
+  remaining: readonly DiffFile["hunks"][number][],
   state: CommentState,
   side: "old" | "new",
 ): void {
+  const current = remaining[0];
+  const previousEnd = side === "old"
+    ? previous.oldStart + previous.oldCount
+    : previous.newStart + previous.newCount;
+  const currentStart = side === "old" ? current.oldStart : current.newStart;
+  if (previousEnd === currentStart) return;
+
   const texts: string[] = [];
-  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
-    const kind = diffLines[i]?.kind;
-    if (
-      kind === "ctx" || side === "old" && kind === "del" ||
-      side === "new" && kind === "add"
-    ) {
-      texts.push((raw[i] ?? "").slice(1));
+  for (const hunk of remaining) {
+    for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+      const kind = diffLines[i]?.kind;
+      if (
+        kind === "ctx" || side === "old" && kind === "del" ||
+        side === "new" && kind === "add"
+      ) {
+        texts.push((raw[i] ?? "").slice(1));
+      }
     }
   }
   const block = state.block;
-  if (block && !texts.some((text) => text.includes(block.close))) {
+  if (block && !texts.some((text) => hasUnquotedToken(text, block.close))) {
     state.block = undefined;
   }
   const literalClose = state.literalClose;
-  if (literalClose && !texts.some((text) => text.includes(literalClose))) {
+  if (
+    literalClose && !texts.some((text) => hasUnescapedToken(text, literalClose))
+  ) {
     state.literalClose = undefined;
   }
-  const heredoc = state.heredoc;
-  if (
-    heredoc && !texts.some((text) => {
-      const candidate = heredoc.stripTabs ? text.replace(/^\t+/u, "") : text;
-      return candidate === heredoc.end;
-    })
-  ) {
-    state.heredoc = undefined;
+  const heredocs = state.heredocs;
+  if (heredocs) {
+    const firstVisibleEnd = heredocs.findIndex((heredoc) =>
+      texts.some((text) => isHeredocEnd(text, heredoc))
+    );
+    state.heredocs = firstVisibleEnd < 0
+      ? undefined
+      : heredocs.slice(firstVisibleEnd);
   }
+}
+
+function hasUnquotedToken(text: string, token: string): boolean {
+  let quote = "";
+  for (let i = 0; i < text.length;) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === "\\") i += 2;
+      else {
+        if (ch === quote) quote = "";
+        i++;
+      }
+    } else if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      i++;
+    } else {
+      if (text.startsWith(token, i)) return true;
+      i++;
+    }
+  }
+  return false;
+}
+
+function hasUnescapedToken(text: string, token: string): boolean {
+  for (let i = 0; i <= text.length - token.length; i++) {
+    if (text.startsWith(token, i) && (i === 0 || text[i - 1] !== "\\")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isHeredocEnd(text: string, heredoc: HeredocState): boolean {
+  const candidate = heredoc.stripTabs ? text.replace(/^\t+/u, "") : text;
+  return candidate === heredoc.end;
 }
 
 function shouldScanFallback(
@@ -356,11 +424,13 @@ function stripCommonComments(
   syntax: CommentSyntax,
   state: CommentState,
 ): string {
-  if (state.heredoc) {
-    const candidate = state.heredoc.stripTabs
-      ? text.replace(/^\t+/u, "")
-      : text;
-    if (candidate === state.heredoc.end) state.heredoc = undefined;
+  const activeHeredocs = state.heredocs;
+  const activeHeredoc = activeHeredocs?.[0];
+  if (activeHeredoc) {
+    if (isHeredocEnd(text, activeHeredoc)) {
+      activeHeredocs.shift();
+      if (activeHeredocs.length === 0) state.heredocs = undefined;
+    }
     return text;
   }
 
@@ -375,7 +445,7 @@ function stripCommonComments(
   }
 
   let quote = "";
-  let heredoc: CommentState["heredoc"];
+  const heredocs: HeredocState[] = [];
   for (let i = start; i < text.length;) {
     if (state.block) {
       if (state.block.nested && text.startsWith(state.block.open, i)) {
@@ -423,10 +493,10 @@ function stripCommonComments(
       i = after;
       continue;
     }
-    if (syntax.heredocs && !heredoc) {
+    if (syntax.heredocs) {
       const match = /^<<(-)?\s*(['"]?)([A-Za-z_]\w*)\2/u.exec(text.slice(i));
       if (match) {
-        heredoc = { end: match[3], stripTabs: match[1] === "-" };
+        heredocs.push({ end: match[3], stripTabs: match[1] === "-" });
       }
     }
     const block = syntax.blocks.find(([open]) => text.startsWith(open, i));
@@ -446,7 +516,7 @@ function stripCommonComments(
     result += ch;
     i++;
   }
-  if (heredoc) state.heredoc = heredoc;
+  if (heredocs.length > 0) state.heredocs = heredocs;
   return result;
 }
 

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -243,7 +243,11 @@ function fallbackCommentLines(
   const result = new Map<number, string>();
   const oldState: CommentState = {};
   const newState: CommentState = {};
-  for (const hunk of file.hunks) {
+  for (const [hunkIndex, hunk] of file.hunks.entries()) {
+    if (hunkIndex > 0) {
+      reconcileStateAfterGap(raw, diffLines, hunk, oldState, "old");
+      reconcileStateAfterGap(raw, diffLines, hunk, newState, "new");
+    }
     for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
       const kind = diffLines[i]?.kind;
       const text = (raw[i] ?? "").slice(1);
@@ -270,6 +274,43 @@ function fallbackCommentLines(
     }
   }
   return result;
+}
+
+/** Keeps multiline state only when this hunk proves the construct stayed open. */
+function reconcileStateAfterGap(
+  raw: readonly string[],
+  diffLines: readonly DiffLine[],
+  hunk: DiffFile["hunks"][number],
+  state: CommentState,
+  side: "old" | "new",
+): void {
+  const texts: string[] = [];
+  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+    const kind = diffLines[i]?.kind;
+    if (
+      kind === "ctx" || side === "old" && kind === "del" ||
+      side === "new" && kind === "add"
+    ) {
+      texts.push((raw[i] ?? "").slice(1));
+    }
+  }
+  const block = state.block;
+  if (block && !texts.some((text) => text.includes(block.close))) {
+    state.block = undefined;
+  }
+  const literalClose = state.literalClose;
+  if (literalClose && !texts.some((text) => text.includes(literalClose))) {
+    state.literalClose = undefined;
+  }
+  const heredoc = state.heredoc;
+  if (
+    heredoc && !texts.some((text) => {
+      const candidate = heredoc.stripTabs ? text.replace(/^\t+/u, "") : text;
+      return candidate === heredoc.end;
+    })
+  ) {
+    state.heredoc = undefined;
+  }
 }
 
 function shouldScanFallback(

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -1,0 +1,490 @@
+/**
+ * Computes alternative added and removed line counts for unified diffs. The
+ * normal mode reports the diff as written. The other modes remove changes
+ * that leave source text unchanged after comments and whitespace are removed.
+ */
+
+import { type DiffFile, type DiffLine, parseDiff } from "./diff.ts";
+import { languageForFile } from "./languages/language.ts";
+import type { Line, TokenClass } from "./model.ts";
+
+/** The line-count policies available in the diff jump list. */
+export type DiffCountMode = "normal" | "whitespace" | "comments";
+
+/** Count policies in the order the jump-list key cycles through them. */
+export const DIFF_COUNT_MODES: readonly DiffCountMode[] = [
+  "normal",
+  "whitespace",
+  "comments",
+];
+
+/** Added and removed line counts. */
+export interface DiffLineCounts {
+  /** Added lines which remain under the selected policy. */
+  readonly adds: number;
+
+  /** Removed lines which remain under the selected policy. */
+  readonly dels: number;
+}
+
+/** Counts for the whole diff and for each file in document order. */
+export interface DiffCounts {
+  /** Counts summed across every file. */
+  readonly totals: DiffLineCounts;
+
+  /** Counts by diff-file index. */
+  readonly files: readonly DiffLineCounts[];
+}
+
+interface ChangedLine {
+  /** Diff-file index containing the line. */
+  readonly file: number;
+
+  /** Side of the diff containing the line. */
+  readonly kind: "add" | "del";
+
+  /** Source text after the diff marker. */
+  readonly text: string;
+
+  /** Text with fallback-language comments removed, when fallback scanning ran. */
+  readonly fallbackText?: string;
+
+  /** Highlighted diff line, used to identify comment spans. */
+  readonly line: Line;
+}
+
+interface MutableCounts {
+  /** Added lines which have not been discounted. */
+  adds: number;
+
+  /** Removed lines which have not been discounted. */
+  dels: number;
+}
+
+/** Computes added and removed counts under `mode`. */
+export function diffCounts(
+  text: string,
+  lines: readonly Line[],
+  mode: DiffCountMode,
+): DiffCounts {
+  const model = parseDiff(text);
+  if (!model) return { totals: { adds: 0, dels: 0 }, files: [] };
+
+  const raw = text.split("\n");
+  const counts: MutableCounts[] = model.files.map(() => ({ adds: 0, dels: 0 }));
+  const byFile: ChangedLine[][] = model.files.map(() => []);
+  const changed: ChangedLine[] = [];
+  for (const [fileIndex, file] of model.files.entries()) {
+    const fallback = fallbackCommentLines(raw, model.lines, lines, file);
+    for (let i = file.headerLine; i <= file.endLine; i++) {
+      const kind = model.lines[i]?.kind;
+      if (kind !== "add" && kind !== "del") continue;
+      if (kind === "add") counts[fileIndex].adds++;
+      else counts[fileIndex].dels++;
+      const line = {
+        file: fileIndex,
+        kind,
+        text: (raw[i] ?? "").slice(1),
+        fallbackText: fallback.get(i),
+        line: lines[i] ?? { text: raw[i] ?? "", spans: [] },
+      };
+      changed.push(line);
+      byFile[fileIndex].push(line);
+    }
+  }
+
+  if (mode === "whitespace") {
+    for (let file = 0; file < model.files.length; file++) {
+      discountPairs(
+        byFile[file],
+        counts,
+        (line) => withoutWhitespace(line.text),
+      );
+    }
+  } else if (mode === "comments") {
+    const remaining: ChangedLine[] = [];
+    for (const line of changed) {
+      const normalized = withoutWhitespace(withoutComments(line));
+      if (normalized.length === 0) decrement(counts[line.file], line.kind);
+      else remaining.push(line);
+    }
+    discountPairs(
+      remaining,
+      counts,
+      (line) => withoutWhitespace(withoutComments(line)),
+    );
+  }
+
+  return {
+    totals: sumDiffLineCounts(counts),
+    files: counts,
+  };
+}
+
+/** Short label for a count policy in the jump-list summary. */
+export function diffCountModeLabel(mode: DiffCountMode): string {
+  switch (mode) {
+    case "normal":
+      return "normal";
+    case "whitespace":
+      return "ignore whitespace-only changes";
+    case "comments":
+      return "ignore comments and whitespace";
+  }
+}
+
+/** Discounts matching additions and removals according to `keyOf`. */
+function discountPairs(
+  lines: readonly ChangedLine[],
+  counts: MutableCounts[],
+  keyOf: (line: ChangedLine) => string,
+): void {
+  const deletions = new Map<
+    string,
+    { readonly lines: ChangedLine[]; next: number }
+  >();
+  for (const line of lines) {
+    if (line.kind !== "del") continue;
+    const key = keyOf(line);
+    const bucket = deletions.get(key) ?? { lines: [], next: 0 };
+    bucket.lines.push(line);
+    deletions.set(key, bucket);
+  }
+  for (const addition of lines) {
+    if (addition.kind !== "add") continue;
+    const bucket = deletions.get(keyOf(addition));
+    const deletion = bucket?.lines[bucket.next];
+    if (!bucket || !deletion) continue;
+    bucket.next++;
+    decrement(counts[deletion.file], "del");
+    decrement(counts[addition.file], "add");
+  }
+}
+
+function decrement(counts: MutableCounts, kind: "add" | "del"): void {
+  if (kind === "add") counts.adds--;
+  else counts.dels--;
+}
+
+/** Sums any set of per-file counts. */
+export function sumDiffLineCounts(
+  counts: readonly DiffLineCounts[],
+): DiffLineCounts {
+  let adds = 0;
+  let dels = 0;
+  for (const file of counts) {
+    adds += file.adds;
+    dels += file.dels;
+  }
+  return { adds, dels };
+}
+
+function withoutWhitespace(text: string): string {
+  return text.replace(/\s/gu, "");
+}
+
+/** Returns one changed line with comment-classified spans removed. */
+function withoutComments(line: ChangedLine): string {
+  if (line.fallbackText !== undefined) return line.fallbackText;
+  let text = line.text;
+  if (
+    line.line.spans.length > 0 &&
+    line.line.spans.map((span) => span.text).join("") === line.line.text
+  ) {
+    let first = true;
+    text = "";
+    for (const span of line.line.spans) {
+      let part = span.text;
+      if (first) {
+        part = [...part].slice(1).join("");
+        first = false;
+      }
+      if (!isCommentSpan(span.cls, part)) text += part;
+    }
+  }
+  return text;
+}
+
+function isCommentSpan(cls: TokenClass, text: string): boolean {
+  return cls === "comment" || cls === "docComment" ||
+    (cls === "sectionHeader" && /^\s*\/\/\s*transformed:/.test(text));
+}
+
+interface CommentSyntax {
+  readonly lines: readonly string[];
+  readonly blocks: readonly (readonly [string, string])[];
+  readonly nestedBlocks: boolean;
+  readonly skipHighlightedCode: boolean;
+  readonly heredocs: boolean;
+}
+
+interface CommentState {
+  block?: {
+    readonly open: string;
+    readonly close: string;
+    depth: number;
+    readonly nested: boolean;
+  };
+  literalClose?: string;
+  heredoc?: { readonly end: string; readonly stripTabs: boolean };
+}
+
+/** Scans each hunk side so block comments carry across changed lines. */
+function fallbackCommentLines(
+  raw: readonly string[],
+  diffLines: readonly DiffLine[],
+  renderedLines: readonly Line[],
+  file: DiffFile,
+): ReadonlyMap<number, string> {
+  const oldSyntax = fallbackSyntaxFor(file.oldPath);
+  const newSyntax = fallbackSyntaxFor(file.newPath);
+  if (!oldSyntax && !newSyntax) return new Map();
+
+  const result = new Map<number, string>();
+  for (const hunk of file.hunks) {
+    const oldState: CommentState = {};
+    const newState: CommentState = {};
+    for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+      const kind = diffLines[i]?.kind;
+      const text = (raw[i] ?? "").slice(1);
+      if (kind === "ctx") {
+        if (
+          oldSyntax && shouldScanFallback(oldSyntax, renderedLines[i], oldState)
+        ) {
+          stripCommonComments(text, oldSyntax, oldState);
+        }
+        if (
+          newSyntax && shouldScanFallback(newSyntax, renderedLines[i], newState)
+        ) {
+          stripCommonComments(text, newSyntax, newState);
+        }
+      } else if (kind === "del" && oldSyntax) {
+        if (shouldScanFallback(oldSyntax, renderedLines[i], oldState)) {
+          result.set(i, stripCommonComments(text, oldSyntax, oldState));
+        }
+      } else if (kind === "add" && newSyntax) {
+        if (shouldScanFallback(newSyntax, renderedLines[i], newState)) {
+          result.set(i, stripCommonComments(text, newSyntax, newState));
+        }
+      }
+    }
+  }
+  return result;
+}
+
+function shouldScanFallback(
+  syntax: CommentSyntax,
+  line: Line | undefined,
+  state: CommentState,
+): boolean {
+  if (!syntax.skipHighlightedCode || state.block !== undefined || !line) {
+    return true;
+  }
+  const source = [...line.text].slice(1).join("");
+  if (/^(?: {4}|\t)/u.test(source)) return false;
+
+  let first = true;
+  let foundCode = false;
+  for (const span of line.spans) {
+    let text = span.text;
+    if (first) {
+      text = [...text].slice(1).join("");
+      first = false;
+    }
+    if (withoutWhitespace(text).length === 0) continue;
+    if (span.cls !== "string" && span.cls !== "template") return true;
+    foundCode = true;
+  }
+  return !foundCode;
+}
+
+function fallbackSyntaxFor(
+  path: string | undefined,
+): CommentSyntax | undefined {
+  const language = languageForFile(path).id;
+  if (language !== "plain-text" && language !== "markdown") return undefined;
+  const syntax = commentSyntaxFor(path ?? "");
+  return syntax.lines.length > 0 || syntax.blocks.length > 0
+    ? syntax
+    : undefined;
+}
+
+/** Removes common comment forms while updating multiline scanning state. */
+function stripCommonComments(
+  text: string,
+  syntax: CommentSyntax,
+  state: CommentState,
+): string {
+  if (state.heredoc) {
+    const candidate = state.heredoc.stripTabs
+      ? text.replace(/^\t+/u, "")
+      : text;
+    if (candidate === state.heredoc.end) state.heredoc = undefined;
+    return text;
+  }
+
+  let start = 0;
+  let result = "";
+  if (state.literalClose) {
+    const end = text.indexOf(state.literalClose);
+    if (end < 0) return text;
+    result = text.slice(0, end + state.literalClose.length);
+    start = result.length;
+    state.literalClose = undefined;
+  }
+
+  let quote = "";
+  for (let i = start; i < text.length;) {
+    if (state.block) {
+      if (state.block.nested && text.startsWith(state.block.open, i)) {
+        state.block.depth++;
+        i += state.block.open.length;
+      } else if (text.startsWith(state.block.close, i)) {
+        state.block.depth--;
+        i += state.block.close.length;
+        if (state.block.depth === 0) state.block = undefined;
+      } else {
+        i++;
+      }
+      continue;
+    }
+    const ch = text[i];
+    if (quote) {
+      result += ch;
+      if (ch === "\\" && i + 1 < text.length) {
+        result += text[++i];
+      } else if (ch === quote) {
+        quote = "";
+      }
+      i++;
+      continue;
+    }
+    if (
+      (ch === '"' || ch === "'" || ch === "`") &&
+      closingQuote(text, i, ch) >= 0
+    ) {
+      quote = ch;
+      result += ch;
+      i++;
+      continue;
+    }
+    const rawString = rustRawStringAt(text, i);
+    if (rawString) {
+      const end = text.indexOf(rawString.close, i + rawString.open.length);
+      if (end < 0) {
+        result += text.slice(i);
+        state.literalClose = rawString.close;
+        break;
+      }
+      const after = end + rawString.close.length;
+      result += text.slice(i, after);
+      i = after;
+      continue;
+    }
+    const block = syntax.blocks.find(([open]) => text.startsWith(open, i));
+    if (block) {
+      state.block = {
+        open: block[0],
+        close: block[1],
+        depth: 1,
+        nested: syntax.nestedBlocks,
+      };
+      i += block[0].length;
+      continue;
+    }
+    if (syntax.lines.some((marker) => startsLineComment(text, i, marker))) {
+      break;
+    }
+    result += ch;
+    i++;
+  }
+  if (syntax.heredocs && !state.heredoc) {
+    const heredoc = /<<(-)?\s*(['"]?)([A-Za-z_]\w*)\2/.exec(result);
+    if (heredoc) {
+      state.heredoc = { end: heredoc[3], stripTabs: heredoc[1] === "-" };
+    }
+  }
+  return result;
+}
+
+function rustRawStringAt(
+  text: string,
+  index: number,
+): { readonly open: string; readonly close: string } | undefined {
+  const match = /^(?:br|r)(#*)"/.exec(text.slice(index));
+  if (!match) return undefined;
+  return { open: match[0], close: `"${match[1]}` };
+}
+
+function startsLineComment(
+  text: string,
+  index: number,
+  marker: string,
+): boolean {
+  if (!text.startsWith(marker, index)) return false;
+  if (marker === "//" && text[index - 1] === ":") return false;
+  if (marker === "#" && index > 0 && !/\s/u.test(text[index - 1])) return false;
+  return true;
+}
+
+function closingQuote(text: string, start: number, quote: string): number {
+  for (let i = start + 1; i < text.length; i++) {
+    if (text[i] === "\\") i++;
+    else if (text[i] === quote) return i;
+  }
+  return -1;
+}
+
+function commentSyntaxFor(path: string): CommentSyntax {
+  const lower = path.toLowerCase();
+  const lines: string[] = [];
+  const blocks: [string, string][] = [];
+  let nestedBlocks = false;
+  let skipHighlightedCode = false;
+  let heredocs = false;
+  const addLine = (marker: string) => {
+    if (!lines.includes(marker)) lines.push(marker);
+  };
+  const addBlock = (open: string, close: string) => {
+    blocks.push([open, close]);
+  };
+
+  if (
+    /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx|m|mm|java|go|rs|swift|kt|kts|scala|groovy|cs|fs|fsx|dart|php|scss|sass|less|proto|sol|zig|vue|svelte)$/
+      .test(
+        lower,
+      )
+  ) {
+    addLine("//");
+    addBlock("/*", "*/");
+  }
+  if (/\.css$/.test(lower)) addBlock("/*", "*/");
+  if (/\.(?:html?|xml|svg|md|markdown|mdown|mkd|mdx|vue|svelte)$/.test(lower)) {
+    addBlock("<!--", "-->");
+  }
+  if (/\.(?:md|markdown|mdown|mkd|mdx)$/.test(lower)) {
+    skipHighlightedCode = true;
+  }
+  if (
+    /\.(?:py|pyi|pyw|ya?ml|sh|bash|zsh|fish|rb|pl|pm|r|ex|exs|php|tf|hcl|toml|ini|cfg|conf|properties)$/
+      .test(
+        lower,
+      ) || /(?:^|\/)(?:dockerfile|makefile|gnumakefile)(?:\..*)?$/.test(lower)
+  ) {
+    addLine("#");
+  }
+  if (/\.(?:sh|bash|zsh)$/.test(lower)) heredocs = true;
+  if (/\.sql$/.test(lower)) {
+    addLine("--");
+    addBlock("/*", "*/");
+  }
+  if (/\.lua$/.test(lower)) addLine("--");
+  if (/\.(?:hs|lhs)$/.test(lower)) {
+    addLine("--");
+    addBlock("{-", "-}");
+    nestedBlocks = true;
+  }
+  if (/\.rs$/.test(lower)) nestedBlocks = true;
+  if (/\.(?:lisp|cl|clj|cljs|edn|scm|rkt|el)$/.test(lower)) addLine(";");
+  return { lines, blocks, nestedBlocks, skipHighlightedCode, heredocs };
+}

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -82,13 +82,15 @@ export function diffCounts(
   const byFile: ChangedLine[][] = model.files.map(() => []);
   const changed: ChangedLine[] = [];
   for (const [fileIndex, file] of model.files.entries()) {
-    const fallback = fallbackCommentLines(
-      raw,
-      model.lines,
-      lines,
-      file,
-      contexts?.[fileIndex],
-    );
+    const fallback = mode === "comments"
+      ? fallbackCommentLines(
+        raw,
+        model.lines,
+        lines,
+        file,
+        contexts?.[fileIndex],
+      )
+      : new Map<number, string>();
     for (let i = file.headerLine; i <= file.endLine; i++) {
       const kind = model.lines[i]?.kind;
       if (kind !== "add" && kind !== "del") continue;

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -36,6 +36,12 @@ export interface DiffCounts {
   readonly files: readonly DiffLineCounts[];
 }
 
+/** Complete file text available to resolve syntax across omitted diff lines. */
+export interface DiffCountFileContext {
+  readonly oldLines?: readonly string[];
+  readonly newLines?: readonly string[];
+}
+
 interface ChangedLine {
   /** Diff-file index containing the line. */
   readonly file: number;
@@ -66,6 +72,7 @@ export function diffCounts(
   text: string,
   lines: readonly Line[],
   mode: DiffCountMode,
+  contexts?: readonly DiffCountFileContext[],
 ): DiffCounts {
   const model = parseDiff(text);
   if (!model) return { totals: { adds: 0, dels: 0 }, files: [] };
@@ -75,7 +82,13 @@ export function diffCounts(
   const byFile: ChangedLine[][] = model.files.map(() => []);
   const changed: ChangedLine[] = [];
   for (const [fileIndex, file] of model.files.entries()) {
-    const fallback = fallbackCommentLines(raw, model.lines, lines, file);
+    const fallback = fallbackCommentLines(
+      raw,
+      model.lines,
+      lines,
+      file,
+      contexts?.[fileIndex],
+    );
     for (let i = file.headerLine; i <= file.endLine; i++) {
       const kind = model.lines[i]?.kind;
       if (kind !== "add" && kind !== "del") continue;
@@ -240,6 +253,7 @@ function fallbackCommentLines(
   diffLines: readonly DiffLine[],
   renderedLines: readonly Line[],
   file: DiffFile,
+  context: DiffCountFileContext | undefined,
 ): ReadonlyMap<number, string> {
   const oldSyntax = fallbackSyntaxFor(file.oldPath);
   const newSyntax = fallbackSyntaxFor(file.newPath);
@@ -248,8 +262,20 @@ function fallbackCommentLines(
   const result = new Map<number, string>();
   const oldState: CommentState = {};
   const newState: CommentState = {};
+  let oldNextLine = 0;
+  let newNextLine = 0;
   for (const [hunkIndex, hunk] of file.hunks.entries()) {
-    if (hunkIndex > 0) {
+    const oldStart = sideStart(hunk.oldStart, hunk.oldCount);
+    const newStart = sideStart(hunk.newStart, hunk.newCount);
+    if (context?.oldLines && oldSyntax) {
+      scanCompleteLines(
+        context.oldLines,
+        oldNextLine,
+        oldStart,
+        oldSyntax,
+        oldState,
+      );
+    } else if (hunkIndex > 0) {
       const previous = file.hunks[hunkIndex - 1];
       const remaining = file.hunks.slice(hunkIndex);
       reconcileStateAfterGap(
@@ -261,6 +287,18 @@ function fallbackCommentLines(
         oldSyntax,
         "old",
       );
+    }
+    if (context?.newLines && newSyntax) {
+      scanCompleteLines(
+        context.newLines,
+        newNextLine,
+        newStart,
+        newSyntax,
+        newState,
+      );
+    } else if (hunkIndex > 0) {
+      const previous = file.hunks[hunkIndex - 1];
+      const remaining = file.hunks.slice(hunkIndex);
       reconcileStateAfterGap(
         raw,
         diffLines,
@@ -295,8 +333,26 @@ function fallbackCommentLines(
         }
       }
     }
+    oldNextLine = oldStart + hunk.oldCount;
+    newNextLine = newStart + hunk.newCount;
   }
   return result;
+}
+
+function sideStart(start: number, count: number): number {
+  return count === 0 ? start : Math.max(0, start - 1);
+}
+
+function scanCompleteLines(
+  lines: readonly string[],
+  start: number,
+  end: number,
+  syntax: CommentSyntax,
+  state: CommentState,
+): void {
+  for (let i = start; i < end && i < lines.length; i++) {
+    stripCommonComments(lines[i], syntax, state);
+  }
 }
 
 /** Keeps multiline state only when this hunk proves the construct stayed open. */

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -351,7 +351,7 @@ function scanCompleteLines(
   state: CommentState,
 ): void {
   for (let i = start; i < end && i < lines.length; i++) {
-    if (shouldScanFallback(syntax, lines[i], state)) {
+    if (shouldScanFallback(syntax, lines[i], state, false)) {
       stripCommonComments(lines[i].text, syntax, state);
     }
   }
@@ -458,21 +458,22 @@ function shouldScanFallback(
   syntax: CommentSyntax,
   line: Line | undefined,
   state: CommentState,
+  hasDiffMarker = true,
 ): boolean {
   if (!syntax.skipHighlightedCode || state.block !== undefined || !line) {
     return true;
   }
-  const source = [...line.text].slice(1).join("");
+  const source = hasDiffMarker ? [...line.text].slice(1).join("") : line.text;
   if (/^(?: {4}|\t)/u.test(source)) return false;
 
   let first = true;
   let foundCode = false;
   for (const span of line.spans) {
     let text = span.text;
-    if (first) {
+    if (first && hasDiffMarker) {
       text = [...text].slice(1).join("");
-      first = false;
     }
+    first = false;
     if (withoutWhitespace(text).length === 0) continue;
     if (span.cls !== "string" && span.cls !== "template") return true;
     foundCode = true;

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -258,6 +258,7 @@ function fallbackCommentLines(
         previous,
         remaining,
         oldState,
+        oldSyntax,
         "old",
       );
       reconcileStateAfterGap(
@@ -266,6 +267,7 @@ function fallbackCommentLines(
         previous,
         remaining,
         newState,
+        newSyntax,
         "new",
       );
     }
@@ -304,6 +306,7 @@ function reconcileStateAfterGap(
   previous: DiffFile["hunks"][number],
   remaining: readonly DiffFile["hunks"][number][],
   state: CommentState,
+  syntax: CommentSyntax | undefined,
   side: "old" | "new",
 ): void {
   const current = remaining[0];
@@ -326,11 +329,17 @@ function reconcileStateAfterGap(
     }
   }
   const block = state.block;
-  if (block && !texts.some((text) => hasUnquotedToken(text, block.close))) {
+  if (
+    block &&
+    !texts.some((text) => hasVisibleClose(text, block.close, syntax))
+  ) {
     state.block = undefined;
   }
   const literalClose = state.literalClose;
-  if (literalClose && !texts.some((text) => text.includes(literalClose))) {
+  if (
+    literalClose &&
+    !texts.some((text) => hasVisibleClose(text, literalClose, syntax))
+  ) {
     state.literalClose = undefined;
   }
   const heredocs = state.heredocs;
@@ -344,7 +353,11 @@ function reconcileStateAfterGap(
   }
 }
 
-function hasUnquotedToken(text: string, token: string): boolean {
+function hasVisibleClose(
+  text: string,
+  token: string,
+  syntax: CommentSyntax | undefined,
+): boolean {
   let quote = "";
   let tokenInsideCurrentQuote = false;
   for (let i = 0; i < text.length;) {
@@ -361,12 +374,17 @@ function hasUnquotedToken(text: string, token: string): boolean {
         }
         i++;
       }
-    } else if (ch === '"' || ch === "'" || ch === "`") {
-      quote = ch;
-      tokenInsideCurrentQuote = false;
-      i++;
     } else {
+      if (
+        syntax?.lines.some((marker) => startsLineComment(text, i, marker))
+      ) {
+        return false;
+      }
       if (text.startsWith(token, i)) return true;
+      if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch;
+        tokenInsideCurrentQuote = false;
+      }
       i++;
     }
   }

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -38,8 +38,8 @@ export interface DiffCounts {
 
 /** Complete file text available to resolve syntax across omitted diff lines. */
 export interface DiffCountFileContext {
-  readonly oldLines?: readonly string[];
-  readonly newLines?: readonly string[];
+  readonly oldLines?: readonly Line[];
+  readonly newLines?: readonly Line[];
 }
 
 interface ChangedLine {
@@ -344,14 +344,16 @@ function sideStart(start: number, count: number): number {
 }
 
 function scanCompleteLines(
-  lines: readonly string[],
+  lines: readonly Line[],
   start: number,
   end: number,
   syntax: CommentSyntax,
   state: CommentState,
 ): void {
   for (let i = start; i < end && i < lines.length; i++) {
-    stripCommonComments(lines[i], syntax, state);
+    if (shouldScanFallback(syntax, lines[i], state)) {
+      stripCommonComments(lines[i].text, syntax, state);
+    }
   }
 }
 

--- a/packages/cli/lib/view/diffcounts.ts
+++ b/packages/cli/lib/view/diffcounts.ts
@@ -330,9 +330,7 @@ function reconcileStateAfterGap(
     state.block = undefined;
   }
   const literalClose = state.literalClose;
-  if (
-    literalClose && !texts.some((text) => hasUnescapedToken(text, literalClose))
-  ) {
+  if (literalClose && !texts.some((text) => text.includes(literalClose))) {
     state.literalClose = undefined;
   }
   const heredocs = state.heredocs;
@@ -348,32 +346,31 @@ function reconcileStateAfterGap(
 
 function hasUnquotedToken(text: string, token: string): boolean {
   let quote = "";
+  let tokenInsideCurrentQuote = false;
   for (let i = 0; i < text.length;) {
     const ch = text[i];
     if (quote) {
-      if (ch === "\\") i += 2;
-      else {
-        if (ch === quote) quote = "";
+      if (text.startsWith(token, i)) tokenInsideCurrentQuote = true;
+      if (ch === "\\") {
+        if (text.startsWith(token, i + 1)) tokenInsideCurrentQuote = true;
+        i += 2;
+      } else {
+        if (ch === quote) {
+          quote = "";
+          tokenInsideCurrentQuote = false;
+        }
         i++;
       }
     } else if (ch === '"' || ch === "'" || ch === "`") {
       quote = ch;
+      tokenInsideCurrentQuote = false;
       i++;
     } else {
       if (text.startsWith(token, i)) return true;
       i++;
     }
   }
-  return false;
-}
-
-function hasUnescapedToken(text: string, token: string): boolean {
-  for (let i = 0; i <= text.length - token.length; i++) {
-    if (text.startsWith(token, i) && (i === 0 || text[i - 1] !== "\\")) {
-      return true;
-    }
-  }
-  return false;
+  return quote !== "" && tokenInsideCurrentQuote;
 }
 
 function isHeredocEnd(text: string, heredoc: HeredocState): boolean {

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -542,6 +542,7 @@ function reconstructNewSide(
       const oldNoNewline = hunkSideHasNoNewline(hunk, "old", raw, diffLines);
       const newNoNewline = hunkSideHasNoNewline(hunk, "new", raw, diffLines);
       if (oldNoNewline || newNoNewline) trailingNewline = !newNoNewline;
+      else if (oldLineCount === 0 && hunk.newCount > 0) trailingNewline = true;
     }
     lines.splice(
       start,

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -113,8 +113,15 @@ export function diffSource(
     fileText: expectedFiles,
     hunks: saveHunks,
   };
-  const diffCountContexts = (text: string) =>
-    buildDiffCountContexts(edit, text);
+  let countContextText: string | undefined;
+  let countContexts: readonly DiffCountFileContext[] = [];
+  const diffCountContexts = (text: string) => {
+    if (text !== countContextText) {
+      countContextText = text;
+      countContexts = buildDiffCountContexts(edit, text);
+    }
+    return countContexts;
+  };
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -527,7 +527,6 @@ function reconstructNewSide(
     ? 0
     : lines.length - (oldTrailingNewline ? 1 : 0);
   let trailingNewline = oldTrailingNewline;
-  let newLineCount = oldLineCount;
   const hunks = [...file.hunks].sort((a, b) =>
     sideStart(b.oldStart, b.oldCount) - sideStart(a.oldStart, a.oldCount) ||
     b.headerLine - a.headerLine
@@ -556,9 +555,7 @@ function reconstructNewSide(
       hunk.oldCount,
       ...replacement,
     );
-    newLineCount += hunk.newCount - hunk.oldCount;
   }
-  if (newLineCount === 0) trailingNewline = false;
   if (trailingNewline && lines.at(-1) !== "") lines.push("");
   if (!trailingNewline && lines.length > 1 && lines.at(-1) === "") lines.pop();
   return lines.join("\n");

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -20,6 +20,7 @@ import {
   type WorkspaceCache,
 } from "./diffdoc.ts";
 import { type DiffHunk, type DiffModel, parseDiff } from "./diff.ts";
+import type { DiffCountFileContext } from "./diffcounts.ts";
 import {
   type CommitHeader,
   type CommitMessage,
@@ -106,6 +107,11 @@ export function diffSource(
     fileText: expectedFiles,
     hunks: saveHunks,
   };
+  const diffCountContexts = buildDiffCountContexts(
+    edit,
+    saveHunks,
+    expectedFiles,
+  );
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace
@@ -117,6 +123,7 @@ export function diffSource(
     return {
       label: null,
       isDiff: true,
+      diffCountContexts,
       editable: false,
       reason:
         "This diff doesn't match any file on disk, so there is nothing to edit.",
@@ -233,6 +240,7 @@ export function diffSource(
       ? shortName(files[0])
       : `${files.length} files`,
     isDiff: true,
+    diffCountContexts,
     editable: true,
     policy,
     logicalEnd: (lines, row) =>
@@ -470,6 +478,29 @@ export function diffSource(
         ? baselineWithCurrentHunks(baseline, current)
         : current,
   };
+}
+
+function buildDiffCountContexts(
+  edit: DiffEdit,
+  hunks: readonly MutableHunk[],
+  fileText: ReadonlyMap<string, string>,
+): readonly DiffCountFileContext[] {
+  const model = parseDiff(edit.sourceText ?? "");
+  if (!model) return [];
+  let hunkIndex = 0;
+  return model.files.map((file, fileIndex) => {
+    let absPath: string | null = null;
+    for (const _hunk of file.hunks) {
+      const hunk = hunks[hunkIndex++];
+      absPath ??= hunk?.absPath ?? null;
+    }
+    const oldLines = edit.oldFileLines[fileIndex]?.map((line) => line.text);
+    const newText = absPath ? fileText.get(absPath) : undefined;
+    return {
+      oldLines: oldLines ?? undefined,
+      newLines: newText?.split("\n"),
+    };
+  });
 }
 
 /** The commit a save would amend when changed text represents HEAD. */

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -19,7 +19,13 @@ import {
   type DiffWorkspace,
   type WorkspaceCache,
 } from "./diffdoc.ts";
-import { type DiffHunk, type DiffModel, parseDiff } from "./diff.ts";
+import {
+  type DiffFile,
+  type DiffHunk,
+  type DiffLine,
+  type DiffModel,
+  parseDiff,
+} from "./diff.ts";
 import type { DiffCountFileContext } from "./diffcounts.ts";
 import {
   type CommitHeader,
@@ -107,11 +113,9 @@ export function diffSource(
     fileText: expectedFiles,
     hunks: saveHunks,
   };
-  const diffCountContexts = buildDiffCountContexts(
-    edit,
-    saveHunks,
-    expectedFiles,
-  );
+  const countContexts = buildDiffCountContexts(edit);
+  const diffCountContexts = (text: string) =>
+    text === edit.sourceText ? countContexts : undefined;
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace
@@ -482,25 +486,54 @@ export function diffSource(
 
 function buildDiffCountContexts(
   edit: DiffEdit,
-  hunks: readonly MutableHunk[],
-  fileText: ReadonlyMap<string, string>,
 ): readonly DiffCountFileContext[] {
   const model = parseDiff(edit.sourceText ?? "");
   if (!model) return [];
-  let hunkIndex = 0;
+  const raw = (edit.sourceText ?? "").split("\n");
   return model.files.map((file, fileIndex) => {
-    let absPath: string | null = null;
-    for (const _hunk of file.hunks) {
-      const hunk = hunks[hunkIndex++];
-      absPath ??= hunk?.absPath ?? null;
-    }
-    const oldLines = edit.oldFileLines[fileIndex]?.map((line) => line.text);
-    const newText = absPath ? fileText.get(absPath) : undefined;
+    const oldLines = edit.oldFileLines[fileIndex] ?? undefined;
+    const newText = oldLines
+      ? reconstructNewSide(file, oldLines, raw, model.lines)
+      : undefined;
+    const newLines = newText === undefined
+      ? undefined
+      : languageForFile(file.newPath ?? file.oldPath).highlightLines(
+        newText,
+        file.newPath ?? file.oldPath,
+      );
     return {
-      oldLines: oldLines ?? undefined,
-      newLines: newText?.split("\n"),
+      oldLines,
+      newLines,
     };
   });
+}
+
+function reconstructNewSide(
+  file: DiffFile,
+  oldLines: readonly Line[],
+  raw: readonly string[],
+  diffLines: readonly DiffLine[],
+): string {
+  const lines = oldLines.map((line) => line.text);
+  const hunks = [...file.hunks].sort((a, b) =>
+    sideStart(b.oldStart, b.oldCount) - sideStart(a.oldStart, a.oldCount) ||
+    b.headerLine - a.headerLine
+  );
+  for (const hunk of hunks) {
+    const replacement: string[] = [];
+    for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+      const kind = diffLines[i]?.kind;
+      if (kind === "ctx" || kind === "add") {
+        replacement.push((raw[i] ?? "").slice(1));
+      }
+    }
+    lines.splice(
+      sideStart(hunk.oldStart, hunk.oldCount),
+      hunk.oldCount,
+      ...replacement,
+    );
+  }
+  return lines.join("\n");
 }
 
 /** The commit a save would amend when changed text represents HEAD. */

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -113,9 +113,8 @@ export function diffSource(
     fileText: expectedFiles,
     hunks: saveHunks,
   };
-  const countContexts = buildDiffCountContexts(edit);
   const diffCountContexts = (text: string) =>
-    text === edit.sourceText ? countContexts : undefined;
+    buildDiffCountContexts(edit, text);
 
   // No file on disk backs this diff (nothing resolved or verified): read-only.
   // A deletion of an entire file has no new-side lines, but its empty workspace
@@ -486,10 +485,11 @@ export function diffSource(
 
 function buildDiffCountContexts(
   edit: DiffEdit,
+  text: string,
 ): readonly DiffCountFileContext[] {
-  const model = parseDiff(edit.sourceText ?? "");
+  const model = parseDiff(text);
   if (!model) return [];
-  const raw = (edit.sourceText ?? "").split("\n");
+  const raw = text.split("\n");
   return model.files.map((file, fileIndex) => {
     const oldLines = edit.oldFileLines[fileIndex] ?? undefined;
     const newText = oldLines
@@ -515,6 +515,12 @@ function reconstructNewSide(
   diffLines: readonly DiffLine[],
 ): string {
   const lines = oldLines.map((line) => line.text);
+  const oldTrailingNewline = lines.length > 1 && lines.at(-1) === "";
+  const oldLineCount = lines.length === 1 && lines[0] === ""
+    ? 0
+    : lines.length - (oldTrailingNewline ? 1 : 0);
+  let trailingNewline = oldTrailingNewline;
+  let newLineCount = oldLineCount;
   const hunks = [...file.hunks].sort((a, b) =>
     sideStart(b.oldStart, b.oldCount) - sideStart(a.oldStart, a.oldCount) ||
     b.headerLine - a.headerLine
@@ -524,16 +530,50 @@ function reconstructNewSide(
     for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
       const kind = diffLines[i]?.kind;
       if (kind === "ctx" || kind === "add") {
-        replacement.push((raw[i] ?? "").slice(1));
+        let text = (raw[i] ?? "").slice(1);
+        if (raw[hunk.headerLine]?.endsWith("\r") && text.endsWith("\r")) {
+          text = text.slice(0, -1);
+        }
+        replacement.push(text);
       }
     }
+    const start = sideStart(hunk.oldStart, hunk.oldCount);
+    if (start + hunk.oldCount === oldLineCount) {
+      const oldNoNewline = hunkSideHasNoNewline(hunk, "old", raw, diffLines);
+      const newNoNewline = hunkSideHasNoNewline(hunk, "new", raw, diffLines);
+      if (oldNoNewline || newNoNewline) trailingNewline = !newNoNewline;
+    }
     lines.splice(
-      sideStart(hunk.oldStart, hunk.oldCount),
+      start,
       hunk.oldCount,
       ...replacement,
     );
+    newLineCount += hunk.newCount - hunk.oldCount;
   }
+  if (newLineCount === 0) trailingNewline = false;
+  if (trailingNewline && lines.at(-1) !== "") lines.push("");
+  if (!trailingNewline && lines.length > 1 && lines.at(-1) === "") lines.pop();
   return lines.join("\n");
+}
+
+function hunkSideHasNoNewline(
+  hunk: DiffHunk,
+  side: "old" | "new",
+  raw: readonly string[],
+  diffLines: readonly DiffLine[],
+): boolean {
+  for (let i = hunk.headerLine + 1; i <= hunk.endLine; i++) {
+    const kind = diffLines[i]?.kind;
+    const belongs = kind === "ctx" || side === "old" && kind === "del" ||
+      side === "new" && kind === "add";
+    if (
+      belongs &&
+      raw[i + 1]?.replace(/\r$/u, "") === "\\ No newline at end of file"
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** The commit a save would amend when changed text represents HEAD. */

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -12,6 +12,7 @@
 
 import type { Document, Line, ViewMode } from "./model.ts";
 import type { DiffHunk, DiffModel } from "./diff.ts";
+import type { DiffCountFileContext } from "./diffcounts.ts";
 import type { LineEndingProvenance } from "./editbuffer.ts";
 import type {
   Highlighter,
@@ -88,6 +89,9 @@ export interface EditableSource {
   /** True for a diff view, whether or not it is editable. Absent or false for a
    * plain file or a non-diff pipe. */
   readonly isDiff?: boolean;
+
+  /** Complete diff sides used to scan syntax hidden between visible hunks. */
+  readonly diffCountContexts?: readonly DiffCountFileContext[];
 
   /** False when there is no underlying file to edit or the selected language
    * is read-only. `reason` is shown when a cursor move is attempted on a

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -91,7 +91,9 @@ export interface EditableSource {
   readonly isDiff?: boolean;
 
   /** Complete diff sides used to scan syntax hidden between visible hunks. */
-  readonly diffCountContexts?: readonly DiffCountFileContext[];
+  diffCountContexts?(
+    text: string,
+  ): readonly DiffCountFileContext[] | undefined;
 
   /** False when there is no underlying file to edit or the selected language
    * is read-only. `reason` is shown when a cursor move is attempted on a

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -25,6 +25,15 @@ export interface DiffFileRange {
   /** The path used for file-category detection (new side, else old side). */
   readonly path: string;
 
+  /** Path on the diff's removed side, when it has one. */
+  readonly oldPath?: string;
+
+  /** Path on the diff's added side, when it has one. */
+  readonly newPath?: string;
+
+  /** Whether Git reports binary content instead of line changes. */
+  readonly binary: boolean;
+
   readonly isTest: boolean;
   readonly isMarkdown: boolean;
 
@@ -58,6 +67,9 @@ export function diffFiles(text: string): DiffFileRange[] {
       headerLine: file.headerLine,
       endLine: file.endLine,
       path,
+      oldPath: file.oldPath,
+      newPath: file.newPath,
+      binary,
       isTest: isTestPath(path),
       isMarkdown: isMarkdownPath(path),
       adds,
@@ -70,6 +82,21 @@ export function diffFiles(text: string): DiffFileRange[] {
         binary,
       }),
     };
+  });
+}
+
+/** Builds a file's collapsed summary with replacement line counts. */
+export function diffFileSummary(
+  file: DiffFileRange,
+  adds = file.adds,
+  dels = file.dels,
+): Line {
+  return summaryLine({
+    oldPath: file.oldPath,
+    newPath: file.newPath,
+    adds,
+    dels,
+    binary: file.binary,
   });
 }
 

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4723,6 +4723,7 @@ export class Session {
           this.#sourceDoc.text,
           this.#sourceDoc.lines,
           this.#jumpCountMode,
+          this.#source?.diffCountContexts,
         ),
       };
     }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4723,7 +4723,7 @@ export class Session {
           this.#sourceDoc.text,
           this.#sourceDoc.lines,
           this.#jumpCountMode,
-          this.#source?.diffCountContexts,
+          this.#source?.diffCountContexts?.(this.#sourceDoc.text),
         ),
       };
     }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -61,9 +61,19 @@ import {
   sourceColumnOf,
 } from "./display.ts";
 import {
+  DIFF_COUNT_MODES,
+  type DiffCountMode,
+  diffCountModeLabel,
+  type DiffCounts,
+  diffCounts,
+  type DiffLineCounts,
+  sumDiffLineCounts,
+} from "./diffcounts.ts";
+import {
   buildFoldPlan,
   type DiffFileRange,
   diffFiles,
+  diffFileSummary,
   type FoldPlan,
   identityFold,
 } from "./fold.ts";
@@ -210,6 +220,9 @@ interface JumpEntry {
 
   /** Short name for the "Jumped to …" confirmation. */
   readonly name: string;
+
+  /** Diff-file index for file rows; absent on commit rows. */
+  readonly fileIndex?: number;
 }
 
 export class Session {
@@ -393,6 +406,13 @@ export class Session {
   #jumpEntries: JumpEntry[] = [];
   #jumpFilter = "";
   #jumpSel = 0;
+  #jumpSearching = false;
+  #jumpCountMode: DiffCountMode = "normal";
+  #jumpCountCache?: {
+    readonly doc: Document;
+    readonly mode: DiffCountMode;
+    readonly counts: DiffCounts;
+  };
 
   constructor(
     doc: Document,
@@ -986,7 +1006,7 @@ export class Session {
         ? `definition: ${this.#input}`
         : this.#mode === "filePicker"
         ? `find file: ${this.#files?.join(this.#pickerDir, this.#pickerFilter)}`
-        : this.#mode === "jumpList"
+        : this.#mode === "jumpList" && this.#jumpSearching
         ? `jump to: ${this.#jumpFilter}`
         : null,
       dialog: this.#promptDialog(),
@@ -2128,6 +2148,11 @@ export class Session {
     const line = this.#foldAnchor().docLine;
     const file = files.find((f) => line >= f.headerLine && line <= f.endLine) ??
       files.find((f) => f.headerLine >= line) ?? files[files.length - 1];
+    this.#toggleFile(file, { docLine: file.headerLine, sourceCol: 0 });
+  }
+
+  /** Toggles one file while restoring `anchor` after its layout changes. */
+  #toggleFile(file: DiffFileRange, anchor = this.#foldAnchor()): void {
     if (this.#collapsed.has(file.index)) {
       this.#collapsed.delete(file.index);
       this.#message = `Showing ${file.path}`;
@@ -2135,7 +2160,7 @@ export class Session {
       this.#collapsed.add(file.index);
       this.#message = `Hiding ${file.path}`;
     }
-    this.#applyFoldChange({ docLine: file.headerLine, sourceCol: 0 });
+    this.#applyFoldChange(anchor);
   }
 
   /** Hide every file (collapse all to summary lines). */
@@ -4485,13 +4510,14 @@ export class Session {
     }
     this.#jumpAll = entries;
     this.#jumpFilter = "";
+    this.#jumpSearching = false;
     this.#overlayScroll = 0;
     this.#mode = "jumpList";
     this.#refreshJump();
     // Open focused on the file the viewport is already reading, so the list
     // starts where the eye is.
     this.#jumpSel = this.#jumpEntryAtViewport();
-    this.#scrollListToSelection(this.#jumpSel);
+    this.#scrollJumpToSelection(this.#jumpSel);
   }
 
   /** Every file the diff touches and every commit whose message it carries, in
@@ -4500,6 +4526,7 @@ export class Session {
     if (!this.#source?.isDiff) return [];
     const texts = this.#currentDoc.lines.map((l) => l.text);
     const subjects = commitSubjects(texts);
+    const counts = this.#jumpDiffCounts();
     const entries: JumpEntry[] = [];
     for (const header of findCommitHeaders(texts)) {
       const subject = subjects.get(header.sha) ?? "";
@@ -4512,11 +4539,17 @@ export class Session {
       });
     }
     for (const file of this.#foldFiles()) {
+      const fileCounts = counts.files[file.index] ?? file;
       entries.push({
         line: file.headerLine,
-        display: fileJumpLine(file, this.#collapsed.has(file.index)),
+        display: fileJumpLine(
+          file,
+          this.#collapsed.has(file.index),
+          fileCounts,
+        ),
         filterText: file.path.toLowerCase(),
         name: file.path,
+        fileIndex: file.index,
       });
     }
     entries.sort((a, b) => a.line - b.line);
@@ -4534,7 +4567,7 @@ export class Session {
       0,
       Math.max(0, this.#jumpEntries.length - 1),
     );
-    this.#scrollListToSelection(this.#jumpSel);
+    this.#scrollJumpToSelection(this.#jumpSel);
   }
 
   /** The index of the entry the viewport currently sits on: the last one whose
@@ -4554,6 +4587,13 @@ export class Session {
     const last = Math.max(0, this.#jumpEntries.length - 1);
     switch (key.name) {
       case "escape":
+        if (this.#jumpSearching) {
+          this.#jumpSearching = false;
+          this.#jumpFilter = "";
+          this.#jumpSel = 0;
+          this.#refreshJump();
+          return;
+        }
         this.#mode = "normal";
         this.#overlayScroll = 0;
         this.#message = "Cancelled";
@@ -4561,19 +4601,20 @@ export class Session {
       case "down":
       case "ctrl-n":
         this.#jumpSel = clamp(this.#jumpSel + 1, 0, last);
-        return this.#scrollListToSelection(this.#jumpSel);
+        return this.#scrollJumpToSelection(this.#jumpSel);
       case "up":
       case "ctrl-p":
         this.#jumpSel = clamp(this.#jumpSel - 1, 0, last);
-        return this.#scrollListToSelection(this.#jumpSel);
+        return this.#scrollJumpToSelection(this.#jumpSel);
       case "pagedown":
+      case "space":
         this.#jumpSel = clamp(this.#jumpSel + 10, 0, last);
-        return this.#scrollListToSelection(this.#jumpSel);
+        return this.#scrollJumpToSelection(this.#jumpSel);
       case "pageup":
         this.#jumpSel = clamp(this.#jumpSel - 10, 0, last);
-        return this.#scrollListToSelection(this.#jumpSel);
+        return this.#scrollJumpToSelection(this.#jumpSel);
       case "backspace":
-        if (this.#jumpFilter.length > 0) {
+        if (this.#jumpSearching && this.#jumpFilter.length > 0) {
           this.#jumpFilter = this.#jumpFilter.slice(0, -1);
           this.#jumpSel = 0;
           this.#refreshJump();
@@ -4584,11 +4625,105 @@ export class Session {
         this.#activateJump();
         return;
     }
-    if (key.char && key.char >= " " && !key.ctrl) {
+    if (this.#jumpSearching && key.char && key.char >= " " && !key.ctrl) {
       this.#jumpFilter += key.char;
       this.#jumpSel = 0;
       this.#refreshJump();
+      return;
     }
+    switch (key.name) {
+      case "/":
+        this.#jumpSearching = true;
+        this.#jumpFilter = "";
+        this.#jumpSel = 0;
+        this.#refreshJump();
+        return;
+      case "f":
+        this.#toggleJumpFile();
+        return;
+      case "F":
+        this.#collapseAllFiles();
+        this.#rebuildJumpEntries();
+        return;
+      case "E":
+        this.#expandAllFiles();
+        this.#rebuildJumpEntries();
+        return;
+      case "T":
+        this.#toggleFileCategory((file) => file.isTest, "test");
+        this.#rebuildJumpEntries();
+        return;
+      case "M":
+        this.#toggleFileCategory((file) => file.isMarkdown, "Markdown");
+        this.#rebuildJumpEntries();
+        return;
+      case "D":
+        this.#cycleJumpCountMode();
+        return;
+    }
+  }
+
+  /** Toggles the file on the highlighted jump-list row. */
+  #toggleJumpFile(): void {
+    const fileIndex = this.#jumpEntries[this.#jumpSel]?.fileIndex;
+    const file = fileIndex === undefined
+      ? undefined
+      : this.#foldFiles()[fileIndex];
+    if (!file) {
+      this.#message = "Select a file to hide or show.";
+      return;
+    }
+    this.#toggleFile(file);
+    this.#rebuildJumpEntries();
+  }
+
+  /** Keeps the selection visible and reveals the summary at the last entry. */
+  #scrollJumpToSelection(selection: number): void {
+    this.#scrollListToSelection(selection);
+    const innerHeight = overlayBox(this.width, this.height).innerH;
+    if (
+      innerHeight > 0 && this.#jumpEntries.length > 0 &&
+      selection === this.#jumpEntries.length - 1
+    ) {
+      this.#overlayScroll = Math.max(
+        0,
+        this.#jumpEntries.length + 3 - innerHeight,
+      );
+    }
+  }
+
+  /** Rebuilds jump rows after visibility or count settings change. */
+  #rebuildJumpEntries(): void {
+    this.#jumpAll = this.#buildJumpEntries();
+    this.#refreshJump();
+  }
+
+  /** Advances to the next diff-count policy and refreshes every count shown. */
+  #cycleJumpCountMode(): void {
+    const index = DIFF_COUNT_MODES.indexOf(this.#jumpCountMode);
+    this.#jumpCountMode = DIFF_COUNT_MODES[
+      (index + 1) % DIFF_COUNT_MODES.length
+    ];
+    this.#rebuildJumpEntries();
+  }
+
+  /** Counts for the current source document under the selected policy. */
+  #jumpDiffCounts(): DiffCounts {
+    if (
+      this.#jumpCountCache?.doc !== this.#sourceDoc ||
+      this.#jumpCountCache.mode !== this.#jumpCountMode
+    ) {
+      this.#jumpCountCache = {
+        doc: this.#sourceDoc,
+        mode: this.#jumpCountMode,
+        counts: diffCounts(
+          this.#sourceDoc.text,
+          this.#sourceDoc.lines,
+          this.#jumpCountMode,
+        ),
+      };
+    }
+    return this.#jumpCountCache.counts;
   }
 
   /** Jump to the highlighted entry and close the list. A filter that matches
@@ -4620,11 +4755,22 @@ export class Session {
       const text = "(no matches)";
       lines.push({ text, spans: [{ col: 0, text, cls: "comment" }] });
     }
+    const counts = this.#jumpDiffCounts();
+    const shown = sumDiffLineCounts(
+      counts.files.filter((_, index) => !this.#collapsed.has(index)),
+    );
+    lines.push(
+      { text: "", spans: [] },
+      jumpCountModeLine(this.#jumpCountMode),
+      jumpCountSummaryLine(counts.totals, shown),
+    );
     return {
       title: "Jump to file or commit",
       lines,
       scroll: this.#overlayScroll,
-      footer: "↑/↓ select · enter jump · esc cancel",
+      footer: this.#jumpSearching
+        ? "type · ↑↓ select · Space page · Enter jump · Esc list"
+        : "↑↓ · Space page · / filter · f F E T M · D counts · Enter · Esc",
       selectedLine: this.#jumpEntries.length > 0 ? this.#jumpSel : undefined,
     };
   }
@@ -4739,22 +4885,55 @@ function commitJumpLine(shortSha: string, subject: string): Line {
 
 /** Add the category keys that affect a file to its jump-list row. Collapsed
  * rows use the dialog's muted style. */
-function fileJumpLine(file: DiffFileRange, collapsed: boolean): Line {
+function fileJumpLine(
+  file: DiffFileRange,
+  collapsed: boolean,
+  counts: DiffLineCounts,
+): Line {
   const flags = `${file.isMarkdown ? "M" : " "}${file.isTest ? "T" : " "}`;
   const prefix = `${flags} `;
+  const summary = diffFileSummary(file, counts.adds, counts.dels);
   const spans: Span[] = [
     { col: 0, text: prefix, cls: "builderCall" },
-    ...file.summary.spans.map((span) => ({
+    ...summary.spans.map((span) => ({
       ...span,
       col: span.col + 3,
     })),
   ];
   return {
-    text: prefix + file.summary.text,
+    text: prefix + summary.text,
     spans: collapsed
       ? spans.map((span) => ({ ...span, cls: "comment" }))
       : spans,
   };
+}
+
+/** Builds the jump-list row naming its current count policy. */
+function jumpCountModeLine(mode: DiffCountMode): Line {
+  const text = `Counts: ${diffCountModeLabel(mode)}`;
+  return { text, spans: [{ col: 0, text, cls: "diffMeta" }] };
+}
+
+/** Builds the styled all-files and shown-files totals row. */
+function jumpCountSummaryLine(
+  all: DiffLineCounts,
+  shown: DiffLineCounts,
+): Line {
+  const spans: Span[] = [];
+  let text = "";
+  const add = (value: string, cls: TokenClass) => {
+    spans.push({ col: cpLen(text), text: value, cls });
+    text += value;
+  };
+  add("All files ", "plain");
+  add(`+${all.adds}`, "diffAdd");
+  add(" ", "whitespace");
+  add(`−${all.dels}`, "diffDel");
+  add(" · Shown files ", "plain");
+  add(`+${shown.adds}`, "diffAdd");
+  add(" ", "whitespace");
+  add(`−${shown.dels}`, "diffDel");
+  return { text, spans };
 }
 
 export function helpOverlay(): {
@@ -4785,6 +4964,8 @@ export function helpOverlay(): {
     ["  T", "hide / show test and test-support files"],
     ["  M", "hide / show Markdown files"],
     ["  i", "list the diff's files and commits, jump to one"],
+    ["  / (in list)", "filter the list"],
+    ["  D (in list)", "cycle its diff counts"],
     ["", ""],
     ["Structure tree", ""],
     ["  W / S", "previous / next sibling (W → parent, S → out, at ends)"],

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4723,7 +4723,9 @@ export class Session {
           this.#sourceDoc.text,
           this.#sourceDoc.lines,
           this.#jumpCountMode,
-          this.#source?.diffCountContexts?.(this.#sourceDoc.text),
+          this.#jumpCountMode === "comments"
+            ? this.#source?.diffCountContexts?.(this.#sourceDoc.text)
+            : undefined,
         ),
       };
     }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4585,19 +4585,23 @@ export class Session {
   #handleJumpList(key: Key): void {
     this.#message = "";
     const last = Math.max(0, this.#jumpEntries.length - 1);
-    switch (key.name) {
-      case "escape":
-        if (this.#jumpSearching) {
-          this.#jumpSearching = false;
-          this.#jumpFilter = "";
-          this.#jumpSel = 0;
-          this.#refreshJump();
-          return;
-        }
-        this.#mode = "normal";
-        this.#overlayScroll = 0;
-        this.#message = "Cancelled";
+    if (
+      key.name === "escape" ||
+      (key.name === "q" && !this.#jumpSearching)
+    ) {
+      if (this.#jumpSearching) {
+        this.#jumpSearching = false;
+        this.#jumpFilter = "";
+        this.#jumpSel = 0;
+        this.#refreshJump();
         return;
+      }
+      this.#mode = "normal";
+      this.#overlayScroll = 0;
+      this.#message = "Cancelled";
+      return;
+    }
+    switch (key.name) {
       case "down":
       case "ctrl-n":
         this.#jumpSel = clamp(this.#jumpSel + 1, 0, last);

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -4607,7 +4607,10 @@ export class Session {
         this.#jumpSel = clamp(this.#jumpSel - 1, 0, last);
         return this.#scrollJumpToSelection(this.#jumpSel);
       case "pagedown":
+        this.#jumpSel = clamp(this.#jumpSel + 10, 0, last);
+        return this.#scrollJumpToSelection(this.#jumpSel);
       case "space":
+        if (this.#jumpSearching) break;
         this.#jumpSel = clamp(this.#jumpSel + 10, 0, last);
         return this.#scrollJumpToSelection(this.#jumpSel);
       case "pageup":

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -172,6 +172,28 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
   });
 
+  it("tracks multiline fallback comments across diff hunks", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,3 +1,3 @@",
+      " /*",
+      "- * old nearby note",
+      "+ * new nearby note",
+      "  * unchanged note",
+      "@@ -20,2 +20,2 @@",
+      "- * old distant note",
+      "+ * new distant note",
+      "  */",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
   it("preserves comment markers inside Rust raw strings", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",
@@ -286,6 +308,23 @@ describe("diffcounts", () => {
     const counts = countsFor(diff);
 
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("does not start shell heredocs from quoted operators", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1,2 +1,2 @@",
+      ' echo "example: <<EOF"',
+      "-# old comment",
+      "+# new comment",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
   });
 
   it("tracks nested block comments in Rust", () => {

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -3,21 +3,27 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
-import { diffCounts } from "../lib/view/diffcounts.ts";
+import {
+  type DiffCountFileContext,
+  diffCounts,
+} from "../lib/view/diffcounts.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument } from "../lib/view/diffdoc.ts";
 
 /** Computes every count policy over one highlighted diff. */
-function countsFor(text: string) {
+function countsFor(
+  text: string,
+  contexts?: readonly DiffCountFileContext[],
+) {
   const model = parseDiff(text)!;
   const { doc } = buildDiffDocument(text, model, {
     resolve: () => null,
     read: () => null,
   });
   return {
-    normal: diffCounts(text, doc.lines, "normal"),
-    whitespace: diffCounts(text, doc.lines, "whitespace"),
-    comments: diffCounts(text, doc.lines, "comments"),
+    normal: diffCounts(text, doc.lines, "normal", contexts),
+    whitespace: diffCounts(text, doc.lines, "whitespace", contexts),
+    comments: diffCounts(text, doc.lines, "comments", contexts),
   };
 }
 
@@ -170,6 +176,81 @@ describe("diffcounts", () => {
     const counts = countsFor(diff);
 
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("uses complete files when a comment opener precedes the first hunk", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -3 +3 @@",
+      "- * old note",
+      "+ * new note",
+      "",
+    ].join("\n");
+    const counts = countsFor(diff, [{
+      oldLines: ["/*", " * hidden note", " * old note", " */"],
+      newLines: ["/*", " * hidden note", " * new note", " */"],
+    }]);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("uses omitted file lines to resolve a multiline close", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "@@ -4 +4 @@",
+      "-run_old();",
+      "+run_new();",
+      "",
+    ].join("\n");
+    const counts = countsFor(diff, [{
+      oldLines: ["/*", " * old note", " */", "run_old();"],
+      newLines: ["/*", " * new note", " */", "run_new();"],
+    }]);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("uses omitted lines before interpreting later comment syntax", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "@@ -4,2 +4,2 @@",
+      "-run_old();",
+      "+run_new();",
+      ' // say "hello */',
+      "",
+    ].join("\n");
+    const counts = countsFor(diff, [{
+      oldLines: [
+        "/*",
+        " * old note",
+        " */",
+        "run_old();",
+        '// say "hello */',
+      ],
+      newLines: [
+        "/*",
+        " * new note",
+        " */",
+        "run_new();",
+        '// say "hello */',
+      ],
+    }]);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
   });
 
   it("tracks multiline fallback comments across diff hunks", () => {

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -301,6 +301,27 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
   });
 
+  it("ignores a block closer in a later line comment", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "@@ -20,2 +20,2 @@",
+      "-run_old();",
+      "+run_new();",
+      ' // say "hello */',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
   it("preserves comment markers inside Rust raw strings", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",
@@ -524,6 +545,27 @@ describe("diffcounts", () => {
     const counts = countsFor(diff);
 
     expect(counts.comments.totals).toEqual({ adds: 2, dels: 2 });
+  });
+
+  it("ignores raw-string closer text in a later ordinary string", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      ' let text = r#"',
+      "-old raw data",
+      "+new raw data",
+      "@@ -20,2 +20,2 @@",
+      "-// old comment",
+      "+// new comment",
+      ' let marker = "not a raw close: \\"#";',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
   });
 
   it("does not start shell heredocs from quoted operators", () => {

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -214,6 +214,72 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
   });
 
+  it("carries fallback comments through contiguous hunks", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old first note",
+      "+ * new first note",
+      "@@ -3,2 +3,2 @@",
+      "- * old second note",
+      "+ * new second note",
+      "  */",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("carries fallback comments through several diff gaps", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old first note",
+      "+ * new first note",
+      "@@ -20 +20 @@",
+      "- * old second note",
+      "+ * new second note",
+      "@@ -40,2 +40,2 @@",
+      "- * old third note",
+      "+ * new third note",
+      "  */",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("ignores quoted block closers after an omitted close", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "@@ -20,2 +20,2 @@",
+      "-run_old();",
+      "+run_new();",
+      ' let marker = "*/";',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
   it("preserves comment markers inside Rust raw strings", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",
@@ -328,6 +394,94 @@ describe("diffcounts", () => {
     const counts = countsFor(diff);
 
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("tracks multiple shell heredocs in declaration order", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1,5 +1,5 @@",
+      " cat <<A <<B",
+      " first body",
+      " A",
+      "-# old second body",
+      "+# new second body",
+      " B",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("carries shell heredocs through several diff gaps", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1,2 +1,2 @@",
+      " cat <<EOF",
+      "-# old first body",
+      "+# new first body",
+      "@@ -20 +20 @@",
+      "-# old second body",
+      "+# new second body",
+      "@@ -40,2 +40,2 @@",
+      "-# old third body",
+      "+# new third body",
+      " EOF",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 3, dels: 3 });
+  });
+
+  it("does not carry shell heredocs past an omitted terminator", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1,2 +1,2 @@",
+      " cat <<EOF",
+      "-old data",
+      "+new data",
+      "@@ -20 +20 @@",
+      "-# old comment",
+      "+# new comment",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("carries Rust raw strings through several diff gaps", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      ' let text = r#"',
+      "-// old first data",
+      "+// new first data",
+      "@@ -20 +20 @@",
+      "-// old second data",
+      "+// new second data",
+      "@@ -40,2 +40,2 @@",
+      "-// old third data",
+      "+// new third data",
+      ' "#;',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 3, dels: 3 });
   });
 
   it("does not start shell heredocs from quoted operators", () => {

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -194,6 +194,26 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
   });
 
+  it("does not carry fallback comments past an omitted close", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "@@ -20 +20 @@",
+      "-run_old();",
+      "+run_new();",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
   it("preserves comment markers inside Rust raw strings", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -280,6 +280,27 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
   });
 
+  it("recognizes a block close after an unmatched quote", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /*",
+      "- * old first note",
+      "+ * new first note",
+      "@@ -20,2 +20,2 @@",
+      "- * old second note",
+      "+ * new second note",
+      ' * say "hello */',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
   it("preserves comment markers inside Rust raw strings", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",
@@ -482,6 +503,27 @@ describe("diffcounts", () => {
     const counts = countsFor(diff);
 
     expect(counts.comments.totals).toEqual({ adds: 3, dels: 3 });
+  });
+
+  it("recognizes a raw-string close after a backslash", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      ' let text = r#"',
+      "-// old first data",
+      "+// new first data",
+      "@@ -20,2 +20,2 @@",
+      "-// old second data",
+      "+// new second data",
+      ' \\"#;',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 2, dels: 2 });
   });
 
   it("does not start shell heredocs from quoted operators", () => {

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -1,0 +1,332 @@
+/** Tests the three line-count policies used by the diff jump list. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { diffCounts } from "../lib/view/diffcounts.ts";
+import { parseDiff } from "../lib/view/diff.ts";
+import { buildDiffDocument } from "../lib/view/diffdoc.ts";
+
+/** Computes every count policy over one highlighted diff. */
+function countsFor(text: string) {
+  const model = parseDiff(text)!;
+  const { doc } = buildDiffDocument(text, model, {
+    resolve: () => null,
+    read: () => null,
+  });
+  return {
+    normal: diffCounts(text, doc.lines, "normal"),
+    whitespace: diffCounts(text, doc.lines, "whitespace"),
+    comments: diffCounts(text, doc.lines, "comments"),
+  };
+}
+
+describe("diffcounts", () => {
+  it("discounts whitespace-only pairs within each file", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +1 @@",
+      "-const value = 1; // same",
+      "+const   value = 1; // same",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.normal.totals).toEqual({ adds: 1, dels: 1 });
+    expect(counts.whitespace.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("discounts comment-only lines and comment-only edits", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,2 @@",
+      "-run(); // before",
+      "-// removed explanation",
+      "+run(); // after",
+      "+  // replacement explanation",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.whitespace.totals).toEqual({ adds: 2, dels: 2 });
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("ignores documentation comments without treating strings as comments", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,2 @@",
+      "-/** old documentation */",
+      '-const url = "https://old.example";',
+      "+/** new documentation */",
+      '+const url = "https://new.example";',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("counts Markdown headings even though they share a display style", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -1 +1 @@",
+      "-# Old heading",
+      "+# New heading",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("recognizes comments in files that use plain-text highlighting", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1 +1 @@",
+      "-fn main() {} // old comment",
+      "+fn main() {} // new comment",
+      "diff --git a/page.html b/page.html",
+      "--- a/page.html",
+      "+++ b/page.html",
+      "@@ -1 +1 @@",
+      "-<!-- old note -->",
+      "+<!-- new note -->",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("does not treat an unquoted URL as a comment", () => {
+    const diff = [
+      "diff --git a/style.scss b/style.scss",
+      "--- a/style.scss",
+      "+++ b/style.scss",
+      "@@ -1 +1 @@",
+      "-background: url(https://old.example/image.png);",
+      "+background: url(https://new.example/image.png);",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("uses highlighter decisions for languages it understands", () => {
+    const diff = [
+      "diff --git a/config.yaml b/config.yaml",
+      "--- a/config.yaml",
+      "+++ b/config.yaml",
+      "@@ -1 +1 @@",
+      "-value: foo#old",
+      "+value: foo#new",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("tracks multiline fallback comments on each side of a hunk", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,3 +1,3 @@",
+      " /*",
+      "- * old note",
+      "+ * new note",
+      "  */",
+      "diff --git a/page.html b/page.html",
+      "--- a/page.html",
+      "+++ b/page.html",
+      "@@ -1,3 +1,3 @@",
+      " <!--",
+      "-old note",
+      "+new note",
+      " -->",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("preserves comment markers inside Rust raw strings", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1 +1 @@",
+      '-const TEXT: &str = r#"a " // old"#;',
+      '+const TEXT: &str = r#"a " // new"#;',
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("preserves hash operators in shell parameter expansions", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1 +1 @@",
+      "-echo ${value#old}",
+      "+echo ${value#new}",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("uses each side's comment syntax when a rename changes extensions", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.ts",
+      "--- a/main.rs",
+      "+++ b/main.ts",
+      "@@ -1 +1 @@",
+      "-run(); // old Rust note",
+      "+run(); // new TypeScript note",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("preserves HTML comment syntax inside Markdown code fences", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -1,3 +1,3 @@",
+      " ```text",
+      "-<!-- old literal -->",
+      "+<!-- new literal -->",
+      " ```",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("ignores HTML comments after Markdown inline code", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -1 +1 @@",
+      "-`same code` <!-- old note -->",
+      "+`same code` <!-- new note -->",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("preserves HTML comment syntax inside indented Markdown code", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -1 +1 @@",
+      "-    <!-- old literal -->",
+      "+    <!-- new literal -->",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("preserves hash-prefixed data inside shell heredocs", () => {
+    const diff = [
+      "diff --git a/run.sh b/run.sh",
+      "--- a/run.sh",
+      "+++ b/run.sh",
+      "@@ -1,3 +1,3 @@",
+      " cat <<EOF",
+      "-# old data",
+      "+# new data",
+      " EOF",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("tracks nested block comments in Rust", () => {
+    const diff = [
+      "diff --git a/main.rs b/main.rs",
+      "--- a/main.rs",
+      "+++ b/main.rs",
+      "@@ -1,2 +1,2 @@",
+      " /* outer /* inner */",
+      "-old outer */",
+      "+new outer */",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
+  it("discounts moved code across files when comments are ignored", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +0,0 @@",
+      "-moved();",
+      "diff --git a/b.ts b/b.ts",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -0,0 +1 @@",
+      "+ moved ( ) ; // relocated",
+      "",
+    ].join("\n");
+
+    const counts = countsFor(diff);
+
+    expect(counts.whitespace.totals).toEqual({ adds: 1, dels: 1 });
+    expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
+    expect(counts.comments.files).toEqual([
+      { adds: 0, dels: 0 },
+      { adds: 0, dels: 0 },
+    ]);
+  });
+});

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -129,8 +129,14 @@ describe("diffcounts", () => {
     const cases = [
       ["style.css", "/* old */", "/* new */"],
       ["query.sql", "-- old", "-- new"],
+      ["query-block.sql", "/* old */", "/* new */"],
       ["script.lua", "-- old", "-- new"],
-      ["module.hs", "{- old -}", "{- new -}"],
+      ["module-line.hs", "-- old", "-- new"],
+      [
+        "module-nested.hs",
+        "{- outer {- inner -} old -}",
+        "{- outer {- inner -} new -}",
+      ],
       ["code.lisp", "; old", "; new"],
     ];
     const diff = cases.flatMap(([path, oldLine, newLine]) => [

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -9,6 +9,11 @@ import {
 } from "../lib/view/diffcounts.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument } from "../lib/view/diffdoc.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
+
+function contextLines(path: string, lines: readonly string[]) {
+  return languageForFile(path).highlightLines(lines.join("\n"), path);
+}
 
 /** Computes every count policy over one highlighted diff. */
 function countsFor(
@@ -189,8 +194,18 @@ describe("diffcounts", () => {
       "",
     ].join("\n");
     const counts = countsFor(diff, [{
-      oldLines: ["/*", " * hidden note", " * old note", " */"],
-      newLines: ["/*", " * hidden note", " * new note", " */"],
+      oldLines: contextLines("main.rs", [
+        "/*",
+        " * hidden note",
+        " * old note",
+        " */",
+      ]),
+      newLines: contextLines("main.rs", [
+        "/*",
+        " * hidden note",
+        " * new note",
+        " */",
+      ]),
     }]);
 
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
@@ -211,8 +226,18 @@ describe("diffcounts", () => {
       "",
     ].join("\n");
     const counts = countsFor(diff, [{
-      oldLines: ["/*", " * old note", " */", "run_old();"],
-      newLines: ["/*", " * new note", " */", "run_new();"],
+      oldLines: contextLines("main.rs", [
+        "/*",
+        " * old note",
+        " */",
+        "run_old();",
+      ]),
+      newLines: contextLines("main.rs", [
+        "/*",
+        " * new note",
+        " */",
+        "run_new();",
+      ]),
     }]);
 
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
@@ -234,20 +259,48 @@ describe("diffcounts", () => {
       "",
     ].join("\n");
     const counts = countsFor(diff, [{
-      oldLines: [
+      oldLines: contextLines("main.rs", [
         "/*",
         " * old note",
         " */",
         "run_old();",
         '// say "hello */',
-      ],
-      newLines: [
+      ]),
+      newLines: contextLines("main.rs", [
         "/*",
         " * new note",
         " */",
         "run_new();",
         '// say "hello */',
-      ],
+      ]),
+    }]);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
+  it("does not treat comments inside omitted Markdown code as syntax", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -4 +4 @@",
+      "-old prose",
+      "+new prose",
+      "",
+    ].join("\n");
+    const counts = countsFor(diff, [{
+      oldLines: contextLines("readme.md", [
+        "```html",
+        "<!-- literal example",
+        "```",
+        "old prose",
+      ]),
+      newLines: contextLines("readme.md", [
+        "```html",
+        "<!-- literal example",
+        "```",
+        "new prose",
+      ]),
     }]);
 
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -125,6 +125,26 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 0, dels: 0 });
   });
 
+  it("recognizes fallback comment syntax across supported file families", () => {
+    const cases = [
+      ["style.css", "/* old */", "/* new */"],
+      ["query.sql", "-- old", "-- new"],
+      ["script.lua", "-- old", "-- new"],
+      ["module.hs", "{- old -}", "{- new -}"],
+      ["code.lisp", "; old", "; new"],
+    ];
+    const diff = cases.flatMap(([path, oldLine, newLine]) => [
+      `diff --git a/${path} b/${path}`,
+      `--- a/${path}`,
+      `+++ b/${path}`,
+      "@@ -1 +1 @@",
+      `-${oldLine}`,
+      `+${newLine}`,
+    ]).concat("").join("\n");
+
+    expect(countsFor(diff).comments.totals).toEqual({ adds: 0, dels: 0 });
+  });
+
   it("does not treat an unquoted URL as a comment", () => {
     const diff = [
       "diff --git a/style.scss b/style.scss",

--- a/packages/cli/test/view-diffcounts.test.ts
+++ b/packages/cli/test/view-diffcounts.test.ts
@@ -306,6 +306,30 @@ describe("diffcounts", () => {
     expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
   });
 
+  it("does not treat comments inside omitted indented Markdown as syntax", () => {
+    const diff = [
+      "diff --git a/readme.md b/readme.md",
+      "--- a/readme.md",
+      "+++ b/readme.md",
+      "@@ -2 +2 @@",
+      "-old prose",
+      "+new prose",
+      "",
+    ].join("\n");
+    const counts = countsFor(diff, [{
+      oldLines: contextLines("readme.md", [
+        "    <!-- literal example",
+        "old prose",
+      ]),
+      newLines: contextLines("readme.md", [
+        "    <!-- literal example",
+        "new prose",
+      ]),
+    }]);
+
+    expect(counts.comments.totals).toEqual({ adds: 1, dels: 1 });
+  });
+
   it("tracks multiline fallback comments across diff hunks", () => {
     const diff = [
       "diff --git a/main.rs b/main.rs",

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -461,6 +461,15 @@ Deno.test("jumplist: complete count context retains final-newline changes", () =
     "\\ No newline at end of file",
     "",
   ].join("\n");
+  const createsWithNewline = [
+    "diff --git a/main.rs b/main.rs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/main.rs",
+    "@@ -0,0 +1 @@",
+    "+value",
+    "",
+  ].join("\n");
 
   assertEquals(
     contexts(addsNewline, "new\n")?.newLines?.map((line) => line.text),
@@ -469,6 +478,10 @@ Deno.test("jumplist: complete count context retains final-newline changes", () =
   assertEquals(
     contexts(removesNewline, "new")?.newLines?.map((line) => line.text),
     ["new"],
+  );
+  assertEquals(
+    contexts(createsWithNewline, "value\n")?.newLines?.map((line) => line.text),
+    ["value", ""],
   );
 });
 

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -186,6 +186,14 @@ Deno.test("jumplist: a git show lists the commit message before its files", () =
   ]);
 });
 
+Deno.test("jumplist: f on a commit asks for a file row", () => {
+  const s = diffSession(SHOW);
+  press(s, "i", "f");
+
+  assertEquals(s.view().message, "Select a file to hide or show.");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+});
+
 Deno.test("jumplist: enter on a file jumps the viewport to its header line", () => {
   // A short viewport, so the last file's header can reach the very top.
   const s = diffSession(SHOW, 6);
@@ -434,15 +442,17 @@ Deno.test("jumplist: complete count context rebuilds after an edit", () => {
 });
 
 Deno.test("jumplist: complete count context retains final-newline changes", () => {
-  const contexts = (diff: string, fileText: string) => {
+  const source = (diff: string, fileText: string) => {
     const ws: DiffWorkspace = {
       resolve: (path) => path === "main.rs" ? path : null,
       read: (path) => path === "main.rs" ? fileText : null,
     };
     const model = parseDiff(diff)!;
     const { edit } = buildDiffDocument(diff, model, ws);
-    return diffSource(ws, edit).diffCountContexts?.(diff)?.[0];
+    return diffSource(ws, edit);
   };
+  const contexts = (diff: string, fileText: string) =>
+    source(diff, fileText).diffCountContexts?.(diff)?.[0];
   const addsNewline = [
     "diff --git a/main.rs b/main.rs",
     "--- a/main.rs",
@@ -472,6 +482,23 @@ Deno.test("jumplist: complete count context retains final-newline changes", () =
     "+value",
     "",
   ].join("\n");
+  const deletesToEmpty = [
+    "diff --git a/main.rs b/main.rs",
+    "--- a/main.rs",
+    "+++ b/main.rs",
+    "@@ -1 +0,0 @@",
+    "-old",
+    "",
+  ].join("\n");
+  const crlfChange = [
+    "diff --git a/main.rs b/main.rs\r",
+    "--- a/main.rs\r",
+    "+++ b/main.rs\r",
+    "@@ -1 +1 @@\r",
+    "-old\r",
+    "+new\r",
+    "",
+  ].join("\n");
 
   assertEquals(
     contexts(addsNewline, "new\n")?.newLines?.map((line) => line.text),
@@ -484,6 +511,18 @@ Deno.test("jumplist: complete count context retains final-newline changes", () =
   assertEquals(
     contexts(createsWithNewline, "value\n")?.newLines?.map((line) => line.text),
     ["value", ""],
+  );
+  assertEquals(
+    contexts(deletesToEmpty, "")?.newLines?.map((line) => line.text),
+    [""],
+  );
+  assertEquals(
+    contexts(crlfChange, "new\r\n")?.newLines?.map((line) => line.text),
+    ["new", ""],
+  );
+  assertEquals(
+    source(addsNewline, "new\n").diffCountContexts?.("not a diff"),
+    [],
   );
 });
 

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -258,6 +258,16 @@ Deno.test("jumplist: a filter matching the commit subject keeps the commit", () 
   assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
 });
 
+Deno.test("jumplist: spaces are entered in a filter", () => {
+  const s = diffSession(SHOW);
+  press(s, "i", "/");
+  type(s, "widget");
+  s.handleKey({ name: "space", char: " " });
+  type(s, "alignment");
+  assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
+  assertEquals(s.view().inputLine, "jump to: widget alignment");
+});
+
 Deno.test("jumplist: enter with no match leaves the list open", () => {
   const s = diffSession(SHOW);
   press(s, "down", "down"); // scroll off the top so "unmoved" is meaningful

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -6,11 +6,12 @@
  */
 
 import { assert, assertEquals } from "@std/assert";
-import { Session } from "../lib/view/session.ts";
 import { parseDiff } from "../lib/view/diff.ts";
 import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { diffSource } from "../lib/view/diffedit.ts";
 import { parseDocument } from "../lib/view/languages/typescript/parse.ts";
+import type { Line } from "../lib/view/model.ts";
+import { Session } from "../lib/view/session.ts";
 
 function press(s: Session, ...names: string[]): void {
   for (const name of names) {
@@ -39,8 +40,23 @@ function diffSession(diffText: string, height = 20): Session {
   );
 }
 
+/** Selectable rows before the jump list's summary. */
+function entryLines(s: Session): readonly Line[] {
+  const lines = s.view().overlay?.lines ?? [];
+  const summary = lines.findIndex((line) => line.text === "");
+  return summary < 0 ? lines : lines.slice(0, summary);
+}
+
+/** Plain text of the selectable jump-list rows. */
 function entryText(s: Session): string[] {
-  return s.view().overlay?.lines.map((l) => l.text) ?? [];
+  return entryLines(s).map((line) => line.text);
+}
+
+/** Plain text of the count-policy and count-total rows. */
+function summaryText(s: Session): string[] {
+  const lines = s.view().overlay?.lines.map((l) => l.text) ?? [];
+  const summary = lines.indexOf("");
+  return summary < 0 ? [] : lines.slice(summary + 1);
 }
 
 const TWO_FILES = [
@@ -96,7 +112,7 @@ Deno.test("jumplist: i lists the diff's files, dirs summarized", () => {
     "   ▸ src/app.ts  +1 −1",
     " T ▸ src/app.test.ts  +1 −0",
   ]);
-  assertEquals(s.view().inputLine, "jump to: ");
+  assertEquals(s.view().inputLine, null);
   assertEquals(s.view().overlay?.title, "Jump to file or commit");
   assertEquals(s.view().overlay?.selectedLine, 0);
 });
@@ -123,7 +139,7 @@ Deno.test("jumplist: new and deleted files color their applicable counts", () =>
   );
   press(s, "i");
 
-  const lines = s.view().overlay!.lines;
+  const lines = s.view().overlay!.lines.slice(0, 2);
   assertEquals(lines.map((line) => line.text), [
     "   ▸ new.ts  +2 (new)",
     "   ▸ gone.ts  −2 (deleted)",
@@ -184,6 +200,38 @@ Deno.test("jumplist: pagedown and pageup jump the selection to the ends", () => 
   assertEquals(s.view().overlay?.selectedLine, 0, "clamped to the first entry");
 });
 
+Deno.test("jumplist: space pages the selection down", () => {
+  const s = diffSession(LOG);
+  press(s, "i");
+  assertEquals(s.view().overlay?.selectedLine, 0);
+  press(s, "space");
+  assertEquals(s.view().overlay?.selectedLine, 3, "clamped to the last entry");
+});
+
+Deno.test("jumplist: selecting the last entry reveals the summary", () => {
+  const s = diffSession(CATEGORY_FILES, 12);
+  press(s, "i", "pagedown");
+  const overlay = s.view().overlay!;
+  assertEquals(overlay.selectedLine, 3);
+  assertEquals(overlay.scroll, 1);
+  assertEquals(overlay.lines.slice(-2).map((line) => line.text), [
+    "Counts: normal",
+    "All files +4 −4 · Shown files +4 −4",
+  ]);
+});
+
+Deno.test("jumplist: a one-row overlay can reveal the summary total", () => {
+  const s = diffSession(TWO_FILES, 7);
+  press(s, "i", "pagedown");
+  const overlay = s.view().overlay!;
+  assertEquals(overlay.selectedLine, 1);
+  assertEquals(overlay.scroll, 4);
+  assertEquals(
+    overlay.lines[overlay.scroll].text,
+    "All files +2 −1 · Shown files +2 −1",
+  );
+});
+
 Deno.test("jumplist: tab jumps the same as enter", () => {
   const s = diffSession(SHOW, 6);
   press(s, "i", "down"); // preselected commit -> src/app.ts
@@ -194,7 +242,7 @@ Deno.test("jumplist: tab jumps the same as enter", () => {
 
 Deno.test("jumplist: typing filters the list", () => {
   const s = diffSession(SHOW);
-  press(s, "i");
+  press(s, "i", "/");
   type(s, "test");
   assertEquals(entryText(s), [" T ▸ src/app.test.ts  +1 −0"]);
   assertEquals(s.view().inputLine, "jump to: test");
@@ -205,7 +253,7 @@ Deno.test("jumplist: typing filters the list", () => {
 
 Deno.test("jumplist: a filter matching the commit subject keeps the commit", () => {
   const s = diffSession(SHOW);
-  press(s, "i");
+  press(s, "i", "/");
   type(s, "widget");
   assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
 });
@@ -215,12 +263,91 @@ Deno.test("jumplist: enter with no match leaves the list open", () => {
   press(s, "down", "down"); // scroll off the top so "unmoved" is meaningful
   const top = s.view().top;
   assert(top > 0);
-  press(s, "i");
+  press(s, "i", "/");
   type(s, "zzz");
   assertEquals(entryText(s), ["(no matches)"]);
   press(s, "enter");
   assert(s.view().overlay !== null, "still open");
   assertEquals(s.view().top, top, "viewport unmoved");
+});
+
+Deno.test("jumplist: escape leaves filtering before it closes the list", () => {
+  const s = diffSession(SHOW);
+  press(s, "i", "/");
+  type(s, "test");
+  press(s, "escape");
+  assertEquals(s.view().inputLine, null);
+  assertEquals(entryText(s).length, 3);
+  assert(s.view().overlay !== null, "list remains open");
+  press(s, "escape");
+  assertEquals(s.view().overlay, null);
+});
+
+Deno.test("jumplist: file visibility keys remain active while browsing", () => {
+  const s = diffSession(TWO_FILES);
+  press(s, "i", "T");
+  assert(entryText(s)[1].startsWith(" T ▸ src/app.test.ts"));
+  assert(
+    s.view().overlay!.lines[1].spans.every((span) => span.cls === "comment"),
+  );
+
+  press(s, "down", "f");
+  assert(
+    s.view().overlay!.lines[1].spans.some((span) => span.cls !== "comment"),
+  );
+  press(s, "F");
+  assert(
+    s.view().overlay!.lines.slice(0, 2).every((line) =>
+      line.spans.every((span) => span.cls === "comment")
+    ),
+  );
+  press(s, "E");
+  assert(
+    s.view().overlay!.lines.slice(0, 2).every((line) =>
+      line.spans.some((span) => span.cls !== "comment")
+    ),
+  );
+});
+
+Deno.test("jumplist: the summary reports all and shown file counts", () => {
+  const s = diffSession(TWO_FILES);
+  press(s, "i");
+  assertEquals(summaryText(s), [
+    "Counts: normal",
+    "All files +2 −1 · Shown files +2 −1",
+  ]);
+  press(s, "T");
+  assertEquals(summaryText(s), [
+    "Counts: normal",
+    "All files +2 −1 · Shown files +1 −1",
+  ]);
+});
+
+Deno.test("jumplist: D cycles the diff-count policy", () => {
+  const s = diffSession(
+    [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +1 @@",
+      "-run(); // before",
+      "+ run ( ) ; // after",
+      "",
+    ].join("\n"),
+  );
+  press(s, "i");
+  assert(entryText(s)[0].endsWith("+1 −1"));
+  press(s, "D");
+  assertEquals(summaryText(s)[0], "Counts: ignore whitespace-only changes");
+  assert(entryText(s)[0].endsWith("+1 −1"));
+  press(s, "D");
+  assertEquals(summaryText(s), [
+    "Counts: ignore comments and whitespace",
+    "All files +0 −0 · Shown files +0 −0",
+  ]);
+  assert(entryText(s)[0].endsWith("+0 −0"));
+  press(s, "D");
+  assertEquals(summaryText(s)[0], "Counts: normal");
 });
 
 Deno.test("jumplist: escape cancels and leaves the viewport put", () => {
@@ -294,7 +421,7 @@ Deno.test("jumplist: files stay listed and jumpable while collapsed", () => {
   press(s, "F"); // collapse every file to a summary line
   press(s, "i");
   assertEquals(entryText(s).length, 3, "commit and both files still listed");
-  const fileLines = s.view().overlay!.lines.slice(1);
+  const fileLines = entryLines(s).slice(1);
   assert(
     fileLines.every((line) =>
       line.spans.every((span) => span.cls === "comment")
@@ -340,8 +467,8 @@ Deno.test("jumplist: file rows use an aligned category-toggle column", () => {
 
 Deno.test("jumplist: only currently collapsed file rows are muted", () => {
   const s = diffSession(CATEGORY_FILES);
-  press(s, "M", "i");
-  const lines = s.view().overlay!.lines;
+  press(s, "i", "M");
+  const lines = entryLines(s);
   for (const line of lines) {
     const markdown = line.text.startsWith("M");
     assertEquals(
@@ -391,6 +518,7 @@ Deno.test("jumplist: an email patch shows and filters by its Subject", () => {
     "   ▸ src/app.ts  +1 −1",
   ]);
   // The subject (with its [PATCH] prefix stripped) is filterable.
+  press(s, "/");
   type(s, "widget");
   assertEquals(entryText(s), ["● commit 012345678  Fix the widget alignment"]);
 });

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -424,7 +424,9 @@ Deno.test("jumplist: complete count context rebuilds after an edit", () => {
   const { edit } = buildDiffDocument(diff, model, ws);
   const source = diffSource(ws, edit);
 
-  assert(source.diffCountContexts?.(diff) !== undefined);
+  const initial = source.diffCountContexts?.(diff);
+  assert(initial !== undefined);
+  assert(source.diffCountContexts?.(diff) === initial);
   const edited = diff.replace("+ * new note", "+ * newer note");
   const context = source.diffCountContexts?.(edited);
   assert(context !== undefined);

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -40,6 +40,26 @@ function diffSession(diffText: string, height = 20): Session {
   );
 }
 
+function diffSessionWithFile(
+  diffText: string,
+  path: string,
+  fileText: string,
+): Session {
+  const ws: DiffWorkspace = {
+    resolve: (candidate) => candidate === path ? path : null,
+    read: (candidate) => candidate === path ? fileText : null,
+  };
+  const model = parseDiff(diffText)!;
+  const { doc, edit } = buildDiffDocument(diffText, model, ws);
+  return new Session(
+    doc,
+    { color: false, showLineNumbers: false },
+    { width: 80, height: 20 },
+    undefined,
+    diffSource(ws, edit),
+  );
+}
+
 /** Selectable rows before the jump list's summary. */
 function entryLines(s: Session): readonly Line[] {
   const lines = s.view().overlay?.lines ?? [];
@@ -358,6 +378,29 @@ Deno.test("jumplist: D cycles the diff-count policy", () => {
   assert(entryText(s)[0].endsWith("+0 −0"));
   press(s, "D");
   assertEquals(summaryText(s)[0], "Counts: normal");
+});
+
+Deno.test("jumplist: counts use syntax before the first hunk", () => {
+  const diff = [
+    "diff --git a/main.rs b/main.rs",
+    "--- a/main.rs",
+    "+++ b/main.rs",
+    "@@ -3 +3 @@",
+    "- * old note",
+    "+ * new note",
+    "",
+  ].join("\n");
+  const s = diffSessionWithFile(
+    diff,
+    "main.rs",
+    ["/*", " * hidden note", " * new note", " */", ""].join("\n"),
+  );
+  press(s, "i", "D", "D");
+
+  assertEquals(summaryText(s), [
+    "Counts: ignore comments and whitespace",
+    "All files +0 −0 · Shown files +0 −0",
+  ]);
 });
 
 Deno.test("jumplist: escape cancels and leaves the viewport put", () => {

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -403,6 +403,31 @@ Deno.test("jumplist: counts use syntax before the first hunk", () => {
   ]);
 });
 
+Deno.test("jumplist: complete count context expires after an edit", () => {
+  const diff = [
+    "diff --git a/main.rs b/main.rs",
+    "--- a/main.rs",
+    "+++ b/main.rs",
+    "@@ -3 +3 @@",
+    "- * old note",
+    "+ * new note",
+    "",
+  ].join("\n");
+  const ws: DiffWorkspace = {
+    resolve: (path) => path === "main.rs" ? path : null,
+    read: (path) =>
+      path === "main.rs"
+        ? ["/*", " * hidden note", " * new note", " */", ""].join("\n")
+        : null,
+  };
+  const model = parseDiff(diff)!;
+  const { edit } = buildDiffDocument(diff, model, ws);
+  const source = diffSource(ws, edit);
+
+  assert(source.diffCountContexts?.(diff) !== undefined);
+  assertEquals(source.diffCountContexts?.(`${diff} `), undefined);
+});
+
 Deno.test("jumplist: escape cancels and leaves the viewport put", () => {
   const s = diffSession(SHOW);
   press(s, "down"); // move the viewport off line 0

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -403,7 +403,7 @@ Deno.test("jumplist: counts use syntax before the first hunk", () => {
   ]);
 });
 
-Deno.test("jumplist: complete count context expires after an edit", () => {
+Deno.test("jumplist: complete count context rebuilds after an edit", () => {
   const diff = [
     "diff --git a/main.rs b/main.rs",
     "--- a/main.rs",
@@ -425,7 +425,51 @@ Deno.test("jumplist: complete count context expires after an edit", () => {
   const source = diffSource(ws, edit);
 
   assert(source.diffCountContexts?.(diff) !== undefined);
-  assertEquals(source.diffCountContexts?.(`${diff} `), undefined);
+  const edited = diff.replace("+ * new note", "+ * newer note");
+  const context = source.diffCountContexts?.(edited);
+  assert(context !== undefined);
+  assertEquals(context[0].newLines?.[2].text, " * newer note");
+});
+
+Deno.test("jumplist: complete count context retains final-newline changes", () => {
+  const contexts = (diff: string, fileText: string) => {
+    const ws: DiffWorkspace = {
+      resolve: (path) => path === "main.rs" ? path : null,
+      read: (path) => path === "main.rs" ? fileText : null,
+    };
+    const model = parseDiff(diff)!;
+    const { edit } = buildDiffDocument(diff, model, ws);
+    return diffSource(ws, edit).diffCountContexts?.(diff)?.[0];
+  };
+  const addsNewline = [
+    "diff --git a/main.rs b/main.rs",
+    "--- a/main.rs",
+    "+++ b/main.rs",
+    "@@ -1 +1 @@",
+    "-old",
+    "\\ No newline at end of file",
+    "+new",
+    "",
+  ].join("\n");
+  const removesNewline = [
+    "diff --git a/main.rs b/main.rs",
+    "--- a/main.rs",
+    "+++ b/main.rs",
+    "@@ -1 +1 @@",
+    "-old",
+    "+new",
+    "\\ No newline at end of file",
+    "",
+  ].join("\n");
+
+  assertEquals(
+    contexts(addsNewline, "new\n")?.newLines?.map((line) => line.text),
+    ["new", ""],
+  );
+  assertEquals(
+    contexts(removesNewline, "new")?.newLines?.map((line) => line.text),
+    ["new"],
+  );
 });
 
 Deno.test("jumplist: escape cancels and leaves the viewport put", () => {

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -296,6 +296,13 @@ Deno.test("jumplist: spaces are entered in a filter", () => {
   assertEquals(s.view().inputLine, "jump to: widget alignment");
 });
 
+Deno.test("jumplist: q is entered in a filter", () => {
+  const s = diffSession(SHOW);
+  press(s, "i", "/", "q");
+  assertEquals(s.view().inputLine, "jump to: q");
+  assert(s.view().overlay !== null, "list remains open");
+});
+
 Deno.test("jumplist: enter with no match leaves the list open", () => {
   const s = diffSession(SHOW);
   press(s, "down", "down"); // scroll off the top so "unmoved" is meaningful
@@ -532,6 +539,16 @@ Deno.test("jumplist: escape cancels and leaves the viewport put", () => {
   const top = s.view().top;
   press(s, "i", "down", "down"); // open and move the selection
   press(s, "escape");
+  assertEquals(s.view().overlay, null);
+  assertEquals(s.view().message, "Cancelled");
+  assertEquals(s.view().top, top, "the view did not move");
+});
+
+Deno.test("jumplist: q cancels and leaves the viewport put", () => {
+  const s = diffSession(SHOW);
+  press(s, "down");
+  const top = s.view().top;
+  press(s, "i", "down", "down", "q");
   assertEquals(s.view().overlay, null);
   assertEquals(s.view().message, "Cancelled");
   assertEquals(s.view().top, top, "the view did not move");


### PR DESCRIPTION
The diff jump list treated every printable key as filter input. This made its file visibility controls unavailable and hid normal paging.

Open the list in browsing mode and reserve `/` for filtering. Keep the file visibility keys active, use Space for paging, and use `D` to cycle three line-count policies.

Compute normal counts, counts that ignore whitespace-only edits, and counts that ignore comments and whitespace. The broadest policy matches moved lines across files. Use syntax highlighting where available and scan common comment forms for plain-text fallback languages. Show the chosen per-file counts and totals for all files and shown files.

Tests cover browsing, filtering, folding, paging, summaries, short terminals, comment syntax, string literals, Markdown code, shell heredocs, renamed files, and moved code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

