### PR TITLE
fix(runner): the speculation overlay writes whole documents

### DIFF
--- a/docs/features/mergeable-collection-writes.md
+++ b/docs/features/mergeable-collection-writes.md
@@ -55,8 +55,9 @@ Carry the append intent through the transaction so the commit emits a
 tail-relative, mergeable operation instead of a reconstructed whole-array diff.
 
 An append commits as a dedicated `append` patch op (`{ op: "append", path,
-values }`). On the server this op inserts its elements at the array's *live*
-tail, creating the array (and the path to it) if it is absent. Because the
+values }`), except from a transaction that emits whole documents (below). On
+the server this op inserts its elements at the array's *live* tail, creating
+the array (and the path to it) if it is absent. Because the
 position is resolved on the server against durable state, the op is correct
 regardless of what the committing session had loaded locally — empty, short, or
 up to date.
@@ -359,6 +360,25 @@ first, since the op carries only the delta.
   asserts a conflict outcome that depends on it. It is kept because the
   guarantee should not rest on that coincidence: nothing obliges a reshape to
   read what it overwrites.
+
+- **A whole-document transaction abandons every intent it holds.** A
+  transaction marked `markWholeDocumentWrites` — or `markAuthoritativeWrites`,
+  which implies it — emits each written document as a whole-document `set` or
+  `delete` and sends no mergeable op at all, so the same rule applies to all of
+  them at once: `getNativeCommit` deletes and poisons every recorded path
+  before the narrowing runs. Here the reads are not belt and braces. The
+  whole-document write is the value the run computed from what it read, so an
+  intent left standing would drop a real dependency.
+
+  Two marks reach this. The client speculation overlay's seal takes it because
+  an entry's operations are layered above a confirmed value that moves under
+  them, and its read set is what the entry's retirement floor is built from
+  (`docs/specs/server-side-execution/speculation.md` §1). Effect-completion
+  writebacks under the serving posture take it through
+  `markAuthoritativeWrites`, and they can hold an intent — llm-dialog's marked
+  update pushes onto the message list. Their commit carries `basisSeq` of NOW
+  and does not export its read set, so what changes there is which local
+  dependencies the transaction registers, not what the server arbitrates.
 
 - **A `removeByValue` that does not account for the whole local array falls back
   too.** Its suppression is `subtree: true` — the array path and everything under

--- a/docs/specs/server-side-execution/speculation.md
+++ b/docs/specs/server-side-execution/speculation.md
@@ -23,6 +23,25 @@ half of Phase 3. Assumes [README.md](README.md) §3.2 and
   not-yet-consequenced event) or `input(bindingId)` (live UI input echo).
 - The overlay is process-memory only. It is NEVER serialized, synced, or
   committed. On reload it is empty and the store is the truth.
+- The seal emits an entry's document operations as WHOLE-DOCUMENT
+  set/delete (`markWholeDocumentWrites`), and refuses a transaction that
+  cannot. The ops are materialized over the confirmed value on every
+  read, and that value moves under them: the space's serving runtime
+  commits the authoritative derivation for the same document, and it
+  arrives before the coverage that retires the entry (§4). A positional
+  array splice re-applied over an array that already carries what it
+  inserts duplicates that element, one that removed elements drops one,
+  and a mergeable append double-applies — so an entry says what its run
+  computed rather than how that differed from the layer it ran over. The
+  mergeable intents the run recorded are abandoned with the ops they
+  would have produced, so the reads those ops would have narrowed out of
+  the commit stay in the entry's read set, which is what its retirement
+  floor and its pending-read documents are built from. Pinned in
+  `speculation-overlay.test.ts` and `array-push-mergeable.test.ts`.
+- A standing entry therefore masks a concurrent authoritative change to
+  any other path of the same document, until the entry retires and the
+  arrived value renders. What a reader sees while it stands is a value
+  some run computed, whole.
 
 ## 2. What may speculate
 

--- a/packages/patterns/integration/topic-board-child-contract.test.ts
+++ b/packages/patterns/integration/topic-board-child-contract.test.ts
@@ -246,11 +246,11 @@ describe("topic-board-pivot-contract", () => {
    * back the rows so the caller can pin the exact set.
    *
    * Waits on content rather than on a count, because `referencedBy` is served
-   * from the board-wide pivot rather than written here: a count that settles
-   * one row away from the expected number — which server execution has been
-   * seen to do — makes a count-wait wait for a number that is never coming,
-   * while a content-wait still resolves the moment the edge lands and the
-   * assertion after it still catches the extra row. */
+   * from the board-wide pivot rather than written here: a count-wait cannot
+   * tell a number that has not arrived from one that never will, and
+   * `waitForCellValue` has no deadline, so a pivot serving the wrong number
+   * hangs it. A content-wait resolves the moment the edge lands, and the
+   * assertion after it still catches an extra row. */
   const awaitInbound = async (
     t: PieceController,
     ...titles: string[]
@@ -288,11 +288,10 @@ describe("topic-board-pivot-contract", () => {
     ),
     fn: async () => {
       // Waits on the three topics this suite filed, which `addTopic` produces
-      // directly, rather than on the pivot's row count — the pivot is
-      // board-wide and has been seen to settle a row away from the topic
-      // count under server execution, which a count-wait would never recover
-      // from. The table is then asserted rather than awaited, so an extra
-      // row still fails.
+      // directly, rather than on the pivot's row count: the pivot is
+      // board-wide, and a count-wait on it would hang rather than fail if it
+      // ever served a different number. The table is then asserted rather
+      // than awaited, so an extra row still fails.
       const topics = (await board.result.getCell()).key("topics");
       await waitForCellValue<unknown[]>(
         cc.runtime,

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -644,16 +644,25 @@ export class SpeculationOverlayDestination
       return { ok: {} };
     }
     const inner = tx.tx;
-    if (inner.sealInto === undefined) {
+    if (
+      inner.sealInto === undefined ||
+      inner.markWholeDocumentWrites === undefined
+    ) {
       // Fail CLOSED: a transport without seal support must not fall
       // back to committing a derivation — that would re-open the
       // client derivation-commit path this destination exists to
-      // remove (speculation.md §6's FORBIDDEN list).
+      // remove (speculation.md §6's FORBIDDEN list). One without the
+      // whole-document mark is refused on the same footing: a seal whose
+      // ops were patches would compose with the layer beneath them, and
+      // swallowing an unsupported mark makes that silent.
+      const missing = inner.sealInto === undefined
+        ? "sealing"
+        : "whole-document writes (speculation.md §1)";
       return {
         error: {
           name: "StorageTransactionAborted",
           message: "speculative derivation refused: the storage " +
-            "transaction does not support sealing, and committing a " +
+            `transaction does not support ${missing}, and committing a ` +
             "derivation client-side is forbidden under " +
             "EXPERIMENTAL_SERVER_EXECUTION (speculation.md §6)",
           reason: new Error("speculation-seal-unsupported"),
@@ -773,6 +782,12 @@ export class SpeculationOverlayDestination
     };
     let result: Result<Unit, CommitError>;
     try {
+      // An entry's ops say what the run computed, not how it differed from
+      // the layer it ran over, because that layer moves under them
+      // (speculation.md §1; IStorageTransaction.markWholeDocumentWrites).
+      // Inside the same try as the seal it precedes, which refuses a
+      // read-only transaction the same way.
+      inner.markWholeDocumentWrites();
       result = await inner.sealInto(collector);
     } catch (cause) {
       // A REJECTED sealInto (review thread r3739139536): without the

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1150,8 +1150,10 @@ export interface IStorageTransaction {
    * Make this transaction's writes AUTHORITATIVE: every value write is
    * recorded and committed even when it equals the currently-visible
    * state, instead of being elided as a no-op (deletes of absent slots
-   * stay no-ops — there is nothing to assert). One-way; there is no
-   * un-mark.
+   * stay no-ops — there is nothing to assert). Implies
+   * {@link markWholeDocumentWrites}, so the writes also commit as
+   * whole-document set/delete and the mergeable intents they recorded are
+   * abandoned. One-way; there is no un-mark.
    *
    * Exists for effect-COMPLETION writebacks under the serving posture
    * (server-execution v2 stage G, serving-loop.md §4): the ordinary
@@ -1174,6 +1176,30 @@ export interface IStorageTransaction {
    * (`normalizeAndDiff`), whose equal-leaf elision sits ABOVE the
    * transaction layer and must yield for the same reason. */
   isAuthoritativeWrites?(): boolean;
+
+  /**
+   * Emit this transaction's document writes as WHOLE-DOCUMENT set/delete
+   * operations rather than as patches or mergeable collection ops, while
+   * leaving the no-op elision alone. Recorded mergeable intents are
+   * abandoned with the ops they would have produced, so the reads
+   * incidental to those ops stay in the commit's read set — the
+   * whole-document write is the value the run computed from what it read.
+   * One-way; there is no un-mark. {@link markAuthoritativeWrites} implies
+   * this and additionally disables the elision.
+   *
+   * Exists for the client speculation overlay (server-execution v2 Phase 2,
+   * speculation.md §1): an overlay entry's operations are layered above the
+   * confirmed value and materialized over it on every read. A patch is
+   * relative to the layer beneath it, and that layer moves — the space's
+   * serving runtime commits the authoritative derivation for the same
+   * document, and it arrives before the entry's watermark coverage retires
+   * the entry. A positional array splice re-applied over an array that
+   * already carries what it inserts duplicates that element; one that
+   * removed elements drops one, and a mergeable append double-applies. A
+   * whole-document set says what the run computed, so the entry renders
+   * that value over whatever lies beneath it.
+   */
+  markWholeDocumentWrites?(): void;
 
   /**
    * Record one mergeable-write delta against the document at `address` (see

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -977,6 +977,13 @@ export class V2StorageTransaction implements IStorageTransaction {
   // state never had, and `replace` cannot create them).
   // Set by effect-completion writebacks under the serving posture; one-way.
   #authoritativeWrites = false;
+  // Whole-document-writes mode (see
+  // IStorageTransaction.markWholeDocumentWrites): the emission half of
+  // authoritative mode on its own — set/delete rather than patches and
+  // mergeable ops — with the no-op elision left in place. Set by the client
+  // speculation overlay's seal, whose entries layer their ops over a
+  // confirmed value that moves under them. One-way.
+  #wholeDocumentWrites = false;
   #commitOrder?: readonly MemorySpace[];
   // Spaces written to, in first-write order. Used as the default commit order.
   #writtenSpaces: MemorySpace[] = [];
@@ -1047,6 +1054,17 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   isAuthoritativeWrites(): boolean {
     return this.#authoritativeWrites;
+  }
+
+  markWholeDocumentWrites(): void {
+    this.#assertWritable("markWholeDocumentWrites()");
+    this.#wholeDocumentWrites = true;
+  }
+
+  /** Whether a document's write is emitted as a whole-document set/delete.
+   * Authoritative mode implies it; whole-document mode is that half alone. */
+  get #emitsWholeDocuments(): boolean {
+    return this.#authoritativeWrites || this.#wholeDocumentWrites;
   }
 
   static create(manager: IStorageManager): IStorageTransaction {
@@ -1350,10 +1368,16 @@ export class V2StorageTransaction implements IStorageTransaction {
       // each, builtin-owned); completions already carry basisSeq=NOW
       // (no per-doc CAS — the hash guards arbitrate), so doc-level
       // last-writer-wins is the ruled posture, not a widening. The
-      // mergeable fast path is skipped too: no completion writeback
-      // records mergeable deltas, and folding them with a whole-doc
-      // set would double-apply.
-      if (!this.#authoritativeWrites) {
+      // mergeable fast path is skipped too: folding a mergeable op with
+      // a whole-doc set would apply its delta twice. A completion
+      // writeback can record one — llm-dialog's marked update pushes
+      // onto the message list — so the intents it recorded are
+      // abandoned below with the ops they would have produced.
+      //
+      // A whole-document transaction (markWholeDocumentWrites — the
+      // client speculation overlay's seal) takes the same emission,
+      // for the reason on that declaration.
+      if (!this.#emitsWholeDocuments) {
         const mergeable = this.#buildMergeableOps(doc);
         const patch = this.#buildPatchOperation(
           id,
@@ -1382,6 +1406,8 @@ export class V2StorageTransaction implements IStorageTransaction {
           operations.push(patch);
           continue;
         }
+      } else {
+        this.#abandonMergeableOps(doc);
       }
 
       operations.push(
@@ -3337,6 +3363,30 @@ export class V2StorageTransaction implements IStorageTransaction {
       (doc.mergeableOpsPoisoned ??= new Set()).add(pathKey);
     }
     return { ops, suppress };
+  }
+
+  // Abandons every mergeable intent a document recorded, for a commit that
+  // emits the document whole. An intent narrows the reads incidental to its op
+  // out of the commit's read set (`commitReadActivities` in ./v2.ts), which is
+  // sound only while the op is what carries that region: a mergeable op
+  // resolves against durable state, so the value it read does not constrain
+  // it. A whole-document set carries the region instead, and it is the value
+  // the run computed from what it read — so those reads are real dependencies
+  // and have to stay. Abandoning is the delete-and-poison shape
+  // `poisonMergeableOp` uses, and it runs inside getNativeCommit, which
+  // precedes the narrowing, so both sides see the same intents.
+  //
+  // For a speculative seal the read set is what the entry's retirement floor
+  // and its pending-read documents are built from, so an intent surviving here
+  // retires the entry against a watermark that never covered what the run read.
+  #abandonMergeableOps(doc: WritableDocumentEntry): void {
+    if (!doc.mergeableOps?.size) {
+      return;
+    }
+    for (const pathKey of [...doc.mergeableOps.keys()]) {
+      doc.mergeableOps.delete(pathKey);
+      (doc.mergeableOpsPoisoned ??= new Set()).add(pathKey);
+    }
   }
 
   // The working / initial state at one intent's path, which its builder turns

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -2564,6 +2564,62 @@ describe("mergeable op guards and single-session branches", () => {
     );
   });
 
+  it("a whole-document transaction emits a set and drops the push's intent", async () => {
+    // `markWholeDocumentWrites` replaces every op with a whole-document set —
+    // the client speculation overlay's seal, whose entries layer their ops over
+    // a confirmed value that moves under them. The append is not sent, so its
+    // intent must not survive to narrow the array read out of the commit's
+    // reads: that read is a real dependency of the value the set carries, and
+    // for a speculative seal it is what the entry's retirement floor is built
+    // from.
+    const tx0 = rt.edit();
+    rt.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["a", "b"]);
+    await tx0.commit({ resolveAt: "verdict" });
+    await rt.storageManager.synced();
+
+    const tx = rt.edit();
+    const cell = rt.getCell<string[]>(space, CAUSE, stringListSchema, tx);
+    cell.push("c");
+    expect([...(getDirectTransactionMergeableOpAddresses(tx) ?? [])].length)
+      .toBe(1);
+
+    tx.tx.markWholeDocumentWrites!();
+    const native = getDirectTransactionNativeCommit(tx, space);
+    expect(native?.operations.map((op) => op.op)).toEqual(["set"]);
+    expect(
+      (native?.operations[0] as { value?: { value?: string[] } }).value?.value,
+    ).toEqual(["a", "b", "c"]);
+    // The array read the append would have narrowed away is in the sealed
+    // commit's reads, which is the claim the abandonment is FOR — the
+    // intent count alone cannot show it, and the whole-document write is
+    // the value the run computed from that read. Asserted before the
+    // intent count so a regression names the consequence, not the
+    // mechanism.
+    const replica = rt.storageManager.open(space).replica;
+    const sealed = replica.sealNative!(
+      native!,
+      tx.tx,
+      new Promise(() => {}),
+      { speculative: true },
+    );
+    const readIds = [
+      ...sealed.commit.reads.confirmed,
+      ...sealed.commit.reads.pending,
+    ].map((read) => read.id);
+    expect(readIds).toContain(cell.getAsNormalizedFullLink().id);
+    expect([...(getDirectTransactionMergeableOpAddresses(tx) ?? [])]).toEqual(
+      [],
+    );
+
+    // Poisoned as well as deleted: a later push on the same transaction
+    // records nothing, so the intent cannot come back after the commit
+    // was built without it.
+    cell.push("d");
+    expect([...(getDirectTransactionMergeableOpAddresses(tx) ?? [])]).toEqual(
+      [],
+    );
+  });
+
   it("nested tail ops abandon only the contained one", async () => {
     // Two tail ops where one op's payload contains the other's target: exactly
     // one intent — the CONTAINED one — is abandoned, and the containing op

--- a/packages/runner/test/speculation-arrival-gate.test.ts
+++ b/packages/runner/test/speculation-arrival-gate.test.ts
@@ -458,6 +458,10 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       const tx = {
         tx: {
           sourceAction: writer,
+          // These doubles hand-build the ops they seal, so the mark has
+          // nothing to shape; it is present because the seal refuses a
+          // transaction that cannot take it.
+          markWholeDocumentWrites: () => {},
           sealInto: (collector: {
             sealSpaceCommit: (
               space: MemorySpace,
@@ -699,6 +703,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
     const tx = {
       tx: {
         sourceAction: { name: "writer" },
+        markWholeDocumentWrites: () => {},
         sealInto: (collector: {
           sealSpaceCommit: (
             space: MemorySpace,
@@ -811,6 +816,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       const tx = {
         tx: {
           sourceAction: { name: "handler" },
+          markWholeDocumentWrites: () => {},
           sealInto: (collector: {
             sealSpaceCommit: (
               space: MemorySpace,
@@ -997,6 +1003,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       const tx = {
         tx: {
           sourceAction: { name: "witness-writer" },
+          markWholeDocumentWrites: () => {},
           sealInto: (collector: {
             sealSpaceCommit: (
               space: MemorySpace,
@@ -1385,6 +1392,7 @@ describe("speculation arrival gate (speculation.md §4, RULED 2026-08-16)", () =
       const tx = {
         tx: {
           sourceAction: { name: "pivot" },
+          markWholeDocumentWrites: () => {},
           sealInto: (collector: {
             sealSpaceCommit: (
               space: MemorySpace,

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -770,6 +770,10 @@ const cascadeDestination = () => {
     const tx = {
       tx: {
         sourceAction: { name: "handler" },
+        // These doubles hand-build the ops they seal, so the mark has nothing
+        // to shape; it is present because the seal refuses a transaction that
+        // cannot take it.
+        markWholeDocumentWrites: () => {},
         sealInto: async (collector: {
           sealSpaceCommit: (
             space: MemorySpace,

--- a/packages/runner/test/speculation-overlay.test.ts
+++ b/packages/runner/test/speculation-overlay.test.ts
@@ -664,6 +664,23 @@ describe("Phase 2 speculation overlay", () => {
     const sealed = await destination.seal(withEventTx);
     expect(sealed.error).toBeDefined();
     expect(sealed.error?.message).toContain("does not support sealing");
+
+    // A transaction that CAN seal but cannot take the whole-document mark
+    // is refused on the same footing: its ops would be patches, which
+    // compose with the layer beneath them (speculation.md §1). Named
+    // separately from the sealing arm so the refusal says which.
+    const patchOnlyTx = {
+      tx: { sealInto: () => Promise.resolve({ ok: {} }) },
+    } as unknown as IExtendedStorageTransaction;
+    stampSpeculationRunContext(patchOnlyTx, {
+      actionId: "spec-derivation-patch-only",
+      kind: "derivation",
+    });
+    const patchOnly = await destination.seal(patchOnlyTx);
+    expect(patchOnly.error).toBeDefined();
+    expect(patchOnly.error?.message).toContain(
+      "does not support whole-document writes",
+    );
   });
 
   it("an authored tx that read a speculative echo is refused LOUDLY at the client, terminal, with no wire export (speculation.md §6; leg-C RULED 2026-08-13)", async () => {
@@ -2429,6 +2446,10 @@ describe("Phase 2 speculation overlay", () => {
     // Seal the speculative entry through the destination.
     const sealTx = {
       tx: {
+        // These doubles hand-build the ops they seal, so the mark has nothing
+        // to shape; it is present because the seal refuses a transaction that
+        // cannot take it.
+        markWholeDocumentWrites: () => {},
         sealInto: (collector: {
           sealSpaceCommit: (
             space: MemorySpace,
@@ -2511,6 +2532,7 @@ describe("Phase 2 speculation overlay", () => {
     const gate = Promise.withResolvers<void>();
     const sealTx = {
       tx: {
+        markWholeDocumentWrites: () => {},
         sealInto: async (collector: {
           sealSpaceCommit: (
             space: MemorySpace,
@@ -2570,6 +2592,7 @@ describe("Phase 2 speculation overlay", () => {
     const verdictsBefore = verdicts.length;
     const rejectTx = {
       tx: {
+        markWholeDocumentWrites: () => {},
         sealInto: async (collector: {
           sealSpaceCommit: (
             space: MemorySpace,
@@ -2663,5 +2686,179 @@ describe("Phase 2 speculation overlay", () => {
       | undefined;
     expect(rendered?.result).toBeUndefined();
     cancelDemand();
+  });
+
+  it("an overlay entry over an ARRAY renders the value its derivation computed, whatever the confirmed value beneath it becomes (the pivot flake: a positional splice re-applied over the authoritative array)", async () => {
+    // An entry's ops sit ABOVE the confirmed value and are materialized
+    // over it on every read, so an op that is POSITIONAL — a splice
+    // carrying an index and an element — describes a value only while the
+    // layer beneath is the one the run diffed against. The authoritative
+    // derivation arrives on that layer before the entry retires, and the
+    // same splice then inserts a second copy of an element the arrived
+    // array already carries.
+    //
+    // The symptom this pins: a board's derived pivot read one row per
+    // topic plus one, and one row short, in the same suite — a doubled
+    // element and a dropped one are the two directions of one re-applied
+    // splice.
+    const LIST_PATTERN = [
+      "import { Default, lift, pattern, Writable } from 'commonfabric';",
+      "const doubleAll = lift(",
+      "  ({ items }: { items: number[] }) => items.map((n) => n * 2),",
+      ");",
+      "export default pattern<",
+      "  { items?: Writable<number[] | Default<[]>> },",
+      "  { doubled: number[] }",
+      ">(({ items }) => ({ doubled: doubleAll({ items: items! }) }));",
+    ].join("\n");
+
+    const openRuntime = (flagOn: boolean) => {
+      const manager = EmulatedStorageManager.connectTo(server, {
+        as: aliceSigner,
+      });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: manager,
+        experimental: { serverExecution: flagOn },
+      });
+      return { manager, runtime };
+    };
+
+    /** Installs the pattern over the shared cells and hands back the
+     * result cell plus a live reader, which IS the demand that makes the
+     * lift run at all. */
+    const install = async (runtime: Runtime) => {
+      const compiled = await runtime.patternManager.compilePattern({
+        main: "/main.tsx",
+        files: [{ name: "/main.tsx", contents: LIST_PATTERN }],
+      }, { space });
+      const argument = runtime.getCell<{ items: number[] }>(
+        space,
+        "splice-arg",
+        undefined,
+      );
+      const result = runtime.getCell<{ doubled: number[] }>(
+        space,
+        "splice-result",
+        compiled.resultSchema,
+      );
+      await argument.sync();
+      await result.sync();
+      const tx = runtime.edit();
+      runtime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+      return { argument, result, release: result.sink(() => {}) };
+    };
+
+    // The confirmed two-element array, committed by an ordinary flag-OFF
+    // client — the deriving committer this test needs, without an
+    // executor host to advance a watermark later on.
+    const seeder = openRuntime(false);
+    let derivedLink;
+    try {
+      const seeded = await install(seeder.runtime);
+      const tx = seeder.runtime.edit();
+      seeded.argument.withTx(tx).set({ items: [1, 2] });
+      expect((await tx.commit()).error).toBeUndefined();
+      await seeder.runtime.idle();
+      await waitUntil(
+        () => (seeded.result.key("doubled").get() ?? []).length === 2,
+        "the seeded two-element array",
+      );
+      await seeder.runtime.storageManager.synced();
+      // The derived document itself, so the arrival below lands on the
+      // very layer an entry's ops are materialized over.
+      derivedLink = seeded.result.key("doubled").resolveAsCell()
+        .getAsNormalizedFullLink();
+      seeded.release();
+    } finally {
+      await seeder.runtime.dispose();
+      await seeder.manager.close();
+    }
+
+    // The flag-ON client, opened over the settled state. Its first run
+    // computes the array already stored, so the no-op elision seals no
+    // entry — which is what leaves the NEXT run diffing against the
+    // CONFIRMED value rather than against an echo of its own.
+    clientManager = EmulatedStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+      experimental: { serverExecution: true },
+    });
+    const client = await install(clientRuntime);
+    await clientRuntime.idle();
+    await waitUntil(
+      () => (client.result.key("doubled").get() ?? []).length === 2,
+      "the stored two-element array at the flag-ON client",
+    );
+    // The same derived document both sides derive into, so the arrival
+    // below lands under the entry this client seals rather than beside it.
+    expect(
+      client.result.key("doubled").resolveAsCell().getAsNormalizedFullLink()
+        .id,
+    ).toBe(derivedLink.id);
+    // Its run computed what is already stored, so nothing sealed.
+    expect(clientRuntime.speculationOverlay?.entryCount(space) ?? 0).toBe(0);
+
+    // The speculative run: three elements diffed against the confirmed
+    // two, which is the splice. Nothing advances the watermark here, so
+    // the entry stands — that is the window the flake lives in, held
+    // open rather than raced.
+    {
+      const tx = clientRuntime.edit();
+      client.argument.withTx(tx).set({ items: [1, 2, 3] });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await clientRuntime.idle();
+    await waitUntil(
+      () => (client.result.key("doubled").get() ?? []).length === 3,
+      "the speculative three-element echo",
+    );
+    expect(clientRuntime.speculationOverlay!.entryCount(space))
+      .toBeGreaterThanOrEqual(1);
+    // Released before the arrival below, so the entry under test is the
+    // one this run sealed and no re-derivation seals another over it.
+    client.release();
+
+    // The authoritative value arrives under the standing entry. Written
+    // from a second session because that is what moves the CONFIRMED
+    // value: a write through this client would land as one more layer
+    // above it. Deliberately NOT the array the speculation computed, so
+    // the assertion separates three outcomes — the entry rendering its
+    // own value, the splice composing with what arrived, and the entry
+    // having quietly retired.
+    const writer = openRuntime(false);
+    try {
+      const arrived = writer.runtime.getCellFromLink<number[]>(derivedLink);
+      await arrived.sync();
+      const tx = writer.runtime.edit();
+      arrived.withTx(tx).set([7, 8, 9]);
+      expect((await tx.commit()).error).toBeUndefined();
+      await writer.runtime.storageManager.synced();
+    } finally {
+      await writer.runtime.dispose();
+      await writer.manager.close();
+    }
+    const replica = clientRuntime.storageManager.open(space).replica;
+    await waitUntil(
+      () =>
+        JSON.stringify(
+          (replica.getNonSpeculativeDocument!(
+            derivedLink.id,
+            derivedLink.scope,
+          ) as { value?: unknown } | undefined)?.value,
+        ) === JSON.stringify([7, 8, 9]),
+      "the authoritative array to reach the client's confirmed view",
+    );
+
+    // The entry still stands, so what renders is the entry's own value —
+    // the three elements its derivation computed — and neither the
+    // arrived array nor those three composed with it.
+    expect(clientRuntime.speculationOverlay!.entryCount(space))
+      .toBeGreaterThanOrEqual(1);
+    expect(client.result.key("doubled").get()).toEqual([2, 4, 6]);
   });
 });


### PR DESCRIPTION
A client's derivation and handler runs do not commit under server execution. Their writes are diverted into the speculation overlay, which seals them into the replica's optimistic pending layer as storage operations. Those operations sit above the confirmed value and are materialized over it on every read.

They were emitted the way a commit's operations are: as the difference between the value the run computed and the value the run started from. For an array that difference is a positional splice, carrying an index, a count of elements to remove, and the elements to add. Such an operation describes a value only while the layer beneath it is still the one the run diffed against.

That layer moves. The space's serving runtime commits the authoritative derivation for the same document, and it arrives before the entry retires: retirement waits on the watermark covering the run's basis, and the derived value arrives on its own schedule. In the window between the two, a splice that appended an element is re-applied over an array that already carries it, and the read sees that element twice. A splice that removed elements drops one instead. A mergeable append double-applies the same way.

The reproduction is the topics board's mention pivot, in the pattern integration suite under server execution. With three topics filed, `crossrefs` read four rows in one run and two in another, in the same step of the same suite, while `topics` read three throughout — which is why the two readings looked like separate defects. Both are one re-applied splice. The board's derived pivot document is written by the client's own lift of the topics array, and the serving runtime's copy of that lift lands underneath it. Nothing durable was ever wrong: the store's value is correct throughout, and only the client's own view composes.

An overlay entry now emits whole-document set and delete operations, so it says what its run computed rather than how that differed from the layer it ran over. The emission already existed for effect-completion writebacks under the serving posture, for the mirror reason — their patch base can name ancestors durable state never had. That mode also disables the no-op elision, which speculation has to keep (a run that agrees with the store must seal no entry at all), so the emission half is now its own one-way mark and authoritative mode implies it. The seal REFUSES a transaction that cannot take the mark, on the same footing as one that cannot seal: swallowing it would leave a future transport sealing patches again, silently.

Emitting the document whole is not enough on its own. A mergeable intent — recorded by push, add-unique, increment, or remove-by-value — narrows the reads incidental to its operation out of the commit's read set. That is sound while the mergeable operation is what carries the region: such an operation resolves against durable state, so the value the run read does not constrain it. A whole-document set carries the region instead, and it is the value the run computed from what it read, so those reads are real dependencies. The whole-document branch therefore abandons every intent the document recorded, in the delete-and-poison shape `poisonMergeableOp` uses, before the narrowing runs. Left standing, an understated read set gives a speculative entry a retirement floor below what its run consumed, and the entry retires against a watermark that never covered it: a handler's optimistic append disappears and comes back when the server's consequence lands.

That reaches effect completions too, and a comment here said it could not — that no completion writeback records mergeable deltas. It does: llm-dialog's `safelyPerformUpdate` marks the effect completion, and the action it runs pushes onto the message list. Abandoning is right there for the same reason, and nothing observable moves, because a completion commits with `basisSeq` of NOW and `commitWave` carries only its operations and preconditions — its read set never reaches the server. What changes is which local dependencies the transaction registers. The comment is corrected rather than the code.

Two consequences worth naming. An entry's document value now masks a concurrent authoritative change to another path of the same document until the entry retires, where a patch would have let it through; the entry is showing speculative state over that whole window anyway, and what it shows is now a value some run actually computed rather than a composition of two. And a pending entry holds the whole document rather than a delta, which is process memory for the entry's lifetime.

The OFF arm is untouched: a runtime without the flag builds no overlay, so nothing reaches the new mark.

Three documents follow the behavior. `speculation.md` §1 gains what the seal emits, the abandonment, and the masking.
`mergeable-collection-writes.md` gains the second abandonment site beside the one it already enumerates. `markAuthoritativeWrites` says it implies whole-document emission and the abandonment, which it did not mention at all.

Two tests pin the two halves, each red on the unfixed tree. The overlay case holds the window open rather than racing it: an ordinary client without the flag is the deriving committer that seeds a confirmed two-element array, the flag-ON client then opens over the settled state so its first run computes what is already stored and seals nothing, its next run diffs three elements against the confirmed two and seals the splice, and a second session writes a DIFFERENT three-element array as the arrival. What renders must be the three elements the derivation computed; unfixed it reads [7, 8, 6, 9], which separates that outcome from the splice composing with what arrived and from the entry having quietly retired. The array-push case asserts the array read is present in the sealed commit's reads, which is what the abandonment is for — unfixed those reads are empty, and an intent count alone could not show it. It pushes again afterwards, so the path is shown poisoned rather than merely deleted.

The pivot suite's own comments explained its waits by naming the defect. They now stand on the reason that outlives it: `waitForCellValue` has no deadline, so a wait for a count it never reaches hangs rather than failing, and a hang says nothing about what went wrong.

Filed as a topic by Wren, who measured the CI rate at roughly one run in twenty on main and traced it to `crossrefTable` being a pure lift that cannot produce four rows from three topics.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

