### PR TITLE
docs(development): the blank-line rule's two gaps, and the four sites they left

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -500,10 +500,11 @@ export interface Donut {
 }
 ```
 
-Two constructs are exempt because the formatter overrules the rule there.
-`deno fmt` removes a blank line between two items of a parenthesized list, and
-between two arms of a union or intersection type, so a documented parameter
-list, argument list, or union runs unbroken:
+Three constructs are exempt because the formatter overrules the rule there.
+`deno fmt` removes a blank line between two items of a parenthesized list,
+between two items of a type parameter list, and between two arms of a union or
+intersection type, so a documented parameter list, argument list, type parameter
+list, or union runs unbroken:
 
 ```ts
 // Shown at module scope.
@@ -570,9 +571,10 @@ treatment.
 The exemptions mirror the ones above. A declaration with nothing after it in
 its file or bracketed block takes no blank line: the closing bracket, or the
 end of the file, is the separator, exactly as the opening bracket is on the
-other side. And the two constructs `deno fmt` will not keep a blank line in are
-exempt here for the reason they are exempt there — the formatter strips one
-after a documented parameter or union arm just as it strips one before.
+other side. And the three constructs `deno fmt` will not keep a blank line in
+are exempt here for the reason they are exempt there — the formatter strips one
+after a documented parameter, type parameter, or union arm just as it strips one
+before.
 
 The rule reaches documented declarations only. Two adjacent members carrying no
 doc comment between them leave no comment's scope in doubt, and stay as they
@@ -580,9 +582,15 @@ are.
 
 For this rule an overload set is one declaration. Its signatures and the
 implementation carrying the code are a single thing to a caller and a single
-thing to the doc comment above them, so no blank line falls between them; the
-one that closes the set goes after the implementation. `deno fmt` keeps a blank
-line between two signatures, so this is a convention no gate will raise.
+thing to the doc comment above them, so no blank line falls between one part of
+the set and the next; the one that closes the set goes after the implementation.
+The blank lines inside the implementation's own body are statement spacing and
+are not what this means.
+
+A set with no implementation to close it — in an interface, or in ambient
+`declare` form — is an overload set all the same, and closes after its last
+signature. `deno fmt` keeps a blank line between two signatures, so this is a
+convention no gate will raise.
 
 ### What gets one
 

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -462,7 +462,7 @@ defect. To title a region of a file or a class, use a section marker; see
 ### The blank line above
 
 A doc comment takes a blank line above it, except where it is the first thing
-in its file or bracketed block, and except in the two constructs `deno fmt`
+in its file or bracketed block, and except in the three constructs `deno fmt`
 will not keep one in.
 
 That blank line is what separates a documented declaration from whatever

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -471,7 +471,6 @@ export interface IKeyable<out T, Wrap extends HKT> {
     k1: K1,
     k2: K2,
   ): Apply<Wrap, T[K1][K2]>;
-
   // Three keys
   key<
     K1 extends keyof T,
@@ -694,7 +693,6 @@ export interface IKeyableOpaque<T> {
     k1: K1,
     k2: K2,
   ): OpaqueCell<UnwrapCell<T>[K1][K2]>;
-
   key<
     K1 extends keyof UnwrapCell<T>,
     K2 extends keyof UnwrapCell<T>[K1],

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1251,16 +1251,22 @@ export type Reactive<T> = T;
 //
 
 /**
- * CellLike is a cell (AnyCell) whose nested values are valid factory inputs.
- * The top level must be AnyCell, but nested values can be plain or wrapped.
- *
- * Note: This is primarily used for type constraints that require a cell.
+ * The cell half of {@link CellLike}: the top level must be a branded cell, and
+ * its nested values can be plain or wrapped. Used for type constraints that
+ * require a cell.
  */
 type CellWrappedValue<T> = AnyBrandedCell<CellWrappedData<T>> & {
   [CELL_LIKE]?: unknown;
 };
 
+/**
+ * A `T`, either plain or wrapped in a cell whose nested values are valid
+ * factory inputs ({@link CellWrappedValue}). The accepting type for a position
+ * — a JSX prop, for instance — that takes a live cell in place of the plain
+ * value.
+ */
 export type CellLike<T> = CellWrappedValue<T> | T;
+
 type CellWrappedData<T> =
   | T
   | AnyBrandedCell<T>

--- a/packages/content-hash/src/interface.ts
+++ b/packages/content-hash/src/interface.ts
@@ -16,18 +16,17 @@ export interface IncrementalHasher {
   update(data: Uint8Array): void;
 
   /**
-   * Finalizes the hash and returns the digest as a `Uint8Array`. The result is
-   * freshly allocated and unshared -- no part of it is a window onto a buffer
-   * the hasher, its implementation, or any other caller retains -- so the
-   * caller may mutate it, or cede it to something that takes ownership of a
-   * buffer.
+   * Finalizes the hash and returns the digest, as bytes or in a named string
+   * encoding.
+   *
+   * The `Uint8Array` result is freshly allocated and unshared -- no part of it
+   * is a window onto a buffer the hasher, its implementation, or any other
+   * caller retains -- so the caller may mutate it, or cede it to something that
+   * takes ownership of a buffer.
    */
+  // As bytes.
   digest(): Uint8Array;
-
-  /**
-   * Finalizes the hash and returns the digest as a string in the given
-   * encoding. Currently only `"base64url"` (unpadded) is supported.
-   */
+  // In an encoding; currently only `"base64url"` (unpadded) is supported.
   digest(encoding: "base64url"): string;
 }
 

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -893,7 +893,6 @@ export interface IKeyable<out T, Wrap extends HKT> {
     k1: K1,
     k2: K2,
   ): Apply<Wrap, T[K1][K2]>;
-
   // Three keys
   key<
     K1 extends keyof T,
@@ -1116,7 +1115,6 @@ export interface IKeyableOpaque<T> {
     k1: K1,
     k2: K2,
   ): OpaqueCell<UnwrapCell<T>[K1][K2]>;
-
   key<
     K1 extends keyof UnwrapCell<T>,
     K2 extends keyof UnwrapCell<T>[K1],

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -1673,16 +1673,22 @@ export type Reactive<T> = T;
 //
 
 /**
- * CellLike is a cell (AnyCell) whose nested values are valid factory inputs.
- * The top level must be AnyCell, but nested values can be plain or wrapped.
- *
- * Note: This is primarily used for type constraints that require a cell.
+ * The cell half of {@link CellLike}: the top level must be a branded cell, and
+ * its nested values can be plain or wrapped. Used for type constraints that
+ * require a cell.
  */
 type CellWrappedValue<T> = AnyBrandedCell<CellWrappedData<T>> & {
   [CELL_LIKE]?: unknown;
 };
 
+/**
+ * A `T`, either plain or wrapped in a cell whose nested values are valid
+ * factory inputs ({@link CellWrappedValue}). The accepting type for a position
+ * — a JSX prop, for instance — that takes a live cell in place of the plain
+ * value.
+ */
 export type CellLike<T> = CellWrappedValue<T> | T;
+
 type CellWrappedData<T> =
   | T
   | AnyBrandedCell<T>

--- a/packages/ui/src/v2/components/cf-code-editor/copresence-client.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/copresence-client.ts
@@ -76,19 +76,20 @@ export interface PresenceSocket {
   /** Closes the socket with an optional protocol code and public reason. */
   close(code?: number, reason?: string): void;
 
-  /** Registers an open-event listener. */
+  /**
+   * Registers a listener for one socket event, typed to the event that name
+   * carries.
+   */
+  // Open.
   addEventListener(type: "open", listener: (event: Event) => void): void;
-
-  /** Registers a message-event listener. */
+  // Message.
   addEventListener(
     type: "message",
     listener: (event: MessageEvent) => void,
   ): void;
-
-  /** Registers an error-event listener. */
+  // Error.
   addEventListener(type: "error", listener: (event: Event) => void): void;
-
-  /** Registers a close-event listener. */
+  // Close.
   addEventListener(type: "close", listener: (event: CloseEvent) => void): void;
 }
 

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -217,8 +217,8 @@ it was written for. The comment reaches on past it, so the members added under
 it look documented when they are not — which is exactly the shape a diff
 appending one member to a run of them puts in front of you. See the same
 document, "The blank line below". An overload set counts as one declaration
-here, so the blank line falls after the implementation and not between the
-signatures.
+here, so the blank line falls after the implementation — or, for a set with none
+to close it, after its last signature — and never between the signatures.
 
 **A missing or misplaced file header** is that same defect one level up, and is
 equally a thing a diff shows you. A file header is a doc comment at the very


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

An ex-post-facto review of #6633 — the rule the doc-comment arc applied — found
two cases its text does not decide, and a census turned each into a population.

## The two gaps

**An overload set with no implementation.** The rule says a set is one
declaration and the blank line closing it "goes after the implementation". A set
declared in an `interface` or in ambient `declare` form has none, so the sentence
never reached it. Such a set is an overload set all the same, and closes after
its last signature. The text also said no blank line falls "between them", of the
signatures and the implementation; it now says between one part of the set and
the next, and says that the implementation body's own statement spacing is not
what that means.

**The formatter-exempt constructs are three, not two.** `deno fmt` strips a blank
line between two items of a type parameter list exactly as it does between two
items of a parenthesized list. No documented type parameter exists in the tree
today — a shape-independent sweep of 4456 files under `packages/` found five
candidates, all false positives on reading — so this correction is
forward-looking. An enumeration asserting itself exhaustive is what makes it
worth fixing now rather than when the first one arrives.

`skills/cf-review` carries the overload sentence and takes the same correction.

## The four code sites

A census found eight implementation-less overload sets. Four already conform or
carry no doc comment; four were waiting on these two sentences.

- **`packages/api/index.ts`** — `IKeyable.key` and `IKeyableOpaque.key` each
  carry a blank line mid-run that **#6655 inserted**. The detector that drove the
  sweep stops extending an overload set when the next signature opens its generic
  list on the line below, so it reported these sites as *missing* a line rather
  than as places a line must not go, and the sweep obeyed the tool over the rule.
  Both blanks reached the served `commonfabric.d.ts` verbatim, so that file is
  regenerated here; the regeneration diff is exactly those two lines.
- **`PresenceSocket.addEventListener`** and **`Hasher.digest`** gave every
  signature its own doc comment, which cannot survive a set with no blank lines
  in it — each comment would lose the blank line above it that
  §"The blank line above" requires. Both fold to the one-comment-and-`//`-labels
  form that §"Where one goes" already asked for.

## Verification

`deno fmt --check`, `deno lint`, `deno check`, `check-docs` (596 blocks),
`check-skill-facts` (49 documents), `check-commonfabric-types` (up to date), and
the `content-hash` and `static` suites. Every added line is within 80 columns.

The formatter claims here were probed rather than assumed, but **off-pin**: this
machine has `deno` 2.9.6 where `mise.toml` pins 2.9.4 and `mise` is not
installed, so `tasks/check.sh` refuses the toolchain by design. CI's pinned run
is the authority on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

