### PR TITLE
style(memory,piece,ui,ts-transformers,test-support): six frozen comments, and five headers read as declarations

### DIFF
--- a/packages/memory/test/v2-client-holdings.test.ts
+++ b/packages/memory/test/v2-client-holdings.test.ts
@@ -6,8 +6,8 @@
  * longer has the session. The session itself holds no documents; the
  * statement is the consumer's, through `holdingsProvider`.
  */
-import { assert } from "@std/assert";
 
+import { assert } from "@std/assert";
 import { expect } from "@std/expect";
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { defer } from "@commonfabric/utils/defer";

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -120,9 +120,10 @@ interface ScheduleStats {
   rejected: number;
   pendingReadAccepts: number;
 
-  /** Sparsely-mutated pending reads the schedule accepted. Both this and
-   * `sparseRejects` must stay at five or more for the declared-set exclusion
-   * to keep differential coverage — the floor the vacuity guard enforces. */
+  /** Sparsely-mutated pending reads the schedule accepted. Summed across
+   * seeds, this and `sparseRejects` must each reach five for the declared-set
+   * exclusion to keep differential coverage — the floor the vacuity guard
+   * enforces on the run-wide totals, not on any one schedule. */
   sparseAccepts: number;
 
   /** The same, for the ones it rejected. */

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -121,8 +121,8 @@ interface ScheduleStats {
   pendingReadAccepts: number;
 
   /** Sparsely-mutated pending reads the schedule accepted. Both this and
-   * `sparseRejects` must stay non-zero for the declared-set exclusion to keep
-   * differential coverage (see the vacuity guard). */
+   * `sparseRejects` must stay at five or more for the declared-set exclusion
+   * to keep differential coverage — the floor the vacuity guard enforces. */
   sparseAccepts: number;
 
   /** The same, for the ones it rejected. */

--- a/packages/memory/test/v2-schema-doc-closure-delivery.test.ts
+++ b/packages/memory/test/v2-schema-doc-closure-delivery.test.ts
@@ -31,8 +31,8 @@
  * a walking selector the traversal loads them anyway and every
  * assertion here passes with the closure pass entirely disabled.
  */
-import { assert } from "@std/assert";
 
+import { assert } from "@std/assert";
 import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import type { JSONSchema } from "@commonfabric/api";

--- a/packages/memory/test/v2-session-holdings.test.ts
+++ b/packages/memory/test/v2-session-holdings.test.ts
@@ -9,8 +9,8 @@
  * The cases drive the server through its wire boundary, the way the
  * closure-delivery pins do: raw connections, raw messages.
  */
-import { assert } from "@std/assert";
 
+import { assert } from "@std/assert";
 import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
@@ -117,6 +117,7 @@ const ids = (entries: readonly { id: string }[]): string[] =>
 describe("session holdings", () => {
   let server: Server;
   let writerSession: string;
+
   /** The union every reader watches: two roots, one of which mentions
    * the leaf schema, so the closure joins `cid:<leaf>`. */
   const roots = ["of:holdings-a", "of:holdings-b"];

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -455,6 +455,7 @@ export type DeliveryDeferral = {
   activeFailureStartedAt?: number;
   state: "failed" | "recovering";
   recoveryEpoch?: string;
+
   /** Positive versioned producer evidence that this failure is permanent. */
   permanentEvidence?: true;
 };
@@ -529,10 +530,13 @@ export type StreamEventEntry = {
    * (events.md §5). */
   error?: string;
 
-  /** Processing-side: the dropped-event notice (events.md §5 T7) —
-   * `{ status: "dropped", reason }` on the entry itself. */
+  /** Processing-side: how the entry ended, where it did not simply run.
+   * `"dropped"` is the dropped-event notice (events.md §5 T7);
+   * `"needs-attention"` has its detail in `attention` below. */
   status?: "dropped" | "needs-attention";
 
+  /** The dropped-event notice's reason, the other half of
+   * `{ status: "dropped", reason }` on the entry itself. */
   reason?: string;
 
   /** Processing-side checkpoint. It is not a consequence and advances no
@@ -920,6 +924,7 @@ export type OperationFieldSnapshot = OperationFieldAddress & {
   baselineHash: string;
   materialized: FabricValue;
   operations: IntegratedOperation[];
+
   /** Lowest cursor from which the retained integrated suffix is contiguous. */
   retainedFrom?: OpCursor;
 
@@ -1584,6 +1589,7 @@ export type SqliteNativeRow = Record<string, FabricValue>;
 
 export type SqliteQueryResult = {
   rows: SqliteNativeRow[];
+
   /** Per-result-column origin, present ONLY when the db needs provenance for
    *  CFC labeling — any column declares `ifc` (Phase 2) or any table declares
    *  a per-row label rule (Phase 3); see `dbNeedsColumnProvenance`. An aliased

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -424,17 +424,20 @@ export type QueryGraphReuseContext = {
   managers?: Map<string, EngineObjectManager>;
 };
 
+/** Source of fresh ids for {@link canonicalSelectorId}. */
+let nextCanonicalSelectorId = 0;
+
+/** Ids already issued, keyed by canonical (interned) selector instance. */
+const canonicalSelectorIds = new WeakMap<SchemaPathSelector, number>();
+
 /**
- * Canonical selector identity for evaluation-cache keys. Interning gives
- * structurally equal selectors one canonical instance
+ * Returns the canonical selector identity for evaluation-cache keys.
+ * Interning gives structurally equal selectors one canonical instance
  * (`internPathSelector`), so reference identity is structural equality and
  * the id is exact. Canonical instances are weakly held, so an id can lapse
  * with its selector and a re-interned equal reappears under a fresh id —
  * that costs a cache miss, never a wrong hit.
  */
-let nextCanonicalSelectorId = 0;
-
-const canonicalSelectorIds = new WeakMap<SchemaPathSelector, number>();
 const canonicalSelectorId = (selector: SchemaPathSelector): number => {
   const interned = internPathSelector(selector);
   let id = canonicalSelectorIds.get(interned);
@@ -479,6 +482,7 @@ export type QueryEvaluationCacheDiagnostics = {
 
   misses: number;
   rotations: number;
+
   /** Serves of a scope-pure entry (identical for every identity). */
   hitsPure: number;
 
@@ -581,7 +585,8 @@ export type QueryEvaluationCache = {
   /** Evaluations that found no usable entry. */
   misses: number;
 
-  /** Times the cache was rotated out for a newer engine seq. */
+  /** Times the cache was rotated out — a newer engine seq, or a different
+   * engine object for the same space. */
   rotations: number;
 };
 

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -163,39 +163,41 @@ function filterOutCell(
 }
 
 /**
- * A cold-start setup repair failed specifically because the CFC SCHEMA
- * MIGRATION rejected the commit — the pinned pattern loads but cannot migrate
- * preserved input or unclassified document data onto a now-required field that
- * carries no default. Generated result fields are not in this class: pattern
- * setup materializes them. This is ONE of the two repair-failure classes the
- * runnability backstop (`PiecesController.#healDefaultRootByRollForward`)
- * acts on — the other is a refused stored argument
- * ({@link isStoredArgumentSchemaRefusal}); every other failure stays
- * fail-closed.
- *
- * The bare `CFC enforcement rejected commit` prefix is NOT a safe trigger: the
- * runner emits it for prepared-digest races, unprepared transactions, and
- * policy/provenance rejections too (`extended-storage-transaction.ts`), none of
- * which are repaired by repointing the root's pattern identity. So we require
- * the machine-stable migration token the CFC prepare tags onto this class
- * (`migration-reason.ts`). Matching a token in the message — not the error
- * class — is what survives the plain-`Error` re-wrap the runner applies at its
- * setup-commit boundary (`runner.ts`), keeping producer and consumer in
- * lockstep across that boundary and across packages.
- *
- * Crucially we match the token only in its FRAMED reason position — `: <token>:
- * ` — the exact shape the prepare catch emits (`${token}: ${message}` recorded
- * as a reason, surfaced by the commit as `…not prepared: ${reason}`). A bare
- * `includes(token)` would also match the token appearing incidentally inside an
- * UNRELATED, user-influenced error — e.g. an ordinary incompatible-type merge
- * failure at a property path literally named `/cfc-schema-migration-incompatible`
- * — and wrongly authorize a root replacement for a non-additive incompatibility.
- * The `: … : ` framing cannot be produced by a path or value that merely
- * contains the token string.
+ * The migration token in its FRAMED reason position — `: <token>: ` — the
+ * exact shape the CFC prepare catch emits (`${token}: ${message}` recorded as
+ * a reason, surfaced by the commit as `…not prepared: ${reason}`). A bare
+ * `includes(token)` would also match the token appearing incidentally inside
+ * an UNRELATED, user-influenced error — e.g. an ordinary incompatible-type
+ * merge failure at a property path literally named
+ * `/cfc-schema-migration-incompatible` — and wrongly authorize a root
+ * replacement for a non-additive incompatibility. The `: … : ` framing cannot
+ * be produced by a path or value that merely contains the token string.
  */
 const FRAMED_MIGRATION_REASON =
   `: ${CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON}: `;
 
+/**
+ * Reports whether a cold-start setup repair failed specifically because the
+ * CFC SCHEMA MIGRATION rejected the commit — the pinned pattern loads but
+ * cannot migrate preserved input or unclassified document data onto a
+ * now-required field that carries no default. Generated result fields are not
+ * in this class: pattern setup materializes them. This is ONE of the two
+ * repair-failure classes the runnability backstop
+ * (`PiecesController.#healDefaultRootByRollForward`) acts on — the other is a
+ * refused stored argument ({@link isStoredArgumentSchemaRefusal}); every other
+ * failure stays fail-closed.
+ *
+ * The bare `CFC enforcement rejected commit` prefix is NOT a safe trigger: the
+ * runner emits it for prepared-digest races, unprepared transactions, and
+ * policy/provenance rejections too (`extended-storage-transaction.ts`), none of
+ * which are repaired by repointing the root's pattern identity. So the check
+ * requires the machine-stable migration token the CFC prepare tags onto this
+ * class (`migration-reason.ts`), and only in its framed position
+ * ({@link FRAMED_MIGRATION_REASON}). Matching a token in the message — not the
+ * error class — is what survives the plain-`Error` re-wrap the runner applies
+ * at its setup-commit boundary (`runner.ts`), keeping producer and consumer in
+ * lockstep across that boundary and across packages.
+ */
 const isCfcMigrationRejection = (error: unknown): boolean =>
   error instanceof Error &&
   error.message.startsWith("CFC enforcement rejected commit") &&

--- a/packages/test-support/src/records/fragment.ts
+++ b/packages/test-support/src/records/fragment.ts
@@ -12,9 +12,11 @@ import { join } from "@std/path";
 import { serializeRecordLine, type TestRecord } from "./schema.ts";
 import { type Environment, recordsDir } from "./paths.ts";
 
-/** Fragment files are `fragment-<ulid>.ndjson` inside the spool. */
+/** Leading half of a fragment file's name: `fragment-<ulid>.ndjson` inside
+ * the spool. */
 export const FRAGMENT_PREFIX = "fragment-";
 
+/** The extension that completes that name. */
 export const FRAGMENT_SUFFIX = ".ndjson";
 
 const encoder = new TextEncoder();

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -138,11 +138,22 @@ export class CrossStageState {
    */
   readonly #reportedDiagnosticKeys = new Set<string>();
 
-  /** Marker family — keyed by node/symbol identity; cache-coupled via context. */
+  /**
+   * First of the four marker-family WeakSets — with
+   * `syntheticComputeCallbackRegistry`, `syntheticComputeOwnedNodeRegistry`,
+   * and `syntheticReactiveCollectionRegistry` below. Each is keyed by
+   * node/symbol identity, with its context-level mutators coupled to
+   * reactive-analysis cache invalidation; `core/mod.ts` defines the family.
+   */
   readonly mapCallbackRegistry = new WeakSet<ts.Node>();
 
+  /** The second marker-family WeakSet, held to the same contract. */
   readonly syntheticComputeCallbackRegistry = new WeakSet<ts.Node>();
+
+  /** The third marker-family WeakSet, held to the same contract. */
   readonly syntheticComputeOwnedNodeRegistry = new WeakSet<ts.Node>();
+
+  /** The fourth marker-family WeakSet, held to the same contract. */
   readonly syntheticReactiveCollectionRegistry:
     SyntheticReactiveCollectionRegistry = new WeakSet();
 

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -198,8 +198,8 @@
  *      compiler itself structures NodeLinks: one private per-node struct, narrow
  *      public accessors, the table never handed out.
  */
-export { TransformationContext } from "./context.ts";
 
+export { TransformationContext } from "./context.ts";
 export { CrossStageState } from "./cross-stage-state.ts";
 export type {
   BuilderSourceSiteOptions,

--- a/packages/ui/src/v2/components/cf-chart/lib/scales.ts
+++ b/packages/ui/src/v2/components/cf-chart/lib/scales.ts
@@ -3,6 +3,7 @@
  *
  * Collects data domains across all marks and creates d3 scales.
  */
+
 // @ts-types="@types/d3-scale"
 import {
   type ScaleBand,
@@ -14,7 +15,6 @@ import {
   type ScaleTime,
   scaleTime,
 } from "d3-scale";
-
 // @ts-types="@types/d3-array"
 import { extent } from "d3-array";
 import type {

--- a/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
+++ b/packages/ui/src/v2/components/cf-markdown/markdown-template.ts
@@ -40,6 +40,9 @@ export interface MarkdownCallbacks {
   checkboxToggled(index: number, checked: boolean): void;
 }
 
+/** Scratch element {@link decodeEntities} parses into; created on first use. */
+let scratch: HTMLElement | undefined;
+
 /**
  * Resolves the HTML character references in a run of markdown text.
  *
@@ -47,12 +50,10 @@ export interface MarkdownCallbacks {
  * output to an HTML parser that resolves them. This one does not, so `&amp;`
  * would otherwise reach the page as four characters rather than one.
  *
- * The assignment below cannot produce an element: `<` and `>` are replaced by
- * their own references first, and every markup construct needs a `<`. What
- * comes back is the single text node the parser built.
+ * The `innerHTML` assignment cannot produce an element: `<` and `>` are
+ * replaced by their own references first, and every markup construct needs a
+ * `<`. What comes back is the single text node the parser built.
  */
-let scratch: HTMLElement | undefined;
-
 function decodeEntities(text: string): string {
   if (!text.includes("&")) return text;
   scratch ??= document.createElement("div");

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -869,9 +869,10 @@ export class CFPieceMenu extends BaseElement {
   /** The piece the menu addresses. */
   declare cell?: CellHandle;
 
-  /** Where the click landed, in client coordinates. */
+  /** Client X coordinate of where the click landed. */
   declare x: number;
 
+  /** Client Y coordinate, read the same way. */
   declare y: number;
 
   static override properties = {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The #6650 half of the ex-post-facto review, judged against `main`. Siblings:
#6693 (the rule), #6694 (`runner` and the comment-rewrite PRs), #6696
(`cf-harness`), #6698 (`cli`).

## Six comments bound to the first of what they covered

| site | the comment | bound to |
|---|---|---|
| `cf-markdown/markdown-template.ts:43` | `decodeEntities`'s whole contract — a verb phrase, plus the `innerHTML` assignment *inside* it | `let scratch` |
| `piece/src/ops/pieces-controller.ts:165` | a predicate's contract, and its matching strategy | the string constant that strategy uses |
| `memory/v2/query.ts:427` | a three-declaration interning mechanism | its bare counter |
| `ts-transformers/core/cross-stage-state.ts:141` | "Marker family" | one of the four WeakSets `core/mod.ts` defines as that family |
| `memory/v2.ts:532` | `{ status: "dropped", reason }` | `status`, which also admits `"needs-attention"` — not the dropped-event notice at all |
| `test-support/src/records/fragment.ts:15` | the `fragment-<ulid>.ndjson` filename shape | the prefix, leaving the suffix bare |

`cf-piece-menu.ts:872` is the seventh, and the sharpest: it is the same pair
shape (`x`/`y` under one "client coordinates" comment) that **this PR itself
split correctly in `cf-render.ts`**, six files away in its own diff — and that
commit's message says a scan for the shape across the tree found one other site.
It found neither this one nor `fragment.ts`.

## One rewrite narrower than the code

`rotations` was given "a newer engine seq", where the rotation test is
`cache.engine !== engine || cache.seq !== currentSeq` and the `engine` field's
own comment, thirty lines up, insists that a different engine object rotates the
cache *exactly as* a seq advance does. And `v2-differential-consistency` says two
counters "must stay non-zero" where the guard it cites enforces five.

## Five file headers read as doc comments

Each header sat flush on its first declaration, so the sweep read it as that
declaration's doc comment and put the blank one declaration too low. The blank
goes where §"File headers" wants it and the fossil comes out.

This is the same class as #6698's eight, and #6655's three. A tree-wide census
finds **48 files** where a leading doc comment is followed immediately by an
import — a certain freeze every time — plus 68 needing per-file judgment.

## Scope

Seven above-rule sites **in files this PR already opens** are conformed. The
twelve in files it does not — `v2/client.ts`, `v2/server.ts`, `bulk-apply.ts`,
`bulk-repair.ts`, `piece-restore.ts` — are reported as a measured residual.

## Verification

Suites green: ts-transformers 1164, memory 592, ui 175 + 52, piece 52,
test-support 28. `deno fmt --check`, `deno lint`, `deno check`. No added line
exceeds eighty columns, measured as characters over the diff's `+` lines.

Gates run **off-pin**: this machine has `deno` 2.9.6 where `mise.toml` pins
2.9.4 and `mise` is not installed. CI's pinned run is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

