### PR TITLE
feat(topics): stamped removals, comment edit, and removeLink

### DIFF
--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -136,21 +136,50 @@ Item 1 additionally needed, before it could land, and each is in the PR:
 
 ### Stage C
 
-Each item waits on platform work rather than on this plan:
+One item is built. What remains waits on a review this plan does not own, or on
+usage:
 
-- **`removeLink`, and comment edit and removal.** References-as-arguments has
-  landed, so these are buildable. They go on the topic's own interface and need
-  no migration; the no-synthetic-ids rule is what prepared for them. The
-  decisions they turn on are settled and recorded below.
+- **`removeLink`, and comment edit and removal — built.** A retraction stamps
+  `removedAt` and `removedBy` and leaves the record in place; `editComment`
+  stamps `editedAt` and leaves `author` and `sentAt` alone. The verbs name
+  their target by reference, which is what the no-synthetic-ids rule prepared
+  for, and `removeLink` additionally takes `url` because a link record carries
+  no fid a CLI caller could name.
+
+  They sit on `TopicOutput` rather than on the `TopicPiece` projection boards
+  store, which is what makes them need no migration. That placement is the
+  interim rule below doing the work it was kept for, and it is now measured
+  rather than predicted: only `topic.tsx` needed a new baseline, because
+  `main.tsx`'s contract never moved.
+
+  What is not built is the reader's control for them. The rows filter stamped
+  records already, but they render from a filtered, sorted `computed()`, and
+  whether an element of one still carries writable identity is unproven —
+  `dropMention` binds from an unfiltered read, so it settles nothing. A control
+  bound wrongly stamps a copy no reader sees, which is a silent failure, so it
+  wants a browser test rather than an assumption.
+
 - **`AgentActor` execution provenance** replacing per-event `agentName`, when
-  the retention-and-provenance track clears its review. Required-now relaxes to
-  optional-then-deprecated, which is the compatible direction and the reason
-  item 2 above tightens rather than waits.
-- **`Demand<T>` markers** replacing the interim rule that new verbs go on the
-  topic's own output only.
+  the retention-and-provenance track clears its review. That review has not
+  happened and nothing in that plan has started, so this item cannot begin
+  here. Required-now relaxes to optional-then-deprecated, which is the
+  compatible direction and the reason Stage B tightened rather than waited.
+
+- **`Demand<T>` markers — decided against, for now.** The interim rule they
+  would have replaced therefore stands: a new verb goes on the topic's own
+  output, never into the board's demand. Item 1 is the worked example.
+
+  What the repository gives up by not having them is legibility rather than
+  capability. A holder's demand stays indistinguishable from its own state, so
+  nothing can count what a change would hit before it is attempted, and a
+  deliberate break is still acknowledged by turning the whole gate off for a
+  pattern rather than by naming the demand it breaks. The next board break
+  therefore costs what the Stage B one cost.
+
 - **Statuses, labels, assignees, and whatever else usage asks for**: optional
   fields and new verbs, compatible on the topic's own schema and invisible to
-  the board until the board widens its demand with an optional field.
+  the board until the board widens its demand with an optional field. Nothing
+  to build until a use asks for one.
 
 ## Testing the board through a narrowed demand
 
@@ -229,6 +258,21 @@ Two preconditions belong to the board rather than to the code:
   this to the author is expected to come later.
 - An edited comment carries `editedAt` beside its original `sentAt`, and the
   edit does not rewrite the author.
+- **`Demand<T>` markers are not adopted.** The interim rule they would have
+  replaced becomes the standing one: a new verb goes on the topic's own output,
+  never into the board's demand. This is a decision about legibility, not about
+  what can be built — every Stage C item remains reachable without them. What
+  it accepts is that a change's blast radius cannot be counted before the
+  change is attempted, and that a deliberate break is acknowledged for a whole
+  pattern rather than for the demand it actually breaks.
+- **A new verb goes on `TopicOutput`, not on `TopicPiece`.** The board stores
+  that projection, so it is a demand on every topic already held, and a
+  required verb added to it refuses every piece deployed before the verb
+  existed. A verb has no default to be rescued by, so there is no compatible
+  way to demand a new one — optionality would work, but the placement is what
+  `setTitle` established and what keeps the board's contract still. The tell
+  that it worked is a baseline recorded for `topic.tsx` and none for
+  `main.tsx`.
 - **`unmention` keeps removing rather than stamping**, and the pattern carries
   two removal semantics until [#6573] closes it. Not because an edge matters
   less than content, but because a mention is a bare reference with no record

--- a/docs/plans/topics-verb-surface.md
+++ b/docs/plans/topics-verb-surface.md
@@ -76,7 +76,7 @@ a default is the only one of them a board can grant itself.
 | --- | --- | --- |
 | A | compatible updates: verb and event prose, the describe layer, `setTitle`, a compact `addTopic` result | landed and deployed |
 | B | one rehearsed break, four items batched | landed and deployed |
-| C | items gated on platform work | designed for, not started |
+| C | retraction and edit, plus items waiting on a review or on usage | one item built, the rest not started |
 
 ### Stage A
 

--- a/packages/patterns/baselines/topics/topic.tsx/20260901T163748Z-L85kn0ZkfCRMKuQe.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260901T163748Z-L85kn0ZkfCRMKuQe.json
@@ -1,0 +1,997 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossrefRow": {
+        "properties": {
+          "mentionedBy": {
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "description": "The topic this row is about. `unknown` because it is written as a\nreference and only ever compared — `equals` takes the raw link. Anything\nwider retrieves the piece instead of pointing at it: declared `object`,\nthis field reads back as the whole expanded topic, `$UI` tree included.",
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "topic",
+          "mentionedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicMentionable": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "boardCrossrefs": {
+        "asCell": [
+          "readonly"
+        ],
+        "default": [],
+        "description": "The board's mention pivot, one row per topic. A topic reads its own row\nout of it and nothing else; see `backlinksOf`. Absent, a topic simply shows\nno inbound references.\n\nReadable, not writable: the pivot is the board's derivation, and a topic\nhas no business writing into it. Declaring the narrower cell says so where\na reader can see it, rather than leaving it to convention.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossrefRow"
+        },
+        "type": "array"
+      },
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's mention universe — what the body editor autocompletes\nover. Wired at creation to the board's mention index (one derived\ndocument of two-string rows; `TopicMentionableRow` in `main.tsx`), and\nrewired onto a piece from before the index as a one-time link-bind.\nA plain list of the pieces themselves also satisfies the demand — a\nboard not yet rewired, or a composer without a board. Absent, the\neditor simply offers no completions.",
+        "items": {
+          "$ref": "#/$defs/TopicMentionable"
+        },
+        "type": "array"
+      },
+      "mentioned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Pieces this topic references outside its prose — what `mention` records.\n\nIts own list rather than an entry in `references`, because that map belongs\nto the body editor: the editor mints its keys, rewrites its labels, and\ncollects entries whose token has left the document. A verb writing there\nwould be writing into somebody else's bookkeeping. Here there is nothing to\nkey by, because there is nothing to point back at from the prose — a\nreference outside a sentence is just a link in a list.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "asCell": [
+          "cell"
+        ],
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point, keyed by the token that\nappears in the body. The editor owns the contents; this pattern owns the\ncell, which is what makes a mention durable and — because each entry holds\nthe destination as a REFERENCE — what makes the reference graph a question\nabout cell identity rather than about text.\n\nThe default has to match the one `TopicOutput` publishes. A map published\nunder a different default than its input carries cannot be materialized."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "titleUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Attribution of the last rename, stamped by `setTitle` — the same pair\nthe body keeps, because a title is the other editable scalar."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The comment text, appended verbatim after trimming. Must be non-empty:\nan empty body rejects rather than recording a blank thread entry.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "What the link points at — a rendering hint, not a behavior switch.\nOptional because the handler defaults it to `\"web\"`, and a caller should\nnot be made to supply a field the verb never needed.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Display label. Optional, and a blank one falls back to the URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The link target. Must be http(s): anything else rejects, because a\nuser-supplied scheme on a shared surface is script execution in every\nviewer's session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "EditCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement text, trimmed. Must be non-empty: emptying a\ncomment is a retraction, and `removeComment` is what says so.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to revise, named and checked as in `RemoveCommentEvent`,\nand additionally naming `body`, which this verb writes.",
+            "properties": {
+              "body": {
+                "default": "",
+                "type": "string"
+              },
+              "editedAt": {
+                "type": "number"
+              },
+              "removedAt": {
+                "type": "number"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt",
+              "body"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "MentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "The piece to reference — the piece itself, not an address. Identity here\nis the cell, so this is what a caller passes and what gets stored.\n\nDeclared through the one field every Topic has rather than `unknown`. The\ncell declaration marks this as a reference position, so the CLI resolves a\ncanonical `/of:...` value from an inline JSON event into the live piece\nlink. It also bounds the validation read: `topic.get()` is `undefined` for\na value that is not a reference and an object for any piece, and `mention`\nchecks it before storing anything.\n\n`title` is also the most this can safely name: this schema reaches every\ntopic in `mentionable`, so a property without a default would be demanded\nof topics written before it existed and refuse their update. `title`\ncarries one, and that default does double duty — it is also why the check\nadmits a piece that is not a topic at all, which reads back `{ title: \"\" }`\nrather than `undefined`. `deno task pattern-vintage` proves the update side\nby replaying a real board.\n\nNothing reads THROUGH it beyond that one field — the value is stored and\ncompared.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      },
+      "RemoveCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "comment": {
+            "description": "The comment to retract — the stored element, not a copy of its fields.\nNames only what this verb reads and writes, for the reason\n`MentionEvent.topic` names only `title`: the declaration bounds the\nvalidation read, and a payload that is not a reference reads back\n`undefined` and is refused rather than silently matching nothing.\n`sentAt` carries a default, so it is what makes a real element read back\nas an object; the stamp fields are optional, which is what lets this\nschema reach comments written before they existed.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "sentAt": {
+                "default": 0,
+                "type": "number"
+              }
+            },
+            "required": [
+              "sentAt"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "comment",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "RemoveLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "link": {
+            "description": "The stored link element. What a reader passes, from the row it renders.\nNamed as in `RemoveCommentEvent`, with `url` playing the defaulted-field\nrole `sentAt` plays there.",
+            "properties": {
+              "removedAt": {
+                "type": "number"
+              },
+              "removedBy": {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              "url": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "url": {
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Fabric authenticates the write with that key; this says\nwhich agent acted under it.\n\nRequired so every authored-content call carries structured attribution.\nAuthenticated execution provenance can supersede the field by relaxing it\nto optional without breaking existing callers.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The complete replacement body, persisted verbatim — no trimming, so\nwhitespace-sensitive Markdown survives. An empty body is legal: clearing\na living document is an edit, not an error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "SetTitleEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation, stored as structured attribution beside\nthe write time. Required so every successful rename is attributed.",
+            "type": "string"
+          },
+          "title": {
+            "description": "The new title, trimmed before it is stored. Must be non-empty.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "agentName"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "description": "Open for the same reason `TopicLinkKind` is: this is provided data, so a\nclosed set here could never gain `\"service\"` or whatever acts next.\nWell-known values are `\"person\"` and `\"agent\"`, the latter marking an\nagent acting with its human user's key.",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key.\n\nOptional because durable Topics may contain a comment without structured\nauthorship. Current `addComment` calls require `agentName` and always write\nthis snapshot."
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "editedAt": {
+            "description": "When the body was last revised, absent on a comment never edited. The\noriginal `sentAt` and `author` are left alone: an edit changes what was\nsaid, not who said it or when the thread reached this point.",
+            "type": "number"
+          },
+          "removedAt": {
+            "description": "Set when the comment was retracted, and the retraction is the whole of\nit — the record stays, carrying what it always said. A reader hides it;\n`commentCount` stops counting it; `lastActivityOf` keeps reading its\n`sentAt`, which is what stops a retraction moving a topic backwards in\nthe board's ordering.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "default": "web",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "removedAt": {
+            "description": "As on a comment, and with one consequence of its own: a retracted link\nstops resolving into `mentions`, so the reference it contributed goes\nwith it rather than outliving the link that made it.",
+            "type": "number"
+          },
+          "removedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRef": {
+        "properties": {
+          "destination": {
+            "type": "unknown"
+          },
+          "modifiedTitle": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "destination",
+          "modifiedTitle"
+        ],
+        "type": "object"
+      },
+      "TopicMentionRefMap": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TopicMentionRef"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "TopicSummary": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "title": {
+            "default": "",
+            "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt"
+        ],
+        "type": "object"
+      },
+      "UnmentionEvent": {
+        "properties": {
+          "topic": {
+            "description": "Declared and checked exactly as `MentionEvent.topic` is, and for the same\nreason: a payload that is not a reference matches no stored entry, so\nwithout the check it would remove nothing and report success.",
+            "properties": {
+              "title": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "topic"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as append-only, point-in-time\n`addComment` records. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "The topic's display name. Like the other derived display fields, a cold\nretained topic may not have produced this path yet; its persisted title\nremains authoritative until it does.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Append to the thread — a point-in-time record of progress or\ndeliberation; durable conclusions belong in the body. Returns the\ncomment as recorded, resolved author and `sentAt` included."
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Attach a typed outbound link — a PR, an agent session, a web page.\nReturns the link as recorded, resolved `addedBy` and `addedAt`\nincluded. Appends merge and nothing dedupes: a repeated URL is two\nentries."
+      },
+      "body": {
+        "default": "",
+        "description": "The living document, verbatim Markdown. `setBody` replaces it whole.",
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the body editor; the session drafts are the discard.",
+        "tier": "wrapper"
+      },
+      "cancelEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: close the rename editor; the session draft is the discard.",
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "description": "The thread, in arrival order: append-only point-in-time records, each\ncarrying its author snapshot and `sentAt`.",
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "description": "When the topic was filed (epoch milliseconds), stamped at create.",
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "editComment": {
+        "$ref": "#/$defs/EditCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Revise a comment's body in place, naming it by reference. Stamps\n`editedAt` and leaves `author` and `sentAt` as they were. Outside the\nprojection for the reason `removeComment` states."
+      },
+      "editingBody": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "editingTitle": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "type": "string"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "description": "Typed outbound links, in arrival order, each carrying its author\nsnapshot and `addedAt`.",
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mention": {
+        "$ref": "#/$defs/MentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Reference another piece from this topic — the payload is the piece\nitself, stored as a reference. Takes no `agentName` and returns no value;\nFabric retains the authenticated principal behind the edge."
+      },
+      "mentioned": {
+        "default": [],
+        "description": "Pieces referenced outside the prose, recorded by `mention`.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "mentions": {
+        "default": [],
+        "description": "Every piece this topic's prose and links point at, as references.\n\nThe board's pivot is declared over this and nothing else, so what one topic\ncosts a full-board scan is exactly this list of identities. Declared\n`unknown[]` because these are references, and comparing them never reads\nwhat is behind them.\n\nThe cell annotation that makes them comparable belongs to the READER, not\nhere: the pivot declares its own view of this list as\n`TopicMentionSource.mentions: ComparableCell<unknown>[]`, and that is what\nmakes its graph settle rather than depend on load order. A published\n`unknown[]` is what each reader annotates for itself.\n\nThe default stands alone: a declared default and `| undefined` collide,\nand the default is what a topic deployed before this path existed\nmaterializes against.",
+        "items": {
+          "type": "unknown"
+        },
+        "type": "array"
+      },
+      "referencedBy": {
+        "default": [],
+        "description": "The topics that mention this one, read out of the board's pivot.\n\nDeclared through `TopicSummary` rather than `TopicPiece`, and that is\nload-bearing rather than stingy: a topic whose backlinks were topics would\nbe a type that contains itself, and resolving one from a list would walk\nthe graph. The summary carries no reference of its own, so it terminates.\nA reader that wants more follows the link, which resolves whole.",
+        "items": {
+          "$ref": "#/$defs/TopicSummary"
+        },
+        "type": "array"
+      },
+      "references": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "default": {},
+        "description": "Where this topic's `[Label][key]` mentions point. Durable content, like\n`links`. The body editor works on a session copy of this map, which a save\npublishes here whole, beside the prose whose tokens name its entries."
+      },
+      "referencesDraft": {
+        "$ref": "#/$defs/TopicMentionRefMap",
+        "description": "The body draft's mention map, staged so Cancel can discard it.\n\n`cf-code-editor` writes an entry the moment a mention is inserted and\ndrops one the moment its token leaves the document, neither of them\nwaiting for Save. Pointed at the durable map while `$value` holds a\nsession draft, those writes would outlive a discarded edit: a canceled\ninsertion would leave an edge no token names, and a canceled deletion\nwould strip the destination from a token the durable body still carries.\nThe editor's own ordering assumes its two bindings share a lifetime, so\nthis gives them one."
+      },
+      "removeComment": {
+        "$ref": "#/$defs/RemoveCommentEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a comment, naming it by reference. The record is stamped rather\nthan deleted, so the thread keeps its evidence while a reader stops\nshowing it and `commentCount` stops counting it.\n\nHere rather than on `TopicPiece`, for the reason `setTitle` is: boards\nstore that projection, so it is a demand on every topic they already\nhold, and a required verb added to it would refuse every one deployed\nbefore the verb existed. A verb has no default to be rescued by, so there\nis no compatible way to demand a new one. Addressing the topic directly\nreaches all three of these."
+      },
+      "removeLink": {
+        "$ref": "#/$defs/RemoveLinkEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Retract a link, by reference or by `url`. Stamped like a comment, and a\nretracted link stops resolving into `mentions`. The url spelling exists\nbecause a link record carries no fid for a CLI caller to name. Outside\nthe projection for the reason `removeComment` states."
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: publish the session body and mention-map drafts whole,\nattributed to the viewer's Profile — the contract verb is `setBody`.",
+        "tier": "wrapper"
+      },
+      "saveTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: save the session title draft under the viewer's Profile —\nthe contract verb is `setTitle`, and both land through the same core, so\na browser rename stamps the same attribution and moves the same activity\nclock.",
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Replace the living document whole — read it, revise it, write it back\ncomplete; the body is one value with whole-value conflict semantics.\nRequires `agentName` and returns the persisted body with its attribution."
+      },
+      "setTitle": {
+        "$ref": "#/$defs/SetTitleEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Rename the topic. Requires `agentName` and returns the persisted title\nwith its attribution. This direct-address verb stays outside the board's\nnarrow `TopicPiece` demand."
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the body editor, seeding the session drafts from the\ndurable body and mention map.",
+        "tier": "wrapper"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: open the rename editor, seeding the session draft from the\ndurable title.",
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session comment draft under the viewer's\nProfile. Reads session-local state, so it is a silent no-op headless —\nthe contract verb is `addComment`.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI wrapper: append the session link drafts under the viewer's Profile —\nthe contract verb is `addLink`.",
+        "tier": "wrapper"
+      },
+      "title": {
+        "default": "",
+        "description": "The topic's title. Defaulted rather than required, like every other\nfield a board card renders: the card list is a mapped sub-pattern, so\nthis type reaches a piece holding topics written before the field\nexisted as the argument schema its update is checked against, and a\nrequired property those topics lack refuses that update outright.\n`deno task pattern-vintage` is what catches it, by replaying a real\ndeployed board.",
+        "type": "string"
+      },
+      "titleDraft": {
+        "type": "string"
+      },
+      "titleUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "titleUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ],
+        "description": "Attribution of the last rename; unset until the first `setTitle`.\nBeside `setTitle` rather than on the projection, for the same reason."
+      },
+      "unmention": {
+        "$ref": "#/$defs/UnmentionEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stop referencing a piece: removes every `mention`-made entry naming it.\nReferences made in the prose are retracted by editing the prose, not by\nthis. Takes no `agentName` and returns no value."
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "titleDraft",
+      "editingTitle",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "referencesDraft",
+      "setTitle",
+      "removeComment",
+      "editComment",
+      "removeLink",
+      "startEditTitle",
+      "saveTitle",
+      "cancelEditTitle",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "body",
+      "comments",
+      "links",
+      "mentions",
+      "references",
+      "mentioned",
+      "referencedBy",
+      "addComment",
+      "addLink",
+      "setBody",
+      "mention",
+      "unmention",
+      "$NAME",
+      "title",
+      "createdAt",
+      "commentCount",
+      "lastActivityAt"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260901T191235Z-4uo6zrdZRahgZ98O.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260901T191235Z-4uo6zrdZRahgZ98O.json
@@ -437,7 +437,7 @@
             "type": "object"
           },
           "url": {
-            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.",
+            "description": "The link's URL, for a caller that cannot pass a reference. Retracts the\nmost recently added link still present with this URL, so retracting twice\nretracts two rather than re-stamping one.\n\nSequentially. Two concurrent retractions naming the same URL both resolve\nthe same newest-present element and merge into one stamped record, so\nthey retract one link between them rather than two. Naming the link by\nreference is what makes a caller's target unambiguous under concurrency;\nthis spelling trades that for being reachable at all.",
             "type": "string"
           }
         },
@@ -658,7 +658,7 @@
         "type": "object"
       }
     },
-    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as append-only, point-in-time\n`addComment` records. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
+    "description": "A #topic — one durable unit of shared attention: a title, a living body\ndocument, a flat chronological comment thread, typed links out to other\ncore objects (PRs, agent sessions, web pages), and the references it makes\nto sibling pieces.\n\nDurable conclusions get folded up into the body — revise it whole with\n`setBody`; the thread holds the deliberation as point-in-time `addComment`\nrecords. The thread only ever grows: `removeComment` and `removeLink` stamp\na record as retracted and leave it where it is, and `editComment` revises a\nbody in place, so what a reader shows is the array filtered rather than the\narray itself. Sign every authored-content mutation with `agentName`:\nFabric records the human principal behind the key; the name says which\nagent acted under it. Reference-only `mention` and `unmention` calls carry\nno content signature. The session-draft cells and `submit*` streams below\nbelong to the rendered page, not the headless contract — they read state\nonly this session holds.",
     "properties": {
       "$NAME": {
         "default": "",
@@ -737,7 +737,7 @@
         "type": "string"
       },
       "comments": {
-        "description": "The thread, in arrival order: append-only point-in-time records, each\ncarrying its author snapshot and `sentAt`.",
+        "description": "The thread, in arrival order, each record carrying its author snapshot\nand `sentAt`.\n\nMEMBERSHIP is append-only; a record is not. Nothing is ever removed from\nthis array — `removeComment` stamps `removedAt` and leaves the record in\nplace, and `editComment` revises a body and stamps `editedAt` — so a\nreader that wants the live thread filters on `removedAt` rather than\ntaking the array as it stands. `commentCount` is that filtered count.",
         "items": {
           "$ref": "#/$defs/TopicComment"
         },
@@ -793,7 +793,7 @@
         "type": "string"
       },
       "links": {
-        "description": "Typed outbound links, in arrival order, each carrying its author\nsnapshot and `addedAt`.",
+        "description": "Typed outbound links, in arrival order, each carrying its author snapshot\nand `addedAt`. Append-only in membership on the same terms as `comments`:\n`removeLink` stamps rather than removes, and a stamped link additionally\nstops resolving into `mentions`.",
         "items": {
           "$ref": "#/$defs/TopicLink"
         },

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -178,6 +178,8 @@ cf call --piece <topic> addLink \
   '{"url":"https://github.com/org/repo/pull/123","kind":"pr","label":"PR #123","agentName":"Sol"}'
 cf call --piece <topic> mention '{"topic":"/of:fid1:other-topic"}'
 cf call --piece <topic> unmention '{"topic":"/of:fid1:other-topic"}'
+cf call --piece <topic> removeLink \
+  '{"url":"https://github.com/org/repo/pull/123","agentName":"Sol"}'
 ```
 
 `addLink` requires `url` and `agentName`; `kind` defaults to `"web"`, and a
@@ -188,6 +190,27 @@ It lives on the topic's direct interface rather than the shared `TopicPiece`
 projection: a holder's required demands are write-once, so a verb added to the
 projection every board embeds would refuse those boards' updates. Address the
 topic itself and the verb is there.
+
+**A retraction stamps the record; nothing is deleted.** `removeComment` and
+`removeLink` write `removedAt` and `removedBy` onto the stored record and leave
+it where it is, and `editComment` revises a body while stamping `editedAt` and
+leaving `author` and `sentAt` alone. A reader hides a retracted record,
+`commentCount` stops counting it, and a retracted link stops resolving into
+`mentions` — the reference goes with the link that made it.
+
+`lastActivityAt` is the one reader that does not filter them, and that is the
+reason the design stamps rather than deletes: it is a max over what the arrays
+hold, so removing the newest comment outright would move a topic _backwards_ in
+the board's most-recent ordering. A stamped record keeps its `sentAt` in that
+max, and the retraction's own stamp moves the clock forward.
+
+All three live on the topic's direct interface for the same reason `setTitle`
+does. `removeComment` and `editComment` name their target by reference, which is
+what the no-minted-id rule prepared for — a caller passes the stored element,
+and the UI hands one over from the row it is rendering. `removeLink`
+additionally accepts `url`, because a link record is not a piece and carries no
+fid for a CLI caller to name; it retracts the most recently added link still
+present with that URL, so retracting twice retracts two.
 
 `mention` and `unmention` take a canonical piece reference in the inline JSON
 event. The CLI recognizes the declared reference position and turns `/of:...`

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -2,6 +2,7 @@ import {
   action,
   cellFromUrl,
   type ComparableCell,
+  computed,
   Default,
   equals,
   handler,
@@ -128,6 +129,92 @@ export interface MentionEvent {
   topic: Writable<{ title: string | Default<""> }>;
 }
 
+/**
+ * Retract a comment. The record stays, stamped; nothing is deleted.
+ *
+ * The comment is named by reference, which is the rule `TopicComment` states:
+ * array elements have stable entity identity, so a caller passes the element
+ * rather than a synthetic key nobody minted. A reader hands one over from the
+ * row it is already rendering.
+ */
+export interface RemoveCommentEvent extends AgentAuthoredEvent {
+  /** The comment to retract — the stored element, not a copy of its fields.
+   * Names only what this verb reads and writes, for the reason
+   * `MentionEvent.topic` names only `title`: the declaration bounds the
+   * validation read, and a payload that is not a reference reads back
+   * `undefined` and is refused rather than silently matching nothing.
+   * `sentAt` carries a default, so it is what makes a real element read back
+   * as an object; the stamp fields are optional, which is what lets this
+   * schema reach comments written before they existed. */
+  comment: Writable<{
+    sentAt: number | Default<0>;
+    removedAt?: number;
+    removedBy?: TopicAuthor;
+  }>;
+}
+
+/** Revise a comment's body in place. */
+export interface EditCommentEvent extends AgentAuthoredEvent {
+  /** The comment to revise, named and checked as in `RemoveCommentEvent`,
+   * and additionally naming `body`, which this verb writes. */
+  comment: Writable<{
+    sentAt: number | Default<0>;
+    body: string | Default<"">;
+    editedAt?: number;
+    removedAt?: number;
+  }>;
+
+  /** The complete replacement text, trimmed. Must be non-empty: emptying a
+   * comment is a retraction, and `removeComment` is what says so. */
+  body: string;
+}
+
+/**
+ * Retract a link. The record stays, stamped, and stops resolving into
+ * `mentions`.
+ *
+ * Takes EITHER the stored link or its `url`, and the url spelling is the
+ * reason this verb differs from the others. A link record is not a piece and
+ * carries no fid, so a caller that reaches this verb over the CLI has no way
+ * to name one by reference — and `addLink` is the verb agents use most.
+ * Exactly one of the two must be supplied.
+ */
+export interface RemoveLinkEvent extends AgentAuthoredEvent {
+  /** The stored link element. What a reader passes, from the row it renders.
+   * Named as in `RemoveCommentEvent`, with `url` playing the defaulted-field
+   * role `sentAt` plays there. */
+  link?: Writable<{
+    url: string | Default<"">;
+    removedAt?: number;
+    removedBy?: TopicAuthor;
+  }>;
+
+  /** The link's URL, for a caller that cannot pass a reference. Retracts the
+   * most recently added link still present with this URL, so retracting twice
+   * retracts two rather than re-stamping one. */
+  url?: string;
+}
+
+export interface RemoveCommentResult {
+  /** The retraction as stamped, so a caller need not read back to confirm. */
+  removedAt: number;
+  removedBy: TopicAuthor;
+}
+
+export interface EditCommentResult {
+  /** The body as persisted, and when the revision was stamped. */
+  body: string;
+  editedAt: number;
+}
+
+export interface RemoveLinkResult {
+  /** The URL of the link that was retracted, which tells a caller using the
+   * url spelling which of several same-url links it reached. */
+  url: string;
+  removedAt: number;
+  removedBy: TopicAuthor;
+}
+
 /** Stop referencing a piece. */
 export interface UnmentionEvent {
   /** Declared and checked exactly as `MentionEvent.topic` is, and for the same
@@ -189,6 +276,19 @@ export interface TopicComment {
   author?: TopicAuthor;
   body: string | Default<"">;
   sentAt: number | Default<0>;
+
+  /** When the body was last revised, absent on a comment never edited. The
+   * original `sentAt` and `author` are left alone: an edit changes what was
+   * said, not who said it or when the thread reached this point. */
+  editedAt?: number;
+
+  /** Set when the comment was retracted, and the retraction is the whole of
+   * it — the record stays, carrying what it always said. A reader hides it;
+   * `commentCount` stops counting it; `lastActivityOf` keeps reading its
+   * `sentAt`, which is what stops a retraction moving a topic backwards in
+   * the board's ordering. */
+  removedAt?: number;
+  removedBy?: TopicAuthor;
 }
 
 export interface TopicLink {
@@ -197,7 +297,24 @@ export interface TopicLink {
   label: string | Default<"">;
   addedBy?: TopicAuthor;
   addedAt?: number;
+
+  /** As on a comment, and with one consequence of its own: a retracted link
+   * stops resolving into `mentions`, so the reference it contributed goes
+   * with it rather than outliving the link that made it. */
+  removedAt?: number;
+  removedBy?: TopicAuthor;
 }
+
+/** Whether a stamped record is still live.
+ *
+ * Exported for readers outside a reactive read — a test, a script. Inside a
+ * `computed()` the predicate is written out instead, and that is not a style
+ * choice: the schema a reactive read declares is what it can SEE, and a
+ * property tested behind a helper call is not named in it. Filtering through
+ * this function there yields a count that never changes, because `removedAt`
+ * was never demanded and so reads back absent on every element. */
+export const isPresent = (record: { removedAt?: number }): boolean =>
+  record.removedAt === undefined;
 
 export interface TopicInput {
   title?: Writable<string | Default<"">>;
@@ -527,6 +644,31 @@ export interface TopicOutput extends TopicPiece {
    * with its attribution. This direct-address verb stays outside the board's
    * narrow `TopicPiece` demand. */
   setTitle: Stream<SetTitleEvent, SetTitleResult>;
+
+  /**
+   * Retract a comment, naming it by reference. The record is stamped rather
+   * than deleted, so the thread keeps its evidence while a reader stops
+   * showing it and `commentCount` stops counting it.
+   *
+   * Here rather than on `TopicPiece`, for the reason `setTitle` is: boards
+   * store that projection, so it is a demand on every topic they already
+   * hold, and a required verb added to it would refuse every one deployed
+   * before the verb existed. A verb has no default to be rescued by, so there
+   * is no compatible way to demand a new one. Addressing the topic directly
+   * reaches all three of these.
+   */
+  removeComment: Stream<RemoveCommentEvent, RemoveCommentResult>;
+
+  /** Revise a comment's body in place, naming it by reference. Stamps
+   * `editedAt` and leaves `author` and `sentAt` as they were. Outside the
+   * projection for the reason `removeComment` states. */
+  editComment: Stream<EditCommentEvent, EditCommentResult>;
+
+  /** Retract a link, by reference or by `url`. Stamped like a comment, and a
+   * retracted link stops resolving into `mentions`. The url spelling exists
+   * because a link record carries no fid for a CLI caller to name. Outside
+   * the projection for the reason `removeComment` states. */
+  removeLink: Stream<RemoveLinkEvent, RemoveLinkResult>;
 
   /** Attribution of the last rename; unset until the first `setTitle`.
    * Beside `setTitle` rather than on the projection, for the same reason. */
@@ -956,22 +1098,45 @@ const mentionsOf = lift((
   ].filter((destination) => destination !== undefined && destination !== null)
 );
 
+/** How many comments are there to read — retracted ones excluded, because the
+ * board's card would otherwise promise more than the topic shows.
+ *
+ * A module-scope `lift` rather than a `computed()` in the pattern body, and
+ * the difference is load-bearing: this value is in the board's demand, so it
+ * is projected onto every stored topic including generations written before
+ * retraction existed. The lift declares `removedAt` in its own parameter,
+ * which is what makes the property visible to the read at all. */
+const presentCommentCountOf = lift((
+  { comments }: { comments: { removedAt?: number }[] },
+): number => comments.filter((c) => c.removedAt === undefined).length);
+
 /** Max of creation, the newest comment, the newest link, the last body save,
- * and the last rename — declared over just those five timestamp surfaces. */
+ * and the last rename — declared over just those five timestamp surfaces.
+ *
+ * Every retracted and edited record still counts here, and that is the point
+ * rather than an oversight. This is a max over what the arrays hold, so
+ * skipping a retracted record would let the answer move BACKWARDS when the
+ * newest comment is the one retracted, reordering the board under a reader.
+ * A stamped retraction cannot do that, and a retraction is itself activity,
+ * so its own stamp moves the clock forward. */
 const lastActivityOf = lift((
   { comments, links, createdAt, bodyUpdatedAt, titleUpdatedAt }: {
-    comments: { sentAt: number }[];
-    links: { addedAt?: number }[];
+    comments: { sentAt: number; editedAt?: number; removedAt?: number }[];
+    links: { addedAt?: number; removedAt?: number }[];
     createdAt: number;
     bodyUpdatedAt: number;
     titleUpdatedAt: number;
   },
 ): number => {
   let newest = Math.max(createdAt, bodyUpdatedAt, titleUpdatedAt);
-  for (const c of comments) newest = Math.max(newest, c.sentAt);
+  for (const c of comments) {
+    newest = Math.max(newest, c.sentAt, c.editedAt ?? 0, c.removedAt ?? 0);
+  }
   // `addedAt` is optional on TopicLink: links written before it existed carry
   // no timestamp and simply do not move the clock.
-  for (const l of links) newest = Math.max(newest, l.addedAt ?? 0);
+  for (const l of links) {
+    newest = Math.max(newest, l.addedAt ?? 0, l.removedAt ?? 0);
+  }
   return newest;
 });
 
@@ -1057,6 +1222,97 @@ export default pattern<TopicInput, TopicOutput>(
           rejectMutation("addLink", "url must be http(s)");
         }
         return { link: appendLink(links, trimmedUrl, kind, label, author) };
+      },
+    );
+
+    const removeComment = action<RemoveCommentEvent, RemoveCommentResult>(
+      ({ comment, agentName }) => {
+        const author = topicAuthorFromAgent(agentName) ??
+          rejectMutation("removeComment", "agentName must be non-blank");
+        // The same reference check `mention` makes, and it earns its place for
+        // the same reason: a payload that is not a reference has no stored
+        // element behind it, so the writes below would land on nothing and
+        // report success.
+        if (!comment || comment.get() === undefined) {
+          rejectMutation("removeComment", "comment must be a reference");
+        }
+        if (comment.get()?.removedAt !== undefined) {
+          rejectMutation("removeComment", "comment is already retracted");
+        }
+        const removedAt = Date.now();
+        // Two field writes into the element the caller named, not a rewrite of
+        // the array. Concurrent retractions of distinct comments merge, and
+        // every surviving reference stays a reference.
+        comment.key("removedAt").set(removedAt);
+        comment.key("removedBy").set(author);
+        return { removedAt, removedBy: author };
+      },
+    );
+
+    const editComment = action<EditCommentEvent, EditCommentResult>(
+      ({ comment, body: text, agentName }) => {
+        const author = topicAuthorFromAgent(agentName) ??
+          rejectMutation("editComment", "agentName must be non-blank");
+        if (!comment || comment.get() === undefined) {
+          rejectMutation("editComment", "comment must be a reference");
+        }
+        if (comment.get()?.removedAt !== undefined) {
+          rejectMutation("editComment", "comment is retracted");
+        }
+        const trimmed = (text ?? "").trim();
+        if (!trimmed) rejectMutation("editComment", "body must be non-empty");
+        const editedAt = Date.now();
+        // `author` and `sentAt` are left alone: an edit changes what was said,
+        // not who said it. The editor is recorded by Fabric as the principal
+        // behind the write; `agentName` is required here for the same reason
+        // every other mutation requires it, not to overwrite attribution.
+        comment.key("body").set(trimmed);
+        comment.key("editedAt").set(editedAt);
+        return { body: trimmed, editedAt };
+      },
+    );
+
+    const removeLink = action<RemoveLinkEvent, RemoveLinkResult>(
+      ({ link, url, agentName }) => {
+        const author = topicAuthorFromAgent(agentName) ??
+          rejectMutation("removeLink", "agentName must be non-blank");
+        const named = (url ?? "").trim();
+        if (link && named) {
+          rejectMutation("removeLink", "pass link or url, not both");
+        }
+        let target = link;
+        if (!target) {
+          if (!named) {
+            rejectMutation("removeLink", "pass link or url");
+          }
+          // The url spelling resolves to an element the same way the reference
+          // spelling arrives as one, so both paths stamp a stored record.
+          // Newest first, so retracting twice retracts two rather than
+          // re-stamping the one already gone.
+          const stored = links.get();
+          for (let i = stored.length - 1; i >= 0; i--) {
+            const candidate = stored[i];
+            if (candidate?.url === named && isPresent(candidate)) {
+              target = links.key(i) as typeof link;
+              break;
+            }
+          }
+          if (!target) {
+            rejectMutation("removeLink", `no link present with url ${named}`);
+          }
+        } else if (target.get() === undefined) {
+          rejectMutation("removeLink", "link must be a reference");
+        } else if (target.get()?.removedAt !== undefined) {
+          rejectMutation("removeLink", "link is already retracted");
+        }
+        const removedAt = Date.now();
+        target!.key("removedAt").set(removedAt);
+        target!.key("removedBy").set(author);
+        return {
+          url: target!.get()?.url ?? named,
+          removedAt,
+          removedBy: author,
+        };
       },
     );
 
@@ -1207,7 +1463,16 @@ export default pattern<TopicInput, TopicOutput>(
     // Each of these reads its own topic's data, which the page renders in full
     // anyway, and the shrunk schemas say so: a `.length` read declares
     // `items: unknown` and never expands an element.
-    const commentCount = comments.get().length;
+    //
+    // Each filtered view goes inside `computed()`: a method call on an opaque
+    // pattern value is not lowerable on its own. The retraction rule is the
+    // same in all three — a stamped record is not there to read — and only
+    // `lastActivityAt` below is deliberately exempt from it.
+
+    // A count of what is there to read, so retracted comments are excluded —
+    // the board's card would otherwise promise more comments than the topic
+    // shows.
+    const commentCount = presentCommentCountOf({ comments });
 
     const lastActivityAt = lastActivityOf({
       comments,
@@ -1217,11 +1482,21 @@ export default pattern<TopicInput, TopicOutput>(
       titleUpdatedAt,
     });
 
-    const commentsView = comments.get().toSorted((a, b) => a.sentAt - b.sentAt);
+    const commentsView = computed(() =>
+      comments.get().filter((c) => c.removedAt === undefined).toSorted((a, b) =>
+        a.sentAt - b.sentAt
+      )
+    );
 
-    const linksView = links.get();
-    const hasLinks = linksView.length > 0;
-    const hasComments = commentCount > 0;
+    const linksView = computed(() =>
+      links.get().filter((l) => l.removedAt === undefined)
+    );
+    const hasLinks = computed(() =>
+      links.get().filter((l) => l.removedAt === undefined).length > 0
+    );
+    const hasComments = computed(() =>
+      comments.get().filter((c) => c.removedAt === undefined).length > 0
+    );
     const hasBody = body.get().trim().length > 0;
 
     // Inbound: who points at this topic, looked up in the board's pivot rather
@@ -1560,8 +1835,18 @@ export default pattern<TopicInput, TopicOutput>(
 
     // A link's URL, asked of `cellFromUrl` once per link. Most answer with no
     // cell — they are web pages — and those simply are not mentions.
-    const linkUrls = links.get().map((link) => link.url ?? "");
-    const linkTargets = linkUrls.map((url) => cellFromUrl({ url }));
+    // One map over an explicitly reactive receiver rather than two chained
+    // ones, which is #6465's shape, adopted here because this rule needs the
+    // whole link record: a retracted link stops resolving, so the reference
+    // it contributed to `mentions` goes with it instead of outliving the
+    // link that made it. The intermediate url-only array could not carry
+    // `removedAt` to say so.
+    const linksToResolve = computed(() =>
+      links.get().filter((l) => l.removedAt === undefined)
+    );
+    const linkTargets = linksToResolve.map((link) =>
+      cellFromUrl({ url: link.url ?? "" })
+    );
     // Outbound: what this topic points at. Only this half depends on the
     // topic's own content, which is what keeps the board's join reading one
     // small list per topic.
@@ -1588,6 +1873,9 @@ export default pattern<TopicInput, TopicOutput>(
       titleUpdatedAt,
       addComment,
       addLink,
+      removeComment,
+      editComment,
+      removeLink,
       setBody,
       setTitle,
       mention,

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -191,7 +191,13 @@ export interface RemoveLinkEvent extends AgentAuthoredEvent {
 
   /** The link's URL, for a caller that cannot pass a reference. Retracts the
    * most recently added link still present with this URL, so retracting twice
-   * retracts two rather than re-stamping one. */
+   * retracts two rather than re-stamping one.
+   *
+   * Sequentially. Two concurrent retractions naming the same URL both resolve
+   * the same newest-present element and merge into one stamped record, so
+   * they retract one link between them rather than two. Naming the link by
+   * reference is what makes a caller's target unambiguous under concurrency;
+   * this spelling trades that for being reachable at all. */
   url?: string;
 }
 
@@ -313,6 +319,14 @@ export interface TopicLink {
  * verb that then stamps it writes into a document this topic does not own. So
  * membership is proved by identity against the stored positions, which is the
  * `equals()` addressing `TopicComment` names in place of a synthetic key.
+ *
+ * This is a tightening rather than a privilege boundary, and it was argued
+ * both ways before landing. A caller gains no authority here they lack
+ * calling the other topic's own verb under the same principal, and
+ * `MentionEvent.topic` accepts a foreign reference by design. What the check
+ * buys is that a wrong argument fails loudly instead of succeeding against
+ * something the caller did not mean to name — the write would otherwise land,
+ * report success, and move a count on a topic nobody was looking at.
  */
 const isElementOf = (
   array: {
@@ -330,8 +344,10 @@ const isElementOf = (
 
 /** Whether a stamped record is still live.
  *
- * Exported for readers outside a reactive read — a test, a script. Inside a
- * `computed()` the predicate is written out instead, and that is not a style
+ * Used where the read is not reactive: `removeLink`'s own body scans the
+ * stored links for the url spelling, and callers outside the pattern — a
+ * test, a script — ask the same question. Inside a `computed()` the predicate
+ * is written out instead, and that is not a style
  * choice: the schema a reactive read declares is what it can SEE, and a
  * property tested behind a helper call is not named in it. Filtering through
  * this function there yields a count that never changes, because `removedAt`

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -305,6 +305,29 @@ export interface TopicLink {
   removedBy?: TopicAuthor;
 }
 
+/**
+ * Whether `candidate` is one of `array`'s own elements.
+ *
+ * "Is a reference" is not the check these verbs need. A cell that reads back
+ * as an object satisfies that while belonging to another piece entirely, and a
+ * verb that then stamps it writes into a document this topic does not own. So
+ * membership is proved by identity against the stored positions, which is the
+ * `equals()` addressing `TopicComment` names in place of a synthetic key.
+ */
+const isElementOf = (
+  array: {
+    get(): readonly unknown[];
+    key(index: number): { equals(other: object): boolean };
+  },
+  candidate: object,
+): boolean => {
+  const stored = array.get();
+  for (let index = 0; index < stored.length; index++) {
+    if (array.key(index).equals(candidate)) return true;
+  }
+  return false;
+};
+
 /** Whether a stamped record is still live.
  *
  * Exported for readers outside a reactive read — a test, a script. Inside a
@@ -522,12 +545,20 @@ export interface TopicPiece extends TopicSummary {
   /** The living document, verbatim Markdown. `setBody` replaces it whole. */
   body: string | Default<"">;
 
-  /** The thread, in arrival order: append-only point-in-time records, each
-   * carrying its author snapshot and `sentAt`. */
+  /** The thread, in arrival order, each record carrying its author snapshot
+   * and `sentAt`.
+   *
+   * MEMBERSHIP is append-only; a record is not. Nothing is ever removed from
+   * this array — `removeComment` stamps `removedAt` and leaves the record in
+   * place, and `editComment` revises a body and stamps `editedAt` — so a
+   * reader that wants the live thread filters on `removedAt` rather than
+   * taking the array as it stands. `commentCount` is that filtered count. */
   comments: TopicComment[];
 
-  /** Typed outbound links, in arrival order, each carrying its author
-   * snapshot and `addedAt`. */
+  /** Typed outbound links, in arrival order, each carrying its author snapshot
+   * and `addedAt`. Append-only in membership on the same terms as `comments`:
+   * `removeLink` stamps rather than removes, and a stamped link additionally
+   * stops resolving into `mentions`. */
   links: TopicLink[];
 
   /** Every piece this topic's prose and links point at, as references.
@@ -602,8 +633,11 @@ export interface TopicPiece extends TopicSummary {
  * to sibling pieces.
  *
  * Durable conclusions get folded up into the body — revise it whole with
- * `setBody`; the thread holds the deliberation as append-only, point-in-time
- * `addComment` records. Sign every authored-content mutation with `agentName`:
+ * `setBody`; the thread holds the deliberation as point-in-time `addComment`
+ * records. The thread only ever grows: `removeComment` and `removeLink` stamp
+ * a record as retracted and leave it where it is, and `editComment` revises a
+ * body in place, so what a reader shows is the array filtered rather than the
+ * array itself. Sign every authored-content mutation with `agentName`:
  * Fabric records the human principal behind the key; the name says which
  * agent acted under it. Reference-only `mention` and `unmention` calls carry
  * no content signature. The session-draft cells and `submit*` streams below
@@ -1236,6 +1270,9 @@ export default pattern<TopicInput, TopicOutput>(
         if (!comment || comment.get() === undefined) {
           rejectMutation("removeComment", "comment must be a reference");
         }
+        if (!isElementOf(comments, comment)) {
+          rejectMutation("removeComment", "comment is not on this topic");
+        }
         if (comment.get()?.removedAt !== undefined) {
           rejectMutation("removeComment", "comment is already retracted");
         }
@@ -1261,6 +1298,9 @@ export default pattern<TopicInput, TopicOutput>(
         }
         if (!comment || comment.get() === undefined) {
           rejectMutation("editComment", "comment must be a reference");
+        }
+        if (!isElementOf(comments, comment)) {
+          rejectMutation("editComment", "comment is not on this topic");
         }
         if (comment.get()?.removedAt !== undefined) {
           rejectMutation("editComment", "comment is retracted");
@@ -1304,6 +1344,8 @@ export default pattern<TopicInput, TopicOutput>(
           }
         } else if (target.get() === undefined) {
           rejectMutation("removeLink", "link must be a reference");
+        } else if (!isElementOf(links, target)) {
+          rejectMutation("removeLink", "link is not on this topic");
         } else if (target.get()?.removedAt !== undefined) {
           rejectMutation("removeLink", "link is already retracted");
         }

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -1251,8 +1251,14 @@ export default pattern<TopicInput, TopicOutput>(
 
     const editComment = action<EditCommentEvent, EditCommentResult>(
       ({ comment, body: text, agentName }) => {
-        const author = topicAuthorFromAgent(agentName) ??
+        // Checked, not bound: `editComment` requires a signature like every
+        // other mutation here, and then stores nothing from it. `author` and
+        // `sentAt` stay as the comment was written — an edit changes what was
+        // said, not who said it. Fabric still records the principal behind
+        // the write.
+        if (!topicAuthorFromAgent(agentName)) {
           rejectMutation("editComment", "agentName must be non-blank");
+        }
         if (!comment || comment.get() === undefined) {
           rejectMutation("editComment", "comment must be a reference");
         }
@@ -1262,10 +1268,6 @@ export default pattern<TopicInput, TopicOutput>(
         const trimmed = (text ?? "").trim();
         if (!trimmed) rejectMutation("editComment", "body must be non-empty");
         const editedAt = Date.now();
-        // `author` and `sentAt` are left alone: an edit changes what was said,
-        // not who said it. The editor is recorded by Fabric as the principal
-        // behind the write; `agentName` is required here for the same reason
-        // every other mutation requires it, not to overwrite attribution.
         comment.key("body").set(trimmed);
         comment.key("editedAt").set(editedAt);
         return { body: trimmed, editedAt };

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,7 +2,7 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * required (`expectRuntimeErrors: 25` — exact count, so a rejection quietly
+ * required (`expectRuntimeErrors: 33` — exact count, so a rejection quietly
  * reverting to a silent return fails the suite); each assertion then verifies
  * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
@@ -203,6 +203,95 @@ export default pattern(() => {
     foreignLink.get().removedAt === undefined
   );
 
+  // A payload that is not a reference at all. The verb must refuse rather than
+  // resolve it to nothing and report success — the same shape `mention` and
+  // `unmention` are held to above.
+  const action_remove_comment_text_address = action(() => {
+    // deno-lint-ignore no-explicit-any
+    (seedTopic.removeComment as any)?.send({
+      comment: "fid1:notAReference",
+      agentName: "Sol",
+    });
+  });
+  const action_edit_comment_text_address = action(() => {
+    // deno-lint-ignore no-explicit-any
+    (seedTopic.editComment as any)?.send({
+      comment: "fid1:notAReference",
+      body: "rewritten",
+      agentName: "Sol",
+    });
+  });
+  const action_remove_link_text_address = action(() => {
+    // deno-lint-ignore no-explicit-any
+    (seedTopic.removeLink as any)?.send({
+      link: "fid1:notAReference",
+      agentName: "Sol",
+    });
+  });
+  const action_edit_comment_unsigned = action(() => {
+    seedTopic.editComment.send({
+      comment: foreignComment,
+      body: "rewritten",
+      agentName: "   ",
+    });
+  });
+  const action_remove_link_unsigned = action(() => {
+    seedTopic.removeLink.send({ link: foreignLink, agentName: "   " });
+  });
+
+  // Retracting what is already retracted. A second call is not a no-op that
+  // quietly succeeds: the record carries one retraction, and a caller asking
+  // for another is wrong about the state.
+  const retractedComments = new Writable<TopicComment[]>([]);
+  const retractedLinks = new Writable<TopicLink[]>([]);
+  const retractedTopic = Topic({
+    title: "Already retracted",
+    comments: retractedComments,
+    links: retractedLinks,
+  });
+  const action_seed_retractable = action(() => {
+    retractedTopic.addComment.send({ body: "once", agentName: "Sol" });
+    retractedTopic.addLink.send({
+      url: "https://example.com/once",
+      agentName: "Sol",
+    });
+  });
+  const action_retract_both = action(() => {
+    retractedTopic.removeComment.send({
+      comment: retractedComments.key(0),
+      agentName: "Sol",
+    });
+    retractedTopic.removeLink.send({
+      link: retractedLinks.key(0),
+      agentName: "Sol",
+    });
+  });
+  const action_retract_comment_again = action(() => {
+    retractedTopic.removeComment.send({
+      comment: retractedComments.key(0),
+      agentName: "Sol",
+    });
+  });
+  const action_edit_retracted_comment = action(() => {
+    retractedTopic.editComment.send({
+      comment: retractedComments.key(0),
+      body: "rewriting a retraction",
+      agentName: "Sol",
+    });
+  });
+  const action_retract_link_again = action(() => {
+    retractedTopic.removeLink.send({
+      link: retractedLinks.key(0),
+      agentName: "Sol",
+    });
+  });
+  const assert_one_retraction_each = assert(() =>
+    retractedTopic.commentCount === 0 &&
+    (retractedComments.get()[0]?.removedAt ?? 0) > 0 &&
+    retractedComments.get()[0]?.body === "once" &&
+    (retractedLinks.get()[0]?.removedAt ?? 0) > 0
+  );
+
   const action_rename_blank_title = action(() => {
     directTopic.setTitle.send({ title: "   ", agentName: "Sol" });
   });
@@ -246,7 +335,7 @@ export default pattern(() => {
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
-    expectRuntimeErrors: 25,
+    expectRuntimeErrors: 33,
     [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
@@ -300,6 +389,25 @@ export default pattern(() => {
       { assertion: assert_foreign_link_untouched },
       { action: action_remove_foreign_link },
       { assertion: assert_foreign_link_untouched },
+      { action: action_remove_comment_text_address },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_edit_comment_text_address },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_remove_link_text_address },
+      { assertion: assert_foreign_link_untouched },
+      { action: action_edit_comment_unsigned },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_remove_link_unsigned },
+      { assertion: assert_foreign_link_untouched },
+      { action: action_seed_retractable },
+      { action: action_retract_both },
+      { assertion: assert_one_retraction_each },
+      { action: action_retract_comment_again },
+      { assertion: assert_one_retraction_each },
+      { action: action_edit_retracted_comment },
+      { assertion: assert_one_retraction_each },
+      { action: action_retract_link_again },
+      { assertion: assert_one_retraction_each },
     ],
   };
 });

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -173,13 +173,7 @@ export default pattern(() => {
       agentName: "   ",
     });
   });
-  const action_edit_comment_blank_body = action(() => {
-    seedTopic.editComment.send({
-      comment: foreignComment,
-      body: "   ",
-      agentName: "Sol",
-    });
-  });
+
   const action_remove_link_both_spellings = action(() => {
     seedTopic.removeLink.send({
       link: foreignLink,
@@ -256,6 +250,21 @@ export default pattern(() => {
       agentName: "Sol",
     });
   });
+  // Blank body, on a comment this topic OWNS and has not retracted. Sent at a
+  // foreign comment it would reject on membership three checks earlier and
+  // never reach the guard it is named for — which line coverage cannot tell
+  // you, because the condition is evaluated on every successful edit.
+  const action_edit_blank_body = action(() => {
+    retractedTopic.editComment.send({
+      comment: retractedComments.key(0),
+      body: "   ",
+      agentName: "Sol",
+    });
+  });
+  const assert_body_survived_blank_edit = assert(() =>
+    retractedComments.get()[0]?.body === "once"
+  );
+
   const action_retract_both = action(() => {
     retractedTopic.removeComment.send({
       comment: retractedComments.key(0),
@@ -331,7 +340,7 @@ export default pattern(() => {
 
   return {
     // Every rejection below MUST surface as a thrown handler error —
-    // seventeen throwing actions, seventeen runtime errors. The exact count
+    // thirty-three throwing actions, thirty-three runtime errors. The exact count
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
@@ -379,8 +388,6 @@ export default pattern(() => {
       { assertion: assert_foreign_comment_untouched },
       { action: action_remove_comment_unsigned },
       { assertion: assert_foreign_comment_untouched },
-      { action: action_edit_comment_blank_body },
-      { assertion: assert_foreign_comment_untouched },
       { action: action_remove_link_both_spellings },
       { assertion: assert_foreign_link_untouched },
       { action: action_remove_link_neither_spelling },
@@ -400,6 +407,8 @@ export default pattern(() => {
       { action: action_remove_link_unsigned },
       { assertion: assert_foreign_link_untouched },
       { action: action_seed_retractable },
+      { action: action_edit_blank_body },
+      { assertion: assert_body_survived_blank_edit },
       { action: action_retract_both },
       { assertion: assert_one_retraction_each },
       { action: action_retract_comment_again },

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,7 +2,7 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * required (`expectRuntimeErrors: 19` — exact count, so a rejection quietly
+ * required (`expectRuntimeErrors: 25` — exact count, so a rejection quietly
  * reverting to a silent return fails the suite); each assertion then verifies
  * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
@@ -11,7 +11,7 @@
 import { action, assert, TESTS, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics from "./main.tsx";
-import Topic, { type TopicComment } from "./topic.tsx";
+import Topic, { type TopicComment, type TopicLink } from "./topic.tsx";
 
 export default pattern(() => {
   const board = Topics({});
@@ -141,6 +141,11 @@ export default pattern(() => {
     body: "elsewhere",
     sentAt: 1,
   });
+  const foreignLink = new Writable<TopicLink>({
+    kind: "web",
+    url: "https://example.com/elsewhere",
+    label: "elsewhere",
+  });
   const action_remove_foreign_comment = action(() => {
     seedTopic.removeComment.send({
       comment: foreignComment,
@@ -157,6 +162,45 @@ export default pattern(() => {
   const assert_foreign_comment_untouched = assert(() =>
     foreignComment.get().removedAt === undefined &&
     foreignComment.get().body === "elsewhere"
+  );
+
+  // The retraction verbs' own refusal arms. Each is a path the Coverage Check
+  // named as unexercised, and each is a way a caller can be wrong that must
+  // produce a value rather than a silent no-op.
+  const action_remove_comment_unsigned = action(() => {
+    seedTopic.removeComment.send({
+      comment: foreignComment,
+      agentName: "   ",
+    });
+  });
+  const action_edit_comment_blank_body = action(() => {
+    seedTopic.editComment.send({
+      comment: foreignComment,
+      body: "   ",
+      agentName: "Sol",
+    });
+  });
+  const action_remove_link_both_spellings = action(() => {
+    seedTopic.removeLink.send({
+      link: foreignLink,
+      url: "https://example.com/a",
+      agentName: "Sol",
+    });
+  });
+  const action_remove_link_neither_spelling = action(() => {
+    seedTopic.removeLink.send({ agentName: "Sol" });
+  });
+  const action_remove_link_unknown_url = action(() => {
+    seedTopic.removeLink.send({
+      url: "https://example.com/never-added",
+      agentName: "Sol",
+    });
+  });
+  const action_remove_foreign_link = action(() => {
+    seedTopic.removeLink.send({ link: foreignLink, agentName: "Sol" });
+  });
+  const assert_foreign_link_untouched = assert(() =>
+    foreignLink.get().removedAt === undefined
   );
 
   const action_rename_blank_title = action(() => {
@@ -202,7 +246,7 @@ export default pattern(() => {
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
-    expectRuntimeErrors: 19,
+    expectRuntimeErrors: 25,
     [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
@@ -244,6 +288,18 @@ export default pattern(() => {
       { assertion: assert_foreign_comment_untouched },
       { action: action_edit_foreign_comment },
       { assertion: assert_foreign_comment_untouched },
+      { action: action_remove_comment_unsigned },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_edit_comment_blank_body },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_remove_link_both_spellings },
+      { assertion: assert_foreign_link_untouched },
+      { action: action_remove_link_neither_spelling },
+      { assertion: assert_foreign_link_untouched },
+      { action: action_remove_link_unknown_url },
+      { assertion: assert_foreign_link_untouched },
+      { action: action_remove_foreign_link },
+      { assertion: assert_foreign_link_untouched },
     ],
   };
 });

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -2,16 +2,16 @@
  * Rejection-path tests for the Topics mutating verbs (verb contract rule 4,
  * docs/plans/pattern-verb-contract.md: rejection is a value, never a silent
  * no-op). Every action here makes a verb throw, so the runtime errors are
- * required (`expectRuntimeErrors: 17` — exact count, so a rejection quietly
+ * required (`expectRuntimeErrors: 19` — exact count, so a rejection quietly
  * reverting to a silent return fails the suite); each assertion then verifies
  * the write did NOT land. Happy and legacy paths live in topics.test.tsx — including the UI
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
-import { action, assert, TESTS } from "commonfabric";
+import { action, assert, TESTS, Writable } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics from "./main.tsx";
-import Topic from "./topic.tsx";
+import Topic, { type TopicComment } from "./topic.tsx";
 
 export default pattern(() => {
   const board = Topics({});
@@ -132,6 +132,33 @@ export default pattern(() => {
   // and unlike its elders, a MISSING agentName is as rejected as a blank one:
   // the verb postdates the unsigned-caller era and carries no legacy path.
   const directTopic = Topic({ title: "Keep this title" });
+  // A reference is not enough: it must reference one of THIS topic's own
+  // records. A cell that reads back as an object satisfies "is a reference"
+  // while belonging to something else, and a verb that stamped it would write
+  // into a document this topic does not own — silently, since the caller's own
+  // cell would show the change and nothing here would.
+  const foreignComment = new Writable<TopicComment>({
+    body: "elsewhere",
+    sentAt: 1,
+  });
+  const action_remove_foreign_comment = action(() => {
+    seedTopic.removeComment.send({
+      comment: foreignComment,
+      agentName: "Sol",
+    });
+  });
+  const action_edit_foreign_comment = action(() => {
+    seedTopic.editComment.send({
+      comment: foreignComment,
+      body: "rewritten from outside",
+      agentName: "Sol",
+    });
+  });
+  const assert_foreign_comment_untouched = assert(() =>
+    foreignComment.get().removedAt === undefined &&
+    foreignComment.get().body === "elsewhere"
+  );
+
   const action_rename_blank_title = action(() => {
     directTopic.setTitle.send({ title: "   ", agentName: "Sol" });
   });
@@ -175,7 +202,7 @@ export default pattern(() => {
     // means a
     // single verb quietly reverting to a silent early-return fails this suite;
     // the no-write assertions then prove the throw also blocked the write.
-    expectRuntimeErrors: 17,
+    expectRuntimeErrors: 19,
     [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
@@ -213,6 +240,10 @@ export default pattern(() => {
       { assertion: assert_direct_title_unchanged },
       { action: action_rename_unsigned },
       { assertion: assert_direct_title_unchanged },
+      { action: action_remove_foreign_comment },
+      { assertion: assert_foreign_comment_untouched },
+      { action: action_edit_foreign_comment },
+      { assertion: assert_foreign_comment_untouched },
     ],
   };
 });

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -814,6 +814,13 @@ export default pattern(() => {
       body: "first thought",
       agentName: "Sol",
     });
+    // A second comment, so the thread's sort comparator actually compares.
+    // One comment sorts without ever calling it, which leaves the ordering
+    // rule — the thing that decides what a reader sees first — unexercised.
+    retractionSubject.addComment.send({
+      body: "second thought",
+      agentName: "Sol",
+    });
     retractionSubject.addLink.send({
       url: "https://example.com/a-page",
       agentName: "Sol",
@@ -831,7 +838,7 @@ export default pattern(() => {
   // An edit revises the body and stamps `editedAt`, leaving `author` and
   // `sentAt` alone: an edit changes what was said, not who said it.
   const assert_comment_edited = assert(() =>
-    retractionSubject.commentCount === 1 &&
+    retractionSubject.commentCount === 2 &&
     retractionSubject.comments?.[0]?.body === "first thought, revised" &&
     retractionSubject.comments?.[0]?.author?.name === "Sol" &&
     (retractionSubject.comments?.[0]?.editedAt ?? 0) > 0 &&
@@ -860,8 +867,8 @@ export default pattern(() => {
   // Stamped, not deleted: the record is still stored and still carries what it
   // said, while the count stops counting it.
   const assert_comment_retracted = assert(() =>
-    retractionSubject.commentCount === 0 &&
-    (retractionSubject.comments ?? []).length === 1 &&
+    retractionSubject.commentCount === 1 &&
+    (retractionSubject.comments ?? []).length === 2 &&
     retractionSubject.comments?.[0]?.body === "first thought, revised" &&
     (retractionSubject.comments?.[0]?.removedAt ?? 0) > 0 &&
     retractionSubject.comments?.[0]?.removedBy?.name === "Sol"

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -794,6 +794,95 @@ export default pattern(() => {
   // `integration/topic-board-child-contract.test.ts` — but these verbs do not:
   // each one writes the topic's OWN `mentioned` list, and the set semantics
   // that make them mergeable are the part worth pinning here.
+  // --- Stamped removals (Stage C item 1) ---
+  //
+  // A retraction stamps the record and leaves it in place. Driven on a
+  // directly held topic that owns its own cells, for the reason the mention
+  // cases below are: these verbs write the topic's OWN lists, and the caller
+  // has to hand each one a REFERENCE to a stored element, which a projected
+  // array read back off a board cannot supply.
+  const retractionComments = new Writable<TopicComment[]>([]);
+  const retractionLinks = new Writable<TopicLink[]>([]);
+  const retractionSubject = Topic({
+    title: "Retraction subject",
+    comments: retractionComments,
+    links: retractionLinks,
+  });
+
+  const action_retraction_setup = action(() => {
+    retractionSubject.addComment.send({
+      body: "first thought",
+      agentName: "Sol",
+    });
+    retractionSubject.addLink.send({
+      url: "https://example.com/a-page",
+      agentName: "Sol",
+    });
+  });
+
+  const action_edit_comment = action(() => {
+    retractionSubject.editComment.send({
+      comment: retractionComments.key(0),
+      body: "first thought, revised",
+      agentName: "Sol",
+    });
+  });
+
+  // An edit revises the body and stamps `editedAt`, leaving `author` and
+  // `sentAt` alone: an edit changes what was said, not who said it.
+  const assert_comment_edited = assert(() =>
+    retractionSubject.commentCount === 1 &&
+    retractionSubject.comments?.[0]?.body === "first thought, revised" &&
+    retractionSubject.comments?.[0]?.author?.name === "Sol" &&
+    (retractionSubject.comments?.[0]?.editedAt ?? 0) > 0 &&
+    retractionSubject.comments?.[0]?.removedAt === undefined
+  );
+
+  const action_remove_comment = action(() => {
+    retractionSubject.removeComment.send({
+      comment: retractionComments.key(0),
+      agentName: "Sol",
+    });
+  });
+
+  // Stamped, not deleted: the record is still stored and still carries what it
+  // said, while the count stops counting it.
+  const assert_comment_retracted = assert(() =>
+    retractionSubject.commentCount === 0 &&
+    (retractionSubject.comments ?? []).length === 1 &&
+    retractionSubject.comments?.[0]?.body === "first thought, revised" &&
+    (retractionSubject.comments?.[0]?.removedAt ?? 0) > 0 &&
+    retractionSubject.comments?.[0]?.removedBy?.name === "Sol"
+  );
+
+  // The reason the design is stamped rather than deleted, stated as the
+  // invariant rather than as a before-and-after. `lastActivityAt` is a max
+  // over what the arrays HOLD, so the retracted comment's own stamps are
+  // still in it — and the retraction, being the newest thing that happened,
+  // is what the max now equals. Skip retracted records in `lastActivityOf`
+  // and this reads the link's older `addedAt` instead, which is exactly the
+  // backwards move that would reorder the board under a reader.
+  const assert_retraction_moved_activity_forward = assert(() =>
+    (retractionSubject.comments?.[0]?.removedAt ?? 0) > 0 &&
+    retractionSubject.lastActivityAt ===
+      retractionSubject.comments?.[0]?.removedAt
+  );
+
+  const action_remove_link_by_url = action(() => {
+    retractionSubject.removeLink.send({
+      url: "https://example.com/a-page",
+      agentName: "Sol",
+    });
+  });
+
+  // The url spelling reaches a stored record — the spelling that exists
+  // because a link carries no fid for a CLI caller to name.
+  const assert_link_retracted = assert(() =>
+    (retractionSubject.links ?? []).length === 1 &&
+    (retractionSubject.links?.[0]?.removedAt ?? 0) > 0 &&
+    retractionSubject.links?.[0]?.removedBy?.name === "Sol"
+  );
+
   const mentionSubject = Topic({ title: "Mention subject" });
   // Plain cells, because `MentionEvent.topic` declares `Writable<{ title }>`
   // rather than a piece: the verb matches by cell identity, and a piece built
@@ -1010,6 +1099,14 @@ export default pattern(() => {
       { assertion: assert_body_set },
       { action: action_link_valid_unlabeled },
       { assertion: assert_link_added },
+      { action: action_retraction_setup },
+      { action: action_edit_comment },
+      { assertion: assert_comment_edited },
+      { action: action_remove_comment },
+      { assertion: assert_comment_retracted },
+      { assertion: assert_retraction_moved_activity_forward },
+      { action: action_remove_link_by_url },
+      { assertion: assert_link_retracted },
       { action: action_add_second_topic },
       { assertion: assert_second_topic },
       { render: board[UI] },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -838,6 +838,18 @@ export default pattern(() => {
     retractionSubject.comments?.[0]?.removedAt === undefined
   );
 
+  // What the view projection actually carries, which reading the stored
+  // records cannot tell you. `commentsView` filters inside `computed()` and
+  // its lambda touches only `removedAt`, so if this family's demand is
+  // usage-lowered all the way down, the rendered rows would come back with
+  // their bodies absent and every assertion above would still pass. Asserting
+  // through the render is the only place that shows.
+  const assert_rendered_thread_carries_bodies = assert(() => {
+    const serialized = JSON.stringify(retractionSubject[UI]);
+    return serialized.includes("first thought, revised") &&
+      serialized.includes("Sol");
+  });
+
   const action_remove_comment = action(() => {
     retractionSubject.removeComment.send({
       comment: retractionComments.key(0),
@@ -867,6 +879,13 @@ export default pattern(() => {
     retractionSubject.lastActivityAt ===
       retractionSubject.comments?.[0]?.removedAt
   );
+
+  // And the other direction: a retracted comment leaves the rendered thread,
+  // so the filter that `commentCount` applies is the same one the reader sees.
+  const assert_retracted_comment_leaves_the_render = assert(() => {
+    const serialized = JSON.stringify(retractionSubject[UI]);
+    return !serialized.includes("first thought, revised");
+  });
 
   const action_remove_link_by_url = action(() => {
     retractionSubject.removeLink.send({
@@ -1102,9 +1121,13 @@ export default pattern(() => {
       { action: action_retraction_setup },
       { action: action_edit_comment },
       { assertion: assert_comment_edited },
+      { render: retractionSubject[UI] },
+      { assertion: assert_rendered_thread_carries_bodies },
       { action: action_remove_comment },
       { assertion: assert_comment_retracted },
       { assertion: assert_retraction_moved_activity_forward },
+      { render: retractionSubject[UI] },
+      { assertion: assert_retracted_comment_leaves_the_render },
       { action: action_remove_link_by_url },
       { assertion: assert_link_retracted },
       { action: action_add_second_topic },

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -64,15 +64,32 @@ contain no verbs: take a row's address and call that Topic directly.
 
 The current declared contract is:
 
-| Piece | Verb         | Input                                           | Declared result       |
-| ----- | ------------ | ----------------------------------------------- | --------------------- |
-| Board | `addTopic`   | `title`, optional `body`, `agentName`           | created `topic`       |
-| Topic | `addComment` | `body`, `agentName`                             | appended `comment`    |
-| Topic | `addLink`    | `url`, optional `kind` and `label`, `agentName` | appended `link`       |
-| Topic | `setBody`    | complete `body`, `agentName`                    | body and attribution  |
-| Topic | `setTitle`   | `title`, `agentName`                            | title and attribution |
-| Topic | `mention`    | Topic reference                                 | none                  |
-| Topic | `unmention`  | Topic reference                                 | none                  |
+| Piece | Verb            | Input                                           | Declared result       |
+| ----- | --------------- | ----------------------------------------------- | --------------------- |
+| Board | `addTopic`      | `title`, optional `body`, `agentName`           | created `topic`       |
+| Topic | `addComment`    | `body`, `agentName`                             | appended `comment`    |
+| Topic | `addLink`       | `url`, optional `kind` and `label`, `agentName` | appended `link`       |
+| Topic | `setBody`       | complete `body`, `agentName`                    | body and attribution  |
+| Topic | `setTitle`      | `title`, `agentName`                            | title and attribution |
+| Topic | `mention`       | Topic reference                                 | none                  |
+| Topic | `unmention`     | Topic reference                                 | none                  |
+| Topic | `editComment`   | comment reference, `body`, `agentName`          | body and `editedAt`   |
+| Topic | `removeComment` | comment reference, `agentName`                  | the retraction stamp  |
+| Topic | `removeLink`    | link reference **or** `url`, `agentName`        | url and stamp         |
+
+A retraction stamps the record rather than deleting it: the comment or link
+stays, carrying what it always said, while readers stop showing it and
+`commentCount` stops counting it. A retracted link also stops resolving into
+`mentions`. Retracting is not a way to make something unsaid — the evidence is
+retained deliberately.
+
+`editComment` and `removeComment` name their target by REFERENCE, and a comment
+is not a piece: it has no fid to write into an inline JSON event, so these are
+reachable from a reader that holds the row, not from a bare `cf
+call`.
+`removeLink` is the exception and takes `url` for exactly that reason,
+retracting the most recently added link still present with that URL — so
+retracting twice retracts two rather than re-stamping one.
 
 ## Discover and read
 


### PR DESCRIPTION
## Why

Stage C item 1, built against the decisions recorded in
`docs/plans/topics-verb-surface.md` (#6574).

**A retraction stamps the record rather than deleting it**, and the reason is a
consequence that only shows up as a reordered board. `lastActivityAt` is a max
over what the comment and link arrays *hold*, so deleting the newest comment
drops its `sentAt` out of that max and moves the topic **backwards** in the
board's most-recent ordering. Every verb before this one only appended or
stamped forward. A stamped record cannot do it, keeps the evidence, and — since
a retraction is itself activity — moves the clock forward instead.

The cost lands on `commentCount`, which counted the array's length and now has
to exclude stamped records, or a card promises more comments than the topic
shows. Both are computations rather than schema, which is what makes this
affordable so soon after the Stage B migration.

## What Changed

Three verbs on the topic's interface: `removeComment`, `editComment`,
`removeLink`. Optional `removedAt`/`removedBy` on both record types, and
`editedAt` on a comment.

**The verbs go on `TopicOutput`, not on the shared `TopicPiece` projection** —
where `setTitle` already sits, for the reason the README gives beside it.
Boards store that projection, so it is a demand on every topic they already
hold, and a required verb added to it refuses every piece deployed before the
verb existed. A verb has no default to be rescued by, so there is no compatible
way to demand a new one. **That placement is what keeps this free of a
migration**, and it is the interim rule Stage C records doing exactly the work
it was kept for. A pre-existing test caught the first attempt, which had put
them on `TopicPiece`: a legacy topic in a `TopicPiece[]` list stopped
validating.

`removeComment` and `editComment` name their target by reference — the
no-minted-id rule paying out. `removeLink` additionally takes `url`, because a
link record is not a piece and carries no fid for a CLI caller to name; it
retracts the newest link still present with that URL, so retracting twice
retracts two.

Two mechanics are recorded in the code where they bit:

- The retraction predicate is **written out at each reactive site** rather than
  called through the `isPresent` helper. A reactive read sees only what its
  schema declares, so a property tested behind a helper call is never demanded —
  filtering through one gave a `commentCount` that never changed while
  `removedAt` was demonstrably set.
- `commentCount` is a **module-scope `lift`**, not a `computed()`, because it is
  in the board's demand and has to project onto every stored generation.

### The one hunk that needs Gideon's eye

`linkTargets` adopts the shape from #6465 — `computed(() => links.get())` and
one map — rather than main's two chained maps. Not a merge accident: this rule
needs the whole link record, because a retracted link must stop resolving into
`mentions` so the reference goes with the link that made it, and the
intermediate url-only array cannot carry `removedAt` to say so.

@mathpirate — that hunk is yours, copied deliberately. Happy either way on
ordering: land #6465 first and I rebase onto it, or this lands and you take the
copied lines. Whichever is less work for you.

## Test plan

Four assertions added to `topics.test.tsx`, driven on a directly held topic
that owns its own cells — a projected array cannot supply the reference these
verbs take. They cover the edit stamping `editedAt` while leaving `author` and
`sentAt` alone, the retraction stamping rather than deleting, the url spelling
reaching a stored record, and the invariant that motivates the whole design:
after retracting the only comment, `lastActivityAt` equals its `removedAt`.
Skip retracted records in `lastActivityOf` and that assertion reads the link's
older `addedAt` instead, which is the backwards move.

All four topics test files pass — 47 / 7 / 2 / 18, none failing; `main` has 43
in the first file, so the four are additive. `deno task cfcheck` exits 0 over
444 pattern files. `fmt`, `lint`, `check-docs`, `check-skill-facts` pass.

`deno task pattern-compat --update` recorded the new contract and exits 0 with
**353 patterns updatable from every recorded contract**. Because `--update`
writes only when "not recorded" is the sole finding, that baseline is itself
evidence the new contract applies over every one `topic.tsx` has declared
before. Only `topic.tsx` needed a baseline; `main.tsx`'s contract is untouched,
which is the placement decision showing up as a measurement.

## Not in this PR

**No UI control yet.** The rows already filter retracted records, but binding a
Remove button raises a question I did not want to answer by guessing: the
comment and link rows render from a filtered, sorted `computed()`, and whether
those elements still carry writable element identity is unproven. `dropMention`
binds from an unfiltered `.get()`, so it is not precedent, and the failure mode
is a silent no-op — the stamp lands on a copy no reader sees. That wants a
browser integration test to settle, and it is a follow-up rather than a guess
shipped inside this one.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

