### PR TITLE
style(lib-shell,fuse,ui,scripts,tasks): the arc's last frozen comments, and one the sweep never reached

### DIFF
--- a/packages/fuse/mount-options.ts
+++ b/packages/fuse/mount-options.ts
@@ -6,11 +6,12 @@
 import type { FuseProvider } from "./platform.ts";
 
 /**
- * Bounds for --attrcache-timeout: zero (leave the NFS client's default
- * caching untouched) or one second to one day.
+ * Lowest `--attrcache-timeout` accepted: zero, which leaves the NFS client's
+ * default caching untouched.
  */
 export const ATTRCACHE_TIMEOUT_MIN_SECONDS = 0;
 
+/** Highest `--attrcache-timeout` accepted: one day. */
 export const ATTRCACHE_TIMEOUT_MAX_SECONDS = 86_400;
 
 /**

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -194,15 +194,17 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   telemetry?: RuntimeTelemetrySink;
 };
 
+/** {@link fetchBuildHash}'s module-level memo. */
+let buildHashPromise: Promise<string | undefined> | undefined;
+
 /**
  * Fetch the worker bundle hash from the build manifest. This cache-busts the
  * mutable root worker URL used by local/legacy builds. Deployed shell builds
  * use their immutable `/builds/<sha>/` namespace instead.
  *
- * Cached at module level — the hash doesn't change within a page session.
+ * Cached — the hash doesn't change within a page session, so the manifest is
+ * fetched at most once.
  */
-let buildHashPromise: Promise<string | undefined> | undefined;
-
 export function fetchBuildHash(): Promise<string | undefined> {
   if (!buildHashPromise) {
     buildHashPromise = (async () => {

--- a/packages/ui/src/v2/core/mentionable.test.ts
+++ b/packages/ui/src/v2/core/mentionable.test.ts
@@ -15,9 +15,9 @@ describe("mentionable", () => {
 
     it("reads piece as a cell rather than a value", () => {
       // The MentionRef.destination shape: an opaque boundary the client
-      // hydrates to a handle. Reading THROUGH it here would put every
-      // listed piece back into the editor's own demand — the cost the
-      // index exists to remove.
+      // reaches by address rather than through its value. Reading THROUGH it
+      // here would put every listed piece back into the editor's own demand —
+      // the cost the index exists to remove.
       expect(MentionableSchema.properties.piece.asCell).toEqual(["cell"]);
       expect(MentionableSchema.properties.piece.properties).toEqual({});
     });

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -28,8 +28,10 @@ export const MentionableSchema = {
   type: "object",
   properties: {
     [NAME]: { type: "string" },
-    // The `MentionRef.destination` shape: an opaque cell boundary, hydrated
-    // to a handle and never read through under this schema.
+    // The `MentionRef.destination` shape: an opaque cell boundary. The value
+    // at this position never carries a usable handle — an `asCell` position
+    // crosses the client boundary as an empty object — so a reader reaches
+    // the piece by ADDRESS and never reads through it under this schema.
     piece: { type: "object", properties: {}, asCell: ["cell"] },
   },
   required: [NAME],

--- a/scripts/ab-harness.ts
+++ b/scripts/ab-harness.ts
@@ -29,8 +29,8 @@
  * finding. Nothing here asserts -- it reports, because what counts as correct
  * is the comparison, not any single run.
  */
-const ROOT = Deno.env.get("CF_ROOT");
 
+const ROOT = Deno.env.get("CF_ROOT");
 if (!ROOT) {
   console.error("set CF_ROOT to a checkout root");
   Deno.exit(2);

--- a/scripts/topics-rehearsal-lib.test.ts
+++ b/scripts/topics-rehearsal-lib.test.ts
@@ -1,8 +1,8 @@
 /** Unit coverage for the pure halves of the Topics export/restore pair; the
  * live halves are exercised by the rehearsal drill
  * (`packages/cli/integration/topics-restore-drill.sh`). */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   buildRestoreDocument,

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -244,10 +244,6 @@ export interface TopicsExport {
   manifest: { fid: string; patternIdentity: string; resultKeys: string[] }[];
 }
 
-/** The known link-valued argument fields a restore handles specially:
- * `mentionable` is re-established with `cf piece link` after the write, and
- * the deprecated `myName` stays retired. */
-
 /**
  * The link-valued argument fields a restore re-establishes with
  * `cf piece link` rather than writing as data, mapped to the board path each
@@ -267,6 +263,11 @@ export const STRUCTURAL_LINK_SOURCES: Record<string, string> = {
 };
 
 export const STRUCTURAL_LINK_FIELDS = Object.keys(STRUCTURAL_LINK_SOURCES);
+
+/**
+ * Retired link-valued fields, recognized so that a restore sets one aside by
+ * name rather than reaching the unknown-link throw below.
+ */
 export const LEGACY_LINK_FIELDS = ["myName"] as const;
 
 export interface RestoreDocument {

--- a/scripts/topics-snapshot-lib.test.ts
+++ b/scripts/topics-snapshot-lib.test.ts
@@ -3,8 +3,8 @@
  * reason its subject does: importing it costs `--allow-ffi`, and keeping that
  * out of the shared lib's test file makes the boundary visible where someone
  * would otherwise reintroduce it. */
-import { describe, it } from "@std/testing/bdd";
 
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { argumentIdOf } from "./topics-snapshot-lib.ts";

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -1891,7 +1891,11 @@ Deno.test("reportBaselineDistance reports an ancestry it could not read", () => 
   );
 });
 
-/** The three-run ancestry above, with one metric measured at each commit. */
+/**
+ * Two of the three runs in the ancestry above, each carrying one metric.
+ * `RUN_ONE_BACK` is deliberately absent: callers derive their run list from
+ * these readings, so leaving it out is what makes a commit unmeasured.
+ */
 function runnerReadings(): [WorkflowRun, BaselineRunReading][] {
   return [
     [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5746 })],


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The tail of the ex-post-facto review, and the last of six. Siblings: #6693 (the
rule), #6694 (`runner`), #6696 (`cf-harness`), #6698 (`cli`), #6700 (`memory`
and friends).

## Three comments bound to the first of what they covered

- **`lib-shell/src/runtime.ts:197`** — an imperative account of fetching the
  build manifest, pinned onto the memo variable beneath it, leaving the exported
  `fetchBuildHash` undocumented. The description moves to the function; the
  variable keeps a one-liner saying it is that function's memo.
- **`fuse/mount-options.ts:8`** — "Bounds for `--attrcache-timeout`" over the
  MIN constant alone. Verified before splitting that zero passes through rather
  than being clamped (`parseAttrcacheTimeoutSeconds` accepts and returns it), so
  each bound can state its own contract truthfully.
- **`scripts/topics-rehearsal-lib.ts:247`** — a doc comment bound to **no
  declaration at all**, sitting directly above another doc comment. TypeScript
  keeps only the nearer one, so this was invisible wherever documentation
  renders. It was also stale: it named two link-valued fields where the map now
  holds three. Its one surviving claim — that the retired `myName` is recognized
  rather than ignored — moves onto `LEGACY_LINK_FIELDS`, which had no comment.

## Three more file headers read as declarations

`topics-rehearsal-lib.test.ts`, `topics-snapshot-lib.test.ts`, `ab-harness.ts`.
Same shape as #6698's eight and #6700's five: the header sat flush on its first
statement, the sweep read it as that statement's doc comment, and put the blank
one line too low. **Sixteen across four PRs now**, against a tree-wide census of
48 certain sites plus 68 needing judgment.

## An overclaim that made an omission look like a bug

`tasks/coverage-check.test.ts:1894` said "the three-run ancestry, with one metric
measured at each commit" where `runnerReadings()` returns two of the three.
`RUN_ONE_BACK` is absent **on purpose** — callers derive their run list from
these readings, so its absence is exactly what makes that commit unmeasured. The
comment now says so.

## One that is not the arc's

`ui/src/v2/core/mentionable.ts:31` and its twin in `mentionable.test.ts`. #6660
corrected the doc comment directly above this one — an `asCell` position crosses
the client boundary as an empty object, so a reader reaches the piece by
**address**, never through the value — and left the `//` note below it, and the
test's copy, still saying "hydrated to a handle". Both now say what that change
established.

## Left alone deliberately

The blank at `schema-generator/test/schema-generator.test.ts:63`, which the sweep
added because the preserved detector reads a `/** */` **inside a template
literal** as real code (one of three tool bugs this review found, all
self-masking). It is rule-unjustified but breaks nothing, and the same call was
made for the one blank #6639 put inside a function body.

## Verification

Suites green: ui 175 + 52, fuse 372, coverage-check 104, lib-shell 5, topics 2.
`deno fmt --check`, `deno lint`, `deno check`. No added line exceeds eighty
columns, measured as characters over the diff's `+` lines.

Gates run **off-pin**: this machine has `deno` 2.9.6 where `mise.toml` pins
2.9.4 and `mise` is not installed. CI's pinned run is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013j3CN3biC4UbWbid8wrSjk


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

