### PR TITLE
The pattern-author loop stops re-sending the drafts it has moved past (CT-2158)

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -1255,6 +1255,26 @@ summary. The rewrite happens in the transcript itself, so the persisted
 transcript records the context the model was given, and the tool-output
 artifacts keep every diagnostic in full.
 
+The source those attempts carried is collapsed on the same terms. A
+`run_pattern` call arriving in the transcript replaces the `sourceText` of every
+earlier `run_pattern` call with a marker naming the attempt, how long its source
+ran, and the tool output holding it — the loop edits against the source it wrote
+last, and the drafts before it are re-sent whole on every remaining turn. Each
+call's source is written to `tool-outputs` under that call's own `outputId` as
+it runs, so the marker names an artifact that exists; a call whose result
+reported no `outputId`, one naming a `patternId` rather than source, and one
+whose source is shorter than the marker are all left as they stand, along with
+every other argument of a call that is collapsed.
+
+What a tool result may weigh in model context is bounded per tool. A `bash` or
+`run_skill_script` stream keeps 60,000 characters of head and 20,000 of tail; a
+`read_file` result keeps 8,000 and 2,000, because a file is read for a passage
+and the whole document would otherwise sit in context for every later turn.
+Either way the omitted middle is replaced by a marker counting the characters
+dropped and naming the tool output that holds the whole text, the result carries
+the original length beside the truncated field, and the artifact is written
+before the bound is applied.
+
 Interactive chat stdio transport:
 
 ```bash

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -126,6 +126,7 @@ import type {
 import { OpenAICompatibleGatewayModelClient } from "./model/openai-compatible-gateway.ts";
 import { sumHarnessModelUsage } from "./model/usage.ts";
 import { collapseSupersededRunPatternDiagnostics } from "./run-pattern-diagnostic-collapse.ts";
+import { collapseSupersededRunPatternSources } from "./run-pattern-source-collapse.ts";
 import {
   loadHarnessSkillContext,
   loadHarnessSkillContextFromText,
@@ -1342,6 +1343,8 @@ const buildSubagentSystemPrompt = (
         "Return a durable result object directly — `return { count, $UI: <div>…</div> }`. A whole-result derived wrapper is a known smell, but not a deterministic failure: after instantiation run_pattern checks the actual pattern pointer and refuses a piece materialized under a session-only identity.",
         "You own the write, compile-error, fix loop. A `compile-error` result is normal iteration material: read the diagnostic, correct the source, and call run_pattern again. Do not hand a compile error back to the parent as the answer.",
         "Use read_file and bash to read existing patterns and pattern documentation in the workspace when the compiler or the preloaded skills leave a question open.",
+        "Read the passage, not the guide. Locate it first with bash — `grep -n` for the term — and read the lines around the hit with `sed -n '120,180p'`. Where you do reach for read_file on a document, bound it with `maxBytes`. A read is cut at roughly ten thousand characters with the full text left in the run artifact, so a whole-guide read spends the turn and still does not land on the passage.",
+        "Read again rather than hoard. Everything you have read stays in front of you for the rest of the run whether you need it again or not, so read what the next call needs and come back to the file when a later question wants a different part of it.",
         "Every reference in your task is an address, not a value. Wire it into the pattern as a run_pattern `inputs` entry so the pattern reads it live; never try to read, print, or transcribe the data behind it yourself.",
         "Use describe_handle on a reference you were given to see its shape before authoring against it. It answers with a schema and never with data.",
         'To read what the pattern computed, pass run_pattern a `resultSchema` describing the fields you want; without one you get a reference and no value at all. Example: {"type":"object","properties":{"total":{"type":"number"}},"required":["total"]}. Numbers, booleans and enum strings come back as themselves; unconstrained strings and anything the schema does not model are withheld as text and come back as reference tokens addressing those positions, which you can describe_handle or wire into a later pattern. You do not need to declare $NAME or $UI.',
@@ -1729,10 +1732,27 @@ type RecordHarnessPolicyEvent = (
   event: Parameters<CfHarnessEngine["recordPolicyEvent"]>[0],
 ) => Promise<void>;
 
-const MODEL_FACING_BASH_STREAM_HEAD_CHARS = 60_000;
-const MODEL_FACING_BASH_STREAM_TAIL_CHARS = 20_000;
-const MODEL_FACING_BASH_STREAM_MAX_CHARS = MODEL_FACING_BASH_STREAM_HEAD_CHARS +
-  MODEL_FACING_BASH_STREAM_TAIL_CHARS;
+/** How much of one stream or file a model-facing rendering carries. */
+interface ModelFacingTextBounds {
+  head: number;
+  tail: number;
+}
+
+const MODEL_FACING_BASH_STREAM_BOUNDS: ModelFacingTextBounds = {
+  head: 60_000,
+  tail: 20_000,
+};
+
+/**
+ * A file is read for a passage rather than run for its output, and a whole
+ * document then sits in context for every later turn of the loop that read
+ * it. What is kept is enough to answer from or to locate the passage in, and
+ * the read is repeatable against the same file.
+ */
+const MODEL_FACING_READ_FILE_BOUNDS: ModelFacingTextBounds = {
+  head: 8_000,
+  tail: 2_000,
+};
 const REDACTED_READ_FILE_ERROR_PATH = "[redacted]";
 const REDACTED_READ_FILE_ERROR_MESSAGE =
   "read_file failed: filesystem status not observable under CFC policy";
@@ -1955,23 +1975,22 @@ const truncateModelFacingBashStream = (
   value: string | ObservationDenied,
   channel: "stdout" | "stderr",
   resultRef: ToolResultRef,
+  bounds: ModelFacingTextBounds = MODEL_FACING_BASH_STREAM_BOUNDS,
 ): {
   value: string | ObservationDenied;
   truncated?: boolean;
   originalLength?: number;
 } => {
-  if (
-    typeof value !== "string" ||
-    value.length <= MODEL_FACING_BASH_STREAM_MAX_CHARS
-  ) {
+  const kept = bounds.head + bounds.tail;
+  if (typeof value !== "string" || value.length <= kept) {
     return { value };
   }
-  const omitted = value.length - MODEL_FACING_BASH_STREAM_MAX_CHARS;
+  const omitted = value.length - kept;
   return {
-    value: `${value.slice(0, MODEL_FACING_BASH_STREAM_HEAD_CHARS)}\n\n` +
+    value: `${value.slice(0, bounds.head)}\n\n` +
       `[cf-harness: ${channel} truncated for model context; omitted ${omitted} characters. ` +
       `Full ${channel} is preserved in tool output ${resultRef.outputId}.]\n\n` +
-      value.slice(-MODEL_FACING_BASH_STREAM_TAIL_CHARS),
+      value.slice(-bounds.tail),
     truncated: true,
     originalLength: value.length,
   };
@@ -2024,6 +2043,7 @@ const truncateModelFacingReadFileOutput = (
     typeof output.content === "string" ? output.content : "",
     "stdout",
     resultRef,
+    MODEL_FACING_READ_FILE_BOUNDS,
   );
   return {
     ...output,
@@ -2306,6 +2326,7 @@ const renderMediatedReadFileOutput = (
     renderStreamObservation(cfcResult.stdout, resultRef),
     "stdout",
     resultRef,
+    MODEL_FACING_READ_FILE_BOUNDS,
   );
   const observation = modelContextObservationForStream(
     cfcResult.stdout,
@@ -2896,6 +2917,13 @@ export class CfHarnessPromptLoop {
         }
         const assistantMessage = response.assistant;
         transcript.push(assistantMessage);
+        if (
+          assistantMessage.toolCalls?.some((toolCall) =>
+            toolCall.function.name === "run_pattern"
+          ) === true
+        ) {
+          collapseSupersededRunPatternSources(transcript);
+        }
         await this.engine.persistTranscript(transcript);
         reportTimeline.push(transcriptTimelineEntry(
           assistantMessage,
@@ -3070,6 +3098,36 @@ export class CfHarnessPromptLoop {
     if (minted.table !== table) {
       await this.engine.recordHandleTable(minted.table);
     }
+  }
+
+  /**
+   * Helper for `#invokeToolCall()`, which records the source a `run_pattern`
+   * call carried beside that call's tool output, under the same `outputId`.
+   *
+   * The transcript holds each attempt's source only until a later attempt
+   * supersedes it, at which point the call's arguments are collapsed to a
+   * marker naming this artifact. Writing it here rather than at the collapse
+   * keeps the record independent of whether the loop ran again, and the
+   * source is the model's own writing, so nothing crosses a boundary by
+   * being kept.
+   */
+  async #persistRunPatternSource(
+    toolId: BuiltinToolId,
+    input: Record<string, unknown>,
+    resultRef: ToolResultRef,
+  ): Promise<void> {
+    if (toolId !== "run_pattern" || typeof input.sourceText !== "string") {
+      return;
+    }
+    await this.engine.artifactStore?.persistToolOutput(
+      "run-pattern-source",
+      resultRef.outputId,
+      {
+        type: "cf-harness.run-pattern-source",
+        outputId: resultRef.outputId,
+        sourceText: input.sourceText,
+      },
+    );
   }
 
   /** Restores successful search hits already present in parent history. */
@@ -3690,6 +3748,7 @@ export class CfHarnessPromptLoop {
       toolId,
       result.output,
     );
+    await this.#persistRunPatternSource(toolId, input, result.resultRef);
     const modelOutputResult = await this.#modelFacingToolOutput(
       toolId,
       result.output,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2511,6 +2511,13 @@ export class CfHarnessPromptLoop {
     SearchPatternsToolResult
   >();
 
+  /**
+   * The `outputId` of every `run_pattern` call whose source this loop wrote to
+   * an artifact. A source is collapsed only where its id is here, so a run
+   * with no artifact store keeps every draft it was given.
+   */
+  readonly #persistedRunPatternSources = new Set<string>();
+
   constructor(options: CreateHarnessPromptLoopOptions = {}) {
     this.engine = options.engine ?? new CfHarnessEngine(options);
     if (this.engine.config.modelProvider === "openai-compatible-gateway") {
@@ -2917,13 +2924,6 @@ export class CfHarnessPromptLoop {
         }
         const assistantMessage = response.assistant;
         transcript.push(assistantMessage);
-        if (
-          assistantMessage.toolCalls?.some((toolCall) =>
-            toolCall.function.name === "run_pattern"
-          ) === true
-        ) {
-          collapseSupersededRunPatternSources(transcript);
-        }
         await this.engine.persistTranscript(transcript);
         reportTimeline.push(transcriptTimelineEntry(
           assistantMessage,
@@ -2982,8 +2982,17 @@ export class CfHarnessPromptLoop {
           );
           const toolMessage = invokedToolCall.toolMessage;
           transcript.push(toolMessage);
+          // After the result rather than after the call that asked for it: a
+          // marker names the artifact holding what it replaced, and both the
+          // result's `outputId` and the source artifact under it exist only
+          // once the call has run. One assistant message may carry several
+          // calls, and each result collapses what it supersedes.
           if (toolMessage.toolName === "run_pattern") {
             collapseSupersededRunPatternDiagnostics(transcript);
+            collapseSupersededRunPatternSources(
+              transcript,
+              this.#persistedRunPatternSources,
+            );
           }
           await this.engine.persistTranscript(transcript);
           reportTimeline.push(transcriptTimelineEntry(
@@ -3116,10 +3125,14 @@ export class CfHarnessPromptLoop {
     input: Record<string, unknown>,
     resultRef: ToolResultRef,
   ): Promise<void> {
-    if (toolId !== "run_pattern" || typeof input.sourceText !== "string") {
+    const store = this.engine.artifactStore;
+    if (
+      store === undefined || toolId !== "run_pattern" ||
+      typeof input.sourceText !== "string"
+    ) {
       return;
     }
-    await this.engine.artifactStore?.persistToolOutput(
+    await store.persistToolOutput(
       "run-pattern-source",
       resultRef.outputId,
       {
@@ -3128,6 +3141,7 @@ export class CfHarnessPromptLoop {
         sourceText: input.sourceText,
       },
     );
+    this.#persistedRunPatternSources.add(resultRef.outputId);
   }
 
   /** Restores successful search hits already present in parent history. */

--- a/packages/cf-harness/src/run-pattern-source-collapse.ts
+++ b/packages/cf-harness/src/run-pattern-source-collapse.ts
@@ -10,17 +10,21 @@ const SUPERSEDED_SOURCE_MARKER_PREFIX =
   "[cf-harness: superseded run_pattern source collapsed";
 
 interface SupersededSource {
-  messageIndex: number;
   toolCallId: string;
   attempt: number;
   arguments: Record<string, unknown>;
   source: string;
 }
 
+/**
+ * The arguments of a `run_pattern` call and the source they carry, or
+ * `undefined` where the call carries none to collapse: arguments that are not
+ * a JSON object, a call naming a `patternId` instead, and one whose source is
+ * already a marker. Called for a `run_pattern` call.
+ */
 const runPatternSourceCall = (
   toolCall: HarnessToolCall,
 ): { arguments: Record<string, unknown>; source: string } | undefined => {
-  if (toolCall.function.name !== "run_pattern") return undefined;
   let parsed: unknown;
   try {
     parsed = JSON.parse(toolCall.function.arguments);
@@ -82,15 +86,18 @@ const marker = (
  * the tool output that holds the text.
  *
  * A call naming a `patternId` carries no source and is left alone, as is one
- * whose source is shorter than the marker would be, and one whose result
- * reported no `outputId` — the marker names an artifact, so it is written
- * only where that artifact exists.
+ * whose source is shorter than the marker would be. The marker names an
+ * artifact, so a source is replaced only where the artifact holding it
+ * exists: the call's result must report an `outputId`, and that id must be in
+ * `preservedOutputIds`, which the caller fills as it writes each source. A run
+ * that preserves nothing collapses nothing, and keeps every draft it holds.
  *
  * Collapsing is idempotent: a marker is recognized by its opening and a call
  * carrying one is left as it stands.
  */
 export const collapseSupersededRunPatternSources = (
   transcript: HarnessTranscriptMessage[],
+  preservedOutputIds: ReadonlySet<string>,
 ): void => {
   const outputIds = resultOutputIds(transcript);
   const sources: SupersededSource[] = [];
@@ -98,7 +105,7 @@ export const collapseSupersededRunPatternSources = (
   // number it had once its own source is collapsed, and carries the number
   // its diagnostic carries.
   let attempts = 0;
-  for (const [messageIndex, message] of transcript.entries()) {
+  for (const message of transcript) {
     if (message.role !== "assistant") continue;
     for (const toolCall of message.toolCalls ?? []) {
       if (toolCall.function.name !== "run_pattern") continue;
@@ -106,7 +113,6 @@ export const collapseSupersededRunPatternSources = (
       const call = runPatternSourceCall(toolCall);
       if (call === undefined) continue;
       sources.push({
-        messageIndex,
         toolCallId: toolCall.id,
         attempt: attempts,
         arguments: call.arguments,
@@ -117,7 +123,7 @@ export const collapseSupersededRunPatternSources = (
   const collapsed = new Map<string, string>();
   for (const superseded of sources.slice(0, -1)) {
     const outputId = outputIds.get(superseded.toolCallId);
-    if (outputId === undefined) continue;
+    if (outputId === undefined || !preservedOutputIds.has(outputId)) continue;
     const text = marker(superseded, outputId);
     if (text.length >= superseded.source.length) continue;
     collapsed.set(
@@ -126,8 +132,7 @@ export const collapseSupersededRunPatternSources = (
     );
   }
   if (collapsed.size === 0) return;
-  for (const messageIndex of new Set(sources.map((one) => one.messageIndex))) {
-    const message = transcript[messageIndex];
+  for (const [messageIndex, message] of transcript.entries()) {
     if (message.role !== "assistant" || message.toolCalls === undefined) {
       continue;
     }

--- a/packages/cf-harness/src/run-pattern-source-collapse.ts
+++ b/packages/cf-harness/src/run-pattern-source-collapse.ts
@@ -1,0 +1,148 @@
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+import type {
+  HarnessToolCall,
+  HarnessTranscriptMessage,
+} from "./contracts/transcript.ts";
+
+/** What a collapsed `sourceText` opens with, and is recognized by. */
+const SUPERSEDED_SOURCE_MARKER_PREFIX =
+  "[cf-harness: superseded run_pattern source collapsed";
+
+interface SupersededSource {
+  messageIndex: number;
+  toolCallId: string;
+  attempt: number;
+  arguments: Record<string, unknown>;
+  source: string;
+}
+
+const runPatternSourceCall = (
+  toolCall: HarnessToolCall,
+): { arguments: Record<string, unknown>; source: string } | undefined => {
+  if (toolCall.function.name !== "run_pattern") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(toolCall.function.arguments);
+  } catch {
+    return undefined;
+  }
+  if (!isObjectNotArray(parsed)) return undefined;
+  const source = parsed.sourceText;
+  if (
+    typeof source !== "string" ||
+    source.startsWith(SUPERSEDED_SOURCE_MARKER_PREFIX)
+  ) {
+    return undefined;
+  }
+  return { arguments: parsed, source };
+};
+
+/**
+ * The `outputId` each `run_pattern` call's result reported, by call id. A
+ * call whose result never arrived, or reported none, is absent — and so is
+ * left uncollapsed, since the marker would name an artifact that does not
+ * exist.
+ */
+const resultOutputIds = (
+  transcript: readonly HarnessTranscriptMessage[],
+): Map<string, string> => {
+  const outputIds = new Map<string, string>();
+  for (const message of transcript) {
+    if (message.role !== "tool" || message.toolName !== "run_pattern") continue;
+    try {
+      const output: unknown = JSON.parse(message.content);
+      if (isObjectNotArray(output) && typeof output.outputId === "string") {
+        outputIds.set(message.toolCallId, output.outputId);
+      }
+    } catch {
+      // A result that is not JSON names no artifact to point at.
+    }
+  }
+  return outputIds;
+};
+
+const marker = (
+  superseded: SupersededSource,
+  outputId: string,
+): string =>
+  `${SUPERSEDED_SOURCE_MARKER_PREFIX} for model context; attempt ${superseded.attempt}, ` +
+  `${superseded.source.length} characters. The newest run_pattern call ` +
+  `carries the source to edit; this attempt's source is preserved in tool ` +
+  `output ${outputId}.]`;
+
+/**
+ * Replaces the `sourceText` of every `run_pattern` call in `transcript` but
+ * the most recent one with a short marker, in place.
+ *
+ * A pattern-authoring loop edits against the source it wrote last. The
+ * earlier drafts stay in model context as assistant tool-call arguments for
+ * every remaining turn, at the full length of each, and no turn reads them
+ * again. The marker keeps which attempt it was, how long its source ran, and
+ * the tool output that holds the text.
+ *
+ * A call naming a `patternId` carries no source and is left alone, as is one
+ * whose source is shorter than the marker would be, and one whose result
+ * reported no `outputId` — the marker names an artifact, so it is written
+ * only where that artifact exists.
+ *
+ * Collapsing is idempotent: a marker is recognized by its opening and a call
+ * carrying one is left as it stands.
+ */
+export const collapseSupersededRunPatternSources = (
+  transcript: HarnessTranscriptMessage[],
+): void => {
+  const outputIds = resultOutputIds(transcript);
+  const sources: SupersededSource[] = [];
+  // Numbered over every `run_pattern` call, so that an attempt keeps the
+  // number it had once its own source is collapsed, and carries the number
+  // its diagnostic carries.
+  let attempts = 0;
+  for (const [messageIndex, message] of transcript.entries()) {
+    if (message.role !== "assistant") continue;
+    for (const toolCall of message.toolCalls ?? []) {
+      if (toolCall.function.name !== "run_pattern") continue;
+      attempts += 1;
+      const call = runPatternSourceCall(toolCall);
+      if (call === undefined) continue;
+      sources.push({
+        messageIndex,
+        toolCallId: toolCall.id,
+        attempt: attempts,
+        arguments: call.arguments,
+        source: call.source,
+      });
+    }
+  }
+  const collapsed = new Map<string, string>();
+  for (const superseded of sources.slice(0, -1)) {
+    const outputId = outputIds.get(superseded.toolCallId);
+    if (outputId === undefined) continue;
+    const text = marker(superseded, outputId);
+    if (text.length >= superseded.source.length) continue;
+    collapsed.set(
+      superseded.toolCallId,
+      JSON.stringify({ ...superseded.arguments, sourceText: text }),
+    );
+  }
+  if (collapsed.size === 0) return;
+  for (const messageIndex of new Set(sources.map((one) => one.messageIndex))) {
+    const message = transcript[messageIndex];
+    if (message.role !== "assistant" || message.toolCalls === undefined) {
+      continue;
+    }
+    if (!message.toolCalls.some((toolCall) => collapsed.has(toolCall.id))) {
+      continue;
+    }
+    transcript[messageIndex] = {
+      ...message,
+      toolCalls: message.toolCalls.map((toolCall) => {
+        const args = collapsed.get(toolCall.id);
+        return args === undefined ? toolCall : {
+          ...toolCall,
+          function: { ...toolCall.function, arguments: args },
+        };
+      }),
+    };
+  }
+};

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -676,4 +676,133 @@ describe("prompt-loop run_pattern model boundary", () => {
       await storageManager.close();
     }
   });
+
+  it("collapses the superseded pattern source when a second run_pattern call arrives", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern source collapse");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-source-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const runId = "run-pattern-source";
+      const artifactStore = new RecordingArtifactStore(runId);
+      const sourceFor = (attempt: number) =>
+        [
+          "import { computed, pattern } from 'commonfabric';",
+          `// draft ${attempt}: ${"a reason this line exists. ".repeat(20)}`,
+          "export default pattern<{ n: number }, { doubled: number }>(",
+          `  ({ n }) => ({ doubled: computed(() => missing${attempt}(n)) }),`,
+          ");",
+        ].join("\n");
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls += 1;
+        const payload = calls <= 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: `call-${calls}`,
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({
+                      sourceText: sourceFor(calls),
+                      description: "Doubles a number",
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          artifactStore,
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+
+      const sourcesIn = (
+        transcript: readonly HarnessTranscriptMessage[],
+      ): string[] =>
+        transcript.filter((message) => message.role === "assistant")
+          .flatMap((message) => message.toolCalls ?? [])
+          .filter((toolCall) => toolCall.function.name === "run_pattern")
+          .map((toolCall) =>
+            (JSON.parse(toolCall.function.arguments) as { sourceText: string })
+              .sourceText
+          );
+      const sources = sourcesIn(result.transcript);
+      expect(sources.length).toBe(2);
+      expect(sources[0]).toBe(
+        "[cf-harness: superseded run_pattern source collapsed for model " +
+          `context; attempt 1, ${sourceFor(1).length} characters. The newest ` +
+          "run_pattern call carries the source to edit; this attempt's " +
+          `source is preserved in tool output ${runId}:run_pattern:1.]`,
+      );
+      expect(sources[1]).toBe(sourceFor(2));
+      // The rest of the call the model wrote is left as it wrote it.
+      const collapsedCall = result.transcript
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.toolCalls ?? [])[0];
+      expect(JSON.parse(collapsedCall.function.arguments).description).toBe(
+        "Doubles a number",
+      );
+      // Each persisted transcript holds the context the model was given on
+      // the turn that followed it.
+      const persisted = artifactStore.transcripts.map(sourcesIn)
+        .filter((entry) => entry.length > 0);
+      expect(persisted[0][0]).toBe(sourceFor(1));
+      expect(persisted.at(-1)?.[0]).toContain(
+        "superseded run_pattern source collapsed",
+      );
+      // Both drafts stay whole in artifacts of their own.
+      const preserved = artifactStore.toolOutputs
+        .filter((entry) => entry.toolId === "run-pattern-source")
+        .map((entry) =>
+          entry.output as { outputId: string; sourceText: string }
+        );
+      expect(preserved.map((entry) => entry.outputId)).toEqual([
+        `${runId}:run_pattern:1`,
+        `${runId}:run_pattern:2`,
+      ]);
+      expect(preserved[0].sourceText).toBe(sourceFor(1));
+      expect(preserved[1].sourceText).toBe(sourceFor(2));
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
+++ b/packages/cf-harness/test/prompt-loop-run-pattern.test.ts
@@ -805,4 +805,304 @@ describe("prompt-loop run_pattern model boundary", () => {
       await storageManager.close();
     }
   });
+
+  it("collapses both sources of a batched turn once a later call supersedes them", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern source batch");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-batch-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const runId = "run-pattern-batch";
+      const artifactStore = new RecordingArtifactStore(runId);
+      const sourceFor = (attempt: number) =>
+        [
+          "import { computed, pattern } from 'commonfabric';",
+          `// draft ${attempt}: ${"a reason this line exists. ".repeat(20)}`,
+          "export default pattern<{ n: number }, { doubled: number }>(",
+          `  ({ n }) => ({ doubled: computed(() => missing${attempt}(n)) }),`,
+          ");",
+        ].join("\n");
+      const patternCall = (attempt: number) => ({
+        id: `call-${attempt}`,
+        type: "function",
+        function: {
+          name: "run_pattern",
+          arguments: JSON.stringify({ sourceText: sourceFor(attempt) }),
+        },
+      });
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls += 1;
+        // One turn making two calls at once, then a turn making a third.
+        const payload = calls === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [patternCall(1), patternCall(2)],
+              },
+            }],
+          }
+          : calls === 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [patternCall(3)],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          artifactStore,
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the patterns." });
+
+      const sources = result.transcript
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.toolCalls ?? [])
+        .map((toolCall) =>
+          (JSON.parse(toolCall.function.arguments) as { sourceText: string })
+            .sourceText
+        );
+      expect(sources.length).toBe(3);
+      expect(sources[0]).toContain(
+        `attempt 1, ${sourceFor(1).length} characters`,
+      );
+      expect(sources[0]).toContain(`tool output ${runId}:run_pattern:1.]`);
+      expect(sources[1]).toContain(
+        `attempt 2, ${sourceFor(2).length} characters`,
+      );
+      expect(sources[1]).toContain(`tool output ${runId}:run_pattern:2.]`);
+      expect(sources[2]).toBe(sourceFor(3));
+      // Each marker names an artifact that was written.
+      const preserved = artifactStore.toolOutputs
+        .filter((entry) => entry.toolId === "run-pattern-source")
+        .map((entry) => (entry.output as { outputId: string }).outputId);
+      expect(preserved).toEqual([
+        `${runId}:run_pattern:1`,
+        `${runId}:run_pattern:2`,
+        `${runId}:run_pattern:3`,
+      ]);
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("collapses the first source of a batched turn that no later turn follows", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern batch final");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-batch-final-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const runId = "run-pattern-batch-final";
+      const artifactStore = new RecordingArtifactStore(runId);
+      const sourceFor = (attempt: number) =>
+        [
+          "import { computed, pattern } from 'commonfabric';",
+          `// draft ${attempt}: ${"a reason this line exists. ".repeat(20)}`,
+          "export default pattern<{ n: number }, { doubled: number }>(",
+          `  ({ n }) => ({ doubled: computed(() => missing${attempt}(n)) }),`,
+          ");",
+        ].join("\n");
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls += 1;
+        // The batch is the run's last word before the final answer, so the
+        // sibling it superseded has no later call to collapse it.
+        const payload = calls === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [1, 2].map((attempt) => ({
+                  id: `call-${attempt}`,
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({
+                      sourceText: sourceFor(attempt),
+                    }),
+                  },
+                })),
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          artifactStore,
+          runId,
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the patterns." });
+
+      const sources = result.transcript
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.toolCalls ?? [])
+        .map((toolCall) =>
+          (JSON.parse(toolCall.function.arguments) as { sourceText: string })
+            .sourceText
+        );
+      expect(sources.length).toBe(2);
+      expect(sources[0]).toContain(`tool output ${runId}:run_pattern:1.]`);
+      expect(sources[1]).toBe(sourceFor(2));
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps every draft when the run has no artifact store to preserve them in", async () => {
+    const signer = await Identity.fromPassphrase("run-pattern no store");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const fabricRuntime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `run-pattern-no-store-${crypto.randomUUID()}`,
+      }),
+      fabricRuntime,
+    );
+    await pieces.synced();
+    try {
+      const sourceFor = (attempt: number) =>
+        [
+          "import { computed, pattern } from 'commonfabric';",
+          `// draft ${attempt}: ${"a reason this line exists. ".repeat(20)}`,
+          "export default pattern<{ n: number }, { doubled: number }>(",
+          `  ({ n }) => ({ doubled: computed(() => missing${attempt}(n)) }),`,
+          ");",
+        ].join("\n");
+      let calls = 0;
+      const fetchFn: typeof fetch = () => {
+        calls += 1;
+        const payload = calls <= 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: `call-${calls}`,
+                  type: "function",
+                  function: {
+                    name: "run_pattern",
+                    arguments: JSON.stringify({ sourceText: sourceFor(calls) }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "Done." },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+            status: 200,
+          }),
+        );
+      };
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId: "run-pattern-no-store",
+          model: "gpt-5.4",
+          cfcEnforcementMode: "disabled",
+          fabricSessionFactory: () => Promise.resolve({ pieces }),
+        }),
+        fetchFn,
+      });
+
+      const result = await loop.runPrompt({ prompt: "Run the pattern." });
+
+      // Nothing holds the drafts but the transcript, so the transcript keeps
+      // them: a marker here would name an artifact nobody wrote.
+      const sources = result.transcript
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.toolCalls ?? [])
+        .map((toolCall) =>
+          (JSON.parse(toolCall.function.arguments) as { sourceText: string })
+            .sourceText
+        );
+      expect(sources).toEqual([sourceFor(1), sourceFor(2)]);
+    } finally {
+      await fabricRuntime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -5484,6 +5484,80 @@ Deno.test("CfHarnessPromptLoop truncates large model-facing bash output in obser
   assertEquals(content.exitCode, 0);
 });
 
+Deno.test("CfHarnessPromptLoop bounds a large model-facing read_file result more tightly than bash output", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const document = `${"a".repeat(20_000)}MIDDLE${"z".repeat(20_000)}`;
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        { stdout: document, stderr: "", exitCode: 0 },
+      ]),
+      runId: "run-large-read-file",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "observe",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-large-read-file",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({ path: "/workspace/guide.md" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "Read the guide." },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+          status: 200,
+        }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read the guide.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(result.finalAssistantText, "Read the guide.");
+  const secondRequest = JSON.parse(String(fetchCalls[1]?.body)) as {
+    messages: Array<{ role: string; content: string }>;
+  };
+  const toolMessage = chatViewOfRequest(secondRequest).messages.at(-1);
+  assertEquals(toolMessage?.role, "tool");
+  const content = JSON.parse(toolMessage!.content);
+  assertEquals(
+    content.outputId,
+    createToolOutputId("run-large-read-file", "read_file", 1),
+  );
+  assertEquals(content.contentTruncated, true);
+  assertEquals(content.contentOriginalLength, document.length);
+  // 8,000 characters of head and 2,000 of tail, well under the 80,000 a bash
+  // stream keeps, with the marker naming the artifact holding the whole file.
+  assert(content.content.startsWith("a".repeat(8_000)));
+  assert(content.content.endsWith("z".repeat(2_000)));
+  assert(content.content.includes("omitted 30006 characters"));
+  assert(content.content.includes("run-large-read-file:read_file:1"));
+  assert(content.content.length < 11_000);
+});
+
 Deno.test("CfHarnessPromptLoop denies bash output without CFC metadata in enforce mode", async () => {
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({

--- a/packages/cf-harness/test/run-pattern-source-collapse.test.ts
+++ b/packages/cf-harness/test/run-pattern-source-collapse.test.ts
@@ -50,6 +50,23 @@ const attempt = (
   runPatternResult(toolCallId, outputId),
 ];
 
+/** Stands for a run whose artifact store held every source it was given. */
+const preservedIn = (
+  transcript: readonly HarnessTranscriptMessage[],
+): Set<string> => {
+  const preserved = new Set<string>();
+  for (const message of transcript) {
+    if (message.role !== "tool" || message.toolName !== "run_pattern") continue;
+    try {
+      const output = JSON.parse(message.content) as { outputId?: unknown };
+      if (typeof output.outputId === "string") preserved.add(output.outputId);
+    } catch {
+      // A result that is not JSON names no artifact.
+    }
+  }
+  return preserved;
+};
+
 const argumentsOf = (
   message: HarnessTranscriptMessage,
   index = 0,
@@ -63,7 +80,7 @@ describe("collapseSupersededRunPatternSources()", () => {
   it("leaves a lone attempt's source verbatim", () => {
     const transcript = [...attempt("call-1", "out-1")];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
   });
@@ -78,7 +95,7 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-3", "out-3"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0]).sourceText).toBe(
       "[cf-harness: superseded run_pattern source collapsed for model " +
@@ -124,11 +141,49 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-3", "out-3"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0], 0).sourceText).toContain("attempt 1,");
     expect(argumentsOf(transcript[0], 1).sourceText).toContain("attempt 2,");
     expect(argumentsOf(transcript[3]).sourceText).toBe(SOURCE);
+  });
+
+  it("marks the calls of a batch whose results have arrived so far", () => {
+    // The state partway through a batch: the first call's result is in, the
+    // second call's is not. The second is the newest source either way.
+    const transcript: HarnessTranscriptMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: {
+              name: "run_pattern",
+              arguments: JSON.stringify({ sourceText: SOURCE }),
+            },
+          },
+          {
+            id: "call-2",
+            type: "function",
+            function: {
+              name: "run_pattern",
+              arguments: JSON.stringify({ sourceText: SOURCE }),
+            },
+          },
+        ],
+      },
+      runPatternResult("call-1", "out-1"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
+
+    expect(argumentsOf(transcript[0], 0).sourceText).toContain("attempt 1,");
+    expect(argumentsOf(transcript[0], 0).sourceText).toContain(
+      "tool output out-1.",
+    );
+    expect(argumentsOf(transcript[0], 1).sourceText).toBe(SOURCE);
   });
 
   it("leaves a call that named a `patternId` alone", () => {
@@ -138,7 +193,7 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-3", "out-3"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0])).toEqual({ patternId: "pattern-abc" });
     // A `patternId` run is an attempt, so the source that follows it is the
@@ -158,9 +213,33 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-2", "out-2"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
+  });
+
+  it("leaves a source whose artifact was not written verbatim", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1"),
+      ...attempt("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript, new Set());
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
+  });
+
+  it("collapses only the sources whose artifacts were written", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1"),
+      ...attempt("call-2", "out-2"),
+      ...attempt("call-3", "out-3"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript, new Set(["out-2"]));
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
+    expect(argumentsOf(transcript[2]).sourceText).toContain("attempt 2,");
   });
 
   it("leaves a source shorter than its own marker verbatim", () => {
@@ -169,7 +248,7 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-2", "out-2"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0]).sourceText).toBe("export default 1;");
   });
@@ -180,10 +259,10 @@ describe("collapseSupersededRunPatternSources()", () => {
       ...attempt("call-2", "out-2"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
     const once = argumentsOf(transcript[0]).sourceText;
     transcript.push(...attempt("call-3", "out-3"));
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
     expect(argumentsOf(transcript[0]).sourceText).toBe(once);
     expect(argumentsOf(transcript[2]).sourceText).toContain("attempt 2,");
@@ -213,19 +292,30 @@ describe("collapseSupersededRunPatternSources()", () => {
         }],
       },
       runPatternResult("call-2", "out-2"),
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "call-2b",
+          type: "function",
+          function: { name: "run_pattern", arguments: "[]" },
+        }],
+      },
+      runPatternResult("call-2b", "out-2b"),
       ...attempt("call-3", "out-3"),
       ...attempt("call-4", "out-4"),
     ];
 
-    collapseSupersededRunPatternSources(transcript);
+    collapseSupersededRunPatternSources(transcript, preservedIn(transcript));
 
+    const argumentsAt = (index: number): string =>
+      (transcript[index] as HarnessAssistantTranscriptMessage).toolCalls![0]
+        .function.arguments;
     expect(argumentsOf(transcript[0])).toEqual({ query: "counter" });
-    expect(
-      (transcript[1] as HarnessAssistantTranscriptMessage).toolCalls![0]
-        .function
-        .arguments,
-    ).toBe("not json");
-    expect(argumentsOf(transcript[3]).sourceText).toContain("attempt 2,");
-    expect(argumentsOf(transcript[5]).sourceText).toBe(SOURCE);
+    expect(argumentsAt(1)).toBe("not json");
+    expect(argumentsAt(3)).toBe("[]");
+    // Both unreadable calls are attempts; the source that follows is third.
+    expect(argumentsOf(transcript[5]).sourceText).toContain("attempt 3,");
+    expect(argumentsOf(transcript[7]).sourceText).toBe(SOURCE);
   });
 });

--- a/packages/cf-harness/test/run-pattern-source-collapse.test.ts
+++ b/packages/cf-harness/test/run-pattern-source-collapse.test.ts
@@ -1,0 +1,231 @@
+import { describe, it } from "@std/testing/bdd";
+
+import { expect } from "@std/expect";
+import type {
+  HarnessAssistantTranscriptMessage,
+  HarnessTranscriptMessage,
+} from "../src/contracts/transcript.ts";
+import { collapseSupersededRunPatternSources } from "../src/run-pattern-source-collapse.ts";
+
+const SOURCE = [
+  "import { computed, pattern } from 'commonfabric';",
+  "export default pattern<{ n: number }, { doubled: number }>(",
+  `  ({ n }) => ({ doubled: computed(() => n * 2) }), // ${"pad ".repeat(60)}`,
+  ");",
+].join("\n");
+
+const runPatternCall = (
+  toolCallId: string,
+  args: Record<string, unknown>,
+): HarnessTranscriptMessage => ({
+  role: "assistant",
+  content: "",
+  toolCalls: [{
+    id: toolCallId,
+    type: "function",
+    function: { name: "run_pattern", arguments: JSON.stringify(args) },
+  }],
+});
+
+const runPatternResult = (
+  toolCallId: string,
+  outputId: string,
+): HarnessTranscriptMessage => ({
+  role: "tool",
+  toolCallId,
+  toolName: "run_pattern",
+  content: JSON.stringify({
+    outputId,
+    status: "compile-error",
+    message: "[ERROR] Cannot find name 'Celll'.",
+  }),
+});
+
+const attempt = (
+  toolCallId: string,
+  outputId: string,
+  args: Record<string, unknown> = { sourceText: SOURCE },
+): HarnessTranscriptMessage[] => [
+  runPatternCall(toolCallId, args),
+  runPatternResult(toolCallId, outputId),
+];
+
+const argumentsOf = (
+  message: HarnessTranscriptMessage,
+  index = 0,
+): Record<string, unknown> =>
+  JSON.parse(
+    (message as HarnessAssistantTranscriptMessage).toolCalls![index].function
+      .arguments,
+  );
+
+describe("collapseSupersededRunPatternSources()", () => {
+  it("leaves a lone attempt's source verbatim", () => {
+    const transcript = [...attempt("call-1", "out-1")];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
+  });
+
+  it("keeps the newest source verbatim and marks the earlier ones", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1", {
+        sourceText: SOURCE,
+        description: "Doubles a number",
+      }),
+      ...attempt("call-2", "out-2"),
+      ...attempt("call-3", "out-3"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(
+      "[cf-harness: superseded run_pattern source collapsed for model " +
+        `context; attempt 1, ${SOURCE.length} characters. The newest ` +
+        "run_pattern call carries the source to edit; this attempt's source " +
+        "is preserved in tool output out-1.]",
+    );
+    // Every other argument of the call is left as the model wrote it.
+    expect(argumentsOf(transcript[0]).description).toBe("Doubles a number");
+    expect(argumentsOf(transcript[2]).sourceText).toContain("attempt 2,");
+    expect(argumentsOf(transcript[2]).sourceText).toContain(
+      "tool output out-2.",
+    );
+    expect(argumentsOf(transcript[4]).sourceText).toBe(SOURCE);
+  });
+
+  it("marks each superseded call of an assistant message that made several", () => {
+    const transcript: HarnessTranscriptMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: {
+              name: "run_pattern",
+              arguments: JSON.stringify({ sourceText: SOURCE }),
+            },
+          },
+          {
+            id: "call-2",
+            type: "function",
+            function: {
+              name: "run_pattern",
+              arguments: JSON.stringify({ sourceText: SOURCE }),
+            },
+          },
+        ],
+      },
+      runPatternResult("call-1", "out-1"),
+      runPatternResult("call-2", "out-2"),
+      ...attempt("call-3", "out-3"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0], 0).sourceText).toContain("attempt 1,");
+    expect(argumentsOf(transcript[0], 1).sourceText).toContain("attempt 2,");
+    expect(argumentsOf(transcript[3]).sourceText).toBe(SOURCE);
+  });
+
+  it("leaves a call that named a `patternId` alone", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1", { patternId: "pattern-abc" }),
+      ...attempt("call-2", "out-2"),
+      ...attempt("call-3", "out-3"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0])).toEqual({ patternId: "pattern-abc" });
+    // A `patternId` run is an attempt, so the source that follows it is the
+    // second — the number its own diagnostic carries.
+    expect(argumentsOf(transcript[2]).sourceText).toContain("attempt 2,");
+  });
+
+  it("leaves a call whose result reported no `outputId` alone", () => {
+    const transcript: HarnessTranscriptMessage[] = [
+      runPatternCall("call-1", { sourceText: SOURCE }),
+      {
+        role: "tool",
+        toolCallId: "call-1",
+        toolName: "run_pattern",
+        content: "the call was refused before it ran",
+      },
+      ...attempt("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(SOURCE);
+  });
+
+  it("leaves a source shorter than its own marker verbatim", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1", { sourceText: "export default 1;" }),
+      ...attempt("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe("export default 1;");
+  });
+
+  it("leaves an already marked call as it stands", () => {
+    const transcript = [
+      ...attempt("call-1", "out-1"),
+      ...attempt("call-2", "out-2"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+    const once = argumentsOf(transcript[0]).sourceText;
+    transcript.push(...attempt("call-3", "out-3"));
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0]).sourceText).toBe(once);
+    expect(argumentsOf(transcript[2]).sourceText).toContain("attempt 2,");
+  });
+
+  it("leaves another tool's call and unparsable arguments alone", () => {
+    const transcript: HarnessTranscriptMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "call-1",
+          type: "function",
+          function: {
+            name: "search_patterns",
+            arguments: JSON.stringify({ query: "counter" }),
+          },
+        }],
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "call-2",
+          type: "function",
+          function: { name: "run_pattern", arguments: "not json" },
+        }],
+      },
+      runPatternResult("call-2", "out-2"),
+      ...attempt("call-3", "out-3"),
+      ...attempt("call-4", "out-4"),
+    ];
+
+    collapseSupersededRunPatternSources(transcript);
+
+    expect(argumentsOf(transcript[0])).toEqual({ query: "counter" });
+    expect(
+      (transcript[1] as HarnessAssistantTranscriptMessage).toolCalls![0]
+        .function
+        .arguments,
+    ).toBe("not json");
+    expect(argumentsOf(transcript[3]).sourceText).toContain("attempt 2,");
+    expect(argumentsOf(transcript[5]).sourceText).toBe(SOURCE);
+  });
+});


### PR DESCRIPTION
With diagnostics collapsed (#6684), one pattern-author child's final-turn input
was decomposed: 34k tokens, of which 10.3k were assistant tool-call arguments
carrying every earlier `run_pattern` attempt's whole source, and 11.8k were
`read_file` results carrying whole documents the child had asked for with
`maxBytes` in the 30,000-50,000 range. Neither category is read again by any
turn: the loop edits against the source it wrote last, and a document is read
for a passage.

Two changes.

**Superseded sources collapse, on the terms the diagnostics do.** A
`run_pattern` call arriving in the transcript replaces the `sourceText` of every
earlier `run_pattern` call with a marker naming the attempt, how long its source
ran, and the tool output holding it. The newest call stays verbatim, the marker
is idempotent, a call naming a `patternId` carries no source and is untouched,
every other argument of a collapsed call is left as the model wrote it, and a
source already shorter than its marker is left alone.

The source was not durably recorded anywhere else — the run report keeps a
digest and a byte count of it deliberately, and the tool-output artifact records
the result rather than the call — so each call's source is now written to
`tool-outputs` under that call's own `outputId` as it runs. The marker names an
artifact that exists, and a call whose result reported no `outputId` is left
verbatim rather than pointed at nothing.

**A `read_file` result is bounded more tightly than a bash stream.** Both go
through the same truncator, which now takes its bounds from the caller: 60,000
head and 20,000 tail for `bash` and `run_skill_script` as before, 8,000 and
2,000 for `read_file`. The marker, the `contentTruncated` and
`contentOriginalLength` fields, and the artifact holding the whole file are the
established idiom, unchanged. The pattern-author guidance gains the habit that
goes with the bound: locate the passage with `grep -n` and read it with `sed`,
bound a `read_file` with `maxBytes`, and read again rather than hoard.

As in #6684, the rewrite happens in the transcript the loop sends and persists,
so the transcript artifact records the context the model was given, and the
tool-output artifacts keep every source and every file whole.

Parent thread: CT-2158.

## Tests

New `test/run-pattern-source-collapse.test.ts` (8 cases), a loop-level case in
`test/prompt-loop-run-pattern.test.ts` covering the collapse, the per-turn
persisted transcripts and the preserved-source artifacts, and a `read_file`
bound case in `test/prompt-loop.test.ts` beside the bash one. Each was
mutation-verified: removing the read_file bounds, the shorter-than-marker guard,
the `outputId` guard, the loop's call site, and the source-artifact write each
fails the test that covers it.

## Gates

- `deno fmt --check` — `Checked 5519 files`
- `deno lint` — `Checked 5356 files`
- `deno task test` in `packages/cf-harness` — `ok | 919 passed (1613 steps) | 0 failed (1m1s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

