### PR TITLE
fix(dashboard): chart known zero-spend days

### DIFF
--- a/packages/dashboard/spend.ts
+++ b/packages/dashboard/spend.ts
@@ -227,6 +227,9 @@ export function spendChart(
   for (const source of sources) {
     if (source.spend) {
       for (const day of source.spend.byDay.keys()) allDays.add(day);
+      if (source.spend.byDay.size > 0 && source.knownMonths) {
+        for (const month of source.knownMonths) allDays.add(`${month}-01`);
+      }
     }
   }
   if (allDays.size < 2) return { chart: "", duration: 0 };

--- a/packages/dashboard/test/spend.test.ts
+++ b/packages/dashboard/test/spend.test.ts
@@ -178,6 +178,26 @@ describe("spend", () => {
     expect(december[0]).toBeGreaterThan(lines[0][10][1]);
   });
 
+  it("starts at known quiet days before the first spend row", () => {
+    const github = source(
+      run("2026-08-18", 15, 1),
+      2,
+      "#58a6ff",
+      ["2026-07", "2026-08", "2026-09"],
+    );
+    const { chart, duration } = spendChart(
+      [github],
+      new Date("2026-09-02T09:00:00Z"),
+      "good",
+      14,
+    );
+    expect(duration).toBe(45 * DAY);
+    const lines = polylines(chart);
+    expect(lines.length).toBe(2);
+    expect(lines[0].length).toBe(45);
+    expect(lines[1].length).toBe(14);
+  });
+
   it("holds a highlight to the days its source reports on", () => {
     const github = source(
       [...NOVEMBER, ...JANUARY],
@@ -222,7 +242,8 @@ describe("spend", () => {
 
   it("marks a day both its neighbors are missing", () => {
     // On 3 January a 2-day lag reaches 1 January, so the January side of the
-    // hole is a single day with nothing to join it to.
+    // hole is a single day with nothing to join it to. The 45-day window opens
+    // on 18 November, whose report makes its first two quiet days real zeros.
     const github = source(
       [...NOVEMBER, ...run("2026-01-01", 1, 2)],
       2,
@@ -237,12 +258,12 @@ describe("spend", () => {
     const lines = polylines(chart);
     // November is the only run of days long enough to draw a line through.
     expect(lines.length).toBe(1);
-    expect(lines[0].length).toBe(11);
+    expect(lines[0].length).toBe(13);
     // 1 January is drawn as a point of its own at the chart's right edge.
     const points = markers(chart);
     expect(points.length).toBe(1);
     expect(points[0][0]).toBe(220);
     // It sits above the $1 November days, at its own $2.
-    expect(points[0][1]).toBeLessThan(lines[0][10][1]);
+    expect(points[0][1]).toBeLessThan(lines[0][12][1]);
   });
 });

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -466,6 +466,7 @@ export const githubCiSpend: Tile = {
         }],
         now,
         status,
+        spend.estimateDays,
       );
       const amount = chart.chart ? "" : ` ${usd(spend.mtd)}`;
       // The ceiling shown beside the headline covers the products the headline


### PR DESCRIPTION
GitHub billing reports omit rows for days without billable usage. The shared spend chart therefore used the first charged day as its left edge, even when earlier months had been read successfully. This made the GitHub spend tile show only 14 days for current data.

Anchor each non-empty source to the starts of its known report months. Existing known-month filtering and the 45-day cap then fill quiet days with zero without inventing data for unread months. Pass GitHub's projection window to the chart so the highlighted tail matches the headline calculation.

A shared spend-chart regression covers 45 displayed days and 14 highlighted days when spending begins partway through the available history. Verified with dashboard tests, browser tests, repository formatting and lint, and the full type check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

