### PR TITLE
Collapse superseded run_pattern diagnostics in the prompt loop (CT-2158)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1239,6 +1239,20 @@ bare fabric identifiers a diagnostic can embed (compiler-generated `fid1:`
 module roots, DIDs, `data:` URIs) are replaced with a `[fabric-id]` placeholder
 in the model-facing message, while the persisted artifact keeps the raw text.
 
+Only the newest such diagnostic is carried at full length. When a `run_pattern`
+result arrives, every earlier failed `run_pattern` result in that loop's
+transcript has its `message` replaced with a one-line summary naming the
+attempt, the status, how many errors the diagnostic reports and what they say —
+or the message's first line, where it reports no compiler error — and the tool
+output holding the full text; the summary is marked with `messageCollapsed` and
+the length it replaced. The newest failure is what the model writes its next
+source against, and the ones before it are re-read on every remaining turn
+without being acted on. Every other field of the result, a policy refusal among
+them, is left as it stands, as is a diagnostic already shorter than its own
+summary. The rewrite happens in the transcript itself, so the persisted
+transcript records the context the model was given, and the tool-output
+artifacts keep every diagnostic in full.
+
 Interactive chat stdio transport:
 
 ```bash

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -125,6 +125,7 @@ import type {
 } from "./model/client.ts";
 import { OpenAICompatibleGatewayModelClient } from "./model/openai-compatible-gateway.ts";
 import { sumHarnessModelUsage } from "./model/usage.ts";
+import { collapseSupersededRunPatternDiagnostics } from "./run-pattern-diagnostic-collapse.ts";
 import {
   loadHarnessSkillContext,
   loadHarnessSkillContextFromText,
@@ -2953,6 +2954,9 @@ export class CfHarnessPromptLoop {
           );
           const toolMessage = invokedToolCall.toolMessage;
           transcript.push(toolMessage);
+          if (toolMessage.toolName === "run_pattern") {
+            collapseSupersededRunPatternDiagnostics(transcript);
+          }
           await this.engine.persistTranscript(transcript);
           reportTimeline.push(transcriptTimelineEntry(
             toolMessage,

--- a/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
+++ b/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
@@ -1,0 +1,160 @@
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+import type {
+  HarnessToolTranscriptMessage,
+  HarnessTranscriptMessage,
+} from "./contracts/transcript.ts";
+
+/** Statuses whose `message` carries a diagnostic the model writes against. */
+const COLLAPSIBLE_STATUSES = new Set(["compile-error", "error"]);
+
+/** Distinct error classes a summary names, the rest counted. */
+const SUMMARY_ERROR_CLASS_LIMIT = 3;
+
+/** Characters kept of an error class, and of a first-line gist. */
+const SUMMARY_TEXT_MAX_CHARS = 100;
+
+/** The lead line of one compiler error, ahead of its code frame. */
+const COMPILER_ERROR_LINE = /^\[ERROR\] (.*)$/gm;
+
+interface CollapsibleFailure {
+  output: Record<string, unknown>;
+  outputId: string;
+  status: string;
+  message: string;
+}
+
+const failureFromContent = (
+  content: string,
+): CollapsibleFailure | undefined => {
+  let output: unknown;
+  try {
+    output = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+  if (!isObjectNotArray(output) || output.messageCollapsed === true) {
+    return undefined;
+  }
+  const { outputId, status, message } = output;
+  if (
+    typeof outputId !== "string" || typeof status !== "string" ||
+    typeof message !== "string" || !COLLAPSIBLE_STATUSES.has(status)
+  ) {
+    return undefined;
+  }
+  return { output, outputId, status, message };
+};
+
+const bounded = (text: string): string =>
+  text.length > SUMMARY_TEXT_MAX_CHARS
+    ? `${text.slice(0, SUMMARY_TEXT_MAX_CHARS)}...`
+    : text;
+
+/**
+ * How many errors the diagnostic reports and what they say, in order of first
+ * appearance and with the number of times each recurs. A message reporting no
+ * compiler error renders as the empty string.
+ */
+const errorClassSummary = (message: string): string => {
+  const counts = new Map<string, number>();
+  for (const [, text] of message.matchAll(COMPILER_ERROR_LINE)) {
+    const error = bounded(text.trim());
+    counts.set(error, (counts.get(error) ?? 0) + 1);
+  }
+  if (counts.size === 0) return "";
+  const named = [...counts.entries()].slice(0, SUMMARY_ERROR_CLASS_LIMIT)
+    .map(([error, count]) => count > 1 ? `"${error}" x${count}` : `"${error}"`);
+  const unnamed = counts.size - named.length;
+  const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
+  return `${total} ${total === 1 ? "error" : "errors"}: ${named.join("; ")}${
+    unnamed > 0 ? `; and ${unnamed} more` : ""
+  }`;
+};
+
+/** The message's first non-empty line, bounded in length. */
+const gist = (message: string): string => {
+  const line = message.split("\n").map((text) => text.trim())
+    .find((text) => text.length > 0) ?? "";
+  return `first line: "${bounded(line)}"`;
+};
+
+const summarize = (failure: CollapsibleFailure, attempt: number): string => {
+  const classes = errorClassSummary(failure.message);
+  return "[cf-harness: superseded run_pattern diagnostic collapsed for " +
+    `model context; attempt ${attempt}, ${failure.status}, ${
+      classes.length > 0 ? classes : gist(failure.message)
+    }. Full diagnostic is preserved in tool output ${failure.outputId}.]`;
+};
+
+/**
+ * The message with its diagnostic replaced by a summary, or `undefined` when
+ * the summary would be no shorter than the diagnostic it replaces.
+ */
+const collapsedMessage = (
+  message: HarnessToolTranscriptMessage,
+  failure: CollapsibleFailure,
+  attempt: number,
+): HarnessToolTranscriptMessage | undefined => {
+  const summary = summarize(failure, attempt);
+  if (summary.length >= failure.message.length) return undefined;
+  return {
+    ...message,
+    content: JSON.stringify({
+      ...failure.output,
+      message: summary,
+      messageCollapsed: true,
+      messageOriginalLength: failure.message.length,
+    }),
+  };
+};
+
+/**
+ * Replaces every failed `run_pattern` result in `transcript` but the most
+ * recent one with a one-line summary of its diagnostic, in place.
+ *
+ * A diagnostic is the model's feedback loop for source it just wrote, and the
+ * newest one is what it writes against. The ones before it stay in model
+ * context for every remaining turn of the loop without being read again, so
+ * each turn after a failure pays for all of them. A summary keeps what a
+ * later turn can still use — which attempt failed, in which way, and on what
+ * — and names the tool output artifact holding the full text.
+ *
+ * The transcript is the context the model is sent, so rewriting it is what
+ * makes the saving real, and the artifact persisted from it then records what
+ * the model was given. Only the free-text `message` of a `compile-error` or
+ * `error` result is replaced, so a structured policy refusal beside it
+ * reaches the model whole, and only where the summary is the shorter of the
+ * two.
+ *
+ * Collapsing is idempotent: a summary carries `messageCollapsed`, and a
+ * message carrying it is left as it stands.
+ */
+export const collapseSupersededRunPatternDiagnostics = (
+  transcript: HarnessTranscriptMessage[],
+): void => {
+  const failures: {
+    index: number;
+    attempt: number;
+    failure: CollapsibleFailure;
+  }[] = [];
+  let attempts = 0;
+  for (const [index, message] of transcript.entries()) {
+    if (message.role !== "tool" || message.toolName !== "run_pattern") {
+      continue;
+    }
+    attempts += 1;
+    const failure = failureFromContent(message.content);
+    if (failure !== undefined) {
+      failures.push({ index, attempt: attempts, failure });
+    }
+  }
+  for (const { index, attempt, failure } of failures.slice(0, -1)) {
+    const collapsed = collapsedMessage(
+      transcript[index] as HarnessToolTranscriptMessage,
+      failure,
+      attempt,
+    );
+    if (collapsed !== undefined) transcript[index] = collapsed;
+  }
+};

--- a/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
+++ b/packages/cf-harness/src/run-pattern-diagnostic-collapse.ts
@@ -57,14 +57,18 @@ const bounded = (text: string): string =>
  * compiler error renders as the empty string.
  */
 const errorClassSummary = (message: string): string => {
+  // Keyed by the whole line: two errors that share a long prefix are two
+  // classes, and bounding before the count merges them into a wrong one.
   const counts = new Map<string, number>();
   for (const [, text] of message.matchAll(COMPILER_ERROR_LINE)) {
-    const error = bounded(text.trim());
+    const error = text.trim();
     counts.set(error, (counts.get(error) ?? 0) + 1);
   }
   if (counts.size === 0) return "";
   const named = [...counts.entries()].slice(0, SUMMARY_ERROR_CLASS_LIMIT)
-    .map(([error, count]) => count > 1 ? `"${error}" x${count}` : `"${error}"`);
+    .map(([error, count]) =>
+      count > 1 ? `"${bounded(error)}" x${count}` : `"${bounded(error)}"`
+    );
   const unnamed = counts.size - named.length;
   const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
   return `${total} ${total === 1 ? "error" : "errors"}: ${named.join("; ")}${

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -3,7 +3,8 @@
  * can embed compiler-generated bare fabric identifiers (the `/fid1:.../`
  * virtual module roots) which the handle boundary deliberately never swaps,
  * so the prompt loop scrubs them from the model-bound rendering while the
- * persisted artifact keeps the raw text.
+ * persisted artifact keeps the raw text. The same boundary is where a
+ * diagnostic superseded by a later failure is collapsed to a summary.
  */
 
 import { expect } from "@std/expect";
@@ -16,6 +17,7 @@ import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
@@ -80,6 +82,9 @@ class RecordingArtifactStore implements HarnessArtifactStore {
     output: unknown;
   }> = [];
 
+  /** Every transcript the run persisted, each as it stood at that moment. */
+  readonly transcripts: HarnessTranscriptMessage[][] = [];
+
   constructor(runId: string) {
     this.runRoot = `${this.artifactRoot}/${runId}`;
   }
@@ -88,7 +93,10 @@ class RecordingArtifactStore implements HarnessArtifactStore {
     return Promise.resolve(`${this.runRoot}/run-state.json`);
   }
 
-  persistTranscript(): Promise<string> {
+  persistTranscript(
+    transcript: readonly HarnessTranscriptMessage[],
+  ): Promise<string> {
+    this.transcripts.push(structuredClone([...transcript]));
     return Promise.resolve(`${this.runRoot}/transcript.json`);
   }
 
@@ -534,6 +542,135 @@ describe("prompt-loop run_pattern model boundary", () => {
       const persistedMessage =
         (persisted?.output as { message: string }).message;
       expect(persistedMessage).toMatch(/fid1:[A-Za-z0-9_-]{43}/);
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("collapses the superseded compile diagnostic when a second run_pattern failure arrives", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern collapse");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-collapse-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const runId = "run-pattern-collapse";
+      const artifactStore = new RecordingArtifactStore(runId);
+      const brokenSource = (missing: string) =>
+        [
+          "import { computed, pattern } from 'commonfabric';",
+          "export default pattern<{ n: number }, { doubled: number }>(",
+          `  ({ n }) => ({ doubled: computed(() => ${missing}(n)) }),`,
+          ");",
+        ].join("\n");
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls += 1;
+        const payload = calls <= 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: `call-${calls}`,
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({
+                      sourceText: brokenSource(`missing-${calls}`),
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          artifactStore,
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+
+      const contents = result.transcript
+        .filter((message) => message.role === "tool")
+        .map((message) =>
+          JSON.parse(message.content) as {
+            status: string;
+            message: string;
+            messageCollapsed?: boolean;
+            messageOriginalLength?: number;
+          }
+        );
+      expect(contents.length).toBe(2);
+      expect(contents[0].status).toBe("compile-error");
+      expect(contents[0].messageCollapsed).toBe(true);
+      expect(contents[0].message).toContain(
+        "superseded run_pattern diagnostic collapsed",
+      );
+      expect(contents[0].message).toContain(
+        "attempt 1, compile-error, 2 errors:",
+      );
+      expect(contents[0].messageOriginalLength).toBeGreaterThan(
+        contents[0].message.length,
+      );
+      expect(contents[1].messageCollapsed).toBe(undefined);
+      expect(contents[1].message).toContain("missing-2");
+      // Each persisted transcript holds the context the model was given on
+      // the turn that followed it: the first diagnostic in full while it was
+      // the newest, and summarized once the second superseded it.
+      const messageAt = (
+        transcript: HarnessTranscriptMessage[],
+      ): string | undefined => {
+        const first = transcript.find((message) => message.role === "tool");
+        return first === undefined
+          ? undefined
+          : (JSON.parse(first.content) as { message: string }).message;
+      };
+      const persisted = artifactStore.transcripts.map(messageAt)
+        .filter((message) => message !== undefined);
+      expect(persisted[0]).toContain("missing-1");
+      expect(persisted.at(-1)).toContain(
+        "superseded run_pattern diagnostic collapsed",
+      );
+      // Both diagnostics stay whole in the tool-output artifacts.
+      const outputs = artifactStore.toolOutputs
+        .filter((entry) => entry.toolId === "run_pattern")
+        .map((entry) => (entry.output as { message: string }).message);
+      expect(outputs.length).toBe(2);
+      expect(outputs[0]).toContain("missing-1");
+      expect(outputs[1]).toContain("missing-2");
     } finally {
       await fabricRuntime.dispose();
       await storageManager.close();

--- a/packages/cf-harness/test/run-pattern-diagnostic-collapse.test.ts
+++ b/packages/cf-harness/test/run-pattern-diagnostic-collapse.test.ts
@@ -138,6 +138,28 @@ describe("collapseSupersededRunPatternDiagnostics()", () => {
     );
   });
 
+  it("counts two errors sharing a long prefix as two classes", () => {
+    const prefix = `Type '{ ${"donut: string; ".repeat(12)}}' is not `;
+    const transcript = [
+      runPatternFailure(
+        "call-1",
+        "out-1",
+        [
+          `[ERROR] ${prefix}assignable to parameter of type 'Glaze'.`,
+          `[ERROR] ${prefix}assignable to parameter of type 'Fryer'.`,
+        ].join("\n"),
+      ),
+      runPatternFailure("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    const message = parseContent(transcript[0]).message as string;
+    expect(message).toContain("2 errors:");
+    expect(message).not.toContain("x2");
+    expect(message.split(`"${prefix.slice(0, 100)}..."`).length - 1).toBe(2);
+  });
+
   it("leaves a diagnostic shorter than its own summary verbatim", () => {
     const transcript = [
       runPatternFailure("call-1", "out-1", "[ERROR] Cannot find name 'x'."),

--- a/packages/cf-harness/test/run-pattern-diagnostic-collapse.test.ts
+++ b/packages/cf-harness/test/run-pattern-diagnostic-collapse.test.ts
@@ -1,0 +1,200 @@
+import { describe, it } from "@std/testing/bdd";
+
+import { expect } from "@std/expect";
+import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
+import { collapseSupersededRunPatternDiagnostics } from "../src/run-pattern-diagnostic-collapse.ts";
+
+const codeFrame = (line: number) =>
+  [
+    "2 | import { computed, pattern } from 'commonfabric';",
+    `${line} |   ({ n }) => ({ doubled: computed(() => missing(n)) }),`,
+    "  |                                         ^",
+  ].join("\n");
+
+const DIAGNOSTIC = [
+  `[ERROR] Cannot find name 'Celll'.\n${codeFrame(12)}`,
+  `[ERROR] Cannot find name 'Celll'.\n${codeFrame(19)}`,
+  `[ERROR] This expression is not callable.\n${codeFrame(24)}`,
+].join("\n\n");
+
+const runPatternFailure = (
+  toolCallId: string,
+  outputId: string,
+  message = DIAGNOSTIC,
+  status = "compile-error",
+): HarnessTranscriptMessage => ({
+  role: "tool",
+  toolCallId,
+  toolName: "run_pattern",
+  content: JSON.stringify({ outputId, status, message }),
+});
+
+const runPatternSuccess = (
+  toolCallId: string,
+  outputId: string,
+): HarnessTranscriptMessage => ({
+  role: "tool",
+  toolCallId,
+  toolName: "run_pattern",
+  content: JSON.stringify({ outputId, status: "ok", resultRef: "ref-1" }),
+});
+
+const contentOf = (message: HarnessTranscriptMessage): string =>
+  (message as { content: string }).content;
+
+const parseContent = (
+  message: HarnessTranscriptMessage,
+): Record<string, unknown> => JSON.parse(contentOf(message));
+
+describe("collapseSupersededRunPatternDiagnostics()", () => {
+  it("leaves a lone failure verbatim", () => {
+    const transcript = [runPatternFailure("call-1", "out-1")];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(parseContent(transcript[0]).message).toBe(DIAGNOSTIC);
+  });
+
+  it("keeps the newest failure verbatim and summarizes the earlier ones", () => {
+    const transcript = [
+      runPatternFailure("call-1", "out-1"),
+      runPatternFailure("call-2", "out-2"),
+      runPatternFailure("call-3", "out-3"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(parseContent(transcript[0]).message).toBe(
+      "[cf-harness: superseded run_pattern diagnostic collapsed for model " +
+        "context; attempt 1, compile-error, 3 errors: " +
+        '"Cannot find name \'Celll\'." x2; "This expression is not callable.". ' +
+        "Full diagnostic is preserved in tool output out-1.]",
+    );
+    expect(parseContent(transcript[1]).message).toContain("attempt 2,");
+    expect(parseContent(transcript[1]).message).toContain("tool output out-2.");
+    expect(parseContent(transcript[2]).message).toBe(DIAGNOSTIC);
+  });
+
+  it("records the collapse and the length of the diagnostic it replaced", () => {
+    const transcript = [
+      runPatternFailure("call-1", "out-1"),
+      runPatternFailure("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(parseContent(transcript[0]).messageCollapsed).toBe(true);
+    expect(parseContent(transcript[0]).messageOriginalLength).toBe(
+      DIAGNOSTIC.length,
+    );
+    expect(parseContent(transcript[1]).messageCollapsed).toBe(undefined);
+  });
+
+  it("numbers an attempt by its position among all `run_pattern` results", () => {
+    const transcript = [
+      runPatternFailure("call-1", "out-1"),
+      runPatternSuccess("call-2", "out-2"),
+      runPatternFailure("call-3", "out-3"),
+      runPatternFailure("call-4", "out-4"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(parseContent(transcript[0]).message).toContain("attempt 1,");
+    expect(parseContent(transcript[2]).message).toContain("attempt 3,");
+  });
+
+  it("keeps the fields beside the diagnostic, a policy refusal among them", () => {
+    const policyRefusal = { gates: ["sink-ceiling"], sinks: ["mail"] };
+    const runtimeFailure = `the commit boundary refused this run. ${
+      "It named no offending input. ".repeat(8)
+    }`;
+    const transcript: HarnessTranscriptMessage[] = [
+      {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "run_pattern",
+        content: JSON.stringify({
+          outputId: "out-1",
+          status: "error",
+          message: runtimeFailure,
+          policyRefusal,
+        }),
+      },
+      runPatternFailure("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    const collapsed = parseContent(transcript[0]);
+    expect(collapsed.outputId).toBe("out-1");
+    expect(collapsed.status).toBe("error");
+    expect(collapsed.policyRefusal).toEqual(policyRefusal);
+    expect(collapsed.message).toBe(
+      "[cf-harness: superseded run_pattern diagnostic collapsed for model " +
+        'context; attempt 1, error, first line: "' +
+        `${runtimeFailure.trim().slice(0, 100)}...". ` +
+        "Full diagnostic is preserved in tool output out-1.]",
+    );
+  });
+
+  it("leaves a diagnostic shorter than its own summary verbatim", () => {
+    const transcript = [
+      runPatternFailure("call-1", "out-1", "[ERROR] Cannot find name 'x'."),
+      runPatternFailure("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(parseContent(transcript[0]).message).toBe(
+      "[ERROR] Cannot find name 'x'.",
+    );
+    expect(parseContent(transcript[0]).messageCollapsed).toBe(undefined);
+  });
+
+  it("leaves an already collapsed summary as it stands", () => {
+    const transcript = [
+      runPatternFailure("call-1", "out-1"),
+      runPatternFailure("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+    const once = contentOf(transcript[0]);
+    transcript.push(runPatternFailure("call-3", "out-3"));
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(contentOf(transcript[0])).toBe(once);
+    expect(parseContent(transcript[1]).messageCollapsed).toBe(true);
+  });
+
+  it("leaves a successful result, another tool's result, and unparsable content alone", () => {
+    const transcript: HarnessTranscriptMessage[] = [
+      runPatternSuccess("call-1", "out-1"),
+      {
+        role: "tool",
+        toolCallId: "call-2",
+        toolName: "bash",
+        content: JSON.stringify({
+          outputId: "out-2",
+          status: "error",
+          message: DIAGNOSTIC,
+        }),
+      },
+      {
+        role: "tool",
+        toolCallId: "call-3",
+        toolName: "run_pattern",
+        content: "not json",
+      },
+      runPatternFailure("call-4", "out-4"),
+      runPatternFailure("call-5", "out-5"),
+    ];
+    const untouched = transcript.slice(0, 3).map(contentOf);
+
+    collapseSupersededRunPatternDiagnostics(transcript);
+
+    expect(transcript.slice(0, 3).map(contentOf)).toEqual(untouched);
+    expect(parseContent(transcript[3]).messageCollapsed).toBe(true);
+    expect(parseContent(transcript[4]).message).toBe(DIAGNOSTIC);
+  });
+});


### PR DESCRIPTION
## Why

CT-2158: each failed run_pattern returns its full compile diagnostic, and the transcript re-sends every one of them on every later turn. Measured: clean turns ~13.9s; after any failure, 55.5s, superlinear to ~76s at five failures. The model progresses through error classes (longest same-class streak 2 of 71 attempts), so the old diagnostics buy nothing.

## What

When a run_pattern result lands, every EARLIER failed run_pattern result in the transcript has its `message` replaced with a one-line summary — attempt number, status, deduplicated `[ERROR]` classes with counts (capped at 3), and the outputId holding the full text. The newest failure stays verbatim: it is what the model writes its next source against.

- In-place on the array the loop sends AND persists, so `transcript.json` records what the model was actually given; `tool-outputs/<id>.json` keeps every raw diagnostic whole.
- Only the free-text `message` of a `compile-error`/`error` result is touched; structured fields (e.g. `policyRefusal`) cross intact.
- Idempotent (`messageCollapsed` marks a summary); a diagnostic already shorter than its summary stays verbatim.
- Follows the `truncateModelFacingBashOutput` idiom (shorten, mark, name the artifact), not a parallel mechanism.

## Measurement note

Falsifier pre-registered for the next round: post-failure turn time returns toward the ~13.9s floor with ok-rate holding. One known interaction to watch: rewriting earlier context invalidates the prompt-cache prefix from the collapse point on.

## Tests

New module tests + a loop test asserting the first persisted transcript holds the first diagnostic in full (while newest) and the last holds it summarized.

Gates: `deno fmt --check` / `deno lint` clean, cf-harness `deno task test` 914 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

