### PR TITLE
A model attempt timed to the end of its response, not to its headers (CT-2158)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -167,7 +167,9 @@ What works today:
   snapshots, and tool outputs, plus explicit skill registry and activation
   artifacts
 - provider-neutral run-report model-attempt diagnostics, one record per attempt,
-  naming the provider and the API operation that served it
+  naming the provider and the API operation that served it, and timing it twice
+  — `durationMs` to the response headers, `responseCompleteDurationMs` to the
+  end of the body or stream, which is the model's own working time
 - provider-reported per-turn token usage in run reports, with aggregate input,
   cached-input, cache-write, output, reasoning, and total tokens surfaced in
   operator and batch results

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -615,12 +615,12 @@ export class OpenAICompatibleGatewayClient {
         `chat completion request failed (${response.status}): ${body}`,
       );
     }
-    const parsed = await response.json() as OpenAIChatCompletionResponse;
-    await emitChatCompletionAttempt(options, {
-      ...diagnostic,
-      responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
-    });
-    return parsed;
+    return await this.#readJsonEmittingAttempt<OpenAIChatCompletionResponse>(
+      response,
+      diagnostic,
+      dispatchedAtMs,
+      options,
+    );
   }
 
   async createResponseJson(
@@ -661,7 +661,33 @@ export class OpenAICompatibleGatewayClient {
         `responses request failed (${response.status}): ${body}`,
       );
     }
-    const parsed = await response.json() as OpenAIResponsesResponse;
+    return await this.#readJsonEmittingAttempt<OpenAIResponsesResponse>(
+      response,
+      diagnostic,
+      dispatchedAtMs,
+      options,
+    );
+  }
+
+  /**
+   * Parses the body of a successful response and emits the one record this
+   * attempt gets, whichever way the parse goes. A body that fails to arrive or
+   * to parse never completed, so its record carries no
+   * `responseCompleteDurationMs`.
+   */
+  async #readJsonEmittingAttempt<T>(
+    response: Response,
+    diagnostic: OpenAIChatCompletionAttemptDiagnostic,
+    dispatchedAtMs: number,
+    options: OpenAIChatCompletionAttemptOptions,
+  ): Promise<T> {
+    let parsed: T;
+    try {
+      parsed = await response.json() as T;
+    } catch (error) {
+      await emitChatCompletionAttempt(options, diagnostic);
+      throw error;
+    }
     await emitChatCompletionAttempt(options, {
       ...diagnostic,
       responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -20,6 +20,12 @@ export interface OpenAICompatibleGatewayClientOptions {
   fetchFn?: HarnessFetch;
 
   /**
+   * Monotonic milliseconds, the source of every measured duration. Defaults to
+   * `performance.now()`.
+   */
+  monotonicNowMs?: () => number;
+
+  /**
    * What caused these requests. Resolved from the process when absent.
    */
   provenance?: HarnessProvenance;
@@ -164,7 +170,23 @@ export interface OpenAIChatCompletionAttemptDiagnostic {
   maxTransportAttempts: number;
   startedAt: string;
   endedAt: string;
+
+  /**
+   * Elapsed time from request dispatch until the response headers arrive. A
+   * gateway that sends headers ahead of the generated tokens ends this long
+   * before the model is done, so it measures the transport rather than the
+   * turn.
+   */
   durationMs: number;
+
+  /**
+   * Elapsed time from request dispatch until the whole response body has been
+   * read — the model's own working time, and the number to compare a turn
+   * against wall clock with. Absent when the caller was handed the response
+   * before its body was read, so this client never saw the exchange end.
+   */
+  responseCompleteDurationMs?: number;
+
   request: OpenAIChatCompletionRequestDiagnosticSummary;
   outcome: OpenAIChatCompletionAttemptOutcome;
   httpStatus?: number;
@@ -360,6 +382,9 @@ const transportErrorAfterRetries = (
 interface ChatCompletionFetchResult {
   response: Response;
   diagnostic: OpenAIChatCompletionAttemptDiagnostic;
+
+  /** Monotonic reading taken as the returned attempt was dispatched. */
+  dispatchedAtMs: number;
 }
 
 export class OpenAICompatibleGatewayClient {
@@ -371,6 +396,7 @@ export class OpenAICompatibleGatewayClient {
   readonly #chatCompletionTransportRetries: number;
   readonly #chatCompletionRetryDelayMs: number;
   readonly #provenance?: HarnessProvenance;
+  readonly #monotonicNowMs: () => number;
 
   constructor(options: OpenAICompatibleGatewayClientOptions) {
     this.baseUrl = new URL(options.baseUrl);
@@ -387,6 +413,12 @@ export class OpenAICompatibleGatewayClient {
       options.chatCompletionRetryDelayMs,
       DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS,
     );
+    this.#monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
+  }
+
+  /** Whole milliseconds elapsed since a monotonic reading. */
+  #elapsedMsSince(startedAtMs: number): number {
+    return Math.max(0, Math.round(this.#monotonicNowMs() - startedAtMs));
   }
 
   #requireApiKey(): string {
@@ -490,7 +522,7 @@ export class OpenAICompatibleGatewayClient {
     for (let attempt = 1; attempt <= maxTransportAttempts; attempt += 1) {
       throwIfChatCompletionAborted(options.signal);
       const startedAt = new Date();
-      const startedAtMs = performance.now();
+      const startedAtMs = this.#monotonicNowMs();
       try {
         const response = await this.#fetchFn(endpoint, init);
         const endedAt = new Date();
@@ -498,6 +530,7 @@ export class OpenAICompatibleGatewayClient {
         const requestId = selectRequestId(response.headers);
         return {
           response,
+          dispatchedAtMs: startedAtMs,
           diagnostic: {
             type: "cf-harness.gateway.chat-completion-attempt",
             operation: operation,
@@ -506,10 +539,7 @@ export class OpenAICompatibleGatewayClient {
             maxTransportAttempts,
             startedAt: startedAt.toISOString(),
             endedAt: endedAt.toISOString(),
-            durationMs: Math.max(
-              0,
-              Math.round(performance.now() - startedAtMs),
-            ),
+            durationMs: this.#elapsedMsSince(startedAtMs),
             request,
             outcome: "http_response",
             httpStatus: response.status,
@@ -521,6 +551,9 @@ export class OpenAICompatibleGatewayClient {
       } catch (error) {
         lastError = error;
         const endedAt = new Date();
+        // A transport failure ends the exchange where it is thrown, so the
+        // two durations are one measurement.
+        const durationMs = this.#elapsedMsSince(startedAtMs);
         await emitChatCompletionAttempt(options, {
           type: "cf-harness.gateway.chat-completion-attempt",
           operation: operation,
@@ -529,7 +562,8 @@ export class OpenAICompatibleGatewayClient {
           maxTransportAttempts,
           startedAt: startedAt.toISOString(),
           endedAt: endedAt.toISOString(),
-          durationMs: Math.max(0, Math.round(performance.now() - startedAtMs)),
+          durationMs,
+          responseCompleteDurationMs: durationMs,
           request,
           outcome: "transport_error",
           errorDetail: errorMessage(error),
@@ -555,14 +589,16 @@ export class OpenAICompatibleGatewayClient {
     payload: OpenAIChatCompletionRequest,
     options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<OpenAIChatCompletionResponse> {
-    const { response, diagnostic } = await this.#fetchChatCompletion(
-      payload,
-      options,
-    );
+    const { response, diagnostic, dispatchedAtMs } = await this
+      .#fetchChatCompletion(
+        payload,
+        options,
+      );
     if (!response.ok) {
       const body = await response.text();
       await emitChatCompletionAttempt(options, {
         ...diagnostic,
+        responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
         ...responseBodyDiagnosticFields(body),
       });
       if (response.status === 401) {
@@ -579,15 +615,19 @@ export class OpenAICompatibleGatewayClient {
         `chat completion request failed (${response.status}): ${body}`,
       );
     }
-    await emitChatCompletionAttempt(options, diagnostic);
-    return await response.json() as OpenAIChatCompletionResponse;
+    const parsed = await response.json() as OpenAIChatCompletionResponse;
+    await emitChatCompletionAttempt(options, {
+      ...diagnostic,
+      responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
+    });
+    return parsed;
   }
 
   async createResponseJson(
     payload: OpenAIResponsesRequest,
     options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<OpenAIResponsesResponse> {
-    const { response, diagnostic } = await this.#fetchResponses(
+    const { response, diagnostic, dispatchedAtMs } = await this.#fetchResponses(
       payload,
       options,
     );
@@ -595,6 +635,7 @@ export class OpenAICompatibleGatewayClient {
       const body = await response.text();
       await emitChatCompletionAttempt(options, {
         ...diagnostic,
+        responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
         ...responseBodyDiagnosticFields(body),
       });
       if (response.status === 401) {
@@ -620,7 +661,11 @@ export class OpenAICompatibleGatewayClient {
         `responses request failed (${response.status}): ${body}`,
       );
     }
-    await emitChatCompletionAttempt(options, diagnostic);
-    return await response.json() as OpenAIResponsesResponse;
+    const parsed = await response.json() as OpenAIResponsesResponse;
+    await emitChatCompletionAttempt(options, {
+      ...diagnostic,
+      responseCompleteDurationMs: this.#elapsedMsSince(dispatchedAtMs),
+    });
+    return parsed;
   }
 }

--- a/packages/cf-harness/src/model/client.ts
+++ b/packages/cf-harness/src/model/client.ts
@@ -24,7 +24,24 @@ export interface HarnessModelAttemptDiagnostic {
   maxTransportAttempts: number;
   startedAt: string;
   endedAt: string;
+
+  /**
+   * Elapsed time from request dispatch until the response headers arrive. A
+   * provider that sends headers ahead of the generated tokens ends this long
+   * before the model is done, so it measures the transport rather than the
+   * turn.
+   */
   durationMs: number;
+
+  /**
+   * Elapsed time from request dispatch until the response is complete — the
+   * whole body read, or the stream closed at its terminal event. This is the
+   * model's own working time, and the number to compare a turn against wall
+   * clock with. Absent when the provider client never observed the exchange
+   * end.
+   */
+  responseCompleteDurationMs?: number;
+
   request: HarnessModelRequestSummary;
   outcome: "http_response" | "transport_error";
   httpStatus?: number;

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -41,6 +41,12 @@ export interface OpenAICodexResponsesClientOptions {
   fetchFn?: HarnessFetch;
   endpoint?: string;
   now?: () => Date;
+
+  /**
+   * Monotonic milliseconds, the source of every measured duration. Defaults to
+   * `performance.now()`.
+   */
+  monotonicNowMs?: () => number;
 }
 
 const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
@@ -185,6 +191,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
   readonly #fetchFn: HarnessFetch;
   readonly #endpoint: string;
   readonly #now: () => Date;
+  readonly #monotonicNowMs: () => number;
 
   constructor(options: OpenAICodexResponsesClientOptions) {
     this.#resolver = options.credentialResolver;
@@ -218,6 +225,12 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       );
     }
     this.#now = options.now ?? (() => new Date());
+    this.#monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
+  }
+
+  /** Whole milliseconds elapsed since a monotonic reading. */
+  #elapsedMsSince(startedAtMs: number): number {
+    return Math.max(0, Math.round(this.#monotonicNowMs() - startedAtMs));
   }
 
   async listModels(
@@ -369,7 +382,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       parallel_tool_calls: true,
     });
     const startedAt = this.#now();
-    const startedAtMs = performance.now();
+    const startedAtMs = this.#monotonicNowMs();
     let response: Response;
     try {
       response = await this.#fetchFn(this.#endpoint, {
@@ -399,6 +412,9 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         error instanceof Error ? error.message : String(error),
         credential,
       );
+      // A transport failure ends the exchange where it is thrown, so the two
+      // durations are one measurement.
+      const durationMs = this.#elapsedMsSince(startedAtMs);
       await emitAttempt(request.onAttempt, {
         type: "cf-harness.model-attempt",
         providerId: this.providerId,
@@ -408,7 +424,8 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         maxTransportAttempts: 1,
         startedAt: startedAt.toISOString(),
         endedAt: endedAt.toISOString(),
-        durationMs: Math.max(0, Math.round(performance.now() - startedAtMs)),
+        durationMs,
+        responseCompleteDurationMs: durationMs,
         request: {
           model: request.model,
           messageCount: request.transcript.length,
@@ -432,7 +449,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       maxTransportAttempts: 1,
       startedAt: startedAt.toISOString(),
       endedAt: endedAt.toISOString(),
-      durationMs: Math.max(0, Math.round(performance.now() - startedAtMs)),
+      durationMs: this.#elapsedMsSince(startedAtMs),
       request: {
         model: request.model,
         messageCount: request.transcript.length,
@@ -456,6 +473,7 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
       }
       await emitAttempt(request.onAttempt, {
         ...baseAttempt,
+        responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
         ...(responseBodyBytes !== undefined ? { responseBodyBytes } : {}),
       });
       if (request.signal?.aborted) throw abortReason(request.signal);
@@ -471,7 +489,6 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         `OpenAI Codex Responses request failed (${response.status})`,
       );
     }
-    await emitAttempt(request.onAttempt, baseAttempt);
     let terminal: Record<string, unknown> | undefined;
     // The ChatGPT Codex backend streams each completed output item via a
     // `response.output_item.done` event, but with `store: false` it returns an
@@ -479,31 +496,40 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
     // not assemble a stored response to echo back). Accumulate the streamed
     // items so the model's message and tool calls are not silently dropped.
     const streamedItems: unknown[] = [];
-    for await (const event of parseSse(response, request.signal)) {
-      const type = event.type;
-      if (type === "response.output_item.done" && event.item !== undefined) {
-        streamedItems.push(event.item);
-      }
-      if (type === "error") {
-        throw providerUnavailable(
-          "OpenAI Codex Responses stream returned an error event",
-        );
-      }
-      if (
-        type === "response.completed" || type === "response.done" ||
-        type === "response.incomplete" || type === "response.failed"
-      ) {
-        if (
-          typeof event.response !== "object" || event.response === null ||
-          Array.isArray(event.response)
-        ) {
+    try {
+      for await (const event of parseSse(response, request.signal)) {
+        const type = event.type;
+        if (type === "response.output_item.done" && event.item !== undefined) {
+          streamedItems.push(event.item);
+        }
+        if (type === "error") {
           throw providerUnavailable(
-            "Codex Responses terminal event did not include a response object",
+            "OpenAI Codex Responses stream returned an error event",
           );
         }
-        terminal = event.response as Record<string, unknown>;
-        break;
+        if (
+          type === "response.completed" || type === "response.done" ||
+          type === "response.incomplete" || type === "response.failed"
+        ) {
+          if (
+            typeof event.response !== "object" || event.response === null ||
+            Array.isArray(event.response)
+          ) {
+            throw providerUnavailable(
+              "Codex Responses terminal event did not include a response object",
+            );
+          }
+          terminal = event.response as Record<string, unknown>;
+          break;
+        }
       }
+    } finally {
+      // The generation happens across this stream, not before it, so the one
+      // record this attempt gets is emitted here — however the stream ended.
+      await emitAttempt(request.onAttempt, {
+        ...baseAttempt,
+        responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
+      });
     }
     if (!terminal) {
       throw providerUnavailable(

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -531,6 +531,10 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         responseCompleteDurationMs: this.#elapsedMsSince(startedAtMs),
       });
     }
+    // Emitting the attempt is the last await the stream's own abort handling
+    // does not cover, so an abort landing during it would otherwise surface as
+    // a completed turn.
+    if (request.signal?.aborted) throw abortReason(request.signal);
     if (!terminal) {
       throw providerUnavailable(
         "Codex Responses stream ended without a terminal response event",

--- a/packages/cf-harness/test/model-attempt-duration.test.ts
+++ b/packages/cf-harness/test/model-attempt-duration.test.ts
@@ -123,6 +123,30 @@ describe("model-attempt-duration", () => {
       expect(attempts.length).toBe(1);
       expect(attempts[0].responseCompleteDurationMs).toBeUndefined();
     });
+
+    it("omits `responseCompleteDurationMs` for a body that fails to parse", async () => {
+      const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
+      const client = new OpenAICompatibleGatewayClient({
+        baseUrl: "https://llm.stage.commontools.dev/",
+        apiKey: "test-key",
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
+        fetchFn: () =>
+          Promise.resolve(new Response("not json", { status: 200 })),
+      });
+
+      await expect(client.createChatCompletionJson({
+        model: "gpt-5.4",
+        messages: [],
+      }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      })).rejects.toThrow();
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].durationMs).toBe(12);
+      expect(attempts[0].responseCompleteDurationMs).toBeUndefined();
+    });
   });
 
   describe("OpenAICodexResponsesClient", () => {
@@ -186,6 +210,65 @@ describe("model-attempt-duration", () => {
 
       expect(attempts.length).toBe(1);
       expect(attempts[0].responseCompleteDurationMs).toBe(500);
+    });
+
+    it("ends both durations at the failure for a transport error", async () => {
+      const attempts: HarnessModelAttemptDiagnostic[] = [];
+      const client = new OpenAICodexResponsesClient({
+        credentialResolver: { resolve: () => Promise.resolve(credential) },
+        monotonicNowMs: scriptedClock([1_000, 1_055]),
+        fetchFn: () => Promise.reject(new Error("connection reset")),
+      });
+
+      await expect(client.complete({
+        model: "gpt-5.4",
+        transcript: [{ role: "user", content: "hi" }],
+        tools: [],
+        nativeModelToolIds: [],
+        runId: "run-123",
+        onAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      })).rejects.toThrow("transport request failed");
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].outcome).toBe("transport_error");
+      expect(attempts[0].durationMs).toBe(55);
+      expect(attempts[0].responseCompleteDurationMs).toBe(55);
+    });
+
+    it("throws the abort reason for an abort landing while the attempt is emitted", async () => {
+      const controller = new AbortController();
+      const client = new OpenAICodexResponsesClient({
+        credentialResolver: { resolve: () => Promise.resolve(credential) },
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
+        fetchFn: () =>
+          Promise.resolve(sse({
+            type: "response.completed",
+            response: {
+              id: "resp_1",
+              status: "completed",
+              output: [{
+                type: "message",
+                id: "msg_1",
+                role: "assistant",
+                content: [{ type: "output_text", text: "hello" }],
+              }],
+            },
+          })),
+      });
+
+      await expect(client.complete({
+        model: "gpt-5.4",
+        transcript: [{ role: "user", content: "hi" }],
+        tools: [],
+        nativeModelToolIds: [],
+        runId: "run-123",
+        signal: controller.signal,
+        onAttempt: () => {
+          controller.abort(new Error("caller went away"));
+        },
+      })).rejects.toThrow("caller went away");
     });
   });
 });

--- a/packages/cf-harness/test/model-attempt-duration.test.ts
+++ b/packages/cf-harness/test/model-attempt-duration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The two durations a model attempt records: `durationMs`, which ends when the
+ * response headers arrive, and `responseCompleteDurationMs`, which ends when
+ * the response body or stream does. Each client is driven with a scripted
+ * monotonic clock, so what a case turns on is which reading the client took at
+ * which point rather than how long anything really took.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import type { OpenAICodexOAuthCredential } from "../src/auth/types.ts";
+import {
+  type OpenAIChatCompletionAttemptDiagnostic,
+  OpenAICompatibleGatewayClient,
+} from "../src/gateway/openai-client.ts";
+import type { HarnessModelAttemptDiagnostic } from "../src/model/client.ts";
+import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
+
+/**
+ * Hands out `readings` in order, repeating the last one once they run out, so
+ * a client that takes an extra reading cannot read past the end of the script.
+ */
+const scriptedClock = (readings: readonly number[]): () => number => {
+  let index = 0;
+  return () => readings[Math.min(index++, readings.length - 1)];
+};
+
+const credential: OpenAICodexOAuthCredential = {
+  type: "oauth",
+  providerId: "openai-codex",
+  accessToken: "access-secret",
+  refreshToken: "refresh-secret",
+  expiresAt: Date.now() + 60_000,
+  accountId: "acct-123",
+};
+
+const sse = (...events: unknown[]): Response =>
+  new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+
+describe("model-attempt-duration", () => {
+  describe("OpenAICompatibleGatewayClient", () => {
+    it("ends `responseCompleteDurationMs` at the read body rather than at the headers", async () => {
+      const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
+      const client = new OpenAICompatibleGatewayClient({
+        baseUrl: "https://llm.stage.commontools.dev/",
+        apiKey: "test-key",
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
+        fetchFn: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                }],
+              }),
+              { status: 200 },
+            ),
+          ),
+      });
+
+      await client.createChatCompletionJson({
+        model: "gpt-5.4",
+        messages: [],
+      }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      });
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].durationMs).toBe(12);
+      expect(attempts[0].responseCompleteDurationMs).toBe(900);
+    });
+
+    it("ends both durations at the failure for a transport error", async () => {
+      const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
+      const client = new OpenAICompatibleGatewayClient({
+        baseUrl: "https://llm.stage.commontools.dev/",
+        apiKey: "test-key",
+        chatCompletionTransportRetries: 0,
+        monotonicNowMs: scriptedClock([1_000, 1_040]),
+        fetchFn: () => Promise.reject(new Error("connection reset")),
+      });
+
+      await expect(client.createResponseJson({
+        model: "gpt-5.6",
+        input: [],
+      }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      })).rejects.toThrow("transport request failed");
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].outcome).toBe("transport_error");
+      expect(attempts[0].durationMs).toBe(40);
+      expect(attempts[0].responseCompleteDurationMs).toBe(40);
+    });
+
+    it("omits `responseCompleteDurationMs` when the caller reads the body", async () => {
+      const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
+      const client = new OpenAICompatibleGatewayClient({
+        baseUrl: "https://llm.stage.commontools.dev/",
+        apiKey: "test-key",
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
+        fetchFn: () => Promise.resolve(new Response("{}", { status: 200 })),
+      });
+
+      const response = await client.createChatCompletion({
+        model: "gpt-5.4",
+        messages: [],
+      }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      });
+      await response.text();
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].responseCompleteDurationMs).toBeUndefined();
+    });
+  });
+
+  describe("OpenAICodexResponsesClient", () => {
+    it("ends `responseCompleteDurationMs` at the terminal stream event", async () => {
+      const attempts: HarnessModelAttemptDiagnostic[] = [];
+      const client = new OpenAICodexResponsesClient({
+        credentialResolver: { resolve: () => Promise.resolve(credential) },
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_900]),
+        fetchFn: () =>
+          Promise.resolve(sse({
+            type: "response.completed",
+            response: {
+              id: "resp_1",
+              status: "completed",
+              output: [{
+                type: "message",
+                id: "msg_1",
+                role: "assistant",
+                content: [{ type: "output_text", text: "hello" }],
+              }],
+            },
+          })),
+      });
+
+      await client.complete({
+        model: "gpt-5.4",
+        transcript: [{ role: "user", content: "hi" }],
+        tools: [],
+        nativeModelToolIds: [],
+        runId: "run-123",
+        onAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      });
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].outcome).toBe("http_response");
+      expect(attempts[0].durationMs).toBe(12);
+      expect(attempts[0].responseCompleteDurationMs).toBe(900);
+    });
+
+    it("records one attempt for a stream that ends without a terminal event", async () => {
+      const attempts: HarnessModelAttemptDiagnostic[] = [];
+      const client = new OpenAICodexResponsesClient({
+        credentialResolver: { resolve: () => Promise.resolve(credential) },
+        monotonicNowMs: scriptedClock([1_000, 1_012, 1_500]),
+        fetchFn: () =>
+          Promise.resolve(sse({ type: "response.output_text.delta" })),
+      });
+
+      await expect(client.complete({
+        model: "gpt-5.4",
+        transcript: [{ role: "user", content: "hi" }],
+        tools: [],
+        nativeModelToolIds: [],
+        runId: "run-123",
+        onAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
+      })).rejects.toThrow("without a terminal response event");
+
+      expect(attempts.length).toBe(1);
+      expect(attempts[0].responseCompleteDurationMs).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Round-4 analysis found `modelAttempts[].durationMs` understates model time ~10×: the clock stopped at response headers, and on the streaming Codex path the whole generation happens after that. Children spend 96–98% of wall in model turns, and the artifact said otherwise. With turn-time fixes queued (CT-2158 diagnostic collapse), the number those fixes claim to improve has to be real first.

## What

- `responseCompleteDurationMs` added alongside `durationMs` (dispatch → end of body/stream). The old field keeps its meaning — nothing programmatic consumed it, but existing artifacts stay comparable, and the gap between the two fields is itself a signal (transport vs generation).
- The Codex client emits its one attempt record after the SSE loop ends, however it ends.
- Transport errors record both durations as the same reading.
- Both clients take an injectable monotonic clock; tests script the readings — no timers.

## Tests

`test/model-attempt-duration.test.ts`: headers-vs-body on the gateway, transport-error equality, absent field on the raw-Response path, terminal-stream case on Codex, one-record-per-attempt on stream exhaustion. Verified failable by mutation.

Gates: `deno fmt --check` / `deno lint` clean, cf-harness `deno task test` 914 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

