### PR TITLE
fix(ui): confirm field writes before trusted actions

### DIFF
--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -505,11 +505,10 @@ export class CFInput extends BaseElement {
   }
 
   /**
-   * Flush any pending edit and await its commit to the bound cell, so callers
-   * can rely on the typed value having been applied and the set() round-trip
-   * completed before continuing. Does not surface a remote-commit rejection (the
-   * underlying set() logs and swallows that). When the field is not bound to a
-   * Cell, it falls back to the cell controller's setValue.
+   * Flushes any pending edit and awaits its confirmed commit to the bound cell.
+   * Resolves once the runtime commits the typed value, and rejects when the
+   * write fails. When the field is not bound to a cell, falls back to the cell
+   * controller's `setValue()`.
    *
    * This is for standalone inputs. Inside a cf-form the form owns durable writes
    * and flushes every field atomically on submit, so commit() resolves without

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -48,7 +48,7 @@ class MockHost {
 // Mock CellController that tracks calls
 class MockCellController<T> implements CellControllerLike<T> {
   private _value: T;
-  private _cell: { set: (value: T) => Promise<void> } | null = null;
+  private _cell: { setStrict: (value: T) => Promise<void> } | null = null;
   setCallCount = 0;
   lastSetValue: T | undefined;
 
@@ -56,7 +56,7 @@ class MockCellController<T> implements CellControllerLike<T> {
     this._value = initialValue;
     if (hasCell) {
       this._cell = {
-        set: (value: T): Promise<void> => {
+        setStrict: (value: T): Promise<void> => {
           this._value = value;
           return Promise.resolve();
         },
@@ -305,7 +305,7 @@ describe("FormFieldController registration behavior", () => {
       flush: async () => {
         const cell = cellController.getCell();
         if (cell) {
-          await cell.set(cellController.getValue());
+          await cell.setStrict(cellController.getValue());
         }
       },
       reset: () => {
@@ -423,6 +423,45 @@ describe("FormFieldController registration behavior", () => {
 
     await expect(registration.flush()).rejects.toThrow("Network error");
   });
+
+  it("returns only after a registered field write is confirmed", async () => {
+    const value = "Launch checklist";
+    let serverDraftBody: string | undefined;
+    let confirmWrite: (() => void) | undefined;
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => value,
+      setValue: () => {},
+      getCell: () => ({
+        setStrict: (next: string) =>
+          new Promise((resolve) => {
+            confirmWrite = () => {
+              serverDraftBody = next;
+              resolve();
+            };
+          }),
+      }),
+    };
+    const formContext = new MockFormContext();
+    const formField = new FormFieldController(host, { cellController });
+    const internals = formField as unknown as {
+      _formContextConsumer: { value: FormContext };
+    };
+    internals._formContextConsumer = { value: formContext };
+    formField.register("draftBody");
+
+    let returned = false;
+    const flushing = formContext.getLastRegistration()!.flush().then(() => {
+      returned = true;
+    });
+    await Promise.resolve();
+
+    expect(returned).toBe(false);
+    expect(confirmWrite).toBeDefined();
+    confirmWrite!();
+    await flushing;
+    expect(serverDraftBody!.trim()).toBe(value);
+  });
 });
 
 describe("captureOriginalValue", () => {
@@ -443,6 +482,77 @@ describe("captureOriginalValue", () => {
 });
 
 describe("FormFieldController commit", () => {
+  it("reads the confirmed cell value after returning", async () => {
+    const value = "Launch checklist";
+    let localDraftBody: string | undefined;
+    let serverDraftBody: string | undefined;
+    const cell = {
+      set: (next: string) => {
+        localDraftBody = next;
+        return Promise.resolve();
+      },
+      setStrict: (next: string) => {
+        localDraftBody = next;
+        serverDraftBody = next;
+        return Promise.resolve();
+      },
+    };
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => value,
+      setValue: () => {},
+      getCell: () => cell,
+    };
+    const formField = new FormFieldController(host, { cellController });
+
+    await formField.commit();
+
+    expect(localDraftBody).toBe(value);
+    expect(serverDraftBody!.trim()).toBe(value);
+  });
+
+  it("returns only after the cell write is confirmed", async () => {
+    let confirmWrite: (() => void) | undefined;
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "Launch checklist",
+      setValue: () => {},
+      getCell: () => ({
+        setStrict: () =>
+          new Promise((resolve) => {
+            confirmWrite = resolve;
+          }),
+      }),
+    };
+    const formField = new FormFieldController(host, { cellController });
+
+    let returned = false;
+    const committing = formField.commit().then(() => {
+      returned = true;
+    });
+    await Promise.resolve();
+
+    expect(returned).toBe(false);
+    expect(confirmWrite).toBeDefined();
+    confirmWrite!();
+    await committing;
+    expect(returned).toBe(true);
+  });
+
+  it("returns confirmed cell write failures to the caller", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "Launch checklist",
+      setValue: () => {},
+      getCell: () => ({
+        setStrict: () => Promise.reject(new Error("commit refused")),
+      }),
+    };
+    const formField = new FormFieldController(host, { cellController });
+
+    await expect(formField.commit()).rejects.toThrow("commit refused");
+  });
+
   it("flushes the cell controller and writes through the cell", async () => {
     const host = new MockHost() as unknown as MockHost & HTMLElement;
     let flushed = false;
@@ -454,7 +564,7 @@ describe("FormFieldController commit", () => {
         flushed = true;
       },
       getCell: () => ({
-        set: (v: string) => {
+        setStrict: (v: string) => {
           cellSet = v;
           return Promise.resolve();
         },
@@ -492,7 +602,7 @@ describe("FormFieldController commit", () => {
       getValue: () => "cell-value",
       setValue: () => {},
       getCell: () => ({
-        set: (v: string) => {
+        setStrict: (v: string) => {
           cellSet = v;
           return Promise.resolve();
         },
@@ -527,7 +637,7 @@ describe("FormFieldController commit", () => {
         flushed = true;
       },
       getCell: () => ({
-        set: (v: string) => {
+        setStrict: (v: string) => {
           cellSet = v;
           return Promise.resolve();
         },

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -462,6 +462,28 @@ describe("FormFieldController registration behavior", () => {
     await flushing;
     expect(serverDraftBody!.trim()).toBe(value);
   });
+
+  it("rejects when a registered field write fails", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "Launch checklist",
+      setValue: () => {},
+      getCell: () => ({
+        setStrict: () => Promise.reject(new Error("Network error")),
+      }),
+    };
+    const formContext = new MockFormContext();
+    const formField = new FormFieldController(host, { cellController });
+    const internals = formField as unknown as {
+      _formContextConsumer: { value: FormContext };
+    };
+    internals._formContextConsumer = { value: formContext };
+    formField.register("draftBody");
+
+    await expect(formContext.getLastRegistration()!.flush()).rejects.toThrow(
+      "Network error",
+    );
+  });
 });
 
 describe("captureOriginalValue", () => {

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -60,12 +60,8 @@ export interface CellControllerLike<T> {
    */
   flush?(): void;
 
-  /**
-   * Optional method to get the underlying CellHandle for direct async operations.
-   * Used by FormFieldController to await cell.set() during flush.
-   * Returns null if no Cell is bound, or the CellHandle with async set().
-   */
-  getCell?(): { set(value: T): Promise<void> } | null;
+  /** Returns the bound cell, or `null` for a plain value. */
+  getCell?(): { setStrict(value: T): Promise<void> } | null;
 }
 
 /**
@@ -171,14 +167,13 @@ export class FormFieldController<T> implements ReactiveController {
   }
 
   /**
-   * Flush the field's current value to the bound cell and await the set()
-   * round-trip. This is for standalone fields: it drains any pending
+   * Flush the field's current value to the bound cell and await its confirmed
+   * write. This is for standalone fields: it drains any pending
    * debounced/throttled write, then writes the current value (buffered value if
    * present, otherwise the cell controller's value) to the bound cell, and
    * rebaselines dirty/reset tracking to the committed value. Resolves once the
-   * local apply and the set() round-trip complete; it does not surface a
-   * remote-commit rejection (the underlying set() logs and swallows that). When
-   * no Cell is bound, it falls back to the cell controller's setValue.
+   * runtime confirms the commit and rejects when the write fails. When no Cell
+   * is bound, it falls back to the cell controller's setValue.
    *
    * In a form context the form owns durable writes: each field buffers its edit
    * and the form flushes them together on submit. So when this field is in a
@@ -197,7 +192,7 @@ export class FormFieldController<T> implements ReactiveController {
       : this._cellController.getValue();
     const cell = this._cellController.getCell?.();
     if (cell) {
-      await cell.set(valueToFlush);
+      await cell.setStrict(valueToFlush);
     } else {
       this._cellController.setValue(valueToFlush);
     }
@@ -250,13 +245,10 @@ export class FormFieldController<T> implements ReactiveController {
         const valueToFlush = this._hasBuffer
           ? this._buffer as T
           : this._cellController.getValue();
-        // If the cell controller can provide the underlying CellHandle,
-        // call set() directly and await it to ensure the update is committed
         const cell = this._cellController.getCell?.();
         if (cell) {
-          await cell.set(valueToFlush);
+          await cell.setStrict(valueToFlush);
         } else {
-          // Fallback to synchronous setValue (for non-Cell values)
           this._cellController.setValue(valueToFlush);
         }
         // Update original value after successful flush


### PR DESCRIPTION
FormFieldController.commit() and registered form flushes awaited CellHandle.set(). That request returns when the worker accepts the write, before the runtime commit finishes. A following trusted DOM action could therefore execute first and read an undefined backing value.

Use the strict cell-write path for explicit field commits and form flushes. The runtime now confirms the backing write before either promise resolves, and a refused write propagates to the caller. Update the public CFInput contract to describe that completion boundary.

Add a deterministic reproduction of the undefined .trim() failure. Cover standalone and registered-form confirmation ordering, plus rejection propagation, with test-owned signals rather than elapsed-time waits.

deflaked by Hixie's agent

Deflaking agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

