### PR TITLE
style(runner,utils,data-model,cf-harness,state-inspector): the comments the sweep bound to the wrong thing

### DIFF
--- a/packages/cf-harness/console/flow.ts
+++ b/packages/cf-harness/console/flow.ts
@@ -34,6 +34,7 @@ export interface ConsoleFlowCell {
   token?: string;
   ref?: string;
   slug?: string;
+
   /** The step whose result minted it. */
   producedByStep?: number;
 
@@ -74,10 +75,10 @@ export interface ConsoleFlowNode {
   /** What CFC decided about the observation. */
   policyDecision?: string;
 
-  /** Whether that decision refused it. */
+  /** Whether a policy event refused it. */
   policyDenied?: boolean;
 
-  /** What the decision said, where it said more than its verdict. */
+  /** What that refusal said, where it said more than the fact of it. */
   policyDetail?: string;
 
   /** Cells this call read. */

--- a/packages/cf-harness/console/flow.ts
+++ b/packages/cf-harness/console/flow.ts
@@ -97,10 +97,15 @@ export interface ConsoleFlowNode {
 
   /**
    * How far this call let across as a plain value, for a call whose result
-   * carried one. A long numeric run is the shape of a channel.
+   * carried one.
    */
   valueBytes?: number;
 
+  /**
+   * The longest run of numbers that value carries, for the same call. An array
+   * of integers is an array of values none of which is sealed, so a long one is
+   * a channel wide enough for arbitrary content.
+   */
   longestNumericRun?: number;
 
   /** The child run this call delegated to, drawn beneath it. */

--- a/packages/data-model-schema/src/schema-intern.ts
+++ b/packages/data-model-schema/src/schema-intern.ts
@@ -29,7 +29,8 @@ const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
  * object schema's lookup by hash takes both halves: deref the `WeakRef` from
  * here, then read the `SchemaAndHash` out of `schemaToSah`. A `SchemaAndHash`
  * is thereby reachable only while its own schema object is alive. A primitive
- * hash is answered from `primInterns` and reaches neither half.
+ * hash takes neither step — it is read straight out of this map, and the
+ * primitive stored here routes to `primInterns`.
  */
 const hashToRef = new Map<
   string,

--- a/packages/data-model/bench/codec-json.bench.ts
+++ b/packages/data-model/bench/codec-json.bench.ts
@@ -33,7 +33,7 @@ import {
   SPARSE,
 } from "./fixtures/codec-fixtures.ts";
 
-/** Encoded forms, for the decode direction. */
+/** Encoded forms of the singles, for the decode direction. */
 const SINGLES_JSON = SINGLES.map(([n, v]) =>
   [n, jsonFromFabricValue(v)] as const
 );

--- a/packages/data-model/bench/codec-realm.bench.ts
+++ b/packages/data-model/bench/codec-realm.bench.ts
@@ -73,7 +73,7 @@ import {
 /** Subjects whose encoded form holds a byte buffer, so decodes only once. */
 const SINGLE_SHOT = new Set(["bytes"]);
 
-/** Encoded forms, for the decode direction of every repeat-safe subject. */
+/** Encoded forms of the repeat-safe singles, for the decode direction. */
 const SINGLES_REALM = SINGLES
   .filter(([name]) => !SINGLE_SHOT.has(name))
   .map(([n, v]) => [n, realmFromFabricValue(v)] as const);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4631,12 +4631,12 @@ const coalesceLabelEntries = (
  * unconditional. A spelling that refuses decomposition simply fails the
  * check and the caller falls through as before.
  */
-// Exported for unit testing of the fallback arms; the persist loop's merge
-// is the one production caller.
 export const decomposeToSameRoot = (
   left: JSONSchema,
   right: JSONSchema,
 ): boolean => {
+  // Exported for unit testing of the fallback arms; the persist loop's merge
+  // is the one production caller.
   if (!isObjectNotArray(left) || !isObjectNotArray(right)) return false;
   try {
     return decomposeSchema(left, { resolveDocument: lookupSchemaDocument })

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -441,6 +441,7 @@ export class SpaceServer implements TransactionSealDestination {
    * the LT1 in-process cascade copy (no streamEntry) is a different
    * producer and is deliberately NOT tracked here. */
   readonly #drainInFlight = new Map<string, "queued" | "marked">();
+
   #currentWave: WaveAccumulator | undefined;
   #sealChain: Promise<unknown> = Promise.resolve();
   #feed: AdmittedCommitNotice[] = [];
@@ -595,6 +596,7 @@ export class SpaceServer implements TransactionSealDestination {
     string,
     { id: string; scopeKey: string }
   >();
+
   // (d′) — server-settle instrumentation (design §6 W4's
   // metric; §2.8 (c)). Per authored input: admission (the feed notice's
   // arrival, `enqueueCommit`) → COVERAGE (the wave commit whose

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -810,6 +810,7 @@ export class WaveAccumulator
     string,
     "owner" | "creation" | "acl"
   >();
+
   readonly #onForeignWriteRefusal:
     | ((info: { space: MemorySpace; actionId?: string }) => void)
     | undefined;

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1110,6 +1110,7 @@ export class PatternManager {
       }
       return { complete: true, sourceDocs, compiledDocs };
     };
+
     /** One full read attempt: the caller-named origin, then the FALLBACK
      * ORIGINS (see `#persistedClosureSpaces`): the caller-named origin is a
      * provenance heuristic and can be closure-less through no fault of any
@@ -1159,6 +1160,7 @@ export class PatternManager {
       }
       return primary;
     };
+
     let origin = await readOriginWithFallbacks();
     if (!origin.complete) {
       // GEOMETRY 3 (verification-coverage.md OW45; direct-CI probe 4, run

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -740,13 +740,13 @@ export interface RemoteClientPresetParams extends CoreParams {
   patternCoverage?: PatternCoverageCollector;
 
   /**
-   * Host-controlled rollout dials, the browserWorker precedent: a client
-   * host (cf-harness's fabric session) may raise enforcement and turn on
-   * flow-label persistence for one session without moving the fleet posture
-   * in `coreOptions`.
+   * Host-controlled rollout dial, on the browserWorker precedent: a client
+   * host (cf-harness's fabric session) may raise enforcement for one session
+   * without moving the fleet posture in `coreOptions`.
    */
   cfcEnforcementMode?: CfcEnforcementMode;
 
+  /** The other such dial: flow-label persistence, on the same terms. */
   cfcFlowLabels?: CfcFlowLabelsMode;
 }
 
@@ -772,10 +772,12 @@ export interface BrowserWorkerPresetParams extends CoreParams {
   /** Map from space DIDs to HTTP or HTTPS origins selected by the shell host. */
   spaceHostMap?: Record<string, string>;
 
-  /** Host-controlled rollout dials, from `InitializationData`. */
+  /** Host-controlled rollout dial, from `InitializationData`. */
   cfcEnforcementMode?: CfcEnforcementMode;
 
+  /** The other such dial, from the same source. */
   cfcFlowLabels?: CfcFlowLabelsMode;
+
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
   telemetry?: RuntimeTelemetry;
   consoleHandler?: ConsoleHandler;

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -310,29 +310,32 @@ export class SpeculationOverlayDestination
    * not enact. */
   readonly #droppedLateEchoTxs = new WeakSet<object>();
 
-  /** DIAGNOSTIC counters (tests). */
+  /** DIAGNOSTIC counter (tests): sweeps the ARRIVAL wake ran. */
   #arrivalSweeps = 0;
 
+  /** DIAGNOSTIC counter (tests): late echoes dropped at seal. */
   #lateEchoDrops = 0;
 
   /** Stage C W2.1: cascade-child echoes retired because an ANCESTOR
    * intent's terminal consequence arrived (`retireIntent` walked the
-   * cascade thread to them), and the subset retired while NO doc they
-   * wrote had yet moved past their read basis in the replica — the
-   * flicker witness (see `retireIntent`). */
+   * cascade thread to them). */
   #cascadeEchoRetirements = 0;
 
+  /** The subset of those retired while NO doc they wrote had yet moved
+   * past their read basis in the replica — the flicker witness; see
+   * `cascadeEchoRetirementUnarrivedCount` for the heuristic it uses. */
   #cascadeEchoRetirementsUnarrived = 0;
 
-  /** F6 telemetry (combined review 2026-08-19): the silent-strand
-   * distinguishers. A `#cascadeParents` eviction at the 4096 bound, or
-   * an ancestry walk stopped at the 64-hop depth cap with chain
-   * remaining, makes a live descendant read as "no ancestor" — the
-   * walk gives up and the entry strands exactly like the pre-W2.1
-   * posture, with nothing else to see. Zero in every expected
-   * workload; nonzero is the signal to look. */
+  /** F6 telemetry (combined review 2026-08-19): one of the two
+   * silent-strand distinguishers, counting `#cascadeParents` evictions
+   * at the 4096 bound. Either distinguisher makes a live descendant read
+   * as "no ancestor" — the walk gives up and the entry strands exactly
+   * like the pre-W2.1 posture, with nothing else to see. Zero in every
+   * expected workload; nonzero is the signal to look. */
   #cascadeThreadEvictions = 0;
 
+  /** The other silent-strand distinguisher: an ancestry walk stopped at
+   * the 64-hop depth cap with chain remaining. */
   #cascadeWalkDepthCaps = 0;
 
   /** space -> last observed watermark (for registration-time sweeps). */
@@ -370,12 +373,21 @@ export class SpeculationOverlayDestination
    * built, shifts the tail down), so a hint is never trusted unread. */
   readonly #intentSidecarStates = new Map<string, { hints: Set<number> }>();
 
-  /** DIAGNOSTIC counters (tests; the `commonfabric.*` surface reads the
-   * logger keys — `speculation-overlay/intent-*`). */
+  /** DIAGNOSTIC counter (tests): intent checks run. The `commonfabric.*`
+   * surface reads none of these counters; it reads the logger keys —
+   * `speculation-overlay/intent-*`. */
   #intentCheckCount = 0;
 
+  /** DIAGNOSTIC counter (tests): sidecar entries visited across all
+   * checks. */
   #intentCheckVisits = 0;
+
+  /** DIAGNOSTIC counter (tests): the largest single check's visit
+   * count. */
   #intentCheckMaxVisits = 0;
+
+  /** DIAGNOSTIC counter (tests): times the intent listener was
+   * installed. */
   #intentListenerInstalls = 0;
 
   /** Subscribers to terminal intent outcomes — the events.md §5 "the
@@ -395,6 +407,7 @@ export class SpeculationOverlayDestination
     string,
     Array<(outcome: IntentConsequence) => void>
   >();
+
   readonly #intentConsequenceMemo = new Map<string, IntentConsequence>();
 
   /** Resolvers parked by `waitForIntentQuiescence`, flushed by the same

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -374,7 +374,7 @@ export class SpeculationOverlayDestination
   readonly #intentSidecarStates = new Map<string, { hints: Set<number> }>();
 
   /** DIAGNOSTIC counter (tests): intent checks run. The `commonfabric.*`
-   * surface reads none of these counters; it reads the logger keys —
+   * surface reads no counter here; it reads the logger keys —
    * `speculation-overlay/intent-*`. */
   #intentCheckCount = 0;
 

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -191,6 +191,7 @@ export class EventAppendQueue {
     QueuedEventAppend,
     (outcome: EventAppendOutcome) => void
   >();
+
   #clientSeq = 0;
   #draining = false;
   #closed = false;
@@ -201,10 +202,12 @@ export class EventAppendQueue {
    * pending forever, wedging dispose-time sanitizers). */
   #retryRelease: (() => void) | undefined;
 
-  /** OW27 pacing: the per-stream token buckets (keyed by sidecar doc id
-   * — one per stream), or undefined when pacing is disabled. */
+  /** OW27 pacing: the rate and burst the buckets refill on, or undefined
+   * when pacing is disabled. */
   readonly #pacing: EventAppendPacing | undefined;
 
+  /** The per-stream token buckets, keyed by sidecar doc id — one per
+   * stream. */
   readonly #buckets = new Map<string, { tokens: number; refilledAt: number }>();
 
   /** DIAGNOSTIC (tests): sends held by pacing so far. */

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -202,8 +202,8 @@ export class EventAppendQueue {
    * pending forever, wedging dispose-time sanitizers). */
   #retryRelease: (() => void) | undefined;
 
-  /** OW27 pacing: the rate and burst the buckets refill on, or undefined
-   * when pacing is disabled. */
+  /** OW27 pacing: the parameters the buckets refill on, or undefined when
+   * pacing is disabled. */
   readonly #pacing: EventAppendPacing | undefined;
 
   /** The per-stream token buckets, keyed by sidecar doc id — one per

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -377,28 +377,9 @@ function narrowAndCombineSelectorForLink(
   return interned;
 }
 
-/**
- * Memoized, canonicalizing wrapper around `ContextualFlowControl.schemaAtPath()` for the hot
- * traversal seams (object properties, array items). The core method now
- * symbolically memoizes its common boolean-default derivations; this seam also
- * covers the marker-object variant used below, which is intentionally outside
- * that cache. It returns one interned (canonical, deep-frozen) result per
- * (schema identity, path, marker variant), so downstream identity-keyed hash
- * caches (most notably the `traverseWithSchema` memo) hit.
- *
- * Only memoizes when `schema` is a memoizable input (interned or deep-frozen
- * — see `isMemoizableSchemaInput()`), so the identity key cannot go stale.
- * (`schemaAtPath()` is deterministic — `ContextualFlowControl` carries no
- * instance state — so a module-level cache across cfc instances is sound.)
- * Mutable input falls back to the exact un-memoized computation.
- *
- * `markers` selects the `$comment` marker pair `#traverseObjectWithSchema`
- * uses to detect properties it should not descend into.
- */
 const EMPTY_PROPERTIES_MARKER: JSONSchema = Object.freeze(
   { $comment: "emptyProperties" },
 );
-
 const MISSING_PROPERTY_MARKER: JSONSchema = Object.freeze(
   { $comment: "missingProperty" },
 );
@@ -413,6 +394,25 @@ onSchemaRegistryClear(() => {
   _schemaAtPathCache = new WeakMap();
 });
 
+/**
+ * Memoized, canonicalizing wrapper around
+ * `ContextualFlowControl.schemaAtPath()` for the hot traversal seams (object
+ * properties, array items). The core method now symbolically memoizes its
+ * common boolean-default derivations; this seam also covers the marker-object
+ * variant used below, which is intentionally outside that cache. It returns one
+ * interned (canonical, deep-frozen) result per (schema identity, path, marker
+ * variant), so downstream identity-keyed hash caches (most notably the
+ * `traverseWithSchema` memo) hit.
+ *
+ * Only memoizes when `schema` is a memoizable input (interned or deep-frozen
+ * — see `isMemoizableSchemaInput()`), so the identity key cannot go stale.
+ * (`schemaAtPath()` is deterministic — `ContextualFlowControl` carries no
+ * instance state — so a module-level cache across cfc instances is sound.)
+ * Mutable input falls back to the exact un-memoized computation.
+ *
+ * `markers` selects the `$comment` marker pair `#traverseObjectWithSchema`
+ * uses to detect properties it should not descend into.
+ */
 function schemaAtPathCanonical(
   schema: JSONSchema,
   path: readonly string[],

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -17,11 +17,13 @@
 //   <dir>/clone.json               manifest: source, hashes, counts
 //   <dir>/.cf-clone                marker — "this store is NOT production"
 //   <dir>/pristine/<did>.sqlite    the baseline; never opened read-write
-//   <dir>/engine-v3/<did>.sqlite   the working copy a toolshed serves
+//   <dir>/engine-v3/engine-v3/<did>.sqlite
+//                                  the working copy a toolshed serves
 //
-// `engine-v3/` is not decoration: it is the on-disk layout the memory server
-// resolves through `resolveSpaceStoreUrl`, so pointing `MEMORY_DIR` at <dir>
-// serves the clone as a live space under the SAME DID.
+// That path is not decoration, and the doubled segment is not a typo: it is
+// what the memory server composes, so `clonePaths` DERIVES it rather than
+// spelling it out. Pointing `MEMORY_DIR` at <dir> then serves the clone as a
+// live space under the SAME DID.
 
 import * as Path from "@std/path";
 // The only read-WRITE database handle in this package, and it opens nothing:

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -44,7 +44,7 @@ import {
   type ScopedEntity,
 } from "./fingerprint.ts";
 
-/** Filenames the layout depends on. */
+/** Manifest filename the layout depends on. */
 const MANIFEST = "clone.json";
 
 /**

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -585,15 +585,6 @@ function getEnvMeasuresEnabled(): boolean {
 }
 
 /**
- * The cap named by `CF_TIMING_MEASURES_CAP`, when it names a positive integer.
- *
- * Separate from the on/off variable because a run that hits the cap stops
- * emitting partway through, which leaves an early-run prefix rather than a
- * sample — and a reader who does not know that will attribute a whole run from
- * its setup. Raising it has to be reachable from wherever emission is.
- */
-
-/**
  * What `CF_TIMING_MEASURES_CAP` means, separated from reading it.
  *
  * Separate because the decision is the part with a rule in it — anything that
@@ -610,6 +601,14 @@ export function parseTimingMeasureCap(
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+/**
+ * The cap named by `CF_TIMING_MEASURES_CAP`, when it names a positive integer.
+ *
+ * Separate from the on/off variable because a run that hits the cap stops
+ * emitting partway through, which leaves an early-run prefix rather than a
+ * sample — and a reader who does not know that will attribute a whole run from
+ * its setup. Raising it has to be reachable from wherever emission is.
+ */
 function getEnvMeasureCap(): number | undefined {
   if (isDeno()) {
     try {
@@ -1637,7 +1636,8 @@ export function resetAllCountBaselines(): void {
 
 /**
  * Resets the timing baseline for every registered logger, so that each
- * logger's `getTimingDeltas()` reports relative to its current timings.
+ * logger's `getTimeStats()` reports its `*SinceBaseline` figures relative to
+ * its current timings.
  */
 export function resetAllTimingBaselines(): void {
   const global = globalThis as unknown as {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

An ex-post-facto review of the doc-comment arc, judged against `main` rather than
against each PR's diff, found comments the sweep's inserted blank line bound to a
declaration they were not written for. A blank line under a misplaced comment
does not move it; it makes the misplacement look deliberate.

## The one the arc had already written down

`packages/runner/src/traverse.ts:380` was the arc's own worked example. Its
census named the site, said the fix was to move the comment rather than space it
— "inserting a blank line there would fix nothing and freeze the real defect in
place" — and #6639 spaced it anyway. Eighteen lines describing
`schemaAtPathCanonical` sat above `EMPTY_PROPERTIES_MARKER`, four declarations
and a call away from what they describe.

The comment moves to its function, its first paragraph rewraps to eighty columns
with its word multiset intact, and the two marker consts go back to adjacent —
the blank between them existed only to serve the misattribution.

## Seven more group headers, bounded onto their first member

Each is now false of what it sits on, or leaves its other members looking
undocumented: two runs of rollout dials in `runtime-presets`, four counter groups
in `overlay-destination` — one naming "the subset" that the blank line cut off,
one naming "the two distinguishers" — and `#pacing` in `event-append-queue`,
whose comment describes the token buckets that `#buckets` holds.

Each splits with the shared reasoning kept on the first member, which is what
#6639 and #6658 did for the two sites of this shape they caught. In
`overlay-destination` the public getters already document every one of these
counters precisely, so each new field comment is written against a claim the file
had already verified rather than an invented one.

## Seven sites the sweep had in scope and did not reach

All predate the arc — by `git blame`, and by a census that is identical run
against the files as `a12ce5db5` left them and as they stand on `main` — so none
arrived from a later change.

## Four comments wrong about the code, not about their placement

- `schema-intern` said a primitive hash "reaches neither half" of the intern
  cache, where `findInternedSchema:204` answers one by reading `hashToRef`,
  seeded at module load at `:56-59` for exactly that. The comment contradicted
  its own earlier sentence.
- `logger` named `getTimingDeltas()`, which exists nowhere in the tree; the
  figures come from `getTimeStats()`'s `*SinceBaseline` fields. Its sibling
  `resetAllCountBaselines` names `getCountDeltas()`, which does exist.
- `flow.ts` tied `policyDenied` and `policyDetail` to "that decision", where the
  code takes them from `policyEvents` and a denial can arrive with no decision
  record; the two spread blocks at `:304-309` are independent.
- A `//` note in `prepare.ts` sat between a doc comment and its declaration,
  where §"Where one goes" puts it inside the body the declaration has.

Plus a missing blank line above a doc comment in `flow.ts`, which had survived
three arc passes over that file.

## Verification

Suites green: runner 1338, cf-harness 919, state-inspector 111, utils 99,
data-model 48, data-model-schema 9. `deno fmt --check`, `deno lint`, and
`deno check` on every touched file. No added line exceeds eighty columns,
measured as characters over the diff's `+` lines.

Gates were run **off-pin**: this machine has `deno` 2.9.6 where `mise.toml` pins
2.9.4 and `mise` is not installed. CI's pinned run is the authority.

## Left alone deliberately

`space-host.ts:49` — a blank line #6639 put inside `normalizeSpaceHost`'s body,
before its `return`. It is the one insertion of 214 that the PR's stated purpose
does not account for, but it breaks no rule: no declaration boundary is involved.
Reverting it would be churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

