### PR TITLE
Fix dashboard sparkline transparency and shared fades

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -266,11 +266,12 @@ on one wash washes out on another.
 
 `palette.ts` holds all of this, and it is the only place any of it is chosen.
 A status color that appears anywhere — a tile, a dot, a headline, a run cell,
-a sparkline's fade, a drill-down row, the favicon — comes from there. A shade
-that follows from another, like the one a sparkline fades up out of, is worked
-out there too rather than written down beside it, so a change to a color or to
-a tile's wash carries to it without a second edit. The shape a dot takes is
-geometry rather than color, and lives with the rest of the tile's CSS.
+a drill-down row, the favicon — comes from there. A shade that follows from
+another is worked out there too rather than written down beside it, so a change
+to a color carries without a second edit. Sparkline strokes fade from a
+transparent version of their own series color over the shared chart axis. The
+shape a dot takes is geometry rather than color, and lives with the rest of the
+tile's CSS.
 
 Think about how a tile makes someone feel before you think about what it
 measures. Prefer an honest gray "unknown" over a false green — a tile that

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -23,7 +23,6 @@ import {
   friendlyError,
   github,
   performanceGithub,
-  SPARK_FADE,
   sparkline,
 } from "./lib.ts";
 import { GitHubRateLimitBudgetError } from "./github-rate-limit.ts";
@@ -2833,7 +2832,7 @@ function renderSeries(
     values,
     CHART_LINE,
     undefined,
-    SPARK_FADE[status],
+    true,
     xs,
     {
       trim: PERFORMANCE_HISTORY_SCALE_TRIM,

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -189,19 +189,73 @@ Deno.test("sparklines share one rendered height", () => {
   assert(labeled.includes("height:28px"));
 });
 
-Deno.test("sparkline: fadeFrom makes the base line a gradient to color at the highlight edge", () => {
-  const svg = sparkline([30, 20, 10, 11, 12, 13], "#727882", { count: 3, color: "#c7ccd4" }, "#101010");
-  assert(/<linearGradient id="[^"]+" x1="0" y1="0" x2="1" y2="0"/.test(svg), "horizontal gradient defined");
-  assert(svg.includes('<stop offset="0" stop-color="#101010"'), "far-left stop is fadeFrom");
-  assert(svg.includes('stop-color="#727882"'), "the gradient resolves to the base color");
+Deno.test("sparkline: fades to base color at the highlight edge", () => {
+  const svg = sparkline(
+    [30, 20, 10, 11, 12, 13],
+    "#727882",
+    { count: 3, color: "#c7ccd4" },
+    true,
+  );
+  assert(
+    svg.includes(
+      'gradientUnits="userSpaceOnUse" x1="0" y1="0" ' +
+        'x2="220" y2="0"',
+    ),
+    "gradient spans the chart axis",
+  );
+  assert(
+    svg.includes(
+      '<stop offset="0" stop-color="#727882" stop-opacity="0"/>',
+    ),
+    "far-left stop is the transparent line color",
+  );
+  assert(
+    svg.includes('stop-color="#727882" stop-opacity="1"'),
+    "the gradient resolves to the opaque base color",
+  );
   const id = svg.match(/id="([^"]+)"/)![1];
   assert(svg.includes(`stroke="url(#${id})"`), "the base line strokes with the gradient");
   assert(svg.includes('stroke="#c7ccd4"'), "the highlight keeps its flat color");
   // transition reaches base color by the tile midpoint (0.5), before the
   // highlight edge at (6-3)/(6-1) = 0.6
   assert(svg.includes('offset="0.500"'), "gradient reaches base color by the midpoint");
-  // no fadeFrom -> flat base stroke, no gradient
-  assert(!/<linearGradient/.test(sparkline([1, 2, 3], "#727882", { count: 2, color: "#eee" })), "no fade without fadeFrom");
+  // No fade -> flat base stroke, no gradient.
+  assert(
+    !/<linearGradient/.test(
+      sparkline([1, 2, 3], "#727882", { count: 2, color: "#eee" }),
+    ),
+    "no gradient without a fade",
+  );
+});
+
+Deno.test("sparkline: fade handoff follows the shared x axis", () => {
+  const partial = sparkline(
+    [30, 20, 10, 11, 12, 13],
+    "#727882",
+    { count: 3, color: "#c7ccd4" },
+    true,
+    [0, 0.05, 0.1, 0.2, 0.4, 0.8],
+  );
+  assert(
+    partial.includes(
+      'offset="0.200" stop-color="#727882" stop-opacity="1"',
+    ),
+    "the fade reaches full opacity where the highlighted tail starts",
+  );
+
+  const onePoint = sparkline(
+    [1, 2, 3, 4],
+    "#727882",
+    { count: 1, color: "#c7ccd4" },
+    true,
+    [0, 0.02, 0.05, 0.1],
+  );
+  assert(
+    onePoint.includes(
+      'offset="0.500" stop-color="#727882" stop-opacity="1"',
+    ),
+    "a one-point tail keeps the midpoint fade",
+  );
 });
 
 Deno.test("multiSparkline: overlaid lines on one shared scale; < 2 points is empty", () => {
@@ -262,22 +316,36 @@ Deno.test("multiSparkline: a trimmed shared scale pools series and centers a fla
   assertEquals(flatYs.filter((y) => y === 17).length, 16);
 });
 
-Deno.test("multiSparkline: fadeFrom gradients each line", () => {
+Deno.test("multiSparkline: fades each line from its transparent color", () => {
   const svg = multiSparkline(
     [
       { vals: [1, 2, 3], color: "#0a0", label: "3" },
       { vals: [4, 5, 6], color: "#00a", label: "6" },
     ],
-    { fadeFrom: "#111" },
+    { fade: true },
   );
-  // each line fades from fadeFrom (left) to its own color at the midpoint
-  assert(svg.includes('stop-color="#111"/><stop offset="0.5" stop-color="#0a0"'), "team line fades to its color");
-  assert(svg.includes('stop-color="#111"/><stop offset="0.5" stop-color="#00a"'), "visitor line fades to its color");
-  assert(/stroke="url\(#mspk-[0-9a-fA-F]+-[0-9a-fA-F]+-\d+\)"/.test(svg), "lines stroke via their gradient");
-  // no fadeFrom -> flat strokes, no gradient defs
+  assert(
+    svg.includes(
+      'stop-color="#0a0" stop-opacity="0"/><stop offset="0.5" ' +
+        'stop-color="#0a0" stop-opacity="1"',
+    ),
+    "team line fades from transparent to opaque",
+  );
+  assert(
+    svg.includes(
+      'stop-color="#00a" stop-opacity="0"/><stop offset="0.5" ' +
+        'stop-color="#00a" stop-opacity="1"',
+    ),
+    "visitor line fades from transparent to opaque",
+  );
+  assert(
+    /stroke="url\(#mspk-[0-9a-fA-F]+-\d+\)"/.test(svg),
+    "lines stroke via their gradient",
+  );
+  // No fade -> flat strokes, no gradient definitions.
   assert(
     !/<linearGradient/.test(multiSparkline([{ vals: [1, 2], color: "#0a0" }, { vals: [3, 4], color: "#00a" }])),
-    "no gradient without fadeFrom",
+    "no gradient without a fade",
   );
 });
 
@@ -325,7 +393,7 @@ Deno.test("lighten: blends a color toward white; non-hex is left alone", () => {
 Deno.test("multiSparkline: highlight redraws the trailing slice in a lighter tint", () => {
   const svg = multiSparkline(
     [{ vals: [1, 2, 3, 4, 5], color: "#10a37f", label: "5" }],
-    { highlight: { count: 2 }, fadeFrom: "#111111" },
+    { highlight: { count: 2 }, fade: true },
   );
   // The base line plus the lighter trailing slice drawn over it.
   assertEquals([...svg.matchAll(/<polyline/g)].length, 2);
@@ -334,7 +402,10 @@ Deno.test("multiSparkline: highlight redraws the trailing slice in a lighter tin
   assert(svg.includes('stop offset="0.5" stop-color="#10a37f"'), "gradient handoff at the midpoint");
   assert(!svg.includes("stroke-opacity"), "a lighter tint, not a flat dim");
   // No highlight -> just the one line, no tint.
-  const plain = multiSparkline([{ vals: [1, 2, 3], color: "#10a37f", label: "3" }], { fadeFrom: "#111111" });
+  const plain = multiSparkline(
+    [{ vals: [1, 2, 3], color: "#10a37f", label: "3" }],
+    { fade: true },
+  );
   assertEquals([...plain.matchAll(/<polyline/g)].length, 1);
 });
 
@@ -355,21 +426,40 @@ Deno.test("a slice covering the whole series leaves the line in its own color", 
   // repaint the whole line in the tint and lose the line's own color.
   const whole = multiSparkline(
     [{ vals: [1, 2, 3, 4], color: "#10a37f", label: "4" }],
-    { highlight: { count: 4 }, fadeFrom: "#111111" },
+    { highlight: { count: 4 }, fade: true },
   );
   assertEquals([...whole.matchAll(/<polyline/g)].length, 1, "base only, no tint over it");
   assert(!whole.includes(lighten("#10a37f")), "the line keeps its own color");
   assert(
-    whole.includes('<stop offset="0" stop-color="#10a37f"'),
-    "the line uses its own color from the left edge",
+    whole.includes(
+      '<stop offset="0" stop-color="#10a37f" stop-opacity="0"/>' +
+        '<stop offset="0.5" stop-color="#10a37f" stop-opacity="1"',
+    ),
+    "the whole window retains the shared fade",
   );
   // Same for a count past the end of the series.
-  const over = multiSparkline([{ vals: [1, 2, 3, 4], color: "#10a37f" }], { highlight: { count: 9 } });
+  const over = multiSparkline(
+    [{ vals: [1, 2, 3, 4], color: "#10a37f" }],
+    { highlight: { count: 9 }, fade: true },
+  );
   assertEquals([...over.matchAll(/<polyline/g)].length, 1);
+  assert(
+    over.includes('offset="0.5" stop-color="#10a37f" stop-opacity="1"'),
+    "a past-the-end window retains the shared fade",
+  );
   // The single-color sparkline behaves the same way.
-  const one = sparkline([1, 2, 3, 4], "#727882", { count: 4, color: "#c7ccd4" }, "#111111");
+  const one = sparkline(
+    [1, 2, 3, 4],
+    "#727882",
+    { count: 4, color: "#c7ccd4" },
+    true,
+  );
   assertEquals([...one.matchAll(/<polyline/g)].length, 1, "base only");
   assert(!one.includes("#c7ccd4"), "the line keeps its own color");
+  assert(
+    one.includes('offset="0.500" stop-color="#727882" stop-opacity="1"'),
+    "the whole window retains the shared fade",
+  );
 });
 
 Deno.test("multiSparkline: every base is drawn before any tint", () => {
@@ -397,7 +487,7 @@ Deno.test("multiSparkline: shared axes and per-line highlights", () => {
       xs: [0.6, 0.8, 1],
       highlightCount: 0,
     },
-  ], { fadeFrom: "#111111" });
+  ], { fade: true });
   const lines = [
     ...svg.matchAll(
       /<polyline points="([^"]*)"[^>]*stroke="([^"]*)"/g,
@@ -421,8 +511,22 @@ Deno.test("multiSparkline: shared axes and per-line highlights", () => {
     [44, 88],
   );
   assert(!svg.includes("<mask"));
-  assert(svg.includes('<stop offset="0.2" stop-color="#10a37f"'));
-  assert(svg.includes('<stop offset="0.5" stop-color="#d97757"'));
+  assert(
+    svg.includes(
+      'gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="220" y2="0"',
+    ),
+    "partial lines fade over the shared chart axis",
+  );
+  assert(
+    svg.includes(
+      '<stop offset="0.2" stop-color="#10a37f" stop-opacity="1"',
+    ),
+  );
+  assert(
+    svg.includes(
+      '<stop offset="0.5" stop-color="#d97757" stop-opacity="1"',
+    ),
+  );
 });
 
 Deno.test("multiSparkline: one-point markers are explicit", () => {
@@ -488,6 +592,33 @@ Deno.test("multiSparkline: large horizontal gaps split paths without losing poin
   }]);
   assertEquals([...offsetBoundary.matchAll(/<polyline/g)].length, 1);
   assertEquals([...offsetBoundary.matchAll(/<circle/g)].length, 0);
+});
+
+Deno.test("multiSparkline: disconnected paths share one chart-axis fade", () => {
+  const svg = multiSparkline([{
+    vals: [1, 2, 3, 4],
+    color: "#d97757",
+    xs: [0, 0.1, 0.7, 0.8],
+    highlightCount: 4,
+    maxXGap: 0.2,
+  }], { fade: true });
+  const strokes = [
+    ...svg.matchAll(/<polyline[^>]*stroke="([^"]+)"/g),
+  ].map((match) => match[1]);
+  assertEquals(strokes.length, 2);
+  assertEquals(new Set(strokes).size, 1);
+  assertEquals([...svg.matchAll(/<linearGradient/g)].length, 1);
+  assert(strokes[0].startsWith("url(#mspk-"));
+  assert(
+    svg.includes(
+      'gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="220" y2="0"',
+    ),
+  );
+  assert(
+    svg.includes(
+      '<stop offset="0.5" stop-color="#d97757" stop-opacity="1"',
+    ),
+  );
 });
 
 Deno.test("multiSparkline: isolated markers use the tint only inside the highlighted tail", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -499,8 +499,6 @@ export function memo<T>(ttlMs: number, fn: () => Promise<T>): () => Promise<T> {
   };
 }
 
-export { SPARK_FADE_CSS as SPARK_FADE } from "./palette.ts";
-
 export function humanDur(ms: number): string {
   const m = Math.floor(ms / 60000);
   if (m < 60) return `${m}m`;
@@ -586,13 +584,14 @@ function scaleValues(
 // trailing `count` points are overdrawn in a second color (e.g. to pick out the
 // most recent runs against a longer trend). The vertical scale is normalized to
 // those recent points' range plus 25% headroom, so older outliers clip off the
-// edges instead of flattening the recent detail into a useless line. `fadeFrom`
-// makes the base line a horizontal gradient from that color on the far left up to
-// `color` by the tile's midpoint. `xs` gives each point's horizontal position as a
-// fraction 0..1 of the width (for placing several sparklines on one shared axis —
-// e.g. a real time axis); a series that doesn't reach the ends occupies only part
-// of the width. Without it, points are spaced evenly. The line has no label of its
-// own — a tile's `duration` slot draws the span in the corner. `scale.trim`
+// edges instead of flattening the recent detail into a useless line. `fade`
+// makes the base line a horizontal gradient from transparent on the far left up
+// to `color` by the tile's midpoint. `xs` gives each point's horizontal
+// position as a fraction 0..1 of the width (for placing several sparklines on
+// one shared axis — e.g. a real time axis); a series that doesn't reach the
+// ends occupies only part of the width. Without it, points are spaced evenly.
+// The line has no label of its own. A tile's `duration` slot draws the span in
+// the corner. `scale.trim`
 // excludes that many values from each end of the sorted scale inputs without
 // removing the points themselves. A series below `scale.minValues`, or too short
 // to leave two scale values, keeps its full range.
@@ -600,7 +599,7 @@ export function sparkline(
   vals: number[],
   color: string,
   highlight?: { count: number; color: string; scaleAll?: boolean },
-  fadeFrom?: string,
+  fade = false,
   xs?: number[],
   scale?: { trim?: number; minValues?: number },
 ): string {
@@ -619,21 +618,35 @@ export function sparkline(
   const pts = vals.map((v, i) =>
     `${xAt(i).toFixed(1)},${(h - 3 - ((v - min) / rng) * (h - 6)).toFixed(1)}`
   );
-  // The base line fades from `fadeFrom` on the far left to `color`, then holds
-  // `color` (SVG extends the last stop). objectBoundingBox units keep the
-  // transition placed regardless of the preserveAspectRatio stretch.
+  // The base line fades from transparent on the far left to `color`, then holds
+  // `color` (SVG extends the last stop). userSpaceOnUse keeps the transition at
+  // the same screen x when `xs` places the line on only part of the chart.
   let defs = "", baseStroke = color;
-  if (fadeFrom) {
+  if (fade) {
     // Reach `color` by the tile's midpoint — or sooner, if the highlight starts
     // before halfway (so the base is fully `color` before the handoff).
-    const edge = highlight
-      ? Math.max(0, Math.min(1, (vals.length - highlight.count) / (vals.length - 1)))
+    const edge = highlight && highlight.count >= 2 && highlight.count < vals.length
+      ? Math.max(
+        0,
+        Math.min(
+          1,
+          xs?.length === vals.length
+            ? xs[vals.length - highlight.count]
+            : (vals.length - highlight.count) / (vals.length - 1),
+        ),
+      )
       : 1;
     const tf = Math.min(0.5, edge);
     if (tf > 0) {
-      const id = `spk-${fadeFrom.replace(/[^0-9a-fA-F]/g, "")}-${color.replace(/[^0-9a-fA-F]/g, "")}-${Math.round(tf * 100)}`;
-      defs = `<defs><linearGradient id="${id}" x1="0" y1="0" x2="1" y2="0">` +
-        `<stop offset="0" stop-color="${fadeFrom}"/><stop offset="${tf.toFixed(3)}" stop-color="${color}"/>` +
+      const id = `spk-${
+        color.replace(/[^0-9a-fA-F]/g, "")
+      }-${Math.round(tf * 100)}`;
+      defs = `<defs><linearGradient id="${id}" ` +
+        `gradientUnits="userSpaceOnUse" x1="0" y1="0" ` +
+        `x2="${w}" y2="0">` +
+        `<stop offset="0" stop-color="${color}" stop-opacity="0"/>` +
+        `<stop offset="${tf.toFixed(3)}" stop-color="${color}" ` +
+        `stop-opacity="1"/>` +
         `</linearGradient></defs>`;
       baseStroke = `url(#${id})`;
     }
@@ -654,11 +667,11 @@ export function sparkline(
 // Overlaid trend lines (each oldest -> newest) sharing one vertical scale, each
 // in its own color. With a per-series `label`, that series' value is placed in a
 // right-hand gutter at the line's end height, in the line color. With
-// `opts.fadeFrom`, each line fades from that color on the far left up to its own
-// color, reaching full color by the midpoint (or by the start of the highlight,
-// if that comes sooner) — like the ci-duration sparkline. A series' `xs`
-// places its points on a shared horizontal axis. Its `highlightCount` redraws
-// its trailing points, including explicit markers, in a lighter tint.
+// `opts.fade`, each line fades from transparent on the far left up to its own
+// color, reaching full opacity by the midpoint (or by the start of the
+// highlight, if that comes sooner) — like the ci-duration sparkline. The `xs`
+// field positions points on a shared horizontal axis. The `highlightCount`
+// field redraws trailing points, including explicit markers, in a lighter tint.
 // `opts.highlight` supplies the count for series that do not set one. `maxXGap`
 // breaks a path when adjacent horizontal positions are farther apart than that
 // fraction of the chart. `showSinglePoint` draws explicit markers for a
@@ -678,7 +691,7 @@ export function multiSparkline(
     showSinglePoint?: boolean;
   }[],
   opts: {
-    fadeFrom?: string;
+    fade?: boolean;
     highlight?: { count: number };
     scale?: { trim?: number; minValues?: number };
   } = {},
@@ -696,11 +709,11 @@ export function multiSparkline(
   const w = 220, h = 34, min = lo - pad, max = hi + pad, rng = (max - min) || 1;
   const yv = (v: number) => h - 3 - ((v - min) / rng) * (h - 6);
 
-  // Each line fades from `fadeFrom` on the left up to its own color, reaching full
-  // color at the handoff `tf`: the midpoint, or the start of the highlight when
-  // that comes sooner (so the base is solid before the handoff). userSpaceOnUse
-  // keeps the transition at the same screen x for every line and avoids the
-  // zero-bbox quirk when a line is flat.
+  // Each line fades from transparent on the left up to its own color, reaching
+  // full opacity at the handoff `tf`: the midpoint, or the start of the
+  // highlight when that comes sooner (so the base is solid before the handoff).
+  // userSpaceOnUse keeps the transition at the same screen x for every line and
+  // avoids the zero-bbox quirk when a line is flat.
   const defs: string[] = [];
   const highlightCount = (
     line: (typeof series)[number],
@@ -708,7 +721,7 @@ export function multiSparkline(
   const highlightEdge = (line: (typeof series)[number]): number => {
     const count = highlightCount(line);
     if (count < 2) return 1;
-    if (count >= line.vals.length) return 0;
+    if (count >= line.vals.length) return 1;
     const index = line.vals.length - count;
     return line.xs?.length === line.vals.length
       ? line.xs[index]
@@ -716,14 +729,17 @@ export function multiSparkline(
   };
   const strokeFor = (line: (typeof series)[number]): string => {
     const color = line.color;
-    if (!opts.fadeFrom) return color;
+    if (!opts.fade) return color;
     const tf = Math.min(0.5, Math.max(0, highlightEdge(line)));
     const off = String(+tf.toFixed(3));
-    const id = `mspk-${opts.fadeFrom.replace(/[^0-9a-fA-F]/g, "")}-${color.replace(/[^0-9a-fA-F]/g, "")}-${Math.round(tf * 100)}`;
+    const id = `mspk-${
+      color.replace(/[^0-9a-fA-F]/g, "")
+    }-${Math.round(tf * 100)}`;
     if (!defs.some((d) => d.includes(`"${id}"`))) {
       defs.push(
         `<linearGradient id="${id}" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="${w}" y2="0">` +
-          `<stop offset="0" stop-color="${opts.fadeFrom}"/><stop offset="${off}" stop-color="${color}"/>` +
+          `<stop offset="0" stop-color="${color}" stop-opacity="0"/>` +
+          `<stop offset="${off}" stop-color="${color}" stop-opacity="1"/>` +
           `</linearGradient>`,
       );
     }

--- a/packages/dashboard/palette.test.ts
+++ b/packages/dashboard/palette.test.ts
@@ -11,7 +11,6 @@ import { expect } from "@std/expect";
 import type { Status } from "./types.ts";
 import {
   LIGHT_STATUS_TEXT,
-  LIGHT_TILE_BASE,
   rgba,
   STATUS_COLOR,
   STATUS_EDGE,
@@ -216,7 +215,7 @@ describe("palette", () => {
 
     it("keeps small text and status indicators legible on a light tile", () => {
       for (const status of STATUSES) {
-        expect(contrastRatio(LIGHT_STATUS_TEXT[status], LIGHT_TILE_BASE))
+        expect(contrastRatio(LIGHT_STATUS_TEXT[status], "#ffffff"))
           .toBeGreaterThanOrEqual(4.5);
       }
     });

--- a/packages/dashboard/palette.ts
+++ b/packages/dashboard/palette.ts
@@ -72,61 +72,6 @@ export const TEXTURE_WIDTH = 8;
 // blue wherever it appears.
 export const RUNNING_COLOR = "#6ea8fe";
 
-// The flat surface a status tints: the tile itself, and the rows of the
-// drill-down pages that wear a status the same way.
-export const TILE_BASE = "#16181d";
-export const LIGHT_TILE_BASE = "#ffffff";
-
-function channels(hex: string): [number, number, number] {
-  const n = parseInt(hex.slice(1), 16);
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
-}
-
-function hex(channels: readonly number[]): string {
-  return `#${
-    channels.map((c) => Math.round(c).toString(16).padStart(2, "0")).join("")
-  }`;
-}
-
-// How much darker than its tile a sparkline's fade sits.
-const FADE_DEPTH = 0.6;
-
-/** The shade a sparkline fades up out of, on a tile of the given status. */
-function fadeUnder(status: Status, tileBase: string, depth: number): string {
-  const base = channels(tileBase);
-  const tint = channels(STATUS_COLOR[status]);
-  return hex(
-    base.map((b, i) => (b + (tint[i] - b) * STATUS_WASH[status]) * depth),
-  );
-}
-
-// The left edge of a sparkline's fade gradient, a shade below the tile's own
-// background so the line fades up out of it. Worked out from the status color
-// and the tile's wash rather than written down beside them, so a change to
-// either carries here on its own.
-export const SPARK_FADE: Record<Status, string> = {
-  good: fadeUnder("good", TILE_BASE, FADE_DEPTH),
-  warn: fadeUnder("warn", TILE_BASE, FADE_DEPTH),
-  bad: fadeUnder("bad", TILE_BASE, FADE_DEPTH),
-  unknown: fadeUnder("unknown", TILE_BASE, FADE_DEPTH),
-};
-
-// On a light tile the line can disappear into the tile's own tinted surface.
-// The CSS theme chooses between these shades and the dark ones above.
-export const LIGHT_SPARK_FADE: Record<Status, string> = {
-  good: fadeUnder("good", LIGHT_TILE_BASE, 1),
-  warn: fadeUnder("warn", LIGHT_TILE_BASE, 1),
-  bad: fadeUnder("bad", LIGHT_TILE_BASE, 1),
-  unknown: fadeUnder("unknown", LIGHT_TILE_BASE, 1),
-};
-
-export const SPARK_FADE_CSS: Record<Status, string> = {
-  good: "var(--spark-fade-good)",
-  warn: "var(--spark-fade-warn)",
-  bad: "var(--spark-fade-bad)",
-  unknown: "var(--spark-fade-unknown)",
-};
-
 /** A `#rrggbb` color as a CSS `rgba()` at the given alpha. */
 export function rgba(hex: string, alpha: number): string {
   const n = parseInt(hex.slice(1), 16);

--- a/packages/dashboard/spend.ts
+++ b/packages/dashboard/spend.ts
@@ -14,8 +14,7 @@
  * dry further back than its lag allows.
  */
 
-import type { Status } from "./types.ts";
-import { multiSparkline, SPARK_FADE } from "./lib.ts";
+import { multiSparkline } from "./lib.ts";
 import { themedChartSeries } from "./theme.ts";
 
 export const DAY_MS = 86_400_000;
@@ -220,7 +219,6 @@ export function summarizeDailySpend(
 export function spendChart(
   sources: SpendChartSource[],
   now: Date,
-  status: Status,
   estimateDays?: number,
 ): { chart: string; duration: number } {
   const allDays = new Set<string>();
@@ -312,7 +310,7 @@ export function spendChart(
   });
   return {
     chart: multiSparkline(lines, {
-      fadeFrom: SPARK_FADE[status],
+      fade: true,
       highlight: { count: highlightDays },
     }),
     duration: end - start + DAY_MS,

--- a/packages/dashboard/test/spend.test.ts
+++ b/packages/dashboard/test/spend.test.ts
@@ -76,7 +76,7 @@ describe("spend", () => {
   it("ends a lagging source at its own known day instead of padding it with zeros", () => {
     const github = source(run("2026-01-01", 20, 1), 2, "#58a6ff");
     const secondary = source(run("2026-01-01", 19, 2), 1, "#f59e0b");
-    const { chart, duration } = spendChart([github, secondary], NOW, "good");
+    const { chart, duration } = spendChart([github, secondary], NOW);
     expect(duration).toBe(20 * DAY);
     const lines = polylines(chart);
     expect(lines.length).toBe(2);
@@ -92,7 +92,7 @@ describe("spend", () => {
 
   it("charts a settled quiet stretch as zeros and stops at the settled horizon", () => {
     const github = source(run("2026-01-01", 10, 18), 2, "#58a6ff");
-    const { chart, duration } = spendChart([github], NOW, "good");
+    const { chart, duration } = spendChart([github], NOW);
     expect(duration).toBe(18 * DAY);
     const lines = polylines(chart);
     expect(lines.length).toBe(1);
@@ -107,7 +107,7 @@ describe("spend", () => {
 
   it("leaves a source alone whose newest day is already its settled horizon", () => {
     const gcp = source(run("2026-01-01", 19, 3), 1, "#4285f4");
-    const { chart, duration } = spendChart([gcp], NOW, "good");
+    const { chart, duration } = spendChart([gcp], NOW);
     expect(duration).toBe(19 * DAY);
     const lines = polylines(chart);
     expect(lines.length).toBe(1);
@@ -118,7 +118,7 @@ describe("spend", () => {
   it("aligns each line's highlight to the shared trailing window", () => {
     const github = source(run("2026-01-01", 20, 1), 2, "#58a6ff");
     const secondary = source(run("2026-01-01", 19, 2), 1, "#f59e0b");
-    const { chart } = spendChart([github, secondary], NOW, "good", 5);
+    const { chart } = spendChart([github, secondary], NOW, 5);
     const lines = polylines(chart);
     // Two bases, then the two bright trailing slices.
     expect(lines.length).toBe(4);
@@ -145,7 +145,7 @@ describe("spend", () => {
       "#58a6ff",
       ["2025-11", "2026-01"],
     );
-    const { chart, duration } = spendChart([github], GAP_NOW, "good");
+    const { chart, duration } = spendChart([github], GAP_NOW);
     expect(duration).toBe(45 * DAY);
     const lines = polylines(chart);
     // Two pieces of base line, then the bright trailing slice.
@@ -168,7 +168,7 @@ describe("spend", () => {
       "#58a6ff",
       ["2025-11", "2025-12", "2026-01"],
     );
-    const { chart } = spendChart([github], GAP_NOW, "good");
+    const { chart } = spendChart([github], GAP_NOW);
     const lines = polylines(chart);
     // One unbroken base line, then the bright trailing slice.
     expect(lines.length).toBe(2);
@@ -188,7 +188,6 @@ describe("spend", () => {
     const { chart, duration } = spendChart(
       [github],
       new Date("2026-09-02T09:00:00Z"),
-      "good",
       14,
     );
     expect(duration).toBe(45 * DAY);
@@ -206,7 +205,7 @@ describe("spend", () => {
       ["2025-11", "2026-01"],
     );
     const continuous = source(run("2025-11-20", 45, 2), 2, "#f59e0b");
-    const { chart } = spendChart([github, continuous], GAP_NOW, "good", 20);
+    const { chart } = spendChart([github, continuous], GAP_NOW, 20);
     const lines = polylines(chart);
     // Two pieces of the holed base line, one whole base line, then a slice of
     // each.
@@ -225,7 +224,7 @@ describe("spend", () => {
     // December was read and January was not, so on 5 January a 2-day lag
     // settles no January day. The line ends on 31 December.
     const github = source(run("2025-12-01", 20, 5), 2, "#58a6ff", ["2025-12"]);
-    const { chart, duration } = spendChart([github], GAP_NOW, "good");
+    const { chart, duration } = spendChart([github], GAP_NOW);
     expect(duration).toBe(31 * DAY);
     const lines = polylines(chart);
     // One base line over December, then the bright trailing slice.
@@ -253,7 +252,6 @@ describe("spend", () => {
     const { chart } = spendChart(
       [github],
       new Date("2026-01-03T09:00:00Z"),
-      "good",
     );
     const lines = polylines(chart);
     // November is the only run of days long enough to draw a line through.

--- a/packages/dashboard/test/theme.test.ts
+++ b/packages/dashboard/test/theme.test.ts
@@ -43,7 +43,7 @@ describe("theme", () => {
       );
     });
 
-    it("defines every status color, text color, and sparkline color in both themes", () => {
+    it("defines every status and text color in both themes", () => {
       for (const status of ["good", "warn", "bad", "unknown"] as const) {
         expect(
           DASHBOARD_THEME_STYLES.match(
@@ -61,11 +61,6 @@ describe("theme", () => {
         expect(
           DASHBOARD_THEME_STYLES.match(
             new RegExp(`--status-${status}-text:`, "g"),
-          )?.length,
-        ).toBe(3);
-        expect(
-          DASHBOARD_THEME_STYLES.match(
-            new RegExp(`--spark-fade-${status}:`, "g"),
           )?.length,
         ).toBe(3);
       }

--- a/packages/dashboard/theme.ts
+++ b/packages/dashboard/theme.ts
@@ -8,13 +8,7 @@
  */
 
 import type { Status } from "./types.ts";
-import {
-  LIGHT_SPARK_FADE,
-  LIGHT_STATUS_TEXT,
-  SPARK_FADE,
-  STATUS_COLOR,
-  STATUS_TEXT,
-} from "./palette.ts";
+import { LIGHT_STATUS_TEXT, STATUS_COLOR, STATUS_TEXT } from "./palette.ts";
 
 export type DashboardTheme = "dark" | "light";
 export type DashboardThemeMode = DashboardTheme | "system";
@@ -82,7 +76,6 @@ const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
 function variables(
   colors: ThemeColors,
   statusText: Record<Status, string>,
-  sparkFade: Record<Status, string>,
   statusIndicator: Record<Status, string>,
 ): string {
   const neutral = Object.entries(colors).map(([name, value]) =>
@@ -91,7 +84,6 @@ function variables(
   const statuses = STATUSES.flatMap((status) => [
     `--status-${status}:${statusIndicator[status]}`,
     `--status-${status}-text:${statusText[status]}`,
-    `--spark-fade-${status}:${sparkFade[status]}`,
   ]);
   return [...neutral, ...statuses].join(";");
 }
@@ -99,13 +91,11 @@ function variables(
 const DARK_VARIABLES = variables(
   DARK_COLORS,
   STATUS_TEXT,
-  SPARK_FADE,
   STATUS_COLOR,
 );
 const LIGHT_VARIABLES = variables(
   LIGHT_THEME_COLORS,
   LIGHT_STATUS_TEXT,
-  LIGHT_SPARK_FADE,
   LIGHT_STATUS_TEXT,
 );
 

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -2435,7 +2435,7 @@ Deno.test("benchmark: stale CPU trends stay out of the headline while their line
         pageLines.map((line) => line.pointCount).sort((a, b) => a - b),
         [2, 2, 2, 2, 2, 2, 8, 8, 8, 8],
       );
-      assertEquals(new Set(pageLines.map((line) => line.stroke)).size, 10);
+      assertEquals(new Set(pageLines.map((line) => line.stroke)).size, 8);
       const pageMarkerColors = [
         ...html.matchAll(/<circle[^>]*fill="([^"]+)"/g),
       ].map((match) => match[1]);

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -91,7 +91,6 @@ import {
   multiSparkline,
   performanceGithub,
   performanceGithubDownload,
-  SPARK_FADE,
 } from "../lib.ts";
 import {
   BENCH_HEADLINE_MAX_AGE_HOURS,
@@ -1220,7 +1219,7 @@ function benchmarkIndexView(
       maxXGap: CPU_LINE_MAX_X_GAP,
       showSinglePoint: true,
     })),
-    { fadeFrom: SPARK_FADE[status] },
+    { fade: true },
   );
   return {
     ...benchmarkDrill,
@@ -1928,7 +1927,7 @@ export function benchPage(
           showSinglePoint: true,
         })),
         {
-          fadeFrom: SPARK_FADE[status],
+          fade: true,
           scale: {
             trim: PERFORMANCE_HISTORY_SCALE_TRIM,
             minValues: PERFORMANCE_HISTORY_SCALE_MIN_VALUES,

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -15,7 +15,7 @@ import {
   type Tile,
   type TileView,
 } from "../types.ts";
-import { escapeHtml, friendlyError, SPARK_FADE, sparkline } from "../lib.ts";
+import { escapeHtml, friendlyError, sparkline } from "../lib.ts";
 import {
   CI_WORKFLOW,
   DUR_GOOD,
@@ -747,7 +747,7 @@ function makeCiDuration(
         extra: sparkline(series, CHART_LINE, {
           count: window.length,
           color: CHART_HIGHLIGHT,
-        }, SPARK_FADE[s]),
+        }, true),
         duration: spanMs,
         href: opts.href,
         hint: opts.hint,

--- a/packages/dashboard/tiles/dau.ts
+++ b/packages/dashboard/tiles/dau.ts
@@ -33,7 +33,7 @@
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { serviceName, SPARK_FADE, sparkline } from "../lib.ts";
+import { serviceName, sparkline } from "../lib.ts";
 import { CHART_LINE } from "../theme.ts";
 
 const TIMEOUT = 15_000;
@@ -176,7 +176,7 @@ export const dau: Tile = {
     const value = series[series.length - 1];
     // One day is a number, not a trend, so there is no line to draw and no span to
     // report: the span describes the chart.
-    const chart = sparkline(series, CHART_LINE, undefined, SPARK_FADE.good);
+    const chart = sparkline(series, CHART_LINE, undefined, true);
 
     return {
       ...drill,

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { escapeHtml, multiSparkline, SPARK_FADE, thin } from "../lib.ts";
+import { escapeHtml, multiSparkline, thin } from "../lib.ts";
 import { dashboardCacheFile } from "../history-files.ts";
 import { themedChartSeries } from "../theme.ts";
 
@@ -271,7 +271,7 @@ export const discordOnline: Tile = {
         { vals: plot.map((h) => h.team), ...teamSeries, label: String(snap.team) },
         { vals: plot.map((h) => h.visitors), ...visitorSeries, label: String(snap.visitors) },
       ],
-      { fadeFrom: SPARK_FADE.good },
+      { fade: true },
     );
     const swatch = (c: string) => `<span class="swatch" style="background:${escapeHtml(c)}"></span>`;
     // With the chart drawn, the counts sit at each line's end; until there are

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -317,7 +317,6 @@ export const gcpSpend: Tile = {
         lagDays: history.lagDays,
       }],
       now,
-      status,
       summary.estimateDays,
     );
 

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -472,7 +472,6 @@ export const githubCiSpend: Tile = {
           knownMonths: spend.months,
         }],
         now,
-        status,
         spend.estimateDays,
       );
       const amount = chart.chart ? "" : ` ${usd(spend.mtd)}`;

--- a/packages/dashboard/tiles/github-members.ts
+++ b/packages/dashboard/tiles/github-members.ts
@@ -12,7 +12,6 @@ import {
   friendlyError,
   github,
   multiSparkline,
-  SPARK_FADE,
   thin,
 } from "../lib.ts";
 import { themedChartSeries } from "../theme.ts";
@@ -191,7 +190,7 @@ export function createGithubMembers(): Tile {
             label: String(collaborators),
           },
         ],
-        { fadeFrom: SPARK_FADE.good },
+        { fade: true },
       );
       const swatch = (color: string) =>
         `<span class="swatch" style="background:${escapeHtml(color)}"></span>`;

--- a/packages/dashboard/tiles/model-spend.ts
+++ b/packages/dashboard/tiles/model-spend.ts
@@ -210,7 +210,6 @@ export const modelSpend: Tile = {
         chartSource(anMap, ANTHROPIC_COLOR, an ? usd(an.mtd) : undefined),
       ],
       now,
-      status,
     );
 
     // The key line. Charted providers show a swatch (their own MTD sits at the line

--- a/packages/dashboard/tiles/prod-errors.ts
+++ b/packages/dashboard/tiles/prod-errors.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Status, Tile, TileView } from "../types.ts";
-import { serviceName, SPARK_FADE, sparkline } from "../lib.ts";
+import { serviceName, sparkline } from "../lib.ts";
 import { CHART_HIGHLIGHT, CHART_LINE } from "../theme.ts";
 
 const RECENT_MS = 12 * 60 * 60 * 1000; // headline number: last 12 hours
@@ -155,7 +155,7 @@ export const prodErrors: Tile = {
       status,
       value: rate === undefined ? "—" : `${rate.toFixed(2)}%`,
       sub: rate === undefined ? "no traces · last 12h" : `${recentErr} err / ${recentTotal} spans · last 12h`,
-      extra: sparkline(series, CHART_LINE, highlight, SPARK_FADE[status]),
+      extra: sparkline(series, CHART_LINE, highlight, true),
       duration: span,
     };
   },


### PR DESCRIPTION
Dashboard sparklines faded from a theme-specific background shade into their series color. That shade remained visibly gray on dark tiles and became white on light tiles instead of disappearing into the surface.

Fade each stroke from zero opacity to full opacity while keeping its own series color. Keep the gradient positioned on the shared chart axis, and retain the midpoint handoff when a highlight window covers an entire short series. This prevents disconnected benchmark paths from restarting or collapsing their fades.

Remove the obsolete palette and theme variables that supplied background fade colors. Update every chart caller and cover transparent stops, partial axes, disconnected paths, and exact or oversized whole-series highlight windows in tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

