### PR TITLE
style(cf-harness): six group comments the sweep bound to one member, and a lost claim

### DIFF
--- a/packages/cf-harness/console/src/cell-chip.ts
+++ b/packages/cf-harness/console/src/cell-chip.ts
@@ -243,13 +243,16 @@ export class ConsoleCell extends LitElement {
   };
 
   #showing = false;
+
   /**
-   * Hover and focus each keep the card up on their own — `:hover, :focus-within`
-   * is an or — so tracking stops only when neither is left. Closing on
-   * `mouseleave` alone strands a card the keyboard is still holding open.
+   * Whether the pointer is over the chip. Hover and focus each keep the card up
+   * on their own — `:hover, :focus-within` is an or — so tracking stops only
+   * when neither is left. Closing on `mouseleave` alone strands a card the
+   * keyboard is still holding open.
    */
   #hovered = false;
 
+  /** Whether focus is inside the chip, which holds the card up the same way. */
   #focused = false;
 
   #open(by: "hover" | "focus"): void {

--- a/packages/cf-harness/scripts/measure-runs.ts
+++ b/packages/cf-harness/scripts/measure-runs.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read
+
 /**
  * Count what console runs did with the pattern index.
  *
@@ -262,6 +263,7 @@ export interface MeasurementTotals {
   delegations: number;
   delegationProfiles: Readonly<Record<string, number>>;
   delegationProfilesUnread: number;
+
   /** `assign_slug` calls. The three counts below partition this one. */
   slugs: number;
 
@@ -274,6 +276,11 @@ export interface MeasurementTotals {
   /** Of those, the ones whose outcome could not be read. */
   slugsUnread: number;
 
+  /**
+   * The slug names themselves, from the assigned calls alone: a refused or
+   * unread call contributes none, and neither does an assigned call whose name
+   * could not be read.
+   */
   slugNames: readonly string[];
 
   /**
@@ -537,6 +544,7 @@ export const totalsOf = (run: RunMeasurement): MeasurementTotals => {
 const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
 const LINE_COMMENT = /(^|[^:])\/\/[^\n]*/g;
 const IMPORT_STATEMENT = /\bimport\s+[\s\S]*?\s+from\s*(['"])([^'"]+)\1\s*;?/g;
+
 /** `import "cf:pattern:…"`, which binds nothing and so carries no `from`. */
 const BARE_IMPORT_STATEMENT = /\bimport\s*(['"])([^'"]+)\1\s*;?/g;
 

--- a/packages/cf-harness/src/pattern-index/publish-render-gate.ts
+++ b/packages/cf-harness/src/pattern-index/publish-render-gate.ts
@@ -154,7 +154,6 @@ export type PatternPublicationReason =
  * `syntheticInputsComplete` reach the tool result; `html` goes only to the
  * run artifact — see the module comment on what that does and does not mean.
  */
-
 export interface PatternRenderVerdict {
   readonly status: PatternPublicationStatus;
   readonly reason: PatternPublicationReason;

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1753,6 +1753,7 @@ const MODEL_FACING_READ_FILE_BOUNDS: ModelFacingTextBounds = {
   head: 8_000,
   tail: 2_000,
 };
+
 const REDACTED_READ_FILE_ERROR_PATH = "[redacted]";
 const REDACTED_READ_FILE_ERROR_MESSAGE =
   "read_file failed: filesystem status not observable under CFC policy";

--- a/packages/cf-harness/src/tools/browser.ts
+++ b/packages/cf-harness/src/tools/browser.ts
@@ -529,17 +529,24 @@ type BrowserHandleResolution =
   | { input?: undefined; error: string };
 
 /**
- * `input` with each bound handle replaced by a placeholder standing in for the
- * value it will resolve to, so the action's shape can be checked before
- * anything is read. The placeholders are only ever seen by `planBrowserAction`
- * — the real values are substituted after resolution — and the URL form is
- * well-formed so an `open` passes its scheme check on shape rather than on
- * the destination, which is validated separately once it is known.
+ * Stands in for a bound handle's value while the action's shape is checked.
+ * Only ever seen by `planBrowserAction` — the real value is substituted after
+ * resolution.
  */
 const HANDLE_SHAPE_PLACEHOLDER = "cf-harness-handle-placeholder";
 
+/**
+ * The same, for a handle in URL position. Well-formed, so an `open` passes its
+ * scheme check on shape rather than on the destination, which is validated
+ * separately once it is known.
+ */
 const HANDLE_SHAPE_PLACEHOLDER_URL = "https://handle.placeholder.invalid/";
 
+/**
+ * `input` with each bound handle replaced by a placeholder standing in for the
+ * value it will resolve to, so the action's shape can be checked before
+ * anything is read.
+ */
 const withHandlePlaceholders = (input: BrowserToolInput): BrowserToolInput => ({
   ...input,
   ...(input.valueHandle !== undefined

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -45,7 +45,7 @@ const signer = await Identity.fromPassphrase("cf-harness describe-handle");
 const HASH_A = "A".repeat(43);
 const REF_A = `/of:fid1:${HASH_A}/summary`;
 
-/** The raw hash the two hostile property names below are built from. */
+/** The raw hash the hostile tagged property name below is built from. */
 const SCRUB_HASH = "C".repeat(43);
 
 /**

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -45,23 +45,27 @@ const signer = await Identity.fromPassphrase("cf-harness describe-handle");
 const HASH_A = "A".repeat(43);
 const REF_A = `/of:fid1:${HASH_A}/summary`;
 
-/**
- * A tagged hash and a DID, each in the position a schema's author controls
- * outright: the name of a property. Neither is a schemed link form, so the
- * handle boundary does not swap them — the scrub is what keeps them out.
- */
+/** The raw hash the two hostile property names below are built from. */
 const SCRUB_HASH = "C".repeat(43);
 
+/**
+ * A tagged hash in the position a schema's author controls outright: the name
+ * of a property. Not a schemed link form, so the handle boundary does not swap
+ * it — the scrub is what keeps it out.
+ */
 const HOSTILE_HASH_NAME = `fid1:${SCRUB_HASH}`;
+
+/** A DID in that same position, kept out the same way. */
 const HOSTILE_DID_NAME = "did:key:z6MkfffDescribeHandleScrubbing";
+
+/** The raw hash the linked property name below is built from. */
+const LINKED_NAME_HASH = "E".repeat(43);
 
 /**
  * A property name that is a link rather than a bare identifier. The scrub
  * deliberately leaves the schemed forms alone, because they are the handle
  * boundary's business: a link is swapped for a token, wherever it sits.
  */
-const LINKED_NAME_HASH = "E".repeat(43);
-
 const LINK_PROPERTY_NAME = `/of:fid1:${LINKED_NAME_HASH}/total`;
 
 /** The sandbox members the prompt loop reaches on a run with no shell work. */

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -51,12 +51,13 @@ const COMMITTED = entity("committed");
 const NEVER_WRITTEN = entity("neverWritten");
 
 /**
- * The space the DID-named database holds, and one this host never opened. The
- * store names its file after its space, so a file named for {@link OWN_DID} is
- * the only proof this reader has of which space its ids belong to.
+ * The space the DID-named database holds. The store names its file after its
+ * space, so a file named for {@link OWN_DID} is the only proof this reader has
+ * of which space its ids belong to.
  */
 const OWN_DID = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
 
+/** A space this host never opened, for the same reason. */
 const FOREIGN_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
 /**
@@ -236,16 +237,19 @@ const documents: Record<string, unknown> = {
 };
 
 /**
- * Bounds narrower than the ones a run records under, each stopping at a place
+ * Bounds narrower than the ones a run records under, stopping at a place
  * {@link DEEPER} reaches: {@link SHALLOW} descends one level, so the link
- * below that is a path it refuses; {@link SPENT} has two values to spend, so
- * it runs out with the rest of the document unenumerated.
+ * below that is a path it refuses.
  */
 const SHALLOW: LinkWalkBounds = {
   maxDepth: 1,
   maxNodes: Number.POSITIVE_INFINITY,
 };
 
+/**
+ * The other such bound: {@link SPENT} has two values to spend, so it runs out
+ * with the rest of the document unenumerated.
+ */
 const SPENT: LinkWalkBounds = { maxDepth: 64, maxNodes: 2 };
 
 /** The documents written as plain JSON rather than through the codec. */

--- a/packages/cf-harness/test/space-labels.test.ts
+++ b/packages/cf-harness/test/space-labels.test.ts
@@ -57,7 +57,7 @@ const NEVER_WRITTEN = entity("neverWritten");
  */
 const OWN_DID = "did:key:z6MkfrQ3tCDZgvJcLwPTvxNsFR8RgTsHTa5JzmnW9pQrUvNq";
 
-/** A space this host never opened, for the same reason. */
+/** A space this host never opened, for the cross-space cases below. */
 const FOREIGN_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
 /**
@@ -247,8 +247,8 @@ const SHALLOW: LinkWalkBounds = {
 };
 
 /**
- * The other such bound: {@link SPENT} has two values to spend, so it runs out
- * with the rest of the document unenumerated.
+ * The other such bound: two values to spend, so it runs out with the rest of
+ * the document unenumerated.
  */
 const SPENT: LinkWalkBounds = { maxDepth: 64, maxNodes: 2 };
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The second batch of ex-post-facto review findings, from #6652 judged against
`main` rather than against its diff. Sibling batches are #6693 (the rule) and
#6694 (`runner` and the comment-rewrite PRs).

## Six group comments bound to one member

A blank line under a comment written over a run of declarations does not narrow
what the comment says; it makes the narrowing look deliberate. Each of these is
now false or incomplete as it stands:

| site | the comment | what it sits on |
|---|---|---|
| `test/space-labels.test.ts:53` | "the space the DID-named database holds, **and one this host never opened**" | `OWN_DID` alone |
| `test/space-labels.test.ts:238` | "**Bounds** narrower … **each** stopping … {@link SPENT} has two values" | `SHALLOW` alone |
| `test/describe-handle.test.ts:48` | "**a tagged hash and a DID**, each in the position … the name of a property" | `SCRUB_HASH` — a bare hash, neither tagged nor a DID nor a property name |
| `test/describe-handle.test.ts:58` | "a property name that is a link" | `LINKED_NAME_HASH` — likewise a bare hash |
| `src/tools/browser.ts:531` | what `withHandlePlaceholders` returns, **and the URL form** | the string const `HANDLE_SHAPE_PLACEHOLDER` |
| `console/src/cell-chip.ts:246` | "hover and focus **each** keep the card up … only when **neither** is left" | `#hovered` alone |

Each splits with the shared reasoning kept on the first member — the treatment
#6652 itself gave four other sites of this exact shape, in this same diff. The
two `describe-handle` sites and `browser.ts` were misplaced before the arc; the
sweep froze them.

## A claim a rewrite dropped

`scripts/measure-runs.ts` split a five-field group comment four ways and left
`slugNames` undocumented, losing "holds only the names the tool assigned". That
is true of the code — `measure-runs.ts:500-501` adds a name only past the unread
and refused arms, and only when the name is readable — and is not derivable from
the field name.

## Two that are not the arc's

- `src/prompt-loop.ts:1755` — #6690 added a documented const directly above
  `REDACTED_READ_FILE_ERROR_PATH`. This is the **only** below-rule violation in
  all 247 files of the package, so it is drift arriving after the sweep, not a
  sweep miss.
- `src/pattern-index/publish-render-gate.ts:157` — a blank line between a doc
  comment and its interface, which the sweep passed over.

## Scope

The above-rule sites **in the files this PR already opens** are conformed too: a
member directly above a doc comment, and a shebang directly above a file header,
both in `measure-runs.ts`. The review found **33 such sites across 15 of the
package's 59 files**, all pre-existing and identical at `1a78b30d1` and at
`main`. Those are reported as a measured residual rather than worked off here.

## Verification

`deno fmt --check`, `deno lint`, `deno check`, and the `cf-harness` suite: 919
passed. No added line exceeds eighty columns, measured as characters over the
diff's `+` lines.

Gates were run **off-pin** — this machine has `deno` 2.9.6 where `mise.toml`
pins 2.9.4 and `mise` is not installed. CI's pinned run is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

