### PR TITLE
refactor(cli): give `cf call` the named-export shape its siblings have

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -39,8 +39,9 @@ possible — a controller stub driving the function's body against a doubled
 piece, with no socket and no server behind it — which is the PR's
 standalone value.
 
-**A3 — extract `callFromCommand`.** Done. `call` carries the named-export
-shape its siblings have: the mount's spelling and the two arrays Cliffy
+**A3 — extract `callFromCommand`.** Done (#6682). `call` carries the
+named-export shape its siblings have: the mount's spelling and the two
+arrays Cliffy
 splits the argv into — this command's own arguments, the line past
 `cf call`, which a grammar refusal reprints, and the words past `--`,
 which the read step parses — are parameters beside the options and the

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -39,13 +39,20 @@ possible — a controller stub driving the function's body against a doubled
 piece, with no socket and no server behind it — which is the PR's
 standalone value.
 
-**A3 — extract `callFromCommand`.** `buildCallCommand`'s action is inline
-and bound to Cliffy's `this` (`getLiteralArgs`); its constituents are
-already exported. The extraction makes the literal-args array a parameter
-and gives `call` the same named-export shape as its siblings. Independent
-value: an inline action body is uncoverable and everything registered
-after it sits in coverage shadow, so extraction retires debt in the
-package where coverage debt is a standing cost.
+**A3 — extract `callFromCommand`.** Done. `call` carries the named-export
+shape its siblings have: the mount's spelling and the two arrays Cliffy
+splits the argv into — this command's own arguments, the line past
+`cf call`, which a grammar refusal reprints, and the words past `--`,
+which the read step parses — are parameters beside the options and the
+positionals, so nothing under the action line needs the binding. The
+dispatch and the `render`/`hint` sinks ride a deps bag, which holds
+collaborators and no data. Its unit tests drive the whole action over a
+stub dispatcher and reach the success tail, which is what the extraction
+is worth in coverage: seven lines of `commands/piece.ts`, measured, and
+no other tracked file moves. The package's coverage shadow is real and
+lies elsewhere — it opens inside the chained `piece` command expression,
+around its first inline action, and `buildCallCommand` is a standalone
+function well before it.
 
 **A4 — exit and output seams audit.** Every seam shuttle calls must accept
 an exit override (`exitWithDataError` / `exitPieceCallFailure` call

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -41,19 +41,18 @@ standalone value.
 
 **A3 — extract `callFromCommand`.** Done (#6682). `call` carries the
 named-export shape its siblings have: the mount's spelling and the two
-arrays Cliffy
-splits the argv into — this command's own arguments, the line past
-`cf call`, which a grammar refusal reprints, and the words past `--`,
-which the read step parses — are parameters beside the options and the
-positionals, so nothing under the action line needs the binding. The
+arrays Cliffy splits the argv into — this command's own arguments, the
+line past `cf call`, which a grammar refusal reprints, and the words past
+`--`, which the read step parses — are parameters beside the options and
+the positionals, so nothing under the action line needs the binding. The
 dispatch and the `render`/`hint` sinks ride a deps bag, which holds
 collaborators and no data. Its unit tests drive the whole action over a
 stub dispatcher and reach the success tail, which is what the extraction
-is worth in coverage: seven lines of `commands/piece.ts`, measured, and
-no other tracked file moves. The package's coverage shadow is real and
-lies elsewhere — it opens inside the chained `piece` command expression,
-around its first inline action, and `buildCallCommand` is a standalone
-function well before it.
+is worth in coverage: seven lines of `commands/piece.ts`, measured, and no
+other tracked file moves. The package's coverage shadow is real and lies
+elsewhere — it opens inside the chained `piece` command expression, around
+its first inline action, and `buildCallCommand` is a standalone function
+well before it.
 
 **A4 — exit and output seams audit.** Every seam shuttle calls must accept
 an exit override (`exitWithDataError` / `exitPieceCallFailure` call

--- a/docs/plans/shuttle/grammar.md
+++ b/docs/plans/shuttle/grammar.md
@@ -229,10 +229,8 @@ Three spellings, and no fourth:
   payload from stdin. The verb name opens the callable's section, so its
   schema-derived flags follow bare — `call topics/3 search --query milk` —
   and `--` closes the section. That is
-  [`../cli-surface-shape.md`](../cli-surface-shape.md) step 10's form;
-  `cf` today still spells it with `--` opening the section, and shuttle
-  speaks step 10 from the start rather than teaching a spelling the arc
-  retires.
+  [`../cli-surface-shape.md`](../cli-surface-shape.md) step 10's form, which
+  `cf` speaks as well, so the two surfaces read one grammar rather than two.
 - `call <piece-handle> <name> [input]` — a piece handle stands wherever a
   typed reference stands, so this is the typed form with the receiver
   already in hand: `call %3 add-reply --body "shipped"` off a listing

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -184,10 +184,10 @@ is the two reads that hand them on. The constituents underneath are
 exported and library-grade (`executePieceCallable`, `pieceCallRawArgs`,
 `pieceCallInvocation`, `resolveInvocationIdentity`,
 `pieceCallPhaseObserver`, `resolveWaitControl`, `parsePieceCallSelection`,
-`boundedSettlement`, `renderPieceCallOutcome`).
-Its deps bag holds collaborators only — the `render`/`hint` sinks and the
-dispatch itself — so a caller holding a connection passes an
-`executePieceCallable` bound to it rather than opening one per call.
+`boundedSettlement`, `renderPieceCallOutcome`). Its deps bag holds
+collaborators only — the `render`/`hint` sinks and the dispatch itself —
+so a caller holding a connection passes an `executePieceCallable` bound to
+it rather than opening one per call.
 
 ## Prerequisite work in `packages/cli`
 

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -173,13 +173,21 @@ injection point that lets a lib function reuse a held controller:
   shuttle-v1 verb reaches one, so each is a conversion for the milestone
   that first calls it.
 
-`call` is the one verb with no seam at all: `buildCallCommand`'s action is
-inline and bound to Cliffy's `this` (`getLiteralArgs`). Its constituents are
-already exported and library-grade (`executePieceCallable`,
-`pieceCallRawArgs`, `pieceCallInvocation`, `resolveInvocationIdentity`,
+`call` has the family's shape too, in `callFromCommand`
+(`commands/piece.ts`). Cliffy splits an invocation into the two arrays it
+holds on the command object bound as an action's `this` — this command's
+own arguments, the line past `cf call` (`getRawArgs`), which a grammar
+refusal reprints after prepending that prefix itself, and the words past
+`--` (`getLiteralArgs`), which the read step parses — so both are
+parameters of the named export, beside the mount's spelling, and the action
+is the two reads that hand them on. The constituents underneath are
+exported and library-grade (`executePieceCallable`, `pieceCallRawArgs`,
+`pieceCallInvocation`, `resolveInvocationIdentity`,
 `pieceCallPhaseObserver`, `resolveWaitControl`, `parsePieceCallSelection`,
-`boundedSettlement`, `renderPieceCallOutcome`), so extraction is mechanical:
-the literal-args array becomes a parameter.
+`boundedSettlement`, `renderPieceCallOutcome`).
+Its deps bag holds collaborators only — the `render`/`hint` sinks and the
+dispatch itself — so a caller holding a connection passes an
+`executePieceCallable` bound to it rather than opening one per call.
 
 ## Prerequisite work in `packages/cli`
 
@@ -193,7 +201,9 @@ Each of these is small and lands on its own; together they are what decision
    it.** Everything a shuttle-v1 verb reaches takes it; what is left is the
    set the inventory above names, each converting for the milestone that
    first calls it.
-3. **Extract `callFromCommand`** from `buildCallCommand`'s inline action.
+3. **`callFromCommand`.** Done. `buildCallCommand`'s action reads the two
+   argv arrays off the command bound to it and hands them on; everything
+   below that line is the named export, which needs no binding.
 4. **Exit discipline.** `exitWithDataError` and `exitPieceCallFailure` call
    `Deno.exit(1)` (typed `never`); `getCellValueFromCommand` reaches the
    former on a data error, which would kill the shell. Both take a `deps`

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1055,9 +1055,14 @@ export function pieceCallPhaseObserver(
 }
 
 /**
- * The success tail of `cf call`, extracted from the command action so
- * it is unit-coverable — command action bodies never execute under the unit
- * suite, the same convention that keeps `cf test` out of its action body
+ * The success tail of `cf call`: a settled invocation's JSON, a tool's
+ * output, or a help page, through the `render`/`hint` sinks a caller
+ * supplies. Standing apart from the action is what lets a test drive each
+ * outcome shape directly rather than through argv and a dispatch; the action
+ * body does run under the unit suite, so what that buys is reaching the
+ * cases, not reaching the lines. `cf test` sits in
+ * `commands/test-command.ts` for a different reason — `deno coverage` drops
+ * a source file whose path ends in `test.ts` from the report
  * (docs/development/COVERAGE.md). Help output returns BEFORE the observer
  * finishes: no invocation ran, so there is no span to close.
  */
@@ -1858,10 +1863,11 @@ reference names the piece by handle or by slug, and may carry the space
       callableArg: string,
       ...tailArgs: string[]
     ) {
-      // Both argv-derived arrays are methods on the command Cliffy binds as
-      // this action's `this`, so they are read here and handed on as values:
-      // the raw arguments a grammar refusal quotes back, and the words past
-      // `--` the read step parses. Nothing below this line needs the binding.
+      // Both argv-derived arrays are returned by methods on the command
+      // Cliffy binds as this action's `this`, so they are read here and
+      // handed on as values: the raw arguments a grammar refusal quotes
+      // back, and the words past `--` the read step parses. Nothing below
+      // this line needs the binding.
       return callFromCommand(
         options,
         spelling,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1853,138 +1853,23 @@ reference names the piece by handle or by slug, and may carry the space
     )
     .stopEarly()
     .arguments("<callable:string> [tail...:string]")
-    .action(async function (
-      // Spelled out because `targetOptions` attaches the target options
-      // after the builder returns, so what the builder declares on its own
-      // is not the whole surface the action receives.
-      options:
-        & PieceCLIOptions
-        & PieceCallReadbackFlags
-        & {
-          quiet?: boolean;
-          verbose?: boolean;
-          await?: boolean;
-          wait?: number | boolean;
-          invocation?: string;
-          invocationSession?: string;
-        },
+    .action(function (
+      options: PieceCallCLIOptions,
       callableArg: string,
       ...tailArgs: string[]
     ) {
-      // The grammar and the positional-address intake come first, and both
-      // are facts about the argv alone: a projection written before the verb,
-      // the words past the marker, and an address standing where `--cell`
-      // would, are all settled before an invocation exists for a refusal to
-      // name a phase to retry from.
-      refuseProjectionBeforeSection(
-        spelling,
-        "the verb",
-        this.getRawArgs(),
+      // Both argv-derived arrays are methods on the command Cliffy binds as
+      // this action's `this`, so they are read here and handed on as values:
+      // the raw arguments a grammar refusal quotes back, and the words past
+      // `--` the read step parses. Nothing below this line needs the binding.
+      return callFromCommand(
         options,
-      );
-      const literalArgs = this.getLiteralArgs();
-      // `-- --help` reaches the verb's own page rather than this command's,
-      // so those words rejoin the section rather than being read here.
-      const asksVerbHelp = readSectionAsksVerbHelp(literalArgs);
-      const readSection = asksVerbHelp ? {} : await parseReadSection(
         spelling,
-        this.getRawArgs(),
-        literalArgs,
-      );
-      const { cell, callableName, tail: sectionTail } = readCallTarget(
-        options,
         callableArg,
         tailArgs,
+        this.getRawArgs(),
+        this.getLiteralArgs(),
       );
-      // Into the section, at the position the verb's parser reads `--help`.
-      // The address intake runs first, since it may take the section's own
-      // first word as the callable name.
-      const tail = asksVerbHelp
-        ? sectionWithVerbHelp(sectionTail, literalArgs)
-        : sectionTail;
-      const readback = { ...readSection, showLinks: options.showLinks };
-      const identity = resolveInvocationIdentity(
-        options.invocation,
-        options.invocationSession,
-      );
-      const invocationId = identity.id;
-      const waitControl = resolveWaitControl({ ...options, ...readback });
-      let phase: InvocationPhase = "initial_sync";
-      const observer = pieceCallPhaseObserver(
-        !!options.verbose,
-        (next) => phase = next,
-      );
-      setQuietMode(!!options.quiet);
-      // Read outside the invocation's failure wrapper below. Nothing is
-      // dispatched here — no callable resolved, no id spent — so a malformed
-      // selection is a data error about the flags, the same one `cf get`
-      // reports. Inside the wrapper it would name an id and a phase to retry
-      // from for a call that was never made; a selection that fails against a
-      // RESULT does sit inside it, and does name one.
-      let selection: CellSelection | undefined;
-      try {
-        selection = await parsePieceCallSelection(readback);
-      } catch (error) {
-        // Both exits below leave without reaching the action's catch, so the
-        // verbose in-flight span is closed here.
-        observer.finish("failed");
-        if (error instanceof CellSelectionError) {
-          exitWithDataError({ message: error.message });
-        }
-        throw error;
-      }
-      try {
-        const invocation = pieceCallInvocation(tail);
-        const pieceConfig = parsePieceOptions({
-          ...options,
-          ...(cell !== undefined && { cell }),
-          json: invocation.jsonOutput,
-        });
-        const result = await boundedSettlement(
-          executePieceCallable(
-            pieceConfig,
-            callableName,
-            invocation.rawArgs,
-            {
-              invocation: identity,
-              // The verb help page names the mount that was invoked, so the
-              // blessed spelling never renders usage lines teaching the
-              // deprecated one — and the deprecated mount names itself,
-              // beside its own notice.
-              helpCommandPrefix: cliCommand(
-                [...spelling.split(" "), "...", callableName],
-              ),
-              skipReadback: waitControl.mode === "commit",
-              showLinks: !!options.showLinks,
-              ...(selection === undefined ? {} : { selection }),
-              onPhase: invocationPhaseReporter(
-                identity,
-                observer.onPhase,
-                undefined,
-                Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
-              ),
-            },
-          ).catch((error) =>
-            reportVerbInputErrorOrRethrow(
-              error,
-              pieceConfig.piece,
-              undefined,
-              observer,
-            )
-          ),
-          waitControl.boundSeconds,
-        );
-        renderPieceCallOutcome(
-          observer,
-          result,
-          callableName,
-          pieceConfig.piece,
-          {},
-          { detached: waitControl.mode === "commit", invocation: identity },
-        );
-      } catch (error) {
-        exitPieceCallFailure(observer, error, invocationId, phase);
-      }
     });
 }
 
@@ -3199,6 +3084,189 @@ export async function setCellValueFromCommand(
       `TIP: Computed values may be stale. Run 'cf piece step --cell ${pieceConfig.piece} ...' to trigger recomputation.`,
     ),
   );
+}
+
+/**
+ * The flags `cf call` reads. Spelled out rather than read off the command
+ * chain because `targetOptions` attaches the target options after the builder
+ * returns, so what the builder declares on its own is not the whole surface
+ * the action receives.
+ */
+export interface PieceCallCLIOptions
+  extends PieceCLIOptions, PieceCallReadbackFlags {
+  /** Suppress hints and next-step suggestions. */
+  quiet?: boolean;
+
+  /** Stream one wall-clock span per observed phase transition to stderr. */
+  verbose?: boolean;
+
+  /**
+   * The explicit spelling of the default wait, which `wait: false`
+   * contradicts.
+   */
+  await?: boolean;
+
+  /**
+   * Patience bound in seconds, or `false` for `--no-wait`, which exits once
+   * this handling's commit is acknowledged and skips the receipt readback.
+   */
+  wait?: number | boolean;
+
+  /** Idempotency key for this dispatch, which needs a session beside it. */
+  invocation?: string;
+
+  /**
+   * Session the invocation id was chosen within, over
+   * `CF_INVOCATION_SESSION`.
+   */
+  invocationSession?: string;
+}
+
+/** The collaborators {@link callFromCommand} dispatches and reports through. */
+export interface PieceCallCommandDependencies {
+  /** The dispatch, which a caller holding its own connection supplies. */
+  executePieceCallable?: typeof executePieceCallable;
+
+  /** Where the outcome goes, stdout unless the caller says otherwise. */
+  render?: typeof render;
+
+  /** Where the next steps go, stderr unless the caller says otherwise. */
+  hint?: typeof hint;
+}
+
+/**
+ * The `cf call` action: settle the grammar against the argv, resolve the
+ * target, dispatch the named callable, and report what came back.
+ *
+ * `spelling` is how the mount names itself, the word a caller writes after
+ * `cf`. Both the corrected line a grammar refusal prints and the callable's
+ * own help page are written in terms of it.
+ *
+ * `rawArgs` is this command's own arguments — the line past `cf <spelling>`,
+ * as they were typed — and `literalArgs` the words past `--`, as Cliffy split
+ * them. A refusal prepends `cf <spelling>` itself, so a caller handing in the
+ * whole line gets it printed twice; nothing checks the two arrays against
+ * each other either, so they come from one split or the corrected line names
+ * words the caller never wrote. Taking both as parameters leaves every input
+ * an ordinary argument, so a caller with no command to bind drives the whole
+ * action: a test over a stubbed dispatch, or a sibling holding a connection
+ * of its own.
+ */
+export async function callFromCommand(
+  options: PieceCallCLIOptions,
+  spelling: string,
+  callableArg: string,
+  tailArgs: string[],
+  rawArgs: readonly string[],
+  literalArgs: readonly string[],
+  deps: PieceCallCommandDependencies = {},
+): Promise<void> {
+  // The grammar and the positional-address intake come first, and both are
+  // facts about the argv alone: a projection written before the verb, the
+  // words past the marker, and an address standing where `--cell` would, are
+  // all settled before an invocation exists for a refusal to name a phase to
+  // retry from.
+  refuseProjectionBeforeSection(spelling, "the verb", rawArgs, options);
+  // `-- --help` reaches the verb's own page rather than this command's, so
+  // those words rejoin the section rather than being read here.
+  const asksVerbHelp = readSectionAsksVerbHelp(literalArgs);
+  const readSection = asksVerbHelp
+    ? {}
+    : await parseReadSection(spelling, rawArgs, literalArgs);
+  const { cell, callableName, tail: sectionTail } = readCallTarget(
+    options,
+    callableArg,
+    tailArgs,
+  );
+  // Into the section, at the position the verb's parser reads `--help`. The
+  // address intake runs first, since it may take the section's own first word
+  // as the callable name.
+  const tail = asksVerbHelp
+    ? sectionWithVerbHelp(sectionTail, literalArgs)
+    : sectionTail;
+  const readback = { ...readSection, showLinks: options.showLinks };
+  const identity = resolveInvocationIdentity(
+    options.invocation,
+    options.invocationSession,
+  );
+  const invocationId = identity.id;
+  const waitControl = resolveWaitControl({ ...options, ...readback });
+  let phase: InvocationPhase = "initial_sync";
+  const observer = pieceCallPhaseObserver(
+    !!options.verbose,
+    (next) => phase = next,
+  );
+  setQuietMode(!!options.quiet);
+  // Read outside the invocation's failure wrapper below. Nothing is
+  // dispatched here — no callable resolved, no id spent — so a malformed
+  // selection is a data error about the flags, the same one `cf get` reports.
+  // Inside the wrapper it would name an id and a phase to retry from for a
+  // call that was never made; a selection that fails against a RESULT does sit
+  // inside it, and does name one.
+  let selection: CellSelection | undefined;
+  try {
+    selection = await parsePieceCallSelection(readback);
+  } catch (error) {
+    // Both exits below leave without reaching the catch clause underneath, so
+    // the verbose in-flight span is closed here.
+    observer.finish("failed");
+    if (error instanceof CellSelectionError) {
+      exitWithDataError({ message: error.message });
+    }
+    throw error;
+  }
+  try {
+    const invocation = pieceCallInvocation(tail);
+    const pieceConfig = parsePieceOptions({
+      ...options,
+      ...(cell !== undefined && { cell }),
+      json: invocation.jsonOutput,
+    });
+    const result = await boundedSettlement(
+      (deps.executePieceCallable ?? executePieceCallable)(
+        pieceConfig,
+        callableName,
+        invocation.rawArgs,
+        {
+          invocation: identity,
+          // The verb help page names the mount that was invoked, so the
+          // blessed spelling never renders usage lines teaching the
+          // deprecated one — and the deprecated mount names itself, beside
+          // its own notice.
+          helpCommandPrefix: cliCommand(
+            [...spelling.split(" "), "...", callableName],
+          ),
+          skipReadback: waitControl.mode === "commit",
+          showLinks: !!options.showLinks,
+          ...(selection === undefined ? {} : { selection }),
+          onPhase: invocationPhaseReporter(
+            identity,
+            observer.onPhase,
+            undefined,
+            Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
+          ),
+        },
+      ).catch((error) =>
+        reportVerbInputErrorOrRethrow(
+          error,
+          pieceConfig.piece,
+          undefined,
+          observer,
+        )
+      ),
+      waitControl.boundSeconds,
+    );
+    renderPieceCallOutcome(
+      observer,
+      result,
+      callableName,
+      pieceConfig.piece,
+      { render: deps.render, hint: deps.hint },
+      { detached: waitControl.mode === "commit", invocation: identity },
+    );
+  } catch (error) {
+    exitPieceCallFailure(observer, error, invocationId, phase);
+  }
 }
 
 export async function getCellCfcLabelFromCommand(

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -1,0 +1,578 @@
+/**
+ * Unit tests for `callFromCommand`, the `cf call` action. Every input is an
+ * ordinary argument — the command's own arguments, the line past `cf call`,
+ * and the words past `--` included — so each case drives the whole action over
+ * a stub dispatcher, and what the assertions turn on is what the action built
+ * from the argv: the arguments it handed the callable, the target it resolved,
+ * the projection it read past the marker, the wait control it derived, the
+ * phases it announced, and the outcome it rendered. No runtime, no socket, and
+ * no server stands behind any of it.
+ *
+ * The bound on that: the two failure exits end the process, so the cases here
+ * are the ones that return or that raise a `ValidationError`, which
+ * `exitPieceCallFailure` rethrows for Cliffy's usage rendering rather than
+ * exiting on.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { ValidationError } from "@cliffy/command";
+
+import {
+  callFromCommand,
+  type PieceCallCLIOptions,
+  type PieceCallCommandDependencies,
+} from "../commands/piece.ts";
+import type {
+  ExecutedPieceCallable,
+  executePieceCallable,
+  PieceCallableDependencies,
+  PieceConfig,
+} from "../lib/piece.ts";
+import { captureStderr } from "./utils.ts";
+
+const SPACE = "did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk";
+const PIECE = "fid1:call-from-command-piece";
+
+/** A target written in the canonical reference form a positional takes. */
+const ADDRESS = "/of:fid1:baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+
+/** What {@link ADDRESS} names once the reference form is stripped off it. */
+const ADDRESSED_PIECE = "of:fid1:baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+
+/** A callable whose own name is written in the shape a reference takes. */
+const ROOTED_CALLABLE = "/archive";
+
+/** The pair `--invocation` and `--invocation-session` name. */
+const INVOCATION = "inv:call-from-command";
+const SESSION = "ses:call-from-command";
+
+/**
+ * The flags every case starts from: a reachable-looking target and a named
+ * invocation, so the identity a case asserts on is the one it wrote rather
+ * than a minted one.
+ */
+const options: PieceCallCLIOptions = {
+  apiUrl: "http://localhost:8000",
+  identity: "/nonexistent/keyfile",
+  space: SPACE,
+  cell: PIECE,
+  invocation: INVOCATION,
+  invocationSession: SESSION,
+};
+
+/** One dispatch the action asked the stub for. */
+interface Dispatch {
+  config: PieceConfig;
+  callableName: string;
+  rawArgs: string[];
+  deps: PieceCallableDependencies;
+}
+
+/**
+ * A dispatcher that records what it was asked for and hands back `outcome`.
+ * `phases` are announced through the observer the action supplied, in order,
+ * before it returns.
+ */
+function stubExecutor(
+  dispatches: Dispatch[],
+  outcome: Partial<ExecutedPieceCallable> = {},
+  phases: readonly ("dispatched" | "committed")[] = [],
+): typeof executePieceCallable {
+  return (config, callableName, rawArgs, deps = {}) => {
+    dispatches.push({ config, callableName, rawArgs, deps });
+    for (const phase of phases) deps.onPhase?.(phase);
+    return Promise.resolve(
+      {
+        parsed: { usedJsonInput: false },
+        resolved: {},
+        ...outcome,
+      } as ExecutedPieceCallable,
+    );
+  };
+}
+
+/** A dispatcher that fails with `error` rather than recording anything. */
+function failingExecutor(error: unknown): typeof executePieceCallable {
+  return () => Promise.reject(error);
+}
+
+/**
+ * Sinks for a case whose subject is the dispatch rather than the output, so
+ * the confirmation and its next steps stay out of the test transcript.
+ */
+const discard: PieceCallCommandDependencies = {
+  render: () => {},
+  hint: () => {},
+};
+
+/** Collects what the action wrote to stdout and to the hint stream. */
+function sinks(): {
+  deps: PieceCallCommandDependencies;
+  rendered: string[];
+  hinted: string[];
+} {
+  const rendered: string[] = [];
+  const hinted: string[] = [];
+  return {
+    deps: {
+      render: (value: unknown) => {
+        rendered.push(String(value));
+      },
+      hint: (message: string) => {
+        hinted.push(message);
+      },
+    },
+    rendered,
+    hinted,
+  };
+}
+
+describe("callFromCommand()", () => {
+  describe("the callable's section", () => {
+    it("hands the words the verb opened the section for to the callable", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        "search",
+        ["--query", "milk"],
+        ["--cell", PIECE, "search", "--query", "milk"],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches.length).toBe(1);
+      expect(dispatches[0].callableName).toBe("search");
+      expect(dispatches[0].rawArgs).toEqual(["--query", "milk"]);
+    });
+
+    it("takes a lone positional payload as the callable's JSON input", async () => {
+      // `--json` on the callable's side is also what tells the command its
+      // stdout is machine-read, so it rides the piece config as well.
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        ['{"title":"Milk"}'],
+        ["--cell", PIECE, "addItem", '{"title":"Milk"}'],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].rawArgs).toEqual(["--json", '{"title":"Milk"}']);
+      expect(dispatches[0].config.jsonOutput).toBe(true);
+    });
+
+    it("puts a marker-routed `--help` where the callable's parser reads it", async () => {
+      const dispatches: Dispatch[] = [];
+      const { deps, rendered } = sinks();
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "addItem", "--", "--help"],
+        ["--help"],
+        {
+          ...deps,
+          executePieceCallable: stubExecutor(dispatches, {
+            helpText: "usage",
+          }),
+        },
+      );
+      expect(dispatches[0].rawArgs).toEqual(["--help"]);
+      expect(rendered).toEqual(["usage"]);
+    });
+  });
+
+  describe("the read step's section", () => {
+    it("shapes the result with a projection written past the marker", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "addItem", "--", "--select", "title"],
+        ["--select", "title"],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].deps.selection?.projection?.source).toBe("title");
+      expect(dispatches[0].deps.selection?.projection?.flag).toBe("--select");
+    });
+
+    it("throws for a projection written before the verb, and dispatches nothing", async () => {
+      // The refusal reprints the caller's own line, so it needs the raw
+      // arguments rather than the parsed flags: a parsed value has lost which
+      // of the two spellings they wrote it in.
+      const dispatches: Dispatch[] = [];
+      await expect(
+        callFromCommand(
+          { ...options, select: "topic.title" },
+          "call",
+          "addTopic",
+          [],
+          ["--cell", PIECE, "--select", "topic.title", "addTopic"],
+          [],
+          { executePieceCallable: stubExecutor(dispatches) },
+        ),
+      ).rejects.toThrow(
+        `write:    cf call --cell ${PIECE} addTopic -- --select topic.title`,
+      );
+      expect(dispatches).toEqual([]);
+    });
+
+    it("throws for a word past the marker that names no read option", async () => {
+      const dispatches: Dispatch[] = [];
+      await expect(
+        callFromCommand(
+          options,
+          "call",
+          "search",
+          [],
+          ["--cell", PIECE, "search", "--", "--query", "milk"],
+          ["--query", "milk"],
+          { executePieceCallable: stubExecutor(dispatches) },
+        ),
+      ).rejects.toThrow(/"--query" is not a read option/);
+      expect(dispatches).toEqual([]);
+    });
+
+    it("throws for a projection past the marker beside `--no-wait`, and dispatches nothing", async () => {
+      // A projection is answered from the receipt a detached exit never
+      // reads, and it arrives from past the marker rather than on the
+      // options object, so the wait control has to be resolved against both.
+      const dispatches: Dispatch[] = [];
+      await expect(
+        callFromCommand(
+          { ...options, wait: false },
+          "call",
+          "addTopic",
+          [],
+          ["--cell", PIECE, "--no-wait", "addTopic", "--", "--select", "t"],
+          ["--select", "t"],
+          { executePieceCallable: stubExecutor(dispatches) },
+        ),
+      ).rejects.toThrow(/receipt readback that --no-wait skips/);
+      expect(dispatches).toEqual([]);
+    });
+  });
+
+  describe("the readback flags", () => {
+    it("asks the dispatch for the link annotation under `--show-links`", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        { ...options, showLinks: true },
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "--show-links", "addItem"],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].deps.showLinks).toBe(true);
+    });
+  });
+
+  describe("the target", () => {
+    it("dispatches against the piece the flags name", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "addItem"],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].config.piece).toBe(PIECE);
+      expect(dispatches[0].config.space).toBe(SPACE);
+    });
+
+    it("takes a leading canonical address as the target, with the callable behind it", async () => {
+      const dispatches: Dispatch[] = [];
+      const { cell: _cell, ...addressed } = options;
+      await callFromCommand(
+        addressed,
+        "call",
+        ADDRESS,
+        ["addItem"],
+        [ADDRESS, "addItem"],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].config.piece).toBe(ADDRESSED_PIECE);
+      expect(dispatches[0].callableName).toBe("addItem");
+    });
+
+    it("takes a rooted positional as the callable name when the flag names the target", async () => {
+      // Nothing reserves the shape of a callable name, so a verb may be
+      // called `/archive`. Writing the flag is the only spelling that
+      // reaches one: it names the target, leaving the positional to be read
+      // as the name.
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        ROOTED_CALLABLE,
+        [],
+        ["--cell", PIECE, ROOTED_CALLABLE],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].config.piece).toBe(PIECE);
+      expect(dispatches[0].callableName).toBe(ROOTED_CALLABLE);
+    });
+  });
+
+  describe("the invocation", () => {
+    it("carries the invocation pair the flags named into the dispatch", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "addItem"],
+        [],
+        { ...discard, executePieceCallable: stubExecutor(dispatches) },
+      );
+      expect(dispatches[0].deps.invocation).toEqual({
+        id: INVOCATION,
+        session: SESSION,
+      });
+    });
+
+    it("names the mount in the help-page prefix the callable renders", async () => {
+      // A mount no `cf` command answers to, so the prefix can carry it only
+      // by reading the parameter. The one production spelling is `call`,
+      // which an implementation ignoring the parameter would print too.
+
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        options,
+        "summon",
+        "addItem",
+        ["--help"],
+        ["--cell", PIECE, "addItem", "--help"],
+        [],
+        {
+          ...discard,
+          executePieceCallable: stubExecutor(dispatches, { helpText: "usage" }),
+        },
+      );
+      expect(dispatches[0].deps.helpCommandPrefix).toBe(
+        "cf summon ... addItem",
+      );
+    });
+  });
+
+  describe("the wait control", () => {
+    it("skips the receipt readback under `--no-wait`", async () => {
+      const dispatches: Dispatch[] = [];
+      await callFromCommand(
+        { ...options, wait: false },
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "--no-wait", "addItem"],
+        [],
+        {
+          ...discard,
+          executePieceCallable: stubExecutor(dispatches, {
+            invocation: { id: INVOCATION, status: "committed" },
+          } as Partial<ExecutedPieceCallable>),
+        },
+      );
+      expect(dispatches[0].deps.skipReadback).toBe(true);
+    });
+
+    it("throws for `--await` beside `--no-wait`, and dispatches nothing", async () => {
+      const dispatches: Dispatch[] = [];
+      await expect(
+        callFromCommand(
+          { ...options, await: true, wait: false },
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "--await", "--no-wait", "addItem"],
+          [],
+          { executePieceCallable: stubExecutor(dispatches) },
+        ),
+      ).rejects.toThrow(/--await and --no-wait contradict each other/);
+      expect(dispatches).toEqual([]);
+    });
+  });
+
+  describe("the outcome", () => {
+    it("writes a settled handler's Invocation JSON with the next steps beside it", async () => {
+      const dispatches: Dispatch[] = [];
+      const { deps, rendered, hinted } = sinks();
+      await callFromCommand(
+        options,
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "addItem"],
+        [],
+        {
+          ...deps,
+          executePieceCallable: stubExecutor(dispatches, {
+            invocation: {
+              id: INVOCATION,
+              status: "settled",
+              result: { title: "Milk" },
+            },
+          } as Partial<ExecutedPieceCallable>),
+        },
+      );
+      expect(JSON.parse(rendered[0])).toEqual({
+        invocation: INVOCATION,
+        status: "settled",
+        result: { title: "Milk" },
+      });
+      expect(hinted[0]).toContain(`cf get --cell ${PIECE}`);
+    });
+
+    it("reports the detached call's recovery beside the receipt it published", async () => {
+      const dispatches: Dispatch[] = [];
+      const { deps, rendered, hinted } = sinks();
+      await callFromCommand(
+        { ...options, wait: false },
+        "call",
+        "addItem",
+        [],
+        ["--cell", PIECE, "--no-wait", "addItem"],
+        [],
+        {
+          ...deps,
+          executePieceCallable: stubExecutor(dispatches, {
+            invocation: {
+              id: INVOCATION,
+              status: "committed",
+              receipt: "/of:receipt-1",
+            },
+          } as Partial<ExecutedPieceCallable>),
+        },
+      );
+      expect(JSON.parse(rendered[0]).status).toBe("committed");
+      expect(hinted[0]).toContain("/of:receipt-1");
+      expect(hinted[0]).toContain(`CF_INVOCATION_SESSION=${SESSION} cf call`);
+    });
+
+    it("writes a tool's output and nothing else to stdout", async () => {
+      const dispatches: Dispatch[] = [];
+      const { deps, rendered } = sinks();
+      await callFromCommand(
+        options,
+        "call",
+        "search",
+        [],
+        ["--cell", PIECE, "search"],
+        [],
+        {
+          ...deps,
+          executePieceCallable: stubExecutor(dispatches, {
+            outputText: '{"found":1}',
+          }),
+        },
+      );
+      expect(rendered).toEqual(['{"found":1}']);
+    });
+
+    it("throws a dispatch's usage failure out to Cliffy rather than exiting", async () => {
+      await expect(
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "addItem"],
+          [],
+          {
+            executePieceCallable: failingExecutor(
+              new ValidationError("no such callable"),
+            ),
+          },
+        ),
+      ).rejects.toThrow(/no such callable/);
+    });
+  });
+
+  describe("the phase report", () => {
+    it("announces the invocation pair on stderr as the dispatch happens", async () => {
+      // The id and the session are what a caller whose process dies past
+      // this line retries with, so both are announced before any network
+      // work rather than reported with the outcome.
+      const dispatches: Dispatch[] = [];
+      const lines = await captureStderr(() =>
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "addItem"],
+          [],
+          {
+            ...discard,
+            executePieceCallable: stubExecutor(dispatches, {}, [
+              "dispatched",
+              "committed",
+            ]),
+          },
+        )
+      );
+      expect(lines).toContain(`invocation: ${INVOCATION}`);
+      expect(lines).toContain(`session: ${SESSION}`);
+    });
+
+    it("streams one span per phase transition under `--verbose`", async () => {
+      const dispatches: Dispatch[] = [];
+      const lines = await captureStderr(() =>
+        callFromCommand(
+          { ...options, verbose: true },
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "--verbose", "addItem"],
+          [],
+          {
+            ...discard,
+            executePieceCallable: stubExecutor(dispatches, {}, [
+              "dispatched",
+              "committed",
+            ]),
+          },
+        )
+      );
+      const spans = lines.filter((line) => line.startsWith("timing: "))
+        .map((line) => line.replace(/ [\d.]+ms$/, ""));
+      expect(spans).toEqual([
+        "timing: initial_sync → dispatched",
+        "timing: dispatched → committed",
+        "timing: committed → settled",
+      ]);
+    });
+
+    it("writes no span without `--verbose`", async () => {
+      const dispatches: Dispatch[] = [];
+      const lines = await captureStderr(() =>
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "addItem"],
+          [],
+          {
+            ...discard,
+            executePieceCallable: stubExecutor(dispatches, {}, ["dispatched"]),
+          },
+        )
+      );
+      expect(lines.filter((line) => line.startsWith("timing: "))).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -383,7 +383,7 @@ describe("callFromCommand()", () => {
           ...discard,
           executePieceCallable: stubExecutor(dispatches, {
             invocation: { id: INVOCATION, status: "committed" },
-          } as Partial<ExecutedPieceCallable>),
+          }),
         },
       );
       expect(dispatches[0].deps.skipReadback).toBe(true);
@@ -425,7 +425,7 @@ describe("callFromCommand()", () => {
               status: "settled",
               result: { title: "Milk" },
             },
-          } as Partial<ExecutedPieceCallable>),
+          }),
         },
       );
       expect(JSON.parse(rendered[0])).toEqual({
@@ -454,7 +454,7 @@ describe("callFromCommand()", () => {
               status: "committed",
               receipt: "/of:receipt-1",
             },
-          } as Partial<ExecutedPieceCallable>),
+          }),
         },
       );
       expect(JSON.parse(rendered[0]).status).toBe("committed");


### PR DESCRIPTION
## Why

`cf piece call`'s action is written inline inside `buildCallCommand`, bound to
Cliffy's `this` because it reads `getRawArgs()` and `getLiteralArgs()`. Every
other verb in `commands/piece.ts` is a named export shaped
`(options, ...positionals, deps)` — the `*FromCommand` family — which is the
shape that lets a unit test run an action body without a command line, and
lets a sibling package call the verb without spawning `cf`. `call` was the one
verb with no such seam.

**On the rationale this stage was scoped around, which did not survive
measurement.** The plan justified the extraction by saying an inline action
body is uncoverable and everything registered after it sits in a coverage
shadow. Measured, neither holds for `call`. Running only `piece-call.test.ts`
— which never calls this function — already reports 70 of the body's 90
executable lines covered, because `test/verb-section.test.ts` and
`test/section-marker.test.ts` drive it through Cliffy with real argv. And the
shadow, which is real, starts at the first inline `.action()` of the chained
`piece` command expression; `buildCallCommand` is a standalone function that
returns before that chain begins.

What the extraction actually buys is the **success tail**: every Cliffy-driven
test fails before the dispatch returns, so `renderPieceCallOutcome` had never
run. That is where the measured −7 uncovered lines come from, and the plan
entry now says that instead of the claim that did not hold.

Third of the stage-A seam PRs behind the merged shuttle design (#6537), after
#6626, #6646 and #6676.

## What Changed

```ts
export async function callFromCommand(
  options: PieceCallCLIOptions,
  spelling: string,
  callableArg: string,
  tailArgs: string[],
  rawArgs: readonly string[],
  literalArgs: readonly string[],
  deps: PieceCallCommandDependencies = {},
): Promise<void>
```

The Cliffy action is now three lines: it reads the two arrays off the binding
and hands them on. Nothing below that line depends on `this`.

**Both argv arrays are parameters, and neither derives from the other.**
Deriving `literalArgs` from `rawArgs.indexOf("--")` would re-implement
Cliffy's split and diverge on real input: `--piece --` makes Cliffy swallow
the marker as the option's value, so the index would be wrong and
`parseReadSection` would refuse a line Cliffy parses cleanly.

**`spelling` is a positional, not a dependency.** It is data, like every other
positional here, where the deps bag holds substitutable collaborators; and a
`?? "call"` default would let a caller omit it and silently get refusals
naming a command they never typed.

This body is a move, not a rewrite. The complete delta against the inline
action is: the two `this` reads become parameters, `spelling` becomes a
parameter, and `executePieceCallable` / `render` / `hint` sit behind `??`
defaults. Statement order, the `try`/`catch` nesting, and the selection read
sitting outside the invocation wrapper are unchanged.

## Test plan

Gates: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, `deno task check-command-docs`, and `deno task test`
in `packages/cli` — exit 0, 1743 parallel + 210 serial passed, 0 failed.

`test/callFromCommand.test.ts` is new: 22 cases driving `callFromCommand`
directly over a stub dispatcher, no runtime, socket, or server. Every case was
verified non-vacuous by mutating the implementation, watching it red, and
restoring the file byte-identically. Two worth naming, because both guard
something nothing else did:

- the help-prefix case passes a synthetic mount (`summon`) rather than
  `call`, so an implementation that ignored the `spelling` parameter and
  printed the one production spelling would fail it;
- `showLinks: !!options.showLinks` is asserted for its **value**; hard-coding
  that line to `false` previously left the whole `packages/cli` suite green.

Behavior is unchanged, and the evidence is that no existing test needed
editing — the only test file in this diff is the new one.
`test/section-marker.test.ts` and `test/verb-section.test.ts` drive
`pieceDataCommand("call")` end to end with real argv and pass untouched, as do
`test/piece.test.ts`, `test/piece-call.test.ts`,
`test/read-options-four-ways.test.ts` and `test/main-command.test.ts`.

Three failure paths have no unit test here, deliberately: a
`CellSelectionError` selection, a `VerbInputValidationError` payload, and a
`WaitBoundExpired` expiry all reach `exitWithDataError` / `exitPieceCallFailure`,
which call `Deno.exit(1)`. Threading the exit override is A4's job; the file
header says so, so A4 knows what it unlocks.

`docs/plans/shuttle/grammar.md` loses a claim that #6622 falsified — that `cf`
still spells the callable section with `--` opening it. It does not; `cf` and
shuttle now read one grammar.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

