### PR TITLE
runtime-client: the worker serves more than one document (multi-document attachment)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -94,6 +94,11 @@ Add a line for each new document to the index below.
 - [`host-embedding.md`](host-embedding.md) — the seams a host that is not the
   labs shell may bind to when it mounts our components and patterns, each one
   pinned by a test that goes red if the contract changes
+- [`multi-document-runtime-attachment.md`](multi-document-runtime-attachment.md)
+  — one worker serving several documents: what each of them owns separately,
+  what all of them share, why an attach asserting a different security context
+  is refused rather than merged, and which traffic still reaches only the
+  document that stood the runtime up
 - [`piece-bulk-operations.md`](piece-bulk-operations.md) — retargeting,
   repairing, and reversing many pieces in one space as one reviewable,
   resumable operation: what a plan row means, what each write proves first,

--- a/docs/features/multi-document-runtime-attachment.md
+++ b/docs/features/multi-document-runtime-attachment.md
@@ -74,6 +74,27 @@ The assertion is a check against misconfiguration, not the authorization. The
 port **is** the capability: a document can only attach because the page that
 owns the worker handed it a duplex.
 
+### No key material crosses an attach port
+
+The initializing client supplies the signer, once. An attaching client
+supplies none: it names the acting principal as a DID, and the runtime refuses
+it when that is not the principal it acts as. So no step of an attach needs a
+key to cross, and a frame carrying one is refused by name — on the sending
+side before it reaches a port, and again on the receiving side — with the path
+the key sits at.
+
+That refusal is loud rather than left to the platform, because the platform's
+answer varies and one of its answers is worse than a refusal. Measured on the
+SP5 spike: a non-extractable `CryptoKey` posted over a `MessagePort` between
+two WKWebViews throws `DataCloneError`, which is an embedding defect — browsers
+carry it — but means a frame with a key in it would fail there as a transport
+error, in a shell, at run time, saying nothing about why. A `DataCloneError`
+seen on this path is therefore never to be "fixed" by finding a way to pass
+the key: the key was not supposed to be in the frame.
+`packages/runtime-client/src/shared/key-material.ts` holds the invariant and
+the finding; the acting principal is additionally required to be a DID, so a
+signer cannot ride in as the field that names one.
+
 ## The protocol
 
 `Attach` is its own request rather than a second `Initialize`. A worker that

--- a/docs/features/multi-document-runtime-attachment.md
+++ b/docs/features/multi-document-runtime-attachment.md
@@ -40,9 +40,11 @@ documents mint the same ones:
   a counter that starts at 1 in every document, so the id alone names a mount
   only while there is one client. A DOM event and a batch acknowledgement reach
   the sending client's own mount, and a batch reaches the client that mounted.
-- **Operation subscriptions.** The subscription id is a UUID, so two clients
-  never collide on one; what the owning client settles is where an update goes
-  and what a departure takes down.
+- **Operation subscriptions and sessions.** The subscription and session ids
+  are UUIDs, so two clients do not collide on one — but that is convention
+  rather than protocol, and nothing on the wire stops one client naming
+  another's. Each records the client that opened it, and only that client can
+  unsubscribe it, close it, or have it torn down with its departure.
 
 Shared, because they are the runtime's rather than any document's: the identity
 the runtime signs as, the storage manager and its memory session, the compile
@@ -51,9 +53,15 @@ cache, and the security context below.
 ## The security context, and why an attach is refused rather than merged
 
 `InitializationData` carries the CFC enforcement mode, the flow-label dial, the
-render declassification policy, the render confidentiality ceiling, and the
-trust snapshot. They are per-runtime, not per-request: there is one signer and
-one posture, and every attached document acts under both.
+render declassification policy, the render confidentiality ceiling, the trust
+snapshot, and the backend and per-space hosts the runtime reads from. They are
+per-runtime, not per-request: there is one signer and one posture, and every
+attached document acts under both. The backend and host map are compared for
+the same reason as the rest — a document believing it reads from somewhere else
+is as wrong about what it has joined as one believing another enforcement mode,
+and its reads would silently go to the runtime's hosts. Both are normalized
+first, so two spellings of one origin are one posture and do not refuse each
+other.
 
 So an attach states the
 [`RuntimeSecurityContext`](../../packages/runtime-client/src/protocol/types.ts)
@@ -110,7 +118,10 @@ replaced existed to prevent.
    arrived over a port does not get to enlarge the family it joined.
 2. The joining document speaks over its end of that port and sends `Attach`,
    carrying its asserted security context. Until that is accepted it may ask
-   for nothing else.
+   for nothing else. An attach that arrives while the runtime is still standing
+   up waits for that rather than refusing; one that arrives after the runtime
+   has been disposed is refused by name, a client joining a runtime-shaped void
+   being the one failure it could not otherwise detect.
 3. Every later request on that duplex carries the attached client, and the
    runtime files what it creates under it.
 
@@ -141,6 +152,12 @@ operation subscriptions stop, its VDOM trees unmount, and the runtime and every
 other client's work keep running. Only the owner's `Dispose` reaches the
 runtime's own, the worker being the owner's page's to end.
 
+Both ways a client ends — refused, or departed — the worker forgets it and lets
+go of its channel, so a page that reloads into a refusal cannot grow the worker
+one listener at a time. A message already in flight from a client that has
+departed is acked in silence, which is how the owner's own post-disposal
+stragglers read.
+
 A dead `MessagePort` emits no event, so a departure is something a client says
 rather than something the worker observes. A document that vanishes without
 sending `Dispose` leaves its subscriptions and mounts behind until the worker
@@ -158,11 +175,23 @@ still goes to the client that initialized it:
 - telemetry markers and terminal event-delivery notices.
 
 For a single document that is every notification it ever had. For an attached
-one it means those four are not delivered: an attached document does not see
-runtime-level console output and is not told about unconfirmed writes. Routing
-them is a question of policy rather than of plumbing — a navigation broadcast
-to every attached document would navigate all of them — and is deliberately
-left until a host needs an answer.
+one, three of the four are a matter of policy and are deliberately left until a
+host needs an answer: console output has no obvious single destination, and
+pending writes are the owner's business anyway — the worker lives in the
+owner's page, so it is the owner's unload that can lose them and the owner's
+handler that gates it.
+
+**The navigation is different, and is a known gap rather than a policy
+choice.** A navigation a pattern asks for belongs to the document whose mount
+raised it, and delivering it to the owner makes one document's intent move
+another's view. Routing it is not possible at this seam: `NavigateCallback` is
+`(target: Cell) => void`, and it is invoked from a post-commit effect flush
+(`packages/runner/src/builtins/navigate-to.ts`), decoupled by then from the
+event dispatch that caused it — so nothing in hand names a mount, and the
+mounts this worker holds cannot be asked which one is responsible. Closing it
+means the runner carrying the raising context to the callback. Until it is
+closed, a host with more than one document should treat pattern-driven
+navigation as reaching the family root.
 
 Console forwarding itself is the owner's for the same reason: the bridge posts
 on the worker's own global, which is the owner's end of the IPC.

--- a/docs/features/multi-document-runtime-attachment.md
+++ b/docs/features/multi-document-runtime-attachment.md
@@ -81,17 +81,23 @@ quietly accepted a second initialization as an attach would make a genuine
 double-initialization bug silent, which is the failure the singleton it
 replaced existed to prevent.
 
-1. The owner's page transfers a `MessagePort` to the worker, alongside an
-   `AttachPort` message. The port rides `postMessage`'s transfer list, a port
-   being no `FabricValue` and having no encoding; the message beside it is the
-   marker saying what the transferred port is for. Only the owner may hand one
-   over — a document that arrived over a port does not get to enlarge the
-   family it joined.
+1. The owner's page calls `WebWorkerRuntimeTransport.attachClientPort(port)`,
+   which transfers the port to the worker alongside an `AttachPort` message.
+   The port rides `postMessage`'s transfer list, a port being no `FabricValue`
+   and having no encoding; the message beside it is the marker saying what the
+   transferred port is for. Only the owner may hand one over — a document that
+   arrived over a port does not get to enlarge the family it joined.
 2. The joining document speaks over its end of that port and sends `Attach`,
    carrying its asserted security context. Until that is accepted it may ask
    for nothing else.
 3. Every later request on that duplex carries the attached client, and the
    runtime files what it creates under it.
+
+An attach that is refused rejects on the joining side, so a document learns it
+is not part of the family rather than waiting on a promise nobody settles.
+Until the attach is accepted the client may send nothing else, and a
+notification — which cannot be refused, having no reply — is dropped rather
+than acted on.
 
 `RuntimeClients.attach` takes anything shaped like a
 [`MessagePortLike`](../../packages/runtime-client/src/shared/message-port-like.ts),
@@ -100,6 +106,12 @@ shell, built by a test from a `MessageChannel` — is not something the worker
 learns. `MessagePortRuntimeTransport` is the other end of the same seam, and
 `RuntimeInternals.create`'s `transport` and `attach` options are how an
 embedder supplies one instead of spawning a dedicated worker.
+
+A page that both runs a runtime and hands ports to it needs the transport in
+its own hands, since `attachClientPort` lives there. `resolveWorkerUrl` is
+exported for exactly that: build the URL, connect a `WebWorkerRuntimeTransport`
+to it, pass that transport to `RuntimeInternals.create`, and keep it for the
+ports handed over later.
 
 ## Departure
 

--- a/docs/features/multi-document-runtime-attachment.md
+++ b/docs/features/multi-document-runtime-attachment.md
@@ -1,0 +1,146 @@
+# Multi-document runtime attachment
+
+A worker runs one runtime and serves any number of documents. The first
+document to reach it stands the runtime up; each later one attaches to the
+runtime already running, over a duplex of its own. This document is what a
+document owns separately, what all of them share, how an attach is refused, and
+which traffic still goes only to the first document.
+
+Read it before changing the worker's message loop, the keys a client-owned
+resource is filed under, or what an attach is checked against.
+
+## Why a document attaches rather than starting its own runtime
+
+A runtime is a `StorageManager`, a compile cache, and a heap. A host that shows
+several documents over one user's data — a native shell placing each pattern in
+its own web view — pays for all three once per document if each boots its own,
+and each then converges on the others only through storage.
+
+Attachment makes those documents one runtime's clients. What they gain is the
+single heap and the single memory session; what they do not gain is isolation
+from each other. **One runtime is one memory session**, so `PerSession`-scoped
+cells and session-scoped navigation are shared across every attached document.
+That is what the shell already does with several pieces in one document;
+attachment preserves it rather than adding per-document isolation.
+
+## What a client owns, and what it shares
+
+A **client** is one document's end of the worker's IPC.
+[`WorkerClient`](../../packages/runtime-client/src/backends/worker-client.ts)
+is where a message addressed to it goes, plus the id everything it owns is
+filed under.
+
+Owned per client, because each document mints these ids inside itself and two
+documents mint the same ones:
+
+- **Cell subscriptions.** Keyed by the client's scoped cell key, so two
+  documents watching one cell are two subscriptions to the runtime. One
+  document's unsubscribe stops its own feed and no other's.
+- **VDOM mounts.** Keyed by the client's scoped mount id. A mount id comes from
+  a counter that starts at 1 in every document, so the id alone names a mount
+  only while there is one client. A DOM event and a batch acknowledgement reach
+  the sending client's own mount, and a batch reaches the client that mounted.
+- **Operation subscriptions.** The subscription id is a UUID, so two clients
+  never collide on one; what the owning client settles is where an update goes
+  and what a departure takes down.
+
+Shared, because they are the runtime's rather than any document's: the identity
+the runtime signs as, the storage manager and its memory session, the compile
+cache, and the security context below.
+
+## The security context, and why an attach is refused rather than merged
+
+`InitializationData` carries the CFC enforcement mode, the flow-label dial, the
+render declassification policy, the render confidentiality ceiling, and the
+trust snapshot. They are per-runtime, not per-request: there is one signer and
+one posture, and every attached document acts under both.
+
+So an attach states the
+[`RuntimeSecurityContext`](../../packages/runtime-client/src/protocol/types.ts)
+it believes it is joining, and the runtime compares it field for field against
+its own. Any disagreement is **refused, by name**. Merging is not available:
+whatever a merge chose, one of the two documents would then be running under a
+posture it does not believe it has. A document that needs a different posture
+needs a different runtime.
+
+The comparison is over the whole of `RuntimeSecurityContext`, and the field
+list is a record keyed by that type, so a field added to the type and not to
+the list is a type error rather than a posture nobody checks. Fields compare
+one at a time, because the two contexts are built in different documents and
+one of them crossed an encoding: a posture carried as an absent property in one
+and as an explicit `undefined` in the other is the same posture.
+
+The assertion is a check against misconfiguration, not the authorization. The
+port **is** the capability: a document can only attach because the page that
+owns the worker handed it a duplex.
+
+## The protocol
+
+`Attach` is its own request rather than a second `Initialize`. A worker that
+quietly accepted a second initialization as an attach would make a genuine
+double-initialization bug silent, which is the failure the singleton it
+replaced existed to prevent.
+
+1. The owner's page transfers a `MessagePort` to the worker, alongside an
+   `AttachPort` message. The port rides `postMessage`'s transfer list, a port
+   being no `FabricValue` and having no encoding; the message beside it is the
+   marker saying what the transferred port is for. Only the owner may hand one
+   over — a document that arrived over a port does not get to enlarge the
+   family it joined.
+2. The joining document speaks over its end of that port and sends `Attach`,
+   carrying its asserted security context. Until that is accepted it may ask
+   for nothing else.
+3. Every later request on that duplex carries the attached client, and the
+   runtime files what it creates under it.
+
+`RuntimeClients.attach` takes anything shaped like a
+[`MessagePortLike`](../../packages/runtime-client/src/shared/message-port-like.ts),
+so how a duplex arrived — carried by a page's opener, relayed by a native
+shell, built by a test from a `MessageChannel` — is not something the worker
+learns. `MessagePortRuntimeTransport` is the other end of the same seam, and
+`RuntimeInternals.create`'s `transport` and `attach` options are how an
+embedder supplies one instead of spawning a dedicated worker.
+
+## Departure
+
+A `Dispose` from an attached client is that client leaving. Its cell and
+operation subscriptions stop, its VDOM trees unmount, and the runtime and every
+other client's work keep running. Only the owner's `Dispose` reaches the
+runtime's own, the worker being the owner's page's to end.
+
+A dead `MessagePort` emits no event, so a departure is something a client says
+rather than something the worker observes. A document that vanishes without
+sending `Dispose` leaves its subscriptions and mounts behind until the worker
+itself goes. Closing that means an app-observable liveness signal, which does
+not exist yet.
+
+## What still reaches only the first document
+
+Four kinds of notification are the runtime's rather than any client's, and each
+still goes to the client that initialized it:
+
+- pattern console output,
+- the navigation a pattern asks for,
+- the pending-writes barrier the shell's beforeunload handler consults,
+- telemetry markers and terminal event-delivery notices.
+
+For a single document that is every notification it ever had. For an attached
+one it means those four are not delivered: an attached document does not see
+runtime-level console output and is not told about unconfirmed writes. Routing
+them is a question of policy rather than of plumbing — a navigation broadcast
+to every attached document would navigate all of them — and is deliberately
+left until a host needs an answer.
+
+Console forwarding itself is the owner's for the same reason: the bridge posts
+on the worker's own global, which is the owner's end of the IPC.
+
+## Where the code is
+
+| Concern | File |
+| --- | --- |
+| A client's identity and outbound sink | `packages/runtime-client/src/backends/worker-client.ts` |
+| The registry and the per-client message loop | `packages/runtime-client/src/backends/client-registry.ts` |
+| Per-client keys, routing, and teardown | `packages/runtime-client/src/backends/runtime-processor.ts` |
+| The duplex shape both ends take | `packages/runtime-client/src/shared/message-port-like.ts` |
+| The joining document's transport | `packages/runtime-client/src/client/transports/message-port/transport-message-port.ts` |
+| `transport` and `attach` for an embedder | `packages/lib-shell/src/runtime.ts` |

--- a/docs/features/multi-document-runtime-attachment.md
+++ b/docs/features/multi-document-runtime-attachment.md
@@ -101,7 +101,18 @@ seen on this path is therefore never to be "fixed" by finding a way to pass
 the key: the key was not supposed to be in the frame.
 `packages/runtime-client/src/shared/key-material.ts` holds the invariant and
 the finding; the acting principal is additionally required to be a DID, so a
-signer cannot ride in as the field that names one.
+signer cannot ride in as the field that names one. The refusal sits in
+`RuntimeConnection.attach`, immediately before the frame reaches a transport,
+so a caller holding a connection directly is covered by it too.
+
+**This is a misbuild detector, not an exfiltration filter.** A secret already
+reduced to bytes or text — a PKCS8 blob, a JWK, a seed as a `Uint8Array` — is
+out of scope and would pass unnoticed. Both ends of an attach are a page and a
+worker at one trust level under one origin, so a sender determined to move
+bytes has the whole payload to do it in; what this catches is the accident of
+handing an attach the signer that initialization takes. The classes it
+recognizes are enumerated rather than derived, so a future codec class able to
+hold a key has to be added to the walker.
 
 ## The protocol
 

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -15,6 +15,7 @@ import {
   RuntimeClientEvents,
   RuntimeClientOptions,
   RuntimeTelemetryMarkerResult,
+  type RuntimeTransport,
 } from "@commonfabric/runtime-client";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -182,8 +183,34 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
    * Override the runtime worker URL. By default, deployed builds use the
    * immutable `/builds/<clientVersion>/` asset namespace while local builds
    * fall back to `/scripts/worker-runtime.js`.
+   *
+   * Ignored when `transport` supplies the connection, there being no worker to
+   * address.
    */
   workerUrl?: URL;
+
+  /**
+   * The connection to the runtime's worker. Absent, this page spawns a
+   * dedicated worker of its own and connects to that, which is what a page
+   * with no runtime around it does.
+   *
+   * Supplied, the embedder has already made the connection and this page
+   * speaks over it. How -- a port a family root's page transferred, a channel
+   * a native shell relays -- is the embedder's to know and nothing here reads.
+   */
+  transport?: RuntimeTransport;
+
+  /**
+   * Join the runtime already running behind `transport` rather than standing
+   * one up. It says which client this page is: the one whose initialization
+   * settles the runtime's identity and security posture, or one attaching to a
+   * runtime whose posture is already settled and which it asserts rather than
+   * declares.
+   *
+   * Only meaningful with `transport`: a worker this page spawned has no
+   * runtime to attach to.
+   */
+  attach?: boolean;
 
   getBuildHash?: () => Promise<string | undefined>;
 
@@ -664,11 +691,20 @@ export class RuntimeInternals extends EventTarget {
     concurrentWatchRefresh,
     getBuildHash = fetchBuildHash,
     workerUrl,
+    transport,
+    attach = false,
     navigate,
     onConsole,
     onError,
     telemetry,
   }: RuntimeInternalsCreateOptions): Promise<RuntimeInternals> {
+    if (attach && !transport) {
+      throw new Error(
+        "`attach` needs a `transport`: a worker this page spawns has no " +
+          "runtime to attach to.",
+      );
+    }
+
     // One runtime per identity: the worker session is always the
     // identity's home session. Spaces — including derived named spaces —
     // are addressed per call; nothing is bound at creation.
@@ -683,46 +719,50 @@ export class RuntimeInternals extends EventTarget {
       `[Identity] User DID: ${identity.did()}`,
     );
 
-    // Production deploys retain each complete module graph under its commit
-    // SHA. Keeping the entry and all of its relative split chunks in that same
-    // immutable namespace prevents a later root deployment from deleting a
-    // chunk that a long-lived page still needs. An explicit worker URL (local
-    // development) or an absent clientVersion retains the mutable root URL and
-    // its manifest cache-buster.
-    const immutableBuildId = workerUrl === undefined && clientVersion
-      ? clientVersion
-      : undefined;
-    const resolvedWorkerUrl = workerUrl ?? new URL(
-      immutableBuildId
-        ? `/builds/${
-          encodeURIComponent(immutableBuildId)
-        }/scripts/worker-runtime.js`
-        : "/scripts/worker-runtime.js",
-      globalThis.location.origin,
-    );
-    if (!immutableBuildId) {
-      const buildHash = await getBuildHash();
-      if (buildHash) resolvedWorkerUrl.searchParams.set("v", buildHash);
+    let connection = transport;
+    if (!connection) {
+      // Production deploys retain each complete module graph under its commit
+      // SHA. Keeping the entry and all of its relative split chunks in that
+      // same immutable namespace prevents a later root deployment from
+      // deleting a chunk that a long-lived page still needs. An explicit
+      // worker URL (local development) or an absent clientVersion retains the
+      // mutable root URL and its manifest cache-buster.
+      const immutableBuildId = workerUrl === undefined && clientVersion
+        ? clientVersion
+        : undefined;
+      const resolvedWorkerUrl = workerUrl ?? new URL(
+        immutableBuildId
+          ? `/builds/${
+            encodeURIComponent(immutableBuildId)
+          }/scripts/worker-runtime.js`
+          : "/scripts/worker-runtime.js",
+        globalThis.location.origin,
+      );
+      if (!immutableBuildId) {
+        const buildHash = await getBuildHash();
+        if (buildHash) resolvedWorkerUrl.searchParams.set("v", buildHash);
+      }
+      connection = await WebWorkerRuntimeTransport.connect({
+        workerUrl: resolvedWorkerUrl,
+      });
     }
-    const transport = await WebWorkerRuntimeTransport.connect({
-      workerUrl: resolvedWorkerUrl,
+
+    const clientOptions = createRuntimeClientOptions({
+      session,
+      apiUrl,
+      spaceHostMap,
+      experimental,
+      cfcEnforcementMode,
+      cfcFlowLabels,
+      cfcRenderCeiling,
+      trustSnapshot,
+      forwardWorkerConsole,
+      patternCoverage,
+      concurrentWatchRefresh,
     });
-    const client = await RuntimeClient.initialize(
-      transport,
-      createRuntimeClientOptions({
-        session,
-        apiUrl,
-        spaceHostMap,
-        experimental,
-        cfcEnforcementMode,
-        cfcFlowLabels,
-        cfcRenderCeiling,
-        trustSnapshot,
-        forwardWorkerConsole,
-        patternCoverage,
-        concurrentWatchRefresh,
-      }),
-    );
+    const client = attach
+      ? await RuntimeClient.attach(connection, clientOptions)
+      : await RuntimeClient.initialize(connection, clientOptions);
 
     // Expose a usable RuntimeInternals immediately. Callers that need
     // storage/piece-manager convergence should await `rt.synced(space)`

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -252,6 +252,46 @@ export function fetchBuildHash(): Promise<string | undefined> {
   return buildHashPromise;
 }
 
+/**
+ * The URL this page's runtime worker is loaded from.
+ *
+ * Production deploys retain each complete module graph under its commit SHA.
+ * Keeping the entry and all of its relative split chunks in that same
+ * immutable namespace prevents a later root deployment from deleting a chunk
+ * that a long-lived page still needs. An explicit `workerUrl` (local
+ * development) or an absent `clientVersion` retains the mutable root URL and
+ * its manifest cache-buster.
+ *
+ * {@link RuntimeInternals.create} calls this for the worker it spawns. It is
+ * exported for the page that spawns one and then hands ports to it: such a
+ * page holds the transport itself, and must reach the same URL doing so.
+ */
+export async function resolveWorkerUrl(
+  options: {
+    workerUrl?: URL;
+    clientVersion?: string;
+    getBuildHash?: () => Promise<string | undefined>;
+  } = {},
+): Promise<URL> {
+  const { workerUrl, clientVersion, getBuildHash = fetchBuildHash } = options;
+  const immutableBuildId = workerUrl === undefined && clientVersion
+    ? clientVersion
+    : undefined;
+  const resolved = workerUrl ?? new URL(
+    immutableBuildId
+      ? `/builds/${
+        encodeURIComponent(immutableBuildId)
+      }/scripts/worker-runtime.js`
+      : "/scripts/worker-runtime.js",
+    globalThis.location.origin,
+  );
+  if (!immutableBuildId) {
+    const buildHash = await getBuildHash();
+    if (buildHash) resolved.searchParams.set("v", buildHash);
+  }
+  return resolved;
+}
+
 export function createRuntimeClientOptions({
   session,
   apiUrl,
@@ -719,33 +759,14 @@ export class RuntimeInternals extends EventTarget {
       `[Identity] User DID: ${identity.did()}`,
     );
 
-    let connection = transport;
-    if (!connection) {
-      // Production deploys retain each complete module graph under its commit
-      // SHA. Keeping the entry and all of its relative split chunks in that
-      // same immutable namespace prevents a later root deployment from
-      // deleting a chunk that a long-lived page still needs. An explicit
-      // worker URL (local development) or an absent clientVersion retains the
-      // mutable root URL and its manifest cache-buster.
-      const immutableBuildId = workerUrl === undefined && clientVersion
-        ? clientVersion
-        : undefined;
-      const resolvedWorkerUrl = workerUrl ?? new URL(
-        immutableBuildId
-          ? `/builds/${
-            encodeURIComponent(immutableBuildId)
-          }/scripts/worker-runtime.js`
-          : "/scripts/worker-runtime.js",
-        globalThis.location.origin,
-      );
-      if (!immutableBuildId) {
-        const buildHash = await getBuildHash();
-        if (buildHash) resolvedWorkerUrl.searchParams.set("v", buildHash);
-      }
-      connection = await WebWorkerRuntimeTransport.connect({
-        workerUrl: resolvedWorkerUrl,
+    const connection = transport ??
+      await WebWorkerRuntimeTransport.connect({
+        workerUrl: await resolveWorkerUrl({
+          workerUrl,
+          clientVersion,
+          getBuildHash,
+        }),
       });
-    }
 
     const clientOptions = createRuntimeClientOptions({
       session,

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -6,6 +6,7 @@ import { navigate } from "@commonfabric/navigation";
 import { slugIdForSpace } from "@commonfabric/runner/slugs";
 import { NameSchema } from "@commonfabric/runner/schemas";
 import {
+  attachOptionsFrom,
   CellHandle,
   FavoritesManager,
   PageHandle,
@@ -782,7 +783,10 @@ export class RuntimeInternals extends EventTarget {
       concurrentWatchRefresh,
     });
     const client = attach
-      ? await RuntimeClient.attach(connection, clientOptions)
+      ? await RuntimeClient.attach(
+        connection,
+        attachOptionsFrom(clientOptions),
+      )
       : await RuntimeClient.initialize(connection, clientOptions);
 
     // Expose a usable RuntimeInternals immediately. Callers that need

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -11,7 +11,11 @@ import {
   defaultRenderConfidentialityCeiling,
   RuntimeInternals,
 } from "@commonfabric/lib-shell";
-import { TransportNotificationType } from "@commonfabric/runtime-client";
+import {
+  EventEmitter,
+  type RuntimeTransport,
+  TransportNotificationType,
+} from "@commonfabric/runtime-client";
 
 type MockRuntimeClientEvents = {
   console: [unknown];
@@ -934,6 +938,101 @@ describe("RuntimeInternals", () => {
           { pageId: "piece-1", runIt: true, space: otherDid },
           { pageId: "piece-1", runIt: true, space: otherDid },
         ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+  });
+
+  describe("an embedder-supplied transport", () => {
+    // A shell page normally boots a dedicated worker of its own. A page whose
+    // runtime is already running in another document's worker is handed a
+    // connection instead, and `attach` is what says which of the two this
+    // page is: the client that stands a runtime up, or one joining the
+    // runtime already there.
+
+    type SentRequest = { type: string; data?: Record<string, unknown> };
+
+    /**
+     * A transport that answers every request with a bare ack, recording what
+     * was asked. It stands for a connection already made, which is what an
+     * embedder supplies.
+     */
+    class StubTransport extends EventEmitter<{ message: [unknown] }> {
+      readonly sent: SentRequest[] = [];
+      disposals = 0;
+
+      send(message: unknown): void {
+        // A transport is handed the envelope itself; encoding it is the
+        // business of the transports that cross a realm boundary.
+        const envelope = message as { msgId?: number; data?: SentRequest };
+        if (envelope.data) this.sent.push(envelope.data);
+        if (typeof envelope.msgId !== "number") return;
+        queueMicrotask(() => this.emit("message", { msgId: envelope.msgId }));
+      }
+
+      dispose(): Promise<void> {
+        this.disposals += 1;
+        return Promise.resolve();
+      }
+    }
+
+    /** Fails the test if anything reaches for a dedicated worker. */
+    async function withNoWorkerConstructible<T>(
+      run: () => Promise<T>,
+    ): Promise<T> {
+      const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
+      (globalThis as { Worker: unknown }).Worker = class {
+        constructor() {
+          throw new Error("a supplied transport must spawn no worker");
+        }
+      };
+      try {
+        return await run();
+      } finally {
+        (globalThis as { Worker: unknown }).Worker = OriginalWorker;
+      }
+    }
+
+    it("attaches over the supplied transport, spawning no worker", async () => {
+      const identity = await Identity.generate({ implementation: "noble" });
+      const transport = new StubTransport();
+      const runtime = await withNoWorkerConstructible(() =>
+        RuntimeInternals.create({
+          identity,
+          apiUrl: new URL("http://shell.test/"),
+          transport: transport as unknown as RuntimeTransport,
+          attach: true,
+        })
+      );
+      try {
+        expect(transport.sent).toHaveLength(1);
+        expect(transport.sent[0].type).toBe("attach");
+        // The acting principal crosses as the DID it derives to. An attach
+        // asserts which principal the runtime acts as; it supplies no signer.
+        expect(transport.sent[0].data?.identity).toBe(identity.did());
+        expect(transport.sent[0].data?.spaceDid).toBe(identity.did());
+        expect(transport.sent[0].data?.cfcEnforcementMode).toBe(
+          "enforce-explicit",
+        );
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("initializes over the supplied transport when not attaching", async () => {
+      const identity = await Identity.generate({ implementation: "noble" });
+      const transport = new StubTransport();
+      const runtime = await withNoWorkerConstructible(() =>
+        RuntimeInternals.create({
+          identity,
+          apiUrl: new URL("http://shell.test/"),
+          transport: transport as unknown as RuntimeTransport,
+        })
+      );
+      try {
+        expect(transport.sent).toHaveLength(1);
+        expect(transport.sent[0].type).toBe("initialize");
       } finally {
         await runtime.dispose();
       }

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -1020,6 +1020,19 @@ describe("RuntimeInternals", () => {
       }
     });
 
+    it("refuses to attach with no transport to attach over", async () => {
+      const identity = await Identity.generate({ implementation: "noble" });
+      await expect(
+        withNoWorkerConstructible(() =>
+          RuntimeInternals.create({
+            identity,
+            apiUrl: new URL("http://shell.test/"),
+            attach: true,
+          })
+        ),
+      ).rejects.toThrow("`attach` needs a `transport`");
+    });
+
     it("initializes over the supplied transport when not attaching", async () => {
       const identity = await Identity.generate({ implementation: "noble" });
       const transport = new StubTransport();

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -1015,6 +1015,14 @@ describe("RuntimeInternals", () => {
         expect(transport.sent[0].data?.cfcEnforcementMode).toBe(
           "enforce-explicit",
         );
+        // The backend is posture, not routing: a document believing it reads
+        // from somewhere else is as wrong about what it joined as one
+        // believing another enforcement mode.
+        expect(transport.sent[0].data?.apiUrl).toBe("http://shell.test/");
+        // And no signer went with it. The initialize frame carries the key
+        // pair; an attach carries a DID and nothing else of the identity.
+        expect(transport.sent[0].data?.spaceIdentity).toBeUndefined();
+        expect(typeof transport.sent[0].data?.identity).toBe("string");
       } finally {
         await runtime.dispose();
       }

--- a/packages/runtime-client/deno.jsonc
+++ b/packages/runtime-client/deno.jsonc
@@ -16,6 +16,7 @@
   },
   "exports": {
     ".": "./src/mod.ts",
+    "./transports/message-port": "./src/client/transports/message-port/transport-message-port.ts",
     "./transports/web-worker": "./src/client/transports/web-worker/transport-web-worker.ts"
   }
 }

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -16,9 +16,11 @@ import { Program } from "@commonfabric/js-compiler";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import {
   $conn,
+  attachOptionsFrom,
   CellHandle,
   type JSONSchema,
   RequestType,
+  type RuntimeAttachOptions,
   RuntimeClient,
   type RuntimeClientOptions,
   type VNode,
@@ -1784,12 +1786,13 @@ export default pattern<Record<string, never>>(() => {
     async function attachingClient(
       owner: { transport: WebWorkerRuntimeTransport },
       options: RuntimeClientOptions,
+      overrides: Partial<RuntimeAttachOptions> = {},
     ) {
       const channel = new MessageChannel();
       owner.transport.attachClientPort(channel.port2);
       return await RuntimeClient.attach(
         new MessagePortRuntimeTransport({ port: channel.port1 }),
-        options,
+        { ...attachOptionsFrom(options), ...overrides },
       );
     }
 
@@ -1922,14 +1925,11 @@ export default pattern<Record<string, never>>(() => {
           "a different operator",
           keyConfig,
         );
-        const channel = new MessageChannel();
-        owner.transport.attachClientPort(channel.port2);
         await assertRejects(
           () =>
-            RuntimeClient.attach(
-              new MessagePortRuntimeTransport({ port: channel.port1 }),
-              { ...owner.options, identity: stranger },
-            ),
+            attachingClient(owner, owner.options, {
+              identity: stranger.did(),
+            }),
           Error,
           "Attach refused",
         );

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@commonfabric/runtime-client";
 import { experimentalOptionsFromEnv } from "@commonfabric/runner";
 import { serverExecutionOnStepSkip } from "../../../tasks/server-execution-on-skips.ts";
+import { MessagePortRuntimeTransport } from "@commonfabric/runtime-client/transports/message-port";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
 import { defer } from "@commonfabric/utils/defer";
 
@@ -1757,6 +1758,186 @@ export default pattern<Record<string, never>>(() => {
       );
     });
   });
+
+  describe("multi-document attachment", () => {
+    // Two documents over one worker's runtime, joined the way a family root's
+    // page joins them: the page that spawned the worker hands a port across,
+    // and the document at the far end attaches to the runtime already running.
+    // Everything under here is real -- a real worker, a real backend, real
+    // ports -- because what these pin is exactly what a stand-in on either
+    // side of the IPC cannot show.
+
+    /**
+     * The owner's client and its transport, which is what a port is handed
+     * over through. `createRuntimeClient` drops the transport it connects, and
+     * these tests need to keep it.
+     */
+    async function owningClient(session: Session) {
+      const transport = await WebWorkerRuntimeTransport.connect();
+      const options = await clientOptionsFor(session);
+      const client = await RuntimeClient.initialize(transport, options);
+      await client.synced(session.space);
+      return { client, transport, options };
+    }
+
+    /** A second document, attached over a port the owner hands the worker. */
+    async function attachingClient(
+      owner: { transport: WebWorkerRuntimeTransport },
+      options: RuntimeClientOptions,
+    ) {
+      const channel = new MessageChannel();
+      owner.transport.attachClientPort(channel.port2);
+      return await RuntimeClient.attach(
+        new MessagePortRuntimeTransport({ port: channel.port1 }),
+        options,
+      );
+    }
+
+    const counterSchema = {
+      type: "object",
+      properties: { counter: { type: "number" } },
+    } as const satisfies JSONSchema;
+
+    it("feeds both documents from one runtime, and one unsubscribe stops one feed", async () => {
+      const session = await createTestSession();
+      const owner = await owningClient(session);
+      const second = await attachingClient(owner, owner.options);
+      try {
+        const cause = "multi-document-attachment-" + crypto.randomUUID();
+        const first = await owner.client.getCell<{ counter: number }>(
+          session.space,
+          cause,
+          counterSchema,
+        );
+        const mirror = await second.getCell<{ counter: number }>(
+          session.space,
+          cause,
+          counterSchema,
+        );
+        await first.set({ counter: 0 });
+        await owner.client.idle();
+        await mirror.sync();
+
+        // Both documents watch the same cell. Before this change the second
+        // subscribe was a no-op on the first's, so the second document heard
+        // nothing and the first's unsubscribe silenced both.
+        const firstSeen: number[] = [];
+        const secondSeen: number[] = [];
+        const sawOne = defer<void>();
+        const cancelFirst = first.subscribe((value) => {
+          if (value) firstSeen.push(value.counter);
+        });
+        const cancelSecond = mirror.subscribe((value) => {
+          if (!value) return;
+          secondSeen.push(value.counter);
+          if (value.counter === 1) sawOne.resolve();
+        });
+
+        await first.set({ counter: 1 });
+        await sawOne.promise;
+        assertEquals(secondSeen.includes(1), true);
+        assertEquals(firstSeen.includes(1), true);
+
+        // The first document leaves the cell. The second's feed is its own.
+        cancelFirst();
+        await owner.client.idle();
+
+        const sawTwo = defer<void>();
+        const secondSeenBefore = secondSeen.length;
+        const firstSeenBefore = firstSeen.length;
+        const watchTwo = mirror.subscribe((value) => {
+          if (value?.counter === 2) sawTwo.resolve();
+        });
+        await first.set({ counter: 2 });
+        await sawTwo.promise;
+
+        // The second document heard the write; the first, having left the
+        // cell, heard nothing further. A write's echo can arrive behind the
+        // local delivery it confirms, so this asks what reached each feed
+        // rather than in which order.
+        assert(secondSeen.length > secondSeenBefore);
+        assertEquals(secondSeen.includes(2), true);
+        assertEquals(firstSeen.includes(2), false);
+        assertEquals(firstSeen.length, firstSeenBefore);
+
+        watchTwo();
+        cancelSecond();
+      } finally {
+        await second.dispose();
+        await owner.client.dispose();
+      }
+    });
+
+    it("keeps the runtime and the first document running when the second leaves", async () => {
+      const session = await createTestSession();
+      const owner = await owningClient(session);
+      const second = await attachingClient(owner, owner.options);
+      const cause = "multi-document-departure-" + crypto.randomUUID();
+      try {
+        const cell = await owner.client.getCell<{ counter: number }>(
+          session.space,
+          cause,
+          counterSchema,
+        );
+        await cell.set({ counter: 0 });
+        await owner.client.idle();
+
+        const mirror = await second.getCell<{ counter: number }>(
+          session.space,
+          cause,
+          counterSchema,
+        );
+        const cancelMirror = mirror.subscribe(() => {});
+        await second.idle();
+
+        // The second document's departure is its own: its subscription stops,
+        // and the runtime it was borrowing keeps serving the first.
+        cancelMirror();
+        await second.dispose();
+
+        const seen: number[] = [];
+        const sawThree = defer<void>();
+        const cancel = cell.subscribe((value) => {
+          if (!value) return;
+          seen.push(value.counter);
+          if (value.counter === 3) sawThree.resolve();
+        });
+        await cell.set({ counter: 3 });
+        await sawThree.promise;
+        // Membership rather than the last value: a write's echo can arrive
+        // behind the local delivery it confirms, so the tail of this list is
+        // delivery order and not what the test is about.
+        assertEquals(seen.includes(3), true);
+        cancel();
+      } finally {
+        await owner.client.dispose();
+      }
+    });
+
+    it("refuses a second document asserting a different acting principal", async () => {
+      const session = await createTestSession();
+      const owner = await owningClient(session);
+      try {
+        const stranger = await Identity.fromPassphrase(
+          "a different operator",
+          keyConfig,
+        );
+        const channel = new MessageChannel();
+        owner.transport.attachClientPort(channel.port2);
+        await assertRejects(
+          () =>
+            RuntimeClient.attach(
+              new MessagePortRuntimeTransport({ port: channel.port1 }),
+              { ...owner.options, identity: stranger },
+            ),
+          Error,
+          "Attach refused",
+        );
+      } finally {
+        await owner.client.dispose();
+      }
+    });
+  });
 });
 
 async function createTestSession(): Promise<Session> {
@@ -1766,10 +1947,15 @@ async function createTestSession(): Promise<Session> {
   });
 }
 
-async function createRuntimeClient(
+/**
+ * What this process's clients are configured with. A second document attaches
+ * by asserting the security half of these, so the two callers build them from
+ * one place rather than each stating a posture of its own.
+ */
+async function clientOptionsFor(
   session: Session,
   extraOptions: Partial<RuntimeClientOptions> = {},
-): Promise<RuntimeClient> {
+): Promise<RuntimeClientOptions> {
   // If a space identity was created, replace it with a transferrable
   // key in Deno using the same derivation as Session
   if (session.spaceIdentity && session.spaceName) {
@@ -1778,8 +1964,7 @@ async function createRuntimeClient(
     ).derive(session.spaceName, keyConfig);
   }
 
-  const transport = await WebWorkerRuntimeTransport.connect();
-  const worker = await RuntimeClient.initialize(transport, {
+  return {
     apiUrl: new URL(API_URL),
     identity: session.as,
     spaceIdentity: session.spaceIdentity,
@@ -1793,7 +1978,18 @@ async function createRuntimeClient(
       ? {}
       : { serverExecution: SERVER_EXECUTION_FROM_ENV },
     ...extraOptions,
-  });
+  };
+}
+
+async function createRuntimeClient(
+  session: Session,
+  extraOptions: Partial<RuntimeClientOptions> = {},
+): Promise<RuntimeClient> {
+  const transport = await WebWorkerRuntimeTransport.connect();
+  const worker = await RuntimeClient.initialize(
+    transport,
+    await clientOptionsFor(session, extraOptions),
+  );
 
   await worker.synced(session.space);
   return worker;

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -34,8 +34,9 @@ import {
   RuntimeErrorCode,
 } from "@/protocol/mod.ts";
 import { RuntimeProcessor } from "@/backends/mod.ts";
-import { postThrough } from "./post-to-client.ts";
+import type { MessagePortLike } from "@/shared/message-port-like.ts";
 import { describeFailure } from "@/shared/utils.ts";
+import { postThrough } from "./post-to-client.ts";
 import {
   type ClientId,
   OWNER_CLIENT_ID,
@@ -71,27 +72,6 @@ const ipcTimingLogger = getLogger("runner.ipc", { enabled: false });
  * cannot flood the channel it is being reported on.
  */
 const MAX_INVALID_REQUEST_RENDER = 512;
-
-/**
- * The far end of one client's duplex, as much of a `MessagePort` as this
- * worker uses. Declared as a shape rather than as the class so that what
- * arrives is a duplex and not a story about how it got here.
- */
-export interface ClientDuplex {
-  postMessage(message: unknown): void;
-
-  addEventListener(
-    type: "message",
-    listener: (event: MessageEvent) => void,
-  ): void;
-
-  /**
-   * Begins delivery. A `MessagePort` queues everything sent to it until this
-   * is called, which is what lets a listener be installed without racing the
-   * messages already in flight.
-   */
-  start?(): void;
-}
 
 export interface RuntimeClientsOptions {
   /**
@@ -150,7 +130,7 @@ export class RuntimeClients {
    * The client is registered but not yet attached: until its
    * {@link RequestType.Attach} is accepted it may ask for nothing else.
    */
-  attach(duplex: ClientDuplex): WorkerClient {
+  attach(duplex: MessagePortLike): WorkerClient {
     const id = this.#nextClientId++;
     const client: WorkerClient = {
       id,

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -20,6 +20,7 @@ import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
+import { isDID } from "@commonfabric/identity";
 import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
   type InitializationData,
@@ -34,6 +35,7 @@ import {
   RuntimeErrorCode,
 } from "@/protocol/mod.ts";
 import { RuntimeProcessor } from "@/backends/mod.ts";
+import { assertNoKeyMaterial } from "@/shared/key-material.ts";
 import type { MessagePortLike } from "@/shared/message-port-like.ts";
 import { describeFailure } from "@/shared/utils.ts";
 import { postThrough } from "./post-to-client.ts";
@@ -269,6 +271,18 @@ export class RuntimeClients {
         // because it is the same fact about the worker.
         if (!this.#runtime) {
           throw new Error("WorkerRuntime not initialized.");
+        }
+        assertNoKeyMaterial(request.data);
+        // The acting principal is stated, never supplied. A frame naming it
+        // as anything but a DID is either carrying a signer past the check
+        // above or is not the frame it claims to be; both are refused here
+        // rather than reaching a comparison that would simply find them
+        // unequal and say something less useful.
+        if (!isDID(request.data.identity)) {
+          throw new Error(
+            "Attach refused: the acting principal must be a DID, which is " +
+              "stated rather than supplied.",
+          );
         }
         this.#runtime.assertAttachable(request.data);
         const registered = this.#attachedClients.get(client.id);

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -97,9 +97,11 @@ export interface RuntimeClientsOptions {
   initializeRuntime?: (data: InitializationData) => Promise<RuntimeProcessor>;
 }
 
-/** One connected client and whether its attach has been settled. */
+/** One connected client, its channel, and whether its attach is settled. */
 type RegisteredClient = {
   client: WorkerClient;
+  duplex: MessagePortLike;
+  listener: (event: MessageEvent) => void;
   attached: boolean;
 };
 
@@ -139,12 +141,40 @@ export class RuntimeClients {
       post: (message) =>
         postThrough((encoded) => duplex.postMessage(encoded), message),
     };
-    this.#attachedClients.set(id, { client, attached: false });
-    duplex.addEventListener("message", (event: MessageEvent) => {
+    const listener = (event: MessageEvent) => {
       void this.handleMessage(client, event);
+    };
+    this.#attachedClients.set(id, {
+      client,
+      duplex,
+      listener,
+      attached: false,
     });
+    duplex.addEventListener("message", listener);
     duplex.start?.();
     return client;
+  }
+
+  /** How many clients this worker is serving besides its owner. */
+  get attachedClientCount(): number {
+    return this.#attachedClients.size;
+  }
+
+  /**
+   * Forgets a client and lets go of its channel.
+   *
+   * Both ways a client ends here -- refused, or departed -- end the same way,
+   * and both have to end: a page that reloads into a refusal would otherwise
+   * leave a listener and a registration behind on every attempt, and a worker
+   * that outlives many panes would accumulate one per pane. A retry mints a
+   * fresh client through the owner, so nothing is lost by letting this one go.
+   */
+  #drop(id: ClientId): void {
+    const registered = this.#attachedClients.get(id);
+    if (!registered) return;
+    this.#attachedClients.delete(id);
+    registered.duplex.removeEventListener?.("message", registered.listener);
+    registered.duplex.close?.();
   }
 
   /**
@@ -266,11 +296,29 @@ export class RuntimeClients {
               "than attaching to it.",
           );
         }
+        // A page may transfer a port and let the document at its far end
+        // attach while the runtime is still standing up, so an attach waits
+        // for an initialization already under way rather than reading the
+        // runtime that is not there yet. A failed initialization settles this
+        // and leaves no runtime, which the check below then refuses -- the
+        // wait cannot turn a failure into an attach.
+        if (this.#initialization) {
+          await this.#initialization.catch(() => undefined);
+        }
         // An attach joins a runtime; it never stands one up. Answered with
         // the same words an ordinary request gets before initialization,
         // because it is the same fact about the worker.
         if (!this.#runtime) {
           throw new Error("WorkerRuntime not initialized.");
+        }
+        // A disposed runtime is the one thing worse than no runtime: a client
+        // that joined one would hold a live-looking connection to something
+        // that answers nothing, and learn of it only by waiting forever.
+        if (this.#runtime.isDisposed()) {
+          throw new Error(
+            "WorkerRuntime has been disposed; there is no runtime to attach " +
+              "to.",
+          );
         }
         assertNoKeyMaterial(request.data);
         // The acting principal is stated, never supplied. A frame naming it
@@ -287,6 +335,17 @@ export class RuntimeClients {
         this.#runtime.assertAttachable(request.data);
         const registered = this.#attachedClients.get(client.id);
         if (registered) registered.attached = true;
+        this.#reply({ msgId }, request.type, client);
+        return;
+      }
+
+      // A client that has departed is gone rather than wrong. Its channel is
+      // dropped on the way out, so this is reached only by a message already
+      // in flight -- and the owner's own post-disposal stragglers are acked
+      // in silence, which is what this is.
+      if (
+        client.id !== this.#owner.id && !this.#attachedClients.has(client.id)
+      ) {
         this.#reply({ msgId }, request.type, client);
         return;
       }
@@ -330,8 +389,8 @@ export class RuntimeClients {
         request.type === RequestType.Dispose && client.id !== this.#owner.id
       ) {
         runtime.disposeClient(client);
-        this.#attachedClients.delete(client.id);
         this.#reply({ msgId }, request.type, client);
+        this.#drop(client.id);
         return;
       }
 
@@ -382,6 +441,13 @@ export class RuntimeClients {
         error: describeFailure(error),
         ...(code ? { code } : {}),
       });
+
+      // A refused attach is terminal for this client: the reply has gone, and
+      // what is let go of here is the registration and the channel. See
+      // `#drop`.
+      if (type === RequestType.Attach && client.id !== this.#owner.id) {
+        this.#drop(client.id);
+      }
     }
   }
 

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -196,10 +196,15 @@ export class RuntimeClients {
 
     // One-way notifications carry no msgId and get no response. Drop them once
     // the worker is gone or disposed; in teardown the main thread may still be
-    // flushing fire-and-forget signals.
+    // flushing fire-and-forget signals. Dropped too from a client whose attach
+    // is not settled -- a notification cannot be refused, so the only refusal
+    // available is not to act on it.
     if (isIPCClientNotification(message)) {
       try {
-        if (this.#runtime && !this.#runtime.isDisposed()) {
+        if (
+          this.#isSpeaking(client) && this.#runtime &&
+          !this.#runtime.isDisposed()
+        ) {
           this.#runtime.handleNotification(message, client);
         }
       } catch (error) {
@@ -288,11 +293,8 @@ export class RuntimeClients {
         return;
       }
 
-      if (client.id !== this.#owner.id) {
-        const registered = this.#attachedClients.get(client.id);
-        if (!registered?.attached) {
-          throw new Error("Client is not attached to the WorkerRuntime.");
-        }
+      if (!this.#isSpeaking(client)) {
+        throw new Error("Client is not attached to the WorkerRuntime.");
       }
 
       if (!this.#runtime) {
@@ -367,6 +369,17 @@ export class RuntimeClients {
         ...(code ? { code } : {}),
       });
     }
+  }
+
+  /**
+   * May `client` ask the runtime for anything? The owner always may. A client
+   * that arrived over a port may once its attach has been accepted, and not
+   * before: until then the runtime has not agreed that this client is one of
+   * its own.
+   */
+  #isSpeaking(client: WorkerClient): boolean {
+    if (client.id === this.#owner.id) return true;
+    return this.#attachedClients.get(client.id)?.attached === true;
   }
 
   /**

--- a/packages/runtime-client/src/backends/client-registry.ts
+++ b/packages/runtime-client/src/backends/client-registry.ts
@@ -1,0 +1,437 @@
+/**
+ * The clients of one worker's runtime, and the message loop each of them is
+ * served by.
+ *
+ * A worker runs exactly one runtime. The first client to arrive stands it up;
+ * every later client attaches to the one already running, over a duplex of its
+ * own. What a client owns is namespaced by the client -- its subscriptions,
+ * its mounts, what its departure takes down -- and what governs it is not: the
+ * runtime's security context is settled at initialization, and an attach
+ * asserting a different one is refused rather than merged.
+ *
+ * How a duplex reaches this worker is deliberately not this module's business.
+ * {@link RuntimeClients.attach} takes anything shaped like a `MessagePort`, so
+ * a port carried by a page's opener, one relayed by a native shell, and one a
+ * test builds from a `MessageChannel` are the same thing here.
+ */
+
+import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+
+import { CompilerStackLoadError } from "@commonfabric/runner";
+import {
+  type InitializationData,
+  type IPCClientMessage,
+  type IPCRemotePost,
+  type IPCRemoteResponse,
+  isAttachPortNotification,
+  isIPCClientMessage,
+  isIPCClientNotification,
+  NotificationType,
+  RequestType,
+  RuntimeErrorCode,
+} from "@/protocol/mod.ts";
+import { RuntimeProcessor } from "@/backends/mod.ts";
+import { postThrough } from "./post-to-client.ts";
+import { describeFailure } from "@/shared/utils.ts";
+import {
+  type ClientId,
+  OWNER_CLIENT_ID,
+  ownerClient,
+  type WorkerClient,
+} from "./worker-client.ts";
+
+// Count-only ledger of request traffic as seen by the worker: one
+// `received/<type>` per request that reached this message handler and one
+// `responded/<type>` (or `responded-error/<type>`) per reply posted back.
+// Counts increment even while the logger is disabled and the lazy args are
+// never evaluated, so this costs ~nothing per request. Read back through
+// `getLoggerCounts()`, and paired with the main thread's pending-request
+// table it classifies a stuck request: absent from `received` means delivery
+// starved; received without a matching `responded` means the handler never
+// returned; both present means the response was lost in transit.
+const ipcLogger = getLogger("runtime-worker.ipc", { enabled: false });
+
+// Worker-side request decomposition, recorded into timing stats (they record
+// even while the logger is disabled) under a `runner.`-prefixed logger so the
+// integration-test load summaries pick them up:
+//   runner.ipc/delivery/<type> — postMessage send → this handler running,
+//     i.e. how long the request sat in the worker's macrotask queue. Uses the
+//     envelope's `sentEpochMs` (timeOrigin-based, comparable across threads).
+//   runner.ipc/handle/<type>   — handleRequest start → settled.
+// A slow client round-trip decomposes as delivery (worker starved) vs handle
+// (handler awaited something slow) vs the residue (response return path).
+const ipcTimingLogger = getLogger("runner.ipc", { enabled: false });
+
+/**
+ * How much of an unreadable request to render in the report about it. Enough
+ * to recognize which message it was, short enough that a hostile payload
+ * cannot flood the channel it is being reported on.
+ */
+const MAX_INVALID_REQUEST_RENDER = 512;
+
+/**
+ * The far end of one client's duplex, as much of a `MessagePort` as this
+ * worker uses. Declared as a shape rather than as the class so that what
+ * arrives is a duplex and not a story about how it got here.
+ */
+export interface ClientDuplex {
+  postMessage(message: unknown): void;
+
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+  ): void;
+
+  /**
+   * Begins delivery. A `MessagePort` queues everything sent to it until this
+   * is called, which is what lets a listener be installed without racing the
+   * messages already in flight.
+   */
+  start?(): void;
+}
+
+export interface RuntimeClientsOptions {
+  /**
+   * Turns the worker's console forwarding on and off. It patches the worker's
+   * own `console`, which is the worker entry's to own, so it arrives from
+   * there rather than being done here.
+   */
+  setConsoleBridge: (enabled: boolean) => void;
+
+  /**
+   * The client that owns the worker. Defaults to the one speaking over the
+   * worker's own global, which is what a real worker has.
+   */
+  owner?: WorkerClient;
+
+  /**
+   * Stands the runtime up. Resolved at call time rather than captured, so a
+   * caller substituting {@link RuntimeProcessor.initialize} still reaches its
+   * substitute.
+   */
+  initializeRuntime?: (data: InitializationData) => Promise<RuntimeProcessor>;
+}
+
+/** One connected client and whether its attach has been settled. */
+type RegisteredClient = {
+  client: WorkerClient;
+  attached: boolean;
+};
+
+export class RuntimeClients {
+  #runtime: RuntimeProcessor | undefined;
+  #initialization: Promise<RuntimeProcessor> | undefined;
+  #attachedClients = new Map<ClientId, RegisteredClient>();
+  #nextClientId: ClientId = OWNER_CLIENT_ID + 1;
+
+  readonly #owner: WorkerClient;
+  readonly #setConsoleBridge: (enabled: boolean) => void;
+  readonly #initializeRuntime: (
+    data: InitializationData,
+  ) => Promise<RuntimeProcessor>;
+
+  constructor(options: RuntimeClientsOptions) {
+    this.#owner = options.owner ?? ownerClient;
+    this.#setConsoleBridge = options.setConsoleBridge;
+    this.#initializeRuntime = options.initializeRuntime ??
+      ((data) => RuntimeProcessor.initialize(data));
+  }
+
+  /** The client that owns the worker and initializes its runtime. */
+  get owner(): WorkerClient {
+    return this.#owner;
+  }
+
+  /**
+   * Serves a further client over `duplex`, returning the client it becomes.
+   * The client is registered but not yet attached: until its
+   * {@link RequestType.Attach} is accepted it may ask for nothing else.
+   */
+  attach(duplex: ClientDuplex): WorkerClient {
+    const id = this.#nextClientId++;
+    const client: WorkerClient = {
+      id,
+      post: (message) =>
+        postThrough((encoded) => duplex.postMessage(encoded), message),
+    };
+    this.#attachedClients.set(id, { client, attached: false });
+    duplex.addEventListener("message", (event: MessageEvent) => {
+      void this.handleMessage(client, event);
+    });
+    duplex.start?.();
+    return client;
+  }
+
+  /**
+   * Handles one message that arrived on `client`'s duplex.
+   *
+   * Every failure below reports or replies rather than throwing: this runs
+   * from a listener, where a throw surfaces as an unhandled rejection and
+   * takes the worker's dispatch with it.
+   */
+  async handleMessage(
+    client: WorkerClient,
+    event: MessageEvent,
+  ): Promise<void> {
+    // Decoded whole, so what arrives is what was sent rather than whatever
+    // structured cloning preserved of it. The encoding end is
+    // `WebWorkerRuntimeTransport.send()`.
+    //
+    // What a decode returns is deep-frozen, so a handler owns what its request
+    // carries and may cede it, but does not edit it -- which is what
+    // `BaseRequest` states as one contract.
+    //
+    // Typed as a request rather than as the `FabricValue` a decode returns:
+    // the guards below are what actually vet it, and every use here is behind
+    // one of them or inside the `catch`, which wants the id of whatever
+    // failed.
+    let message: IPCClientMessage;
+
+    try {
+      message = fabricFromRealmValue(event.data) as IPCClientMessage;
+    } catch (error) {
+      // Defense in depth, as at the other end. Nothing undecodable should
+      // reach here, and if something does there is no `msgId` to answer under
+      // -- so this reports rather than replies, and the request it belonged to
+      // is left to time out.
+      client.post({
+        type: NotificationType.ErrorReport,
+        message: `Undecodable message from the client: ${
+          describeFailure(error)
+        }`,
+      });
+      return;
+    }
+
+    // A port handed over for a further client. It is the channel's own
+    // traffic: the port rides the transfer list rather than the message, so it
+    // is recognized before anything looks at the runtime.
+    if (isAttachPortNotification(message)) {
+      this.#handleAttachPort(client, event);
+      return;
+    }
+
+    // One-way notifications carry no msgId and get no response. Drop them once
+    // the worker is gone or disposed; in teardown the main thread may still be
+    // flushing fire-and-forget signals.
+    if (isIPCClientNotification(message)) {
+      try {
+        if (this.#runtime && !this.#runtime.isDisposed()) {
+          this.#runtime.handleNotification(message, client);
+        }
+      } catch (error) {
+        console.error("[RuntimeWorker] Notification error:", error);
+      }
+      return;
+    }
+
+    try {
+      if (!isIPCClientMessage(message)) {
+        // Rendered by `value-debug` rather than `JSON.stringify`, which is
+        // wrong for exactly what the decode above admits: it throws on a
+        // `bigint` anywhere in the tree -- replacing this report with one that
+        // names nothing -- and renders a `FabricPrimitive` as `{}`.
+        throw new Error(
+          `Invalid IPC request: ${
+            toCompactDebugString(message, MAX_INVALID_REQUEST_RENDER)
+          }`,
+        );
+      }
+      const { msgId, data: request } = message;
+      ipcLogger.debug(`received/${request.type}`, () => []);
+      const receivedAt = performance.now();
+      const sentEpochMs = (message as { sentEpochMs?: number }).sentEpochMs;
+      if (typeof sentEpochMs === "number") {
+        const deliveryMs = performance.timeOrigin + receivedAt - sentEpochMs;
+        if (deliveryMs > 0) {
+          ipcTimingLogger.time(
+            receivedAt - deliveryMs,
+            receivedAt,
+            "delivery",
+            request.type,
+          );
+        }
+      }
+
+      if (request.type === RequestType.Initialize) {
+        if (client.id !== this.#owner.id) {
+          throw new Error(
+            "Only the client that owns the worker may initialize its runtime.",
+          );
+        }
+        if (this.#initialization) {
+          throw new Error("Initialization of WorkerRuntime already attempted.");
+        }
+        this.#setConsoleBridge(request.data.forwardWorkerConsole === true);
+        this.#initialization = this.#initializeRuntime(request.data);
+        this.#runtime = await this.#initialization;
+        this.#reply({ msgId: message.msgId }, request.type, client);
+        return;
+      }
+
+      if (request.type === RequestType.Attach) {
+        if (client.id === this.#owner.id) {
+          throw new Error(
+            "The client that owns the worker initializes its runtime rather " +
+              "than attaching to it.",
+          );
+        }
+        // An attach joins a runtime; it never stands one up. Answered with
+        // the same words an ordinary request gets before initialization,
+        // because it is the same fact about the worker.
+        if (!this.#runtime) {
+          throw new Error("WorkerRuntime not initialized.");
+        }
+        this.#runtime.assertAttachable(request.data);
+        const registered = this.#attachedClients.get(client.id);
+        if (registered) registered.attached = true;
+        this.#reply({ msgId }, request.type, client);
+        return;
+      }
+
+      // Toggling console forwarding is handled here, not in the
+      // RuntimeProcessor, because the console patch lives in the worker entry.
+      // It is independent of runtime initialization, so it is answered before
+      // the init check. The owner's alone: what the bridge forwards goes to
+      // the worker's own global, which is the owner's end of the IPC.
+      if (request.type === RequestType.SetForwardWorkerConsole) {
+        if (client.id !== this.#owner.id) {
+          throw new Error(
+            "Only the client that owns the worker may forward its console.",
+          );
+        }
+        this.#setConsoleBridge(request.enabled);
+        this.#reply({ msgId }, request.type, client);
+        return;
+      }
+
+      if (client.id !== this.#owner.id) {
+        const registered = this.#attachedClients.get(client.id);
+        if (!registered?.attached) {
+          throw new Error("Client is not attached to the WorkerRuntime.");
+        }
+      }
+
+      if (!this.#runtime) {
+        throw new Error("WorkerRuntime not initialized.");
+      }
+      const runtime = this.#runtime;
+      if (runtime.isDisposed()) {
+        // After disposal, silently ack any late-arriving requests.
+        // Components may still be unsubscribing or finishing in-flight
+        // operations during teardown — no point erroring on these.
+        this.#reply({ msgId }, request.type, client);
+        return;
+      }
+
+      // A `Dispose` from an attached client is that client leaving, not the
+      // runtime ending: the runtime belongs to the worker, and the worker to
+      // the owner. Only the owner's `Dispose` reaches the runtime's own.
+      if (
+        request.type === RequestType.Dispose && client.id !== this.#owner.id
+      ) {
+        runtime.disposeClient(client);
+        this.#attachedClients.delete(client.id);
+        this.#reply({ msgId }, request.type, client);
+        return;
+      }
+
+      const handleStart = performance.now();
+      let response;
+      try {
+        response = await runtime.handleRequest(request, client);
+      } finally {
+        // Record handling latency whether or not the request threw, so
+        // error-heavy periods do not silently underreport it.
+        ipcTimingLogger.time(handleStart, "handle", request.type);
+      }
+      const payload: IPCRemoteResponse = response !== undefined
+        ? { msgId, data: response }
+        : { msgId };
+      this.#reply(payload, request.type, client);
+    } catch (error) {
+      console.error("[RuntimeWorker] Error:", error);
+      const type = isIPCClientMessage(message) ? message.data.type : "invalid";
+      ipcLogger.debug(`responded-error/${type}`, () => []);
+      const code = error instanceof CompilerStackLoadError
+        ? RuntimeErrorCode.CompilerStackLoadFailed
+        : undefined;
+
+      // A reply is addressed by `msgId`, and what reaches here need not have
+      // one: the decode above admits every `FabricValue`, `undefined` and a
+      // `bigint` among them, and `Invalid IPC request` is thrown precisely for
+      // what is no message at all. Reading `msgId` off that would throw from
+      // inside this `catch`, which is the one place a throw has nowhere to go
+      // -- out of an async listener it surfaces as an unhandled rejection,
+      // taking with it the report it was in the middle of making.
+      const msgId = isObjectNotArray(message) &&
+          typeof message.msgId === "number"
+        ? message.msgId
+        : undefined;
+      if (msgId === undefined) {
+        client.post({
+          type: NotificationType.ErrorReport,
+          message: `Malformed message from the client: ${
+            describeFailure(error)
+          }`,
+        });
+        return;
+      }
+
+      client.post({
+        msgId,
+        error: describeFailure(error),
+        ...(code ? { code } : {}),
+      });
+    }
+  }
+
+  /**
+   * Takes the port transferred alongside an attach-port message and serves a
+   * further client over it.
+   *
+   * Only the owner may hand one over. A client that arrived over a port does
+   * not get to enlarge the family it joined -- the worker belongs to the page
+   * that spawned it, and who else may speak to the runtime is that page's
+   * decision.
+   */
+  #handleAttachPort(client: WorkerClient, event: MessageEvent): void {
+    if (client.id !== this.#owner.id) {
+      client.post({
+        type: NotificationType.ErrorReport,
+        message:
+          "Only the client that owns the worker may hand it a client port.",
+      });
+      return;
+    }
+    const port = event.ports?.[0];
+    if (!port) {
+      client.post({
+        type: NotificationType.ErrorReport,
+        message: "An attach-port message arrived with no port to attach.",
+      });
+      return;
+    }
+    this.attach(port);
+  }
+
+  /**
+   * Posts one reply and records it in the ledger by what actually went. An
+   * encoding failure substitutes an error reply, and counting that as a
+   * response would say the request succeeded.
+   */
+  #reply(
+    payload: IPCRemoteResponse,
+    type: RequestType,
+    client: WorkerClient,
+  ): void {
+    const delivered = client.post(payload as IPCRemotePost);
+    ipcLogger.debug(
+      `${delivered ? "responded" : "responded-error"}/${type}`,
+      () => [],
+    );
+  }
+}

--- a/packages/runtime-client/src/backends/post-to-client.ts
+++ b/packages/runtime-client/src/backends/post-to-client.ts
@@ -33,10 +33,23 @@ const MAX_UNDELIVERABLE_RENDER = 512;
  * does not.
  */
 export function postToClient(message: IPCRemotePost): boolean {
+  // `self` is read at call time rather than captured at module load, so that a
+  // test driving this without a real worker can substitute its own.
+  return postThrough((encoded) => self.postMessage(encoded), message);
+}
+
+/**
+ * Posts one message through `send`, which is what a client other than the
+ * worker's owner is reached by: its own port rather than the worker's global.
+ * Everything the doc above says of {@link postToClient} is said of this, which
+ * is where it happens.
+ */
+export function postThrough(
+  send: (encoded: unknown) => void,
+  message: IPCRemotePost,
+): boolean {
   try {
-    // `self` is read at call time rather than captured at module load, so
-    // that a test driving this without a real worker can substitute its own.
-    self.postMessage(realmFromFabricValue(message));
+    send(realmFromFabricValue(message));
     return true;
   } catch (error) {
     // Defense in depth, and the mirror of the two decodes. Both steps above
@@ -50,9 +63,7 @@ export function postToClient(message: IPCRemotePost): boolean {
     // where a throw is an uncaught error rather than something that becomes
     // an error reply. Losing one message loudly beats taking the worker's
     // dispatch with it.
-    self.postMessage(
-      realmFromFabricValue(undeliverableMessageFrom(message, error)),
-    );
+    send(realmFromFabricValue(undeliverableMessageFrom(message, error)));
     return false;
   }
 }

--- a/packages/runtime-client/src/backends/runtime-error.ts
+++ b/packages/runtime-client/src/backends/runtime-error.ts
@@ -1,5 +1,9 @@
 import { CompilerStackLoadError } from "@commonfabric/runner";
-import { NotificationType, RuntimeErrorCode } from "@/protocol/mod.ts";
+import {
+  type ErrorNotification,
+  NotificationType,
+  RuntimeErrorCode,
+} from "@/protocol/mod.ts";
 import { postToClient } from "./post-to-client.ts";
 
 function runtimeErrorCode(error: Error): RuntimeErrorCode | undefined {
@@ -8,15 +12,24 @@ function runtimeErrorCode(error: Error): RuntimeErrorCode | undefined {
     : undefined;
 }
 
-/** Post an asynchronous renderer error to the shell. */
-export function postRuntimeError(error: Error): void {
+/**
+ * The report an asynchronous renderer error crosses as. Built rather than
+ * posted, so that a caller holding one client of several sends it to that
+ * client instead of to the worker's own global.
+ */
+export function runtimeErrorPost(error: Error): ErrorNotification {
   const code = runtimeErrorCode(error);
-  postToClient({
+  return {
     type: NotificationType.ErrorReport,
     message: error.message,
     ...(code ? { code } : {}),
     stackTrace: error.stack,
-  });
+  };
+}
+
+/** Post an asynchronous renderer error to the shell. */
+export function postRuntimeError(error: Error): void {
+  postToClient(runtimeErrorPost(error));
 }
 
 type ContextualRuntimeError = Error & {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -639,6 +639,22 @@ export const hasExplicitSubscriptionSchema = (schema: unknown): boolean =>
     typeof schema === "object" && schema !== null &&
     Object.keys(schema).length > 0);
 
+/**
+ * Where a mount's render errors go: the client that mounted it, and no other.
+ *
+ * A render error belongs to the document showing the tree rather than to
+ * whichever client happens to own the worker, and a reconciler reports one
+ * from deep inside a render. Named here so that rule is one a test can state,
+ * the render failures that raise it being reachable only through a pattern.
+ */
+export function mountErrorSink(
+  client: WorkerClient,
+): (error: Error) => void {
+  return (error) => {
+    client.post(runtimeErrorPost(error));
+  };
+}
+
 export function securityContextFrom(
   data: InitializationData,
   identity: DID,
@@ -2935,7 +2951,7 @@ export class RuntimeProcessor {
         });
         return batchId;
       },
-      onError: (error) => client.post(runtimeErrorPost(error)),
+      onError: mountErrorSink(client),
     });
 
     // Mount the cell - the reconciler will subscribe and emit initial ops

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -684,7 +684,7 @@ export function securityContextFrom(
  * carried as an absent property in one and as an explicit `undefined` in the
  * other is the same posture and compares equal here.
  */
-function securityContextDifferences(
+export function securityContextDifferences(
   asserted: RuntimeSecurityContext,
   running: RuntimeSecurityContext,
 ): string[] {

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -90,7 +90,6 @@ import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { linkRefPayload } from "@commonfabric/runner/shared";
 import { RemoteResponse } from "@commonfabric/runtime-client";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   getLogger,
   getLoggerCountsBreakdown,
@@ -223,6 +222,11 @@ import {
 } from "@/protocol/mod.ts";
 
 import type { VDomOp } from "@/protocol/types.ts";
+import {
+  normalizeOrigin,
+  normalizeSpaceHostMap,
+  securityContextDifferences,
+} from "@/shared/security-context.ts";
 import { cellRefToKey, describeFailure } from "@/shared/utils.ts";
 import { postToClient } from "./post-to-client.ts";
 import {
@@ -230,6 +234,7 @@ import {
   runtimeErrorPost,
 } from "./runtime-error.ts";
 import {
+  type ClientId,
   clientKeyPrefix,
   clientScopedKey,
   ownerClient,
@@ -634,37 +639,14 @@ export const hasExplicitSubscriptionSchema = (schema: unknown): boolean =>
     typeof schema === "object" && schema !== null &&
     Object.keys(schema).length > 0);
 
-/**
- * Every field a {@link RuntimeSecurityContext} carries, as a record so that a
- * field added to that type and not to this one is a type error. What an attach
- * is checked against has to be the whole context: a field nobody compares is a
- * posture a second document can hold while the first believes otherwise.
- */
-const SECURITY_CONTEXT_FIELDS: Record<
-  keyof Required<RuntimeSecurityContext>,
-  true
-> = {
-  cfcEnforcementMode: true,
-  cfcFlowLabels: true,
-  experimental: true,
-  identity: true,
-  renderConfidentialityCeiling: true,
-  renderDeclassificationPolicy: true,
-  spaceDid: true,
-  trustSnapshot: true,
-};
-
-/**
- * The security context a runtime stood up from this data runs under. The
- * acting principal arrives as a key pair and is recorded here as the DID it
- * derives to, which is what an attach states and all an attach may state.
- */
 export function securityContextFrom(
   data: InitializationData,
   identity: DID,
 ): RuntimeSecurityContext {
   return {
     identity,
+    apiUrl: normalizeOrigin(data.apiUrl),
+    spaceHostMap: normalizeSpaceHostMap(data.spaceHostMap),
     spaceDid: data.spaceDid,
     experimental: data.experimental,
     cfcEnforcementMode: data.cfcEnforcementMode,
@@ -673,25 +655,6 @@ export function securityContextFrom(
     renderConfidentialityCeiling: data.renderConfidentialityCeiling,
     trustSnapshot: data.trustSnapshot,
   };
-}
-
-/**
- * The fields on which `asserted` and `running` disagree, in a fixed order, or
- * an empty list where they agree throughout.
- *
- * Compared field by field rather than as two whole objects: the two are built
- * in different documents and one of them crossed an encoding, so a posture
- * carried as an absent property in one and as an explicit `undefined` in the
- * other is the same posture and compares equal here.
- */
-export function securityContextDifferences(
-  asserted: RuntimeSecurityContext,
-  running: RuntimeSecurityContext,
-): string[] {
-  const fields = Object.keys(SECURITY_CONTEXT_FIELDS).sort() as (
-    keyof RuntimeSecurityContext
-  )[];
-  return fields.filter((field) => !deepEqual(asserted[field], running[field]));
 }
 
 type RuntimeOperationTarget = {
@@ -703,6 +666,12 @@ type RuntimeOperationSession = {
   cellKey: string;
   target: RuntimeOperationTarget;
   subscriptions: Set<string>;
+  /**
+   * The client that opened this session. A session id is a UUID its client
+   * minted, which keeps two clients from colliding but does not stop one
+   * naming another's -- so who may close it is recorded rather than assumed.
+   */
+  clientId: ClientId;
 };
 
 export class RuntimeProcessor {
@@ -1135,10 +1104,15 @@ export class RuntimeProcessor {
    * came to leave. Only {@link dispose} ends a runtime, and only the client
    * that stood it up asks for that.
    *
-   * One residue is left behind on purpose: an operation session the departing
-   * client opened and never subscribed on. A session is reaped when its last
-   * subscription goes, which the unsubscribes below do, and one with no
-   * subscription at all is a target address holding nothing live.
+   * `pieceSourceConfirmations` is deliberately not swept. It holds a two-phase
+   * confirmation for a PIECE, keyed by the piece rather than by a client, and
+   * its token is a UUID handed to whoever prepared the change -- so a
+   * departing client takes the only means of confirming its pending entry with
+   * it, and what is left is a token nobody holds, replaced the next time
+   * anyone prepares a change to that piece. Two clients preparing one piece's
+   * change do collide there, the second prepare invalidating the first's
+   * token; that is a refusal rather than a lost write, and it is the same
+   * collision two tabs have today.
    */
   disposeClient(client: WorkerClient): void {
     const prefix = clientKeyPrefix(client);
@@ -1158,7 +1132,7 @@ export class RuntimeProcessor {
       this.handleOperationUnsubscribe({
         type: RequestType.OperationUnsubscribe,
         subscriptionId,
-      });
+      }, client);
     }
 
     for (const [key, mount] of [...this.vdomMounts]) {
@@ -1166,6 +1140,11 @@ export class RuntimeProcessor {
       mount.cancel();
       mount.reconciler.unmount();
       this.vdomMounts.delete(key);
+    }
+
+    for (const [sessionId, session] of [...this.operationSessions]) {
+      if (session.clientId !== client.id) continue;
+      this.operationSessions.delete(sessionId);
     }
   }
 
@@ -1383,7 +1362,8 @@ export class RuntimeProcessor {
 
   private operationTarget(
     cell: CellGetRequest["cell"],
-    operationSessionId?: string,
+    operationSessionId: string | undefined,
+    client: WorkerClient,
   ) {
     if (
       operationSessionId !== undefined &&
@@ -1432,6 +1412,7 @@ export class RuntimeProcessor {
       cellKey,
       target,
       subscriptions: new Set<string>(),
+      clientId: client.id,
     };
     this.operationSessions.set(sessionKey, session);
     return { ...target, sessionKey, session };
@@ -1439,20 +1420,24 @@ export class RuntimeProcessor {
 
   async handleOperationCapabilities(
     request: OperationCapabilitiesRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<OperationCapabilitiesResponse> {
     const { capability } = this.operationTarget(
       request.cell,
       request.operationSessionId,
+      client,
     );
     return { codecs: [...await capability.operationCodecs()] };
   }
 
   async handleOperationQuery(
     request: OperationQueryRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<OperationFieldResponse> {
     const { capability, address } = this.operationTarget(
       request.cell,
       request.operationSessionId,
+      client,
     );
     const field = await capability.queryOperationField({
       ...address,
@@ -1463,10 +1448,12 @@ export class RuntimeProcessor {
 
   async handleOperationApply(
     request: OperationApplyRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<OperationApplyResponse> {
     const { capability, address } = this.operationTarget(
       request.cell,
       request.operationSessionId,
+      client,
     );
     const resolution = await capability.applyOperation({
       op: "apply-op",
@@ -1492,6 +1479,7 @@ export class RuntimeProcessor {
     const { capability, address, sessionKey, session } = this.operationTarget(
       request.cell,
       request.operationSessionId,
+      client,
     );
     // A subscription id is a UUID the client mints, so two clients never
     // collide on one. What the owning client settles is where an update goes,
@@ -1554,10 +1542,12 @@ export class RuntimeProcessor {
 
   async handleOperationRelease(
     request: OperationReleaseRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<BooleanResponse> {
     const { capability, address } = this.operationTarget(
       request.cell,
       request.operationSessionId,
+      client,
     );
     await capability.releaseOperationField({
       op: "release-op-field",
@@ -1570,11 +1560,18 @@ export class RuntimeProcessor {
 
   handleOperationUnsubscribe(
     request: OperationUnsubscribeRequest,
+    client: WorkerClient = ownerClient,
   ): BooleanResponse {
     const subscription = this.operationSubscriptions.get(
       request.subscriptionId,
     );
-    if (subscription === undefined) return { value: false };
+    // A subscription is its subscriber's to stop, and no one else's. The id
+    // is a UUID, so another client naming it is a client that came by it
+    // somehow rather than one that guessed it -- which is the case worth
+    // refusing.
+    if (subscription === undefined || subscription.client.id !== client.id) {
+      return { value: false };
+    }
     this.operationSubscriptions.delete(request.subscriptionId);
     subscription.cancelled = true;
     subscription.cancel?.();
@@ -1590,9 +1587,14 @@ export class RuntimeProcessor {
 
   handleOperationSessionClose(
     request: OperationSessionCloseRequest,
+    client: WorkerClient = ownerClient,
   ): BooleanResponse {
+    const session = this.operationSessions?.get(request.operationSessionId);
+    if (session === undefined || session.clientId !== client.id) {
+      return { value: false };
+    }
     return {
-      value: this.operationSessions?.delete(request.operationSessionId),
+      value: this.operationSessions.delete(request.operationSessionId),
     };
   }
 
@@ -2704,19 +2706,19 @@ export class RuntimeProcessor {
       case RequestType.CellGetCfcLabel:
         return await this.handleCellGetCfcLabel(request);
       case RequestType.OperationQuery:
-        return await this.handleOperationQuery(request);
+        return await this.handleOperationQuery(request, client);
       case RequestType.OperationCapabilities:
-        return await this.handleOperationCapabilities(request);
+        return await this.handleOperationCapabilities(request, client);
       case RequestType.OperationApply:
-        return await this.handleOperationApply(request);
+        return await this.handleOperationApply(request, client);
       case RequestType.OperationRelease:
-        return await this.handleOperationRelease(request);
+        return await this.handleOperationRelease(request, client);
       case RequestType.OperationSubscribe:
         return await this.handleOperationSubscribe(request, client);
       case RequestType.OperationUnsubscribe:
-        return this.handleOperationUnsubscribe(request);
+        return this.handleOperationUnsubscribe(request, client);
       case RequestType.OperationSessionClose:
-        return this.handleOperationSessionClose(request);
+        return this.handleOperationSessionClose(request, client);
       case RequestType.SqliteQuery:
         return await this.handleSqliteQuery(request);
       case RequestType.SqliteExec:

--- a/packages/runtime-client/src/backends/runtime-processor.ts
+++ b/packages/runtime-client/src/backends/runtime-processor.ts
@@ -90,6 +90,7 @@ import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { linkRefPayload } from "@commonfabric/runner/shared";
 import { RemoteResponse } from "@commonfabric/runtime-client";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   getLogger,
   getLoggerCountsBreakdown,
@@ -99,6 +100,7 @@ import {
   resetAllCountBaselines,
   resetAllTimingBaselines,
 } from "@commonfabric/utils/logger";
+import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
@@ -187,6 +189,7 @@ import {
   RequestType,
   type ResolveEventAttentionRequest,
   type ResolveSpaceNameRequest,
+  type RuntimeSecurityContext,
   type SetActionRunTraceEnabledRequest,
   type SetBreakpointsRequest,
   type SetLoggerEnabledRequest,
@@ -224,8 +227,14 @@ import { cellRefToKey, describeFailure } from "@/shared/utils.ts";
 import { postToClient } from "./post-to-client.ts";
 import {
   postContextualRuntimeError,
-  postRuntimeError,
+  runtimeErrorPost,
 } from "./runtime-error.ts";
+import {
+  clientKeyPrefix,
+  clientScopedKey,
+  ownerClient,
+  type WorkerClient,
+} from "./worker-client.ts";
 import {
   assertFabricLoggerFlags,
   createCellRef,
@@ -625,6 +634,66 @@ export const hasExplicitSubscriptionSchema = (schema: unknown): boolean =>
     typeof schema === "object" && schema !== null &&
     Object.keys(schema).length > 0);
 
+/**
+ * Every field a {@link RuntimeSecurityContext} carries, as a record so that a
+ * field added to that type and not to this one is a type error. What an attach
+ * is checked against has to be the whole context: a field nobody compares is a
+ * posture a second document can hold while the first believes otherwise.
+ */
+const SECURITY_CONTEXT_FIELDS: Record<
+  keyof Required<RuntimeSecurityContext>,
+  true
+> = {
+  cfcEnforcementMode: true,
+  cfcFlowLabels: true,
+  experimental: true,
+  identity: true,
+  renderConfidentialityCeiling: true,
+  renderDeclassificationPolicy: true,
+  spaceDid: true,
+  trustSnapshot: true,
+};
+
+/**
+ * The security context a runtime stood up from this data runs under. The
+ * acting principal arrives as a key pair and is recorded here as the DID it
+ * derives to, which is what an attach states and all an attach may state.
+ */
+export function securityContextFrom(
+  data: InitializationData,
+  identity: DID,
+): RuntimeSecurityContext {
+  return {
+    identity,
+    spaceDid: data.spaceDid,
+    experimental: data.experimental,
+    cfcEnforcementMode: data.cfcEnforcementMode,
+    cfcFlowLabels: data.cfcFlowLabels,
+    renderDeclassificationPolicy: data.renderDeclassificationPolicy,
+    renderConfidentialityCeiling: data.renderConfidentialityCeiling,
+    trustSnapshot: data.trustSnapshot,
+  };
+}
+
+/**
+ * The fields on which `asserted` and `running` disagree, in a fixed order, or
+ * an empty list where they agree throughout.
+ *
+ * Compared field by field rather than as two whole objects: the two are built
+ * in different documents and one of them crossed an encoding, so a posture
+ * carried as an absent property in one and as an explicit `undefined` in the
+ * other is the same posture and compares equal here.
+ */
+function securityContextDifferences(
+  asserted: RuntimeSecurityContext,
+  running: RuntimeSecurityContext,
+): string[] {
+  const fields = Object.keys(SECURITY_CONTEXT_FIELDS).sort() as (
+    keyof RuntimeSecurityContext
+  )[];
+  return fields.filter((field) => !deepEqual(asserted[field], running[field]));
+}
+
 type RuntimeOperationTarget = {
   capability: IOperationStorageCapability;
   address: OperationFieldAddress;
@@ -652,10 +721,18 @@ export class RuntimeProcessor {
   private identity: Identity;
   private _isDisposed = false;
   private disposingPromise: Promise<void> | undefined;
+  // Cell subscriptions, by the subscribing client's scoped cell key. Two
+  // clients watching one cell are two subscriptions, so that one client's
+  // unsubscribe stops its own feed and no one else's.
   private subscriptions = new Map<string, Cancel>();
   private operationSubscriptions = new Map<
     string,
-    { cancel?: Cancel; cancelled: boolean; sessionKey?: string }
+    {
+      cancel?: Cancel;
+      cancelled: boolean;
+      sessionKey?: string;
+      client: WorkerClient;
+    }
   >();
   private operationSessions = new Map<string, RuntimeOperationSession>();
   private pieceSourceConfirmations = new Map<
@@ -663,13 +740,19 @@ export class RuntimeProcessor {
     { token: string; prepared: PreparedPieceSourceChange }
   >();
   private telemetry: RuntimeTelemetry;
+  // Whom this runtime acts as and under which enforcement configuration,
+  // fixed by the client that initialized it. A runtime carries exactly one,
+  // and every client attached to it is checked against this one.
+  readonly #securityContext: RuntimeSecurityContext;
   #telemetryEnabled = false;
   #intentOutcomeCancel: Cancel | undefined;
 
-  // VDOM mounts: mountId -> { reconciler, cancel }
+  // VDOM mounts, by the mounting client's scoped mount id. A mount id comes
+  // from a counter that starts at 1 in each client's own document, so the id
+  // alone names a mount only while there is one client.
   private vdomMounts = new Map<
-    number,
-    { reconciler: WorkerReconciler; cancel: Cancel }
+    string,
+    { reconciler: WorkerReconciler; cancel: Cancel; client: WorkerClient }
   >();
   private vdomBatchIdCounter = 0;
   // Render-boundary declassification policy applied to every mount's
@@ -695,6 +778,7 @@ export class RuntimeProcessor {
     initSpace: DID,
     identity: Identity,
     telemetry: RuntimeTelemetry,
+    securityContext: RuntimeSecurityContext,
   ) {
     this.runtime = runtime;
     this.cc = cc;
@@ -702,6 +786,7 @@ export class RuntimeProcessor {
     this.identity = identity;
     this.telemetry = telemetry;
     this.telemetry.addEventListener("telemetry", this.#onTelemetry);
+    this.#securityContext = securityContext;
   }
 
   static async initialize(data: InitializationData): Promise<RuntimeProcessor> {
@@ -824,6 +909,7 @@ export class RuntimeProcessor {
       space,
       identity,
       telemetry,
+      securityContextFrom(data, identity.did()),
     );
     // InitializationData crosses postMessage with no runtime validation, so a
     // typo'd host config or version-skewed peer must fail CLOSED, not open:
@@ -1011,6 +1097,76 @@ export class RuntimeProcessor {
 
   isDisposed(): boolean {
     return this._isDisposed;
+  }
+
+  /**
+   * Refuses an attach whose asserted security context is not this runtime's.
+   *
+   * One runtime is one signer under one enforcement configuration, so every
+   * document attached to it acts as the same principal with the same posture.
+   * A client asserting anything else is asking for a runtime this is not, and
+   * the two contexts are never merged: a merge would leave each document
+   * believing a posture the runtime does not hold. The refusal is the honest
+   * answer, and a second runtime is the remedy.
+   *
+   * @throws If any field of the asserted context differs from the running
+   *   one's. The message names every field that differs.
+   */
+  assertAttachable(asserted: RuntimeSecurityContext): void {
+    const differing = securityContextDifferences(
+      asserted,
+      this.#securityContext,
+    );
+    if (differing.length === 0) return;
+    const named = differing.map((field) => backtickQuote(field)).join(", ");
+    throw new Error(
+      "Attach refused: the asserted security context differs from the " +
+        `runtime's at ${named}.`,
+    );
+  }
+
+  /**
+   * Tears down everything one client owns, leaving the runtime and every other
+   * client's work running. This is what a client's departure costs: its cell
+   * and operation subscriptions stop, its VDOM trees unmount, and nothing else
+   * moves.
+   *
+   * The runtime itself is never touched here, however the departing client
+   * came to leave. Only {@link dispose} ends a runtime, and only the client
+   * that stood it up asks for that.
+   *
+   * One residue is left behind on purpose: an operation session the departing
+   * client opened and never subscribed on. A session is reaped when its last
+   * subscription goes, which the unsubscribes below do, and one with no
+   * subscription at all is a target address holding nothing live.
+   */
+  disposeClient(client: WorkerClient): void {
+    const prefix = clientKeyPrefix(client);
+
+    for (const [key, cancel] of [...this.subscriptions]) {
+      if (!key.startsWith(prefix)) continue;
+      cancel();
+      this.subscriptions.delete(key);
+    }
+
+    for (
+      const [subscriptionId, subscription] of [
+        ...this.operationSubscriptions,
+      ]
+    ) {
+      if (subscription.client.id !== client.id) continue;
+      this.handleOperationUnsubscribe({
+        type: RequestType.OperationUnsubscribe,
+        subscriptionId,
+      });
+    }
+
+    for (const [key, mount] of [...this.vdomMounts]) {
+      if (!key.startsWith(prefix)) continue;
+      mount.cancel();
+      mount.reconciler.unmount();
+      this.vdomMounts.delete(key);
+    }
   }
 
   /**
@@ -1328,6 +1484,7 @@ export class RuntimeProcessor {
 
   async handleOperationSubscribe(
     request: OperationSubscribeRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<BooleanResponse> {
     if (this.operationSubscriptions.has(request.subscriptionId)) {
       return { value: false };
@@ -1336,12 +1493,17 @@ export class RuntimeProcessor {
       request.cell,
       request.operationSessionId,
     );
+    // A subscription id is a UUID the client mints, so two clients never
+    // collide on one. What the owning client settles is where an update goes,
+    // and what a departing client takes with it.
     const subscription: {
       cancel?: Cancel;
       cancelled: boolean;
       sessionKey?: string;
+      client: WorkerClient;
     } = {
       cancelled: false,
+      client,
       ...(sessionKey === undefined ? {} : { sessionKey }),
     };
     this.operationSubscriptions.set(request.subscriptionId, subscription);
@@ -1357,7 +1519,7 @@ export class RuntimeProcessor {
             subscription
         ) return;
         queueMicrotask(() =>
-          postToClient({
+          client.post({
             type: NotificationType.OperationUpdate,
             subscriptionId: request.subscriptionId,
             field: field,
@@ -1486,8 +1648,11 @@ export class RuntimeProcessor {
     if (result.error) throw new Error(result.error.message);
   }
 
-  handleCellSubscribe(request: CellSubscribeRequest): BooleanResponse {
-    const key = cellRefToKey(request.cell);
+  handleCellSubscribe(
+    request: CellSubscribeRequest,
+    client: WorkerClient = ownerClient,
+  ): BooleanResponse {
+    const key = clientScopedKey(client, cellRefToKey(request.cell));
 
     if (this.subscriptions.has(key)) {
       return { value: false };
@@ -1531,7 +1696,7 @@ export class RuntimeProcessor {
       // in a microtask so that the subscription response returns
       // before a notification fires.
       queueMicrotask(() =>
-        postToClient({
+        client.post({
           type: NotificationType.CellUpdate,
           cell: request.cell,
           value: converted,
@@ -1544,8 +1709,11 @@ export class RuntimeProcessor {
     return { value: true };
   }
 
-  handleCellUnsubscribe(request: CellUnsubscribeRequest): BooleanResponse {
-    const key = cellRefToKey(request.cell);
+  handleCellUnsubscribe(
+    request: CellUnsubscribeRequest,
+    client: WorkerClient = ownerClient,
+  ): BooleanResponse {
+    const key = clientScopedKey(client, cellRefToKey(request.cell));
     const cancel = this.subscriptions.get(key);
     if (cancel) {
       cancel();
@@ -2510,6 +2678,7 @@ export class RuntimeProcessor {
 
   async handleRequest(
     request: IPCClientRequest,
+    client: WorkerClient = ownerClient,
   ): Promise<RemoteResponse | void> {
     switch (request.type) {
       case RequestType.Dispose:
@@ -2527,9 +2696,9 @@ export class RuntimeProcessor {
       case RequestType.CellSend:
         return this.handleCellSend(request);
       case RequestType.CellSubscribe:
-        return this.handleCellSubscribe(request);
+        return this.handleCellSubscribe(request, client);
       case RequestType.CellUnsubscribe:
-        return this.handleCellUnsubscribe(request);
+        return this.handleCellUnsubscribe(request, client);
       case RequestType.CellResolveAsCell:
         return this.handleCellResolveAsCell(request);
       case RequestType.CellGetCfcLabel:
@@ -2543,7 +2712,7 @@ export class RuntimeProcessor {
       case RequestType.OperationRelease:
         return await this.handleOperationRelease(request);
       case RequestType.OperationSubscribe:
-        return await this.handleOperationSubscribe(request);
+        return await this.handleOperationSubscribe(request, client);
       case RequestType.OperationUnsubscribe:
         return this.handleOperationUnsubscribe(request);
       case RequestType.OperationSessionClose:
@@ -2655,9 +2824,9 @@ export class RuntimeProcessor {
       case RequestType.UploadBlob:
         return await this.handleUploadBlob(request);
       case RequestType.VDomMount:
-        return this.handleVDomMount(request);
+        return this.handleVDomMount(request, client);
       case RequestType.VDomUnmount:
-        return this.handleVDomUnmount(request);
+        return this.handleVDomUnmount(request, client);
       default:
         throw new Error(`Unknown message type: ${(request as any).type}`);
     }
@@ -2668,12 +2837,15 @@ export class RuntimeProcessor {
    * channel back to the sender, so handlers return void; a throw propagates to
    * the worker message loop, which logs it worker-side.
    */
-  handleNotification(notification: IPCClientNotification): void {
+  handleNotification(
+    notification: IPCClientNotification,
+    client: WorkerClient = ownerClient,
+  ): void {
     switch (notification.type) {
       case ClientNotificationType.VDomEvent:
-        return this.handleVDomEvent(notification);
+        return this.handleVDomEvent(notification, client);
       case ClientNotificationType.VDomBatchApplied:
-        return this.handleVDomBatchApplied(notification);
+        return this.handleVDomBatchApplied(notification, client);
       default:
         console.warn(
           `[RuntimeProcessor] Unknown notification type: ${
@@ -2684,11 +2856,17 @@ export class RuntimeProcessor {
   }
 
   /**
-   * Handle a DOM event dispatched from the main thread.
-   * This routes the event to the appropriate reconciler based on mountId.
+   * Handle a DOM event dispatched from the main thread. It reaches the
+   * reconciler of the sending client's own mount, so one document's events
+   * never find another document's handlers.
    */
-  handleVDomEvent(request: VDomEventNotification): void {
-    const mount = this.vdomMounts.get(request.mountId);
+  handleVDomEvent(
+    request: VDomEventNotification,
+    client: WorkerClient = ownerClient,
+  ): void {
+    const mount = this.vdomMounts.get(
+      clientScopedKey(client, request.mountId),
+    );
     if (!mount) {
       console.warn(
         `[RuntimeProcessor] No mount found for mountId: ${request.mountId}`,
@@ -2715,12 +2893,20 @@ export class RuntimeProcessor {
    * Handle a request to start VDOM rendering for a cell.
    * Creates a WorkerReconciler, subscribes to the cell, and sends VDomBatch notifications.
    */
-  handleVDomMount(request: VDomMountRequest): VDomMountResponse {
+  handleVDomMount(
+    request: VDomMountRequest,
+    client: WorkerClient = ownerClient,
+  ): VDomMountResponse {
     const { mountId, cell: cellRef } = request;
+    const key = clientScopedKey(client, mountId);
 
-    // Check if already mounted
-    if (this.vdomMounts.has(mountId)) {
-      this.handleVDomUnmount({ type: RequestType.VDomUnmount, mountId });
+    // Check if already mounted. Scoped to this client, so a second client
+    // mounting under the same id mounts rather than displacing the first.
+    if (this.vdomMounts.has(key)) {
+      this.handleVDomUnmount(
+        { type: RequestType.VDomUnmount, mountId },
+        client,
+      );
     }
 
     // Get the cell from the runtime and apply rendererVDOMSchema
@@ -2736,7 +2922,9 @@ export class RuntimeProcessor {
       membershipProvider: this.renderMembershipProvider,
       onOps: (ops: VDomOp[]) => {
         const batchId = this.vdomBatchIdCounter++;
-        postToClient({
+        // `mountId` as the client sent it: the scoping is this worker's
+        // bookkeeping, and the client knows its mounts by its own ids.
+        client.post({
           type: NotificationType.VDomBatch,
           batchId,
           ops,
@@ -2745,14 +2933,14 @@ export class RuntimeProcessor {
         });
         return batchId;
       },
-      onError: postRuntimeError,
+      onError: (error) => client.post(runtimeErrorPost(error)),
     });
 
     // Mount the cell - the reconciler will subscribe and emit initial ops
     const cancel = reconciler.mount(cell);
 
     // Track this mount
-    this.vdomMounts.set(mountId, { reconciler, cancel });
+    this.vdomMounts.set(key, { reconciler, cancel, client });
 
     return { rootId: reconciler.getRootNodeId() };
   }
@@ -2760,10 +2948,13 @@ export class RuntimeProcessor {
   /**
    * Handle a request to stop VDOM rendering for a mount.
    */
-  handleVDomUnmount(request: VDomUnmountRequest): void {
+  handleVDomUnmount(
+    request: VDomUnmountRequest,
+    client: WorkerClient = ownerClient,
+  ): void {
     const { mountId } = request;
 
-    const mount = this.vdomMounts.get(mountId);
+    const mount = this.vdomMounts.get(clientScopedKey(client, mountId));
     if (!mount) {
       console.warn(`[RuntimeProcessor] Mount ${mountId} not found for unmount`);
       return;
@@ -2772,11 +2963,16 @@ export class RuntimeProcessor {
     // Cancel subscriptions and clean up
     mount.cancel();
     mount.reconciler.unmount();
-    this.vdomMounts.delete(mountId);
+    this.vdomMounts.delete(clientScopedKey(client, mountId));
   }
 
-  handleVDomBatchApplied(request: VDomBatchAppliedNotification): void {
-    const mount = this.vdomMounts.get(request.mountId);
+  handleVDomBatchApplied(
+    request: VDomBatchAppliedNotification,
+    client: WorkerClient = ownerClient,
+  ): void {
+    const mount = this.vdomMounts.get(
+      clientScopedKey(client, request.mountId),
+    );
     if (!mount) {
       return;
     }

--- a/packages/runtime-client/src/backends/web-worker/index.ts
+++ b/packages/runtime-client/src/backends/web-worker/index.ts
@@ -8,50 +8,16 @@
 import "core-js/proposals/explicit-resource-management";
 import "core-js/proposals/async-explicit-resource-management";
 
-import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { unrefTimer } from "@commonfabric/utils/sleep";
-import { isObjectNotArray } from "@commonfabric/utils/types";
 
-import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
-  IPCClientMessage,
-  IPCRemoteResponse,
-  isIPCClientMessage,
-  isIPCClientNotification,
-  NotificationType,
-  RequestType,
-  RuntimeErrorCode,
   TransportNotificationType,
   WORKER_CONSOLE_LEVELS,
   WorkerConsoleLevel,
 } from "@/protocol/mod.ts";
-import { RuntimeProcessor } from "@/backends/mod.ts";
+import { RuntimeClients } from "@/backends/client-registry.ts";
 import { postToClient } from "@/backends/post-to-client.ts";
-import { describeFailure } from "@/shared/utils.ts";
-
-// Count-only ledger of request traffic as seen by the worker: one
-// `received/<type>` per request that reached this message handler and one
-// `responded/<type>` (or `responded-error/<type>`) per reply posted back.
-// Counts increment even while the logger is disabled and the lazy args are
-// never evaluated, so this costs ~nothing per request. Read back through
-// `getLoggerCounts()`, and paired with the main thread's pending-request
-// table it classifies a stuck request: absent from `received` means delivery
-// starved; received without a matching `responded` means the handler never
-// returned; both present means the response was lost in transit.
-const ipcLogger = getLogger("runtime-worker.ipc", { enabled: false });
-
-// Worker-side request decomposition, recorded into timing stats (they record
-// even while the logger is disabled) under a `runner.`-prefixed logger so the
-// integration-test load summaries pick them up:
-//   runner.ipc/delivery/<type> — postMessage send → this handler running,
-//     i.e. how long the request sat in the worker's macrotask queue. Uses the
-//     envelope's `sentEpochMs` (timeOrigin-based, comparable across threads).
-//   runner.ipc/handle/<type>   — handleRequest start → settled.
-// A slow client round-trip decomposes as delivery (worker starved) vs handle
-// (handler awaited something slow) vs the residue (response return path).
-const ipcTimingLogger = getLogger("runner.ipc", { enabled: false });
 
 // Worker event-loop lag probe (`runner.loop/workerLag`): each tick records how
 // far past schedule the timer fired — long synchronous stretches (compile,
@@ -74,9 +40,6 @@ const loopLagLogger = getLogger("runner.loop", { enabled: false });
     expected = now + LOOP_LAG_SAMPLE_MS;
   }, LOOP_LAG_SAMPLE_MS));
 }
-
-let worker: RuntimeProcessor | undefined;
-let workerInitialization: Promise<RuntimeProcessor> | undefined;
 
 type ConsoleMethod = (...args: unknown[]) => void;
 
@@ -147,175 +110,15 @@ function setWorkerConsoleBridge(enabled: boolean): void {
   else uninstallWorkerConsoleBridge();
 }
 
-/**
- * How much of an unreadable request to render in the report about it. Enough
- * to recognize which message it was, short enough that a hostile payload
- * cannot flood the channel it is being reported on.
- */
-const MAX_INVALID_REQUEST_RENDER = 512;
+// One runtime per worker, served to every client that reaches it. The owner
+// speaks over the global this listener is installed on; a further client
+// arrives as a port the owner transfers, and the same loop serves it.
+const clients = new RuntimeClients({
+  setConsoleBridge: setWorkerConsoleBridge,
+});
 
-/**
- * Posts one reply and records it in the ledger by what actually went. An
- * encoding failure substitutes an error reply, and counting that as a
- * response would say the request succeeded.
- */
-function postReply(payload: IPCRemoteResponse, type: RequestType): void {
-  const delivered = postToClient(payload);
-  ipcLogger.debug(
-    `${delivered ? "responded" : "responded-error"}/${type}`,
-    () => [],
-  );
-}
-
-self.addEventListener("message", async (event: MessageEvent) => {
-  // Decoded whole, so what arrives is what was sent rather than whatever
-  // structured cloning preserved of it. The encoding end is
-  // `WebWorkerRuntimeTransport.send()`.
-  //
-  // What a decode returns is deep-frozen, so a handler owns what its request
-  // carries and may cede it, but does not edit it -- which is what
-  // `BaseRequest` states as one contract.
-  //
-  // Typed as a request rather than as the `FabricValue` a decode returns: the
-  // guards below are what actually vet it, and every use here is behind one
-  // of them or inside the `catch`, which wants the id of whatever failed.
-  let message: IPCClientMessage;
-
-  try {
-    message = fabricFromRealmValue(event.data) as IPCClientMessage;
-  } catch (error) {
-    // Defense in depth, as at the other end. Nothing undecodable should reach
-    // here, and if something does there is no `msgId` to answer under -- so
-    // this reports rather than replies, and the request it belonged to is left
-    // to time out. Throwing instead would surface as an unhandled rejection
-    // out of this async listener, which is the quiet failure to avoid.
-    postToClient({
-      type: NotificationType.ErrorReport,
-      message: `Undecodable message from the client: ${describeFailure(error)}`,
-    });
-    return;
-  }
-
-  // One-way notifications carry no msgId and get no response. Drop them once
-  // the worker is gone or disposed; in teardown the main thread may still be
-  // flushing fire-and-forget signals.
-  if (isIPCClientNotification(message)) {
-    try {
-      if (worker && !worker.isDisposed()) {
-        worker.handleNotification(message);
-      }
-    } catch (error) {
-      console.error("[RuntimeWorker] Notification error:", error);
-    }
-    return;
-  }
-
-  try {
-    if (!isIPCClientMessage(message)) {
-      // Rendered by `value-debug` rather than `JSON.stringify`, which is
-      // wrong for exactly what the decode above admits: it throws on a
-      // `bigint` anywhere in the tree -- replacing this report with one that
-      // names nothing -- and renders a `FabricPrimitive` as `{}`.
-      throw new Error(
-        `Invalid IPC request: ${
-          toCompactDebugString(message, MAX_INVALID_REQUEST_RENDER)
-        }`,
-      );
-    }
-    const { msgId, data: request } = message;
-    ipcLogger.debug(`received/${request.type}`, () => []);
-    const receivedAt = performance.now();
-    const sentEpochMs = (message as { sentEpochMs?: number }).sentEpochMs;
-    if (typeof sentEpochMs === "number") {
-      const deliveryMs = performance.timeOrigin + receivedAt - sentEpochMs;
-      if (deliveryMs > 0) {
-        ipcTimingLogger.time(
-          receivedAt - deliveryMs,
-          receivedAt,
-          "delivery",
-          request.type,
-        );
-      }
-    }
-
-    if (request.type === RequestType.Initialize) {
-      if (workerInitialization) {
-        throw new Error("Initialization of WorkerRuntime already attempted.");
-      }
-      setWorkerConsoleBridge(request.data.forwardWorkerConsole === true);
-      workerInitialization = RuntimeProcessor.initialize(
-        request.data,
-      );
-      worker = await workerInitialization;
-      postReply({ msgId: message.msgId }, request.type);
-      return;
-    }
-
-    // Toggling console forwarding is handled here, not in the RuntimeProcessor,
-    // because the console patch lives in this worker entry. It is independent
-    // of runtime initialization, so it is answered before the init check.
-    if (request.type === RequestType.SetForwardWorkerConsole) {
-      setWorkerConsoleBridge(request.enabled);
-      postReply({ msgId }, request.type);
-      return;
-    }
-
-    if (!worker) {
-      throw new Error("WorkerRuntime not initialized.");
-    }
-    if (worker.isDisposed()) {
-      // After disposal, silently ack any late-arriving requests.
-      // Components may still be unsubscribing or finishing in-flight
-      // operations during teardown — no point erroring on these.
-      postReply({ msgId }, request.type);
-      return;
-    }
-
-    const handleStart = performance.now();
-    let response;
-    try {
-      response = await worker.handleRequest(request);
-    } finally {
-      // Record handling latency whether or not the request threw, so
-      // error-heavy periods do not silently underreport it.
-      ipcTimingLogger.time(handleStart, "handle", request.type);
-    }
-    const payload: IPCRemoteResponse = response !== undefined
-      ? { msgId, data: response }
-      : { msgId };
-    postReply(payload, request.type);
-  } catch (error) {
-    console.error("[RuntimeWorker] Error:", error);
-    const type = isIPCClientMessage(message) ? message.data.type : "invalid";
-    ipcLogger.debug(`responded-error/${type}`, () => []);
-    const code = error instanceof CompilerStackLoadError
-      ? RuntimeErrorCode.CompilerStackLoadFailed
-      : undefined;
-
-    // A reply is addressed by `msgId`, and what reaches here need not have
-    // one: the decode above admits every `FabricValue`, `undefined` and a
-    // `bigint` among them, and `Invalid IPC request` is thrown precisely for
-    // what is no message at all. Reading `msgId` off that would throw from
-    // inside this `catch`, which is the one place a throw has nowhere to go --
-    // out of an async listener it surfaces as an unhandled rejection, taking
-    // with it the report it was in the middle of making.
-    const msgId = isObjectNotArray(message) && typeof message.msgId === "number"
-      ? message.msgId
-      : undefined;
-    if (msgId === undefined) {
-      postToClient({
-        type: NotificationType.ErrorReport,
-        message: `Malformed message from the client: ${describeFailure(error)}`,
-      });
-      return;
-    }
-
-    postToClient({
-      msgId,
-      error: describeFailure(error),
-      ...(code ? { code } : {}),
-    });
-  }
+self.addEventListener("message", (event: MessageEvent) => {
+  void clients.handleMessage(clients.owner, event);
 });
 
 // `postMessage` is absent from a main-thread global, where a test importing

--- a/packages/runtime-client/src/backends/worker-client.ts
+++ b/packages/runtime-client/src/backends/worker-client.ts
@@ -1,0 +1,80 @@
+/**
+ * One client of a worker's runtime: where a message addressed to it goes, and
+ * the id everything it owns is namespaced under.
+ *
+ * A worker runs one runtime and serves any number of clients. The first stands
+ * the runtime up and speaks over the worker's own global; each later one
+ * arrives over a duplex of its own and attaches to the runtime already
+ * running. What separates them here is ownership -- whose subscription this
+ * is, whose mount an event belongs to, what a disconnect takes down -- and not
+ * authority, which is the runtime's single security context and the same for
+ * all of them.
+ */
+
+import type { IPCRemotePost } from "@/protocol/mod.ts";
+import { postToClient } from "./post-to-client.ts";
+
+/** Identifies one client of a worker's runtime, for that client's lifetime. */
+export type ClientId = number;
+
+/** The worker's end of one client's duplex. */
+export interface WorkerClient {
+  /**
+   * This client's id. Every key a client-owned resource is filed under
+   * carries it, so two documents that each name their first mount `1` name
+   * two different mounts.
+   */
+  readonly id: ClientId;
+
+  /**
+   * Posts one message to this client, returning whether what was asked for is
+   * what went -- the contract {@link postToClient} states, which is the
+   * owner's implementation of this method.
+   */
+  post(message: IPCRemotePost): boolean;
+}
+
+/**
+ * The id of the client that initialized the runtime. Fixed rather than minted,
+ * because it is the id every handler falls back to: a call that names no
+ * client is the single-client call it has always been.
+ */
+export const OWNER_CLIENT_ID: ClientId = 0;
+
+/**
+ * The client that owns the worker: the one whose initialization stood the
+ * runtime up, reached through the worker's own global rather than through a
+ * port. There is exactly one per worker, which is why it is a value here
+ * rather than something constructed -- it stands for the global the worker
+ * already has.
+ */
+export const ownerClient: WorkerClient = {
+  id: OWNER_CLIENT_ID,
+  post: postToClient,
+};
+
+/**
+ * Files a client-supplied id under the client that supplied it. Clients mint
+ * their ids independently -- a VDOM mount id comes from a per-document counter
+ * that starts at 1 in every document -- so such an id names a resource only
+ * while there is one client, and this is what names one while there are
+ * several.
+ *
+ * The id is a number and the separator a space, so the first space is always
+ * the boundary however the rest of the key is spelled. That is what lets
+ * {@link clientKeyPrefix} select one client's keys from a map by prefix.
+ */
+export function clientScopedKey(
+  client: WorkerClient,
+  key: string | number,
+): string {
+  return `${client.id} ${key}`;
+}
+
+/**
+ * The prefix every key {@link clientScopedKey} builds for `client` starts
+ * with, which is what a per-client teardown scans a map for.
+ */
+export function clientKeyPrefix(client: WorkerClient): string {
+  return `${client.id} `;
+}

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -30,6 +30,7 @@ import {
   OperationUpdateNotification,
   PendingWritesNotification,
   RequestType,
+  type RuntimeSecurityContext,
   SerializedDomEvent,
   TelemetryNotification,
   VDomBatchNotification,
@@ -237,12 +238,35 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     return this as InitializedRuntimeConnection;
   }
 
+  /**
+   * Joins the runtime already running behind this transport, asserting the
+   * security context it is believed to run under.
+   *
+   * @throws If the runtime refuses the assertion, or if no runtime is running
+   *   behind the transport to join.
+   */
+  async attach(
+    context: RuntimeSecurityContext,
+  ): Promise<InitializedRuntimeConnection> {
+    await this.request<RequestType.Attach>({
+      type: RequestType.Attach,
+      data: context,
+    });
+    this.#initialized = true;
+    return this as InitializedRuntimeConnection;
+  }
+
   request<
     T extends keyof Commands,
   >(
     data: CommandRequest<T>,
   ): Promise<CommandResponse<T>> {
-    if (!this.#initialized && data.type !== RequestType.Initialize) {
+    // Initialize and Attach are the two requests that make a connection
+    // usable, so each is the one thing an unusable connection may send.
+    if (
+      !this.#initialized && data.type !== RequestType.Initialize &&
+      data.type !== RequestType.Attach
+    ) {
       throw new Error("RuntimeConnection is uninitialized.");
     }
     const signal = this.#lifetime.signal;

--- a/packages/runtime-client/src/client/connection.ts
+++ b/packages/runtime-client/src/client/connection.ts
@@ -36,6 +36,7 @@ import {
   VDomBatchNotification,
   VDomMountResponse,
 } from "@/protocol/mod.ts";
+import { assertNoKeyMaterial } from "@/shared/key-material.ts";
 import { RuntimeTransport } from "./transport.ts";
 import { EventEmitter } from "./emitter.ts";
 import { $onCellUpdate, CellHandle } from "@/cell-handle.ts";
@@ -242,12 +243,19 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
    * Joins the runtime already running behind this transport, asserting the
    * security context it is believed to run under.
    *
-   * @throws If the runtime refuses the assertion, or if no runtime is running
-   *   behind the transport to join.
+   * @throws If the context holds key material, if the runtime refuses the
+   *   assertion, or if no runtime is running behind the transport to join.
    */
   async attach(
     context: RuntimeSecurityContext,
   ): Promise<InitializedRuntimeConnection> {
+    // The last thing before the frame reaches a transport, which is why the
+    // invariant is enforced here and not only in `RuntimeClient.attach`: this
+    // class is exported, so a caller can hold one directly, and a context
+    // read through getters between that check and this send is not the one
+    // that was checked. `key-material.ts` states what is being kept out and
+    // why the platform is not left to decide it.
+    assertNoKeyMaterial(context);
     await this.request<RequestType.Attach>({
       type: RequestType.Attach,
       data: context,

--- a/packages/runtime-client/src/client/transports/message-port/transport-message-port.ts
+++ b/packages/runtime-client/src/client/transports/message-port/transport-message-port.ts
@@ -1,0 +1,101 @@
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+
+import {
+  type ErrorNotification,
+  type IPCClientMessage,
+  type IPCClientNotification,
+  type IPCRemoteMessage,
+  type IPCRemotePost,
+  NotificationType,
+} from "@/protocol/mod.ts";
+import { EventEmitter } from "@/client/emitter.ts";
+import {
+  RuntimeTransport,
+  RuntimeTransportEvents,
+} from "@/client/transport.ts";
+import type { MessagePortLike } from "@/shared/message-port-like.ts";
+import { describeFailure } from "@/shared/utils.ts";
+
+export interface MessagePortRuntimeTransportOptions {
+  /** The duplex the worker is reached over. */
+  port: MessagePortLike;
+}
+
+/**
+ * A connection to a runtime already running in someone else's worker, reached
+ * over a port that worker has been handed.
+ *
+ * The difference from the dedicated-worker transport is what it does not do.
+ * It spawns nothing, so there is no worker URL and no readiness to wait for:
+ * the far end is a runtime already serving another document, and a port only
+ * exists because that document's page handed one over. Nor does it terminate
+ * anything on disposal -- it drops its own end of the channel, and the runtime
+ * outlives it.
+ */
+export class MessagePortRuntimeTransport
+  extends EventEmitter<RuntimeTransportEvents>
+  implements RuntimeTransport {
+  #disposed = false;
+  readonly #port: MessagePortLike;
+
+  constructor(options: MessagePortRuntimeTransportOptions) {
+    super();
+    this.#port = options.port;
+    this.#port.addEventListener("message", this.#handleMessage);
+    // A port queues what is sent to it until it is started, so the listener
+    // above is in place before the first message can be delivered.
+    this.#port.start?.();
+  }
+
+  /** @inheritDoc */
+  send(data: IPCClientMessage | IPCClientNotification): void {
+    // Encoded exactly as the dedicated-worker transport encodes it, that
+    // being what the worker's message loop decodes. The narrowing the encoding
+    // imposes on the value model is stated there.
+    this.#port.postMessage(realmFromFabricValue(data));
+  }
+
+  /** @inheritDoc */
+  dispose(): Promise<void> {
+    this.#disposed = true;
+    this.removeAllListeners();
+    this.#port.close?.();
+    return Promise.resolve();
+  }
+
+  async [Symbol.asyncDispose]() {
+    await this.dispose();
+  }
+
+  /**
+   * Handles one message from the worker. What a decode returns is deep-frozen,
+   * so a consumer of a response or a notification reads it rather than
+   * reshaping it in place.
+   */
+  #handleMessage = (event: MessageEvent): void => {
+    if (this.#disposed) return;
+
+    let data: IPCRemotePost;
+
+    try {
+      data = fabricFromRealmValue(event.data) as IPCRemotePost;
+    } catch (error) {
+      // Defense in depth. Everything the worker posts is the result of a
+      // successful encode, so nothing undecodable should arrive. When one
+      // does, losing the message loudly beats an exception leaving this
+      // listener, which would take the connection's whole dispatch with it.
+      this.emit("message", {
+        type: NotificationType.ErrorReport,
+        message: `Undecodable message from the worker: ${
+          describeFailure(error)
+        }`,
+      } as ErrorNotification);
+      return;
+    }
+
+    this.emit("message", data as IPCRemoteMessage);
+  };
+}

--- a/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/src/client/transports/web-worker/transport-web-worker.ts
@@ -5,6 +5,7 @@ import {
 import { defer } from "@commonfabric/utils/defer";
 import { isDeno } from "@commonfabric/utils/env";
 import {
+  ClientTransportNotificationType,
   ErrorNotification,
   IPCClientMessage,
   IPCClientNotification,
@@ -69,6 +70,29 @@ export class WebWorkerRuntimeTransport
     // connection without passing through one of those, of which
     // `PageCreateRequest.argument` is the field to know about.
     this.#worker.postMessage(realmFromFabricValue(data));
+  }
+
+  /**
+   * Hands the worker a duplex for a further document to reach the runtime
+   * over, and gives up this page's end of it.
+   *
+   * Only the page holding this transport can do so: it spawned the worker, and
+   * who else may speak to the runtime is its decision. What the far end of
+   * `port` does next is send an `Attach` asserting the security context it
+   * believes the runtime runs under, which the runtime refuses if it is not
+   * its own.
+   *
+   * The port travels the transfer list rather than the message beside it -- a
+   * port is no `FabricValue` and has no encoding -- and is neutered here by
+   * the transfer, so this page cannot go on speaking over it.
+   */
+  attachClientPort(port: MessagePort): void {
+    this.#worker.postMessage(
+      realmFromFabricValue({
+        type: ClientTransportNotificationType.AttachPort,
+      }),
+      [port],
+    );
   }
 
   /** @inheritDoc */

--- a/packages/runtime-client/src/protocol/guards.ts
+++ b/packages/runtime-client/src/protocol/guards.ts
@@ -10,9 +10,11 @@
 import { isDID } from "@commonfabric/identity";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
+  AttachPortNotification,
   CellRef,
   CellUpdateNotification,
   ClientNotificationType,
+  ClientTransportNotificationType,
   ConsoleNotification,
   ErrorNotification,
   EventNeedsAttentionNotification,
@@ -290,6 +292,20 @@ export function isVDomBatchNotification(
     value.type === NotificationType.VDomBatch &&
     typeof value.batchId === "number" &&
     Array.isArray(value.ops)
+  );
+}
+
+/**
+ * Is `value` an {@link AttachPortNotification}? What it recognizes is the
+ * marker alone -- the port the marker is about travels beside the message, in
+ * the transfer list, so nothing here can look at it.
+ */
+export function isAttachPortNotification(
+  value: unknown,
+): value is AttachPortNotification {
+  return (
+    isObjectNotArray(value) &&
+    value.type === ClientTransportNotificationType.AttachPort
   );
 }
 

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -875,10 +875,28 @@ export type InitializeRequest = BaseRequest & {
  * it believes the runtime acts as and never supplies a signer of its own.
  * Every other field is the initialization field of the same name, so what an
  * attach asserts and what initialization declared compare directly.
+ *
+ * `apiUrl` and `spaceHostMap` are here as posture rather than as routing: a
+ * document believing it reads from a different backend than the runtime does
+ * is as wrong about what it is joined to as one believing a different
+ * enforcement mode, and the reads would silently go to the runtime's hosts.
+ * Both are normalized before they are stored or asserted, so two spellings of
+ * one origin are one posture.
+ *
+ * **Every field here holds plain JSON-shaped values only.** They are compared
+ * with `deepEqual`, which compares a class instance by its enumerable own
+ * properties -- so a `FabricValue`-carrying field would compare EQUAL between
+ * two different values whose state lives in private fields, and an attach
+ * asserting a different one would be accepted. A field that must carry such a
+ * value needs `valueEqual` from `data-model` and a deliberate decision about
+ * what equality means for it; adding one without that is a false accept, not
+ * a missing check.
  */
 export type RuntimeSecurityContext =
   & Pick<
     InitializationData,
+    | "apiUrl"
+    | "spaceHostMap"
     | "spaceDid"
     | "experimental"
     | "cfcEnforcementMode"

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -84,7 +84,21 @@ export enum RequestType {
   Initialize = "initialize",
 
   /**
-   * Tears the worker's runtime down. Requests arriving after it are acked in
+   * Joins a client to the runtime a first client already stood up, over a
+   * duplex of its own. It carries the {@link RuntimeSecurityContext} the
+   * joining client believes it is joining, and is refused when that disagrees
+   * with the one the runtime runs under -- a runtime acts as one principal
+   * under one enforcement configuration, and an attach never merges a second.
+   * Refused too before any {@link RequestType.Initialize}: an attach joins a
+   * runtime rather than standing one up.
+   */
+  Attach = "attach",
+
+  /**
+   * Tears down what the requesting client owns. From the client that
+   * initialized the runtime that is the runtime itself; from an attached one
+   * it is that client's own subscriptions and mounts, the runtime and every
+   * other client's work left running. Requests arriving after it are acked in
    * silence rather than refused, teardown running concurrently with whatever
    * the client had in flight.
    */
@@ -510,6 +524,34 @@ export enum TransportNotificationType {
 }
 
 /**
+ * Main-thread-to-worker signals the worker entry acts on itself, rather than
+ * handing to the runtime. The mirror of {@link TransportNotificationType}, and
+ * its own enum for the same reason: this is the channel's traffic, and no
+ * `RuntimeProcessor` ever sees it.
+ */
+export enum ClientTransportNotificationType {
+  /**
+   * Hands the worker one end of a duplex a further client will speak over;
+   * see {@link AttachPortNotification}.
+   */
+  AttachPort = "client:attach-port",
+}
+
+/**
+ * Gives the worker a duplex for a new client. The port itself rides the
+ * `postMessage` transfer list rather than this message -- a port is not a
+ * `FabricValue` and has no encoding -- so what crosses here is the marker that
+ * says what the transferred port is for.
+ *
+ * Accepted only from the client that initialized the runtime, which is the one
+ * that owns the worker. A client that arrived over a port does not get to
+ * enlarge the family it joined.
+ */
+export type AttachPortNotification = {
+  type: ClientTransportNotificationType.AttachPort;
+};
+
+/**
  * A request together with the id its answer will carry. The only shape the
  * client sends that expects a reply -- a notification carries neither.
  */
@@ -820,6 +862,46 @@ export type InitializeRequest = BaseRequest & {
    * What the runtime is stood up from.
    */
   data: InitializationData;
+};
+
+/**
+ * The part of an {@link InitializationData} a runtime's security posture is
+ * made of: whom it acts as, and under which enforcement configuration. One
+ * runtime carries exactly one of these, fixed by the client that initialized
+ * it, and every client attached to that runtime shares it.
+ *
+ * `identity` is the acting principal's DID rather than the key pair
+ * {@link InitializationData} carries, because an attach states which principal
+ * it believes the runtime acts as and never supplies a signer of its own.
+ * Every other field is the initialization field of the same name, so what an
+ * attach asserts and what initialization declared compare directly.
+ */
+export type RuntimeSecurityContext =
+  & Pick<
+    InitializationData,
+    | "spaceDid"
+    | "experimental"
+    | "cfcEnforcementMode"
+    | "cfcFlowLabels"
+    | "renderDeclassificationPolicy"
+    | "renderConfidentialityCeiling"
+    | "trustSnapshot"
+  >
+  & {
+    /** The principal the runtime acts as. */
+    identity: DID;
+  };
+
+/**
+ * The {@link RequestType.Attach} request. Its `data` is the context the
+ * joining client asserts, which the worker compares field for field against
+ * the running runtime's and refuses on any disagreement.
+ */
+export type AttachRequest = BaseRequest & {
+  type: RequestType.Attach;
+
+  /** The security context this client believes it is joining. */
+  data: RuntimeSecurityContext;
 };
 
 /** The {@link RequestType.Dispose} request, which carries no payload. */
@@ -2676,6 +2758,7 @@ export type VDomMountResponse = {
  */
 export type IPCClientRequest =
   | InitializeRequest
+  | AttachRequest
   | DisposeRequest
   | CellGetRequest
   | CellPullRequest
@@ -3251,6 +3334,10 @@ export type Commands = {
   // Runtime requests
   [RequestType.Initialize]: {
     request: InitializeRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.Attach]: {
+    request: AttachRequest;
     response: EmptyResponse;
   };
   [RequestType.Dispose]: {

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -66,11 +66,13 @@ import {
   type PieceSourceView,
   type PieceUpdateSourceResponse,
   RequestType,
+  type RuntimeSecurityContext,
   type SpaceAclCapability,
   type SpaceAclView,
   TelemetryNotification,
   type UploadBlobResponse,
 } from "./protocol/mod.ts";
+import { assertNoKeyMaterial } from "./shared/key-material.ts";
 import { cellRefToInstanceId } from "./shared/utils.ts";
 
 export interface RuntimeClientOptions
@@ -307,7 +309,9 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     options: RuntimeClientOptions,
   ): Promise<RuntimeClient> {
     assertRenderDeclassificationPolicy(options.renderDeclassificationPolicy);
-    const attached = await (new RuntimeConnection(transport)).attach({
+    const context: RuntimeSecurityContext = {
+      // The acting principal as a DID: an attach states which principal the
+      // runtime acts as and supplies no signer of its own.
       identity: options.identity.did(),
       spaceDid: options.spaceDid,
       experimental: options.experimental,
@@ -316,7 +320,14 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       renderDeclassificationPolicy: options.renderDeclassificationPolicy,
       renderConfidentialityCeiling: options.renderConfidentialityCeiling,
       trustSnapshot: options.trustSnapshot,
-    });
+    };
+    // The far side refuses this too, and refusing before the send is what
+    // matters for a shell: `key-material.ts` records why, and the short of it
+    // is that a `MessagePort` between two WKWebViews throws `DataCloneError`
+    // on a key rather than carrying it. A frame refused here never reaches a
+    // port, so that failure has nothing to happen to.
+    assertNoKeyMaterial(context);
+    const attached = await (new RuntimeConnection(transport)).attach(context);
     return new RuntimeClient(attached, options);
   }
 

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -92,6 +92,24 @@ export type RuntimeClientEvents = {
 export const $conn = Symbol("$request");
 
 /**
+ * Refuses a render-declassification policy that names no known posture.
+ *
+ * It is a security knob, so a host's own config error surfaces here, early and
+ * loudly. The worker side additionally fails CLOSED -- an unknown value there
+ * becomes `deny` -- for peers that do not come through this entry point.
+ *
+ * @throws If `policy` is present and is neither `allow` nor `deny`.
+ */
+function assertRenderDeclassificationPolicy(policy: unknown): void {
+  if (policy === undefined || policy === "allow" || policy === "deny") return;
+  throw new Error(
+    `Invalid renderDeclassificationPolicy: ${
+      JSON.stringify(policy)
+    } (expected "allow" or "deny")`,
+  );
+}
+
+/**
  * RuntimeClient provides a main-thread interface to a Runtime running elsewhere.
  */
 export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
@@ -272,25 +290,41 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     return this.#conn.signal;
   }
 
+  /**
+   * Joins a runtime a first client already stood up, over a transport already
+   * connected to that runtime's worker.
+   *
+   * What `options` says of the runtime's security posture is asserted rather
+   * than declared: the runtime is running under a posture of its own, and an
+   * attach whose assertion differs anywhere is refused. Everything else in
+   * `options` describes this client, and reaches nothing across the wire.
+   *
+   * @throws If the runtime refuses the attach, or if there is no runtime to
+   *   attach to.
+   */
+  static async attach(
+    transport: RuntimeTransport,
+    options: RuntimeClientOptions,
+  ): Promise<RuntimeClient> {
+    assertRenderDeclassificationPolicy(options.renderDeclassificationPolicy);
+    const attached = await (new RuntimeConnection(transport)).attach({
+      identity: options.identity.did(),
+      spaceDid: options.spaceDid,
+      experimental: options.experimental,
+      cfcEnforcementMode: options.cfcEnforcementMode,
+      cfcFlowLabels: options.cfcFlowLabels,
+      renderDeclassificationPolicy: options.renderDeclassificationPolicy,
+      renderConfidentialityCeiling: options.renderConfidentialityCeiling,
+      trustSnapshot: options.trustSnapshot,
+    });
+    return new RuntimeClient(attached, options);
+  }
+
   static async initialize(
     transport: RuntimeTransport,
     options: RuntimeClientOptions,
   ): Promise<RuntimeClient> {
-    // renderDeclassificationPolicy is a security knob: reject unknown values
-    // loudly here, where the host's own config error can surface early. The
-    // worker side additionally fails CLOSED (treats unknown as "deny") for
-    // peers that don't go through this entry point.
-    const renderPolicy = options.renderDeclassificationPolicy;
-    if (
-      renderPolicy !== undefined && renderPolicy !== "allow" &&
-      renderPolicy !== "deny"
-    ) {
-      throw new Error(
-        `Invalid renderDeclassificationPolicy: ${
-          JSON.stringify(renderPolicy)
-        } (expected "allow" or "deny")`,
-      );
-    }
+    assertRenderDeclassificationPolicy(options.renderDeclassificationPolicy);
     const initialized = await (new RuntimeConnection(transport)).initialize({
       apiUrl: options.apiUrl.toString(),
       spaceHostMap: options.spaceHostMap,

--- a/packages/runtime-client/src/runtime-client.ts
+++ b/packages/runtime-client/src/runtime-client.ts
@@ -73,6 +73,10 @@ import {
   type UploadBlobResponse,
 } from "./protocol/mod.ts";
 import { assertNoKeyMaterial } from "./shared/key-material.ts";
+import {
+  normalizeOrigin,
+  normalizeSpaceHostMap,
+} from "./shared/security-context.ts";
 import { cellRefToInstanceId } from "./shared/utils.ts";
 
 export interface RuntimeClientOptions
@@ -80,6 +84,35 @@ export interface RuntimeClientOptions
   apiUrl: URL;
   identity: Identity;
   spaceIdentity?: Identity;
+}
+
+/**
+ * What a client needs to join a runtime someone else stood up.
+ *
+ * Its own type rather than {@link RuntimeClientOptions} because of one field:
+ * `identity` is a DID here, never an `Identity`. An attaching client states
+ * which principal the runtime acts as and supplies no signer, so a document
+ * holding one of these structurally cannot hand a key across -- there is no
+ * key in it to hand. `RuntimeClientOptions` keeps the `Identity`, and is what
+ * initialization takes.
+ *
+ * The rest is the security posture this client asserts. Nothing here is
+ * declared to the runtime: the runtime is running under a posture of its own,
+ * and an assertion that differs anywhere is refused.
+ */
+export interface RuntimeAttachOptions extends
+  Omit<
+    RuntimeSecurityContext,
+    "apiUrl" | "spaceHostMap" | "identity"
+  > {
+  /** The backend this client believes the runtime reads from. */
+  apiUrl: URL;
+
+  /** The per-space hosts this client believes the runtime resolves against. */
+  spaceHostMap?: Record<string, string>;
+
+  /** The principal this client believes the runtime acts as. */
+  identity: DID;
 }
 
 export type RuntimeClientEvents = {
@@ -90,6 +123,32 @@ export type RuntimeClientEvents = {
   pendingwriteschange: [{ pending: boolean }];
   eventneedsattention: [EventAttentionNotice];
 };
+
+/**
+ * The same posture, in the form a client that joins a runtime states it.
+ *
+ * Written out field by field rather than spread, because what is dropped is
+ * the point: the acting principal becomes the DID it derives to, and both
+ * `Identity` values -- the signer and the space identity -- are left behind.
+ * A client that attaches asserts which principal the runtime acts as and
+ * supplies no key, and this is where a page's signer stops.
+ */
+export function attachOptionsFrom(
+  options: RuntimeClientOptions,
+): RuntimeAttachOptions {
+  return {
+    apiUrl: options.apiUrl,
+    spaceHostMap: options.spaceHostMap,
+    identity: options.identity.did(),
+    spaceDid: options.spaceDid,
+    experimental: options.experimental,
+    cfcEnforcementMode: options.cfcEnforcementMode,
+    cfcFlowLabels: options.cfcFlowLabels,
+    renderDeclassificationPolicy: options.renderDeclassificationPolicy,
+    renderConfidentialityCeiling: options.renderConfidentialityCeiling,
+    trustSnapshot: options.trustSnapshot,
+  };
+}
 
 export const $conn = Symbol("$request");
 
@@ -126,11 +185,11 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
 
   private constructor(
     conn: InitializedRuntimeConnection,
-    _options: RuntimeClientOptions,
+    principal: DID | undefined,
   ) {
     super();
     this.#conn = conn;
-    this.#principal = _options.identity?.did();
+    this.#principal = principal;
     this.#conn.on("console", this.#onConsole);
     this.#conn.on("navigaterequest", this.#onNavigateRequest);
     this.#conn.on("error", this.#onError);
@@ -306,13 +365,16 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    */
   static async attach(
     transport: RuntimeTransport,
-    options: RuntimeClientOptions,
+    options: RuntimeAttachOptions,
   ): Promise<RuntimeClient> {
     assertRenderDeclassificationPolicy(options.renderDeclassificationPolicy);
     const context: RuntimeSecurityContext = {
-      // The acting principal as a DID: an attach states which principal the
-      // runtime acts as and supplies no signer of its own.
-      identity: options.identity.did(),
+      identity: options.identity,
+      // Normalized as the runtime normalizes what it was initialized with, so
+      // that agreeing on a backend does not depend on agreeing on how to spell
+      // one.
+      apiUrl: normalizeOrigin(options.apiUrl.toString()),
+      spaceHostMap: normalizeSpaceHostMap(options.spaceHostMap),
       spaceDid: options.spaceDid,
       experimental: options.experimental,
       cfcEnforcementMode: options.cfcEnforcementMode,
@@ -328,7 +390,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     // port, so that failure has nothing to happen to.
     assertNoKeyMaterial(context);
     const attached = await (new RuntimeConnection(transport)).attach(context);
-    return new RuntimeClient(attached, options);
+    return new RuntimeClient(attached, options.identity);
   }
 
   static async initialize(
@@ -353,7 +415,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       patternCoverage: options.patternCoverage,
       concurrentWatchRefresh: options.concurrentWatchRefresh,
     });
-    return new RuntimeClient(initialized, options);
+    return new RuntimeClient(initialized, options.identity?.did());
   }
 
   getCellFromRef<T>(

--- a/packages/runtime-client/src/shared/key-material.ts
+++ b/packages/runtime-client/src/shared/key-material.ts
@@ -24,8 +24,26 @@
  * keeps its state in `#` fields, so there is nothing to walk into -- which is
  * also what makes the check exact rather than a guess at what a key looks
  * like.
+ *
+ * **What this is not.** A secret already reduced to bytes or to text -- a
+ * PKCS8 blob, a JWK, a seed as a `Uint8Array`, a private key pasted into a
+ * string -- is out of scope, and nothing here would notice one. That is not a
+ * gap to close: the two ends of an attach are a page and a worker under one
+ * origin at one trust level, and a sender determined to move bytes has the
+ * whole payload to do it in. This detects a MISBUILT frame -- the accident of
+ * handing an attach the signer that initialization takes -- and is worth
+ * exactly that. Reading it as an exfiltration filter would be reading a
+ * type-check as a sandbox.
+ *
+ * **Keeping it true.** The classes below are enumerated, not derived, so a
+ * newly registered codec class that can hold a `CryptoKey` -- or a new
+ * instance shape that carries state past the enumerable-property walk -- has
+ * to be added here, exactly as a new field on `RuntimeSecurityContext` has to
+ * be added to the roster it is compared against. Neither is a check a machine
+ * will notice is missing.
  */
 
+import { BaseFabricInstance } from "@commonfabric/data-model/fabric-bases";
 import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
 
 /**
@@ -78,6 +96,37 @@ function findIn(
       if (found !== undefined) return found;
     }
     return undefined;
+  }
+
+  // A decoded instance keeps its state in `#` fields, so the walk over
+  // enumerable properties below sees an empty object. That is exactly the way
+  // a key pair can arrive unseen: a tag this realm does not know decodes into
+  // an `UnknownValue` carrying whatever rode under it, and one the decoder
+  // refused into a `ProblematicValue` doing the same. Their state is public,
+  // so it is walked like anything else.
+  if (value instanceof BaseFabricInstance && "state" in value) {
+    const found = findIn(
+      (value as { state: unknown }).state,
+      path === "" ? "state" : `${path}.state`,
+      seen,
+    );
+    if (found !== undefined) return found;
+  }
+
+  // A `Map` and a `Set` have no enumerable own properties either. Their
+  // contents are named `{key}` and `{}` so a path says which kind it walked
+  // through.
+  if (value instanceof Map) {
+    for (const [key, entry] of value) {
+      const found = findIn(entry, `${path}{${String(key)}}`, seen);
+      if (found !== undefined) return found;
+    }
+  }
+  if (value instanceof Set) {
+    for (const entry of value) {
+      const found = findIn(entry, `${path}{}`, seen);
+      if (found !== undefined) return found;
+    }
   }
 
   for (const [key, entry] of Object.entries(value)) {

--- a/packages/runtime-client/src/shared/key-material.ts
+++ b/packages/runtime-client/src/shared/key-material.ts
@@ -1,0 +1,100 @@
+/**
+ * The invariant: **no key material ever crosses an attach port.**
+ *
+ * A runtime acts as one principal, and the client that initializes it is the
+ * one that supplies the signer. A client that attaches supplies none: it
+ * states which principal it believes the runtime acts as, as a DID, and the
+ * runtime refuses the attach when that is not the principal it acts as. So
+ * there is no step at which an attaching document needs to hand a key across,
+ * and an attach frame carrying one is a frame built wrong.
+ *
+ * It is refused here, by name, rather than left to the platform, because the
+ * platform's answer varies and one of its answers is worse than a refusal.
+ * Measured on the SP5 spike: a non-extractable `CryptoKey` posted over a
+ * `MessagePort` between two WKWebViews throws `DataCloneError` -- an embedding
+ * defect, since browsers carry it -- so a frame with a key in it fails there
+ * as a transport error, in a shell, at run time, saying nothing about why. The
+ * refusal below is what turns that into a named protocol failure everywhere,
+ * and it is the reason not to "fix" a `DataCloneError` by finding a way to
+ * pass the key: the key was never supposed to be in the frame.
+ *
+ * What counts as key material is what holds a key in this codebase: a
+ * `FabricKeyPair`, in either of its arms, and a bare `CryptoKey`. Both are
+ * recognized by their class rather than by their contents -- a `FabricKeyPair`
+ * keeps its state in `#` fields, so there is nothing to walk into -- which is
+ * also what makes the check exact rather than a guess at what a key looks
+ * like.
+ */
+
+import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
+
+/**
+ * Where `value` holds key material, or `undefined` where it holds none.
+ *
+ * The path is dotted, with array indices in brackets, so a refusal can name
+ * the field a caller has to fix: `trustSnapshot.signer`, `atoms[1].key`. The
+ * empty string means `value` is itself key material.
+ *
+ * A value reached twice is walked once, so a cyclic value -- which a context
+ * built on this side of the wire may be, having been through no decode -- is
+ * answered rather than descended forever.
+ */
+export function findKeyMaterial(value: unknown): string | undefined {
+  return findIn(value, "", new Set<object>());
+}
+
+/**
+ * Refuses a frame holding key material, naming where it sits.
+ *
+ * This is the protocol layer's refusal, and the whole of the invariant this
+ * module states. It is loud on purpose: a frame that reached here with a key
+ * in it was built wrong, and the alternative -- letting the platform decide --
+ * is a `DataCloneError` in one embedding and silent success in another.
+ *
+ * @throws If `frame` holds a `FabricKeyPair` or a `CryptoKey` anywhere.
+ */
+export function assertNoKeyMaterial(frame: unknown): void {
+  const at = findKeyMaterial(frame);
+  if (at === undefined) return;
+  throw new Error(
+    `Attach refused: an attach carries no key material, and this one holds ` +
+      `some at ${at === "" ? "its root" : `\`${at}\``}.`,
+  );
+}
+
+function findIn(
+  value: unknown,
+  path: string,
+  seen: Set<object>,
+): string | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  if (isKeyMaterial(value)) return path;
+  if (seen.has(value)) return undefined;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      const found = findIn(value[index], `${path}[${index}]`, seen);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    const found = findIn(entry, path === "" ? key : `${path}.${key}`, seen);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/**
+ * Is `value` a key, or a pair of them? `CryptoKey` is absent from some
+ * realms this runs in, so it is read off the global rather than named
+ * directly.
+ */
+function isKeyMaterial(value: object): boolean {
+  if (value instanceof FabricKeyPair) return true;
+  const cryptoKey = (globalThis as { CryptoKey?: unknown }).CryptoKey;
+  return typeof cryptoKey === "function" &&
+    value instanceof (cryptoKey as new () => object);
+}

--- a/packages/runtime-client/src/shared/message-port-like.ts
+++ b/packages/runtime-client/src/shared/message-port-like.ts
@@ -24,6 +24,15 @@ export interface MessagePortLike {
   start?(): void;
 
   /**
+   * Stops delivery to `listener`. Absent from a duplex that cannot be
+   * detached from, in which case letting go of it is `close`'s job alone.
+   */
+  removeEventListener?(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+  ): void;
+
+  /**
    * Releases the channel. Absent from a duplex whose lifetime is not its
    * holder's to end.
    */

--- a/packages/runtime-client/src/shared/message-port-like.ts
+++ b/packages/runtime-client/src/shared/message-port-like.ts
@@ -1,0 +1,31 @@
+/**
+ * A duplex both ends of this connection can be carried over.
+ *
+ * The runtime is reached over a channel, and which channel is not the
+ * runtime's business: a `MessagePort` a page's opener handed across, one a
+ * native shell relays, and one a test builds from a `MessageChannel` are the
+ * same thing to it. Naming the shape rather than the class is what says so.
+ */
+export interface MessagePortLike {
+  /** Sends one encoded message to the far end. */
+  postMessage(message: unknown): void;
+
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+  ): void;
+
+  /**
+   * Begins delivery. A `MessagePort` queues everything sent to it until this
+   * is called, which is what lets a listener be installed without racing the
+   * messages already in flight. Absent from a duplex that delivers from the
+   * moment it exists.
+   */
+  start?(): void;
+
+  /**
+   * Releases the channel. Absent from a duplex whose lifetime is not its
+   * holder's to end.
+   */
+  close?(): void;
+}

--- a/packages/runtime-client/src/shared/security-context.ts
+++ b/packages/runtime-client/src/shared/security-context.ts
@@ -1,0 +1,91 @@
+/**
+ * A runtime's security posture, and what it means for two of them to agree.
+ *
+ * One runtime acts as one principal under one enforcement configuration. A
+ * client that attaches asserts the posture it believes it is joining, and this
+ * is where that assertion is settled. Both ends build a context, so the pieces
+ * live here rather than on either side of the IPC.
+ */
+
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import type { RuntimeSecurityContext } from "@/protocol/mod.ts";
+
+/**
+ * One spelling for one origin. A `URL` round-trip settles the variance two
+ * documents can differ by while meaning the same host -- an absent trailing
+ * slash, a default port written out -- so that agreeing on a backend does not
+ * depend on agreeing on how to write it. A value no `URL` can parse is left as
+ * it stands and compares literally, which is what an unparseable host
+ * deserves.
+ */
+export function normalizeOrigin(value: string): string {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * A host map whose origins are spelled one way, or `undefined` where there is
+ * no map. An empty map and an absent one are the same posture -- every space
+ * resolving to the backend -- and both read as `undefined` here, so the two
+ * spellings of "no per-space hosts" do not refuse each other.
+ */
+export function normalizeSpaceHostMap(
+  map: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (map === undefined) return undefined;
+  const entries = Object.entries(map);
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(
+    entries.map(([space, origin]) => [space, normalizeOrigin(origin)]),
+  );
+}
+
+/**
+ * Every field a {@link RuntimeSecurityContext} carries, as a record so that a
+ * field added to that type and not to this one is a type error. What an attach
+ * is checked against has to be the whole context: a field nobody compares is a
+ * posture a second document can hold while the first believes otherwise.
+ */
+const SECURITY_CONTEXT_FIELDS: Record<
+  keyof Required<RuntimeSecurityContext>,
+  true
+> = {
+  apiUrl: true,
+  cfcEnforcementMode: true,
+  cfcFlowLabels: true,
+  experimental: true,
+  identity: true,
+  renderConfidentialityCeiling: true,
+  renderDeclassificationPolicy: true,
+  spaceDid: true,
+  spaceHostMap: true,
+  trustSnapshot: true,
+};
+
+/**
+ * The security context a runtime stood up from this data runs under. The
+ * acting principal arrives as a key pair and is recorded here as the DID it
+ * derives to, which is what an attach states and all an attach may state.
+ */
+/**
+ * The fields on which `asserted` and `running` disagree, in a fixed order, or
+ * an empty list where they agree throughout.
+ *
+ * Compared field by field rather than as two whole objects: the two are built
+ * in different documents and one of them crossed an encoding, so a posture
+ * carried as an absent property in one and as an explicit `undefined` in the
+ * other is the same posture and compares equal here.
+ */
+export function securityContextDifferences(
+  asserted: RuntimeSecurityContext,
+  running: RuntimeSecurityContext,
+): string[] {
+  const fields = Object.keys(SECURITY_CONTEXT_FIELDS).sort() as (
+    keyof RuntimeSecurityContext
+  )[];
+  return fields.filter((field) => !deepEqual(asserted[field], running[field]));
+}

--- a/packages/runtime-client/test/attach-round-trip.test.ts
+++ b/packages/runtime-client/test/attach-round-trip.test.ts
@@ -15,7 +15,7 @@ import { RuntimeClients } from "@/backends/client-registry.ts";
 import type { WorkerClient } from "@/backends/worker-client.ts";
 import { MessagePortRuntimeTransport } from "@/client/transports/message-port/transport-message-port.ts";
 import type { MessagePortLike } from "@/shared/message-port-like.ts";
-import { RuntimeClient, type RuntimeClientOptions } from "@/runtime-client.ts";
+import { type RuntimeAttachOptions, RuntimeClient } from "@/runtime-client.ts";
 
 // The two halves of an attachment, joined over a real channel: a worker's
 // client registry at one end and the `RuntimeClient` a joining document holds
@@ -39,10 +39,10 @@ const keyPair = new FabricKeyPair(
   new Uint8Array(32),
 );
 
-function clientOptions(as: Identity): RuntimeClientOptions {
+function clientOptions(as: Identity): RuntimeAttachOptions {
   return {
     apiUrl: new URL("http://attach-round-trip.test/"),
-    identity: as,
+    identity: as.did(),
     spaceDid,
     cfcEnforcementMode: "enforce-strict",
   };
@@ -57,6 +57,7 @@ function workerSide() {
   const requests: Array<{ type: RequestType; client: WorkerClient }> = [];
   const running: RuntimeSecurityContext = {
     identity: identity.did(),
+    apiUrl: "http://attach-round-trip.test/",
     spaceDid,
     cfcEnforcementMode: "enforce-strict",
   };
@@ -175,7 +176,7 @@ describe("attach-round-trip", () => {
             trustSnapshot: {
               id: "principal",
               signer: keyPair,
-            } as unknown as RuntimeClientOptions["trustSnapshot"],
+            } as unknown as RuntimeAttachOptions["trustSnapshot"],
           },
         ),
       ).rejects.toThrow("no key material");

--- a/packages/runtime-client/test/attach-round-trip.test.ts
+++ b/packages/runtime-client/test/attach-round-trip.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
+import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
 
 import {
@@ -13,6 +14,7 @@ import type { RuntimeProcessor } from "@/backends/mod.ts";
 import { RuntimeClients } from "@/backends/client-registry.ts";
 import type { WorkerClient } from "@/backends/worker-client.ts";
 import { MessagePortRuntimeTransport } from "@/client/transports/message-port/transport-message-port.ts";
+import type { MessagePortLike } from "@/shared/message-port-like.ts";
 import { RuntimeClient, type RuntimeClientOptions } from "@/runtime-client.ts";
 
 // The two halves of an attachment, joined over a real channel: a worker's
@@ -30,6 +32,12 @@ const otherIdentity = await Identity.fromPassphrase("someone-else", {
 });
 
 const spaceDid = identity.did();
+
+const keyPair = new FabricKeyPair(
+  "Ed25519",
+  new Uint8Array(32),
+  new Uint8Array(32),
+);
 
 function clientOptions(as: Identity): RuntimeClientOptions {
   return {
@@ -136,6 +144,46 @@ describe("attach-round-trip", () => {
       ),
     ).rejects.toThrow("Attach refused");
     expect(worker.requests).toEqual([]);
+  });
+
+  it("refuses to send an attach holding key material, before it reaches a port", async () => {
+    // The far side refuses one too, and this is the one that matters for a
+    // shell: a `MessagePort` between two WKWebViews throws `DataCloneError`
+    // on a non-extractable `CryptoKey`, so a frame carrying one would fail as
+    // a transport error saying nothing about why. Refused here by name, and
+    // never posted.
+    const worker = await runningWorker();
+    const channel = new MessageChannel();
+    worker.clients.attach(channel.port2);
+    const posted: unknown[] = [];
+    const watchedPort: MessagePortLike = {
+      postMessage: (message) => {
+        posted.push(message);
+        channel.port1.postMessage(message);
+      },
+      addEventListener: (type, listener) =>
+        channel.port1.addEventListener(type, listener),
+      start: () => channel.port1.start(),
+      close: () => channel.port1.close(),
+    };
+    try {
+      await expect(
+        RuntimeClient.attach(
+          new MessagePortRuntimeTransport({ port: watchedPort }),
+          {
+            ...clientOptions(identity),
+            trustSnapshot: {
+              id: "principal",
+              signer: keyPair,
+            } as unknown as RuntimeClientOptions["trustSnapshot"],
+          },
+        ),
+      ).rejects.toThrow("no key material");
+      expect(posted).toEqual([]);
+      expect(worker.requests).toEqual([]);
+    } finally {
+      channel.port1.close();
+    }
   });
 
   it("delivers a notification addressed to one client to that client alone", async () => {

--- a/packages/runtime-client/test/attach-round-trip.test.ts
+++ b/packages/runtime-client/test/attach-round-trip.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { realmFromFabricValue } from "@commonfabric/data-model/codecs";
+import { Identity } from "@commonfabric/identity";
+
+import {
+  type ErrorNotification,
+  NotificationType,
+  RequestType,
+  type RuntimeSecurityContext,
+} from "@/protocol/mod.ts";
+import type { RuntimeProcessor } from "@/backends/mod.ts";
+import { RuntimeClients } from "@/backends/client-registry.ts";
+import type { WorkerClient } from "@/backends/worker-client.ts";
+import { MessagePortRuntimeTransport } from "@/client/transports/message-port/transport-message-port.ts";
+import { RuntimeClient, type RuntimeClientOptions } from "@/runtime-client.ts";
+
+// The two halves of an attachment, joined over a real channel: a worker's
+// client registry at one end and the `RuntimeClient` a joining document holds
+// at the other. Each half is pinned on its own elsewhere; what is only true of
+// the pair is that they speak the same protocol -- that what one encodes the
+// other reads, and that a refusal reaches the caller as a rejection rather
+// than as a promise nobody settles.
+
+const identity = await Identity.fromPassphrase("attach-round-trip", {
+  implementation: "noble",
+});
+const otherIdentity = await Identity.fromPassphrase("someone-else", {
+  implementation: "noble",
+});
+
+const spaceDid = identity.did();
+
+function clientOptions(as: Identity): RuntimeClientOptions {
+  return {
+    apiUrl: new URL("http://attach-round-trip.test/"),
+    identity: as,
+    spaceDid,
+    cfcEnforcementMode: "enforce-strict",
+  };
+}
+
+/**
+ * A worker-side registry serving a runtime whose security context is the one
+ * `clientOptions` asserts. The processor records which client each request
+ * carried, and hands back the client so a test can post to it.
+ */
+function workerSide() {
+  const requests: Array<{ type: RequestType; client: WorkerClient }> = [];
+  const running: RuntimeSecurityContext = {
+    identity: identity.did(),
+    spaceDid,
+    cfcEnforcementMode: "enforce-strict",
+  };
+  const processor = {
+    isDisposed: () => false,
+    assertAttachable: (asserted: RuntimeSecurityContext) => {
+      if (asserted.identity === running.identity) return;
+      throw new Error(
+        "Attach refused: the asserted security context differs from the " +
+          "runtime's at `identity`.",
+      );
+    },
+    handleRequest: (request: { type: RequestType }, client: WorkerClient) => {
+      requests.push({ type: request.type, client });
+      return Promise.resolve(undefined);
+    },
+    handleNotification: () => {},
+    disposeClient: () => {},
+    dispose: () => Promise.resolve(),
+  };
+  const clients = new RuntimeClients({
+    setConsoleBridge: () => {},
+    owner: { id: 0, post: () => true },
+    initializeRuntime: () =>
+      Promise.resolve(processor as unknown as RuntimeProcessor),
+  });
+  return { clients, requests };
+}
+
+/** A registry with its runtime already standing. */
+async function runningWorker() {
+  const worker = workerSide();
+  await worker.clients.handleMessage(
+    worker.clients.owner,
+    new MessageEvent("message", {
+      data: realmFromFabricValue({
+        msgId: 1,
+        data: {
+          type: RequestType.Initialize,
+          data: {
+            apiUrl: "http://attach-round-trip.test/",
+            identity: { placeholder: true },
+            spaceDid,
+          },
+        },
+      } as never),
+    }),
+  );
+  return worker;
+}
+
+/** Joins `clients` from the far end of a fresh channel. */
+function joiningSide(clients: RuntimeClients) {
+  const channel = new MessageChannel();
+  clients.attach(channel.port2);
+  return new MessagePortRuntimeTransport({ port: channel.port1 });
+}
+
+describe("attach-round-trip", () => {
+  it("joins a running runtime over a port and carries the joining client", async () => {
+    const worker = await runningWorker();
+    const client = await RuntimeClient.attach(
+      joiningSide(worker.clients),
+      clientOptions(identity),
+    );
+    try {
+      await client.idle();
+      expect(worker.requests.map(({ type }) => type)).toEqual([
+        RequestType.Idle,
+      ]);
+      // Every request from this document is filed under the client its port
+      // became, not under the one that stood the runtime up.
+      expect(worker.requests[0].client.id).toBe(1);
+    } finally {
+      await client.dispose();
+    }
+  });
+
+  it("rejects an attach asserting an identity the runtime does not act as", async () => {
+    const worker = await runningWorker();
+    await expect(
+      RuntimeClient.attach(
+        joiningSide(worker.clients),
+        clientOptions(otherIdentity),
+      ),
+    ).rejects.toThrow("Attach refused");
+    expect(worker.requests).toEqual([]);
+  });
+
+  it("delivers a notification addressed to one client to that client alone", async () => {
+    const worker = await runningWorker();
+    const first = await RuntimeClient.attach(
+      joiningSide(worker.clients),
+      clientOptions(identity),
+    );
+    const second = await RuntimeClient.attach(
+      joiningSide(worker.clients),
+      clientOptions(identity),
+    );
+    try {
+      const firstErrors: ErrorNotification[] = [];
+      const secondErrors: ErrorNotification[] = [];
+      first.on("error", (error) => firstErrors.push(error));
+      let arrived: (() => void) | undefined;
+      second.on("error", (error) => {
+        secondErrors.push(error);
+        arrived?.();
+      });
+
+      await first.idle();
+      await second.idle();
+      const secondClient = worker.requests[1].client;
+      expect(secondClient.id).toBe(2);
+
+      const reported = new Promise<void>((resolve) => (arrived = resolve));
+      secondClient.post({
+        type: NotificationType.ErrorReport,
+        message: "for the second document only",
+      });
+      await reported;
+
+      expect(secondErrors.map(({ message }) => message)).toEqual([
+        "for the second document only",
+      ]);
+      expect(firstErrors).toEqual([]);
+    } finally {
+      await first.dispose();
+      await second.dispose();
+    }
+  });
+});

--- a/packages/runtime-client/test/backends/RuntimeClients.test.ts
+++ b/packages/runtime-client/test/backends/RuntimeClients.test.ts
@@ -393,6 +393,37 @@ describe("RuntimeClients", () => {
         }
       });
 
+      it("drops a notification from a client that has not attached", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const port = await attachPort(h);
+        try {
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              {
+                type: ClientNotificationType.VDomBatchApplied,
+                mountId: 1,
+                batchId: 2,
+              } as never,
+            ),
+          );
+          // A notification is answered by nothing, so there is no reply to
+          // wait on. Round-tripping a request that IS answered puts this one
+          // behind a settled point: the loop is ordered, so a notification
+          // that reached the runtime would have done so by now.
+          const replied = port.next();
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              { msgId: 6, data: { type: RequestType.Idle } } as never,
+            ),
+          );
+          await replied;
+          expect(h.notifications).toEqual([]);
+        } finally {
+          port.channel.port1.close();
+        }
+      });
+
       it("reports an attach-port message that carries no port", async () => {
         const h = harness();
         await h.initialize(1);

--- a/packages/runtime-client/test/backends/RuntimeClients.test.ts
+++ b/packages/runtime-client/test/backends/RuntimeClients.test.ts
@@ -4,6 +4,7 @@ import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
+import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
 import type { DID } from "@commonfabric/identity";
 
 import {
@@ -19,6 +20,12 @@ import { RuntimeClients } from "@/backends/client-registry.ts";
 import type { WorkerClient } from "@/backends/worker-client.ts";
 
 type Posted = Record<string, unknown>;
+
+const keyPair = new FabricKeyPair(
+  "Ed25519",
+  new Uint8Array(32),
+  new Uint8Array(32),
+);
 
 const spaceDid = "did:key:z6Mk-runtime-clients-space" as DID;
 const identityDid = "did:key:z6Mk-runtime-clients-identity" as DID;
@@ -305,6 +312,38 @@ describe("RuntimeClients", () => {
         expect(h.owner.posted[0].error).toContain(
           "initializes its runtime rather than attaching",
         );
+      });
+
+      it("refuses an attach carrying key material, naming where it sits", async () => {
+        // The invariant `findKeyMaterial` states: an attaching client supplies
+        // no signer, so a key in the frame is a frame built wrong. Refused
+        // here rather than left to the platform, whose answer in a WKWebView
+        // is a bare `DataCloneError`.
+        const h = harness();
+        await h.initialize(1);
+        const { received, channel } = await attachedClient(h, {
+          ...runningContext,
+          trustSnapshot: {
+            id: "principal",
+            signer: keyPair,
+          } as unknown as RuntimeSecurityContext["trustSnapshot"],
+        });
+        channel.port1.close();
+        expect(received).toHaveLength(1);
+        expect(received[0].error).toContain("no key material");
+        expect(received[0].error).toContain("`trustSnapshot.signer`");
+      });
+
+      it("refuses an attach whose acting principal is not a DID", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const { received, channel } = await attachedClient(h, {
+          ...runningContext,
+          identity: { publicKey: "raw" } as unknown as DID,
+        });
+        channel.port1.close();
+        expect(received).toHaveLength(1);
+        expect(received[0].error).toContain("acting principal");
       });
 
       it("refuses a request from a client that has not attached", async () => {

--- a/packages/runtime-client/test/backends/RuntimeClients.test.ts
+++ b/packages/runtime-client/test/backends/RuntimeClients.test.ts
@@ -115,6 +115,7 @@ function harness(
   const owner = testClient(0);
   const consoleBridge: boolean[] = [];
   let release: (() => void) | undefined;
+  let initializeCount = 0;
   const held = options.initializeSlowly
     ? new Promise<void>((resolve) => (release = resolve))
     : Promise.resolve();
@@ -122,6 +123,7 @@ function harness(
     owner: owner.client,
     setConsoleBridge: (enabled) => consoleBridge.push(enabled),
     initializeRuntime: async () => {
+      initializeCount += 1;
       await held;
       if (options.failInitialization) throw new Error("init exploded");
       return fake.processor;
@@ -152,6 +154,7 @@ function harness(
     deliver,
     initialize,
     releaseInitialization: () => release?.(),
+    initializeCount: () => initializeCount,
   };
 }
 
@@ -380,6 +383,93 @@ describe("RuntimeClients", () => {
         channel.port1.close();
         expect(received).toHaveLength(1);
         expect(received[0].error).toContain("acting principal");
+      });
+
+      it("refuses an `Initialize` from a client that does not own the worker", async () => {
+        // An attached document asking to stand the runtime up would be
+        // re-deciding the identity and posture every other client is already
+        // running under.
+        const h = harness();
+        await h.initialize(1);
+        const joiner = attachDirect(h);
+        await h.deliver(joiner.client, {
+          msgId: 1,
+          data: { type: RequestType.Attach, data: runningContext },
+        });
+        joiner.posted.length = 0;
+
+        await h.deliver(joiner.client, {
+          msgId: 2,
+          data: {
+            type: RequestType.Initialize,
+            data: initializationData,
+          },
+        });
+
+        expect(joiner.posted).toHaveLength(1);
+        expect(joiner.posted[0].error).toContain(
+          "Only the client that owns the worker may initialize",
+        );
+        // And the runtime it was already serving is the one still serving.
+        expect(h.initializeCount()).toBe(1);
+      });
+
+      it("refuses console forwarding from a client that does not own the worker", async () => {
+        // What the bridge forwards goes to the worker's own global, which is
+        // the owner's end of the IPC, so an attached client turning it on
+        // would be redirecting the owner's console.
+        const h = harness();
+        await h.initialize(1);
+        const joiner = attachDirect(h);
+        await h.deliver(joiner.client, {
+          msgId: 1,
+          data: { type: RequestType.Attach, data: runningContext },
+        });
+        h.consoleBridge.length = 0;
+        joiner.posted.length = 0;
+
+        await h.deliver(joiner.client, {
+          msgId: 2,
+          data: { type: RequestType.SetForwardWorkerConsole, enabled: true },
+        });
+
+        expect(joiner.posted).toHaveLength(1);
+        expect(joiner.posted[0].error).toContain(
+          "Only the client that owns the worker may forward its console",
+        );
+        // The refusal is the whole of it: the bridge was never toggled.
+        expect(h.consoleBridge).toEqual([]);
+      });
+
+      it("refuses a second attach on a channel whose first was already refused", async () => {
+        // A client may have two attaches in flight. The first refusal lets go
+        // of the client, and the second has to find it already gone without
+        // failing over it.
+        const h = harness();
+        await h.initialize(1);
+        const joiner = attachDirect(h);
+        const wrong = {
+          ...runningContext,
+          identity: "did:key:z6Mk-someone-else" as DID,
+        };
+
+        await h.deliver(joiner.client, {
+          msgId: 1,
+          data: { type: RequestType.Attach, data: wrong },
+        });
+        await h.deliver(joiner.client, {
+          msgId: 2,
+          data: { type: RequestType.Attach, data: wrong },
+        });
+
+        // Both are refused by name. Letting go of a client does not turn a
+        // later attach on that channel into silence: an attach is answered on
+        // its merits whether or not the worker still holds a registration,
+        // and the second `#drop` finds nothing to drop without failing.
+        expect(joiner.posted).toHaveLength(2);
+        expect(joiner.posted[0].error).toContain("Attach refused");
+        expect(joiner.posted[1].error).toContain("Attach refused");
+        expect(h.clients.attachedClientCount).toBe(0);
       });
 
       it("refuses an attach to a runtime that has been disposed", async () => {

--- a/packages/runtime-client/test/backends/RuntimeClients.test.ts
+++ b/packages/runtime-client/test/backends/RuntimeClients.test.ts
@@ -32,6 +32,7 @@ const identityDid = "did:key:z6Mk-runtime-clients-identity" as DID;
 
 const runningContext: RuntimeSecurityContext = {
   identity: identityDid,
+  apiUrl: "http://runtime-clients.test/",
   spaceDid,
   cfcEnforcementMode: "enforce-strict",
 };
@@ -66,8 +67,9 @@ function fakeProcessor() {
   const notifications: Array<{ type: string; clientId: number }> = [];
   const disposedClients: number[] = [];
   let runtimeDisposals = 0;
+  let disposed = false;
   const processor = {
-    isDisposed: () => false,
+    isDisposed: () => disposed,
     assertAttachable: (asserted: RuntimeSecurityContext) => {
       if (asserted.identity === runningContext.identity) return;
       throw new Error(
@@ -102,17 +104,28 @@ function fakeProcessor() {
     notifications,
     disposedClients,
     runtimeDisposals: () => runtimeDisposals,
+    setDisposed: (value: boolean) => (disposed = value),
   };
 }
 
-function harness() {
+function harness(
+  options: { initializeSlowly?: boolean; failInitialization?: boolean } = {},
+) {
   const fake = fakeProcessor();
   const owner = testClient(0);
   const consoleBridge: boolean[] = [];
+  let release: (() => void) | undefined;
+  const held = options.initializeSlowly
+    ? new Promise<void>((resolve) => (release = resolve))
+    : Promise.resolve();
   const clients = new RuntimeClients({
     owner: owner.client,
     setConsoleBridge: (enabled) => consoleBridge.push(enabled),
-    initializeRuntime: () => Promise.resolve(fake.processor),
+    initializeRuntime: async () => {
+      await held;
+      if (options.failInitialization) throw new Error("init exploded");
+      return fake.processor;
+    },
   });
   const deliver = (client: WorkerClient, message: unknown, ports?: unknown[]) =>
     clients.handleMessage(
@@ -131,7 +144,15 @@ function harness() {
       msgId,
       data: { type: RequestType.Initialize, data: initializationData },
     });
-  return { ...fake, clients, owner, consoleBridge, deliver, initialize };
+  return {
+    ...fake,
+    clients,
+    owner,
+    consoleBridge,
+    deliver,
+    initialize,
+    releaseInitialization: () => release?.(),
+  };
 }
 
 /**
@@ -153,6 +174,21 @@ function portReader(port: MessagePort) {
     /** Settles on the next message to arrive. Called before what prompts it. */
     next: () => new Promise<void>((resolve) => (arrived = resolve)),
   };
+}
+
+/**
+ * Registers a client over a duplex the test drives by hand, so that a message
+ * reaches the loop when the test says rather than on the port's next task.
+ */
+function attachDirect(h: ReturnType<typeof harness>) {
+  const posted: Posted[] = [];
+  const client = h.clients.attach({
+    postMessage: (message) => {
+      posted.push(fabricFromRealmValue(message as never) as Posted);
+    },
+    addEventListener: () => {},
+  });
+  return { client, posted };
 }
 
 /** Hands the worker a port and returns this end of it. */
@@ -344,6 +380,97 @@ describe("RuntimeClients", () => {
         channel.port1.close();
         expect(received).toHaveLength(1);
         expect(received[0].error).toContain("acting principal");
+      });
+
+      it("refuses an attach to a runtime that has been disposed", async () => {
+        // The worst failure this could have: a client joining a
+        // runtime-shaped void and finding out only when nothing answers.
+        const h = harness();
+        await h.initialize(1);
+        h.setDisposed(true);
+        const { received, channel } = await attachedClient(h);
+        channel.port1.close();
+        expect(received).toHaveLength(1);
+        expect(received[0].error).toContain("disposed");
+      });
+
+      it("waits for an initialization already under way", async () => {
+        // Pipelining: the owner's page transfers a port and the joining
+        // document attaches before the runtime has finished standing up.
+        // Attaching waits for that rather than reading the absent runtime
+        // and refusing. Delivered by hand so the attach is provably in
+        // flight while the initialization is -- through a port it would
+        // arrive on a later task, by which time there is nothing to race.
+        const h = harness({ initializeSlowly: true });
+        const initialized = h.initialize(1);
+        const joiner = attachDirect(h);
+        const attaching = h.deliver(joiner.client, {
+          msgId: 1,
+          data: { type: RequestType.Attach, data: runningContext },
+        });
+        h.releaseInitialization();
+        await initialized;
+        await attaching;
+        expect(joiner.posted).toEqual([{ msgId: 1 }]);
+      });
+
+      it("refuses an attach when the initialization it waited for failed", async () => {
+        const h = harness({ initializeSlowly: true, failInitialization: true });
+        const initialized = h.initialize(1);
+        const joiner = attachDirect(h);
+        const attaching = h.deliver(joiner.client, {
+          msgId: 1,
+          data: { type: RequestType.Attach, data: runningContext },
+        });
+        h.releaseInitialization();
+        await initialized;
+        await attaching;
+        expect(joiner.posted).toHaveLength(1);
+        expect(joiner.posted[0].error).toBe("WorkerRuntime not initialized.");
+      });
+
+      it("drops a refused client's registration, so a retry loop cannot grow the worker", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const before = h.clients.attachedClientCount;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const { channel } = await attachedClient(h, {
+            ...runningContext,
+            identity: "did:key:z6Mk-someone-else" as DID,
+          });
+          channel.port1.close();
+        }
+        expect(h.clients.attachedClientCount).toBe(before);
+      });
+
+      it("acks rather than refuses traffic from a client that has departed", async () => {
+        // The owner's stragglers are silently acked after disposal; an
+        // attached client's teardown traffic reads the same way.
+        const h = harness();
+        await h.initialize(1);
+        const port = await attachedClient(h);
+        try {
+          const departed = port.next();
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              { msgId: 2, data: { type: RequestType.Dispose } } as never,
+            ),
+          );
+          await departed;
+          expect(h.clients.attachedClientCount).toBe(0);
+
+          // Delivered by hand: the registry drops its side of a departed
+          // client's channel, so nothing could arrive over the port itself.
+          const straggler = testClient(1);
+          await h.deliver(straggler.client, {
+            msgId: 3,
+            data: { type: RequestType.Idle },
+          });
+          expect(straggler.posted).toEqual([{ msgId: 3 }]);
+          expect(h.requests).toEqual([]);
+        } finally {
+          port.channel.port1.close();
+        }
       });
 
       it("refuses a request from a client that has not attached", async () => {

--- a/packages/runtime-client/test/backends/RuntimeClients.test.ts
+++ b/packages/runtime-client/test/backends/RuntimeClients.test.ts
@@ -1,0 +1,409 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+import type { DID } from "@commonfabric/identity";
+
+import {
+  ClientNotificationType,
+  ClientTransportNotificationType,
+  type InitializationData,
+  NotificationType,
+  RequestType,
+  type RuntimeSecurityContext,
+} from "@/protocol/mod.ts";
+import type { RuntimeProcessor } from "@/backends/mod.ts";
+import { RuntimeClients } from "@/backends/client-registry.ts";
+import type { WorkerClient } from "@/backends/worker-client.ts";
+
+type Posted = Record<string, unknown>;
+
+const spaceDid = "did:key:z6Mk-runtime-clients-space" as DID;
+const identityDid = "did:key:z6Mk-runtime-clients-identity" as DID;
+
+const runningContext: RuntimeSecurityContext = {
+  identity: identityDid,
+  spaceDid,
+  cfcEnforcementMode: "enforce-strict",
+};
+
+const initializationData = {
+  apiUrl: "http://runtime-clients.test/",
+  identity: { placeholder: true },
+  spaceDid,
+  cfcEnforcementMode: "enforce-strict",
+} as unknown as InitializationData;
+
+/** A capturing client, standing in for one end of a duplex. */
+function testClient(id: number) {
+  const posted: Posted[] = [];
+  const client: WorkerClient = {
+    id,
+    post: (message) => {
+      posted.push(message as unknown as Posted);
+      return true;
+    },
+  };
+  return { client, posted };
+}
+
+/**
+ * A processor that records what the message loop asked of it. Standing a real
+ * one up wants identities and storage, and what these tests turn on is which
+ * client each call carries and what a refusal says.
+ */
+function fakeProcessor() {
+  const requests: Array<{ type: RequestType; clientId: number }> = [];
+  const notifications: Array<{ type: string; clientId: number }> = [];
+  const disposedClients: number[] = [];
+  let runtimeDisposals = 0;
+  const processor = {
+    isDisposed: () => false,
+    assertAttachable: (asserted: RuntimeSecurityContext) => {
+      if (asserted.identity === runningContext.identity) return;
+      throw new Error(
+        "Attach refused: the asserted security context differs from the " +
+          "runtime's at `identity`.",
+      );
+    },
+    handleRequest: (
+      request: { type: RequestType },
+      client: WorkerClient,
+    ) => {
+      requests.push({ type: request.type, clientId: client.id });
+      return Promise.resolve(undefined);
+    },
+    handleNotification: (
+      notification: { type: string },
+      client: WorkerClient,
+    ) => {
+      notifications.push({ type: notification.type, clientId: client.id });
+    },
+    disposeClient: (client: WorkerClient) => {
+      disposedClients.push(client.id);
+    },
+    dispose: () => {
+      runtimeDisposals += 1;
+      return Promise.resolve();
+    },
+  };
+  return {
+    processor: processor as unknown as RuntimeProcessor,
+    requests,
+    notifications,
+    disposedClients,
+    runtimeDisposals: () => runtimeDisposals,
+  };
+}
+
+function harness() {
+  const fake = fakeProcessor();
+  const owner = testClient(0);
+  const consoleBridge: boolean[] = [];
+  const clients = new RuntimeClients({
+    owner: owner.client,
+    setConsoleBridge: (enabled) => consoleBridge.push(enabled),
+    initializeRuntime: () => Promise.resolve(fake.processor),
+  });
+  const deliver = (client: WorkerClient, message: unknown, ports?: unknown[]) =>
+    clients.handleMessage(
+      client,
+      new MessageEvent("message", {
+        // Encoded as a client's transport sends it: the loop decodes every
+        // arriving envelope, so a raw object reads as damaged.
+        data: realmFromFabricValue(message as never),
+        ...(ports === undefined
+          ? {}
+          : { ports: ports as unknown as MessagePort[] }),
+      }),
+    );
+  const initialize = (msgId: number) =>
+    deliver(owner.client, {
+      msgId,
+      data: { type: RequestType.Initialize, data: initializationData },
+    });
+  return { ...fake, clients, owner, consoleBridge, deliver, initialize };
+}
+
+/**
+ * Reads one client's end of a channel, recording every message and handing out
+ * a promise for the next one. A reply is a real event, so a test waits on the
+ * reply itself rather than on a delay chosen to outlast it.
+ */
+function portReader(port: MessagePort) {
+  const received: Posted[] = [];
+  let arrived: (() => void) | undefined;
+  port.addEventListener("message", (event) => {
+    received.push(fabricFromRealmValue(event.data as never) as Posted);
+    arrived?.();
+    arrived = undefined;
+  });
+  port.start();
+  return {
+    received,
+    /** Settles on the next message to arrive. Called before what prompts it. */
+    next: () => new Promise<void>((resolve) => (arrived = resolve)),
+  };
+}
+
+/** Hands the worker a port and returns this end of it. */
+async function attachPort(h: ReturnType<typeof harness>) {
+  const channel = new MessageChannel();
+  const reader = portReader(channel.port1);
+  await h.deliver(
+    h.owner.client,
+    { type: ClientTransportNotificationType.AttachPort },
+    [channel.port2],
+  );
+  return { channel, ...reader };
+}
+
+/** Attaches a client over a real channel and returns its far end. */
+async function attachedClient(
+  h: ReturnType<typeof harness>,
+  context: RuntimeSecurityContext = runningContext,
+) {
+  const port = await attachPort(h);
+  const replied = port.next();
+  port.channel.port1.postMessage(
+    realmFromFabricValue(
+      { msgId: 1, data: { type: RequestType.Attach, data: context } } as never,
+    ),
+  );
+  await replied;
+  return port;
+}
+
+describe("RuntimeClients", () => {
+  describe("instance members", () => {
+    describe("handleMessage()", () => {
+      it("acks the owner's `Initialize` and stands the runtime up", async () => {
+        const h = harness();
+        await h.initialize(1);
+        expect(h.owner.posted).toEqual([{ msgId: 1 }]);
+      });
+
+      it("refuses a second `Initialize`", async () => {
+        const h = harness();
+        await h.initialize(1);
+        h.owner.posted.length = 0;
+        await h.initialize(2);
+        expect(h.owner.posted).toEqual([{
+          msgId: 2,
+          error: "Initialization of WorkerRuntime already attempted.",
+        }]);
+      });
+
+      it("refuses a request before the runtime is initialized", async () => {
+        const h = harness();
+        await h.deliver(h.owner.client, {
+          msgId: 1,
+          data: { type: RequestType.Idle },
+        });
+        expect(h.owner.posted).toEqual([{
+          msgId: 1,
+          error: "WorkerRuntime not initialized.",
+        }]);
+      });
+
+      it("answers `SetForwardWorkerConsole` before any initialization", async () => {
+        const h = harness();
+        await h.deliver(h.owner.client, {
+          msgId: 1,
+          data: { type: RequestType.SetForwardWorkerConsole, enabled: true },
+        });
+        expect(h.owner.posted).toEqual([{ msgId: 1 }]);
+        expect(h.consoleBridge).toEqual([true]);
+      });
+
+      it("carries the owner's client into every handled request", async () => {
+        const h = harness();
+        await h.initialize(1);
+        await h.deliver(h.owner.client, {
+          msgId: 2,
+          data: { type: RequestType.Idle },
+        });
+        expect(h.requests).toEqual([{
+          type: RequestType.Idle,
+          clientId: 0,
+        }]);
+      });
+
+      it("carries the owner's client into every notification", async () => {
+        const h = harness();
+        await h.initialize(1);
+        await h.deliver(h.owner.client, {
+          type: ClientNotificationType.VDomBatchApplied,
+          mountId: 1,
+          batchId: 2,
+        });
+        expect(h.notifications).toEqual([{
+          type: ClientNotificationType.VDomBatchApplied,
+          clientId: 0,
+        }]);
+      });
+
+      it("tears the runtime down on the owner's `Dispose`", async () => {
+        const h = harness();
+        await h.initialize(1);
+        await h.deliver(h.owner.client, {
+          msgId: 2,
+          data: { type: RequestType.Dispose },
+        });
+        expect(h.requests).toEqual([{
+          type: RequestType.Dispose,
+          clientId: 0,
+        }]);
+        expect(h.disposedClients).toEqual([]);
+      });
+    });
+
+    describe("attach()", () => {
+      it("acks an attach whose security context is the runtime's", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const { received, channel } = await attachedClient(h);
+        channel.port1.close();
+        expect(received).toEqual([{ msgId: 1 }]);
+      });
+
+      it("refuses an attach whose security context differs", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const { received, channel } = await attachedClient(h, {
+          ...runningContext,
+          identity: "did:key:z6Mk-someone-else" as DID,
+        });
+        channel.port1.close();
+        expect(received).toHaveLength(1);
+        expect(received[0].msgId).toBe(1);
+        expect(received[0].error).toContain("Attach refused");
+        expect(received[0].error).toContain("`identity`");
+      });
+
+      it("refuses an attach before the runtime is initialized", async () => {
+        const h = harness();
+        const { received, channel } = await attachedClient(h);
+        channel.port1.close();
+        expect(received).toEqual([{
+          msgId: 1,
+          error: "WorkerRuntime not initialized.",
+        }]);
+      });
+
+      it("refuses an `Attach` from the client that owns the worker", async () => {
+        const h = harness();
+        await h.initialize(1);
+        h.owner.posted.length = 0;
+        await h.deliver(h.owner.client, {
+          msgId: 2,
+          data: { type: RequestType.Attach, data: runningContext },
+        });
+        expect(h.owner.posted).toHaveLength(1);
+        expect(h.owner.posted[0].error).toContain(
+          "initializes its runtime rather than attaching",
+        );
+      });
+
+      it("refuses a request from a client that has not attached", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const port = await attachPort(h);
+        try {
+          const replied = port.next();
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              { msgId: 5, data: { type: RequestType.Idle } } as never,
+            ),
+          );
+          await replied;
+          expect(port.received).toEqual([{
+            msgId: 5,
+            error: "Client is not attached to the WorkerRuntime.",
+          }]);
+          expect(h.requests).toEqual([]);
+        } finally {
+          port.channel.port1.close();
+        }
+      });
+
+      it("carries the attached client into its own requests", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const port = await attachedClient(h);
+        try {
+          const replied = port.next();
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              { msgId: 2, data: { type: RequestType.Idle } } as never,
+            ),
+          );
+          await replied;
+          expect(h.requests).toEqual([{ type: RequestType.Idle, clientId: 1 }]);
+        } finally {
+          port.channel.port1.close();
+        }
+      });
+
+      it("tears down only the departing client on an attached `Dispose`", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const port = await attachedClient(h);
+        try {
+          const replied = port.next();
+          port.channel.port1.postMessage(
+            realmFromFabricValue(
+              { msgId: 2, data: { type: RequestType.Dispose } } as never,
+            ),
+          );
+          await replied;
+          expect(h.disposedClients).toEqual([1]);
+          expect(h.runtimeDisposals()).toBe(0);
+          expect(h.requests).toEqual([]);
+        } finally {
+          port.channel.port1.close();
+        }
+      });
+
+      it("refuses a port transferred by a client that is not the owner", async () => {
+        const h = harness();
+        await h.initialize(1);
+        const attached = await attachedClient(h);
+        attached.received.length = 0;
+        const second = new MessageChannel();
+        try {
+          const reported = attached.next();
+          attached.channel.port1.postMessage(
+            realmFromFabricValue(
+              { type: ClientTransportNotificationType.AttachPort } as never,
+            ),
+            [second.port2],
+          );
+          await reported;
+          expect(attached.received).toHaveLength(1);
+          expect(attached.received[0].type).toBe(NotificationType.ErrorReport);
+          expect(attached.received[0].message).toContain(
+            "Only the client that owns the worker",
+          );
+        } finally {
+          attached.channel.port1.close();
+          second.port1.close();
+        }
+      });
+
+      it("reports an attach-port message that carries no port", async () => {
+        const h = harness();
+        await h.initialize(1);
+        h.owner.posted.length = 0;
+        await h.deliver(h.owner.client, {
+          type: ClientTransportNotificationType.AttachPort,
+        });
+        expect(h.owner.posted).toHaveLength(1);
+        expect(h.owner.posted[0].type).toBe(NotificationType.ErrorReport);
+        expect(h.owner.posted[0].message).toContain("no port");
+      });
+    });
+  });
+});

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -71,6 +71,7 @@ import {
   getCell,
   mapCellRefsToSigilLinks,
 } from "@/backends/utils.ts";
+import type { WorkerClient } from "@/backends/worker-client.ts";
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
@@ -4268,7 +4269,7 @@ describe("runtime-processor", () => {
       const dispatched: unknown[] = [];
       const processor = {
         vdomMounts: new Map([[
-          "mount-1",
+          "0 mount-1",
           {
             reconciler: {
               dispatchEvent: (_handlerId: string, event: unknown) => {
@@ -5200,8 +5201,10 @@ describe("runtime-processor", () => {
 
       const state = {
         runtime,
+        // Keyed as the processor keys a mount: by the mounting client's
+        // scoped mount id, which for a call naming no client is the owner's.
         vdomMounts: new Map<
-          number,
+          string,
           { reconciler: unknown; cancel: () => void }
         >(),
         vdomBatchIdCounter: 0,
@@ -5220,7 +5223,7 @@ describe("runtime-processor", () => {
           mountId: 1,
           cell: cell.getAsNormalizedFullLink() as unknown as CellRef,
         });
-        const mount = state.vdomMounts.get(1);
+        const mount = state.vdomMounts.get("0 1");
         expect(mount).toBeDefined();
         const policy = (mount!.reconciler as { rootRenderPolicy?: unknown })
           .rootRenderPolicy as RootRenderPolicy;
@@ -5276,9 +5279,9 @@ describe("runtime-processor", () => {
 
     function makeState(dispatchResult: boolean, calls: unknown[][]) {
       return {
-        vdomMounts: new Map<number, { reconciler: unknown }>([
+        vdomMounts: new Map<string, { reconciler: unknown }>([
           [
-            7,
+            "0 7",
             {
               reconciler: {
                 dispatchEvent(handlerId: number, event: unknown): boolean {
@@ -5370,7 +5373,7 @@ describe("runtime-processor", () => {
         RuntimeProcessor.prototype,
       ) as RuntimeProcessor;
       (processor as unknown as { vdomMounts: unknown }).vdomMounts = new Map([[
-        1,
+        "0 1",
         {
           reconciler: {
             dispatchEvent: (handlerId: number, event: unknown) =>
@@ -6115,6 +6118,343 @@ describe("runtime-processor", () => {
         cell: ref,
         sql: "DELETE FROM notes",
       })).resolves.toBeUndefined();
+    });
+  });
+
+  describe("RuntimeProcessor multi-client namespacing", () => {
+    // One worker runs one runtime and serves several documents at once. Every
+    // id a client supplies is minted inside that document -- a VDOM mount id
+    // comes from a counter that starts at 1 in each of them -- so what one
+    // client calls mount 1 and what another calls mount 1 are two mounts, and
+    // a cell two documents both watch is two subscriptions. Each test here
+    // holds one client's work still while another client's is set up, torn
+    // down, or fed.
+
+    type PostedMessage = Record<string, unknown>;
+
+    function testClient(id: number) {
+      const posted: PostedMessage[] = [];
+      const client: WorkerClient = {
+        id,
+        post: (message) => {
+          posted.push(message as PostedMessage);
+          return true;
+        },
+      };
+      return { client, posted };
+    }
+
+    const cellRef = {
+      space: cfcSigner.did(),
+      id: `of:${fid("multi-client-cell")}`,
+      path: [],
+      type: "application/json",
+    } as unknown as CellRef;
+
+    describe("cell subscriptions", () => {
+      function subscriptionHarness() {
+        const cancelled: number[] = [];
+        const sinks: Array<(value: unknown, cfcLabel: unknown) => void> = [];
+        const processor = {
+          subscriptions: new Map<string, () => void>(),
+          runtime: {
+            getCellFromLink: () => ({
+              sink: (
+                callback: (value: unknown, cfcLabel: unknown) => void,
+              ) => {
+                const nth = sinks.push(callback);
+                return () => cancelled.push(nth);
+              },
+            }),
+          },
+        } as unknown as RuntimeProcessor;
+        return { processor, sinks, cancelled };
+      }
+
+      const subscribe = (
+        processor: RuntimeProcessor,
+        client: WorkerClient,
+      ) =>
+        RuntimeProcessor.prototype.handleCellSubscribe.call(processor, {
+          type: RequestType.CellSubscribe,
+          cell: cellRef,
+        }, client);
+
+      const unsubscribe = (
+        processor: RuntimeProcessor,
+        client: WorkerClient,
+      ) =>
+        RuntimeProcessor.prototype.handleCellUnsubscribe.call(processor, {
+          type: RequestType.CellUnsubscribe,
+          cell: cellRef,
+        }, client);
+
+      it("gives each client its own subscription to the same cell", () => {
+        const { processor, sinks } = subscriptionHarness();
+        expect(subscribe(processor, testClient(1).client)).toEqual({
+          value: true,
+        });
+        expect(subscribe(processor, testClient(2).client)).toEqual({
+          value: true,
+        });
+        expect(sinks).toHaveLength(2);
+      });
+
+      it("returns `false` for a second subscription by the same client", () => {
+        const { processor, sinks } = subscriptionHarness();
+        const { client } = testClient(1);
+        expect(subscribe(processor, client)).toEqual({ value: true });
+        expect(subscribe(processor, client)).toEqual({ value: false });
+        expect(sinks).toHaveLength(1);
+      });
+
+      it("keeps one client's feed running when another unsubscribes the same cell", async () => {
+        const { processor, sinks, cancelled } = subscriptionHarness();
+        const first = testClient(1);
+        const second = testClient(2);
+        subscribe(processor, first.client);
+        subscribe(processor, second.client);
+
+        expect(unsubscribe(processor, first.client)).toEqual({ value: true });
+        expect(cancelled).toEqual([1]);
+
+        sinks[1]({ n: 2 }, undefined);
+        // The sink posts from a microtask, so the subscription response
+        // returns before the notification.
+        await Promise.resolve();
+
+        expect(second.posted).toHaveLength(1);
+        expect(second.posted[0].type).toBe(NotificationType.CellUpdate);
+        expect(first.posted).toEqual([]);
+      });
+
+      it("returns `false` for an unsubscribe of another client's subscription", () => {
+        const { processor, cancelled } = subscriptionHarness();
+        subscribe(processor, testClient(1).client);
+        expect(unsubscribe(processor, testClient(2).client)).toEqual({
+          value: false,
+        });
+        expect(cancelled).toEqual([]);
+      });
+    });
+
+    describe("VDOM mounts", () => {
+      const handleVDomMount = (RuntimeProcessor.prototype as unknown as {
+        handleVDomMount: (
+          this: unknown,
+          request: unknown,
+          client: WorkerClient,
+        ) => unknown;
+      }).handleVDomMount;
+      const handleVDomUnmount = RuntimeProcessor.prototype.handleVDomUnmount;
+
+      async function mountState() {
+        const { runtime } = createRuntime();
+        const space = cfcSigner.did();
+        const tx = runtime.edit();
+        const cell = runtime.getCell<string>(
+          space,
+          "multi-client-vdom-mount",
+          undefined,
+          tx,
+        );
+        cell.set("hello");
+        const commit = await tx.commit();
+        expect(commit.ok !== undefined).toBe(true);
+
+        const state = {
+          runtime,
+          vdomMounts: new Map<
+            string,
+            { reconciler: unknown; cancel: () => void }
+          >(),
+          vdomBatchIdCounter: 0,
+          renderDeclassificationPolicy: "allow",
+          renderConfidentialityCeiling: undefined,
+          handleVDomUnmount,
+        };
+        const link = cell.getAsNormalizedFullLink() as unknown as CellRef;
+        return { runtime, state, link };
+      }
+
+      it("keeps one client's mount when another mounts under the same mount id", async () => {
+        const { runtime, state, link } = await mountState();
+        const first = testClient(1);
+        const second = testClient(2);
+        const hadPostMessage = "postMessage" in globalThis;
+        const originalPostMessage =
+          (globalThis as { postMessage?: unknown }).postMessage;
+        (globalThis as { postMessage?: unknown }).postMessage = () => {};
+        try {
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, first.client);
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, second.client);
+
+          expect(state.vdomMounts.size).toBe(2);
+        } finally {
+          await runtime.dispose();
+          if (hadPostMessage) {
+            (globalThis as { postMessage?: unknown }).postMessage =
+              originalPostMessage;
+          } else {
+            delete (globalThis as { postMessage?: unknown }).postMessage;
+          }
+        }
+      });
+
+      it("sends each mount's batches to the client that mounted it", async () => {
+        const { runtime, state, link } = await mountState();
+        const first = testClient(1);
+        const second = testClient(2);
+        const hadPostMessage = "postMessage" in globalThis;
+        const originalPostMessage =
+          (globalThis as { postMessage?: unknown }).postMessage;
+        const strayPosts: unknown[] = [];
+        (globalThis as { postMessage?: unknown }).postMessage = (
+          message: unknown,
+        ) => {
+          strayPosts.push(message);
+        };
+        try {
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, first.client);
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, second.client);
+          // The reconciler flushes its ops on a microtask.
+          await Promise.resolve();
+          await Promise.resolve();
+
+          const batches = (posted: PostedMessage[]) =>
+            posted.filter((message) =>
+              message.type === NotificationType.VDomBatch
+            );
+          expect(batches(first.posted).length).toBeGreaterThan(0);
+          expect(batches(second.posted).length).toBeGreaterThan(0);
+          expect(strayPosts).toEqual([]);
+        } finally {
+          await runtime.dispose();
+          if (hadPostMessage) {
+            (globalThis as { postMessage?: unknown }).postMessage =
+              originalPostMessage;
+          } else {
+            delete (globalThis as { postMessage?: unknown }).postMessage;
+          }
+        }
+      });
+    });
+
+    describe("event routing", () => {
+      function eventState() {
+        const dispatched: Array<{ mount: string; handlerId: number }> = [];
+        const acknowledged: Array<{ mount: string; batchId: number }> = [];
+        const reconciler = (mount: string) => ({
+          dispatchEvent: (handlerId: number) => {
+            dispatched.push({ mount, handlerId });
+            return true;
+          },
+          acknowledgeBatchApplied: (batchId: number) => {
+            acknowledged.push({ mount, batchId });
+          },
+          unmount: () => {},
+        });
+        const processor = Object.create(
+          RuntimeProcessor.prototype,
+        ) as RuntimeProcessor;
+        (processor as unknown as { vdomMounts: unknown }).vdomMounts = new Map([
+          ["1 1", { reconciler: reconciler("first"), cancel: () => {} }],
+          ["2 1", { reconciler: reconciler("second"), cancel: () => {} }],
+        ]);
+        return { processor, dispatched, acknowledged };
+      }
+
+      it("routes a DOM event to the mount of the client that sent it", () => {
+        const { processor, dispatched } = eventState();
+        processor.handleNotification({
+          type: ClientNotificationType.VDomEvent,
+          mountId: 1,
+          handlerId: 7,
+          event: { type: "click" } as never,
+          nodeId: 3,
+        }, testClient(2).client);
+        expect(dispatched).toEqual([{ mount: "second", handlerId: 7 }]);
+      });
+
+      it("routes a batch acknowledgement to the mount of the client that sent it", () => {
+        const { processor, acknowledged } = eventState();
+        processor.handleNotification({
+          type: ClientNotificationType.VDomBatchApplied,
+          mountId: 1,
+          batchId: 42,
+        }, testClient(1).client);
+        expect(acknowledged).toEqual([{ mount: "first", batchId: 42 }]);
+      });
+    });
+
+    describe("disposeClient()", () => {
+      function departureState() {
+        const cancelled: string[] = [];
+        const unmounted: string[] = [];
+        const processor = Object.create(
+          RuntimeProcessor.prototype,
+        ) as RuntimeProcessor;
+        const state = processor as unknown as {
+          subscriptions: Map<string, () => void>;
+          operationSubscriptions: Map<string, unknown>;
+          operationSessions: Map<string, unknown>;
+          vdomMounts: Map<string, unknown>;
+          runtime: unknown;
+        };
+        state.subscriptions = new Map([
+          ["1 cell-a", () => cancelled.push("first/cell-a")],
+          ["2 cell-a", () => cancelled.push("second/cell-a")],
+        ]);
+        state.operationSubscriptions = new Map();
+        state.operationSessions = new Map();
+        state.vdomMounts = new Map([
+          ["1 1", {
+            reconciler: { unmount: () => unmounted.push("first/1") },
+            cancel: () => cancelled.push("first/mount-1"),
+          }],
+          ["2 1", {
+            reconciler: { unmount: () => unmounted.push("second/1") },
+            cancel: () => cancelled.push("second/mount-1"),
+          }],
+        ]);
+        state.runtime = {
+          dispose: () => {
+            throw new Error("the runtime must outlive a departing client");
+          },
+        };
+        return { processor, state, cancelled, unmounted };
+      }
+
+      it("cancels only the departing client's subscriptions and mounts", () => {
+        const { processor, state, cancelled, unmounted } = departureState();
+        processor.disposeClient(testClient(1).client);
+        expect(cancelled).toEqual(["first/cell-a", "first/mount-1"]);
+        expect(unmounted).toEqual(["first/1"]);
+        expect([...state.subscriptions.keys()]).toEqual(["2 cell-a"]);
+        expect([...state.vdomMounts.keys()]).toEqual(["2 1"]);
+      });
+
+      it("leaves the runtime running", () => {
+        const { processor } = departureState();
+        expect(() => processor.disposeClient(testClient(1).client)).not
+          .toThrow();
+      });
     });
   });
 });

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -47,6 +47,7 @@ import { StorageManager as WorkerStorageManager } from "@commonfabric/runner/sto
 
 import { parseLink } from "@commonfabric/runner";
 import * as V2Storage from "@commonfabric/runner/storage/v2";
+import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
   type CellRef,
   type CfcLabelView,
@@ -54,10 +55,12 @@ import {
   type GetPatternSourcesRequest,
   NotificationType,
   RequestType,
+  RuntimeErrorCode,
 } from "@/protocol/mod.ts";
 import {
   assertServerExecutionPostureAgreement,
   browserWorkerParamsFromInitializationData,
+  mountErrorSink,
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
   RuntimeProcessor,
@@ -6309,6 +6312,42 @@ describe("runtime-processor", () => {
         }
       });
 
+      it("replaces a client's own mount when it mounts that id again", async () => {
+        // Scoping the key changed which mounts collide, not what a collision
+        // does: one client re-using its own mount id still replaces what was
+        // there, and is left holding one mount rather than two.
+        const { runtime, state, link } = await mountState();
+        const { client } = testClient(1);
+        const hadPostMessage = "postMessage" in globalThis;
+        const originalPostMessage =
+          (globalThis as { postMessage?: unknown }).postMessage;
+        (globalThis as { postMessage?: unknown }).postMessage = () => {};
+        try {
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, client);
+          const first = state.vdomMounts.get("1 1");
+          handleVDomMount.call(state, {
+            type: RequestType.VDomMount,
+            mountId: 1,
+            cell: link,
+          }, client);
+
+          expect(state.vdomMounts.size).toBe(1);
+          expect(state.vdomMounts.get("1 1")).not.toBe(first);
+        } finally {
+          await runtime.dispose();
+          if (hadPostMessage) {
+            (globalThis as { postMessage?: unknown }).postMessage =
+              originalPostMessage;
+          } else {
+            delete (globalThis as { postMessage?: unknown }).postMessage;
+          }
+        }
+      });
+
       it("sends each mount's batches to the client that mounted it", async () => {
         const { runtime, state, link } = await mountState();
         const first = testClient(1);
@@ -6353,6 +6392,28 @@ describe("runtime-processor", () => {
             delete (globalThis as { postMessage?: unknown }).postMessage;
           }
         }
+      });
+    });
+
+    describe("mountErrorSink()", () => {
+      it("posts a render error to the client that mounted, and no other", () => {
+        const mounting = testClient(1);
+        const other = testClient(2);
+        mountErrorSink(mounting.client)(new Error("render blew up"));
+        expect(mounting.posted).toHaveLength(1);
+        expect(mounting.posted[0].type).toBe(NotificationType.ErrorReport);
+        expect(mounting.posted[0].message).toBe("render blew up");
+        expect(other.posted).toEqual([]);
+      });
+
+      it("carries a compiler-stack failure's code, so the shell can act on it", () => {
+        const mounting = testClient(1);
+        mountErrorSink(mounting.client)(
+          new CompilerStackLoadError(new TypeError("chunk fetch failed")),
+        );
+        expect(mounting.posted[0].code).toBe(
+          RuntimeErrorCode.CompilerStackLoadFailed,
+        );
       });
     });
 
@@ -6493,7 +6554,12 @@ describe("runtime-processor", () => {
         const state = processor as unknown as {
           subscriptions: Map<string, () => void>;
           operationSubscriptions: Map<string, unknown>;
-          operationSessions: Map<string, unknown>;
+          operationSessions: Map<string, {
+            cellKey: string;
+            target: unknown;
+            subscriptions: Set<string>;
+            clientId: number;
+          }>;
           vdomMounts: Map<string, unknown>;
           runtime: unknown;
         };
@@ -6501,8 +6567,34 @@ describe("runtime-processor", () => {
           ["1 cell-a", () => cancelled.push("first/cell-a")],
           ["2 cell-a", () => cancelled.push("second/cell-a")],
         ]);
-        state.operationSubscriptions = new Map();
-        state.operationSessions = new Map();
+        state.operationSubscriptions = new Map([
+          ["op-of-first", {
+            cancelled: false,
+            cancel: () => cancelled.push("first/op"),
+            client: testClient(1).client,
+            sessionKey: "session-of-first",
+          }],
+          ["op-of-second", {
+            cancelled: false,
+            cancel: () => cancelled.push("second/op"),
+            client: testClient(2).client,
+            sessionKey: "session-of-second",
+          }],
+        ]);
+        state.operationSessions = new Map([
+          ["session-of-first", {
+            cellKey: "cell",
+            target: {},
+            subscriptions: new Set(["op-of-first"]),
+            clientId: 1,
+          }],
+          ["session-of-second", {
+            cellKey: "cell",
+            target: {},
+            subscriptions: new Set(["op-of-second"]),
+            clientId: 2,
+          }],
+        ]);
         state.vdomMounts = new Map([
           ["1 1", {
             reconciler: { unmount: () => unmounted.push("first/1") },
@@ -6524,10 +6616,49 @@ describe("runtime-processor", () => {
       it("cancels only the departing client's subscriptions and mounts", () => {
         const { processor, state, cancelled, unmounted } = departureState();
         processor.disposeClient(testClient(1).client);
-        expect(cancelled).toEqual(["first/cell-a", "first/mount-1"]);
+        expect(cancelled).toEqual([
+          "first/cell-a",
+          "first/op",
+          "first/mount-1",
+        ]);
         expect(unmounted).toEqual(["first/1"]);
         expect([...state.subscriptions.keys()]).toEqual(["2 cell-a"]);
         expect([...state.vdomMounts.keys()]).toEqual(["2 1"]);
+      });
+
+      it("stops the departing client's operation feeds and no other's", () => {
+        const { processor, state } = departureState();
+        processor.disposeClient(testClient(1).client);
+        expect([...state.operationSubscriptions.keys()]).toEqual([
+          "op-of-second",
+        ]);
+      });
+
+      it("forgets the departing client's operation sessions and no other's", () => {
+        const { processor, state } = departureState();
+        processor.disposeClient(testClient(1).client);
+        expect([...state.operationSessions.keys()]).toEqual([
+          "session-of-second",
+        ]);
+      });
+
+      it("forgets a session the departing client opened and never subscribed on", () => {
+        // The unsubscribes reap a session as its last subscription goes, so
+        // this sweep is what a session with none of its own needs: it holds a
+        // target address nobody is reading, and nothing else would remove it.
+        const { processor, state } = departureState();
+        state.operationSessions.set("session-never-used", {
+          cellKey: "cell",
+          target: {},
+          subscriptions: new Set<string>(),
+          clientId: 1,
+        });
+
+        processor.disposeClient(testClient(1).client);
+
+        expect([...state.operationSessions.keys()]).toEqual([
+          "session-of-second",
+        ]);
       });
 
       it("leaves the runtime running", () => {

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -15,7 +15,7 @@ import {
 import { isValidFabricValue } from "@commonfabric/data-model/fabric-value";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { getLogger } from "@commonfabric/utils/logger";
-import { type DID, Identity } from "@commonfabric/identity";
+import { Identity } from "@commonfabric/identity";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,
@@ -54,7 +54,6 @@ import {
   type GetPatternSourcesRequest,
   NotificationType,
   RequestType,
-  type RuntimeSecurityContext,
 } from "@/protocol/mod.ts";
 import {
   assertServerExecutionPostureAgreement,
@@ -62,7 +61,6 @@ import {
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
   RuntimeProcessor,
-  securityContextDifferences,
   subscribeEventAttentionNotifications,
   toConsoleDebugValue,
 } from "@/backends/runtime-processor.ts";
@@ -6405,6 +6403,86 @@ describe("runtime-processor", () => {
       });
     });
 
+    describe("operation sessions and subscriptions", () => {
+      // A subscription id and a session id are UUIDs the client mints, which
+      // is convention rather than protocol: nothing on the wire stops one
+      // client naming another's. Each of these hands a client the other's id.
+
+      function operationState() {
+        const cancelled: string[] = [];
+        const processor = Object.create(
+          RuntimeProcessor.prototype,
+        ) as RuntimeProcessor;
+        const state = processor as unknown as {
+          operationSubscriptions: Map<string, unknown>;
+          operationSessions: Map<string, unknown>;
+        };
+        state.operationSubscriptions = new Map([
+          ["sub-of-first", {
+            cancelled: false,
+            cancel: () => cancelled.push("first"),
+            client: testClient(1).client,
+            sessionKey: "session-of-first",
+          }],
+        ]);
+        state.operationSessions = new Map([
+          ["session-of-first", {
+            cellKey: "cell",
+            target: {},
+            subscriptions: new Set(["sub-of-first"]),
+            clientId: 1,
+          }],
+        ]);
+        return { processor, state, cancelled };
+      }
+
+      it("returns `false` when a client unsubscribes another client's subscription", () => {
+        const { processor, state, cancelled } = operationState();
+        expect(
+          processor.handleOperationUnsubscribe({
+            type: RequestType.OperationUnsubscribe,
+            subscriptionId: "sub-of-first",
+          }, testClient(2).client),
+        ).toEqual({ value: false });
+        expect(cancelled).toEqual([]);
+        expect(state.operationSubscriptions.has("sub-of-first")).toBe(true);
+      });
+
+      it("returns `true` when the subscribing client unsubscribes its own", () => {
+        const { processor, state, cancelled } = operationState();
+        expect(
+          processor.handleOperationUnsubscribe({
+            type: RequestType.OperationUnsubscribe,
+            subscriptionId: "sub-of-first",
+          }, testClient(1).client),
+        ).toEqual({ value: true });
+        expect(cancelled).toEqual(["first"]);
+        expect(state.operationSubscriptions.has("sub-of-first")).toBe(false);
+      });
+
+      it("returns `false` when a client closes another client's session", () => {
+        const { processor, state } = operationState();
+        expect(
+          processor.handleOperationSessionClose({
+            type: RequestType.OperationSessionClose,
+            operationSessionId: "session-of-first",
+          }, testClient(2).client),
+        ).toEqual({ value: false });
+        expect(state.operationSessions.has("session-of-first")).toBe(true);
+      });
+
+      it("returns `true` when the owning client closes its own session", () => {
+        const { processor, state } = operationState();
+        expect(
+          processor.handleOperationSessionClose({
+            type: RequestType.OperationSessionClose,
+            operationSessionId: "session-of-first",
+          }, testClient(1).client),
+        ).toEqual({ value: true });
+        expect(state.operationSessions.has("session-of-first")).toBe(false);
+      });
+    });
+
     describe("disposeClient()", () => {
       function departureState() {
         const cancelled: string[] = [];
@@ -6457,83 +6535,6 @@ describe("runtime-processor", () => {
         expect(() => processor.disposeClient(testClient(1).client)).not
           .toThrow();
       });
-    });
-  });
-
-  describe("securityContextDifferences()", () => {
-    // A runtime is one signer under one enforcement configuration, and an
-    // attach states which it believes it is joining. What this returns is
-    // what an attach is refused by name for.
-
-    const running: RuntimeSecurityContext = {
-      identity: cfcSigner.did(),
-      spaceDid: cfcSigner.did(),
-      cfcEnforcementMode: "enforce-strict",
-      cfcFlowLabels: "persist",
-      renderDeclassificationPolicy: "deny",
-      renderConfidentialityCeiling: { atoms: [], caveatKinds: ["influence"] },
-      trustSnapshot: { id: `principal:${cfcSigner.did()}` },
-    };
-
-    it("returns an empty list for the same context", () => {
-      expect(securityContextDifferences({ ...running }, running)).toEqual([]);
-    });
-
-    it("returns an empty list when a field is absent on one side and `undefined` on the other", () => {
-      // The two contexts are built in different documents and one of them
-      // crossed an encoding, so these are the same posture.
-      const asserted = { ...running, experimental: undefined };
-      expect(securityContextDifferences(asserted, running)).toEqual([]);
-    });
-
-    it("names the acting principal when it differs", () => {
-      expect(
-        securityContextDifferences(
-          { ...running, identity: "did:key:z6Mk-someone-else" as DID },
-          running,
-        ),
-      ).toEqual(["identity"]);
-    });
-
-    it("names the enforcement mode when it differs", () => {
-      expect(
-        securityContextDifferences(
-          { ...running, cfcEnforcementMode: "observe" },
-          running,
-        ),
-      ).toEqual(["cfcEnforcementMode"]);
-    });
-
-    it("names a ceiling that differs deep inside", () => {
-      expect(
-        securityContextDifferences(
-          {
-            ...running,
-            renderConfidentialityCeiling: {
-              atoms: [],
-              caveatKinds: ["influence", "and-one-more"],
-            },
-          },
-          running,
-        ),
-      ).toEqual(["renderConfidentialityCeiling"]);
-    });
-
-    it("names an absent field the running context declares", () => {
-      const { trustSnapshot: _dropped, ...asserted } = running;
-      expect(securityContextDifferences(asserted, running)).toEqual([
-        "trustSnapshot",
-      ]);
-    });
-
-    it("names every differing field, in a fixed order", () => {
-      expect(
-        securityContextDifferences({
-          ...running,
-          identity: "did:key:z6Mk-someone-else" as DID,
-          cfcFlowLabels: "off",
-        }, running),
-      ).toEqual(["cfcFlowLabels", "identity"]);
     });
   });
 });

--- a/packages/runtime-client/test/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/test/backends/runtime-processor.test.ts
@@ -15,7 +15,7 @@ import {
 import { isValidFabricValue } from "@commonfabric/data-model/fabric-value";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { getLogger } from "@commonfabric/utils/logger";
-import { Identity } from "@commonfabric/identity";
+import { type DID, Identity } from "@commonfabric/identity";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,
@@ -54,6 +54,7 @@ import {
   type GetPatternSourcesRequest,
   NotificationType,
   RequestType,
+  type RuntimeSecurityContext,
 } from "@/protocol/mod.ts";
 import {
   assertServerExecutionPostureAgreement,
@@ -61,6 +62,7 @@ import {
   renderConfidentialityResolverFor,
   renderMembershipProviderFor,
   RuntimeProcessor,
+  securityContextDifferences,
   subscribeEventAttentionNotifications,
   toConsoleDebugValue,
 } from "@/backends/runtime-processor.ts";
@@ -6455,6 +6457,83 @@ describe("runtime-processor", () => {
         expect(() => processor.disposeClient(testClient(1).client)).not
           .toThrow();
       });
+    });
+  });
+
+  describe("securityContextDifferences()", () => {
+    // A runtime is one signer under one enforcement configuration, and an
+    // attach states which it believes it is joining. What this returns is
+    // what an attach is refused by name for.
+
+    const running: RuntimeSecurityContext = {
+      identity: cfcSigner.did(),
+      spaceDid: cfcSigner.did(),
+      cfcEnforcementMode: "enforce-strict",
+      cfcFlowLabels: "persist",
+      renderDeclassificationPolicy: "deny",
+      renderConfidentialityCeiling: { atoms: [], caveatKinds: ["influence"] },
+      trustSnapshot: { id: `principal:${cfcSigner.did()}` },
+    };
+
+    it("returns an empty list for the same context", () => {
+      expect(securityContextDifferences({ ...running }, running)).toEqual([]);
+    });
+
+    it("returns an empty list when a field is absent on one side and `undefined` on the other", () => {
+      // The two contexts are built in different documents and one of them
+      // crossed an encoding, so these are the same posture.
+      const asserted = { ...running, experimental: undefined };
+      expect(securityContextDifferences(asserted, running)).toEqual([]);
+    });
+
+    it("names the acting principal when it differs", () => {
+      expect(
+        securityContextDifferences(
+          { ...running, identity: "did:key:z6Mk-someone-else" as DID },
+          running,
+        ),
+      ).toEqual(["identity"]);
+    });
+
+    it("names the enforcement mode when it differs", () => {
+      expect(
+        securityContextDifferences(
+          { ...running, cfcEnforcementMode: "observe" },
+          running,
+        ),
+      ).toEqual(["cfcEnforcementMode"]);
+    });
+
+    it("names a ceiling that differs deep inside", () => {
+      expect(
+        securityContextDifferences(
+          {
+            ...running,
+            renderConfidentialityCeiling: {
+              atoms: [],
+              caveatKinds: ["influence", "and-one-more"],
+            },
+          },
+          running,
+        ),
+      ).toEqual(["renderConfidentialityCeiling"]);
+    });
+
+    it("names an absent field the running context declares", () => {
+      const { trustSnapshot: _dropped, ...asserted } = running;
+      expect(securityContextDifferences(asserted, running)).toEqual([
+        "trustSnapshot",
+      ]);
+    });
+
+    it("names every differing field, in a fixed order", () => {
+      expect(
+        securityContextDifferences({
+          ...running,
+          identity: "did:key:z6Mk-someone-else" as DID,
+          cfcFlowLabels: "off",
+        }, running),
+      ).toEqual(["cfcFlowLabels", "identity"]);
     });
   });
 });

--- a/packages/runtime-client/test/client/connection.test.ts
+++ b/packages/runtime-client/test/client/connection.test.ts
@@ -4,7 +4,11 @@ import {
   fabricFromRealmValue,
   realmFromFabricValue,
 } from "@commonfabric/data-model/codecs";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import {
+  FabricBytes,
+  FabricKeyPair,
+} from "@commonfabric/data-model/fabric-primitives";
+import type { DID } from "@commonfabric/identity";
 import { toValuePath } from "@commonfabric/memory/v2";
 import { getLogger } from "@commonfabric/utils/logger";
 import { RuntimeConnection } from "@/client/connection.ts";
@@ -17,6 +21,7 @@ import {
   type OperationUpdateNotification,
   RequestType,
   RuntimeErrorCode,
+  type RuntimeSecurityContext,
 } from "@/protocol/mod.ts";
 import type {
   RuntimeTransport,
@@ -667,5 +672,46 @@ describe("connection", () => {
       expect(captured.data.body.slice()).toEqual(new Uint8Array([1, 2, 3]));
       expect(body.slice()).toEqual(new Uint8Array([1, 2, 3]));
     });
+  });
+});
+
+describe("RuntimeConnection.attach()", () => {
+  // The choke point: the last thing before a frame reaches a transport. A
+  // caller holding a `RuntimeConnection` directly does not pass through
+  // `RuntimeClient.attach`, so the guarantee that no key material crosses a
+  // port has to live here rather than only there.
+
+  const context: RuntimeSecurityContext = {
+    identity: "did:key:z6Mk-connection-attach" as DID,
+    apiUrl: "http://connection.test/",
+    spaceDid: "did:key:z6Mk-connection-attach" as DID,
+  };
+
+  it("sends the asserted context and marks the connection usable", async () => {
+    const transport = new FakeTransport();
+    const conn = new RuntimeConnection(transport);
+    await conn.attach(context);
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]).toMatchObject({
+      data: { type: RequestType.Attach, data: context },
+    });
+  });
+
+  it("refuses a context holding key material, sending nothing", async () => {
+    const transport = new FakeTransport();
+    const conn = new RuntimeConnection(transport);
+    const keyPair = new FabricKeyPair(
+      "Ed25519",
+      new Uint8Array(32),
+      new Uint8Array(32),
+    );
+    await expect(conn.attach({
+      ...context,
+      trustSnapshot: {
+        id: "principal",
+        signer: keyPair,
+      } as unknown as RuntimeSecurityContext["trustSnapshot"],
+    })).rejects.toThrow("no key material");
+    expect(transport.sent).toEqual([]);
   });
 });

--- a/packages/runtime-client/test/client/transport-message-port.test.ts
+++ b/packages/runtime-client/test/client/transport-message-port.test.ts
@@ -11,6 +11,7 @@ import {
   RequestType,
 } from "@/protocol/mod.ts";
 import { MessagePortRuntimeTransport } from "@/client/transports/message-port/transport-message-port.ts";
+import type { MessagePortLike } from "@/shared/message-port-like.ts";
 
 /**
  * Both ends of a real channel: the transport speaks over one, and the test
@@ -77,6 +78,27 @@ describe("MessagePortRuntimeTransport", () => {
       });
     });
 
+    describe("[Symbol.asyncDispose]()", () => {
+      it("disposes the transport at the end of an `await using` block", async () => {
+        const channel = new MessageChannel();
+        let transport: MessagePortRuntimeTransport;
+        {
+          await using held = new MessagePortRuntimeTransport({
+            port: channel.port1,
+          });
+          transport = held;
+        }
+        // The block ended, so the transport is disposed: a message from the
+        // far end reaches no listener.
+        const seen: unknown[] = [];
+        transport.on("message", (message) => seen.push(message));
+        channel.port2.postMessage(realmFromFabricValue({ msgId: 1 } as never));
+        await Promise.resolve();
+        expect(seen).toEqual([]);
+        channel.port2.close();
+      });
+    });
+
     describe("message handling", () => {
       it("emits a decoded response from the far end", async () => {
         const { transport, far } = connectedPair();
@@ -97,6 +119,37 @@ describe("MessagePortRuntimeTransport", () => {
           await transport.dispose();
           far.close();
         }
+      });
+
+      it("emits nothing after disposal over a duplex it cannot close", async () => {
+        // `close` is optional on a duplex, so a transport cannot rely on the
+        // channel going quiet when it lets go. What it can do is stop
+        // emitting, which is what a consumer torn down alongside it needs.
+        let deliver: ((event: MessageEvent) => void) | undefined;
+        const uncloseable: MessagePortLike = {
+          postMessage: () => {},
+          addEventListener: (_type, listener) => (deliver = listener),
+        };
+        const transport = new MessagePortRuntimeTransport({
+          port: uncloseable,
+        });
+        const seen: unknown[] = [];
+        transport.on("message", (message) => seen.push(message));
+
+        deliver?.(
+          new MessageEvent("message", {
+            data: realmFromFabricValue({ msgId: 1 } as never),
+          }),
+        );
+        expect(seen).toHaveLength(1);
+
+        await transport.dispose();
+        deliver?.(
+          new MessageEvent("message", {
+            data: realmFromFabricValue({ msgId: 2 } as never),
+          }),
+        );
+        expect(seen).toHaveLength(1);
       });
 
       it("reports a message that does not decode as an error notification", async () => {

--- a/packages/runtime-client/test/client/transport-message-port.test.ts
+++ b/packages/runtime-client/test/client/transport-message-port.test.ts
@@ -1,0 +1,124 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  fabricFromRealmValue,
+  realmFromFabricValue,
+} from "@commonfabric/data-model/codecs";
+
+import {
+  type ErrorNotification,
+  NotificationType,
+  RequestType,
+} from "@/protocol/mod.ts";
+import { MessagePortRuntimeTransport } from "@/client/transports/message-port/transport-message-port.ts";
+
+/**
+ * Both ends of a real channel: the transport speaks over one, and the test
+ * reads and writes the other as the worker would.
+ */
+function connectedPair() {
+  const channel = new MessageChannel();
+  const transport = new MessagePortRuntimeTransport({ port: channel.port1 });
+  const received: unknown[] = [];
+  let arrived: (() => void) | undefined;
+  channel.port2.addEventListener("message", (event) => {
+    received.push(fabricFromRealmValue(event.data as never));
+    arrived?.();
+    arrived = undefined;
+  });
+  channel.port2.start();
+  return {
+    transport,
+    far: channel.port2,
+    received,
+    /** Settles on the next message the far end reads. */
+    next: () => new Promise<void>((resolve) => (arrived = resolve)),
+  };
+}
+
+describe("MessagePortRuntimeTransport", () => {
+  describe("instance members", () => {
+    describe("send()", () => {
+      it("delivers the encoded envelope to the far end", async () => {
+        const { transport, far, received, next } = connectedPair();
+        try {
+          const delivered = next();
+          transport.send({
+            msgId: 1,
+            data: { type: RequestType.Idle },
+          });
+          await delivered;
+          expect(received).toEqual([{
+            msgId: 1,
+            data: { type: RequestType.Idle },
+          }]);
+        } finally {
+          await transport.dispose();
+          far.close();
+        }
+      });
+    });
+
+    describe("dispose()", () => {
+      it("stops emitting messages that arrive after it", async () => {
+        const { transport, far } = connectedPair();
+        const seen: unknown[] = [];
+        transport.on("message", (message) => seen.push(message));
+        try {
+          await transport.dispose();
+          far.postMessage(realmFromFabricValue({ msgId: 1 } as never));
+          // The port is closed, so nothing can arrive; a yield gives anything
+          // still queued its chance to be wrong.
+          await Promise.resolve();
+          expect(seen).toEqual([]);
+        } finally {
+          far.close();
+        }
+      });
+    });
+
+    describe("message handling", () => {
+      it("emits a decoded response from the far end", async () => {
+        const { transport, far } = connectedPair();
+        const seen: unknown[] = [];
+        let arrived: (() => void) | undefined;
+        transport.on("message", (message) => {
+          seen.push(message);
+          arrived?.();
+        });
+        try {
+          const emitted = new Promise<void>((resolve) => (arrived = resolve));
+          far.postMessage(
+            realmFromFabricValue({ msgId: 7, data: { value: true } } as never),
+          );
+          await emitted;
+          expect(seen).toEqual([{ msgId: 7, data: { value: true } }]);
+        } finally {
+          await transport.dispose();
+          far.close();
+        }
+      });
+
+      it("reports a message that does not decode as an error notification", async () => {
+        const { transport, far } = connectedPair();
+        const seen: ErrorNotification[] = [];
+        let arrived: (() => void) | undefined;
+        transport.on("message", (message) => {
+          seen.push(message as ErrorNotification);
+          arrived?.();
+        });
+        try {
+          const emitted = new Promise<void>((resolve) => (arrived = resolve));
+          far.postMessage({ not: "an encoding" });
+          await emitted;
+          expect(seen).toHaveLength(1);
+          expect(seen[0].type).toBe(NotificationType.ErrorReport);
+          expect(seen[0].message).toContain("Undecodable message");
+        } finally {
+          await transport.dispose();
+          far.close();
+        }
+      });
+    });
+  });
+});

--- a/packages/runtime-client/test/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/test/client/transport-web-worker.test.ts
@@ -4,6 +4,8 @@ import { type ErrorNotification, NotificationType } from "@/protocol/mod.ts";
 import { expect } from "@std/expect";
 import { TransportNotificationType } from "@/protocol/mod.ts";
 import { WebWorkerRuntimeTransport } from "@/client/transports/web-worker/transport-web-worker.ts";
+import { ClientTransportNotificationType } from "@/protocol/mod.ts";
+import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 
 // Exercises the transport's handling of forwarded worker console output
 // without a real worker: a fake Worker class lets us construct the transport,
@@ -16,8 +18,8 @@ class FakeWorker extends EventTarget {
     super();
     FakeWorker.instances.push(this);
   }
-  postMessage(message: unknown): void {
-    this.posted.push(message);
+  postMessage(message: unknown, transfer?: unknown[]): void {
+    this.posted.push(transfer === undefined ? message : [message, transfer]);
   }
   terminate(): void {
     this.terminated = true;
@@ -304,6 +306,31 @@ describe("WebWorkerRuntimeTransport", () => {
       expect(emitted).toContainEqual(ipc);
 
       await transport.dispose();
+    });
+  });
+
+  describe("attachClientPort()", () => {
+    // A further document reaches the runtime over a port this worker is
+    // handed. Only the page holding this transport can hand one over -- it is
+    // the page that spawned the worker -- so this is where that happens.
+
+    it("transfers the port alongside the marker saying what it is for", () => {
+      const transport = makeTransport();
+      const worker = FakeWorker.instances[FakeWorker.instances.length - 1];
+      const channel = new MessageChannel();
+      try {
+        transport.attachClientPort(channel.port2);
+        expect(worker.posted).toHaveLength(1);
+        const [message, transfer] = worker.posted[0] as [unknown, unknown[]];
+        expect(fabricFromRealmValue(message as never)).toEqual({
+          type: ClientTransportNotificationType.AttachPort,
+        });
+        // The port rides the transfer list rather than the message: a port is
+        // no `FabricValue` and has no encoding.
+        expect(transfer).toEqual([channel.port2]);
+      } finally {
+        channel.port1.close();
+      }
     });
   });
 });

--- a/packages/runtime-client/test/runtime-client.test.ts
+++ b/packages/runtime-client/test/runtime-client.test.ts
@@ -2,7 +2,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
-import { RuntimeClient } from "@/runtime-client.ts";
+import { attachOptionsFrom, RuntimeClient } from "@/runtime-client.ts";
+import { findKeyMaterial } from "@/shared/key-material.ts";
 import {
   type CellRef,
   NotificationType,
@@ -49,7 +50,7 @@ describe("RuntimeClient", () => {
       const conn = { on: () => {}, signal } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       expect(client.signal).toBe(signal);
     });
   });
@@ -64,9 +65,11 @@ describe("RuntimeClient", () => {
 
     function clientWith(identity?: Identity): RuntimeClient {
       const conn = { on: () => {} } as unknown as never;
+      // The constructor takes the acting principal itself, an attaching
+      // client having only a DID to give it.
       return new (RuntimeClient as unknown as {
-        new (conn: never, options: unknown): RuntimeClient;
-      })(conn, identity === undefined ? {} : { identity });
+        new (conn: never, principal: unknown): RuntimeClient;
+      })(conn, identity?.did());
     }
 
     it("identifies space, user, and session instances at their scopes", async () => {
@@ -117,7 +120,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       return { client, requests };
     }
 
@@ -150,7 +153,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       await client.setMemoryMessageCompression(false);
 
@@ -179,7 +182,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       const result = await client.getPieceSource(
         "of:fid1:piece",
@@ -212,7 +215,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       const result = await client.getPieceSourceRevision(
         "of:fid1:piece",
@@ -248,7 +251,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       const response = await client.updatePieceSource(
         "of:fid1:piece",
@@ -286,7 +289,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       const space = access.space as never;
 
       expect(await client.getSpaceAcl(space)).toBe(access);
@@ -343,7 +346,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       const clone = await client.clonePiece(
         "of:fid1:piece",
         sourceSpace as never,
@@ -380,7 +383,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       await client.clonePiece(
         "of:fid1:piece",
@@ -412,7 +415,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       expect(await client.resolveSpaceName("notebook")).toBe(space);
       expect(requests).toEqual([{
@@ -437,7 +440,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       return { client, handlers };
     }
 
@@ -500,7 +503,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
 
       expect(await client.listEventAttention(notice.space)).toEqual([notice]);
       expect(await client.resolveEventAttention(notice, "retry")).toEqual({
@@ -529,7 +532,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       const observed: unknown[] = [];
       client.on("eventneedsattention", (value) => observed.push(value));
 
@@ -558,7 +561,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       return { client, requests };
     }
 
@@ -595,7 +598,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       expect(client.getPendingRequests()).toEqual(pending);
       expect(client.getRequestTimeline()).toEqual(timeline);
     });
@@ -613,7 +616,7 @@ describe("RuntimeClient", () => {
       } as unknown as never;
       const client = new (RuntimeClient as unknown as {
         new (conn: never, options: unknown): RuntimeClient;
-      })(conn, {});
+      })(conn, undefined);
       const body = new Uint8Array([1, 2, 3]);
 
       const upload = client.uploadBlob({
@@ -647,5 +650,48 @@ describe("RuntimeClient", () => {
       expect(request.body).toBeInstanceOf(FabricBytes);
       expect(request.body.slice()).toEqual(new Uint8Array([1, 2, 3]));
     });
+  });
+});
+
+describe("attachOptionsFrom()", () => {
+  // What it drops is the point: a document that attaches holds no signer, so
+  // neither `Identity` survives the mapping. `findKeyMaterial` refuses a frame
+  // holding one; this is what keeps one from being built.
+
+  it("returns the acting principal as a DID and keeps no `Identity`", async () => {
+    const identity = await Identity.fromPassphrase("attach-options-signer");
+    const spaceIdentity = await Identity.fromPassphrase("attach-options-space");
+    const attach = attachOptionsFrom({
+      apiUrl: new URL("http://backend.test/"),
+      identity,
+      spaceIdentity,
+      spaceDid: identity.did(),
+      cfcEnforcementMode: "enforce-strict",
+    });
+
+    expect(attach.identity).toBe(identity.did());
+    expect(Object.values(attach)).not.toContain(identity);
+    expect(Object.values(attach)).not.toContain(spaceIdentity);
+    expect("spaceIdentity" in attach).toBe(false);
+    expect(findKeyMaterial(attach)).toBeUndefined();
+  });
+
+  it("carries the posture fields an attach asserts", async () => {
+    const identity = await Identity.fromPassphrase("attach-options-posture");
+    const attach = attachOptionsFrom({
+      apiUrl: new URL("http://backend.test/"),
+      identity,
+      spaceDid: identity.did(),
+      spaceHostMap: { [identity.did()]: "http://memory.test/" },
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    expect(attach.apiUrl.toString()).toBe("http://backend.test/");
+    expect(attach.spaceHostMap).toEqual({
+      [identity.did()]: "http://memory.test/",
+    });
+    expect(attach.cfcEnforcementMode).toBe("observe");
+    expect(attach.cfcFlowLabels).toBe("persist");
   });
 });

--- a/packages/runtime-client/test/shared/key-material.test.ts
+++ b/packages/runtime-client/test/shared/key-material.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
+
+import { findKeyMaterial } from "@/shared/key-material.ts";
+
+const keyPair = new FabricKeyPair(
+  "Ed25519",
+  new Uint8Array(32),
+  new Uint8Array(32),
+);
+
+describe("findKeyMaterial()", () => {
+  it("returns `undefined` for a value holding none", () => {
+    expect(findKeyMaterial({
+      identity: "did:key:z6Mk-someone",
+      trustSnapshot: { id: "principal:did:key:z6Mk-someone" },
+      atoms: [{ type: "Resource", subject: "did:key:z6Mk-someone" }],
+    })).toBeUndefined();
+  });
+
+  it("returns `undefined` for a primitive", () => {
+    expect(findKeyMaterial("did:key:z6Mk-someone")).toBeUndefined();
+    expect(findKeyMaterial(undefined)).toBeUndefined();
+    expect(findKeyMaterial(42)).toBeUndefined();
+  });
+
+  it("names the field a key pair sits directly under", () => {
+    expect(findKeyMaterial({ identity: keyPair })).toBe("identity");
+  });
+
+  it("names the path of a key pair nested inside", () => {
+    expect(findKeyMaterial({ trustSnapshot: { signer: keyPair } })).toBe(
+      "trustSnapshot.signer",
+    );
+  });
+
+  it("names the index of a key pair inside an array", () => {
+    expect(findKeyMaterial({ atoms: [{}, { key: keyPair }] })).toBe(
+      "atoms[1].key",
+    );
+  });
+
+  it("names the value itself when it is a key pair", () => {
+    expect(findKeyMaterial(keyPair)).toBe("");
+  });
+
+  it("returns `undefined` for a cycle holding no key material", () => {
+    // A context built on this side of the wire has not been through a decode,
+    // so nothing has flattened it into a tree first.
+    const cyclic: Record<string, unknown> = { identity: "did:key:z6Mk-a" };
+    cyclic.self = cyclic;
+    expect(findKeyMaterial(cyclic)).toBeUndefined();
+  });
+
+  it("finds a key pair reached past a cycle", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    cyclic.trustSnapshot = { signer: keyPair };
+    expect(findKeyMaterial(cyclic)).toBe("trustSnapshot.signer");
+  });
+});

--- a/packages/runtime-client/test/shared/key-material.test.ts
+++ b/packages/runtime-client/test/shared/key-material.test.ts
@@ -1,5 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import {
+  ProblematicValue,
+  UnknownValue,
+} from "@commonfabric/data-model/codec-common";
 import { FabricKeyPair } from "@commonfabric/data-model/fabric-primitives";
 
 import { findKeyMaterial } from "@/shared/key-material.ts";
@@ -43,6 +47,37 @@ describe("findKeyMaterial()", () => {
 
   it("names the value itself when it is a key pair", () => {
     expect(findKeyMaterial(keyPair)).toBe("");
+  });
+
+  it("names the path of a key pair wrapped under an unknown wire tag", () => {
+    // A tag this realm does not know decodes into an `UnknownValue` holding
+    // whatever rode under it. Its state lives in a `#` field, so the walk
+    // over enumerable properties sees an empty object and would pass a key
+    // pair straight through.
+    const unknown = new UnknownValue("Bytes@1", keyPair as unknown as never);
+    expect(findKeyMaterial({ trustSnapshot: unknown })).toBe(
+      "trustSnapshot.state",
+    );
+  });
+
+  it("names the path of a key pair inside a value the decoder refused", () => {
+    const problematic = new ProblematicValue(
+      "Whatever@1",
+      { signer: keyPair },
+      "unreadable",
+    );
+    expect(findKeyMaterial({ trustSnapshot: problematic })).toBe(
+      "trustSnapshot.state.signer",
+    );
+  });
+
+  it("names the path of a key pair inside a native map or set", () => {
+    // A `Map` has no enumerable own properties either, so its contents are
+    // reached the same way an instance's state is.
+    expect(findKeyMaterial({ hosts: new Map([["a", keyPair]]) })).toBe(
+      "hosts{a}",
+    );
+    expect(findKeyMaterial({ atoms: new Set([keyPair]) })).toBe("atoms{}");
   });
 
   it("returns `undefined` for a cycle holding no key material", () => {

--- a/packages/runtime-client/test/shared/key-material.test.ts
+++ b/packages/runtime-client/test/shared/key-material.test.ts
@@ -80,6 +80,20 @@ describe("findKeyMaterial()", () => {
     expect(findKeyMaterial({ atoms: new Set([keyPair]) })).toBe("atoms{}");
   });
 
+  it("walks past a map and a set holding none, and finds what follows", () => {
+    // The containers are walked through rather than around: an innocent one
+    // neither refuses the frame nor stops the search before what comes after
+    // it.
+    expect(findKeyMaterial({ hosts: new Map([["a", "http://h/"]]) }))
+      .toBeUndefined();
+    expect(findKeyMaterial({ atoms: new Set(["public"]) })).toBeUndefined();
+    expect(findKeyMaterial({
+      hosts: new Map([["a", "http://h/"]]),
+      atoms: new Set(["public"]),
+      signer: keyPair,
+    })).toBe("signer");
+  });
+
   it("returns `undefined` for a cycle holding no key material", () => {
     // A context built on this side of the wire has not been through a decode,
     // so nothing has flattened it into a tree first.

--- a/packages/runtime-client/test/shared/security-context.test.ts
+++ b/packages/runtime-client/test/shared/security-context.test.ts
@@ -1,0 +1,174 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { DID } from "@commonfabric/identity";
+
+import type { RuntimeSecurityContext } from "@/protocol/mod.ts";
+import {
+  normalizeOrigin,
+  normalizeSpaceHostMap,
+  securityContextDifferences,
+} from "@/shared/security-context.ts";
+
+const signerDid = "did:key:z6Mk-security-context-signer" as DID;
+
+describe("securityContextDifferences()", () => {
+  // A runtime is one signer under one enforcement configuration, and an
+  // attach states which it believes it is joining. What this returns is
+  // what an attach is refused by name for.
+
+  const running: RuntimeSecurityContext = {
+    identity: signerDid,
+    spaceDid: signerDid,
+    apiUrl: "http://runtime.test/",
+    spaceHostMap: { [signerDid]: "http://memory.test/" },
+    cfcEnforcementMode: "enforce-strict",
+    cfcFlowLabels: "persist",
+    renderDeclassificationPolicy: "deny",
+    renderConfidentialityCeiling: { atoms: [], caveatKinds: ["influence"] },
+    trustSnapshot: { id: `principal:${signerDid}` },
+  };
+
+  it("returns an empty list for the same context", () => {
+    expect(securityContextDifferences({ ...running }, running)).toEqual([]);
+  });
+
+  it("returns an empty list when a field is absent on one side and `undefined` on the other", () => {
+    // The two contexts are built in different documents and one of them
+    // crossed an encoding, so these are the same posture.
+    const asserted = { ...running, experimental: undefined };
+    expect(securityContextDifferences(asserted, running)).toEqual([]);
+  });
+
+  it("names the backend when it differs", () => {
+    expect(
+      securityContextDifferences(
+        { ...running, apiUrl: "http://elsewhere.test/" },
+        running,
+      ),
+    ).toEqual(["apiUrl"]);
+  });
+
+  it("names the per-space host map when it differs", () => {
+    expect(
+      securityContextDifferences(
+        { ...running, spaceHostMap: { [signerDid]: "http://o.test/" } },
+        running,
+      ),
+    ).toEqual(["spaceHostMap"]);
+  });
+
+  it("names the acting principal when it differs", () => {
+    expect(
+      securityContextDifferences(
+        { ...running, identity: "did:key:z6Mk-someone-else" as DID },
+        running,
+      ),
+    ).toEqual(["identity"]);
+  });
+
+  it("names the enforcement mode when it differs", () => {
+    expect(
+      securityContextDifferences(
+        { ...running, cfcEnforcementMode: "observe" },
+        running,
+      ),
+    ).toEqual(["cfcEnforcementMode"]);
+  });
+
+  it("names a ceiling that differs deep inside", () => {
+    expect(
+      securityContextDifferences(
+        {
+          ...running,
+          renderConfidentialityCeiling: {
+            atoms: [],
+            caveatKinds: ["influence", "and-one-more"],
+          },
+        },
+        running,
+      ),
+    ).toEqual(["renderConfidentialityCeiling"]);
+  });
+
+  it("names an absent field the running context declares", () => {
+    const { trustSnapshot: _dropped, ...asserted } = running;
+    expect(securityContextDifferences(asserted, running)).toEqual([
+      "trustSnapshot",
+    ]);
+  });
+
+  it("names every differing field, in a fixed order", () => {
+    expect(
+      securityContextDifferences({
+        ...running,
+        identity: "did:key:z6Mk-someone-else" as DID,
+        cfcFlowLabels: "off",
+      }, running),
+    ).toEqual(["cfcFlowLabels", "identity"]);
+  });
+});
+
+describe("normalizeOrigin()", () => {
+  it("returns one spelling for an origin written two ways", () => {
+    expect(normalizeOrigin("http://memory.test")).toBe(
+      normalizeOrigin("http://memory.test/"),
+    );
+  });
+
+  it("returns one spelling for a default port written out", () => {
+    expect(normalizeOrigin("http://memory.test:80/")).toBe(
+      normalizeOrigin("http://memory.test/"),
+    );
+  });
+
+  it("returns an unparseable value unchanged", () => {
+    expect(normalizeOrigin("not a url")).toBe("not a url");
+  });
+});
+
+describe("normalizeSpaceHostMap()", () => {
+  it("returns `undefined` for an absent map", () => {
+    expect(normalizeSpaceHostMap(undefined)).toBeUndefined();
+  });
+
+  it("returns `undefined` for an empty map, which is the same posture", () => {
+    expect(normalizeSpaceHostMap({})).toBeUndefined();
+  });
+
+  it("returns one spelling for each origin it holds", () => {
+    expect(normalizeSpaceHostMap({ [signerDid]: "http://memory.test" }))
+      .toEqual(normalizeSpaceHostMap({ [signerDid]: "http://memory.test/" }));
+  });
+});
+
+describe("a context normalized on both sides", () => {
+  // The spurious refusal this exists to prevent: one document builds its
+  // context from a `URL` and the other from the string an initialization
+  // carried, and the two spell one backend differently.
+
+  it("agrees when one side wrote the backend without a trailing slash", () => {
+    const asserted: RuntimeSecurityContext = {
+      identity: signerDid,
+      spaceDid: signerDid,
+      apiUrl: normalizeOrigin(new URL("http://backend.test").toString()),
+    };
+    const running: RuntimeSecurityContext = {
+      identity: signerDid,
+      spaceDid: signerDid,
+      apiUrl: normalizeOrigin("http://backend.test"),
+    };
+    expect(securityContextDifferences(asserted, running)).toEqual([]);
+  });
+
+  it("agrees when one side carries no host map and the other an empty one", () => {
+    const base: RuntimeSecurityContext = {
+      identity: signerDid,
+      spaceDid: signerDid,
+      apiUrl: normalizeOrigin("http://backend.test"),
+    };
+    expect(securityContextDifferences(
+      { ...base, spaceHostMap: normalizeSpaceHostMap({}) },
+      { ...base, spaceHostMap: normalizeSpaceHostMap(undefined) },
+    )).toEqual([]);
+  });
+});


### PR DESCRIPTION
# One worker, several documents

## Why

A worker runs one runtime and, until this change, one client. The backend
refused a second initialization, kept cell subscriptions under the cell's key
alone, and kept VDOM mounts under a mount id each document mints from its own
counter starting at 1. Those are not three independent gaps; together they mean
a second document cannot reach a running runtime at all. Its subscribe would
silently no-op on the first document's, its unsubscribe would stop the first
document's feed, and its mount would force-unmount the first document's tree.

What needs this is a host that shows several documents over one user's data —
a native shell placing each pattern in its own web view. Each document booting
its own runtime pays for a `StorageManager`, a compile cache, and a heap per
document, and the documents then converge on each other only through storage.
Attaching them to one runtime is one heap, one memory session, and convergent
state with no round trip.

This is P4 of Loom's Weaver pane-model arc — the design doc is
[loom#5138](https://github.com/commontoolsinc/loom/pull/5138), D5 ("the runtime
family"), with the pattern-panes D4 hazards it turns into contracts. The
transport was decided on SP5's evidence: **opener-carried `MessagePort`s**, a
family root's page handing an attached document's port to the runtime. Nothing
here depends on that decision — the seam takes a duplex and never learns how it
arrived — but it is why the seam is shaped this way. The codec addendum that
constrains the frame format is [loom#5352](https://github.com/commontoolsinc/loom/pull/5352).

## The seam

Three new pieces, and the rule that they are indifferent to how a port arrived:

- `shared/message-port-like.ts` — `MessagePortLike`, as much of a `MessagePort`
  as either end uses. A port carried by a page's opener, one relayed by a native
  shell, and one a test builds from a `MessageChannel` are the same thing.
- `backends/worker-client.ts` — `WorkerClient` is where a message addressed to
  one client goes, plus the id everything it owns is filed under.
- `backends/client-registry.ts` — `RuntimeClients`, the per-client message loop,
  lifted out of the worker entry (which drops from 329 lines to 127 and is now
  wiring only).

On the client side, `MessagePortRuntimeTransport` is the joining document's end;
the difference from the dedicated-worker transport is what it does not do — it
spawns nothing, so there is no readiness to wait for, and terminates nothing, so
the runtime outlives it. `RuntimeInternals.create` gains `transport?` and
`attach?`; absent both, a page spawns its own worker exactly as before.

One thing the design sketch did not anticipate: the owner's page could not hand
a port over at all, because `WebWorkerRuntimeTransport` keeps its `Worker`
private. `attachClientPort(port)` is that missing half, and it belongs on the
transport for the reason it is restricted to the owner — the page that spawned
the worker decides who else speaks to the runtime. A page that both runs a
runtime and hands ports to it therefore holds the transport itself, so
`resolveWorkerUrl` is exported rather than duplicated by every such page.

The frame format is the codec-realm envelope the worker transport already
posts, in both directions. The only thing outside it is the port, which rides
`postMessage`'s transfer list because a port is no `FabricValue`; the message
beside it is the marker saying what the transferred port is for.

## The security model

**One runtime is one signer under one enforcement configuration.** A client that
attaches states the `RuntimeSecurityContext` it believes it is joining, and the
runtime compares it field for field. Any disagreement is refused by name, never
merged — whatever a merge chose, one of the two documents would then be running
under a posture it does not believe it has.

The field list is a record keyed by the context type, so a field added to the
type and not to the list is a type error rather than a posture nobody checks.
Fields compare one at a time, because the two contexts are built in different
documents and one crossed an encoding: a posture carried as an absent property
in one and an explicit `undefined` in the other is the same posture. The backend
and per-space hosts are compared for the same reason as the enforcement fields —
a document believing it reads from somewhere else would have its reads go
silently to the runtime's hosts — and both are normalized first, so two
spellings of one origin do not refuse each other.

**The assertion is a check against misconfiguration, not the authorization.**
The port is the capability: a document can attach only because the page that
owns the worker handed it a duplex.

**No key material ever crosses an attach port.** The initializing client
supplies the signer, once; an attaching client supplies none, naming the acting
principal as a DID. `RuntimeAttachOptions` takes that DID rather than an
`Identity`, so a document that attaches structurally has no key to hand across,
and `findKeyMaterial` refuses a frame holding one anyway — on the sending side
before it reaches a port, and again on receipt, each naming the path the key
sits at.

The refusal sits in `RuntimeConnection.attach`, the last thing before a frame
reaches a transport, so a caller holding a connection directly is covered too.
The walk descends into decoded instance state — a tag this realm does not know
decodes into an `UnknownValue` carrying whatever rode under it, and its state
lives past the enumerable-property walk — and into `Map` and `Set` contents,
which hide the same way.

**This is a misbuild detector, not an exfiltration filter.** A secret already
reduced to bytes or text — a PKCS8 blob, a JWK, a seed as a `Uint8Array` — is
out of scope and would pass unnoticed. Both ends of an attach are a page and a
worker at one trust level under one origin, so a sender determined to move
bytes has the whole payload to do it in; what this catches is the accident of
handing an attach the signer that initialization takes. The classes it
recognizes are enumerated rather than derived, so a future codec class able to
hold a key has to be added to the walker — the same standing obligation as a
new field on `RuntimeSecurityContext`.

That refusal is loud rather than left to the platform, because the platform's
answer varies and one of its answers is worse than a refusal. SP5 measured a
non-extractable `CryptoKey` throwing `DataCloneError` over a `MessagePort`
between two WKWebViews — an embedding defect, since browsers carry it — which
would make such a frame fail as a transport error, in a shell, at run time,
saying nothing about why. The finding is recorded at the refusal site, because
the wrong repair for that error is to find a way to pass the key.

`RuntimeSecurityContext` also carries the comparability contract it depends on:
every field holds plain JSON-shaped values only. `deepEqual` compares a class
instance by its enumerable own properties, so a `FabricValue`-carrying field
would compare equal between two different values and accept an attach that
should have been refused. A field that must carry one needs `valueEqual` and a
deliberate decision.

## The four requirements

Each is probe-pinned, and each test was watched failing first.

| Requirement | Tests | Red-first evidence |
| --- | --- | --- |
| Subscriptions namespaced by client | `runtime-processor.test.ts` → "cell subscriptions" (4) | one sink instead of two; `sinks[1] is not a function` |
| Mount ids namespaced by client | → "VDOM mounts" (2) | `vdomMounts.size` 1 not 2; 0 batches reach either client |
| Per-client cleanup, never the runtime | → "disposeClient()" (2), `RuntimeClients.test.ts` departure | `processor.disposeClient is not a function` |
| Event and frame routing by client | → "event routing" (2) | the event reaches the wrong mount |

Beyond the four: 27 `RuntimeClients` tests (attach accepted, refused, before
init, mid-init, to a disposed runtime, from the owner; port carrier owner-only;
unattached refusal; departure), 9 for the security-context comparison and its
normalization, 8 for `findKeyMaterial`, 8 for the port transport,
`attach-round-trip.test.ts` joining a real `RuntimeClient` to a real registry
over a real channel, `RuntimeConnection.attach` pinned on sending nothing when
it refuses, and `attachOptionsFrom` pinned on what it drops.

**Single-client behavior is unchanged and pinned.** Every handler takes
`client: WorkerClient = ownerClient`, so a call naming no client is the
single-client call it always was; every pre-existing error string and branch
order is preserved.

## The proof

`integration/client.test.ts` → "multi-document attachment" runs against a real
worker and a real backend: both documents fed from one runtime with the first's
unsubscribe leaving the second's feed alone; the second document's departure
taking down its own work and nothing else; an attach asserting a different
acting principal refused.

It was verified by breaking it — with `clientScopedKey` returning the bare key,
the first case never settles, because the second document's subscribe is once
again a no-op on the first's.

## What this does not do

**A navigation a pattern asks for still reaches the family root, not the
document whose mount raised it.** This is a known gap, not a policy choice.
`NavigateCallback` is `(target: Cell) => void` and is invoked from a post-commit
effect flush (`runner/src/builtins/navigate-to.ts`), by then decoupled from the
event dispatch that caused it — so nothing in hand names a mount, and the
worker's mounts cannot be asked which one is responsible. Closing it means the
runner carrying the raising context to the callback, which is a runner change
rather than a change at this seam. A host with more than one document should
treat pattern-driven navigation as reaching the root until then.

Console output and telemetry likewise reach the owner alone, which is a policy
question left open. Pending writes are the owner's by right: the worker lives in
the owner's page, so it is the owner's unload that can lose them.

A departure is something a client says rather than something the worker
observes, because a dead `MessagePort` emits no event. `disposeClient` is the
call site a future liveness signal plugs into.

`pieceSourceConfirmations` is not swept on departure: it is keyed by piece, and
its token is a UUID the preparer holds, so a departing client takes the only
means of confirming its own pending entry with it.

## Test plan

Run green: `deno task check`; `deno fmt --check`; `deno lint`; the standalone
gates (`check-docs`, `check-no-waitfor`, `check-unused-deps`,
`check-single-copy-deps`, `check-package-cycles`, `check-skill-facts`,
`check-control-characters`, `check-conflict-markers`, and the rest); unit suites
for `runtime-client` (26 files, 556 steps), `lib-shell`, `html`, `shell`, `ui`,
`integration`, and `runner` (1338 files, 8045 steps); and the `runtime-client`
**integration** lane (50 steps) against a live local toolshed.

**Not run locally, for CI to cover:** the browser integration lanes (`shell`,
`patterns`, `patterns-reload`, and the unfiltered root `deno task test`), which
launch Chrome and need an unsandboxed session; and `deno task cfcheck`, no
pattern being touched.

A new live document, `docs/features/multi-document-runtime-attachment.md`,
describes what each document owns, what they share, the security model, and both
gaps above; `docs/features/README.md` indexes it.

## Credit

The findings folded in `e65c073d5` and `54282e4ea` came from adversarial review
passes
that verified the gate, the isolation, and the key-material invariant under
attack and found no break — every one of these was a way the attachment could be
wrong without anything going red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019i6e9FAKrQ7aNjPsAZrUxD


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

