### PR TITLE
A batch refuses a console that is not the cell it names (CT-2110)

### DIFF
--- a/packages/cf-harness/console/README.md
+++ b/packages/cf-harness/console/README.md
@@ -122,6 +122,7 @@ column refers to the per-process cookie obtained by loading `/`.
 | `POST` | `/api/cancel`                | Yes   | Cancels the active turn                                                                 |
 | `GET`  | `/api/sessions`              | Yes   | Durable session summaries                                                               |
 | `GET`  | `/api/status`                | Yes   | Session status and artifact roots                                                       |
+| `GET`  | `/api/policy`                | Yes   | What a new session here would run under                                                 |
 | `GET`  | `/api/turns/<turnId>/result` | Yes   | Durable structured result for a completed turn                                          |
 | `GET`  | `/api/events`                | Yes   | Live and replayed chat events over SSE                                                  |
 | `GET`  | `/api/runs`                  | Yes   | Run summaries                                                                           |
@@ -217,6 +218,39 @@ Status requires the per-process token cookie obtained by loading the console
 page. The top-level fields are present even before the console has any sessions,
 so an unattended client can check the route contract before starting a model
 turn.
+
+### Policy route
+
+`GET /api/policy` returns what a session started here **would** run under, which
+is the same question the status route answers only for sessions that already
+exist:
+
+| field                     | value                                                                 |
+| ------------------------- | --------------------------------------------------------------------- |
+| `systemPromptSha256`      | SHA-256 of the seeded system prompt, or `null` when none is seeded    |
+| `allowedToolIds`          | the tools a new session's policy asks for                             |
+| `allowedSubagentProfiles` | the subagent profiles it authorizes                                   |
+| `artifactRoot`            | where runs are filed                                                  |
+| `fabricSpace`             | the space name runs build in                                          |
+| `sessionDbPath`           | the durable session store, or `null` when sessions are held in memory |
+
+The prompt crosses as a digest and never as text, so a client can check that
+this console holds the prompt it was told to run without the prompt leaving the
+process. `allowedToolIds` is what the policy asks for; the prompt loop withholds
+a tool again when its backing is absent, so this says a session may reach a tool
+rather than that a turn will hold it.
+
+The route carries the token, as the status route carrying the same policy on a
+live session does — and the space name and the two host paths, which nothing
+outside this server's own page has business reading. The health route's
+exemption is for a client that has no token yet and wants liveness; a client
+acting on this answer has loaded the page and holds one.
+
+An unattended client is the caller this route is for: the measurement batch
+runner refuses a whole batch when the console it found is not the cell its
+`--cell-spec` names, before the first task spends anything. That file's shape is
+in
+[the measurement protocol](../docs/pattern-index-measurement.md#the-cell-spec).
 
 ## CFC
 

--- a/packages/cf-harness/console/policy.ts
+++ b/packages/cf-harness/console/policy.ts
@@ -13,6 +13,8 @@
 
 import { encodeHex } from "@std/encoding/hex";
 
+import { sha256 } from "@commonfabric/content-hash";
+
 import type { HarnessChatPolicy } from "../src/contracts/interactive-chat.ts";
 
 /** What the server was configured with, for {@link consolePolicyReport}. */
@@ -55,18 +57,16 @@ export interface ConsolePolicyReport {
 }
 
 /** `text`'s SHA-256, hex encoded. */
-const sha256Hex = async (text: string): Promise<string> =>
-  encodeHex(
-    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text)),
-  );
+const sha256Hex = (text: string): string =>
+  encodeHex(sha256(new TextEncoder().encode(text)));
 
 /** What a new session would run under, holding no prompt text. */
-export const consolePolicyReport = async (
+export const consolePolicyReport = (
   input: ConsolePolicyInput,
-): Promise<ConsolePolicyReport> => ({
+): ConsolePolicyReport => ({
   systemPromptSha256: input.systemPrompt === undefined
     ? null
-    : await sha256Hex(input.systemPrompt),
+    : sha256Hex(input.systemPrompt),
   allowedToolIds: [...input.policy.allowedToolIds],
   allowedSubagentProfiles: [...input.policy.allowedSubagentProfiles],
   fabricSpace: input.fabricSpace,

--- a/packages/cf-harness/console/policy.ts
+++ b/packages/cf-harness/console/policy.ts
@@ -1,0 +1,75 @@
+/**
+ * What a new console session would run under, as the server discloses it.
+ *
+ * A session's own policy reaches a client through `/api/status`, which can
+ * only describe sessions that exist. An unattended client deciding whether
+ * this console is the one it was told to measure has to decide that before it
+ * starts a session, and the two questions want the same fields.
+ *
+ * The seeded system prompt crosses as a digest and never as text. A prompt is
+ * the operator's, it can hold anything, and a client checking that this
+ * console runs *the* prompt needs to compare rather than to read.
+ */
+
+import { encodeHex } from "@std/encoding/hex";
+
+import type { HarnessChatPolicy } from "../src/contracts/interactive-chat.ts";
+
+/** What the server was configured with, for {@link consolePolicyReport}. */
+export interface ConsolePolicyInput {
+  policy: HarnessChatPolicy;
+  fabricSpace: string;
+  artifactRoot: string;
+
+  /** The seeded system prompt, when the server was started with one. */
+  systemPrompt?: string;
+
+  /** The durable session store, absent when sessions are held in memory. */
+  sessionDbPath?: string;
+}
+
+/**
+ * The effective session policy, as `GET /api/policy` returns it.
+ *
+ * Every optional part of the configuration is reported as `null` rather than
+ * left out, so a client reading a field can tell a server that has none from
+ * one whose answer predates the field.
+ */
+export interface ConsolePolicyReport {
+  /** The seeded system prompt's SHA-256, or `null` for a server with none. */
+  systemPromptSha256: string | null;
+
+  /**
+   * The tools a new session's policy asks for. The prompt loop withholds one
+   * again when its backing is absent, so this is what the console asks for
+   * rather than what a turn ends up holding.
+   */
+  allowedToolIds: readonly string[];
+
+  allowedSubagentProfiles: readonly string[];
+  fabricSpace: string;
+  artifactRoot: string;
+
+  /** The durable session store, or `null` when sessions are held in memory. */
+  sessionDbPath: string | null;
+}
+
+/** `text`'s SHA-256, hex encoded. */
+const sha256Hex = async (text: string): Promise<string> =>
+  encodeHex(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text)),
+  );
+
+/** What a new session would run under, holding no prompt text. */
+export const consolePolicyReport = async (
+  input: ConsolePolicyInput,
+): Promise<ConsolePolicyReport> => ({
+  systemPromptSha256: input.systemPrompt === undefined
+    ? null
+    : await sha256Hex(input.systemPrompt),
+  allowedToolIds: [...input.policy.allowedToolIds],
+  allowedSubagentProfiles: [...input.policy.allowedSubagentProfiles],
+  fabricSpace: input.fabricSpace,
+  artifactRoot: input.artifactRoot,
+  sessionDbPath: input.sessionDbPath ?? null,
+});

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -996,7 +996,7 @@ export class ConsoleServer {
       });
     }
     if (request.method === "GET" && url.pathname === "/api/policy") {
-      return Response.json(await this.#policy());
+      return Response.json(this.#policy());
     }
     if (
       request.method === "GET" && url.pathname.startsWith("/api/turns/")
@@ -1206,7 +1206,7 @@ export class ConsoleServer {
    * digest, so a client can check that this console holds the prompt it was
    * told to measure without the prompt's text leaving the process.
    */
-  #policy(): Promise<ConsolePolicyReport> {
+  #policy(): ConsolePolicyReport {
     return consolePolicyReport({
       policy: this.#sessionPolicy(),
       fabricSpace: this.#config.fabricSession.space,

--- a/packages/cf-harness/console/server.ts
+++ b/packages/cf-harness/console/server.ts
@@ -95,6 +95,7 @@ import type { CreateHarnessPromptLoopOptions } from "../src/prompt-loop.ts";
 import type { HarnessChatSessionStore } from "../src/session-store.ts";
 import { FileSystemHarnessArtifactStore } from "../src/artifacts.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
+import { type ConsolePolicyReport, consolePolicyReport } from "./policy.ts";
 import {
   listConsoleRuns,
   readConsoleRun,
@@ -994,6 +995,9 @@ export class ConsoleServer {
         ...this.#service.status(url.searchParams.get("sessionId") ?? undefined),
       });
     }
+    if (request.method === "GET" && url.pathname === "/api/policy") {
+      return Response.json(await this.#policy());
+    }
     if (
       request.method === "GET" && url.pathname.startsWith("/api/turns/")
     ) {
@@ -1185,6 +1189,38 @@ export class ConsoleServer {
   }
 
   /**
+   * The policy every new session here is started with. One expression rather
+   * than two because `/api/policy` answers for the sessions `/api/task`
+   * creates, and a client that acts on the answer is owed the same object the
+   * next session actually gets.
+   */
+  #sessionPolicy(): HarnessChatPolicy {
+    return consoleChatPolicy(
+      this.#config.patternIndex !== undefined,
+      this.#config.skillsSh !== undefined,
+    );
+  }
+
+  /**
+   * What a new session would run under. The seeded system prompt crosses as a
+   * digest, so a client can check that this console holds the prompt it was
+   * told to measure without the prompt's text leaving the process.
+   */
+  #policy(): Promise<ConsolePolicyReport> {
+    return consolePolicyReport({
+      policy: this.#sessionPolicy(),
+      fabricSpace: this.#config.fabricSession.space,
+      artifactRoot: this.#config.artifactRoot,
+      ...(this.#config.systemPrompt !== undefined
+        ? { systemPrompt: this.#config.systemPrompt }
+        : {}),
+      ...(this.#config.sessionDbPath !== undefined
+        ? { sessionDbPath: this.#config.sessionDbPath }
+        : {}),
+    });
+  }
+
+  /**
    * Starts a turn, in the session the request names or in a new one. One
    * request rather than two because a session with no turn is not a thing
    * anyone asked for, and the page needs both identifiers before it can
@@ -1218,10 +1254,7 @@ export class ConsoleServer {
         workspace: { hostPath: this.#config.workspacePath },
         model: this.#config.model,
         artifactRoot: this.#config.artifactRoot,
-        policy: consoleChatPolicy(
-          this.#config.patternIndex !== undefined,
-          this.#config.skillsSh !== undefined,
-        ),
+        policy: this.#sessionPolicy(),
       });
       if (!session.ok) {
         return chatErrorResponse(session);

--- a/packages/cf-harness/docs/pattern-index-measurement.md
+++ b/packages/cf-harness/docs/pattern-index-measurement.md
@@ -217,7 +217,7 @@ passed.
 ```json
 {
   "label": "phase 3, composition under the authored prompt",
-  "systemPromptSha256": "3f786850e387550fdab836ed7e6dc881de23001b",
+  "systemPromptSha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
   "requiredToolIds": ["run_pattern", "search_patterns", "record_feedback"],
   "forbiddenToolIds": ["web_search"],
   "requiredSubagentProfiles": ["pattern-author"],
@@ -241,7 +241,11 @@ passed.
 Stating a set as a whole and in parts at once is refused rather than resolved:
 `allowedToolIds` beside `requiredToolIds` is a file that has not decided which
 claim it makes. So is a name in both the required and the forbidden list, and a
-field name nothing asserts, which would otherwise pass silently as a typo.
+field name nothing asserts, which would otherwise pass silently as a typo. An
+empty required or forbidden list is refused for the same reason: every console
+offers at least nothing, so the field looks like a check and is not. An empty
+whole set is kept, because there it is the strongest claim the file can make —
+that the policy offers nothing at all.
 
 A mismatch refuses the batch with exit code 6, names every disagreeing field
 with expected against actual, and starts no task. So does a console that will

--- a/packages/cf-harness/docs/pattern-index-measurement.md
+++ b/packages/cf-harness/docs/pattern-index-measurement.md
@@ -128,15 +128,20 @@ also refuses by default. `--allow-diverged` is the explicit opt-out for a batch
 that intentionally measures such a server; a commit that cannot be checked
 remains a non-fatal `unchecked` reading.
 
+`--cell-spec=<file>` states what this experiment requires of the console, and
+refuses the whole batch before the first task when the console is something
+else. See [The cell spec](#the-cell-spec).
+
 The runner loads the console page to pick up the token cookie every `/api` route
 is gated on. Before reading the index or starting a paid model turn, it requires
 `/api/status` to carry an absolute top-level `artifactRoot` and a `sessions`
-array. It then reads the index and runs each task in its own session. It waits
-on the console's own `turn_completed`, `turn_failed` or `turn_canceled` event,
-read off the server-sent event stream, and on nothing else. There is no timeout:
-a turn that hangs is a batch that hangs, which an operator can see and release
-with a `POST /api/cancel`, rather than a bound that turns a slow run into a
-failed one.
+array, and — when a cell spec was named — the console's `/api/policy` to satisfy
+every field of it. It then reads the index and runs each task in its own
+session. It waits on the console's own `turn_completed`, `turn_failed` or
+`turn_canceled` event, read off the server-sent event stream, and on nothing
+else. There is no timeout: a turn that hangs is a batch that hangs, which an
+operator can see and release with a `POST /api/cancel`, rather than a bound that
+turns a slow run into a failed one.
 
 After a turn settles, the runner locates its root run under the session's
 `artifactRoot`, falling back to the console-wide root. A candidate must have
@@ -194,6 +199,70 @@ carries its own identifier, so without the hop it would read as pre-existing and
 count a composition of seeded work as evidence against the seeding.
 
 Hops beyond the first are not resolved, and the report says so.
+
+## The cell spec
+
+A suite says what the batch asks the model. A cell spec says what the console
+has to be for those answers to mean anything, and it is checked before the first
+task rather than read out of the artifacts afterwards. A console whose policy
+cannot offer the tool an experiment exists to test produces a night of runs that
+look, in every other artifact, exactly like runs that chose not to use it.
+
+The file is JSON, passed as `--cell-spec`. Every field is optional and every
+field present is asserted; a field left out is not checked and the report says
+so. `label` names the spec and asserts nothing, and a file carrying nothing else
+is refused — a check that checks nothing is indistinguishable from one that
+passed.
+
+```json
+{
+  "label": "phase 3, composition under the authored prompt",
+  "systemPromptSha256": "3f786850e387550fdab836ed7e6dc881de23001b",
+  "requiredToolIds": ["run_pattern", "search_patterns", "record_feedback"],
+  "forbiddenToolIds": ["web_search"],
+  "requiredSubagentProfiles": ["pattern-author"],
+  "fabricSpace": "pattern-index-demo",
+  "artifactRoot": "/Users/me/labs/packages/cf-harness/.cf-harness-console/runs",
+  "sessionDbPath": "/Users/me/labs/packages/cf-harness/.cf-harness-console/sessions.sqlite"
+}
+```
+
+| field                                                    | asserts                                                                       |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `systemPromptSha256`                                     | the SHA-256 of the seeded system prompt, or `null` for a console seeding none |
+| `allowedToolIds`                                         | the whole tool set, compared as a set                                         |
+| `requiredToolIds` / `forbiddenToolIds`                   | tools the policy must offer, and must not                                     |
+| `allowedSubagentProfiles`                                | the whole profile set                                                         |
+| `requiredSubagentProfiles` / `forbiddenSubagentProfiles` | profiles the policy must authorize, and must not                              |
+| `fabricSpace`                                            | the space the runs write into                                                 |
+| `artifactRoot`                                           | where the console files its runs                                              |
+| `sessionDbPath`                                          | the durable session store, or `null` for sessions held in memory              |
+
+Stating a set as a whole and in parts at once is refused rather than resolved:
+`allowedToolIds` beside `requiredToolIds` is a file that has not decided which
+claim it makes. So is a name in both the required and the forbidden list, and a
+field name nothing asserts, which would otherwise pass silently as a typo.
+
+A mismatch refuses the batch with exit code 6, names every disagreeing field
+with expected against actual, and starts no task. So does a console that will
+not disclose its policy at all: a spec was named, and nothing can report it
+satisfied.
+
+The prompt crosses as a digest and never as text. Take one with
+`shasum -a 256 <the prompt file>` and paste the hex.
+
+Two limits worth holding. `/api/policy` reports what the console's policy
+**asks** for, and the prompt loop withholds a tool again when its backing is
+absent — so a spec naming `search_patterns` proves the policy offers it, not
+that a turn will hold it; the index pre-flight is what says the backing answers.
+And the digest covers the seeded system prompt alone, not the tool descriptors
+or the subagent guidance that also reach a model.
+
+The spec describes a console, because a console is the only thing this runner
+starts work on. `measure-runs` reads runs that are already on disk and spends
+nothing, so it has nothing to refuse; a `cf-harness` CLI run states its own
+policy in the flags that start it, where it is visible in the command rather
+than in a server somebody else configured.
 
 ## The batch publishes into the corpus it is measuring
 

--- a/packages/cf-harness/scripts/cell-spec.ts
+++ b/packages/cf-harness/scripts/cell-spec.ts
@@ -85,15 +85,31 @@ const ASSERTING_FIELDS: readonly string[] = [
   ...NULLABLE_STRING_FIELDS,
 ];
 
+/**
+ * One list field's entries, or `undefined` when the file leaves it out.
+ *
+ * A part-list is empty only by mistake: `requiredToolIds: []` asserts that the
+ * policy offers at least nothing, which every console satisfies, and a file of
+ * such lists would pass the whole-spec guard below while checking as little as
+ * a file with no fields at all. `allowEmpty` is for the whole-set fields,
+ * where an empty list is the strongest claim the spec can make rather than the
+ * weakest — that the policy offers nothing.
+ */
 const stringList = (
   value: unknown,
   field: string,
+  allowEmpty: boolean,
 ): readonly string[] | undefined => {
   if (value === undefined) return undefined;
   if (
     !Array.isArray(value) || value.some((entry) => typeof entry !== "string")
   ) {
     throw new Error(`a cell spec's ${field} must be a list of strings`);
+  }
+  if (value.length === 0 && !allowEmpty) {
+    throw new Error(
+      `a cell spec's ${field} is empty, which every console satisfies; name at least one entry or leave the field out`,
+    );
   }
   return value as readonly string[];
 };
@@ -135,9 +151,9 @@ export const parseCellSpec = (input: unknown): CellSpec => {
     spec[field] = raw[field];
   }
   for (const [exact, required, forbidden] of SET_FIELDS) {
-    const exactSet = stringList(raw[exact], exact);
-    const requiredSet = stringList(raw[required], required);
-    const forbiddenSet = stringList(raw[forbidden], forbidden);
+    const exactSet = stringList(raw[exact], exact, true);
+    const requiredSet = stringList(raw[required], required, false);
+    const forbiddenSet = stringList(raw[forbidden], forbidden, false);
     if (
       exactSet !== undefined &&
       (requiredSet !== undefined || forbiddenSet !== undefined)

--- a/packages/cf-harness/scripts/cell-spec.ts
+++ b/packages/cf-harness/scripts/cell-spec.ts
@@ -1,0 +1,264 @@
+/**
+ * What a measurement batch requires of the console it is about to spend money
+ * on, and whether the console it found satisfies it.
+ *
+ * Every field an experiment depends on and cannot see from a transcript is
+ * checkable before the first task: which tools the policy offers, which
+ * subagent profiles it authorizes, which system prompt is seeded, which space
+ * the runs write into, and which stores this console holds. A batch that
+ * verifies those afterwards, by reading the artifacts it paid for, has already
+ * spent the run that would have told it.
+ *
+ * A spec asserts only the fields it carries. What it leaves out is not
+ * asserted and is not reported as satisfied.
+ */
+
+import type { ConsolePolicyReport } from "../console/policy.ts";
+
+/**
+ * One cell's expected configuration, as a `--cell-spec` file holds it.
+ *
+ * `allowedToolIds` states the whole set; `requiredToolIds` and
+ * `forbiddenToolIds` state parts of it. A file carrying both has not decided
+ * which claim it is making, and {@link parseCellSpec} refuses it rather than
+ * letting one silently win. The subagent profile fields work the same way.
+ *
+ * `systemPromptSha256` admits `null`, which asserts that this console seeds no
+ * system prompt at all — a condition an experiment can depend on as readily as
+ * on a particular prompt.
+ */
+export interface CellSpec {
+  label?: string;
+  systemPromptSha256?: string | null;
+  allowedToolIds?: readonly string[];
+  requiredToolIds?: readonly string[];
+  forbiddenToolIds?: readonly string[];
+  allowedSubagentProfiles?: readonly string[];
+  requiredSubagentProfiles?: readonly string[];
+  forbiddenSubagentProfiles?: readonly string[];
+  fabricSpace?: string;
+  artifactRoot?: string;
+  sessionDbPath?: string | null;
+}
+
+/** One field the console disagreed with the spec on. */
+export interface CellSpecMismatch {
+  field: string;
+  expected: string;
+  actual: string;
+}
+
+/**
+ * Whether the console is the cell the batch was told to measure.
+ *
+ * `unasked` is a batch that named no spec, and it is a distinct reading from
+ * one whose every field held: the first asserted nothing, and a report that
+ * called it a match would claim a check nobody ran.
+ */
+export type CellSpecPreflight =
+  | { kind: "unasked" }
+  | { kind: "matched"; spec: CellSpec; policy: ConsolePolicyReport }
+  | {
+    kind: "refused";
+    reason: string;
+    spec?: CellSpec;
+    mismatches?: readonly CellSpecMismatch[];
+  };
+
+const SET_FIELDS = [
+  ["allowedToolIds", "requiredToolIds", "forbiddenToolIds"],
+  [
+    "allowedSubagentProfiles",
+    "requiredSubagentProfiles",
+    "forbiddenSubagentProfiles",
+  ],
+] as const;
+
+const STRING_FIELDS = ["label", "fabricSpace", "artifactRoot"] as const;
+
+const NULLABLE_STRING_FIELDS = ["systemPromptSha256", "sessionDbPath"] as const;
+
+/** Every field that asserts something, so a spec asserting nothing is caught. */
+const ASSERTING_FIELDS: readonly string[] = [
+  ...SET_FIELDS.flat(),
+  ...STRING_FIELDS.filter((field) => field !== "label"),
+  ...NULLABLE_STRING_FIELDS,
+];
+
+const stringList = (
+  value: unknown,
+  field: string,
+): readonly string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) || value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(`a cell spec's ${field} must be a list of strings`);
+  }
+  return value as readonly string[];
+};
+
+/**
+ * Reads a cell spec's contents, or says what is wrong with it.
+ *
+ * A spec that asserts nothing is refused. Passing `--cell-spec` and having it
+ * check nothing is the failure this pre-flight exists to remove, and it is
+ * indistinguishable from a passing check in every artifact the batch writes.
+ */
+export const parseCellSpec = (input: unknown): CellSpec => {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new Error("a cell spec must be a JSON object");
+  }
+  const raw = input as Record<string, unknown>;
+  const known = new Set<string>([...ASSERTING_FIELDS, "label"]);
+  const unknownFields = Object.keys(raw).filter((key) => !known.has(key));
+  if (unknownFields.length > 0) {
+    // A misspelled field asserts nothing while looking as though it does,
+    // which is the same silent pass as an empty spec.
+    throw new Error(
+      `a cell spec names fields nothing asserts: ${unknownFields.join(", ")}`,
+    );
+  }
+  const spec: Record<string, unknown> = {};
+  for (const field of STRING_FIELDS) {
+    if (raw[field] === undefined) continue;
+    if (typeof raw[field] !== "string" || raw[field].trim() === "") {
+      throw new Error(`a cell spec's ${field} must be a non-empty string`);
+    }
+    spec[field] = raw[field];
+  }
+  for (const field of NULLABLE_STRING_FIELDS) {
+    if (raw[field] === undefined) continue;
+    if (raw[field] !== null && typeof raw[field] !== "string") {
+      throw new Error(`a cell spec's ${field} must be a string or null`);
+    }
+    spec[field] = raw[field];
+  }
+  for (const [exact, required, forbidden] of SET_FIELDS) {
+    const exactSet = stringList(raw[exact], exact);
+    const requiredSet = stringList(raw[required], required);
+    const forbiddenSet = stringList(raw[forbidden], forbidden);
+    if (
+      exactSet !== undefined &&
+      (requiredSet !== undefined || forbiddenSet !== undefined)
+    ) {
+      throw new Error(
+        `a cell spec states ${exact} as a whole set and also as ${required}/${forbidden}; it is one or the other`,
+      );
+    }
+    const both = (requiredSet ?? []).filter((entry) =>
+      (forbiddenSet ?? []).includes(entry)
+    );
+    if (both.length > 0) {
+      throw new Error(
+        `a cell spec names ${
+          both.join(", ")
+        } as both ${required} and ${forbidden}`,
+      );
+    }
+    if (exactSet !== undefined) spec[exact] = exactSet;
+    if (requiredSet !== undefined) spec[required] = requiredSet;
+    if (forbiddenSet !== undefined) spec[forbidden] = forbiddenSet;
+  }
+  if (!ASSERTING_FIELDS.some((field) => spec[field] !== undefined)) {
+    throw new Error(
+      "a cell spec asserts nothing; name at least one of " +
+        ASSERTING_FIELDS.join(", "),
+    );
+  }
+  return spec as CellSpec;
+};
+
+const named = (values: readonly string[]): string =>
+  values.length === 0 ? "(none)" : [...values].sort().join(", ");
+
+/**
+ * Where the console disagrees with the spec, field by field.
+ *
+ * A set is compared as a set: order and repetition in either the spec or the
+ * console's answer say nothing about what a session can reach.
+ */
+export const checkCellSpec = (
+  spec: CellSpec,
+  policy: ConsolePolicyReport,
+): readonly CellSpecMismatch[] => {
+  const mismatches: CellSpecMismatch[] = [];
+  const scalar = (
+    field: string,
+    expected: string | null | undefined,
+    actual: string | null,
+  ): void => {
+    if (expected === undefined || expected === actual) return;
+    mismatches.push({
+      field,
+      expected: expected ?? "(none)",
+      actual: actual ?? "(none)",
+    });
+  };
+  scalar(
+    "systemPromptSha256",
+    spec.systemPromptSha256,
+    policy.systemPromptSha256,
+  );
+  scalar("fabricSpace", spec.fabricSpace, policy.fabricSpace);
+  scalar("artifactRoot", spec.artifactRoot, policy.artifactRoot);
+  scalar("sessionDbPath", spec.sessionDbPath, policy.sessionDbPath);
+  const sets = [
+    {
+      exact: spec.allowedToolIds,
+      required: spec.requiredToolIds,
+      forbidden: spec.forbiddenToolIds,
+      field: "allowedToolIds",
+      actual: policy.allowedToolIds,
+    },
+    {
+      exact: spec.allowedSubagentProfiles,
+      required: spec.requiredSubagentProfiles,
+      forbidden: spec.forbiddenSubagentProfiles,
+      field: "allowedSubagentProfiles",
+      actual: policy.allowedSubagentProfiles,
+    },
+  ] as const;
+  for (const entry of sets) {
+    const held = new Set(entry.actual);
+    if (entry.exact !== undefined) {
+      const expected = new Set(entry.exact);
+      const missing = [...expected].filter((id) => !held.has(id));
+      const extra = [...held].filter((id) => !expected.has(id));
+      if (missing.length > 0 || extra.length > 0) {
+        mismatches.push({
+          field: entry.field,
+          expected: named([...expected]),
+          actual: named([...held]),
+        });
+      }
+    }
+    const missing = (entry.required ?? []).filter((id) => !held.has(id));
+    if (missing.length > 0) {
+      mismatches.push({
+        field: `${entry.field} (must include)`,
+        expected: `at least ${named(missing)}`,
+        actual: named([...held]),
+      });
+    }
+    const present = (entry.forbidden ?? []).filter((id) => held.has(id));
+    if (present.length > 0) {
+      mismatches.push({
+        field: `${entry.field} (must exclude)`,
+        expected: `none of ${named(present)}`,
+        actual: named([...held]),
+      });
+    }
+  }
+  return mismatches;
+};
+
+/** What the batch refuses with when the console is not the cell. */
+export const describeCellSpecMismatches = (
+  mismatches: readonly CellSpecMismatch[],
+): string =>
+  mismatches
+    .map((mismatch) =>
+      `${mismatch.field}: expected ${mismatch.expected}; this console reports ${mismatch.actual}`
+    )
+    .join("; ");

--- a/packages/cf-harness/scripts/run-measurement-batch.ts
+++ b/packages/cf-harness/scripts/run-measurement-batch.ts
@@ -28,17 +28,31 @@
  *   deno task measure-batch suite.json --out=./measurements/tonight
  *   deno task measure-batch suite.json --fabric-api-url=http://localhost:8040
  *   deno task measure-batch suite.json --expect-git-sha=<sha>
+ *   deno task measure-batch suite.json --cell-spec=./cell.json
  *   deno task measure-batch suite.json --allow-diverged
+ *
+ * `--cell-spec` is what refuses a misconfigured console before the first task
+ * spends anything: the file states the tools, subagent profiles, system
+ * prompt, space and stores this experiment requires, and the batch checks them
+ * against what the console says a session here would run under.
  */
 
 import { parseArgs } from "@std/cli/parse-args";
 import { ensureDir } from "@std/fs";
 import { isAbsolute, join } from "@std/path";
 
+import type { ConsolePolicyReport } from "../console/policy.ts";
 import type {
   HarnessChatEventEnvelope,
   HarnessChatSessionStatus,
 } from "../src/contracts/interactive-chat.ts";
+import {
+  type CellSpec,
+  type CellSpecPreflight,
+  checkCellSpec,
+  describeCellSpecMismatches,
+  parseCellSpec,
+} from "./cell-spec.ts";
 import {
   foldTotals,
   measureRunFamily,
@@ -847,6 +861,51 @@ export class ConsoleClient {
     return { kind: "ready", artifactRoot };
   }
 
+  /**
+   * What a new session here would run under, or why nobody can say.
+   *
+   * `/api/status` carries a session's policy and can only describe sessions
+   * that exist, so it cannot answer this before the first task — which is the
+   * only place the answer is worth anything.
+   */
+  async policy(): Promise<ConsolePolicyReport | { error: string }> {
+    let answer: unknown;
+    try {
+      answer = await this.#json("/api/policy");
+    } catch (error) {
+      return {
+        error: `/api/policy could not be read: ${describeError(error)}`,
+      };
+    }
+    if (typeof answer !== "object" || answer === null) {
+      return { error: "/api/policy did not return a JSON object" };
+    }
+    const report = answer as Record<string, unknown>;
+    for (const field of ["allowedToolIds", "allowedSubagentProfiles"]) {
+      if (!Array.isArray(report[field])) {
+        return { error: `/api/policy is missing the ${field} array` };
+      }
+    }
+    for (const field of ["fabricSpace", "artifactRoot"]) {
+      if (typeof report[field] !== "string") {
+        return { error: `/api/policy is missing the ${field} field` };
+      }
+    }
+    return {
+      systemPromptSha256: typeof report.systemPromptSha256 === "string"
+        ? report.systemPromptSha256
+        : null,
+      allowedToolIds: report.allowedToolIds as readonly string[],
+      allowedSubagentProfiles: report
+        .allowedSubagentProfiles as readonly string[],
+      fabricSpace: report.fabricSpace as string,
+      artifactRoot: report.artifactRoot as string,
+      sessionDbPath: typeof report.sessionDbPath === "string"
+        ? report.sessionDbPath
+        : null,
+    };
+  }
+
   /** What the index holds, read through the console's own signed proxy. */
   async indexSnapshot(): Promise<IndexSnapshot> {
     try {
@@ -1132,6 +1191,7 @@ export interface BatchResult {
   startedAt: string;
   endedAt: string;
   consolePreflight: ConsolePreflight;
+  cellSpec: CellSpecPreflight;
   preflight: IndexPreflight;
   posture: PosturePreflight;
 
@@ -1308,6 +1368,36 @@ export const resolveImportedPatternOrigins = async (
     );
   }
   return origins;
+};
+
+/**
+ * Whether the console is the cell the batch was told to measure.
+ *
+ * A console that will not say what it runs under refuses the batch as surely
+ * as one that says the wrong thing: a spec was named, and nothing here can
+ * report it as satisfied.
+ */
+export const preflightCellSpec = async (
+  client: ConsoleClient,
+  spec: CellSpec | undefined,
+): Promise<CellSpecPreflight> => {
+  if (spec === undefined) return { kind: "unasked" };
+  const policy = await client.policy();
+  if ("error" in policy) {
+    return {
+      kind: "refused",
+      reason:
+        `this batch was given a cell spec, and the console would not say what a session here runs under: ${policy.error}`,
+      spec,
+    };
+  }
+  const mismatches = checkCellSpec(spec, policy);
+  return mismatches.length === 0 ? { kind: "matched", spec, policy } : {
+    kind: "refused",
+    reason: describeCellSpecMismatches(mismatches),
+    spec,
+    mismatches,
+  };
 };
 
 /** Whether each named pattern was findable, asked of the index by name. */
@@ -1694,6 +1784,45 @@ const renderConsolePreflight = (preflight: ConsolePreflight): string =>
     : `**The console status contract was refused, so no task ran.** ${preflight.reason}\n`;
 
 /**
+ * Whether the console satisfied the cell spec, before the first task.
+ *
+ * A batch that named no spec says so rather than leaving the section out: an
+ * experiment whose policy structurally could not offer the tool it exists to
+ * test reads, in every other part of this report, exactly like one whose model
+ * chose not to use it.
+ */
+const renderCellSpec = (preflight: CellSpecPreflight): string => {
+  if (preflight.kind === "unasked") {
+    return "This batch named no cell spec, so nothing here says the console " +
+      "offered the tools, subagent profiles, system prompt, space, or stores " +
+      "this experiment depends on. What the sessions ran under is recorded " +
+      "below; it is not checked against anything.\n";
+  }
+  if (preflight.kind === "matched") {
+    const asserted = Object.keys(preflight.spec).filter((field) =>
+      field !== "label"
+    ).sort();
+    return `Checked against the cell spec${
+      preflight.spec.label === undefined ? "" : ` \`${preflight.spec.label}\``
+    } before the first task, and every field it names held: ${
+      asserted.join(", ")
+    }. Fields the spec does not name are unchecked.\n`;
+  }
+  const lines = [
+    `**The console was not the cell this batch was told to measure, so no task ran.** ${preflight.reason}`,
+  ];
+  if (preflight.mismatches !== undefined) {
+    lines.push(
+      "",
+      ...preflight.mismatches.map((mismatch) =>
+        `- \`${mismatch.field}\`: expected ${mismatch.expected}, and this console reports ${mismatch.actual}`
+      ),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+};
+
+/**
  * Which task imported which published pattern.
  *
  * The count alone cannot tell one claim from another: composing a pattern an
@@ -1822,6 +1951,9 @@ export const renderBatchReport = (batch: BatchResult): string => {
     "## Did the console expose the measurement contract",
     "",
     renderConsolePreflight(batch.consolePreflight),
+    "## Was this the cell the batch was told to measure",
+    "",
+    renderCellSpec(batch.cellSpec),
     "## What the fabric server reported it was running",
     "",
     renderPosture(batch.posture),
@@ -1910,7 +2042,14 @@ export const main = async (
   postureReader: typeof preflightPosture = preflightPosture,
 ): Promise<number> => {
   const flags = parseArgs([...args], {
-    string: ["console", "out", "fabric-api-url", "base", "expect-git-sha"],
+    string: [
+      "console",
+      "out",
+      "fabric-api-url",
+      "base",
+      "expect-git-sha",
+      "cell-spec",
+    ],
     boolean: ["allow-diverged"],
     default: {
       console: DEFAULT_CONSOLE_URL,
@@ -1922,19 +2061,41 @@ export const main = async (
   const suitePath = flags._.map(String)[0];
   if (suitePath === undefined) {
     log(
-      "usage: measure-batch <suite.json> [--console=URL] [--out=DIR] [--allow-diverged]",
+      "usage: measure-batch <suite.json> [--console=URL] [--out=DIR] [--cell-spec=FILE] [--allow-diverged]",
     );
     return 2;
   }
   const suite = parseMeasurementSuite(
     JSON.parse(await Deno.readTextFile(suitePath)),
   );
+  // Both files are read and validated before a socket is opened, so a
+  // malformed spec costs nothing and a console that is not running is the only
+  // thing a reachability failure can mean.
+  const spec = flags["cell-spec"] === undefined
+    ? undefined
+    : parseCellSpec(JSON.parse(await Deno.readTextFile(flags["cell-spec"])));
   const client = await ConsoleClient.open(flags.console);
   const startedAt = new Date().toISOString();
   const consolePreflight = await client.preflightStatus();
   if (consolePreflight.kind === "refused") {
     log(
       `the console status contract was refused, so no task ran: ${consolePreflight.reason}`,
+    );
+  }
+  // Asked of the console before anything else it knows, because a cell whose
+  // policy cannot offer the tool an experiment exists to test spends every
+  // task producing evidence about a different experiment.
+  const cellSpec = consolePreflight.kind === "refused"
+    ? {
+      kind: "refused" as const,
+      reason:
+        "the console status pre-flight refused first, so the cell spec was not checked",
+      ...(spec !== undefined ? { spec } : {}),
+    }
+    : await preflightCellSpec(client, spec);
+  if (cellSpec.kind === "refused" && consolePreflight.kind !== "refused") {
+    log(
+      `the console is not the cell this batch names, so no task ran: ${cellSpec.reason}`,
     );
   }
   // The server's CFC block is recorded rather than differenced against the
@@ -1968,6 +2129,12 @@ export const main = async (
       reason:
         "the console status pre-flight refused first, so the index was not asked",
     }
+    : cellSpec.kind === "refused"
+    ? {
+      kind: "refused" as const,
+      reason:
+        "the cell spec pre-flight refused first, so the index was not asked",
+    }
     : posture.kind === "refused"
     ? {
       kind: "refused" as const,
@@ -1988,8 +2155,9 @@ export const main = async (
     )
     : await readSupersededVisibility(client, suite.supersededPatternIds ?? []);
   const results: TaskResult[] = [];
-  if (consolePreflight.kind === "refused") {
-    // The named refusal was logged when the status was read.
+  if (consolePreflight.kind === "refused" || cellSpec.kind === "refused") {
+    // Both refusals were logged where they were read, and each names what it
+    // found rather than the index question it stopped short of.
   } else if (preflight.kind === "refused") {
     log(`the index did not answer, so no task ran: ${preflight.reason}`);
   } else {
@@ -2032,6 +2200,7 @@ export const main = async (
     startedAt,
     endedAt: new Date().toISOString(),
     consolePreflight,
+    cellSpec,
     preflight,
     posture,
     importedPatternOrigins,
@@ -2060,6 +2229,7 @@ export const main = async (
   // and did not all complete: the first is a machine to fix before trying
   // again, the second is a result to read.
   if (consolePreflight.kind === "refused") return 5;
+  if (cellSpec.kind === "refused") return 6;
   if (posture.kind === "refused") return 4;
   if (preflight.kind === "refused") return 3;
   return results.every((result) => result.outcome.kind === "turn_completed")

--- a/packages/cf-harness/scripts/run-measurement-batch.ts
+++ b/packages/cf-harness/scripts/run-measurement-batch.ts
@@ -880,29 +880,43 @@ export class ConsoleClient {
     if (typeof answer !== "object" || answer === null) {
       return { error: "/api/policy did not return a JSON object" };
     }
+    // Every field is required, and the two nullable ones have to arrive as an
+    // explicit `null`. Reading a field the console never sent as "it has none"
+    // would pass a spec asserting `null` against a console that disclosed
+    // nothing, which is the vacuous check this pre-flight exists to remove.
     const report = answer as Record<string, unknown>;
     for (const field of ["allowedToolIds", "allowedSubagentProfiles"]) {
-      if (!Array.isArray(report[field])) {
-        return { error: `/api/policy is missing the ${field} array` };
+      const value = report[field];
+      if (
+        !Array.isArray(value) ||
+        value.some((entry) => typeof entry !== "string")
+      ) {
+        return {
+          error: `/api/policy did not report ${field} as a list of strings`,
+        };
       }
     }
     for (const field of ["fabricSpace", "artifactRoot"]) {
       if (typeof report[field] !== "string") {
-        return { error: `/api/policy is missing the ${field} field` };
+        return { error: `/api/policy did not report ${field} as a string` };
+      }
+    }
+    for (const field of ["systemPromptSha256", "sessionDbPath"]) {
+      if (report[field] !== null && typeof report[field] !== "string") {
+        return {
+          error:
+            `/api/policy did not report ${field} as a string or null, so this console said nothing about it`,
+        };
       }
     }
     return {
-      systemPromptSha256: typeof report.systemPromptSha256 === "string"
-        ? report.systemPromptSha256
-        : null,
+      systemPromptSha256: report.systemPromptSha256 as string | null,
       allowedToolIds: report.allowedToolIds as readonly string[],
       allowedSubagentProfiles: report
         .allowedSubagentProfiles as readonly string[],
       fabricSpace: report.fabricSpace as string,
       artifactRoot: report.artifactRoot as string,
-      sessionDbPath: typeof report.sessionDbPath === "string"
-        ? report.sessionDbPath
-        : null,
+      sessionDbPath: report.sessionDbPath as string | null,
     };
   }
 

--- a/packages/cf-harness/test/cell-spec.test.ts
+++ b/packages/cf-harness/test/cell-spec.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { ConsolePolicyReport } from "../console/policy.ts";
+import {
+  checkCellSpec,
+  describeCellSpecMismatches,
+  parseCellSpec,
+} from "../scripts/cell-spec.ts";
+
+/** What a correctly configured measurement console reports about itself. */
+const POLICY: ConsolePolicyReport = {
+  systemPromptSha256:
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  allowedToolIds: ["shell", "run_pattern", "search_patterns"],
+  allowedSubagentProfiles: ["default", "pattern-author"],
+  fabricSpace: "measurement",
+  artifactRoot: "/console/runs",
+  sessionDbPath: "/console/sessions.sqlite",
+};
+
+describe("cell-spec", () => {
+  describe("parseCellSpec()", () => {
+    it("returns only the fields the file carries", () => {
+      expect(parseCellSpec({ label: "phase 3", fabricSpace: "measurement" }))
+        .toEqual({ label: "phase 3", fabricSpace: "measurement" });
+    });
+
+    it("returns a spec whose `systemPromptSha256` is `null`, which asserts that no prompt is seeded", () => {
+      expect(parseCellSpec({ systemPromptSha256: null })).toEqual({
+        systemPromptSha256: null,
+      });
+    });
+
+    it("throws for a spec that is not a JSON object", () => {
+      expect(() => parseCellSpec(["measurement"])).toThrow(
+        "a cell spec must be a JSON object",
+      );
+    });
+
+    it("throws for a spec whose only field is its label, which checks nothing", () => {
+      expect(() => parseCellSpec({ label: "phase 3" })).toThrow(
+        "a cell spec asserts nothing",
+      );
+    });
+
+    it("throws for a field name nothing asserts", () => {
+      expect(() => parseCellSpec({ allowedTools: ["shell"] })).toThrow(
+        "names fields nothing asserts: allowedTools",
+      );
+    });
+
+    it("throws for a spec stating a tool set both as a whole and in parts", () => {
+      expect(() =>
+        parseCellSpec({
+          allowedToolIds: ["shell"],
+          requiredToolIds: ["run_pattern"],
+        })
+      ).toThrow("it is one or the other");
+    });
+
+    it("throws for a profile named as both required and forbidden", () => {
+      expect(() =>
+        parseCellSpec({
+          requiredSubagentProfiles: ["pattern-author"],
+          forbiddenSubagentProfiles: ["pattern-author"],
+        })
+      ).toThrow(
+        "as both requiredSubagentProfiles and forbiddenSubagentProfiles",
+      );
+    });
+
+    it("throws for a tool list holding something other than strings", () => {
+      expect(() => parseCellSpec({ requiredToolIds: [7] })).toThrow(
+        "requiredToolIds must be a list of strings",
+      );
+    });
+
+    it("throws for an empty space name, which asserts nothing while looking as though it does", () => {
+      expect(() => parseCellSpec({ fabricSpace: "  " })).toThrow(
+        "fabricSpace must be a non-empty string",
+      );
+    });
+  });
+
+  describe("checkCellSpec()", () => {
+    it("returns no mismatch for a spec every field of which the console satisfies", () => {
+      expect(
+        checkCellSpec({
+          fabricSpace: "measurement",
+          artifactRoot: "/console/runs",
+          sessionDbPath: "/console/sessions.sqlite",
+          systemPromptSha256: POLICY.systemPromptSha256,
+          requiredToolIds: ["run_pattern", "search_patterns"],
+          forbiddenToolIds: ["web_search"],
+          allowedSubagentProfiles: ["pattern-author", "default"],
+        }, POLICY),
+      ).toEqual([]);
+    });
+
+    it("returns no mismatch for an exact set given in another order", () => {
+      expect(
+        checkCellSpec({
+          allowedToolIds: ["search_patterns", "shell", "run_pattern"],
+        }, POLICY),
+      ).toEqual([]);
+    });
+
+    it("returns a mismatch naming the whole set on either side for an exact set the console does not hold", () => {
+      expect(checkCellSpec({ allowedToolIds: ["run_pattern"] }, POLICY))
+        .toEqual([{
+          field: "allowedToolIds",
+          expected: "run_pattern",
+          actual: "run_pattern, search_patterns, shell",
+        }]);
+    });
+
+    it("returns a mismatch naming only the missing ids for a must-include list", () => {
+      expect(checkCellSpec({ requiredToolIds: ["record_feedback"] }, POLICY))
+        .toEqual([{
+          field: "allowedToolIds (must include)",
+          expected: "at least record_feedback",
+          actual: "run_pattern, search_patterns, shell",
+        }]);
+    });
+
+    it("returns a mismatch naming only the offered ids for a must-exclude list", () => {
+      expect(
+        checkCellSpec({ forbiddenToolIds: ["shell", "web_search"] }, POLICY),
+      ).toEqual([{
+        field: "allowedToolIds (must exclude)",
+        expected: "none of shell",
+        actual: "run_pattern, search_patterns, shell",
+      }]);
+    });
+
+    it("returns a mismatch for a console seeding a prompt where the spec expects none", () => {
+      expect(checkCellSpec({ systemPromptSha256: null }, POLICY)).toEqual([{
+        field: "systemPromptSha256",
+        expected: "(none)",
+        actual: POLICY.systemPromptSha256,
+      }]);
+    });
+
+    it("returns a mismatch for a console holding no session store where the spec names one", () => {
+      expect(
+        checkCellSpec({ sessionDbPath: "/console/sessions.sqlite" }, {
+          ...POLICY,
+          sessionDbPath: null,
+        }),
+      ).toEqual([{
+        field: "sessionDbPath",
+        expected: "/console/sessions.sqlite",
+        actual: "(none)",
+      }]);
+    });
+
+    it("returns one mismatch per disagreeing field", () => {
+      expect(
+        checkCellSpec({
+          fabricSpace: "somewhere-else",
+          artifactRoot: "/elsewhere/runs",
+        }, POLICY).map((mismatch) => mismatch.field),
+      ).toEqual(["fabricSpace", "artifactRoot"]);
+    });
+  });
+
+  describe("describeCellSpecMismatches()", () => {
+    it("returns one clause per mismatch, each naming expected against actual", () => {
+      expect(
+        describeCellSpecMismatches(
+          checkCellSpec({ fabricSpace: "somewhere-else" }, POLICY),
+        ),
+      ).toBe(
+        "fabricSpace: expected somewhere-else; this console reports measurement",
+      );
+    });
+  });
+});

--- a/packages/cf-harness/test/cell-spec.test.ts
+++ b/packages/cf-harness/test/cell-spec.test.ts
@@ -76,6 +76,36 @@ describe("cell-spec", () => {
       );
     });
 
+    it("throws for a prompt digest that is neither a string nor `null`", () => {
+      expect(() => parseCellSpec({ systemPromptSha256: false })).toThrow(
+        "systemPromptSha256 must be a string or null",
+      );
+    });
+
+    it("throws for a session store path given as a number", () => {
+      expect(() => parseCellSpec({ sessionDbPath: 7 })).toThrow(
+        "sessionDbPath must be a string or null",
+      );
+    });
+
+    it("throws for an empty must-include list, which every console satisfies", () => {
+      expect(() => parseCellSpec({ requiredToolIds: [] })).toThrow(
+        "requiredToolIds is empty, which every console satisfies",
+      );
+    });
+
+    it("throws for an empty must-exclude profile list", () => {
+      expect(() => parseCellSpec({ forbiddenSubagentProfiles: [] })).toThrow(
+        "forbiddenSubagentProfiles is empty",
+      );
+    });
+
+    it("returns an empty whole set, which asserts that the policy offers nothing", () => {
+      expect(parseCellSpec({ allowedToolIds: [] })).toEqual({
+        allowedToolIds: [],
+      });
+    });
+
     it("throws for an empty space name, which asserts nothing while looking as though it does", () => {
       expect(() => parseCellSpec({ fabricSpace: "  " })).toThrow(
         "fabricSpace must be a non-empty string",
@@ -130,6 +160,14 @@ describe("cell-spec", () => {
       ).toEqual([{
         field: "allowedToolIds (must exclude)",
         expected: "none of shell",
+        actual: "run_pattern, search_patterns, shell",
+      }]);
+    });
+
+    it("returns a mismatch for a policy offering tools where the spec names an empty whole set", () => {
+      expect(checkCellSpec({ allowedToolIds: [] }, POLICY)).toEqual([{
+        field: "allowedToolIds",
+        expected: "(none)",
         actual: "run_pattern, search_patterns, shell",
       }]);
     });

--- a/packages/cf-harness/test/console/policy.test.ts
+++ b/packages/cf-harness/test/console/policy.test.ts
@@ -11,8 +11,8 @@ const INPUT = {
 };
 
 describe("consolePolicyReport()", () => {
-  it("returns the tools and profiles the policy names", async () => {
-    const report = await consolePolicyReport(INPUT);
+  it("returns the tools and profiles the policy names", () => {
+    const report = consolePolicyReport(INPUT);
 
     expect(report.allowedToolIds).toEqual([
       ...DEFAULT_HARNESS_CHAT_POLICY.allowedToolIds,
@@ -24,15 +24,15 @@ describe("consolePolicyReport()", () => {
     expect(report.artifactRoot).toBe("/console/runs");
   });
 
-  it("returns `null` for the prompt and the store a server was not given", async () => {
-    const report = await consolePolicyReport(INPUT);
+  it("returns `null` for the prompt and the store a server was not given", () => {
+    const report = consolePolicyReport(INPUT);
 
     expect(report.systemPromptSha256).toBeNull();
     expect(report.sessionDbPath).toBeNull();
   });
 
-  it("returns the prompt's SHA-256 and never its text", async () => {
-    const report = await consolePolicyReport({
+  it("returns the prompt's SHA-256 and never its text", () => {
+    const report = consolePolicyReport({
       ...INPUT,
       systemPrompt: "abc",
       sessionDbPath: "/console/sessions.sqlite",
@@ -45,9 +45,21 @@ describe("consolePolicyReport()", () => {
     expect(report.sessionDbPath).toBe("/console/sessions.sqlite");
   });
 
-  it("returns different digests for prompts differing by one character", async () => {
-    const one = await consolePolicyReport({ ...INPUT, systemPrompt: "abc" });
-    const other = await consolePolicyReport({ ...INPUT, systemPrompt: "abd" });
+  it("returns a digest over the prompt's UTF-8 bytes", () => {
+    // Both digests are what `shasum -a 256` prints for the same text, so an
+    // operator who takes one that way and pastes it into a cell spec gets a
+    // match. A prompt outside ASCII is what tells the encodings apart.
+
+    expect(consolePolicyReport({ ...INPUT, systemPrompt: "héllo" })).toEqual({
+      ...consolePolicyReport(INPUT),
+      systemPromptSha256:
+        "3c48591d8d098a4538f5e013dfcf406e948eac4d3277b10bf614e295d6068179",
+    });
+  });
+
+  it("returns different digests for prompts differing by one character", () => {
+    const one = consolePolicyReport({ ...INPUT, systemPrompt: "abc" });
+    const other = consolePolicyReport({ ...INPUT, systemPrompt: "abd" });
 
     expect(one.systemPromptSha256).not.toBe(other.systemPromptSha256);
   });

--- a/packages/cf-harness/test/console/policy.test.ts
+++ b/packages/cf-harness/test/console/policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { consolePolicyReport } from "../../console/policy.ts";
+import { DEFAULT_HARNESS_CHAT_POLICY } from "../../src/contracts/interactive-chat.ts";
+
+const INPUT = {
+  policy: DEFAULT_HARNESS_CHAT_POLICY,
+  fabricSpace: "measurement",
+  artifactRoot: "/console/runs",
+};
+
+describe("consolePolicyReport()", () => {
+  it("returns the tools and profiles the policy names", async () => {
+    const report = await consolePolicyReport(INPUT);
+
+    expect(report.allowedToolIds).toEqual([
+      ...DEFAULT_HARNESS_CHAT_POLICY.allowedToolIds,
+    ]);
+    expect(report.allowedSubagentProfiles).toEqual([
+      ...DEFAULT_HARNESS_CHAT_POLICY.allowedSubagentProfiles,
+    ]);
+    expect(report.fabricSpace).toBe("measurement");
+    expect(report.artifactRoot).toBe("/console/runs");
+  });
+
+  it("returns `null` for the prompt and the store a server was not given", async () => {
+    const report = await consolePolicyReport(INPUT);
+
+    expect(report.systemPromptSha256).toBeNull();
+    expect(report.sessionDbPath).toBeNull();
+  });
+
+  it("returns the prompt's SHA-256 and never its text", async () => {
+    const report = await consolePolicyReport({
+      ...INPUT,
+      systemPrompt: "abc",
+      sessionDbPath: "/console/sessions.sqlite",
+    });
+
+    expect(report.systemPromptSha256).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    expect(JSON.stringify(report)).not.toContain("abc");
+    expect(report.sessionDbPath).toBe("/console/sessions.sqlite");
+  });
+
+  it("returns different digests for prompts differing by one character", async () => {
+    const one = await consolePolicyReport({ ...INPUT, systemPrompt: "abc" });
+    const other = await consolePolicyReport({ ...INPUT, systemPrompt: "abd" });
+
+    expect(one.systemPromptSha256).not.toBe(other.systemPromptSha256);
+  });
+});

--- a/packages/cf-harness/test/console/server.test.ts
+++ b/packages/cf-harness/test/console/server.test.ts
@@ -689,6 +689,31 @@ describe("console/server", () => {
     });
   });
 
+  describe("GET /api/policy", () => {
+    it("returns what a session started here would run under, before any session exists", async () => {
+      const response = await server.handle(
+        getRequest("/api/policy", { cookie }),
+      );
+
+      expect(response.status).toBe(200);
+      const policy = consoleChatPolicy(false, false);
+      expect(await response.json()).toEqual({
+        systemPromptSha256: null,
+        allowedToolIds: [...policy.allowedToolIds],
+        allowedSubagentProfiles: [...policy.allowedSubagentProfiles],
+        fabricSpace: config().fabricSession.space,
+        artifactRoot: config().artifactRoot,
+        sessionDbPath: null,
+      });
+    });
+
+    it("answers 403 without the token, as the route carrying the same policy on a session does", async () => {
+      const response = await server.handle(getRequest("/api/policy"));
+
+      expect(response.status).toBe(403);
+    });
+  });
+
   describe("GET /api/health", () => {
     it("reports the configured Fabric API and unverified session liveness without a token", async () => {
       const response = await server.handle(getRequest("/api/health"));

--- a/packages/cf-harness/test/run-measurement-batch.test.ts
+++ b/packages/cf-harness/test/run-measurement-batch.test.ts
@@ -11,6 +11,7 @@ import {
   type IndexPreflight,
   type IndexSnapshot,
   parseMeasurementSuite,
+  preflightCellSpec,
   preflightPosture,
   readAncestry,
   readServerMeta,
@@ -41,9 +42,13 @@ const CONSOLE_PREFLIGHT = {
 };
 
 const renderBatchReport = (
-  batch: Omit<BatchResult, "consolePreflight">,
+  batch: Omit<BatchResult, "consolePreflight" | "cellSpec">,
 ): string =>
-  renderBatchReportImpl({ ...batch, consolePreflight: CONSOLE_PREFLIGHT });
+  renderBatchReportImpl({
+    ...batch,
+    consolePreflight: CONSOLE_PREFLIGHT,
+    cellSpec: { kind: "unasked" },
+  });
 
 const TOKEN = "cf_harness_console_token=fixture-token";
 
@@ -130,6 +135,12 @@ interface FakeConsoleOptions {
 
   /** What `/api/meta` answers, standing in for the fabric server. */
   meta?: unknown;
+
+  /**
+   * What `/api/policy` answers, or `null` for a console that does not serve
+   * the route at all.
+   */
+  policy?: unknown;
 
   /** What `getPattern` reports each pattern depends on. */
   dependencies?: Readonly<Record<string, readonly string[]>>;
@@ -231,6 +242,11 @@ const startFakeConsole = (options: FakeConsoleOptions): FakeConsole => {
         }],
       });
     }
+    if (url.pathname === "/api/policy") {
+      return options.policy === null
+        ? new Response("not found", { status: 404 })
+        : Response.json(options.policy ?? POLICY);
+    }
     if (url.pathname === "/api/index/call") {
       if (options.indexFault) {
         return new Response(
@@ -298,6 +314,17 @@ const patternOf = (
   score,
   events: { published: 1 },
 });
+
+/** What the stand-in console says a session started there would run under. */
+const POLICY = {
+  systemPromptSha256:
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  allowedToolIds: ["shell", "run_pattern", "search_patterns"],
+  allowedSubagentProfiles: ["default", "pattern-author"],
+  fabricSpace: "measurement",
+  artifactRoot: "/console/runs",
+  sessionDbPath: "/console/sessions.sqlite",
+};
 
 const META = {
   gitSha: "7baa03f462e5a1e4b5e477bd2162c880c5e5bc4a",
@@ -1364,6 +1391,89 @@ describe("run-measurement-batch", () => {
     });
   });
 
+  describe("preflightCellSpec()", () => {
+    const withClient = async (
+      options: FakeConsoleOptions,
+      body: (client: ConsoleClient) => Promise<void>,
+    ): Promise<void> => {
+      const console_ = startFakeConsole(options);
+      try {
+        await body(await ConsoleClient.open(console_.url));
+      } finally {
+        await console_.close();
+      }
+    };
+
+    it("returns `unasked` for a batch that named no spec", async () => {
+      await withClient({ streams: [] }, async (client) => {
+        expect(await preflightCellSpec(client, undefined)).toEqual({
+          kind: "unasked",
+        });
+      });
+    });
+
+    it("returns a match for a spec every field of which the console satisfies", async () => {
+      await withClient({ streams: [] }, async (client) => {
+        const spec = {
+          requiredToolIds: ["run_pattern", "search_patterns"],
+          requiredSubagentProfiles: ["pattern-author"],
+          fabricSpace: "measurement",
+        };
+        const preflight = await preflightCellSpec(client, spec);
+        expect(preflight.kind).toBe("matched");
+      });
+    });
+
+    it("returns a refusal naming each mismatched field with expected against actual", async () => {
+      await withClient({ streams: [] }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          fabricSpace: "other-space",
+          requiredToolIds: ["record_feedback"],
+          forbiddenToolIds: ["shell"],
+        });
+        expect(preflight.kind).toBe("refused");
+        const mismatches = preflight.kind === "refused"
+          ? preflight.mismatches ?? []
+          : [];
+        expect(mismatches.map((mismatch) => mismatch.field)).toEqual([
+          "fabricSpace",
+          "allowedToolIds (must include)",
+          "allowedToolIds (must exclude)",
+        ]);
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "expected other-space; this console reports measurement",
+        );
+      });
+    });
+
+    it("returns a refusal for a console that does not serve the policy route", async () => {
+      await withClient({ streams: [], policy: null }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          fabricSpace: "measurement",
+        });
+        expect(preflight.kind).toBe("refused");
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "/api/policy could not be read",
+        );
+      });
+    });
+
+    it("returns a refusal for a policy answer carrying no tool list", async () => {
+      await withClient({
+        streams: [],
+        policy: { fabricSpace: "measurement", artifactRoot: "/console/runs" },
+      }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          fabricSpace: "measurement",
+        });
+        expect(preflight.kind).toBe("refused");
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "missing the allowedToolIds array",
+        );
+      });
+    });
+  });
+
   describe("preflightIndex()", () => {
     it("returns the result and candidate counts for an index that answered", async () => {
       const console_ = startFakeConsole({ streams: [completedStream()] });
@@ -2058,6 +2168,107 @@ describe("run-measurement-batch", () => {
       } finally {
         // the directory is removed by this block's afterEach
       }
+    });
+
+    /** Writes a cell spec beside the suite and points the command at it. */
+    const cellSpecArgs = async (
+      dir: string,
+      spec: unknown,
+    ): Promise<readonly string[]> => {
+      const path = `${dir}/cell.json`;
+      await Deno.writeTextFile(path, JSON.stringify(spec));
+      return [`--cell-spec=${path}`];
+    };
+
+    it("returns 6, starts no task, and names each mismatch when the console is not the cell", async () => {
+      const specDir = await Deno.makeTempDir();
+      temporaryDirectories.push(specDir);
+      const args = await cellSpecArgs(specDir, {
+        label: "phase 3",
+        fabricSpace: "somewhere-else",
+        forbiddenSubagentProfiles: ["pattern-author"],
+      });
+      const { code, dir, logs } = await runMain(
+        { streams: [completedStream()] },
+        ONE_TASK,
+        args,
+      );
+      expect(code).toBe(6);
+      const report = await Deno.readTextFile(`${dir}/out/report.md`);
+      expect(report).toContain(
+        "**The console was not the cell this batch was told to measure, so no task ran.**",
+      );
+      expect(report).toContain(
+        "`fabricSpace`: expected somewhere-else, and this console reports measurement",
+      );
+      expect(report).toContain(
+        "`allowedSubagentProfiles (must exclude)`: expected none of pattern-author",
+      );
+      expect(report).toContain(
+        "the cell spec pre-flight refused first, so the index was not asked",
+      );
+      expect(
+        logs.some((line) =>
+          line.includes("the console is not the cell this batch names")
+        ),
+      ).toBe(true);
+      const json = JSON.parse(
+        await Deno.readTextFile(`${dir}/out/report.json`),
+      );
+      expect(json.results).toHaveLength(0);
+    });
+
+    it("returns 0 and records which fields were checked when the console satisfies the spec", async () => {
+      const specDir = await Deno.makeTempDir();
+      temporaryDirectories.push(specDir);
+      const args = await cellSpecArgs(specDir, {
+        label: "phase 3",
+        fabricSpace: "measurement",
+        requiredToolIds: ["run_pattern", "search_patterns"],
+        requiredSubagentProfiles: ["pattern-author"],
+        systemPromptSha256: POLICY.systemPromptSha256,
+        sessionDbPath: POLICY.sessionDbPath,
+      });
+      const { code, dir } = await runMain(
+        {
+          streams: [completedStream()],
+          runId: "fixture-run",
+          artifactRoot: FIXTURE_ROOT,
+        },
+        ONE_TASK,
+        args,
+      );
+      expect(code).toBe(0);
+      const report = await Deno.readTextFile(`${dir}/out/report.md`);
+      expect(report).toContain("Checked against the cell spec `phase 3`");
+      expect(report).toContain("fabricSpace");
+      expect(report).toContain("Fields the spec does not name are unchecked.");
+    });
+
+    it("returns 6 when a spec was named and the console will not disclose its policy", async () => {
+      const specDir = await Deno.makeTempDir();
+      temporaryDirectories.push(specDir);
+      const args = await cellSpecArgs(specDir, { fabricSpace: "measurement" });
+      const { code, dir } = await runMain(
+        {
+          streams: [completedStream()],
+          policy: null,
+        },
+        ONE_TASK,
+        args,
+      );
+      expect(code).toBe(6);
+      const report = await Deno.readTextFile(`${dir}/out/report.md`);
+      expect(report).toContain("would not say what a session here runs under");
+    });
+
+    it("throws for a spec that asserts nothing, before any socket is opened", async () => {
+      const specDir = await Deno.makeTempDir();
+      temporaryDirectories.push(specDir);
+      const args = await cellSpecArgs(specDir, { label: "asserts nothing" });
+      await expect(
+        runMain({ streams: [completedStream()] }, ONE_TASK, args),
+      ).rejects.toThrow("a cell spec asserts nothing");
     });
 
     it("returns 4 and does not ask the index when the server is not the expected commit", async () => {

--- a/packages/cf-harness/test/run-measurement-batch.test.ts
+++ b/packages/cf-harness/test/run-measurement-batch.test.ts
@@ -1468,8 +1468,87 @@ describe("run-measurement-batch", () => {
         });
         expect(preflight.kind).toBe("refused");
         expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
-          "missing the allowedToolIds array",
+          "did not report allowedToolIds as a list of strings",
         );
+      });
+    });
+
+    it("returns a refusal for a policy answer that is not a JSON object", async () => {
+      await withClient(
+        { streams: [], policy: "measurement" },
+        async (client) => {
+          const preflight = await preflightCellSpec(client, {
+            fabricSpace: "measurement",
+          });
+          expect(preflight.kind).toBe("refused");
+          expect(preflight.kind === "refused" ? preflight.reason : "")
+            .toContain(
+              "did not return a JSON object",
+            );
+        },
+      );
+    });
+
+    it("returns a refusal for a tool list holding something other than strings", async () => {
+      await withClient({
+        streams: [],
+        policy: { ...POLICY, allowedToolIds: ["shell", 7] },
+      }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          fabricSpace: "measurement",
+        });
+        expect(preflight.kind).toBe("refused");
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "did not report allowedToolIds as a list of strings",
+        );
+      });
+    });
+
+    it("returns a refusal for a policy answer naming no space", async () => {
+      await withClient({
+        streams: [],
+        policy: { ...POLICY, fabricSpace: undefined },
+      }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          fabricSpace: "measurement",
+        });
+        expect(preflight.kind).toBe("refused");
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "did not report fabricSpace as a string",
+        );
+      });
+    });
+
+    it("refuses a spec asserting no prompt against a console that left the field out, rather than reading it as none", async () => {
+      // Absent and `null` are the same value to a reader that coerces, and
+      // they are different facts: one console says it seeds no prompt, the
+      // other says nothing at all.
+
+      await withClient({
+        streams: [],
+        policy: { ...POLICY, systemPromptSha256: undefined },
+      }, async (client) => {
+        const preflight = await preflightCellSpec(client, {
+          systemPromptSha256: null,
+        });
+        expect(preflight.kind).toBe("refused");
+        expect(preflight.kind === "refused" ? preflight.reason : "").toContain(
+          "this console said nothing about it",
+        );
+      });
+    });
+
+    it("returns a match for a console that reported an explicit `null` prompt and store", async () => {
+      await withClient({
+        streams: [],
+        policy: { ...POLICY, systemPromptSha256: null, sessionDbPath: null },
+      }, async (client) => {
+        expect(
+          (await preflightCellSpec(client, {
+            systemPromptSha256: null,
+            sessionDbPath: null,
+          })).kind,
+        ).toBe("matched");
       });
     });
   });


### PR DESCRIPTION
## Why

Four experiment cells were voided in one day by conditions assembled by hand and verified only after the fact: a console whose policy structurally could not offer the tool under test, a CLI run silently substituting the wrong subagent profile, two consoles sharing a store, a prompt condition assumed rather than checked. Analysts do these parity checks by reading artifacts after the batch has spent its runs. This moves the checkable parts before task 1.

## What

- `--cell-spec <path>`: JSON, every field optional, every present field asserted — seeded-system-prompt SHA-256 (or null for none), allowed tools (whole set, or required/forbidden lists), subagent profiles (same three forms), fabric space, artifact root, session store path (null = in-memory). A spec asserting nothing is refused: a check that checks nothing is indistinguishable from one that passed.
- Mismatch: exit 6, no task started, every disagreeing field named expected-vs-actual.
- New `GET /api/policy` on the console disclosing what a new session would run under; shares one policy expression with `/api/task` so it describes the sessions that actually run. Token-gated like `/api/status` (it carries the space name and two host paths); the prompt crosses as a digest only.
- Docs: console README route table + policy-route reasoning; measurement doc gains the field table and an honest list of what stays unverifiable pre-run (tool backing, skills root, store exclusivity, path aliasing).

## Tests

`test/cell-spec.test.ts`, `test/console/policy.test.ts`, plus blocks in the runner and server tests. Fixtures only; no live services; no sleeps.

Gates: `deno fmt --check` / `deno lint` clean, cf-harness `deno task test` 915 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

