### PR TITLE
style(cli): eight file headers the sweep bound to an import, and four frozen pairs

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3054,9 +3054,11 @@ export interface PieceCLIOptions {
    * the leading name.
    */
   cell?: string;
+
   apiUrl?: string;
   identity?: string;
   space?: string;
+
   /**
    * Whether `space` was written on the command line rather than supplied by
    * `CF_SPACE`. Cliffy merges an environment value into the option and keeps

--- a/packages/cli/integration/fuse-memory-proxy.ts
+++ b/packages/cli/integration/fuse-memory-proxy.ts
@@ -28,6 +28,7 @@ export class TraceBeforeRelayQueue {
 
 export type FuseMemoryProxy = {
   server: Deno.HttpServer;
+
   /** Resolves after every received upstream frame has reached the trace. */
   idle(): Promise<void>;
 };

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -390,6 +390,7 @@ export interface RollbackRunDependencies {
 /** A rollback run's report, beside the plan the derivation produced. */
 export interface RollbackRunResult {
   report: ApplyReport;
+
   /** The derived plan, so a caller can report what it was run from. */
   plan: PiecePlan;
 }

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -36,6 +36,7 @@ import { isSlugAddress, isValidSlug } from "@commonfabric/runner/slugs";
 export interface NormalizedLLMFriendlyRef {
   /** The piece, as the reference spelled it: a handle or a slug. */
   pieceId: string;
+
   scope?: CellScope;
 
   /**

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -134,10 +134,12 @@ let patternCoveragePath: string | undefined;
 let patternCoverageRoot: string | undefined;
 const runtimeErrors: string[] = [];
 
-/** Channel 1: console.error/warn captured via the harness console event. */
+/** Channel 1: console.error calls captured via the harness console event. */
 const consoleErrors: string[] = [];
 
+/** Channel 1: console.warn calls, captured the same way. */
 const consoleWarnings: string[] = [];
+
 const continuousUiErrors: Error[] = [];
 let continuousUiCancel: (() => void) | undefined;
 // Run-phase gate for channel 1 (mirrors test-runner.ts): flips true at the

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -22,9 +22,10 @@ export interface Style {
 export const ESC = "\x1b";
 export const CSI = `${ESC}[`;
 
-/** Operating System Command introducer and its BEL terminator. */
+/** Operating System Command introducer. */
 const OSC = `${ESC}]`;
 
+/** The BEL terminator that closes an OSC sequence. */
 const BEL = "\x07";
 export const RESET = `${CSI}0m`;
 

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -35,9 +35,10 @@ export interface CardTarget {
   /** Index into the card's `info` lines (for highlight + reveal). */
   readonly cardLine: number;
 
-  /** Destination line/column in the main document. */
+  /** Destination line in the main document. */
   readonly destLine: number;
 
+  /** Destination column on that line. */
   readonly destCol: number;
 
   /** Char offset of the declaration to select, when the target is a definition. */

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -1057,7 +1057,9 @@ interface HunkCtx {
    * `newLanguage` across a rename that changes the extension. */
   oldLanguage: Language;
 
-  /** New-side path, whose extension the parsers use to pick a script variant. */
+  /**
+   * New-side path, whose extension the parsers use to pick a script variant.
+   */
   newFileName: string | undefined;
 
   /** Old-side path, read the same way. */

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -166,10 +166,11 @@ export const ui = {
   searchMatch: { fg: C.ink, bg: C.cyan } as Style,
   searchCurrent: { fg: C.ink, bg: C.yellow, bold: true } as Style,
 
-  /** A dialog is a panel a shade lighter than the editor, with a bright frame
-   * and a drop shadow, distinct from the content behind it. */
+  /** Background of an overlay or dialog panel: a shade lighter than the
+   * editor, distinct from the content behind it. */
   overlayBg: C.panel,
 
+  /** The panel's bright frame. */
   overlayBorder: { fg: C.white, bold: true } as Style,
 
   /** Border of an overlay that shows source (an editor window). */

--- a/packages/cli/lib/write-receipt.ts
+++ b/packages/cli/lib/write-receipt.ts
@@ -1,8 +1,3 @@
-import type {
-  IExtendedStorageTransaction,
-  MemorySpace,
-} from "@commonfabric/runner";
-
 /**
  * The receipt a write leaves behind: the space it landed in, named on stderr
  * once a write has actually happened.
@@ -30,6 +25,11 @@ import type {
  * do, so a new write path carries it by construction and a command that only
  * writes under `--apply` says nothing on a dry run.
  */
+
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "@commonfabric/runner";
 
 /**
  * Spaces already receipted in this process, so a command whose work runs

--- a/packages/cli/test/multi-user-step-reading.test.ts
+++ b/packages/cli/test/multi-user-step-reading.test.ts
@@ -8,8 +8,8 @@
  * delivered every object as `undefined`; and reporting the classified keys
  * back to an author named nothing they had written.
  */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/program-root.test.ts
+++ b/packages/cli/test/program-root.test.ts
@@ -4,8 +4,8 @@
  * deno.json(c) declaring a package `name`; a nameless config only wires tasks
  * and must not capture the walk.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { inferProgramRoot } from "../lib/program-root.ts";

--- a/packages/cli/test/read-options-four-ways.test.ts
+++ b/packages/cli/test/read-options-four-ways.test.ts
@@ -1,33 +1,3 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { expect } from "@std/expect";
-import { dirname, join } from "@std/path";
-import { Identity } from "@commonfabric/identity";
-import {
-  type Cell,
-  type JSONSchema,
-  type MemorySpace,
-  type NormalizedFullLink,
-  Runtime,
-} from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  type CallableResolution,
-  executeResolvedCallable,
-} from "../lib/callable.ts";
-import { getCellValue } from "../lib/piece.ts";
-import { projectWishValue, resolveWish } from "../lib/wish.ts";
-import {
-  type ExecutedMountedCallableFile,
-  executeMountedCallableFile,
-} from "../lib/exec.ts";
-import { renderExecOutcome } from "../commands/exec.ts";
-import { writeMountState } from "../lib/fuse.ts";
-import {
-  type CellSelection,
-  parseCellSelectionOptions,
-} from "../lib/cell-selection.ts";
-import { safeStringify } from "../lib/render.ts";
-
 /**
  * The exit criterion of the read options: **the same cell, reached four ways,
  * renders identically under the same selection.**
@@ -58,6 +28,37 @@ import { safeStringify } from "../lib/render.ts";
  * resolves through — the selection step under test is the production one in
  * every arrival.
  */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { dirname, join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import {
+  type Cell,
+  type JSONSchema,
+  type MemorySpace,
+  type NormalizedFullLink,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  type CallableResolution,
+  executeResolvedCallable,
+} from "../lib/callable.ts";
+import { getCellValue } from "../lib/piece.ts";
+import { projectWishValue, resolveWish } from "../lib/wish.ts";
+import {
+  type ExecutedMountedCallableFile,
+  executeMountedCallableFile,
+} from "../lib/exec.ts";
+import { renderExecOutcome } from "../commands/exec.ts";
+import { writeMountState } from "../lib/fuse.ts";
+import {
+  type CellSelection,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
+import { safeStringify } from "../lib/render.ts";
+
 const userIdentity = await Identity.fromPassphrase("cf-four-ways-user");
 
 const profileSpace = (await Identity.fromPassphrase("cf-four-ways-profile"))
@@ -226,10 +227,10 @@ describe("read options, four ways", () => {
 
   /** `cf exec <mountedFile>` — the read that arrives through a filesystem
    * mount. A real mount-state file and a real mounted callable path; the
-   * runtime under it is the same one the other three read through. */
-
-  /** `cf exec`'s whole outcome, so both the selected value and the envelope
-   * written around it can be read from one drive of the command. */
+   * runtime under it is the same one the other three read through.
+   *
+   * Answers with `cf exec`'s whole outcome, so both the selected value and the
+   * envelope written around it can be read from one drive of the command. */
   async function execOutcome(
     profile: Cell<unknown>,
     selection: CellSelection,

--- a/packages/cli/test/test-runner-action-event.test.ts
+++ b/packages/cli/test/test-runner-action-event.test.ts
@@ -5,8 +5,8 @@
  * not one of those, and reading it that way delivered `undefined` in place of
  * every object.
  */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-program-root.test.ts
+++ b/packages/cli/test/test-runner-program-root.test.ts
@@ -5,8 +5,8 @@
  * ancestor the file's own directory anchors it, and an import that climbs out
  * is refused by name rather than reported as a missing file it never named.
  */
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-step-kinds.test.ts
+++ b/packages/cli/test/test-runner-step-kinds.test.ts
@@ -4,8 +4,8 @@
  * in a single-user one, but the runner still has to know them: a step holding
  * one matched no discriminant and the run reported it as malformed.
  */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/test-runner-timing-measures.test.ts
+++ b/packages/cli/test/test-runner-timing-measures.test.ts
@@ -8,8 +8,8 @@
  * tests still pass, the file still exists, and only the numbers are wrong —
  * which is why it is pinned here rather than left to a reading of the code.
  */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";

--- a/packages/cli/test/wish-read-options.test.ts
+++ b/packages/cli/test/wish-read-options.test.ts
@@ -1,3 +1,10 @@
+/**
+ * `cf wish`'s read options, against the emulated runtime the rest of the wish
+ * read is exercised on (test/wish.test.ts). A wish resolves a query rather
+ * than an address, but it still terminates in a cell, and that cell is what
+ * these shape.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -9,12 +16,6 @@ import {
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
 
-/**
- * `cf wish`'s read options, against the emulated runtime the rest of the wish
- * read is exercised on (test/wish.test.ts). A wish resolves a query rather
- * than an address, but it still terminates in a cell, and that cell is what
- * these shape.
- */
 const userIdentity = await Identity.fromPassphrase("cf-wish-read-options-user");
 
 const profileSpace =


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The `cli` half of the ex-post-facto review, from #6645 and #6665 judged against
`main`. Siblings: #6693 (the rule), #6694 (`runner` and the comment-rewrite
PRs), #6696 (`cf-harness`).

## Eight file headers bound to an import

Each of these files carried a file header with no blank line under it — a
pre-existing violation of §"File headers", whose blank is load-bearing
*precisely* because it "keeps the header from being read as the doc comment of
the first declaration under it". #6645 read header-plus-first-statement as a
documented declaration and inserted the blank **below the statement**,
certifying the misreading rather than fixing it. In the test files it also split
the import block into two `deno fmt` groups.

Six get the blank where it belongs and give the arc's back:
`test-runner-step-kinds`, `multi-user-step-reading`, `program-root`,
`test-runner-action-event`, `test-runner-program-root`,
`test-runner-timing-measures`.

Two sat **below** their import block, which §"File headers" names as failing
twice over. `read-options-four-ways.test.ts` and `wish-read-options.test.ts`
move their header to the top of the file.

A note on scale, since it bears on whether this is worth a rule rather than a
patch: this class has now been found independently in **three** review targets —
8 here, 5 in #6650's packages, 3 in #6655's — and a census of all 4667 tracked
`.ts`/`.tsx` files finds **48 tree-wide where a leading doc comment is followed
immediately by an import**, which is a certain freeze every time, plus 68 more
needing per-file judgment. This PR fixes only `cli`'s.

## Four pair comments frozen onto the first member

| file | the comment | bound to |
|---|---|---|
| `lib/view/ansi.ts:25` | "Operating System Command introducer **and its BEL terminator**" | `OSC` |
| `lib/view/card.ts:38` | "Destination **line/column**" | `destLine` |
| `lib/multi-user-test-worker.ts:137` | "console.**error/warn**" | `consoleErrors` |
| `lib/view/theme.ts:169` | "…with **a bright frame** and a drop shadow" | `overlayBg` |

Two of the four spell their conjunction as a slash, which is why the sweep's own
third net — "a plural or conjunction anywhere in the comment's first sentence" —
could not see them.

`theme.ts` also **drops a claim that was never true of these two colors**: the
drop shadow is drawn by `render.ts`'s own shadow pass, not carried by either
value. And the "dialog" framing was always too narrow — `render.ts:1279-1282`
styles cards and file peeks through the same pair.

## Two that are not the arc's

#6678 documented `PieceCLIOptions.cell` and `NormalizedLLMFriendlyRef.pieceId`
without a blank below, so each comment now reaches over the members after it.

## One over-wide line the arc added

`lib/view/diffdoc.ts:1060`, at 81 characters — the only such line among the 136
the two PRs added, and `deno fmt` does not reflow comments, so nothing
mechanical catches it.

## Five adjacent-rule sites

Conformed per the scope set for files a fix PR already opens. The one worth
naming: `read-options-four-ways.test.ts:228` had **two doc comments in a row**,
and TypeScript keeps only the nearer one — so the first was invisible wherever
documentation renders. Merged rather than deleted.

## Verification

`deno fmt --check`, `deno lint`, `deno check`, and the `cli` suite: 210 passed.
No added line exceeds eighty columns, measured as characters over the diff's `+`
lines.

Gates run **off-pin**: this machine has `deno` 2.9.6 where `mise.toml` pins
2.9.4 and `mise` is not installed. CI's pinned run is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

