### PR TITLE
feat(utils): IndexTrackingStack

### DIFF
--- a/packages/utils/deno.jsonc
+++ b/packages/utils/deno.jsonc
@@ -28,6 +28,7 @@
     "./env": "./src/env.ts",
     "./equal-ignoring-symbols": "./src/equal-ignoring-symbols.ts",
     "./framework-result-keys": "./src/framework-result-keys.ts",
+    "./index-tracking-stack": "./src/index-tracking-stack.ts",
     "./logger": "./src/logger.ts",
     "./markdown": "./src/markdown.ts",
     "./objects": "./src/objects.ts",

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -1,0 +1,162 @@
+/**
+ * What a push and a pop cost, across the three states the stack can be in and
+ * with and without a repeated object in play.
+ *
+ * The states are what make this more than one figure. `IndexTrackingStack`
+ * answers by scanning until it has been `INDEX_AT` entries tall, and from an
+ * index after that -- and it keeps the index for the rest of its life. So a
+ * stack that once went past the threshold and came back down is not the same
+ * stack as one that never went up, at the same height, and the middle group
+ * below is what prices that decision:
+ *
+ * | state | index | height while timed |
+ * | --- | --- | --- |
+ * | `scanning` | never built | below `INDEX_AT` |
+ * | `crossed` | built, then descended | below `INDEX_AT` |
+ * | `indexed` | built | above `INDEX_AT` |
+ *
+ * `scanning` and `crossed` do the same work at the same height and differ only
+ * in which structure answers, so the gap between them is the price of keeping
+ * the index. `indexed` is what a deep graph pays.
+ *
+ * A repeated object is measured separately throughout, because it is what the
+ * index has to record per object rather than as a single number: a push adds a
+ * position to an existing entry rather than making one, and a pop takes a
+ * position off rather than removing the entry.
+ *
+ * Every case times a batch of operations of one kind, and nothing else. The
+ * scaffolding -- the state each stack has to be brought to, and the pushes a
+ * pop batch needs -- is built outside the timed region.
+ *
+ * That is why an iteration works over a pool of stacks rather than one. Deno
+ * ignores `start()` and `end()` for an iteration averaging under 10 us, and a
+ * batch small enough to stay inside the `crossed` state's height band is far
+ * under that on its own -- so the figure would silently become the scaffolding
+ * plus the batch, which is a different measurement and a much larger one.
+ * Running the batch against `POOL` stacks puts the timed region well past the
+ * threshold while leaving each stack inside its band.
+ *
+ * Run with:
+ *
+ *     deno task bench
+ */
+
+import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
+
+/** How many operations one timed batch performs, against one stack. */
+const BATCH = 32;
+
+/**
+ * How many stacks one iteration runs its batch against. Sized so that the
+ * timed region is long enough for Deno to honor the explicit timer, `BATCH`
+ * being capped by the height band the `crossed` state has to stay inside.
+ */
+const POOL = 128;
+
+/** How far above `INDEX_AT` the indexed state sits. */
+const ABOVE = 8;
+
+/** How far below `INDEX_AT` the crossed state comes back down to. */
+const BELOW = 8;
+
+/** Distinct objects, as many as asked for. */
+function objects(count: number): object[] {
+  const out: object[] = [];
+
+  for (let at = 0; at < count; at++) out.push({ at });
+
+  return out;
+}
+
+/**
+ * A batch of `BATCH` objects. Every fourth one is the same object where
+ * `repeated` asks for it, so the batch holds several positions of one object
+ * rather than a single incidental pair.
+ */
+function batchOf(repeated: boolean): object[] {
+  const out = objects(BATCH);
+
+  if (repeated) {
+    const shared = {};
+
+    for (let at = 0; at < BATCH; at += 4) out[at] = shared;
+  }
+
+  return out;
+}
+
+/** The three states, as the height a stack is brought to and how it got there. */
+const STATES = [
+  { name: "scanning", climb: 0, settle: 0 },
+  {
+    name: "crossed",
+    climb: IndexTrackingStack.INDEX_AT + ABOVE,
+    settle: BELOW,
+  },
+  {
+    name: "indexed",
+    climb: IndexTrackingStack.INDEX_AT + ABOVE,
+    settle: IndexTrackingStack.INDEX_AT + ABOVE,
+  },
+] as const;
+
+/** A stack brought to the given state, ready for a batch to be timed against. */
+function stackIn(state: typeof STATES[number]): IndexTrackingStack {
+  const stack = new IndexTrackingStack();
+
+  for (const value of objects(state.climb)) stack.push(value);
+  while (stack.depth > state.settle) stack.pop();
+
+  return stack;
+}
+
+/** A pool of stacks, each brought to the given state. */
+function poolIn(state: typeof STATES[number]): IndexTrackingStack[] {
+  const out: IndexTrackingStack[] = [];
+
+  for (let at = 0; at < POOL; at++) out.push(stackIn(state));
+
+  return out;
+}
+
+for (const repeated of [false, true]) {
+  const which = repeated ? "one object repeated" : "distinct objects";
+
+  for (const state of STATES) {
+    const baseline = state.name === "scanning";
+
+    Deno.bench({
+      name: `push, ${state.name}`,
+      group: `push — ${which}`,
+      baseline,
+    }, (b) => {
+      const pool = poolIn(state);
+      const batch = batchOf(repeated);
+
+      b.start();
+      for (const stack of pool) {
+        for (const value of batch) stack.push(value);
+      }
+      b.end();
+    });
+
+    Deno.bench({
+      name: `pop, ${state.name}`,
+      group: `pop — ${which}`,
+      baseline,
+    }, (b) => {
+      const pool = poolIn(state);
+      const batch = batchOf(repeated);
+
+      for (const stack of pool) {
+        for (const value of batch) stack.push(value);
+      }
+
+      b.start();
+      for (const stack of pool) {
+        for (let at = 0; at < BATCH; at++) stack.pop();
+      }
+      b.end();
+    });
+  }
+}

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -3,21 +3,25 @@
  * with and without a repeated object in play.
  *
  * The states are what make this more than one figure. `IndexTrackingStack`
- * answers by scanning until it has been `INDEX_AT` entries tall, and from an
- * index after that -- and it keeps the index for the rest of its life. So a
- * stack that once went past the threshold and came back down is not the same
- * stack as one that never went up, at the same height, and the middle group
- * below is what prices that decision:
+ * answers by scanning while it is short, from an index once it has been
+ * `INDEX_AT` entries tall, and by scanning again once it has come back below
+ * `DROP_BELOW`:
  *
  * | state | index | height while timed |
  * | --- | --- | --- |
  * | `scanning` | never built | below `INDEX_AT` |
- * | `crossed` | built, then descended | below `INDEX_AT` |
+ * | `crossed` | built, then dropped on the way down | below `DROP_BELOW` |
  * | `indexed` | built | above `INDEX_AT` |
  *
- * `scanning` and `crossed` do the same work at the same height and differ only
- * in which structure answers, so the gap between them is the price of keeping
- * the index. `indexed` is what a deep graph pays.
+ * `scanning` and `crossed` do the same work at the same height, so the two of
+ * them meeting is what says the index was dropped rather than carried. No test
+ * can say it, the drop changing no answer.  `indexed` is what a deep graph
+ * pays.
+ *
+ * The `oscillating` group is what says the two marks are far enough apart. A
+ * stack swinging inside either mark neither builds nor drops; only one
+ * swinging across the whole gap rebuilds, and that band is here to be watched
+ * rather than because it is expected.
  *
  * A repeated object is measured separately throughout, because it is what the
  * index has to record per object rather than as a single number: a push adds a
@@ -56,7 +60,7 @@ const POOL = 128;
 /** How far above `INDEX_AT` the indexed state sits. */
 const ABOVE = 8;
 
-/** How far below `INDEX_AT` the crossed state comes back down to. */
+/** How far below `DROP_BELOW` the crossed state comes back down to. */
 const BELOW = 8;
 
 /** Distinct objects, as many as asked for. */
@@ -91,7 +95,7 @@ const STATES = [
   {
     name: "crossed",
     climb: IndexTrackingStack.INDEX_AT + ABOVE,
-    settle: BELOW,
+    settle: IndexTrackingStack.DROP_BELOW - BELOW,
   },
   {
     name: "indexed",
@@ -117,6 +121,54 @@ function poolIn(state: typeof STATES[number]): IndexTrackingStack[] {
   for (let at = 0; at < POOL; at++) out.push(stackIn(state));
 
   return out;
+}
+
+/**
+ * The oscillating cases, as the band a stack swings through: one that never
+ * indexes, one that indexes and stays above `DROP_BELOW`, and one that crosses
+ * both marks on every swing.
+ */
+const BANDS = [
+  {
+    name: "below the threshold",
+    floor: 0,
+    ceiling: IndexTrackingStack.INDEX_AT - 8,
+  },
+  {
+    name: "above the low mark",
+    floor: IndexTrackingStack.INDEX_AT - 8,
+    ceiling: IndexTrackingStack.INDEX_AT + 48,
+  },
+  {
+    name: "across both marks",
+    floor: IndexTrackingStack.DROP_BELOW - 8,
+    ceiling: IndexTrackingStack.INDEX_AT + 48,
+  },
+] as const;
+
+/** How many operations one oscillating iteration performs. */
+const SWING_OPS = 10240;
+
+for (const band of BANDS) {
+  const swing = band.ceiling - band.floor;
+
+  Deno.bench({
+    name: `oscillating ${band.name}`,
+    group: "oscillating",
+    baseline: band.name === "below the threshold",
+  }, (b) => {
+    const stack = new IndexTrackingStack();
+    const batch = objects(band.ceiling);
+
+    for (const value of batch.slice(0, band.floor)) stack.push(value);
+
+    b.start();
+    for (let done = 0; done < SWING_OPS; done += swing * 2) {
+      for (let at = 0; at < swing; at++) stack.push(batch[band.floor + at]!);
+      for (let at = 0; at < swing; at++) stack.pop();
+    }
+    b.end();
+  });
 }
 
 for (const repeated of [false, true]) {

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -47,6 +47,9 @@
 
 import { IndexTrackingStack } from "@commonfabric/utils/index-tracking-stack";
 
+/** The marks this class arranges itself around, which the cases are set by. */
+const MARKS = IndexTrackingStack.accessForTestingOnly;
+
 /** How many operations one timed batch performs, against one stack. */
 const BATCH = 32;
 
@@ -91,13 +94,13 @@ const STATES = [
   { name: "scanning", climb: 0, settle: 0 },
   {
     name: "crossed",
-    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    climb: MARKS.ADD_INDEX_AT + ABOVE,
     settle: 0,
   },
   {
     name: "indexed",
-    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
-    settle: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    climb: MARKS.ADD_INDEX_AT + ABOVE,
+    settle: MARKS.ADD_INDEX_AT + ABOVE,
   },
 ] as const;
 
@@ -129,17 +132,17 @@ const BANDS = [
   {
     name: "below the threshold",
     floor: 0,
-    ceiling: IndexTrackingStack.ADD_INDEX_AT - 8,
+    ceiling: MARKS.ADD_INDEX_AT - 8,
   },
   {
     name: "above the low mark",
-    floor: IndexTrackingStack.ADD_INDEX_AT - 8,
-    ceiling: IndexTrackingStack.ADD_INDEX_AT + 48,
+    floor: MARKS.ADD_INDEX_AT - 8,
+    ceiling: MARKS.ADD_INDEX_AT + 48,
   },
   {
     name: "across both marks",
-    floor: IndexTrackingStack.DROP_INDEX_BELOW - 8,
-    ceiling: IndexTrackingStack.ADD_INDEX_AT + 48,
+    floor: MARKS.DROP_INDEX_BELOW - 8,
+    ceiling: MARKS.ADD_INDEX_AT + 48,
   },
 ] as const;
 
@@ -180,8 +183,7 @@ const LOOKUPS = 64;
  * stack can sit here either with an index or without one, which is what makes
  * the comparison a comparison.
  */
-const LOOKUP_HEIGHT =
-  (IndexTrackingStack.ADD_INDEX_AT + IndexTrackingStack.DROP_INDEX_BELOW) / 2;
+const LOOKUP_HEIGHT = (MARKS.ADD_INDEX_AT + MARKS.DROP_INDEX_BELOW) / 2;
 
 /**
  * The lookup subjects, as how a stack of `LOOKUP_HEIGHT` got there. The first
@@ -193,13 +195,13 @@ const LOOKUP_SUBJECTS = [
   { name: "no index", climb: LOOKUP_HEIGHT, settle: LOOKUP_HEIGHT },
   {
     name: "index, between the marks",
-    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    climb: MARKS.ADD_INDEX_AT + ABOVE,
     settle: LOOKUP_HEIGHT,
   },
   {
     name: "index, above the high mark",
-    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
-    settle: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    climb: MARKS.ADD_INDEX_AT + ABOVE,
+    settle: MARKS.ADD_INDEX_AT + ABOVE,
   },
 ] as const;
 

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -89,13 +89,24 @@ function batchOf(repeated: boolean): object[] {
   return out;
 }
 
-/** The three states, as the height a stack reaches and where it settles. */
+/**
+ * The states, as the height a stack reaches and where it settles. `between` is
+ * the one the lookup groups exist for: tall enough to have built an index and
+ * not short enough to have dropped it, at a height a scan would still be
+ * cheap at.
+ */
 const STATES = [
   { name: "scanning", climb: 0, settle: 0 },
   {
     name: "crossed",
     climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
     settle: IndexTrackingStack.DROP_INDEX_BELOW - BELOW,
+  },
+  {
+    name: "between",
+    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    settle: (IndexTrackingStack.ADD_INDEX_AT +
+      IndexTrackingStack.DROP_INDEX_BELOW) / 2,
   },
   {
     name: "indexed",
@@ -169,6 +180,89 @@ for (const band of BANDS) {
     }
     b.end();
   });
+}
+
+/** How many lookups one timed batch performs, against one stack. */
+const LOOKUPS = 64;
+
+/**
+ * The height the lookup groups measure at, chosen between the two marks: a
+ * stack can sit here either with an index or without one, which is what makes
+ * the comparison a comparison.
+ */
+const LOOKUP_HEIGHT =
+  (IndexTrackingStack.ADD_INDEX_AT + IndexTrackingStack.DROP_INDEX_BELOW) / 2;
+
+/**
+ * The lookup subjects, as how a stack of `LOOKUP_HEIGHT` got there. The first
+ * two sit at the same height and differ only in whether an index exists, so
+ * the gap between them is what consulting one costs against scanning. The
+ * third is the height an index is actually for.
+ */
+const LOOKUP_SUBJECTS = [
+  { name: "no index", climb: LOOKUP_HEIGHT, settle: LOOKUP_HEIGHT },
+  {
+    name: "index, between the marks",
+    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    settle: LOOKUP_HEIGHT,
+  },
+  {
+    name: "index, above the high mark",
+    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    settle: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+  },
+] as const;
+
+/**
+ * A pool of stacks in the given lookup subject's state, each with the object
+ * sitting at its bottom.
+ */
+function lookupPool(
+  subject: typeof LOOKUP_SUBJECTS[number],
+): { stack: IndexTrackingStack; bottom: object }[] {
+  const out: { stack: IndexTrackingStack; bottom: object }[] = [];
+
+  for (let at = 0; at < POOL; at++) {
+    const stack = new IndexTrackingStack();
+    const held = objects(subject.climb);
+
+    for (const value of held) stack.push(value);
+    while (stack.depth > subject.settle) stack.pop();
+
+    out.push({ stack, bottom: held[0]! });
+  }
+
+  return out;
+}
+
+// The two ends of what a scan can be asked for. A miss is what it cannot cut
+// short, so it reads the whole stack; a hit at the bottom is `indexOf`'s first
+// comparison, so it reads one entry. A keyed lookup costs the same either way,
+// and between them the pair says where each structure wins.
+//
+// A caller asks for one or the other far more often than at random. The cycle
+// guard this class was written for asks `indexOf(value) >= 0` once per
+// container and misses every time, a graph with no cycle in it never being an
+// ancestor of itself.
+for (const [what, held] of [["a miss", false], ["the bottom", true]] as const) {
+  for (const subject of LOOKUP_SUBJECTS) {
+    Deno.bench({
+      name: `indexOf ${subject.name}`,
+      group: `indexOf — ${what}`,
+      baseline: subject.name === "no index",
+    }, (b) => {
+      const pool = lookupPool(subject);
+      const absent = {};
+
+      b.start();
+      for (const { stack, bottom } of pool) {
+        const sought = held ? bottom : absent;
+
+        for (let at = 0; at < LOOKUPS; at++) stack.indexOf(sought);
+      }
+      b.end();
+    });
+  }
 }
 
 for (const repeated of [false, true]) {

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -4,14 +4,14 @@
  *
  * The states are what make this more than one figure. `IndexTrackingStack`
  * answers by scanning while it is short, from an index once it has been
- * `INDEX_AT` entries tall, and by scanning again once it has come back below
- * `DROP_BELOW`:
+ * `ADD_INDEX_AT` entries tall, and by scanning again once it has come back
+ * below `DROP_INDEX_BELOW`:
  *
  * | state | index | height while timed |
  * | --- | --- | --- |
- * | `scanning` | never built | below `INDEX_AT` |
- * | `crossed` | built, then dropped on the way down | below `DROP_BELOW` |
- * | `indexed` | built | above `INDEX_AT` |
+ * | `scanning` | never built | below `ADD_INDEX_AT` |
+ * | `crossed` | built, then dropped | below `DROP_INDEX_BELOW` |
+ * | `indexed` | built | above `ADD_INDEX_AT` |
  *
  * `scanning` and `crossed` do the same work at the same height, so the two of
  * them meeting is what says the index was dropped rather than carried. No test
@@ -57,10 +57,10 @@ const BATCH = 32;
  */
 const POOL = 128;
 
-/** How far above `INDEX_AT` the indexed state sits. */
+/** How far above `ADD_INDEX_AT` the indexed state sits. */
 const ABOVE = 8;
 
-/** How far below `DROP_BELOW` the crossed state comes back down to. */
+/** How far below `DROP_INDEX_BELOW` the crossed state comes back down to. */
 const BELOW = 8;
 
 /** Distinct objects, as many as asked for. */
@@ -89,22 +89,22 @@ function batchOf(repeated: boolean): object[] {
   return out;
 }
 
-/** The three states, as the height a stack is brought to and how it got there. */
+/** The three states, as the height a stack reaches and where it settles. */
 const STATES = [
   { name: "scanning", climb: 0, settle: 0 },
   {
     name: "crossed",
-    climb: IndexTrackingStack.INDEX_AT + ABOVE,
-    settle: IndexTrackingStack.DROP_BELOW - BELOW,
+    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    settle: IndexTrackingStack.DROP_INDEX_BELOW - BELOW,
   },
   {
     name: "indexed",
-    climb: IndexTrackingStack.INDEX_AT + ABOVE,
-    settle: IndexTrackingStack.INDEX_AT + ABOVE,
+    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
+    settle: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
   },
 ] as const;
 
-/** A stack brought to the given state, ready for a batch to be timed against. */
+/** A stack in the given state, ready for a batch to be timed against it. */
 function stackIn(state: typeof STATES[number]): IndexTrackingStack {
   const stack = new IndexTrackingStack();
 
@@ -125,24 +125,24 @@ function poolIn(state: typeof STATES[number]): IndexTrackingStack[] {
 
 /**
  * The oscillating cases, as the band a stack swings through: one that never
- * indexes, one that indexes and stays above `DROP_BELOW`, and one that crosses
- * both marks on every swing.
+ * indexes, one that indexes and stays above `DROP_INDEX_BELOW`, and one that
+ * crosses both marks on every swing.
  */
 const BANDS = [
   {
     name: "below the threshold",
     floor: 0,
-    ceiling: IndexTrackingStack.INDEX_AT - 8,
+    ceiling: IndexTrackingStack.ADD_INDEX_AT - 8,
   },
   {
     name: "above the low mark",
-    floor: IndexTrackingStack.INDEX_AT - 8,
-    ceiling: IndexTrackingStack.INDEX_AT + 48,
+    floor: IndexTrackingStack.ADD_INDEX_AT - 8,
+    ceiling: IndexTrackingStack.ADD_INDEX_AT + 48,
   },
   {
     name: "across both marks",
-    floor: IndexTrackingStack.DROP_BELOW - 8,
-    ceiling: IndexTrackingStack.INDEX_AT + 48,
+    floor: IndexTrackingStack.DROP_INDEX_BELOW - 8,
+    ceiling: IndexTrackingStack.ADD_INDEX_AT + 48,
   },
 ] as const;
 

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -102,8 +102,8 @@ const STATES = [
 ] as const;
 
 /** A stack in the given state, ready for a batch to be timed against it. */
-function stackIn(state: typeof STATES[number]): IndexTrackingStack {
-  const stack = new IndexTrackingStack();
+function stackIn(state: typeof STATES[number]): IndexTrackingStack<object> {
+  const stack = new IndexTrackingStack<object>();
 
   for (const value of objects(state.climb)) stack.push(value);
   while (stack.depth > state.settle) stack.pop();
@@ -112,8 +112,8 @@ function stackIn(state: typeof STATES[number]): IndexTrackingStack {
 }
 
 /** A pool of stacks, each brought to the given state. */
-function poolIn(state: typeof STATES[number]): IndexTrackingStack[] {
-  const out: IndexTrackingStack[] = [];
+function poolIn(state: typeof STATES[number]): IndexTrackingStack<object>[] {
+  const out: IndexTrackingStack<object>[] = [];
 
   for (let at = 0; at < POOL; at++) out.push(stackIn(state));
 
@@ -158,7 +158,7 @@ for (const band of BANDS) {
     group: "oscillating",
     baseline: band.name === "below the threshold",
   }, (b) => {
-    const stack = new IndexTrackingStack();
+    const stack = new IndexTrackingStack<object>();
     const batch = objects(band.ceiling);
 
     for (const value of batch.slice(0, band.floor)) stack.push(value);
@@ -209,11 +209,11 @@ const LOOKUP_SUBJECTS = [
  */
 function lookupPool(
   subject: typeof LOOKUP_SUBJECTS[number],
-): { stack: IndexTrackingStack; bottom: object }[] {
-  const out: { stack: IndexTrackingStack; bottom: object }[] = [];
+): { stack: IndexTrackingStack<object>; bottom: object }[] {
+  const out: { stack: IndexTrackingStack<object>; bottom: object }[] = [];
 
   for (let at = 0; at < POOL; at++) {
-    const stack = new IndexTrackingStack();
+    const stack = new IndexTrackingStack<object>();
     const held = objects(subject.climb);
 
     for (const value of held) stack.push(value);

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -60,9 +60,6 @@ const POOL = 128;
 /** How far above `ADD_INDEX_AT` the indexed state sits. */
 const ABOVE = 8;
 
-/** How far below `DROP_INDEX_BELOW` the crossed state comes back down to. */
-const BELOW = 8;
-
 /** Distinct objects, as many as asked for. */
 function objects(count: number): object[] {
   const out: object[] = [];
@@ -89,24 +86,13 @@ function batchOf(repeated: boolean): object[] {
   return out;
 }
 
-/**
- * The states, as the height a stack reaches and where it settles. `between` is
- * the one the lookup groups exist for: tall enough to have built an index and
- * not short enough to have dropped it, at a height a scan would still be
- * cheap at.
- */
+/** The three states, as the height a stack reaches and where it settles. */
 const STATES = [
   { name: "scanning", climb: 0, settle: 0 },
   {
     name: "crossed",
     climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
-    settle: IndexTrackingStack.DROP_INDEX_BELOW - BELOW,
-  },
-  {
-    name: "between",
-    climb: IndexTrackingStack.ADD_INDEX_AT + ABOVE,
-    settle: (IndexTrackingStack.ADD_INDEX_AT +
-      IndexTrackingStack.DROP_INDEX_BELOW) / 2,
+    settle: 0,
   },
   {
     name: "indexed",
@@ -157,8 +143,12 @@ const BANDS = [
   },
 ] as const;
 
-/** How many operations one oscillating iteration performs. */
-const SWING_OPS = 10240;
+/**
+ * How many operations one oscillating iteration performs. Divisible by twice
+ * every band's swing, so each band runs the count exactly rather than
+ * overshooting it by a different remainder.
+ */
+const SWING_OPS = 11088;
 
 for (const band of BANDS) {
   const swing = band.ceiling - band.floor;

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -3,7 +3,7 @@
  * with and without a repeated object in play.
  *
  * The states are what make this more than one figure. `IndexTrackingStack`
- * answers by scanning while it is short, from an index once it has been
+ * operates by scanning while it is short, from an index once it has been
  * `ADD_INDEX_AT` entries tall, and by scanning again once it has come back
  * below `DROP_INDEX_BELOW`:
  *
@@ -15,7 +15,7 @@
  *
  * `scanning` and `crossed` do the same work at the same height, so the two of
  * them meeting is what says the index was dropped rather than carried. No test
- * can say it, the drop changing no answer.  `indexed` is what a deep graph
+ * can say it, the drop changing no answer. `indexed` is what a deep graph
  * pays.
  *
  * The `oscillating` group is what says the two marks are far enough apart. A

--- a/packages/utils/src/index-tracking-stack.bench.ts
+++ b/packages/utils/src/index-tracking-stack.bench.ts
@@ -109,6 +109,12 @@ function stackIn(state: typeof STATES[number]): IndexTrackingStack<object> {
   const stack = new IndexTrackingStack<object>();
 
   for (const value of objects(state.climb)) stack.push(value);
+
+  // An index is built by a lookup rather than by growth, so a stack that has
+  // only been pushed to has none however tall it got. The states that are
+  // meant to hold one ask for it here, before anything is timed.
+  stack.indexOf(stack);
+
   while (stack.depth > state.settle) stack.pop();
 
   return stack;
@@ -127,6 +133,11 @@ function poolIn(state: typeof STATES[number]): IndexTrackingStack<object>[] {
  * The oscillating cases, as the band a stack swings through: one that never
  * indexes, one that indexes and stays above `DROP_INDEX_BELOW`, and one that
  * crosses both marks on every swing.
+ *
+ * Each step looks a value up and then pushes it, which is the shape of the
+ * caller these bands stand for -- and the shape that matters, an index being
+ * built by a lookup rather than by growth. A band that only pushed and popped
+ * would never build one, and all three would measure the same thing.
  */
 const BANDS = [
   {
@@ -168,7 +179,12 @@ for (const band of BANDS) {
 
     b.start();
     for (let done = 0; done < SWING_OPS; done += swing * 2) {
-      for (let at = 0; at < swing; at++) stack.push(batch[band.floor + at]!);
+      for (let at = 0; at < swing; at++) {
+        const value = batch[band.floor + at]!;
+
+        stack.indexOf(value);
+        stack.push(value);
+      }
       for (let at = 0; at < swing; at++) stack.pop();
     }
     b.end();
@@ -219,6 +235,11 @@ function lookupPool(
     const held = objects(subject.climb);
 
     for (const value of held) stack.push(value);
+
+    // Built here rather than by the first timed lookup, which would otherwise
+    // pay for it and report the build as the cost of a lookup.
+    stack.indexOf(stack);
+
     while (stack.depth > subject.settle) stack.pop();
 
     out.push({ stack, bottom: held[0]! });

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -6,38 +6,15 @@
  *
  * Values are compared as `Object.is` compares them: by identity for an object,
  * by value for a primitive, `NaN` matching itself, and `-0` distinct from `0`.
- * Neither structure beneath does that on its own -- `Array.prototype.indexOf`
- * compares strictly, so it finds a `0` for a `-0` and never finds a `NaN`, and
- * a `Map` normalizes a `-0` key to `0`. Both are given the comparison instead:
- * the scan through {@link #same}, and the index through {@link #keyFor}, which
- * stands a symbol in for each of the two values a `Map` cannot key as
- * `Object.is` would have it. Two values take the same key exactly when
- * `Object.is` calls them the same value.
- *
- * `===` and `Object.is` part company on numbers alone, so a `typeof` check is
- * all an ordinary stack pays for any of it.
- *
- * Both lookups are answered by scanning while the stack is short, and by an
- * index once it has reached {@link #ADD_INDEX_AT} values. Which one is used
- * is not observable beyond the cost: a scan is linear in the stack's height
- * where a keyed lookup is not, and the two are within reach of each other only
- * over a range that a short stack sits well below.
- *
- * What the marks weigh is the whole of a stack's use, maintenance included,
- * rather than a lookup on its own. Where an index exists it is used, at any
- * height: maintaining it is what a short stack is being spared, and that is
- * already spent by the time a lookup asks.
- *
- * The index is dropped again once the stack falls below
- * {@link #DROP_INDEX_BELOW}, so a stack that grew tall once and came back down
- * goes back to scanning rather than paying for a height it no longer has. The
- * two marks are kept apart so that ordinary movement does not build and drop
- * repeatedly: only a stack swinging across the whole gap between them
- * rebuilds, and one hovering near either mark does not.
  *
  * A value may be pushed more than once, and then occupies as many positions as
- * it was pushed at. That is what makes the two lookups differ, and what the
- * index has to record per value rather than as a single number.
+ * it was pushed at. {@link #indexOf} names the lowest of them and {@link
+ * #lastIndexOf} the highest, and a pop takes the highest away.
+ *
+ * A lookup does not get slower as the stack grows: past {@link #ADD_INDEX_AT}
+ * values it keeps an index, and drops it again below
+ * {@link #DROP_INDEX_BELOW}. Where an answer came from is not observable
+ * beyond what it cost.
  */
 export class IndexTrackingStack<T> {
   /** The values, in order, so a value's position is its index. */
@@ -45,8 +22,14 @@ export class IndexTrackingStack<T> {
 
   /**
    * The positions each value occupies, ascending, while the stack is tall
-   * enough to want them, and `undefined` otherwise. Keyed by
-   * {@link #keyFor}, not by the value itself.
+   * enough to want them, and `undefined` otherwise. Keyed by {@link #keyFor},
+   * not by the value itself.
+   *
+   * Kept once built until the stack falls below {@link #DROP_INDEX_BELOW}, and
+   * used at every height while it exists: what a short stack is spared is
+   * maintaining this, and that is already spent by the time a lookup asks.
+   * The two marks are far enough apart that ordinary movement does not build
+   * and drop repeatedly -- a stack has to swing across the whole gap.
    */
   #positions: Map<unknown, number[]> | undefined;
 
@@ -238,6 +221,12 @@ export class IndexTrackingStack<T> {
 
   /**
    * Whether two values are the same one, which is what this class compares by.
+   *
+   * `Array.prototype.indexOf` will not do it: it compares strictly, so it
+   * finds a `0` for a `-0` and never finds a `NaN`. `===` and `Object.is` part
+   * company on numbers and only on numbers, so the `typeof` here is not a
+   * heuristic -- it is exactly the set that needs the slower answer, and a
+   * stack of anything else pays one check for all of it.
    */
   static #same(a: unknown, b: unknown): boolean {
     return (typeof a === "number") ? Object.is(a, b) : (a === b);
@@ -245,9 +234,13 @@ export class IndexTrackingStack<T> {
 
   /**
    * The index key for the given value: the value itself, except for the two a
-   * `Map` does not key as {@link #same} would have it. A `NaN` needs no
-   * standing in as `Map` is written today, and gets one anyway, so that the
-   * pair is read as one rule rather than as one rule and one coincidence.
+   * `Map` does not key as {@link #same} would have it. A `Map` normalizes a
+   * `-0` key to `0`, so those two would otherwise share an entry. Two values
+   * take the same key exactly when {@link #same} calls them the same value.
+   *
+   * A `NaN` needs no standing in as `Map` is written today, and gets one
+   * anyway, so that the pair is read as one rule rather than as one rule and
+   * one coincidence. Nothing tests the difference, there being none to see.
    *
    * The `typeof` runs first and settles it for everything that is not a
    * number, which is what keeps this off the cost of an ordinary stack.

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -20,15 +20,22 @@ export class IndexTrackingStack {
 
   /**
    * The positions each object occupies, ascending, once the stack has been
-   * tall enough to want them, and `undefined` until then. Kept for the rest of
-   * the stack's life once built: a stack that reached the height once is apt
-   * to reach it again, and rebuilding at each crossing would cost more than
-   * maintaining it.
+   * tall enough to want them, and `undefined` until then.
+   *
+   * Kept for the rest of the stack's life once built, so a stack that has been
+   * past {@link #INDEX_AT} and come back down goes on answering from the index
+   * at a height where a stack that never went up would still be scanning --
+   * and goes on paying for it, at about what it pays above the threshold. A
+   * caller that pushes deep once and then stays shallow for a long time is the
+   * shape that costs.
    */
   #positions: Map<object, number[]> | undefined;
 
-  /** How many objects the stack holds. */
-  get length(): number {
+  /**
+   * How deep the stack is: how many objects it holds, which is also the index
+   * the next object pushed will take.
+   */
+  get depth(): number {
     return this.#stack.length;
   }
 
@@ -63,10 +70,25 @@ export class IndexTrackingStack {
   }
 
   /**
+   * Pops the topmost object off the stack and returns it.
+   *
+   * @throws If the stack is empty.
+   */
+  pop(): object {
+    const value = this.popElseUndefined();
+
+    if (value === undefined) {
+      throw new Error("Cannot pop an empty stack.");
+    }
+
+    return value;
+  }
+
+  /**
    * Pops the topmost object off the stack and returns it, or returns
    * `undefined` if the stack is empty.
    */
-  pop(): object | undefined {
+  popElseUndefined(): object | undefined {
     const value = this.#stack.pop();
 
     if (value === undefined) {
@@ -86,6 +108,21 @@ export class IndexTrackingStack {
     }
 
     return value;
+  }
+
+  /**
+   * Pops the topmost object off the stack, which has to be the given one.
+   * The stack is left as it was if it is not: what a caller has to sort out
+   * is one unbalanced push and pop, not that plus a pop it did not intend.
+   *
+   * @throws If the stack is empty, or its topmost object is not `expected`.
+   */
+  popExpect(expected: object): void {
+    if (this.#stack[this.#stack.length - 1] !== expected) {
+      throw new Error("Popped an object other than the expected one.");
+    }
+
+    this.pop();
   }
 
   /** Pushes an object onto the stack, at the current top. */

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -235,7 +235,7 @@ export class IndexTrackingStack<T> {
   static #keyFor(value: unknown): unknown {
     if (typeof value !== "number") {
       return value;
-    } else if (value !== value) {
+    } else if (Number.isNaN(value)) {
       return IndexTrackingStack.#NAN;
     } else if (Object.is(value, -0)) {
       return IndexTrackingStack.#NEGATIVE_ZERO;

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -5,17 +5,17 @@
  * change while things are pushed above it.
  *
  * Both lookups are answered by scanning while the stack is short, and by an
- * index once it has grown past {@link #INDEX_AT}. Which one answers is not
- * observable beyond the cost: a scan is linear in the stack's height where a
- * keyed lookup is not, and the two are within reach of each other only over a
- * range that a short stack sits well below.
+ * index once it has reached {@link #ADD_INDEX_AT} objects. Which one answers
+ * is not observable beyond the cost: a scan is linear in the stack's height
+ * where a keyed lookup is not, and the two are within reach of each other only
+ * over a range that a short stack sits well below.
  *
- * The index is dropped again once the stack falls below {@link #DROP_BELOW},
- * so a stack that grew tall once and came back down goes back to scanning
- * rather than paying for a height it no longer has. The two marks are kept
- * apart so that ordinary movement does not build and drop repeatedly: only a
- * stack swinging across the whole gap between them rebuilds, and one hovering
- * near either mark does not.
+ * The index is dropped again once the stack falls below
+ * {@link #DROP_INDEX_BELOW}, so a stack that grew tall once and came back down
+ * goes back to scanning rather than paying for a height it no longer has. The
+ * two marks are kept apart so that ordinary movement does not build and drop
+ * repeatedly: only a stack swinging across the whole gap between them
+ * rebuilds, and one hovering near either mark does not.
  *
  * An object may be pushed more than once, and then occupies as many positions
  * as it was pushed at. That is what makes the two lookups differ, and what the
@@ -106,7 +106,7 @@ export class IndexTrackingStack {
         this.#positions!.delete(value);
       }
 
-      if (this.#stack.length < IndexTrackingStack.DROP_BELOW) {
+      if (this.#stack.length < IndexTrackingStack.DROP_INDEX_BELOW) {
         this.#positions = undefined;
       }
     }
@@ -143,7 +143,7 @@ export class IndexTrackingStack {
       } else {
         found.push(at);
       }
-    } else if (this.#stack.length > IndexTrackingStack.INDEX_AT) {
+    } else if (this.#stack.length >= IndexTrackingStack.ADD_INDEX_AT) {
       const positions = new Map<object, number[]>();
 
       for (let index = 0; index < this.#stack.length; index++) {
@@ -166,16 +166,16 @@ export class IndexTrackingStack {
   //
 
   /**
-   * The height past which an index is built. Set well below the height at
-   * which a scan and a keyed lookup cost the same, so that reaching it never
-   * costs more than not having reached it.
+   * The height at which an index is built. Set well below the height at which
+   * a scan and a keyed lookup cost the same, so that reaching it never costs
+   * more than not having reached it.
    */
-  static readonly INDEX_AT = 64;
+  static readonly ADD_INDEX_AT = 64;
 
   /**
    * The height below which the index is dropped. The gap between this and
-   * {@link #INDEX_AT} is what keeps a stack from building and dropping over
-   * and over: a stack has to swing across the whole of it to rebuild.
+   * {@link #ADD_INDEX_AT} is what keeps a stack from building and dropping
+   * over and over: a stack has to swing across the whole of it to rebuild.
    */
-  static readonly DROP_BELOW = 32;
+  static readonly DROP_INDEX_BELOW = 32;
 }

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -4,11 +4,18 @@
  * value pushed is at index `0`, and an index does not change while things are
  * pushed above it.
  *
- * Values are compared the way `Map` compares its keys: by identity for an
- * object, by value for a primitive, and `NaN` matching itself. That is not
- * what `Array.prototype.indexOf` does -- it compares strictly, and so never
- * finds a `NaN` -- which matters here because both are used, and the two have
- * to agree.
+ * Values are compared as `Object.is` compares them: by identity for an object,
+ * by value for a primitive, `NaN` matching itself, and `-0` distinct from `0`.
+ * Neither structure beneath does that on its own -- `Array.prototype.indexOf`
+ * compares strictly, so it finds a `0` for a `-0` and never finds a `NaN`, and
+ * a `Map` normalizes a `-0` key to `0`. Both are given the comparison instead:
+ * the scan through {@link #same}, and the index through {@link #keyFor}, which
+ * stands a symbol in for each of the two values a `Map` cannot key as
+ * `Object.is` would have it. Two values take the same key exactly when
+ * `Object.is` calls them the same value.
+ *
+ * `===` and `Object.is` part company on numbers alone, so a `typeof` check is
+ * all an ordinary stack pays for any of it.
  *
  * Both lookups are answered by scanning while the stack is short, and by an
  * index once it has reached {@link #ADD_INDEX_AT} values. Which one is used
@@ -38,9 +45,10 @@ export class IndexTrackingStack<T> {
 
   /**
    * The positions each value occupies, ascending, while the stack is tall
-   * enough to want them, and `undefined` otherwise.
+   * enough to want them, and `undefined` otherwise. Keyed by
+   * {@link #keyFor}, not by the value itself.
    */
-  #positions: Map<T, number[]> | undefined;
+  #positions: Map<unknown, number[]> | undefined;
 
   /**
    * How deep the stack is: how many values it holds, which is also the index
@@ -58,12 +66,14 @@ export class IndexTrackingStack<T> {
     const positions = this.#positions;
 
     if (positions !== undefined) {
-      return positions.get(value)?.[0] ?? -1;
-    } else if (value === value) {
-      return this.#stack.indexOf(value);
+      return positions.get(IndexTrackingStack.#keyFor(value))?.[0] ?? -1;
+    } else if (typeof value === "number") {
+      return this.#stack.findIndex((held) =>
+        IndexTrackingStack.#same(held, value)
+      );
     }
 
-    return this.#stack.findIndex((held) => held !== held);
+    return this.#stack.indexOf(value);
   }
 
   /**
@@ -74,14 +84,16 @@ export class IndexTrackingStack<T> {
     const positions = this.#positions;
 
     if (positions !== undefined) {
-      const found = positions.get(value);
+      const found = positions.get(IndexTrackingStack.#keyFor(value));
 
       return (found === undefined) ? -1 : found[found.length - 1]!;
-    } else if (value === value) {
-      return this.#stack.lastIndexOf(value);
+    } else if (typeof value === "number") {
+      return this.#stack.findLastIndex((held) =>
+        IndexTrackingStack.#same(held, value)
+      );
     }
 
-    return this.#stack.findLastIndex((held) => held !== held);
+    return this.#stack.lastIndexOf(value);
   }
 
   /**
@@ -123,10 +135,7 @@ export class IndexTrackingStack<T> {
 
     const top = this.#stack[this.#stack.length - 1] as T;
 
-    // Compared as the index compares, rather than with `!==`, so that a `NaN`
-    // expectation is met by a `NaN` on top. An empty stack has been refused
-    // above, so this is not reading past the bottom for it.
-    if (!((top === expected) || ((top !== top) && (expected !== expected)))) {
+    if (!IndexTrackingStack.#same(top, expected)) {
       throw new Error("The top of the stack is not the expected value.");
     }
 
@@ -140,22 +149,23 @@ export class IndexTrackingStack<T> {
     this.#stack.push(value);
 
     if (this.#positions !== undefined) {
-      const found = this.#positions.get(value);
+      const key = IndexTrackingStack.#keyFor(value);
+      const found = this.#positions.get(key);
 
       if (found === undefined) {
-        this.#positions.set(value, [at]);
+        this.#positions.set(key, [at]);
       } else {
         found.push(at);
       }
     } else if (this.#stack.length >= IndexTrackingStack.ADD_INDEX_AT) {
-      const positions = new Map<T, number[]>();
+      const positions = new Map<unknown, number[]>();
 
       for (let index = 0; index < this.#stack.length; index++) {
-        const value = this.#stack[index] as T;
-        const found = positions.get(value);
+        const key = IndexTrackingStack.#keyFor(this.#stack[index] as T);
+        const found = positions.get(key);
 
         if (found === undefined) {
-          positions.set(value, [index]);
+          positions.set(key, [index]);
         } else {
           found.push(index);
         }
@@ -170,15 +180,22 @@ export class IndexTrackingStack<T> {
    */
   #popNonEmpty(): T {
     const value = this.#stack.pop() as T;
-    const found = this.#positions?.get(value);
+    const positions = this.#positions;
 
-    if (found !== undefined) {
-      // The positions of one value ascend, and what came off the stack is the
-      // highest of them, so it is the last of these.
-      found.pop();
+    // Nothing below is reached, nor the key computed for it, while there is no
+    // index -- which is the whole of what a short stack does here.
+    if (positions !== undefined) {
+      const key = IndexTrackingStack.#keyFor(value);
+      const found = positions.get(key);
 
-      if (found.length === 0) {
-        this.#positions!.delete(value);
+      if (found !== undefined) {
+        // The positions of one value ascend, and what came off the stack is
+        // the highest of them, so it is the last of these.
+        found.pop();
+
+        if (found.length === 0) {
+          positions.delete(key);
+        }
       }
 
       if (this.#stack.length < IndexTrackingStack.DROP_INDEX_BELOW) {
@@ -194,6 +211,18 @@ export class IndexTrackingStack<T> {
   //
 
   /**
+   * Stands in for `NaN` as an index key, so that nothing rests on how a `Map`
+   * happens to treat one.
+   */
+  static readonly #NAN = Symbol("NaN");
+
+  /**
+   * Stands in for `-0` as an index key. A `Map` normalizes a `-0` key to `0`,
+   * so the two would share an entry and become indistinguishable.
+   */
+  static readonly #NEGATIVE_ZERO = Symbol("negative zero");
+
+  /**
    * The height at which an index is built. Set well below the height at which
    * a scan and a keyed lookup cost the same, so that reaching it never costs
    * more than not having reached it.
@@ -206,4 +235,32 @@ export class IndexTrackingStack<T> {
    * over and over: a stack has to swing across the whole of it to rebuild.
    */
   static readonly DROP_INDEX_BELOW = 32;
+
+  /**
+   * Whether two values are the same one, which is what this class compares by.
+   */
+  static #same(a: unknown, b: unknown): boolean {
+    return (typeof a === "number") ? Object.is(a, b) : (a === b);
+  }
+
+  /**
+   * The index key for the given value: the value itself, except for the two a
+   * `Map` does not key as {@link #same} would have it. A `NaN` needs no
+   * standing in as `Map` is written today, and gets one anyway, so that the
+   * pair is read as one rule rather than as one rule and one coincidence.
+   *
+   * The `typeof` runs first and settles it for everything that is not a
+   * number, which is what keeps this off the cost of an ordinary stack.
+   */
+  static #keyFor(value: unknown): unknown {
+    if (typeof value !== "number") {
+      return value;
+    } else if (value !== value) {
+      return IndexTrackingStack.#NAN;
+    } else if (Object.is(value, -0)) {
+      return IndexTrackingStack.#NEGATIVE_ZERO;
+    }
+
+    return value;
+  }
 }

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -13,7 +13,7 @@
  *
  * A lookup does not get slower as the stack grows.
  */
-export class IndexTrackingStack<T> {
+export class IndexTrackingStack<T = unknown> {
   /** The values, in order, so a value's position is its index. */
   readonly #stack: T[] = [];
 

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -11,9 +11,7 @@
  * it was pushed at. {@link #indexOf} names the lowest of them and {@link
  * #lastIndexOf} the highest, and a pop takes the highest away.
  *
- * A lookup does not get slower as the stack grows. How that is arranged, and
- * the heights it is arranged around, are this class's own business and not
- * something to write code against.
+ * A lookup does not get slower as the stack grows.
  */
 export class IndexTrackingStack<T> {
   /** The values, in order, so a value's position is its index. */

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -18,15 +18,15 @@ export class IndexTrackingStack<T> {
   readonly #stack: T[] = [];
 
   /**
-   * The positions each value occupies, ascending, while the stack is tall
-   * enough to want them, and `undefined` otherwise. Keyed by {@link #keyFor},
-   * not by the value itself.
+   * The positions each value occupies, ascending, and `undefined` while there
+   * is none. Keyed by {@link #keyFor}, not by the value itself.
    *
-   * Kept once built until the stack falls below {@link #DROP_INDEX_BELOW},
-   * and used at every height while it exists: what a short stack is spared is
-   * maintaining this, and that is already spent by the time a lookup asks.
-   * The two marks are far enough apart that ordinary movement does not build
-   * and drop repeatedly -- a stack has to swing across the whole gap.
+   * Built by {@link #indexIfWanted} and dropped once the stack falls below
+   * {@link #DROP_INDEX_BELOW}. Used at every height while it exists: what a
+   * short stack is spared is maintaining this, and that is already spent by
+   * the time a lookup asks. The two marks are far enough apart that ordinary
+   * movement does not build and drop repeatedly -- a stack has to swing
+   * across the whole gap.
    */
   #positions: Map<unknown, number[]> | undefined;
 
@@ -47,7 +47,7 @@ export class IndexTrackingStack<T> {
    * the stack.
    */
   indexOf(value: T): number {
-    const positions = this.#positions;
+    const positions = this.#indexIfWanted();
 
     if (positions !== undefined) {
       return positions.get(IndexTrackingStack.#keyFor(value))?.[0] ?? -1;
@@ -67,7 +67,7 @@ export class IndexTrackingStack<T> {
    * the stack.
    */
   lastIndexOf(value: T): number {
-    const positions = this.#positions;
+    const positions = this.#indexIfWanted();
 
     if (positions !== undefined) {
       const found = positions.get(IndexTrackingStack.#keyFor(value));
@@ -132,6 +132,9 @@ export class IndexTrackingStack<T> {
 
     this.#stack.push(value);
 
+    // Only an index that already exists is maintained. Building one is
+    // {@link #indexIfWanted}'s business, and a stack nobody asks a position of
+    // never has one to maintain.
     if (this.#positions !== undefined) {
       const key = IndexTrackingStack.#keyFor(value);
       const found = this.#positions.get(key);
@@ -141,22 +144,40 @@ export class IndexTrackingStack<T> {
       } else {
         found.push(at);
       }
-    } else if (this.#stack.length >= IndexTrackingStack.#ADD_INDEX_AT) {
-      const positions = new Map<unknown, number[]>();
-
-      for (let index = 0; index < this.#stack.length; index++) {
-        const key = IndexTrackingStack.#keyFor(this.#stack[index] as T);
-        const found = positions.get(key);
-
-        if (found === undefined) {
-          positions.set(key, [index]);
-        } else {
-          found.push(index);
-        }
-      }
-
-      this.#positions = positions;
     }
+  }
+
+  /**
+   * The index, built first if the stack is tall enough to want one and has
+   * none, and `undefined` if it is not.
+   *
+   * Built here rather than as the stack grows, because height alone is no
+   * reason to have one: what an index is for is answering a lookup, and a
+   * stack that is never asked never needs it.
+   */
+  #indexIfWanted(): Map<unknown, number[]> | undefined {
+    if (this.#positions !== undefined) {
+      return this.#positions;
+    } else if (this.#stack.length < IndexTrackingStack.#ADD_INDEX_AT) {
+      return undefined;
+    }
+
+    const positions = new Map<unknown, number[]>();
+
+    for (let index = 0; index < this.#stack.length; index++) {
+      const key = IndexTrackingStack.#keyFor(this.#stack[index] as T);
+      const found = positions.get(key);
+
+      if (found === undefined) {
+        positions.set(key, [index]);
+      } else {
+        found.push(index);
+      }
+    }
+
+    this.#positions = positions;
+
+    return positions;
   }
 
   /**

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -10,6 +10,11 @@
  * where a keyed lookup is not, and the two are within reach of each other only
  * over a range that a short stack sits well below.
  *
+ * What the marks weigh is the whole of a stack's use, maintenance included,
+ * rather than a lookup on its own. Where an index exists it answers, at any
+ * height: maintaining it is what a short stack is being spared, and that is
+ * already spent by the time a lookup asks.
+ *
  * The index is dropped again once the stack falls below
  * {@link #DROP_INDEX_BELOW}, so a stack that grew tall once and came back down
  * goes back to scanning rather than paying for a height it no longer has. The

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -54,9 +54,9 @@ export class IndexTrackingStack<T> {
       return this.#stack.findIndex((held) =>
         IndexTrackingStack.#same(held, value)
       );
+    } else {
+      return this.#stack.indexOf(value);
     }
-
-    return this.#stack.indexOf(value);
   }
 
   /**
@@ -74,9 +74,9 @@ export class IndexTrackingStack<T> {
       return this.#stack.findLastIndex((held) =>
         IndexTrackingStack.#same(held, value)
       );
+    } else {
+      return this.#stack.lastIndexOf(value);
     }
-
-    return this.#stack.lastIndexOf(value);
   }
 
   /**
@@ -252,8 +252,8 @@ export class IndexTrackingStack<T> {
       return IndexTrackingStack.#NAN;
     } else if (Object.is(value, -0)) {
       return IndexTrackingStack.#NEGATIVE_ZERO;
+    } else {
+      return value;
     }
-
-    return value;
   }
 }

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -5,13 +5,13 @@
  * change while things are pushed above it.
  *
  * Both lookups are answered by scanning while the stack is short, and by an
- * index once it has reached {@link #ADD_INDEX_AT} objects. Which one answers
+ * index once it has reached {@link #ADD_INDEX_AT} objects. Which one is used
  * is not observable beyond the cost: a scan is linear in the stack's height
  * where a keyed lookup is not, and the two are within reach of each other only
  * over a range that a short stack sits well below.
  *
  * What the marks weigh is the whole of a stack's use, maintenance included,
- * rather than a lookup on its own. Where an index exists it answers, at any
+ * rather than a lookup on its own. Where an index exists it is used, at any
  * height: maintaining it is what a short stack is being spared, and that is
  * already spent by the time a lookup asks.
  *

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -191,16 +191,20 @@ export class IndexTrackingStack<T> {
     // index -- which is the whole of what a short stack does here.
     if (positions !== undefined) {
       const key = IndexTrackingStack.#keyFor(value);
-      const found = positions.get(key);
 
-      if (found !== undefined) {
-        // The positions of one value ascend, and what came off the stack is
-        // the highest of them, so it is the last of these.
-        found.pop();
+      // Not an optional lookup: while an index exists, every value in the
+      // stack has an entry in it. The build takes the whole stack, and the
+      // only two places that change the stack are this one and `push()`, both
+      // of which maintain it. Asserting rather than testing is deliberate --
+      // a test here would skip silently, and leave a corrupt index behind.
+      const found = positions.get(key)!;
 
-        if (found.length === 0) {
-          positions.delete(key);
-        }
+      // The positions of one value ascend, and what came off the stack is the
+      // highest of them, so it is the last of these.
+      found.pop();
+
+      if (found.length === 0) {
+        positions.delete(key);
       }
 
       if (this.#stack.length < IndexTrackingStack.#DROP_INDEX_BELOW) {

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -4,11 +4,18 @@
  * bottom, so the first object pushed is at index `0`, and an index does not
  * change while things are pushed above it.
  *
- * Both lookups are answered by scanning below {@link #INDEX_AT} entries, and
- * by an index built and maintained past that. Which one answers is not
+ * Both lookups are answered by scanning while the stack is short, and by an
+ * index once it has grown past {@link #INDEX_AT}. Which one answers is not
  * observable beyond the cost: a scan is linear in the stack's height where a
  * keyed lookup is not, and the two are within reach of each other only over a
  * range that a short stack sits well below.
+ *
+ * The index is dropped again once the stack falls below {@link #DROP_BELOW},
+ * so a stack that grew tall once and came back down goes back to scanning
+ * rather than paying for a height it no longer has. The two marks are kept
+ * apart so that ordinary movement does not build and drop repeatedly: only a
+ * stack swinging across the whole gap between them rebuilds, and one hovering
+ * near either mark does not.
  *
  * An object may be pushed more than once, and then occupies as many positions
  * as it was pushed at. That is what makes the two lookups differ, and what the
@@ -19,15 +26,8 @@ export class IndexTrackingStack {
   readonly #stack: object[] = [];
 
   /**
-   * The positions each object occupies, ascending, once the stack has been
-   * tall enough to want them, and `undefined` until then.
-   *
-   * Kept for the rest of the stack's life once built, so a stack that has been
-   * past {@link #INDEX_AT} and come back down goes on answering from the index
-   * at a height where a stack that never went up would still be scanning --
-   * and goes on paying for it, at about what it pays above the threshold. A
-   * caller that pushes deep once and then stays shallow for a long time is the
-   * shape that costs.
+   * The positions each object occupies, ascending, while the stack is tall
+   * enough to want them, and `undefined` otherwise.
    */
   #positions: Map<object, number[]> | undefined;
 
@@ -105,6 +105,10 @@ export class IndexTrackingStack {
       if (found.length === 0) {
         this.#positions!.delete(value);
       }
+
+      if (this.#stack.length < IndexTrackingStack.DROP_BELOW) {
+        this.#positions = undefined;
+      }
     }
 
     return value;
@@ -162,9 +166,16 @@ export class IndexTrackingStack {
   //
 
   /**
-   * The height past which an index is kept. Set well below the height at which
-   * a scan and a keyed lookup cost the same, so that crossing it never costs
-   * more than not having crossed it.
+   * The height past which an index is built. Set well below the height at
+   * which a scan and a keyed lookup cost the same, so that reaching it never
+   * costs more than not having reached it.
    */
   static readonly INDEX_AT = 64;
+
+  /**
+   * The height below which the index is dropped. The gap between this and
+   * {@link #INDEX_AT} is what keeps a stack from building and dropping over
+   * and over: a stack has to swing across the whole of it to rebuild.
+   */
+  static readonly DROP_BELOW = 32;
 }

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -11,10 +11,9 @@
  * it was pushed at. {@link #indexOf} names the lowest of them and {@link
  * #lastIndexOf} the highest, and a pop takes the highest away.
  *
- * A lookup does not get slower as the stack grows: past {@link #ADD_INDEX_AT}
- * values it keeps an index, and drops it again below
- * {@link #DROP_INDEX_BELOW}. Where an answer came from is not observable
- * beyond what it cost.
+ * A lookup does not get slower as the stack grows. How that is arranged, and
+ * the heights it is arranged around, are this class's own business and not
+ * something to write code against.
  */
 export class IndexTrackingStack<T> {
   /** The values, in order, so a value's position is its index. */
@@ -25,8 +24,8 @@ export class IndexTrackingStack<T> {
    * enough to want them, and `undefined` otherwise. Keyed by {@link #keyFor},
    * not by the value itself.
    *
-   * Kept once built until the stack falls below {@link #DROP_INDEX_BELOW}, and
-   * used at every height while it exists: what a short stack is spared is
+   * Kept once built until the stack falls below {@link #DROP_INDEX_BELOW},
+   * and used at every height while it exists: what a short stack is spared is
    * maintaining this, and that is already spent by the time a lookup asks.
    * The two marks are far enough apart that ordinary movement does not build
    * and drop repeatedly -- a stack has to swing across the whole gap.
@@ -140,7 +139,7 @@ export class IndexTrackingStack<T> {
       } else {
         found.push(at);
       }
-    } else if (this.#stack.length >= IndexTrackingStack.ADD_INDEX_AT) {
+    } else if (this.#stack.length >= IndexTrackingStack.#ADD_INDEX_AT) {
       const positions = new Map<unknown, number[]>();
 
       for (let index = 0; index < this.#stack.length; index++) {
@@ -181,7 +180,7 @@ export class IndexTrackingStack<T> {
         }
       }
 
-      if (this.#stack.length < IndexTrackingStack.DROP_INDEX_BELOW) {
+      if (this.#stack.length < IndexTrackingStack.#DROP_INDEX_BELOW) {
         this.#positions = undefined;
       }
     }
@@ -210,14 +209,33 @@ export class IndexTrackingStack<T> {
    * a scan and a keyed lookup cost the same, so that reaching it never costs
    * more than not having reached it.
    */
-  static readonly ADD_INDEX_AT = 64;
+  static readonly #ADD_INDEX_AT = 64;
 
   /**
    * The height below which the index is dropped. The gap between this and
    * {@link #ADD_INDEX_AT} is what keeps a stack from building and dropping
    * over and over: a stack has to swing across the whole of it to rebuild.
    */
-  static readonly DROP_INDEX_BELOW = 32;
+  static readonly #DROP_INDEX_BELOW = 32;
+
+  /**
+   * The heights this class arranges itself around, for a test or a benchmark
+   * to bound its cases with.
+   *
+   * The name is the documentation. These are a tuning decision, not part of
+   * what this class promises, and code that reads them is written against a
+   * number that is free to move. A test that has to straddle a threshold has
+   * no other way to find it, which is the whole of why this exists.
+   */
+  static get accessForTestingOnly(): {
+    ADD_INDEX_AT: number;
+    DROP_INDEX_BELOW: number;
+  } {
+    return {
+      ADD_INDEX_AT: IndexTrackingStack.#ADD_INDEX_AT,
+      DROP_INDEX_BELOW: IndexTrackingStack.#DROP_INDEX_BELOW,
+    };
+  }
 
   /**
    * The index key for the given value: the value itself, except for the two a

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -1,0 +1,133 @@
+/**
+ * A stack of objects offering `Array`-style {@link #indexOf} and {@link
+ * #lastIndexOf}, comparing by identity. An object's index is counted from the
+ * bottom, so the first object pushed is at index `0`, and an index does not
+ * change while things are pushed above it.
+ *
+ * Both lookups are answered by scanning below {@link #INDEX_AT} entries, and
+ * by an index built and maintained past that. Which one answers is not
+ * observable beyond the cost: a scan is linear in the stack's height where a
+ * keyed lookup is not, and the two are within reach of each other only over a
+ * range that a short stack sits well below.
+ *
+ * An object may be pushed more than once, and then occupies as many positions
+ * as it was pushed at. That is what makes the two lookups differ, and what the
+ * index has to record per object rather than as a single number.
+ */
+export class IndexTrackingStack {
+  /** The objects, in order, so an object's position is its index. */
+  readonly #stack: object[] = [];
+
+  /**
+   * The positions each object occupies, ascending, once the stack has been
+   * tall enough to want them, and `undefined` until then. Kept for the rest of
+   * the stack's life once built: a stack that reached the height once is apt
+   * to reach it again, and rebuilding at each crossing would cost more than
+   * maintaining it.
+   */
+  #positions: Map<object, number[]> | undefined;
+
+  /** How many objects the stack holds. */
+  get length(): number {
+    return this.#stack.length;
+  }
+
+  /**
+   * The lowest index at which the given object sits, or `-1` if it is not in
+   * the stack.
+   */
+  indexOf(value: object): number {
+    const positions = this.#positions;
+
+    if (positions === undefined) {
+      return this.#stack.indexOf(value);
+    }
+
+    return positions.get(value)?.[0] ?? -1;
+  }
+
+  /**
+   * The highest index at which the given object sits, or `-1` if it is not in
+   * the stack.
+   */
+  lastIndexOf(value: object): number {
+    const positions = this.#positions;
+
+    if (positions === undefined) {
+      return this.#stack.lastIndexOf(value);
+    }
+
+    const found = positions.get(value);
+
+    return (found === undefined) ? -1 : found[found.length - 1]!;
+  }
+
+  /**
+   * Pops the topmost object off the stack and returns it, or returns
+   * `undefined` if the stack is empty.
+   */
+  pop(): object | undefined {
+    const value = this.#stack.pop();
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const found = this.#positions?.get(value);
+
+    if (found !== undefined) {
+      // The positions of one object ascend, and what came off the stack is the
+      // highest of them, so it is the last of these.
+      found.pop();
+
+      if (found.length === 0) {
+        this.#positions!.delete(value);
+      }
+    }
+
+    return value;
+  }
+
+  /** Pushes an object onto the stack, at the current top. */
+  push(value: object): void {
+    const at = this.#stack.length;
+
+    this.#stack.push(value);
+
+    if (this.#positions !== undefined) {
+      const found = this.#positions.get(value);
+
+      if (found === undefined) {
+        this.#positions.set(value, [at]);
+      } else {
+        found.push(at);
+      }
+    } else if (this.#stack.length > IndexTrackingStack.INDEX_AT) {
+      const positions = new Map<object, number[]>();
+
+      for (let index = 0; index < this.#stack.length; index++) {
+        const value = this.#stack[index]!;
+        const found = positions.get(value);
+
+        if (found === undefined) {
+          positions.set(value, [index]);
+        } else {
+          found.push(index);
+        }
+      }
+
+      this.#positions = positions;
+    }
+  }
+
+  //
+  // Static members
+  //
+
+  /**
+   * The height past which an index is kept. Set well below the height at which
+   * a scan and a keyed lookup cost the same, so that crossing it never costs
+   * more than not having crossed it.
+   */
+  static readonly INDEX_AT = 64;
+}

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -192,11 +192,12 @@ export class IndexTrackingStack<T> {
     if (positions !== undefined) {
       const key = IndexTrackingStack.#keyFor(value);
 
-      // Not an optional lookup: while an index exists, every value in the
-      // stack has an entry in it. The build takes the whole stack, and the
-      // only two places that change the stack are this one and `push()`, both
-      // of which maintain it. Asserting rather than testing is deliberate --
-      // a test here would skip silently, and leave a corrupt index behind.
+      // Non-nullish type assertion (`!`) below, because `key` is in the map
+      // by construction: while an index exists, every value in the stack has
+      // an entry in it. The build takes the whole stack, and the only two
+      // places that change the stack are this one and `push()`, both of which
+      // maintain it. Asserting rather than testing is deliberate -- a test
+      // here would skip silently, and leave a corrupt index behind.
       const found = positions.get(key)!;
 
       // The positions of one value ascend, and what came off the stack is the

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -51,9 +51,11 @@ export class IndexTrackingStack<T> {
     if (positions !== undefined) {
       return positions.get(IndexTrackingStack.#keyFor(value))?.[0] ?? -1;
     } else if (typeof value === "number") {
-      return this.#stack.findIndex((held) =>
-        IndexTrackingStack.#same(held, value)
-      );
+      // `Array.prototype.indexOf` compares strictly, so it would find a `0`
+      // for a `-0` and never find a `NaN`. `===` and `Object.is` part company
+      // on numbers and only on numbers, so this arm is exactly the set that
+      // needs the slower search.
+      return this.#stack.findIndex((held) => Object.is(held, value));
     } else {
       return this.#stack.indexOf(value);
     }
@@ -71,9 +73,7 @@ export class IndexTrackingStack<T> {
 
       return (found === undefined) ? -1 : found[found.length - 1]!;
     } else if (typeof value === "number") {
-      return this.#stack.findLastIndex((held) =>
-        IndexTrackingStack.#same(held, value)
-      );
+      return this.#stack.findLastIndex((held) => Object.is(held, value));
     } else {
       return this.#stack.lastIndexOf(value);
     }
@@ -118,7 +118,7 @@ export class IndexTrackingStack<T> {
 
     const top = this.#stack[this.#stack.length - 1] as T;
 
-    if (!IndexTrackingStack.#same(top, expected)) {
+    if (!Object.is(top, expected)) {
       throw new Error("The top of the stack is not the expected value.");
     }
 
@@ -220,23 +220,10 @@ export class IndexTrackingStack<T> {
   static readonly DROP_INDEX_BELOW = 32;
 
   /**
-   * Whether two values are the same one, which is what this class compares by.
-   *
-   * `Array.prototype.indexOf` will not do it: it compares strictly, so it
-   * finds a `0` for a `-0` and never finds a `NaN`. `===` and `Object.is` part
-   * company on numbers and only on numbers, so the `typeof` here is not a
-   * heuristic -- it is exactly the set that needs the slower answer, and a
-   * stack of anything else pays one check for all of it.
-   */
-  static #same(a: unknown, b: unknown): boolean {
-    return (typeof a === "number") ? Object.is(a, b) : (a === b);
-  }
-
-  /**
    * The index key for the given value: the value itself, except for the two a
-   * `Map` does not key as {@link #same} would have it. A `Map` normalizes a
+   * `Map` does not key as `Object.is` would have it. A `Map` normalizes a
    * `-0` key to `0`, so those two would otherwise share an entry. Two values
-   * take the same key exactly when {@link #same} calls them the same value.
+   * take the same key exactly when `Object.is` calls them the same value.
    *
    * A `NaN` needs no standing in as `Map` is written today, and gets one
    * anyway, so that the pair is read as one rule rather than as one rule and

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -1,11 +1,17 @@
 /**
- * A stack of objects offering `Array`-style {@link #indexOf} and {@link
- * #lastIndexOf}, comparing by identity. An object's index is counted from the
- * bottom, so the first object pushed is at index `0`, and an index does not
- * change while things are pushed above it.
+ * A stack of values offering `Array`-style {@link #indexOf} and {@link
+ * #lastIndexOf}. A value's index is counted from the bottom, so the first
+ * value pushed is at index `0`, and an index does not change while things are
+ * pushed above it.
+ *
+ * Values are compared the way `Map` compares its keys: by identity for an
+ * object, by value for a primitive, and `NaN` matching itself. That is not
+ * what `Array.prototype.indexOf` does -- it compares strictly, and so never
+ * finds a `NaN` -- which matters here because both are used, and the two have
+ * to agree.
  *
  * Both lookups are answered by scanning while the stack is short, and by an
- * index once it has reached {@link #ADD_INDEX_AT} objects. Which one is used
+ * index once it has reached {@link #ADD_INDEX_AT} values. Which one is used
  * is not observable beyond the cost: a scan is linear in the stack's height
  * where a keyed lookup is not, and the two are within reach of each other only
  * over a range that a short stack sits well below.
@@ -22,120 +28,113 @@
  * repeatedly: only a stack swinging across the whole gap between them
  * rebuilds, and one hovering near either mark does not.
  *
- * An object may be pushed more than once, and then occupies as many positions
- * as it was pushed at. That is what makes the two lookups differ, and what the
- * index has to record per object rather than as a single number.
+ * A value may be pushed more than once, and then occupies as many positions as
+ * it was pushed at. That is what makes the two lookups differ, and what the
+ * index has to record per value rather than as a single number.
  */
-export class IndexTrackingStack {
-  /** The objects, in order, so an object's position is its index. */
-  readonly #stack: object[] = [];
+export class IndexTrackingStack<T> {
+  /** The values, in order, so a value's position is its index. */
+  readonly #stack: T[] = [];
 
   /**
-   * The positions each object occupies, ascending, while the stack is tall
+   * The positions each value occupies, ascending, while the stack is tall
    * enough to want them, and `undefined` otherwise.
    */
-  #positions: Map<object, number[]> | undefined;
+  #positions: Map<T, number[]> | undefined;
 
   /**
-   * How deep the stack is: how many objects it holds, which is also the index
-   * the next object pushed will take.
+   * How deep the stack is: how many values it holds, which is also the index
+   * the next value pushed will take.
    */
   get depth(): number {
     return this.#stack.length;
   }
 
   /**
-   * The lowest index at which the given object sits, or `-1` if it is not in
+   * The lowest index at which the given value sits, or `-1` if it is not in
    * the stack.
    */
-  indexOf(value: object): number {
+  indexOf(value: T): number {
     const positions = this.#positions;
 
-    if (positions === undefined) {
+    if (positions !== undefined) {
+      return positions.get(value)?.[0] ?? -1;
+    } else if (value === value) {
       return this.#stack.indexOf(value);
     }
 
-    return positions.get(value)?.[0] ?? -1;
+    return this.#stack.findIndex((held) => held !== held);
   }
 
   /**
-   * The highest index at which the given object sits, or `-1` if it is not in
+   * The highest index at which the given value sits, or `-1` if it is not in
    * the stack.
    */
-  lastIndexOf(value: object): number {
+  lastIndexOf(value: T): number {
     const positions = this.#positions;
 
-    if (positions === undefined) {
+    if (positions !== undefined) {
+      const found = positions.get(value);
+
+      return (found === undefined) ? -1 : found[found.length - 1]!;
+    } else if (value === value) {
       return this.#stack.lastIndexOf(value);
     }
 
-    const found = positions.get(value);
-
-    return (found === undefined) ? -1 : found[found.length - 1]!;
+    return this.#stack.findLastIndex((held) => held !== held);
   }
 
   /**
-   * Pops the topmost object off the stack and returns it.
+   * Pops the topmost value off the stack and returns it.
    *
    * @throws If the stack is empty.
    */
-  pop(): object {
-    const value = this.popElseUndefined();
-
-    if (value === undefined) {
+  pop(): T {
+    if (this.#stack.length === 0) {
       throw new Error("Cannot pop an empty stack.");
     }
 
-    return value;
+    return this.#popNonEmpty();
   }
 
   /**
-   * Pops the topmost object off the stack and returns it, or returns
+   * Pops the topmost value off the stack and returns it, or returns
    * `undefined` if the stack is empty.
+   *
+   * This cannot tell an empty stack from one whose topmost value is
+   * `undefined`, so it is for a caller whose `T` does not admit that. One
+   * whose `T` does has {@link #depth} to ask with, and {@link #pop}.
    */
-  popElseUndefined(): object | undefined {
-    const value = this.#stack.pop();
-
-    if (value === undefined) {
-      return undefined;
-    }
-
-    const found = this.#positions?.get(value);
-
-    if (found !== undefined) {
-      // The positions of one object ascend, and what came off the stack is the
-      // highest of them, so it is the last of these.
-      found.pop();
-
-      if (found.length === 0) {
-        this.#positions!.delete(value);
-      }
-
-      if (this.#stack.length < IndexTrackingStack.DROP_INDEX_BELOW) {
-        this.#positions = undefined;
-      }
-    }
-
-    return value;
+  popElseUndefined(): T | undefined {
+    return (this.#stack.length === 0) ? undefined : this.#popNonEmpty();
   }
 
   /**
-   * Pops the topmost object off the stack, which has to be the given one.
-   * The stack is left as it was if it is not: what a caller has to sort out
-   * is one unbalanced push and pop, not that plus a pop it did not intend.
+   * Pops the topmost value off the stack, which has to be the given one. The
+   * stack is left as it was if it is not: what a caller has to sort out is one
+   * unbalanced push and pop, not that plus a pop it did not intend.
    *
-   * @throws If the stack is empty, or its topmost object is not `expected`.
+   * @throws If the stack is empty, or its topmost value is not `expected`.
    */
-  popExpect(expected: object): void {
-    if (this.#stack[this.#stack.length - 1] !== expected) {
-      throw new Error("Popped an object other than the expected one.");
+  popExpect(expected: T): void {
+    if (this.#stack.length === 0) {
+      throw new Error("Cannot pop an empty stack.");
     }
 
-    this.pop();
+    const top = this.#stack[this.#stack.length - 1] as T;
+
+    // Compared as the index compares, rather than with `!==`, so that a `NaN`
+    // expectation is met by a `NaN` on top. An empty stack has been refused
+    // above, so this is not reading past the bottom for it.
+    if (!((top === expected) || ((top !== top) && (expected !== expected)))) {
+      throw new Error("The top of the stack is not the expected value.");
+    }
+
+    this.#popNonEmpty();
   }
 
-  /** Pushes an object onto the stack, at the current top. */
-  push(value: object): void {
+  /** Pushes a value onto the stack, at the current top. */
+  push(value: T): void {
     const at = this.#stack.length;
 
     this.#stack.push(value);
@@ -149,10 +148,10 @@ export class IndexTrackingStack {
         found.push(at);
       }
     } else if (this.#stack.length >= IndexTrackingStack.ADD_INDEX_AT) {
-      const positions = new Map<object, number[]>();
+      const positions = new Map<T, number[]>();
 
       for (let index = 0; index < this.#stack.length; index++) {
-        const value = this.#stack[index]!;
+        const value = this.#stack[index] as T;
         const found = positions.get(value);
 
         if (found === undefined) {
@@ -164,6 +163,30 @@ export class IndexTrackingStack {
 
       this.#positions = positions;
     }
+  }
+
+  /**
+   * Pops off a stack already known not to be empty, and returns what came off.
+   */
+  #popNonEmpty(): T {
+    const value = this.#stack.pop() as T;
+    const found = this.#positions?.get(value);
+
+    if (found !== undefined) {
+      // The positions of one value ascend, and what came off the stack is the
+      // highest of them, so it is the last of these.
+      found.pop();
+
+      if (found.length === 0) {
+        this.#positions!.delete(value);
+      }
+
+      if (this.#stack.length < IndexTrackingStack.DROP_INDEX_BELOW) {
+        this.#positions = undefined;
+      }
+    }
+
+    return value;
   }
 
   //

--- a/packages/utils/src/index-tracking-stack.ts
+++ b/packages/utils/src/index-tracking-stack.ts
@@ -30,6 +30,10 @@ export class IndexTrackingStack<T> {
    */
   #positions: Map<unknown, number[]> | undefined;
 
+  //
+  // Instance members
+  //
+
   /**
    * How deep the stack is: how many values it holds, which is also the index
    * the next value pushed will take.

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -30,7 +30,7 @@ const TALL = IndexTrackingStack.ADD_INDEX_AT + 5;
  * threshold.
  */
 function stackOf(height: number, values: readonly object[]) {
-  const stack = new IndexTrackingStack();
+  const stack = new IndexTrackingStack<object>();
 
   for (const filler of objects(height)) stack.push(filler);
   for (const value of values) stack.push(value);
@@ -41,11 +41,11 @@ function stackOf(height: number, values: readonly object[]) {
 describe("IndexTrackingStack", () => {
   describe("depth", () => {
     it("is zero for a fresh stack", () => {
-      expect(new IndexTrackingStack().depth).toBe(0);
+      expect(new IndexTrackingStack<object>().depth).toBe(0);
     });
 
     it("counts what has been pushed and not popped", () => {
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of objects(TALL)) stack.push(value);
       expect(stack.depth).toBe(TALL);
@@ -55,7 +55,7 @@ describe("IndexTrackingStack", () => {
     });
 
     it("stays at zero when an empty stack is popped", () => {
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       stack.popElseUndefined();
 
@@ -65,12 +65,12 @@ describe("IndexTrackingStack", () => {
 
   describe("pop()", () => {
     it("throws for an empty stack", () => {
-      expect(() => new IndexTrackingStack().pop()).toThrow();
+      expect(() => new IndexTrackingStack<object>().pop()).toThrow();
     });
 
     it("returns the objects it pops, topmost first", () => {
       const held = objects(3);
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of held) stack.push(value);
 
@@ -92,12 +92,13 @@ describe("IndexTrackingStack", () => {
 
   describe("popElseUndefined()", () => {
     it("returns `undefined` for an empty stack", () => {
-      expect(new IndexTrackingStack().popElseUndefined()).toBeUndefined();
+      expect(new IndexTrackingStack<object>().popElseUndefined())
+        .toBeUndefined();
     });
 
     it("returns the objects it pops, topmost first", () => {
       const held = objects(2);
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of held) stack.push(value);
 
@@ -120,7 +121,7 @@ describe("IndexTrackingStack", () => {
   describe("popExpect()", () => {
     it("pops the object it was told to expect", () => {
       const held = objects(2);
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of held) stack.push(value);
       stack.popExpect(held[1]!);
@@ -131,7 +132,7 @@ describe("IndexTrackingStack", () => {
 
     it("throws for an object that is in the stack but not on top", () => {
       const held = objects(2);
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of held) stack.push(value);
 
@@ -139,7 +140,7 @@ describe("IndexTrackingStack", () => {
     });
 
     it("throws for an object the stack does not hold", () => {
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       stack.push({});
 
@@ -147,12 +148,12 @@ describe("IndexTrackingStack", () => {
     });
 
     it("throws for an empty stack", () => {
-      expect(() => new IndexTrackingStack().popExpect({})).toThrow();
+      expect(() => new IndexTrackingStack<object>().popExpect({})).toThrow();
     });
 
     it("leaves the stack as it was when it throws", () => {
       const held = objects(2);
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const value of held) stack.push(value);
       expect(() => stack.popExpect(held[0]!)).toThrow();
@@ -267,13 +268,105 @@ describe("IndexTrackingStack", () => {
     }
   });
 
+  describe("a domain holding `undefined` and `NaN`", () => {
+    // What a parametric stack costs: `undefined` stops being a signal, and the
+    // scan and the index stop agreeing on their own. Each case runs on both
+    // sides of the threshold, since only one of the two is at issue in each.
+    for (
+      const [where, height] of [["scanning", 0], ["indexed", TALL]] as const
+    ) {
+      describe(where, () => {
+        /** A stack of the padded height, then the given values. */
+        function stackOfAny(values: readonly unknown[]) {
+          const stack = new IndexTrackingStack<unknown>();
+
+          for (const filler of objects(height)) stack.push(filler);
+          for (const value of values) stack.push(value);
+
+          return stack;
+        }
+
+        it("finds `undefined` where it was pushed", () => {
+          const stack = stackOfAny([undefined, {}, undefined]);
+
+          expect(stack.indexOf(undefined)).toBe(height);
+          expect(stack.lastIndexOf(undefined)).toBe(height + 2);
+        });
+
+        it("finds `NaN`, which strict comparison never would", () => {
+          const stack = stackOfAny([NaN, {}, NaN]);
+
+          expect(stack.indexOf(NaN)).toBe(height);
+          expect(stack.lastIndexOf(NaN)).toBe(height + 2);
+        });
+
+        it("treats `-0` and `0` as one value, as a `Map` key would", () => {
+          const stack = stackOfAny([-0]);
+
+          expect(stack.indexOf(0)).toBe(height);
+          expect(stack.lastIndexOf(-0)).toBe(height);
+        });
+
+        it("pops an expected `undefined` off the top", () => {
+          const stack = stackOfAny([undefined]);
+
+          stack.popExpect(undefined);
+
+          expect(stack.depth).toBe(height);
+        });
+
+        it("pops an expected `NaN` off the top", () => {
+          const stack = stackOfAny([NaN]);
+
+          stack.popExpect(NaN);
+
+          expect(stack.depth).toBe(height);
+        });
+      });
+    }
+
+    it("refuses `popExpect(undefined)` on an empty stack", () => {
+      // The trap the type parameter opens: reading past the bottom of an empty
+      // stack yields `undefined`, which would meet the expectation.
+      expect(() => new IndexTrackingStack<unknown>().popExpect(undefined))
+        .toThrow();
+    });
+
+    it("refuses `pop()` on an empty stack whose domain holds `undefined`", () => {
+      expect(() => new IndexTrackingStack<unknown>().pop()).toThrow();
+    });
+
+    it("pops an `undefined` that is really there", () => {
+      const stack = new IndexTrackingStack<unknown>();
+
+      stack.push(undefined);
+
+      expect(stack.pop()).toBeUndefined();
+      expect(stack.depth).toBe(0);
+    });
+
+    it("leaves `depth` to tell an empty stack from a held `undefined`", () => {
+      // `popElseUndefined()` cannot, which is what its doc says; this is what
+      // a caller uses instead.
+      const held = new IndexTrackingStack<unknown>();
+      const empty = new IndexTrackingStack<unknown>();
+
+      held.push(undefined);
+
+      expect(held.popElseUndefined()).toBeUndefined();
+      expect(empty.popElseUndefined()).toBeUndefined();
+      expect(held.depth).toBe(0);
+      expect(empty.depth).toBe(0);
+    });
+  });
+
   describe("crossing the threshold", () => {
     it("answers the same after coming back down as a stack that never went up", () => {
       // The index outlives the height that built it, so from here on the two
       // implementations are being compared directly on the same question.
       const held = objects(4);
-      const climbed = new IndexTrackingStack();
-      const flat = new IndexTrackingStack();
+      const climbed = new IndexTrackingStack<object>();
+      const flat = new IndexTrackingStack<object>();
 
       for (const filler of objects(TALL)) climbed.push(filler);
       for (let at = 0; at < TALL; at++) climbed.pop();
@@ -294,7 +387,7 @@ describe("IndexTrackingStack", () => {
       // is used afterwards is the scan -- over a stack that a `Map` was
       // tracking a moment ago, and has to have stopped tracking cleanly.
       const twice = {};
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       stack.push(twice);
       stack.push(twice);
@@ -311,7 +404,7 @@ describe("IndexTrackingStack", () => {
       // A rebuild from a stack that has held an index before is a different
       // path from the first build, and it has to arrive at the same answers.
       const twice = {};
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       for (const filler of objects(TALL)) stack.push(filler);
       while (stack.depth > 0) stack.pop();
@@ -329,7 +422,7 @@ describe("IndexTrackingStack", () => {
       // already holding two positions is the case where that grouping has to
       // produce a pair rather than overwrite.
       const twice = {};
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       stack.push(twice);
       stack.push(twice);
@@ -343,7 +436,7 @@ describe("IndexTrackingStack", () => {
       // The index is built from the stack as it stands, so what was pushed
       // before the crossing has to arrive in it.
       const early = {};
-      const stack = new IndexTrackingStack();
+      const stack = new IndexTrackingStack<object>();
 
       stack.push(early);
       for (const filler of objects(TALL)) stack.push(filler);

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -38,33 +38,33 @@ function stackOf(height: number, values: readonly object[]) {
 }
 
 describe("IndexTrackingStack", () => {
-  describe("length", () => {
+  describe("depth", () => {
     it("is zero for a fresh stack", () => {
-      expect(new IndexTrackingStack().length).toBe(0);
+      expect(new IndexTrackingStack().depth).toBe(0);
     });
 
     it("counts what has been pushed and not popped", () => {
       const stack = new IndexTrackingStack();
 
       for (const value of objects(TALL)) stack.push(value);
-      expect(stack.length).toBe(TALL);
+      expect(stack.depth).toBe(TALL);
 
       for (let at = 0; at < 10; at++) stack.pop();
-      expect(stack.length).toBe(TALL - 10);
+      expect(stack.depth).toBe(TALL - 10);
     });
 
     it("stays at zero when an empty stack is popped", () => {
       const stack = new IndexTrackingStack();
 
-      stack.pop();
+      stack.popElseUndefined();
 
-      expect(stack.length).toBe(0);
+      expect(stack.depth).toBe(0);
     });
   });
 
   describe("pop()", () => {
-    it("returns `undefined` for an empty stack", () => {
-      expect(new IndexTrackingStack().pop()).toBeUndefined();
+    it("throws for an empty stack", () => {
+      expect(() => new IndexTrackingStack().pop()).toThrow();
     });
 
     it("returns the objects it pops, topmost first", () => {
@@ -76,7 +76,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.pop()).toBe(held[2]);
       expect(stack.pop()).toBe(held[1]);
       expect(stack.pop()).toBe(held[0]);
-      expect(stack.pop()).toBeUndefined();
+      expect(() => stack.pop()).toThrow();
     });
 
     it("returns the objects it pops from an indexed stack", () => {
@@ -86,6 +86,92 @@ describe("IndexTrackingStack", () => {
       expect(stack.pop()).toBe(held[2]);
       expect(stack.pop()).toBe(held[1]);
       expect(stack.pop()).toBe(held[0]);
+    });
+  });
+
+  describe("popElseUndefined()", () => {
+    it("returns `undefined` for an empty stack", () => {
+      expect(new IndexTrackingStack().popElseUndefined()).toBeUndefined();
+    });
+
+    it("returns the objects it pops, topmost first", () => {
+      const held = objects(2);
+      const stack = new IndexTrackingStack();
+
+      for (const value of held) stack.push(value);
+
+      expect(stack.popElseUndefined()).toBe(held[1]);
+      expect(stack.popElseUndefined()).toBe(held[0]);
+      expect(stack.popElseUndefined()).toBeUndefined();
+    });
+
+    it("maintains the index, given an indexed stack", () => {
+      const twice = {};
+      const stack = stackOf(TALL, [twice, {}, twice]);
+
+      expect(stack.popElseUndefined()).toBe(twice);
+
+      expect(stack.lastIndexOf(twice)).toBe(TALL);
+      expect(stack.depth).toBe(TALL + 2);
+    });
+  });
+
+  describe("popExpect()", () => {
+    it("pops the object it was told to expect", () => {
+      const held = objects(2);
+      const stack = new IndexTrackingStack();
+
+      for (const value of held) stack.push(value);
+      stack.popExpect(held[1]!);
+
+      expect(stack.depth).toBe(1);
+      expect(stack.indexOf(held[1]!)).toBe(-1);
+    });
+
+    it("throws for an object that is in the stack but not on top", () => {
+      const held = objects(2);
+      const stack = new IndexTrackingStack();
+
+      for (const value of held) stack.push(value);
+
+      expect(() => stack.popExpect(held[0]!)).toThrow();
+    });
+
+    it("throws for an object the stack does not hold", () => {
+      const stack = new IndexTrackingStack();
+
+      stack.push({});
+
+      expect(() => stack.popExpect({})).toThrow();
+    });
+
+    it("throws for an empty stack", () => {
+      expect(() => new IndexTrackingStack().popExpect({})).toThrow();
+    });
+
+    it("leaves the stack as it was when it throws", () => {
+      const held = objects(2);
+      const stack = new IndexTrackingStack();
+
+      for (const value of held) stack.push(value);
+      expect(() => stack.popExpect(held[0]!)).toThrow();
+
+      expect(stack.depth).toBe(2);
+      expect(stack.indexOf(held[0]!)).toBe(0);
+      expect(stack.lastIndexOf(held[1]!)).toBe(1);
+    });
+
+    it("maintains the index, given an indexed stack", () => {
+      // The successful arm has to be a real pop on either side of the
+      // threshold, index maintenance included.
+      const twice = {};
+      const stack = stackOf(TALL, [twice, {}, twice]);
+
+      stack.popExpect(twice);
+
+      expect(stack.depth).toBe(TALL + 2);
+      expect(stack.lastIndexOf(twice)).toBe(TALL);
+      expect(stack.indexOf(twice)).toBe(TALL);
     });
   });
 
@@ -193,7 +279,7 @@ describe("IndexTrackingStack", () => {
       for (const value of held) climbed.push(value);
       for (const value of held) flat.push(value);
 
-      expect(climbed.length).toBe(flat.length);
+      expect(climbed.depth).toBe(flat.depth);
       held.forEach((value, at) => {
         expect(climbed.indexOf(value)).toBe(flat.indexOf(value));
         expect(climbed.indexOf(value)).toBe(at);

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -300,11 +300,76 @@ describe("IndexTrackingStack", () => {
           expect(stack.lastIndexOf(NaN)).toBe(height + 2);
         });
 
-        it("treats `-0` and `0` as one value, as a `Map` key would", () => {
+        it("finds `0` where `0` was pushed, and not where `-0` was", () => {
+          const stack = stackOfAny([-0, 0]);
+
+          expect(stack.indexOf(0)).toBe(height + 1);
+          expect(stack.lastIndexOf(0)).toBe(height + 1);
+        });
+
+        it("finds `-0` where `-0` was pushed, and not where `0` was", () => {
+          const stack = stackOfAny([0, -0]);
+
+          expect(stack.indexOf(-0)).toBe(height + 1);
+          expect(stack.lastIndexOf(-0)).toBe(height + 1);
+        });
+
+        it("holds `-0` and `0` apart across every position of each", () => {
+          const stack = stackOfAny([-0, 0, -0, 0]);
+
+          expect(stack.indexOf(-0)).toBe(height);
+          expect(stack.lastIndexOf(-0)).toBe(height + 2);
+          expect(stack.indexOf(0)).toBe(height + 1);
+          expect(stack.lastIndexOf(0)).toBe(height + 3);
+        });
+
+        it("does not find a `-0` for a `NaN`, nor either for the other", () => {
+          const stack = stackOfAny([NaN]);
+
+          expect(stack.indexOf(-0)).toBe(-1);
+          expect(stack.indexOf(0)).toBe(-1);
+          expect(stack.lastIndexOf(-0)).toBe(-1);
+        });
+
+        it("finds neither `0` nor `-0` in a stack holding neither", () => {
+          const stack = stackOfAny([1, {}]);
+
+          expect(stack.indexOf(0)).toBe(-1);
+          expect(stack.indexOf(-0)).toBe(-1);
+          expect(stack.lastIndexOf(0)).toBe(-1);
+          expect(stack.lastIndexOf(-0)).toBe(-1);
+        });
+
+        it("pops an expected `-0` and refuses an expected `0` for it", () => {
           const stack = stackOfAny([-0]);
 
+          expect(() => stack.popExpect(0)).toThrow();
+          expect(stack.depth).toBe(height + 1);
+
+          stack.popExpect(-0);
+
+          expect(stack.depth).toBe(height);
+        });
+
+        it("pops an expected `0` and refuses an expected `-0` for it", () => {
+          const stack = stackOfAny([0]);
+
+          expect(() => stack.popExpect(-0)).toThrow();
+
+          stack.popExpect(0);
+
+          expect(stack.depth).toBe(height);
+        });
+
+        it("stops finding a popped `-0` while keeping a `0` below it", () => {
+          // The stand-in key the index gives `-0` has to come off with it, and
+          // to have been a different entry from the one `0` holds.
+          const stack = stackOfAny([0, -0]);
+
+          stack.pop();
+
+          expect(stack.indexOf(-0)).toBe(-1);
           expect(stack.indexOf(0)).toBe(height);
-          expect(stack.lastIndexOf(-0)).toBe(height);
         });
 
         it("pops an expected `undefined` off the top", () => {

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -288,6 +288,41 @@ describe("IndexTrackingStack", () => {
       expect(climbed.indexOf({})).toBe(flat.indexOf({}));
     });
 
+    it("answers from the scan again once the index has been dropped", () => {
+      // Coming back down past `DROP_BELOW` drops the index, so what answers
+      // afterwards is the scan -- over a stack that a `Map` was tracking a
+      // moment ago, and has to have stopped tracking cleanly.
+      const twice = {};
+      const stack = new IndexTrackingStack();
+
+      stack.push(twice);
+      stack.push(twice);
+      for (const filler of objects(TALL)) stack.push(filler);
+      while (stack.depth > 2) stack.pop();
+
+      expect(stack.depth).toBe(2);
+      expect(stack.indexOf(twice)).toBe(0);
+      expect(stack.lastIndexOf(twice)).toBe(1);
+      expect(stack.indexOf({})).toBe(-1);
+    });
+
+    it("builds the index again when it grows back past the threshold", () => {
+      // A rebuild from a stack that has held an index before is a different
+      // path from the first build, and it has to arrive at the same answers.
+      const twice = {};
+      const stack = new IndexTrackingStack();
+
+      for (const filler of objects(TALL)) stack.push(filler);
+      while (stack.depth > 0) stack.pop();
+
+      stack.push(twice);
+      stack.push(twice);
+      for (const filler of objects(TALL)) stack.push(filler);
+
+      expect(stack.indexOf(twice)).toBe(0);
+      expect(stack.lastIndexOf(twice)).toBe(1);
+    });
+
     it("carries both positions of an object already held twice into the index", () => {
       // The index is built by grouping the stack as it stands, so an object
       // already holding two positions is the case where that grouping has to

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -2,7 +2,7 @@
  * `IndexTrackingStack` answers its two lookups two ways -- by scanning, and
  * from the index it builds once it is tall enough -- so every question worth
  * asking gets asked on both sides of
- * {@link IndexTrackingStack.ADD_INDEX_AT}. The two must agree, and a stack
+ * `ADD_INDEX_AT`. The two must agree, and a stack
  * that crosses the threshold and comes back down must answer as one that never
  * crossed it.
  */
@@ -22,7 +22,12 @@ function objects(count: number): object[] {
 }
 
 /** How tall a stack has to be for the index to have been built. */
-const TALL = IndexTrackingStack.ADD_INDEX_AT + 5;
+/**
+ * The marks the class arranges itself around, which a test has to straddle.
+ */
+const MARKS = IndexTrackingStack.accessForTestingOnly;
+
+const TALL = MARKS.ADD_INDEX_AT + 5;
 
 /**
  * A stack holding the given objects, padded first to `height` with distinct

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -403,9 +403,11 @@ describe("IndexTrackingStack", () => {
   }
 
   describe("special values through an index that is already live", () => {
-    // The build sweeps the whole stack, so a value pushed before it is keyed
-    // by a different piece of code from one pushed after. These are the after
-    // case, which is the one a lookup alone does not reach.
+    // Three different pieces of code key the index: the build sweeps a whole
+    // stack, `push()` keys one value onto a live index, and `pop()` keys one
+    // off. A suite that reaches only the build passes while either of the
+    // others is broken, so each gets its own group here.
+
     /** A stack tall enough to hold an index, holding it, and holding a `0`. */
     function indexedStack() {
       const stack = new IndexTrackingStack<unknown>();
@@ -417,71 +419,76 @@ describe("IndexTrackingStack", () => {
       return stack;
     }
 
-    it("finds a `NaN` pushed onto a stack that is already indexed", () => {
-      const stack = indexedStack();
+    describe("push()", () => {
+      it("keys a `NaN` pushed onto an already-indexed stack", () => {
+        const stack = indexedStack();
 
-      stack.push(NaN);
+        stack.push(NaN);
 
-      expect(stack.indexOf(NaN)).toBe(TALL + 1);
-      expect(stack.lastIndexOf(NaN)).toBe(TALL + 1);
+        expect(stack.indexOf(NaN)).toBe(TALL + 1);
+        expect(stack.lastIndexOf(NaN)).toBe(TALL + 1);
+      });
+
+      it("keys a `-0` apart from a `0` the stack already holds", () => {
+        const stack = indexedStack();
+
+        stack.push(-0);
+
+        expect(stack.indexOf(-0)).toBe(TALL + 1);
+        expect(stack.indexOf(0)).toBe(TALL);
+      });
     });
 
-    it("keeps a `-0` pushed onto an indexed stack apart from a held `0`", () => {
-      const stack = indexedStack();
+    describe("pop()", () => {
+      it("takes a `-0` off without disturbing a held `0`", () => {
+        // Keyed by the raw value it would take a position off the `0` entry
+        // instead, a `Map` reading a `-0` key as `0`.
+        const stack = indexedStack();
 
-      stack.push(-0);
+        stack.push(-0);
+        stack.pop();
 
-      expect(stack.indexOf(-0)).toBe(TALL + 1);
-      expect(stack.indexOf(0)).toBe(TALL);
+        expect(stack.indexOf(0)).toBe(TALL);
+        expect(stack.indexOf(-0)).toBe(-1);
+      });
+
+      it("takes a `NaN` off, after which it is not found", () => {
+        const stack = indexedStack();
+
+        stack.push(NaN);
+        stack.pop();
+
+        expect(stack.indexOf(NaN)).toBe(-1);
+        expect(stack.indexOf(0)).toBe(TALL);
+      });
     });
 
-    it("pops a `-0` off an indexed stack without disturbing a held `0`", () => {
-      // Popping keyed by the raw value would take a position off the `0`
-      // entry instead, since a `Map` reads a `-0` key as `0`.
-      const stack = indexedStack();
+    describe("indexOf()", () => {
+      // The build runs here, a lookup being what triggers one, so these are
+      // the cases where a value was already on the stack when it was keyed.
+      it("sweeps a `-0` and a `0` into separate entries as it builds", () => {
+        const stack = new IndexTrackingStack<unknown>();
 
-      stack.push(-0);
-      stack.pop();
+        stack.push(0);
+        stack.push(-0);
+        for (const filler of objects(TALL)) stack.push(filler);
+        stack.indexOf({});
 
-      expect(stack.indexOf(0)).toBe(TALL);
-      expect(stack.indexOf(-0)).toBe(-1);
-    });
+        expect(stack.indexOf(0)).toBe(0);
+        expect(stack.indexOf(-0)).toBe(1);
+      });
 
-    it("pops a `NaN` off an indexed stack and stops finding it", () => {
-      const stack = indexedStack();
+      it("sweeps a `NaN` into its own entry as it builds", () => {
+        const stack = new IndexTrackingStack<unknown>();
 
-      stack.push(NaN);
-      stack.pop();
+        stack.push(NaN);
+        stack.push(0);
+        for (const filler of objects(TALL)) stack.push(filler);
+        stack.indexOf({});
 
-      expect(stack.indexOf(NaN)).toBe(-1);
-      expect(stack.indexOf(0)).toBe(TALL);
-    });
-
-    it("sweeps a `-0` and a `0` into separate entries when the index is built", () => {
-      // The other side of the same coin: a value already on the stack when
-      // the index is built is keyed by the build loop rather than by `push()`,
-      // and the two have to agree about what a `-0` is.
-      const stack = new IndexTrackingStack<unknown>();
-
-      stack.push(0);
-      stack.push(-0);
-      for (const filler of objects(TALL)) stack.push(filler);
-      stack.indexOf({});
-
-      expect(stack.indexOf(0)).toBe(0);
-      expect(stack.indexOf(-0)).toBe(1);
-    });
-
-    it("sweeps a `NaN` into its own entry when the index is built", () => {
-      const stack = new IndexTrackingStack<unknown>();
-
-      stack.push(NaN);
-      stack.push(0);
-      for (const filler of objects(TALL)) stack.push(filler);
-      stack.indexOf({});
-
-      expect(stack.indexOf(NaN)).toBe(0);
-      expect(stack.indexOf(0)).toBe(1);
+        expect(stack.indexOf(NaN)).toBe(0);
+        expect(stack.indexOf(0)).toBe(1);
+      });
     });
   });
 

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -38,6 +38,11 @@ function stackOf(height: number, values: readonly object[]) {
   const stack = new IndexTrackingStack<object>();
 
   for (const filler of objects(height)) stack.push(filler);
+
+  // An index is built by a lookup, not by growth, so a padded stack is not an
+  // indexed one until something has asked it a position.
+  stack.indexOf({});
+
   for (const value of values) stack.push(value);
 
   return stack;
@@ -439,6 +444,7 @@ describe("IndexTrackingStack", () => {
       const flat = new IndexTrackingStack<object>();
 
       for (const filler of objects(TALL)) climbed.push(filler);
+      climbed.indexOf({});
       for (let at = 0; at < TALL; at++) climbed.pop();
       for (const value of held) climbed.push(value);
       for (const value of held) flat.push(value);
@@ -462,6 +468,7 @@ describe("IndexTrackingStack", () => {
       stack.push(twice);
       stack.push(twice);
       for (const filler of objects(TALL)) stack.push(filler);
+      stack.indexOf({});
       while (stack.depth > 2) stack.pop();
 
       expect(stack.depth).toBe(2);
@@ -477,6 +484,7 @@ describe("IndexTrackingStack", () => {
       const stack = new IndexTrackingStack<object>();
 
       for (const filler of objects(TALL)) stack.push(filler);
+      stack.indexOf({});
       while (stack.depth > 0) stack.pop();
 
       stack.push(twice);

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -11,7 +11,27 @@ import { expect } from "@std/expect";
 
 import { IndexTrackingStack } from "../src/index-tracking-stack.ts";
 
-/** Distinct objects, as many as a test asks for. */
+/**
+ * The marks the class arranges itself around, which a test has to straddle.
+ */
+const MARKS = IndexTrackingStack.accessForTestingOnly;
+
+/** How tall a stack has to be for the index to have been built. */
+const TALL = MARKS.ADD_INDEX_AT + 5;
+
+/** The two lookups, and which position of a repeated value each reports. */
+const LOOKUPS = [
+  { name: "indexOf", reports: "lowest" },
+  { name: "lastIndexOf", reports: "highest" },
+] as const;
+
+/**
+ * The two states a lookup can be answered from, as the height a stack is
+ * padded to before a case's own values go onto it.
+ */
+const ARMS = [["scanning", 0], ["indexed", TALL]] as const;
+
+/** Distinct objects, as many as asked for. */
 function objects(count: number): object[] {
   const out: object[] = [];
 
@@ -21,25 +41,17 @@ function objects(count: number): object[] {
 }
 
 /**
- * The marks the class arranges itself around, which a test has to straddle.
+ * A stack padded to `height` with distinct objects and then given `values`.
+ *
+ * The lookup between the two is what makes the indexed arm indexed *before*
+ * the values arrive, so that they go in through the maintenance path rather
+ * than being swept up by a later build. Which of the three sites keys a value
+ * is the thing most easily left untested here.
  */
-const MARKS = IndexTrackingStack.accessForTestingOnly;
-
-/** How tall a stack has to be for the index to have been built. */
-const TALL = MARKS.ADD_INDEX_AT + 5;
-
-/**
- * A stack holding the given objects, padded first to `height` with distinct
- * objects of its own, so that one test body can be run on either side of the
- * threshold.
- */
-function stackOf(height: number, values: readonly object[]) {
-  const stack = new IndexTrackingStack<object>();
+function stackOf(height: number, values: readonly unknown[]) {
+  const stack = new IndexTrackingStack<unknown>();
 
   for (const filler of objects(height)) stack.push(filler);
-
-  // An index is built by a lookup, not by growth, so a padded stack is not an
-  // indexed one until something has asked it a position.
   stack.indexOf({});
 
   for (const value of values) stack.push(value);
@@ -70,14 +82,32 @@ describe("IndexTrackingStack", () => {
 
       expect(stack.depth).toBe(0);
     });
+
+    it("tells an empty stack from one holding an `undefined`", () => {
+      // `popElseUndefined()` cannot, which is what its doc says; this is what
+      // a caller uses instead.
+      const held = new IndexTrackingStack<unknown>();
+      const empty = new IndexTrackingStack<unknown>();
+
+      held.push(undefined);
+
+      expect(held.popElseUndefined()).toBeUndefined();
+      expect(empty.popElseUndefined()).toBeUndefined();
+      expect(held.depth).toBe(0);
+      expect(empty.depth).toBe(0);
+    });
   });
 
   describe("pop()", () => {
-    it("throws for an empty stack", () => {
+    it("throws given an empty stack", () => {
       expect(() => new IndexTrackingStack<object>().pop()).toThrow();
     });
 
-    it("returns the objects it pops, topmost first", () => {
+    it("throws given an empty stack whose domain holds `undefined`", () => {
+      expect(() => new IndexTrackingStack<unknown>().pop()).toThrow();
+    });
+
+    it("returns the values it pops, topmost first", () => {
       const held = objects(3);
       const stack = new IndexTrackingStack<object>();
 
@@ -89,13 +119,22 @@ describe("IndexTrackingStack", () => {
       expect(() => stack.pop()).toThrow();
     });
 
-    it("returns the objects it pops from an indexed stack", () => {
+    it("returns the values it pops from an indexed stack", () => {
       const held = objects(3);
       const stack = stackOf(TALL, held);
 
       expect(stack.pop()).toBe(held[2]);
       expect(stack.pop()).toBe(held[1]);
       expect(stack.pop()).toBe(held[0]);
+    });
+
+    it("pops an `undefined` that is really there", () => {
+      const stack = new IndexTrackingStack<unknown>();
+
+      stack.push(undefined);
+
+      expect(stack.pop()).toBeUndefined();
+      expect(stack.depth).toBe(0);
     });
   });
 
@@ -105,7 +144,7 @@ describe("IndexTrackingStack", () => {
         .toBeUndefined();
     });
 
-    it("returns the objects it pops, topmost first", () => {
+    it("returns the values it pops, topmost first", () => {
       const held = objects(2);
       const stack = new IndexTrackingStack<object>();
 
@@ -128,7 +167,7 @@ describe("IndexTrackingStack", () => {
   });
 
   describe("popExpect()", () => {
-    it("pops the object it was told to expect", () => {
+    it("pops the value it was told to expect", () => {
       const held = objects(2);
       const stack = new IndexTrackingStack<object>();
 
@@ -139,7 +178,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.indexOf(held[1]!)).toBe(-1);
     });
 
-    it("throws for an object that is in the stack but not on top", () => {
+    it("throws given a value that is in the stack but not on top", () => {
       const held = objects(2);
       const stack = new IndexTrackingStack<object>();
 
@@ -148,7 +187,7 @@ describe("IndexTrackingStack", () => {
       expect(() => stack.popExpect(held[0]!)).toThrow();
     });
 
-    it("throws for an object the stack does not hold", () => {
+    it("throws given a value the stack does not hold", () => {
       const stack = new IndexTrackingStack<object>();
 
       stack.push({});
@@ -156,8 +195,15 @@ describe("IndexTrackingStack", () => {
       expect(() => stack.popExpect({})).toThrow();
     });
 
-    it("throws for an empty stack", () => {
+    it("throws given an empty stack", () => {
       expect(() => new IndexTrackingStack<object>().popExpect({})).toThrow();
+    });
+
+    it("throws given an empty stack rather than meeting an `undefined`", () => {
+      // The trap a parametric domain opens: reading past the bottom of an
+      // empty stack yields `undefined`, which would meet the expectation.
+      expect(() => new IndexTrackingStack<unknown>().popExpect(undefined))
+        .toThrow();
     });
 
     it("leaves the stack as it was when it throws", () => {
@@ -173,8 +219,6 @@ describe("IndexTrackingStack", () => {
     });
 
     it("maintains the index, given an indexed stack", () => {
-      // The successful arm has to be a real pop on either side of the
-      // threshold, index maintenance included.
       const twice = {};
       const stack = stackOf(TALL, [twice, {}, twice]);
 
@@ -184,212 +228,11 @@ describe("IndexTrackingStack", () => {
       expect(stack.lastIndexOf(twice)).toBe(TALL);
       expect(stack.indexOf(twice)).toBe(TALL);
     });
-  });
 
-  describe("indexOf() and lastIndexOf()", () => {
-    for (
-      const [where, height] of [["scanning", 0], ["indexed", TALL]] as const
-    ) {
+    for (const [where, height] of ARMS) {
       describe(where, () => {
-        it("reports -1 for an object it does not hold", () => {
-          const stack = stackOf(height, []);
-
-          expect(stack.indexOf({})).toBe(-1);
-          expect(stack.lastIndexOf({})).toBe(-1);
-        });
-
-        it("reports each object's position", () => {
-          const held = objects(4);
-          const stack = stackOf(height, held);
-
-          held.forEach((value, at) => {
-            expect(stack.indexOf(value)).toBe(height + at);
-            expect(stack.lastIndexOf(value)).toBe(height + at);
-          });
-        });
-
-        it("compares by identity rather than by value", () => {
-          const stack = stackOf(height, [{ same: 1 }]);
-
-          expect(stack.indexOf({ same: 1 })).toBe(-1);
-          expect(stack.lastIndexOf({ same: 1 })).toBe(-1);
-        });
-
-        it("reports -1 for an object that has been popped", () => {
-          const [kept, dropped] = objects(2) as [object, object];
-          const stack = stackOf(height, [kept, dropped]);
-
-          stack.pop();
-
-          expect(stack.indexOf(kept)).toBe(height);
-          expect(stack.indexOf(dropped)).toBe(-1);
-          expect(stack.lastIndexOf(dropped)).toBe(-1);
-        });
-
-        it("reports the lowest and the highest position of a repeated object", () => {
-          const twice = {};
-          const stack = stackOf(height, [twice, {}, twice]);
-
-          expect(stack.indexOf(twice)).toBe(height);
-          expect(stack.lastIndexOf(twice)).toBe(height + 2);
-        });
-
-        it("keeps the earlier position of a repeated object when the later one is popped", () => {
-          const twice = {};
-          const stack = stackOf(height, [twice, {}, twice]);
-
-          stack.pop();
-
-          expect(stack.indexOf(twice)).toBe(height);
-          expect(stack.lastIndexOf(twice)).toBe(height);
-        });
-
-        it("walks back through the positions of an object held three times", () => {
-          // Two occurrences would not tell a positions stack from a pair of
-          // numbers; three is where popping through them has to be in order.
-          const thrice = {};
-          const stack = stackOf(height, [thrice, {}, thrice, {}, thrice]);
-
-          expect(stack.indexOf(thrice)).toBe(height);
-          expect(stack.lastIndexOf(thrice)).toBe(height + 4);
-
-          stack.pop();
-          expect(stack.lastIndexOf(thrice)).toBe(height + 2);
-
-          stack.pop();
-          stack.pop();
-          expect(stack.lastIndexOf(thrice)).toBe(height);
-          expect(stack.indexOf(thrice)).toBe(height);
-        });
-
-        it("reports -1 once every position of a repeated object is popped", () => {
-          const twice = {};
-          const stack = stackOf(height, [twice, {}, twice]);
-
-          stack.pop();
-          stack.pop();
-          stack.pop();
-
-          expect(stack.indexOf(twice)).toBe(-1);
-          expect(stack.lastIndexOf(twice)).toBe(-1);
-        });
-      });
-    }
-  });
-
-  describe("a domain holding `undefined` and `NaN`", () => {
-    // What a parametric stack costs: `undefined` stops being a signal, and the
-    // scan and the index stop agreeing on their own. Each case runs on both
-    // sides of the threshold, since only one of the two is at issue in each.
-    for (
-      const [where, height] of [["scanning", 0], ["indexed", TALL]] as const
-    ) {
-      describe(where, () => {
-        /**
-         * A stack of the padded height, then the given values. The lookup
-         * between the two is what makes the indexed arm indexed *before* the
-         * values arrive, so that they go in through the maintenance path
-         * rather than being swept up by a later build.
-         */
-        function stackOfAny(values: readonly unknown[]) {
-          const stack = new IndexTrackingStack<unknown>();
-
-          for (const filler of objects(height)) stack.push(filler);
-          stack.indexOf({});
-
-          for (const value of values) stack.push(value);
-
-          return stack;
-        }
-
-        it("finds `undefined` where it was pushed", () => {
-          const stack = stackOfAny([undefined, {}, undefined]);
-
-          expect(stack.indexOf(undefined)).toBe(height);
-          expect(stack.lastIndexOf(undefined)).toBe(height + 2);
-        });
-
-        it("finds `NaN`, which strict comparison never would", () => {
-          const stack = stackOfAny([NaN, {}, NaN]);
-
-          expect(stack.indexOf(NaN)).toBe(height);
-          expect(stack.lastIndexOf(NaN)).toBe(height + 2);
-        });
-
-        it("finds `0` where `0` was pushed, and not where `-0` was", () => {
-          const stack = stackOfAny([-0, 0]);
-
-          expect(stack.indexOf(0)).toBe(height + 1);
-          expect(stack.lastIndexOf(0)).toBe(height + 1);
-        });
-
-        it("finds `-0` where `-0` was pushed, and not where `0` was", () => {
-          const stack = stackOfAny([0, -0]);
-
-          expect(stack.indexOf(-0)).toBe(height + 1);
-          expect(stack.lastIndexOf(-0)).toBe(height + 1);
-        });
-
-        it("holds `-0` and `0` apart across every position of each", () => {
-          const stack = stackOfAny([-0, 0, -0, 0]);
-
-          expect(stack.indexOf(-0)).toBe(height);
-          expect(stack.lastIndexOf(-0)).toBe(height + 2);
-          expect(stack.indexOf(0)).toBe(height + 1);
-          expect(stack.lastIndexOf(0)).toBe(height + 3);
-        });
-
-        it("does not find a `-0` for a `NaN`, nor either for the other", () => {
-          const stack = stackOfAny([NaN]);
-
-          expect(stack.indexOf(-0)).toBe(-1);
-          expect(stack.indexOf(0)).toBe(-1);
-          expect(stack.lastIndexOf(-0)).toBe(-1);
-        });
-
-        it("finds neither `0` nor `-0` in a stack holding neither", () => {
-          const stack = stackOfAny([1, {}]);
-
-          expect(stack.indexOf(0)).toBe(-1);
-          expect(stack.indexOf(-0)).toBe(-1);
-          expect(stack.lastIndexOf(0)).toBe(-1);
-          expect(stack.lastIndexOf(-0)).toBe(-1);
-        });
-
-        it("pops an expected `-0` and refuses an expected `0` for it", () => {
-          const stack = stackOfAny([-0]);
-
-          expect(() => stack.popExpect(0)).toThrow();
-          expect(stack.depth).toBe(height + 1);
-
-          stack.popExpect(-0);
-
-          expect(stack.depth).toBe(height);
-        });
-
-        it("pops an expected `0` and refuses an expected `-0` for it", () => {
-          const stack = stackOfAny([0]);
-
-          expect(() => stack.popExpect(-0)).toThrow();
-
-          stack.popExpect(0);
-
-          expect(stack.depth).toBe(height);
-        });
-
-        it("stops finding a popped `-0` while keeping a `0` below it", () => {
-          // The stand-in key the index gives `-0` has to come off with it, and
-          // to have been a different entry from the one `0` holds.
-          const stack = stackOfAny([0, -0]);
-
-          stack.pop();
-
-          expect(stack.indexOf(-0)).toBe(-1);
-          expect(stack.indexOf(0)).toBe(height);
-        });
-
         it("pops an expected `undefined` off the top", () => {
-          const stack = stackOfAny([undefined]);
+          const stack = stackOf(height, [undefined]);
 
           stack.popExpect(undefined);
 
@@ -397,49 +240,167 @@ describe("IndexTrackingStack", () => {
         });
 
         it("pops an expected `NaN` off the top", () => {
-          const stack = stackOfAny([NaN]);
+          const stack = stackOf(height, [NaN]);
 
           stack.popExpect(NaN);
 
           expect(stack.depth).toBe(height);
         });
+
+        it("pops an expected `-0` off the top", () => {
+          const stack = stackOf(height, [-0]);
+
+          stack.popExpect(-0);
+
+          expect(stack.depth).toBe(height);
+        });
+
+        it("throws given a `0` expected of a `-0` on top", () => {
+          const stack = stackOf(height, [-0]);
+
+          expect(() => stack.popExpect(0)).toThrow();
+          expect(stack.depth).toBe(height + 1);
+        });
+
+        it("pops an expected `0` off the top", () => {
+          const stack = stackOf(height, [0]);
+
+          stack.popExpect(0);
+
+          expect(stack.depth).toBe(height);
+        });
+
+        it("throws given a `-0` expected of a `0` on top", () => {
+          const stack = stackOf(height, [0]);
+
+          expect(() => stack.popExpect(-0)).toThrow();
+          expect(stack.depth).toBe(height + 1);
+        });
       });
     }
-
-    it("refuses `popExpect(undefined)` on an empty stack", () => {
-      // The trap the type parameter opens: reading past the bottom of an empty
-      // stack yields `undefined`, which would meet the expectation.
-      expect(() => new IndexTrackingStack<unknown>().popExpect(undefined))
-        .toThrow();
-    });
-
-    it("refuses `pop()` on an empty stack whose domain holds `undefined`", () => {
-      expect(() => new IndexTrackingStack<unknown>().pop()).toThrow();
-    });
-
-    it("pops an `undefined` that is really there", () => {
-      const stack = new IndexTrackingStack<unknown>();
-
-      stack.push(undefined);
-
-      expect(stack.pop()).toBeUndefined();
-      expect(stack.depth).toBe(0);
-    });
-
-    it("leaves `depth` to tell an empty stack from a held `undefined`", () => {
-      // `popElseUndefined()` cannot, which is what its doc says; this is what
-      // a caller uses instead.
-      const held = new IndexTrackingStack<unknown>();
-      const empty = new IndexTrackingStack<unknown>();
-
-      held.push(undefined);
-
-      expect(held.popElseUndefined()).toBeUndefined();
-      expect(empty.popElseUndefined()).toBeUndefined();
-      expect(held.depth).toBe(0);
-      expect(empty.depth).toBe(0);
-    });
   });
+
+  for (const lookup of LOOKUPS) {
+    describe(`${lookup.name}()`, () => {
+      /** The position of a repeated value this lookup reports, of two. */
+      const ofTwo = (first: number, last: number) =>
+        (lookup.reports === "lowest") ? first : last;
+
+      for (const [where, height] of ARMS) {
+        describe(where, () => {
+          it("reports -1 for a value it does not hold", () => {
+            const stack = stackOf(height, []);
+
+            expect(stack[lookup.name]({})).toBe(-1);
+          });
+
+          it("reports each value's position", () => {
+            const held = objects(4);
+            const stack = stackOf(height, held);
+
+            held.forEach((value, at) => {
+              expect(stack[lookup.name](value)).toBe(height + at);
+            });
+          });
+
+          it("compares by identity rather than by value", () => {
+            const stack = stackOf(height, [{ same: 1 }]);
+
+            expect(stack[lookup.name]({ same: 1 })).toBe(-1);
+          });
+
+          it("reports -1 for a value that has been popped", () => {
+            const [kept, dropped] = objects(2) as [object, object];
+            const stack = stackOf(height, [kept, dropped]);
+
+            stack.pop();
+
+            expect(stack[lookup.name](kept)).toBe(height);
+            expect(stack[lookup.name](dropped)).toBe(-1);
+          });
+
+          it(`reports the ${lookup.reports} position of a repeated value`, () => {
+            const twice = {};
+            const stack = stackOf(height, [twice, {}, twice]);
+
+            expect(stack[lookup.name](twice)).toBe(ofTwo(height, height + 2));
+          });
+
+          it("keeps the earlier position when the later one is popped", () => {
+            const twice = {};
+            const stack = stackOf(height, [twice, {}, twice]);
+
+            stack.pop();
+
+            expect(stack[lookup.name](twice)).toBe(height);
+          });
+
+          it("walks back through the positions of a value held three times", () => {
+            // Two occurrences would not tell a positions stack from a pair of
+            // numbers; three is where popping through them has to be in order.
+            const thrice = {};
+            const stack = stackOf(height, [thrice, {}, thrice, {}, thrice]);
+
+            expect(stack[lookup.name](thrice))
+              .toBe(ofTwo(height, height + 4));
+
+            stack.pop();
+            expect(stack[lookup.name](thrice))
+              .toBe(ofTwo(height, height + 2));
+
+            stack.pop();
+            stack.pop();
+            expect(stack[lookup.name](thrice)).toBe(height);
+          });
+
+          it("reports -1 once every position of a repeated value is popped", () => {
+            const twice = {};
+            const stack = stackOf(height, [twice, {}, twice]);
+
+            stack.pop();
+            stack.pop();
+            stack.pop();
+
+            expect(stack[lookup.name](twice)).toBe(-1);
+          });
+
+          it("finds `undefined` where it was pushed", () => {
+            const stack = stackOf(height, [undefined, {}, undefined]);
+
+            expect(stack[lookup.name](undefined))
+              .toBe(ofTwo(height, height + 2));
+          });
+
+          it("finds `NaN`, which strict comparison never would", () => {
+            const stack = stackOf(height, [NaN, {}, NaN]);
+
+            expect(stack[lookup.name](NaN)).toBe(ofTwo(height, height + 2));
+          });
+
+          it("holds `-0` and `0` apart across every position of each", () => {
+            const stack = stackOf(height, [-0, 0, -0, 0]);
+
+            expect(stack[lookup.name](-0)).toBe(ofTwo(height, height + 2));
+            expect(stack[lookup.name](0)).toBe(ofTwo(height + 1, height + 3));
+          });
+
+          it("does not find a zero of either sign for a `NaN`", () => {
+            const stack = stackOf(height, [NaN]);
+
+            expect(stack[lookup.name](-0)).toBe(-1);
+            expect(stack[lookup.name](0)).toBe(-1);
+          });
+
+          it("finds neither `0` nor `-0` in a stack holding neither", () => {
+            const stack = stackOf(height, [1, {}]);
+
+            expect(stack[lookup.name](0)).toBe(-1);
+            expect(stack[lookup.name](-0)).toBe(-1);
+          });
+        });
+      }
+    });
+  }
 
   describe("special values through an index that is already live", () => {
     // The build sweeps the whole stack, so a value pushed before it is keyed
@@ -486,6 +447,16 @@ describe("IndexTrackingStack", () => {
       expect(stack.indexOf(-0)).toBe(-1);
     });
 
+    it("pops a `NaN` off an indexed stack and stops finding it", () => {
+      const stack = indexedStack();
+
+      stack.push(NaN);
+      stack.pop();
+
+      expect(stack.indexOf(NaN)).toBe(-1);
+      expect(stack.indexOf(0)).toBe(TALL);
+    });
+
     it("sweeps a `-0` and a `0` into separate entries when the index is built", () => {
       // The other side of the same coin: a value already on the stack when
       // the index is built is keyed by the build loop rather than by `push()`,
@@ -511,16 +482,6 @@ describe("IndexTrackingStack", () => {
 
       expect(stack.indexOf(NaN)).toBe(0);
       expect(stack.indexOf(0)).toBe(1);
-    });
-
-    it("pops a `NaN` off an indexed stack and stops finding it", () => {
-      const stack = indexedStack();
-
-      stack.push(NaN);
-      stack.pop();
-
-      expect(stack.indexOf(NaN)).toBe(-1);
-      expect(stack.indexOf(0)).toBe(TALL);
     });
   });
 
@@ -548,9 +509,9 @@ describe("IndexTrackingStack", () => {
     });
 
     it("answers from the scan again once the index has been dropped", () => {
-      // Coming back down past `DROP_INDEX_BELOW` drops the index, so what
-      // is used afterwards is the scan -- over a stack that a `Map` was
-      // tracking a moment ago, and has to have stopped tracking cleanly.
+      // Coming back down past the low mark drops the index, so what is used
+      // afterwards is the scan -- over a stack that a `Map` was tracking a
+      // moment ago, and has to have stopped tracking cleanly.
       const twice = {};
       const stack = new IndexTrackingStack<object>();
 
@@ -584,8 +545,8 @@ describe("IndexTrackingStack", () => {
       expect(stack.lastIndexOf(twice)).toBe(1);
     });
 
-    it("carries both positions of an object already held twice into the index", () => {
-      // The index is built by grouping the stack as it stands, so an object
+    it("carries both positions of a value already held twice into the index", () => {
+      // The index is built by grouping the stack as it stands, so a value
       // already holding two positions is the case where that grouping has to
       // produce a pair rather than overwrite.
       const twice = {};
@@ -594,22 +555,10 @@ describe("IndexTrackingStack", () => {
       stack.push(twice);
       stack.push(twice);
       for (const filler of objects(TALL)) stack.push(filler);
+      stack.indexOf({});
 
       expect(stack.indexOf(twice)).toBe(0);
       expect(stack.lastIndexOf(twice)).toBe(1);
-    });
-
-    it("carries the objects already held into the index it builds", () => {
-      // The index is built from the stack as it stands, so what was pushed
-      // before the crossing has to arrive in it.
-      const early = {};
-      const stack = new IndexTrackingStack<object>();
-
-      stack.push(early);
-      for (const filler of objects(TALL)) stack.push(filler);
-
-      expect(stack.indexOf(early)).toBe(0);
-      expect(stack.lastIndexOf(early)).toBe(0);
     });
   });
 });

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -21,12 +21,12 @@ function objects(count: number): object[] {
   return out;
 }
 
-/** How tall a stack has to be for the index to have been built. */
 /**
  * The marks the class arranges itself around, which a test has to straddle.
  */
 const MARKS = IndexTrackingStack.accessForTestingOnly;
 
+/** How tall a stack has to be for the index to have been built. */
 const TALL = MARKS.ADD_INDEX_AT + 5;
 
 /**

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -49,7 +49,7 @@ function objects(count: number): object[] {
  * is the thing most easily left untested here.
  */
 function stackOf(height: number, values: readonly unknown[]) {
-  const stack = new IndexTrackingStack<unknown>();
+  const stack = new IndexTrackingStack();
 
   for (const filler of objects(height)) stack.push(filler);
   stack.indexOf({});
@@ -86,8 +86,8 @@ describe("IndexTrackingStack", () => {
     it("tells an empty stack from one holding an `undefined`", () => {
       // `popElseUndefined()` cannot, which is what its doc says; this is what
       // a caller uses instead.
-      const held = new IndexTrackingStack<unknown>();
-      const empty = new IndexTrackingStack<unknown>();
+      const held = new IndexTrackingStack();
+      const empty = new IndexTrackingStack();
 
       held.push(undefined);
 
@@ -104,7 +104,7 @@ describe("IndexTrackingStack", () => {
     });
 
     it("throws given an empty stack whose domain holds `undefined`", () => {
-      expect(() => new IndexTrackingStack<unknown>().pop()).toThrow();
+      expect(() => new IndexTrackingStack().pop()).toThrow();
     });
 
     it("returns the values it pops, topmost first", () => {
@@ -129,7 +129,7 @@ describe("IndexTrackingStack", () => {
     });
 
     it("pops an `undefined` that is really there", () => {
-      const stack = new IndexTrackingStack<unknown>();
+      const stack = new IndexTrackingStack();
 
       stack.push(undefined);
 
@@ -202,7 +202,7 @@ describe("IndexTrackingStack", () => {
     it("throws given an empty stack rather than meeting an `undefined`", () => {
       // The trap a parametric domain opens: reading past the bottom of an
       // empty stack yields `undefined`, which would meet the expectation.
-      expect(() => new IndexTrackingStack<unknown>().popExpect(undefined))
+      expect(() => new IndexTrackingStack().popExpect(undefined))
         .toThrow();
     });
 
@@ -410,7 +410,7 @@ describe("IndexTrackingStack", () => {
 
     /** A stack tall enough to hold an index, holding it, and holding a `0`. */
     function indexedStack() {
-      const stack = new IndexTrackingStack<unknown>();
+      const stack = new IndexTrackingStack();
 
       for (const filler of objects(TALL)) stack.push(filler);
       stack.push(0);
@@ -467,7 +467,7 @@ describe("IndexTrackingStack", () => {
       // The build runs here, a lookup being what triggers one, so these are
       // the cases where a value was already on the stack when it was keyed.
       it("sweeps a `-0` and a `0` into separate entries as it builds", () => {
-        const stack = new IndexTrackingStack<unknown>();
+        const stack = new IndexTrackingStack();
 
         stack.push(0);
         stack.push(-0);
@@ -479,7 +479,7 @@ describe("IndexTrackingStack", () => {
       });
 
       it("sweeps a `NaN` into its own entry as it builds", () => {
-        const stack = new IndexTrackingStack<unknown>();
+        const stack = new IndexTrackingStack();
 
         stack.push(NaN);
         stack.push(0);

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -26,10 +26,15 @@ const LOOKUPS = [
 ] as const;
 
 /**
- * The two states a lookup can be answered from, as the height a stack is
- * padded to before a case's own values go onto it.
+ * The two heights every question is asked at, as what a stack is padded to
+ * before a case's own values go onto it. Named for the height rather than for
+ * what answers there: which structure does is the one thing a test cannot
+ * see, and the point of asking twice is that it makes no difference.
  */
-const ARMS = [["scanning", 0], ["indexed", TALL]] as const;
+const ARMS = [
+  ["below the high water mark", 0],
+  ["above the high water mark", TALL],
+] as const;
 
 /** Distinct objects, as many as asked for. */
 function objects(count: number): object[] {
@@ -119,7 +124,7 @@ describe("IndexTrackingStack", () => {
       expect(() => stack.pop()).toThrow();
     });
 
-    it("returns the values it pops from an indexed stack", () => {
+    it("returns the values it pops from above the high water mark", () => {
       const held = objects(3);
       const stack = stackOf(TALL, held);
 
@@ -155,7 +160,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.popElseUndefined()).toBeUndefined();
     });
 
-    it("maintains the index, given an indexed stack", () => {
+    it("leaves the right positions behind, above the high water mark", () => {
       const twice = {};
       const stack = stackOf(TALL, [twice, {}, twice]);
 
@@ -218,7 +223,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.lastIndexOf(held[1]!)).toBe(1);
     });
 
-    it("maintains the index, given an indexed stack", () => {
+    it("leaves the right positions behind, above the high water mark", () => {
       const twice = {};
       const stack = stackOf(TALL, [twice, {}, twice]);
 
@@ -402,11 +407,12 @@ describe("IndexTrackingStack", () => {
     });
   }
 
-  describe("special values through an index that is already live", () => {
-    // Three different pieces of code key the index: the build sweeps a whole
-    // stack, `push()` keys one value onto a live index, and `pop()` keys one
-    // off. A suite that reaches only the build passes while either of the
-    // others is broken, so each gets its own group here.
+  describe("special values across the high water mark", () => {
+    // A value can reach the far side of the mark three ways -- pushed onto a
+    // stack already past it, popped off one, or already on the stack when it
+    // was passed -- and internally each is a different piece of code keying
+    // the same value. A suite that covers one passes while the others are
+    // broken, so each gets its own group here.
 
     /** A stack tall enough to hold an index, holding it, and holding a `0`. */
     function indexedStack() {
@@ -420,7 +426,7 @@ describe("IndexTrackingStack", () => {
     }
 
     describe("push()", () => {
-      it("keys a `NaN` pushed onto an already-indexed stack", () => {
+      it("finds a `NaN` pushed on past the high water mark", () => {
         const stack = indexedStack();
 
         stack.push(NaN);
@@ -429,7 +435,7 @@ describe("IndexTrackingStack", () => {
         expect(stack.lastIndexOf(NaN)).toBe(TALL + 1);
       });
 
-      it("keys a `-0` apart from a `0` the stack already holds", () => {
+      it("tells a `-0` pushed on past the mark from a `0` already held", () => {
         const stack = indexedStack();
 
         stack.push(-0);
@@ -464,9 +470,10 @@ describe("IndexTrackingStack", () => {
     });
 
     describe("indexOf()", () => {
-      // The build runs here, a lookup being what triggers one, so these are
-      // the cases where a value was already on the stack when it was keyed.
-      it("sweeps a `-0` and a `0` into separate entries as it builds", () => {
+      // A lookup is what reckons with everything already on the stack, so
+      // these are the cases where the values were there before the mark was
+      // passed.
+      it("tells a `-0` from a `0` held since before the mark was passed", () => {
         const stack = new IndexTrackingStack();
 
         stack.push(0);
@@ -478,7 +485,7 @@ describe("IndexTrackingStack", () => {
         expect(stack.indexOf(-0)).toBe(1);
       });
 
-      it("sweeps a `NaN` into its own entry as it builds", () => {
+      it("finds a `NaN` held since before the mark was passed", () => {
         const stack = new IndexTrackingStack();
 
         stack.push(NaN);
@@ -492,8 +499,8 @@ describe("IndexTrackingStack", () => {
     });
   });
 
-  describe("crossing the threshold", () => {
-    it("answers the same after coming back down as a stack that never went up", () => {
+  describe("crossing the water marks", () => {
+    it("behaves after climbing past the marks and back as one that never did", () => {
       // The index outlives the height that built it, so from here on the two
       // implementations are being compared directly on the same question.
       const held = objects(4);
@@ -515,7 +522,7 @@ describe("IndexTrackingStack", () => {
       expect(climbed.indexOf({})).toBe(flat.indexOf({}));
     });
 
-    it("answers from the scan again once the index has been dropped", () => {
+    it("reports the same positions after falling below the low water mark", () => {
       // Coming back down past the low mark drops the index, so what is used
       // afterwards is the scan -- over a stack that a `Map` was tracking a
       // moment ago, and has to have stopped tracking cleanly.
@@ -534,7 +541,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.indexOf({})).toBe(-1);
     });
 
-    it("builds the index again when it grows back past the threshold", () => {
+    it("reports the same positions after a second climb past the high mark", () => {
       // A rebuild from a stack that has held an index before is a different
       // path from the first build, and it has to arrive at the same answers.
       const twice = {};
@@ -552,7 +559,7 @@ describe("IndexTrackingStack", () => {
       expect(stack.lastIndexOf(twice)).toBe(1);
     });
 
-    it("carries both positions of a value already held twice into the index", () => {
+    it("reports both positions of a value held twice since before the climb", () => {
       // The index is built by grouping the stack as it stands, so a value
       // already holding two positions is the case where that grouping has to
       // produce a pair rather than overwrite.

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `IndexTrackingStack` answers its two lookups two ways -- by scanning, and
+ * from the index it builds once it is tall enough -- so every question worth
+ * asking gets asked on both sides of {@link IndexTrackingStack.INDEX_AT}. The
+ * two must agree, and a stack that crosses the threshold and comes back down
+ * must answer as one that never crossed it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { IndexTrackingStack } from "../src/index-tracking-stack.ts";
+
+/** Distinct objects, as many as a test asks for. */
+function objects(count: number): object[] {
+  const out: object[] = [];
+
+  for (let at = 0; at < count; at++) out.push({ at });
+
+  return out;
+}
+
+/** How tall a stack has to be for the index to have been built. */
+const TALL = IndexTrackingStack.INDEX_AT + 5;
+
+/**
+ * A stack holding the given objects, padded first to `height` with distinct
+ * objects of its own, so that one test body can be run on either side of the
+ * threshold.
+ */
+function stackOf(height: number, values: readonly object[]) {
+  const stack = new IndexTrackingStack();
+
+  for (const filler of objects(height)) stack.push(filler);
+  for (const value of values) stack.push(value);
+
+  return stack;
+}
+
+describe("IndexTrackingStack", () => {
+  describe("length", () => {
+    it("is zero for a fresh stack", () => {
+      expect(new IndexTrackingStack().length).toBe(0);
+    });
+
+    it("counts what has been pushed and not popped", () => {
+      const stack = new IndexTrackingStack();
+
+      for (const value of objects(TALL)) stack.push(value);
+      expect(stack.length).toBe(TALL);
+
+      for (let at = 0; at < 10; at++) stack.pop();
+      expect(stack.length).toBe(TALL - 10);
+    });
+
+    it("stays at zero when an empty stack is popped", () => {
+      const stack = new IndexTrackingStack();
+
+      stack.pop();
+
+      expect(stack.length).toBe(0);
+    });
+  });
+
+  describe("pop()", () => {
+    it("returns `undefined` for an empty stack", () => {
+      expect(new IndexTrackingStack().pop()).toBeUndefined();
+    });
+
+    it("returns the objects it pops, topmost first", () => {
+      const held = objects(3);
+      const stack = new IndexTrackingStack();
+
+      for (const value of held) stack.push(value);
+
+      expect(stack.pop()).toBe(held[2]);
+      expect(stack.pop()).toBe(held[1]);
+      expect(stack.pop()).toBe(held[0]);
+      expect(stack.pop()).toBeUndefined();
+    });
+
+    it("returns the objects it pops from an indexed stack", () => {
+      const held = objects(3);
+      const stack = stackOf(TALL, held);
+
+      expect(stack.pop()).toBe(held[2]);
+      expect(stack.pop()).toBe(held[1]);
+      expect(stack.pop()).toBe(held[0]);
+    });
+  });
+
+  describe("indexOf() and lastIndexOf()", () => {
+    for (
+      const [where, height] of [["scanning", 0], ["indexed", TALL]] as const
+    ) {
+      describe(where, () => {
+        it("reports -1 for an object it does not hold", () => {
+          const stack = stackOf(height, []);
+
+          expect(stack.indexOf({})).toBe(-1);
+          expect(stack.lastIndexOf({})).toBe(-1);
+        });
+
+        it("reports each object's position", () => {
+          const held = objects(4);
+          const stack = stackOf(height, held);
+
+          held.forEach((value, at) => {
+            expect(stack.indexOf(value)).toBe(height + at);
+            expect(stack.lastIndexOf(value)).toBe(height + at);
+          });
+        });
+
+        it("compares by identity rather than by value", () => {
+          const stack = stackOf(height, [{ same: 1 }]);
+
+          expect(stack.indexOf({ same: 1 })).toBe(-1);
+          expect(stack.lastIndexOf({ same: 1 })).toBe(-1);
+        });
+
+        it("reports -1 for an object that has been popped", () => {
+          const [kept, dropped] = objects(2) as [object, object];
+          const stack = stackOf(height, [kept, dropped]);
+
+          stack.pop();
+
+          expect(stack.indexOf(kept)).toBe(height);
+          expect(stack.indexOf(dropped)).toBe(-1);
+          expect(stack.lastIndexOf(dropped)).toBe(-1);
+        });
+
+        it("reports the lowest and the highest position of a repeated object", () => {
+          const twice = {};
+          const stack = stackOf(height, [twice, {}, twice]);
+
+          expect(stack.indexOf(twice)).toBe(height);
+          expect(stack.lastIndexOf(twice)).toBe(height + 2);
+        });
+
+        it("keeps the earlier position of a repeated object when the later one is popped", () => {
+          const twice = {};
+          const stack = stackOf(height, [twice, {}, twice]);
+
+          stack.pop();
+
+          expect(stack.indexOf(twice)).toBe(height);
+          expect(stack.lastIndexOf(twice)).toBe(height);
+        });
+
+        it("walks back through the positions of an object held three times", () => {
+          // Two occurrences would not tell a positions stack from a pair of
+          // numbers; three is where popping through them has to be in order.
+          const thrice = {};
+          const stack = stackOf(height, [thrice, {}, thrice, {}, thrice]);
+
+          expect(stack.indexOf(thrice)).toBe(height);
+          expect(stack.lastIndexOf(thrice)).toBe(height + 4);
+
+          stack.pop();
+          expect(stack.lastIndexOf(thrice)).toBe(height + 2);
+
+          stack.pop();
+          stack.pop();
+          expect(stack.lastIndexOf(thrice)).toBe(height);
+          expect(stack.indexOf(thrice)).toBe(height);
+        });
+
+        it("reports -1 once every position of a repeated object is popped", () => {
+          const twice = {};
+          const stack = stackOf(height, [twice, {}, twice]);
+
+          stack.pop();
+          stack.pop();
+          stack.pop();
+
+          expect(stack.indexOf(twice)).toBe(-1);
+          expect(stack.lastIndexOf(twice)).toBe(-1);
+        });
+      });
+    }
+  });
+
+  describe("crossing the threshold", () => {
+    it("answers the same after coming back down as a stack that never went up", () => {
+      // The index outlives the height that built it, so from here on the two
+      // implementations are being compared directly on the same question.
+      const held = objects(4);
+      const climbed = new IndexTrackingStack();
+      const flat = new IndexTrackingStack();
+
+      for (const filler of objects(TALL)) climbed.push(filler);
+      for (let at = 0; at < TALL; at++) climbed.pop();
+      for (const value of held) climbed.push(value);
+      for (const value of held) flat.push(value);
+
+      expect(climbed.length).toBe(flat.length);
+      held.forEach((value, at) => {
+        expect(climbed.indexOf(value)).toBe(flat.indexOf(value));
+        expect(climbed.indexOf(value)).toBe(at);
+        expect(climbed.lastIndexOf(value)).toBe(flat.lastIndexOf(value));
+      });
+      expect(climbed.indexOf({})).toBe(flat.indexOf({}));
+    });
+
+    it("carries both positions of an object already held twice into the index", () => {
+      // The index is built by grouping the stack as it stands, so an object
+      // already holding two positions is the case where that grouping has to
+      // produce a pair rather than overwrite.
+      const twice = {};
+      const stack = new IndexTrackingStack();
+
+      stack.push(twice);
+      stack.push(twice);
+      for (const filler of objects(TALL)) stack.push(filler);
+
+      expect(stack.indexOf(twice)).toBe(0);
+      expect(stack.lastIndexOf(twice)).toBe(1);
+    });
+
+    it("carries the objects already held into the index it builds", () => {
+      // The index is built from the stack as it stands, so what was pushed
+      // before the crossing has to arrive in it.
+      const early = {};
+      const stack = new IndexTrackingStack();
+
+      stack.push(early);
+      for (const filler of objects(TALL)) stack.push(filler);
+
+      expect(stack.indexOf(early)).toBe(0);
+      expect(stack.lastIndexOf(early)).toBe(0);
+    });
+  });
+});

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -291,7 +291,7 @@ describe("IndexTrackingStack", () => {
 
     it("answers from the scan again once the index has been dropped", () => {
       // Coming back down past `DROP_INDEX_BELOW` drops the index, so what
-      // answers afterwards is the scan -- over a stack that a `Map` was
+      // is used afterwards is the scan -- over a stack that a `Map` was
       // tracking a moment ago, and has to have stopped tracking cleanly.
       const twice = {};
       const stack = new IndexTrackingStack();

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -1,9 +1,10 @@
 /**
  * `IndexTrackingStack` answers its two lookups two ways -- by scanning, and
  * from the index it builds once it is tall enough -- so every question worth
- * asking gets asked on both sides of {@link IndexTrackingStack.INDEX_AT}. The
- * two must agree, and a stack that crosses the threshold and comes back down
- * must answer as one that never crossed it.
+ * asking gets asked on both sides of
+ * {@link IndexTrackingStack.ADD_INDEX_AT}. The two must agree, and a stack
+ * that crosses the threshold and comes back down must answer as one that never
+ * crossed it.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -21,7 +22,7 @@ function objects(count: number): object[] {
 }
 
 /** How tall a stack has to be for the index to have been built. */
-const TALL = IndexTrackingStack.INDEX_AT + 5;
+const TALL = IndexTrackingStack.ADD_INDEX_AT + 5;
 
 /**
  * A stack holding the given objects, padded first to `height` with distinct
@@ -289,9 +290,9 @@ describe("IndexTrackingStack", () => {
     });
 
     it("answers from the scan again once the index has been dropped", () => {
-      // Coming back down past `DROP_BELOW` drops the index, so what answers
-      // afterwards is the scan -- over a stack that a `Map` was tracking a
-      // moment ago, and has to have stopped tracking cleanly.
+      // Coming back down past `DROP_INDEX_BELOW` drops the index, so what
+      // answers afterwards is the scan -- over a stack that a `Map` was
+      // tracking a moment ago, and has to have stopped tracking cleanly.
       const twice = {};
       const stack = new IndexTrackingStack();
 

--- a/packages/utils/test/index-tracking-stack.test.ts
+++ b/packages/utils/test/index-tracking-stack.test.ts
@@ -1,10 +1,9 @@
 /**
  * `IndexTrackingStack` answers its two lookups two ways -- by scanning, and
  * from the index it builds once it is tall enough -- so every question worth
- * asking gets asked on both sides of
- * `ADD_INDEX_AT`. The two must agree, and a stack
- * that crosses the threshold and comes back down must answer as one that never
- * crossed it.
+ * asking gets asked on both sides of the height that builds one. The two must
+ * agree, and a stack that crosses that height and comes back down must answer
+ * as one that never crossed it.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -286,11 +285,18 @@ describe("IndexTrackingStack", () => {
       const [where, height] of [["scanning", 0], ["indexed", TALL]] as const
     ) {
       describe(where, () => {
-        /** A stack of the padded height, then the given values. */
+        /**
+         * A stack of the padded height, then the given values. The lookup
+         * between the two is what makes the indexed arm indexed *before* the
+         * values arrive, so that they go in through the maintenance path
+         * rather than being swept up by a later build.
+         */
         function stackOfAny(values: readonly unknown[]) {
           const stack = new IndexTrackingStack<unknown>();
 
           for (const filler of objects(height)) stack.push(filler);
+          stack.indexOf({});
+
           for (const value of values) stack.push(value);
 
           return stack;
@@ -432,6 +438,89 @@ describe("IndexTrackingStack", () => {
       expect(empty.popElseUndefined()).toBeUndefined();
       expect(held.depth).toBe(0);
       expect(empty.depth).toBe(0);
+    });
+  });
+
+  describe("special values through an index that is already live", () => {
+    // The build sweeps the whole stack, so a value pushed before it is keyed
+    // by a different piece of code from one pushed after. These are the after
+    // case, which is the one a lookup alone does not reach.
+    /** A stack tall enough to hold an index, holding it, and holding a `0`. */
+    function indexedStack() {
+      const stack = new IndexTrackingStack<unknown>();
+
+      for (const filler of objects(TALL)) stack.push(filler);
+      stack.push(0);
+      stack.indexOf({});
+
+      return stack;
+    }
+
+    it("finds a `NaN` pushed onto a stack that is already indexed", () => {
+      const stack = indexedStack();
+
+      stack.push(NaN);
+
+      expect(stack.indexOf(NaN)).toBe(TALL + 1);
+      expect(stack.lastIndexOf(NaN)).toBe(TALL + 1);
+    });
+
+    it("keeps a `-0` pushed onto an indexed stack apart from a held `0`", () => {
+      const stack = indexedStack();
+
+      stack.push(-0);
+
+      expect(stack.indexOf(-0)).toBe(TALL + 1);
+      expect(stack.indexOf(0)).toBe(TALL);
+    });
+
+    it("pops a `-0` off an indexed stack without disturbing a held `0`", () => {
+      // Popping keyed by the raw value would take a position off the `0`
+      // entry instead, since a `Map` reads a `-0` key as `0`.
+      const stack = indexedStack();
+
+      stack.push(-0);
+      stack.pop();
+
+      expect(stack.indexOf(0)).toBe(TALL);
+      expect(stack.indexOf(-0)).toBe(-1);
+    });
+
+    it("sweeps a `-0` and a `0` into separate entries when the index is built", () => {
+      // The other side of the same coin: a value already on the stack when
+      // the index is built is keyed by the build loop rather than by `push()`,
+      // and the two have to agree about what a `-0` is.
+      const stack = new IndexTrackingStack<unknown>();
+
+      stack.push(0);
+      stack.push(-0);
+      for (const filler of objects(TALL)) stack.push(filler);
+      stack.indexOf({});
+
+      expect(stack.indexOf(0)).toBe(0);
+      expect(stack.indexOf(-0)).toBe(1);
+    });
+
+    it("sweeps a `NaN` into its own entry when the index is built", () => {
+      const stack = new IndexTrackingStack<unknown>();
+
+      stack.push(NaN);
+      stack.push(0);
+      for (const filler of objects(TALL)) stack.push(filler);
+      stack.indexOf({});
+
+      expect(stack.indexOf(NaN)).toBe(0);
+      expect(stack.indexOf(0)).toBe(1);
+    });
+
+    it("pops a `NaN` off an indexed stack and stops finding it", () => {
+      const stack = indexedStack();
+
+      stack.push(NaN);
+      stack.pop();
+
+      expect(stack.indexOf(NaN)).toBe(-1);
+      expect(stack.indexOf(0)).toBe(TALL);
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`IndexTrackingStack<T>` — a stack of values offering `Array`-style `indexOf()`
and `lastIndexOf()`, plus `push()`, `pop()`, `popElseUndefined()`,
`popExpect()`, and a `depth`.

What it promises a caller is that a lookup does not get slower as the stack
grows. How that is arranged is its own business: a short stack is searched, and
a tall one keeps an index — built the first time something asks it a position,
and dropped again once it comes well back down.

`pop()` refuses an empty stack rather than answering `undefined`, which a
parametric `T` makes ambiguous; `popElseUndefined()` is the arm for a caller
whose domain excludes it. `popExpect(expected)` pops the topmost value, which
has to be the given one, and leaves the stack as it was if it is not — so what
a caller has to sort out is one unbalanced push and pop, not that plus a pop it
did not intend. It asks the stack's height before comparing, because reading
past the bottom of an empty stack yields `undefined`, which would otherwise
meet an `undefined` expectation.

The two heights are `static #private`. `readonly` is erased, so a public
constant is a public writable property the type system merely disapproves of,
and a value the engine cannot treat as constant. A test and a benchmark still
have to straddle a threshold, so `accessForTestingOnly` hands them over under a
name that is its own documentation.

## What "the same value" means here

`Object.is`: identity for an object, value for a primitive, `NaN` matching
itself, and `-0` distinct from `0`. Neither structure beneath does that on its
own — `Array.prototype.indexOf` compares strictly, so it finds a `0` for a `-0`
and never finds a `NaN`, and a `Map` normalizes a `-0` key to `0`. So a stack
would have found a `NaN` above the threshold and missed it below: a wrong
answer whose only trigger is how tall the stack happened to be.

Both are given the comparison instead. The scan calls `Object.is` directly; the
index takes it through a key function that stands a symbol in for each of the
two values a `Map` cannot key that way. Two values take the same key exactly
when `Object.is` calls them the same value.

A `NaN` needs no standing in as `Map` is written today, and gets one anyway, so
the pair reads as one rule rather than as one rule and one coincidence. **No
test can tell**, and the ablation table below is where that shows.

`===` and `Object.is` part company on numbers and only on numbers, so the
`typeof` check that routes between them is not a heuristic — it is exactly the
set that needs the slower answer, and is all a stack of anything else pays.

## Where the heights come from

The same walk over a 6000-container subject, run both ways, with the container
count held roughly constant while the depth varies:

| height | keyed set | scan | |
| --- | --- | --- | --- |
| 4 | 394.5 | 210.9 | 0.53x |
| 8 | 299.5 | 190.4 | 0.64x |
| 16 | 279.5 | 191.2 | 0.68x |
| 32 | 278.7 | 193.6 | 0.69x |
| 64 | 276.8 | 198.1 | 0.72x |
| 128 | 264.4 | 215.1 | 0.81x |
| 256 | 272.1 | 270.6 | 0.99x |
| 1000 | 218.6 | 568.0 | 2.60x |

Microseconds per walk. The scan wins to about 256 entries and loses badly past
it, so the index is added at 64 — well below the crossover, so that reaching it
never costs more than not having reached it — and dropped below 32, far enough
under that a stack has to swing 32 entries to rebuild.

## What an operation costs

`src/index-tracking-stack.bench.ts` covers pushing, popping and looking up,
with and without a repeated value, across the states the stack can be in.
Microseconds per timed batch:

| | never indexed | grew tall, came back down | above the high mark |
| --- | --- | --- | --- |
| push | 21.5 | 19.2 | 112.7 |
| pop | 6.5 | 6.4 | 46.1 |

The middle column meeting the first is what says the index is dropped rather
than carried. **No test can say it** — the drop changes no answer — so those
two columns parting is the only signal, and the benchmark is the instrument.
Without the low-water mark that column read 92.8 and 56.1: a stack that went
deep once paid roughly the deep price forever.

Lookups, at a height between the two marks, 8192 per batch:

| | no index | index present |
| --- | --- | --- |
| miss | 75.8 | 31.4 |
| hit at position 0 | 34.6 | 36.1 |

A miss is what a scan cannot cut short, and misses are what a cycle guard asks
almost exclusively — which is why an index that exists is used at every height
rather than only above the threshold. Maintaining it is what a short stack is
spared, and that is already spent by the time a lookup asks.

| oscillation band | µs |
| --- | --- |
| inside the low mark | 64.5 |
| above the low mark, crossing the high one | 192.4 |
| across both marks every swing | 229.5 |

Each step looks a value up and then pushes it, which is the shape of the caller
these bands stand for. Only the last rebuilds, at about a fifth more than
carrying the index — the case the gap between the marks exists to make rare
rather than impossible, and it is here to be watched.

An iteration runs its batch against a pool of stacks rather than one, because
Deno ignores an explicit timer for an iteration averaging under 10 µs — and a
batch small enough to stay inside a state's height band is far under that on
its own, which would silently turn each figure into the scaffolding plus the
batch. The first version of this benchmark did exactly that and reported one
state as 26x slower than another.

## Why both lookups, and what asking for both found

Supporting `lastIndexOf()` as well as `indexOf()` turned up a defect in holding
one index per value. A value pushed twice left the map naming only its later
position, so popping deleted the entry outright while the value was still in
the stack — after which `indexOf()` answered `-1` for something it held. The
index records the positions each value occupies, so both lookups are answered
from it and a pop restores the earlier position rather than dropping the value.

## Tests

Every question is asked on both sides of the high mark, as a parameterized
pair: one arm short, one padded past it. Absent value, each value's position,
identity rather than equality, `-1` after a pop, lowest and highest of a
repeated value, the earlier position surviving when the later is popped, `-1`
once every position is popped, and walking back through three occurrences.
Threshold tests cover a stack that climbs and comes back down, a value — or a
pair of positions — already held when the index is built, answers after the
index has been dropped, and a rebuild after that.

A group covers what a parametric domain opens up: `undefined` found where it
was pushed, `NaN` found where strict comparison never would, both zeros held
apart across every position of each, `popExpect` refusing a `0` for a `-0` and
the reverse, a popped `-0` leaving a `0` below it findable, `popExpect` and
`pop` refusing an empty stack whose domain admits `undefined`, and `depth` as
what tells an empty stack from one holding an `undefined`.

**A test cannot observe which structure answered**, that being the design goal,
so the coverage claim rests on ablations. Each runs with a control arm, so that
a filter reporting nothing cannot be read as a pass, and each is named by the
substitution it makes:

| ablation | steps failed |
| --- | --- |
| control — no ablation | 0, passes |
| the index is never built | 0 — see below |
| the `NaN` stand-in key is dropped | 0 — see below |
| `popExpect` stops refusing an empty stack | 2 |
| the build loop keys by the raw value | 3 |
| the scan compares strictly for numbers | 7 |
| the pop keys its lookup by the raw value | 8 |
| `popExpect` compares strictly | 9 |
| the `-0` stand-in key is dropped | 10 |
| `indexOf` reads the last position | 12 |
| `lastIndexOf` reads the first position | 12 |
| `push` keys its maintenance by the raw value | 14 |
| `pop` does not clear the index | 16 |
| `push` does not maintain the index at all | 31 |

Three of those key the index, and they are three different pieces of code: the
build sweeps a whole stack, `push()` keys one value onto a live index, and the
pop keys one off. Each has its own row, because a suite that reaches only the
build will pass while either of the other two is broken — which is what these
tests did until the cases that push and pop special values onto a live index
were added.

The two zero rows are the design showing through rather than gaps. An index
that is never built means everything is searched, and searching gives the same
answers — that is what "not observable beyond the cost" means, and the
benchmark is what covers it. The `NaN` stand-in is redundant with how `Map`
happens to key a `NaN`, and is kept so the pair reads as one rule.

`deno coverage` reports no uncovered line in the new file, with no directive
anywhere.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





