### PR TITLE
fix(test-selection): hold each lane to its own budget

### DIFF
--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1645,9 +1645,9 @@ lanes times 230 seconds each, it fills in four passes.
    no history. An item excluded above comes back into this pass if the
    change touches what it covers, since that is very likely a fix. Every
    item taken here leaves the selectable set, so no later pass can run one
-   of them again. This pass can in principle exceed the budget; when it
-   does, the runner says so in the job summary rather than silently
-   dropping work.
+   of them again. This pass can in principle put a lane past its budget;
+   when it does, the runner says in the job summary how far past, rather
+   than silently dropping work.
 2. **Value first, 60 percent of the remaining budget.** Items in
    descending order of value, ignoring cost. This is what gets the
    expensive, genuinely broken integration test into the run.
@@ -1664,8 +1664,9 @@ behind 40 seconds of setup correctly loses to 40 seconds of tests that
 need nothing.
 
 Repeats are applied last, to items already selected, and are charged their
-full cost. An item that would be repeated but no longer fits runs once
-rather than being dropped: one observation beats none.
+full cost. An item that would be repeated but no longer fits gives up runs
+until it does, down to one, rather than being dropped: one observation
+beats none.
 
 ### Filling the lanes
 
@@ -1678,10 +1679,33 @@ cheapest place to put the next batch that needs it. That is the mechanism
 by which "tests needing the same environment are grouped together" falls
 out of the packing rather than being a special case in it.
 
+The cheapest lane is chosen from among the lanes that can still hold the
+work, which is what makes the 230 seconds a constraint on the packing
+rather than a figure it aims at. When the cheapest lane is full the item
+goes to the next-cheapest one with room for it, so a suite whose overhead
+one lane has already paid collects that lane's share of the suite and no
+more. Each pass spends a share of the whole run's budget and no lane
+passes its own, so the packing ends with all five lanes close to 230
+seconds, and what the pull request waits on is 230 seconds rather than
+whichever lane the grouping favored.
+
+The mandatory pass is the one allowed past a lane's budget. It takes its
+items largest first, so an item filling most of a lane is offered the
+lanes that are still empty; an item offered lanes that are already full
+has nowhere to go but past one lane's budget. When a mandatory item fits
+in no lane it goes where the lane's finishing time rises least, which
+spreads an unavoidable overrun across the five rather than settling it on
+one.
+
 A batch that on its own exceeds a lane's budget is split, paying its
 suite's setup twice. A single *item* cannot be split, so an item costing
 more than the planned budget is given a lane to itself and allowed to run
-up to the hard five-minute bound rather than the planned 230 seconds.
+up to the hard five-minute bound rather than the planned 230 seconds. The
+lane carrying it carries nothing else, because everything else would have
+to fit in what is left under the planned budget and there is nothing left.
+Repeats get no such lane, since a repeat is what an item gives up to fit:
+an item wanting three runs of a hundred seconds runs twice inside the
+planned budget rather than three times inside the bound.
 
 The refreshed census finds one item that does not fit. The `piece-call`
 dispatch section of `packages/cli/integration/integration.sh` took 386

--- a/docs/plans/pull-request-test-selection.md
+++ b/docs/plans/pull-request-test-selection.md
@@ -1684,10 +1684,13 @@ work, which is what makes the 230 seconds a constraint on the packing
 rather than a figure it aims at. When the cheapest lane is full the item
 goes to the next-cheapest one with room for it, so a suite whose overhead
 one lane has already paid collects that lane's share of the suite and no
-more. Each pass spends a share of the whole run's budget and no lane
-passes its own, so the packing ends with all five lanes close to 230
-seconds, and what the pull request waits on is 230 seconds rather than
-whichever lane the grouping favored.
+more. The value, density and exploration passes each spend a share of the
+whole run's budget, and none of the three puts a lane past its own. The
+corpus holds far more than a run can fit, so between them those passes
+fill every lane, and what the pull request waits on is 230 seconds rather
+than whichever lane the grouping favored. Two things are allowed past a
+lane's budget, and the next two paragraphs are about them: the mandatory
+pass, and an item costing more than a whole lane.
 
 The mandatory pass is the one allowed past a lane's budget. It takes its
 items largest first, so an item filling most of a lane is offered the

--- a/tasks/test-selection.ts
+++ b/tasks/test-selection.ts
@@ -307,8 +307,8 @@ export function planLines(
   }
   if (result.overBudgetSeconds > 0) {
     lines.push(
-      `the mandatory set alone overran by ` +
-        `${result.overBudgetSeconds.toFixed(1)}s`,
+      `the mandatory set alone puts a lane ` +
+        `${result.overBudgetSeconds.toFixed(1)}s past its budget`,
     );
   }
   for (const entry of result.unschedulable) {

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -2,8 +2,14 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { testIdentityKey } from "@commonfabric/test-support/records";
 
-import { plan, type PlanInput, seededOrder, type Selection } from "./plan.ts";
-import type { Manifest, ManifestEntry } from "./manifest.ts";
+import {
+  plan,
+  type PlanInput,
+  seededOrder,
+  type Selection,
+  type SelectionReason,
+} from "./plan.ts";
+import type { Calibration, Manifest, ManifestEntry } from "./manifest.ts";
 import { sampleEntry, sampleManifest } from "./testing.ts";
 import { LANES, VALUE_FLOOR } from "./policy.ts";
 
@@ -42,6 +48,16 @@ function selected(result: ReturnType<typeof plan>): Selection[] {
 
 function keysOf(result: ReturnType<typeof plan>): string[] {
   return selected(result).map((s) => testIdentityKey(s.entry.test)).sort();
+}
+
+/** Every identity of a manifest, mandatory, in the manifest's own order. */
+function everything(manifest: Manifest): Map<string, SelectionReason> {
+  return new Map(
+    manifest.entries.map((entry) => [
+      testIdentityKey(entry.test),
+      "changed" as const,
+    ]),
+  );
 }
 
 describe("plan", () => {
@@ -102,14 +118,26 @@ describe("plan", () => {
       const manifest = sampleManifest({
         entries: entries(4, () => ({ cost: 100 })),
       });
-      const mandatory = new Map(
-        manifest.entries.map((entry) =>
-          [testIdentityKey(entry.test), "changed" as const] as const
-        ),
-      );
-      const result = run(manifest, { mandatory, budgetSeconds: 10 });
-      expect(result.overBudgetSeconds).toBeCloseTo(350, 6);
+      const result = run(manifest, {
+        mandatory: everything(manifest),
+        budgetSeconds: 10,
+      });
+      expect(result.overBudgetSeconds).toBeCloseTo(90, 6);
       expect(selected(result).length).toBe(4);
+    });
+
+    it("says a lane is past its budget where the run's total fits", () => {
+      // Six identities at 120 seconds, in five lanes of 230. The six fit
+      // the run's 1,150 seconds between them, and the sixth still fits no
+      // lane: five of them are carrying 120 seconds each already.
+      const manifest = sampleManifest({
+        entries: entries(6, () => ({ cost: 120 })),
+      });
+      const result = run(manifest, {
+        mandatory: everything(manifest),
+        budgetSeconds: 230,
+      });
+      expect(result.overBudgetSeconds).toBeCloseTo(10, 6);
     });
   });
 
@@ -203,6 +231,101 @@ describe("plan", () => {
       const result = run(manifest, { lanes: 1, budgetSeconds: 4 });
       expect(selected(result).length).toBe(3);
       expect(selected(result).every((s) => s.repeats >= 1)).toBe(true);
+    });
+  });
+
+  describe("the lane budget", () => {
+    // A suite charging an overhead every lane that opens it pays. That is
+    // what makes the lane which has already paid it the cheapest place
+    // for the rest of the suite, and so what a per-lane budget has to
+    // overrule.
+    const grouped: Calibration = {
+      setupCost: {},
+      suites: { "workspace-unit": { overhead: 10, correction: 1 } },
+      unitOverhead: {},
+      prologue: 0,
+    };
+
+    it("gives no lane more work than one lane's budget", () => {
+      const manifest = sampleManifest({
+        entries: entries(500, () => ({ cost: 1 })),
+        calibration: grouped,
+      });
+      for (const lane of run(manifest, { budgetSeconds: 20 }).lanes) {
+        expect(lane.projectedSeconds).toBeLessThanOrEqual(20);
+      }
+    });
+
+    it("fills every lane rather than one lane five times over", () => {
+      const manifest = sampleManifest({
+        entries: entries(500, () => ({ cost: 1 })),
+        calibration: grouped,
+      });
+      for (const lane of run(manifest, { budgetSeconds: 40 }).lanes) {
+        expect(lane.projectedSeconds).toBeCloseTo(40, 6);
+      }
+    });
+
+    it("gives an identity larger than a lane's budget a lane to itself", () => {
+      const manifest = sampleManifest({
+        entries: entries(60, (i) => (i === 0 ? { cost: 250 } : { cost: 1 })),
+        calibration: grouped,
+      });
+      const result = run(manifest, { budgetSeconds: 230, boundSeconds: 300 });
+      const alone = result.lanes.find((lane) =>
+        lane.selections.some((s) => s.entry.test.n === "case 0")
+      )!;
+      expect(alone.selections.length).toBe(1);
+      expect(alone.projectedSeconds).toBeCloseTo(260, 6);
+    });
+
+    it("holds a repeated identity to the budget rather than the bound", () => {
+      // The lane to itself is for an identity that cannot be split. Three
+      // runs of a hundred seconds do not fit a lane's budget and two do,
+      // so the identity gives up a run rather than the lane its budget.
+      const manifest = sampleManifest({
+        entries: entries(1, () => ({ cost: 100, repeats: 3 })),
+      });
+      const result = run(manifest, { budgetSeconds: 230, boundSeconds: 300 });
+      expect(selected(result)[0]!.repeats).toBe(2);
+      expect(result.lanes[0]!.projectedSeconds).toBeCloseTo(200, 6);
+    });
+
+    it("takes the largest mandatory identity before the small ones", () => {
+      // Nine identities that between them fill most of the lanes, and one
+      // costing most of a lane on its own. Taken in the order the caller
+      // listed them, the nine leave the tenth no lane it fits inside;
+      // taken largest first, all ten fit.
+      const manifest = sampleManifest({
+        entries: entries(10, (i) => (i === 9 ? { cost: 90 } : { cost: 18 })),
+      });
+      const result = run(manifest, {
+        mandatory: everything(manifest),
+        budgetSeconds: 100,
+      });
+      expect(selected(result).length).toBe(10);
+      for (const lane of result.lanes) {
+        expect(lane.projectedSeconds).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it("spreads a mandatory set no lane can hold over all of them", () => {
+      // Twenty identities that must run, costing between them nearly
+      // twice what the five lanes hold. Each lane carries four of them,
+      // rather than one lane carrying the whole overrun.
+      const manifest = sampleManifest({
+        entries: entries(20, () => ({ cost: 30 })),
+        calibration: grouped,
+      });
+      const result = run(manifest, {
+        mandatory: everything(manifest),
+        budgetSeconds: 70,
+      });
+      for (const lane of result.lanes) {
+        expect(lane.selections.length).toBe(4);
+        expect(lane.projectedSeconds).toBeCloseTo(130, 6);
+      }
+      expect(result.overBudgetSeconds).toBeCloseTo(60, 6);
     });
   });
 

--- a/tasks/test-selection/plan.test.ts
+++ b/tasks/test-selection/plan.test.ts
@@ -68,6 +68,11 @@ describe("plan", () => {
       expect(result.lanes.map((lane) => lane.lane)).toEqual([1, 2, 3, 4, 5]);
     });
 
+    it("refuses to pack into no lanes at all", () => {
+      const manifest = sampleManifest({ entries: entries(3) });
+      expect(() => run(manifest, { lanes: 0 })).toThrow(RangeError);
+    });
+
     it("puts no identity in two lanes", () => {
       const result = run(sampleManifest({ entries: entries(200) }));
       const keys = keysOf(result);

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -315,14 +315,15 @@ function place(
  * ordering. Then exploration, so the unselected corpus keeps producing
  * data.
  *
- * What each pass may spend is a share of the whole run's budget rather
- * than of each lane's, so an expensive test can have a lane to itself
- * while the others carry the tail. What keeps any one lane from running
- * long is separate from the shares: a lane takes no work past its own
- * budget, and the lane that carries an identity costing more than a whole
- * lane's budget carries that identity and nothing else. The two together
- * are what make every lane finish near the budget, which is the number
- * the pull request waits on.
+ * What the last three passes may spend is a share of the whole run's
+ * budget rather than of each lane's, so an expensive test can have a lane
+ * to itself while the others carry the tail. What keeps any one lane from
+ * running long is separate from the shares: those three passes put no
+ * work in a lane past that lane's budget, and the lane that carries an
+ * identity costing more than a whole lane's budget carries that identity
+ * and nothing else. Together they make every lane finish near the budget,
+ * which is the number the pull request waits on. The mandatory pass is
+ * bounded by neither, and reports how far past a lane it went.
  */
 export function plan(input: PlanInput): Plan {
   const manifest = input.manifest;

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -54,7 +54,12 @@ export interface LaneAssignment {
   lane: number;
   selections: Selection[];
 
-  /** Seconds of work this lane is expected to take, setup included. */
+  /**
+   * Seconds of work this lane is expected to take, setup included. It
+   * stops at the lane budget, except for a lane holding a single identity
+   * costing more than that, which runs up to the hard bound, and for a
+   * mandatory set that fits in no lane, which `overBudgetSeconds` reports.
+   */
   projectedSeconds: number;
 
   /** The capabilities its batches need, in a stable order. */
@@ -68,7 +73,13 @@ export interface Plan {
   /** Identities the manifest withheld, so a lane can say why. */
   withheld: Manifest["withheld"];
 
-  /** Set when the mandatory pass alone did not fit. */
+  /**
+   * Seconds by which the mandatory pass alone put the longest lane past a
+   * lane's budget, and zero where every lane held what it was given. The
+   * longest lane is what a pull request waits on, which is why this is
+   * that figure rather than the amount the five lanes' total was overrun
+   * by.
+   */
   overBudgetSeconds: number;
 
   /**
@@ -206,72 +217,118 @@ function marginalCost(
   return cost;
 }
 
-function place(
-  input: PlanInput,
-  lanes: Filling[],
-  entry: ManifestEntry,
-  reason: SelectionReason,
-  repeats: number,
-): number {
-  // Longest-processing-time scheduling: the cheapest lane to add this to
-  // wins, which is what makes tests needing the same environment group
-  // together rather than being a special case in the packer.
-  let best = lanes[0]!;
-  let bestCost = marginalCost(input.manifest, input, best, entry, repeats);
-  for (const lane of lanes.slice(1)) {
-    const cost = marginalCost(input.manifest, input, lane, entry, repeats);
-    if (cost < bestCost || (cost === bestCost && lane.load < best.load)) {
-      best = lane;
-      bestCost = cost;
-    }
-  }
-  best.selections.push({ entry, reason, repeats });
-  best.load += bestCost;
-  best.suites.add(entry.suite);
-  best.units.add(entry.unit);
-  for (const capability of input.capabilities.get(entry.suite) ?? []) {
-    best.capabilities.add(capability);
-  }
-  return bestCost;
+/** A lane an identity could go in, and what it would cost there. */
+interface Spot {
+  lane: Filling;
+  cost: number;
 }
 
 /**
- * Whether a lane could take this identity without going past the share of
- * the total budget this pass is allowed. The passes are bounded by shares
- * of the whole rather than per lane, so an expensive test can have a lane
- * to itself while the others carry the tail.
+ * What a lane may hold. A lane running one identity once and nothing else
+ * may go up to the hard bound, which is where an identity costing more
+ * than a whole lane's budget runs: it cannot be split, so a lane to
+ * itself is the only place it goes. A repeat can be split — dropping one
+ * run of it is what `fill` does — so a lane repeating an identity stops
+ * at the budget like any other.
  */
-function fits(
+function capacity(
+  lane: Filling,
+  repeats: number,
+  laneBudget: number,
+  bound: number,
+): number {
+  return lane.selections.length === 0 && repeats === 1 ? bound : laneBudget;
+}
+
+/**
+ * Where this identity could go.
+ *
+ * `fitting` is the cheapest lane that can still hold it inside that
+ * lane's own capacity, which is what makes tests needing the same
+ * environment group together rather than being a special case in the
+ * packer. Lanes of equal cost are separated by load, so the emptier one
+ * wins.
+ *
+ * `shortest` is the lane the identity would leave shortest, whether or
+ * not that lane can hold it. Only the mandatory pass uses it, and only
+ * when nothing fits: that pass may put a lane past its budget, and
+ * putting the overrun where the finishing time rises least is what keeps
+ * the longest lane down.
+ */
+function spotsFor(
   input: PlanInput,
-  lanes: Filling[],
+  lanes: readonly Filling[],
   entry: ManifestEntry,
   repeats: number,
-  ceiling: number,
-): boolean {
-  const cheapest = Math.min(
-    ...lanes.map((lane) =>
-      marginalCost(input.manifest, input, lane, entry, repeats)
-    ),
-  );
-  const spent = lanes.reduce((total, lane) => total + lane.load, 0);
-  return spent + cheapest <= ceiling;
+  laneBudget: number,
+  bound: number,
+): { fitting?: Spot; shortest?: Spot } {
+  let fitting: Spot | undefined;
+  let shortest: Spot | undefined;
+  for (const lane of lanes) {
+    const cost = marginalCost(input.manifest, input, lane, entry, repeats);
+    if (
+      shortest === undefined ||
+      lane.load + cost < shortest.lane.load + shortest.cost
+    ) {
+      shortest = { lane, cost };
+    }
+    if (lane.load + cost > capacity(lane, repeats, laneBudget, bound)) {
+      continue;
+    }
+    if (
+      fitting === undefined || cost < fitting.cost ||
+      (cost === fitting.cost && lane.load < fitting.lane.load)
+    ) {
+      fitting = { lane, cost };
+    }
+  }
+  return { fitting, shortest };
+}
+
+function place(
+  input: PlanInput,
+  spot: Spot,
+  entry: ManifestEntry,
+  reason: SelectionReason,
+  repeats: number,
+): void {
+  const lane = spot.lane;
+  lane.selections.push({ entry, reason, repeats });
+  lane.load += spot.cost;
+  lane.suites.add(entry.suite);
+  lane.units.add(entry.unit);
+  for (const capability of input.capabilities.get(entry.suite) ?? []) {
+    lane.capabilities.add(capability);
+  }
 }
 
 /**
  * Works out what runs, and where.
  *
- * Four passes in order. Mandatory first, which can in principle exceed
- * the budget and says so when it does rather than silently dropping work.
+ * Four passes in order. Mandatory first, which can in principle put a
+ * lane past its budget and says how far past rather than silently
+ * dropping work.
  * Then value, ignoring cost, which is what gets the expensive genuinely
  * broken integration test into the run. Then density, which sweeps up the
  * cheap tail the value floor puts at the top of the value-per-second
  * ordering. Then exploration, so the unselected corpus keeps producing
  * data.
+ *
+ * What each pass may spend is a share of the whole run's budget rather
+ * than of each lane's, so an expensive test can have a lane to itself
+ * while the others carry the tail. What keeps any one lane from running
+ * long is separate from the shares: a lane takes no work past its own
+ * budget, and the lane that carries an identity costing more than a whole
+ * lane's budget carries that identity and nothing else. The two together
+ * are what make every lane finish near the budget, which is the number
+ * the pull request waits on.
  */
 export function plan(input: PlanInput): Plan {
   const manifest = input.manifest;
   const laneCount = input.lanes ?? LANES;
-  const budget = (input.budgetSeconds ?? LANE_BUDGET_SECONDS) * laneCount;
+  const laneBudget = input.budgetSeconds ?? LANE_BUDGET_SECONDS;
+  const budget = laneBudget * laneCount;
   const lanes: Filling[] = Array.from({ length: laneCount }, (_, i) => ({
     lane: i + 1,
     selections: [],
@@ -327,9 +384,12 @@ export function plan(input: PlanInput): Plan {
       return !taken.has(key) && !excluded.has(key);
     });
 
-  // An identity the manifest has never heard of still has to run, and the
-  // caller says so by naming it mandatory. It has no entry, so one is
-  // made for it at the floor, costing nothing anybody measured.
+  const required: {
+    key: string;
+    reason: SelectionReason;
+    entry: ManifestEntry;
+    cost: number;
+  }[] = [];
   for (const [key, reason] of input.mandatory) {
     // Not even a mandatory identity is placed past the hard bound: the
     // lane would be killed and the run would report a timeout rather than
@@ -344,13 +404,45 @@ export function plan(input: PlanInput): Plan {
     // far as anything here knows.
     const entry = byKey.get(key) ?? unknownEntry(key, input);
     if (entry === undefined) continue;
-    taken.add(key);
+    required.push({
+      key,
+      reason,
+      entry,
+      cost: loneCost(manifest, input, entry),
+    });
+  }
+
+  // Longest-processing-time scheduling, which wants the largest piece of
+  // work placed first: an expensive identity offered a set of lanes that
+  // are already full has nowhere to go but past one lane's budget, where
+  // the same identity offered empty lanes fits inside one. Every
+  // mandatory identity runs whatever the order, so ordering this pass
+  // decides only where the work lands. The key breaks ties, so two
+  // identities costing the same are ordered the same way in every lane.
+  required.sort((a, b) =>
+    b.cost - a.cost || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
+  );
+
+  for (const { key, reason, entry } of required) {
     // Mandatory work runs once. A repeat covers nothing a measured run
-    // did not, and this pass is the one allowed to exceed the budget.
-    place(input, lanes, entry, reason, 1);
+    // did not, and this pass is the one allowed to put a lane past its
+    // budget: it takes a lane that can hold the work where there is one,
+    // and the lane it leaves shortest where there is not.
+    const spots = spotsFor(input, lanes, entry, 1, laneBudget, bound);
+    const spot = spots.fitting ?? spots.shortest;
+    if (spot === undefined) continue;
+    taken.add(key);
+    place(input, spot, entry, reason, 1);
   }
   const mandatoryLoad = laneLoad(lanes);
-  const overBudget = Math.max(0, mandatoryLoad - budget);
+  // A mandatory set larger than the whole run's budget leaves some lane
+  // past its own share of it, so measuring the longest lane reports that
+  // case as well as the case the total misses: work that fits the run
+  // between them but that no one lane can hold its part of.
+  const overBudget = lanes.reduce(
+    (most, lane) => Math.max(most, lane.load - laneBudget),
+    0,
+  );
 
   // The three shares are of what the mandatory pass left, so a change
   // that forced a great deal of work in does not then get a full budget
@@ -366,6 +458,8 @@ export function plan(input: PlanInput): Plan {
     remaining().sort((a, b) => b.score - a.score),
     "value",
     mandatoryLoad + left * FILL_VALUE_SHARE,
+    laneBudget,
+    bound,
     withRepeats,
   );
 
@@ -380,6 +474,8 @@ export function plan(input: PlanInput): Plan {
     ),
     "density",
     mandatoryLoad + left * (FILL_VALUE_SHARE + FILL_DENSITY_SHARE),
+    laneBudget,
+    bound,
     withRepeats,
   );
 
@@ -396,6 +492,8 @@ export function plan(input: PlanInput): Plan {
     "exploration",
     mandatoryLoad +
       left * (FILL_VALUE_SHARE + FILL_DENSITY_SHARE + FILL_EXPLORATION_SHARE),
+    laneBudget,
+    bound,
     withRepeats,
   );
 
@@ -451,6 +549,13 @@ function laneLoad(lanes: readonly Filling[]): number {
   return lanes.reduce((total, lane) => total + lane.load, 0);
 }
 
+/**
+ * Takes candidates in the order given, up to this pass's share of the
+ * whole run's budget and no further. The share is of the whole rather
+ * than of each lane, so an expensive test can have a lane to itself while
+ * the others carry the tail; what stops any one lane running long is the
+ * lane's own capacity, which `spotsFor` applies.
+ */
 function fill(
   input: PlanInput,
   lanes: Filling[],
@@ -458,19 +563,23 @@ function fill(
   candidates: readonly ManifestEntry[],
   reason: SelectionReason,
   ceiling: number,
+  laneBudget: number,
+  bound: number,
   repeatsOf: (entry: ManifestEntry) => number,
 ): void {
   for (const entry of candidates) {
     const key = testIdentityKey(entry.test);
     if (taken.has(key)) continue;
-    // An identity that would be repeated but no longer fits runs once:
-    // one observation beats none.
-    let repeats = repeatsOf(entry);
-    while (repeats > 1 && !fits(input, lanes, entry, repeats, ceiling)) {
-      repeats--;
+    const spent = laneLoad(lanes);
+    // An identity that would be repeated but no longer fits runs fewer
+    // times, down to once: one observation beats none.
+    for (let repeats = repeatsOf(entry); repeats >= 1; repeats--) {
+      const spot = spotsFor(input, lanes, entry, repeats, laneBudget, bound)
+        .fitting;
+      if (spot === undefined || spent + spot.cost > ceiling) continue;
+      taken.add(key);
+      place(input, spot, entry, reason, repeats);
+      break;
     }
-    if (!fits(input, lanes, entry, repeats, ceiling)) continue;
-    taken.add(key);
-    place(input, lanes, entry, reason, repeats);
   }
 }

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -114,7 +114,7 @@ export interface PlanInput {
    */
   unknown?: ReadonlyMap<string, { suite: string; unit: string }>;
 
-  /** How many lanes to fill. Defaults to the dial. */
+  /** How many lanes to fill, at least one. Defaults to the dial. */
   lanes?: number;
 
   /** Seconds each lane may fill. Defaults to the dial. */
@@ -328,6 +328,13 @@ function place(
 export function plan(input: PlanInput): Plan {
   const manifest = input.manifest;
   const laneCount = input.lanes ?? LANES;
+  // Every pass below reaches for a lane to put work in, so there has to
+  // be one.
+  if (laneCount < 1) {
+    throw new RangeError(
+      `a plan needs a lane to fill, and was asked for ${laneCount}`,
+    );
+  }
   const laneBudget = input.budgetSeconds ?? LANE_BUDGET_SECONDS;
   const budget = laneBudget * laneCount;
   const lanes: Filling[] = Array.from({ length: laneCount }, (_, i) => ({
@@ -430,9 +437,8 @@ export function plan(input: PlanInput): Plan {
     // budget: it takes a lane that can hold the work where there is one,
     // and the lane it leaves shortest where there is not.
     const spots = spotsFor(input, lanes, entry, 1, laneBudget, bound);
-    // Every lane is a candidate for work that fits in none of them, so a
-    // lane list with anything in it yields a shortest lane, and the list
-    // is one this function built.
+    // Every lane is a candidate for work that fits in none of them, and
+    // there is at least one lane, so there is always a shortest.
     const spot = spots.fitting ?? spots.shortest!;
     taken.add(key);
     place(input, spot, entry, reason, 1);

--- a/tasks/test-selection/plan.ts
+++ b/tasks/test-selection/plan.ts
@@ -430,8 +430,10 @@ export function plan(input: PlanInput): Plan {
     // budget: it takes a lane that can hold the work where there is one,
     // and the lane it leaves shortest where there is not.
     const spots = spotsFor(input, lanes, entry, 1, laneBudget, bound);
-    const spot = spots.fitting ?? spots.shortest;
-    if (spot === undefined) continue;
+    // Every lane is a candidate for work that fits in none of them, so a
+    // lane list with anything in it yields a shortest lane, and the list
+    // is one this function built.
+    const spot = spots.fitting ?? spots.shortest!;
     taken.add(key);
     place(input, spot, entry, reason, 1);
   }


### PR DESCRIPTION
The packer bounded what a pull request's tests may cost in total, five lanes times 230 seconds, and never bounded what any one lane may cost. Placement chose the lane where an identity was cheapest to add, which is what groups tests needing the same environment together, and a lane that has already paid a suite's overhead is cheaper for every remaining test of that suite however much work it is carrying. The whole suite therefore landed in one lane. On a corpus of 800 cheap unit tests, 60 pattern integration tests behind a Toolshed server, 40 browser tests and 8 slow command-line arms, the five lanes came out at 887, 179, 81, 0 and 0 seconds against a budget of 230 each: the first lane four times past the five-minute bound it is killed at, and two lanes idle. The long pole is what a pull request waits on, so a total that fits says nothing useful.

A lane now takes no work past its own budget. The cheapest lane is chosen from among the lanes that can still hold the identity, so when the lane holding a suite fills up the next-cheapest one with room takes over. The one exception is the case the design already called for: an identity costing more than a whole lane's budget cannot be split, so a lane holding it and nothing else may run up to the hard bound. A repeat can be split, and gives up a run instead — an identity wanting three runs of a hundred seconds runs twice inside the budget rather than three times inside the bound.

The mandatory pass, the one pass allowed past a lane's budget, now takes its identities largest first. That is what longest-processing-time scheduling asks for and what the packer's own comment claimed it did: placed after the lanes have filled, an identity costing most of a lane has nowhere to go but past one lane's budget, where the same identity offered empty lanes fits inside one. Every mandatory identity runs whatever the order, so ordering this pass decides only where the work lands. Where a mandatory identity fits in no lane it goes where the lane's finishing time rises least, spreading an unavoidable overrun over the five rather than settling it on one.

`overBudgetSeconds` reports how far the longest lane is past a lane's budget rather than how far the five lanes' total is past the run's. A mandatory set larger than the whole budget leaves some lane past its own share of it by arithmetic, so nothing that was reported stops being reported, and the new figure also covers the case the total misses: six mandatory identities at 120 seconds fit 1,150 seconds of lanes between them, and the sixth fits no lane once the other five are carrying 120 seconds each.

On the corpus above the same packer now fills the five lanes to 223.8, 225.4, 223.8, 228.6 and 230.0 seconds, a spread of 6.2 seconds. The total falls from 1147.2 to 1131.6 seconds, which is the Toolshed setup being paid in four lanes instead of one; that is the price of the tests with a record of catching things being spread over the lanes that can hold them.

Seven tests cover the new behavior. Each was run against the previous packer and fails there for the reason it names: a lane at 100 seconds against a 20-second budget, a lane at 200 where each should hold 40, 60 identities in the lane that should hold one, three runs of an identity where two fit, a mandatory lane at 108 against 100, and all twenty identities of a mandatory set in one lane instead of four each.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

