### PR TITLE
feat(cli): thread the caller's exit and sinks through the shuttle seams

### DIFF
--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -72,17 +72,18 @@ process's. `announce` beside those carries what a call publishes in
 flight — the invocation pair, and the spans under `--verbose` — which
 raw stderr serves for a one-shot command and corrupts for a caller
 drawing its own screen. The bulk seams — survey, repair, retarget,
-`setsrc --check` — are on no v1 verb's path and keep the exits they
-have. Each threaded
-seam carries the test the override makes possible: an injected exit that
-throws, and the report read back as a value.
+`setsrc --check` — are on no v1 verb's path and keep the exits they have.
+Each threaded seam carries the test the override makes possible: an
+injected exit that throws, and the report read back as a value.
 
 **A5 — module-global state.** `quietMode` is a file-level `let`;
 `setLLMUrl` is written by both `loadPieces` and
-`PiecesController.initialize`. Either scope them per connection, or land a
-recorded limit: one connection per process for shuttle v1, revisited when
-multiple places arrive. The cheap honest move is the recorded limit; the
-PR is whichever the review rules.
+`PiecesController.initialize`; `receipted` (`lib/write-receipt.ts`)
+memoizes the write receipt per process, so a shell names a space once and
+says nothing for the writes after. Either scope them per connection, or
+land a recorded limit: one connection per process for shuttle v1,
+revisited when multiple places arrive. The cheap honest move is the
+recorded limit; the PR is whichever the review rules.
 
 ## Stage B — the shuttle package
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -68,8 +68,12 @@ describing the shell's exit as a second failure of the call.
 and next steps land where the caller puts them, and the confirmation
 `cf call` puts on stderr for a JSON payload — so that stdout stays the
 machine surface — rides the caller's `printError` rather than the
-process's. The bulk seams — survey, repair, retarget, `setsrc --check` —
-are on no v1 verb's path and keep the exits they have. Each threaded
+process's. `announce` beside those carries what a call publishes in
+flight — the invocation pair, and the spans under `--verbose` — which
+raw stderr serves for a one-shot command and corrupts for a caller
+drawing its own screen. The bulk seams — survey, repair, retarget,
+`setsrc --check` — are on no v1 verb's path and keep the exits they
+have. Each threaded
 seam carries the test the override makes possible: an injected exit that
 throws, and the report read back as a value.
 

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -56,8 +56,11 @@ well before it.
 
 **A4 — exit and output seams audit.** Done (#6704). `exitWithDataError` and
 `exitPieceCallFailure` default to `Deno.exit(1)` and take a `deps`
-override in its place — `printError`, `printHint`, and an `exit` typed
-`never` — and every seam a v1 verb reaches forwards the caller's own:
+override in its place, each with an `exit` typed `never` beside the sinks
+its own report needs — `printError` and `printHint` for the data error,
+`printError` and `render` for the call failure, whose expiry writes
+Invocation JSON to the machine surface. Every seam a v1 verb reaches
+forwards the caller's own:
 `getCellValueFromCommand`, and `callFromCommand` at each of its three
 exits, the payload rejection reported from inside the dispatch's promise
 chain included. An `exit` typed `never` throws rather than returning, so

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -54,7 +54,7 @@ elsewhere — it opens inside the chained `piece` command expression, around
 its first inline action, and `buildCallCommand` is a standalone function
 well before it.
 
-**A4 — exit and output seams audit.** Done. `exitWithDataError` and
+**A4 — exit and output seams audit.** Done (#6704). `exitWithDataError` and
 `exitPieceCallFailure` default to `Deno.exit(1)` and take a `deps`
 override in its place — `printError`, `printHint`, and an `exit` typed
 `never` — and every seam a v1 verb reaches forwards the caller's own:

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -65,11 +65,13 @@ that rejection's throw lands in the action's own catch;
 `callFromCommand` records that an exit ran and rethrows, rather than
 describing the shell's exit as a second failure of the call.
 `describePieceFromCommand` takes `render`/`hint` beside them, so its page
-and next steps land where the caller puts them. The bulk seams — survey,
-repair, retarget, `setsrc --check` — are on no v1 verb's path and keep
-the exits they have. Each threaded seam carries the test the override
-makes possible: an injected exit that throws, and the report read back as
-a value.
+and next steps land where the caller puts them, and the confirmation
+`cf call` puts on stderr for a JSON payload — so that stdout stays the
+machine surface — rides the caller's `printError` rather than the
+process's. The bulk seams — survey, repair, retarget, `setsrc --check` —
+are on no v1 verb's path and keep the exits they have. Each threaded
+seam carries the test the override makes possible: an injected exit that
+throws, and the report read back as a value.
 
 **A5 — module-global state.** `quietMode` is a file-level `let`;
 `setLLMUrl` is written by both `loadPieces` and

--- a/docs/plans/shuttle/build-sequence.md
+++ b/docs/plans/shuttle/build-sequence.md
@@ -54,12 +54,22 @@ elsewhere — it opens inside the chained `piece` command expression, around
 its first inline action, and `buildCallCommand` is a standalone function
 well before it.
 
-**A4 — exit and output seams audit.** Every seam shuttle calls must accept
-an exit override (`exitWithDataError` / `exitPieceCallFailure` call
-`Deno.exit(1)` by default — a data error must not kill the shell) and
-route output through the `render`/`hint` deps rather than stray
-`console.error`. One audit PR that threads what is missing, with the test
-that proves a data error surfaces as a value.
+**A4 — exit and output seams audit.** Done. `exitWithDataError` and
+`exitPieceCallFailure` default to `Deno.exit(1)` and take a `deps`
+override in its place — `printError`, `printHint`, and an `exit` typed
+`never` — and every seam a v1 verb reaches forwards the caller's own:
+`getCellValueFromCommand`, and `callFromCommand` at each of its three
+exits, the payload rejection reported from inside the dispatch's promise
+chain included. An `exit` typed `never` throws rather than returning, so
+that rejection's throw lands in the action's own catch;
+`callFromCommand` records that an exit ran and rethrows, rather than
+describing the shell's exit as a second failure of the call.
+`describePieceFromCommand` takes `render`/`hint` beside them, so its page
+and next steps land where the caller puts them. The bulk seams — survey,
+repair, retarget, `setsrc --check` — are on no v1 verb's path and keep
+the exits they have. Each threaded seam carries the test the override
+makes possible: an injected exit that throws, and the report read back as
+a value.
 
 **A5 — module-global state.** `quietMode` is a file-level `let`;
 `setLLMUrl` is written by both `loadPieces` and

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -189,6 +189,21 @@ collaborators only — the `render`/`hint` sinks and the dispatch itself —
 so a caller holding a connection passes an `executePieceCallable` bound to
 it rather than opening one per call.
 
+Not every v1 verb lands on a `*FromCommand` action, and which ones do not
+is what decides whether a bare `Deno.exit` in some Cliffy action is
+shuttle's problem. `get`, `set`, `call` and `describe` go through the
+named exports (`getCellValueFromCommand`, `setCellValueFromCommand`,
+`callFromCommand`, `describePieceFromCommand`); `ls` goes through
+`listPiecesFromCommand` and `listSlugsFromCommand`; `wish` through
+`readWish`. The two that do not are composed from the library instead:
+**`link` calls `linkPieces` (`lib/piece.ts`) directly**, which is the seam
+A2 gave it and which raises `LinkValidationError` as a value, so the
+inline action behind `cf piece link` — exit and all — is not on shuttle's
+path; and **`verbs` composes `listPieceCallables` (`lib/piece.ts`) with
+the exported `verbListingLines` / `verbListingJson` / `verbListingNotes`
+and `partitionVerbListing`**, rendering the rows itself rather than
+running that command's inline action.
+
 ## Prerequisite work in `packages/cli`
 
 Each of these is small and lands on its own; together they are what decision
@@ -221,35 +236,60 @@ Each of these is small and lands on its own; together they are what decision
    the dispatch happens, and the spans under `--verbose` — to `announce`.
    What the seam prints, the caller decides where.
 
-   `announce` is one sink rather than two because no caller wants half of
-   that pair captured, and it is separate from `printError` because both
-   its streams are published whether or not the call goes on to fail. Raw
-   stderr, which a caller supplying nothing still gets, suits a command
-   that owns the terminal for one invocation; a caller drawing its own
-   screen is corrupted by a line written behind the frame, so the views
-   the pager substrate carries need these as events they can place.
+   `announce` is one sink rather than several because its three streams —
+   the pair, the spans, and the per-phase lines
+   `CF_TEST_ANNOUNCE_INVOCATION_PHASES` adds — interleave in one temporal
+   stream, and splitting them would leave a caller rendering them as
+   ordered events reassembling an order it was handed already sorted. It
+   is separate from `printError` because all three are published whether
+   or not the call goes on to fail. Raw stderr, which a caller supplying
+   nothing still gets, suits a command that owns the terminal for one
+   invocation; a caller drawing its own screen is corrupted by a line
+   written behind the frame, so the views the pager substrate carries
+   need these as events they can place.
 
-   One stream reaches the process's stderr regardless, and a caller
-   holding one of its own cannot redirect it: the **write receipt**,
-   `noteWroteTo` (`lib/write-receipt.ts`), which `set`, `link` and `call`
-   all reach. It wants a sink of its own rather than the hint stream,
-   because `--quiet` deliberately does not silence it, and a memo per
-   connection rather than per process, which is item 6's subject.
+   Two kinds of writing still reach the process, and they are different
+   problems. The first is a **designed output with no sink**: the write
+   receipt, `noteWroteTo` (`lib/write-receipt.ts`), which `set`, `link`
+   and `call` all reach. It wants a sink of its own rather than the hint
+   stream, because `--quiet` deliberately does not silence it, and a memo
+   per connection rather than per process — its `receipted` set, which
+   item 6 names beside the other two globals.
 
-   The `console.error` calls in `lib/piece.ts` are outside a v1 verb's
-   path or outside a seam's reach. The navigate wiring sits inside
-   `loadPieces`, which takes a config and no deps; the pin-rewrite report
-   belongs to `piece new` and to `setsrc` either side of `--check`, and
-   the inspect warning to `piece map`. The phase trace wraps operations
-   throughout the module, `linkPieces` among them, but writes nothing
-   unless `CF_CLI_TRACE_TIMINGS=1` asks it to.
+   The second is **lib-internal warnings no seam reaches**, all in
+   `lib/piece.ts`, and the sweep is of every `console.*` there rather
+   than the error ones alone:
+
+   - `loadPieceForCallables` warns on `console.warn` when it cannot
+     ensure the default pattern. `call` reaches it through
+     `resolvePieceCallable`, `verbs` through `listPieceCallables`, and
+     `describe` through `describePiece` — three v1 verbs, and the last of
+     them a seam that takes `render`/`hint` and cannot route this.
+   - `withRuntimeCleanupOnFailure` warns twice on `console.warn` when
+     disposal itself fails after a failed connect, and `loadPieces` wraps
+     its whole body in it, so any v1 verb can reach both.
+   - The navigate callback inside `loadPieces` writes three lines, and
+     one of them goes to **`console.log` — raw stdout** — whenever
+     `jsonOutput` is false, which is every `cf call` without `--json`.
+     Behind a full-screen frame that corrupts the drawing, and it lands
+     in the machine surface besides. It is the one on this list to fix
+     first.
+
+   The rest of that file is off a v1 verb's path: the pin-rewrite report
+   belongs to `piece new` and to `setsrc` either side of `--check`, the
+   `savePiecePattern` warning to `setsrc`, the `searchPieces` warning to
+   a `search` verb v1 defers, and the inspect warning to `piece map`. The
+   phase trace wraps operations throughout the module, `linkPieces` among
+   them, but writes nothing unless `CF_CLI_TRACE_TIMINGS=1` asks it to.
 
    Sweep each as views need it captured.
 6. **Module-global state.** `quietMode` is a file-level `let` set on every
    `FromCommand` entry; `setLLMUrl` is a global written by both `loadPieces`
    and `PiecesController.initialize`, so two connections on different API
-   URLs would fight. Scope them, or accept one-connection-per-process for
-   v1 and record the limit.
+   URLs would fight; and `receipted` (`lib/write-receipt.ts`) memoizes the
+   write receipt per process, so a long-lived shell names a space once and
+   stays silent for every write after. Scope them, or accept
+   one-connection-per-process for v1 and record the limit.
 7. **Disposal.** `withRuntimeCleanupOnFailure` disposes only on throw; the
    success path relies on process exit. In a long-lived shell every
    un-injected call leaks a runtime, a storage manager, and a WebSocket —

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -214,17 +214,32 @@ Each of these is small and lands on its own; together they are what decision
    rendering. `callFromCommand` reports its payload rejection from inside
    the dispatch's promise chain, so it records that an exit ran and rethrows
    rather than describing the shim's own throw as a second failure.
-5. **Output capture.** Every seam a v1 verb reaches routes its output —
-   the value or page, the next steps, and a failure's report — through
-   `render`, `hint`, and `printError` deps. The `console.error` calls in
-   `lib/piece.ts` do not: the navigate wiring and the phase trace sit
-   inside `loadPieces`, which takes a config and no deps, and the rest
-   belong to `setsrc` and `piece map`. `noteWroteTo`
-   (`lib/write-receipt.ts`) is the write receipt, which `--quiet`
-   deliberately does not silence, so it wants a sink of its own rather
-   than the hint stream — and a memo per process rather than per
-   connection, which is item 6's subject. Sweep as views need them
-   captured.
+5. **Output capture.** What a caller captures today is the seam's own
+   output: for every seam a v1 verb reaches, the value or page goes to
+   `render`, the next steps to `hint`, and a failure's report to
+   `printError`. What the seam prints, the caller decides where.
+
+   Three streams reach the process's stderr regardless, and a caller
+   holding one of its own cannot redirect them. The **write receipt**,
+   `noteWroteTo` (`lib/write-receipt.ts`), which `set`, `link` and `call`
+   all reach: it wants a sink of its own rather than the hint stream,
+   because `--quiet` deliberately does not silence it, and a memo per
+   connection rather than per process, which is item 6's subject. The
+   **invocation announcement** and the **`--verbose` span stream** from
+   `callFromCommand`: each names a fact about this process — the pair to
+   retry with, the wall clock — rather than the call's outcome, so
+   neither is the failure report `printError` carries, and capturing them
+   wants a sink named for what they are.
+
+   The `console.error` calls in `lib/piece.ts` are outside a v1 verb's
+   path or outside a seam's reach. The navigate wiring sits inside
+   `loadPieces`, which takes a config and no deps; the pin-rewrite report
+   belongs to `piece new` and to `setsrc` either side of `--check`, and
+   the inspect warning to `piece map`. The phase trace wraps operations
+   throughout the module, `linkPieces` among them, but writes nothing
+   unless `CF_CLI_TRACE_TIMINGS=1` asks it to.
+
+   Sweep each as views need it captured.
 6. **Module-global state.** `quietMode` is a file-level `let` set on every
    `FromCommand` entry; `setLLMUrl` is a global written by both `loadPieces`
    and `PiecesController.initialize`, so two connections on different API

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -214,22 +214,27 @@ Each of these is small and lands on its own; together they are what decision
    rendering. `callFromCommand` reports its payload rejection from inside
    the dispatch's promise chain, so it records that an exit ran and rethrows
    rather than describing the shim's own throw as a second failure.
-5. **Output capture.** What a caller captures today is the seam's own
-   output: for every seam a v1 verb reaches, the value or page goes to
-   `render`, the next steps to `hint`, and a failure's report to
-   `printError`. What the seam prints, the caller decides where.
+5. **Output capture.** What a caller captures is the seam's own output:
+   for every seam a v1 verb reaches, the value or page goes to `render`,
+   the next steps to `hint`, a failure's report to `printError`, and the
+   lines a call publishes while it is in flight — the invocation pair as
+   the dispatch happens, and the spans under `--verbose` — to `announce`.
+   What the seam prints, the caller decides where.
 
-   Three streams reach the process's stderr regardless, and a caller
-   holding one of its own cannot redirect them. The **write receipt**,
+   `announce` is one sink rather than two because no caller wants half of
+   that pair captured, and it is separate from `printError` because both
+   its streams are published whether or not the call goes on to fail. Raw
+   stderr, which a caller supplying nothing still gets, suits a command
+   that owns the terminal for one invocation; a caller drawing its own
+   screen is corrupted by a line written behind the frame, so the views
+   the pager substrate carries need these as events they can place.
+
+   One stream reaches the process's stderr regardless, and a caller
+   holding one of its own cannot redirect it: the **write receipt**,
    `noteWroteTo` (`lib/write-receipt.ts`), which `set`, `link` and `call`
-   all reach: it wants a sink of its own rather than the hint stream,
+   all reach. It wants a sink of its own rather than the hint stream,
    because `--quiet` deliberately does not silence it, and a memo per
-   connection rather than per process, which is item 6's subject. The
-   **invocation announcement** and the **`--verbose` span stream** from
-   `callFromCommand`: each names a fact about this process — the pair to
-   retry with, the wall clock — rather than the call's outcome, so
-   neither is the failure report `printError` carries, and capturing them
-   wants a sink named for what they are.
+   connection rather than per process, which is item 6's subject.
 
    The `console.error` calls in `lib/piece.ts` are outside a v1 verb's
    path or outside a seam's reach. The navigate wiring sits inside

--- a/docs/plans/shuttle/runtime-integration.md
+++ b/docs/plans/shuttle/runtime-integration.md
@@ -204,15 +204,27 @@ Each of these is small and lands on its own; together they are what decision
 3. **`callFromCommand`.** Done. `buildCallCommand`'s action reads the two
    argv arrays off the command bound to it and hands them on; everything
    below that line is the named export, which needs no binding.
-4. **Exit discipline.** `exitWithDataError` and `exitPieceCallFailure` call
-   `Deno.exit(1)` (typed `never`); `getCellValueFromCommand` reaches the
-   former on a data error, which would kill the shell. Both take a `deps`
-   override — shuttle threads an exit shim through every seam it calls, and
-   catches the `ValidationError` that `exitPieceCallFailure` rethrows for
-   Cliffy's usage rendering.
-5. **Output capture.** The `FromCommand` seams accept `render`/`hint` deps;
-   stray `console.error` calls in `lib/piece.ts` do not. Sweep as views
-   need them captured.
+4. **Exit discipline.** Done. `exitWithDataError` and `exitPieceCallFailure`
+   default to `Deno.exit(1)` (typed `never`) and take a `deps` override in
+   its place, which the seams a v1 verb reaches forward:
+   `getCellValueFromCommand` on a data error, and `callFromCommand` at each
+   of its three exits. Shuttle's shim therefore throws rather than returns —
+   what an `exit` typed `never` requires — and shuttle catches it beside the
+   `ValidationError` that `exitPieceCallFailure` rethrows for Cliffy's usage
+   rendering. `callFromCommand` reports its payload rejection from inside
+   the dispatch's promise chain, so it records that an exit ran and rethrows
+   rather than describing the shim's own throw as a second failure.
+5. **Output capture.** Every seam a v1 verb reaches routes its output —
+   the value or page, the next steps, and a failure's report — through
+   `render`, `hint`, and `printError` deps. The `console.error` calls in
+   `lib/piece.ts` do not: the navigate wiring and the phase trace sit
+   inside `loadPieces`, which takes a config and no deps, and the rest
+   belong to `setsrc` and `piece map`. `noteWroteTo`
+   (`lib/write-receipt.ts`) is the write receipt, which `--quiet`
+   deliberately does not silence, so it wants a sink of its own rather
+   than the hint stream — and a memo per process rather than per
+   connection, which is item 6's subject. Sweep as views need them
+   captured.
 6. **Module-global state.** `quietMode` is a file-level `let` set on every
    `FromCommand` entry; `setLLMUrl` is a global written by both `loadPieces`
    and `PiecesController.initialize`, so two connections on different API

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3178,6 +3178,17 @@ export interface PieceCallCommandDependencies {
   printError?: (message: string) => void;
 
   /**
+   * Where the call's in-flight lines go, stderr unless the caller says
+   * otherwise: the invocation pair as the dispatch happens, and the spans
+   * under `--verbose`. One sink rather than two, because no caller wants
+   * one of the pair captured and the other left writing behind its screen.
+   *
+   * Distinct from `printError` because these are published while the call
+   * is in flight and whether or not it goes on to fail.
+   */
+  announce?: (message: string) => void;
+
+  /**
    * How a failed call ends the caller. `Deno.exit` by default, which a shell
    * replaces with a shim that throws, so the failure arrives as a value.
    */
@@ -3242,14 +3253,19 @@ export async function callFromCommand(
   const invocationId = identity.id;
   const waitControl = resolveWaitControl({ ...options, ...readback });
   let phase: InvocationPhase = "initial_sync";
-  // The span stream keeps the process's stderr rather than taking a sink from
-  // `deps`. The three the caller supplies carry the call's outcome — its
-  // value, its next steps, its failure — and a wall-clock span is a fact
-  // about this process instead, so `printError` would be reporting a failure
-  // that has not happened. Capturing spans wants a sink named for them.
+  // The in-flight lines — the invocation pair as the dispatch happens, and
+  // the spans under --verbose — go where `announce` puts them. Raw stderr
+  // suits a command that owns the terminal for the length of one
+  // invocation; a caller drawing its own screen is corrupted by a line
+  // written behind the frame, and it needs these as events it can place.
+  //
+  // They stay apart from `printError` for all that: both are published
+  // while the call is in flight and whether or not it goes on to fail, so a
+  // failure sink would be naming a failure that has not happened.
   const observer = pieceCallPhaseObserver(
     !!options.verbose,
     (next) => phase = next,
+    deps.announce,
   );
   setQuietMode(!!options.quiet);
   // Both data-error reports below end the caller, so each goes to the
@@ -3312,15 +3328,10 @@ export async function callFromCommand(
           skipReadback: waitControl.mode === "commit",
           showLinks: !!options.showLinks,
           ...(selection === undefined ? {} : { selection }),
-          // The announcement keeps the process's stderr for the reason the
-          // span stream does: the pair it names is what a caller retries
-          // with, published as the dispatch happens and whether or not the
-          // call goes on to fail, so it is not the failure report
-          // `printError` is the sink for.
           onPhase: invocationPhaseReporter(
             identity,
             observer.onPhase,
-            undefined,
+            deps.announce,
             Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
           ),
         },

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3179,9 +3179,11 @@ export interface PieceCallCommandDependencies {
 
   /**
    * Where the call's in-flight lines go, stderr unless the caller says
-   * otherwise: the invocation pair as the dispatch happens, and the spans
-   * under `--verbose`. One sink rather than two, because no caller wants
-   * one of the pair captured and the other left writing behind its screen.
+   * otherwise: the invocation pair as the dispatch happens, the spans under
+   * `--verbose`, and the per-phase lines `CF_TEST_ANNOUNCE_INVOCATION_PHASES`
+   * adds. One sink rather than several because the three interleave in one
+   * temporal stream, and splitting them would leave a caller rendering them
+   * as ordered events to reassemble an order it was handed already sorted.
    *
    * Distinct from `printError` because these are published while the call
    * is in flight and whether or not it goes on to fail.
@@ -3345,12 +3347,16 @@ export async function callFromCommand(
       ),
       waitControl.boundSeconds,
     );
+    // The bag goes whole, here and at the failure exit below. Re-listing the
+    // fields a callee accepts is a claim about that callee's type which
+    // nothing rechecks when it grows a sink, and a dropped one is invisible:
+    // the default writes to the process and the caller sees no gap.
     renderPieceCallOutcome(
       observer,
       result,
       callableName,
       pieceConfig.piece,
-      { render: deps.render, hint: deps.hint, printError: deps.printError },
+      deps,
       { detached: waitControl.mode === "commit", invocation: identity },
     );
   } catch (error) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -756,8 +756,11 @@ export function verbInputErrorReport(
 /**
  * Print a data-error report — message plus optional hint — to stderr and exit
  * 1. The single exit path for the `cf get` / `piece link` data errors
- * above. The `deps` seam lets unit tests observe the wiring without a real
- * process exit; runtime callers use the defaults.
+ * above. The `deps` seam puts both sinks and the exit itself in the caller's
+ * hands: a one-shot verb takes the defaults and ends the process, while a
+ * caller that has to survive the report supplies an `exit` that throws and
+ * reads what its own sinks were handed. `exit` is typed `never`, so throwing
+ * is the only way such a caller can write one.
  */
 export function exitWithDataError(
   report: { message: string; hint?: string },
@@ -783,12 +786,12 @@ export function exitWithDataError(
  * unreachable from a unit test. The `deps` seam is `exitWithDataError`'s,
  * threaded so a test can observe the report without a real process exit.
  *
- * `observer` is the call's phase observer: this exit bypasses the action's
- * catch (it terminates the process from inside the promise chain), so the
- * verbose in-flight span must be closed HERE — otherwise a pre-dispatch
- * payload rejection under --verbose would leave the initial_sync span
- * dangling with no failure timing. A rethrown error is closed by the
- * action's own failure exit instead.
+ * `observer` is the call's phase observer, and its verbose in-flight span is
+ * closed HERE. The exit leaves from inside the dispatch's promise chain,
+ * ending the process by default and throwing where a caller supplied its
+ * own, so a pre-dispatch payload rejection under --verbose would otherwise
+ * leave the initial_sync span dangling with no failure timing. A rethrown
+ * error is closed by the action's own failure exit instead.
  */
 export function reportVerbInputErrorOrRethrow(
   error: unknown,
@@ -2992,13 +2995,37 @@ export interface PieceGetCLIOptions extends PieceLabelCLIOptions {
   schema?: string;
 }
 
+/**
+ * The collaborators {@link getCellValueFromCommand} and
+ * {@link setCellValueFromCommand} read, write, and report through.
+ */
 export interface PieceCellCommandDependencies {
+  /** The read, which a caller holding its own connection supplies. */
   getCellValue?: typeof getCellValue;
+
+  /** The write, which a caller holding its own connection supplies. */
   setCellValue?: typeof setCellValue;
+
+  /** Where the written value comes from, standard input by default. */
   drainStdin?: typeof drainStdin;
+
+  /** Where the value goes, stdout unless the caller says otherwise. */
   render?: typeof render;
+
+  /** Where the next steps go, stderr unless the caller says otherwise. */
   hint?: typeof hint;
+
+  /** The data-error report itself, for a caller replacing the whole exit. */
   exitWithDataError?: typeof exitWithDataError;
+
+  /** Where a data error's message goes, stderr unless the caller says so. */
+  printError?: (message: string) => void;
+
+  /**
+   * How a data error ends the caller. `Deno.exit` by default, which a shell
+   * replaces with a shim that throws, so the error arrives as a value.
+   */
+  exit?: (code: number) => never;
 }
 
 /**
@@ -3048,7 +3075,13 @@ export async function getCellValueFromCommand(
       input,
       piece: pieceConfig.piece,
     });
-    if (report) (deps.exitWithDataError ?? exitWithDataError)(report);
+    if (report) {
+      (deps.exitWithDataError ?? exitWithDataError)(report, {
+        printError: deps.printError,
+        printHint: deps.hint,
+        exit: deps.exit,
+      });
+    }
     throw error;
   }
 }
@@ -3140,6 +3173,15 @@ export interface PieceCallCommandDependencies {
 
   /** Where the next steps go, stderr unless the caller says otherwise. */
   hint?: typeof hint;
+
+  /** Where a failure's report goes, stderr unless the caller says so. */
+  printError?: (message: string) => void;
+
+  /**
+   * How a failed call ends the caller. `Deno.exit` by default, which a shell
+   * replaces with a shim that throws, so the failure arrives as a value.
+   */
+  exit?: (code: number) => never;
 }
 
 /**
@@ -3205,6 +3247,24 @@ export async function callFromCommand(
     (next) => phase = next,
   );
   setQuietMode(!!options.quiet);
+  // Both data-error reports below end the caller, so each goes to the
+  // caller's own sinks rather than to the process's: a shell supplies an
+  // `exit` that throws, and reads the report as the value it acts on.
+  //
+  // A supplied `exit` throws, where `Deno.exit` does not come back at all,
+  // and that difference is what `exitTaken` is for: the payload rejection is
+  // reported from inside the dispatch's promise chain, so its throw lands in
+  // the catch at the bottom of this function, which would otherwise describe
+  // the caller's own exit as a second, invented failure of the call.
+  let exitTaken = false;
+  const dataErrorSinks = {
+    printError: deps.printError,
+    printHint: deps.hint,
+    exit: (code: number): never => {
+      exitTaken = true;
+      return (deps.exit ?? Deno.exit)(code);
+    },
+  };
   // Read outside the invocation's failure wrapper below. Nothing is
   // dispatched here — no callable resolved, no id spent — so a malformed
   // selection is a data error about the flags, the same one `cf get` reports.
@@ -3219,7 +3279,7 @@ export async function callFromCommand(
     // the verbose in-flight span is closed here.
     observer.finish("failed");
     if (error instanceof CellSelectionError) {
-      exitWithDataError({ message: error.message });
+      exitWithDataError({ message: error.message }, dataErrorSinks);
     }
     throw error;
   }
@@ -3258,7 +3318,7 @@ export async function callFromCommand(
         reportVerbInputErrorOrRethrow(
           error,
           pieceConfig.piece,
-          undefined,
+          dataErrorSinks,
           observer,
         )
       ),
@@ -3273,7 +3333,8 @@ export async function callFromCommand(
       { detached: waitControl.mode === "commit", invocation: identity },
     );
   } catch (error) {
-    exitPieceCallFailure(observer, error, invocationId, phase);
+    if (exitTaken) throw error;
+    exitPieceCallFailure(observer, error, invocationId, phase, deps);
   }
 }
 
@@ -4430,6 +4491,12 @@ export async function listSlugsFromCommand(
 
 export interface PieceDescribeCommandDependencies {
   describePiece?: typeof describePiece;
+
+  /** Where the page goes, stdout unless the caller says otherwise. */
+  render?: typeof render;
+
+  /** Where the next steps go, stderr unless the caller says otherwise. */
+  hint?: typeof hint;
 }
 
 /** `cf piece describe`'s action, held apart from the cliffy chain the way
@@ -4444,15 +4511,16 @@ export async function describePieceFromCommand(
 ): Promise<void> {
   setQuietMode(!!options.quiet);
   const pieceConfig = parsePieceOptions(options);
+  const print = deps.render ?? render;
   const description = await (deps.describePiece ?? describePiece)(pieceConfig);
   if (options.json) {
-    render(pieceDescribeJson(description, !!options.all), { json: true });
+    print(pieceDescribeJson(description, !!options.all), { json: true });
     return;
   }
   for (const line of pieceDescribeLines(description, !!options.all)) {
-    render(line);
+    print(line);
   }
-  hint(
+  (deps.hint ?? hint)(
     cliText(
       `TIP: 'cf piece verbs --cell ${pieceConfig.piece} --json' has each verb's schemas; 'cf call --cell ${pieceConfig.piece} <verb> --help' documents one verb.`,
     ),

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3242,6 +3242,11 @@ export async function callFromCommand(
   const invocationId = identity.id;
   const waitControl = resolveWaitControl({ ...options, ...readback });
   let phase: InvocationPhase = "initial_sync";
+  // The span stream keeps the process's stderr rather than taking a sink from
+  // `deps`. The three the caller supplies carry the call's outcome — its
+  // value, its next steps, its failure — and a wall-clock span is a fact
+  // about this process instead, so `printError` would be reporting a failure
+  // that has not happened. Capturing spans wants a sink named for them.
   const observer = pieceCallPhaseObserver(
     !!options.verbose,
     (next) => phase = next,
@@ -3307,6 +3312,11 @@ export async function callFromCommand(
           skipReadback: waitControl.mode === "commit",
           showLinks: !!options.showLinks,
           ...(selection === undefined ? {} : { selection }),
+          // The announcement keeps the process's stderr for the reason the
+          // span stream does: the pair it names is what a caller retries
+          // with, published as the dispatch happens and whether or not the
+          // call goes on to fail, so it is not the failure report
+          // `printError` is the sink for.
           onPhase: invocationPhaseReporter(
             identity,
             observer.onPhase,
@@ -3329,7 +3339,7 @@ export async function callFromCommand(
       result,
       callableName,
       pieceConfig.piece,
-      { render: deps.render, hint: deps.hint },
+      { render: deps.render, hint: deps.hint, printError: deps.printError },
       { detached: waitControl.mode === "commit", invocation: identity },
     );
   } catch (error) {

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -535,6 +535,37 @@ describe("callFromCommand()", () => {
       expect(rendered).toEqual(['{"found":1}']);
     });
 
+    it("hands a JSON-input handler's confirmation to the caller's error sink", async () => {
+      // A payload given as JSON puts the confirmation on stderr, so that
+      // stdout stays the machine surface — and stderr, for a caller holding
+      // one, is its own `printError` rather than this process's. The
+      // captured lines are what says the confirmation went to the sink
+      // instead of past it.
+
+      const dispatches: Dispatch[] = [];
+      const { deps, printed, hinted, rendered } = exitSinks();
+      const escaped = await captureStderr(() =>
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          ['{"title":"Milk"}'],
+          ["--cell", PIECE, "addItem", '{"title":"Milk"}'],
+          [],
+          {
+            ...deps,
+            executePieceCallable: stubExecutor(dispatches, {
+              parsed: { usedJsonInput: true },
+            } as Partial<ExecutedPieceCallable>),
+          },
+        )
+      );
+      expect(printed).toEqual([`Called handler "addItem" on piece ${PIECE}`]);
+      expect(escaped).toEqual([]);
+      expect(rendered).toEqual([]);
+      expect(hinted[0]).toContain(`cf get --cell ${PIECE}`);
+    });
+
     it("throws a dispatch's usage failure out to Cliffy rather than exiting", async () => {
       await expect(
         callFromCommand(

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -644,7 +644,7 @@ describe("callFromCommand()", () => {
           "call",
           "addItem",
           [],
-          ["--piece", PIECE, "addItem", "--", "--filter", "title ="],
+          ["--cell", PIECE, "addItem", "--", "--filter", "title ="],
           ["--filter", "title ="],
           { ...deps, executePieceCallable: stubExecutor(dispatches) },
         ),
@@ -663,7 +663,7 @@ describe("callFromCommand()", () => {
           "call",
           "addItem",
           [],
-          ["--piece", PIECE, "addItem"],
+          ["--cell", PIECE, "addItem"],
           [],
           {
             ...deps,
@@ -679,7 +679,7 @@ describe("callFromCommand()", () => {
       expect(printed).toEqual([
         'Invalid input for "addItem": missing required property title',
       ]);
-      expect(hinted[0]).toContain(`cf piece verbs --piece ${PIECE}`);
+      expect(hinted[0]).toContain(`cf piece verbs --cell ${PIECE}`);
       expect(exited).toEqual([1]);
     });
 
@@ -692,7 +692,7 @@ describe("callFromCommand()", () => {
             "call",
             "addItem",
             [],
-            ["--piece", PIECE, "addItem"],
+            ["--cell", PIECE, "addItem"],
             [],
             {
               ...deps,
@@ -719,7 +719,7 @@ describe("callFromCommand()", () => {
             "call",
             "addItem",
             [],
-            ["--piece", PIECE, "addItem"],
+            ["--cell", PIECE, "addItem"],
             [],
             {
               ...deps,

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -8,10 +8,11 @@
  * phases it announced, and the outcome it rendered. No runtime, no socket, and
  * no server stands behind any of it.
  *
- * The bound on that: the two failure exits end the process, so the cases here
- * are the ones that return or that raise a `ValidationError`, which
- * `exitPieceCallFailure` rethrows for Cliffy's usage rendering rather than
- * exiting on.
+ * A case reaching a failure exit supplies an `exit` of its own — one that
+ * throws, which is the only shape an `exit` typed `never` leaves open — and
+ * reads the report off its own sinks rather than losing the runner to
+ * `Deno.exit`. `exitPieceCallFailure` rethrows a `ValidationError` instead of
+ * exiting, so Cliffy still renders the usage screen for one.
  */
 
 import { expect } from "@std/expect";
@@ -23,7 +24,9 @@ import {
   callFromCommand,
   type PieceCallCLIOptions,
   type PieceCallCommandDependencies,
+  WaitBoundExpired,
 } from "../commands/piece.ts";
+import { VerbInputValidationError } from "../lib/callable.ts";
 import type {
   ExecutedPieceCallable,
   executePieceCallable,
@@ -93,9 +96,19 @@ function stubExecutor(
   };
 }
 
-/** A dispatcher that fails with `error` rather than recording anything. */
-function failingExecutor(error: unknown): typeof executePieceCallable {
-  return () => Promise.reject(error);
+/**
+ * A dispatcher that fails with `error` rather than recording anything,
+ * announcing `phases` through the observer the action supplied first, so a
+ * case can choose the furthest phase the failure report names.
+ */
+function failingExecutor(
+  error: unknown,
+  phases: readonly ("dispatched" | "committed")[] = [],
+): typeof executePieceCallable {
+  return (_config, _callableName, _rawArgs, deps = {}) => {
+    for (const phase of phases) deps.onPhase?.(phase);
+    return Promise.reject(error);
+  };
 }
 
 /**
@@ -126,6 +139,46 @@ function sinks(): {
     },
     rendered,
     hinted,
+  };
+}
+
+/**
+ * Sinks standing in for the process's, as a caller holding a connection
+ * supplies them. `exit` throws rather than ending anything, which is what an
+ * `exit` typed `never` has to do, so a case reads the failure report back as
+ * a value instead of losing the runner to it.
+ */
+function exitSinks(): {
+  deps: PieceCallCommandDependencies;
+  printed: string[];
+  hinted: string[];
+  rendered: string[];
+  exited: number[];
+} {
+  const printed: string[] = [];
+  const hinted: string[] = [];
+  const rendered: string[] = [];
+  const exited: number[] = [];
+  return {
+    deps: {
+      render: (value: unknown) => {
+        rendered.push(String(value));
+      },
+      hint: (message: string) => {
+        hinted.push(message);
+      },
+      printError: (message: string) => {
+        printed.push(message);
+      },
+      exit: (code: number): never => {
+        exited.push(code);
+        throw new Error("exit-sentinel");
+      },
+    },
+    printed,
+    hinted,
+    rendered,
+    exited,
   };
 }
 
@@ -573,6 +626,116 @@ describe("callFromCommand()", () => {
         )
       );
       expect(lines.filter((line) => line.startsWith("timing: "))).toEqual([]);
+    });
+  });
+
+  describe("the failure exits", () => {
+    // Each case supplies an `exit` of its own, so what would end a process
+    // ends the call instead and the report is left on the caller's sinks —
+    // the message it prints, the remedy it hints, and the retry key beside
+    // it are all values a caller still holds after the failure.
+
+    it("reports a malformed read selection to the caller, and dispatches nothing", async () => {
+      const dispatches: Dispatch[] = [];
+      const { deps, printed, exited } = exitSinks();
+      await expect(
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--piece", PIECE, "addItem", "--", "--filter", "title ="],
+          ["--filter", "title ="],
+          { ...deps, executePieceCallable: stubExecutor(dispatches) },
+        ),
+      ).rejects.toThrow("exit-sentinel");
+      expect(printed).toHaveLength(1);
+      expect(printed[0]).toMatch(/^Invalid --filter predicate at column 7/);
+      expect(exited).toEqual([1]);
+      expect(dispatches).toEqual([]);
+    });
+
+    it("reports a rejected payload with the verb listing to point at", async () => {
+      const { deps, printed, hinted, exited } = exitSinks();
+      await expect(
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--piece", PIECE, "addItem"],
+          [],
+          {
+            ...deps,
+            executePieceCallable: failingExecutor(
+              new VerbInputValidationError(
+                "addItem",
+                "missing required property title",
+              ),
+            ),
+          },
+        ),
+      ).rejects.toThrow("exit-sentinel");
+      expect(printed).toEqual([
+        'Invalid input for "addItem": missing required property title',
+      ]);
+      expect(hinted[0]).toContain(`cf piece verbs --piece ${PIECE}`);
+      expect(exited).toEqual([1]);
+    });
+
+    it("names the phase a failed dispatch reached beside its invocation id", async () => {
+      const { deps, printed, exited } = exitSinks();
+      await captureStderr(async () => {
+        await expect(
+          callFromCommand(
+            options,
+            "call",
+            "addItem",
+            [],
+            ["--piece", PIECE, "addItem"],
+            [],
+            {
+              ...deps,
+              executePieceCallable: failingExecutor(new Error("send blew up"), [
+                "dispatched",
+              ]),
+            },
+          ),
+        ).rejects.toThrow("exit-sentinel");
+      });
+      expect(printed).toEqual([
+        "send blew up",
+        `invocation: ${INVOCATION} phase: dispatched`,
+      ]);
+      expect(exited).toEqual([1]);
+    });
+
+    it("writes an expired call's Invocation JSON to the caller's own stdout", async () => {
+      const { deps, printed, rendered, exited } = exitSinks();
+      await captureStderr(async () => {
+        await expect(
+          callFromCommand(
+            options,
+            "call",
+            "addItem",
+            [],
+            ["--piece", PIECE, "addItem"],
+            [],
+            {
+              ...deps,
+              executePieceCallable: failingExecutor(new WaitBoundExpired(5), [
+                "dispatched",
+              ]),
+            },
+          ),
+        ).rejects.toThrow("exit-sentinel");
+      });
+      expect(JSON.parse(rendered[0])).toEqual({
+        invocation: INVOCATION,
+        status: "dispatched",
+      });
+      expect(printed[1]).toBe(`invocation: ${INVOCATION} phase: dispatched`);
+      expect(exited).toEqual([1]);
     });
   });
 });

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -658,6 +658,71 @@ describe("callFromCommand()", () => {
       );
       expect(lines.filter((line) => line.startsWith("timing: "))).toEqual([]);
     });
+
+    it("hands the invocation pair to the caller's `announce`, and writes none of it to the process", async () => {
+      // Raw stderr is fine for a command that owns the terminal, and wrong
+      // for a caller drawing its own screen: a line written behind the frame
+      // corrupts it. The captured stderr is what says the announcement went
+      // to the sink rather than past it.
+
+      const dispatches: Dispatch[] = [];
+      const announced: string[] = [];
+      const escaped = await captureStderr(() =>
+        callFromCommand(
+          options,
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "addItem"],
+          [],
+          {
+            ...discard,
+            announce: (message: string) => {
+              announced.push(message);
+            },
+            executePieceCallable: stubExecutor(dispatches, {}, ["dispatched"]),
+          },
+        )
+      );
+      expect(announced).toEqual([
+        `invocation: ${INVOCATION}`,
+        `session: ${SESSION}`,
+      ]);
+      expect(escaped).toEqual([]);
+    });
+
+    it("hands the `--verbose` spans to the caller's `announce`, and writes none of them to the process", async () => {
+      const dispatches: Dispatch[] = [];
+      const announced: string[] = [];
+      const escaped = await captureStderr(() =>
+        callFromCommand(
+          { ...options, verbose: true },
+          "call",
+          "addItem",
+          [],
+          ["--cell", PIECE, "--verbose", "addItem"],
+          [],
+          {
+            ...discard,
+            announce: (message: string) => {
+              announced.push(message);
+            },
+            executePieceCallable: stubExecutor(dispatches, {}, [
+              "dispatched",
+              "committed",
+            ]),
+          },
+        )
+      );
+      const spans = announced.filter((line) => line.startsWith("timing: "))
+        .map((line) => line.replace(/ [\d.]+ms$/, ""));
+      expect(spans).toEqual([
+        "timing: initial_sync → dispatched",
+        "timing: dispatched → committed",
+        "timing: committed → settled",
+      ]);
+      expect(escaped).toEqual([]);
+    });
   });
 
   describe("the failure exits", () => {

--- a/packages/cli/test/callFromCommand.test.ts
+++ b/packages/cli/test/callFromCommand.test.ts
@@ -153,11 +153,13 @@ function exitSinks(): {
   printed: string[];
   hinted: string[];
   rendered: string[];
+  announced: string[];
   exited: number[];
 } {
   const printed: string[] = [];
   const hinted: string[] = [];
   const rendered: string[] = [];
+  const announced: string[] = [];
   const exited: number[] = [];
   return {
     deps: {
@@ -170,6 +172,9 @@ function exitSinks(): {
       printError: (message: string) => {
         printed.push(message);
       },
+      announce: (message: string) => {
+        announced.push(message);
+      },
       exit: (code: number): never => {
         exited.push(code);
         throw new Error("exit-sentinel");
@@ -178,6 +183,7 @@ function exitSinks(): {
     printed,
     hinted,
     rendered,
+    announced,
     exited,
   };
 }
@@ -780,8 +786,8 @@ describe("callFromCommand()", () => {
     });
 
     it("names the phase a failed dispatch reached beside its invocation id", async () => {
-      const { deps, printed, exited } = exitSinks();
-      await captureStderr(async () => {
+      const { deps, printed, announced, exited } = exitSinks();
+      const escaped = await captureStderr(async () => {
         await expect(
           callFromCommand(
             options,
@@ -803,12 +809,17 @@ describe("callFromCommand()", () => {
         "send blew up",
         `invocation: ${INVOCATION} phase: dispatched`,
       ]);
+      expect(announced).toEqual([
+        `invocation: ${INVOCATION}`,
+        `session: ${SESSION}`,
+      ]);
+      expect(escaped).toEqual([]);
       expect(exited).toEqual([1]);
     });
 
     it("writes an expired call's Invocation JSON to the caller's own stdout", async () => {
-      const { deps, printed, rendered, exited } = exitSinks();
-      await captureStderr(async () => {
+      const { deps, printed, rendered, announced, exited } = exitSinks();
+      const escaped = await captureStderr(async () => {
         await expect(
           callFromCommand(
             options,
@@ -831,6 +842,11 @@ describe("callFromCommand()", () => {
         status: "dispatched",
       });
       expect(printed[1]).toBe(`invocation: ${INVOCATION} phase: dispatched`);
+      expect(announced).toEqual([
+        `invocation: ${INVOCATION}`,
+        `session: ${SESSION}`,
+      ]);
+      expect(escaped).toEqual([]);
       expect(exited).toEqual([1]);
     });
   });

--- a/packages/cli/test/piece-describe.test.ts
+++ b/packages/cli/test/piece-describe.test.ts
@@ -535,7 +535,7 @@ describe("piece-describe", () => {
         },
       });
       expect(rendered).toContain("NAME    Work tracker");
-      expect(hinted[0]).toContain("cf piece verbs --piece board");
+      expect(hinted[0]).toContain("cf piece verbs --cell board");
     });
 
     it("is the action the piece command registers for describe", () => {

--- a/packages/cli/test/piece-describe.test.ts
+++ b/packages/cli/test/piece-describe.test.ts
@@ -516,6 +516,28 @@ describe("piece-describe", () => {
       expect(out).toContain("  addItem");
     });
 
+    it("writes the page and its next steps to the sinks the caller supplies", async () => {
+      // Without the sinks the page reaches stdout and the tip reaches
+      // stderr, which is right for a one-shot verb and wrong for a caller
+      // that has somewhere else to put them. A supplied sink is handed the
+      // message whatever `--quiet` says, suppressing it being the caller's
+      // decision from there on rather than this command's.
+
+      const rendered: unknown[] = [];
+      const hinted: string[] = [];
+      await describePieceFromCommand(OPTIONS, {
+        describePiece: () => Promise.resolve(DESCRIPTION),
+        render: (value) => {
+          rendered.push(value);
+        },
+        hint: (message) => {
+          hinted.push(message);
+        },
+      });
+      expect(rendered).toContain("NAME    Work tracker");
+      expect(hinted[0]).toContain("cf piece verbs --piece board");
+    });
+
     it("is the action the piece command registers for describe", () => {
       const registered = piece.getCommand("describe") as unknown as {
         actionHandler: unknown;

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -689,6 +689,40 @@ describe("cli piece parsing", () => {
     expect(rendered).toEqual([{ ok: true }, { ok: true }]);
   });
 
+  it("getCellValueFromCommand() leaves an unresolved path on the caller's sinks rather than exiting", async () => {
+    // The exit the injected one stands in for is `Deno.exit(1)`, which no
+    // long-lived caller survives. An `exit` typed `never` throws instead, so
+    // the report the read failed with — its message, the remedy, and the
+    // code — is left as values the caller still holds.
+
+    const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
+    const printed: string[] = [];
+    const hinted: string[] = [];
+    const exited: number[] = [];
+    await expect(
+      getCellValueFromCommand(base, `/${LLM_HANDLE}/items/0`, "title", {
+        getCellValue: (() =>
+          Promise.reject(
+            new Error('Cannot access path "items/0/title"'),
+          )) as never,
+        render: () => {},
+        printError: (message) => {
+          printed.push(message);
+        },
+        hint: (message) => {
+          hinted.push(message);
+        },
+        exit: (code): never => {
+          exited.push(code);
+          throw new Error("exit-sentinel");
+        },
+      }),
+    ).rejects.toThrow("exit-sentinel");
+    expect(printed).toEqual(['Cannot access path "items/0/title"']);
+    expect(hinted[0]).toContain("retry with --input");
+    expect(exited).toEqual([1]);
+  });
+
   it("setCellValueFromCommand() writes through a positional address and requires a path", async () => {
     const base = { apiUrl: API_URL, space: SPACE, identity: ID, quiet: true };
     const writes: unknown[][] = [];


### PR DESCRIPTION
## Why

A data error must not kill a shell. `cf`'s seams end a data error by calling
`Deno.exit(1)`, which is right for a one-shot command and fatal for any host
that outlives one — the caller never gets to act on the error, because it has
no caller left.

The stage was scoped around threading an exit override that turned out to
already exist: `exitWithDataError` and `exitPieceCallFailure` both accept
`deps?: { printError, printHint, exit }` today. What was missing is that the
**callers do not forward one**. Of 14 direct call sites, two did. So this is
threading and an output sweep, not a new mechanism, and the plan entry now
says that rather than what it assumed.

The same argument covers output. A seam that writes through `console.error`
is unreachable to a caller holding its own transport, and for shuttle
specifically it is worse than unreachable: B3 draws a full-screen pager, and a
line written behind that frame corrupts it.

Fourth of the stage-A seam PRs behind the merged shuttle design (#6537), after
#6626, #6646, #6676 and #6682.

## What Changed

**Exits.** Every seam a v1 verb reaches now forwards an exit override:
`getCellValueFromCommand`, and `callFromCommand` at each of its three exits.
A supplied `exit` **throws** — which an `exit` typed `never` requires — so the
caller catches it and reads the report as a value.

That difference exposed a real defect. `callFromCommand` reports its payload
rejection from inside the dispatch's promise chain, so the shim's throw lands
in the function's own `catch`, which then described the caller's exit as a
second, invented failure — an `exit-sentinel` line and a bogus
`phase: initial_sync`. An `exitTaken` flag records that an exit ran and
rethrows instead. The test that pins it reproduces both invented lines when
the guard is removed.

**Output.** The seams route through `render`, `hint`, `printError`, and a new
`announce` carrying the call's in-flight lines — the invocation pair as the
dispatch happens, and the `--verbose` spans. `announce` is deliberately
separate from `printError`, because those lines are published whether or not
the call goes on to fail, and one sink rather than several because the streams
interleave in one temporal order a caller renders as events.

Every deps bag is now passed **whole** rather than re-listed field by field.
Re-listing is a claim about the callee's type that nothing rechecks when it
grows a sink, and a dropped field is invisible — the default writes to the
process and the caller sees no gap. That is not hypothetical: this PR dropped
`printError` on the `usedJsonInput` branch and needed a round to notice.

## Test plan

Gates run on this diff, serially: `deno fmt --check`, `deno lint`,
`deno task check`, `deno task check-docs`, and `deno task test` in
`packages/cli` — exit 0, 1758 parallel + 210 serial, 0 failed.

Seven new cases across `test/callFromCommand.test.ts`, `test/piece.test.ts`
and `test/piece-describe.test.ts`, each driving a seam with an injected exit
that throws a sentinel and asserting the data error arrives as a value the
caller can act on. Every case was verified non-vacuous by mutating the
implementation, watching it red, and restoring the file byte-identically.

The sink tests assert **both directions** — that the line reaches the caller's
sink, and that nothing escapes to the process's stderr — because "arrived" and
"did not leak" are different facts and only the pair catches a duplicate.

## A limit this PR records rather than fixes

`docs/plans/shuttle/runtime-integration.md` now separates two problems it
previously conflated. The **write receipt** (`noteWroteTo`) is a designed
output with no sink of its own: `--quiet` deliberately does not silence it
while it does silence hints, so it cannot ride `hint`, and its per-process
memo (`receipted`) is module-global state belonging with A5's. Beside it sit
**lib-internal warnings no seam reaches** — `loadPieceForCallables`'s
default-pattern warning on `call`/`verbs`/`describe`, two disposal warnings in
`withRuntimeCleanupOnFailure`, and the navigate line, which for a non-`--json`
call reaches **stdout**. That last one is the first to fix for B3, and the
document now says so instead of claiming one stream escapes when four do.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

